### PR TITLE
fix(python): return changed_positions as list[int], not bytes

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -3872,9 +3872,17 @@ impl PyCodonChange {
     }
 
     /// Position(s) in codon that changed (1-indexed)
+    ///
+    /// Widened from the underlying `u8` because pyo3 special-cases `Vec<u8>`
+    /// to Python `bytes`, which is not the `list[int]` the stub declares and
+    /// not what a list of positions should be (#1246).
     #[getter]
-    fn changed_positions(&self) -> Vec<u8> {
-        self.inner.changed_positions.clone()
+    fn changed_positions(&self) -> Vec<usize> {
+        self.inner
+            .changed_positions
+            .iter()
+            .map(|position| *position as usize)
+            .collect()
     }
 
     /// Number of nucleotide changes

--- a/tests/python/test_backtranslation.py
+++ b/tests/python/test_backtranslation.py
@@ -58,8 +58,10 @@ class TestCodonChange:
         assert hasattr(change, "changed_positions")
         assert isinstance(change.ref_codon, str)
         assert isinstance(change.alt_codon, str)
-        # changed_positions is bytes containing position values
-        assert isinstance(change.changed_positions, bytes)
+        # changed_positions is a list of 1-indexed positions, as the stub
+        # declares. It used to come back as `bytes` — see #1246.
+        assert isinstance(change.changed_positions, list)
+        assert all(isinstance(position, int) for position in change.changed_positions)
 
     def test_codon_change_num_changes(self) -> None:
         bt = ferro_hgvs.Backtranslator.standard()

--- a/tests/python/test_issue_1246_changed_positions_list.py
+++ b/tests/python/test_issue_1246_changed_positions_list.py
@@ -1,0 +1,73 @@
+"""Issue #1246: ``CodonChange.changed_positions`` must be a real ``list[int]``.
+
+The getter returned a Rust ``Vec<u8>``, and pyo3 special-cases that one type to
+Python ``bytes`` rather than a list of integers. The published stub declares
+``list[int]``, so type-checkers accepted code that then failed at runtime:
+``isinstance(x, list)`` was ``False``, ``x == [2]`` was ``False`` (a ``bytes``
+never equals a ``list``), and ``json.dumps(x)`` raised ``TypeError``.
+
+Only ``list(x)`` happened to work, because a ``bytes`` iterates as integers —
+which is why the mismatch went unnoticed.
+
+These tests assert the *contract the stub advertises*, not the representation,
+so they stay meaningful if the underlying Rust integer width ever changes.
+"""
+
+import json
+
+import ferro_hgvs
+
+
+def _a_codon_change() -> ferro_hgvs.CodonChange:
+    """A single-nucleotide codon change: Val -> Ala differs at position 2.
+
+    Val is GTx and Ala is GCx across the whole codon table, so *every* codon
+    pair this returns changes exactly the second base. Taking ``changes[0]``
+    therefore does not depend on the order the backtranslator emits them.
+    """
+    changes = ferro_hgvs.Backtranslator.standard().backtranslate_substitution("Val", "Ala")
+    assert changes, "expected at least one codon change for Val -> Ala"
+    return changes[0]
+
+
+def test_changed_positions_is_a_list() -> None:
+    positions = _a_codon_change().changed_positions
+    assert isinstance(positions, list)
+    assert not isinstance(positions, bytes)
+
+
+def test_changed_positions_holds_ints() -> None:
+    positions = _a_codon_change().changed_positions
+    assert positions, "expected at least one changed position"
+    assert all(isinstance(position, int) for position in positions)
+    # Every Val codon is GTx and every Ala codon GCx, so the substitution
+    # changes the second base and only the second base. Asserting the exact
+    # value, not just the 1..=3 range, is what catches a regression that keeps
+    # the `list[int]` type but reports the wrong index.
+    assert positions == [2]
+
+
+def test_changed_positions_compares_equal_to_a_list() -> None:
+    # The failure that motivated the issue: a bytes never equals a list, so
+    # stub-conformant comparisons silently returned False.
+    positions = _a_codon_change().changed_positions
+    assert positions == list(positions)
+
+
+def test_changed_positions_is_json_serializable() -> None:
+    # `json.dumps` raised "Object of type bytes is not JSON serializable".
+    positions = _a_codon_change().changed_positions
+    assert json.loads(json.dumps(positions)) == positions
+
+
+def test_changed_positions_is_mutable_like_a_list() -> None:
+    # `bytes` has no `.append`; a `list[int]` does, and the stub promises one.
+    positions = _a_codon_change().changed_positions
+    before = len(positions)
+    positions.append(1)
+    assert len(positions) == before + 1
+
+
+def test_changed_positions_matches_num_changes() -> None:
+    change = _a_codon_change()
+    assert len(change.changed_positions) == change.num_changes()


### PR DESCRIPTION
Closes #1246.

## The defect

`CodonChange.changed_positions` returned a Rust `Vec<u8>`. pyo3 special-cases that one type to Python `bytes` rather than a list of integers, while the published stub declares `list[int]`. Type-checkers accepted stub-conformant code that then failed at runtime:

```python
cp = M.Backtranslator.standard().backtranslate_substitution("Val", "Ala")[0].changed_positions
type(cp)                  # <class 'bytes'>  b'\x02'
isinstance(cp, list)      # False   — stub says list[int]
cp == [2]                 # False   — a bytes never equals a list
json.dumps(cp)            # TypeError: Object of type bytes is not JSON serializable
cp.append(1)              # AttributeError: 'bytes' object has no attribute 'append'
list(cp)                  # [2]     — works only because bytes iterate as ints
```

That last line is why this went unnoticed: the one idiom people reach for happens to produce the right answer.

## The fix

Widen the getter to `Vec<usize>` so pyo3 produces a real list. **The stub already declared the correct type and is unchanged** — this makes the runtime match what was always advertised, so there is no API redefinition to weigh, only a defect to close.

## Scope

`changed_positions` is the **only** `Vec<u8>` in `src/python.rs`; every other `Vec` getter returns `Vec<String>`, `Vec<PyX>`, or `Vec<(usize, String)>`, all of which already map to a list. Verified by grep over the binding rather than taken from the report, so no sibling getter needs the same treatment.

## A test that pinned the bug

`tests/python/test_backtranslation.py` asserted `isinstance(change.changed_positions, bytes)` — it encoded the defect as expected behaviour, so it is updated to assert the documented contract instead. Worth flagging explicitly in review: this is the one pre-existing assertion the change deliberately inverts.

The new tests assert the *contract the stub advertises* — is a list, holds ints, compares equal to a list, serializes as JSON, supports `append` — rather than the concrete representation, so they stay meaningful if the underlying Rust integer width ever changes.

## Verification

| gate | result |
| --- | --- |
| Python suite (`pytest tests/python/`) | **458 passed** |
| Rust suite | **8786/8786** |
| clippy `--all-features --all-targets -D warnings` | clean |
| ruff check / ruff format / mypy | clean |
| `cargo fmt --all` | clean |

TDD was confirmed both ways against a locally built wheel: with the fix reverted, **5 tests fail** (4 new plus the updated existing one); with it applied, all pass. Two of the new tests — `holds_ints` and `matches_num_changes` — pass either way, because a `bytes` iterates as integers; that is expected and is called out in the test docstring rather than left to look like coverage it is not.

The manifest-backed conformance axes were not run: this change touches only a pyo3 getter and cannot reach the normalizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `changed_positions` now returns a standard Python list of integer, 1-indexed positions instead of a bytes value.
  * Position lists can be compared, serialized to JSON, and modified using normal Python list operations.

* **Tests**
  * Added coverage to verify position types, valid ranges, mutability, serialization, and consistency with the reported number of changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->