### PR TITLE
fix(normalize): clamp an insertion saturated at a contig bound on the g. axis

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -604,11 +604,40 @@ fn insertion_to_boundary_delins(
     })
 }
 
-/// Rewrite in place a post-shuffle insertion that has saturated at a
-/// **transcript** boundary, into the equivalent `delins` — the only spelling of
-/// that haplotype the `n.` / `r.` axes, and the `c.` axis outside the CDS, can
+/// Which ends of the `seq` slice handed to [`clamp_insertion_at_sequence_bounds`]
+/// are true boundaries of the underlying entity.
+///
+/// The transcript-axis callers pass the whole transcript, so both ends are real
+/// ([`SequenceEnds::WHOLE`]). `normalize_genome` passes a **window** into the
+/// contig, where an end is real only when the window happens to be flush with the
+/// contig there. Clamping at a window edge that is merely where the fetch stopped
+/// would assert a boundary that does not exist and rewrite a perfectly valid
+/// interior insertion into a `delins` at the wrong place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SequenceEnds {
+    /// `seq[0]` is the entity's first base.
+    five_prime: bool,
+    /// `seq[len-1]` is the entity's last base.
+    three_prime: bool,
+}
+
+impl SequenceEnds {
+    /// The slice is the entire entity, so both of its ends are real boundaries.
+    const WHOLE: Self = Self {
+        five_prime: true,
+        three_prime: true,
+    };
+}
+
+/// Rewrite in place a post-shuffle insertion that has saturated at a **sequence**
+/// boundary, into the equivalent `delins` — the only spelling of that haplotype
+/// the `n.` / `r.` axes, the `c.` axis outside the CDS, and the `g.` axis can
 /// express. Leaves `edit`/`start`/`end` untouched for anything that is not a
 /// boundary-saturated literal insertion.
+///
+/// Named for the *sequence* rather than the transcript since #1205: nothing in it
+/// is transcript-specific — it enforces `[1, seq.len()]`, which is equally the
+/// contig bounds — and `normalize_genome` is now a caller.
 ///
 /// `n.` and `r.` number the transcript directly: there is no position `0` and
 /// no `*`-suffixed overflow axis, so an insertion driven to rest immediately
@@ -652,33 +681,38 @@ fn insertion_to_boundary_delins(
 /// | `c.` (CDS region) | `cds_start` / `cds_end` | `normalize_cds` |
 /// | `c.` (UTR regions) | transcript `1` / `len` | this helper |
 /// | `n.`, `r.` | transcript `1` / `len` | this helper |
-/// | `g.` | contig `1` / `len` | **nobody — see #1205** |
+/// | `g.` | contig `1` / `len` | `normalize_genome` (#1205) |
 /// | `m.`, `o.` | circular, so position 1 has a valid 5' neighbour | n/a |
 ///
-/// The invariant is therefore **per-axis, not global**: `normalize_genome` has
-/// no clamp, so a 5'-saturated insertion at a contig start still escapes as
-/// `g.1ins<A'>` — the same unparseable shape, on the axis the spec uses for its
-/// own counter-example (`DNA/insertion.md:95-101` rejects `g.123insG`).
-/// Tracked in #1205 and deliberately not fixed here: the contig bounds are a
-/// different boundary, it changes output on the hottest axis, and `m.`/`o.`
-/// need a wraparound answer rather than this `delins` rewrite. Nothing in this
-/// helper is transcript-specific — it enforces `[1, seq.len()]` — so #1205 is
-/// expected to add a fourth caller rather than new logic.
-fn clamp_insertion_at_transcript_bounds(
+/// `normalize_genome` became the fourth caller in #1205, which closes the last
+/// non-circular gap: before it, a 5'-saturated insertion at a contig start
+/// escaped as `g.1ins<A\'>` — the same unparseable shape, on the axis the spec
+/// uses for its own counter-example (`DNA/insertion.md:95-101` rejects
+/// `g.123insG`) — and a 3'-saturated one as `g.<len>_<len+1>ins<A\'>`, whose
+/// second anchor is past the contig end.
+///
+/// `m.`/`o.` remain deliberately uncovered: a circular reference wraps, so
+/// position 1 HAS a valid 5\' neighbour (the last base) and the correct output
+/// there is a wraparound description, not this `delins` rewrite.
+///
+/// The genomic caller passes a **window** rather than the whole contig, so it
+/// must say which of its ends are real — see [`SequenceEnds`].
+fn clamp_insertion_at_sequence_bounds(
     seq: &[u8],
     edit: &mut NaEdit,
     start: &mut u64,
     end: &mut u64,
+    ends: SequenceEnds,
 ) {
     // Cheapest discriminating guard first: only two resting places qualify, and
-    // both are two register compares against values already in hand. `tx_len ==
+    // both are two register compares against values already in hand. `seq_len ==
     // 0` needs no separate guard — `insertion_to_boundary_delins` bails on an
     // anchor outside `seq`, which an empty `seq` always is.
-    let tx_len = seq.len() as u64;
-    let (anchor, side) = if *start == 1 && *end == 1 {
+    let seq_len = seq.len() as u64;
+    let (anchor, side) = if ends.five_prime && *start == 1 && *end == 1 {
         (1, BoundarySide::FivePrime)
-    } else if *start == tx_len && *end == tx_len + 1 {
-        (tx_len, BoundarySide::ThreePrime)
+    } else if ends.three_prime && *start == seq_len && *end == seq_len + 1 {
+        (seq_len, BoundarySide::ThreePrime)
     } else {
         return;
     };
@@ -2753,14 +2787,47 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let rel_end = end - window_start;
 
         // Perform normalization
-        let (new_rel_start, new_rel_end, new_edit, mut warnings) = self.normalize_na_edit(
+        let (mut new_rel_start, mut new_rel_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                ref_seq.as_bytes(),
+                edit,
+                rel_start,
+                rel_end,
+                &Boundaries::new(0, ref_seq.len() as u64),
+                CodonGate::NotApplicable, // genomic context: no reading frame
+            )?;
+
+        // #1205: an insertion driven to rest against a contig end has no valid
+        // pair of adjacent anchors there, exactly as on the transcript axes
+        // (#1202) — 5' it escapes as the single-position `g.1ins<A'>`, which
+        // `DNA/insertion.md:95-101` rejects by name and ferro's own parser
+        // refuses; 3' as `g.<len>_<len+1>ins<A'>`, whose second anchor is past
+        // the contig end. Rewrite both to the equivalent `delins`.
+        //
+        // `ref_seq` is a WINDOW into the contig, not the whole thing, so its ends
+        // are contig boundaries only where the window is flush with the contig —
+        // otherwise the "boundary" is just where the fetch stopped, and clamping
+        // there would invent one. The 5' side is flush iff the window started at
+        // the contig's first base; the 3' side iff the window's last base is the
+        // contig's last. With no length available we cannot establish flushness,
+        // so we do not clamp — the same conservative choice
+        // `clamp_fetch_end_to_contig` makes on the read side.
+        //
+        // Runs on window-relative coordinates, before the conversion back to
+        // genomic ones, mirroring the ordering the three transcript callers hold
+        // (clamp in the frame `ref_seq` is indexed in, then convert).
+        let contig_len = self.provider.get_sequence_length(&accession).ok();
+        clamp_insertion_at_sequence_bounds(
             ref_seq.as_bytes(),
-            edit,
-            rel_start,
-            rel_end,
-            &Boundaries::new(0, ref_seq.len() as u64),
-            CodonGate::NotApplicable, // genomic context: no reading frame
-        )?;
+            &mut new_edit,
+            &mut new_rel_start,
+            &mut new_rel_end,
+            SequenceEnds {
+                five_prime: window_start == 0,
+                three_prime: contig_len
+                    .is_some_and(|len| window_start + ref_seq.len() as u64 >= len),
+            },
+        );
 
         // Adjust back to genomic coordinates
         let new_start = new_rel_start + window_start;
@@ -3795,11 +3862,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // either clamp above has already rewritten `new_edit` to a `Delins`, so
         // it is inert after them — no double-clamp. Runs before the CDS
         // conversion so the arithmetic stays in transcript space.
-        clamp_insertion_at_transcript_bounds(
+        clamp_insertion_at_sequence_bounds(
             seq,
             &mut new_edit,
             &mut new_tx_start,
             &mut new_tx_end,
+            SequenceEnds::WHOLE,
         );
 
         // Convert back to CDS coordinates
@@ -4144,7 +4212,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `new_end` from `len + 1` onto exactly `len` (== `boundaries.right`
         // for the insertion bounds), so clamping first would divert a saturated
         // insertion into the junction-crossing engine.
-        clamp_insertion_at_transcript_bounds(seq, &mut new_edit, &mut new_start, &mut new_end);
+        clamp_insertion_at_sequence_bounds(
+            seq,
+            &mut new_edit,
+            &mut new_start,
+            &mut new_end,
+            SequenceEnds::WHOLE,
+        );
 
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
@@ -5664,7 +5738,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // The `c.` spelling of the same edit was already stable precisely
         // because this clamp exists there (`c.1delinsCCC`).
         //
-        // #1202's `clamp_insertion_at_transcript_bounds` below does NOT cover
+        // #1202's `clamp_insertion_at_sequence_bounds` below does NOT cover
         // this: it fires only at transcript `1` / `len`, whereas these saturate
         // at the CDS bounds, where the far side (`r.-1`, `r.*1`) is perfectly
         // representable. Two different boundaries, both needed.
@@ -5731,11 +5805,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // the CDS clamps above, mirroring `normalize_cds`'s ordering; either of
         // those has already rewritten `new_edit` to a `Delins`, so this is inert
         // after them.
-        clamp_insertion_at_transcript_bounds(
+        clamp_insertion_at_sequence_bounds(
             seq,
             &mut new_edit,
             &mut new_tx_start,
             &mut new_tx_end,
+            SequenceEnds::WHOLE,
         );
 
         // Convert each normalized tx position back to a CDS-relative `r.`
@@ -9674,6 +9749,101 @@ mod codon_gate_tests {
                 CodonGate::NotApplicable => panic!("{cds:?} should have produced a coding gate"),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod sequence_bounds_clamp_tests {
+    use super::*;
+    use crate::hgvs::edit::{Base, InsertedSequence, Sequence};
+
+    fn literal_insertion(bases: &str) -> NaEdit {
+        let bases: Vec<Base> = bases
+            .chars()
+            .map(|c| Base::from_char(c).expect("test bases must be A/C/G/T"))
+            .collect();
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::new(bases)),
+        }
+    }
+
+    /// The 5'-saturated shape is rewritten when the slice's first base really is
+    /// the entity's first base.
+    #[test]
+    fn clamps_at_a_real_five_prime_bound() {
+        let (mut edit, mut start, mut end) = (literal_insertion("CG"), 1, 1);
+        clamp_insertion_at_sequence_bounds(
+            b"CCCCAAAA",
+            &mut edit,
+            &mut start,
+            &mut end,
+            SequenceEnds::WHOLE,
+        );
+        assert!(matches!(edit, NaEdit::Delins { .. }), "{edit:?}");
+        assert_eq!((start, end), (1, 1));
+    }
+
+    /// …and NOT when that end of the slice is merely where a fetch stopped.
+    ///
+    /// This is the guard `normalize_genome` needs and the transcript callers do
+    /// not: it passes a window into the contig, so an interior window edge is not
+    /// a contig bound, and clamping there would rewrite a valid insertion into a
+    /// `delins` asserting a boundary that does not exist. Unit-tested directly
+    /// because the end-to-end route to it is not currently constructible — on the
+    /// `g.` axis an alt has to be tandem-compatible with the reference to shuffle
+    /// at all, and such an alt becomes repeat notation or a `dup` long before it
+    /// could walk a whole window's width. The guard is therefore correctness by
+    /// construction rather than a fix for an observed output.
+    #[test]
+    fn does_not_clamp_at_a_window_edge_that_is_not_a_bound() {
+        for ends in [
+            SequenceEnds {
+                five_prime: false,
+                three_prime: true,
+            },
+            SequenceEnds {
+                five_prime: false,
+                three_prime: false,
+            },
+        ] {
+            let (mut edit, mut start, mut end) = (literal_insertion("CG"), 1, 1);
+            clamp_insertion_at_sequence_bounds(b"CCCCAAAA", &mut edit, &mut start, &mut end, ends);
+            assert!(
+                matches!(edit, NaEdit::Insertion { .. }),
+                "{ends:?}: {edit:?}"
+            );
+            assert_eq!((start, end), (1, 1));
+        }
+    }
+
+    /// The 3' side, both ways round.
+    #[test]
+    fn three_prime_bound_is_gated_the_same_way() {
+        let seq = b"CCCCAAAA"; // len 8, so the saturated shape is (8, 9)
+        let (mut edit, mut start, mut end) = (literal_insertion("CG"), 8, 9);
+        clamp_insertion_at_sequence_bounds(
+            seq,
+            &mut edit,
+            &mut start,
+            &mut end,
+            SequenceEnds::WHOLE,
+        );
+        assert!(matches!(edit, NaEdit::Delins { .. }), "{edit:?}");
+        assert_eq!((start, end), (8, 8));
+
+        let (mut edit, mut start, mut end) = (literal_insertion("CG"), 8, 9);
+        clamp_insertion_at_sequence_bounds(
+            seq,
+            &mut edit,
+            &mut start,
+            &mut end,
+            SequenceEnds {
+                five_prime: true,
+                three_prime: false,
+            },
+        );
+        assert!(matches!(edit, NaEdit::Insertion { .. }), "{edit:?}");
+        assert_eq!((start, end), (8, 9));
     }
 }
 

--- a/tests/it/issue_1205_genome_contig_bounds_clamp.rs
+++ b/tests/it/issue_1205_genome_contig_bounds_clamp.rs
@@ -1,0 +1,206 @@
+//! Issue #1205 — a `g.`-axis insertion that saturates at a contig bound must be
+//! clamped to a `delins`, exactly as the transcript axes already do (#1202).
+//!
+//! `normalize_genome` had no boundary clamp. #1202 introduced the rewrite and
+//! wired it into `normalize_cds`, `normalize_tx` and `normalize_rna` — three call
+//! sites, all numbered against a transcript — leaving the most heavily used axis
+//! uncovered. Both ends escape, in the two shapes #1202 describes:
+//!
+//! | direction | input | before | why it is wrong |
+//! |---|---|---|---|
+//! | 5' | `g.1_2insGC` | `g.1insCG` | single-position insertion; ferro's own parser rejects it |
+//! | 3' | `g.13_14insGGA` | `g.15_16insAGG` | `g.16` is past the end of a 15-base contig |
+//!
+//! The 5' shape is the one the spec names, on this very axis
+//! (`DNA/insertion.md:95-101`):
+//!
+//! > **Can I describe a variant as `g.123insG`?**
+//! > No, since the description is not unequivocal, it is not allowed.
+//! > What does the description mean, the insertion of a `G` **at** position
+//! > `g.123` or the insertion of a `G` **after** position `g.123`?
+//!
+//! An insertion needs two adjacent flanking anchors; `g.1ins…` has one.
+//!
+//! **Reachability.** GRCh38 primary chromosomes open with telomeric `N` runs, so
+//! this is unlikely on a primary assembly. It is reachable on small or custom
+//! references whose first bases are a homopolymer — plasmids, viral genomes,
+//! scaffolds, synthetic contigs — and on any `NC_`/`NG_` slice a user supplies.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// The issue's probe contig: `C`×4, `A`×7, `G`×4. 15 bases, so both ends are
+/// within one fetch window and both bounds are exercisable.
+const CONTIG: &str = "CCCCAAAAAAAGGGG";
+
+fn normalize(input: &str, dir: ShuffleDirection) -> String {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_PROBE.1", CONTIG);
+    let normalizer =
+        Normalizer::with_config(provider, NormalizeConfig::default().with_direction(dir));
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"))
+        .to_string()
+}
+
+/// Assert the exact canonical form, that it re-parses, and that it is a fixed
+/// point.
+///
+/// Re-parsing is not boilerplate here: the 5' defect's output was rejected by
+/// ferro's own parser, so "can ferro read back what it just wrote" is the
+/// property under test as much as the string itself.
+fn assert_canonical(input: &str, dir: ShuffleDirection, expected: &str) {
+    let once = normalize(input, dir);
+    assert_eq!(once, expected, "{input} ({dir:?}) canonical form");
+    parse_hgvs(&once).unwrap_or_else(|e| panic!("{once} must re-parse: {e}"));
+    assert_eq!(normalize(&once, dir), once, "{once} must be a fixed point");
+}
+
+/// Apply "replace 1-based inclusive `start..=end` of [`CONTIG`] with `insert`",
+/// returning the edited sequence. `start > end` denotes a pure insertion between
+/// the two flanking positions.
+///
+/// Deliberately dumb string splicing, independent of the normalizer: it is what
+/// lets the equivalence assertions below prove the rewrite preserves the
+/// haplotype rather than merely restating what the normalizer did.
+fn splice(start: usize, end: usize, insert: &str) -> String {
+    let (before, rest) = CONTIG.split_at(start - 1);
+    let after = &rest[(end + 1).saturating_sub(start)..];
+    format!("{before}{insert}{after}")
+}
+
+// ---------------------------------------------------------------------------
+// The defect at each contig bound
+// ---------------------------------------------------------------------------
+
+/// 5' saturation. The shuffle drives the insertion to rest immediately 5' of
+/// `g.1`, where the coordinate identity gives `delete ref[1]` (= `C`),
+/// `insert CG ++ C`.
+#[test]
+fn five_prime_saturated_insertion_clamps_at_contig_start() {
+    assert_canonical(
+        "NC_PROBE.1:g.1_2insGC",
+        ShuffleDirection::FivePrime,
+        "NC_PROBE.1:g.1delinsCGC",
+    );
+}
+
+/// 3' saturation, the mirror: `delete ref[15]` (= `G`), `insert G ++ AGG`.
+///
+/// The alt is `GGA` rather than a clean homopolymer because a tandem alt never
+/// reaches this shape on `g.` — with no codon-frame gate on the genomic axis, two
+/// or more copies become repeat notation and a single copy becomes a `dup`, both
+/// before any saturation. `GGA` shifts twice through the `G`×4 tract and then
+/// mismatches, which is what leaves it an insertion resting on the bound.
+#[test]
+fn three_prime_saturated_insertion_clamps_at_contig_end() {
+    assert_canonical(
+        "NC_PROBE.1:g.13_14insGGA",
+        ShuffleDirection::ThreePrime,
+        "NC_PROBE.1:g.15delinsGAGG",
+    );
+}
+
+/// The rewrite must describe the same haplotype, not merely a parseable one.
+///
+/// Both sides are spliced into the reference by hand here, so this does not go
+/// through the normalizer and cannot be satisfied by an internally-consistent but
+/// wrong rewrite.
+#[test]
+fn the_clamped_delins_describes_the_same_sequence() {
+    // 5': insert `GC` between g.1 and g.2  ==  replace g.1 with `CGC`.
+    assert_eq!(splice(2, 1, "GC"), splice(1, 1, "CGC"));
+    // 3': insert `GGA` between g.13 and g.14  ==  replace g.15 with `GAGG`.
+    //
+    // Note the input is stated at g.13_14 but the shuffled payload is `AGG`; the
+    // 3'-shifted insertion between g.15 and g.16 is the same haplotype, which the
+    // first equality below pins before the delins comparison.
+    assert_eq!(splice(14, 13, "GGA"), splice(16, 15, "AGG"));
+    assert_eq!(splice(16, 15, "AGG"), splice(15, 15, "GAGG"));
+}
+
+// ---------------------------------------------------------------------------
+// Controls: the clamp must not fire away from the bounds
+// ---------------------------------------------------------------------------
+
+/// The same alt one position 5' of the saturating case comes to rest inside the
+/// contig, so it keeps two valid anchors and must stay an insertion.
+#[test]
+fn interior_insertion_is_left_alone() {
+    assert_canonical(
+        "NC_PROBE.1:g.12_13insGGA",
+        ShuffleDirection::ThreePrime,
+        "NC_PROBE.1:g.14_15insAGG",
+    );
+}
+
+/// …and on the 5' side.
+#[test]
+fn five_prime_interior_insertion_is_left_alone() {
+    assert_canonical(
+        "NC_PROBE.1:g.3_4insGC",
+        ShuffleDirection::FivePrime,
+        "NC_PROBE.1:g.2_3insCG",
+    );
+}
+
+/// A tandem expansion whose tract runs to the contig start becomes repeat
+/// notation, which is not an insertion and so is not the clamp's business. Guards
+/// against the clamp firing on position alone rather than on shape.
+#[test]
+fn repeat_notation_reaching_the_contig_start_is_untouched() {
+    assert_canonical(
+        "NC_PROBE.1:g.2_3insCC",
+        ShuffleDirection::FivePrime,
+        "NC_PROBE.1:g.1_4C[6]",
+    );
+}
+
+/// An insertion that cannot shuffle at all is unaffected, even written against
+/// the first bases of the contig.
+#[test]
+fn non_shuffling_insertion_at_the_contig_start_is_untouched() {
+    assert_canonical(
+        "NC_PROBE.1:g.1_2insCG",
+        ShuffleDirection::FivePrime,
+        "NC_PROBE.1:g.1_2insCG",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scope boundary: circular references are NOT clamped
+// ---------------------------------------------------------------------------
+
+/// `m.` (and `o.`) are deliberately left out of this fix, and this pins that
+/// boundary so a later change does not extend the clamp there by reflex.
+///
+/// A circular reference wraps: position 1 HAS a valid 5' neighbour — the last
+/// base — so the correct output for a 5'-saturated insertion there is a
+/// wraparound description, not this `delins` rewrite. Applying the genomic clamp
+/// would produce a well-formed but semantically wrong answer, which is worse than
+/// the status quo.
+///
+/// To be explicit about what that status quo is: `m.` currently emits the same
+/// invalid single-position form this PR fixes on `g.` (`m.1insCG`). That is a real
+/// defect and is **not** fixed here — it needs the circular answer, tracked
+/// separately. This test therefore asserts only that the clamp did not fire; it
+/// does not bless the output.
+#[test]
+fn mito_axis_is_not_clamped() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_012920.1", CONTIG);
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NC_012920.1:m.1_2insGC").expect("parse");
+    let rendered = normalizer
+        .normalize(&variant)
+        .expect("normalize")
+        .to_string();
+    assert!(
+        !rendered.contains("delins"),
+        "the genomic contig clamp must not reach the circular axis, got {rendered}",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -141,6 +141,7 @@ mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;
 mod issue_1202_transcript_bounds_insertion_clamp;
 mod issue_1204_gated_dup_fallback;
+mod issue_1205_genome_contig_bounds_clamp;
 mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;


### PR DESCRIPTION
Closes #1205

`normalize_genome` had no boundary clamp. #1202 introduced the rewrite and wired it into `normalize_cds`, `normalize_tx` and `normalize_rna` — three call sites, all numbered against a transcript — leaving the most heavily used axis uncovered. Both ends escape, in the two shapes #1202 describes:

| direction | input | before | why it is wrong |
|---|---|---|---|
| 5' | `g.1_2insGC` | `g.1insCG` | single-position insertion — **ferro's own parser rejects it** |
| 3' | `g.13_14insGGA` | `g.15_16insAGG` | `g.16` is past the end of a 15-base contig |

The 5' shape is the one the spec rejects by name, on this very axis (`DNA/insertion.md:95-101`):

> **Can I describe a variant as `g.123insG`?**
> No, since the description is not unequivocal, it is not allowed. What does the description mean, the insertion of a `G` **at** position `g.123` or the insertion of a `G` **after** position `g.123`?

So normalization emitted a description ferro cannot read back:

```
parse error: single-position insertion not allowed on g.; the anchor MUST be two
adjacent positions (e.g. g.123_124insATG, not g.123insATG) per DNA/insertion.md:95-101
```

## Fix

`normalize_genome` becomes the fourth caller, and the helper is renamed `clamp_insertion_at_sequence_bounds` — nothing in it was transcript-specific, it enforces `[1, seq.len()]`, which is equally the contig bounds.

```
5'  g.1_2insGC     ->  g.1delinsCGC      (delete g.1 = C, insert CG ++ C)
3'  g.13_14insGGA  ->  g.15delinsGAGG    (delete g.15 = G, insert G ++ AGG)
```

### The one genuine difference from the transcript callers

They hand the helper the **whole** transcript. `normalize_genome` hands it a ±`window_size` **window** into the contig, so `seq.len()` is not the contig length, and a window edge is a contig bound only where the window happens to be flush with the contig. Clamping at an edge that is merely where the fetch stopped would rewrite a valid interior insertion into a `delins` asserting a boundary that does not exist.

The helper therefore takes a `SequenceEnds` saying which of its ends are real. The three transcript callers pass `SequenceEnds::WHOLE`; `normalize_genome` computes flushness — `window_start == 0` for the 5' side, the window's last base being the contig's last for the 3'. With no contig length available it does not clamp, the same conservative choice `clamp_fetch_end_to_contig` already makes on the read side.

I could not construct an end-to-end input that rests on a non-flush window edge, and I do not think one exists today: on `g.` an alt must be tandem-compatible with the reference to shuffle at all, and such an alt becomes repeat notation (≥2 copies) or a `dup` (1 copy) long before it could walk a whole window's width. **The guard is correctness by construction, not a fix for an observed output** — so it is covered by a direct unit test rather than a fixture, and labelled as such.

### `m.`/`o.` are deliberately excluded

A circular reference wraps: position 1 HAS a valid 5' neighbour (the last base), so the correct output for a saturated insertion there is a wraparound description, not this `delins`. Applying the genomic clamp would give a well-formed but semantically wrong answer.

To be explicit, since it came up while testing: **`m.` currently has the same defect** — `NC_012920.1:m.1_2insGC` → `m.1insCG`, also unparseable. That is not fixed here and is filed separately as #1217. Note what that investigation turned up: the "circular references need a wraparound answer" rationale for excluding `m.` does not hold, because #129 established that ferro *rejects* the wraparound `ins` spelling by design (the spec's reversed-range exception covers `del`/`dup`/`delins`, not `ins`). The likely fix there is this same `delins` clamp — `m.16569delinsGCG` — so #1217 is probably a fifth caller rather than a different mechanism. It also reproduces on the real rCRS, and catches `g.` variants on mitochondrial accessions, which this PR's clamp does not reach because they are coerced to the mito path. The test for the boundary asserts only that the clamp does not reach `m.`; it does not bless the current output.

## Tests

`tests/it/issue_1205_genome_contig_bounds_clamp.rs`, on the issue's own probe contig (`C`×4 `A`×7 `G`×4):

- both defect cases, each asserted exactly, re-parsed, and checked as a fixed point — re-parsing is the property under test here, not boilerplate;
- an **independent equivalence check**: both the input insertion and the clamped `delins` are spliced into the reference by hand (no normalizer involved) and the resulting sequences compared, so the rewrite is shown to preserve the haplotype rather than merely to be parseable;
- four controls — the same alt one position 5' of each bound (stays an insertion), a tandem expansion whose tract reaches the contig start (stays repeat notation, so the clamp keys on shape and not just position), and a non-shuffling insertion written at `g.1_2`;
- the `m.` scope boundary.

Note on the 3' fixture: the alt is `GGA` rather than a homopolymer because a tandem alt never reaches the saturated shape on `g.` — with no codon-frame gate there, ≥2 copies become repeat notation and 1 copy becomes a `dup`. `GGA` shifts twice through the `G`×4 tract and then mismatches, which is what leaves it an insertion resting on the bound. (The issue predicted `g.13_14insGCA` would saturate; it does not — it rests at `g.14_15`, inside the contig. `GGA` is the input that actually reproduces.)

Three unit tests cover the `SequenceEnds` gating directly, including the non-flush case above.

## Verification

- `cargo nextest run --features dev` — **8647 passed, 0 failed, 145 skipped**; delta over the base is exactly the 11 new tests, so no existing expectation moved.
- Identical under `FERRO_ASSERT_IDEMPOTENT=1`.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- Rebased onto `f9ae3be` (#1212).
- **Not run: the manifest-backed conformance axes** — both reference volumes are offline in this session, so those 145 skipped. This changes `g.`-axis output, and while the shape requires a contig whose first/last bases are a shufflable tract (GRCh38 primaries open with telomeric `N`), the nightly reference-aware job is what would confirm no ledger movement.

Independent of #1213/#1214 (`normalize_genome` and the helper's signature; no overlap with the codon-gate work).


