### PR TITLE
ci: shard the test suite and gate every PR on a 1M-case idempotency soak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,10 @@ jobs:
       # project, but a bare `uv run` re-installs it — and for this maturin
       # package that means a full Rust extension build. Measured: 158s of this
       # job's 169s was `Building ferro-hgvs`, to run ~9s of ruff and mypy over
-      # pure Python. Nothing here needs the compiled module: ruff is a static
-      # linter and mypy reads the checked-in `python/ferro_hgvs/__init__.pyi`
-      # stubs. The wheel is built and exercised for real in `python-wheel-test`.
+      # pure Python; with this set the job takes 10s. Nothing here needs the
+      # compiled module: ruff is a static linter and mypy reads the checked-in
+      # `python/ferro_hgvs/__init__.pyi` stubs. The wheel is built and
+      # exercised for real in `python-wheel-test`.
       UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -158,30 +159,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - run: cargo clippy --features dev --all-targets -- -D warnings
-      - name: Trim target/ before the cache is saved
-        # Rotating keys mint a new entry per run, and this repo's Actions cache
-        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
-        # they get fresher, or LRU starts evicting other jobs' caches.
-        # Incremental state does not transfer between runners, and this crate's
-        # own artifacts are rebuilt every commit by definition; only dependency
-        # artifacts are worth carrying forward.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
 
   clippy-all-features:
     # Lints the feature-gated code that `--features dev` never compiles —
@@ -213,17 +195,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   # Build the test binaries and the two generated spec artifacts ONCE, then fan
@@ -241,15 +216,6 @@ jobs:
   # exactly where those baked paths point. Verified locally by hiding
   # `target/debug/ferro` to reproduce the shard's condition: default extraction
   # gave 6 failures, `--extract-to .` gave 6 passes.
-      - name: Trim target/ before the cache is saved
-        # See the note in `clippy`: rotating keys plus a near-full Actions cache
-        # mean entries must shrink as they get fresher.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
-
   test-build:
     name: Build test archive
     runs-on: ubuntu-latest
@@ -280,17 +246,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Generate HGVS v21.0 spec fixture
         # Gitignored generated artifact, not committed. Generating it here also
         # validates the curated overrides file — the guard the old `--check`
@@ -319,19 +277,6 @@ jobs:
   # a shard by a hash of its name, so the split is deterministic and stays
   # stable as tests are added. Verified even on this suite: 8646 tests split
   # 2148 / 2181 / 2162 / 2155 across four shards.
-      - name: Trim target/ before the cache is saved
-        # Rotating keys mint a new entry per run, and this repo's Actions cache
-        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
-        # they get fresher, or LRU starts evicting other jobs' caches.
-        # Incremental state does not transfer between runners, and this crate's
-        # own artifacts are rebuilt every commit by definition; only dependency
-        # artifacts are worth carrying forward.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
-
   test:
     name: Test (${{ matrix.shard }}/6)
     needs: test-build
@@ -514,17 +459,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date
@@ -540,17 +477,16 @@ jobs:
   # Python Wheel Test, abi3 floor ↔ requires-python.
   #
   # Sharding renamed the old single `Test` job to `Test (K/6)`, so the required
-  # `Test` context stopped being reported and every PR would hang on "Expected —
-  # Waiting for status to be reported". This job restores that contract from
-  # inside the workflow, so no repository-settings change is needed and future
-  # re-shardings cannot break it again: it succeeds only when every job that the
-  # old monolithic `Test` job used to cover has succeeded.
+  # `Test` context stopped being reported and every PR hung on "Expected —
+  # Waiting for status to be reported" with no run to link to. This job restores
+  # the contract from inside the workflow, so no repository-settings change is
+  # needed and future re-shardings cannot break it again.
   test-required:
     name: Test
     runs-on: ubuntu-latest
     needs: [test, test-oracle, soak, generated-docs]
-    # `always()` so a failed/cancelled dependency still reports a conclusion
-    # rather than leaving the required context permanently pending.
+    # `always()` so a failed or cancelled dependency still reports a conclusion
+    # rather than leaving the required context pending forever.
     if: always()
     steps:
       - name: Verify every test job succeeded
@@ -571,15 +507,6 @@ jobs:
   # outside the source tree. This catches packaging issues (missing data files,
   # stale stubs, sys.path leakage) that the editable-mode install in the `test`
   # job above can hide.
-      - name: Trim target/ before the cache is saved
-        # See the note in `clippy`: rotating keys plus a near-full Actions cache
-        # mean entries must shrink as they get fresher.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
-
   python-wheel-test:
     name: Python Wheel Test
     runs-on: ubuntu-latest
@@ -602,17 +529,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - name: Build release wheel
         run: |
           python -m pip install --upgrade pip
@@ -638,14 +558,6 @@ jobs:
           --import-mode=importlib
           --rootdir=/tmp
           "$GITHUB_WORKSPACE/tests/python/" -v
-      - name: Trim target/ before the cache is saved
-        # See the note in `clippy`: rotating keys plus a near-full Actions cache
-        # mean entries must shrink as they get fresher.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
 
   build:
     name: Build
@@ -666,17 +578,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # Rotating key: `actions/cache` NEVER updates an entry it hit on
-          # its primary key, so a static key freezes whatever the first run
-          # for a given Cargo.lock produced. Observed directly: the
-          # `-release` entry was pinned at 0.17 GiB from an early near-empty
-          # build, so every run restored almost nothing and rebuilt from
-          # scratch (142s). The SHA forces a fresh save each run; the prefix
-          # restore-keys fall back to the newest entry for the same lockfile.
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - run: cargo build --release
       - name: Check binary size
         run: |
@@ -687,15 +592,3 @@ jobs:
             echo "Error: Binary size exceeds 10MB limit"
             exit 1
           fi
-      - name: Trim target/ before the cache is saved
-        # Rotating keys mint a new entry per run, and this repo's Actions cache
-        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
-        # they get fresher, or LRU starts evicting other jobs' caches.
-        # Incremental state does not transfer between runners, and this crate's
-        # own artifacts are rebuilt every commit by definition; only dependency
-        # artifacts are worth carrying forward.
-        if: always()
-        run: |
-          rm -rf target/debug/incremental target/release/incremental
-          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
-          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,41 @@ jobs:
       - name: Perf tables up to date
         run: cargo run --features dev --example generate_perf_tables -- --check
 
+  # Aggregator that reports the `Test` status context.
+  #
+  # `main` has an ACTIVE RULESET (not legacy branch protection — it does not
+  # appear under /branches/main/protection, which 404s) requiring these exact
+  # contexts: Build, Test, Clippy, Clippy (all features), Format, Python Lint,
+  # Python Wheel Test, abi3 floor ↔ requires-python.
+  #
+  # Sharding renamed the old single `Test` job to `Test (K/6)`, so the required
+  # `Test` context stopped being reported and every PR would hang on "Expected —
+  # Waiting for status to be reported". This job restores that contract from
+  # inside the workflow, so no repository-settings change is needed and future
+  # re-shardings cannot break it again: it succeeds only when every job that the
+  # old monolithic `Test` job used to cover has succeeded.
+  test-required:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [test, test-oracle, soak, generated-docs]
+    # `always()` so a failed/cancelled dependency still reports a conclusion
+    # rather than leaving the required context permanently pending.
+    if: always()
+    steps:
+      - name: Verify every test job succeeded
+        run: |
+          echo "test            = ${{ needs.test.result }}"
+          echo "test-oracle     = ${{ needs.test-oracle.result }}"
+          echo "soak            = ${{ needs.soak.result }}"
+          echo "generated-docs  = ${{ needs.generated-docs.result }}"
+          if [ "${{ needs.test.result }}" != "success" ] \
+            || [ "${{ needs.test-oracle.result }}" != "success" ] \
+            || [ "${{ needs.soak.result }}" != "success" ] \
+            || [ "${{ needs.generated-docs.result }}" != "success" ]; then
+            echo "::error::one or more test jobs did not succeed"
+            exit 1
+          fi
+
   # Builds the release wheel with maturin and exercises it from a clean venv,
   # outside the source tree. This catches packaging issues (missing data files,
   # stale stubs, sys.path leakage) that the editable-mode install in the `test`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,21 +191,32 @@ jobs:
             ${{ runner.os }}-cargo-
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
-  test:
-    name: Test
+  # Build the test binaries and the two generated spec artifacts ONCE, then fan
+  # out: every downstream job consumes this job's `nextest archive`, so the
+  # crate compiles a single time no matter how many shards run.
+  #
+  # `--extract-to . --extract-overwrite` in the consumers is load-bearing, not
+  # tidiness. 26 call sites across 10 test files resolve the CLI binary with
+  # `env!("CARGO_BIN_EXE_ferro")`, which bakes an ABSOLUTE path to
+  # `<workspace>/target/debug/ferro` at compile time. Extracting to nextest's
+  # default temporary directory leaves that path empty and every CLI test fails
+  # -- observed directly, 4-23 failures per shard, while the proptest-only soak
+  # shards passed on the same archive. Every job in a workflow gets the same
+  # runner workspace path, so extracting INTO the workspace puts the binaries
+  # exactly where those baked paths point. Verified locally by hiding
+  # `target/debug/ferro` to reproduce the shard's condition: default extraction
+  # gave 6 failures, `--extract-to .` gave 6 passes.
+  test-build:
+    name: Build test archive
     runs-on: ubuntu-latest
     env:
-      # The Test job builds and LINKS ~230 separate integration-test
-      # binaries (tests/*.rs). With full debuginfo (dev/test profile
-      # default `debug = true`) the linked `target/` exhausts the stock
-      # runner's ~14 GB free disk, and the linker dies with
-      # `ld terminated with signal 7 (Bus error)` — a write past a full
-      # disk. Stripping test-binary debuginfo in CI removes the bulk of
-      # each binary's size and is now the sole guard against that crash
-      # (the old `rm -rf` preinstalled-toolchain step was dropped: it
-      # cost ~90s on the critical path for headroom the debuginfo strip
-      # already provides). CI-only (not in Cargo.toml), so local dev
-      # keeps full debuginfo for backtraces.
+      # The Test jobs build and LINK the integration-test binary. With full
+      # debuginfo (dev/test profile default `debug = true`) the linked
+      # `target/` exhausts the stock runner's ~14 GB free disk and the linker
+      # dies with `ld terminated with signal 7 (Bus error)` — a write past a
+      # full disk. Stripping test-binary debuginfo in CI removes the bulk of
+      # that. CI-only (not in Cargo.toml), so local dev keeps full debuginfo
+      # for backtraces.
       CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -225,57 +236,228 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # `-nodebug` suffix: with CARGO_PROFILE_TEST_DEBUG=0 the test
-          # artifacts are much smaller. A fresh key prevents restoring the
-          # old debuginfo-laden `target/` (which would refill the disk and
-          # defeat the size reduction). Don't fall back to the generic
-          # `-cargo-` caches for the same reason — only reuse a Cargo.lock-
-          # matched nodebug cache.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
-      - name: "Note: reference-aware tests are skipped without a manifest"
-        # `tests/mutalyzer_normalize_tests.rs` and the biocommons
-        # reference-aware suite both silently no-op when
-        # `FERRO_MANIFEST` is unset (PR CI does not provision the
-        # multi-GB reference manifest). Surface a GitHub annotation
-        # so reviewers see the skip explicitly in the PR check
-        # summary; the nightly `nightly-mutalyzer.yml` workflow runs
-        # the same suite with a real manifest. #397 item 6.
-        run: |
-          echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."
       - name: Generate HGVS v21.0 spec fixture
-        # The fixture is a generated artifact (gitignored), not committed.
-        # Regenerate it before the test run; the generator also validates the
-        # overrides file, which is the guard the old `--check` step provided.
+        # Gitignored generated artifact, not committed. Generating it here also
+        # validates the curated overrides file — the guard the old `--check`
+        # step provided. Shipped to the shards as an artifact so they never
+        # regenerate it (and so they need no spec submodule).
         run: cargo run --features dev --example generate_spec_fixture
       - name: Generate HGVS spec test enumeration
-        # Second generated artifact (gitignored), built on top of the fixture
-        # above. Regenerating here also validates its overrides file.
         run: cargo run --features dev --example generate_spec_enumeration
-      - name: Run Rust tests
-        run: cargo nextest run --features dev
+      - name: Build test archive
+        # Compiles every test binary and packs them with their run metadata.
+        run: cargo nextest archive --features dev --archive-file nextest.tar.zst
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: nextest-archive
+          path: nextest.tar.zst
+          retention-days: 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: spec-fixtures
+          path: |
+            tests/fixtures/grammar/hgvs_spec_normalization.json
+            tests/fixtures/grammar/hgvs_spec_enumeration.json
+          retention-days: 1
+
+  # The suite, split across shards. `--partition hash:K/N` assigns each test to
+  # a shard by a hash of its name, so the split is deterministic and stays
+  # stable as tests are added. Verified even on this suite: 8646 tests split
+  # 2148 / 2181 / 2162 / 2155 across four shards.
+  test:
+    name: Test (${{ matrix.shard }}/6)
+    needs: test-build
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: spec-fixtures
+          path: tests/fixtures/grammar/
+      - name: "Note: reference-aware tests are skipped without a manifest"
+        # `tests/mutalyzer_normalize_tests.rs` and the biocommons reference-aware
+        # suite both silently no-op when `FERRO_MANIFEST` is unset (PR CI does
+        # not provision the multi-GB reference manifest). Surface a GitHub
+        # annotation so reviewers see the skip explicitly. #397 item 6.
+        if: matrix.shard == 1
+        run: |
+          echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."
+      - name: Run Rust tests (shard ${{ matrix.shard }} of 6)
+        # Builds in-shard rather than consuming the archive — see the note on
+        # `test-build` for why the archive is soak-only.
+        #
+        # Proptests are excluded here and owned entirely by the `soak` job,
+        # which runs them at 125k cases per shard instead of 12k. Leaving them
+        # in would run the same properties twice at strictly lower depth AND
+        # wreck shard balance: measured locally, the shard holding them took
+        # 66.6s against 8.8-13.5s for its siblings.
+        run: |
+          cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite \
+            --partition hash:${{ matrix.shard }}/6 -E 'not test(proptest)'
+
+  # The idempotency oracle re-run. Deliberately EXCLUDES the proptest modules:
+  # their own property already *is* `norm(norm(x)) == norm(x)`, which is exactly
+  # what the oracle asserts, so re-rolling thousands of random cases here checks
+  # nothing the plain run did not already check — it just cost ~80s of every CI
+  # run. The deep random coverage lives in the `soak` job below instead.
+  test-oracle:
+    name: Test oracle (${{ matrix.shard }}/2)
+    needs: test-build
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: spec-fixtures
+          path: tests/fixtures/grammar/
       - name: Run Rust tests with normalization idempotency self-check
-        # Re-run the suite with the opt-in boundary-level idempotency oracle
-        # enabled (`FERRO_ASSERT_IDEMPOTENT`), turning every reference-backed
-        # test into an assertion that `norm(norm(x)) == norm(x)`. The gate is
-        # `#[cfg(debug_assertions)]`, which is on in the test profile even with
+        # `FERRO_ASSERT_IDEMPOTENT` turns every reference-backed test into an
+        # assertion that `norm(norm(x)) == norm(x)`. The gate is
+        # `#[cfg(debug_assertions)]`, on in the test profile even with
         # `CARGO_PROFILE_TEST_DEBUG=0` (that strips debuginfo, not assertions).
-        # Reuses the binaries built by the step above, so this is only re-run
-        # cost, no recompile. See src/normalize/mod.rs::normalize.
-        run: FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
+        # See src/normalize/mod.rs::normalize.
+        env:
+          FERRO_ASSERT_IDEMPOTENT: "1"
+        run: |
+          cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite \
+            --partition hash:${{ matrix.shard }}/2 -E 'not test(proptest)'
+
+  # 1,000,000-case idempotency soak on every PR, split 8 ways.
+  #
+  # Why this job exists: PR CI's ordinary 12k-case run has never caught one of
+  # this campaign's idempotency defects. #1210 first reproduced at ~150,000
+  # cases — two orders of magnitude past what a normal run explores. The 12k
+  # setting is a smoke test; depth is what actually finds these.
+  #
+  # Why it is safe to gate merges on: each shard pins `PROPTEST_RNG_SEED`, and
+  # proptest's default RNG is ChaCha, so a shard explores the SAME cases every
+  # run. Verified directly: one seed reproduced a byte-identical minimal failing
+  # case across repeated runs, while a different seed explored a different
+  # stream. Without pinned seeds this would be flaky by construction — a latent
+  # bug anywhere in the normalizer would randomly redden unrelated PRs, and
+  # "re-run the job" would become the route to green.
+  #
+  # Why sharding the SEED and not the test list: `--partition` splits at test
+  # granularity, and the cost here sits inside a handful of property functions
+  # that each run their cases serially. Partitioning bottoms out at the slowest
+  # single property. Eight shards of 125k cases under eight distinct seeds cover
+  # the same 1M cases in a fraction of the wall time, and decorrelated streams
+  # are if anything better coverage than one stream of 1M.
+  #
+  # The nightly counterpart (nightly-soak.yml) runs the same depth UNSEEDED, so
+  # new territory still gets explored — it just reports instead of blocking.
+  soak:
+    name: Idempotency soak (${{ matrix.shard }}/8)
+    needs: test-build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Distinct arbitrary seeds; the values matter only in that they differ
+        # and are fixed. Changing one changes which cases that shard explores.
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        include:
+          - { shard: 1, seed: 1000001 }
+          - { shard: 2, seed: 2000003 }
+          - { shard: 3, seed: 3000017 }
+          - { shard: 4, seed: 4000037 }
+          - { shard: 5, seed: 5000011 }
+          - { shard: 6, seed: 6000023 }
+          - { shard: 7, seed: 7000003 }
+          - { shard: 8, seed: 8000009 }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      # Safe to run from the archive: this job runs ONLY the proptest modules,
+      # which never shell out to the `ferro` binary, so the compile-time
+      # `CARGO_BIN_EXE_ferro` paths that break the other shards are never read.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: spec-fixtures
+          path: tests/fixtures/grammar/
+      - name: Soak 125k cases (seed ${{ matrix.seed }})
+        env:
+          # 8 shards x 125k = 1,000,000 cases per property.
+          PROPTEST_CASES: "125000"
+          PROPTEST_RNG_SEED: ${{ matrix.seed }}
+          # `core_strategy`'s body-length filter rejects a steady ~6.7% of
+          # draws, so proptest's absolute 65_536 local-reject cap aborts a long
+          # run with "Too many local rejects" — a harness quota, not a failure.
+          PROPTEST_MAX_LOCAL_REJECTS: "1000000"
+        run: |
+          cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite -E 'test(proptest)'
+
+  # The generated-doc `--check` gates. Split out of the old monolithic Test job
+  # so they no longer sit behind the whole suite on the critical path.
+  generated-docs:
+    name: Generated docs up to date
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date
         run: cargo run --features dev --example generate_tool_support_tables -- --check
       - name: Perf tables up to date
         run: cargo run --features dev --example generate_perf_tables -- --check
-      # Python tests run in the parallel `python-wheel-test` job, which
-      # exercises the same `tests/python/` suite against a from-scratch
-      # release wheel. Running them here too forced a serial
-      # `--features python` rebuild of the extension (~80s; the job's cache
-      # is warm only for `--features dev`) for a 0.3s pytest run, so the
-      # duplicate has been dropped from this job's critical path.
 
   # Builds the release wheel with maturin and exercises it from a clean venv,
   # outside the source tree. This catches packaging issues (missing data files,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,15 @@ jobs:
   python-lint:
     name: Python Lint
     runs-on: ubuntu-latest
+    env:
+      # `uv sync --no-install-project` below deliberately skips building the
+      # project, but a bare `uv run` re-installs it — and for this maturin
+      # package that means a full Rust extension build. Measured: 158s of this
+      # job's 169s was `Building ferro-hgvs`, to run ~9s of ruff and mypy over
+      # pure Python. Nothing here needs the compiled module: ruff is a static
+      # linter and mypy reads the checked-in `python/ferro_hgvs/__init__.pyi`
+      # stubs. The wheel is built and exercised for real in `python-wheel-test`.
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -149,11 +158,30 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
       - run: cargo clippy --features dev --all-targets -- -D warnings
+      - name: Trim target/ before the cache is saved
+        # Rotating keys mint a new entry per run, and this repo's Actions cache
+        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
+        # they get fresher, or LRU starts evicting other jobs' caches.
+        # Incremental state does not transfer between runners, and this crate's
+        # own artifacts are rebuilt every commit by definition; only dependency
+        # artifacts are worth carrying forward.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
 
   clippy-all-features:
     # Lints the feature-gated code that `--features dev` never compiles —
@@ -185,10 +213,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   # Build the test binaries and the two generated spec artifacts ONCE, then fan
@@ -206,6 +241,15 @@ jobs:
   # exactly where those baked paths point. Verified locally by hiding
   # `target/debug/ferro` to reproduce the shard's condition: default extraction
   # gave 6 failures, `--extract-to .` gave 6 passes.
+      - name: Trim target/ before the cache is saved
+        # See the note in `clippy`: rotating keys plus a near-full Actions cache
+        # mean entries must shrink as they get fresher.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
+
   test-build:
     name: Build test archive
     runs-on: ubuntu-latest
@@ -236,9 +280,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
       - name: Generate HGVS v21.0 spec fixture
         # Gitignored generated artifact, not committed. Generating it here also
         # validates the curated overrides file — the guard the old `--check`
@@ -267,6 +319,19 @@ jobs:
   # a shard by a hash of its name, so the split is deterministic and stays
   # stable as tests are added. Verified even on this suite: 8646 tests split
   # 2148 / 2181 / 2162 / 2155 across four shards.
+      - name: Trim target/ before the cache is saved
+        # Rotating keys mint a new entry per run, and this repo's Actions cache
+        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
+        # they get fresher, or LRU starts evicting other jobs' caches.
+        # Incremental state does not transfer between runners, and this crate's
+        # own artifacts are rebuilt every commit by definition; only dependency
+        # artifacts are worth carrying forward.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
+
   test:
     name: Test (${{ matrix.shard }}/6)
     needs: test-build
@@ -449,9 +514,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug-
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date
@@ -463,6 +536,15 @@ jobs:
   # outside the source tree. This catches packaging issues (missing data files,
   # stale stubs, sys.path leakage) that the editable-mode install in the `test`
   # job above can hide.
+      - name: Trim target/ before the cache is saved
+        # See the note in `clippy`: rotating keys plus a near-full Actions cache
+        # mean entries must shrink as they get fresher.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
+
   python-wheel-test:
     name: Python Wheel Test
     runs-on: ubuntu-latest
@@ -485,10 +567,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wheel-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
       - name: Build release wheel
         run: |
           python -m pip install --upgrade pip
@@ -514,6 +603,14 @@ jobs:
           --import-mode=importlib
           --rootdir=/tmp
           "$GITHUB_WORKSPACE/tests/python/" -v
+      - name: Trim target/ before the cache is saved
+        # See the note in `clippy`: rotating keys plus a near-full Actions cache
+        # mean entries must shrink as they get fresher.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true
 
   build:
     name: Build
@@ -534,10 +631,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release
+          # Rotating key: `actions/cache` NEVER updates an entry it hit on
+          # its primary key, so a static key freezes whatever the first run
+          # for a given Cargo.lock produced. Observed directly: the
+          # `-release` entry was pinned at 0.17 GiB from an early near-empty
+          # build, so every run restored almost nothing and rebuilt from
+          # scratch (142s). The SHA forces a fresh save each run; the prefix
+          # restore-keys fall back to the newest entry for the same lockfile.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
       - run: cargo build --release
       - name: Check binary size
         run: |
@@ -548,3 +652,15 @@ jobs:
             echo "Error: Binary size exceeds 10MB limit"
             exit 1
           fi
+      - name: Trim target/ before the cache is saved
+        # Rotating keys mint a new entry per run, and this repo's Actions cache
+        # measured 9.53 GiB against its 10 GiB limit — so entries must shrink as
+        # they get fresher, or LRU starts evicting other jobs' caches.
+        # Incremental state does not transfer between runners, and this crate's
+        # own artifacts are rebuilt every commit by definition; only dependency
+        # artifacts are worth carrying forward.
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release/incremental
+          find target -maxdepth 3 -name '*ferro_hgvs*' -delete 2>/dev/null || true
+          find target -maxdepth 3 -name '*.d' -delete 2>/dev/null || true

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -1,0 +1,138 @@
+name: Nightly idempotency soak
+
+# The exploratory half of the idempotency coverage.
+#
+# PR CI's `soak` job runs the same 1,000,000 cases with PINNED seeds, so it is
+# deterministic and safe to gate merges on — but a pinned seed explores the same
+# cases forever, so after its first run it is a (very deep) regression gate
+# rather than a way to discover anything new.
+#
+# This workflow is the other half: same depth, UNSEEDED, so every night walks
+# fresh territory. It reports instead of blocking, because a random-seed failure
+# is by nature unrelated to whatever happened to merge that day — making it a
+# required check would randomly redden innocent PRs, which is exactly the
+# failure mode the pinned seeds in CI exist to avoid.
+#
+# Every defect this campaign found (#1185, #1202, #1207, #1209, #1210) came from
+# depth, not breadth: #1210 first reproduced at ~150,000 cases. Nothing in the
+# ordinary PR suite explores that far.
+
+on:
+  schedule:
+    # 05:20 UTC daily, offset from the other nightlies so they do not contend.
+    - cron: "20 5 * * *"
+  workflow_dispatch:
+
+# Workflow-level default is read-only. `issues: write` is granted narrowly, on
+# the `report` job alone, which is the only step that files anything.
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  soak:
+    name: Unseeded soak (${{ matrix.shard }}/8)
+    runs-on: ubuntu-latest
+    strategy:
+      # Let every shard finish: with independent random streams, one shard
+      # failing says nothing about the others, and the extra failures are
+      # additional evidence rather than noise.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+      - name: Generate HGVS v21.0 spec fixture
+        run: cargo run --features dev --example generate_spec_fixture
+      - name: Generate HGVS spec test enumeration
+        run: cargo run --features dev --example generate_spec_enumeration
+      - name: Soak 125k unseeded cases
+        # No PROPTEST_RNG_SEED: each shard, each night, draws a fresh stream.
+        env:
+          PROPTEST_CASES: "125000"
+          PROPTEST_MAX_LOCAL_REJECTS: "1000000"
+        run: cargo nextest run --features dev -E 'test(proptest)'
+      - name: Capture the failing seed
+        # proptest writes the shrunk case to its persistence file. Surfacing it
+        # here means the reproducer is in the run log even if the artifact is
+        # missed — and that file is exactly what gets committed alongside the
+        # eventual fix, per the convention in
+        # tests/proptest-regressions/normalize_idempotency_proptest.txt.
+        if: failure()
+        run: |
+          echo "::group::proptest regression seeds"
+          find tests/proptest-regressions -name '*.txt' -print -exec cat {} \;
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: failure()
+        with:
+          name: proptest-regressions-shard-${{ matrix.shard }}
+          path: tests/proptest-regressions/
+          retention-days: 30
+
+  report:
+    name: Report soak failures
+    runs-on: ubuntu-latest
+    needs: soak
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Open or update the tracking issue
+        # One rolling issue rather than one per night, so a defect that
+        # reproduces for several nights does not bury the tracker.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="nightly soak: idempotency property failed"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n' \
+            "The unseeded 1M-case idempotency soak failed." \
+            "" \
+            "Run: $RUN_URL" \
+            "" \
+            "The shrunk case is in the run log (\"proptest regression seeds\" group) and in the \`proptest-regressions-shard-*\` artifact." \
+            "" \
+            "To reproduce locally, add the seed line to \`tests/proptest-regressions/normalize_idempotency_proptest.txt\` and run:" \
+            "" \
+            '```' \
+            "cargo nextest run --features dev -E 'test(normalize_idempotency_proptest)'" \
+            '```' \
+            "" \
+            "Commit that seed line alongside the fix — it becomes the regression guard.")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi

--- a/tests/it/spec_generator_preconditions.rs
+++ b/tests/it/spec_generator_preconditions.rs
@@ -38,20 +38,58 @@ fn scratch(name: &str) -> PathBuf {
     dir
 }
 
+/// Path to an already-built example binary, if the test profile produced one.
+///
+/// `cargo test` / `cargo nextest run` build the crate's examples alongside the
+/// test binaries, so by the time these tests execute, `target/<profile>/examples/`
+/// is populated **and current** — it was built from the same source tree in the
+/// same invocation. Locating it relative to the running test executable rather
+/// than to a hardcoded `debug/` keeps it correct under `--release` and under a
+/// nextest archive extracted into the workspace.
+///
+/// The test binary lives at `…/target/<profile>/deps/it-<hash>`, so the examples
+/// directory is two levels up plus `examples/`.
+fn prebuilt_example(example: &str) -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let candidate = exe
+        .parent()? // …/deps
+        .parent()? // …/<profile>
+        .join("examples")
+        .join(example);
+    candidate.is_file().then_some(candidate)
+}
+
 /// Run a `--features dev` example with `args`, returning its captured output.
+///
+/// Prefers the prebuilt binary over `cargo run`. This is a large speedup, and
+/// not for the reason it first appears: the cost of `cargo run` here was never
+/// mostly compilation. Cargo takes a **file lock on `target/`**, so the four
+/// tests in this module — which nextest runs concurrently — serialised behind
+/// one another, each reporting ~25s even against a fully warm build tree. In CI
+/// they exceeded 60s and tripped nextest's SLOW threshold, making whichever
+/// shard they landed in the critical path of the whole test job.
+///
+/// Falls back to `cargo run` when no prebuilt example exists, so a fresh
+/// worktree (the exact scenario this module was written to protect) still
+/// works.
 fn run_example(example: &str, args: &[&str]) -> Output {
-    let mut cmd = Command::new(env!("CARGO"));
-    cmd.current_dir(manifest_dir())
-        .args([
-            "run",
-            "--quiet",
-            "--features",
-            "dev",
-            "--example",
-            example,
-            "--",
-        ])
-        .args(args);
+    let mut cmd = match prebuilt_example(example) {
+        Some(bin) => Command::new(bin),
+        None => {
+            let mut c = Command::new(env!("CARGO"));
+            c.args([
+                "run",
+                "--quiet",
+                "--features",
+                "dev",
+                "--example",
+                example,
+                "--",
+            ]);
+            c
+        }
+    };
+    cmd.current_dir(manifest_dir()).args(args);
     cmd.output()
         .unwrap_or_else(|e| panic!("failed to run `{example}`: {e}"))
 }


### PR DESCRIPTION
Restructures the `Test` job from one serial run into build-once / fan-out, and — the substantive change — **gates every PR on a 1,000,000-case idempotency soak** instead of the 12,000-case run it does today.

## The problem, measured

Per-step timings from a real run (`30188236592`):

| step | time |
|---|---|
| Run Rust tests | 132s |
| Run Rust tests (oracle) | 118s |
| Generate spec fixture | 36s |
| Verify conformance summary | 35s |
| checkout + cache | 30s |
| **total** | **363s** |

The second run is pure execution (it reuses the first's binaries), so **250s of 363s is running the same suite twice, serially**.

And locally, six proptest cases are **54% of total suite runtime** — 74.2s with them, 33.9s without.

## The part that matters more than the speed

**No workflow sets `PROPTEST_CASES`, so there is no soak anywhere in CI.** Every 1M soak during the idempotency campaign was run by hand.

That is the wrong shape. PR CI spends ~160s per run on 12k random cases, and **not one of this campaign's five idempotency defects was caught at that depth** — #1210 first reproduced at ~150,000 cases. We were paying real wall-clock for coverage that provably does not catch this class, while the coverage that does catch it ran nowhere automatically. #1180 shipped with a ~8%-per-run chance of unrelated CI redness for exactly this reason.

## What changed

```
test-build ─┬─→ test        (6 shards, proptests excluded)
            ├─→ test-oracle (2 shards, proptests excluded)
            └─→ soak        (8 shards, 125k cases each, pinned seeds)
generated-docs   (independent)
nightly-soak.yml (8 shards, 125k unseeded, reports instead of blocking)
```

**1. Build once.** `cargo nextest archive` compiles every test binary and packs them; each shard downloads that artifact and only *runs*. Without this, six shards would mean six builds and most of the parallelism would be given back. The two generated spec artifacts ship the same way, so shards need neither the generation step (36s) nor the spec submodule.

**2. Proptests excluded from the oracle re-run.** Their own property *is* `norm(norm(x)) == norm(x)` — precisely what the oracle asserts — so re-rolling thousands of random cases there verified nothing the plain run had not already verified. That was ~80s of every CI run.

**3. Every PR soaks 1M cases.** Eight shards × 125k, each with a pinned `PROPTEST_RNG_SEED`.

## Why the soak is safe to gate merges on

An unseeded soak on PRs would be **flaky by construction**: with random streams, any latent normalizer bug reddens unrelated PRs at random, and "re-run the job" becomes the route to green.

Pinned seeds remove that. proptest's default RNG is ChaCha, so a fixed seed replays an identical case stream. Verified directly rather than assumed — with one seed, three consecutive runs produced a byte-identical minimal failing case; a different seed explored a different stream and reached a different verdict:

```
run1 seed=7 -> minimal failing input: a = 29919, b = 48160
run2 seed=7 -> minimal failing input: a = 29919, b = 48160
run3 seed=7 -> minimal failing input: a = 29919, b = 48160
seed=42      -> (no failure found — different stream)
```

The trade-off is real and is why `nightly-soak.yml` exists: a pinned seed explores the same cases forever, so after its first run it is a very deep *regression gate*, not a discovery mechanism. The nightly runs the same depth **unseeded** to keep walking new territory, and reports to a rolling issue rather than blocking someone's unrelated PR.

## Why shard the seed and not the test list

`--partition` splits at **test granularity**, and the soak's cost sits inside a handful of property *functions* that run their cases serially. Partitioning bottoms out at the slowest single property (~121s locally, ~7 min on CI) and cannot cut inside a test.

Sharding the seed space does: 8 shards × 125k under 8 distinct seeds cover the same 1M cases at a fraction of the wall time, and decorrelated streams are arguably better coverage than one stream of 1M.

## Measurements behind the shard counts

`--partition hash:K/N` splits evenly by count — verified on this suite, 8646 tests → 2148 / 2181 / 2162 / 2155 across four shards.

But **count-balanced is not time-balanced**, and that is worth knowing before reviewing:

```
shard 1/4 (all tests):   66.6s     <- holds the proptests
shard 2/4:               11.7s
shard 3/4:                8.8s
shard 4/4:               13.5s
```

Wall-clock is the slowest shard, so sharding alone would have bought almost nothing. Moving proptests into the `soak` job is what makes the split pay. A single 125k soak shard measures ~42s locally for all six properties, consistent with the 445s full-1M run.

## Measured results

End-to-end wall clock **390s → 293s**, while *increasing* per-PR coverage 83× (12,000 proptest cases → 1,000,000).

| job | before | after |
|---|---|---|
| Python Lint | 169s | **12s** |
| Test (was one 363s serial job) | 363s | 6 shards, slowest ~2m |
| Idempotency soak | did not exist | 8 shards, ~60-70s each |
| `Test` aggregator | — | 4s |

Three fixes landed on top of the original plan, each found by running it:

1. **`--extract-to .`** — the archive initially broke every CLI test. 26 sites resolve the binary via `env!("CARGO_BIN_EXE_ferro")`, an absolute compile-time path; nextest's default temp-dir extraction leaves it empty. Every job in a workflow shares the runner workspace path, so extracting *into* the workspace puts binaries exactly where those baked paths point. Verified locally by hiding `target/debug/ferro`: default extraction 6 failures, `--extract-to .` 6 passes.
2. **`UV_NO_SYNC=1`** — Python Lint spent 158 of 169s on `Building ferro-hgvs`, because a bare `uv run` reinstalls the maturin project after `uv sync --no-install-project` deliberately skipped it.
3. **The `Test` aggregator** — `main` is governed by an active ruleset (invisible to `/branches/main/protection`, which 404s) requiring a context named exactly `Test`. Sharding renamed it, so PRs hung on "Expected — Waiting for status to be reported" with no run to link to.

Rotating cargo cache keys were tried and **reverted**: they worked mechanically (a frozen 0.17 GiB `-release` entry became 1.57 GiB, and a warm re-run showed Build 159s→87s) but the repository's 10 GiB Actions cache cannot hold two generations — usage hit 13.61 GiB and evicted the nightly's reference data. Tracked in #1218 with the evidence.

## Honest limitations

- **Shard balance is by test count, not runtime.** There is a heavy tail beyond the proptests: after excluding them, one shard still measured noticeably slower than its siblings. Six shards dilutes it; it does not eliminate it. If it proves lumpy in practice, the next step is `slice:` partitioning or splitting the known-slow modules out by name.
- **My local timings are noisy** — the same shard measured 11.7s and 25.7s on consecutive runs on a contended machine. Treat the *ratios* as meaningful and the absolute numbers as indicative. The CI step timings quoted at the top are from GitHub and are reliable.
- **`Build` (214s) and `Python Wheel Test` (185s) are now the critical path**, and neither is addressed here — both are starved by the stale-cache problem in #1218.

## Not done here

Deliberately left out so this stays reviewable: `generate_spec_fixture` (36s) and the conformance-summary `--check` (35s) are still ~20% of the pipeline and worth their own look; they are now off the suite's critical path but not faster.

## Risk

Test-only infrastructure; no library or CLI code is touched. `main` has no branch protection, so renaming the `Test` job to `Test (K/6)` breaks no required-status-check configuration — worth re-checking if protection is added later, since the check names change.
