### PR TITLE
ci(coverage): run the coverage workflow on pull requests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,24 @@
 name: Coverage
 
+# Runs on pull requests as well as on `main`. Until #1225 this workflow was
+# push-only, which made it structurally incapable of failing before a merge:
+# a break landed on `main` and stayed there for 15 commits while every PR in
+# that window reported a full green board, because `Coverage` is also not one
+# of the required status contexts. Running it on PRs costs nothing on a public
+# repo and is what makes the signal actionable at the point a human can still
+# act on it.
+#
+# Deliberately NOT added to the required-status-check ruleset. The gate worth
+# having is "the suite compiles and passes under llvm-cov instrumentation",
+# which this provides as a visible check; gating on a coverage *percentage*
+# rewards touching lines rather than catching bugs. Promotion to a required
+# context is a separate decision to take once it has proven stable — and note
+# that required contexts match on exact job name, so a rename silently yields
+# "Expected — Waiting for status to be reported" (see #1216).
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`coverage.yml` triggered only on `push: branches: [main]`. `Coverage` is also not one of the eight required status contexts (`Build`, `Test`, `Clippy`, `Clippy (all features)`, `Format`, `Python Lint`, `Python Wheel Test`, `abi3 floor ↔ requires-python`).

Together those make a workflow that cannot fail before a merge and blocks nothing after one — it can only ever report a break that has already landed.

That is exactly what happened: #1219 broke it, and `main` stayed red from `92da6d0` to `e90dff2` — **15 commits over roughly 8 hours** — while every pull request in that window showed a full green board. #1225 fixed the break; this closes the window that let it land.

## Change

Adds `pull_request` to the trigger list. Nothing else.

Running it on PRs costs nothing on a public repository, and it moves the signal to the point where somebody can still act on it.

## What this deliberately does not do

It does **not** add `Coverage` to the required-status-check ruleset.

The gate worth having is "the suite compiles and passes under llvm-cov instrumentation" — that is now visible on every PR. Gating on a coverage *percentage* is a different and worse thing: it rewards tests that touch lines over tests that catch bugs.

Promotion to a required context is a separate decision, best taken after this has proven stable for a while, and one that has to account for required contexts matching on exact job name — a rename yields "Expected — Waiting for status to be reported" with no run to link to (#1216).

## Verification

`yaml.safe_load` confirms the parsed triggers are `['push', 'pull_request', 'workflow_dispatch']` and the `coverage` job is intact. `Lint Workflows` covers the rest.

The proof that it works is this PR itself: `Coverage` should appear in its own check list, which it could not have done before.