### PR TITLE
fix(normalize): split a delins at unchanged bases regardless of length

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -10,6 +10,9 @@ use crate::hgvs::variant::{
     Accession, AllelePhase, CdsVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant, RnaVariant,
     TxVariant,
 };
+use crate::normalize::boundary::Boundaries;
+use crate::normalize::config::ShuffleDirection;
+use crate::normalize::shuffle::shuffle;
 use crate::normalize::verify;
 use crate::reference::ReferenceProvider;
 
@@ -211,6 +214,11 @@ enum GEdit {
     /// read from the reference window once fetched, so it participates in the
     /// collapse exactly like an `Ins { gap: e, .. }`.
     Dup { s: i64, e: i64 },
+    /// Inversion of the inclusive span `[s, e]`: replaced by its own reverse
+    /// complement, read from the reference window once fetched. Only the
+    /// sequence-first canonicalizer builds this; `collapse_overlapping_cis_edits`
+    /// refuses inversion members.
+    Inv { s: i64, e: i64 },
 }
 
 /// Report whether `variants` contains two or more insertion-like cis members
@@ -396,7 +404,12 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     let covered: Vec<(i64, i64)> = edits
         .iter()
         .filter_map(|e| match e {
-            GEdit::Del { s, e } | GEdit::Delins { s, e, .. } => Some((*s, *e)),
+            // `Inv` is unreachable here — the builder above refuses inversion
+            // members — but it is a replacement over `[s, e]`, so classify it
+            // as one rather than leaving a misleading `None`.
+            GEdit::Del { s, e } | GEdit::Delins { s, e, .. } | GEdit::Inv { s, e } => {
+                Some((*s, *e))
+            }
             GEdit::Sub { pos, .. } => Some((*pos, *pos)),
             GEdit::Ins { .. } | GEdit::Dup { .. } => None,
         })
@@ -532,6 +545,21 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
                 // Tandem copy of ref[s..=e] inserted immediately 3' of `e`.
                 let bytes: Vec<u8> = (*s..=*e).map(|p| ref_bytes[idx(p)]).collect();
                 after[idx(*e)].extend(bytes);
+            }
+            GEdit::Inv { s, e } => {
+                // Unreachable: the builder above refuses inversion members.
+                // Kept correct rather than stubbed so exhaustiveness never
+                // silently drops an edit.
+                let span: Vec<u8> = (*s..=*e).map(|p| ref_bytes[idx(p)]).collect();
+                for (offset, base) in span.iter().rev().enumerate() {
+                    // Refuse rather than assign `None`: `cell[_] = None` means
+                    // *deleted*, so a base whose complement is unknown would be
+                    // silently dropped instead of declining the collapse.
+                    let Some(complement) = complement_base(*base) else {
+                        return variants;
+                    };
+                    cell[idx(*s + offset as i64)] = Some(complement);
+                }
             }
         }
     }
@@ -1772,6 +1800,1057 @@ fn shift_rna_interval(interval: &mut Interval<RnaPos>, delta: i64) {
             pos.base -= delta;
         }
     });
+}
+
+// ----------------------------------------------------------------------------
+// Sequence-first canonicalization (#1229-#1235)
+// ----------------------------------------------------------------------------
+
+/// Longest reference window the sequence-first canonicalizer will fetch.
+///
+/// Bounds the cost of a group whose members are far apart; a wider group is
+/// refused and falls back to the per-member pipeline.
+const MAX_CANONICAL_WINDOW: i64 = 4096;
+
+/// Padding either side of the changed interval, giving the 3'-shift room.
+const CANONICAL_PAD: i64 = 128;
+
+/// Longest changed block the canonicalizer will *split* into several members.
+///
+/// The separation rule (`delins.md:17`) says changes separated by unchanged
+/// nucleotides are described individually, but `delins.md:44-47` keeps a single
+/// spanning delins for a large replacement whose interior only *coincidentally*
+/// aligns ("parts of the inserted sequence align … the delins format is
+/// recommended"), and gives no threshold. A long block is that regime: emit one
+/// delins rather than an alignment artefact. The spec's own counter-example
+/// spans 52 nt.
+const MAX_SPLIT_BLOCK: usize = 32;
+
+/// Unchanged reference bases two pieces of a net insertion must be separated by
+/// before the split between them is believed. See `separations_are_meaningful`.
+const MIN_PIECE_SEPARATION: usize = 2;
+
+/// One derived edit: a maximal run of change over the reference window, as
+/// 0-based half-open offsets into that window plus its replacement bases.
+///
+/// A pure insertion has `ref_start == ref_end` (a zero-width span at the gap).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Piece {
+    ref_start: usize,
+    ref_end: usize,
+    alt: Vec<u8>,
+}
+
+impl Piece {
+    /// Whether this piece claims `offset` as changed.
+    fn claims(&self, offset: usize) -> bool {
+        offset >= self.ref_start && offset < self.ref_end
+    }
+
+    /// Whether this piece is a pure deletion or a pure insertion.
+    ///
+    /// Only these may be 3'-shifted. `shuffle`'s rotation invariant — advance
+    /// one position when the base leaving the span equals the base entering it
+    /// — holds only when the span is *either* removed or inserted, never both.
+    /// Rotating a `delins` changes the resulting sequence, and the spec scopes
+    /// the rule the same way: "for deletions, duplications, and insertions, the
+    /// most 3' position possible is arbitrarily assigned to have been changed"
+    /// (`checklist.md:37`).
+    fn is_pure_indel(&self) -> bool {
+        let ref_len = self.ref_end - self.ref_start;
+        (self.alt.is_empty() && ref_len > 0) || (ref_len == 0 && !self.alt.is_empty())
+    }
+}
+
+/// One column of an alignment between the reference and result blocks.
+///
+/// `None` on either side is a gap. Both-`Some` columns are matches when the
+/// bases agree and substitutions when they do not.
+type Column = (Option<usize>, Option<usize>);
+
+/// Re-derive a cis allele (or a lone member) from the sequence it produces.
+///
+/// This is the sequence-first canonicalization of #1235. Rather than
+/// normalizing each member in isolation — which makes the result depend on how
+/// the variant was spelled and lets one member's 3'-shift run over a sibling —
+/// it applies the whole group to the reference, re-derives the minimal edit set
+/// from the (reference, result) pair, and partitions and types that set once,
+/// globally. Two encodings of one variant therefore converge, and members
+/// cannot overlap by construction.
+///
+/// The spec is explicit that the description follows from the sequence and not
+/// from the input spelling: `delins.md:86-89` *deleted* its former carve-out
+/// permitting a two-member spelling for a variant "likely a combination of two
+/// other variants".
+///
+/// Returns `variants` unchanged whenever the path does not apply — no reference
+/// window, a repeat/uncertain/protein member, a mixed axis, and so on. Refusal
+/// is the established convention here (see `collapse_overlapping_cis_edits`).
+pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
+    variants: Vec<HgvsVariant>,
+    phase: AllelePhase,
+    provider: &P,
+) -> Vec<HgvsVariant> {
+    if variants.is_empty() || (variants.len() > 1 && phase != AllelePhase::Cis) {
+        return variants;
+    }
+    let Some(kind) = cis_kind_of(&variants[0]) else {
+        return variants;
+    };
+    // Genomic axes only, for now. The transcript axes (`c.`/`n.`/`r.`) layer
+    // several rules on top of a raw re-derivation that this pass does not yet
+    // model: the CDS/UTR and transcript-end insertion clamps (#1202, #1205,
+    // #1207, #1209, #383, #387), the exon-junction exception to the 3' rule
+    // (`general.md:44`), the coding one-amino-acid exception to the separation
+    // rule (`general.md:35`, still current law — SVD-WG010 was rejected), and
+    // the `r.` `U`/`T` alphabet. Re-deriving without them silently discards
+    // them. All of #1229-#1235 were reported on `g.`; the transcript axes are
+    // tracked as follow-up.
+    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
+        return variants;
+    }
+    let body = body_region(kind);
+    let Some((template_accession, _, _, _, _)) = cis_axis_parts(&variants[0], kind) else {
+        return variants;
+    };
+    let template_accession = template_accession.clone();
+
+    let Some(edits) = collect_canonical_edits(&variants, kind, body, &template_accession) else {
+        return variants;
+    };
+
+    // Window: the union of every member's footprint, padded for the 3'-shift.
+    let Some((c_lo, c_hi)) = edit_span_union(&edits) else {
+        return variants;
+    };
+    let w_lo = (c_lo - CANONICAL_PAD).max(1);
+    let w_hi = c_hi + CANONICAL_PAD;
+    if w_hi - w_lo + 1 > MAX_CANONICAL_WINDOW {
+        return variants;
+    }
+
+    let Some(delta) = axis_sequence_delta(kind, &template_accession, provider) else {
+        return variants;
+    };
+    let accession = template_accession.transcript_accession();
+    let start0 = w_lo + delta - 1;
+    if start0 < 0 {
+        return variants;
+    }
+    // A short read at the 3' end is normal near the sequence end; retry with the
+    // window the provider can actually serve so terminal variants still resolve.
+    let Some(ref_bytes) = fetch_canonical_window(provider, &accession, start0, w_lo, w_hi, delta)
+    else {
+        return variants;
+    };
+
+    // A member that misstates its reference base is a reference mismatch, not a
+    // canonicalization problem: strict mode must still reject it and lenient
+    // mode must still warn. Both live in the per-member pipeline, so refuse and
+    // let it run (#1052, #1097).
+    if !stated_reference_bases_match(&variants, kind, &ref_bytes, w_lo) {
+        return variants;
+    }
+    let Some(result) = apply_edits_to_window(&edits, &ref_bytes, w_lo) else {
+        return variants;
+    };
+
+    // Trim to the minimal changed block. Trimming first is what makes the
+    // window choice canonical: `[4_6del;8A>T]` and `[5_7del;8A>T]` span
+    // different windows but trim to the same block, which is precisely why they
+    // must converge (#1234).
+    let (lo, hi_ref, hi_alt) = trim_common_flanks(&ref_bytes, &result);
+    if lo == hi_ref && lo == hi_alt {
+        return variants; // no net change; leave it to the existing pipeline.
+    }
+
+    let mut pieces = partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+    for piece in &mut pieces {
+        piece.ref_start += lo;
+        piece.ref_end += lo;
+    }
+    shift_pieces_three_prime(&mut pieces, &ref_bytes);
+    coalesce_adjacent_pieces(&mut pieces);
+
+    // A canonicalization may re-partition and re-type the change. It may not
+    // describe *more* change than the input already did.
+    //
+    // `best_alignment` considers only single-gap alignments — one contiguous
+    // indel plus substitutions — because letting it place compensating gaps lets
+    // it manufacture matches from coincidence and shred a genuinely contiguous
+    // replacement (#1034/#1040/#182). That restriction is sound only while the
+    // block *has* a single-gap explanation as economical as the input's own.
+    // When two members' length changes do not cancel within one gap — a `+3`
+    // insertion and a `-3` deletion 11 nt apart, or simply two separate
+    // deletions — the lone gap parks at one end and the remaining columns pair
+    // up position-wise, so the offset between them reads as a run of
+    // substitutions. The derived form then marks more columns changed than the
+    // input did (12 against 7 for
+    // `NG_012337.1(NM_012459.2):c.[10del;23_25del;36_37insAAT]`) and merges
+    // across ten bases the input left unchanged (`general.md:34`). That is a
+    // worse description, not a canonical one, so refuse and let the per-member
+    // pipeline — which never re-aligns across members — answer.
+    //
+    // The bound is one-sided and self-limiting: it can never refuse a
+    // single-member input, because the pieces of a single-gap alignment
+    // partition that alignment's columns, so `sum(max(ref_i, alt_i))` is at most
+    // `max(ref, alt)`; the 3'-shift preserves each piece's weight and coalescing
+    // can only lower it. Every "stays delins" case (#1034, #1040, #182, #422) is
+    // single-member and therefore untouched.
+    //
+    // Strict on purpose: #1229, #1231, #1233 and #1234 all sit exactly at
+    // equality, and equality is where prioritisation (`general.md:56`) may
+    // legitimately prefer the re-derived shape.
+    if changed_columns_of_pieces(&pieces) > changed_columns_of_edits(&edits) {
+        return variants;
+    }
+    if needs_unsupported_form(&pieces, &ref_bytes) {
+        return variants;
+    }
+    // Re-partitioning is the point of this pass, but *merging* two members
+    // across a base the input left between them is not: two variants separated
+    // by one or more unchanged nucleotides are described individually
+    // (`general.md:34`). Only a shift that closes the gap may merge them, and
+    // that shows up as pieces still outnumbering nothing — so the check applies
+    // exactly when the derivation has produced fewer pieces than there were
+    // members.
+    if pieces.len() < edits.len() {
+        if let Some(separators) = input_separator_positions(&edits, w_lo) {
+            if pieces
+                .iter()
+                .any(|p| separators.iter().any(|sep| p.claims(*sep)))
+            {
+                return variants;
+            }
+        }
+    }
+    // A derivation that collapses to a single pure insertion belongs to the
+    // per-member pipeline, which owns the terminal-insertion clamps (#1205,
+    // #1217) and duplication recovery. Re-deriving one here would undo a clamp
+    // the pipeline had already applied.
+    if pieces.len() == 1 && pieces[0].is_pure_indel() && !pieces[0].alt.is_empty() {
+        return variants;
+    }
+
+    let Some(rebuilt) = rebuild_members(&pieces, &variants[0], kind, body, w_lo) else {
+        return variants;
+    };
+    if rebuilt == variants {
+        return variants;
+    }
+    // Never let canonicalization silently change what the variant means.
+    debug_assert_eq!(
+        collect_canonical_edits(&rebuilt, kind, body, &template_accession)
+            .and_then(|e| apply_edits_to_window(&e, &ref_bytes, w_lo)),
+        Some(result),
+        "sequence-first canonicalization changed the resulting sequence"
+    );
+    rebuilt
+}
+
+/// The `CisKind` a variant belongs to, or `None` for an axis the sequence-first
+/// path does not serve (protein has no apply-to-reference; `o.` is circular).
+fn cis_kind_of(variant: &HgvsVariant) -> Option<CisKind> {
+    match variant {
+        HgvsVariant::Genome(_) => Some(CisKind::Genome),
+        HgvsVariant::Mt(_) => Some(CisKind::Mt),
+        HgvsVariant::Cds(_) => Some(CisKind::Cds),
+        HgvsVariant::Tx(_) => Some(CisKind::Tx),
+        HgvsVariant::Rna(_) => Some(CisKind::Rna),
+        _ => None,
+    }
+}
+
+/// Lower every member to a [`GEdit`], or refuse the group.
+///
+/// Refuses anything whose description carries information the resulting
+/// sequence does not: repeats (the spec says a repeat and a del/dup spelling of
+/// one change are *both* correct and declines to choose — `open-issues.md:88`),
+/// conversions, methylation, copy number, identity/`=`, and uncertain edits.
+/// Also refuses a mixed axis, a second accession, and any member outside the
+/// positive body region (a contiguous window would happily produce `c.-1_1`,
+/// which is not valid HGVS).
+fn collect_canonical_edits(
+    variants: &[HgvsVariant],
+    kind: CisKind,
+    body: Region,
+    template_accession: &Accession,
+) -> Option<Vec<GEdit>> {
+    let mut edits = Vec::with_capacity(variants.len());
+    for v in variants {
+        let (accession, region, s, e, edit) = cis_axis_parts(v, kind)?;
+        if accession != template_accession || region != body {
+            return None;
+        }
+        match edit {
+            NaEdit::Insertion { sequence } => {
+                let bases = sequence.bases()?;
+                if e != s + 1 {
+                    return None;
+                }
+                edits.push(GEdit::Ins {
+                    gap: s,
+                    alt: bases.to_vec(),
+                });
+            }
+            NaEdit::Deletion { .. } => edits.push(GEdit::Del { s, e }),
+            NaEdit::Substitution { alternative, .. } => {
+                if s != e {
+                    return None;
+                }
+                edits.push(GEdit::Sub {
+                    pos: s,
+                    alt: *alternative,
+                });
+            }
+            NaEdit::Delins { sequence, .. } => {
+                let bases = sequence.bases()?;
+                edits.push(GEdit::Delins {
+                    s,
+                    e,
+                    alt: bases.to_vec(),
+                });
+            }
+            NaEdit::Inversion { .. } => {
+                if e <= s {
+                    return None; // a 1-nt "inversion" is not valid (inversion.md:16)
+                }
+                edits.push(GEdit::Inv { s, e });
+            }
+            NaEdit::Duplication {
+                uncertain_extent: None,
+                ..
+            } => edits.push(GEdit::Dup { s, e }),
+            _ => return None,
+        }
+    }
+    Some(edits)
+}
+
+/// Whether every member's *stated* reference base agrees with the window.
+///
+/// `NaEdit` optionally carries the reference bases the submitter asserted
+/// (`c.5A>T`, `c.5_7delACG`). Where present they must match, otherwise the
+/// variant is a reference mismatch and belongs to the per-member pipeline's
+/// strict-reject / warn path rather than to canonicalization.
+fn stated_reference_bases_match(
+    variants: &[HgvsVariant],
+    kind: CisKind,
+    ref_bytes: &[u8],
+    w_lo: i64,
+) -> bool {
+    for v in variants {
+        let Some((_, _, s, _, edit)) = cis_axis_parts(v, kind) else {
+            return false;
+        };
+        let stated = match edit {
+            NaEdit::Substitution { reference, .. } => Some(vec![*reference]),
+            NaEdit::Deletion {
+                sequence: Some(seq),
+                ..
+            }
+            | NaEdit::Delins {
+                deleted: Some(seq), ..
+            } => Some(seq.bases().to_vec()),
+            _ => None,
+        };
+        let Some(stated) = stated else { continue };
+        for (offset, base) in stated.iter().enumerate() {
+            let index = s - w_lo + offset as i64;
+            if index < 0 || index as usize >= ref_bytes.len() {
+                return false;
+            }
+            if !ref_bytes[index as usize].eq_ignore_ascii_case(&base.to_u8()) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Inclusive 1-based span covering every edit's reference footprint.
+fn edit_span_union(edits: &[GEdit]) -> Option<(i64, i64)> {
+    let mut lo = i64::MAX;
+    let mut hi = i64::MIN;
+    for edit in edits {
+        let (s, e) = match edit {
+            GEdit::Ins { gap, .. } => (*gap, *gap + 1),
+            GEdit::Del { s, e }
+            | GEdit::Delins { s, e, .. }
+            | GEdit::Inv { s, e }
+            | GEdit::Dup { s, e } => (*s, *e),
+            GEdit::Sub { pos, .. } => (*pos, *pos),
+        };
+        lo = lo.min(s);
+        hi = hi.max(e);
+    }
+    (lo <= hi).then_some((lo, hi))
+}
+
+/// Offset between the member axis and the fetched sequence: 0 for `g.`/`m.`/`n.`,
+/// `cds_start - 1` for the CDS-relative `c.`/`r.` axes.
+fn axis_sequence_delta<P: ReferenceProvider>(
+    kind: CisKind,
+    accession: &Accession,
+    provider: &P,
+) -> Option<i64> {
+    match kind {
+        CisKind::Genome | CisKind::Mt | CisKind::Tx => Some(0),
+        CisKind::Cds | CisKind::Rna => {
+            let tx = provider
+                .get_transcript(&accession.transcript_accession())
+                .ok()?;
+            i64::try_from(tx.cds_start?).ok().map(|start| start - 1)
+        }
+    }
+}
+
+/// Fetch the window `[w_lo, w_hi]` on the member axis.
+///
+/// The padding routinely runs past the end of the sequence, and providers
+/// reject an out-of-range request rather than truncating, so clamp to the known
+/// length and retry. The window only needs to cover the edits plus whatever
+/// shift room exists; a shorter window simply means less room. An empty read
+/// means the window is unusable.
+fn fetch_canonical_window<P: ReferenceProvider>(
+    provider: &P,
+    accession: &str,
+    start0: i64,
+    w_lo: i64,
+    w_hi: i64,
+    delta: i64,
+) -> Option<Vec<u8>> {
+    debug_assert!(w_hi >= w_lo, "canonical window must be ordered");
+    let end0 = w_hi + delta;
+    if let Ok(seq) = provider.get_sequence(accession, start0 as u64, end0 as u64) {
+        if !seq.is_empty() {
+            return Some(seq.into_bytes());
+        }
+    }
+    let length = i64::try_from(provider.get_sequence_length(accession).ok()?).ok()?;
+    let clamped = end0.min(length);
+    if clamped <= start0 {
+        return None;
+    }
+    let seq = provider
+        .get_sequence(accession, start0 as u64, clamped as u64)
+        .ok()?;
+    (!seq.is_empty()).then(|| seq.into_bytes())
+}
+
+/// Apply every edit to the window, returning the resulting bytes.
+///
+/// Returns `None` if an edit falls outside the window, a stated reference base
+/// cannot be read, or **two edits claim the same reference position**. That last
+/// case is the #1234 corruption: an allele whose members overlap has no
+/// well-defined resulting sequence — applying it depends on member order — so
+/// refusing is the only honest answer. It is also what stops this pass from
+/// laundering an already-corrupt allele into a plausible-looking one.
+fn apply_edits_to_window(edits: &[GEdit], ref_bytes: &[u8], w_lo: i64) -> Option<Vec<u8>> {
+    // Refuse a descending span before any arithmetic touches it.
+    //
+    // `e < s` means the member wraps the origin of a circular genome — the `m.`
+    // axis admits `m.16569_1del`. This window is linear, so such a member cannot
+    // be applied, and every way of trying is silently wrong:
+    //
+    // * `Dup` sizes a `Vec` from `(e - s + 1) as usize`, and `(1 - 16569 + 1)`
+    //   reinterprets as ~1.8e19 — `Vec::with_capacity` then **aborts the
+    //   process**, in release as well as debug, on the valid input
+    //   `NC_012920.1:m.[16569_1dup;5A>G]`. That is reachable from
+    //   `Normalizer::normalize`, so it is a denial-of-service surface for the
+    //   `web-service` build, not merely a test-time panic.
+    // * `Del`/`Inv`/`Delins` iterate `s..=e` and call `claim(.., s, e)`, both of
+    //   which are *empty* ranges when `e < s`. The member claims nothing,
+    //   changes nothing, and `rebuild_members` then emits the allele with it
+    //   **deleted** — `m.[16569_1del;5A>G]` came back as plain `m.5A>G`.
+    //
+    // `edit_span_union` only catches this when the wraparound member is alone
+    // (its `lo <= hi` check fails); paired with any sibling the bogus union
+    // passes. Refusing here sends the allele to the per-member pipeline, which
+    // applies the `is_wraparound_genome` guard that `cis_axis_parts` does not.
+    for edit in edits {
+        let descending = match edit {
+            GEdit::Del { s, e }
+            | GEdit::Dup { s, e }
+            | GEdit::Inv { s, e }
+            | GEdit::Delins { s, e, .. } => e < s,
+            GEdit::Ins { .. } | GEdit::Sub { .. } => false,
+        };
+        if descending {
+            return None;
+        }
+    }
+
+    let n = ref_bytes.len();
+    let idx = |p: i64| -> Option<usize> {
+        let i = p - w_lo;
+        (i >= 0 && (i as usize) < n).then_some(i as usize)
+    };
+    let mut cell: Vec<Option<u8>> = ref_bytes.iter().map(|b| Some(*b)).collect();
+    let mut after: Vec<Vec<u8>> = vec![Vec::new(); n];
+    let mut claimed = vec![false; n];
+    // Claim `[s, e]` for one edit, refusing if another already holds any of it.
+    let claim = |claimed: &mut Vec<bool>, s: i64, e: i64| -> Option<()> {
+        for p in s..=e {
+            let i = idx(p)?;
+            if std::mem::replace(&mut claimed[i], true) {
+                return None;
+            }
+        }
+        Some(())
+    };
+
+    for edit in edits {
+        match edit {
+            GEdit::Del { s, e } => {
+                claim(&mut claimed, *s, *e)?;
+                for p in *s..=*e {
+                    cell[idx(p)?] = None;
+                }
+            }
+            GEdit::Sub { pos, alt } => {
+                claim(&mut claimed, *pos, *pos)?;
+                cell[idx(*pos)?] = Some(alt.to_u8());
+            }
+            GEdit::Delins { s, e, alt } => {
+                claim(&mut claimed, *s, *e)?;
+                for p in *s..=*e {
+                    cell[idx(p)?] = None;
+                }
+                after[idx(*s)?].extend(alt.iter().map(|b| b.to_u8()));
+            }
+            GEdit::Ins { gap, alt } => {
+                // An insertion occupies no reference position, so it claims
+                // none; two insertions at one gap are caught below.
+                let slot = idx(*gap)?;
+                if !after[slot].is_empty() {
+                    return None;
+                }
+                after[slot].extend(alt.iter().map(|b| b.to_u8()));
+            }
+            GEdit::Dup { s, e } => {
+                let mut copied = Vec::with_capacity((*e - *s + 1) as usize);
+                for p in *s..=*e {
+                    copied.push(ref_bytes[idx(p)?]);
+                }
+                let slot = idx(*e)?;
+                if !after[slot].is_empty() {
+                    return None;
+                }
+                after[slot].extend(copied);
+            }
+            GEdit::Inv { s, e } => {
+                claim(&mut claimed, *s, *e)?;
+                let span: Vec<u8> = (*s..=*e)
+                    .map(|p| idx(p).map(|i| ref_bytes[i]))
+                    .collect::<Option<_>>()?;
+                for (offset, base) in span.iter().rev().enumerate() {
+                    cell[idx(*s + offset as i64)?] = Some(complement_base(*base)?);
+                }
+            }
+        }
+    }
+
+    // A `Delins` writes its replacement into `after[start]` while blanking the
+    // whole span, so the replacement lands 3' of the (now deleted) first base —
+    // the same position it occupies in the reference.
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        if let Some(b) = cell[i] {
+            out.push(b);
+        }
+        out.extend(&after[i]);
+    }
+    Some(out)
+}
+
+/// Watson-Crick complement of an IUPAC base, preserving case-insensitively as
+/// uppercase. `None` for a byte that is not a recognised base.
+fn complement_base(base: u8) -> Option<u8> {
+    let c = crate::sequence::reverse_complement(&(base as char).to_string());
+    c.bytes().next().map(|b| b.to_ascii_uppercase())
+}
+
+/// Trim the common prefix and suffix of the reference and result blocks.
+///
+/// Returns `(prefix_len, ref_end, alt_end)` as offsets into the two slices.
+fn trim_common_flanks(reference: &[u8], result: &[u8]) -> (usize, usize, usize) {
+    let mut lo = 0;
+    while lo < reference.len() && lo < result.len() && reference[lo] == result[lo] {
+        lo += 1;
+    }
+    let mut hi_ref = reference.len();
+    let mut hi_alt = result.len();
+    while hi_ref > lo && hi_alt > lo && reference[hi_ref - 1] == result[hi_alt - 1] {
+        hi_ref -= 1;
+        hi_alt -= 1;
+    }
+    (lo, hi_ref, hi_alt)
+}
+
+/// Partition a changed block into maximal runs of change separated by at least
+/// one unchanged base.
+///
+/// Equal-length blocks compare position-wise — there is no alignment choice to
+/// make, which is why #1230/#1231/#1233 have a single answer. Unequal-length
+/// blocks do have a choice: the minimal edit set is *not* unique (#1232 has four
+/// equally minimal, equally stable encodings). We pick the alignment that
+/// maximizes matched bases — the separation rule (`delins.md:17`) wants the
+/// pieces — and break ties by placing the indel 5'-most. The tie-break is an
+/// implementer's choice; the spec does not reach it. Each piece is 3'-shifted
+/// afterwards, so the 3' rule is still honoured per member.
+fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
+    let whole = || {
+        vec![Piece {
+            ref_start: 0,
+            ref_end: reference.len(),
+            alt: result.to_vec(),
+        }]
+    };
+    if reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK {
+        return whole();
+    }
+    let Some(columns) = best_alignment(reference, result) else {
+        return whole();
+    };
+    let pieces = pieces_from_columns(&columns, reference, result);
+    if pieces.is_empty() {
+        return whole();
+    }
+    if result.len() > reference.len() && !separations_are_meaningful(&pieces) {
+        return whole();
+    }
+    pieces
+}
+
+/// Alignment columns a description marks as changed.
+///
+/// One member occupies `max(|span|, |replacement|)` columns: a substitution costs
+/// 1, an `n`-base deletion or insertion costs `n`, an `n`->`m` `delins` costs
+/// `max(n, m)`. Summed over the members this is the count of non-matching columns
+/// the description implies — the quantity HGVS asks a description to minimise,
+/// and so a search-free bound on how much change a re-derivation may claim.
+///
+/// Spans are clamped at zero rather than trusted, for the same reason
+/// `apply_edits_to_window` refuses them: a wraparound member has `e < s`, and
+/// `(e - s + 1) as usize` on those wraps to ~1.8e19.
+fn changed_columns_of_edits(edits: &[GEdit]) -> usize {
+    fn span(s: i64, e: i64) -> usize {
+        (e - s + 1).max(0) as usize
+    }
+    edits
+        .iter()
+        .map(|edit| match edit {
+            GEdit::Sub { .. } => 1,
+            GEdit::Ins { alt, .. } => alt.len(),
+            GEdit::Del { s, e } | GEdit::Dup { s, e } | GEdit::Inv { s, e } => span(*s, *e),
+            GEdit::Delins { s, e, alt } => span(*s, *e).max(alt.len()),
+        })
+        .sum()
+}
+
+/// The same measure for a derived piece set (see `changed_columns_of_edits`).
+fn changed_columns_of_pieces(pieces: &[Piece]) -> usize {
+    pieces
+        .iter()
+        .map(|piece| (piece.ref_end - piece.ref_start).max(piece.alt.len()))
+        .sum()
+}
+
+/// Whether the unchanged runs separating these pieces are long enough to be real
+/// separation rather than a byproduct of the alignment search.
+///
+/// `best_alignment` scores every single-gap placement and keeps the highest, so
+/// it actively hunts for the placement with the most matches. A lone unchanged
+/// base inside a heavily rewritten block is very often that hunt's own artefact
+/// rather than a base the variant left alone.
+///
+/// **This threshold is an implementer's calibration, not a spec mandate**, and it
+/// is worth being exact about that. `delins.md:44-47` does rule that a
+/// replacement whose payload merely "aligns" is better described as one `delins`,
+/// and the harm it names — tools drawing wrong protein consequences — is exactly
+/// what the conformance corpus shows, where splitting
+/// `g.5207_5212delinsGTCCTGTGCTCATTATCTGGC` turns a single
+/// `p.(Arg53_Arg54delinsSerCysAlaHisTyrLeuAla)` into three bogus ones. But that
+/// worked example is a net *deletion* (52 nt -> 14 nt), so the spec does not
+/// itself draw the line where this does.
+///
+/// Two properties were measured rather than assumed, and both pin the shape:
+///
+/// * **Restricted to net insertions.** Extending it to net deletions breaks
+///   #1232 and #1157, which split a shorter payload at a genuinely unchanged
+///   base, and breaks confluence outright: a two-member input collapsing to one
+///   piece re-arms the `input_separator_positions` veto and returns verbatim,
+///   while the spanning spelling stays spanning — two stable strings for one
+///   variant.
+/// * **Measured before the 3'-shift.** Re-checking afterwards lets every one of
+///   the corpus's coincidental splits back through, because a shift widens the
+///   gap to a piece's left neighbour.
+///
+/// Alternatives that look more principled do not survive measurement. Gating on
+/// `best_alignment`'s score margin cannot work at all: in these cases the winning
+/// placement *is* the 5'-most one, so the margin is zero. Match-density variants
+/// trade corpus rows against unit tests without a threshold that satisfies both.
+fn separations_are_meaningful(pieces: &[Piece]) -> bool {
+    pieces
+        .windows(2)
+        .all(|pair| pair[1].ref_start.saturating_sub(pair[0].ref_end) >= MIN_PIECE_SEPARATION)
+}
+
+/// The alignment maximizing matched bases, ties broken by the 5'-most gap.
+///
+/// The minimal edit set is **not** unique when the blocks differ in length —
+/// #1232 has four equally minimal, equally stable encodings of one variant — so
+/// a deterministic tie-break is required, not optional. Maximizing matches is
+/// what the separation rule (`delins.md:17`) asks for; the 5'-most tie-break is
+/// arbitrary, since the spec does not reach it, but each piece is 3'-shifted
+/// afterwards so the 3' rule is still honoured per member.
+///
+/// Only single-gap alignments are considered: one contiguous indel plus
+/// substitutions. Allowing compensating gaps (a deletion *and* an insertion
+/// inside one block) lets the aligner manufacture matches from coincidence and
+/// shred a genuinely contiguous replacement — the regime `delins.md:44-47`
+/// warns about, seen concretely in the #1034/#1040/#182 "stays delins" cases.
+fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
+    if reference.len() == result.len() {
+        return Some((0..reference.len()).map(|i| (Some(i), Some(i))).collect());
+    }
+    let (shorter_is_ref, gap_len) = if reference.len() < result.len() {
+        (true, result.len() - reference.len())
+    } else {
+        (false, reference.len() - result.len())
+    };
+    let anchored = if shorter_is_ref {
+        reference.len()
+    } else {
+        result.len()
+    };
+
+    let mut best: Option<(usize, Vec<Column>)> = None;
+    for k in 0..=anchored {
+        let columns =
+            single_gap_alignment(k, gap_len, shorter_is_ref, reference.len(), result.len());
+        let matches = columns
+            .iter()
+            .filter(|(r, a)| match (r, a) {
+                (Some(ri), Some(ai)) => reference[*ri] == result[*ai],
+                _ => false,
+            })
+            .count();
+        // Strictly greater keeps the first (5'-most) alignment on a tie.
+        if best.as_ref().is_none_or(|(score, _)| matches > *score) {
+            best = Some((matches, columns));
+        }
+    }
+    best.map(|(_, columns)| columns)
+}
+
+/// Columns for an alignment with a single gap of `gap_len` after `k` aligned
+/// positions. The gap is on the reference side when `shorter_is_ref` (a net
+/// insertion) and on the result side otherwise (a net deletion).
+fn single_gap_alignment(
+    k: usize,
+    gap_len: usize,
+    shorter_is_ref: bool,
+    ref_len: usize,
+    alt_len: usize,
+) -> Vec<Column> {
+    let mut columns = Vec::with_capacity(ref_len.max(alt_len));
+    for i in 0..k {
+        columns.push((Some(i), Some(i)));
+    }
+    if shorter_is_ref {
+        for j in 0..gap_len {
+            columns.push((None, Some(k + j)));
+        }
+        for i in k..ref_len {
+            columns.push((Some(i), Some(i + gap_len)));
+        }
+    } else {
+        for j in 0..gap_len {
+            columns.push((Some(k + j), None));
+        }
+        for i in k..alt_len {
+            columns.push((Some(i + gap_len), Some(i)));
+        }
+    }
+    columns
+}
+
+/// Group consecutive changed columns into pieces.
+fn pieces_from_columns(columns: &[Column], reference: &[u8], result: &[u8]) -> Vec<Piece> {
+    let changed = |(r, a): &Column| match (r, a) {
+        (Some(ri), Some(ai)) => reference[*ri] != result[*ai],
+        _ => true,
+    };
+    let mut pieces: Vec<Piece> = Vec::new();
+    let mut run: Vec<Column> = Vec::new();
+    let mut next_ref = 0usize;
+
+    let flush = |run: &mut Vec<Column>, boundary: usize, pieces: &mut Vec<Piece>| {
+        if run.is_empty() {
+            return;
+        }
+        let ref_indices: Vec<usize> = run.iter().filter_map(|(r, _)| *r).collect();
+        let (ref_start, ref_end) = match (ref_indices.first(), ref_indices.last()) {
+            (Some(first), Some(last)) => (*first, *last + 1),
+            // Pure insertion: a zero-width span at the following reference base.
+            _ => (boundary, boundary),
+        };
+        let alt = run
+            .iter()
+            .filter_map(|(_, a)| *a)
+            .map(|ai| result[ai])
+            .collect();
+        pieces.push(Piece {
+            ref_start,
+            ref_end,
+            alt,
+        });
+        run.clear();
+    };
+
+    for column in columns {
+        if let Some(ri) = column.0 {
+            next_ref = ri;
+        }
+        if changed(column) {
+            run.push(*column);
+        } else {
+            flush(&mut run, next_ref, &mut pieces);
+        }
+    }
+    flush(&mut run, reference.len(), &mut pieces);
+    pieces
+}
+
+/// 3'-shift each length-changing piece, clamped so it cannot reach a sibling.
+///
+/// The clamp is the #1234 fix. The 3' rule (`general.md:41`) is stated per
+/// description with no allele-awareness, and the only text that ever addressed
+/// cross-member shifting was the *rejected* SVD-WG010. Left unbounded, a
+/// deletion shifts over a downstream substitution and the two members overlap —
+/// malformed, and denoting a different sequence. Substitutions are anchored and
+/// never shift.
+fn shift_pieces_three_prime(pieces: &mut [Piece], ref_bytes: &[u8]) {
+    for i in 0..pieces.len() {
+        if !pieces[i].is_pure_indel() {
+            continue;
+        }
+        let left = if i == 0 { 0 } else { pieces[i - 1].ref_end };
+        let right = pieces
+            .get(i + 1)
+            .map_or(ref_bytes.len(), |next| next.ref_start);
+        let bounds = Boundaries::new(left as u64, right as u64);
+        let shuffled = shuffle(
+            ref_bytes,
+            &pieces[i].alt,
+            pieces[i].ref_start as u64,
+            pieces[i].ref_end as u64,
+            &bounds,
+            ShuffleDirection::ThreePrime,
+        );
+        let old_start = pieces[i].ref_start;
+        let new_start = shuffled.start as usize;
+        pieces[i].ref_start = new_start;
+        pieces[i].ref_end = shuffled.end as usize;
+
+        // `shuffle` returns coordinates only. Moving a *pure insertion*'s point
+        // 3' by `k` rotates the inserted sequence left by `k mod len`: inserting
+        // `TG` before position 16 is not the variant that inserts `TG` before
+        // 17. Leaving `alt` alone emits a description denoting a *different*
+        // sequence, and because the wrong form is a stable fixed point no
+        // idempotency check can see it — only the pass's own round-trip assert
+        // caught it, on 56 conformance rows.
+        //
+        // `k mod len` is not a guess: `shuffle`'s insertion predicate compares
+        // `ref[start + k]` against `alt[(new_end - start) % alt.len()]`, so
+        // `shuffle` already *defines* the post-shift payload as
+        // `rotate_left(k mod len)`. The same modulus emits exactly the variant
+        // `shuffle` proved legal. A pure deletion has an empty `alt`.
+        //
+        // This is the hazard the per-member pipeline documents inside
+        // `Normalizer::normalize_na_edit` (the #1157 follow-up).
+        if !pieces[i].alt.is_empty() {
+            // A 3'-shuffle only ever advances: it initialises its cursor to
+            // `start` and mutates it solely via `new_start += 1`. Unlike the
+            // `mod.rs` precedent, which serves both directions and once
+            // regressed 5' insertions by clamping leftward moves with
+            // `saturating_sub`, this call site is `ThreePrime`-only, so a
+            // leftward move would be a bug in `shuffle`, not a case to handle.
+            debug_assert!(
+                new_start >= old_start,
+                "a 3'-shuffle cannot move a piece 5' (old={old_start}, new={new_start})",
+            );
+            let rotation = new_start.saturating_sub(old_start) % pieces[i].alt.len();
+            if rotation > 0 {
+                pieces[i].alt.rotate_left(rotation);
+            }
+        }
+    }
+}
+
+/// Merge pieces the 3'-shift left touching.
+///
+/// Two or more consecutive changed nucleotides are one delins
+/// (`delins.md:16`), so once a shift closes the gap the pieces must combine —
+/// this is what turns #1234's clamped `5_7del` plus `8A>T` into `5_8delinsT`.
+fn coalesce_adjacent_pieces(pieces: &mut Vec<Piece>) {
+    let mut i = 1;
+    while i < pieces.len() {
+        if pieces[i - 1].ref_end >= pieces[i].ref_start {
+            let next = pieces.remove(i);
+            let prev = &mut pieces[i - 1];
+            prev.ref_end = prev.ref_end.max(next.ref_end);
+            prev.alt.extend(next.alt);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Turn pieces back into HGVS members on the group's own axis.
+fn rebuild_members(
+    pieces: &[Piece],
+    template: &HgvsVariant,
+    kind: CisKind,
+    body: Region,
+    w_lo: i64,
+) -> Option<Vec<HgvsVariant>> {
+    let mut members = Vec::with_capacity(pieces.len());
+    for piece in pieces {
+        let anchor = anchor_for_piece(piece, body, w_lo)?;
+        members.push(match (kind, template) {
+            (CisKind::Genome, HgvsVariant::Genome(g)) => {
+                HgvsVariant::Genome(build_genome_merged(g, anchor))
+            }
+            (CisKind::Mt, HgvsVariant::Mt(m)) => HgvsVariant::Mt(build_mt_merged(m, anchor)),
+            (CisKind::Cds, HgvsVariant::Cds(c)) => HgvsVariant::Cds(build_cds_merged(c, anchor)),
+            (CisKind::Tx, HgvsVariant::Tx(t)) => HgvsVariant::Tx(build_tx_merged(t, anchor)),
+            (CisKind::Rna, HgvsVariant::Rna(r)) => HgvsVariant::Rna(build_rna_merged(r, anchor)),
+            _ => return None,
+        });
+    }
+    (!members.is_empty()).then_some(members)
+}
+
+/// Build the [`Anchor`] for one piece, typing it under the spec's rules.
+///
+/// [`build_naedit`] already picks insertion / deletion / delins from the span
+/// and replacement, which covers the mandates that 1 nt → 1 nt is a
+/// substitution (`delins.md:15`) and that consecutive changes are one delins
+/// (`delins.md:16`). Inversion and tandem duplication are *not* built here —
+/// [`needs_unsupported_form`] refuses the whole group when a piece would need
+/// either, leaving them to the per-member pipeline.
+fn anchor_for_piece(piece: &Piece, body: Region, w_lo: i64) -> Option<Anchor> {
+    let alt: Vec<Base> = piece
+        .alt
+        .iter()
+        .filter_map(|b| Base::from_char(*b as char))
+        .collect();
+    if alt.len() != piece.alt.len() {
+        return None; // non-IUPAC byte; refuse rather than mangle.
+    }
+    let start = w_lo + piece.ref_start as i64;
+    let end = w_lo + piece.ref_end as i64 - 1;
+    Some(Anchor {
+        region: body,
+        start,
+        end,
+        alt,
+    })
+}
+
+/// Reference positions the input left unchanged *between* two of its members,
+/// as 0-based offsets into the window.
+///
+/// Two variants separated by one or more unchanged nucleotides are described
+/// individually and **not** as one delins (`general.md:34`, restated in every
+/// DNA page). So a re-derivation may split a member and may merge members the
+/// 3'-shift made adjacent, but it must never swallow a base the input itself
+/// held between two members: `[1006_1008del;1009_1010insCCC]` leaves 1009
+/// untouched, and collapsing it to `1006_1009delinsTCCC` merges across it
+/// (#180).
+///
+/// An insertion consumes no reference base, so its footprint is the junction it
+/// sits in rather than a span.
+fn input_separator_positions(edits: &[GEdit], w_lo: i64) -> Option<Vec<usize>> {
+    let mut footprints: Vec<(i64, i64)> = edits
+        .iter()
+        .map(|edit| match edit {
+            // An insertion between `gap` and `gap + 1` touches neither base;
+            // represent it as the empty span just past `gap`.
+            GEdit::Ins { gap, .. } => (*gap + 1, *gap),
+            GEdit::Dup { s: _, e } => (*e + 1, *e),
+            GEdit::Del { s, e } | GEdit::Delins { s, e, .. } | GEdit::Inv { s, e } => (*s, *e),
+            GEdit::Sub { pos, .. } => (*pos, *pos),
+        })
+        .collect();
+    if footprints.len() < 2 {
+        return None;
+    }
+    footprints.sort_unstable();
+    let mut separators = Vec::new();
+    for pair in footprints.windows(2) {
+        let (_, previous_end) = pair[0];
+        let (next_start, _) = pair[1];
+        for position in (previous_end + 1)..next_start {
+            let offset = position - w_lo;
+            if offset >= 0 {
+                separators.push(offset as usize);
+            }
+        }
+    }
+    (!separators.is_empty()).then_some(separators)
+}
+
+/// Whether any piece would have to be rendered as an inversion or a tandem
+/// duplication.
+///
+/// [`build_naedit`] only produces insertion / deletion / delins / identity, and
+/// the spec is emphatic that these two forms are not interchangeable with those:
+/// an inversion is the reverse complement of its span (`inversion.md:5`), and a
+/// tandem duplication **must** be described as a `dup`, never an insertion
+/// (`duplication.md:18`). Rather than teach the builder two more shapes, refuse
+/// the group and let the existing per-member pipeline — which already gets both
+/// right — handle it. Refusing costs nothing here: these are exactly the cases
+/// where a single member is already canonical.
+fn needs_unsupported_form(pieces: &[Piece], ref_bytes: &[u8]) -> bool {
+    pieces
+        .iter()
+        .any(|piece| is_inversion(piece, ref_bytes) || is_tandem_duplication(piece, ref_bytes))
+}
+
+/// A piece is an inversion when its replacement is the reverse complement of
+/// its own span and spans more than one nucleotide (`inversion.md:5,16` — a
+/// 1-nt "inversion" is a substitution).
+fn is_inversion(piece: &Piece, ref_bytes: &[u8]) -> bool {
+    let span = &ref_bytes[piece.ref_start..piece.ref_end];
+    span.len() > 1
+        && span.len() == piece.alt.len()
+        && reverse_complement_bytes(span).is_some_and(|rc| rc == piece.alt)
+}
+
+/// A piece is a tandem duplication when it is a pure insertion whose bases
+/// repeat the reference immediately 5' of the insertion point.
+fn is_tandem_duplication(piece: &Piece, ref_bytes: &[u8]) -> bool {
+    if piece.ref_start != piece.ref_end || piece.alt.is_empty() {
+        return false;
+    }
+    let Some(source_start) = piece.ref_start.checked_sub(piece.alt.len()) else {
+        return false;
+    };
+    ref_bytes[source_start..piece.ref_start].eq_ignore_ascii_case(&piece.alt)
+}
+
+/// Reverse complement of a byte slice, or `None` on a non-IUPAC byte.
+fn reverse_complement_bytes(bases: &[u8]) -> Option<Vec<u8>> {
+    let text = std::str::from_utf8(bases).ok()?;
+    Some(
+        crate::sequence::reverse_complement(text)
+            .to_ascii_uppercase()
+            .into_bytes(),
+    )
 }
 
 #[cfg(test)]

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1815,16 +1815,20 @@ const MAX_CANONICAL_WINDOW: i64 = 4096;
 /// Padding either side of the changed interval, giving the 3'-shift room.
 const CANONICAL_PAD: i64 = 128;
 
-/// Longest changed block the canonicalizer will *split* into several members.
+/// Longest changed block the canonicalizer will attempt to partition.
 ///
-/// The separation rule (`delins.md:17`) says changes separated by unchanged
-/// nucleotides are described individually, but `delins.md:44-47` keeps a single
-/// spanning delins for a large replacement whose interior only *coincidentally*
-/// aligns ("parts of the inserted sequence align … the delins format is
-/// recommended"), and gives no threshold. A long block is that regime: emit one
-/// delins rather than an alignment artefact. The spec's own counter-example
-/// spans 52 nt.
-const MAX_SPLIT_BLOCK: usize = 32;
+/// This is a cost bound, not a policy: the alignment is quadratic in the block
+/// length, and a block this long is a structural event rather than a few
+/// nucleotide changes. It is deliberately far above the size at which the
+/// separation rule (`delins.md:17`) is the interesting question.
+///
+/// It is *not* the `delins.md:44-47` "coincidental alignment" guard. That
+/// concern — a large replacement whose interior only accidentally aligns, which
+/// the spec keeps as one delins — is handled structurally instead: only
+/// single-gap alignments are considered, so the aligner cannot manufacture
+/// matches by opening compensating gaps, and a block is split only where a base
+/// genuinely survives unchanged.
+const MAX_SPLIT_BLOCK: usize = 1024;
 
 /// Unchanged reference bases two pieces of a net insertion must be separated by
 /// before the split between them is believed. See `separations_are_meaningful`.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1587,6 +1587,108 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// would reject via `normalize()`. In the default lenient config every
     /// `should_reject_*` is false, so the ladder is a no-op and the warnings pass
     /// straight through.
+    /// Whether a lone (non-allele) member is a shape the sequence-first pass
+    /// can improve: a `delins` or an `inv`, the two forms that may be hiding an
+    /// unchanged interior base and so need re-partitioning (#1230, #1232).
+    fn is_splittable_single_member_impl(variant: &HgvsVariant) -> bool {
+        let edit = match variant {
+            HV::Genome(g) => &g.loc_edit.edit,
+            HV::Mt(m) => &m.loc_edit.edit,
+            HV::Cds(c) => &c.loc_edit.edit,
+            HV::Tx(t) => &t.loc_edit.edit,
+            HV::Rna(r) => &r.loc_edit.edit,
+            _ => return false,
+        };
+        matches!(
+            edit.inner(),
+            Some(NaEdit::Delins { .. }) | Some(NaEdit::Inversion { .. })
+        )
+    }
+
+    /// Re-derive the variant from the sequence it produces (#1229-#1235).
+    ///
+    /// The per-member pipeline normalizes each cis-allele member in isolation,
+    /// which makes the canonical form depend on the input spelling and lets one
+    /// member's 3'-shift run over a sibling. This pass runs once, at the top
+    /// level, over the already-normalized variant: it applies the whole thing to
+    /// the reference, re-derives the edit set from the (reference, result) pair,
+    /// and partitions it globally. See `merge::canonicalize_from_sequence`.
+    ///
+    /// Canonicalizing can expose further work for the per-member pipeline (a
+    /// derived member may itself 3'-shift), so the two alternate to a fixed
+    /// point. The loop is bounded: each pass either reaches a fixed point or is
+    /// abandoned in favour of the last stable value, so this can never diverge.
+    fn canonicalize_from_sequence(
+        &self,
+        variant: HgvsVariant,
+        warnings: Vec<NormalizationWarning>,
+    ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        /// Alternations between the sequence-first pass and `normalize_core`.
+        /// Two is enough for every shape seen so far; the bound only exists so
+        /// a pathological input cannot spin.
+        const MAX_PASSES: usize = 4;
+
+        let mut current = variant;
+        let mut warnings = warnings;
+        for _ in 0..MAX_PASSES {
+            let Some(canonical) = self.sequence_first_pass(&current) else {
+                return Ok((current, warnings));
+            };
+            if canonical == current {
+                return Ok((current, warnings));
+            }
+            // The re-derived form is expressed in raw coordinates; hand it back
+            // to the per-member pipeline so axis-specific canonicalization
+            // (position shapes, boundary clamps, warnings) is applied to it.
+            let (renormalized, pass_warnings) = self.normalize_core(&canonical)?;
+            // Only keep this pass's warnings if its result is the one we keep.
+            // Extending first would duplicate every warning the re-derivation
+            // reproduces from the previous pass whenever it settles back on
+            // `current`.
+            if renormalized == current {
+                return Ok((current, warnings));
+            }
+            warnings.extend(pass_warnings);
+            current = renormalized;
+        }
+        Ok((current, warnings))
+    }
+
+    /// One sequence-first re-derivation. `None` when the variant is not a shape
+    /// the pass serves (protein, trans alleles, fusions, and so on).
+    fn sequence_first_pass(&self, variant: &HgvsVariant) -> Option<HgvsVariant> {
+        // Only shapes where a partition decision actually exists. A lone
+        // substitution / deletion / insertion / duplication already has exactly
+        // one canonical partition, so re-deriving it can only lose what the
+        // per-member pipeline added (gene symbol, RNA `U` alphabet, boundary and
+        // exon-junction clamps). A lone `delins` or `inv` is different: those are
+        // precisely the single-member forms that may need splitting (#1230,
+        // #1232).
+        let (members, phase, uncertain) = match variant {
+            HV::Allele(allele) => {
+                if allele.uncertain || allele.phase != AllelePhase::Cis || allele.variants.len() < 2
+                {
+                    return None;
+                }
+                (allele.variants.clone(), allele.phase, allele.uncertain)
+            }
+            single if Self::is_splittable_single_member_impl(single) => {
+                (vec![variant.clone()], AllelePhase::Cis, false)
+            }
+            _ => return None,
+        };
+        let rebuilt = merge::canonicalize_from_sequence(members, phase, &self.provider);
+        match rebuilt.len() {
+            0 => None,
+            1 => rebuilt.into_iter().next(),
+            _ => {
+                let mut allele = crate::hgvs::variant::AlleleVariant::new(rebuilt, phase);
+                allele.uncertain = uncertain;
+                Some(HV::Allele(allele))
+            }
+        }
+    }
+
     pub(crate) fn normalize_core_checked(
         &self,
         variant: &HgvsVariant,
@@ -1595,6 +1697,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `detect_shuffle_infos` work `normalize_with_diagnostics` does) and wrap
         // with empty infos; the ladder below only inspects warnings.
         let (normalized, warnings) = self.normalize_core(variant)?;
+        // Re-derive from the resulting sequence. This runs *after* the
+        // per-member pipeline, which is safe because the sibling clamp (#1234)
+        // guarantees the members it produces are disjoint — an allele whose
+        // members overlap has no well-defined resulting sequence, so
+        // canonicalizing one would be canonicalizing a corrupted form.
+        let (normalized, warnings) = self.canonicalize_from_sequence(normalized, warnings)?;
         let result = NormalizeResult::with_warnings(normalized, warnings);
 
         // EINTRONIC (#486): reject an intronic offset on a bare transcript

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -1,0 +1,288 @@
+//! Property test for #1235's acceptance criterion: **confluence**.
+//!
+//! Idempotency is necessary but not sufficient. A normalizer can be perfectly
+//! idempotent and still non-confluent — every spelling its own fixed point —
+//! which is exactly the failure mode #1229-#1233 reported: several encodings of
+//! one variant, each stable, none agreeing. A consumer keying on the normalized
+//! string then silently over-splits one variant into several.
+//!
+//! `normalize_idempotency_proptest` already fuzzes confluence for *homopolymer
+//! boundary* spellings of a single edit. This file covers the cis-allele case:
+//! one haplotype spelled as separate substitutions, as one spanning delins, and
+//! as runs grouped into delins members must all reach one string.
+//!
+//! Cases are **valid by construction** — the encodings are generated from a
+//! chosen set of changed positions over a known core, so each one provably
+//! describes the same resulting sequence. There is no skip path: an unparseable
+//! render or a failed normalize is a bug, not a case to discard.
+//!
+//! Scope: the genomic axis, matching where the sequence-first canonicalization
+//! is enabled. Extending this to `c.`/`n.`/`r.` should follow that work.
+
+use crate::common::synthetic::{SyntheticBuilder, PAD_OFFSET};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
+
+/// HGVS position of 0-based index `i` into the core sequence.
+fn hgvs_position(index: usize) -> u64 {
+    PAD_OFFSET + 1 + index as u64
+}
+
+/// A haplotype: a core sequence plus the positions whose base changes, each
+/// with its replacement. Substitution-only, so every encoding below is
+/// length-preserving and provably describes the same resulting sequence.
+#[derive(Debug, Clone)]
+struct Haplotype {
+    core: String,
+    /// `(index into core, replacement base)`, strictly ascending by index.
+    changes: Vec<(usize, char)>,
+}
+
+impl Haplotype {
+    /// One member per changed position: `g.[257A>G;259C>T]`.
+    fn as_substitutions(&self) -> String {
+        let members: Vec<String> = self
+            .changes
+            .iter()
+            .map(|(index, alt)| {
+                let reference = self.core.as_bytes()[*index] as char;
+                format!("{}{reference}>{alt}", hgvs_position(*index))
+            })
+            .collect();
+        format!("NC_TEST.1:g.[{}]", members.join(";"))
+    }
+
+    /// One delins spanning the first to the last changed position, carrying the
+    /// unchanged interior bases through unchanged.
+    fn as_spanning_delins(&self) -> String {
+        let first = self.changes.first().expect("non-empty").0;
+        let last = self.changes.last().expect("non-empty").0;
+        let mut replacement: Vec<char> = self.core[first..=last].chars().collect();
+        for (index, alt) in &self.changes {
+            replacement[index - first] = *alt;
+        }
+        let replacement: String = replacement.into_iter().collect();
+        format!(
+            "NC_TEST.1:g.{}_{}delins{replacement}",
+            hgvs_position(first),
+            hgvs_position(last)
+        )
+    }
+
+    /// Maximal runs of consecutive changed positions, each rendered as one
+    /// member: a lone position as a substitution, a run as a delins.
+    fn as_grouped_runs(&self) -> String {
+        let mut members: Vec<String> = Vec::new();
+        let mut run: Vec<(usize, char)> = Vec::new();
+        let flush = |run: &mut Vec<(usize, char)>, members: &mut Vec<String>, core: &str| {
+            match run.len() {
+                0 => {}
+                1 => {
+                    let (index, alt) = run[0];
+                    let reference = core.as_bytes()[index] as char;
+                    members.push(format!("{}{reference}>{alt}", hgvs_position(index)));
+                }
+                _ => {
+                    let first = run[0].0;
+                    let last = run[run.len() - 1].0;
+                    let replacement: String = run.iter().map(|(_, alt)| *alt).collect();
+                    members.push(format!(
+                        "{}_{}delins{replacement}",
+                        hgvs_position(first),
+                        hgvs_position(last)
+                    ));
+                }
+            }
+            run.clear();
+        };
+        for change in &self.changes {
+            if run
+                .last()
+                .is_some_and(|(previous, _)| change.0 != previous + 1)
+            {
+                flush(&mut run, &mut members, &self.core);
+            }
+            run.push(*change);
+        }
+        flush(&mut run, &mut members, &self.core);
+        format!("NC_TEST.1:g.[{}]", members.join(";"))
+    }
+
+    fn encodings(&self) -> Vec<String> {
+        vec![
+            self.as_substitutions(),
+            self.as_spanning_delins(),
+            self.as_grouped_runs(),
+        ]
+    }
+}
+
+fn normalize(provider: &MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider.clone());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// Cores biased toward repeats and complementary pairs, so 3'-shifting and
+/// inversion recognition are actually exercised rather than a random string
+/// where nothing shifts and nothing is a palindrome.
+fn core_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            Just("A".to_string()),
+            Just("C".to_string()),
+            Just("G".to_string()),
+            Just("T".to_string()),
+            Just("AA".to_string()),
+            Just("AT".to_string()),
+            Just("GC".to_string()),
+            Just("CAG".to_string()),
+        ],
+        6..14,
+    )
+    .prop_map(|parts| parts.concat())
+}
+
+/// Replacement bases are chosen from the three that *differ* from the
+/// reference, so every generated change is real and the strategy never has to
+/// reject a case. Filtering after the fact instead (drop a change whose
+/// replacement happened to equal the reference, then `prop_assume!` at least two
+/// survive) rejects often enough to trip proptest's global-reject cap once the
+/// case count is raised to the soak's 125k.
+fn differing_base(reference: u8, choice: usize) -> char {
+    let alternatives: Vec<char> = "ACGT"
+        .chars()
+        .filter(|base| *base as u8 != reference)
+        .collect();
+    alternatives[choice % alternatives.len()]
+}
+
+fn haplotype_strategy() -> impl Strategy<Value = Haplotype> {
+    core_strategy().prop_flat_map(|core| {
+        let length = core.len();
+        // Two or three changed positions, which is where partitioning decisions
+        // (adjacent vs separated) actually arise.
+        prop::collection::btree_set(0..length, 2..=3).prop_flat_map(move |indices| {
+            let core = core.clone();
+            let indices: Vec<usize> = indices.into_iter().collect();
+            let choices = prop::collection::vec(0..3usize, indices.len());
+            choices.prop_map(move |choices| {
+                let changes: Vec<(usize, char)> = indices
+                    .iter()
+                    .zip(choices.iter())
+                    .map(|(index, choice)| {
+                        (*index, differing_base(core.as_bytes()[*index], *choice))
+                    })
+                    .collect();
+                Haplotype {
+                    core: core.clone(),
+                    changes,
+                }
+            })
+        })
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 512, ..ProptestConfig::default() })]
+
+    /// Every encoding of one haplotype normalizes to one string.
+    #[test]
+    fn all_encodings_of_one_haplotype_converge(haplotype in haplotype_strategy()) {
+        let provider = SyntheticBuilder::genomic(&haplotype.core).build();
+        let encodings = haplotype.encodings();
+        let normalized: Vec<String> = encodings
+            .iter()
+            .map(|input| normalize(&provider, input))
+            .collect();
+
+        let first = &normalized[0];
+        for (input, output) in encodings.iter().zip(normalized.iter()) {
+            prop_assert_eq!(
+                output,
+                first,
+                "encodings of one haplotype diverged:\n  {} -> {}\n  {} -> {}",
+                encodings[0], first, input, output
+            );
+        }
+    }
+
+    /// The canonical form is itself a fixed point, so convergence is to a
+    /// genuine canonical form rather than to a shared way-point.
+    #[test]
+    fn the_converged_form_is_a_fixed_point(haplotype in haplotype_strategy()) {
+        let provider = SyntheticBuilder::genomic(&haplotype.core).build();
+        let once = normalize(&provider, &haplotype.as_substitutions());
+        let twice = normalize(&provider, &once);
+        prop_assert_eq!(&twice, &once, "`{}` is not a fixed point", once);
+    }
+
+    /// No normalized cis allele contains overlapping or out-of-order members —
+    /// the structural half of #1235's acceptance criteria.
+    #[test]
+    fn members_are_disjoint_and_ascending(haplotype in haplotype_strategy()) {
+        use ferro_hgvs::hgvs::variant::HgvsVariant;
+        let provider = SyntheticBuilder::genomic(&haplotype.core).build();
+        let normalizer = Normalizer::new(provider);
+        for input in haplotype.encodings() {
+            let parsed = parse_hgvs(&input).expect("valid by construction");
+            let normalized = normalizer.normalize(&parsed).expect("normalize");
+            let HgvsVariant::Allele(allele) = &normalized else {
+                continue;
+            };
+            let mut previous_end: Option<i64> = None;
+            for member in &allele.variants {
+                let HgvsVariant::Genome(genome) = member else {
+                    continue;
+                };
+                let interval = &genome.loc_edit.location;
+                let (Some(start), Some(end)) = (interval.start.inner(), interval.end.inner())
+                else {
+                    continue;
+                };
+                let (start, end) = (start.base as i64, end.base as i64);
+                if let Some(previous) = previous_end {
+                    prop_assert!(
+                        start > previous,
+                        "`{}` -> `{}`: member at {} overlaps the previous member ending at {}",
+                        input, normalized, start, previous
+                    );
+                }
+                previous_end = Some(end);
+            }
+        }
+    }
+}
+
+/// Non-vacuity guard: the strategy must actually produce both adjacent and
+/// separated changed positions, otherwise the properties above could pass while
+/// exercising only one partitioning shape.
+#[test]
+fn the_strategy_generates_both_adjacent_and_separated_changes() {
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
+
+    let mut runner = TestRunner::deterministic();
+    let (mut adjacent, mut separated) = (false, false);
+    for _ in 0..512 {
+        let haplotype = haplotype_strategy()
+            .new_tree(&mut runner)
+            .expect("strategy produces a value")
+            .current();
+        for pair in haplotype.changes.windows(2) {
+            if pair[1].0 == pair[0].0 + 1 {
+                adjacent = true;
+            } else {
+                separated = true;
+            }
+        }
+        if adjacent && separated {
+            return;
+        }
+    }
+    panic!("strategy never produced both adjacent and separated changes (adjacent={adjacent}, separated={separated})");
+}

--- a/tests/it/issue_1157_delins_reduction_shift.rs
+++ b/tests/it/issue_1157_delins_reduction_shift.rs
@@ -134,18 +134,26 @@ fn decomposed_cis_allele_is_not_collapsed_into_a_spanning_delins() {
 }
 
 #[test]
-fn single_delins_is_not_decomposed_into_an_allele() {
-    // The length-changing delins stays a single delins; it is not rewritten as
-    // the decomposed allele. Together with the test above, this pins that the
-    // two sequence-identical encodings remain distinct after normalization.
-    assert_eq!(norm(CASE_A_CORE, CASE_A_DELINS), CASE_A_DELINS);
+fn single_delins_is_decomposed_at_its_unchanged_bases() {
+    // Re-blessed for #1235. #1160's scope note closed "case A" on the argument
+    // that collapsing the decomposed allele into one spanning delins would be
+    // wrong — which is true, and the test above still pins it. But that leaves
+    // the other direction, which is the one #1157 actually asked about: the
+    // spanning delins covers unchanged bases at 259 and 261, and changes
+    // separated by unchanged nucleotides are described individually
+    // (`delins.md:17`, restated in every DNA page). So the delins decomposes
+    // *into* the allele, and both encodings reach one canonical form.
+    assert_eq!(
+        norm(CASE_A_CORE, CASE_A_DELINS),
+        "NC_TEST.1:g.[257_258delinsGA;260C>T;262_263del]",
+    );
 }
 
 #[test]
-fn sequence_identical_delins_and_allele_do_not_normalize_equal() {
-    // The scope-decision point of #1157 in one assertion: same resulting
-    // sequence, different canonical forms — by design.
-    assert_ne!(
+fn sequence_identical_delins_and_allele_normalize_equal() {
+    // The point of #1235: two encodings of one variant converge. This assertion
+    // was `assert_ne!` under #1160's scope decision.
+    assert_eq!(
         norm(CASE_A_CORE, CASE_A_DELINS),
         norm(CASE_A_CORE, CASE_A_ALLELE),
     );

--- a/tests/it/issue_1158_equivalence_resulting_sequence.rs
+++ b/tests/it/issue_1158_equivalence_resulting_sequence.rs
@@ -28,19 +28,23 @@ fn level(core: &str, a: &str, b: &str) -> EquivalenceLevel {
 
 /// Core `AGTCAGT` at HGVS 257..=263. Replacing all seven bases with `GATTA`
 /// (`g.257_263delinsGATTA`) yields the same sequence as the decomposed cis
-/// allele `[257A>G;258G>A;260C>T;262_263del]` — but ferro keeps them in
-/// different canonical forms (the length-changing delins stays a delins; the
-/// allele normalizes to `[257_258delinsGA;260C>T;262_263del]`). Same resulting
-/// sequence, different normalized strings. This is issue #1158's case A.
+/// allele `[257A>G;258G>A;260C>T;262_263del]`. Since #1235 both encodings
+/// normalize to `[257_258delinsGA;260C>T;262_263del]`, so the checker now
+/// reaches the stronger `NormalizedMatch` rung rather than falling through to
+/// `SequenceMatch`. This is issue #1158's case A.
 const CASE_A_CORE: &str = "AGTCAGT";
 const CASE_A_DELINS: &str = "NC_TEST.1:g.257_263delinsGATTA";
 const CASE_A_ALLELE: &str = "NC_TEST.1:g.[257A>G;258G>A;260C>T;262_263del]";
 
 #[test]
 fn delins_and_decomposed_allele_with_same_sequence_are_equivalent() {
+    // Re-blessed for #1235: the two encodings now converge under `normalize`,
+    // so they match at the normalized-string rung. `SequenceMatch` remains the
+    // rung for pairs that stay in different canonical forms — see the
+    // length-changing cases below.
     assert_eq!(
         level(CASE_A_CORE, CASE_A_DELINS, CASE_A_ALLELE),
-        EquivalenceLevel::SequenceMatch,
+        EquivalenceLevel::NormalizedMatch,
     );
 }
 

--- a/tests/it/issue_1235_cis_allele_confluence.rs
+++ b/tests/it/issue_1235_cis_allele_confluence.rs
@@ -1,0 +1,342 @@
+//! Cis-allele confluence: #1229-#1235.
+//!
+//! `Normalizer::normalize` used to normalize each cis-allele member in
+//! isolation rather than re-deriving the allele from the resulting sequence.
+//! Two consequences, both covered here:
+//!
+//! * **non-confluence** — several encodings of one variant each normalized to a
+//!   different stable string (#1229, #1230, #1231, #1232, #1233), so any
+//!   consumer keying on the normalized string silently over-split the variant;
+//! * **silent corruption** — a deletion 3'-shifted across a sibling
+//!   substitution, emitting overlapping members that denote a *different*
+//!   sequence (#1234).
+//!
+//! The synthetic `TEMPLATE` reference is the one from the issue reproductions,
+//! kept verbatim so these tests and the reports stay comparable.
+
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+use std::io::Write;
+
+const SEQ: &str = concat!(
+    "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCG",
+    "TACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA"
+);
+
+fn provider() -> JsonProvider {
+    let n = SEQ.len() as u64;
+    let json = serde_json::json!({
+        "version": "1.0",
+        "transcripts": [{
+            "id": "TEMPLATE-gene.1",
+            "chromosome": "TEMPLATE",
+            "strand": "+",
+            "sequence": SEQ,
+            "cds_start": 1,
+            "cds_end": n - (n % 3),
+            "genomic_start": 1,
+            "genomic_end": n,
+            "protein_id": "TEMPLATE-gene.1",
+            "exons": [{
+                "number": 1, "start": 1, "end": n,
+                "genomic_start": 1, "genomic_end": n
+            }]
+        }],
+        "genomic_sequences": { "TEMPLATE": SEQ }
+    });
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    write!(f, "{json}").expect("write json");
+    JsonProvider::from_json(f.path()).expect("load reference")
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(provider());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// Assert every encoding normalizes to `canonical`, and that `canonical` is
+/// itself a fixed point. The second half is what makes this a confluence
+/// check rather than a table of expected strings.
+fn converges_to(canonical: &str, encodings: &[&str]) {
+    for input in encodings {
+        assert_eq!(
+            normalize_to_string(input),
+            canonical,
+            "`{input}` should normalize to `{canonical}`"
+        );
+    }
+    assert_eq!(
+        normalize_to_string(canonical),
+        canonical,
+        "`{canonical}` should be a normalization fixed point"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Per-issue regressions
+// ----------------------------------------------------------------------------
+
+/// #1229 — an `inv` member must not block coalescing of an adjacent run.
+///
+/// Ref `CAC` at 4-6 becomes `AGT`. Three consecutive changed nucleotides are
+/// one delins (`delins.md:16`); `AGT` is not the reverse complement of `CAC`
+/// (that is `GTG`), so this is not an inversion.
+#[test]
+fn issue_1229_adjacent_inv_member_coalesces() {
+    converges_to(
+        "TEMPLATE:g.4_6delinsAGT",
+        &[
+            "TEMPLATE:g.[4C>A;5A>G;6C>T]",
+            "TEMPLATE:g.[4C>A;5_6inv]",
+            "TEMPLATE:g.4_6delinsAGT",
+        ],
+    );
+}
+
+/// #1230 — an `inv` whose interior bases are unchanged is really the end
+/// substitutions.
+///
+/// Ref `GATG` at 20-23 becomes `CATC`. Only positions 20 and 23 change; the
+/// interior `AT` is a complementary pair and is untouched. Changes separated by
+/// unchanged nucleotides are described individually (`inversion.md:21`), and
+/// prioritisation ranks substitution above inversion (`general.md:56`).
+///
+/// The spec has no worked example of an inversion with an unchanged interior,
+/// so this direction is a documented implementer's choice, not a spec citation.
+#[test]
+fn issue_1230_inv_with_unchanged_interior_becomes_substitutions() {
+    converges_to(
+        "TEMPLATE:g.[20G>C;23G>C]",
+        &[
+            "TEMPLATE:g.20_23inv",
+            "TEMPLATE:g.20_23delinsCATC",
+            "TEMPLATE:g.[20G>C;23G>C]",
+        ],
+    );
+}
+
+/// #1231 — `[dup;del]` reduces to the substitutions it actually describes.
+///
+/// Positions 36 and 38 change, separated by unchanged 37. Prioritisation puts
+/// substitution above duplication (`general.md:56`).
+#[test]
+fn issue_1231_dup_del_reduces_to_substitutions() {
+    converges_to(
+        "TEMPLATE:g.[36A>C;38T>A]",
+        &["TEMPLATE:g.[35dup;38del]", "TEMPLATE:g.[36A>C;38T>A]"],
+    );
+}
+
+/// #1232 — a spanning delins must not be retained across an unchanged interior
+/// base (`delins.md:17`).
+///
+/// All four encodings below are stable fixed points on v0.11.0 — the issue
+/// reported two of them. The tie-break between `[35_37del;39T>A]` and
+/// `[35C>T;37_39del]` (equally minimal, equally stable) is an implementer's
+/// choice: the partition is taken 5'-most, then each member is 3'-shifted.
+#[test]
+fn issue_1232_spanning_delins_splits_at_unchanged_base() {
+    converges_to(
+        "TEMPLATE:g.[35_37del;39T>A]",
+        &[
+            "TEMPLATE:g.35_39delinsTA",
+            "TEMPLATE:g.[35_37del;39T>A]",
+            "TEMPLATE:g.[35C>T;37_39del]",
+            "TEMPLATE:g.[35_36delinsT;38_39del]",
+        ],
+    );
+}
+
+/// #1233 — `[ins;del]` reduces to substitutions. Highest-frequency shape in the
+/// reporter's saturation-mutagenesis counting run.
+#[test]
+fn issue_1233_ins_del_reduces_to_substitutions() {
+    converges_to(
+        "TEMPLATE:g.[36A>T;38T>A]",
+        &["TEMPLATE:g.[35_36insT;38del]", "TEMPLATE:g.[36A>T;38T>A]"],
+    );
+}
+
+/// #1234 — a deletion's 3'-shift must stop at a sibling, not cross it.
+///
+/// `[4_6del;8A>T]` used to emit `[6_8del;8A>T]`: both members claim position 8,
+/// which is malformed *and* denotes a different sequence (ferro read it as a
+/// bare `6_8del`, swallowing the substitution). The deletion may shift only to
+/// `5_7`, after which it is adjacent to the substitution and the two coalesce.
+#[test]
+fn issue_1234_deletion_shift_clamps_at_sibling() {
+    converges_to(
+        "TEMPLATE:g.5_8delinsT",
+        &[
+            "TEMPLATE:g.[4_6del;8A>T]",
+            "TEMPLATE:g.[5_7del;8A>T]",
+            "TEMPLATE:g.4_8delinsCT",
+            "TEMPLATE:g.[5A>T;6_8del]",
+            "TEMPLATE:g.[4_5del;7_8delinsT]",
+            "TEMPLATE:g.5_8delinsT",
+        ],
+    );
+}
+
+/// #1234 — a lone deletion with no sibling still shifts to its standalone
+/// 3'-most position. Guards against fixing the clamp by disabling the shift.
+#[test]
+fn issue_1234_lone_deletion_still_shifts_fully() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.4_6del"),
+        "TEMPLATE:g.6_8del"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// #1235 acceptance criteria
+// ----------------------------------------------------------------------------
+
+/// #1235 — no normalized cis allele may contain overlapping or out-of-order
+/// members. `[4_6del;8A>T]` violated this before the fix.
+#[test]
+fn normalized_cis_members_are_disjoint_and_ordered() {
+    use ferro_hgvs::hgvs::variant::HgvsVariant;
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[35dup;38del]",
+        "TEMPLATE:g.[35_36insT;38del]",
+        "TEMPLATE:g.[4C>A;5_6inv]",
+        "TEMPLATE:g.[35_37del;39T>A]",
+        "TEMPLATE:g.[20G>C;23G>C]",
+    ];
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let HgvsVariant::Allele(allele) = &normalized else {
+            continue; // collapsed to a single member: trivially disjoint
+        };
+        let mut prev_end: Option<i64> = None;
+        for member in &allele.variants {
+            let (start, end) = member_span(member)
+                .unwrap_or_else(|| panic!("no span for member of `{normalized}`"));
+            assert!(
+                start <= end,
+                "`{normalized}`: member span {start}..{end} is inverted"
+            );
+            if let Some(prev) = prev_end {
+                assert!(
+                    start > prev,
+                    "`{input}` -> `{normalized}`: member starting at {start} overlaps or \
+                     precedes the previous member ending at {prev}"
+                );
+            }
+            prev_end = Some(end);
+        }
+    }
+}
+
+/// Span of a simple genomic member, as `(start, end)` inclusive.
+fn member_span(variant: &ferro_hgvs::hgvs::variant::HgvsVariant) -> Option<(i64, i64)> {
+    use ferro_hgvs::hgvs::variant::HgvsVariant;
+    let HgvsVariant::Genome(g) = variant else {
+        return None;
+    };
+    let interval = &g.loc_edit.location;
+    let start = interval.start.inner()?.base as i64;
+    let end = interval.end.inner()?.base as i64;
+    Some((start, end))
+}
+
+/// #1235 — `normalize` is idempotent for every case in this file.
+#[test]
+fn normalization_is_idempotent() {
+    let inputs = [
+        "TEMPLATE:g.[4C>A;5A>G;6C>T]",
+        "TEMPLATE:g.[4C>A;5_6inv]",
+        "TEMPLATE:g.20_23inv",
+        "TEMPLATE:g.20_23delinsCATC",
+        "TEMPLATE:g.[35dup;38del]",
+        "TEMPLATE:g.35_39delinsTA",
+        "TEMPLATE:g.[35C>T;37_39del]",
+        "TEMPLATE:g.[35_36insT;38del]",
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.4_8delinsCT",
+        "TEMPLATE:g.4_6del",
+    ];
+    for input in inputs {
+        let once = normalize_to_string(input);
+        let twice = normalize_to_string(&once);
+        assert_eq!(once, twice, "`{input}` is not idempotent");
+    }
+}
+
+/// #1234 — `normalize` must never change the resulting sequence. Checked
+/// through ferro's own `EquivalenceChecker`, which reported the old corrupt
+/// output as equal to a *different* variant.
+#[test]
+fn normalization_preserves_the_resulting_sequence() {
+    use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[35dup;38del]",
+        "TEMPLATE:g.[35_36insT;38del]",
+        "TEMPLATE:g.[4C>A;5_6inv]",
+        "TEMPLATE:g.35_39delinsTA",
+        "TEMPLATE:g.20_23inv",
+        // Derives a pure-insertion piece that actually shifts, so its payload
+        // must rotate. This is the only input here that covers that, and this
+        // assertion is the only oracle for it that survives `--release` (the
+        // round-trip check inside the pass is `debug_assert`-only).
+        "TEMPLATE:g.[4C>A;6_7insCGA]",
+    ];
+    let checker = EquivalenceChecker::new(provider());
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let level = checker.check(&parsed, &normalized).expect("check").level;
+        // Any rung at or above `SequenceMatch` means the resulting sequence
+        // survived; `NormalizedMatch` is the stronger claim that the two also
+        // normalize to one string.
+        assert!(
+            matches!(
+                level,
+                EquivalenceLevel::Identical
+                    | EquivalenceLevel::NormalizedMatch
+                    | EquivalenceLevel::SequenceMatch
+            ),
+            "`{input}` -> `{normalized}` changed the resulting sequence ({level:?})"
+        );
+    }
+}
+
+/// A derived pure-insertion piece must rotate its payload when it 3'-shifts.
+///
+/// `shuffle` returns coordinates only. Moving an insertion point 3' by `k`
+/// rotates the inserted sequence left by `k mod len` — `shuffle`'s own predicate
+/// defines it that way, comparing `ref[start + k]` against
+/// `alt[(new_end - start) % alt.len()]`. Writing back the shifted coordinates
+/// while leaving `alt` alone therefore emits a description denoting a
+/// *different* sequence, and because the wrong form is a stable fixed point no
+/// idempotency check can see it.
+///
+/// Here the derived insertion of `CGA` before `g.7` shifts one position, because
+/// `ref[7] == 'C' == payload[0]`; a second step is blocked (`payload[1] == 'G'`
+/// against `ref[8] == 'A'`). So the payload rotates to `GAC` at `7_8`. The
+/// sibling `4C>A` keeps the piece count above the lone-insertion bail.
+///
+/// A three-base payload is deliberate: with one base every rotation is the
+/// identity, so a shorter payload would pass even unrotated and prove nothing.
+#[test]
+fn shifted_insertion_piece_rotates_its_payload() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4C>A;6_7insCGA]"),
+        "TEMPLATE:g.[4C>A;7_8insGAC]",
+        "the shifted insertion must be spelled from the ROTATED payload",
+    );
+}

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -270,12 +270,15 @@ fn rna_cross_reference_coding_expands_cds_relative() {
         !out.contains("AAA"),
         "transcript-relative AAA must not appear in output; got {out}",
     );
-    // The normalizer suffix-trims "ATG" to "AT" (trailing G matches ref).
-    // Presence of "g.10_14" in the output confirms CDS-relative expansion
-    // succeeded (transcript-relative "AAA" would produce "g.10_15").
-    assert!(
-        out.contains("g.10_14"),
-        "CDS-relative r.1_3 (ATG) must normalize to g.10_14 range; got {out}",
+    // The normalizer suffix-trims "ATG" to "AT" (trailing G matches ref), then
+    // (#1235) splits the result at the unchanged base at 13, since changes
+    // separated by unchanged nucleotides are described individually
+    // (`delins.md:17`). The span still ends at 14, which is what confirms
+    // CDS-relative expansion succeeded — transcript-relative "AAA" would reach
+    // 15.
+    assert_eq!(
+        out, "NC_000022.10:g.[10_12del;14C>T]",
+        "CDS-relative r.1_3 (ATG) must normalize within the 10_14 range; got {out}",
     );
 }
 
@@ -414,14 +417,54 @@ fn cross_reference_inv_suffix_expands_inside_a_complex_bracket() {
         inv_payload_provider(),
     )
     .expect("inv-suffixed cross-reference in a Complex bracket must expand (#1184)");
-    // Pin the whole description, not just the `delins…` tail: the replaced range
-    // (`g.10_15` == `CTATAG`) shares no base with the payload, so the canonical
-    // split cannot trim either endpoint and the anchor must stay `10_15`. The
-    // payload is the literal `A` followed by the reverse complement `AACCCC`,
-    // and the flattening leaves no bracket behind.
+    // Pin the whole description, not just the `delins…` tail. The payload is the
+    // literal `A` followed by the reverse complement `AACCCC`, and the
+    // flattening leaves no bracket behind.
+    //
+    // Pin the whole description, not just the `delins…` tail. The payload is the
+    // literal `A` followed by the reverse complement `AACCCC`, and the
+    // flattening leaves no bracket behind.
+    //
+    // Stays ONE spanning delins. A 6 nt span replaced by a 7 nt payload leaves
+    // `g.12` matching, but that is a lone coincidental base inside a net
+    // insertion, and `delins.md:44-47` prefers the spanning `delins` when the
+    // payload merely "aligns" — the corpus agrees, failing the same way when this
+    // split is allowed. A #1235 revision had re-blessed this to two members on
+    // the strength of that one match; that was the coincidental-alignment trap.
     assert_eq!(
         out, "NC_000022.10:g.10_15delinsAAACCCC",
-        "literal `A` then the reverse complement `AACCCC`, at the unshifted anchor",
+        "literal `A` then the reverse complement `AACCCC`; the match at 12 is coincidence",
+    );
+
+    // The collapsed form is a fixed point.
+    assert_eq!(
+        normalize("NC_000022.10:g.10_15delinsAAACCCC", inv_payload_provider()).expect("normalize"),
+        "NC_000022.10:g.10_15delinsAAACCCC",
+        "the spanning delins must be a normalization fixed point",
+    );
+
+    // KNOWN LIMITATION, pinned deliberately so it is visible rather than merely
+    // absent: the hand-written two-member spelling of this same variant does
+    // *not* converge on the spanning delins. Two stable strings, one variant.
+    //
+    // It cannot be closed from here. The two-member input trips the
+    // `input_separator_positions` veto (`general.md:34` — do not merge across a
+    // base the input left unchanged), which returns it verbatim. Letting a
+    // coincidence-driven collapse override that veto does close this case, but it
+    // also merges `g.[306dup;308C>A]` into `g.307_308delinsCGA`, breaking #999 —
+    // and the collapse cannot tell the two apart, because both are two-member
+    // inputs whose derived pieces collapse to one. The veto is what protects
+    // #999, so it stays and this case stays split.
+    //
+    // Change this assertion only alongside a fix that keeps #999 green.
+    assert_eq!(
+        normalize(
+            "NC_000022.10:g.[10_11delinsAA;13_15delinsCCCC]",
+            inv_payload_provider()
+        )
+        .expect("normalize"),
+        "NC_000022.10:g.[10_11delinsAA;13_15delinsCCCC]",
+        "the two-member spelling is left alone by the separator veto (known non-confluence)",
     );
 }
 

--- a/tests/it/long_delins_splits_at_unchanged_bases.rs
+++ b/tests/it/long_delins_splits_at_unchanged_bases.rs
@@ -1,0 +1,64 @@
+//! A delins must split at its unchanged bases regardless of how long it is.
+//!
+//! The canonicalizer originally refused to partition any block longer than
+//! 32 nt, on the reading that `delins.md:44-47` keeps a long replacement as one
+//! spanning delins. That conflated two different things. The spec's concern
+//! there is *coincidental* alignment — "parts of the inserted sequence align" —
+//! not length as such, and the separation rule (`delins.md:17`) carries no
+//! length qualifier at all. The coincidence concern is now handled
+//! structurally: only single-gap alignments are considered, so a block is split
+//! only where a base genuinely survives unchanged.
+//!
+//! The remaining cap is a cost bound on a quadratic alignment, far above the
+//! sizes at which this question is interesting.
+
+use crate::common::synthetic::{hgvs, SyntheticBuilder};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    format!(
+        "{}",
+        normalizer
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"))
+    )
+}
+
+/// A 40 nt delins — comfortably past the old 32 nt cap — whose interior leaves
+/// one base untouched. It must be described as two members, exactly as the same
+/// shape is at 5 nt.
+#[test]
+fn a_delins_longer_than_the_old_cap_still_splits() {
+    // Core: 40 bases. The replacement changes everything except position 20.
+    let core = "ACGT".repeat(10);
+    let mut replacement: Vec<char> = core
+        .chars()
+        .map(|base| match base {
+            'A' => 'C',
+            'C' => 'A',
+            'G' => 'T',
+            _ => 'G',
+        })
+        .collect();
+    // Keep index 19 (HGVS position 20 within the core) identical to the
+    // reference, so the block has a genuine unchanged interior base.
+    replacement[19] = core.as_bytes()[19] as char;
+    let replacement: String = replacement.into_iter().collect();
+
+    let provider = SyntheticBuilder::genomic(&core).build();
+    let input = hgvs(
+        &format!("NC_TEST.1:g.{{0}}_{{1}}delins{replacement}"),
+        &[1, core.len() as u64],
+    );
+    let out = normalize(provider, &input);
+    assert!(
+        out.contains(';'),
+        "a 40 nt delins with an unchanged interior base must split into members, got `{out}`"
+    );
+    assert!(
+        !out.contains(&replacement),
+        "the spanning replacement must not survive intact, got `{out}`"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -285,6 +285,7 @@ mod issue_98_minus_strand_intronic_orientation;
 mod issue_999_shift_created_adjacency_collapse;
 mod issue_l2_w4001_swapped_positions;
 mod legacy_integration;
+mod long_delins_splits_at_unchanged_bases;
 mod lrg_inference_tests;
 mod m_shift_matrix;
 mod mavedb_tests;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -34,6 +34,7 @@ mod breakpoint_insertion;
 mod build_transcript_library_parity;
 mod bulk_fixture_tests;
 mod cds_utr3_crossing_shift_idempotency;
+mod cis_allele_confluence_proptest;
 mod civic_validation;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -149,6 +149,7 @@ mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
 mod issue_1217_mito_terminus_insertion_clamp;
 mod issue_1234_sibling_clamped_shift;
+mod issue_1235_cis_allele_confluence;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/proptest-regressions/normalize_idempotency_proptest.txt
+++ b/tests/proptest-regressions/normalize_idempotency_proptest.txt
@@ -10,3 +10,5 @@ cc ce2247887cce1fd6f6e7f2854dccbb108e64e6aac1a4ae826d5403a5c2853f0e # shrinks to
 cc 87f7c72196c50a21cb8322872c481d0e71cd9867a62d343a467e434d803c89eb # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.1_2dup" }
 cc 963ed918c565168dda03912561f65f99d0a3a5398c144fdd1dd0157e4c5563ae # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.11_12dup" }
 cc 8d1ceaa8eae1c6162271d431b2cb4395e0359a560661739dc5402acd0d9bdf33 # shrinks to case = Case { core: "CCCCAACACACGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15delinsgaa" }
+cc 24fe771b144622c1c4e142a45e3fc249cb5854ebf628a862b56e84b448fe9937 # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: Genomic, hgvs: "NC_TEST.1:g.264_266delinsG" }
+cc eefd532b0deeee1b5d2768acd582bf9bfeb81cbfe4a46cb6b5a5d537561f5db7 # shrinks to case = Case { core: "CCCCAAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15con4_5" }

--- a/tests/python/test_issue_1158_equivalence_resulting_sequence.py
+++ b/tests/python/test_issue_1158_equivalence_resulting_sequence.py
@@ -3,7 +3,13 @@
 ``EquivalenceChecker.check`` returned ``NotEquivalent`` for two variants with
 the same resulting sequence when they used different (but equivalent) HGVS
 encodings of a complex indel. A sequence-level rung now reconstructs each
-variant's edited sequence against the reference and reports ``SequenceMatch``.
+variant's edited sequence against the reference, so such pairs report as
+equivalent.
+
+These tests assert *equivalence*, not which rung established it. Since #1235
+these two encodings converge under ``normalize``, so the checker settles at
+``NormalizedMatch`` before the sequence rung is needed — an improvement that
+would otherwise read as a regression against a hard-coded ``SequenceMatch``.
 
 The reference here is fully synthetic (no real accession, coordinates, or
 reference bases): the core ``AGTCAGT`` sits at 1-based g.21..=27, padded on both
@@ -44,15 +50,27 @@ def _level(checker, a: str, b: str) -> "ferro_hgvs.EquivalenceLevel":
 
 # A single length-changing delins over g.21..=27 replacing AGTCAGT with GATTA,
 # and its decomposition as a cis allele of the same edit. Same resulting
-# sequence, different normalized strings.
+# sequence.
 DELINS = "TEMPLATE:g.21_27delinsGATTA"
 ALLELE = "TEMPLATE:g.[21A>G;22G>A;24C>T;26_27del]"
 
+# Rungs that all mean "these are the same variant". The issue's contract is
+# equivalence, not which mechanism established it, so assert against this set
+# rather than one rung: as normalization improves, a pair can start matching at
+# an *earlier* rung, which is a better answer and must not read as a regression.
+# (#1235 did exactly that — these two now converge under `normalize`, so the
+# checker settles at `NormalizedMatch` without needing the sequence rung.)
+EQUIVALENT_LEVELS = (
+    ferro_hgvs.EquivalenceLevel.Identical,
+    ferro_hgvs.EquivalenceLevel.NormalizedMatch,
+    ferro_hgvs.EquivalenceLevel.SequenceMatch,
+)
 
-def test_delins_vs_decomposed_allele_is_sequence_match(tmp_path):
+
+def test_delins_vs_decomposed_allele_is_equivalent(tmp_path):
     checker = _checker(tmp_path)
     result = checker.check(ferro_hgvs.parse(DELINS), ferro_hgvs.parse(ALLELE))
-    assert result.level == ferro_hgvs.EquivalenceLevel.SequenceMatch
+    assert result.level in EQUIVALENT_LEVELS, result.level
     assert result.level.is_equivalent()
 
 


### PR DESCRIPTION
> Stacked on #1238 → #1237 → #1236. Base retargets as those merge.

## What's wrong

The sequence-first canonicalizer refused to partition any changed block longer than 32 nt, on the reading that `delins.md:44-47` keeps a long replacement as one spanning delins. That conflated two different things.

The spec's concern in that passage is **coincidental alignment** — *"parts of the inserted sequence align"*, where a mechanical partition invents structure that is not there — not length as such. The separation rule (`delins.md:17`) carries **no length qualifier**: two variants separated by one or more unchanged nucleotides are described individually, whether the span is five nucleotides or fifty.

Keeping the cap meant a long delins silently escaped the rule, so two encodings of one long variant still failed to converge — the exact defect #1229–#1233 are about, just above an arbitrary threshold.

## The fix

The coincidence concern is handled **structurally**, and already was: only single-gap alignments are considered, so the aligner cannot manufacture matches by opening compensating gaps, and a block is split only where a base genuinely survives unchanged. (Removing that restriction was tried and broke 30 "stays delins" tests — which is precisely the hazard `delins.md:44-47` describes, and why the structural guard is the right place for it.)

What remains is a cost bound on a quadratic alignment, raised to 1024 and documented as a cost bound rather than as policy.

## Verification

New regression test: a 40 nt delins — past the old cap — with one unchanged interior base now splits into members. 8797/8797 pass; `fmt` and `clippy` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of long sequence replacements, allowing them to be split at unchanged bases even when they exceed the previous size limit.
  * Preserved more accurate canonicalized output for complex, long replacements.

* **Tests**
  * Added coverage verifying that long replacements are correctly partitioned rather than represented as one spanning change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->