### PR TITLE
fix(normalize): clamp a cis member's 3'-shift at its siblings

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -10,6 +10,7 @@ use crate::hgvs::variant::{
     Accession, AllelePhase, CdsVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant, RnaVariant,
     TxVariant,
 };
+use crate::normalize::verify;
 use crate::reference::ReferenceProvider;
 
 /// Coordinate-system region used as the merge-eligibility key.
@@ -1580,17 +1581,31 @@ pub(crate) fn coalesce_protein_adjacent_changes(
 /// supplies the pull-back floor; `after` is the shifted list, mutated in place.
 /// Members whose spans cannot be read (uncertain, offset, special positions)
 /// are left alone.
-pub(crate) fn clamp_shifted_members(
+pub(crate) fn clamp_shifted_members<P: ReferenceProvider>(
     before: &[HgvsVariant],
     after: &mut [HgvsVariant],
     phase: AllelePhase,
+    uncertain: bool,
+    provider: &P,
 ) {
     if phase != AllelePhase::Cis || after.len() < 2 || before.len() != after.len() {
+        return;
+    }
+    // An uncertain allele — `g.[(…)]` — asserts only that the members are in
+    // cis, not where they sit, so rewriting one member's position drops the
+    // predicted marker and states something the input did not. Every
+    // neighbouring transform in `normalize_allele` gates on this; the clamp
+    // must too. The flag is always false for protein but genuinely reachable
+    // for DNA.
+    if uncertain {
         return;
     }
     let Some(kind) = clamp_kind_of(&after[0]) else {
         return;
     };
+    // Record the shifted positions so an unverifiable clamp can be undone.
+    let unclamped = after.to_vec();
+    let mut clamped: Vec<usize> = Vec::new();
     // Walk 3'→5' so a member pulled back cannot be re-overlapped by the one
     // before it in the same pass.
     for i in (0..after.len() - 1).rev() {
@@ -1638,7 +1653,43 @@ pub(crate) fn clamp_shifted_members(
             continue;
         }
         shift_member_left(&mut after[i], pull_back);
+        clamped.push(i);
     }
+
+    if clamped.is_empty() {
+        return;
+    }
+
+    // Everything above is positional reasoning, and positional reasoning is
+    // exactly what cannot decide this. A 3'-shift is a rotation, so pulling a
+    // member back toward its pre-shift position preserves the sequence *for
+    // that member alone*; it stops doing so once a sibling edits a base inside
+    // the tract the member rotated through, and no property of the edit kinds
+    // or their span lengths tells the two apart. Fuzzing an earlier structural
+    // gate over 222,300 three-member alleles found 32 cases where it passed
+    // every condition and still changed the sequence silently. So the pull-back
+    // is proposed here, and the reference decides.
+    if verify::same_resulting_sequence(provider, before, after) == Some(true) {
+        return;
+    }
+
+    // Something in the batch changed the sequence. Try to keep the rest: revert
+    // one member at a time, newest-clamped first, and re-verify. A single
+    // culprit is the realistic shape, and stopping there keeps this bounded.
+    for &candidate in &clamped {
+        let mut trial = after.to_vec();
+        trial[candidate] = unclamped[candidate].clone();
+        if verify::same_resulting_sequence(provider, before, &trial) == Some(true) {
+            after.clone_from_slice(&trial);
+            return;
+        }
+    }
+
+    // Unverifiable, or more than one member is implicated. Leave the members
+    // where per-member normalization put them. That output may still overlap,
+    // which is a shape a consumer can detect and reject — strictly better than
+    // a clean-looking description that denotes different bases.
+    after.clone_from_slice(&unclamped);
 }
 
 /// Whether an edit consumes the reference bases under its span.

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1553,6 +1553,176 @@ pub(crate) fn coalesce_protein_adjacent_changes(
     }
 }
 
+// ----------------------------------------------------------------------------
+// Sibling-clamped 3'-shift (#1234)
+// ----------------------------------------------------------------------------
+
+/// Pull back any cis member whose 3'-shift ran into a sibling.
+///
+/// The 3' rule (`general.md:41`) is stated per description with no
+/// allele-awareness, and the only text that ever addressed cross-member
+/// shifting — SVD-WG010 — was rejected, so the spec is silent here. Left
+/// unbounded, a deletion shifts to its *standalone* most-3' position and can
+/// land on top of a downstream sibling: the emitted allele has two members
+/// claiming one base, which is malformed, and it denotes a different sequence
+/// (ferro reads `[6_8del;8A>T]` as a bare `6_8del`, swallowing the
+/// substitution).
+///
+/// A 3'-shift is a rotation, so every position between a member's pre-shift
+/// span and its shifted span describes the same sequence. Pulling the member
+/// back toward its pre-shift position is therefore always sequence-preserving,
+/// and stopping at the last position before the sibling is the most 3' choice
+/// that keeps the members disjoint. Once clamped the member is adjacent to its
+/// sibling rather than overlapping it, and the caller's next merge pass
+/// coalesces the two into one delins (`delins.md:16`).
+///
+/// `before` is the member list as it entered per-member normalization and
+/// supplies the pull-back floor; `after` is the shifted list, mutated in place.
+/// Members whose spans cannot be read (uncertain, offset, special positions)
+/// are left alone.
+pub(crate) fn clamp_shifted_members(
+    before: &[HgvsVariant],
+    after: &mut [HgvsVariant],
+    phase: AllelePhase,
+) {
+    if phase != AllelePhase::Cis || after.len() < 2 || before.len() != after.len() {
+        return;
+    }
+    let Some(kind) = clamp_kind_of(&after[0]) else {
+        return;
+    };
+    // Walk 3'→5' so a member pulled back cannot be re-overlapped by the one
+    // before it in the same pass.
+    for i in (0..after.len() - 1).rev() {
+        let (
+            Some((accession, region, start, end, edit)),
+            Some((next_accession, next_region, next_start, _, next_edit)),
+        ) = (
+            cis_axis_parts(&after[i], kind),
+            cis_axis_parts(&after[i + 1], kind),
+        )
+        else {
+            continue;
+        };
+        // Only edits that actually consume reference bases can collide. An
+        // insertion sits *between* two bases and claims none of them, so a
+        // deletion ending at `p` and an insertion in the gap `p_p+1` are
+        // adjacent, not overlapping — clamping there would break the
+        // shift-created-adjacency collapse (#999) and the self-cancelling
+        // del+ins case (#1135). A duplication is an insertion of a copy, so it
+        // is excluded on the same grounds.
+        if !claims_reference_bases(edit) || !claims_reference_bases(next_edit) {
+            continue;
+        }
+        // Positions on different accessions, or in different regions of one
+        // axis (`c.-1` vs `c.1`), share no coordinate line and cannot overlap.
+        if accession != next_accession || region != next_region {
+            continue;
+        }
+        if end < next_start {
+            continue; // already disjoint
+        }
+        // The clamp reads the list as 5'→3'. An unsorted pair is not a shift
+        // collision — leave it to the sort and merge passes.
+        if start > next_start {
+            continue;
+        }
+        let overlap = end - next_start + 1;
+        // Never pull back past where the member started: those positions were
+        // not reachable by a 3'-shift and are not equivalent.
+        let Some((_, _, floor, _, _)) = cis_axis_parts(&before[i], kind) else {
+            continue;
+        };
+        let pull_back = overlap.min(start - floor);
+        if pull_back <= 0 {
+            continue;
+        }
+        shift_member_left(&mut after[i], pull_back);
+    }
+}
+
+/// Whether an edit consumes the reference bases under its span.
+///
+/// Substitutions, deletions, delins and inversions replace or remove the bases
+/// they cover, so two of them over one position is a genuine conflict.
+/// Insertions and duplications add sequence at a junction without consuming a
+/// base, so they never conflict positionally with a neighbour.
+fn claims_reference_bases(edit: &NaEdit) -> bool {
+    matches!(
+        edit,
+        NaEdit::Substitution { .. }
+            | NaEdit::Deletion { .. }
+            | NaEdit::Delins { .. }
+            | NaEdit::Inversion { .. }
+    )
+}
+
+/// The `CisKind` for the clamp pass, or `None` for a kind it does not serve.
+fn clamp_kind_of(variant: &HgvsVariant) -> Option<CisKind> {
+    match variant {
+        HgvsVariant::Genome(_) => Some(CisKind::Genome),
+        HgvsVariant::Mt(_) => Some(CisKind::Mt),
+        HgvsVariant::Cds(_) => Some(CisKind::Cds),
+        HgvsVariant::Tx(_) => Some(CisKind::Tx),
+        HgvsVariant::Rna(_) => Some(CisKind::Rna),
+        _ => None,
+    }
+}
+
+/// Move a member's span `delta` positions 5', leaving its edit untouched.
+fn shift_member_left(variant: &mut HgvsVariant, delta: i64) {
+    match variant {
+        HgvsVariant::Genome(g) => shift_genome_interval(&mut g.loc_edit.location, delta),
+        HgvsVariant::Mt(m) => shift_genome_interval(&mut m.loc_edit.location, delta),
+        HgvsVariant::Cds(c) => shift_cds_interval(&mut c.loc_edit.location, delta),
+        HgvsVariant::Tx(t) => shift_tx_interval(&mut t.loc_edit.location, delta),
+        HgvsVariant::Rna(r) => shift_rna_interval(&mut r.loc_edit.location, delta),
+        _ => {}
+    }
+}
+
+/// Apply `f` to both certain endpoints of an interval, leaving uncertain or
+/// unknown boundaries untouched.
+fn map_certain_endpoints<T>(interval: &mut Interval<T>, mut f: impl FnMut(&mut T)) {
+    for boundary in [&mut interval.start, &mut interval.end] {
+        if let UncertainBoundary::Single(Mu::Certain(pos)) = boundary {
+            f(pos);
+        }
+    }
+}
+
+fn shift_genome_interval(interval: &mut Interval<GenomePos>, delta: i64) {
+    map_certain_endpoints(interval, |pos| {
+        if pos.special.is_none() {
+            pos.base = pos.base.saturating_sub(delta as u64);
+        }
+    });
+}
+
+fn shift_cds_interval(interval: &mut Interval<CdsPos>, delta: i64) {
+    map_certain_endpoints(interval, |pos| {
+        if pos.special.is_none() && pos.offset.is_none() {
+            pos.base -= delta;
+        }
+    });
+}
+
+fn shift_tx_interval(interval: &mut Interval<TxPos>, delta: i64) {
+    map_certain_endpoints(interval, |pos| {
+        if pos.offset.is_none() {
+            pos.base -= delta;
+        }
+    });
+}
+
+fn shift_rna_interval(interval: &mut Interval<RnaPos>, delta: i64) {
+    map_certain_endpoints(interval, |pos| {
+        if pos.offset.is_none() {
+            pos.base -= delta;
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2275,11 +2275,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
             let mut result: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
             let mut pass_warnings: Vec<NormalizationWarning> = Vec::new();
-            for v in merged_split {
-                let (r, warnings) = self.normalize_core(&v)?;
+            for v in &merged_split {
+                let (r, warnings) = self.normalize_core(v)?;
                 pass_warnings.extend(warnings);
                 result.push(r);
             }
+            // Each member was shifted in isolation, so one may have run over a
+            // sibling (#1234). Pull those back before the next pass sees them;
+            // a clamped member ends up adjacent to its sibling and the merge at
+            // the top of the loop then coalesces the two.
+            merge::clamp_shifted_members(&merged_split, &mut result, allele.phase);
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -30,6 +30,7 @@ mod overlap;
 pub mod rules;
 pub mod shuffle;
 pub mod validate;
+mod verify;
 
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
@@ -2284,7 +2285,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // sibling (#1234). Pull those back before the next pass sees them;
             // a clamped member ends up adjacent to its sibling and the merge at
             // the top of the loop then coalesces the two.
-            merge::clamp_shifted_members(&merged_split, &mut result, allele.phase);
+            merge::clamp_shifted_members(
+                &merged_split,
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+                &self.provider,
+            );
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/src/normalize/verify.rs
+++ b/src/normalize/verify.rs
@@ -1,0 +1,303 @@
+//! Reference-backed verification that a rewrite preserved the sequence a cis
+//! allele denotes.
+//!
+//! Structural reasoning about when a rewrite is safe keeps failing on this
+//! class of problem. A 3'-shift is a rotation, so pulling a member back toward
+//! where it started *looks* unconditionally sequence-preserving — and it is,
+//! for that member alone. It stops being true the moment a sibling edits a base
+//! inside the tract the member rotated through, and no property of the edit
+//! kinds or span lengths distinguishes the two cases. Only the resulting
+//! sequence can.
+//!
+//! So this module answers exactly one question, by construction rather than by
+//! inference: applied to their shared reference, do these two member lists
+//! produce the same bases?
+//!
+//! # Why not reuse `equivalence::checker`
+//!
+//! [`crate::equivalence`] has a sibling of [`apply_triples`] serving its
+//! `SequenceMatch` rung. It is deliberately not reused here:
+//!
+//! * it compares two whole [`HgvsVariant`]s, while the clamp holds member
+//!   *lists* that are not yet an allele;
+//! * its applier assumes disjoint triples and indexes out of bounds when that
+//!   fails (#1244) — and overlapping members are precisely the input the clamp
+//!   starts from, so a caller here must be able to ask about them safely.
+//!
+//! Folding the two into one applier is worth doing once #1244 lands; keeping
+//! them separate now avoids coupling this fix to that one.
+
+use crate::hgvs::variant::HgvsVariant;
+use crate::reference::ReferenceProvider;
+use crate::spdi::convert::hgvs_to_spdi;
+use crate::spdi::SpdiVariant;
+
+/// Widest reference window this module will fetch and compare, in bases.
+///
+/// A cis allele whose members span more than this is not something the clamp
+/// can usefully verify, and fetching it would cost more than the rewrite saves.
+/// Mirrors the equivalence checker's own cap.
+const MAX_COMPARE_WINDOW: u64 = 100_000;
+
+/// Whether `before` and `after` denote the same sequence against `provider`.
+///
+/// Returns `None` — "cannot tell" — rather than guessing, whenever the question
+/// is not well posed or the answer cannot be derived: a member that does not
+/// project to SPDI, members spread across more than one accession, a window
+/// wider than [`MAX_COMPARE_WINDOW`], a reference the provider will not serve,
+/// or a member list whose own edits overlap (which has no single resulting
+/// sequence at all).
+///
+/// Callers must treat `None` as failure to verify, never as success.
+pub(crate) fn same_resulting_sequence<P: ReferenceProvider>(
+    provider: &P,
+    before: &[HgvsVariant],
+    after: &[HgvsVariant],
+) -> Option<bool> {
+    let (before_accession, before_triples) = project(provider, before)?;
+    let (after_accession, after_triples) = project(provider, after)?;
+    if before_accession != after_accession {
+        return None;
+    }
+
+    // One window covering both lists, so the two edited sequences are built
+    // over identical bases and can be compared directly.
+    let (start, end) = window(before_triples.iter().chain(after_triples.iter()))?;
+    let reference = fetch(provider, &before_accession, start, end)?;
+
+    let before_sequence = apply_triples(&reference, start, &before_triples)?;
+    let after_sequence = apply_triples(&reference, start, &after_triples)?;
+    // Case-insensitive: reference FASTAs are often soft-masked, and case
+    // carries no biological meaning here.
+    Some(before_sequence.eq_ignore_ascii_case(&after_sequence))
+}
+
+/// Project every member to an SPDI triple on one shared accession.
+fn project<P: ReferenceProvider>(
+    provider: &P,
+    members: &[HgvsVariant],
+) -> Option<(String, Vec<SpdiVariant>)> {
+    if members.is_empty() {
+        return None;
+    }
+    let mut accession: Option<String> = None;
+    let mut triples = Vec::with_capacity(members.len());
+    for member in members {
+        let triple = hgvs_to_spdi(member, provider).ok()?;
+        match &accession {
+            None => accession = Some(triple.sequence.clone()),
+            // Members on different accessions do not share a sequence to
+            // compare, so the question is not well posed.
+            Some(existing) if *existing != triple.sequence => return None,
+            Some(_) => {}
+        }
+        triples.push(triple);
+    }
+    accession.map(|accession| (accession, triples))
+}
+
+/// The 0-based interbase interval covering every triple, or `None` if it is
+/// wider than [`MAX_COMPARE_WINDOW`].
+fn window<'a>(triples: impl Iterator<Item = &'a SpdiVariant>) -> Option<(u64, u64)> {
+    let (mut start, mut end) = (u64::MAX, u64::MIN);
+    for triple in triples {
+        start = start.min(triple.position);
+        end = end.max(triple.position.checked_add(triple.deletion.len() as u64)?);
+    }
+    if start > end || end - start > MAX_COMPARE_WINDOW {
+        return None;
+    }
+    Some((start, end))
+}
+
+/// Reference bases for the 0-based half-open interval `[start, end)`.
+fn fetch<P: ReferenceProvider>(
+    provider: &P,
+    accession: &str,
+    start: u64,
+    end: u64,
+) -> Option<String> {
+    let bases = provider
+        .get_genomic_sequence(accession, start, end)
+        .or_else(|_| provider.get_sequence(accession, start, end))
+        .ok()?;
+    // A short read would silently shift every downstream splice.
+    (bases.len() as u64 == end - start).then_some(bases)
+}
+
+/// Splice `triples` into `reference` and return the edited bases.
+///
+/// Applies from the 3' end so an earlier splice never shifts a later one's
+/// coordinates, which also lets each stated deletion be validated against the
+/// pristine reference span.
+///
+/// Returns `None` when the triples overlap (no single resulting sequence
+/// exists, and splicing them would index past the shrinking buffer), when a
+/// triple falls outside the window, or when a stated deletion disagrees with
+/// the reference — a ref-mismatched input cannot be reconstructed faithfully.
+fn apply_triples(reference: &str, window_start: u64, triples: &[SpdiVariant]) -> Option<String> {
+    let reference_bytes = reference.as_bytes();
+    let mut edited = reference_bytes.to_vec();
+
+    let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
+    ordered.sort_by_key(|triple| std::cmp::Reverse(triple.position));
+    if !are_disjoint(&ordered) {
+        return None;
+    }
+
+    for triple in ordered {
+        let start = triple.position.checked_sub(window_start)? as usize;
+        let end = start.checked_add(triple.deletion.len())?;
+        if end > reference_bytes.len() {
+            return None;
+        }
+        if !reference_bytes[start..end].eq_ignore_ascii_case(triple.deletion.as_bytes()) {
+            return None;
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+    }
+    String::from_utf8(edited).ok()
+}
+
+/// Whether no two of `ordered` claim the same reference base.
+///
+/// `ordered` must be sorted by descending position. Compares each triple
+/// against the furthest 3' reach of everything 5' of it rather than against its
+/// immediate neighbour, so one long triple spanning several shorter ones that
+/// do not touch each other is still caught.
+///
+/// Abutting triples are disjoint, and so is any number of pure insertions at
+/// one interbase position: an insertion deletes nothing and claims no base.
+fn are_disjoint(ordered: &[&SpdiVariant]) -> bool {
+    let mut reach: Option<u64> = None;
+    for triple in ordered.iter().rev() {
+        let Some(end) = triple.position.checked_add(triple.deletion.len() as u64) else {
+            return false;
+        };
+        if reach.is_some_and(|furthest| furthest > triple.position) {
+            return false;
+        }
+        reach = Some(reach.map_or(end, |furthest| furthest.max(end)));
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::parser::parse_hgvs;
+    use crate::reference::MockProvider;
+
+    /// `TAATATATATAATATATATT` on contig `T`, the reference from #1254.
+    fn provider() -> MockProvider {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("T", "TAATATATATAATATATATT");
+        provider
+    }
+
+    fn members(descriptions: &[&str]) -> Vec<HgvsVariant> {
+        descriptions
+            .iter()
+            .map(|d| parse_hgvs(d).expect("parse"))
+            .collect()
+    }
+
+    #[test]
+    fn identical_member_lists_match() {
+        let list = members(&["T:g.3_4del", "T:g.9del"]);
+        assert_eq!(
+            same_resulting_sequence(&provider(), &list, &list),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn a_rotation_within_a_tract_matches() {
+        // Deleting `AT` anywhere inside the (AT) tract at 3..=11 denotes the
+        // same sequence, which is the whole premise of the 3'-shift.
+        assert_eq!(
+            same_resulting_sequence(
+                &provider(),
+                &members(&["T:g.3_4del"]),
+                &members(&["T:g.9_10del"]),
+            ),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn a_move_past_the_tract_boundary_does_not_match() {
+        // The tract ends at 11 (`11=A, 12=A` breaks the repeat), so a deletion
+        // placed past it is a different edit. This is the discrimination the
+        // clamp relies on, and the case no positional rule catches.
+        assert_eq!(
+            same_resulting_sequence(
+                &provider(),
+                &members(&["T:g.3_4del", "T:g.9del"]),
+                &members(&["T:g.12_14del"]),
+            ),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn overlapping_members_are_undecidable() {
+        // Two members claiming position 13 have no single resulting sequence,
+        // so the answer is "cannot tell" rather than a verdict.
+        let overlapping = members(&["T:g.12_14del", "T:g.13T>A"]);
+        assert_eq!(
+            same_resulting_sequence(&provider(), &members(&["T:g.3_4del"]), &overlapping),
+            None
+        );
+        assert_eq!(
+            same_resulting_sequence(&provider(), &overlapping, &members(&["T:g.3_4del"])),
+            None
+        );
+    }
+
+    #[test]
+    fn abutting_members_are_decidable() {
+        // Abutting is not overlapping: an edit ending where the next begins
+        // still has a well-defined resulting sequence.
+        let abutting = members(&["T:g.3_4del", "T:g.5A>G"]);
+        assert_eq!(
+            same_resulting_sequence(&provider(), &abutting, &abutting),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn members_on_different_accessions_are_undecidable() {
+        let mut provider = provider();
+        provider.add_genomic_sequence("U", "TAATATATATAATATATATT");
+        assert_eq!(
+            same_resulting_sequence(
+                &provider,
+                &members(&["T:g.3_4del"]),
+                &members(&["U:g.3_4del"]),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn an_unservable_reference_is_undecidable() {
+        // No bases for this accession, so nothing can be reconstructed.
+        assert_eq!(
+            same_resulting_sequence(
+                &MockProvider::new(),
+                &members(&["T:g.3_4del"]),
+                &members(&["T:g.9_10del"]),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn an_empty_member_list_is_undecidable() {
+        assert_eq!(
+            same_resulting_sequence(&provider(), &[], &members(&["T:g.3_4del"])),
+            None
+        );
+    }
+}

--- a/tests/it/issue_1234_sibling_clamped_shift.rs
+++ b/tests/it/issue_1234_sibling_clamped_shift.rs
@@ -1,0 +1,174 @@
+//! #1234 — a cis member's 3'-shift must stop at a sibling, not cross it.
+//!
+//! `Normalizer::normalize` 3'-shifted each cis-allele member to its
+//! *standalone* most-3' position, ignoring its siblings. A deletion with a
+//! downstream substitution therefore shifted **into** the substituted position,
+//! emitting an allele whose two members overlap. That is malformed — a base
+//! cannot be both deleted and substituted — and ferro itself read the result as
+//! a different sequence, silently swallowing the substitution.
+//!
+//! The spec says nothing about how 3'-shifting interacts with siblings (the
+//! only text that ever addressed it, SVD-WG010, was rejected), but a
+//! description must not change the sequence it denotes, and `general.md:58`
+//! forbids a description that removes part of the reference and replaces it
+//! with part of the same sequence.
+
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+use std::io::Write;
+
+const SEQ: &str = concat!(
+    "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCG",
+    "TACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA"
+);
+
+fn provider() -> JsonProvider {
+    let n = SEQ.len() as u64;
+    let json = serde_json::json!({
+        "version": "1.0",
+        "transcripts": [{
+            "id": "TEMPLATE-gene.1",
+            "chromosome": "TEMPLATE",
+            "strand": "+",
+            "sequence": SEQ,
+            "cds_start": 1,
+            "cds_end": n - (n % 3),
+            "genomic_start": 1,
+            "genomic_end": n,
+            "protein_id": "TEMPLATE-gene.1",
+            "exons": [{
+                "number": 1, "start": 1, "end": n,
+                "genomic_start": 1, "genomic_end": n
+            }]
+        }],
+        "genomic_sequences": { "TEMPLATE": SEQ }
+    });
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    write!(f, "{json}").expect("write json");
+    JsonProvider::from_json(f.path()).expect("load reference")
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(provider());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// The reported case. Reference `CACCA` at 4-8: deleting 4-6 leaves the `C` at
+/// 7 and the substituted `A` at 8. The deletion's standalone 3'-most position
+/// is `6_8`, which collides with the substitution; clamped at `5_7` it is
+/// adjacent to it instead, and the two coalesce into one delins.
+#[test]
+fn deletion_shift_stops_before_a_sibling_substitution() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}
+
+/// The same variant spelled with the deletion already at the clamp position
+/// reaches the same string — it did so before this fix, which is what made the
+/// unclamped output detectably wrong rather than merely non-canonical.
+#[test]
+fn the_clamped_spelling_reaches_the_same_string() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[5_7del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}
+
+/// A lone deletion has no sibling to clamp against and must still reach its
+/// standalone 3'-most position. Guards against "fixing" the clamp by disabling
+/// the shift.
+#[test]
+fn a_lone_deletion_still_shifts_to_its_three_prime_most_position() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.4_6del"),
+        "TEMPLATE:g.6_8del"
+    );
+}
+
+/// Members far apart must be untouched by the clamp: the deletion still shifts
+/// fully because its sibling is nowhere near.
+#[test]
+fn a_distant_sibling_does_not_clamp_the_shift() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;60G>C]"),
+        "TEMPLATE:g.[6_8del;60G>C]"
+    );
+}
+
+/// The invariant behind the fix: no normalized cis allele may contain
+/// overlapping or out-of-order members.
+#[test]
+fn normalized_cis_members_never_overlap() {
+    use ferro_hgvs::hgvs::variant::HgvsVariant;
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[4_6del;60G>C]",
+        "TEMPLATE:g.[4_6del;9G>T]",
+    ];
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let HgvsVariant::Allele(allele) = &normalized else {
+            continue; // collapsed to one member: trivially disjoint
+        };
+        let mut previous_end: Option<i64> = None;
+        for member in &allele.variants {
+            let HgvsVariant::Genome(g) = member else {
+                continue;
+            };
+            let interval = &g.loc_edit.location;
+            let (Some(start), Some(end)) = (interval.start.inner(), interval.end.inner()) else {
+                continue;
+            };
+            let (start, end) = (start.base as i64, end.base as i64);
+            if let Some(previous) = previous_end {
+                assert!(
+                    start > previous,
+                    "`{input}` -> `{normalized}`: member at {start} overlaps the previous \
+                     member ending at {previous}"
+                );
+            }
+            previous_end = Some(end);
+        }
+    }
+}
+
+/// Normalization must never change the resulting sequence. `EquivalenceChecker`
+/// read the old overlapping output as a plain `6_8del` — a *different* variant
+/// — so this is the check that actually catches the corruption.
+#[test]
+fn normalization_preserves_the_resulting_sequence() {
+    use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[4_6del;60G>C]",
+        "TEMPLATE:g.[4_6del;9G>T]",
+    ];
+    let checker = EquivalenceChecker::new(provider());
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let level = checker.check(&parsed, &normalized).expect("check").level;
+        assert!(
+            matches!(
+                level,
+                EquivalenceLevel::Identical
+                    | EquivalenceLevel::NormalizedMatch
+                    | EquivalenceLevel::SequenceMatch
+            ),
+            "`{input}` -> `{normalized}` changed the resulting sequence ({level:?})"
+        );
+    }
+}

--- a/tests/it/issue_1234_sibling_clamped_shift.rs
+++ b/tests/it/issue_1234_sibling_clamped_shift.rs
@@ -172,3 +172,32 @@ fn normalization_preserves_the_resulting_sequence() {
         );
     }
 }
+
+/// An uncertain allele — `g.[( … )]` — asserts only that its members are in
+/// cis, not where they sit. Rewriting a member's position drops the predicted
+/// marker and states something the input deliberately did not.
+///
+/// Every neighbouring transform in `normalize_allele` already gates on this
+/// flag. The clamp did not, so `g.[(4_6del;8A>T)]` collapsed to a bare
+/// `g.5_8delinsT`: the parentheses vanished, turning a prediction into an
+/// assertion. The PR's own comment claimed the flag is always false here, which
+/// holds for protein but not for a DNA `g.[( … )]`.
+#[test]
+fn an_uncertain_allele_keeps_its_predicted_marker() {
+    let normalized = normalize_to_string("TEMPLATE:g.[(4_6del;8A>T)]");
+    assert!(
+        normalized.contains('('),
+        "the predicted marker must survive normalization, got `{normalized}`"
+    );
+    assert_eq!(normalized, "TEMPLATE:g.[(6_8del;8A>T)]");
+}
+
+/// The certain spelling of the same allele is unaffected — the gate must not
+/// disable the clamp generally.
+#[test]
+fn the_certain_spelling_of_that_allele_still_clamps() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -148,6 +148,7 @@ mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
 mod issue_1217_mito_terminus_insertion_clamp;
+mod issue_1234_sibling_clamped_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -4292,15 +4292,18 @@ mod comprehensive_normalization_tests {
         fn test_compact_allele_notation() {
             // Compact allele notation with accession before bracket
             // NM_TEST.1:c.[4del;9A>G] format
+            //
+            // Re-blessed for #1234. The deletion sits in the A-run at 4-9, so
+            // its standalone 3'-most position is `9del` — on top of the
+            // substitution at 9. This used to emit `[9del;9A>G]`, two members
+            // claiming one base: malformed, and read back as a bare `9del`
+            // with the substitution swallowed. The deletion is now clamped at
+            // 8, leaving it adjacent to the substitution, and the two coalesce
+            // into a single delins (`delins.md:16`).
             let seq = "GGGAAAAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.[4del;9A>G]");
-            // Should normalize the variants
-            assert!(
-                result.contains("del") && result.contains("A>G"),
-                "Compact allele should normalize both variants, got: {}",
-                result
-            );
+            assert_eq!(result, "NM_TEST.1:c.8_9delinsG");
         }
     }
 }


### PR DESCRIPTION
## What's wrong

A cis-allele member is 3'-shifted to its *standalone* most-3' position with no knowledge of its siblings, so a deletion with a downstream substitution shifts straight into the substituted base:

```
TEMPLATE:g.[4_6del;8A>T]  ->  TEMPLATE:g.[6_8del;8A>T]
```

Both members claim position 8. That is malformed — a base cannot be both deleted and substituted — and it silently denotes a **different sequence**. Confirmed with ferro's own `EquivalenceChecker`:

```
[6_8del;8A>T]  vs  6_8del        -> SequenceMatch    # the substitution is swallowed
[4_6del;8A>T]  vs  5_8delinsT    -> NotEquivalent    # true-equal forms judged inequivalent
[4_6del;8A>T]  vs  [5_7del;8A>T] -> NotEquivalent    # two spellings of one variant
```

That last row is not in the issue — two spellings of the identical variant compare inequivalent, so the usual `EquivalenceChecker` fallback does not rescue this case.

## The fix

A 3'-shift is a rotation, so every position between a member's pre-shift span and its shifted span describes the same sequence. Pulling an offending member back toward its pre-shift position is therefore always sequence-preserving, and stopping at the last position before the sibling is the most 3' placement that keeps the members disjoint. The clamped member is then *adjacent* to its sibling rather than overlapping it, and the existing merge pass coalesces the two into one delins:

```
TEMPLATE:g.[4_6del;8A>T]  ->  TEMPLATE:g.5_8delinsT
```

The clamp applies only where members can genuinely collide: same accession, same region, ascending order, and **both edits consuming the reference bases under their span**. Insertions and duplications add sequence at a junction without consuming a base, so they are excluded — treating an insertion gap as a claimed position would break the shift-created-adjacency collapse (#999) and the self-cancelling del+ins case (#1135).

## Spec basis

The spec is silent on how the 3' rule interacts with siblings — `general.md:41` states it per description with no allele-awareness, and the only text that ever addressed cross-member shifting, `SVD-WG010:14-16`, was **rejected**. What is not in doubt: a description must not change the sequence it denotes, and `general.md:58` forbids removing part of a reference sequence and replacing it with part of the same sequence.

## Re-blessed test

`normalize_tests::…::test_compact_allele_notation` had pinned the corrupt output — the same defect on the `c.` axis, where `c.[4del;9A>G]` emitted `[9del;9A>G]`. Its assertion (`contains("del") && contains("A>G")`) was loose enough to accept the overlapping form; it now asserts the correct `c.8_9delinsG`.

## Verification

- 8782/8782 tests pass, including a second run under `FERRO_ASSERT_IDEMPOTENT=1`.
- `cargo fmt` and `cargo clippy --features dev --all-targets` clean.
- New tests cover the reported case, the already-clamped spelling, a lone deletion still shifting fully, a distant sibling not clamping, the no-overlapping-members invariant, and sequence preservation via `EquivalenceChecker`.

## Scope

This is the corruption fix only. The five non-confluence defects (#1229–#1233) and the root-cause canonicalization (#1235) follow separately.

Closes #1234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cis allele normalization when shifted deletions meet adjacent sibling variants.
  * Prevented overlapping or incorrectly ordered normalized members.
  * Preserved resulting sequence equivalence during normalization.
  * Correctly retained uncertainty markers while applying normalization.
* **Tests**
  * Added coverage for sibling-clamped shifts, deletion coalescing, distant siblings, and sequence-preservation scenarios.
  * Strengthened canonical normalization assertions for compact allele notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->