### PR TITLE
fix(test): stop spec_generator_preconditions running a stale example binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,25 @@ jobs:
       - name: Build test archive
         # Compiles every test binary and packs them with their run metadata.
         run: cargo nextest archive --features dev --archive-file nextest.tar.zst
+      - name: Stage the generator examples for the shards
+        # `spec_generator_preconditions` executes these two binaries. nextest
+        # does NOT build examples, so the shards cannot rely on finding them,
+        # and they must not shell out to cargo either (they run from the
+        # archive with no build state). Both were already built and run by the
+        # generate steps above, so ship them alongside the archive.
+        run: |
+          mkdir -p staged-examples
+          cp target/debug/examples/generate_spec_fixture \
+             target/debug/examples/generate_spec_enumeration staged-examples/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive
           path: nextest.tar.zst
+          retention-days: 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: generator-examples
+          path: staged-examples/
           retention-days: 1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -300,6 +315,13 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: generator-examples
+          path: target/debug/examples/
+      - name: Restore the executable bit on the staged examples
+        # Artifact upload does not preserve the executable bit.
+        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
       - name: "Note: reference-aware tests are skipped without a manifest"
         # `tests/mutalyzer_normalize_tests.rs` and the biocommons reference-aware
         # suite both silently no-op when `FERRO_MANIFEST` is unset (PR CI does
@@ -317,6 +339,11 @@ jobs:
         # in would run the same properties twice at strictly lower depth AND
         # wreck shard balance: measured locally, the shard holding them took
         # 66.6s against 8.8-13.5s for its siblings.
+        env:
+          # The staged binaries above are current by construction (built and run
+          # by `test-build` from this same commit), so the tests must use them
+          # rather than shelling out to cargo, which has no build state here.
+          FERRO_PREBUILT_EXAMPLES: "1"
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
@@ -350,6 +377,13 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: generator-examples
+          path: target/debug/examples/
+      - name: Restore the executable bit on the staged examples
+        # Artifact upload does not preserve the executable bit.
+        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
       - name: Run Rust tests with normalization idempotency self-check
         # `FERRO_ASSERT_IDEMPOTENT` turns every reference-backed test into an
         # assertion that `norm(norm(x)) == norm(x)`. The gate is
@@ -358,6 +392,7 @@ jobs:
         # See src/normalize/mod.rs::normalize.
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
+          FERRO_PREBUILT_EXAMPLES: "1"
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
@@ -422,6 +457,13 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: generator-examples
+          path: target/debug/examples/
+      - name: Restore the executable bit on the staged examples
+        # Artifact upload does not preserve the executable bit.
+        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
       - name: Soak 125k cases (seed ${{ matrix.seed }})
         env:
           # 8 shards x 125k = 1,000,000 cases per property.
@@ -431,6 +473,7 @@ jobs:
           # draws, so proptest's absolute 65_536 local-reject cap aborts a long
           # run with "Too many local rejects" — a harness quota, not a failure.
           PROPTEST_MAX_LOCAL_REJECTS: "1000000"
+          FERRO_PREBUILT_EXAMPLES: "1"
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite -E 'test(proptest)'

--- a/tests/it/spec_generator_preconditions.rs
+++ b/tests/it/spec_generator_preconditions.rs
@@ -38,59 +38,101 @@ fn scratch(name: &str) -> PathBuf {
     dir
 }
 
-/// Path to an already-built example binary, if the test profile produced one.
+/// Build the two generator examples exactly once per test binary, and return
+/// the path to the requested one.
 ///
-/// `cargo test` / `cargo nextest run` build the crate's examples alongside the
-/// test binaries, so by the time these tests execute, `target/<profile>/examples/`
-/// is populated **and current** — it was built from the same source tree in the
-/// same invocation. Locating it relative to the running test executable rather
-/// than to a hardcoded `debug/` keeps it correct under `--release` and under a
-/// nextest archive extracted into the workspace.
+/// # Why not just `cargo run --example`
 ///
-/// The test binary lives at `…/target/<profile>/deps/it-<hash>`, so the examples
-/// directory is two levels up plus `examples/`.
-fn prebuilt_example(example: &str) -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let candidate = exe
-        .parent()? // …/deps
-        .parent()? // …/<profile>
-        .join("examples")
-        .join(example);
-    candidate.is_file().then_some(candidate)
-}
+/// That is what this module did originally, and it was pathologically slow —
+/// but not for the reason it looks like. Cargo takes a **file lock on
+/// `target/`**, so the four tests here, which nextest runs concurrently,
+/// serialised behind one another: each reported ~25s even against a fully warm
+/// build tree, and in CI they blew past nextest's 60s SLOW threshold and made
+/// whichever shard held them the critical path of the whole test job.
+///
+/// # Why not just invoke `target/<profile>/examples/<name>` directly
+///
+/// Tried, and it is **wrong**. `cargo test` / `cargo nextest run` do *not*
+/// rebuild examples, so the binary sitting in `examples/` can be arbitrarily
+/// old. Observed directly: a `generate_spec_enumeration` binary from the
+/// previous day produced the pre-#1201 error message, and this module's test
+/// for #1201's guard failed against source that unmistakably contained it. A
+/// stale binary makes these tests assert things about code that is not the code
+/// under test — a far worse failure than being slow.
+///
+/// # What this does
+///
+/// One `cargo build` for both examples, behind a `Once`, then direct execution.
+/// The build is current by construction, and it happens exactly once no matter
+/// how many tests run concurrently — so the cargo lock is taken once rather
+/// than per test, which is where the speedup comes from.
+///
+/// `FERRO_PREBUILT_EXAMPLES` skips even that single build, for the one context
+/// where the binaries are known-current and cargo is unavailable: CI's sharded
+/// test jobs, which run from a nextest archive after `test-build` has already
+/// built and executed both generators.
+fn built_example(example: &str) -> PathBuf {
+    static BUILD: std::sync::Once = std::sync::Once::new();
+    static BUILD_OK: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-/// Run a `--features dev` example with `args`, returning its captured output.
-///
-/// Prefers the prebuilt binary over `cargo run`. This is a large speedup, and
-/// not for the reason it first appears: the cost of `cargo run` here was never
-/// mostly compilation. Cargo takes a **file lock on `target/`**, so the four
-/// tests in this module — which nextest runs concurrently — serialised behind
-/// one another, each reporting ~25s even against a fully warm build tree. In CI
-/// they exceeded 60s and tripped nextest's SLOW threshold, making whichever
-/// shard they landed in the critical path of the whole test job.
-///
-/// Falls back to `cargo run` when no prebuilt example exists, so a fresh
-/// worktree (the exact scenario this module was written to protect) still
-/// works.
-fn run_example(example: &str, args: &[&str]) -> Output {
-    let mut cmd = match prebuilt_example(example) {
-        Some(bin) => Command::new(bin),
-        None => {
-            let mut c = Command::new(env!("CARGO"));
-            c.args([
-                "run",
+    // CI builds both examples in the `test-build` job (it runs them to generate
+    // the spec artifacts) and sets this variable, so the sharded test jobs —
+    // which execute from a nextest archive and have no cargo build state at all
+    // — must not shell out to cargo. A cargo invocation there would rebuild the
+    // world per shard.
+    let prebuilt = std::env::var_os("FERRO_PREBUILT_EXAMPLES").is_some();
+
+    BUILD.call_once(|| {
+        if prebuilt {
+            BUILD_OK.store(true, std::sync::atomic::Ordering::SeqCst);
+            return;
+        }
+        let status = Command::new(env!("CARGO"))
+            .current_dir(manifest_dir())
+            .args([
+                "build",
                 "--quiet",
                 "--features",
                 "dev",
                 "--example",
-                example,
-                "--",
-            ]);
-            c
-        }
-    };
-    cmd.current_dir(manifest_dir()).args(args);
-    cmd.output()
+                "generate_spec_fixture",
+                "--example",
+                "generate_spec_enumeration",
+            ])
+            .status();
+        let ok = matches!(status, Ok(s) if s.success());
+        BUILD_OK.store(ok, std::sync::atomic::Ordering::SeqCst);
+    });
+    assert!(
+        BUILD_OK.load(std::sync::atomic::Ordering::SeqCst),
+        "failed to build the generator examples"
+    );
+
+    // The test binary lives at `…/target/<profile>/deps/it-<hash>`, so the
+    // examples directory is two levels up. Deriving it from `current_exe`
+    // rather than hardcoding `debug/` keeps this correct under `--release` and
+    // under a nextest archive extracted into the workspace.
+    let exe = std::env::current_exe().expect("current_exe");
+    let path = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("target/<profile>")
+        .join("examples")
+        .join(example);
+    assert!(
+        path.is_file(),
+        "expected a freshly built example at {}",
+        path.display()
+    );
+    path
+}
+
+/// Run a `--features dev` example with `args`, returning its captured output.
+fn run_example(example: &str, args: &[&str]) -> Output {
+    Command::new(built_example(example))
+        .current_dir(manifest_dir())
+        .args(args)
+        .output()
         .unwrap_or_else(|e| panic!("failed to run `{example}`: {e}"))
 }
 


### PR DESCRIPTION
Fixes a correctness regression I introduced in #1216.

## The bug

#1216 changed this module to invoke `target/<profile>/examples/<name>` directly instead of `cargo run --example`, justified by this claim:

> `cargo test` / `cargo nextest run` build the crate's examples alongside the test binaries, so by the time these tests execute, `target/<profile>/examples/` is populated **and current**.

**That is false — nextest does not build examples.** The binary can be arbitrarily old.

Caught on the very next PR to rebase onto `main`. `spec_generator_preconditions::empty_spec_checkout_is_rejected_by_the_enumeration_generator_too` failed with the **pre-#1201** error message (`overrides.repairs references inputs that are not spec-stated negatives`) against a tree that unmistakably contains #1201's guard:

```
generate_spec_enumeration   Jul 25 00:43   <- stale
generate_spec_fixture       Jul 25 23:55
```

The tests were asserting things about code that was not the code under test. That is strictly worse than the slowness #1216 set out to fix — a slow test tells the truth.

## The fix

Build both examples exactly **once** per test binary behind a `Once`, then execute them directly.

This keeps the real source of #1216's speedup, which was never about avoiding compilation: cargo takes a **file lock on `target/`**, so four concurrently-running tests each invoking `cargo run` serialised behind one another. Taking that lock once instead of four times is the win. Currency is now guaranteed rather than assumed.

## The CI half

The sharded test jobs run from a nextest archive with no cargo build state, so a cargo invocation there would rebuild the world *per shard* — much worse than the original problem. `test-build` already builds and runs both generators, so it now stages them as an artifact the shards restore, with `FERRO_PREBUILT_EXAMPLES` telling the tests to use them without consulting cargo.

Two paths, both correct:

| context | mechanism | module wall time |
|---|---|---|
| local | one `cargo build` behind `Once` | **16.2s** (was 26s) |
| CI shards | staged artifact, no cargo | **0.91s** |

## Verification

- Both modes exercised locally: default path 6/6 pass in 16.2s; `FERRO_PREBUILT_EXAMPLES=1` 6/6 pass in 0.91s.
- Full suite **8651 passed, 0 failed**; clippy and fmt clean.
- The staleness itself is now impossible to reintroduce silently: the prebuilt path asserts the binary exists, and is only taken when CI explicitly declares it fresh.

## Lesson worth keeping

The original change was measured for speed and not for correctness — I confirmed it was faster and assumed it was equivalent. The assumption was load-bearing, unstated in any test, and wrong. The comment in the new code records why the obvious shortcut is unsafe, so the next person does not retry it.