### PR TITLE
ci: report post-merge workflow failures as rolling issues

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,3 +51,21 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 30
+
+  report-failure:
+    needs: coverage
+    if: failure()
+    uses: ./.github/workflows/report-failure.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      title: "coverage: the test suite fails under llvm-cov"
+      summary: >-
+        The `Coverage` workflow failed. This usually means the suite does not build or pass under llvm-cov instrumentation, not that coverage dropped.
+      hint: |
+          Reproduce locally:
+          ```
+          cargo llvm-cov --features dev --workspace
+          ```
+          A frequent cause is a test that shells out to `cargo` without forwarding `--target-dir`: llvm-cov builds into `target/llvm-cov-target/`, which a nested cargo does not inherit (#1225).

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -298,3 +298,17 @@ jobs:
           else
             echo "Validation report not available" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  report-failure:
+    needs: [run-comparison-tests, run-standard-tests]
+    if: failure()
+    uses: ./.github/workflows/report-failure.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      title: "external API validation failed"
+      summary: >-
+        The scheduled external-API validation run failed.
+      hint: |
+          This talks to third-party services (mutalyzer, VariantValidator), so a failure may be an upstream outage rather than a ferro defect. Check the run log before assuming a regression.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -87,3 +87,21 @@ jobs:
           name: fuzz-crashes-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/
           if-no-files-found: ignore
+
+  report-failure:
+    needs: fuzz
+    if: failure()
+    uses: ./.github/workflows/report-failure.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      title: "fuzz: a target found a crash"
+      summary: >-
+        A fuzz target failed. The parser is expected to reject bad input, never panic on it.
+      hint: |
+          The crashing input is in the run artifacts. Reproduce:
+          ```
+          cargo fuzz run <target> <artifact>
+          ```
+          Commit the artifact as a regression seed alongside the fix.

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -145,3 +145,21 @@ jobs:
           name: ferro-xfail-${{ github.run_id }}
           path: /tmp/ferro-xfail/
           if-no-files-found: warn
+
+  report-failure:
+    needs: reference-aware-tests
+    if: failure()
+    uses: ./.github/workflows/report-failure.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      title: "nightly reference-aware tests failed"
+      summary: >-
+        The nightly manifest-backed conformance run failed.
+      hint: |
+          These axes only run with a prepared reference (`FERRO_MANIFEST`), so they cannot run on a pull request. Reproduce on a box with the reference:
+          ```
+          FERRO_MANIFEST=<ref>/manifest.json cargo nextest run --features dev
+          ```
+          A moved conformance baseline is re-blessable; a new live divergence is not.

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -177,3 +177,17 @@ jobs:
             echo "::warning::startup median ${median}s exceeds warn threshold ${STARTUP_WARN_MEDIAN}s"
           fi
           echo "startup OK: min=${min}s median=${median}s"
+
+  report-failure:
+    needs: startup-budget
+    if: failure()
+    uses: ./.github/workflows/report-failure.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      title: "nightly perf: startup budget exceeded"
+      summary: >-
+        The nightly startup perf budget was exceeded.
+      hint: |
+          Perf regressions compound quietly, so bisect promptly. Reference loading dominates startup; see #1178 / #1186 for what that path costs.

--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -1,0 +1,109 @@
+# Reusable failure reporter for workflows that cannot fail on a pull request.
+#
+# A workflow that only ever runs after a merge — on a schedule, or on push to
+# `main` — has no way to stop the break it detects. Its red X is decoration
+# unless something turns it into work somebody sees. Before this existed, six
+# of the seven such workflows here had no alerting at all, and `Coverage`
+# demonstrated the consequence: it stayed red for 15 commits (`92da6d0` ..
+# `e90dff2`) while every pull request in that window reported a full green
+# board (#1225, #1226).
+#
+# `nightly-soak` already had the right pattern and this is a straight
+# generalisation of it: ONE rolling issue per workflow, updated rather than
+# re-filed, so a defect that reproduces nightly does not bury the tracker.
+#
+# Usage — add a job to the caller, gated on `failure()`:
+#
+#     report:
+#       needs: [<the job(s) that can fail>]
+#       if: failure()
+#       uses: ./.github/workflows/report-failure.yml
+#       with:
+#         title: "nightly perf: startup budget exceeded"
+#         summary: "The startup perf budget was exceeded."
+#         hint: |
+#           Reproduce locally with:
+#           ```
+#           cargo run --release --bin ferro -- ...
+#           ```
+#       permissions:
+#         contents: read
+#         issues: write
+#
+# `needs:` matters. `if: failure()` alone is true when *any* earlier job in the
+# run failed, but without `needs` the reporter can start before the job it is
+# reporting on has finished.
+name: Report failure
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        description: >-
+          Issue title. Must be STABLE for a given failure mode — it is the
+          lookup key for the rolling issue, so anything varying per run (a
+          date, a run id, a shard number) would file a fresh issue every time
+          and defeat the whole point.
+        required: true
+        type: string
+      summary:
+        description: One-line statement of what failed.
+        required: true
+        type: string
+      hint:
+        description: >-
+          Optional reproduction guidance appended to the body. Markdown.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    name: Open or update the tracking issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ inputs.title }}
+          SUMMARY: ${{ inputs.summary }}
+          HINT: ${{ inputs.hint }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # `--search "<title> in:title"` is a fuzzy full-text match, so an
+          # unrelated issue whose title merely contains these words could come
+          # back first. Filter for an exact title match before treating a hit
+          # as "the" rolling issue — otherwise a comment lands on a stranger's
+          # issue and the real one is never created.
+          #
+          # The comparison reads the title through jq's `env`, not by
+          # interpolating it into the jq program: a title containing a quote
+          # would otherwise produce a malformed filter, and the value is
+          # workflow-supplied input.
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title \
+            --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty')
+          BODY=$(printf '%s\n' \
+            "$SUMMARY" \
+            "" \
+            "- Workflow: \`$WORKFLOW\`" \
+            "- Commit: \`$SHA\`" \
+            "- Run: $RUN_URL" \
+            "" \
+            "$HINT" \
+            "" \
+            "_This workflow does not run on pull requests, so this failure could not have been caught before merge. One rolling issue is used per failure mode; repeat occurrences are added as comments._")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi


### PR DESCRIPTION
A workflow that can only run *after* a merge — on a schedule, or on push to `main` — cannot stop the break it detects. Unless something turns its failure into work a human sees, its red X is decoration.

Six of the seven such workflows here had no alerting at all:

| Workflow | Runs on PRs | Alerted on failure (before) |
|---|---|---|
| `nightly-soak` | no | **yes** — rolling issue |
| `coverage` | no† | no |
| `nightly-mutalyzer` | no | no |
| `nightly-perf` | no | no |
| `fuzz` | no | no |
| `external-validation` | no | no |
| `deploy-local` | no | no ‡ |

† #1226 adds `pull_request` to coverage separately.
‡ Left alone — a deploy failure is immediately visible to whoever deployed, and it has no scheduled trigger.

`Coverage` demonstrated the cost. #1219 broke it, and `main` stayed red from `92da6d0` to `e90dff2` — **15 commits, ~8 hours** — while every PR in that window showed a full green board, because `Coverage` is also not a required status context. It was found by a human reading the Actions tab, not by any mechanism.

## Approach

`nightly-soak` already had the right answer: **one rolling issue per failure mode**, updated rather than re-filed, so a defect that reproduces nightly does not bury the tracker. This generalises that into a `workflow_call` reusable workflow and wires up the five that lacked it.

Each caller supplies a stable `title` (the lookup key for the rolling issue), a one-line `summary`, and a `hint` naming the command that reproduces *that* failure locally — a coverage break points at `cargo llvm-cov` and the `--target-dir` trap from #1225; a fuzz crash points at `cargo fuzz run <target> <artifact>`.

## Two details worth keeping

**Callers gate on `needs:` as well as `if: failure()`.** `failure()` alone is true whenever *any* earlier job in the run failed; without `needs`, the reporter can start before the job it reports on has finished.

**The exact-title match reads the title through jq's `env`**, not by interpolating it into the jq program. `gh issue list --search "<title> in:title"` is a fuzzy full-text match, so an exact filter is required — otherwise a comment lands on an unrelated issue whose title merely shares words, and the real rolling issue is never opened. Interpolating a title containing a quote would produce a malformed filter.

## `nightly-soak` keeps its bespoke step

Its body cites shard artifacts and a proptest seed-line reproduction workflow that do not generalise. Migrating it would mean either flattening that detail or growing the reporter a richer body input; neither is worth doing speculatively. It can move later.

## Verification

- `actionlint` clean across all workflows (it is installed locally; CI runs it plus `zizmor`).
- All six modified/added files parse under `yaml.safe_load`, with expected job lists.
- The jq filter was exercised against a payload containing both a fuzzy-matching decoy and an exact match with an embedded quote: it returns the exact match and ignores the decoy.
- No `actions/checkout` in the reusable workflow, so it does not touch the `persist-credentials` surface; the title/summary/hint reach the script through `env:` rather than `${{ }}` interpolation into `run:`.

The reporter cannot be exercised end-to-end without deliberately failing a scheduled workflow, so its first real run will be its first live test. That is a known limit of this shape — the mitigation is that the script is small, lint-clean, and its one non-obvious expression was verified directly.