### PR TITLE
fix(normalize): clamp an insertion saturated at a mitochondrial terminus

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -682,7 +682,8 @@ impl SequenceEnds {
 /// | `c.` (UTR regions) | transcript `1` / `len` | this helper |
 /// | `n.`, `r.` | transcript `1` / `len` | this helper |
 /// | `g.` | contig `1` / `len` | `normalize_genome` (#1205) |
-/// | `m.`, `o.` | circular, so position 1 has a valid 5' neighbour | n/a |
+/// | `m.` | contig `1` / `len` | `normalize_mt` (#1217) |
+/// | `o.` | n/a — returned unchanged, no shuffle runs | n/a |
 ///
 /// `normalize_genome` became the fourth caller in #1205, which closes the last
 /// non-circular gap: before it, a 5'-saturated insertion at a contig start
@@ -691,9 +692,24 @@ impl SequenceEnds {
 /// `g.123insG`) — and a 3'-saturated one as `g.<len>_<len+1>ins<A\'>`, whose
 /// second anchor is past the contig end.
 ///
-/// `m.`/`o.` remain deliberately uncovered: a circular reference wraps, so
-/// position 1 HAS a valid 5\' neighbour (the last base) and the correct output
-/// there is a wraparound description, not this `delins` rewrite.
+/// `normalize_mt` became the fifth in #1217. #1205 had left it out on the
+/// grounds that a circular reference wraps, so position 1 HAS a valid 5\'
+/// neighbour (the last base) and the correct output there is a wraparound
+/// description rather than this `delins` rewrite. That does not hold: #129
+/// established, and `issue_129_mt_circular_wraparound.rs` pins, that ferro
+/// **rejects** `m.<high>_<low>ins`. The spec's reversed-range exception
+/// (`deletion.md:17`, SVD-WG006) is granted to `del`/`dup` — `delins` inherits
+/// it by composition — while `insertion.md` is silent, so the general 5\'→3\'
+/// rule applies, which is also how mutalyzer and biocommons read it. The
+/// wraparound `ins` is therefore not an available answer and the
+/// single-position `delins`, which needs no reversed range at all, is. (#129
+/// separately disabled 3\'-rule shifting across the origin, so coming to rest
+/// at the terminus is already the intended behavior; only its rendering was
+/// wrong.)
+///
+/// `o.` stays out: `normalize_core` returns circular `o.` variants unchanged, so
+/// no shuffle runs and nothing can saturate. A genuine circular normalizer is
+/// #951.
 ///
 /// The genomic caller passes a **window** rather than the whole contig, so it
 /// must say which of its ends are real — see [`SequenceEnds`].
@@ -6248,14 +6264,52 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // has no canonical "CDS" exemption boundary in the same sense as
         // nuclear `c.`; the spec's mito chapter doesn't carry the
         // codon-frame clause), so the gate is `NotApplicable`.
-        let (new_rel_start, new_rel_end, new_edit, mut warnings) = self.normalize_na_edit(
+        let (mut new_rel_start, mut new_rel_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                ref_seq.as_bytes(),
+                edit,
+                rel_start,
+                rel_end,
+                &Boundaries::new(0, ref_seq.len() as u64),
+                CodonGate::NotApplicable,
+            )?;
+
+        // #1217: an insertion driven to rest against either mitochondrial
+        // terminus has no valid pair of adjacent anchors there, exactly as on
+        // the transcript axes (#1202) and the `g.` axis (#1205) — 5' it escapes
+        // as the single-position `m.1ins<A'>`, which `DNA/insertion.md:95-101`
+        // rejects by name and ferro's own parser refuses; 3' as
+        // `m.<len>_<len+1>ins<A'>`, whose second anchor is past the contig end.
+        //
+        // Circularity does not supply an escape here. #1205 left `m.` out on the
+        // grounds that position 1 has a valid 5' neighbour on a circular
+        // reference, so the answer ought to be a wraparound description — but
+        // #129 established that ferro **rejects** `m.<high>_<low>ins` (the
+        // reversed-range exception at `deletion.md:17` / SVD-WG006 covers
+        // `del`/`dup`, and `delins` by composition; `insertion.md` is silent, so
+        // the general 5'→3' rule applies, as both mutalyzer and biocommons
+        // read it). So the wraparound `ins` is not an available answer, and the
+        // single-position `delins` — which needs no reversed range — is. #129
+        // also disabled 3'-rule shifting across the origin, so resting at the
+        // terminus is already the intended behavior; only its rendering was
+        // wrong.
+        //
+        // Same windowed-flushness reasoning as `normalize_genome`: `ref_seq` is
+        // a window, so an end is a real contig bound only where the window is
+        // flush with it, and with no length available we cannot establish
+        // flushness and so do not clamp.
+        let contig_len = self.provider.get_sequence_length(&accession).ok();
+        clamp_insertion_at_sequence_bounds(
             ref_seq.as_bytes(),
-            edit,
-            rel_start,
-            rel_end,
-            &Boundaries::new(0, ref_seq.len() as u64),
-            CodonGate::NotApplicable,
-        )?;
+            &mut new_edit,
+            &mut new_rel_start,
+            &mut new_rel_end,
+            SequenceEnds {
+                five_prime: window_start == 0,
+                three_prime: contig_len
+                    .is_some_and(|len| window_start + ref_seq.len() as u64 >= len),
+            },
+        );
 
         let new_start = new_rel_start + window_start;
         let new_end = new_rel_end + window_start;

--- a/tests/it/issue_1205_genome_contig_bounds_clamp.rs
+++ b/tests/it/issue_1205_genome_contig_bounds_clamp.rs
@@ -169,38 +169,20 @@ fn non_shuffling_insertion_at_the_contig_start_is_untouched() {
 }
 
 // ---------------------------------------------------------------------------
-// Scope boundary: circular references are NOT clamped
+// Scope boundary: the circular axes
 // ---------------------------------------------------------------------------
-
-/// `m.` (and `o.`) are deliberately left out of this fix, and this pins that
-/// boundary so a later change does not extend the clamp there by reflex.
-///
-/// A circular reference wraps: position 1 HAS a valid 5' neighbour — the last
-/// base — so the correct output for a 5'-saturated insertion there is a
-/// wraparound description, not this `delins` rewrite. Applying the genomic clamp
-/// would produce a well-formed but semantically wrong answer, which is worse than
-/// the status quo.
-///
-/// To be explicit about what that status quo is: `m.` currently emits the same
-/// invalid single-position form this PR fixes on `g.` (`m.1insCG`). That is a real
-/// defect and is **not** fixed here — it needs the circular answer, tracked
-/// separately. This test therefore asserts only that the clamp did not fire; it
-/// does not bless the output.
-#[test]
-fn mito_axis_is_not_clamped() {
-    let mut provider = MockProvider::new();
-    provider.add_genomic_sequence("NC_012920.1", CONTIG);
-    let normalizer = Normalizer::with_config(
-        provider,
-        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
-    );
-    let variant = parse_hgvs("NC_012920.1:m.1_2insGC").expect("parse");
-    let rendered = normalizer
-        .normalize(&variant)
-        .expect("normalize")
-        .to_string();
-    assert!(
-        !rendered.contains("delins"),
-        "the genomic contig clamp must not reach the circular axis, got {rendered}",
-    );
-}
+//
+// This file used to carry a `mito_axis_is_not_clamped` test pinning `m.` as
+// deliberately out of scope, on the reasoning that a circular reference wraps —
+// position 1 HAS a valid 5' neighbour — so the right answer there was a
+// wraparound description rather than this `delins` rewrite. That test explicitly
+// asserted only that the clamp had not fired and did *not* bless the output,
+// because the output (`m.1insCG`) was the same invalid single-position form this
+// file fixes on `g.`.
+//
+// #1217 resolved that open question the other way and removed the boundary: the
+// wraparound `ins` is a form ferro rejects by design (#129), so the
+// single-position `delins` is the only available answer on `m.` too, and
+// `normalize_mt` became the fifth caller of the clamp. The `m.`-axis behavior now
+// lives in `issue_1217_mito_terminus_insertion_clamp.rs`, which also pins that
+// `o.` remains untouched (it is returned unchanged, so nothing can saturate).

--- a/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
+++ b/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
@@ -1,0 +1,338 @@
+//! Issue #1217 — an `m.`-axis insertion that saturates at a mitochondrial
+//! terminus must be clamped to a `delins`, exactly as the transcript axes
+//! (#1202) and the `g.` axis (#1205) already do.
+//!
+//! `normalize_mt` was the one caller of `clamp_insertion_at_sequence_bounds`
+//! never wired up, so both ends escaped in the two shapes #1202 describes:
+//!
+//! | direction | input | before | why it is wrong |
+//! |---|---|---|---|
+//! | 5' | `m.1_2insGC` | `m.1insCG` | single-position insertion; ferro's own parser rejects it |
+//! | 3' | `m.13_14insGGA` | `m.15_16insAGG` | `m.16` is past the end of a 15-base contig |
+//!
+//! The 5' shape is the one the spec names by example
+//! (`DNA/insertion.md:95-101`): an insertion needs two adjacent flanking
+//! anchors, and `m.1ins…` has one.
+//!
+//! ## Why not a wraparound `ins`
+//!
+//! #1205 left `m.` out on the grounds that a circular reference wraps, so
+//! position 1 has a valid 5' neighbour and the answer ought to be a wraparound
+//! description. That rationale does not survive contact with #129, which
+//! established — and `issue_129_mt_circular_wraparound.rs` pins — that ferro
+//! **rejects** `m.<high>_<low>ins` by design: the spec's reversed-range
+//! exception (`deletion.md:17`, SVD-WG006) is granted to `del`/`dup`, and
+//! `delins` inherits it by composition, but `insertion.md` is silent so the
+//! general 5'→3' rule applies. Both mutalyzer and biocommons reject all
+//! reversed ranges. So `m.16569_1insCG` is not an available answer.
+//!
+//! The single-position `delins` is, and it needs no reversed range at all:
+//! it is the same coordinate identity `insertion_to_boundary_delins` already
+//! applies on the other four axes. #129 also disabled 3'-rule shifting across
+//! the origin, so the shuffle coming to rest at the terminus is already the
+//! intended behaviour — what was broken is only how that resting place was
+//! rendered.
+//!
+//! ## `o.` is out of scope
+//!
+//! Circular `o.` variants are returned unchanged by `normalize_core` — no
+//! shuffle runs at all — so they cannot reach this clamp. Pinned below.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+use std::path::{Path, PathBuf};
+
+/// Probe contig: `C`×4, `A`×7, `G`×4 — 15 bases, so both ends sit inside one
+/// fetch window and both bounds are exercisable. Deliberately the same shape
+/// as #1205's contig, so the `m.` expectations below are directly comparable
+/// to the `g.` ones and any divergence between the axes is visible.
+const CONTIG: &str = "CCCCAAAAAAAGGGG";
+
+/// The mitochondrial accession, which is what routes these through
+/// `normalize_mt` — including the `g.`-spelled inputs, which `normalize_core`
+/// coerces to the mito path when the accession `is_mitochondrial()`.
+const MT: &str = "NC_012920.1";
+
+fn normalize(input: &str, dir: ShuffleDirection) -> String {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(MT, CONTIG);
+    let normalizer =
+        Normalizer::with_config(provider, NormalizeConfig::default().with_direction(dir));
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"))
+        .to_string()
+}
+
+/// Assert the exact canonical form, that it re-parses, and that it is a fixed
+/// point.
+///
+/// Re-parsing is the property under test as much as the string is: the 5'
+/// defect emitted a form ferro's own parser rejects, and the wraparound
+/// spelling this fix deliberately avoids would be rejected too (#129).
+fn assert_canonical(input: &str, dir: ShuffleDirection, expected: &str) {
+    let once = normalize(input, dir);
+    assert_eq!(once, expected, "{input} ({dir:?}) canonical form");
+    parse_hgvs(&once).unwrap_or_else(|e| panic!("{once} must re-parse: {e}"));
+    assert_eq!(normalize(&once, dir), once, "{once} must be a fixed point");
+}
+
+/// Apply "replace 1-based inclusive `start..=end` of [`CONTIG`] with `insert`",
+/// returning the edited sequence. `start > end` denotes a pure insertion
+/// between the two flanking positions.
+///
+/// Deliberately dumb string splicing, independent of the normalizer: it is
+/// what lets the equivalence assertion prove the rewrite preserves the
+/// haplotype rather than merely restating what the normalizer did.
+fn splice(start: usize, end: usize, insert: &str) -> String {
+    let (before, rest) = CONTIG.split_at(start - 1);
+    let after = &rest[(end + 1).saturating_sub(start)..];
+    format!("{before}{insert}{after}")
+}
+
+// ---------------------------------------------------------------------------
+// The defect at each mitochondrial terminus
+// ---------------------------------------------------------------------------
+
+/// 5' saturation. The shuffle drives the insertion to rest immediately 5' of
+/// `m.1`, where the coordinate identity gives `delete ref[1]` (= `C`),
+/// `insert CG ++ C`.
+#[test]
+fn five_prime_saturated_insertion_clamps_at_mito_start() {
+    assert_canonical(
+        &format!("{MT}:m.1_2insGC"),
+        ShuffleDirection::FivePrime,
+        &format!("{MT}:m.1delinsCGC"),
+    );
+}
+
+/// 3' saturation, the mirror: `delete ref[15]` (= `G`), `insert G ++ AGG`.
+///
+/// The alt is `GGA` rather than a clean homopolymer because a tandem alt never
+/// reaches this shape: with `CodonGate::NotApplicable` on the mito axis, two or
+/// more copies become repeat notation and a single copy becomes a `dup`, both
+/// before any saturation. `GGA` shifts twice through the `G`×4 tract and then
+/// mismatches, which is what leaves it an insertion resting on the bound.
+#[test]
+fn three_prime_saturated_insertion_clamps_at_mito_end() {
+    assert_canonical(
+        &format!("{MT}:m.13_14insGGA"),
+        ShuffleDirection::ThreePrime,
+        &format!("{MT}:m.15delinsGAGG"),
+    );
+}
+
+/// A `g.`-spelled variant on a mitochondrial accession is affected too:
+/// `normalize_core` coerces `HV::Genome` to the mito path when the accession
+/// `is_mitochondrial()` (#487), so #1205's contig clamp never saw it and the
+/// fix has to land in `normalize_mt` to cover this spelling.
+///
+/// Note the output is `m.`, not `g.` — the coercion is what #487 requires.
+#[test]
+fn genome_spelled_mito_insertion_is_clamped_too() {
+    assert_canonical(
+        &format!("{MT}:g.1_2insGC"),
+        ShuffleDirection::FivePrime,
+        &format!("{MT}:m.1delinsCGC"),
+    );
+}
+
+/// The rewrite must describe the same haplotype, not merely a parseable one.
+///
+/// Both sides are spliced into the reference by hand here, so this does not go
+/// through the normalizer and cannot be satisfied by an internally-consistent
+/// but wrong rewrite.
+#[test]
+fn the_clamped_delins_describes_the_same_sequence() {
+    // 5': insert `GC` between m.1 and m.2  ==  replace m.1 with `CGC`.
+    assert_eq!(splice(2, 1, "GC"), splice(1, 1, "CGC"));
+    // 3': insert `GGA` between m.13 and m.14  ==  replace m.15 with `GAGG`.
+    //
+    // The input is stated at m.13_14 but the shuffled payload is `AGG`; the
+    // 3'-shifted insertion between m.15 and m.16 is the same haplotype, which
+    // the first equality pins before the delins comparison.
+    assert_eq!(splice(14, 13, "GGA"), splice(16, 15, "AGG"));
+    assert_eq!(splice(16, 15, "AGG"), splice(15, 15, "GAGG"));
+}
+
+/// The clamp must not reach for the wraparound spelling #129 rejects.
+///
+/// Stated as its own test because it is the judgement call this issue records:
+/// the tempting "circular references wrap, so use the last base as the 5'
+/// neighbour" answer would emit `m.15_1ins…`, which ferro's parser refuses.
+/// Asserting on the absence of a reversed range is weaker than the exact-form
+/// assertions above, but it fails loudly if a later change swaps strategies.
+#[test]
+fn the_clamp_does_not_emit_a_wraparound_insertion() {
+    for (input, dir) in [
+        (format!("{MT}:m.1_2insGC"), ShuffleDirection::FivePrime),
+        (format!("{MT}:m.13_14insGGA"), ShuffleDirection::ThreePrime),
+    ] {
+        let out = normalize(&input, dir);
+        assert!(
+            !out.contains("ins") || out.contains("delins"),
+            "{input} must not come back as a bare ins at the origin, got {out}",
+        );
+        // A reversed range is the specific shape #129 rejects; `15_1` and
+        // `1_15`-with-a-wrap are both spelled with an underscore, so the
+        // exact-form tests above carry the precision. This checks the parser
+        // agrees, which is the property #129 actually pins.
+        parse_hgvs(&out).unwrap_or_else(|e| panic!("{out} must re-parse: {e}"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Controls: the clamp must not fire away from the termini
+// ---------------------------------------------------------------------------
+
+/// The same alt one position 5' of the saturating case comes to rest inside the
+/// contig, so it keeps two valid anchors and must stay an insertion.
+#[test]
+fn interior_insertion_is_left_alone() {
+    assert_canonical(
+        &format!("{MT}:m.12_13insGGA"),
+        ShuffleDirection::ThreePrime,
+        &format!("{MT}:m.14_15insAGG"),
+    );
+}
+
+/// …and on the 5' side.
+#[test]
+fn five_prime_interior_insertion_is_left_alone() {
+    assert_canonical(
+        &format!("{MT}:m.3_4insGC"),
+        ShuffleDirection::FivePrime,
+        &format!("{MT}:m.2_3insCG"),
+    );
+}
+
+/// A tandem expansion whose tract runs to the contig start becomes repeat
+/// notation, which is not an insertion and so is not the clamp's business.
+/// Guards against the clamp firing on position alone rather than on shape.
+#[test]
+fn repeat_notation_reaching_the_mito_start_is_untouched() {
+    assert_canonical(
+        &format!("{MT}:m.2_3insCC"),
+        ShuffleDirection::FivePrime,
+        &format!("{MT}:m.1_4C[6]"),
+    );
+}
+
+/// An insertion that cannot shuffle at all is unaffected, even written against
+/// the first bases of the contig.
+#[test]
+fn non_shuffling_insertion_at_the_mito_start_is_untouched() {
+    assert_canonical(
+        &format!("{MT}:m.1_2insCG"),
+        ShuffleDirection::FivePrime,
+        &format!("{MT}:m.1_2insCG"),
+    );
+}
+
+/// `o.` is returned unchanged by `normalize_core` — no shuffle runs, so no
+/// saturation and nothing for the clamp to fix. Pins that this fix does not
+/// extend there by reflex; a real circular normalizer is #951.
+#[test]
+fn circular_o_axis_is_untouched() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("J01749.1", CONTIG);
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("J01749.1:o.1_2insGC").expect("parse");
+    let rendered = normalizer
+        .normalize(&variant)
+        .expect("normalize")
+        .to_string();
+    assert_eq!(
+        rendered, "J01749.1:o.1_2insGC",
+        "o. variants pass through unchanged",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The real rCRS, reference-gated
+// ---------------------------------------------------------------------------
+//
+// The mock contig above proves the clamp's mechanics; this proves the defect
+// was reachable on the actual mitochondrial reference rather than only on a
+// contrived one. The rCRS terminal bases are what make it reachable without a
+// contrived contig: it ends `…ACATCACGATG` and begins `GATCACAGGT…`, so a `G`
+// sits on both sides of the origin and a payload can shuffle onto the terminus.
+//
+// Skips unless `FERRO_MANIFEST` points at a prepared reference, the same gate
+// the other reference-backed axis tests use.
+
+fn manifest_path() -> Option<PathBuf> {
+    // FERRO_MANIFEST, when set, is authoritative — no fallback to well-known
+    // paths, so CI can disable the runner with `FERRO_MANIFEST=/nonexistent`.
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+/// Check a group of `(input, expected)` cases that share one shuffle direction
+/// against the real rCRS, or skip when no manifest is available.
+///
+/// Cases are grouped by direction because the direction is fixed when the
+/// `Normalizer` is constructed and `MultiFastaProvider` is not `Clone` — so one
+/// group is one manifest load. (The other reference-backed tests dodge this with
+/// a hand-rolled `Arc<MultiFastaProvider>` newtype forwarding all of
+/// `ReferenceProvider`; two copies of that boilerplate already exist and a third
+/// is not worth two cases.)
+fn check_rcrs(dir: ShuffleDirection, cases: &[(&str, &str)]) {
+    let Some(path) = manifest_path() else {
+        eprintln!("issue_1217: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let provider = ferro_hgvs::MultiFastaProvider::from_manifest(&path)
+        .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display()));
+    let normalizer =
+        Normalizer::with_config(provider, NormalizeConfig::default().with_direction(dir));
+
+    for (input, expected) in cases {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let out = normalizer
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("normalize {input}: {e}"))
+            .to_string();
+        assert_eq!(&out, expected, "{input} ({dir:?}) on the real rCRS");
+        parse_hgvs(&out).unwrap_or_else(|e| panic!("{out} must re-parse: {e}"));
+    }
+}
+
+/// 3' (the default direction) on the real rCRS: delete `m.16569` (= `G`),
+/// insert `G ++ CG`. The `g.`-spelled input is the same case routed through
+/// #487's coercion.
+#[test]
+fn real_rcrs_three_prime_terminal_insertion_is_clamped() {
+    check_rcrs(
+        ShuffleDirection::ThreePrime,
+        &[
+            (
+                "NC_012920.1:m.16568_16569insGC",
+                "NC_012920.1:m.16569delinsGCG",
+            ),
+            (
+                "NC_012920.1:g.16568_16569insGC",
+                "NC_012920.1:m.16569delinsGCG",
+            ),
+        ],
+    );
+}
+
+/// 5' on the real rCRS: delete `m.1` (= `G`), insert `GC ++ G`.
+#[test]
+fn real_rcrs_five_prime_terminal_insertion_is_clamped() {
+    check_rcrs(
+        ShuffleDirection::FivePrime,
+        &[("NC_012920.1:m.1_2insCG", "NC_012920.1:m.1delinsGCG")],
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -145,6 +145,7 @@ mod issue_1205_genome_contig_bounds_clamp;
 mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
+mod issue_1217_mito_terminus_insertion_clamp;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
`normalize_mt` was the one caller of `clamp_insertion_at_sequence_bounds` never wired up, so an insertion the shuffle drove against either end of the mitochondrial reference was emitted with an anchor that does not exist.

| direction | input | before | after |
|---|---|---|---|
| 5' | `m.1_2insGC` | `m.1insCG` | `m.1delinsCGC` |
| 3' | `m.13_14insGGA` | `m.15_16insAGG` | `m.15delinsGAGG` |

The 5' shape is a single-position insertion — the form `DNA/insertion.md:95-101` rejects by name ("the description is not unequivocal"), and which ferro's own parser refuses, so normalization was producing output it could not read back. The 3' shape's second anchor is past the contig end (W4004 `PositionPastEnd`).

A `g.`-spelled variant on a mitochondrial accession is affected too: `normalize_core` coerces `HV::Genome` to the mito path when the accession `is_mitochondrial()` (#487), so #1205's contig clamp never saw it and the fix has to land in `normalize_mt` to cover that spelling.

## Why `delins` and not a wraparound `ins`

#1205 deliberately left `m.` out, reasoning that a circular reference wraps — position 1 *has* a valid 5' neighbour — so the right answer was a wraparound description rather than a `delins` rewrite. That rationale does not survive contact with #129, which established (and `issue_129_mt_circular_wraparound.rs` pins) that ferro **rejects** `m.<high>_<low>ins` by design. The spec's reversed-range exception (`deletion.md:17`, SVD-WG006) is granted to `del`/`dup`, and `delins` inherits it by composition, while `insertion.md` is silent — so the general 5'→3' rule applies, which is also how mutalyzer and biocommons read it.

So `m.16569_1insCG` is not an available answer. The single-position `delins` is, and it needs no reversed range at all — it is the same coordinate identity `insertion_to_boundary_delins` already applies on the other four axes. #129 separately disabled 3'-rule shifting across the origin, so the shuffle coming to rest at the terminus is already the intended behaviour; only its rendering was wrong.

`o.` stays out of scope: `normalize_core` returns circular `o.` variants unchanged, so no shuffle runs and nothing can saturate. Pinned by a test. A genuine circular normalizer remains #951.

## Changes

- `normalize_mt` becomes the fifth caller of `clamp_insertion_at_sequence_bounds`, computing `SequenceEnds` flushness exactly as `normalize_genome` does — `ref_seq` is a window, so an end is a real contig bound only where the window is flush with it, and with no length available we do not clamp.
- The helper's doc-comment axis table is corrected: `m.` moves from "circular, so position 1 has a valid 5' neighbour — n/a" to a real clamp site, with the #129 reasoning recorded, and `o.` is restated as out of scope for a different reason (no shuffle runs at all).
- #1205's `mito_axis_is_not_clamped` is removed and replaced by a comment pointing at the new file. That test pinned exactly the scope boundary this PR closes; it asserted only that the clamp had not fired and explicitly did **not** bless the invalid output, so removing it loses no coverage.

## Tests

Written first, confirmed failing for the right reason before the fix — the two red assertions were `m.1insCG` and `m.15_16insAGG`, matching the issue's repro exactly.

`tests/it/issue_1217_mito_terminus_insertion_clamp.rs`: both directions, the `g.`-coercion path, a hand-spliced haplotype-equivalence check that does not go through the normalizer, a re-parse + fixed-point assertion on every case, an explicit check that no wraparound `ins` is emitted, and controls (interior insertions on both sides, repeat notation reaching the start, a non-shuffling insertion, and `o.` untouched).

Also included is a reference-gated test pinning the issue's exact rCRS strings — `NC_012920.1:m.16568_16569insGC` → `m.16569delinsGCG` and `m.1_2insCG` (5') → `m.1delinsGCG` — which is what shows the defect was reachable on the real mitochondrial reference rather than only on a contrived contig.

**Evidence note:** the mock-backed tests above are the ones I ran. The reference-gated test **skipped** in my local runs — no prepared reference was reachable from this machine (neither the scratch nor the backup volume is currently mounted), so `FERRO_MANIFEST` was unset. Its expected strings are derived from the rCRS terminal bases quoted in the issue (`…ACATCACGATG` / `GATCACAGGT…`), not from an observed run here. It will execute for the first time in the nightly reference-aware job.

## Validation

- `cargo nextest run --features dev` → 8731 passed, 0 failed, 145 skipped
- `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev` → 8731 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings` → clean

Suite size moves 8720 → 8731: twelve new tests, less #1205's removed scope-boundary test.

Closes #1217