### PR TITLE
feat(normalize): add a tsv output format reporting which variants changed

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -7,8 +7,10 @@
 
 use clap::{Parser, Subcommand};
 use ferro_hgvs::cli::{
-    output_error as cli_output_error, output_error_with_context as cli_output_error_with_context,
-    parse_genome_build, parse_shuffle_direction, parse_vcf_line, process_input_line, OutputFormat,
+    normalize_tsv_row, normalize_tsv_summary, output_error as cli_output_error,
+    output_error_with_context as cli_output_error_with_context, parse_genome_build,
+    parse_shuffle_direction, parse_vcf_line, process_input_line, OutputFormat,
+    NORMALIZE_TSV_HEADER,
 };
 use ferro_hgvs::config::{apply_override, FerroConfig, OverrideSource};
 use ferro_hgvs::error_handling::{
@@ -23,6 +25,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Parser)]
 #[command(name = "ferro")]
@@ -227,8 +230,11 @@ enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Output format
-        #[arg(short = 'f', long, default_value = "text", value_parser = ["text", "json"])]
+        /// Output format. `tsv` writes a header-bearing table (one row per
+        /// input: line, input, normalized, changed, status, detail) plus a
+        /// summary line on stderr, for answering "which of my variants
+        /// changed?".
+        #[arg(short = 'f', long, default_value = "text", value_parser = ["text", "json", "tsv"])]
         format: String,
 
         /// Shuffle direction (3prime or 5prime)
@@ -1350,6 +1356,7 @@ fn run_hgvs_to_vcf(
 }
 
 /// Outcome of processing one input line in the batch normalize/parse driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LineStatus {
     /// Line was blank/comment and produced no output (not counted).
     Skipped,
@@ -1378,6 +1385,19 @@ impl LineResult {
             status: LineStatus::Skipped,
         }
     }
+}
+
+/// Write the `normalize --format tsv` header row, when that is the format.
+///
+/// Deliberately called only once the run's input is known to be readable: writing
+/// it while opening the output stream made `--input missing.txt` leave behind a
+/// header-only artifact byte-identical to the one a *successful* empty-input run
+/// produces, with nothing on the output stream to tell the two apart.
+fn write_tsv_header<W: Write>(writer: &mut W, tsv: bool) -> io::Result<()> {
+    if tsv {
+        writeln!(writer, "{}", NORMALIZE_TSV_HEADER)?;
+    }
+    Ok(())
 }
 
 /// Number of input lines processed per batch before their results are written.
@@ -1514,6 +1534,77 @@ fn run_normalize(
     let mut total_count = 0usize;
     let start = Instant::now();
 
+    // TSV is a *reporting* format rather than a per-variant rendering: every
+    // input becomes exactly one row (failures included), so it needs its own
+    // per-variant path and a header written before any row. Keeping it entirely
+    // out of `process` below is what guarantees `text` and `json` output is
+    // byte-for-byte unchanged.
+    let tsv = format == "tsv";
+    // Counted separately from success/error because only TSV reports it, and the
+    // batch driver's per-line closure must be `Sync` (it may run on a rayon
+    // pool), so the counter cannot be a captured `&mut usize`.
+    let changed_count = AtomicUsize::new(0);
+
+    // Render one input variant as a TSV row, classifying a failure by the phase
+    // it happened in. `line` is the 1-based input line number, or `None` for a
+    // single positional variant, which has no line context. Warnings go to `err`
+    // in the same shape as the text format *and* into the row's `detail`, so a
+    // lenient-mode correction is both greppable where it always was and
+    // correlatable to the row it explains.
+    let tsv_row = |line: Option<usize>, v: &str, err: &mut dyn Write| -> (String, LineStatus) {
+        use ferro_hgvs::cli::{NormalizeTsvFailure, NormalizeTsvOutcome};
+
+        let failed = |phase: NormalizeTsvFailure, detail: &str| -> (String, LineStatus) {
+            (
+                normalize_tsv_row(line, v, NormalizeTsvOutcome::Failed(phase, detail)).row,
+                LineStatus::Err,
+            )
+        };
+
+        let mut preprocess_result = preprocessor.preprocess(v);
+        if let Some(rejection) = preprocess_result.take_rejection_error() {
+            return failed(NormalizeTsvFailure::Preprocess, &rejection.to_string());
+        }
+        let corrections: Vec<(&str, &str)> = preprocess_result
+            .warnings
+            .iter()
+            .map(|w| (w.error_type.code(), w.message.as_str()))
+            .collect();
+        for warning in &preprocess_result.warnings {
+            let _ = writeln!(
+                err,
+                "warning[{}]: {}",
+                warning.error_type.code(),
+                warning.message
+            );
+        }
+        let parsed = match parse_hgvs(&preprocess_result.preprocessed) {
+            Ok(parsed) => parsed,
+            Err(e) => return failed(NormalizeTsvFailure::Parse, &e.to_string()),
+        };
+        match normalizer.normalize(&parsed) {
+            Ok(normalized) => {
+                let normalized_str = normalized.to_string();
+                let row = normalize_tsv_row(
+                    line,
+                    v,
+                    NormalizeTsvOutcome::Normalized {
+                        normalized: normalized_str.as_str(),
+                        corrections: &corrections,
+                    },
+                );
+                // The verdict comes back from the renderer rather than being
+                // recomputed here, so the summary's `changed` count and the
+                // column cannot drift apart.
+                if row.changed {
+                    changed_count.fetch_add(1, Ordering::Relaxed);
+                }
+                (row.row, LineStatus::Ok)
+            }
+            Err(e) => failed(NormalizeTsvFailure::Normalize, &e.to_string()),
+        }
+    };
+
     // Per-line work, factored so it can run serially or in parallel: `out`
     // receives the success output (the order-critical stdout/file stream) and
     // `err` receives text-mode warnings. Both are written into per-line buffers
@@ -1586,7 +1677,20 @@ fn run_normalize(
         // `output_error`). Warnings go straight to the live stderr.
         total_count += 1;
         let mut stderr = io::stderr();
-        if let Err(e) = process(v, &mut writer, &mut stderr) {
+        if tsv {
+            // A failure is a row here too, so `--format tsv` on one positional
+            // variant reports the same way as a one-line `--input` file — except
+            // for the `line` column, which is empty because there is no file to
+            // number lines in.
+            write_tsv_header(&mut writer, tsv)?;
+            let (row, status) = tsv_row(None, v, &mut stderr);
+            writeln!(writer, "{}", row)?;
+            if status == LineStatus::Ok {
+                success_count += 1;
+            } else {
+                error_count += 1;
+            }
+        } else if let Err(e) = process(v, &mut writer, &mut stderr) {
             output_error(v, &e, format)?;
             error_count += 1;
         } else {
@@ -1605,6 +1709,20 @@ fn run_normalize(
             let Some(variant_str) = process_input_line(line, is_first) else {
                 return LineResult::skipped();
             };
+            if tsv {
+                // One row per line, failures included: the row *is* the error
+                // report, so nothing goes to the per-line stderr buffer except
+                // preprocessing warnings.
+                let mut err = Vec::new();
+                let (row, status) = tsv_row(Some(line_num + 1), variant_str, &mut err);
+                let mut out = Vec::new();
+                let _ = writeln!(out, "{}", row);
+                return LineResult {
+                    stdout: out,
+                    stderr: err,
+                    status,
+                };
+            }
             let mut out = Vec::new();
             let mut err = Vec::new();
             let status = match process(variant_str, &mut out, &mut err) {
@@ -1630,7 +1748,10 @@ fn run_normalize(
         };
 
         let (t, s, er) = if let Some(input_path) = input {
+            // Open before the header is written: a missing input file must not
+            // leave a header-only artifact behind (see `write_tsv_header`).
             let file = std::fs::File::open(input_path)?;
+            write_tsv_header(&mut writer, tsv)?;
             run_batch(
                 io::BufReader::new(file).lines(),
                 &mut writer,
@@ -1640,6 +1761,7 @@ fn run_normalize(
         } else {
             let stdin = io::stdin();
             let reader = stdin.lock();
+            write_tsv_header(&mut writer, tsv)?;
             run_batch(reader.lines(), &mut writer, workers, &item)?
         };
         total_count += t;
@@ -1650,12 +1772,32 @@ fn run_normalize(
     // The reference provider (cdot maps + FASTA index, ~1.4 GB) is owned by
     // `normalizer`. Running its destructor here only frees memory the OS
     // reclaims at process exit anyway — on a batch run ~10% of wall time is
-    // spent walking the millions of map entries to drop them. `process`
-    // borrowed `normalizer`, but its last use is above, so that borrow has
-    // already ended; leak `normalizer` so the process can exit without the
-    // teardown. `writer` is independent (output is passed in, not captured)
-    // and still flushes on its own drop, so this does not affect output.
+    // spent walking the millions of map entries to drop them. Both `process` and
+    // `tsv_row` borrowed `normalizer`, but the last use of either is above, so
+    // those borrows have already ended; leak `normalizer` so the process can exit
+    // without the teardown. `writer` is independent (output is passed in, not
+    // captured) and still flushes on its own drop, so this does not affect output.
     std::mem::forget(normalizer);
+
+    // The run summary answers "how many of my variants changed?" without the
+    // caller having to re-read the table. It goes to stderr so the output stream
+    // stays a table whose every line is a row.
+    if tsv {
+        // Flush before claiming counts: with `--output` the rows are sitting in a
+        // `BufWriter` whose `Drop` would swallow a write error, so flushing here
+        // is what turns a failed write into a reported failure rather than a
+        // summary that asserts rows were emitted. (Bare stdout is a `LineWriter`,
+        // already flushed per row, so there this is a no-op.)
+        writer.flush()?;
+        eprintln!(
+            "{}",
+            normalize_tsv_summary(
+                total_count,
+                changed_count.load(Ordering::Relaxed),
+                error_count
+            )
+        );
+    }
 
     let elapsed = start.elapsed();
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -1,4 +1,32 @@
 //! Output formatting utilities for CLI operations
+//!
+//! # `ferro normalize --format tsv`
+//!
+//! The TSV writer ([`NORMALIZE_TSV_HEADER`], [`normalize_tsv_row`],
+//! [`normalize_tsv_summary`]) renders a *report*: one row per input variant,
+//! failures included, so the table answers "which of my variants changed, and to
+//! what?" over a whole file. Its columns are:
+//!
+//! | column | meaning |
+//! |---|---|
+//! | `line` | 1-based line number in the `--input` file; empty for a single positional variant, which has no line context |
+//! | `input` | the variant exactly as read, sanitized (see below) |
+//! | `normalized` | the normalized HGVS string; empty for a failure |
+//! | `changed` | `true`/`false` for a success; **empty** for a failure, which has no normalized string to compare against — this is what keeps the column consistent with [`normalize_tsv_summary`], whose `unchanged` count also excludes failures |
+//! | `status` | `ok`, or a [`NormalizeTsvFailure`] token |
+//! | `detail` | the failure message, or — on an `ok` row — the preprocessing corrections that were applied, `; `-joined |
+//!
+//! Two properties a consumer can rely on:
+//!
+//! - **`status` names the stage that rejected the input under the active error
+//!   mode**, not an intrinsic property of the input. See
+//!   [`NormalizeTsvFailure`].
+//! - **Every physical line of the output is either the header or one row of
+//!   exactly six tab-separated fields.** Fields are sanitized (see
+//!   [`normalize_tsv_row`]) so no control character can split or shift a row.
+//!   Skip exactly the first line to reach the rows; an input line that happens
+//!   to be the literal text `input` cannot be mistaken for a second header,
+//!   because its row is preceded by the `line` column.
 
 use crate::error::FerroError;
 use std::io::{self, Write};
@@ -414,6 +442,273 @@ pub fn output_transcript_annotation<W: Write>(
             writeln!(writer, "  {} ({}) -> {}", transcript, gene, hgvs)
         }
     }
+}
+
+/// Header row emitted once at the top of `ferro normalize --format tsv` output.
+///
+/// Kept next to [`normalize_tsv_row`] so the column order can only be changed in
+/// one place; a consumer that pins column positions therefore cannot be broken
+/// by an edit to only one of the two.
+pub const NORMALIZE_TSV_HEADER: &str = "line\tinput\tnormalized\tchanged\tstatus\tdetail";
+
+/// The phase in which a variant failed, as the short token written to the
+/// `status` column of a `normalize --format tsv` row.
+///
+/// The phases are distinguished because they tell a caller different things: a
+/// preprocessing rejection means the input was refused before parsing (usually
+/// under `--error-mode strict`), a parse failure means the HGVS grammar rejected
+/// it, and a normalization failure means it parsed but could not be normalized
+/// (e.g. the reference lacks the accession).
+///
+/// # `status` is a property of `(input, error mode)`, not of the input alone
+///
+/// The token names **which stage rejected the input under the active error
+/// mode**, and stages run in order: preprocess, then parse, then normalize. The
+/// preprocessor is error-mode-driven, so widening or narrowing `--error-mode`
+/// moves the boundary between `preprocess_error` and the later tokens *for the
+/// same input*. A grammar violation the preprocessor happens to inspect first is
+/// therefore reported as `preprocess_error` when that mode rejects it — for
+/// example `NM_000088.3:c.(1_2)ins` under `--error-mode strict` yields
+/// `preprocess_error` with a parse-shaped `detail`, while a mode that lets it
+/// through reaches the parser and yields `parse_error`.
+///
+/// A consumer that wants to bucket "malformed input" against "policy rejection"
+/// must therefore key off the error mode it passed, not off the token alone;
+/// treating the token as an intrinsic classification of the variant string will
+/// mis-bucket exactly these cases. What the token *is* good for is telling a
+/// caller how far a given run got, and — held at a fixed error mode — it is
+/// stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormalizeTsvFailure {
+    /// Input rejected by the error-mode preprocessor, before parsing.
+    Preprocess,
+    /// Input could not be parsed as HGVS.
+    Parse,
+    /// Input parsed but could not be normalized.
+    Normalize,
+}
+
+impl NormalizeTsvFailure {
+    /// The stable, machine-readable token for this phase.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ferro_hgvs::cli::NormalizeTsvFailure;
+    ///
+    /// assert_eq!(NormalizeTsvFailure::Parse.token(), "parse_error");
+    /// ```
+    pub fn token(self) -> &'static str {
+        match self {
+            NormalizeTsvFailure::Preprocess => "preprocess_error",
+            NormalizeTsvFailure::Parse => "parse_error",
+            NormalizeTsvFailure::Normalize => "normalize_error",
+        }
+    }
+}
+
+/// What became of one input variant, as rendered by [`normalize_tsv_row`].
+///
+/// Modelled as a sum type so a row can never claim both a normalized string and
+/// a failure status: the `changed` and `status` columns are derived from this,
+/// never passed in alongside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormalizeTsvOutcome<'a> {
+    /// Normalization succeeded.
+    Normalized {
+        /// The normalized HGVS string.
+        normalized: &'a str,
+        /// Preprocessing corrections applied on the way, as `(code, message)`
+        /// pairs. Rendered into the `detail` column so a row that is `changed`
+        /// only because the input was corrected says so *in the table*, rather
+        /// than only in an un-correlatable stderr warning.
+        corrections: &'a [(&'a str, &'a str)],
+    },
+    /// Normalization did not happen, carrying the failing phase and its message.
+    Failed(NormalizeTsvFailure, &'a str),
+}
+
+/// Whether `c` would break the "one row, one physical line, six fields" shape.
+///
+/// [`char::is_control`] covers the obvious tab/LF/CR plus the rest of C0/C1 —
+/// notably VT (`U+000B`), FF (`U+000C`), the file/record/group/unit separators
+/// (`U+001C`–`U+001F`) and ESC (`U+001B`), which would inject ANSI escapes into
+/// a terminal that `cat`s the file. The three explicit cases are the non-control
+/// separators: NEL (`U+0085`) is C1 (and so already a control char, listed here
+/// for symmetry), and LS/PS (`U+2028`/`U+2029`) are not control characters at
+/// all. All of them are line breaks to Python's `str.splitlines()` — the most
+/// likely way a pipeline reads this table — so leaving any of them through turns
+/// one row into two.
+fn breaks_tsv_row(c: char) -> bool {
+    c.is_control() || matches!(c, '\u{0085}' | '\u{2028}' | '\u{2029}')
+}
+
+/// Replace every run of row-breaking characters with a single space.
+///
+/// An error message is arbitrary text and may legitimately contain a tab or a
+/// line break; emitting it raw would split one logical row into several physical
+/// ones (or shift the columns), silently corrupting the table for every
+/// downstream consumer. Substituting a space keeps the row readable while making
+/// the "one line, six fields" shape unconditional. Runs collapse to one space so
+/// a `\r\n` (or an indented multi-line diagnostic) does not leave a trail of
+/// whitespace behind.
+fn sanitize_tsv_field(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_run = false;
+    for c in s.chars() {
+        if breaks_tsv_row(c) {
+            if !in_run {
+                out.push(' ');
+                in_run = true;
+            }
+        } else {
+            out.push(c);
+            in_run = false;
+        }
+    }
+    out
+}
+
+/// One rendered `normalize --format tsv` row plus the `changed` verdict it was
+/// built from.
+///
+/// The flag is handed back rather than recomputed by the caller so the run
+/// summary's `changed` count and the row's `changed` column cannot drift apart:
+/// there is exactly one comparison, here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizeTsvRow {
+    /// The rendered row, without a trailing newline.
+    pub row: String,
+    /// Whether the normalized string differed from the input. Always `false` for
+    /// a failure, which has nothing to compare — the row's `changed` column is
+    /// left *empty* in that case (see [`normalize_tsv_row`]), so a caller
+    /// counting changes and a caller filtering the column agree.
+    pub changed: bool,
+}
+
+/// Render one `ferro normalize --format tsv` row (no trailing newline).
+///
+/// Columns are `line`, `input`, `normalized`, `changed`, `status`, `detail`,
+/// matching [`NORMALIZE_TSV_HEADER`] and documented in the [module
+/// docs](self#ferro-normalize---format-tsv). `line`, `normalized`, `changed` and
+/// `detail` are empty for the cases where they do not apply, and every text field
+/// is sanitized so the row cannot contain a character that would split or shift
+/// it.
+///
+/// # Arguments
+///
+/// * `line` - 1-based input line number, or `None` for a single positional variant
+/// * `input` - The variant exactly as read from the input
+/// * `outcome` - What normalization produced for it
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::cli::{normalize_tsv_row, NormalizeTsvFailure, NormalizeTsvOutcome};
+///
+/// let changed = normalize_tsv_row(
+///     Some(4),
+///     "NM_000088.3:c.459delA",
+///     NormalizeTsvOutcome::Normalized {
+///         normalized: "NM_000088.3:c.459del",
+///         corrections: &[],
+///     },
+/// );
+/// assert!(changed.changed);
+/// assert_eq!(changed.row, "4\tNM_000088.3:c.459delA\tNM_000088.3:c.459del\ttrue\tok\t");
+///
+/// // A failure leaves both `normalized` and `changed` empty.
+/// let failed = normalize_tsv_row(
+///     None,
+///     "bogus",
+///     NormalizeTsvOutcome::Failed(NormalizeTsvFailure::Parse, "not an accession"),
+/// );
+/// assert!(!failed.changed);
+/// assert_eq!(failed.row, "\tbogus\t\t\tparse_error\tnot an accession");
+/// ```
+pub fn normalize_tsv_row(
+    line: Option<usize>,
+    input: &str,
+    outcome: NormalizeTsvOutcome<'_>,
+) -> NormalizeTsvRow {
+    // One match yields every derived piece, so no two columns can disagree about
+    // which arm they came from. The comparison is on the *unsanitized* strings:
+    // sanitization is a rendering concern, and an HGVS string never contains a
+    // character that sanitization would touch anyway.
+    //
+    // `changed` renders as the empty string on failure rather than `false`: a
+    // failed row has no normalized string, so claiming it is "unchanged" would be
+    // a false statement about it — and would contradict `normalize_tsv_summary`,
+    // whose `unchanged` count excludes failures.
+    let (normalized, changed, changed_col, status, detail) = match outcome {
+        NormalizeTsvOutcome::Normalized {
+            normalized,
+            corrections,
+        } => {
+            let changed = normalized != input;
+            (
+                normalized,
+                changed,
+                if changed { "true" } else { "false" },
+                "ok",
+                join_tsv_corrections(corrections),
+            )
+        }
+        NormalizeTsvOutcome::Failed(phase, detail) => {
+            ("", false, "", phase.token(), detail.to_string())
+        }
+    };
+    let row = format!(
+        "{}\t{}\t{}\t{}\t{}\t{}",
+        line.map(|n| n.to_string()).unwrap_or_default(),
+        sanitize_tsv_field(input),
+        sanitize_tsv_field(normalized),
+        changed_col,
+        status,
+        sanitize_tsv_field(&detail)
+    );
+    NormalizeTsvRow { row, changed }
+}
+
+/// Render preprocessing corrections as one `detail` value: `CODE: message`,
+/// `; `-joined.
+///
+/// The separator is `; ` because a correction message may itself contain a comma
+/// or a colon, so a more common separator would be ambiguous to split on.
+fn join_tsv_corrections(corrections: &[(&str, &str)]) -> String {
+    corrections
+        .iter()
+        .map(|(code, message)| format!("{code}: {message}"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Render the one-line `normalize --format tsv` run summary (no trailing newline).
+///
+/// Written to stderr, never to the output stream, so stdout stays a table a
+/// consumer can parse without having to skip a trailing non-row line.
+///
+/// # Arguments
+///
+/// * `total` - Rows emitted (every non-skipped input variant)
+/// * `changed` - Rows whose normalized string differed from the input
+/// * `failed` - Rows that carry a failure status
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::cli::normalize_tsv_summary;
+///
+/// assert_eq!(
+///     normalize_tsv_summary(10, 3, 1),
+///     "summary: total=10 changed=3 unchanged=6 failed=1"
+/// );
+/// ```
+pub fn normalize_tsv_summary(total: usize, changed: usize, failed: usize) -> String {
+    // Unchanged counts only *successful* rows: a failed row has no normalized
+    // string, so calling it "unchanged" would be a false claim about it.
+    let unchanged = total.saturating_sub(changed).saturating_sub(failed);
+    format!("summary: total={total} changed={changed} unchanged={unchanged} failed={failed}")
 }
 
 /// Render projection warnings as a JSON array of `{code, message}` objects.
@@ -875,6 +1170,207 @@ mod tests {
         assert_eq!(
             escape_json("line1\nline2\t\"quoted\"\r\\"),
             r#"line1\nline2\t\"quoted\"\r\\"#
+        );
+    }
+
+    // ===== normalize --format tsv Tests =====
+
+    /// Build a `Normalized` outcome with no preprocessing corrections.
+    fn normalized(s: &str) -> NormalizeTsvOutcome<'_> {
+        NormalizeTsvOutcome::Normalized {
+            normalized: s,
+            corrections: &[],
+        }
+    }
+
+    /// Split a rendered row into its fields, asserting the row is one physical
+    /// line with exactly as many fields as the header declares, and that no field
+    /// carries a character that any reasonable line-splitter would break on.
+    ///
+    /// The "one physical line" check deliberately does *not* go through
+    /// `str::lines()`: that splits on exactly `\n`/`\r\n`, i.e. it shares the
+    /// blind spot an incomplete sanitizer would have. Inspecting for
+    /// [`char::is_control`] plus the three non-control separators instead means
+    /// the assertion is independent of the implementation's notion of a break.
+    fn tsv_fields(row: &str) -> Vec<&str> {
+        let expected = NORMALIZE_TSV_HEADER.split('\t').count();
+        let fields: Vec<&str> = row.split('\t').collect();
+        assert_eq!(
+            fields.len(),
+            expected,
+            "row does not have {expected} fields: {row:?}"
+        );
+        for c in row.chars() {
+            assert!(
+                !(c.is_control() || matches!(c, '\u{0085}' | '\u{2028}' | '\u{2029}')) || c == '\t',
+                "row carries {c:?} (U+{:04X}), which splits or shifts it: {row:?}",
+                c as u32
+            );
+        }
+        fields
+    }
+
+    #[test]
+    fn tsv_header_names_the_six_documented_columns() {
+        assert_eq!(
+            tsv_fields(NORMALIZE_TSV_HEADER),
+            vec!["line", "input", "normalized", "changed", "status", "detail"]
+        );
+    }
+
+    #[test]
+    fn tsv_row_marks_an_unchanged_variant() {
+        let row = normalize_tsv_row(
+            Some(7),
+            "NM_000088.3:c.459A>G",
+            normalized("NM_000088.3:c.459A>G"),
+        );
+        assert!(!row.changed);
+        assert_eq!(
+            tsv_fields(&row.row),
+            vec![
+                "7",
+                "NM_000088.3:c.459A>G",
+                "NM_000088.3:c.459A>G",
+                "false",
+                "ok",
+                ""
+            ]
+        );
+    }
+
+    #[test]
+    fn tsv_row_marks_a_changed_variant() {
+        let row = normalize_tsv_row(
+            Some(1),
+            "NM_000088.3:c.459delA",
+            normalized("NM_000088.3:c.459del"),
+        );
+        assert!(row.changed);
+        assert_eq!(
+            tsv_fields(&row.row),
+            vec![
+                "1",
+                "NM_000088.3:c.459delA",
+                "NM_000088.3:c.459del",
+                "true",
+                "ok",
+                ""
+            ]
+        );
+    }
+
+    #[test]
+    fn tsv_row_omits_the_line_column_without_line_context() {
+        // The single-positional path has no line number to report; the column is
+        // empty rather than a fabricated `1`.
+        let row = normalize_tsv_row(None, "x", normalized("x"));
+        assert_eq!(tsv_fields(&row.row)[0], "");
+    }
+
+    #[test]
+    fn tsv_row_reports_preprocessing_corrections_as_the_detail() {
+        // The most common reason a row is `changed` is a preprocessing
+        // correction; the table has to say which one, or the change is
+        // unexplained.
+        let row = normalize_tsv_row(
+            Some(2),
+            "NM_000088.3:c.459delA",
+            NormalizeTsvOutcome::Normalized {
+                normalized: "NM_000088.3:c.459del",
+                corrections: &[
+                    ("W3025", "deletion with explicit deleted sequence"),
+                    ("W2003", "extra whitespace removed"),
+                ],
+            },
+        );
+        assert_eq!(
+            tsv_fields(&row.row)[5],
+            "W3025: deletion with explicit deleted sequence; W2003: extra whitespace removed"
+        );
+    }
+
+    #[test]
+    fn tsv_row_leaves_normalized_and_changed_empty_on_failure() {
+        // `changed` must be empty, not `false`: `normalize_tsv_summary` excludes
+        // failures from its `unchanged` count, so a `false` here would make
+        // `awk -F'\t' '$4=="false"'` and the summary disagree.
+        for (phase, token) in [
+            (NormalizeTsvFailure::Preprocess, "preprocess_error"),
+            (NormalizeTsvFailure::Parse, "parse_error"),
+            (NormalizeTsvFailure::Normalize, "normalize_error"),
+        ] {
+            let row =
+                normalize_tsv_row(Some(3), "bogus", NormalizeTsvOutcome::Failed(phase, "why"));
+            assert!(!row.changed);
+            assert_eq!(
+                tsv_fields(&row.row),
+                vec!["3", "bogus", "", "", token, "why"]
+            );
+        }
+    }
+
+    #[test]
+    fn tsv_row_sanitizes_every_row_breaking_character() {
+        // The motivating case: an error message containing a tab and a newline
+        // would otherwise split one row into three and shift the columns of the
+        // first, corrupting the whole table from that point on. The exotic
+        // separators matter just as much — Python's `str.splitlines()`, the
+        // likeliest reader, breaks on all of them.
+        let row = normalize_tsv_row(
+            Some(1),
+            "in\tput\nwith\u{000B}breaks\u{2028}here",
+            NormalizeTsvOutcome::Failed(
+                NormalizeTsvFailure::Parse,
+                "one\u{000C}two\u{001C}three\u{0085}four\u{2029}five\u{001B}[31m\r\n",
+            ),
+        );
+        // `tsv_fields` itself asserts the row carries no breaking character.
+        assert_eq!(
+            tsv_fields(&row.row),
+            vec![
+                "1",
+                "in put with breaks here",
+                "",
+                "",
+                "parse_error",
+                // Runs collapse, so the trailing `\r\n` leaves one space.
+                "one two three four five [31m ",
+            ]
+        );
+    }
+
+    #[test]
+    fn tsv_row_sanitizes_a_normalized_string_too() {
+        // `normalized` comes from `Display` on a parsed variant and so should
+        // never contain a tab — sanitizing it anyway means no future `Display`
+        // change can corrupt the table.
+        let row = normalize_tsv_row(Some(1), "in", normalized("a\tb"));
+        assert_eq!(
+            tsv_fields(&row.row),
+            vec!["1", "in", "a b", "true", "ok", ""]
+        );
+    }
+
+    #[test]
+    fn tsv_summary_derives_unchanged_from_total() {
+        assert_eq!(
+            normalize_tsv_summary(10, 3, 1),
+            "summary: total=10 changed=3 unchanged=6 failed=1"
+        );
+        assert_eq!(
+            normalize_tsv_summary(0, 0, 0),
+            "summary: total=0 changed=0 unchanged=0 failed=0"
+        );
+    }
+
+    #[test]
+    fn tsv_summary_never_underflows() {
+        // Defensive: the counters are maintained by the CLI, and a saturating
+        // subtraction is preferable to a panic in a summary line.
+        assert_eq!(
+            normalize_tsv_summary(1, 5, 5),
+            "summary: total=1 changed=5 unchanged=0 failed=5"
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,8 +10,9 @@ pub mod project;
 
 // Re-export commonly used items
 pub use format::{
-    output_error, output_error_with_context, output_project_error, output_projection,
-    output_result, OutputFormat,
+    normalize_tsv_row, normalize_tsv_summary, output_error, output_error_with_context,
+    output_project_error, output_projection, output_result, NormalizeTsvFailure,
+    NormalizeTsvOutcome, NormalizeTsvRow, OutputFormat, NORMALIZE_TSV_HEADER,
 };
 pub use parse::{
     parse_genome_build, parse_shuffle_direction, parse_vcf_line, parse_vcf_line_with_build,

--- a/tests/it/cli_normalize_tsv.rs
+++ b/tests/it/cli_normalize_tsv.rs
@@ -1,0 +1,583 @@
+//! Integration tests for `ferro normalize --format tsv`.
+//!
+//! The format exists to answer "which of these variants does ferro change, and
+//! to what?" over a list, so the properties worth pinning are: a header is
+//! always present, every input yields exactly one row (a failure included), the
+//! `changed` column agrees with both the `input`/`normalized` columns and the
+//! stderr summary, each row names the input line it came from, and nothing but
+//! rows reaches the output stream.
+//!
+//! All tests run under the mock provider (no `--reference`), so they need no
+//! external data. `--error-mode silent` is used where a preprocessing
+//! correction is wanted as the source of a change: under the default strict mode
+//! those same inputs are rejected instead, which the strict-mode test covers.
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+/// The header the table must always start with.
+const HEADER: &str = "line\tinput\tnormalized\tchanged\tstatus\tdetail";
+
+/// Number of columns in the table.
+const COLUMNS: usize = 6;
+
+/// A variant the mock provider normalizes back to itself.
+const UNCHANGED: &str = "NM_000088.3:c.459A>G";
+/// A variant whose redundant deleted sequence is dropped by the *preprocessor*,
+/// so it normalizes to a different string.
+const CHANGED_IN: &str = "NM_000088.3:c.459delA";
+const CHANGED_OUT: &str = "NM_000088.3:c.459del";
+/// A deletion inside the `CCCC` homopolymer at c.16-19 of the mock `NM_000088.3`
+/// sequence: the *normalizer* 3'-shifts it, so this is a change produced by the
+/// feature's headline code path rather than by a preprocessing rewrite.
+const SHIFTED_IN: &str = "NM_000088.3:c.16del";
+const SHIFTED_OUT: &str = "NM_000088.3:c.19del";
+
+/// Mirror of `BATCH_CHUNK_LINES` in `src/bin/ferro.rs`. Integration tests cannot
+/// import items from a `bin` target, so this is duplicated here; the runtime
+/// assertion in the parallel test verifies the chosen input size still spans
+/// multiple chunks, so drift in the real constant fails loudly.
+const BATCH_CHUNK_LINES: usize = 8192;
+
+/// One completed `ferro normalize` run.
+struct Run {
+    stdout: String,
+    stderr: String,
+    success: bool,
+}
+
+impl Run {
+    /// The output stream split into lines, with the header line removed after
+    /// asserting it is present, first, and the only one.
+    fn rows(&self) -> Vec<&str> {
+        let mut lines = self.stdout.lines();
+        assert_eq!(
+            lines.next(),
+            Some(HEADER),
+            "first output line must be the TSV header; got:\n{}",
+            self.stdout
+        );
+        let rows: Vec<&str> = lines.collect();
+        assert!(
+            !rows.contains(&HEADER),
+            "the header must appear exactly once:\n{}",
+            self.stdout
+        );
+        rows
+    }
+
+    /// The single row for a one-variant run, split into its fields.
+    fn only_row_fields(&self) -> Vec<&str> {
+        let rows = self.rows();
+        assert_eq!(rows.len(), 1, "expected exactly one row, got {rows:?}");
+        fields(rows[0])
+    }
+
+    /// The `summary:` line from stderr.
+    fn summary(&self) -> &str {
+        self.stderr
+            .lines()
+            .find(|l| l.starts_with("summary:"))
+            .unwrap_or_else(|| panic!("no summary line on stderr:\n{}", self.stderr))
+    }
+}
+
+/// Split one row into its fields, asserting the column count.
+fn fields(row: &str) -> Vec<&str> {
+    let f: Vec<&str> = row.split('\t').collect();
+    assert_eq!(
+        f.len(),
+        COLUMNS,
+        "row does not have {COLUMNS} fields: {row:?}"
+    );
+    f
+}
+
+/// Run `ferro normalize` with the given extra arguments.
+fn run(args: &[&str]) -> Run {
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .arg("normalize")
+        .args(args)
+        .output()
+        .expect("run ferro normalize");
+    Run {
+        stdout: String::from_utf8(out.stdout).expect("stdout is UTF-8"),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        success: out.status.success(),
+    }
+}
+
+/// Write `variants` to a temporary input file, one per line. The handle is
+/// returned so the file outlives the run.
+fn input_file(variants: &[&str]) -> NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+    for v in variants {
+        writeln!(tf, "{v}").unwrap();
+    }
+    tf.flush().unwrap();
+    tf
+}
+
+/// Run `ferro normalize --format tsv` over an input file of `variants`.
+fn run_tsv(variants: &[&str]) -> Run {
+    let tf = input_file(variants);
+    run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+    ])
+}
+
+#[test]
+fn emits_a_header_even_for_empty_input() {
+    // A consumer reading the table with a header-aware parser must not have to
+    // special-case "no variants matched".
+    let run = run_tsv(&[]);
+    assert!(run.success, "empty input should succeed: {}", run.stderr);
+    assert!(run.rows().is_empty());
+}
+
+#[test]
+fn reports_an_unchanged_variant_as_unchanged() {
+    let run = run_tsv(&[UNCHANGED]);
+    assert!(run.success, "{}", run.stderr);
+    assert_eq!(
+        run.only_row_fields(),
+        vec!["1", UNCHANGED, UNCHANGED, "false", "ok", ""]
+    );
+}
+
+#[test]
+fn reports_a_changed_variant_with_its_new_form() {
+    let run = run_tsv(&[CHANGED_IN]);
+    assert!(run.success, "{}", run.stderr);
+    assert_eq!(
+        run.only_row_fields(),
+        vec!["1", CHANGED_IN, CHANGED_OUT, "true", "ok", ""]
+    );
+}
+
+#[test]
+fn reports_a_change_produced_by_the_normalizer_itself() {
+    // The headline case: no preprocessing rewrite is involved, the normalizer
+    // 3'-shifts the deletion through a homopolymer. Runs under the default
+    // (strict) error mode precisely to show the change is not a correction.
+    let tf = input_file(&[SHIFTED_IN]);
+    let run = run(&["-f", "tsv", "-i", tf.path().to_str().unwrap()]);
+    assert!(run.success, "{}", run.stderr);
+    assert_eq!(
+        run.only_row_fields(),
+        vec![
+            "1",
+            SHIFTED_IN,
+            SHIFTED_OUT,
+            "true",
+            "ok",
+            // No correction was applied, so nothing explains the change but the
+            // normalization itself.
+            ""
+        ]
+    );
+    assert!(
+        run.summary().contains("changed=1"),
+        "a normalizer-driven change must be counted: {}",
+        run.summary()
+    );
+}
+
+#[test]
+fn a_malformed_variant_becomes_a_row_and_does_not_abort_the_run() {
+    // The whole point of the format: one bad line must not cost the caller the
+    // rows for the good lines that follow it.
+    let run = run_tsv(&[UNCHANGED, "not-a-variant", CHANGED_IN]);
+    let rows = run.rows();
+    assert_eq!(rows.len(), 3, "every input must yield a row: {rows:?}");
+
+    let bad = fields(rows[1]);
+    assert_eq!(bad[0], "2");
+    assert_eq!(bad[1], "not-a-variant");
+    assert_eq!(bad[2], "", "a failed variant has no normalized form");
+    assert_eq!(bad[3], "", "a failed variant has no changed verdict");
+    assert_eq!(bad[4], "parse_error");
+    assert!(!bad[5].is_empty(), "a failure must carry a detail message");
+
+    // The rows around it are the same as they would be on their own.
+    assert_eq!(fields(rows[0])[4], "ok");
+    assert_eq!(
+        fields(rows[2]),
+        vec!["3", CHANGED_IN, CHANGED_OUT, "true", "ok", ""]
+    );
+
+    // Exit code behavior is unchanged: any failed variant still fails the run.
+    assert!(!run.success, "a failed variant must still exit non-zero");
+}
+
+#[test]
+fn the_changed_column_agrees_with_the_summary() {
+    // The summary excludes failures from its `unchanged` count, so the column has
+    // to leave `changed` *empty* on a failure — otherwise `changed=false` rows and
+    // the summary's `unchanged` count are two different numbers for the same
+    // question.
+    let run = run_tsv(&[UNCHANGED, CHANGED_IN, "not-a-variant", UNCHANGED]);
+    let rows = run.rows();
+    let count = |want: &str| rows.iter().filter(|r| fields(r)[3] == want).count();
+    let (changed, unchanged, failed) = (count("true"), count("false"), count(""));
+    assert_eq!((changed, unchanged, failed), (1, 2, 1), "rows: {rows:?}");
+    assert_eq!(
+        run.summary(),
+        format!(
+            "summary: total={} changed={changed} unchanged={unchanged} failed={failed}",
+            rows.len()
+        )
+    );
+}
+
+#[test]
+fn distinguishes_the_phase_a_variant_failed_in() {
+    // Under the default strict mode a redundant deleted sequence is rejected by
+    // the preprocessor rather than corrected, and an out-of-range position gets
+    // past the parser and fails in the normalizer. The tokens must tell those
+    // apart from a grammar failure.
+    let tf = input_file(&[CHANGED_IN, "NM_000088.3:c.99999A>G", "not-a-variant"]);
+    let run = run(&[
+        "--error-mode",
+        "strict",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+    ]);
+    let rows = run.rows();
+    assert_eq!(rows.len(), 3, "{rows:?}");
+    assert_eq!(fields(rows[0])[4], "preprocess_error");
+    assert_eq!(fields(rows[1])[4], "normalize_error");
+    assert_eq!(fields(rows[2])[4], "parse_error");
+    for row in &rows {
+        let f = fields(row);
+        assert_eq!(f[2], "", "a failed variant has no normalized form: {row:?}");
+        assert_eq!(f[3], "", "a failed variant has no changed verdict: {row:?}");
+        assert!(!f[5].is_empty(), "a failure must carry a detail: {row:?}");
+    }
+}
+
+#[test]
+fn a_successful_row_explains_a_correction_in_its_detail() {
+    // Under lenient mode the preprocessor rewrites the input and the row is
+    // `changed` because of it. The reason has to be *in the row*: the stderr
+    // warning carries no line or row identifier, so it cannot be correlated back.
+    let tf = input_file(&[UNCHANGED, CHANGED_IN]);
+    let run = run(&[
+        "--error-mode",
+        "lenient",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+    ]);
+    assert!(run.success, "{}", run.stderr);
+    let rows = run.rows();
+    assert_eq!(fields(rows[0])[5], "", "an uncorrected row has no detail");
+
+    let corrected = fields(rows[1]);
+    assert_eq!(corrected[3], "true");
+    assert_eq!(corrected[4], "ok");
+    assert!(
+        corrected[5].starts_with("W3025: "),
+        "a corrected row must name the correction code and message: {corrected:?}"
+    );
+
+    // The warning also still goes to stderr, exactly as it did before.
+    assert!(
+        run.stderr.contains("warning[W3025]: "),
+        "the stderr warning must be kept: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn line_numbers_survive_skipped_lines() {
+    // The row index is not a substitute for the line number: blank and comment
+    // lines are skipped, so the two diverge from the first skip onwards.
+    let mut tf = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+    writeln!(tf, "# a comment").unwrap();
+    writeln!(tf).unwrap();
+    writeln!(tf, "{UNCHANGED}").unwrap();
+    writeln!(tf).unwrap();
+    writeln!(tf, "not-a-variant").unwrap();
+    tf.flush().unwrap();
+
+    let run = run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+    ]);
+    let rows = run.rows();
+    assert_eq!(rows.len(), 2, "{rows:?}");
+    assert_eq!(fields(rows[0])[0], "3");
+    assert_eq!(fields(rows[1])[0], "5");
+}
+
+#[test]
+fn a_failure_detail_cannot_break_the_table() {
+    // A parse error message quotes the offending input, so an input containing
+    // control characters is the CLI-level route to a would-be multi-line detail
+    // field. Every physical line of the output must still be one full row, and no
+    // field may carry anything a line-splitter would break on — including the
+    // separators `str::lines()` ignores but Python's `splitlines()` honours.
+    let exotic = "NM_000088.3:c.459A>G\tx\u{000B}y\u{2028}z\u{0085}w\u{001B}[31m";
+    let tf = input_file(&[exotic]);
+    let run = run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+    ]);
+    let rows = run.rows();
+    assert_eq!(rows.len(), 1, "the input must stay one row: {rows:?}");
+    for row in &rows {
+        for f in fields(row) {
+            assert!(
+                !f.chars()
+                    .any(|c| c.is_control() || matches!(c, '\u{0085}' | '\u{2028}' | '\u{2029}')),
+                "no field may carry a row-breaking character: {row:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_summary_goes_to_stderr_and_never_to_the_table() {
+    let run = run_tsv(&[UNCHANGED, CHANGED_IN, "not-a-variant"]);
+    assert_eq!(
+        run.summary(),
+        "summary: total=3 changed=1 unchanged=1 failed=1"
+    );
+    assert!(
+        !run.stdout.contains("summary:"),
+        "the summary must not pollute the table:\n{}",
+        run.stdout
+    );
+    // Every output line is a row (plus the header), so a naive `tail -n +2`
+    // consumer never sees a non-row line.
+    for row in &run.rows() {
+        fields(row);
+    }
+}
+
+#[test]
+fn honors_the_output_flag() {
+    let tf = input_file(&[UNCHANGED, CHANGED_IN]);
+    let out = tempfile::Builder::new().suffix(".tsv").tempfile().unwrap();
+    let run = run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-i",
+        tf.path().to_str().unwrap(),
+        "-o",
+        out.path().to_str().unwrap(),
+    ]);
+    assert!(run.success, "{}", run.stderr);
+    assert!(
+        run.stdout.is_empty(),
+        "with --output nothing should reach stdout: {}",
+        run.stdout
+    );
+    let written = std::fs::read_to_string(out.path()).unwrap();
+    let lines: Vec<&str> = written.lines().collect();
+    assert_eq!(lines.len(), 3, "header plus two rows: {lines:?}");
+    assert_eq!(lines[0], HEADER);
+    assert_eq!(fields(lines[1])[3], "false");
+    assert_eq!(fields(lines[2])[3], "true");
+}
+
+#[test]
+fn a_missing_input_file_writes_no_table() {
+    // Writing the header while opening the output stream made this produce a
+    // header-only artifact byte-identical to a *successful* empty-input run, with
+    // no summary to tell the two apart.
+    let out = tempfile::Builder::new().suffix(".tsv").tempfile().unwrap();
+    let missing = out.path().with_extension("does-not-exist.txt");
+    assert!(!missing.exists());
+    let run = run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-i",
+        missing.to_str().unwrap(),
+        "-o",
+        out.path().to_str().unwrap(),
+    ]);
+    assert!(!run.success, "a missing input file must fail the run");
+    assert_eq!(
+        std::fs::read_to_string(out.path()).unwrap(),
+        "",
+        "a failed open must leave no table behind"
+    );
+}
+
+#[test]
+fn works_for_a_single_positional_variant() {
+    // `--format tsv` must not be silently ignored outside `--input` mode. The
+    // `line` column is empty there: there is no file whose lines to number.
+    let ok = run(&["--error-mode", "silent", "-f", "tsv", CHANGED_IN]);
+    assert!(ok.success, "{}", ok.stderr);
+    assert_eq!(
+        ok.only_row_fields(),
+        vec!["", CHANGED_IN, CHANGED_OUT, "true", "ok", ""]
+    );
+
+    let bad = run(&["--error-mode", "silent", "-f", "tsv", "not-a-variant"]);
+    let f = bad.only_row_fields();
+    assert_eq!(f[0], "");
+    assert_eq!(f[1], "not-a-variant");
+    assert_eq!(f[4], "parse_error");
+    assert!(!bad.success, "a failed variant must still exit non-zero");
+}
+
+#[test]
+fn a_single_positional_variant_honors_the_output_flag() {
+    let out = tempfile::Builder::new().suffix(".tsv").tempfile().unwrap();
+    let run = run(&[
+        "--error-mode",
+        "silent",
+        "-f",
+        "tsv",
+        "-o",
+        out.path().to_str().unwrap(),
+        CHANGED_IN,
+    ]);
+    assert!(run.success, "{}", run.stderr);
+    assert!(
+        run.stdout.is_empty(),
+        "with --output nothing should reach stdout: {}",
+        run.stdout
+    );
+    let written = std::fs::read_to_string(out.path()).unwrap();
+    assert_eq!(
+        written,
+        format!("{HEADER}\n\t{CHANGED_IN}\t{CHANGED_OUT}\ttrue\tok\t\n")
+    );
+}
+
+#[test]
+fn parallel_tsv_output_is_byte_identical_to_serial() {
+    // The batch driver may fan out across a rayon pool, so the table must be
+    // invariant under worker count: one header, the same bytes, input order
+    // preserved across chunk boundaries.
+    let n = 20_000;
+    assert!(
+        n > 2 * BATCH_CHUNK_LINES,
+        "n={n} no longer spans multiple chunks (BATCH_CHUNK_LINES={BATCH_CHUNK_LINES}); \
+         raise n so ordering is exercised across chunk boundaries"
+    );
+    let mut tf = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+    for i in 1..=n {
+        // Comments and blank lines are skipped, so the `line` column and the row
+        // index diverge — which is exactly what makes the column worth checking.
+        if i % 100 == 0 {
+            writeln!(tf, "# comment at {i}").unwrap();
+        }
+        if i % 50 == 0 {
+            writeln!(tf).unwrap();
+        }
+        writeln!(tf, "NM_000088.3:c.{i}A>G").unwrap();
+    }
+    tf.flush().unwrap();
+    let path = tf.path().to_str().unwrap();
+
+    let serial = run(&["--error-mode", "silent", "-f", "tsv", "-j", "1", "-i", path]);
+    assert!(serial.success, "{}", serial.stderr);
+    let rows = serial.rows();
+    assert_eq!(rows.len(), n, "every variant must yield a row");
+
+    // Input order preserved: the inputs come back in the order written, and the
+    // line numbers are strictly increasing.
+    let mut last_line = 0usize;
+    for (i, row) in rows.iter().enumerate() {
+        let f = fields(row);
+        assert_eq!(
+            f[1],
+            format!("NM_000088.3:c.{}A>G", i + 1),
+            "row {i} out of order"
+        );
+        let line: usize = f[0].parse().expect("line column is a number");
+        assert!(line > last_line, "line numbers must increase: {row:?}");
+        last_line = line;
+    }
+
+    for workers in [2usize, 4, 8] {
+        let parallel = run(&[
+            "--error-mode",
+            "silent",
+            "-f",
+            "tsv",
+            "-j",
+            &workers.to_string(),
+            "-i",
+            path,
+        ]);
+        assert!(parallel.success, "{}", parallel.stderr);
+        assert_eq!(
+            serial.stdout, parallel.stdout,
+            "the table for -j{workers} differs from serial (-j1)"
+        );
+        assert_eq!(
+            serial.summary(),
+            parallel.summary(),
+            "the summary for -j{workers} differs from serial (-j1)"
+        );
+    }
+}
+
+#[test]
+fn text_and_json_output_is_untouched() {
+    // The `tsv` addition must be purely additive: these are the exact byte
+    // streams the two pre-existing formats produced before it existed.
+    let variants = [UNCHANGED, CHANGED_IN, "not-a-variant"];
+    let tf = input_file(&variants);
+    let path = tf.path().to_str().unwrap();
+
+    let text = run(&["--error-mode", "silent", "-f", "text", "-i", path]);
+    assert_eq!(
+        text.stdout,
+        format!("{UNCHANGED}\n{CHANGED_IN} -> {CHANGED_OUT}\n")
+    );
+    assert!(
+        !text.stderr.contains("summary:"),
+        "the TSV summary must not appear in text mode:\n{}",
+        text.stderr
+    );
+
+    let json = run(&["--error-mode", "silent", "-f", "json", "-i", path]);
+    assert_eq!(
+        json.stdout,
+        format!(
+            "{{\"input\": \"{UNCHANGED}\", \"output\": \"{UNCHANGED}\", \
+             \"status\": \"ok\", \"corrections\": []}}\n\
+             {{\"input\": \"{CHANGED_IN}\", \"output\": \"{CHANGED_OUT}\", \
+             \"status\": \"ok\", \"corrections\": []}}\n"
+        )
+    );
+    assert!(
+        !json.stderr.contains("summary:"),
+        "the TSV summary must not appear in json mode:\n{}",
+        json.stderr
+    );
+
+    // The default format is still `text`, not the new one.
+    let default = run(&["--error-mode", "silent", "-i", path]);
+    assert_eq!(default.stdout, text.stdout);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -38,6 +38,7 @@ mod civic_validation;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;
 mod cli_convert_gff_flags;
+mod cli_normalize_tsv;
 mod cli_parallel_annotate;
 mod cli_parallel_normalize;
 mod cli_parallel_parse;


### PR DESCRIPTION
> **Stacked on #1240** (`fix/runtime-sequence-preservation-guard`). The base branch will retarget to `main` as the stack merges — review only the top commit here.

## Problem

`ferro normalize` already takes a list of variants (`--input`), but there is no good way to answer the question people actually bring to it: *given this list, which variants does ferro normalize to something different, and to what?* Today that means eyeballing the arrow-separated `text` output (where a changed variant is `in -> out` and an unchanged one is just `out`, so "did it change?" is inferred from the presence of an arrow) or writing a JSON consumer.

## The flag

`ferro normalize --format tsv` emits a header-bearing table, one row per input variant:

```
input	normalized	changed	status	detail
NM_000088.3:c.459A>G	NM_000088.3:c.459A>G	false	ok
NM_000088.3:c.459delA	NM_000088.3:c.459del	true	ok
not-a-variant		false	parse_error	Parse error at position 0: Failed to parse accession: ...
```

- `input` — the variant exactly as read.
- `normalized` — the normalized string, empty when normalization did not happen.
- `changed` — whether `normalized` differs from `input`. Because it compares against the input *as read*, an error-mode preprocessing correction counts as a change, which is what a caller asking "did ferro touch this?" wants.
- `status` — `ok`, or the phase that failed: `preprocess_error` (refused by the error-mode preprocessor before parsing), `parse_error` (rejected by the HGVS grammar), `normalize_error` (parsed, but could not be normalized). The three are distinguished because they tell a caller different things — a `normalize_error` usually means the reference lacks the accession, not that the string is malformed.
- `detail` — the error message when there is one, otherwise empty.

A one-line summary goes to **stderr**, never stdout, so the output stream stays a table whose every line is a row:

```
summary: total=3 changed=1 unchanged=1 failed=1
```

`--output` is honored (the table goes to the file, the summary still to stderr), and the single-positional-`variant` form works too, so the flag is never silently ignored.

Failures are **rows, not aborts**: a bad line does not cost the caller the rows for the lines after it. Exit-code behavior is unchanged — as before, any failed variant still fails the run with `N variant(s) failed to normalize`.

## Sanitization guarantee

Every field has tab, newline, and carriage return replaced with a space. An error message is arbitrary text (it frequently quotes the offending input), so emitting it raw could split one logical row into several physical ones and shift the columns of everything after it. Sanitizing unconditionally makes the "one physical line, five fields" shape a property of the format rather than a property of well-behaved inputs. There is a unit test for exactly that, plus an integration test that drives a tab through the CLI.

## Existing formats are untouched

`tsv` gets its own per-variant path rather than an extra arm inside the existing renderer, so `text` and `json` cannot drift as a side effect. `text_and_json_output_is_untouched` pins both byte streams (and that `text` is still the default) for the same input.

## Tests

New unit tests in `src/cli/format.rs` (row/summary rendering, sanitization, all three failure tokens) and a new integration module `tests/it/cli_normalize_tsv.rs` covering: header present (including on empty input), unchanged, changed, malformed-becomes-a-row-and-continues, the three failure phases, tab sanitization end-to-end, summary on stderr only, `--output`, the single positional variant, and text/json invariance.

Suite: **8797 → 8815 passing** (18 new), `cargo fmt --all` clean, `cargo clippy --all-features --all-targets -- -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tsv` output support to the `normalize` command.
  * TSV output includes a header and one row per input line, including failures.
  * Added per-row status, line details, normalized values, and change indicators.
  * Added an end-of-run summary reporting total, changed, unchanged, and failed rows.
  * Supports TSV output for positional input, files, standard input, and output redirection.

* **Bug Fixes**
  * TSV fields are sanitized to prevent malformed rows or unintended line breaks.
  * Output remains deterministic when processing inputs in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->