### PR TITLE
fix(project): surface the engine's own reason for an unavailable axis

### DIFF
--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -129,12 +129,15 @@ fn engine_error_is_unavailable(e: &FerroError) -> bool {
 /// Read the chosen axis off a completed projection, rendering its HGVS string
 /// or reporting it unavailable.
 pub fn select_axis(projection: &VariantProjection, axis: Axis) -> AxisOutcome {
-    let field = match axis {
-        Axis::Genomic => &projection.genomic,
-        Axis::Coding => &projection.coding,
-        Axis::Noncoding => &projection.noncoding,
-        Axis::Protein => &projection.protein,
-        Axis::Rna => &projection.rna,
+    let declines = &projection.axis_decline_reasons;
+    // Read the axis and its recorded decline reason together, so the reason can
+    // never be taken from a *different* axis than the one being reported.
+    let (field, decline) = match axis {
+        Axis::Genomic => (&projection.genomic, &declines.genomic),
+        Axis::Coding => (&projection.coding, &declines.coding),
+        Axis::Noncoding => (&projection.noncoding, &declines.noncoding),
+        Axis::Protein => (&projection.protein, &declines.protein),
+        Axis::Rna => (&projection.rna, &declines.rna),
     };
     let tx = projection.transcript_id.clone();
     // #1182: the projection's normalization warnings were read off nowhere and
@@ -150,9 +153,37 @@ pub fn select_axis(projection: &VariantProjection, axis: Axis) -> AxisOutcome {
         },
         None => AxisOutcome::Unavailable {
             transcript_id: Some(tx),
-            reason: format!("no {}. representation for this variant", axis.code()),
+            reason: unavailable_reason(axis, decline.as_deref()),
             warnings,
         },
+    }
+}
+
+/// Phrase why `axis` is unavailable.
+///
+/// The engine's own explanation *replaces* the synthesized string when one was
+/// recorded (#1198). The synthesized string is derived from nothing but the axis
+/// code, so it restates what both output formats already say — text writes
+/// `[<axis>]: unavailable:` and JSON carries `"axis"` plus
+/// `"status": "unavailable"` — while the real explanation was computed, logged
+/// at `trace`, and dropped.
+///
+/// With no recorded explanation the wording is unchanged. An axis can be absent
+/// because it was never applicable, or because its decline is not one the
+/// projector records (see [`crate::project::AxisDeclineReasons`]) — and
+/// inventing a cause for
+/// either would trade one generic answer for a wrong one.
+///
+/// This does **not** widen what exits 0. Which errors are a clean decline is
+/// decided by [`engine_error_is_unavailable`] for a failed *projection*, and by
+/// the projector's best-effort axis contract for a failed *axis* — an
+/// underivable axis has always been reported as unavailable at exit 0, whatever
+/// its error's class, so that the other four axes survive. This function only
+/// changes what that record says, never whether it is emitted.
+fn unavailable_reason(axis: Axis, decline: Option<&str>) -> String {
+    match decline {
+        Some(explanation) => explanation.to_string(),
+        None => format!("no {}. representation for this variant", axis.code()),
     }
 }
 
@@ -263,7 +294,7 @@ mod tests {
     use super::*;
     use crate::data::cdot::{CdotMapper, CdotTranscript};
     use crate::data::projection::Projector;
-    use crate::project::VariantProjection;
+    use crate::project::{AxisDeclineReasons, VariantProjection};
     use crate::reference::mock::MockProvider;
     use crate::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
     use crate::reference::Strand;
@@ -322,6 +353,7 @@ mod tests {
             is_intronic: false,
             is_utr: false,
             affects_init: false,
+            axis_decline_reasons: AxisDeclineReasons::default(),
         }
     }
 
@@ -377,6 +409,75 @@ mod tests {
             AxisOutcome::Rendered { warnings, .. } => assert!(warnings.is_empty()),
             other => panic!("expected Rendered, got {other:?}"),
         }
+    }
+
+    /// #1198: when the engine recorded *why* an axis declined, that explanation
+    /// must reach the outcome — verbatim, and *instead of* the string
+    /// synthesized from the axis code alone. Decorating it with the synthesized
+    /// string would put the axis and its unavailability into the reason twice
+    /// over, since both output formats already state each of them.
+    #[test]
+    fn select_axis_surfaces_a_recorded_decline_reason_verbatim() {
+        let engine_explanation =
+            "transcript position n.0 (start) is outside NM_000088.3: `n.` numbering starts at 1";
+        let mut proj = projection_with(None, None);
+        proj.axis_decline_reasons.noncoding = Some(engine_explanation.to_string());
+        match select_axis(&proj, Axis::Noncoding) {
+            AxisOutcome::Unavailable { reason, .. } => {
+                assert!(
+                    !reason.contains("representation for this variant"),
+                    "the synthesized string must be replaced, not decorated; got {reason:?}"
+                );
+                assert_eq!(reason, engine_explanation);
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    /// A reason recorded for one axis must not be reported against another —
+    /// the whole point is that the explanation is *this* axis's, so borrowing
+    /// it would be a new way of lying about the cause.
+    #[test]
+    fn select_axis_does_not_borrow_another_axis_decline_reason() {
+        let mut proj = projection_with(None, None);
+        proj.axis_decline_reasons.noncoding = Some("the n. axis's own problem".to_string());
+        match select_axis(&proj, Axis::Protein) {
+            AxisOutcome::Unavailable { reason, .. } => {
+                assert_eq!(reason, "no p. representation for this variant");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    /// With nothing recorded the wording is unchanged: most absent axes were
+    /// never applicable to the input, and inventing a cause would be worse than
+    /// saying nothing.
+    #[test]
+    fn select_axis_keeps_the_generic_reason_when_nothing_was_recorded() {
+        let proj = projection_with(None, None);
+        match select_axis(&proj, Axis::Noncoding) {
+            AxisOutcome::Unavailable { reason, .. } => {
+                assert_eq!(reason, "no n. representation for this variant");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    /// The axis value, not the presence of a reason, decides which outcome you
+    /// get. Checking the reason first — plausible, since it is the new input to
+    /// this function — would report a rendered axis as unavailable.
+    #[test]
+    fn a_decline_reason_does_not_override_a_rendered_axis() {
+        let mut proj = projection_with(Some("NC_000017.11:g.50198003C>A"), None);
+        proj.axis_decline_reasons.genomic = Some("stale".to_string());
+        assert_eq!(
+            select_axis(&proj, Axis::Genomic),
+            AxisOutcome::Rendered {
+                transcript_id: "NM_000088.3".to_string(),
+                output: "NC_000017.11:g.50198003C>A".to_string(),
+                warnings: Vec::new(),
+            }
+        );
     }
 
     #[test]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -9,4 +9,4 @@ pub(crate) mod rna;
 mod transcript_axis;
 
 pub use projector::VariantProjector;
-pub use result::VariantProjection;
+pub use result::{AxisDeclineReasons, VariantProjection};

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -22,7 +22,7 @@ use crate::project::protein::{
     read_cds_start_codon, render_silent_identity, try_project_cis_combined_inframe,
     whole_exon_deletion_span, CisCombined, RefProteinBundle,
 };
-use crate::project::result::VariantProjection;
+use crate::project::result::{AxisDeclineReasons, VariantProjection};
 use crate::reference::transcript::Transcript;
 use crate::reference::ReferenceProvider;
 use std::collections::HashMap;
@@ -3236,6 +3236,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .clone();
             return Ok(VariantProjection {
                 normalization_warnings: Vec::new(),
+                axis_decline_reasons: AxisDeclineReasons::default(),
                 // No inner variant to derive a genomic form from; report `None`
                 // rather than wrapping the (possibly non-genomic) input allele
                 // into `.genomic`. Consistent with `coding`/`protein`, which are
@@ -3287,6 +3288,24 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .collect();
         let noncoding = noncoding_variants
             .map(|variants| HgvsVariant::Allele(AlleleVariant::new(variants, allele.phase)));
+
+        // #1198: because the rule above is all-or-nothing, an absent allele `n.`
+        // axis means at least one member's was absent — and that member may have
+        // recorded why. Carry it up rather than letting the aggregate fall back
+        // to the generic wording: the explanation already exists, and dropping it
+        // here would reintroduce exactly the defect being fixed. The reason is
+        // labelled as a member's, since it describes one member's coordinates and
+        // not the whole allele. Several members may have declined; the first
+        // recorded cause is reported, because one true cause is more use than
+        // none and picking a "primary" among them would be invention.
+        let noncoding_decline = if noncoding.is_none() {
+            inner_projections
+                .iter()
+                .find_map(|p| p.axis_decline_reasons.noncoding.as_deref())
+                .map(|reason| format!("an allele member has no n. form: {reason}"))
+        } else {
+            None
+        };
 
         // A cis allele whose member disrupts the translation initiation codon
         // has an unknown whole-protein consequence: once initiation is uncertain
@@ -3417,6 +3436,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons {
+                noncoding: noncoding_decline,
+                ..Default::default()
+            },
             genomic,
             coding,
             noncoding,
@@ -3997,6 +4020,66 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(protein)
     }
 
+    /// Derive the `n.` (transcript-relative) axis from resolved CDS positions,
+    /// keeping the reason when the derivation declines.
+    ///
+    /// Best-effort by contract: a derivation edge — the transcript sequence not
+    /// being fetchable, or a `c.` position 5' of the transcript's first base
+    /// (#1193) — leaves the axis `None` rather than failing the whole
+    /// projection, because one underivable axis must not cost the other four.
+    ///
+    /// #1198: the *derivation's* declining error is returned alongside the
+    /// (absent) axis instead of only being logged at `trace`. It was previously
+    /// computed and dropped, which left `ferro project` able to say only that an
+    /// axis was unavailable, never why. Recording a reason does not change the
+    /// exit code — the axis is still a clean decline, per the best-effort
+    /// contract above — it only stops the explanation being thrown away.
+    ///
+    /// Only explanations that are about the *user's variant* are recorded — see
+    /// [`variant_decline_explanation`]. A failure to *fetch* the transcript is
+    /// deliberately excluded on the same rule: it is a fact about the reference
+    /// installation, so reporting "Reference not found: NM_X" as the answer to
+    /// "why is there no `n.` form?" would mislabel the cause, and the `r.` axis
+    /// — which fails on the very same fetch a few lines later — would keep the
+    /// generic wording, telling the user two different stories about one
+    /// problem. That arm is defensive in any case: on the paths reached today a
+    /// missing transcript has already failed the whole projection before the
+    /// `n.` derivation runs.
+    ///
+    /// Returns `(axis, decline_reason)`; the reason is `None` whenever the axis
+    /// is `Some`.
+    fn noncoding_axis_with_reason(
+        &self,
+        normalized: &HgvsVariant,
+        transcript_id: &str,
+        cds_start: &CdsPos,
+        cds_end: &CdsPos,
+        c_edit: &NaEdit,
+        gene_symbol: Option<String>,
+    ) -> (Option<HgvsVariant>, Option<String>) {
+        let tx = match self.cached_get_transcript_for_variant(normalized, transcript_id) {
+            Ok(tx) => tx,
+            Err(e) => {
+                log::trace!("c→n derivation failed for {transcript_id}: {e}");
+                return (None, None);
+            }
+        };
+        match crate::project::transcript_axis::noncoding_from_coding(
+            cds_start,
+            cds_end,
+            &tx,
+            c_edit,
+            transcript_id,
+            gene_symbol,
+        ) {
+            Ok(v) => (Some(v), None),
+            Err(e) => {
+                log::trace!("c→n derivation failed for {transcript_id}: {e}");
+                (None, variant_decline_explanation(&e))
+            }
+        }
+    }
+
     /// Direct c.→p. projection for a bare transcript coding input (no
     /// `genomic_context` parent). The c.→g.→CDS roundtrip cannot run without a
     /// genome alignment, but protein prediction only needs the transcript's
@@ -4103,24 +4186,17 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // gene symbol (`cds.gene_symbol`) so the n. form matches the `coding`
         // form (which is the raw input here) rather than disagreeing on the
         // gene tag. Best-effort — a derivation edge (e.g. legacy c.0) is logged
-        // and leaves the axis None rather than failing the whole projection.
-        let noncoding = match self.cached_get_transcript_for_variant(normalized, transcript_id) {
-            Ok(tx) => match crate::project::transcript_axis::noncoding_from_coding(
-                &cds_start,
-                &cds_end,
-                &tx,
-                &edit,
-                transcript_id,
-                cds.gene_symbol.clone(),
-            ) {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    log::trace!("c→n derivation failed for {transcript_id}: {e}");
-                    None
-                }
-            },
-            Err(_) => None,
-        };
+        // and leaves the axis None rather than failing the whole projection —
+        // but the declining error's message is kept so it can reach the user
+        // (#1198) instead of being computed and dropped.
+        let (noncoding, noncoding_decline) = self.noncoding_axis_with_reason(
+            normalized,
+            transcript_id,
+            &cds_start,
+            &cds_end,
+            &edit,
+            cds.gene_symbol.clone(),
+        );
 
         // Build-scope the `predict_rna` transcript fetch via the shared helper
         // for consistency with the allele site and the genome-pivot path (#843).
@@ -4166,6 +4242,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons {
+                noncoding: noncoding_decline,
+                ..Default::default()
+            },
             genomic,
             coding,
             noncoding,
@@ -4412,6 +4492,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         if !is_coding {
             return Ok(VariantProjection {
                 normalization_warnings: Vec::new(),
+                axis_decline_reasons: AxisDeclineReasons::default(),
                 genomic,
                 coding: None,
                 noncoding: Some(noncoding_axis),
@@ -4490,6 +4571,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons::default(),
             genomic,
             coding,
             // The non-coding axis is the input itself for an `n.` input, and the
@@ -5128,26 +5210,17 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // path is currently pinned unsupported — see
         // `tests/issue_328_projector_accepts_cnr.rs` — so this arm is not yet
         // reached, but carries the correct semantics for when it is).
-        let noncoding = if is_coding {
-            match self.cached_get_transcript_for_variant(&cache_variant, transcript_id) {
-                Ok(tx) => match crate::project::transcript_axis::noncoding_from_coding(
-                    &cds_start,
-                    &cds_end,
-                    &tx,
-                    &c_edit,
-                    transcript_id,
-                    gene_symbol.clone(),
-                ) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        log::trace!("c→n derivation failed for {transcript_id}: {e}");
-                        None
-                    }
-                },
-                Err(_) => None,
-            }
+        let (noncoding, noncoding_decline) = if is_coding {
+            self.noncoding_axis_with_reason(
+                &cache_variant,
+                transcript_id,
+                &cds_start,
+                &cds_end,
+                &c_edit,
+                gene_symbol.clone(),
+            )
         } else {
-            Some(coding.clone())
+            (Some(coding.clone()), None)
         };
 
         // `.genomic` is the canonical g. *output*. For a g. input it is the
@@ -5213,6 +5286,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons {
+                noncoding: noncoding_decline,
+                ..Default::default()
+            },
             genomic,
             coding,
             noncoding,
@@ -5298,6 +5375,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Some(VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons::default(),
             genomic,
             coding,
             noncoding: None,
@@ -5371,6 +5449,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         };
         VariantProjection {
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons::default(),
             genomic: Some(genomic),
             coding,
             noncoding: None,
@@ -5384,6 +5463,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             is_utr: false,
             affects_init: false,
         }
+    }
+}
+
+/// The part of a declining error that explains the **user's variant**, ready to
+/// be recorded as an axis decline reason — or `None` when the error explains
+/// something else and the generic wording is the more honest answer.
+///
+/// Two filters, both about not misleading the reader of a
+/// `status: unavailable` record (#1198):
+///
+/// 1. **The `FerroError` class label is dropped.** `Display` prefixes a class
+///    (`Invalid coordinates: …`). That label is right when the error is reported
+///    as a failure, but wrong here: `NM_004006.3:c.-238` is a perfectly valid
+///    `c.` coordinate, and calling it invalid beside `status: unavailable`
+///    asserts two contradictory things about one record. Only the message body
+///    — the part that actually describes the variant — is kept.
+/// 2. **Errors about the reference data are not recorded at all.**
+///    `ConversionError { msg: "Transcript has no CDS" }` (reachable when cdot
+///    calls a transcript coding but the provider's record carries no
+///    `cds_start`) is a fact about the reference installation, not the variant —
+///    the same rule that excludes a transcript-fetch failure. Answering "why is
+///    there no `n.` form?" with internal conversion jargon would replace one
+///    unhelpful string with a differently unhelpful one.
+///
+/// Anything not matched falls back to the generic wording, which is the safe
+/// default: a new derivation error is not surfaced until someone has judged its
+/// message fit for a user to read.
+fn variant_decline_explanation(e: &FerroError) -> Option<String> {
+    match e {
+        // The #1193 out-of-transcript refusal: names the refused position, the
+        // transcript, and the rule. The one message here written for a user.
+        FerroError::InvalidCoordinates { msg } => Some(msg.clone()),
+        _ => None,
     }
 }
 
@@ -9464,6 +9576,7 @@ mod tests {
             });
             let proj = VariantProjection {
                 normalization_warnings: Vec::new(),
+                axis_decline_reasons: AxisDeclineReasons::default(),
                 genomic: Some(genomic),
                 coding: Some(coding),
                 noncoding: None,
@@ -9534,6 +9647,7 @@ mod tests {
             });
             let proj = VariantProjection {
                 normalization_warnings: Vec::new(),
+                axis_decline_reasons: AxisDeclineReasons::default(),
                 genomic: None,
                 coding: Some(coding),
                 noncoding: None,
@@ -13405,6 +13519,7 @@ mod tests {
             is_utr: false,
             affects_init: false,
             normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons::default(),
         };
         // Multi-exon-spanning: c.5+10_20-10del deletes exon(s) between bases 5 and
         // 20 → Opaque (not ProteinIrrelevant).

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -3,6 +3,43 @@
 use crate::hgvs::variant::HgvsVariant;
 use crate::normalize::NormalizationWarning;
 
+/// Why each axis of a [`VariantProjection`] is `None`, when the engine
+/// actually computed an explanation.
+///
+/// An axis is `None` for two very different reasons: it was never applicable to
+/// this input (there is nothing to explain), or a derivation *was* attempted and
+/// declined. Only the second case has an explanation, and it used to be logged
+/// at `trace` level and dropped — so `ferro project` could report *that* an axis
+/// was unavailable but never *why*, falling back to a string synthesized from
+/// the axis code alone (#1198).
+///
+/// Each field names the like-named axis of [`VariantProjection`] and holds an
+/// explanation written for a user to read — see the projector's
+/// `variant_decline_explanation`, which drops the `FerroError` class label and
+/// refuses to record errors that describe the reference data rather than the
+/// variant.
+///
+/// **`None` does not mean "no reason exists."** A field is `None` when that axis
+/// is present, when it was never applicable to the input, *or* when its decline
+/// is one this type does not record. Only `noncoding` is populated today — for
+/// both a single variant and an allele, whose members' reasons are carried up —
+/// and the projector still has articulated-but-unrecorded declines on the other
+/// axes: the genomic re-anchor failure in `frame_projection_owned`, the
+/// `cds_start_incomplete` gate that drops `coding`/`protein`/`rna` together, and
+/// the non-initiator protein decline. Wiring each of those is a judgement call
+/// about what is meaningful to a user, not a mechanical extension, so callers
+/// must keep their own fallback wording and must not read an absent reason as
+/// evidence that none was computed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AxisDeclineReasons {
+    pub genomic: Option<String>,
+    pub coding: Option<String>,
+    pub noncoding: Option<String>,
+    pub protein: Option<String>,
+    pub rna: Option<String>,
+}
+
 /// A variant resolved across coordinate systems.
 ///
 /// Each coordinate axis is independently optional: a projection carries
@@ -56,4 +93,8 @@ pub struct VariantProjection {
     /// normalize entry points; deep projection-building helpers default it to
     /// empty and the entry point attaches the captured set.
     pub normalization_warnings: Vec<NormalizationWarning>,
+    /// Why an axis above is `None`, for the axes whose derivation declined with
+    /// an explanation. See [`AxisDeclineReasons`]; empty (all-`None`) on a
+    /// projection where nothing was attempted and refused.
+    pub axis_decline_reasons: AxisDeclineReasons,
 }

--- a/tests/it/cli_project.rs
+++ b/tests/it/cli_project.rs
@@ -150,3 +150,97 @@ fn bare_genomic_with_transcript_renders_coding() {
         other => panic!("expected Rendered, got {other:?}"),
     }
 }
+
+/// #1198: an unavailable axis must report the engine's *own* explanation, not a
+/// string synthesized from the axis code alone.
+///
+/// `NM_TEST.1` begins its CDS at transcript base 1, so `c.-1` lies 5' of the
+/// transcript's first base and `noncoding_from_coding` refuses it (#1193) with a
+/// precise message. That message was computed and then dropped, leaving the user
+/// with the generic "no n. representation for this variant".
+///
+/// A deletion, not a substitution: `c.-1` is not a base of this transcript at
+/// all, so a substitution would have to assert a reference base that cannot be
+/// checked. The issue's own reproducer (`c.-238del`) has the same shape.
+#[test]
+fn unavailable_n_axis_reports_the_engines_explanation() {
+    let vp = fixture();
+    let variant = parse_hgvs("NM_TEST.1:c.-1del").unwrap();
+    let outcome = project_axis(&vp, &variant, Axis::Noncoding, None).unwrap();
+    match outcome {
+        AxisOutcome::Unavailable {
+            reason, warnings, ..
+        } => {
+            // Asserted by substance, not by exact string: the load-bearing claim
+            // is that the reason names the refused position and the transcript,
+            // which is what the synthesized string could never do. Pinning the
+            // whole sentence would couple this test to `FerroError`'s Display
+            // prefix and to #1193's prose, neither of which it has an opinion on.
+            assert_ne!(
+                reason, "no n. representation for this variant",
+                "the synthesized string must not survive when the engine explained itself"
+            );
+            // The `FerroError` class label must not come with it: `c.-1` is a
+            // valid `c.` coordinate, so "Invalid coordinates:" beside
+            // `status: unavailable` would assert two contradictory things.
+            assert!(
+                !reason.starts_with("Invalid coordinates:"),
+                "the error's class label must be stripped; got {reason:?}"
+            );
+            for expected in ["n.0", "NM_TEST.1", "5' of the transcript's first base"] {
+                assert!(
+                    reason.contains(expected),
+                    "the reason must carry the engine's explanation ({expected:?} missing); \
+                     got {reason:?}"
+                );
+            }
+            // #1182's contract still holds on this arm: an axis can be
+            // unavailable *because* of what a warning describes, so the reason
+            // must not have displaced the warnings.
+            assert_eq!(
+                warnings.iter().map(|w| w.code.as_str()).collect::<Vec<_>>(),
+                ["POSITION_PAST_END"],
+                "the reason and the warnings must coexist"
+            );
+        }
+        other => panic!("expected Unavailable, got {other:?}"),
+    }
+}
+
+/// The converse of the test above: a derivable axis must not acquire a decline
+/// reason. A reason that is always populated would be as uninformative as the
+/// generic string it replaces.
+#[test]
+fn a_derivable_n_axis_records_no_decline_reason() {
+    let vp = fixture();
+    let variant = parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+    let projection = vp.project_variant(&variant, "NM_TEST.1").unwrap();
+    assert!(
+        projection.noncoding.is_some(),
+        "c.4 is inside the CDS, so the n. axis must derive"
+    );
+    assert_eq!(projection.axis_decline_reasons.noncoding, None);
+}
+
+/// #1198: an allele's `n.` axis is all-or-nothing, so when it is absent at least
+/// one member's was — and the member's recorded reason must be carried up rather
+/// than the aggregate falling back to the generic string. Dropping it there would
+/// reintroduce the same defect one level out.
+#[test]
+fn an_allele_carries_up_a_members_decline_reason() {
+    let vp = fixture();
+    // The second member lies 5' of the transcript's first base, so its own `n.`
+    // derivation is refused and the whole allele's `n.` axis goes absent.
+    let variant = parse_hgvs("NM_TEST.1:c.[4C>A;-1del]").unwrap();
+    let outcome = project_axis(&vp, &variant, Axis::Noncoding, None).unwrap();
+    match outcome {
+        AxisOutcome::Unavailable { reason, .. } => {
+            assert!(
+                reason.contains("allele member") && reason.contains("n.0"),
+                "the member's explanation must reach the aggregate, labelled as a \
+                 member's; got {reason:?}"
+            );
+        }
+        other => panic!("expected Unavailable, got {other:?}"),
+    }
+}


### PR DESCRIPTION
`ferro project` reported every unavailable axis as `no <axis>. representation for this variant` — a string synthesized in `select_axis` from nothing but the axis code. Meanwhile the `c.`→`n.` derivation computed a precise refusal, logged it at `trace`, and dropped it. The diagnosis was produced correctly and thrown away before it could reach anyone — the same shape as the W4004 defect #1193 just fixed.

## What changed

`VariantProjection` gains `axis_decline_reasons: AxisDeclineReasons` (a per-axis `Option<String>`). The two `noncoding_from_coding` call sites the issue names now go through one `noncoding_axis_with_reason` helper that returns `(axis, reason)` instead of two copy-pasted `log::trace!`-and-drop blocks, and `select_axis` reports the recorded reason for the axis it is reporting on.

Before/after, on the issue's own reproducer shape:

```
$ ferro project 'NM_004006.3:c.-238del' --axis n --error-mode lenient --reference <dir>

before (origin/main 3388b3f):
  # NM_004006.3:c.-238del [n]: unavailable: no n. representation for this variant
after:
  # NM_004006.3:c.-238del [n]: unavailable: transcript position n.0 (start) is outside NM_004006.3: `n.` numbering starts at 1, so this c. position lies 5' of the transcript's first base
```

The best-effort axis contract is untouched: one underivable axis still leaves the other four intact. Nothing about which records exit 0 changes — only what they say.

## The reason replaces the synthesized string rather than wrapping it

Both formats already state the axis and the unavailability independently of `reason` — text writes `# <input> [<axis>]: unavailable:` and JSON carries `"axis"` plus `"status": "unavailable"` — so prefixing would say each of those twice. `src/cli/format.rs` is unchanged (byte-identical to `main`), and #1193's four `output_projection` tests pass untouched.

With nothing recorded the wording is unchanged, because an absent axis usually was never applicable rather than attempted and refused.

## Only explanations about the *user's variant* are recorded

This is the part that decides whether the fix actually helps, so it is a deliberate filter (`variant_decline_explanation`) rather than a blanket `e.to_string()`:

- **The `FerroError` class label is dropped.** `Display` renders `Invalid coordinates: <msg>`. `NM_004006.3:c.-238` is a perfectly valid `c.` coordinate, so `Invalid coordinates:` sitting beside `"status": "unavailable"` would assert two contradictory things about one record. Only the message body is kept.
- **Errors about the reference data are not recorded at all.** `ConversionError { msg: "Transcript has no CDS" }` (reachable when cdot calls a transcript coding but the provider's record has no `cds_start`) and a transcript-*fetch* failure are facts about the reference installation, not the variant. Surfacing them would answer "why is there no `n.` form?" with internal conversion jargon — one unhelpful string traded for another — and the `r.` axis, which fails on the same fetch, would keep the generic wording, telling the user two different stories about one problem.

Anything unmatched falls back to the generic wording, which is the safe default: a new derivation error is not surfaced until someone has judged its message fit to read.

## Alleles carry a member's reason up

An allele's `n.` axis is all-or-nothing, so when it is absent at least one member's was — and the member's reason already existed. It is carried up, labelled as a member's since it describes one member's coordinates and not the whole allele:

```
an allele member has no n. form: transcript position n.0 (start) is outside NM_TEST.1: `n.` numbering starts at 1, …
```

Several members may have declined; the first recorded cause is reported, because one true cause is more use than none and nominating a "primary" among them would be invention.

## Honesty of the new field

`AxisDeclineReasons` has five fields and only `noncoding` is populated. That is documented on the type rather than implied, including the declines the projector still articulates and does **not** record (the genomic re-anchor failure in `frame_projection_owned`, the `cds_start_incomplete` gate that drops `coding`/`protein`/`rna` together, the non-initiator protein decline). Wiring each is a judgement call about what a user can act on, not a mechanical extension. The doc states explicitly that `None` does not mean no reason exists, so callers keep their own fallback wording.

The symmetric shape is load-bearing rather than speculative: it lets `select_axis` read the axis and its reason in a single match arm, which makes reporting one axis's reason against another structurally unrepresentable. `#[non_exhaustive]` + `Default` means the unpopulated fields carry no semver commitment.

## Tests

TDD: the integration test was written first and failed with `got "no n. representation for this variant"`, re-confirmed on the rebased base.

- `tests/it/cli_project.rs` — end-to-end through the real projector on the `MockProvider` fixture: the reason replaces the generic string, names the refused position and transcript, does **not** carry the `Invalid coordinates:` class label, and coexists with #1182's `POSITION_PAST_END` warning; the converse (a derivable axis records no reason); the allele carry-up.
- `src/cli/project.rs` — the reason is used verbatim not decorated; a reason recorded for one axis is never reported against another; the generic wording survives when nothing was recorded; a reason does not override a rendered axis.

Each was checked to fail without its fix, and the allele test was confirmed non-vacuous by disabling the propagation. Chose `c.-1del` over `c.-1C>A` so no test asserts a reference base at a position the fixture transcript does not have.

## Spec

`n.` numbering "from the first to the last nucleotide of the reference sequence" (`background/numbering.md:52`), and describing nucleotides beyond a transcript's boundaries using that transcript is not allowed (`:54`) — so `c.-238` on a transcript with `cds_start = 238` has no `n.` form, and refusing it is correct. Not over-refusing: the boundary position still renders (pinned by #1193's existing `transcript_axis.rs` tests).

## Verification

`cargo fmt --check` and `cargo clippy --all-features --all-targets -D warnings` are clean. **8727/8727** tests pass, and **8727/8727** again under `FERRO_ASSERT_IDEMPOTENT=1`. Both spec artifacts were regenerated first; no fixture or baseline churn.

Rebased onto current `origin/main` (`3388b3f`, carrying #1215 and #1171) and re-verified after the rebase with `cargo check --all-targets --features dev` plus the two full runs above.

### What each claim rests on

Every user-visible string quoted in this PR body was produced by the **final tree against the prepared reference** (cdot 0.2.32 GRCh38, 273423 transcripts) — not by a mock:

- the before/after above, whose "before" was captured by building `origin/main` at `3388b3f` and running the same command against the same reference;
- the JSON shape, confirming the reason coexists with #1182's warning and duplicates neither `axis` nor `status`:
  ```json
  {"input": "NM_004006.3:c.-238del", "axis": "n", "output": null, "status": "unavailable",
   "reason": "transcript position n.0 (start) is outside NM_004006.3: `n.` numbering starts at 1, so this c. position lies 5' of the transcript's first base",
   "warnings": [{"code": "POSITION_PAST_END", "message": "NM_004006.3:c.-238 lies past the 5utr-start (bound 237)"}]}
  ```
- the control that a derivable axis is unaffected (`c.100del` renders `NM_004006.3:n.338del`, no reason);
- the allele carry-up, in both cis (`c.[-238del;100del]`) and trans (`c.[-238del];[100del]`) forms.

The committed integration tests run on `MockProvider`, because the suite must pass without a prepared reference. Those are what CI enforces; the runs above are the separate evidence that the same behavior holds on real reference data.

**Not verified.** The scratch reference is offline, so the reference-backed runs used the backup mirror — same reference identity (`28288ed4c39ee856`), but without scratch's later `NM_002001.2` backfill. That is immaterial here: every case above uses `NM_004006.3`. No conformance-axis or ledger run was attempted, and none should be needed — this change moves no baseline and alters no projection output, only the wording of an already-unavailable axis.

## Noted, deliberately not fixed here

- `transcript_axis.rs`'s comment cites `numbering.md:31` (the `c.0` analogue) for an `n.` rule; the load-bearing `:54` is uncited. Pre-existing from #1193, outside this diff.
- `--axis c` still echoes the input `c.-238del` unchanged while `--axis n` refuses it. Consistent with #1193's deliberate scope, and moot under the `strict` default that rejects the input outright.
- `AxisOutcome::Unavailable` carries no machine-readable code, so a JSON consumer wanting to branch on the cause must read `status`/`axis` rather than parse `reason`. Adding one would change the JSON shape a second time right after #1193 did; better as its own change.
- The Python bindings do not expose `axis_decline_reasons`.

Closes #1198

