### PR TITLE
chore(ci): finish the generator bin rename in the artifact names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,9 @@ jobs:
         # ship them alongside the archive. As `[[bin]]` targets they land in
         # `target/debug/`, not `target/debug/examples/`.
         run: |
-          mkdir -p staged-examples
+          mkdir -p staged-generators
           cp target/debug/generate_spec_fixture \
-             target/debug/generate_spec_enumeration staged-examples/
+             target/debug/generate_spec_enumeration staged-generators/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive
@@ -278,8 +278,8 @@ jobs:
           retention-days: 1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: generator-examples
-          path: staged-examples/
+          name: generator-binaries
+          path: staged-generators/
           retention-days: 1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -318,7 +318,7 @@ jobs:
           path: tests/fixtures/grammar/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generator-examples
+          name: generator-binaries
           path: target/debug/
       - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.
@@ -380,7 +380,7 @@ jobs:
           path: tests/fixtures/grammar/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generator-examples
+          name: generator-binaries
           path: target/debug/
       - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.
@@ -460,7 +460,7 @@ jobs:
           path: tests/fixtures/grammar/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: generator-examples
+          name: generator-binaries
           path: target/debug/
       - name: Restore the executable bit on the staged generators
         # Artifact upload does not preserve the executable bit.


### PR DESCRIPTION
Follow-up to #1228, which converted \`generate_spec_fixture\` and \`generate_spec_enumeration\` from examples to \`[[bin]]\` targets.

That PR corrected every path — the binaries now come from \`target/debug/\` rather than \`target/debug/examples/\` — but the CI artifact and its staging directory kept their example-era names. The artifact was \`generator-examples\` and the directory \`staged-examples\`, while the files inside are plain bins.

This renames them to \`generator-binaries\` and \`staged-generators\`. The upload and all three shard downloads move together, so the artifact stays resolvable; nothing else references either name. No behavior change.

Verified: the YAML parses, and the artifact name is symmetric across the one upload and three downloads.

## Note on the one #1228 review finding deliberately not applied

CodeRabbit flagged the nested \`cargo run\` in \`tests/it/common/fixture_gen.rs\` as "the last remaining nested \`cargo run\` — the same axis problem the PR just eliminated elsewhere", and the obvious fix is to swap it for \`CARGO_BIN_EXE_*\`.

That would reintroduce the Critical bug #1228 fixed. \`fixture_gen\` is reached from \`hgvs_spec_normalization_tests\`, \`idempotency_tests\` and \`spec_enumeration_tests\`, none of which are \`dev\`-gated, and \`env!\` resolves at compile time — so an ungated module expanding it fails to build the whole \`it\` target without \`--features dev\`. The \`generator\` argument is also a runtime string, which \`env!\` cannot take. Resolving at run time is what keeps the helper callable from ungated modules. #1228 added a comment at the call site recording this so the next pass does not re-flag it; no change is wanted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI artifact staging and naming for generator binaries.
  * Adjusted downstream test and soak jobs to use the renamed artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->