### PR TITLE
refactor(normalize): require an explicit ErrorConfig at every entry point

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1487,13 +1487,15 @@ fn run_normalize(
 
     let preprocessor = error_config.preprocessor();
     // #1181: the error configuration must reach the *normalizer*, not just the
-    // preprocessor. `NormalizeConfig::default()` is lenient by construction, so
-    // without this every `--error-mode` (and every `--ignore`/`--reject`
+    // preprocessor, or every `--error-mode` (and every `--ignore`/`--reject`
     // override, which `build_error_config` folds into the same `ErrorConfig`)
-    // was silently discarded and all modes behaved as lenient.
-    let config = NormalizeConfig::default()
-        .with_direction(parse_shuffle_direction(direction))
-        .with_error_config(error_config.clone());
+    // is silently discarded and all modes behave as lenient.
+    // `for_entry_point` takes the error configuration as a required argument,
+    // so the omission cannot recur at this call site (#1197). It is not a
+    // whole-crate guarantee — see the constructor's docs and the entry-point
+    // scan in `tests/it/issue_1197_required_error_config.rs`.
+    let config =
+        NormalizeConfig::for_entry_point(parse_shuffle_direction(direction), error_config.clone());
 
     // Create reference provider from directory
     let provider = create_reference_provider(reference.map(|p| p.as_path()), strict_reference)?;
@@ -1720,11 +1722,24 @@ fn run_project(
     // #1182: `project` normalizes its input before projecting, so the error
     // configuration has to reach that normalizer or every normalizer-level
     // diagnostic (W4004 among them) is unreachable — the same defect #1181
-    // fixed on `normalize`. `NormalizeConfig::default()` is lenient by
-    // construction, so this is what makes `--error-mode strict` mean anything
-    // here.
+    // fixed on `normalize`. This is what makes `--error-mode strict` reach the
+    // normalizer here.
+    //
+    // It does *not* make the whole `ErrorConfig` effective on `project`:
+    // unlike `run_normalize` and `run_parse`, this path never builds
+    // `error_config.preprocessor()`, so the preprocessing half of `--ignore` /
+    // `--reject` is still discarded. That is a pre-existing gap of the same
+    // family as #1181, out of scope here; noted so the line above is not read
+    // as a stronger claim than it makes.
+    //
+    // `project` has no direction flag; naming the 3' default explicitly is the
+    // price of a constructor that cannot silently default the error
+    // configuration (#1197), and it documents the choice at the call site.
     let projector = VariantProjector::new(Projector::new(cdot), provider).with_normalize_config(
-        ferro_hgvs::normalize::NormalizeConfig::default().with_error_config(error_config.clone()),
+        ferro_hgvs::normalize::NormalizeConfig::for_entry_point(
+            ferro_hgvs::normalize::ShuffleDirection::ThreePrime,
+            error_config.clone(),
+        ),
     );
 
     let mut writer: Box<dyn Write> = match output {

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -112,6 +112,52 @@ impl NormalizeConfig {
         Self::default()
     }
 
+    /// Build the configuration for an **entry point** — a seam where a shuffle
+    /// direction and an error mode arrive from outside the library (the CLI,
+    /// the PyO3 bindings, the web service).
+    ///
+    /// Both settings are required arguments, which is the whole point:
+    /// `NormalizeConfig::default().with_direction(d)` silently fills in every
+    /// field the caller does not name, and `error_config` defaults to
+    /// [`ErrorConfig::lenient`]. That is the shape that produced #1181 — the
+    /// CLI built an `ErrorConfig` from `--error-mode`, passed it into
+    /// `run_normalize`, and then constructed the normalizer's config without
+    /// it, so the flag (and `--ignore` / `--reject` with it) was inert from the
+    /// initial commit through 678 commits and roughly five months. #1191 fixed
+    /// that one call site; this constructor removes the shape (#1197).
+    ///
+    /// Forgetting the error configuration *in this call* cannot compile, just
+    /// as it cannot in the web service's struct literal. Note the limit of that
+    /// guarantee: it binds only callers who choose this constructor. `default`,
+    /// `new`, the `lenient`/`strict`/`silent` presets and `Normalizer::new` all
+    /// remain reachable and all supply an error configuration the caller never
+    /// named, so a *new* entry point can still elide one and compile. What
+    /// stops it is a lint, not the type system —
+    /// `tests/it/issue_1197_required_error_config.rs` scans the entry-point
+    /// seams for those shapes and fails the build.
+    ///
+    /// Prefer this over the builder chain at every entry point; the builder
+    /// remains for library callers that deliberately want the lenient default.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ferro_hgvs::error_handling::ErrorConfig;
+    /// use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+    ///
+    /// let config =
+    ///     NormalizeConfig::for_entry_point(ShuffleDirection::ThreePrime, ErrorConfig::strict());
+    /// assert_eq!(config.shuffle_direction, ShuffleDirection::ThreePrime);
+    /// assert!(config.should_reject_ref_mismatch());
+    /// ```
+    pub fn for_entry_point(direction: ShuffleDirection, error_config: ErrorConfig) -> Self {
+        Self {
+            shuffle_direction: direction,
+            error_config,
+            ..Default::default()
+        }
+    }
+
     /// Create a config with strict error handling (reject reference mismatches)
     pub fn strict() -> Self {
         Self {
@@ -400,6 +446,40 @@ impl NormalizeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `for_entry_point` must carry the error configuration it is handed, and
+    /// the builder chain it replaces must not — that contrast is the hazard
+    /// #1197 removes. Asserting both halves keeps the test from passing merely
+    /// because `default()` happens to agree with the requested mode.
+    #[test]
+    fn for_entry_point_carries_the_error_config_the_builder_chain_defaults_away() {
+        let explicit =
+            NormalizeConfig::for_entry_point(ShuffleDirection::FivePrime, ErrorConfig::strict());
+        assert_eq!(explicit.shuffle_direction, ShuffleDirection::FivePrime);
+        assert!(
+            explicit.should_reject_ref_mismatch(),
+            "the strict config handed in must arrive",
+        );
+
+        let defaulted = NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime);
+        assert!(
+            !defaulted.should_reject_ref_mismatch(),
+            "premise: the builder chain silently supplies a *lenient* error config, which is \
+             the omission that made `--error-mode` inert for five months (#1181)",
+        );
+    }
+
+    /// Every other field must keep its documented default, so the constructor
+    /// is a narrowing of `default()` rather than a second source of truth.
+    #[test]
+    fn for_entry_point_leaves_other_fields_at_their_defaults() {
+        let config =
+            NormalizeConfig::for_entry_point(ShuffleDirection::ThreePrime, ErrorConfig::silent());
+        let default = NormalizeConfig::default();
+        assert_eq!(config.cross_boundaries, default.cross_boundaries);
+        assert_eq!(config.window_size, default.window_size);
+        assert_eq!(config.prevent_overlap, default.prevent_overlap);
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -758,6 +758,12 @@ pub struct VariantProjector<P: ReferenceProvider + Clone> {
 
 impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     pub fn new(projector: Projector, provider: P) -> Self {
+        // Deliberately the lenient library default, not an entry-point config:
+        // this is a library constructor with no external error mode to carry, so
+        // it is out of scope for #1197's `for_entry_point` rule. Entry points
+        // override it — the `project` CLI does so via `with_normalize_config`
+        // (#1193) — and `tests/it/issue_1197_required_error_config.rs` scans only
+        // the CLI / PyO3 / service seams for that reason.
         let normalizer = Normalizer::with_config(provider.clone(), NormalizeConfig::default());
         Self {
             projector,

--- a/src/python.rs
+++ b/src/python.rs
@@ -176,6 +176,17 @@ fn parse_direction_or_raise(direction: &str) -> PyResult<ShuffleDirection> {
     })
 }
 
+/// Resolve an optional `error_config=` keyword argument to the `ErrorConfig`
+/// the normalizer should use.
+///
+/// `None` means "the caller did not ask for a mode", which resolves to lenient
+/// — the same handling these entry points have always had, when it came from
+/// `NormalizeConfig::default()`. Naming it here keeps the default visible now
+/// that [`NormalizeConfig::for_entry_point`] requires the argument (#1197).
+fn error_config_or_default(error_config: Option<&PyErrorConfig>) -> ErrorConfig {
+    error_config.map_or_else(ErrorConfig::lenient, |ec| ec.inner.clone())
+}
+
 /// Validate the `protein_stop` argument at the Python boundary → `TerStyle`.
 fn parse_protein_stop_or_raise(value: &str) -> PyResult<crate::hgvs::location::TerStyle> {
     match value {
@@ -490,7 +501,14 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
     let variant = parse_hgvs(hgvs_string)
         .map_err(|e| ferro_typed("ParseError", format!("Parse error: {e}"), &e))?;
 
-    let config = NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+    // This convenience API takes no error-mode argument, so the lenient default
+    // is a deliberate choice rather than a dropped parameter — `for_entry_point`
+    // makes it explicit at the call site instead of inheriting it silently
+    // (#1197). Callers wanting strict handling construct a `Normalizer`.
+    let config = NormalizeConfig::for_entry_point(
+        parse_direction_or_raise(direction)?,
+        ErrorConfig::lenient(),
+    );
     // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
     let provider = JsonProvider::with_test_data();
     // This free function always uses genome-less test data; surface the
@@ -873,8 +891,12 @@ impl PyHgvsVariant {
     ///     A new PyHgvsVariant representing the normalized variant
     #[pyo3(signature = (direction="3prime"))]
     fn normalize(&self, py: Python<'_>, direction: &str) -> PyResult<PyHgvsVariant> {
-        let config =
-            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+        // No error-mode argument on this convenience method either; the lenient
+        // default is stated rather than inherited (#1197).
+        let config = NormalizeConfig::for_entry_point(
+            parse_direction_or_raise(direction)?,
+            ErrorConfig::lenient(),
+        );
         // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
         let provider = JsonProvider::with_test_data();
         // Genome-less test data; surface the reduced-capability signal once per
@@ -1089,11 +1111,10 @@ impl PyNormalizer {
         // invalid direction always raises `ValueError` regardless of whether the
         // reference path is valid — a bad/missing path must not mask (or be
         // masked by) the argument error.
-        let mut config =
-            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
-        if let Some(ec) = error_config {
-            config = config.with_error_config(ec.inner.clone());
-        }
+        let config = NormalizeConfig::for_entry_point(
+            parse_direction_or_raise(direction)?,
+            error_config_or_default(error_config),
+        );
 
         let (provider, kind) = match reference_json {
             Some(path) => (
@@ -1136,11 +1157,10 @@ impl PyNormalizer {
     ) -> PyResult<Self> {
         // Validate `direction` before loading the manifest (see `new`): a bad
         // manifest path must not mask an invalid-direction `ValueError`.
-        let mut config =
-            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
-        if let Some(ec) = error_config {
-            config = config.with_error_config(ec.inner.clone());
-        }
+        let config = NormalizeConfig::for_entry_point(
+            parse_direction_or_raise(direction)?,
+            error_config_or_default(error_config),
+        );
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
         let normalizer = Self {
             provider,
@@ -1997,11 +2017,10 @@ fn parse_projector_boundary_args(
     assembly: Option<&str>,
     error_config: Option<&PyErrorConfig>,
 ) -> PyResult<(NormalizeConfig, Option<&'static str>)> {
-    let mut config =
-        NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
-    if let Some(ec) = error_config {
-        config = config.with_error_config(ec.inner.clone());
-    }
+    let config = NormalizeConfig::for_entry_point(
+        parse_direction_or_raise(direction)?,
+        error_config_or_default(error_config),
+    );
     let assembly_build = match assembly {
         Some(name) => Some(
             crate::liftover::aliases::normalize_assembly_name(name).ok_or_else(|| {

--- a/tests/it/issue_1197_required_error_config.rs
+++ b/tests/it/issue_1197_required_error_config.rs
@@ -1,0 +1,343 @@
+//! Issue #1197 — a dropped `ErrorConfig` must not be a silent lenient default.
+//!
+//! `NormalizeConfig::default().with_direction(d)` fills in every field the
+//! caller does not name, and `error_config` defaults to **lenient**. That is
+//! the shape that produced #1181: the CLI built an `ErrorConfig` from
+//! `--error-mode`, passed it into `run_normalize`, and then constructed the
+//! normalizer's config without it — so the flag was inert from the initial
+//! commit through 678 commits and roughly five months, taking `--ignore` and
+//! `--reject` with it. #1191 fixed that one call site; the *pattern* that
+//! allowed the omission survived at every other entry point.
+//!
+//! The web service never had the bug, and not by discipline — by construction:
+//! it builds the config with a struct literal, which must name every field, so
+//! omitting `error_config` is a compile error.
+//!
+//! This module pins the generalisation of that property. Entry-point seams —
+//! the CLI, the PyO3 bindings, the web service — must construct a
+//! `NormalizeConfig` in a way that *forces* the error configuration to be
+//! named: either [`NormalizeConfig::for_entry_point`], whose `error_config`
+//! parameter cannot be omitted, or a struct literal.
+//!
+//! ## Why a source scan
+//!
+//! There is no live defect to regress against — every seam threads the config
+//! correctly today (verified while investigating #1196). A behavioral test
+//! would therefore pass before and after, proving nothing. The property being
+//! added is *structural*: "the next entry point cannot get this wrong". A scan
+//! is the only thing that can fail when it is violated, and it is the same
+//! technique `error_code_audit.rs` already uses for the error-code registry.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Entry-point seams: everything that turns an external request (a CLI
+/// invocation, a Python call, an HTTP request) into a `Normalizer`. These are
+/// exactly the places where an error mode arrives from outside and can be
+/// dropped on the floor.
+const ENTRY_POINT_PATHS: &[&str] = &["src/bin/ferro.rs", "src/python.rs", "src/service"];
+
+/// Constructors that decide `error_config` without the caller naming it, so an
+/// error mode arriving from outside is silently discarded. Using one of these
+/// inside an [`ENTRY_POINT_PATHS`] file is the defect shape #1181 shipped with.
+///
+/// The preset builders matter as much as the defaulting ones:
+/// `NormalizeConfig::lenient().with_direction(d)` reintroduces #1181 exactly,
+/// while containing neither `default()` nor `new()`. `Normalizer::new` is the
+/// documented idiomatic constructor and hardcodes a lenient config.
+const ELIDING_CONSTRUCTORS: &[&str] = &[
+    "NormalizeConfig::default()",
+    "NormalizeConfig::new()",
+    "NormalizeConfig::lenient()",
+    "NormalizeConfig::strict()",
+    "NormalizeConfig::silent()",
+    "Normalizer::new(",
+];
+
+/// True when `needle` occurs in `haystack` at an identifier boundary — i.e. not
+/// as the tail of a longer path. Without this, `Normalizer::new(` matches
+/// `HgvsRsNormalizer::new(` (`src/service/tools/hgvs_rs.rs`), which is an
+/// unrelated type and a false positive.
+fn contains_at_identifier_boundary(haystack: &str, needle: &str) -> bool {
+    let mut from = 0;
+    while let Some(rel) = haystack[from..].find(needle) {
+        let at = from + rel;
+        let preceded_by_ident = haystack[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == ':');
+        if !preceded_by_ident {
+            return true;
+        }
+        from = at + 1;
+    }
+    false
+}
+
+/// Collect `path:line` for every construction in an entry-point file that
+/// elides the error configuration. Whole-line comments are skipped (they may
+/// legitimately name the pattern they warn about); `#[cfg(test)]` bodies are
+/// deliberately left in scope, since a test that builds an entry-point config
+/// the old way is also worth flagging.
+fn defaulting_constructions() -> BTreeSet<String> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut hits = BTreeSet::new();
+    for rel in ENTRY_POINT_PATHS {
+        scan(&manifest.join(rel), rel, &mut hits);
+    }
+    hits
+}
+
+/// Count the `.rs` files an [`ENTRY_POINT_PATHS`] entry actually resolves to.
+/// A seam that has been renamed or moved would otherwise make the scan below
+/// pass by scanning nothing at all.
+fn rust_files_under(rel: &str) -> usize {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let mut count = 0;
+    count_rust_files(&path, &mut count);
+    count
+}
+
+fn count_rust_files(path: &Path, count: &mut usize) {
+    if path.is_dir() {
+        if let Ok(rd) = std::fs::read_dir(path) {
+            for entry in rd.flatten() {
+                count_rust_files(&entry.path(), count);
+            }
+        }
+    } else if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("rs") {
+        // `is_file` is the load-bearing half: a path's extension is `rs`
+        // whether or not the file exists, so testing the extension alone would
+        // happily "find" a seam that had been renamed out from under us.
+        *count += 1;
+    }
+}
+
+fn scan(path: &Path, rel: &str, hits: &mut BTreeSet<String>) {
+    if !path.exists() {
+        return;
+    }
+    if path.is_dir() {
+        if let Ok(rd) = std::fs::read_dir(path) {
+            for entry in rd.flatten() {
+                let child = entry.path();
+                let name = child.file_name().unwrap_or_default().to_string_lossy();
+                scan(&child, &format!("{rel}/{name}"), hits);
+            }
+        }
+        return;
+    }
+    if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+        return;
+    }
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let lines: Vec<&str> = text.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let code = line.trim_start();
+        // A comment may legitimately name the pattern it is warning about.
+        if code.starts_with("//") {
+            continue;
+        }
+        if ELIDING_CONSTRUCTORS
+            .iter()
+            .any(|c| contains_at_identifier_boundary(line, c))
+        {
+            hits.insert(format!("{rel}:{}", i + 1));
+            continue;
+        }
+        // A `NormalizeConfig { .. }` struct literal is only safe because it
+        // must name every field. `..Default::default()` re-opens the hole — and
+        // it is the exact shape `for_entry_point` itself uses, so it would
+        // otherwise read as idiomatic. Flag any literal whose body never
+        // mentions `error_config`.
+        if opens_a_struct_literal(line) && struct_literal_elides_error_config(&lines, i) {
+            hits.insert(format!("{rel}:{}", i + 1));
+        }
+    }
+}
+
+/// True when `line` opens a `NormalizeConfig { .. }` *value*, as opposed to
+/// naming the type in a declaration. `-> NormalizeConfig {` (a function return
+/// type), `struct NormalizeConfig {` and `impl .. for NormalizeConfig {` all
+/// end in the same two tokens and are not constructions.
+fn opens_a_struct_literal(line: &str) -> bool {
+    let needle = "NormalizeConfig {";
+    let Some(at) = line.find(needle) else {
+        return false;
+    };
+    if !contains_at_identifier_boundary(line, needle) {
+        return false;
+    }
+    let before = line[..at].trim_end();
+    if before.ends_with("->") {
+        return false;
+    }
+    let head = line.trim_start();
+    !(head.starts_with("struct ")
+        || head.starts_with("pub struct ")
+        || head.starts_with("impl ")
+        || before.contains(" for "))
+}
+
+/// Walk a `NormalizeConfig {` literal opened on `start` to its balanced close,
+/// reporting whether the body ever names `error_config`.
+fn struct_literal_elides_error_config(lines: &[&str], start: usize) -> bool {
+    let mut depth = 0i32;
+    let mut names_error_config = false;
+    for line in &lines[start..] {
+        let code = line.trim_start();
+        if !code.starts_with("//") && line.contains("error_config") {
+            names_error_config = true;
+        }
+        for ch in line.chars() {
+            match ch {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+        }
+        if depth <= 0 {
+            break;
+        }
+    }
+    !names_error_config
+}
+
+/// An entry point must not build its `NormalizeConfig` from a defaulting
+/// constructor — the lenient `error_config` it silently supplies is precisely
+/// the bug #1181 shipped for five months.
+#[test]
+fn entry_points_do_not_build_a_defaulting_normalize_config() {
+    let hits = defaulting_constructions();
+    assert!(
+        hits.is_empty(),
+        "entry-point seams must construct `NormalizeConfig` in a way that forces the error \
+         configuration to be named — `NormalizeConfig::for_entry_point(direction, error_config)` \
+         or a struct literal. A defaulting constructor supplies a silent *lenient* \
+         `error_config`, which is how `--error-mode` stayed inert for five months (#1181, \
+         #1197). Offending sites:\n  {:?}",
+        hits
+    );
+}
+
+/// Every declared seam must actually resolve to Rust source. Without this, a
+/// renamed or relocated entry point turns the scan above into a no-op that
+/// passes because it looked at nothing — the precise failure mode a structural
+/// test has to rule out before its green result means anything.
+#[test]
+fn every_declared_entry_point_path_resolves_to_rust_source() {
+    for rel in ENTRY_POINT_PATHS {
+        let found = rust_files_under(rel);
+        assert!(
+            found > 0,
+            "entry-point seam {rel:?} matched no `.rs` files — it was renamed or moved, and the \
+             scan is silently covering nothing. Update `ENTRY_POINT_PATHS` to the new location.",
+        );
+    }
+}
+
+/// The scanner must actually be able to see the pattern it forbids, otherwise
+/// the test above could pass because the scan is broken rather than because
+/// the tree is clean. Exercises the real [`scan`] function against a written
+/// file rather than re-implementing the match inline — an inline check would
+/// pass even if `scan` itself were broken.
+#[test]
+fn the_scan_recognises_a_defaulting_construction() {
+    let dir = std::env::temp_dir().join(format!("ferro-1197-scan-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp scan dir");
+    let file = dir.join("seam.rs");
+    std::fs::write(
+        &file,
+        "fn build(d: ShuffleDirection) -> NormalizeConfig {\n    \
+         let config = NormalizeConfig::default().with_direction(d);\n    \
+         // NormalizeConfig::default() in a comment must not be flagged\n    \
+         config\n}\n",
+    )
+    .expect("write temp seam");
+
+    let mut hits = BTreeSet::new();
+    scan(&file, "seam.rs", &mut hits);
+    std::fs::remove_dir_all(&dir).ok();
+
+    assert_eq!(
+        hits,
+        BTreeSet::from(["seam.rs:2".to_string()]),
+        "`scan` must flag the bare defaulting construction on line 2 and ignore the comment \
+         naming the same pattern on line 3",
+    );
+}
+
+/// Write `body` to a scratch `.rs` file, scan it, and return the hit lines.
+fn scan_snippet(tag: &str, body: &str) -> BTreeSet<String> {
+    let dir = std::env::temp_dir().join(format!("ferro-1197-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp scan dir");
+    let file = dir.join("seam.rs");
+    std::fs::write(&file, body).expect("write temp seam");
+    let mut hits = BTreeSet::new();
+    scan(&file, "seam.rs", &mut hits);
+    std::fs::remove_dir_all(&dir).ok();
+    hits
+}
+
+/// The preset builders are the bypass a `default()`/`new()`-only list misses:
+/// `NormalizeConfig::lenient()` reintroduces #1181 verbatim while containing
+/// neither forbidden token.
+#[test]
+fn the_scan_flags_the_preset_builders_that_hardcode_an_error_config() {
+    for preset in ["lenient", "strict", "silent"] {
+        let body = format!("fn build(d: ShuffleDirection) -> NormalizeConfig {{\n    NormalizeConfig::{preset}().with_direction(d)\n}}\n");
+        assert_eq!(
+            scan_snippet(preset, &body),
+            BTreeSet::from(["seam.rs:2".to_string()]),
+            "`NormalizeConfig::{preset}()` at an entry point discards the caller's error mode \
+             and must be flagged",
+        );
+    }
+}
+
+/// `Normalizer::new` hardcodes a lenient config, but the matcher must not trip
+/// on an unrelated type whose name merely ends in `Normalizer`.
+#[test]
+fn the_scan_flags_normalizer_new_without_colliding_with_a_longer_type_name() {
+    assert_eq!(
+        scan_snippet(
+            "norm-new",
+            "fn a(p: P) -> Normalizer {\n    Normalizer::new(p)\n}\n"
+        ),
+        BTreeSet::from(["seam.rs:2".to_string()]),
+        "`Normalizer::new` hardcodes a lenient error config and must be flagged",
+    );
+    assert!(
+        scan_snippet(
+            "norm-collide",
+            "fn a(c: C) -> R {\n    HgvsRsNormalizer::new(&c)\n}\n"
+        )
+        .is_empty(),
+        "`HgvsRsNormalizer::new` is an unrelated type — matching it would be a false positive \
+         (it is live at src/service/tools/hgvs_rs.rs)",
+    );
+}
+
+/// A struct literal is only a safeguard while it must name every field.
+/// `..Default::default()` re-opens the hole silently.
+#[test]
+fn the_scan_flags_a_struct_literal_that_defaults_away_the_error_config() {
+    let eliding = "fn a(d: ShuffleDirection) -> NormalizeConfig {\n    \
+                   NormalizeConfig {\n        shuffle_direction: d,\n        \
+                   ..Default::default()\n    }\n}\n";
+    assert_eq!(
+        scan_snippet("lit-elide", eliding),
+        BTreeSet::from(["seam.rs:2".to_string()]),
+        "a `NormalizeConfig` literal that defaults away `error_config` must be flagged",
+    );
+
+    let explicit = "fn a(d: ShuffleDirection, ec: ErrorConfig) -> NormalizeConfig {\n    \
+                    NormalizeConfig {\n        shuffle_direction: d,\n        \
+                    error_config: ec,\n        ..Default::default()\n    }\n}\n";
+    assert!(
+        scan_snippet("lit-explicit", explicit).is_empty(),
+        "a literal that names `error_config` is exactly the safe shape and must not be flagged",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -140,6 +140,7 @@ mod issue_1183_rna_axis_ins_expansion;
 mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;
 mod issue_1196_error_config_reachability;
+mod issue_1197_required_error_config;
 mod issue_1202_transcript_bounds_insertion_clamp;
 mod issue_1204_gated_dup_fallback;
 mod issue_1205_genome_contig_bounds_clamp;


### PR DESCRIPTION
`NormalizeConfig::default().with_direction(d)` fills in every field the caller does not name, and `error_config` defaults to lenient. That is the shape that produced #1181: the CLI built an `ErrorConfig` from `--error-mode`, passed it into `run_normalize`, then constructed the normalizer's config without it — so the flag, and `--ignore`/`--reject` with it, was inert from the initial commit through 678 commits and roughly five months. #1191 fixed that one call site. This removes the construction pattern that allowed the omission.

The web service never had the bug, and not by discipline: it uses a struct literal (`src/service/tools/ferro.rs:66`), which must name every field, so omitting `error_config` there is a compile error. `NormalizeConfig::for_entry_point(direction, error_config)` gives the builder-chain callers an equivalent constructor whose error configuration cannot be omitted.

## What this does and does not guarantee

An adversarial reviewer's strongest finding was that the original commit subject — "make a dropped `ErrorConfig` a compile error at every entry point" — was **false**, and it was. Nothing became a compile error. `default`, `new`, the `lenient`/`strict`/`silent` presets and `Normalizer::new` all remain `pub` and all supply an error configuration the caller never named, so a *new* entry point can still elide one and compile. The subject and the rustdoc now say **lint**, and the rustdoc states the limit explicitly rather than implying the type system is doing the work.

Since there is no live defect to regress against — every seam threads the config correctly today — the guard is a source scan over the entry-point seams, the technique `error_code_audit.rs` already uses. A behavioral test would pass before and after and prove nothing; the property is structural.

## The scan, and why it is not the usual toothless one

The reviewer's second finding was that a two-literal `contains` scan is trivially bypassable, and gave a working bypass. It is now closed, along with the other evasions found:

- **Preset builders and `Normalizer::new` are rejected**, not just `default()`/`new()`. `NormalizeConfig::lenient().with_direction(d)` reintroduces #1181 verbatim while containing neither obvious token — that was the reviewer's verbatim bypass, and it now fails.
- **Matching is at identifier boundaries**, so `Normalizer::new(` does not fire on the live, unrelated `HgvsRsNormalizer::new(` (`src/service/tools/hgvs_rs.rs:46`). Pinned in both directions.
- **A `NormalizeConfig { .. }` literal that defaults `error_config` away is flagged.** This one matters because it is the exact shape `for_entry_point` itself uses, so it would otherwise read as idiomatic. Detection walks the literal to its balanced close and requires the body to name `error_config`; a declaration guard keeps `-> NormalizeConfig {` return types and `impl` blocks from false-positiving.
- **Every declared seam must resolve to real Rust source**, so renaming `src/python.rs` cannot turn the scan into a silent no-op that passes having read nothing.
- **The premise tests drive the real `scan`** over written fixtures instead of re-implementing the predicate inline. The original premise test asserted against a string literal and could not have detected a broken scanner — its own docstring claimed the opposite.

## Verification

Every guard was mutation-tested; two of the mutations found real defects, which is the only reason to trust the rest:

- Reintroducing the #1181 shape (`NormalizeConfig::default().with_direction(...)`) in `run_normalize` → fails, naming `src/bin/ferro.rs:1497`. So the scan does catch the original bug.
- The reviewer's bypass (`NormalizeConfig::lenient().with_direction(...)`) → fails at the same site.
- Renaming a seam in `ENTRY_POINT_PATHS` → **initially passed**, exposing a bug in the new guard: a path's extension is `rs` whether or not the file exists, so the extension check alone "found" a file that was not there. Fixed with an `is_file()` test; the mutation now fails as intended.
- The struct-literal detector **initially false-positived** on `-> NormalizeConfig {` function signatures, caught by its own premise test before it could reach the scan of real code.

Test counts observed locally, on this branch rebased onto `origin/main` at `3388b3f`:

- `cargo nextest run --features dev` → **8728 run, 8728 passed, 145 skipped**
- `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev` → **8728 run, 8728 passed, 145 skipped**
- `cargo fmt --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo check --features python` clean.

## No behavior change

All seven conversions are value-identical, verified field by field against `impl Default for NormalizeConfig` (`src/normalize/config.rs:83-93`). `Default` writes literally `error_config: ErrorConfig::lenient()`, which is exactly what the two convenience Python APIs now pass explicitly; `with_error_config` is a plain field assignment with no side effects; and `ShuffleDirection`'s `#[default]` is `ThreePrime`, so the `project` seam naming it explicitly is a no-op. The direction-validation-before-manifest-load ordering in `PyNormalizer` still holds — Rust evaluates call arguments left to right and `error_config_or_default` is infallible.

## Known gaps, deliberately not fixed here

- **`ferro project` never builds `error_config.preprocessor()`**, unlike `run_normalize` and `run_parse`, so the preprocessing half of `--ignore`/`--reject` is still discarded there even though `Commands::Project` accepts all three flags. Pre-existing and the same family as #1181. The comment this PR adds at that call site previously overstated the fix; it now says exactly which half works and names the gap. Worth its own issue.
- **`EquivalenceChecker` and `BatchProcessor`** (`src/python.rs:2662`, `:3390`) reach `Normalizer::new` indirectly and so get a lenient config. Neither exposes an `error_config=` kwarg, so no user-supplied mode is dropped, but by this PR's own standard they are the same case. A text scan cannot see indirect construction, so closing this needs an API change rather than a stronger lint.
- **`src/service/tools/ferro.rs:70`** sets `prevent_overlap: false` with the comment `// Keep default` while the default is `true`. The field is documented as vestigial with no runtime effect, so this is a wrong comment rather than a bug — untouched to keep this PR's diff to its subject.

## Relationship to #1196 / #1220

#1220 is the live fix (six enforced warning codes that never reached the error config). This is the prevention half and should land after it. The two are independent — near-disjoint files.

Closes #1197
