### PR TITLE
fix(normalize): describe a one-base inversion residue as a substitution

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -8212,6 +8212,41 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
                 if let Some((new_s, new_e)) = rules::shorten_inversion(ref_seq, start_idx, end_idx)
                 {
+                    // A one-base residue is a substitution to that base's
+                    // complement, not an inversion: `inversion.md:5` defines an
+                    // inversion as more than one nucleotide and `:16` names the
+                    // substitution as its replacement. #1079 enforces the same
+                    // rule in the parser, which can only reject `g.234inv`
+                    // because deriving the substitution needs the reference
+                    // sequence; here we have it. Emitting identity instead
+                    // silently discarded the variant (#1249).
+                    if new_e == new_s + 1 {
+                        if let Some((reference, alternative)) =
+                            rules::complementary_substitution(ref_seq[new_s])
+                        {
+                            let pos = index_to_hgvs_pos(new_s);
+                            return Ok((
+                                pos,
+                                pos,
+                                NaEdit::Substitution {
+                                    reference,
+                                    alternative,
+                                },
+                                warnings,
+                            ));
+                        }
+                        // Not a base we can complement into a typed
+                        // substitution. Unreachable as written:
+                        // `shorten_inversion` yields a one-base residue only
+                        // for a base whose complement differs from it, which
+                        // `complement` answers only for the IUPAC alphabet
+                        // `Base` models — a byte outside it is left unchanged,
+                        // reads as self-complementary, and collapses to
+                        // identity before reaching here. Kept as a defensive
+                        // fallback: leave the inversion as authored rather than
+                        // assert or invent an edit.
+                        return Ok((start, end, canonicalize_edit(edit), warnings));
+                    }
                     return Ok((
                         index_to_hgvs_pos(new_s),
                         new_e as u64,

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -894,7 +894,22 @@ pub(crate) fn deletion_to_repeat(
     })
 }
 
-/// Get the complement of a DNA base
+/// Get the complement of a nucleotide, over the whole IUPAC alphabet that
+/// [`crate::hgvs::edit::Base`] models.
+///
+/// Ambiguity codes complement by complementing their member set: `R` (A/G)
+/// becomes `Y` (C/T), `B` (not A) becomes `V` (not T), and so on. `W` (A/T),
+/// `S` (C/G) and `N` are the only genuinely self-complementary symbols.
+///
+/// Modelling the ambiguity codes matters because callers ask
+/// [`is_self_complementary`] whether "inverting this base changes nothing".
+/// Mapping an unmodelled symbol to itself made that test lie: `R` looked
+/// self-complementary, so an inversion resolving to a lone `R` was silently
+/// discarded as identity even though its reverse complement is `Y`.
+///
+/// The complement is returned uppercase regardless of input case, matching the
+/// long-standing behaviour for A/C/G/T/U. Bytes outside the alphabet are still
+/// returned unchanged — there is no meaningful complement to report for them.
 fn complement(base: u8) -> u8 {
     match base {
         b'A' | b'a' => b'T',
@@ -902,8 +917,66 @@ fn complement(base: u8) -> u8 {
         b'G' | b'g' => b'C',
         b'C' | b'c' => b'G',
         b'U' | b'u' => b'A', // RNA
-        _ => base,           // N and other IUPAC codes
+        // IUPAC ambiguity codes, complemented member-set-wise.
+        b'R' | b'r' => b'Y', // A/G  -> C/T
+        b'Y' | b'y' => b'R', // C/T  -> A/G
+        b'K' | b'k' => b'M', // G/T  -> A/C
+        b'M' | b'm' => b'K', // A/C  -> G/T
+        b'B' | b'b' => b'V', // C/G/T -> A/C/G
+        b'V' | b'v' => b'B', // A/C/G -> C/G/T
+        b'D' | b'd' => b'H', // A/G/T -> A/C/T
+        b'H' | b'h' => b'D', // A/C/T -> A/G/T
+        // Self-complementary: W (A/T), S (C/G), N (any).
+        b'W' | b'w' => b'W',
+        b'S' | b's' => b'S',
+        b'N' | b'n' => b'N',
+        _ => base, // Not a nucleotide we model.
     }
+}
+
+/// True when `last` is the complement of `first`, i.e. inverting the pair
+/// changes nothing.
+///
+/// Compares case-insensitively. [`complement`] always answers uppercase, so a
+/// raw `complement(x) == y` test silently fails for soft-masked reference bases:
+/// `complement(b'a')` is `b'T'`, which never equals `b't'`. Reference sequences
+/// really do arrive soft-masked (see
+/// `issue_1235_cis_allele_confluence::soft_masked_reference_yields_the_same_canonical_form`),
+/// so every complement comparison in the inversion-shortening path goes through
+/// here and treats `a` exactly like `A`.
+fn is_complementary_pair(first: u8, last: u8) -> bool {
+    let first = first.to_ascii_uppercase();
+    complement(first) == last.to_ascii_uppercase()
+}
+
+/// True when inverting `base` on its own changes nothing, i.e. it is one of the
+/// self-complementary symbols `W` (A/T), `S` (C/G) and `N`.
+///
+/// Bytes outside the modelled alphabet answer `true` as well, because
+/// [`complement`] returns them unchanged — there is no complement to substitute
+/// in, so the caller must not describe one.
+fn is_self_complementary(base: u8) -> bool {
+    is_complementary_pair(base, base)
+}
+
+/// The `reference > alternative` pair that describes inverting a single base:
+/// the base itself and its complement.
+///
+/// Returns `None` when the base is its own complement (nothing is substituted)
+/// or when either side is not a typed [`crate::hgvs::edit::Base`], so callers
+/// never fabricate a substitution they cannot spell.
+pub fn complementary_substitution(
+    base: u8,
+) -> Option<(crate::hgvs::edit::Base, crate::hgvs::edit::Base)> {
+    use crate::hgvs::edit::Base;
+
+    if is_self_complementary(base) {
+        return None;
+    }
+    Some((
+        Base::from_char(base as char)?,
+        Base::from_char(complement(base) as char)?,
+    ))
 }
 
 /// Shorten an inversion by removing outer bases that cancel out
@@ -912,8 +985,20 @@ fn complement(base: u8) -> u8 {
 /// inverting them produces no net change, so they can be excluded.
 /// This is repeated until no more cancellation is possible.
 ///
-/// Returns the shortened (start, end) positions (0-indexed), or None if
-/// the inversion reduces to identity (0 or 1 base).
+/// Returns the shortened (start, end) positions (0-indexed), or `None` if the
+/// inversion reduces to identity.
+///
+/// A residue of **two or more** bases is still an inversion. A residue of
+/// exactly **one** base is not identity: that base is replaced by its own
+/// complement, which `DNA/inversion.md:16` says to describe as a substitution
+/// ("a one-nucleotide inversion should be described as a substitution"). Such a
+/// residue is returned as a one-base range so the caller can emit that
+/// substitution; only a self-complementary base (`W`, `S`, `N`) collapses to
+/// identity. Conflating the one- and zero-base cases silently dropped real
+/// variants — see #1249.
+///
+/// Note for external callers: a span that once yielded `None` may now yield a
+/// one-base range.
 pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(usize, usize)> {
     if start >= end || end > ref_seq.len() {
         return None;
@@ -922,13 +1007,17 @@ pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(us
     let mut s = start;
     let mut e = end;
 
-    // Keep shrinking while outer bases are complementary
-    while s < e {
+    // Keep shrinking while the outer *pair* is complementary. The bound is
+    // `s + 1 < e`, not `s < e`: at `e == s + 1` the span is a single base and
+    // `ref_seq[s]` and `ref_seq[e - 1]` are the same byte, so a
+    // self-complementary centre would cancel against itself and drive `e` below
+    // `s`. The lone-centre case is classified after the loop instead.
+    while s + 1 < e {
         let first = ref_seq[s];
         let last = ref_seq[e - 1]; // e is exclusive
 
         // Check if first base is complement of last base
-        if complement(first) == last {
+        if is_complementary_pair(first, last) {
             s += 1;
             e -= 1;
         } else {
@@ -936,9 +1025,18 @@ pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(us
         }
     }
 
-    // If inversion shrinks to 0 or 1 base, it's identity
-    if e <= s + 1 {
-        return None; // Becomes identity - no inversion needed
+    // Every base cancelled against its partner, so the inversion is a genuine
+    // no-op. This is the only span that shrinks to nothing, and it requires an
+    // even length.
+    if e == s {
+        return None;
+    }
+
+    // An odd-length span always leaves a centre base. Inverting one base
+    // replaces it with its complement, so it is identity only when the base is
+    // its own complement.
+    if e == s + 1 && is_self_complementary(ref_seq[s]) {
+        return None;
     }
 
     Some((s, e))
@@ -4089,6 +4187,174 @@ mod tests {
         let (s, e) = result2.unwrap();
         assert_eq!(s, 0);
         assert_eq!(e, 4);
+    }
+
+    #[test]
+    fn complement_models_the_iupac_ambiguity_codes() {
+        // Ambiguity codes complement by complementing their member set.
+        for (base, expected) in [
+            (b'R', b'Y'), // A/G   -> C/T
+            (b'Y', b'R'), // C/T   -> A/G
+            (b'K', b'M'), // G/T   -> A/C
+            (b'M', b'K'), // A/C   -> G/T
+            (b'B', b'V'), // C/G/T -> A/C/G
+            (b'V', b'B'), // A/C/G -> C/G/T
+            (b'D', b'H'), // A/G/T -> A/C/T
+            (b'H', b'D'), // A/C/T -> A/G/T
+        ] {
+            assert_eq!(
+                complement(base),
+                expected,
+                "complement({}) should be {}",
+                base as char,
+                expected as char
+            );
+            // Lowercase complements to the same uppercase symbol as A/C/G/T/U do.
+            assert_eq!(complement(base.to_ascii_lowercase()), expected);
+        }
+
+        // Only W, S and N are genuinely self-complementary.
+        for base in *b"WSN" {
+            assert_eq!(
+                complement(base),
+                base,
+                "{} is self-complementary",
+                base as char
+            );
+        }
+    }
+
+    #[test]
+    fn shorten_inversion_keeps_an_ambiguous_one_base_residue() {
+        // "ART": A(0) cancels against T(2), leaving R at the centre. R is not
+        // self-complementary — its reverse complement is Y — so the residue must
+        // survive as a one-base range for the caller to describe. Treating it as
+        // identity would silently discard the variant, which is #1249 all over
+        // again for the IUPAC codes.
+        let result = shorten_inversion(b"ART", 0, 3);
+        assert_eq!(result, Some((1, 2)));
+        assert_eq!(
+            complementary_substitution(b'R'),
+            Some((crate::hgvs::edit::Base::R, crate::hgvs::edit::Base::Y)),
+            "a lone R inverts to Y"
+        );
+    }
+
+    #[test]
+    fn shorten_inversion_never_returns_a_backwards_range() {
+        // A self-complementary centre base used to cancel against *itself* —
+        // `ref_seq[s]` and `ref_seq[e - 1]` are the same byte once the span is
+        // one base wide — driving `e` below `s` and yielding `Some((2, 1))`.
+        // These spans are identity and must report `None`.
+        for seq in [b"ANT", b"AWT", b"AST"] {
+            assert_eq!(
+                shorten_inversion(seq, 0, 3),
+                None,
+                "{} reduces to a self-complementary centre, i.e. identity",
+                std::str::from_utf8(seq).unwrap()
+            );
+        }
+
+        // The invariant, stated directly: whatever the sequence, a returned
+        // range is non-empty and correctly ordered.
+        for seq in [
+            b"ART".as_slice(),
+            b"ANT".as_slice(),
+            b"RR".as_slice(),
+            b"RY".as_slice(),
+            b"NNN".as_slice(),
+            b"ATGCAT".as_slice(),
+        ] {
+            if let Some((s, e)) = shorten_inversion(seq, 0, seq.len()) {
+                assert!(
+                    s < e,
+                    "{} produced a backwards range ({s}, {e})",
+                    std::str::from_utf8(seq).unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn shorten_inversion_cancels_ambiguity_codes_only_when_they_pair() {
+        // revcomp("RY") == "RY", so the pair genuinely cancels to identity.
+        assert_eq!(shorten_inversion(b"RY", 0, 2), None);
+
+        // revcomp("RR") == "YY", so nothing cancels and the inversion stands.
+        // Before the IUPAC codes were modelled, `complement(R) == R` made this
+        // look like a complementary pair and collapsed it to identity.
+        assert_eq!(shorten_inversion(b"RR", 0, 2), Some((0, 2)));
+    }
+
+    #[test]
+    fn shorten_inversion_treats_soft_masked_bases_like_uppercase() {
+        // `complement` always answers uppercase, so every `complement(x) == y`
+        // test used to fail on a soft-masked reference: `complement(b'a')` is
+        // `b'T'`, never `b't'`. That made lowercase spans behave differently
+        // from the identical uppercase span at both comparison sites — the
+        // outer-pair loop and the lone-centre check.
+        for (lower, upper) in [
+            (b"at".as_slice(), b"AT".as_slice()), // outer pair cancels to nothing
+            (b"awt".as_slice(), b"AWT".as_slice()), // cancels to a self-complementary centre
+            (b"ast".as_slice(), b"AST".as_slice()),
+            (b"ant".as_slice(), b"ANT".as_slice()),
+            (b"art".as_slice(), b"ART".as_slice()), // centre survives: revcomp(r) is y
+            (b"rr".as_slice(), b"RR".as_slice()),   // nothing cancels
+            (b"atgcat".as_slice(), b"ATGCAT".as_slice()),
+        ] {
+            assert_eq!(
+                shorten_inversion(lower, 0, lower.len()),
+                shorten_inversion(upper, 0, upper.len()),
+                "{} and {} must shorten identically",
+                std::str::from_utf8(lower).unwrap(),
+                std::str::from_utf8(upper).unwrap()
+            );
+        }
+
+        // The two headline cases, spelled out rather than left to the parity
+        // check above: a soft-masked self-complementary centre is identity, and
+        // a soft-masked non-self-complementary centre still survives.
+        assert_eq!(shorten_inversion(b"awt", 0, 3), None);
+        assert_eq!(shorten_inversion(b"art", 0, 3), Some((1, 2)));
+    }
+
+    #[test]
+    fn complementary_substitution_never_describes_a_base_as_itself() {
+        // A soft-masked self-complementary base used to escape the identity
+        // branch — `complement(b'w')` is `b'W'`, which is not `b'w'` — and then
+        // `Base::from_char` uppercased both sides, yielding the degenerate
+        // `Some((W, W))`. Normalization returned that straight out of the
+        // `Inversion` arm as `<pos>W>W`, bypassing the `ref == alt` → identity
+        // rewrite that only runs on the original input edit.
+        for base in *b"WSNwsn" {
+            assert_eq!(
+                complementary_substitution(base),
+                None,
+                "{} is self-complementary, so inverting it substitutes nothing",
+                base as char
+            );
+        }
+
+        // Bases that do have a distinct complement are unaffected, in either case.
+        for (base, reference, alternative) in [
+            (b'a', crate::hgvs::edit::Base::A, crate::hgvs::edit::Base::T),
+            (b'A', crate::hgvs::edit::Base::A, crate::hgvs::edit::Base::T),
+            (b'r', crate::hgvs::edit::Base::R, crate::hgvs::edit::Base::Y),
+            (b'R', crate::hgvs::edit::Base::R, crate::hgvs::edit::Base::Y),
+        ] {
+            assert_eq!(
+                complementary_substitution(base),
+                Some((reference, alternative)),
+                "{} inverts to its complement",
+                base as char
+            );
+        }
+
+        // A byte outside the modelled alphabet has no complement to substitute
+        // in, upper or lower case.
+        for base in *b"Xx" {
+            assert_eq!(complementary_substitution(base), None);
+        }
     }
 
     // =========================================================================

--- a/tests/it/issue_1249_inv_one_base_residue.rs
+++ b/tests/it/issue_1249_inv_one_base_residue.rs
@@ -1,0 +1,269 @@
+//! Issue #1249: an `inv` whose complementary outer bases all cancel down to a
+//! *single* remaining base must become a substitution, not identity.
+//!
+//! # The bug
+//!
+//! `rules::shorten_inversion` peels complementary outer pairs off an inversion.
+//! That peeling is sound: when the first base is the complement of the last,
+//! both endpoints survive the reverse complement unchanged, so neither needs
+//! describing. What was unsound is the stopping condition — it treated a
+//! residue of **zero or one** base as identity:
+//!
+//! ```text
+//! reference   CCAATGGCC
+//! g.3_5inv    span AAT, revcomp ATT   ->  ferro emitted g.3_5=
+//! applied     CCATTGGCC                   the sequence DID change
+//! ```
+//!
+//! A zero-base residue really is identity: every base cancelled. A **one**-base
+//! residue is not — that base is replaced by its own complement, and no
+//! standard base is self-complementary. `AAT` peels its `A..T` pair and leaves
+//! `A` at position 4, which inverts to `T`, so the variant is `g.4A>T`.
+//!
+//! # Spec
+//!
+//! `DNA/inversion.md:5` defines an inversion as **more than one nucleotide**,
+//! and `:16` gives the replacement rule outright:
+//!
+//! > by definition, the region inverted (`positions_inverted`) contains **more
+//! > than one nucleotide**. The description `g.234inv` is therefore not
+//! > allowed; a one-nucleotide inversion should be described as a
+//! > [substitution](substitution.md).
+//!
+//! So the residue is emitted as a substitution to its complement — never as a
+//! one-base `inv`, and never as `=`.
+//!
+//! This is the normalizer-side counterpart to #1079, which enforces the same
+//! rule in the *parser*. #1079 can only reject `g.234inv`, because recovering
+//! the substitution needs the reference sequence and the parser has none. The
+//! normalizer has the reference, so it performs the rewrite #1079 documents.
+//!
+//! # Why it matters twice
+//!
+//! Beyond losing the variant outright — `=` asserts the reference is unchanged,
+//! so any consumer filtering identities drops it silently — it is also a
+//! **confluence** break of the kind #1229–#1235 track: the `delins` and
+//! substitution spellings of this very variant normalize correctly, and only
+//! the `inv` spelling is lost.
+
+use crate::common::synthetic::{normalize_to_string, SyntheticBuilder, PAD_OFFSET};
+
+/// 1-based HGVS position of the `n`-th (1-based) core base on a genomic build.
+fn at(n: u64) -> u64 {
+    PAD_OFFSET + n
+}
+
+/// Normalize `input` against a genomic provider carrying `core`.
+fn norm(core: &str, input: &str) -> String {
+    normalize_to_string(SyntheticBuilder::genomic(core).build(), input)
+}
+
+fn complement(b: u8) -> u8 {
+    match b {
+        b'A' => b'T',
+        b'T' => b'A',
+        b'G' => b'C',
+        b'C' => b'G',
+        other => other,
+    }
+}
+
+fn revcomp(seq: &str) -> String {
+    seq.bytes().rev().map(|b| complement(b) as char).collect()
+}
+
+/// The sequence that `g.<s>_<e>inv` produces, computed independently of the
+/// normalizer: splice the reverse complement of the span back into `seq`.
+/// `s`/`e` are 1-based inclusive positions into `seq`.
+fn apply_inv(seq: &str, s: usize, e: usize) -> String {
+    format!("{}{}{}", &seq[..s - 1], revcomp(&seq[s - 1..e]), &seq[e..])
+}
+
+// ---------------------------------------------------------------------------
+// The reported case.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn one_base_residue_becomes_a_substitution_to_its_complement() {
+    // CCAATGGCC: the 3_5 span is AAT. The outer A..T pair is complementary and
+    // cancels, leaving `A` at core position 4, which inverts to `T`.
+    let input = format!("NC_TEST.1:g.{}_{}inv", at(3), at(5));
+    assert_eq!(
+        norm("CCAATGGCC", &input),
+        format!("NC_TEST.1:g.{}A>T", at(4)),
+        "an inv leaving a one-base residue is a substitution, not identity"
+    );
+}
+
+#[test]
+fn an_explicit_inverted_sequence_takes_the_same_path() {
+    // The `invAAT` spelling must not escape the rewrite.
+    let input = format!("NC_TEST.1:g.{}_{}invAAT", at(3), at(5));
+    assert_eq!(
+        norm("CCAATGGCC", &input),
+        format!("NC_TEST.1:g.{}A>T", at(4))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The even-length counterpart must stay identity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_fully_cancelling_even_span_is_still_identity() {
+    // TTGGCCAA: the 3_6 span is GGCC. Both outer pairs (G..C, G..C) cancel and
+    // nothing remains, so this genuinely denotes no change. The fix must not
+    // turn these into substitutions.
+    let input = format!("NC_TEST.1:g.{}_{}inv", at(3), at(6));
+    assert_eq!(
+        norm("TTGGCCAA", &input),
+        format!("NC_TEST.1:g.{}_{}=", at(3), at(6))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Confluence: every spelling of this variant must agree (#1229–#1235 family).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_spelling_of_the_variant_normalizes_alike() {
+    let core = "CCAATGGCC";
+    let expected = format!("NC_TEST.1:g.{}A>T", at(4));
+    let spellings = [
+        format!("NC_TEST.1:g.{}_{}inv", at(3), at(5)),
+        format!("NC_TEST.1:g.{}_{}invAAT", at(3), at(5)),
+        format!("NC_TEST.1:g.{}_{}delinsATT", at(3), at(5)),
+        format!("NC_TEST.1:g.{}_{}delAATinsATT", at(3), at(5)),
+        format!("NC_TEST.1:g.{}A>T", at(4)),
+    ];
+    for spelling in &spellings {
+        assert_eq!(
+            norm(core, spelling),
+            expected,
+            "spelling `{spelling}` must converge with the others"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustive parity sweep — the invariant behind the whole fix.
+// ---------------------------------------------------------------------------
+
+/// No inversion may normalize to `=` unless applying it really leaves the
+/// reference unchanged, and one that does leave it unchanged must still say so.
+///
+/// Sweeping every 4^L core for L in 3..=6 covers both parities: an even-length
+/// span whose outer pairs all cancel reduces to nothing and is identity, while
+/// an odd-length one always retains a centre base that changes. Before the fix
+/// this failed on 16 cores at L=3 and 64 at L=5 (`4^((L+1)/2)`), i.e. on every
+/// odd-length span that cancelled completely — there were no false positives to
+/// weigh against, so the old branch was wrong in every case it fired.
+#[test]
+fn identity_is_emitted_only_when_the_sequence_is_actually_unchanged() {
+    const BASES: [u8; 4] = *b"ACGT";
+
+    for len in 3..=6usize {
+        for n in 0..4usize.pow(len as u32) {
+            let mut k = n;
+            let core: String = (0..len)
+                .map(|_| {
+                    let b = BASES[k % 4] as char;
+                    k /= 4;
+                    b
+                })
+                .collect();
+
+            let input = format!("NC_TEST.1:g.{}_{}inv", at(1), at(len as u64));
+            let out = norm(&core, &input);
+            let emitted_identity = out.ends_with('=');
+            let unchanged = apply_inv(&core, 1, len) == core;
+
+            assert_eq!(
+                emitted_identity,
+                unchanged,
+                "core {core}: normalize gave `{out}`, but applying the inversion \
+                 {} the sequence",
+                if unchanged { "left" } else { "changed" }
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The rewrite is axis-independent: it lives in the shared `NaEdit::Inversion`
+// arm, so c. and n. must behave identically to g.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_rewrite_applies_on_the_cds_axis() {
+    use ferro_hgvs::reference::transcript::Strand;
+    // Whole transcript is the reference for c., so positions are literal.
+    let provider = SyntheticBuilder::cds("CCAATGGCC", 1, 9, Strand::Plus).build();
+    assert_eq!(
+        normalize_to_string(provider, "NM_TEST.1:c.3_5inv"),
+        "NM_TEST.1:c.4A>T"
+    );
+}
+
+#[test]
+fn the_rewrite_applies_on_the_noncoding_axis() {
+    use ferro_hgvs::reference::transcript::Strand;
+    let provider = SyntheticBuilder::noncoding("CCAATGGCC", Strand::Plus).build();
+    assert_eq!(
+        normalize_to_string(provider, "NR_TEST.1:n.3_5inv"),
+        "NR_TEST.1:n.4A>T"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// IUPAC ambiguity codes in the reference.
+//
+// The peeling test is `complement(first) == last`, and `complement` originally
+// modelled only A/C/G/T/U — every other symbol mapped to itself. That made an
+// ambiguity code look self-complementary, which broke the same two ways this
+// issue is about:
+//
+//   * `R` (A/G) inverts to `Y` (C/T), but looked like identity, so an inversion
+//     resolving to a lone `R` was silently discarded — #1249 again.
+//   * a lone centre base cancelled against *itself* (`ref_seq[s]` and
+//     `ref_seq[e - 1]` are the same byte once the span is one base wide),
+//     driving the shortened end below the shortened start.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_ambiguous_one_base_residue_becomes_a_substitution() {
+    // ART: A cancels against T, leaving R. revcomp(R) == Y, so this is a real
+    // change and must be described, not dropped as `=`.
+    assert_eq!(
+        norm("ART", &format!("NC_TEST.1:g.{}_{}inv", at(1), at(3))),
+        format!("NC_TEST.1:g.{}R>Y", at(2))
+    );
+}
+
+#[test]
+fn a_self_complementary_residue_is_identity() {
+    // W (A/T), S (C/G) and N are the only self-complementary symbols: each is
+    // its own reverse complement, so the span really is unchanged.
+    for centre in ["W", "S", "N"] {
+        let core = format!("A{centre}T");
+        assert_eq!(
+            norm(&core, &format!("NC_TEST.1:g.{}_{}inv", at(1), at(3))),
+            format!("NC_TEST.1:g.{}_{}=", at(1), at(3)),
+            "{core}: a self-complementary centre leaves the sequence unchanged"
+        );
+    }
+}
+
+#[test]
+fn an_ambiguous_pair_cancels_only_when_it_actually_complements() {
+    // revcomp("RY") == "RY" -- a genuine no-op.
+    assert_eq!(
+        norm("RY", &format!("NC_TEST.1:g.{}_{}inv", at(1), at(2))),
+        format!("NC_TEST.1:g.{}_{}=", at(1), at(2))
+    );
+    // revcomp("RR") == "YY" -- nothing cancels, so the inversion stands.
+    assert_eq!(
+        norm("RR", &format!("NC_TEST.1:g.{}_{}inv", at(1), at(2))),
+        format!("NC_TEST.1:g.{}_{}inv", at(1), at(2))
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -160,6 +160,7 @@ mod issue_1234_sibling_clamped_shift;
 mod issue_1235_cis_allele_confluence;
 mod issue_1235_transcript_axes;
 mod issue_1244_equivalence_overlap_panic;
+mod issue_1249_inv_one_base_residue;
 mod issue_1254_sibling_crossing_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
Closes #1249.

## The defect

`rules::shorten_inversion` peels complementary outer pairs off an inversion. That peeling is sound: when the first base is the complement of the last, both endpoints survive the reverse complement unchanged, so neither needs describing. The stopping condition was not — it treated a residue of **zero or one** base as identity.

Only zero is identity. A one-base residue is replaced by its own complement, and no standard base is self-complementary, so it is always a real change.

```
reference   CCAATGGCC
g.3_5inv    span AAT, revcomp ATT   ->  ferro emitted  g.3_5=
applied     CCATTGGCC                   the sequence DID change
correct                                 g.4A>T
```

## Why this is worse than a spelling difference

`=` asserts the reference is unchanged at that span, so the variant is normalized out of existence with no warning, and any consumer that filters identities drops it silently.

It was also a **confluence** break of the kind #1229–#1235 track — only the `inv` spelling was lost:

| spelling of the same variant | before | after |
| --- | --- | --- |
| `g.3_5inv` | `g.3_5=` ❌ | `g.4A>T` |
| `g.3_5invAAT` | `g.3_5=` ❌ | `g.4A>T` |
| `g.3_5delinsATT` | `g.4A>T` | `g.4A>T` |
| `g.3_5delAATinsATT` | `g.4A>T` | `g.4A>T` |
| `g.4A>T` | `g.4A>T` | `g.4A>T` |

## Scope, measured

An exhaustive sweep of every 4^L span for L in 3..=7 (21,824 cases) splits exactly on parity — an even-length span whose outer pairs all cancel reduces to nothing and *is* identity; an odd-length one always retains a centre base that changes:

| span length | wrongly emitted `=` | correctly emitted `=` |
| --- | --- | --- |
| 3 | 16 | – |
| 4 | – | 16 |
| 5 | 64 | – |
| 6 | – | 64 |
| 7 | 256 | – |
| **total** | **336** | **80** |

Every case the old branch fired on was wrong; there were no correct cases to weigh against it. The 80 genuine identities are unaffected and are pinned by a test.

## Spec basis

`DNA/inversion.md:5` defines an inversion as **more than one nucleotide**; `:16` gives the replacement rule directly:

> by definition, the region inverted (`positions_inverted`) contains **more than one nucleotide**. The description `g.234inv` is therefore not allowed; a one-nucleotide inversion should be described as a substitution.

This is the normalizer-side counterpart to #1079, which enforces the same rule in the *parser*. #1079 can only reject a literal `g.234inv` and documents why it cannot rewrite it — recovering the substitution needs the reference sequence, which the parser does not have. The normalizer does have it, so it performs exactly the rewrite #1079 describes. No calibration or judgement call is involved: the spec names the output form.

## The change

Two edits, plus one small helper.

- `src/normalize/rules.rs` — `shorten_inversion` returns `None` only for a genuinely empty residue, or for a one-base residue whose base is its own complement. `complement` maps every IUPAC code it does not model to itself, so `N` (and any other self-complementary code) stays identity and the new substitution path is confined to A/C/G/T/U.
- `src/normalize/rules.rs` — new `complementary_substitution(base)` returns the typed `(reference, alternative)` pair, or `None` rather than fabricating a substitution it cannot spell.
- `src/normalize/mod.rs` — the `NaEdit::Inversion` arm emits that substitution for a one-base residue. A residue it cannot type falls back to leaving the inversion as authored, rather than asserting or inventing an edit.

The sibling caller (`rules.rs`, `canonicalize_delins` step 4d) is unaffected. After greedy shared-affix trimming a true reverse complement can never have complementary outer bases — that would imply a shared prefix the trimmer already consumed — so it never sees a one-base residue and its `debug_assert!(e > s + 1)` still holds.

## Compatibility

`shorten_inversion` is public API (`ferro_hgvs::normalize::rules`), so the behaviour change is observable: a span that previously returned `None` may now return a one-base range. The signature is unchanged. This is called out in the function's doc comment.

## Verification

| gate | result |
| --- | --- |
| conformance axes (`FERRO_MANIFEST`) | **170/170**, zero hard-FAIL rows |
| mock suite | **8793/8793** |
| clippy `--all-features --all-targets -D warnings` | clean |
| `cargo fmt --all` | clean |

New tests in `tests/it/issue_1249_inv_one_base_residue.rs`: the reported case, the `invAAT` spelling, the even-length identity control, the five-spelling confluence check, `c.` and `n.` axis coverage, and the exhaustive parity sweep. All six failed before the change; the even-length control passed before and after, which is the guard against over-correction.

## Reading order

`src/normalize/rules.rs` first (the corrected stopping condition and the helper), then the `NaEdit::Inversion` arm in `src/normalize/mod.rs`, then the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected normalization of single-base inversions so they are represented as substitutions when appropriate.
  * Preserved identity results when an inversion fully cancels out.
  * Improved handling of IUPAC ambiguity codes and complementary bases.
  * Applied consistent behavior across coding, noncoding, and genomic sequence descriptions.

* **Tests**
  * Added comprehensive coverage for inversion normalization, equivalent variant forms, ambiguity codes, and sequence edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->