### PR TITLE
refactor(dev): make the spec generators binaries so cargo locates them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,22 +254,23 @@ jobs:
         # validates the curated overrides file — the guard the old `--check`
         # step provided. Shipped to the shards as an artifact so they never
         # regenerate it (and so they need no spec submodule).
-        run: cargo run --features dev --example generate_spec_fixture
+        run: cargo run --features dev --bin generate_spec_fixture
       - name: Generate HGVS spec test enumeration
-        run: cargo run --features dev --example generate_spec_enumeration
+        run: cargo run --features dev --bin generate_spec_enumeration
       - name: Build test archive
         # Compiles every test binary and packs them with their run metadata.
         run: cargo nextest archive --features dev --archive-file nextest.tar.zst
-      - name: Stage the generator examples for the shards
-        # `spec_generator_preconditions` executes these two binaries. nextest
-        # does NOT build examples, so the shards cannot rely on finding them,
-        # and they must not shell out to cargo either (they run from the
-        # archive with no build state). Both were already built and run by the
-        # generate steps above, so ship them alongside the archive.
+      - name: Stage the generator binaries for the shards
+        # `spec_generator_preconditions` executes these two binaries. They are
+        # `required-features = ["dev"]` bin targets, and the shards run from the
+        # nextest archive with no build state, so they must not shell out to
+        # cargo. Both were already built and run by the generate steps above, so
+        # ship them alongside the archive. As `[[bin]]` targets they land in
+        # `target/debug/`, not `target/debug/examples/`.
         run: |
           mkdir -p staged-examples
-          cp target/debug/examples/generate_spec_fixture \
-             target/debug/examples/generate_spec_enumeration staged-examples/
+          cp target/debug/generate_spec_fixture \
+             target/debug/generate_spec_enumeration staged-examples/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive
@@ -318,10 +319,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: generator-examples
-          path: target/debug/examples/
-      - name: Restore the executable bit on the staged examples
+          path: target/debug/
+      - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.
-        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
+        run: chmod +x target/debug/generate_spec_fixture target/debug/generate_spec_enumeration
       - name: "Note: reference-aware tests are skipped without a manifest"
         # `tests/mutalyzer_normalize_tests.rs` and the biocommons reference-aware
         # suite both silently no-op when `FERRO_MANIFEST` is unset (PR CI does
@@ -380,10 +381,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: generator-examples
-          path: target/debug/examples/
-      - name: Restore the executable bit on the staged examples
+          path: target/debug/
+      - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.
-        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
+        run: chmod +x target/debug/generate_spec_fixture target/debug/generate_spec_enumeration
       - name: Run Rust tests with normalization idempotency self-check
         # `FERRO_ASSERT_IDEMPOTENT` turns every reference-backed test into an
         # assertion that `norm(norm(x)) == norm(x)`. The gate is
@@ -460,10 +461,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: generator-examples
-          path: target/debug/examples/
-      - name: Restore the executable bit on the staged examples
+          path: target/debug/
+      - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.
-        run: chmod +x target/debug/examples/generate_spec_fixture target/debug/examples/generate_spec_enumeration
+        run: chmod +x target/debug/generate_spec_fixture target/debug/generate_spec_enumeration
       - name: Soak 125k cases (seed ${{ matrix.seed }})
         env:
           # 8 shards x 125k = 1,000,000 cases per property.

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -206,10 +206,10 @@ jobs:
       # The spec-normalization fixture is a generated artifact (gitignored);
       # regenerate it before the suite so the reader tests find it.
       - name: Generate HGVS v21.0 spec fixture
-        run: cargo run --features dev --example generate_spec_fixture
+        run: cargo run --features dev --bin generate_spec_fixture
 
       - name: Generate HGVS spec test enumeration
-        run: cargo run --features dev --example generate_spec_enumeration
+        run: cargo run --features dev --bin generate_spec_enumeration
 
       # `dev` bundles every testable feature; `slow-tests` is
       # intentionally opt-in because it requires a ~1 GB ClinVar

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -67,9 +67,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Generate HGVS v21.0 spec fixture
-        run: cargo run --features dev --example generate_spec_fixture
+        run: cargo run --features dev --bin generate_spec_fixture
       - name: Generate HGVS spec test enumeration
-        run: cargo run --features dev --example generate_spec_enumeration
+        run: cargo run --features dev --bin generate_spec_enumeration
       - name: Soak 125k unseeded cases
         # No PROPTEST_RNG_SEED: each shard, each night, draws a fresh stream.
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       # the build cost is paid only when actually pushing.
       - id: generate-spec-fixture
         name: generate_spec_fixture
-        entry: cargo run --features dev --example generate_spec_fixture
+        entry: cargo run --features dev --bin generate_spec_fixture
         language: system
         # always_run (not types: [rust]) — a push that only touches the
         # spec submodule or the overrides file still needs the guard, and
@@ -54,7 +54,7 @@ repos:
       # as a `bash -c` chain that re-invoked the fixture generator.
       - id: generate-spec-enumeration
         name: generate_spec_enumeration
-        entry: cargo run --features dev --example generate_spec_enumeration
+        entry: cargo run --features dev --bin generate_spec_enumeration
         language: system
         always_run: true
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,16 @@ skips its own check.
 
 ### Generated spec fixture (not committed)
 
-`tests/fixtures/grammar/hgvs_spec_normalization.json` is a **generated build artifact** — it is `.gitignore`d, not committed. It is produced by the `generate_spec_fixture` example from the HGVS spec submodule, the parser's behavior, and the curated `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`. (Committing it made every parser PR a merge-conflict magnet, since each PR regenerated the whole file.)
+`tests/fixtures/grammar/hgvs_spec_normalization.json` is a **generated build artifact** — it is `.gitignore`d, not committed. It is produced by the `generate_spec_fixture` binary from the HGVS spec submodule, the parser's behavior, and the curated `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`. (Committing it made every parser PR a merge-conflict magnet, since each PR regenerated the whole file.)
 
 ```bash
-cargo run --features dev --example generate_spec_fixture            # (re)generate it
-cargo run --features dev --example generate_spec_fixture -- --output <path>   # write elsewhere
+cargo run --features dev --bin generate_spec_fixture            # (re)generate it
+cargo run --features dev --bin generate_spec_fixture -- --output <path>   # write elsewhere
 ```
+
+Replace `<path>` with the destination you want; the first form writes to the default
+location above. Do not substitute a machine-specific absolute path into a committed file
+(see [Repository Hygiene](#no-machine-local-paths-in-committed-files)).
 
 The tests that read it (`tests/it/hgvs_spec_normalization_tests.rs`, `tests/it/idempotency_tests.rs`, `tests/it/mito_circular_audit.rs`, `tests/it/protein_silent_eq.rs`, `tests/it/protein_unknown_roundtrip.rs`) call a shared helper (`tests/it/common/spec_fixture.rs`) that regenerates it on demand if missing, so a fresh `cargo test` "just works" (one-time generation). CI and the pre-push hook regenerate it explicitly before the test run — plain generation, not `--check`, because generation is what validates the committed overrides against the spec checkout.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ If your PR changes any normalization output:
    # compares against. (On a fresh worktree there is nothing to snapshot;
    # regenerate on `main` first if you want a baseline.)
    cp tests/fixtures/grammar/hgvs_spec_normalization.json /tmp/spec-fixture-before.json
-   cargo run --features dev --example generate_spec_fixture
+   cargo run --features dev --bin generate_spec_fixture
    ```
 
 2. Inspect the change against that snapshot — not `git diff`, which shows
@@ -190,7 +190,7 @@ override file.
    override against it, so a stale override fails the build.
 
    ```bash
-   cargo run --features dev --example generate_spec_fixture
+   cargo run --features dev --bin generate_spec_fixture
    ```
 
    The pre-push hook runs the same command for the same reason. `--check` is a
@@ -198,7 +198,7 @@ override file.
    — and is never a gate:
 
    ```bash
-   cargo run --features dev --example generate_spec_fixture -- --check
+   cargo run --features dev --bin generate_spec_fixture -- --check
    ```
 
    (Contrast the tool-support tables below, whose outputs *are* committed. There

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,15 @@ exclude = [
     "/acgt-landing/",
 ]
 
+# The two spec generators live under `examples/` but are declared as `[[bin]]`
+# targets below (they need `CARGO_BIN_EXE_*`). With auto-discovery on, cargo
+# would ALSO register them as example targets — verified: `cargo metadata`
+# reported each file twice, once as `bin` and once as `example` — compiling
+# both copies of a ~2000-line target every build. Turning discovery off makes
+# every example explicit, which is why the five previously-implicit ones are
+# declared below alongside the six that already were.
+autoexamples = false
+
 [lib]
 name = "ferro_hgvs"
 # cdylib is required for Python bindings (built via maturin)
@@ -86,7 +95,7 @@ web-service = ["dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:trac
 # Long-running tests (e.g., full ClinVar validation). Run with: cargo test --release --features slow-tests
 slow-tests = []
 # dev feature includes all testable features (python requires maturin for building)
-dev = ["validation", "mmap", "benchmark", "parallel", "protein-fetch", "web-service"]
+dev = ["validation", "mmap", "benchmark", "parallel", "protein-fetch", "web-service", "dep:pulldown-cmark", "dep:anyhow", "dep:serde_yaml"]
 
 [dependencies.dhat]
 version = "0.3"
@@ -187,16 +196,41 @@ optional = true
 version = "5"
 optional = true
 
+# Markdown parsing for the HGVS spec harvest (`examples/common/spec_harvest.rs`).
+#
+# OPTIONAL, and pulled in only by the non-default `dev` feature, so an ordinary
+# consumer never resolves or builds it. It sits here rather than in
+# `[dev-dependencies]` because the two spec generators are `[[bin]]` targets and
+# binaries — unlike examples — cannot use dev-dependencies. See the `[[bin]]`
+# blocks below for why they must be binaries.
+# `anyhow` and `serde_yaml` are ALSO needed by the two generator `[[bin]]`
+# targets, for the same reason as `pulldown-cmark`: binaries cannot use
+# dev-dependencies. Both are optional and reached only through the non-default
+# `dev` feature, so an ordinary consumer resolves neither.
+#
+# They deliberately REMAIN in `[dev-dependencies]` as well. Other test and
+# example targets use them, and `tests/it` still compiles without `--features
+# dev`; dropping the dev-dependency would break those configurations. Cargo
+# permits a crate in both sections and unifies them for test targets.
+[dependencies.anyhow]
+version = "1"
+optional = true
+
+[dependencies.serde_yaml]
+version = "0.9"
+optional = true
+
+[dependencies.pulldown-cmark]
+version = "0.13"
+default-features = false
+optional = true
+
 [dev-dependencies]
 proptest = "1.0"
 criterion = "0.5"
 flate2 = "1.0"
 tempfile = "3.14"
 rstest = "0.23"
-# Used by examples/generate_spec_fixture.rs to extract HGVS strings from the
-# vendored v21.0 spec. Examples (unlike binaries under src/bin) have access to
-# dev-dependencies, so these stay out of the runtime dependency tree.
-pulldown-cmark = { version = "0.13", default-features = false }
 serde_yaml = "0.9"
 anyhow = "1"
 # Used by examples/build_conformance_snapshot.rs to record a per-entry SHA-256 of
@@ -224,12 +258,34 @@ required-features = ["dev"]
 name = "generate_perf_tables"
 required-features = ["dev"]
 
-# These two carry `#[cfg(test)]` unit tests (in the example and in the shared
-# `common/` modules they include via `#[path]`). Cargo does not build an
-# example's tests unless the target opts in with `test = true`, so without this
-# their tests silently never run under `cargo nextest --features dev`.
-[[example]]
+# The two spec generators are BINARIES, not examples.
+#
+# Tests must locate and run them, and `CARGO_BIN_EXE_<name>` — which cargo
+# defines for bins only — is the only way to get that path right for the cargo
+# invocation actually in flight. Deriving it by hand from `current_exe()` meant
+# re-deriving the invocation, and produced a silent wrong-path bug twice: on the
+# profile axis (#1224) and on the target-dir axis under `cargo llvm-cov`
+# (#1225, which left `main` red for 15 commits). `CARGO_BIN_EXE_*` is resolved
+# by cargo, so it is correct under any profile, target dir or cross-compile, and
+# cargo guarantees the binary is freshly built before integration tests run.
+#
+# Their sources stay under `examples/` so the `#[path = "common/..."]` includes
+# they share with `extract_spec_enumeration_windows` keep resolving;
+# `autoexamples = false` in `[package]` stops cargo also auto-discovering them
+# as example targets.
+#
+# `test = true` because both carry `#[cfg(test)]` unit tests, in the target and
+# in the shared `common/` modules. Cargo does not build a target's tests unless
+# it opts in, so without this they silently never run.
+[[bin]]
 name = "generate_spec_enumeration"
+path = "examples/generate_spec_enumeration.rs"
+required-features = ["dev"]
+test = true
+
+[[bin]]
+name = "generate_spec_fixture"
+path = "examples/generate_spec_fixture.rs"
 required-features = ["dev"]
 test = true
 
@@ -238,6 +294,25 @@ name = "extract_spec_enumeration_windows"
 required-features = ["dev"]
 test = true
 
+[[example]]
+name = "derive_tx_placements"
+required-features = ["dev"]
+
+[[example]]
+name = "extract_biocommons_windows"
+required-features = ["dev"]
+
+[[example]]
+name = "generate_conformance_summary"
+required-features = ["dev"]
+
+[[example]]
+name = "projector-bench"
+required-features = ["dev"]
+
+[[example]]
+name = "report_conformance_reference_gaps"
+required-features = ["dev"]
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/examples/common/generated_artifact.rs
+++ b/examples/common/generated_artifact.rs
@@ -27,18 +27,20 @@ use std::path::Path;
 ///   never been generated is a cold cache, not drift: there is no committed
 ///   baseline it could have drifted from. Materialise it and say so.
 ///
-/// `label` names the artifact in messages; `example` is the generator to rerun.
+/// `label` names the artifact in messages; `generator` is the generator to
+/// rerun. Both generators are `[[bin]]` targets, so the printed command must say
+/// `--bin`; `--example` would name a target that no longer exists.
 pub fn check_up_to_date(
     path: &Path,
     rendered: &str,
     label: &str,
-    example: &str,
+    generator: &str,
 ) -> anyhow::Result<()> {
     match std::fs::read_to_string(path) {
         Ok(on_disk) if on_disk == rendered => Ok(()),
         Ok(_) => {
             eprintln!(
-                "{label} {} is out of date; rerun: cargo run --features dev --example {example}",
+                "{label} {} is out of date; rerun: cargo run --features dev --bin {generator}",
                 path.display()
             );
             Err(anyhow::anyhow!("{label} out of date"))

--- a/examples/generate_spec_enumeration.rs
+++ b/examples/generate_spec_enumeration.rs
@@ -22,9 +22,9 @@
 //! artifact**: gitignored, regenerated on demand. Only the hand-curated
 //! overrides, this generator, and the test driver are committed.
 //!
-//! Run:   `cargo run --features dev --example generate_spec_enumeration`
-//! Check: `cargo run --features dev --example generate_spec_enumeration -- --check`
-//! Census: `cargo run --features dev --example generate_spec_enumeration -- --census`
+//! Run:   `cargo run --features dev --bin generate_spec_enumeration`
+//! Check: `cargo run --features dev --bin generate_spec_enumeration -- --check`
+//! Census: `cargo run --features dev --bin generate_spec_enumeration -- --census`
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -288,7 +288,7 @@ mod dedup {
             let text = std::fs::read_to_string(path).map_err(|e| {
                 anyhow::anyhow!(
                     "read {}: {e}\nHint: regenerate it first with \
-                     `cargo run --features dev --example generate_spec_fixture`",
+                     `cargo run --features dev --bin generate_spec_fixture`",
                     path.display()
                 )
             })?;
@@ -1939,7 +1939,7 @@ mod render {
         let doc = Document {
             description:
                 "Exhaustive, non-redundant HGVS spec test enumeration. Generated artifact - \
-                 gitignored, regenerate with `cargo run --features dev --example \
+                 gitignored, regenerate with `cargo run --features dev --bin \
                  generate_spec_enumeration`. Complements (never restates) \
                  hgvs_spec_normalization.json.",
             spec: SpecBlock {

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -14,8 +14,8 @@
 //!     cache, not drift (the file is gitignored, so there is no committed
 //!     baseline), and is simply generated.
 //!
-//! Run: `cargo run --features dev --example generate_spec_fixture`
-//! Check: `cargo run --features dev --example generate_spec_fixture -- --check`
+//! Run: `cargo run --features dev --bin generate_spec_fixture`
+//! Check: `cargo run --features dev --bin generate_spec_fixture -- --check`
 //!
 //! See: docs/superpowers/specs/2026-05-03-issue-84-hgvs-v21-normalization-fixture-design.md
 

--- a/tests/it/common/fixture_gen.rs
+++ b/tests/it/common/fixture_gen.rs
@@ -4,10 +4,10 @@
 //! `hgvs_spec_enumeration.json` (see [`super::spec_enumeration`]) are generated
 //! build artifacts, not committed files (see `CLAUDE.md`): tracking them made
 //! every parser PR a merge-conflict magnet. Each is produced by running a
-//! `--features dev` example with `--output <tmp>` and atomically renaming the
+//! `--features dev` generator binary with `--output <tmp>` and atomically renaming the
 //! result into place. This module holds the one regeneration flow they share —
 //! locking, subprocess execution, temp-file cleanup, atomic rename — so the two
-//! callers are thin wrappers that differ only in path, example name, temp stem,
+//! callers are thin wrappers that differ only in path, generator name, temp stem,
 //! and an optional prerequisite fixture to satisfy first.
 
 use std::path::{Path, PathBuf};
@@ -30,7 +30,7 @@ pub fn fixture_path(relative: &str) -> PathBuf {
 }
 
 /// Ensure `path` exists, regenerating it via
-/// `cargo run --features dev --example <example> -- --output <tmp>` when it is
+/// `cargo run --features dev --bin <generator> -- --output <tmp>` when it is
 /// missing. `dependency` runs first (before the lock is taken) to satisfy any
 /// fixture the generator itself reads; pass `|| {}` when there is none. `label`
 /// names the fixture in panic messages. Idempotent and safe to call from many
@@ -38,7 +38,7 @@ pub fn fixture_path(relative: &str) -> PathBuf {
 /// atomically, so a partially written file is never observed.
 pub fn ensure_generated_fixture(
     path: &Path,
-    example: &str,
+    generator: &str,
     tmp_stem: &str,
     label: &str,
     dependency: impl FnOnce(),
@@ -64,6 +64,19 @@ pub fn ensure_generated_fixture(
     let dir = path.parent().expect("fixture path has a parent directory");
     let tmp = dir.join(format!("{tmp_stem}.{}.tmp", std::process::id()));
 
+    // Deliberately a nested `cargo run`, NOT `CARGO_BIN_EXE_<generator>`.
+    //
+    // The generator-executing test modules (`spec_generator_preconditions`,
+    // `issue_1046_generator_gitdir_leak`) do use `CARGO_BIN_EXE_*`, and should:
+    // they are `#[cfg(feature = "dev")]`. This helper is not. It is reached from
+    // `hgvs_spec_normalization_tests`, `idempotency_tests` and
+    // `spec_enumeration_tests`, which are ungated so that a plain `cargo test`
+    // still runs them. `env!` resolves at *compile* time and cargo defines
+    // `CARGO_BIN_EXE_*` only for bins it builds — and both generators are
+    // `required-features = ["dev"]` — so expanding it here would fail to compile
+    // the whole `it` target without `--features dev`. `generator` is also a
+    // runtime string, which `env!` cannot take. Resolving the generator at run
+    // time is what keeps this callable from ungated modules.
     let status = Command::new(env!("CARGO"))
         .current_dir(manifest_dir)
         .args([
@@ -71,15 +84,15 @@ pub fn ensure_generated_fixture(
             "--quiet",
             "--features",
             "dev",
-            "--example",
-            example,
+            "--bin",
+            generator,
             "--",
             "--output",
         ])
         .arg(&tmp)
         .status()
-        .unwrap_or_else(|e| panic!("failed to run `{example}` example: {e}"));
-    assert!(status.success(), "`{example}` exited with failure");
+        .unwrap_or_else(|e| panic!("failed to run `{generator}` binary: {e}"));
+    assert!(status.success(), "`{generator}` exited with failure");
 
     // Atomically install the result. If a sibling test binary won the race and
     // already created the final file, drop our redundant temp copy.

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -4,7 +4,7 @@
 //! output for every variant string in the v21.0 spec. Rows whose `current`
 //! diverges from `spec_expected` carry a `todo` link to the #83 audit.
 //!
-//! Regenerate the fixture: `cargo run --features dev --example generate_spec_fixture`.
+//! Regenerate the fixture: `cargo run --features dev --bin generate_spec_fixture`.
 //! That run is also the guard on the committed overrides, and is what CI and the
 //! pre-push hook use. Adding `-- --check` instead asks only whether the local
 //! (gitignored) artifact is current — useful for spotting whether a code change
@@ -208,7 +208,7 @@ fn pinned_v21_normalization_behavior() {
         panic!(
             "{} row(s) drifted from the pinned current behavior. First {} shown.\n\n{}\n\n\
              If this drift is intentional, regenerate the fixture:\n  \
-             cargo run --features dev --example generate_spec_fixture",
+             cargo run --features dev --bin generate_spec_fixture",
             diffs.len(),
             diffs.len().min(20),
             preview,

--- a/tests/it/issue_1046_generator_gitdir_leak.rs
+++ b/tests/it/issue_1046_generator_gitdir_leak.rs
@@ -34,31 +34,17 @@ fn rev_parse(dir: &Path, rev: &str) -> Option<String> {
     Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
-/// The target directory root of the running test binary
-/// (`<target>/<profile>/deps/<test-exe>` → `<target>`). This tracks whatever
-/// `--target-dir` / `CARGO_TARGET_DIR` the outer `cargo test` used, including
-/// the `target/llvm-cov-target` override that the coverage job passes on the
-/// command line (which nested cargo invocations do *not* otherwise inherit).
-fn target_dir() -> PathBuf {
-    let mut p = std::env::current_exe().expect("current_exe");
-    p.pop(); // drop the test-exe filename → .../deps/
-    p.pop(); // drop deps → .../<profile>/
-    p.pop(); // drop <profile> → .../<target>/
-    p
-}
-
-/// Path to the built `generate_spec_fixture` example under the profile that the
-/// running test binary was built with (`<target>/<profile>/deps/<test-exe>` →
-/// `<target>/<profile>/examples/generate_spec_fixture`). This is robust to
-/// `CARGO_TARGET_DIR` and the active profile, and avoids invoking the example
-/// through `cargo run` (which would leak our hostile GIT env into cargo too).
-fn example_binary() -> PathBuf {
-    let mut p = std::env::current_exe().expect("current_exe");
-    p.pop(); // drop the test-exe filename → .../deps/
-    p.pop(); // drop deps → .../<profile>/
-    p.push("examples");
-    p.push("generate_spec_fixture");
-    p
+/// Path to the `generate_spec_fixture` binary, from cargo.
+///
+/// This used to re-derive `<target>/<profile>/examples/<name>` from
+/// `current_exe()`. That derivation is exactly what produced the wrong-path
+/// bugs in #1224 (profile axis) and #1225 (target-dir axis, which left `main`
+/// red for 15 commits). `CARGO_BIN_EXE_*` is resolved by cargo for the
+/// invocation actually running, so no axis can be missed — and cargo builds
+/// the binary before this test runs, which is why the explicit `cargo build`
+/// that used to precede this call is gone too.
+fn generator_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_generate_spec_fixture"))
 }
 
 #[test]
@@ -98,31 +84,13 @@ fn commit_sha_is_submodule_pin_under_hook_git_env() {
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     };
 
-    // Build the example (a fast no-op when already built). Pin `--target-dir`
-    // to the outer test binary's target root so the example lands exactly where
-    // `example_binary()` looks: the coverage job passes `--target-dir` on the
-    // command line, and that override is not inherited by this nested cargo
-    // invocation (which would otherwise build into the default `target/`).
-    let build = Command::new(env!("CARGO"))
-        .current_dir(&root)
-        .args([
-            "build",
-            "--quiet",
-            "--features",
-            "dev",
-            "--example",
-            "generate_spec_fixture",
-        ])
-        .arg("--target-dir")
-        .arg(target_dir())
-        .status()
-        .expect("build generate_spec_fixture example");
-    assert!(build.success(), "example build failed");
-
-    let bin = example_binary();
+    // Cargo builds the generator before this test runs and hands us its path via
+    // `CARGO_BIN_EXE_*`, so there is no nested `cargo build` and no
+    // profile/target-dir reconstruction to get wrong.
+    let bin = generator_binary();
     assert!(
         bin.exists(),
-        "example binary not found at {}",
+        "generator binary not found at {}",
         bin.display()
     );
 
@@ -131,7 +99,7 @@ fn commit_sha_is_submodule_pin_under_hook_git_env() {
         std::process::id()
     ));
 
-    // Run the example directly (no cargo) with the hostile GIT env set.
+    // Run the generator directly (no cargo) with the hostile GIT env set.
     let status = Command::new(&bin)
         .current_dir(&root)
         .arg("--output")
@@ -139,7 +107,7 @@ fn commit_sha_is_submodule_pin_under_hook_git_env() {
         .env("GIT_DIR", &outer_git_dir)
         .env("GIT_WORK_TREE", &root)
         .status()
-        .expect("run generate_spec_fixture example");
+        .expect("run generate_spec_fixture");
     assert!(status.success(), "generator exited with failure");
 
     let text = std::fs::read_to_string(&tmp).expect("read generated fixture");

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -97,6 +97,11 @@ mod issue_1039_convert_gff_fasta_error;
 mod issue_1040_inv_overrecognition_probes;
 mod issue_1041_repro;
 mod issue_1044_mito_window_clamp;
+// Same gate as `spec_generator_preconditions` below, and for the same reason:
+// this module resolves `CARGO_BIN_EXE_generate_spec_fixture` with `env!`, which
+// is a *compile-time* lookup, so a plain `cargo test` would fail to build the
+// whole `it` target rather than skip these tests.
+#[cfg(feature = "dev")]
 mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
@@ -333,6 +338,11 @@ mod spdi_tests;
 mod spec_canonical_locks;
 mod spec_coverage_misc;
 mod spec_enumeration_tests;
+// `CARGO_BIN_EXE_generate_spec_*` is defined only for bin targets cargo builds,
+// and both generators are `required-features = ["dev"]`. Without this gate a
+// plain `cargo test` (no `--features dev`) fails to compile the whole `it`
+// target rather than merely skipping these tests.
+#[cfg(feature = "dev")]
 mod spec_generator_preconditions;
 mod strict_del_size_suffix_mode;
 mod strict_explicit_seq_size_modes;

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -10,7 +10,7 @@
 //! parses and obeys the MUST-level shape rules — nothing more.
 //!
 //! The fixture is generated and gitignored; regenerate it with
-//! `cargo run --features dev --example generate_spec_enumeration`.
+//! `cargo run --features dev --bin generate_spec_enumeration`.
 //!
 //! Rows whose recorded behaviour diverges from the spec are **not** failures
 //! here. They are classified (`repair-diverges`, `false-acceptance`,
@@ -199,7 +199,7 @@ fn enumeration_replays_recorded_behavior() {
     assert!(
         diffs.is_empty(),
         "{} enumeration row(s) drifted. Regenerate if intentional:\n  \
-         cargo run --features dev --example generate_spec_enumeration\n\n{}",
+         cargo run --features dev --bin generate_spec_enumeration\n\n{}",
         diffs.len(),
         diffs
             .iter()
@@ -244,7 +244,7 @@ fn every_row_carries_provenance() {
 /// regression *or* a fix — trips this and must be re-blessed deliberately.
 ///
 /// Regenerate the numbers with:
-///   `cargo run --features dev --example generate_spec_enumeration -- --census`
+///   `cargo run --features dev --bin generate_spec_enumeration -- --census`
 /// and read `by_status` in the generated fixture.
 const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // Spec-forbidden strings ferro parses and renders anyway.
@@ -308,7 +308,7 @@ fn divergence_budget_is_unchanged() {
 /// `every_observed_status_is_accounted_for` fails and names it, turning "a new
 /// status category appeared" into a deliberate, reviewed decision instead of a
 /// silent pass. Regenerate the roster of observed statuses with:
-///   `cargo run --features dev --example generate_spec_enumeration -- --census`
+///   `cargo run --features dev --bin generate_spec_enumeration -- --census`
 /// and read `by_status` in the generated fixture.
 const KNOWN_PASSING_STATUSES: &[Status] = &[
     // Spec-forbidden string that ferro rejected outright (parse error) — the

--- a/tests/it/spec_generator_preconditions.rs
+++ b/tests/it/spec_generator_preconditions.rs
@@ -38,233 +38,63 @@ fn scratch(name: &str) -> PathBuf {
     dir
 }
 
-/// Build the two generator examples exactly once per test binary, and return
-/// the path to the requested one.
+/// Absolute path to a generator binary, provided by cargo.
 ///
-/// # Why not just `cargo run --example`
+/// # Why `CARGO_BIN_EXE_*` and not a hand-derived path
 ///
-/// That is what this module did originally, and it was pathologically slow —
-/// but not for the reason it looks like. Cargo takes a **file lock on
-/// `target/`**, so the four tests here, which nextest runs concurrently,
-/// serialised behind one another: each reported ~25s even against a fully warm
-/// build tree, and in CI they blew past nextest's 60s SLOW threshold and made
-/// whichever shard held them the critical path of the whole test job.
+/// This helper used to shell out to `cargo build` and then locate the output
+/// itself. Locating it means reconstructing the cargo invocation that is
+/// actually in flight — profile, target directory, features — and every
+/// coordinate missed is a silent wrong-path bug:
 ///
-/// # Why not just invoke `target/<profile>/examples/<name>` directly
+/// - the build ignored the profile, so `--release` looked in
+///   `target/release/examples/` for something written to `target/debug/`
+///   (#1224). Worse than the one hard failure, a sibling test *passed* against
+///   a stale release binary left over from an earlier build — exactly the
+///   staleness the machinery existed to prevent;
+/// - the build then ignored the target directory, so under `cargo llvm-cov`
+///   (which builds into `target/llvm-cov-target/`) all four tests failed, and
+///   `main` stayed red for 15 commits because `Coverage` runs only after a
+///   merge and gates nothing (#1225).
 ///
-/// Tried, and it is **wrong**. `cargo test` / `cargo nextest run` do *not*
-/// rebuild examples, so the binary sitting in `examples/` can be arbitrarily
-/// old. Observed directly: a `generate_spec_enumeration` binary from the
-/// previous day produced the pre-#1201 error message, and this module's test
-/// for #1201's guard failed against source that unmistakably contained it. A
-/// stale binary makes these tests assert things about code that is not the code
-/// under test — a far worse failure than being slow.
+/// Cargo defines `CARGO_BIN_EXE_<name>` for every `[[bin]]` target of the
+/// package under test, resolved for the invocation in hand. It is correct
+/// under any profile, target dir, or cross-compile, and cargo guarantees the
+/// binary is built and current before integration tests run — so the `Once`,
+/// the nested build, the path arithmetic, and the `FERRO_PREBUILT_EXAMPLES`
+/// escape hatch for CI's nextest archives all become unnecessary. That is why
+/// the generators are declared as `[[bin]]` in `Cargo.toml`.
 ///
-/// # What this does
-///
-/// One `cargo build` for both examples, behind a `Once`, then direct execution.
-/// The build is current by construction, and it happens exactly once no matter
-/// how many tests run concurrently — so the cargo lock is taken once rather
-/// than per test, which is where the speedup comes from.
-///
-/// `FERRO_PREBUILT_EXAMPLES` skips even that single build, for the one context
-/// where the binaries are known-current and cargo is unavailable: CI's sharded
-/// test jobs, which run from a nextest archive after `test-build` has already
-/// built and executed both generators.
-///
-/// # The build and the lookup must agree on the profile
-///
-/// Both halves are derived from the same `target/<profile>/` directory. Getting
-/// only one of them right is worse than getting both wrong: a `--release` run
-/// used to build into `target/debug/examples/` and then look in
-/// `target/release/examples/`, which failed outright for
-/// `generate_spec_enumeration` and — far worse — silently *succeeded* for
-/// `generate_spec_fixture` whenever a stale release binary happened to be
-/// sitting there, resurrecting exactly the staleness this helper exists to
-/// prevent.
-fn built_example(example: &str) -> PathBuf {
-    static BUILD: std::sync::Once = std::sync::Once::new();
-    static BUILD_OK: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-    // CI builds both examples in the `test-build` job (it runs them to generate
-    // the spec artifacts) and sets this variable, so the sharded test jobs —
-    // which execute from a nextest archive and have no cargo build state at all
-    // — must not shell out to cargo. A cargo invocation there would rebuild the
-    // world per shard.
-    let prebuilt = std::env::var_os("FERRO_PREBUILT_EXAMPLES").is_some();
-
-    // The test binary lives at `…/target/<profile>/deps/it-<hash>`, so the
-    // examples directory is two levels up. Deriving it from `current_exe`
-    // rather than hardcoding `debug/` keeps this correct under `--release` and
-    // under a nextest archive extracted into the workspace.
-    let exe = std::env::current_exe().expect("current_exe");
-    let profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("target/<profile>")
-        .to_path_buf();
-    let profile = profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("debug")
-        .to_string();
-    // …and the target directory is one level above that. It is NOT always
-    // `<manifest>/target`: `cargo llvm-cov` builds into
-    // `target/llvm-cov-target/`, and `--target-dir` / `CARGO_TARGET_DIR` can
-    // point anywhere. The nested build must be told, or it writes to the
-    // default `target/` while the lookup reads somewhere else entirely.
-    let target_dir = profile_dir
-        .parent()
-        .expect("target dir above target/<profile>")
-        .to_path_buf();
-
-    BUILD.call_once(|| {
-        if prebuilt {
-            BUILD_OK.store(true, std::sync::atomic::Ordering::SeqCst);
-            return;
-        }
-        let status = Command::new(env!("CARGO"))
-            .current_dir(manifest_dir())
-            .args(build_args(&profile, &target_dir))
-            .status();
-        let ok = matches!(status, Ok(s) if s.success());
-        BUILD_OK.store(ok, std::sync::atomic::Ordering::SeqCst);
-    });
-    assert!(
-        BUILD_OK.load(std::sync::atomic::Ordering::SeqCst),
-        "failed to build the generator examples"
-    );
-
-    let path = profile_dir.join("examples").join(example);
-    assert!(
-        path.is_file(),
-        "expected a freshly built example at {}",
-        path.display()
-    );
-    path
+/// The whole module is `dev`-gated: `CARGO_BIN_EXE_*` exists only for targets
+/// cargo actually builds, and both generators are `required-features = ["dev"]`.
+fn spec_fixture_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_generate_spec_fixture")
 }
 
-/// `cargo build` arguments that place both generator examples in
-/// `<target_dir>/<profile>/examples/`.
-///
-/// Both coordinates are passed explicitly, because the nested cargo inherits
-/// neither from the parent test run:
-///
-/// - `profile` is the *directory* name under the target dir, which is not
-///   always the profile name: cargo writes the built-in `dev` profile into
-///   `debug/`, while every other profile's directory matches its name. So
-///   `debug` means "pass no profile flag" and anything else is forwarded
-///   verbatim via `--profile`, which also covers custom profiles.
-/// - `target_dir` is forwarded via `--target-dir`. `cargo llvm-cov` drives
-///   `cargo test --target-dir target/llvm-cov-target`, and that flag does not
-///   reach a grandchild cargo — without this the build lands in the default
-///   `target/` while the lookup reads
-///   `target/llvm-cov-target/<profile>/examples/`.
-fn build_args(profile: &str, target_dir: &std::path::Path) -> Vec<String> {
-    let mut args: Vec<String> = [
-        "build",
-        "--quiet",
-        "--features",
-        "dev",
-        "--example",
-        "generate_spec_fixture",
-        "--example",
-        "generate_spec_enumeration",
-    ]
-    .iter()
-    .map(|s| s.to_string())
-    .collect();
-    if profile != "debug" {
-        args.push("--profile".to_string());
-        args.push(profile.to_string());
-    }
-    args.push("--target-dir".to_string());
-    args.push(target_dir.display().to_string());
-    args
+fn spec_enumeration_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_generate_spec_enumeration")
 }
 
-#[cfg(test)]
-mod build_args_tests {
-    use super::build_args;
-    use std::path::Path;
-
-    fn args(profile: &str) -> Vec<String> {
-        build_args(profile, Path::new("/w/target"))
-    }
-
-    /// The `dev` profile builds into `<target>/debug`, so no profile flag is
-    /// passed — adding `--profile debug` would be an error (there is no
-    /// `debug` profile; the profile is named `dev`).
-    #[test]
-    fn debug_profile_passes_no_profile_flag() {
-        let a = args("debug");
-        assert!(
-            !a.iter().any(|x| x == "--profile"),
-            "unexpected --profile in {a:?}"
-        );
-    }
-
-    /// A `--release` test binary must build its examples into
-    /// `<target>/release/examples/`, or the lookup finds a stale binary or none.
-    #[test]
-    fn release_profile_is_forwarded() {
-        let a = args("release");
-        let i = a
-            .iter()
-            .position(|x| x == "--profile")
-            .expect("--profile must be passed for a non-debug profile");
-        assert_eq!(a[i + 1], "release");
-    }
-
-    /// Custom profiles use their own directory name, so forwarding the
-    /// directory name verbatim is correct for them too.
-    #[test]
-    fn custom_profile_is_forwarded_verbatim() {
-        let a = args("release-lto");
-        let i = a.iter().position(|x| x == "--profile").expect("--profile");
-        assert_eq!(a[i + 1], "release-lto");
-    }
-
-    /// The target directory must be forwarded on every profile.
-    ///
-    /// `cargo llvm-cov` drives `cargo test --target-dir target/llvm-cov-target`,
-    /// and that flag does not reach the cargo this helper spawns. Without
-    /// `--target-dir` the examples land in the default `target/` while the
-    /// lookup reads `target/llvm-cov-target/<profile>/examples/` — the mismatch
-    /// that turned the `Coverage` workflow red for 15 commits while every
-    /// required PR check stayed green.
-    #[test]
-    fn target_dir_is_always_forwarded() {
-        for profile in ["debug", "release"] {
-            let a = build_args(profile, Path::new("/w/target/llvm-cov-target"));
-            let i = a
-                .iter()
-                .position(|x| x == "--target-dir")
-                .unwrap_or_else(|| panic!("--target-dir missing for {profile}: {a:?}"));
-            assert_eq!(a[i + 1], "/w/target/llvm-cov-target");
-        }
-    }
-
-    /// Whatever the profile, both generators must be requested — the helper's
-    /// single-build-for-both property is what keeps the cargo lock cost at one
-    /// acquisition per test binary.
-    #[test]
-    fn both_generators_are_always_requested() {
-        for profile in ["debug", "release"] {
-            let a = args(profile);
-            assert!(a.iter().any(|x| x == "generate_spec_fixture"));
-            assert!(a.iter().any(|x| x == "generate_spec_enumeration"));
-        }
-    }
+/// Resolve a generator binary by the name the tests use.
+///
+/// Nothing is built here: both generators are `[[bin]]` targets that cargo has
+/// already built, and `CARGO_BIN_EXE_*` hands us the path.
+fn generator_binary(generator: &str) -> PathBuf {
+    let path = match generator {
+        "generate_spec_fixture" => spec_fixture_bin(),
+        "generate_spec_enumeration" => spec_enumeration_bin(),
+        other => panic!("unknown generator {other}"),
+    };
+    PathBuf::from(path)
 }
 
-/// Run a `--features dev` example with `args`, returning its captured output.
-fn run_example(example: &str, args: &[&str]) -> Output {
-    Command::new(built_example(example))
+/// Run a `--features dev` generator with `args`, returning its captured output.
+fn run_generator(generator: &str, args: &[&str]) -> Output {
+    Command::new(generator_binary(generator))
         .current_dir(manifest_dir())
         .args(args)
         .output()
-        .unwrap_or_else(|e| panic!("failed to run `{example}`: {e}"))
+        .unwrap_or_else(|e| panic!("failed to run `{generator}`: {e}"))
 }
 
 fn stderr_of(out: &Output) -> String {
@@ -356,7 +186,7 @@ fn spec_dir_if_initialised() -> Option<PathBuf> {
 #[test]
 fn empty_spec_checkout_names_the_submodule_not_the_overrides() {
     let empty = scratch("empty-spec-dir");
-    let out = run_example(
+    let out = run_generator(
         "generate_spec_fixture",
         &[
             "--spec-dir",
@@ -394,7 +224,7 @@ fn empty_spec_checkout_names_the_submodule_not_the_overrides() {
 #[test]
 fn empty_spec_checkout_is_rejected_by_the_enumeration_generator_too() {
     let empty = scratch("empty-spec-dir-enum");
-    let out = run_example(
+    let out = run_generator(
         "generate_spec_enumeration",
         &[
             "--spec-dir",
@@ -439,7 +269,7 @@ fn check_generates_an_absent_artifact_instead_of_failing() {
     let output = dir.join("hgvs_spec_normalization.json");
     assert!(!output.exists(), "scratch output must start absent");
 
-    let out = run_example(
+    let out = run_generator(
         "generate_spec_fixture",
         &[
             "--spec-dir",
@@ -478,7 +308,7 @@ fn check_still_reports_a_stale_artifact_and_leaves_it_alone() {
     let stale = "{\"not\": \"the real fixture\"}\n";
     std::fs::write(&output, stale).expect("seed a stale artifact");
 
-    let out = run_example(
+    let out = run_generator(
         "generate_spec_fixture",
         &[
             "--spec-dir",
@@ -519,10 +349,13 @@ fn pre_push_hooks_run_plain_generation_like_ci() {
     let hooks = pre_commit_hooks();
     let ci_runs = ci_run_commands();
 
-    for example in ["generate_spec_fixture", "generate_spec_enumeration"] {
-        let plain = format!("cargo run --features dev --example {example}");
+    for generator in ["generate_spec_fixture", "generate_spec_enumeration"] {
+        // `--bin`, not `--example`: both generators are `[[bin]]` targets so
+        // tests can locate them via `CARGO_BIN_EXE_*`. The hooks and CI must
+        // agree with that, or the pre-push hook silently builds nothing.
+        let plain = format!("cargo run --features dev --bin {generator}");
 
-        let hook_id = example.replace('_', "-");
+        let hook_id = generator.replace('_', "-");
         let hook = hooks
             .iter()
             .find(|h| h.id == hook_id)
@@ -544,7 +377,7 @@ fn pre_push_hooks_run_plain_generation_like_ci() {
         // run what CI runs" is precisely the claim being pinned.
         assert!(
             ci_runs.iter().any(|r| r.trim() == plain),
-            "expected CI to run plain `{example}`, matching the pre-push hook",
+            "expected CI to run plain `{generator}`, matching the pre-push hook",
         );
     }
 


### PR DESCRIPTION
The two spec generators were examples, so tests had to locate the built artifact themselves. Locating it means reconstructing the cargo invocation actually in flight — profile, target directory, features — and every coordinate missed is a silent wrong-path bug. Two shipped in a single day:

- **#1224** — the build ignored the profile, so `--release` looked in `target/release/examples/` for something written to `target/debug/`. The loud half was one failing test. The quiet half was a *sibling test passing against a stale release binary* — precisely the staleness the machinery existed to prevent.
- **#1225** — the build then ignored the target directory, so under `cargo llvm-cov` (which builds into `target/llvm-cov-target/`) all four tests failed. `main` stayed red for **15 commits**, because `Coverage` runs only after a merge and gates nothing.

Same defect, different axes — and the axes are not enumerable. `--features`, `--target`, `CARGO_BUILD_*` and `RUSTFLAGS` are all still out there.

## Cargo already solves this, for binaries

`CARGO_BIN_EXE_<name>` is defined for every `[[bin]]` target of the package under test, resolved by cargo for the invocation actually running, and cargo guarantees the binary is built and current before integration tests execute.

So the generators become `[[bin]]` targets and the whole derivation disappears — with it the `Once`, the nested `cargo build`, the path arithmetic, and the `FERRO_PREBUILT_EXAMPLES` escape hatch that existed only because CI's sharded jobs run from a nextest archive with no cargo available. The repo already runs 26 sites on `env!("CARGO_BIN_EXE_ferro")`, so this joins a path that is already paved and already handled by CI's `--extract-to .`.

A **second copy** of the same hand-derived path lived in `issue_1046_generator_gitdir_leak.rs`. It is gone too, along with its manual build step.

## It is also faster, which is what the original machinery was for

#1219 introduced the nested build because `cargo run --example` serialised this module's tests behind cargo's `target/` file lock at ~25 s each. With no nested cargo there is no second lock acquisition at all:

| | before | after |
|---|---|---|
| `spec_generator_preconditions` | ~20–37 s | **~0.7 s** |
| full `--features dev` suite | ~37 s | **~20 s** |

## Cost, stated plainly

**Three dev-dependencies become optional dependencies** — `pulldown-cmark`, `anyhow`, `serde_yaml` — because binaries, unlike examples, cannot use dev-dependencies. (I originally expected only `pulldown-cmark`; the other two surfaced during the build.) All three are reached solely through the non-default `dev` feature, so an ordinary consumer resolves none of them. `anyhow` and `serde_yaml` **remain** in `[dev-dependencies]` too, because other targets use them and `tests/it` still compiles without `--features dev`.

**`spec_generator_preconditions` is now `#[cfg(feature = "dev")]`.** `CARGO_BIN_EXE_*` exists only for targets cargo builds, and both generators are `required-features = ["dev"]`; without the gate a plain `cargo test` fails to compile the entire `it` target rather than skipping these tests.

**`autoexamples = false`.** With auto-discovery on, cargo registered each generator *twice* — once as a bin, once as an example — compiling both copies of a ~2000-line target. `cargo metadata` confirmed it directly. The five previously-implicit examples are now declared explicitly alongside the six that already were.

## Call sites

Every `--example generate_spec_*` becomes `--bin`: CI, the pre-push hooks, the nightly and external-validation workflows, the on-demand fixture regenerator, `CONTRIBUTING.md`, `CLAUDE.md`, and the generators' own docs. The existing hook/CI parity test asserts the new form, so hooks, CI and tests cannot drift apart.

## Validation

| Check | Result |
|---|---|
| `cargo nextest run --features dev` | **8786 passed**, 0 failed, 145 skipped |
| `cargo check --tests` (no `dev`) | clean — the gate works |
| alternate `--target-dir` (the llvm-cov shape) | **7 passed** — #1225's reproduction |
| `--release` | **7 passed** — #1224's reproduction |
| `cargo fmt --check`, `clippy --all-features --all-targets -D warnings` | clean |
| `cargo run --features dev --bin generate_spec_{fixture,enumeration}` | both exit 0 |

Both original reproductions pass structurally now rather than by patch, which is the point: there is no longer a path for them to get wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Spec fixture and enumeration generators now run consistently as dedicated binaries (instead of examples).
  * CI and local pre-push setup were updated to stage and execute the correct generator artifacts.
* **Tests**
  * Generator-dependent integration tests now run only when development mode is enabled, using Cargo-provided binary executables.
* **Documentation**
  * Contributor and generator guidance was updated to use the correct regeneration/validation commands for the HGVS v21.0 fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->