### PR TITLE
fix(normalize): fall back to dup, not ins, where the codon gate refuses a repeat

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7703,7 +7703,35 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             let ins_edit = NaEdit::Insertion {
                                 sequence: InsertedSequence::Literal(Sequence::new(bases)),
                             };
-                            return Ok((ins_start, ins_end, ins_edit, warnings));
+                            // Re-enter on the derived insertion rather than
+                            // returning it raw (#1204), exactly as the
+                            // `DupToRepeatResult::GatedInsertion` arm below does.
+                            // All three spellings of a gated expansion — `unit[N]`
+                            // here, `dup` there, a directly written `ins` — then
+                            // reach the SAME insertion canonicalization, so they
+                            // agree on the output form. Returning the literal
+                            // straight out left this one path unable to promote to
+                            // the `dup` the spec prescribes (`repeated.md` L22),
+                            // which made `norm(unit[N])` an `ins` while
+                            // `norm(norm(unit[N]))` was a `dup` — a
+                            // non-idempotency the moment the insertion path
+                            // learned to promote. The rule layer also anchors this
+                            // insertion at the tract's 3' flank regardless of
+                            // direction, so re-entry is what shuffles it to the
+                            // direction-appropriate resting place and subjects it
+                            // to the same boundary clamps.
+                            //
+                            // Terminates: the derived edit is an `Insertion`, and
+                            // the `Insertion` arm never re-enters this `Repeat`
+                            // arm. `is_coding` / `cds_span` are threaded unchanged
+                            // — same transcript, same CDS bounds (#1185).
+                            let (rec_start, rec_end, rec_edit, mut rec_warnings) = self
+                                .normalize_na_edit(
+                                    ref_seq, &ins_edit, ins_start, ins_end, boundaries, is_coding,
+                                    cds_span,
+                                )?;
+                            warnings.append(&mut rec_warnings);
+                            return Ok((rec_start, rec_end, rec_edit, warnings));
                         }
                         // Defensive fallback: rule layer returned a base byte
                         // that doesn't fit the Base alphabet (e.g. N). Don't
@@ -7891,43 +7919,46 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         self.config.shuffle_direction,
                     );
 
-                    // Codon-frame gate (repeated.md): in c., if the alt is
-                    // >=2 copies of a non-codon-aligned unit, the spec
-                    // mandates ins<literal>, not dup. The smallest-unit
-                    // length is rotation-invariant, so we can compute it
-                    // once from `seq_bytes` and apply the same gate at
-                    // every dup-emission site below. In practice the gate
-                    // never fires when `ins_to_dup` is `Some` (that helper
-                    // only returns for single-unit alts, where
-                    // `smallest_unit.len() == seq_bytes.len()`), but we
-                    // guard the (a) fast path and (c) single-copy fallback
-                    // anyway so the spec rule is explicit at each site and
-                    // survives future changes to `insertion_to_duplication`.
-                    let smallest_unit = rules::smallest_repeat_unit(&seq_bytes);
-                    let codon_blocks_dup = is_coding
-                        && smallest_unit.len() < seq_bytes.len()
-                        && !smallest_unit.len().is_multiple_of(3);
-
-                    if !codon_blocks_dup {
-                        if let Some(rules::InsToDupResult {
-                            start: dup_start,
-                            end: dup_end,
-                            ref_count,
-                            ..
-                        }) = ins_to_dup.as_ref()
-                        {
-                            if *ref_count >= 2 {
-                                return Ok((
-                                    *dup_start,
-                                    *dup_end,
-                                    NaEdit::Duplication {
-                                        sequence: None,
-                                        length: None,
-                                        uncertain_extent: None,
-                                    },
-                                    warnings,
-                                ));
-                            }
+                    // No codon-frame gate on the dup paths below (#1204). The
+                    // `repeated.md` exception forbids *repeat notation* for a
+                    // non-triplet unit in the CDS, and names `dup` as the
+                    // replacement for exactly this case — "use
+                    // `NM_024312.4:c.2692_2693dup` and **not**
+                    // `NM_024312.4:c.2686A[10]`" (DNA L22, RNA L25). The gate is
+                    // therefore applied where repeat notation is decided —
+                    // `insertion_to_repeat` above and `duplication_to_repeat` in
+                    // the Duplication arm, both of which return `None` / reroute
+                    // here when it fires — and must NOT be re-applied here, or
+                    // the prescribed `dup` is unreachable and the spec's *other*
+                    // replacement (a flat `ins`) is emitted for both cases.
+                    //
+                    // Which of the two the spec prescribes is decided by the
+                    // reference, not by the gate, and the three paths below
+                    // already decide it correctly: each emits a `dup` only where
+                    // the alt equals an adjacent same-length reference tract, so
+                    // the change genuinely IS a duplication. The spec's second
+                    // example — four `TA` copies added to a `TA[2]` tract — has
+                    // no such tract (the added bases are twice its length), so
+                    // none of them fire and it falls through to
+                    // `c.1741_1742insTATATATA` as prescribed.
+                    if let Some(rules::InsToDupResult {
+                        start: dup_start,
+                        end: dup_end,
+                        ref_count,
+                        ..
+                    }) = ins_to_dup.as_ref()
+                    {
+                        if *ref_count >= 2 {
+                            return Ok((
+                                *dup_start,
+                                *dup_end,
+                                NaEdit::Duplication {
+                                    sequence: None,
+                                    length: None,
+                                    uncertain_extent: None,
+                                },
+                                warnings,
+                            ));
                         }
                     }
 
@@ -7985,7 +8016,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     let three_prime_match = pos_idx + ins_len <= ref_seq.len()
                         && ref_seq[pos_idx..pos_idx + ins_len] == rotated_seq[..];
 
-                    if !codon_blocks_dup && (five_prime_match || three_prime_match) {
+                    if five_prime_match || three_prime_match {
                         // Side-aware dup anchor. `insertion_is_duplication`-
                         // equivalent checks above return true if EITHER the
                         // preceding ref tract (5'-side: `ref[pos-L..pos]`)
@@ -8091,7 +8122,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         start: dup_start,
                         end: dup_end,
                         ..
-                    }) = ins_to_dup.as_ref().filter(|_| !codon_blocks_dup)
+                    }) = ins_to_dup.as_ref()
                     {
                         // (c) Single-copy tract fallback. Reached when (a) declined
                         // because `ref_count < 2` and (b) declined because the post-

--- a/tests/it/dup_shift_matrix.rs
+++ b/tests/it/dup_shift_matrix.rs
@@ -193,18 +193,29 @@ mod cds_plus {
     }
 
     #[rstest]
-    // Case 1: 2-A dup in 5-A homopolymer. unit_len=1; codon-frame gate forbids
-    // A[7] in c., so emits insAA at the 3' tract flanking position per spec
-    // (≥2 added unit copies → ins<literal>).
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}insAA", &[7u64, 8u64])]
-    // Case 2: 4-A dup in 4-A homopolymer (full tract dup) → insAAAA.
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insAAAA", &[6u64, 7u64])]
+    // Cases 1, 2 and 5 carry non-triplet units, so the codon-frame gate refuses
+    // repeat notation. Re-blessed from `ins` literals to `dup` by #1204: the gate
+    // forbids *repeat notation*, and `repeated.md` L22 names `dup` as the
+    // replacement for exactly this shape — "use `NM_024312.4:c.2692_2693dup` and
+    // **not** `c.2686A[10]`". In each case the added bases duplicate an adjacent
+    // same-length reference tract, which is what makes `dup` a faithful
+    // description; the flat `ins` remains the answer only where no such tract
+    // exists (the spec's other replacement, `c.1741_1742insTATATATA`).
+    //
+    // Case 1: 2-A dup in a 5-A homopolymer (tract c.3_7). A[7] is forbidden in
+    // c.; the two added A's copy the tract's 3'-most pair, so the 3'-rule dup is
+    // c.6_7.
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}dup", &[6u64, 7u64])]
+    // Case 2: 4-A dup of the whole 4-A tract (c.3_6). That is the tract's only
+    // 4-base window, so the input is already canonical and is now a fixed point.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}dup", &[3u64, 6u64])]
     // Case 3: 2 GCAs dup'd in 3-GCA tandem → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}dup", &[3u64, 8u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
     // Case 4: cyclic GCA tract → GCA[5].
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}dup", &[4u64, 9u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 5: AT periodicity. unit_len=2; gate forbids AT[7] in c. → insATAT.
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insATAT", &[12u64, 13u64])]
+    // Case 5: AT periodicity, unit_len=2. AT[7] is forbidden in c.; the added
+    // `ATAT` copies the 3'-most 4 bases of the c.3_12 tract → dup at c.9_12.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}dup", &[9u64, 12u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -317,18 +328,29 @@ mod cds_minus {
     }
 
     #[rstest]
-    // Case 1: 2-A dup in 5-A homopolymer. unit_len=1; codon-frame gate forbids
-    // A[7] in c., so emits insAA at the 3' tract flanking position per spec
-    // (≥2 added unit copies → ins<literal>).
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}insAA", &[7u64, 8u64])]
-    // Case 2: 4-A dup in 4-A homopolymer (full tract dup) → insAAAA.
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insAAAA", &[6u64, 7u64])]
+    // Cases 1, 2 and 5 carry non-triplet units, so the codon-frame gate refuses
+    // repeat notation. Re-blessed from `ins` literals to `dup` by #1204: the gate
+    // forbids *repeat notation*, and `repeated.md` L22 names `dup` as the
+    // replacement for exactly this shape — "use `NM_024312.4:c.2692_2693dup` and
+    // **not** `c.2686A[10]`". In each case the added bases duplicate an adjacent
+    // same-length reference tract, which is what makes `dup` a faithful
+    // description; the flat `ins` remains the answer only where no such tract
+    // exists (the spec's other replacement, `c.1741_1742insTATATATA`).
+    //
+    // Case 1: 2-A dup in a 5-A homopolymer (tract c.3_7). A[7] is forbidden in
+    // c.; the two added A's copy the tract's 3'-most pair, so the 3'-rule dup is
+    // c.6_7.
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}dup", &[6u64, 7u64])]
+    // Case 2: 4-A dup of the whole 4-A tract (c.3_6). That is the tract's only
+    // 4-base window, so the input is already canonical and is now a fixed point.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}dup", &[3u64, 6u64])]
     // Case 3: 2 GCAs dup'd in 3-GCA tandem → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}dup", &[3u64, 8u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
     // Case 4: cyclic GCA tract → GCA[5].
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}dup", &[4u64, 9u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 5: AT periodicity. unit_len=2; gate forbids AT[7] in c. → insATAT.
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insATAT", &[12u64, 13u64])]
+    // Case 5: AT periodicity, unit_len=2. AT[7] is forbidden in c.; the added
+    // `ATAT` copies the 3'-most 4 bases of the c.3_12 tract → dup at c.9_12.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}dup", &[9u64, 12u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/it/five_prime_boundary_delins_unification.rs
+++ b/tests/it/five_prime_boundary_delins_unification.rs
@@ -1,21 +1,34 @@
-//! Regression tests for the 5'/3' homopolymer-boundary insertion/dup → delins
+//! Regression tests for the 5'/3' homopolymer-boundary insertion/dup
 //! unification (idempotency-campaign follow-up to PR #1169; resolves the #387
 //! CDS-end saturation latent and the dup-path non-confluence).
 //!
 //! At a CDS-interior homopolymer that saturates against a coding boundary, every
-//! spelling of the same haplotype — whether written as a dup or a direct
-//! insertion, at any start position — must normalize to ONE valid, idempotent
-//! `c.<cds_boundary>delins…` form. ferro's design forbids re-axing a CDS-interior
-//! edit onto the 3'UTR (`c.*N`) axis (see the CDS-start/-end clamps in
-//! `src/normalize/mod.rs`), so the canonical boundary form is the delins, not a
-//! `c.<cds_end>_*1ins…` spanning insertion. Spanning *duplications*
-//! (`c.7_*1dup`) remain the spec-canonical form and are preserved.
+//! spelling of the same haplotype — dup, direct insertion, `delins`, `unit[N]`,
+//! at any start position — must normalize to ONE valid, idempotent form. That
+//! convergence is what this file locks. **Which** form it converges to depends on
+//! whether a duplication describes the change, and both regimes are covered here:
 //!
-//! Before this fix the dup path returned the 3'-anchored `c.7_*1insAA` verbatim
-//! (bypassing both boundary clamps), the direct-insertion path was non-confluent
-//! (`c.1delinsAAA` / `c.1_3delinsAAAAA` / `c.1_4delinsAAAAAA`), and every 5' form
-//! re-normalized to the INVALID single-position `c.1insAA` (which ferro's own
-//! parser rejects).
+//! - **The added bases copy an adjacent same-length reference tract** → a `dup`,
+//!   which needs no clamp: it sits wholly inside the CDS with two valid anchors.
+//!   `repeated.md` L22 prescribes exactly this ("use `NM_024312.4:c.2692_2693dup`
+//!   and **not** `c.2686A[10]`") and biocommons agrees, rewriting even a
+//!   boundary `delins` into it (`NM_212556.2:c.1delinsAA` → `c.1dup`).
+//!   Re-blessed from `c.1delinsAAA` / `c.7delinsAAA` by #1204.
+//! - **The added bases are longer than the tract**, so no duplication describes
+//!   them → the insertion saturates the boundary and is clamped to
+//!   `c.<cds_boundary>delins…`. ferro's design forbids re-axing a CDS-interior
+//!   edit onto the 3'UTR (`c.*N`) axis (see the CDS-start/-end clamps in
+//!   `src/normalize/mod.rs`), so this remains the canonical boundary form rather
+//!   than a `c.<cds_end>_*1ins…` spanning insertion.
+//!
+//! Spanning *duplications* (`c.7_*1dup`) remain the spec-canonical form and are
+//! preserved in both regimes (#401).
+//!
+//! Before the original fix the dup path returned the 3'-anchored `c.7_*1insAA`
+//! verbatim (bypassing both boundary clamps), the direct-insertion path was
+//! non-confluent (`c.1delinsAAA` / `c.1_3delinsAAAAA` / `c.1_4delinsAAAAAA`), and
+//! every 5' form re-normalized to the INVALID single-position `c.1insAA` (which
+//! ferro's own parser rejects).
 
 use crate::common::synthetic::SyntheticBuilder;
 use ferro_hgvs::reference::transcript::Strand;
@@ -40,119 +53,124 @@ fn assert_reparses(s: &str) {
     parse_hgvs(s).unwrap_or_else(|e| panic!("normalizer emitted un-parseable HGVS {s:?}: {e}"));
 }
 
-const A7: &str = "AAAAAAA"; // 7-A CDS, cds 1..=7, no UTR either side.
-
-// ---- 5' direction: all spellings converge to c.1delinsAAA -------------------
-
-#[test]
-fn five_prime_boundary_dup_becomes_start_delins() {
-    for input in ["c.1_2dup", "c.3_4dup", "c.6_7dup"] {
-        let out = norm(
-            A7,
-            1,
-            7,
-            &format!("NM_TEST.1:{input}"),
-            ShuffleDirection::FivePrime,
-        );
-        assert_eq!(out, "NM_TEST.1:c.1delinsAAA", "5' {input}");
-    }
-}
-
-#[test]
-fn five_prime_boundary_insertion_becomes_start_delins() {
-    for input in ["c.1_2insAA", "c.3_4insAA", "c.5_6insAA", "c.6_7insAA"] {
-        let out = norm(
-            A7,
-            1,
-            7,
-            &format!("NM_TEST.1:{input}"),
-            ShuffleDirection::FivePrime,
-        );
-        assert_eq!(out, "NM_TEST.1:c.1delinsAAA", "5' {input}");
-    }
-}
-
-#[test]
-fn five_prime_boundary_delins_is_idempotent() {
-    let once = norm(
-        A7,
-        1,
-        7,
-        "NM_TEST.1:c.1delinsAAA",
-        ShuffleDirection::FivePrime,
-    );
-    assert_eq!(
-        once, "NM_TEST.1:c.1delinsAAA",
-        "c.1delinsAAA must be a 5' fixed point"
-    );
-}
-
-#[test]
-fn five_prime_boundary_output_always_reparses() {
-    for input in ["c.1_2dup", "c.6_7dup", "c.1_2insAA", "c.6_7insAA"] {
-        let out = norm(
-            A7,
-            1,
-            7,
-            &format!("NM_TEST.1:{input}"),
-            ShuffleDirection::FivePrime,
-        );
+/// Assert every spelling in `inputs` normalizes to `expected`, that each output
+/// re-parses, and that `expected` is a fixed point.
+///
+/// Convergence and the fixed point are separate properties and this file needs
+/// both: one target every spelling reaches, which re-normalizes to itself.
+fn assert_all_converge(
+    core: &str,
+    cds_start: u64,
+    cds_end: u64,
+    inputs: &[&str],
+    dir: ShuffleDirection,
+    expected: &str,
+) {
+    for input in inputs {
+        let out = norm(core, cds_start, cds_end, &format!("NM_TEST.1:{input}"), dir);
+        assert_eq!(out, expected, "{dir:?} {input}");
         assert_reparses(&out);
     }
+    assert_eq!(
+        norm(core, cds_start, cds_end, expected, dir),
+        expected,
+        "{expected} must be a {dir:?} fixed point",
+    );
 }
 
-// ---- 3' direction: all spellings converge to c.7delinsAAA -------------------
+const A7: &str = "AAAAAAA"; // 7-A CDS, cds 1..=7, no UTR either side.
 
-#[test]
-fn three_prime_boundary_dup_becomes_end_delins() {
-    for input in ["c.1_2dup", "c.3_4dup", "c.6_7dup"] {
-        let out = norm(
-            A7,
-            1,
-            7,
-            &format!("NM_TEST.1:{input}"),
-            ShuffleDirection::ThreePrime,
-        );
-        assert_eq!(out, "NM_TEST.1:c.7delinsAAA", "3' {input}");
-    }
-}
+/// Every spelling of "+2 `A` into the 7-`A` tract". The `A[9]` row is what
+/// #1204's second half added: before it, the `unit[N]` spelling short-circuited
+/// to a raw `ins` and was the one spelling that did NOT converge with the others.
+const PLUS_TWO_SPELLINGS: &[&str] = &[
+    "c.1_2dup",
+    "c.3_4dup",
+    "c.6_7dup",
+    "c.1_2insAA",
+    "c.3_4insAA",
+    "c.5_6insAA",
+    "c.6_7insAA",
+    "c.1delinsAAA",
+    "c.1A[9]",
+];
 
-#[test]
-fn three_prime_boundary_insertion_becomes_end_delins() {
-    for input in ["c.1_2insAA", "c.3_4insAA", "c.5_6insAA", "c.6_7insAA"] {
-        let out = norm(
-            A7,
-            1,
-            7,
-            &format!("NM_TEST.1:{input}"),
-            ShuffleDirection::ThreePrime,
-        );
-        assert_eq!(out, "NM_TEST.1:c.7delinsAAA", "3' {input}");
-    }
-}
+/// Eight added `A`s, written from three different start positions. No `A` tract
+/// eight bases long exists to copy, so no duplication describes this and it must
+/// stay an insertion — which then saturates the coding boundary and clamps.
+const PLUS_EIGHT_SPELLINGS: &[&str] = &["c.1_2insAAAAAAAA", "c.3_4insAAAAAAAA", "c.6_7insAAAAAAAA"];
 
+// ---- The duplication regime: all spellings converge to one dup --------------
+
+/// The 5'-most duplicated pair in the tract is `c.1_2`.
 #[test]
-fn three_prime_boundary_delins_is_idempotent() {
-    let once = norm(
+fn five_prime_boundary_spellings_converge_to_start_dup() {
+    assert_all_converge(
         A7,
         1,
         7,
-        "NM_TEST.1:c.7delinsAAA",
-        ShuffleDirection::ThreePrime,
+        PLUS_TWO_SPELLINGS,
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.1_2dup",
     );
-    assert_eq!(
-        once, "NM_TEST.1:c.7delinsAAA",
-        "c.7delinsAAA must be a 3' fixed point"
+}
+
+/// …and the 3'-most is `c.6_7`, which is the shape `repeated.md` L22 shows:
+/// `c.2692_2693dup` names the two 3'-most bases of the `A[8]` tract at
+/// `c.2686_2693`.
+#[test]
+fn three_prime_boundary_spellings_converge_to_end_dup() {
+    assert_all_converge(
+        A7,
+        1,
+        7,
+        PLUS_TWO_SPELLINGS,
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.6_7dup",
+    );
+}
+
+// ---- The clamp regime: an alt longer than the tract has no dup --------------
+
+/// Eight added `A`s against a seven-base tract clamp to the minimal
+/// single-base-anchored `delins`: `delete c.1` (`A`), `insert AAAAAAAAA`, net +8.
+///
+/// This is the case that keeps the #1170 / #387 / #1208 boundary clamps covered
+/// now that the dup-able shapes above resolve before reaching them. Without a row
+/// of this shape the clamp would be left with no direct test.
+#[test]
+fn five_prime_over_long_insertion_still_clamps_to_start_delins() {
+    assert_all_converge(
+        A7,
+        1,
+        7,
+        PLUS_EIGHT_SPELLINGS,
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.1delinsAAAAAAAAA",
+    );
+}
+
+/// The 3' mirror: `delete c.7`, `insert AAAAAAAAA`.
+#[test]
+fn three_prime_over_long_insertion_still_clamps_to_end_delins() {
+    assert_all_converge(
+        A7,
+        1,
+        7,
+        PLUS_EIGHT_SPELLINGS,
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.7delinsAAAAAAAAA",
     );
 }
 
 // ---- WITH a real 3'UTR: spanning dups preserved, not over-clamped -----------
 
 /// `AAAAAAAGCG`: A-run CDS c.1..=7, 3'UTR = `GCG` (so c.*1 = 'G' EXISTS).
-/// A homopolymer insertion at the boundary still clamps to the CDS-end delins
-/// (CDS-interior edit stays on the CDS axis)…
+/// A dup-able homopolymer addition resolves to the CDS-interior dup, and the
+/// existence of a representable far side (`c.*1`) does not tempt it onto the UTR
+/// axis.
 #[test]
-fn with_3utr_homopolymer_insertion_clamps_to_end_delins() {
+fn with_3utr_homopolymer_insertion_becomes_the_end_dup() {
     let out = norm(
         "AAAAAAAGCG",
         1,
@@ -160,7 +178,21 @@ fn with_3utr_homopolymer_insertion_clamps_to_end_delins() {
         "NM_TEST.1:c.6_7insAA",
         ShuffleDirection::ThreePrime,
     );
-    assert_eq!(out, "NM_TEST.1:c.7delinsAAA");
+    assert_eq!(out, "NM_TEST.1:c.6_7dup");
+}
+
+/// …and the over-long alt on the same transcript still clamps at the CDS end
+/// rather than escaping onto `c.*1`.
+#[test]
+fn with_3utr_over_long_insertion_still_clamps_to_end_delins() {
+    let out = norm(
+        "AAAAAAAGCG",
+        1,
+        7,
+        "NM_TEST.1:c.6_7insAAAAAAAA",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(out, "NM_TEST.1:c.7delinsAAAAAAAAA");
 }
 
 /// …but a genuine boundary-spanning *duplication* (`AG` = dup of c.7_*1) is the

--- a/tests/it/ins_repeat_b1_matrix.rs
+++ b/tests/it/ins_repeat_b1_matrix.rs
@@ -187,20 +187,30 @@ mod cds_plus {
 
     #[rstest]
     fn multi_copy_ins_homopolymer_unit_blocks_in_cds() {
-        // unit_len=1 in c. → codon-frame gate forbids A[N]. Caller emits
-        // ins literal at the 3' tract flanking position.
+        // unit_len=1 in c. → the codon-frame gate forbids A[N]. The fallback is
+        // the `dup` the spec prescribes for this shape, not an `ins` literal
+        // (#1204, `repeated.md` L22: "use `c.2692_2693dup` and **not**
+        // `c.2686A[10]`"): the two added A's copy the 3'-most pair of the 4-A
+        // tract at c.3_6, so the 3'-rule dup is c.5_6.
         let p = provider("ACAAAACGTACGTACGTAC");
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAA", &[2, 3]));
-        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[5, 6]));
     }
 
     #[rstest]
     fn multi_copy_ins_dinucleotide_unit_blocks_in_cds() {
-        // unit_len=2 in c. → gate forbids AT[N]. Mirrors the spec's
-        // c.1741_1742insTATATATA example.
+        // unit_len=2 in c. → the gate forbids AT[N], and the fallback is a `dup`
+        // (#1204). Previously asserted as `c.7_8insATAT` and described as
+        // mirroring the spec's `c.1741_1742insTATATATA` example — it does not:
+        // there, four `TA` copies are added to a two-copy tract, so the added
+        // bases are longer than the whole tract and no `dup` describes them. Here
+        // the added `ATAT` sits inside a six-base `AT` tract (c.2_7) and copies
+        // c.4_7 exactly, which is the spec's FIRST replacement, the `dup` one.
+        // `ins_shift_matrix`'s case 2 covers the genuinely-longer-than-the-tract
+        // shape.
         let p = provider("CATATATCACGTACGTACGT");
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[1, 2]));
-        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[7, 8]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[4, 7]));
     }
 
     #[rstest]
@@ -210,8 +220,11 @@ mod cds_plus {
         // `insertion_to_duplication`) emits `dup` at the tract-aligned 3'-most
         // position; the codon-frame gate does NOT block single-copy
         // additions, since the gate fires only when the alt itself is >=2
-        // copies of a non-codon-aligned unit. Regression lock-in for the
-        // codon_blocks_dup guard applied to the fast path.
+        // copies of a non-codon-aligned unit. Unaffected by #1204, which removed
+        // that gate from the dup paths entirely: it was provably dead on this
+        // one (`insertion_to_duplication` returns `Some` only for single-copy
+        // alts, where the gate's `smallest_unit.len() < alt.len()` clause is
+        // false), so this case pinned the fast path before and pins it now.
         let p = provider("CATATATCACGTACGTACGT");
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAT", &[1, 2]));
         assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[6, 7]));
@@ -229,13 +242,17 @@ mod cds_plus {
     fn round_trip_dup_form_and_repeat_form_in_cds() {
         // Round-trip lock: dup-form and repeat-form of the same edit must
         // canonicalize identically under the codon-frame gate. 4-A ref,
-        // c.3_4dup vs c.3_6A[6] both → `c.6_7insAA`.
+        // c.3_4dup vs c.3_6A[6] both → `c.5_6dup` (#1204 re-blessed the shared
+        // target from `c.6_7insAA`; the agreement itself is what this locks, and
+        // #1204 is what made the `unit[N]` spelling reach the same
+        // canonicalization as the other two rather than short-circuiting to a raw
+        // `ins`).
         let p1 = provider("ACAAAACGTACGTACGTAC");
         let p2 = provider("ACAAAACGTACGTACGTAC");
         let r1 = normalize_to_string(p1, &hgvs("NM_TEST.1:c.{0}_{1}dup", &[3, 4]));
         let r2 = normalize_to_string(p2, &hgvs("NM_TEST.1:c.{0}_{1}A[6]", &[3, 6]));
         assert_eq!(r1, r2, "dup-form and repeat-form must agree");
-        assert_eq!(r1, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+        assert_eq!(r1, hgvs("NM_TEST.1:c.{0}_{1}dup", &[5, 6]));
     }
 }
 
@@ -259,7 +276,7 @@ mod cds_minus {
     fn multi_copy_ins_homopolymer_unit_blocks_in_cds_minus() {
         let p = provider("ACAAAACGTACGTACGTAC");
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAA", &[2, 3]));
-        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[5, 6]));
     }
 
     #[rstest]
@@ -268,7 +285,7 @@ mod cds_minus {
         // Mirrors cds_plus::multi_copy_ins_dinucleotide_unit_blocks_in_cds.
         let p = provider("CATATATCACGTACGTACGT");
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[1, 2]));
-        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[7, 8]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[4, 7]));
     }
 
     #[rstest]

--- a/tests/it/ins_shift_matrix.rs
+++ b/tests/it/ins_shift_matrix.rs
@@ -289,15 +289,24 @@ mod cds_plus {
     }
 
     #[rstest]
-    // Case 1: 2 A's added to AAA tract. unit_len=1; codon-frame gate forbids
-    // A[N] in c., emit insAA at the 3' tract flanking position per spec.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}insAA", &[5u64, 6u64])]
-    // Case 2: 4 A's added to AAA tract → insAAAA (gate blocks A[N], unit_len=1).
+    // Cases 1 and 4 carry non-triplet units, so the codon-frame gate refuses
+    // repeat notation and #1204 re-blessed them from `ins` to the `dup` that
+    // `repeated.md` L22 prescribes. Case 2 is the contrast that makes the rule
+    // legible: its alt is LONGER than the tract it lands in, so no duplication
+    // describes it and the flat `ins` literal stays — the spec's other
+    // replacement (`c.1741_1742insTATATATA`), unchanged by #1204.
+    //
+    // Case 1: 2 A's added to the AAA tract at c.3_5. A[5] is forbidden in c.;
+    // the added pair copies the tract's 3'-most two bases → dup at c.4_5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}dup", &[4u64, 5u64])]
+    // Case 2: 4 A's added to the same 3-A tract. Four added bases cannot copy a
+    // three-base tract, so this stays an `ins` at the 3' flank.
     #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}insAAAA", &[5u64, 6u64])]
     // Case 3: 2 GCA units added → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 4: 2 AC units added → insACAC (gate blocks AC[N], unit_len=2).
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}insACAC", &[8u64, 9u64])]
+    // Case 4: 2 AC units added, unit_len=2. AC[N] is forbidden in c.; the added
+    // `ACAC` copies c.5_8 of the c.2_8 alternating tract → dup there.
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}dup", &[5u64, 8u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -443,15 +452,24 @@ mod cds_minus {
     }
 
     #[rstest]
-    // Case 1: 2 A's added to AAA tract. unit_len=1; codon-frame gate forbids
-    // A[N] in c., emit insAA at the 3' tract flanking position per spec.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}insAA", &[5u64, 6u64])]
-    // Case 2: 4 A's added to AAA tract → insAAAA (gate blocks A[N], unit_len=1).
+    // Cases 1 and 4 carry non-triplet units, so the codon-frame gate refuses
+    // repeat notation and #1204 re-blessed them from `ins` to the `dup` that
+    // `repeated.md` L22 prescribes. Case 2 is the contrast that makes the rule
+    // legible: its alt is LONGER than the tract it lands in, so no duplication
+    // describes it and the flat `ins` literal stays — the spec's other
+    // replacement (`c.1741_1742insTATATATA`), unchanged by #1204.
+    //
+    // Case 1: 2 A's added to the AAA tract at c.3_5. A[5] is forbidden in c.;
+    // the added pair copies the tract's 3'-most two bases → dup at c.4_5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}dup", &[4u64, 5u64])]
+    // Case 2: 4 A's added to the same 3-A tract. Four added bases cannot copy a
+    // three-base tract, so this stays an `ins` at the 3' flank.
     #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}insAAAA", &[5u64, 6u64])]
     // Case 3: 2 GCA units added → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 4: 2 AC units added → insACAC (gate blocks AC[N], unit_len=2).
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}insACAC", &[8u64, 9u64])]
+    // Case 4: 2 AC units added, unit_len=2. AC[N] is forbidden in c.; the added
+    // `ACAC` copies c.5_8 of the c.2_8 alternating tract → dup there.
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}dup", &[5u64, 8u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/it/issue_1185_cds_end_3utr_shift.rs
+++ b/tests/it/issue_1185_cds_end_3utr_shift.rs
@@ -223,14 +223,21 @@ fn dup_whose_shifted_tract_leaves_the_cds_gets_repeat_notation_in_one_pass() {
 
 /// The control that proves the gate was narrowed, not disabled. A non-triplet
 /// unit whose tract stays **entirely inside** the CDS must still be refused
-/// repeat notation and rendered as an `ins` literal — the spec's own remedy
-/// ("use `NM_024312.4:c.1741_1742insTATATATA` and **not** `c.1738TA[6]`").
+/// repeat notation — no `AC[6]` here, unlike the straddling case above.
+///
+/// Re-blessed by #1204 from the `ins` literal `c.9_10insACAC`. The gate forbids
+/// repeat notation, and of the spec's two replacements this input takes the first:
+/// the added `ACAC` copies `c.6_9`, the 3'-most four bases of the `c.2_9` tract, so
+/// it is a duplication ("use `NM_024312.4:c.2692_2693dup`"). The `ins` remedy
+/// ("use `c.1741_1742insTATATATA` and **not** `c.1738TA[6]`") is for added bases no
+/// duplication covers, which are longer than the tract they land in; that shape is
+/// pinned in `issue_1204_gated_dup_fallback` and `ins_shift_matrix`'s case 2.
 #[test]
-fn control_non_triplet_dup_inside_the_cds_still_renders_as_ins_literal() {
+fn control_non_triplet_dup_inside_the_cds_is_still_refused_repeat_notation() {
     assert_one_pass(
         coding_transcript("GACACACACGGGTTT", &"GGGTTT".repeat(4), Strand::Plus),
         "NM_UTR3.1:c.2_5dup",
-        "NM_UTR3.1:c.9_10insACAC",
+        "NM_UTR3.1:c.6_9dup",
     );
 }
 

--- a/tests/it/issue_1192_rna_codon_frame_gate.rs
+++ b/tests/it/issue_1192_rna_codon_frame_gate.rs
@@ -119,23 +119,30 @@ fn normalize(provider: MockProvider, input: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// The `c.` spelling, pinning the behaviour the `r.` axis has to match: the
-/// gate fires and the expansion is rerouted to an `ins` literal rather than
-/// `A[8]`.
+/// gate fires, so `A[8]` is refused and the description stays a `dup`.
+///
+/// Re-blessed by #1204 from `c.9_10insAA`. What this test is for is unchanged —
+/// the absence of repeat notation is the assertion — but the *fallback* is now the
+/// form the same spec sentence prescribes: "use `NM_024312.4:c.2692_2693dup` and
+/// **not** `c.2686A[10]`", i.e. a `dup` over the tract's 3'-most pair, which here
+/// is `c.8_9` and makes the input its own canonical form.
 #[test]
 fn cds_homopolymer_expansion_inside_cds_is_gated() {
     assert_eq!(
         normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:c.8_9dup"),
-        "NM_RFRAME.1:c.9_10insAA",
+        "NM_RFRAME.1:c.8_9dup",
     );
 }
 
-/// The same bases on `r.`. Before the fix this rendered as `r.4_9a[8]` — the
-/// shape the spec explicitly forbids on a coding RNA reference.
+/// The same bases on `r.`. Before #1194 this rendered as `r.4_9a[8]` — the shape
+/// the spec explicitly forbids on a coding RNA reference — and before #1204 as
+/// `r.9_10insaa`. Both axes moved together at each step, which is this file's
+/// contract.
 #[test]
 fn rna_homopolymer_expansion_inside_cds_is_gated() {
     assert_eq!(
         normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:r.8_9dup"),
-        "NM_RFRAME.1:r.9_10insaa",
+        "NM_RFRAME.1:r.8_9dup",
     );
 }
 

--- a/tests/it/issue_1204_gated_dup_fallback.rs
+++ b/tests/it/issue_1204_gated_dup_fallback.rs
@@ -1,0 +1,275 @@
+//! Issue #1204 — where the codon-frame gate refuses repeat notation inside the
+//! CDS, the fallback must be the spec's `dup`, not a flat `ins` literal.
+//!
+//! `DNA/repeated.md` L21-22 states the exception and, crucially, gives **two**
+//! replacements of **different shapes**:
+//!
+//! > **exception**: using a coding DNA reference sequence ("c." description), a
+//! > repeated sequence variant description can be used only for repeat units
+//! > with a length which is a multiple of 3 […]
+//! > Consequently, use `NM_024312.4:c.2692_2693dup` and **not**
+//! > `NM_024312.4:c.2686A[10]`; use `NM_024312.4:c.1741_1742insTATATATA` and
+//! > **not** `NM_024312.4:c.1738TA[6]`.
+//!
+//! `RNA/repeated.md` L25 states it identically for a coding RNA reference
+//! (`r.2692_2693dup`, `r.1741_1742insuauauaua`).
+//!
+//! The two replacements are not interchangeable, and which one applies is
+//! decided by the reference, not by the gate:
+//!
+//! - `c.2692_2693dup` — the added bases duplicate the immediately adjacent
+//!   reference bases (`A[8]` + `AA`: the two added `A`s are a copy of the tract's
+//!   two 3'-most bases), so the change *is* a duplication and `dup` describes it.
+//! - `c.1741_1742insTATATATA` — four `TA` copies added to a two-copy `TA` tract.
+//!   The added 8 bases are longer than the whole adjacent tract, so no `dup`
+//!   describes them and the flat literal is the only form left.
+//!
+//! ferro emitted the `ins` form for both: the gate that (correctly) refuses
+//! repeat notation also suppressed the `ins` → `dup` promotion, so the
+//! duplication half of the guidance was unreachable. The gate belongs only in
+//! the repeat path — `dup` is not repeat notation and the exception says nothing
+//! against it.
+//!
+//! Every case is asserted on **both** the `c.` and `r.` axes. `r.` on a coding
+//! transcript IS the `c.` axis (`background/numbering.md` L58/L61, #469), so the
+//! pairing is what makes a divergence a defect rather than a fixture artifact —
+//! the same reasoning #1192 and #1194 used for the gate itself.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Length of the 5'UTR, so `c.1` / `r.1` is transcript base `UTR5_LEN + 1`.
+const UTR5_LEN: usize = 30;
+
+/// Build a single-exon coding transcript `C * 30` (5'UTR) ++ `cds` ++ `utr3`.
+///
+/// Padded with `C` rather than via `SyntheticBuilder`'s `ACGT` repeats: an
+/// `ACGT` pad contains both an `A` and a `TA`, either of which a tract under
+/// test could cycle straight into, and a padding artifact of exactly that shape
+/// produced a retracted finding once before (see #1192's fixture note). Every
+/// tract below is flanked by a base that cannot continue it.
+fn coding_transcript(cds: &str, utr3: &str) -> MockProvider {
+    let sequence = format!("{}{cds}{utr3}", "C".repeat(UTR5_LEN));
+    let tx_len = sequence.len() as u64;
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_RFRAME.1".to_string(),
+        Some("RFRAME_TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some((UTR5_LEN + 1) as u64),
+        Some((UTR5_LEN + cds.len()) as u64),
+        vec![Exon::new(1, 1, tx_len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// The spec's **first** replacement, transposed onto a short fixture.
+///
+/// CDS `ATG` ++ `A`×6 ++ `GGGTAA`, i.e. an `A[6]` tract at `c.4_9` flanked by
+/// `G` on both sides (`c.3` = `G`, `c.10` = `G`) and clear of both UTRs. Adding
+/// two `A`s takes it to `A[8]`, which the gate must refuse (unit length 1 is
+/// never a multiple of 3) — and the two added bases duplicate `c.8_9`, so `dup`
+/// is the form the spec prescribes. Same tract as #1192's fixture, so the two
+/// files pin the same bases.
+fn homopolymer_tract_in_cds() -> MockProvider {
+    coding_transcript("ATGAAAAAAGGGTAA", &"G".repeat(30))
+}
+
+/// The spec's **second** replacement, transposed onto a short fixture.
+///
+/// CDS `ATG` ++ `TATA` ++ `GGGTAA`, i.e. a `TA[2]` tract at `c.4_7` flanked by
+/// `G` at `c.3` and `c.8`. Adding four `TA` copies takes it to `TA[6]`, which the
+/// gate must refuse (unit length 2). The eight added bases are twice the length
+/// of the whole adjacent tract, so no duplication describes them and the flat
+/// `ins` literal must survive. This is the half of the guidance that was already
+/// correct, and the guard that the fix does not over-reach into it.
+fn dinucleotide_tract_in_cds() -> MockProvider {
+    coding_transcript("ATGTATAGGGTAA", &"G".repeat(30))
+}
+
+/// Normalize `input` and render the result.
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse");
+    normalizer
+        .normalize(&variant)
+        .expect("normalize")
+        .to_string()
+}
+
+/// Normalize `input`, assert it renders as `expected`, and assert `expected` is
+/// a re-parseable fixed point.
+///
+/// The fixed-point half matters here beyond the usual idempotency hygiene: the
+/// defect's `ins` output and the correct `dup` output are both stable, so an
+/// idempotency-only assertion would pass on the bug. The exact-string assertion
+/// is what distinguishes them; the fixed point rules out trading this defect for
+/// a normalize-twice divergence.
+fn assert_normalizes_to(provider: fn() -> MockProvider, input: &str, expected: &str) {
+    assert_eq!(
+        normalize(provider(), input),
+        expected,
+        "normalizing {input}"
+    );
+    assert_eq!(
+        normalize(provider(), expected),
+        expected,
+        "{expected} must be a fixed point",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The defect: the gated fallback must be `dup` where the change is one
+// ---------------------------------------------------------------------------
+
+/// A `dup` spelling of the spec's first case stays a `dup`. Before the fix this
+/// rendered as `c.9_10insAA` — the second replacement's shape applied to the
+/// first replacement's input.
+#[test]
+fn cds_gated_homopolymer_dup_stays_a_dup() {
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:c.8_9dup",
+        "NM_RFRAME.1:c.8_9dup",
+    );
+}
+
+/// …and the same bases on `r.`, where #1194 wired the gate. Before the fix:
+/// `r.9_10insaa`.
+#[test]
+fn rna_gated_homopolymer_dup_stays_a_dup() {
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:r.8_9dup",
+        "NM_RFRAME.1:r.8_9dup",
+    );
+}
+
+/// The `ins`-spelled twin of the same change canonicalizes to that same `dup`.
+///
+/// This is the assertion that matches the spec's own wording most literally —
+/// "use `c.2692_2693dup`" is an instruction about the *output* form, whatever
+/// the input spelling — and it pins spelling-independence: a `dup` and an `ins`
+/// describing identical bases must not normalize to different descriptions.
+#[test]
+fn cds_gated_homopolymer_insertion_becomes_a_dup() {
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:c.9_10insAA",
+        "NM_RFRAME.1:c.8_9dup",
+    );
+}
+
+/// …and on `r.`, with the RNA `u`/lowercase spelling on input.
+#[test]
+fn rna_gated_homopolymer_insertion_becomes_a_dup() {
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:r.9_10insaa",
+        "NM_RFRAME.1:r.8_9dup",
+    );
+}
+
+/// The gate itself is untouched: repeat notation is still refused. Redundant
+/// with the exact-string assertions above by construction, asserted separately
+/// so a future re-blessing cannot quietly hand `A[8]` back — the form the spec
+/// marks invalid, and the whole point of #1192/#1194.
+#[test]
+fn the_gated_dup_is_not_repeat_notation() {
+    for input in [
+        "NM_RFRAME.1:c.8_9dup",
+        "NM_RFRAME.1:r.8_9dup",
+        "NM_RFRAME.1:c.9_10insAA",
+        "NM_RFRAME.1:r.9_10insaa",
+    ] {
+        let rendered = normalize(homopolymer_tract_in_cds(), input);
+        assert!(
+            !rendered.contains('['),
+            "repeat notation is forbidden inside the CDS for a unit of length 1, \
+             got {rendered} for {input}",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The other half of the spec's guidance, which must not regress
+// ---------------------------------------------------------------------------
+
+/// Four `TA` copies added to a `TA[2]` tract: no `dup` describes eight added
+/// bases against a four-base tract, so the flat `ins` literal is correct and
+/// must survive. This is the guard that the `dup` fallback is driven by the
+/// reference rather than applied to every gated expansion.
+#[test]
+fn cds_gated_dinucleotide_expansion_stays_an_insertion() {
+    assert_normalizes_to(
+        dinucleotide_tract_in_cds,
+        "NM_RFRAME.1:c.7_8insTATATATA",
+        "NM_RFRAME.1:c.7_8insTATATATA",
+    );
+}
+
+/// …and its `r.` sibling, the form `RNA/repeated.md` L25 spells out.
+#[test]
+fn rna_gated_dinucleotide_expansion_stays_an_insertion() {
+    assert_normalizes_to(
+        dinucleotide_tract_in_cds,
+        "NM_RFRAME.1:r.7_8insuauauaua",
+        "NM_RFRAME.1:r.7_8insuauauaua",
+    );
+}
+
+/// A *single* added `TA` copy against the same tract is a duplication, and the
+/// gate must not suppress it either — the `TA` unit is no more codon-aligned
+/// than the homopolymer above, so this pins that the fix keys on "the added
+/// bases duplicate the adjacent reference", not on the unit being a homopolymer.
+///
+/// Derived from the fixture: the tract is `c.4_7` = `TATA`, `c.8` = `G` cannot
+/// continue it, so the 3'-most duplicated unit is `c.6_7`.
+#[test]
+fn cds_gated_dinucleotide_duplication_stays_a_dup() {
+    assert_normalizes_to(
+        dinucleotide_tract_in_cds,
+        "NM_RFRAME.1:c.6_7dup",
+        "NM_RFRAME.1:c.6_7dup",
+    );
+}
+
+/// …and on `r.`.
+#[test]
+fn rna_gated_dinucleotide_duplication_stays_a_dup() {
+    assert_normalizes_to(
+        dinucleotide_tract_in_cds,
+        "NM_RFRAME.1:r.6_7dup",
+        "NM_RFRAME.1:r.6_7dup",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls — the gate's carve-outs are unaffected
+// ---------------------------------------------------------------------------
+
+/// Outside the CDS the gate never fires, so repeat notation — not `dup` and not
+/// `ins` — remains the canonical form. `DNA/repeated.md` L23-24: "This
+/// restriction only applies to the coding sequence, which does not include the
+/// introns or the UTR sequence."
+#[test]
+fn utr5_homopolymer_expansion_still_earns_repeat_notation() {
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:c.-2_-1dup",
+        "NM_RFRAME.1:c.-30_-1C[32]",
+    );
+    assert_normalizes_to(
+        homopolymer_tract_in_cds,
+        "NM_RFRAME.1:r.-2_-1dup",
+        "NM_RFRAME.1:r.-30_-1c[32]",
+    );
+}

--- a/tests/it/issue_1207_rna_cds_boundary_clamp.rs
+++ b/tests/it/issue_1207_rna_cds_boundary_clamp.rs
@@ -1,5 +1,8 @@
 //! Issue #1207 — an `r.`-axis insertion that saturates at a CDS boundary must be
-//! clamped to a `delins`, exactly as the `c.` axis already does.
+//! clamped to a `delins`, exactly as the `c.` axis already does. (See the #1204
+//! note below: the `dup`-spelled repros this was filed with now resolve to a `dup`
+//! before reaching the clamp, so the clamp itself is pinned on the insertion
+//! shapes no duplication describes.)
 //!
 //! `normalize_cds` has rewritten a saturated insertion at `cds_start` since
 //! #1170 and at `cds_end` since #387. `normalize_rna` never got either, which
@@ -23,6 +26,24 @@
 //! Every expectation below is derived from the fixture by hand and asserted
 //! exactly, and each `r.` case is pinned against its `c.` sibling — the axis
 //! parity is the actual contract (#469: on a coding transcript `r.` IS `c.`).
+//!
+//! **Updated by #1204.** The `dup` inputs in the table above no longer reach the
+//! clamp at all: their added bases copy an adjacent same-length tract, so the
+//! gated fallback is the `dup` that `repeated.md` L22 prescribes, and a `dup` has
+//! two in-CDS anchors — there is no boundary to repair. The non-idempotency this
+//! file was filed for is fixed either way, and both regimes are now pinned side by
+//! side:
+//!
+//! | input | added vs. tract | result |
+//! |---|---|---|
+//! | `r.1_2dup` (5') | 2 added, `C[4]` tract | `r.1_2dup` — no clamp needed |
+//! | `r.2_3insccccc` (5') | 5 added, `C[4]` tract | `r.1delinscccccc` — clamped |
+//! | `r.13_14dup` (3') | 2 added, `G[4]` tract | `r.13_14dup` — no clamp needed |
+//! | `r.12_13insggggg` (3') | 5 added, `G[4]` tract | `r.14delinsgggggg` — clamped |
+//!
+//! The clamp rows are what keep this file's subject covered: an alt longer than
+//! the tract it lands in cannot be spelled as a duplication, so it stays an
+//! insertion, saturates the boundary, and must be rewritten.
 
 use crate::common::synthetic::{SyntheticBuilder, PAD_OFFSET};
 use ferro_hgvs::reference::transcript::Strand;
@@ -78,18 +99,54 @@ fn assert_canonical(input: &str, dir: ShuffleDirection, expected: &str) {
 }
 
 // ---------------------------------------------------------------------------
-// The defect: 5' saturation at cds_start
+// The 5' boundary at cds_start
 // ---------------------------------------------------------------------------
 
-/// `r.1_2dup` duplicates `cc` at the CDS start. The 5' shuffle drives the
-/// resulting insertion to rest immediately 5' of `cds_start`, so the identity
-/// gives `delete ref[cds_start]` (= `c`), `insert cc ++ c`.
+/// `r.1_2dup` duplicates `cc` at the CDS start.
+///
+/// Re-blessed by #1204 from `r.1delinsccc`. The 5' shuffle still drives the
+/// derived insertion to rest immediately 5' of `cds_start`, but the two added
+/// `c`s copy `r.1_2` — the 5'-most pair of the `C[4]` tract — so the change is a
+/// duplication and `repeated.md` L22 prescribes `dup` for it. A `dup` needs no
+/// clamp: both its anchors are inside the CDS, which is exactly the boundary
+/// problem the clamp exists to repair. #1207's non-idempotency is fixed either
+/// way; the clamp regime it was filed against is pinned below, on the shape that
+/// no duplication describes.
 #[test]
-fn rna_five_prime_saturated_insertion_clamps_at_cds_start() {
+fn rna_five_prime_boundary_dup_resolves_without_clamping() {
     assert_canonical(
         "NM_TEST.1:r.1_2dup",
         ShuffleDirection::FivePrime,
-        "NM_TEST.1:r.1delinsccc",
+        "NM_TEST.1:r.1_2dup",
+    );
+}
+
+/// The `c.` sibling. Parity with `r.` is the contract; that both axes moved
+/// together under #1204 is what shows the re-blessing is not `r.`-only drift.
+#[test]
+fn cds_five_prime_boundary_dup_resolves_without_clamping() {
+    assert_canonical(
+        "NM_TEST.1:c.1_2dup",
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.1_2dup",
+    );
+}
+
+/// Five added `c`s against the four-base `C[4]` tract: there is no five-base `C`
+/// tract to copy, so no duplication describes this. It stays an insertion, the 5'
+/// shuffle saturates it at `cds_start`, and the clamp applies the identity
+/// `delete ref[cds_start]` (= `c`), `insert ccccc ++ c`.
+///
+/// This is #1207's actual contract — an `r.`-axis insertion saturated at a CDS
+/// boundary must be clamped, as the `c.` axis already did — restated on an input
+/// the dup promotion cannot absorb. Without a row of this shape #1204 would leave
+/// the clamp this file exists for with no direct coverage.
+#[test]
+fn rna_five_prime_saturated_insertion_clamps_at_cds_start() {
+    assert_canonical(
+        "NM_TEST.1:r.2_3insccccc",
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:r.1delinscccccc",
     );
 }
 
@@ -98,35 +155,56 @@ fn rna_five_prime_saturated_insertion_clamps_at_cds_start() {
 #[test]
 fn cds_five_prime_saturated_insertion_clamps_at_cds_start() {
     assert_canonical(
-        "NM_TEST.1:c.1_2dup",
+        "NM_TEST.1:c.2_3insCCCCC",
         ShuffleDirection::FivePrime,
-        "NM_TEST.1:c.1delinsCCC",
+        "NM_TEST.1:c.1delinsCCCCCC",
     );
 }
 
 // ---------------------------------------------------------------------------
-// The mirror: 3' saturation at cds_end
+// The mirror: the 3' boundary at cds_end
 // ---------------------------------------------------------------------------
 
-/// `r.13_14dup` duplicates `gg` at the CDS end. The 3' shuffle drives the
-/// insertion to rest immediately 3' of `cds_end`, so the identity gives
-/// `delete ref[cds_end]` (= `g`), `insert g ++ gg`.
+/// `r.13_14dup` duplicates `gg` at the CDS end; the added pair copies the
+/// 3'-most two bases of the `G[4]` tract, so this is the `dup` regime.
+/// Re-blessed by #1204 from `r.14delinsggg`.
 #[test]
-fn rna_three_prime_saturated_insertion_clamps_at_cds_end() {
+fn rna_three_prime_boundary_dup_resolves_without_clamping() {
     assert_canonical(
         "NM_TEST.1:r.13_14dup",
         ShuffleDirection::ThreePrime,
-        "NM_TEST.1:r.14delinsggg",
+        "NM_TEST.1:r.13_14dup",
     );
 }
 
 /// The `c.` sibling for the 3' boundary.
 #[test]
-fn cds_three_prime_saturated_insertion_clamps_at_cds_end() {
+fn cds_three_prime_boundary_dup_resolves_without_clamping() {
     assert_canonical(
         "NM_TEST.1:c.13_14dup",
         ShuffleDirection::ThreePrime,
-        "NM_TEST.1:c.14delinsGGG",
+        "NM_TEST.1:c.13_14dup",
+    );
+}
+
+/// The clamp regime at `cds_end`: five added `g`s against the `G[4]` tract give
+/// `delete ref[cds_end]` (= `g`), `insert g ++ ggggg`.
+#[test]
+fn rna_three_prime_saturated_insertion_clamps_at_cds_end() {
+    assert_canonical(
+        "NM_TEST.1:r.12_13insggggg",
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:r.14delinsgggggg",
+    );
+}
+
+/// The `c.` sibling for the 3' clamp.
+#[test]
+fn cds_three_prime_saturated_insertion_clamps_at_cds_end() {
+    assert_canonical(
+        "NM_TEST.1:c.12_13insGGGGG",
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.14delinsGGGGGG",
     );
 }
 
@@ -135,28 +213,46 @@ fn cds_three_prime_saturated_insertion_clamps_at_cds_end() {
 // ---------------------------------------------------------------------------
 
 /// The `r.` result must be the `c.` result re-rendered as RNA (lowercase, `u`
-/// for `T`) for both boundaries and both directions. Asserting the relationship
-/// rather than only the values keeps this honest if the canonical spelling of a
-/// boundary clamp ever changes: the two axes must move together.
+/// for `T`) for both boundaries, both directions, and both regimes. Asserting the
+/// relationship rather than only the values keeps this honest when the canonical
+/// spelling of a boundary result changes — as #1204 changed the `dup` rows here:
+/// the two axes must move together, whatever they move to.
+///
+/// Note the earlier version of this test required the `c.` answer to contain
+/// `delins` and panicked otherwise, which hard-coded the clamp regime into what is
+/// supposed to be a shape-agnostic parity property. It now finds whichever edit
+/// keyword the answer carries, so a `dup` row is compared the same way a `delins`
+/// row is.
 #[test]
 fn rna_and_cds_axes_agree_at_both_cds_boundaries() {
-    for (dir, positions) in [
-        (ShuffleDirection::FivePrime, "1_2"),
-        (ShuffleDirection::ThreePrime, "13_14"),
+    /// Re-render a `c.` description as its `r.` sibling: swap the axis, then
+    /// lowercase from the edit keyword on and map `t` to `u`. Positions are left
+    /// alone, so this is safe for keywords that carry no bases (`dup`, `del`).
+    fn as_rna(cds: &str) -> String {
+        let swapped = cds.replace(":c.", ":r.");
+        let split = ["delins", "dup", "ins", "del", "inv"]
+            .iter()
+            .filter_map(|kw| swapped.find(kw))
+            .min()
+            .unwrap_or_else(|| panic!("no edit keyword in {cds}"));
+        let (prefix, edit) = swapped.split_at(split);
+        format!("{prefix}{}", edit.to_lowercase().replace('t', "u"))
+    }
+
+    for (dir, input) in [
+        // the dup regime
+        (ShuffleDirection::FivePrime, "1_2dup"),
+        (ShuffleDirection::ThreePrime, "13_14dup"),
+        // the clamp regime
+        (ShuffleDirection::FivePrime, "2_3insCCCCC"),
+        (ShuffleDirection::ThreePrime, "12_13insGGGGG"),
     ] {
-        let rna = normalize(&format!("NM_TEST.1:r.{positions}dup"), dir);
-        let cds = normalize(&format!("NM_TEST.1:c.{positions}dup"), dir);
-        let as_rna = {
-            let swapped = cds.replace(":c.", ":r.");
-            let split = swapped.find("delins").unwrap_or_else(|| {
-                panic!("expected the c. answer for {positions} ({dir:?}) to be a delins; got {cds}")
-            });
-            let (prefix, edit) = swapped.split_at(split);
-            format!("{prefix}{}", edit.to_lowercase().replace('t', "u"))
-        };
+        let rna = normalize(&format!("NM_TEST.1:r.{}", input.to_lowercase()), dir);
+        let cds = normalize(&format!("NM_TEST.1:c.{input}"), dir);
         assert_eq!(
-            rna, as_rna,
-            "r. and c. must agree at the CDS boundary ({positions}, {dir:?})",
+            rna,
+            as_rna(&cds),
+            "r. and c. must agree at the CDS boundary ({input}, {dir:?})",
         );
     }
 }
@@ -165,11 +261,17 @@ fn rna_and_cds_axes_agree_at_both_cds_boundaries() {
 // Non-regression: the clamp must not fire away from the boundaries
 // ---------------------------------------------------------------------------
 
-/// An interior dup must be untouched by the new clamp. `r.5_6dup` sits in the
-/// `A`×6 tract (`r.5`..`r.10`), so the 3' shuffle rests the insertion just past
-/// the tract at `r.10_11` with payload `aa`; the codon-frame gate refuses repeat
-/// notation there (1-nt unit, wholly inside the CDS, #1192), and `r.10_11` is
-/// nowhere near `cds_end` (`r.14`), so the boundary clamp must not fire.
+/// An interior dup must be untouched by the clamp. `r.5_6dup` sits in the `A`×6
+/// tract (`r.5`..`r.10`), so the 3' shuffle rests the derived insertion just past
+/// the tract; the codon-frame gate refuses repeat notation there (1-nt unit,
+/// wholly inside the CDS, #1192), and the resting place is nowhere near `cds_end`
+/// (`r.14`), so the boundary clamp must not fire.
+///
+/// Re-blessed by #1204 from `r.10_11insaa` / `c.10_11insAA`: this row never had
+/// anything to do with the clamp, and its `ins` expectation was itself an instance
+/// of the #1204 defect — the added `aa` copies `r.9_10`, the 3'-most pair of the
+/// tract, so the gated fallback is a `dup`. The clamp still does not fire, which is
+/// what this test is for.
 ///
 /// Both axes are pinned, so this also shows the interior case keeps `r.`/`c.`
 /// parity — the property, not just "no delins appeared".
@@ -178,12 +280,12 @@ fn interior_dup_is_untouched_by_the_clamp() {
     assert_canonical(
         "NM_TEST.1:r.5_6dup",
         ShuffleDirection::ThreePrime,
-        "NM_TEST.1:r.10_11insaa",
+        "NM_TEST.1:r.9_10dup",
     );
     assert_canonical(
         "NM_TEST.1:c.5_6dup",
         ShuffleDirection::ThreePrime,
-        "NM_TEST.1:c.10_11insAA",
+        "NM_TEST.1:c.9_10dup",
     );
 }
 

--- a/tests/it/issue_1210_repeat_gate_tract_span.rs
+++ b/tests/it/issue_1210_repeat_gate_tract_span.rs
@@ -137,11 +137,19 @@ fn interior_tract_is_still_codon_gated() {
         coding_transcript_with_utrs("CCCCAAAAAAAAGGGG", Strand::Plus),
         "NM_TEST.1:r.11_12insaa",
     );
-    // Gated: the tract is CDS-resident and the unit is 1 nt, so the expansion
-    // stays a literal insertion, 3'-shifted to the end of the `A` run at `c.12`.
+    // Gated: the tract is CDS-resident and the unit is 1 nt, so repeat notation
+    // is refused — which is what this guard is for, and is unchanged.
+    assert!(
+        !once.contains('['),
+        "a CDS-interior 1-nt tract must not become a repeat, got {once}",
+    );
+    // The fallback form is the `dup` `repeated.md` L22 prescribes for this shape
+    // ("use `NM_024312.4:c.2692_2693dup`"): the added `aa` copies `r.11_12`, the
+    // 3'-most pair of the `A` run at `r.5_12`. Re-blessed from `r.12_13insaa` by
+    // #1204, which is about the fallback and not about whether the gate fires.
     assert_eq!(
-        once, "NM_TEST.1:r.12_13insaa",
-        "a CDS-interior 1-nt tract must stay an insertion, not become a repeat"
+        once, "NM_TEST.1:r.11_12dup",
+        "a CDS-interior 1-nt tract must stay gated, falling back to the dup"
     );
     assert_eq!(twice, once, "and is a fixed point");
 }

--- a/tests/it/issue_209_repeat_3prime_remaining.rs
+++ b/tests/it/issue_209_repeat_3prime_remaining.rs
@@ -510,15 +510,16 @@ mod cds_proper_still_gates {
 
     #[test]
     fn cds_proper_homopolymer_dup_still_gated() {
-        // CDS-proper A[5] at c.4..c.8. Dup of "AA" at c.4_5 must
-        // emit `c.8_9insAA` (codon-frame gate fires because
-        // unit_len=1 in a coding context). Pins existing behavior
-        // identical to `tests/dup_shift_matrix.rs::cds_minus::
-        // multi_base_dup_of_multiple_units::case_1` (modulo strand)
-        // — locks in that the B4-remaining fix does NOT regress
-        // CDS-proper gating.
+        // CDS-proper A[5] at c.4..c.8. Dup of "AA" at c.4_5 is refused repeat
+        // notation (the codon-frame gate fires: unit_len=1 in a coding context)
+        // and falls back to the `dup` the spec prescribes, over the tract's
+        // 3'-most pair — `c.7_8dup`. Re-blessed from `c.8_9insAA` by #1204;
+        // still identical to `tests/dup_shift_matrix.rs::cds_minus::
+        // multi_base_dup_of_multiple_units::case_1` (modulo strand), and still
+        // locks in that the B4-remaining fix does NOT regress CDS-proper gating
+        // — the gate fires, it just no longer costs us the `dup` spelling.
         let p = make_provider();
-        assert_canonical_round_trip(p, "NM_CDSP.1:c.4_5dup", "NM_CDSP.1:c.8_9insAA");
+        assert_canonical_round_trip(p, "NM_CDSP.1:c.4_5dup", "NM_CDSP.1:c.7_8dup");
     }
 
     #[test]

--- a/tests/it/issue_383_canon_cds_start_clamp.rs
+++ b/tests/it/issue_383_canon_cds_start_clamp.rs
@@ -234,26 +234,52 @@ fn five_prime_insertion_long_homopolymer_shift_clamps_at_cds_start() {
     // `c.-1_1insAA` — strictly inside 5'UTR even though the input was
     // CDS-interior.
     //
-    // Clamp form is the MINIMAL, single-base-anchored delins at c.1:
-    // `c.1delinsAAA` (= delete c.1 = "A", insert 3 A's = net +2). Applying
-    // this to the ref `GGG | AAAAAAAAAAAAAAAAAAAA | G...` yields
-    // `GGG + AAA + ref[c.2..]` = `GGG + 22*A + G...`, the same total as the
-    // input `c.5_6insAA` (insert 2 A's into the 20-A tract).
+    // Re-blessed by #1204 from `c.1delinsAAA` to `c.1_2dup`. The two added A's
+    // copy `c.1_2`, the 5'-most pair of the 20-A tract, so the change IS a
+    // duplication and `repeated.md` L22 prescribes `dup` — which also needs no
+    // clamp, since both its anchors are inside the CDS. What this test pins is
+    // unchanged: a CDS-interior insertion that 5'-shifts the length of the tract
+    // must not escape to `c.-1_1insAA` (strictly inside the 5'UTR), and every
+    // start position of the same haplotype must reach ONE idempotent form.
     //
-    // (Re-blessed from the earlier width-varying `c.1_3delinsAAAAA`: the
-    // boundary clamp now rewrites via the exact coordinate identity
-    // `delete ref[cds_start], insert A' ++ ref[cds_start]` keyed on the
-    // shuffled `A'`, so every start position of the same haplotype collapses
-    // to ONE minimal, idempotent form — confluence. The `k`-widened form was
-    // equivalent but non-confluent, e.g. `c.6_7insAA` gave a different
-    // `c.1_4delinsAAAAAA`.)
+    // (Previously re-blessed from the width-varying `c.1_3delinsAAAAA` for that
+    // same confluence: the clamp rewrites via the exact coordinate identity
+    // `delete ref[cds_start], insert A' ++ ref[cds_start]` keyed on the shuffled
+    // `A'`, where the `k`-widened form gave e.g. `c.1_4delinsAAAAAA` for
+    // `c.6_7insAA`.)
     assert_eq!(
         normalize_with_provider(
             provider_homopolymer(),
             ShuffleDirection::FivePrime,
             "NM_TEST383HP.1:c.5_6insAA",
         ),
-        "NM_TEST383HP.1:c.1delinsAAA",
+        "NM_TEST383HP.1:c.1_2dup",
+    );
+}
+
+/// The clamp regime on the same fixture, so this file keeps a homopolymer row
+/// that actually reaches the CDS-start rewrite after #1204.
+///
+/// 21 added A's against a 20-A tract: there is no 21-base A tract to copy, so no
+/// duplication describes it, it stays an insertion, and the 5' shift saturates at
+/// `cds_start`. Clamp form is the MINIMAL single-base-anchored delins at c.1 —
+/// `delete c.1` (= "A"), `insert 22 A's` (net +21). Applying that to the ref
+/// `GGG | A×20 | G…` yields `GGG + A×22 + ref[c.2..]` = `GGG + A×41 + G…`, the
+/// same total as inserting 21 A's into the 20-A tract.
+///
+/// A shorter alt cannot reach here: any alt at most as long as the tract copies an
+/// adjacent window of itself and resolves as a `dup` instead. That is a property of
+/// the shapes, not a gap — the clamp is also covered by the non-tandem
+/// `c.1_2insCA` biocommons rows above, which never had a duplication to promote to.
+#[test]
+fn five_prime_over_long_insertion_still_clamps_at_cds_start() {
+    assert_eq!(
+        normalize_with_provider(
+            provider_homopolymer(),
+            ShuffleDirection::FivePrime,
+            "NM_TEST383HP.1:c.5_6insAAAAAAAAAAAAAAAAAAAAA",
+        ),
+        "NM_TEST383HP.1:c.1delinsAAAAAAAAAAAAAAAAAAAAAA",
     );
 }
 
@@ -264,16 +290,18 @@ fn five_prime_insertion_far_interior_homopolymer_shift_clamps() {
     // and alt.len() = 3, so x = 20 >> alt.len() + 1 = 4 — the buggy
     // branch was silently no-op'ing on inputs of this shape.
     //
-    // Minimal single-base-anchored clamp form: delete c.1 = "A", insert
-    // 4 A's (net +3), extending the 20-A tract by the alt length. Re-blessed
-    // from the earlier width-varying `c.1_17delinsAAAAAAAAAAAAAAAAAAAA` for
-    // confluence (see the sibling long-homopolymer test).
+    // Re-blessed by #1204 from `c.1delinsAAAA` to `c.1_3dup`: the three added A's
+    // copy `c.1_3`, the 5'-most triple of the tract. Same reasoning as the sibling
+    // long-homopolymer test, and the property under test — a deep-interior start
+    // must still collapse to the 5'-canonical form for this haplotype, not no-op
+    // into the UTR — is unchanged. (Previously re-blessed from the width-varying
+    // `c.1_17delinsAAAAAAAAAAAAAAAAAAAA` for confluence.)
     assert_eq!(
         normalize_with_provider(
             provider_homopolymer(),
             ShuffleDirection::FivePrime,
             "NM_TEST383HP.1:c.20_21insAAA",
         ),
-        "NM_TEST383HP.1:c.1delinsAAAA",
+        "NM_TEST383HP.1:c.1_3dup",
     );
 }

--- a/tests/it/issue_736_rna_uracil_normalize.rs
+++ b/tests/it/issue_736_rna_uracil_normalize.rs
@@ -67,12 +67,16 @@ fn rna_two_base_u_insertion_is_gated_like_the_c_axis() {
     // RNA reference for units whose length is not a multiple of 3, and a
     // homopolymer unit is length 1, so the codon-frame gate must fire. On the
     // same transcript and bases the three axes now read:
-    //   c.3_4insTT  -> c.5_6insTT   (gated: coding, unit not codon-aligned)
-    //   r.3_4insuu  -> r.5_6insuu   (must match c.; this assertion)
+    //   c.3_4insTT  -> c.4_5dup     (gated: coding, unit not codon-aligned)
+    //   r.3_4insuu  -> r.4_5dup     (must match c.; this assertion)
     //   n.3_4insTT  -> n.3_5T[5]    (no reading frame, so repeat notation is fine)
-    // The `u` spelling of the inserted bases — the point of #736 — survives the
-    // round trip, which is what this file exists to pin.
-    assert_eq!(normalize("NM_U.1:r.3_4insuu"), "NM_U.1:r.5_6insuu");
+    // Re-blessed again by #1204: the gate refuses repeat notation, and the
+    // fallback is the `dup` the same spec sentence prescribes rather than an `ins`
+    // literal — here over `r.4_5`, the 3'-most pair of the `TTT` run at r.3_5.
+    // Note the canonical `dup` carries no bases at all, so the `u`-spelling
+    // round trip that #736 is about is pinned by the single-`u` case above (which
+    // has always collapsed to `r.5dup`) and by the `insgg` case below, not here.
+    assert_eq!(normalize("NM_U.1:r.3_4insuu"), "NM_U.1:r.4_5dup");
 }
 
 /// The two sibling axes the re-blessing above is justified against. They were
@@ -86,8 +90,9 @@ fn rna_two_base_u_insertion_is_gated_like_the_c_axis() {
 fn c_and_n_axes_bracket_the_gated_r_axis_expectation() {
     assert_eq!(
         normalize("NM_U.1:c.3_4insTT"),
-        "NM_U.1:c.5_6insTT",
-        "c. is gated: coding footprint, unit length 1 is not codon-aligned",
+        "NM_U.1:c.4_5dup",
+        "c. is gated: coding footprint, unit length 1 is not codon-aligned, so \
+         repeat notation is refused and the fallback is the prescribed dup (#1204)",
     );
     assert_eq!(
         normalize("NM_U.1:n.3_4insTT"),

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -137,6 +137,7 @@ mod issue_1183_rna_axis_ins_expansion;
 mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;
 mod issue_1202_transcript_bounds_insertion_clamp;
+mod issue_1204_gated_dup_fallback;
 mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -707,32 +707,31 @@ mod output_tests {
     #[test]
     fn test_multi_insertion_in_homopolymer_codon_frame_blocks_repeat_in_cds() {
         // Per HGVS spec (repeated.md codon-frame exception): in c. context,
-        // repeat notation requires unit_len % 3 == 0. unit_len=1 (A) is
-        // forbidden, so the canonical form stays as `ins<literal>`, not A[N].
-        let seq = "GGGGAAAAAAAGGGG"; // 7 A's
+        // repeat notation requires unit_len % 3 == 0, so unit_len=1 (A) is
+        // forbidden. The same sentence names the replacement — "use
+        // `NM_024312.4:c.2692_2693dup`" — and the two added A's copy the 3'-most
+        // pair of the 7-A tract at c.5_11, so the canonical form is `c.10_11dup`
+        // (#1204; previously an `ins` literal). Asserted exactly rather than as
+        // "contains ins and not A[": the exact form implies the no-repeat-notation
+        // property this test is about, and also pins the dup's position.
+        let seq = "GGGGAAAAAAAGGGG"; // 7 A's at c.5..c.11
         let provider = provider_with_transcript("NM_TEST.1", seq);
         let result = normalize_to_string(provider, "NM_TEST.1:c.5_6insAA");
-        assert!(
-            result.contains("ins") && !result.contains("A["),
-            "c. + unit_len=1 must not emit A[N], got: {}",
-            result
-        );
+        assert_eq!(result, "NM_TEST.1:c.10_11dup");
     }
 
     #[test]
     fn test_multi_dup_in_homopolymer_codon_frame_blocks_repeat_in_cds() {
-        // 2-base dup in 7-A tract: per spec the structurally-canonical form
-        // is repeat notation A[9], but the c. codon-frame exception forbids
-        // it (unit_len=1). Falls back to literal `ins<dup_seq>` per the
-        // GatedInsertion path in duplication_to_repeat.
-        let seq = "GGGGAAAAAAAGGGG"; // 7 A's at pos 5-11
+        // 2-base dup in a 7-A tract: repeat notation A[9] would be the
+        // structurally-canonical form, but the c. codon-frame exception forbids it
+        // (unit_len=1). The GatedInsertion path in duplication_to_repeat reroutes
+        // it, and since the added pair copies c.10_11 the result is that `dup`
+        // (#1204) — the same answer as the `ins` spelling above, which is the
+        // spelling-independence #1204 also bought.
+        let seq = "GGGGAAAAAAAGGGG"; // 7 A's at c.5..c.11
         let provider = provider_with_transcript("NM_TEST.1", seq);
         let result = normalize_to_string(provider, "NM_TEST.1:c.5_6dup");
-        assert!(
-            result.contains("ins") && !result.contains("A["),
-            "c. + unit_len=1 dup must not emit A[N], got: {}",
-            result
-        );
+        assert_eq!(result, "NM_TEST.1:c.10_11dup");
     }
 }
 
@@ -3524,32 +3523,28 @@ mod comprehensive_normalization_tests {
         }
 
         #[test]
-        fn test_multiple_a_insertion_into_tract_in_cds_stays_as_ins() {
-            // Sequence: GGGAAAGGG (3 A's at positions 4-6).
-            // Per HGVS spec (repeated.md codon-frame exception): in c.
-            // context, repeat notation requires unit_len % 3 == 0. With
-            // unit_len=1 the canonical form is `ins<literal>`, not A[N].
+        fn test_multiple_a_insertion_into_tract_in_cds_becomes_the_prescribed_dup() {
+            // Sequence: GGGAAAGGG (3 A's at c.4_6). Per HGVS spec (repeated.md
+            // codon-frame exception): in c. context repeat notation requires
+            // unit_len % 3 == 0, so A[6] is forbidden. The three added A's are
+            // exactly a copy of the whole c.4_6 tract, so the prescribed
+            // replacement is `dup` over it (#1204), not the `ins` literal this
+            // asserted before.
             let seq = "GGGAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insAAA");
-            assert!(
-                result.contains("insAAA") && !result.contains("A["),
-                "c. + unit_len=1 must emit insAAA literal, got: {}",
-                result
-            );
+            assert_eq!(result, "NM_TEST.1:c.4_6dup");
         }
 
         #[test]
-        fn test_t_insertion_in_t_tract_in_cds_stays_as_ins() {
-            // Sequence: AAATTTAAA (T's at positions 4-6). c. + unit_len=1.
+        fn test_t_insertion_in_t_tract_in_cds_becomes_the_prescribed_dup() {
+            // Sequence: AAATTTAAA (T's at c.4_6). c. + unit_len=1, so T[5] is
+            // forbidden; the two added T's copy c.5_6, the tract's 3'-most pair,
+            // so the fallback is that `dup` (#1204, re-blessed from `insTT`).
             let seq = "AAATTTAAA";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insTT");
-            assert!(
-                result.contains("insTT") && !result.contains("T["),
-                "c. + unit_len=1 must emit insTT literal, got: {}",
-                result
-            );
+            assert_eq!(result, "NM_TEST.1:c.5_6dup");
         }
 
         #[test]
@@ -3567,18 +3562,17 @@ mod comprehensive_normalization_tests {
         }
 
         #[test]
-        fn test_large_homopolymer_expansion_in_cds_stays_as_ins() {
-            // Sequence: GGAAAAAGGG (5 A's at positions 3-7). Inserting 5 A's
-            // would normally produce A[10]; the c. codon-frame gate forbids
-            // A[N] (unit_len=1), so the canonical form is `ins<literal>`.
+        fn test_large_homopolymer_expansion_in_cds_becomes_the_prescribed_dup() {
+            // Sequence: GGAAAAAGGG (5 A's at c.3_7). Inserting 5 A's would
+            // normally produce A[10]; the c. codon-frame gate forbids A[N]
+            // (unit_len=1). The five added A's are exactly a copy of the whole
+            // c.3_7 tract, so the fallback is `dup` over it (#1204, re-blessed
+            // from `insAAAAA`). An alt LONGER than the tract has no such copy and
+            // does stay an `ins` — see `ins_shift_matrix`'s case 2.
             let seq = "GGAAAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.7_8insAAAAA");
-            assert!(
-                result.contains("insAAAAA") && !result.contains("A["),
-                "c. + unit_len=1 must emit insAAAAA literal, got: {}",
-                result
-            );
+            assert_eq!(result, "NM_TEST.1:c.3_7dup");
         }
     }
 

--- a/tests/it/repeat_input_idempotency.rs
+++ b/tests/it/repeat_input_idempotency.rs
@@ -146,7 +146,10 @@ fn five_prime_codon_gated_repeat_expansion_is_idempotent() {
         "NM_TEST.1:c.4A[5]",
         ShuffleDirection::FivePrime,
     );
-    assert_eq!(once, "NM_TEST.1:c.3_4insAA", "must name the 5' flank");
+    assert_eq!(
+        once, "NM_TEST.1:c.4_5dup",
+        "must name the 5'-most duplicated pair"
+    );
     assert_eq!(
         norm_cds("CCCAAACCC", &once, ShuffleDirection::FivePrime),
         once,
@@ -162,7 +165,7 @@ fn three_prime_codon_gated_repeat_expansion_unchanged() {
         "NM_TEST.1:c.4A[5]",
         ShuffleDirection::ThreePrime,
     );
-    assert_eq!(once, "NM_TEST.1:c.6_7insAA");
+    assert_eq!(once, "NM_TEST.1:c.5_6dup");
     assert_eq!(
         norm_cds("CCCAAACCC", &once, ShuffleDirection::ThreePrime),
         once,


### PR DESCRIPTION
Closes #1204

`repeated.md` L21-22 states the codon-frame exception and gives **two** replacements, of **different shapes**:

> Consequently, use `NM_024312.4:c.2692_2693dup` and **not** `NM_024312.4:c.2686A[10]`; use `NM_024312.4:c.1741_1742insTATATATA` and **not** `NM_024312.4:c.1738TA[6]`.

Which one applies is decided by the reference, not by the gate. `c.2692_2693dup` — the two added `A`s copy the two 3'-most bases of the `A[8]` tract, so the change *is* a duplication. `c.1741_1742insTATATATA` — four `TA` copies added to a two-copy tract, so the added bases are twice the length of the whole adjacent tract and no `dup` describes them. ferro emitted the `ins` form for both: the gate that (correctly) refuses repeat notation also suppressed the `ins` → `dup` promotion, so the duplication half of the guidance was unreachable.

```
NM_RFRAME.1:c.8_9dup  ->  c.9_10insAA     (was)
                      ->  c.8_9dup        (now — and a fixed point)
```

## Fix

Remove the codon-frame condition from the three dup-emission sites in the insertion path. The gate belongs where *repeat notation* is decided — `insertion_to_repeat` and `duplication_to_repeat`, both of which already return `None` / reroute here when it fires — and a `dup` is not repeat notation. Each of those three sites emits a `dup` only where the alt equals an adjacent same-length reference tract, so the spec's second example has nothing to promote to and still falls through to the flat literal.

On two of the three the condition was **provably dead**: `insertion_to_duplication` returns `Some` only for single-copy alts (`added_copies != 1` → `None`), where the gate's `smallest_unit.len() < alt.len()` clause is false by construction. The in-code comment said as much ("in practice the gate never fires when `ins_to_dup` is `Some`"). Only the post-shuffle simple-dup site was live, and it is the one the spec's first example lands on.

### Second defect, found while fixing the first

The gated `unit[N]` path returned its derived `ins` literal raw instead of re-entering `normalize_na_edit`, as the `dup` path has done since #1208. It was therefore the one gated spelling that could not promote:

| | pass 1 | pass 2 |
|---|---|---|
| `c.4A[5]` (before) | `c.3_4insAA` | `c.4_5dup` |

A non-idempotency the moment the insertion path learned to promote — caught by `normalize_idempotency_proptest::repeat_input_is_idempotent`, not by me. Routing it through the same canonicalization fixes it and buys confluence the file that covers it never had: all four spellings of "+2 `A` into a 7-`A` tract" (`dup`, `ins`, `delins`, `A[9]`), from any start position, now reach one form.

## Evidence this is the right direction

**The spec's own counter-example, on the real reference.** `spec_enumeration_tests::enumeration_replays_recorded_behavior` replays `NM_024312.4:c.2686A[10]` — the exact string `repeated.md` marks invalid — through the committed hermetic reference slice:

```
recorded : NM_024312.4:c.2693_2694insAA
observed : NM_024312.4:c.2692_2693dup
```

Byte-for-byte the form the spec says to use. Six rows moved (the `c.`/`r.` spellings × the `project-c`/`project-n`/`project-r` dimensions); the divergence budget is unchanged.

**biocommons agrees, on both halves.** From the committed corpus:

- `NM_212556.2:c.1delinsAA` → `c.1dup` and `NM_212556.2:c.1401delinsAA` → `c.1401dup` — it rewrites even a *boundary* `delins` into the dup when the change is one.
- `NM_001166478.1:c.35_36dup` → `c.36_37dup` — a 2-base (non-triplet) dup inside the CDS stays a dup and shifts.
- `NM_212556.2:c.1_2insCA` → `c.1delinsACA` — and where the change is *not* a duplication, the boundary `delins` is still right.

`biocommons_normalize_tests::axis_normalized_hermetic` (the corpus against committed real reference windows) passes unchanged by this PR, so nothing in it moved.

## Blast radius: 38 expectations across 12 files

Every one moves `ins` → `dup`, or `delins` → `dup` at a CDS boundary. Each site carries its derivation. The two groups worth review attention:

**Boundary clamps (#1170 / #387 / #1208 / #383).** A dup-able homopolymer addition at `cds_start` / `cds_end` now resolves to a `dup` before the clamp is consulted — `c.1_2dup` rather than `c.1delinsCCC` — because a `dup` has two in-CDS anchors and so is not the shape the clamp exists to repair. **The clamp is not stranded:** an alt longer than the tract it lands in has no duplication to promote to, still saturates, and still clamps. I added a row of that shape everywhere a re-blessed row was the clamp's only coverage:

| file | dup regime | clamp regime (new) |
|---|---|---|
| `issue_1207_rna_cds_boundary_clamp` | `r.1_2dup` → `r.1_2dup` | `r.2_3insccccc` → `r.1delinscccccc` |
| `five_prime_boundary_delins_unification` | 9 spellings → `c.1_2dup` | 3 spellings → `c.1delinsAAAAAAAAA` |
| `issue_383_canon_cds_start_clamp` | `c.5_6insAA` → `c.1_2dup` | `c.5_6insAAAAAAAAAAAAAAAAAAAAA` → `c.1delinsAAAAAAAAAAAAAAAAAAAAAA` |

`#401` spanning dups (`c.7_*1dup`) and the `#383`/`#387` `delins`-input carve-out are untouched.

**`issue_1207_rna_cds_boundary_clamp::interior_dup_is_untouched_by_the_clamp`** never had anything to do with the clamp, and its `r.10_11insaa` expectation was itself an instance of this defect. It is now `r.9_10dup`; the clamp still does not fire, which is what the test is for.

Two comments were wrong on their own terms and are corrected rather than carried forward: `ins_repeat_b1_matrix`'s dinucleotide case described itself as mirroring the spec's `insTATATATA` example when its alt sits *inside* the tract (so it is the `dup` half), and `issue_1207`'s axis-parity test required the `c.` answer to contain `delins`, hard-coding one regime into what is meant to be a shape-agnostic property.

## Verification

- `cargo nextest run --features dev` — **8644 passed, 0 failed, 145 skipped**; identical under `FERRO_ASSERT_IDEMPOTENT=1`.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `generate_tool_support_tables -- --check` clean (no drift in the committed tables).
- Rebased onto `5fec184` (#1211).
- **Not run: the manifest-backed conformance axes.** Both the scratch and backup reference volumes are offline in this session, so `mutalyzer_normalize_tests::axis_normalized` and its siblings skipped (145 skipped above). The hermetic corpora above are real-reference and did run; the nightly reference-aware job is what covers the rest, and a homopolymer-dup change on the `c.` axis is the kind that can move those ledgers.

## Interaction with the open campaign

- **#1212 (issue #1210) has since merged, and this branch is rebased onto it** (`f9ae3be`). It touches the same gate from the other side: it decides *whether* to gate (re-answering for the tract rather than the input span), where this decides *what the fallback is* once gated. Complementary, as expected — but it did move one expectation, so the count above is now **39 across 13 files**:

  `issue_1210_repeat_gate_tract_span::interior_tract_is_still_codon_gated` expected `r.12_13insaa` for a CDS-interior 1-nt tract. That is this defect's shape, so it is now `r.11_12dup` (the added `aa` copies `r.11_12`, the 3'-most pair of the `r.5_12` run). The guard's actual claim — a CDS-interior 1-nt tract is *refused repeat notation* — is untouched, and I made that explicit by asserting `!contains('[')` alongside the exact form, so the two properties can no longer be conflated.
- **#1206** (the `CodonGate` refactor) is stacked on this branch, since both edit `normalize_na_edit` — including the new recursive call site this adds.

Closes #1195 — the same defect, filed separately and citing `DNA/duplication.md:18` ("when a variant can be described as a duplication, it **must** be described as a duplication and not as, e.g., an insertion") where #1204 cites `repeated.md`. One fix, one set of tests, both spec citations satisfied.
