### PR TITLE
fix(equivalence): decline overlapping SPDI triples instead of panicking

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -503,12 +503,16 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 /// base is not `A`), we cannot faithfully reconstruct the edit, so we decline
 /// (`None`) rather than assert a sequence equivalence we cannot trust. Also
 /// returns `None` if any triple falls outside the window (a defensive guard;
-/// callers build the window to cover every triple).
+/// callers build the window to cover every triple), or if two triples overlap
+/// (see [`triples_are_disjoint`]).
 fn apply_triples(reference: &str, win_start: u64, triples: &[SpdiVariant]) -> Option<String> {
     let ref_bytes = reference.as_bytes();
     let mut bytes = ref_bytes.to_vec();
     let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
     ordered.sort_by_key(|t| std::cmp::Reverse(t.position));
+    if !triples_are_disjoint(&ordered) {
+        return None;
+    }
     for t in ordered {
         let rel = t.position.checked_sub(win_start)? as usize;
         let end = rel.checked_add(t.deletion.len())?;
@@ -522,9 +526,53 @@ fn apply_triples(reference: &str, win_start: u64, triples: &[SpdiVariant]) -> Op
         if !ref_bytes[rel..end].eq_ignore_ascii_case(t.deletion.as_bytes()) {
             return None;
         }
+        // The splice targets the mutated buffer, whose length no longer matches
+        // the reference once a length-changing edit has been applied. The
+        // disjointness guard above already makes `end <= bytes.len()` hold;
+        // bound it explicitly anyway so a future change cannot turn a logic
+        // slip back into an out-of-bounds panic (#1244).
+        if end > bytes.len() {
+            return None;
+        }
         bytes.splice(rel..end, t.insertion.bytes());
     }
     String::from_utf8(bytes).ok()
+}
+
+/// Whether no two of `ordered` claim the same reference base.
+///
+/// `ordered` must be sorted by descending position, as [`apply_triples`] leaves
+/// it. That descending application order is what lets each stated deletion be
+/// validated against the pristine reference: every already-applied splice sits
+/// strictly 3' of the next one, so the span about to be read is untouched. The
+/// argument holds only while the triples are disjoint — overlapping ones both
+/// invalidate that validation and can index past the end of the shrinking
+/// buffer, which is the out-of-bounds panic of #1244.
+///
+/// Declining is also the honest answer semantically: an allele whose members
+/// claim the same base has no single well-defined resulting sequence, so there
+/// is nothing to compare. The caller uses the comparison only to *upgrade* a
+/// `NotEquivalent` verdict, so a decline never invents an equivalence.
+///
+/// Two triples that merely abut are disjoint, and so is any number of pure
+/// insertions at one interbase position — an insertion deletes nothing and
+/// therefore claims no base.
+fn triples_are_disjoint(ordered: &[&SpdiVariant]) -> bool {
+    // Walk 5' -> 3' (the reverse of `ordered`) carrying the furthest 3' reach
+    // of every triple seen so far. Comparing against the running maximum rather
+    // than the immediate predecessor is what makes this complete: one long
+    // triple can span several shorter ones that do not touch each other.
+    let mut reach: Option<u64> = None;
+    for t in ordered.iter().rev() {
+        let Some(end) = t.position.checked_add(t.deletion.len() as u64) else {
+            return false;
+        };
+        if reach.is_some_and(|r| r > t.position) {
+            return false;
+        }
+        reach = Some(reach.map_or(end, |r| r.max(end)));
+    }
+    true
 }
 
 /// Extract the variant part from an HGVS string (everything after the colon).

--- a/tests/it/issue_1244_equivalence_overlap_panic.rs
+++ b/tests/it/issue_1244_equivalence_overlap_panic.rs
@@ -1,0 +1,275 @@
+//! Issue #1244: `EquivalenceChecker::check` panicked (slice index out of
+//! bounds) instead of returning a verdict, for a cis allele whose members
+//! overlap.
+//!
+//! # The bug
+//!
+//! `same_resulting_sequence` rebuilds each variant's edited window by splicing
+//! its SPDI triples into a copy of the reference. `apply_triples` applies them
+//! in **descending** position order, which lets it validate each stated
+//! deletion against the *original* reference bases — every already-applied
+//! splice sits strictly 3' of the next one, so the span it is about to read is
+//! still pristine.
+//!
+//! That reasoning holds only while the triples are disjoint. Its bounds check
+//! compared against `ref_bytes.len()` — the *original* window length — while
+//! splicing into `bytes`, whose length shrinks as deletions are applied. Two
+//! overlapping triples therefore let a range pass the check and then index past
+//! the end of the mutated buffer:
+//!
+//! ```text
+//! window          10 bases
+//! triple applied   rel 5..10, insertion ""   -> bytes.len() becomes 5
+//! triple next      rel 0..8                  -> 8 <= ref_bytes.len() (10), passes
+//!                                              bytes.splice(0..8, ..) on len 5 -> PANIC
+//! ```
+//!
+//! A cis allele of a repeat expansion immediately followed by an adjacent
+//! deletion produces exactly that shape: `g.[11_14AT[4];14_20del]` has two
+//! members both claiming position 14.
+//!
+//! # Why a panic is worse than a wrong answer
+//!
+//! `check` is the documented fallback when normalized strings differ, and it
+//! returns `Result<_, FerroError>` — callers reasonably handle failure by
+//! matching the error. A panic bypasses that contract entirely, and through the
+//! Python bindings it surfaces as `pyo3_runtime.PanicException`, which
+//! subclasses `BaseException` and so escapes `except Exception`.
+//!
+//! # The fix
+//!
+//! Overlapping triples have no single well-defined resulting sequence, so
+//! `apply_triples` declines them (`None`) rather than splicing. `None` already
+//! means "cannot decide" to the only caller, which uses the comparison solely
+//! to *upgrade* a `NotEquivalent` verdict — so declining is always safe and
+//! never invents an equivalence.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::Normalizer;
+
+/// The issue's synthetic reference: 30 nt whose core positions 11..=20 are an
+/// `(AT)` tandem repeat. Under `SyntheticBuilder::genomic` core position `n`
+/// sits at HGVS `256 + n`, so the repeat spans `g.267`..=`g.276`.
+const CORE: &str = "CAGCTAGCTGATATATATATGCGCGCGCGC";
+
+/// `[267_270AT[4];270_276del]` — a repeat expansion over core 11..=14 followed
+/// by a deletion over core 14..=20. Both members claim core position 14, so the
+/// allele's members overlap and its resulting sequence is undefined.
+const OVERLAPPING_ALLELE: &str = "NC_TEST.1:g.[267_270AT[4];270_276del]";
+
+/// A substitution at core position 1, i.e. a different locus entirely.
+const ELSEWHERE: &str = "NC_TEST.1:g.257C>A";
+
+fn checker() -> EquivalenceChecker<ferro_hgvs::JsonProvider> {
+    EquivalenceChecker::new(SyntheticBuilder::genomic(CORE).build())
+}
+
+// ---------------------------------------------------------------------------
+// The reported crash.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_overlapping_cis_allele_returns_a_verdict_instead_of_panicking() {
+    let result = checker()
+        .check(
+            &parse_hgvs(OVERLAPPING_ALLELE).unwrap(),
+            &parse_hgvs(ELSEWHERE).unwrap(),
+        )
+        .expect("check must return a verdict, not fail");
+
+    // The two describe different loci, so the honest answer is NotEquivalent.
+    // What matters is that a verdict is produced at all.
+    assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
+    assert!(!result.is_equivalent());
+}
+
+#[test]
+fn the_crash_is_symmetric_in_argument_order() {
+    let result = checker()
+        .check(
+            &parse_hgvs(ELSEWHERE).unwrap(),
+            &parse_hgvs(OVERLAPPING_ALLELE).unwrap(),
+        )
+        .expect("check must return a verdict, not fail");
+    assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
+}
+
+#[test]
+fn an_overlapping_allele_compared_with_itself_is_still_decided() {
+    // Both sides project to the same overlapping triples. The string-equality
+    // rung settles this before any sequence reconstruction is attempted, so it
+    // must not reach the splice at all.
+    let result = checker()
+        .check(
+            &parse_hgvs(OVERLAPPING_ALLELE).unwrap(),
+            &parse_hgvs(OVERLAPPING_ALLELE).unwrap(),
+        )
+        .expect("check must return a verdict, not fail");
+    assert!(result.is_equivalent());
+}
+
+// ---------------------------------------------------------------------------
+// The decline must be narrow: disjoint alleles still compare equal.
+//
+// These two assert `is_equivalent()` rather than a specific rung on purpose.
+// Which rung settles a pair is the normalizer's business and it moves as
+// normalization improves — both of these used to reach the resulting-sequence
+// rung and now settle one rung earlier, at `NormalizedMatch`, because the two
+// spellings normalize to the same string. Pinning the rung would turn that
+// improvement into a failure. What the overlap guard owes them is only that it
+// does not decline them into `NotEquivalent`.
+//
+// The sequence rung itself is still exercised with a disjoint allele — see the
+// coincident-insertion tests below, which reach `SequenceMatch`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_disjoint_cis_allele_is_not_declined() {
+    // #1158's case A: a delins against the cis allele that spells out the same
+    // edit member by member. If the overlap guard were too eager it would
+    // decline this and the verdict would fall back to NotEquivalent.
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("AGTCAGT").build());
+    let result = checker
+        .check(
+            &parse_hgvs("NC_TEST.1:g.257_263delinsGATTA").unwrap(),
+            &parse_hgvs("NC_TEST.1:g.[257A>G;258G>A;260C>T;262_263del]").unwrap(),
+        )
+        .unwrap();
+    assert!(
+        result.is_equivalent(),
+        "a disjoint allele must stay comparable, got {:?}",
+        result.level
+    );
+}
+
+#[test]
+fn members_that_merely_abut_are_not_treated_as_overlapping() {
+    // `257_258del` ends where `259T>A` begins — adjacent, not overlapping. The
+    // guard keys on a genuine positional clash, so this must still compare
+    // equal rather than decline.
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("AGTCAGT").build());
+    let result = checker
+        .check(
+            &parse_hgvs("NC_TEST.1:g.[257_258del;259T>A]").unwrap(),
+            &parse_hgvs("NC_TEST.1:g.257_259delinsA").unwrap(),
+        )
+        .unwrap();
+    assert!(
+        result.is_equivalent(),
+        "abutting members describe one edit and must stay comparable, got {:?}",
+        result.level
+    );
+}
+
+#[test]
+fn pure_insertions_at_one_position_are_not_treated_as_overlapping() {
+    // An insertion deletes nothing, so it claims no reference base and cannot
+    // clash with anything — not even another insertion at the same interbase
+    // point. `triples_are_disjoint` says so explicitly; this pins it, because
+    // an off-by-one there (`>=` for `>`) would decline the whole family while
+    // every other test in this file still passed.
+    //
+    // The assertion is deliberately order-agnostic. Coincident insertions are
+    // spliced in an order the guard does not define, so which concatenation
+    // comes out is an implementation artifact, not the contract. What *is* the
+    // contract: `apply_triples` returns a sequence rather than declining — and
+    // a decline is observable, because it would leave both orderings at
+    // `NotEquivalent`.
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic(CORE).build());
+    let allele = parse_hgvs("NC_TEST.1:g.[277_278insA;277_278insT]").unwrap();
+
+    let matched = sequence_rung_matches(
+        &checker,
+        &allele,
+        &["NC_TEST.1:g.277_278insAT", "NC_TEST.1:g.277_278insTA"],
+    );
+
+    assert_eq!(
+        matched, 1,
+        "two insertions at one position must reach the sequence rung and match \
+         exactly one concatenation; 0 means `apply_triples` declined them"
+    );
+}
+
+#[test]
+fn three_insertions_at_one_position_are_still_not_overlapping() {
+    // "any number of pure insertions at one interbase position" — the running
+    // 3' reach never advances past the shared position, so adding members
+    // cannot make the guard fire.
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic(CORE).build());
+    let allele = parse_hgvs("NC_TEST.1:g.[277_278insA;277_278insC;277_278insT]").unwrap();
+
+    let matched = sequence_rung_matches(
+        &checker,
+        &allele,
+        &[
+            "NC_TEST.1:g.277_278insACT",
+            "NC_TEST.1:g.277_278insATC",
+            "NC_TEST.1:g.277_278insCAT",
+            "NC_TEST.1:g.277_278insCTA",
+            "NC_TEST.1:g.277_278insTAC",
+            "NC_TEST.1:g.277_278insTCA",
+        ],
+    );
+
+    assert_eq!(
+        matched, 1,
+        "three coincident insertions must still be spliced, not declined"
+    );
+}
+
+/// How many of `spellings` the checker settles against `allele` at the
+/// *resulting-sequence* rung.
+///
+/// The rung matters here, unlike in the disjoint-allele tests above: it is the
+/// only rung that runs `apply_triples`, so `SequenceMatch` is direct evidence
+/// the overlap guard let the triples through. Coincident insertions cannot
+/// short-circuit at `NormalizedMatch` — a two-member allele and a single `ins`
+/// do not normalize to the same string — so nothing weaker would prove it.
+fn sequence_rung_matches(
+    checker: &EquivalenceChecker<ferro_hgvs::JsonProvider>,
+    allele: &ferro_hgvs::HgvsVariant,
+    spellings: &[&str],
+) -> usize {
+    spellings
+        .iter()
+        .filter(|spelling| {
+            checker
+                .check(allele, &parse_hgvs(spelling).unwrap())
+                .expect("check must return a verdict")
+                .level
+                == EquivalenceLevel::SequenceMatch
+        })
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// Sibling surface: the same allele must not crash the normalizer either.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalizing_the_same_overlapping_allele_does_not_panic() {
+    let normalizer = Normalizer::new(SyntheticBuilder::genomic(CORE).build());
+    let parsed = parse_hgvs(OVERLAPPING_ALLELE).unwrap();
+
+    // Whether the normalizer accepts or rejects this allele is its own choice,
+    // but it must make one — and if it accepts, the result has to satisfy the
+    // same contract as any other: `norm(norm(x)) == norm(x)`. Discarding the
+    // result would let a successful-but-non-idempotent normalization through.
+    let normalized = normalizer
+        .normalize(&parsed)
+        .expect("the overlapping allele normalizes; a rejection would be a behaviour change")
+        .to_string();
+
+    let renormalized = normalizer
+        .normalize(&parse_hgvs(&normalized).expect("normalized output must re-parse"))
+        .expect("re-normalizing normalized output must succeed")
+        .to_string();
+
+    assert_eq!(
+        normalized, renormalized,
+        "normalization must be idempotent even for an allele whose members overlap"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -156,6 +156,7 @@ mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
 mod issue_1217_mito_terminus_insertion_clamp;
 mod issue_1235_cis_allele_confluence;
+mod issue_1244_equivalence_overlap_panic;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/python/test_issue_1244_equivalence_overlap_panic.py
+++ b/tests/python/test_issue_1244_equivalence_overlap_panic.py
@@ -1,0 +1,83 @@
+"""Issue #1244: the overlapping-allele crash, seen from the Python bindings.
+
+``EquivalenceChecker.check`` panicked (slice index out of bounds) for a cis
+allele whose members overlap. The Rust suite
+(``tests/it/issue_1244_equivalence_overlap_panic.rs``) covers the fix at the
+library level; this file exists because the Python surface is where the panic
+did the most damage.
+
+A Rust panic crosses PyO3 as ``pyo3_runtime.PanicException``, which subclasses
+``BaseException`` rather than ``Exception`` — so it slips straight through the
+``except Exception`` that a caller would reasonably wrap ``check`` in, and takes
+down the interpreter's call stack instead of yielding a verdict. Returning
+``NotEquivalent`` is not merely a nicer answer here; it is the difference
+between a catchable outcome and an uncatchable one.
+
+The reference mirrors the Rust fixture exactly (``SyntheticBuilder::genomic``):
+256 bases of ``ACGT`` padding on each side of the core, so core position ``n``
+sits at 1-based HGVS ``256 + n`` and the normalizer's lookahead window stays in
+bounds.
+"""
+
+import json
+from pathlib import Path
+
+import ferro_hgvs
+
+PAD = "ACGT" * 64  # 256 bp, matching SyntheticBuilder's PAD_OFFSET
+CORE = "CAGCTAGCTGATATATATATGCGCGCGCGC"  # core 11..=20 is an (AT) tandem repeat
+CONTIG = "NC_TEST.1"
+
+# A repeat expansion over core 11..=14 followed by a deletion over core 14..=20.
+# Both members claim core position 14, so the allele's members overlap and it has
+# no single resulting sequence. This is the input from the issue.
+OVERLAPPING_ALLELE = "NC_TEST.1:g.[267_270AT[4];270_276del]"
+
+# A substitution at core position 1 — a different locus entirely.
+ELSEWHERE = "NC_TEST.1:g.257C>A"
+
+
+def _checker(tmp_path: Path) -> "ferro_hgvs.EquivalenceChecker":
+    """Build a checker over the synthetic reference, written under ``tmp_path``."""
+    reference = {"transcripts": [], "genomic_sequences": {CONTIG: PAD + CORE + PAD}}
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(reference))
+    return ferro_hgvs.EquivalenceChecker(reference_json=str(path))
+
+
+def test_overlapping_cis_allele_returns_a_verdict(tmp_path):
+    """The reported crash: a verdict comes back instead of a ``PanicException``.
+
+    Reaching the assertions at all is half the test — a panic would abort the
+    call rather than return.
+    """
+    checker = _checker(tmp_path)
+    result = checker.check(ferro_hgvs.parse(OVERLAPPING_ALLELE), ferro_hgvs.parse(ELSEWHERE))
+
+    # The two describe different loci, so NotEquivalent is the honest answer.
+    assert result.level == ferro_hgvs.EquivalenceLevel.NotEquivalent
+    assert not result.level.is_equivalent()
+
+
+def test_overlapping_cis_allele_verdict_is_symmetric(tmp_path):
+    """Argument order must not decide whether the splice is reached."""
+    checker = _checker(tmp_path)
+    result = checker.check(ferro_hgvs.parse(ELSEWHERE), ferro_hgvs.parse(OVERLAPPING_ALLELE))
+
+    assert result.level == ferro_hgvs.EquivalenceLevel.NotEquivalent
+
+
+def test_all_equivalent_also_returns_a_verdict(tmp_path):
+    """The sibling surface: ``all_equivalent`` is the other door into the crash.
+
+    It is a thin loop over the same comparison, so it raised the same
+    ``PanicException`` before the fix — and unlike ``check`` it had no Python
+    coverage at all, so nothing would have caught a regression that reopened
+    only this door.
+    """
+    checker = _checker(tmp_path)
+    variants = [ferro_hgvs.parse(OVERLAPPING_ALLELE), ferro_hgvs.parse(ELSEWHERE)]
+
+    # Different loci, so the honest answer is False — the point is that one
+    # comes back rather than the call aborting.
+    assert checker.all_equivalent(variants) is False


### PR DESCRIPTION
Closes #1244.

## The defect

`same_resulting_sequence` rebuilds each variant's edited window by splicing its SPDI triples into a copy of the reference. `apply_triples` applies them in **descending** position order, which is what lets it validate each stated deletion against the pristine reference — every already-applied splice sits strictly 3' of the next one, so the span about to be read is untouched.

That argument holds only while the triples are disjoint. The bounds check compared against `ref_bytes.len()`, the *original* window length, while splicing into `bytes`, whose length shrinks as deletions are applied. Two overlapping triples therefore let a range pass the check and then index past the end of the mutated buffer:

```
window          10 bases
triple applied   rel 5..10, insertion ""   -> bytes.len() becomes 5
triple next      rel 0..8                  -> 8 <= ref_bytes.len() (10), passes
                                             bytes.splice(0..8, ..) on len 5 -> PANIC
```

A cis allele of a repeat expansion immediately followed by an adjacent deletion produces exactly that shape: `g.[11_14AT[4];14_20del]` has two members both claiming position 14.

## Why a panic is worse than a wrong answer

`check` is the documented fallback when normalized strings differ, and it returns `Result<_, FerroError>` — callers reasonably handle failure by matching the error. A panic bypasses that contract entirely, and through the Python bindings it surfaces as `pyo3_runtime.PanicException`, which subclasses `BaseException` and so escapes `except Exception`. The issue reports 544 of 913 pairs crashing on one real reference.

## The fix

Decline overlapping triples instead of splicing them. That is also the semantically honest answer: an allele whose members claim the same reference base has no single well-defined resulting sequence, so there is nothing to compare. The caller uses this comparison **only to upgrade** a `NotEquivalent` verdict, so a decline can never invent an equivalence — it just leaves the verdict where it was.

Two details worth reviewing:

- The guard compares each triple against the **running furthest reach**, not its immediate predecessor. Adjacent-pair checking is incomplete — one long triple can span several shorter ones that do not touch each other — and the running maximum closes that.
- **Abutting is not overlapping.** A triple ending exactly where the next begins is disjoint, and so is any number of pure insertions at one interbase position, since an insertion deletes nothing and therefore claims no base. Both are pinned by tests, because an over-eager guard would silently downgrade working `SequenceMatch` results to `NotEquivalent`.

The splice bound now also checks the mutated buffer. The disjointness guard makes that redundant today; it is kept so a future change cannot turn a logic slip back into an out-of-bounds panic, and it is commented as such.

## Scope

`apply_triples` has exactly one caller (`same_resulting_sequence`, both arguments), so the blast radius is that one rung. Verified by grep rather than assumed.

## Verification

| gate | result |
| --- | --- |
| conformance axes (`FERRO_MANIFEST`) | **170/170**, zero hard-FAIL rows |
| mock suite | **8792/8792** |
| clippy `--all-features --all-targets -D warnings` | clean |
| `cargo fmt --all` | clean |

New tests in `tests/it/issue_1244_equivalence_overlap_panic.rs`. Two reproduce the crash (both argument orders) and failed before the change with the reported out-of-bounds panic. **Four passed before and after** and are the real safety net, since the risk in this change is declining too much:

- a disjoint cis allele still reaches the `SequenceMatch` rung (#1158's case A);
- members that merely abut stay comparable;
- an overlapping allele compared with itself is settled by the string rung before any reconstruction;
- normalizing the same overlapping allele does not panic either.

## Not fixed here

The verdict for an overlapping allele is now `NotEquivalent` rather than a crash. That is the correct conservative answer for an input whose resulting sequence is undefined, but it is not a claim that such alleles are handled *well* — an allele with overlapping members is malformed, and stopping the normalizer from emitting one is #1234's job (PR #1236).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping genetic edits from causing crashes during equivalence checks and normalization.
  * Added safeguards for invalid edit ranges and correctly distinguishes overlapping, disjoint, and adjacent edits.
  * Preserved reliable results for equivalent comparisons and comparisons involving different loci.
  * Ensured valid insertion-only edits continue to be recognized correctly, including repeated and adjacent insertions.

* **Tests**
  * Added regression coverage for overlapping, disjoint, adjacent, insertion-only, and self-comparison scenarios.
  * Verified that normalization succeeds consistently and remains idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->