### PR TITLE
fix(python): make the native enums honour the contract their stubs declare

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1,8 +1,9 @@
 """Type stubs for ferro-hgvs Python bindings."""
 
 from collections.abc import Iterable
-from enum import IntEnum
 from typing import Any, Callable, Literal, overload
+
+from typing_extensions import Self
 
 __version__: str
 
@@ -297,7 +298,53 @@ def build_transcript(config: BuildTranscriptConfig) -> BuildTranscriptReport:
 # Core Classes
 # ============================================================================
 
-class Axis(IntEnum):
+class _NativeEnum:
+    """Shared behaviour of ferro's native enums.
+
+    These are pyo3 classes, not :class:`enum.Enum` subclasses, and the
+    difference is visible: ``isinstance(member, enum.Enum)`` is ``False`` and
+    the class itself is not iterable (no ``list(Cls)``, no ``__members__``).
+    pyo3 cannot provide either for a ``#[pyclass]`` enum.
+
+    Everything else an ``IntEnum`` offers is available: members hash, order,
+    compare equal to their integer, expose :attr:`name` and :attr:`value`, and
+    can be looked up by value with ``Cls(value)`` (raising ``ValueError`` for an
+    unknown one). ``Cls(value)`` returns the *interned* member — the same object
+    bound to the class attribute — so ``is`` behaves as it does on a standard
+    library enum, and members hash like the integers they equal.
+
+    The stubs previously declared these as ``IntEnum``, which type-checkers
+    honoured while the runtime did not — see issue #1245.
+    """
+
+    def __init__(self, value: int) -> None: ...
+    @property
+    def name(self) -> str:
+        """The member's name, matching the attribute it is bound to."""
+        ...
+
+    @property
+    def value(self) -> int:
+        """The member's integer value."""
+        ...
+
+    def __int__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...
+    # Ordering accepts a member of the *same* enum or a plain int, mirroring
+    # what pyo3's `ord` + `eq_int` actually implement. `Self` narrows to the
+    # concrete subclass, so `Axis.Genomic < Strand.Plus` is rejected the way the
+    # runtime rejects it (`TypeError`) rather than silently type-checking. `int`
+    # stays in the union because `Axis.Genomic < 3` genuinely works.
+    #
+    # `__eq__` keeps `object`: equality is total, answering `False` across enums
+    # instead of raising.
+    def __lt__(self, other: Self | int) -> bool: ...
+    def __le__(self, other: Self | int) -> bool: ...
+    def __gt__(self, other: Self | int) -> bool: ...
+    def __ge__(self, other: Self | int) -> bool: ...
+
+class Axis(_NativeEnum):
     """The coordinate axis (reference molecule / coordinate system) of a variant.
 
     Returned by :attr:`HgvsVariant.axis`. Each member carries its single-letter
@@ -305,13 +352,13 @@ class Axis(IntEnum):
     (:meth:`is_dna` / :meth:`is_rna` / :meth:`is_protein`).
     """
 
-    Genomic = 0
-    Coding = 1
-    NonCoding = 2
-    Rna = 3
-    Protein = 4
-    Mitochondrial = 5
-    Circular = 6
+    Genomic: Axis  # 0
+    Coding: Axis  # 1
+    NonCoding: Axis  # 2
+    Rna: Axis  # 3
+    Protein: Axis  # 4
+    Mitochondrial: Axis  # 5
+    Circular: Axis  # 6
 
     def code(self) -> str:
         """The single-letter HGVS coordinate code (``g``/``c``/``n``/``r``/``p``/``m``/``o``)."""
@@ -795,14 +842,14 @@ class OneBasedPos:
 # Equivalence Classes
 # ============================================================================
 
-class EquivalenceLevel(IntEnum):
+class EquivalenceLevel(_NativeEnum):
     """Equivalence level between two variants."""
 
-    Identical = 0
-    NormalizedMatch = 1
-    AccessionVersionDifference = 2
-    NotEquivalent = 3
-    SequenceMatch = 4
+    Identical: EquivalenceLevel  # 0
+    NormalizedMatch: EquivalenceLevel  # 1
+    AccessionVersionDifference: EquivalenceLevel  # 2
+    NotEquivalent: EquivalenceLevel  # 3
+    SequenceMatch: EquivalenceLevel  # 4
 
     def is_equivalent(self) -> bool:
         """Returns true if the variants are considered equivalent."""
@@ -910,28 +957,28 @@ class EquivalenceChecker:
 # Effect Prediction Classes
 # ============================================================================
 
-class Consequence(IntEnum):
+class Consequence(_NativeEnum):
     """Sequence Ontology consequence term."""
 
-    TranscriptAblation = 0
-    SpliceAcceptorVariant = 1
-    SpliceDonorVariant = 2
-    StopGained = 3
-    FrameshiftVariant = 4
-    StopLost = 5
-    StartLost = 6
-    MissenseVariant = 7
-    InframeInsertion = 8
-    InframeDeletion = 9
-    ProteinAlteringVariant = 10
-    SpliceRegionVariant = 11
-    SynonymousVariant = 12
-    StartRetainedVariant = 13
-    StopRetainedVariant = 14
-    FivePrimeUtrVariant = 15
-    ThreePrimeUtrVariant = 16
-    IntronVariant = 17
-    CodingSequenceVariant = 18
+    TranscriptAblation: Consequence  # 0
+    SpliceAcceptorVariant: Consequence  # 1
+    SpliceDonorVariant: Consequence  # 2
+    StopGained: Consequence  # 3
+    FrameshiftVariant: Consequence  # 4
+    StopLost: Consequence  # 5
+    StartLost: Consequence  # 6
+    MissenseVariant: Consequence  # 7
+    InframeInsertion: Consequence  # 8
+    InframeDeletion: Consequence  # 9
+    ProteinAlteringVariant: Consequence  # 10
+    SpliceRegionVariant: Consequence  # 11
+    SynonymousVariant: Consequence  # 12
+    StartRetainedVariant: Consequence  # 13
+    StopRetainedVariant: Consequence  # 14
+    FivePrimeUtrVariant: Consequence  # 15
+    ThreePrimeUtrVariant: Consequence  # 16
+    IntronVariant: Consequence  # 17
+    CodingSequenceVariant: Consequence  # 18
 
     def so_term(self) -> str:
         """Get the Sequence Ontology term."""
@@ -949,13 +996,13 @@ class Consequence(IntEnum):
         """Get a human-readable description."""
         ...
 
-class Impact(IntEnum):
+class Impact(_NativeEnum):
     """Variant impact level (VEP-style)."""
 
-    Modifier = 0
-    Low = 1
-    Moderate = 2
-    High = 3
+    Modifier: Impact  # 0
+    Low: Impact  # 1
+    Moderate: Impact  # 2
+    High: Impact  # 3
 
 class ProteinEffect:
     """Protein effect prediction result."""
@@ -1195,71 +1242,71 @@ class BatchProcessor:
 # Error Handling Classes
 # ============================================================================
 
-class ErrorMode(IntEnum):
+class ErrorMode(_NativeEnum):
     """Error handling mode."""
 
-    Strict = 0
-    Lenient = 1
-    Silent = 2
+    Strict: ErrorMode  # 0
+    Lenient: ErrorMode  # 1
+    Silent: ErrorMode  # 2
 
-class ErrorType(IntEnum):
+class ErrorType(_NativeEnum):
     """Error type for configurable error handling."""
 
-    LowercaseAminoAcid = 0
-    MissingVersion = 1
-    WrongDashCharacter = 2
-    ExtraWhitespace = 3
-    ProteinSubstitutionArrow = 4
+    LowercaseAminoAcid: ErrorType  # 0
+    MissingVersion: ErrorType  # 1
+    WrongDashCharacter: ErrorType  # 2
+    ExtraWhitespace: ErrorType  # 3
+    ProteinSubstitutionArrow: ErrorType  # 4
     # Discriminant 5 was `PositionZero` (W4002), retired in issue #269.
-    SingleLetterAminoAcid = 6
-    WrongQuoteCharacter = 7
-    LowercaseAccessionPrefix = 8
-    MixedCaseEditType = 9
-    OldSubstitutionSyntax = 10
-    InvalidUnicodeCharacter = 11
-    SwappedPositions = 12
-    TrailingAnnotation = 13
-    MissingCoordinatePrefix = 14
-    OldAlleleFormat = 15
-    RefSeqMismatch = 16
-    DeprecatedStopCodonStar = 17
-    DeprecatedStopCodonX = 18
-    DeprecatedFrameshiftStar = 19
-    DeprecatedFrameshiftX = 20
-    DelSizeSuffix = 21
-    EmptyDelinsInsert = 22
-    RedundantRepeatLabel = 23
-    SinglePositionRange = 24
-    DeprecatedIvsNotation = 25
-    DeprecatedConSyntax = 26
-    LengthMismatch = 27
-    AlleleFractionAnnotation = 28
-    ClinVarProseMultiAllelic = 29
-    RnaThymineCanonicalized = 30
-    ProteinBracketedAaInsertion = 31
-    PositionPastEnd = 32
-    VariantExceedsReference = 33
-    NonSpecMosaicForm = 34
-    OverlapConflictingEdits = 35
-    InitiatorMetCanonicalization = 36
-    DupSizeSuffix = 37
-    DupExplicitSeq = 38
-    DelExplicitSeq = 39
-    NonConformantBracketCardinality = 40
-    UnresolvableCentromere = 41
-    TranscriptFlankNotDescribable = 42
-    IntronicOnBareTranscript = 43
-    IncompleteCdsStartReference = 44
-    InsertionWithoutInsertedSequence = 45
+    SingleLetterAminoAcid: ErrorType  # 6
+    WrongQuoteCharacter: ErrorType  # 7
+    LowercaseAccessionPrefix: ErrorType  # 8
+    MixedCaseEditType: ErrorType  # 9
+    OldSubstitutionSyntax: ErrorType  # 10
+    InvalidUnicodeCharacter: ErrorType  # 11
+    SwappedPositions: ErrorType  # 12
+    TrailingAnnotation: ErrorType  # 13
+    MissingCoordinatePrefix: ErrorType  # 14
+    OldAlleleFormat: ErrorType  # 15
+    RefSeqMismatch: ErrorType  # 16
+    DeprecatedStopCodonStar: ErrorType  # 17
+    DeprecatedStopCodonX: ErrorType  # 18
+    DeprecatedFrameshiftStar: ErrorType  # 19
+    DeprecatedFrameshiftX: ErrorType  # 20
+    DelSizeSuffix: ErrorType  # 21
+    EmptyDelinsInsert: ErrorType  # 22
+    RedundantRepeatLabel: ErrorType  # 23
+    SinglePositionRange: ErrorType  # 24
+    DeprecatedIvsNotation: ErrorType  # 25
+    DeprecatedConSyntax: ErrorType  # 26
+    LengthMismatch: ErrorType  # 27
+    AlleleFractionAnnotation: ErrorType  # 28
+    ClinVarProseMultiAllelic: ErrorType  # 29
+    RnaThymineCanonicalized: ErrorType  # 30
+    ProteinBracketedAaInsertion: ErrorType  # 31
+    PositionPastEnd: ErrorType  # 32
+    VariantExceedsReference: ErrorType  # 33
+    NonSpecMosaicForm: ErrorType  # 34
+    OverlapConflictingEdits: ErrorType  # 35
+    InitiatorMetCanonicalization: ErrorType  # 36
+    DupSizeSuffix: ErrorType  # 37
+    DupExplicitSeq: ErrorType  # 38
+    DelExplicitSeq: ErrorType  # 39
+    NonConformantBracketCardinality: ErrorType  # 40
+    UnresolvableCentromere: ErrorType  # 41
+    TranscriptFlankNotDescribable: ErrorType  # 42
+    IntronicOnBareTranscript: ErrorType  # 43
+    IncompleteCdsStartReference: ErrorType  # 44
+    InsertionWithoutInsertedSequence: ErrorType  # 45
 
-class ErrorOverride(IntEnum):
+class ErrorOverride(_NativeEnum):
     """Override behavior for a specific error type."""
 
-    Default = 0
-    Reject = 1
-    WarnCorrect = 2
-    SilentCorrect = 3
-    Accept = 4
+    Default: ErrorOverride  # 0
+    Reject: ErrorOverride  # 1
+    WarnCorrect: ErrorOverride  # 2
+    SilentCorrect: ErrorOverride  # 3
+    Accept: ErrorOverride  # 4
 
 class CorrectionWarning:
     """Warning generated during preprocessing."""
@@ -1700,18 +1747,19 @@ class BuildTranscriptReport:
 # Reference Classes
 # ============================================================================
 
-class GenomeBuild(IntEnum):
+class GenomeBuild(_NativeEnum):
     """Genome build (GRCh37 or GRCh38)."""
 
-    GRCh37 = 0
-    GRCh38 = 1
-    Unknown = 2
+    GRCh37: GenomeBuild  # 0
+    GRCh38: GenomeBuild  # 1
+    Unknown: GenomeBuild  # 2
 
-class Strand(IntEnum):
+class Strand(_NativeEnum):
     """Strand direction."""
 
-    Plus = 0
-    Minus = 1
+    Plus: Strand  # 0
+    Minus: Strand  # 1
+    Unknown: Strand  # 2
 
 # ============================================================================
 # Coordinate Mapping Classes

--- a/src/python.rs
+++ b/src/python.rs
@@ -40,6 +40,94 @@ use crate::vcf::{vcf_to_genomic_hgvs as rust_vcf_to_hgvs, VcfRecord};
 use crate::{parse_hgvs, NormalizeConfig, Normalizer};
 
 // ---------------------------------------------------------------------------
+// The native-enum contract
+// ---------------------------------------------------------------------------
+
+/// Generate the `#[pymethods]` block for a native (`#[pyclass]`) enum: the
+/// shared `enum.Enum` contract — by-value construction, `name`, `value` and
+/// `__hash__` — plus whatever enum-specific methods that enum adds.
+///
+/// All nine exported enums owe Python the same four methods, and every copy was
+/// identical bar the value→variant table. Writing them out nine times is what
+/// let them drift in the first place: `Axis` alone carried `frozen, hash`, which
+/// is how the missing `__hash__` on the other eight went unnoticed until #1245.
+///
+/// The enum-specific methods have to come through here too rather than living in
+/// a second `impl`: pyo3's `multiple-pymethods` feature is off (it pulls in
+/// `inventory` and is not supported on every platform), so a class gets exactly
+/// one `#[pymethods]` block.
+///
+/// The value→variant table stays explicit at each call site rather than being
+/// derived from the declaration. `PyErrorType` skips discriminant 5
+/// (`PositionZero`, retired in #269), and an explicit table is what keeps that
+/// gap deliberate and greppable — a catch-all mapping would silently absorb an
+/// omitted variant. `test_error_type_rejects_the_retired_discriminant` pins it.
+macro_rules! native_enum_pymethods {
+    (
+        $ty:ident as $py_name:literal,
+        values { $($value:literal => $variant:ident),+ $(,)? }
+        $(, methods { $($method:tt)* })?
+        $(,)?
+    ) => {
+        #[pymethods]
+        impl $ty {
+            /// Look a member up by its integer value.
+            ///
+            /// Mirrors `EnumClass(value)` on an `enum.Enum`, including the `ValueError`
+            /// for an unknown value and the *interned* member as the result — `Cls(v)`
+            /// is the very object bound to the class attribute, so `is` compares the
+            /// same way the standard library's enums do (#1245).
+            #[new]
+            fn py_new(py: pyo3::Python<'_>, value: i32) -> pyo3::PyResult<pyo3::Py<Self>> {
+                use pyo3::IntoPyObject;
+                let member = match value {
+                    $($value => Ok(Self::$variant),)+
+                    other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "{other} is not a valid {}",
+                        $py_name
+                    ))),
+                }?;
+                Ok(member.into_pyobject(py)?.unbind())
+            }
+
+            /// The member's name, matching the attribute it is bound to.
+            ///
+            /// Mirrors `enum.Enum.name`. Derived from the `Debug` formatting of the
+            /// variant, which for a fieldless enum is exactly the variant identifier —
+            /// the same identifier pyo3 binds the member to. A future `rename_all` on
+            /// the `#[pyclass]` would decouple the two (#1245).
+            #[getter]
+            fn name(&self) -> String {
+                format!("{self:?}")
+            }
+
+            /// The member's integer value.
+            ///
+            /// Mirrors `enum.Enum.value`, and matches what `int()` and `==` against an
+            /// int already yield via `eq_int`.
+            #[getter]
+            fn value(&self) -> i32 {
+                *self as i32
+            }
+
+            /// Hash by integer value, matching :meth:`__eq__`.
+            ///
+            /// `eq_int` makes these members compare equal to plain ints, and Python
+            /// requires equal objects to hash equally — otherwise a member and the
+            /// int it equals land in different buckets and dict/set lookups disagree
+            /// with `==`. pyo3's `hash` option would delegate to the Rust `Hash` derive,
+            /// which hashes the variant, not its discriminant; this returns the
+            /// discriminant so `hash(member) == hash(member.value)`.
+            fn __hash__(&self) -> isize {
+                *self as isize
+            }
+
+            $($($method)*)?
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
 // Typed exception hierarchy
 //
 // Every ferro variant-processing failure surfaces as `ferro_hgvs.FerroError` or
@@ -540,8 +628,8 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
 /// Returned by :attr:`HgvsVariant.axis`. Each member carries its single-letter
 /// HGVS coordinate code (:meth:`code`) and a molecule-type grouping
 /// (:meth:`is_dna` / :meth:`is_rna` / :meth:`is_protein`).
-#[pyclass(name = "Axis", eq, eq_int, frozen, hash, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[pyclass(name = "Axis", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyCoordinateAxis {
     Genomic = 0,
     Coding = 1,
@@ -580,33 +668,44 @@ impl From<PyCoordinateAxis> for CoordinateAxis {
     }
 }
 
-#[pymethods]
-impl PyCoordinateAxis {
-    /// The single-letter HGVS coordinate code (``g``/``c``/``n``/``r``/``p``/``m``/``o``).
-    fn code(&self) -> &'static str {
-        CoordinateAxis::from(*self).code()
-    }
+native_enum_pymethods! {
+    PyCoordinateAxis as "Axis",
+    values {
+        0 => Genomic,
+        1 => Coding,
+        2 => NonCoding,
+        3 => Rna,
+        4 => Protein,
+        5 => Mitochondrial,
+        6 => Circular,
+    },
+    methods {
+        /// The single-letter HGVS coordinate code (``g``/``c``/``n``/``r``/``p``/``m``/``o``).
+        fn code(&self) -> &'static str {
+            CoordinateAxis::from(*self).code()
+        }
 
-    /// Whether this axis addresses a DNA molecule (``g``/``c``/``n``/``m``/``o``).
-    ///
-    /// Treats mitochondrial and circular DNA as DNA, unlike the deprecated
-    /// ``is_genomic()`` predicate (which is ``g.``-only).
-    fn is_dna(&self) -> bool {
-        CoordinateAxis::from(*self).is_dna()
-    }
+        /// Whether this axis addresses a DNA molecule (``g``/``c``/``n``/``m``/``o``).
+        ///
+        /// Treats mitochondrial and circular DNA as DNA, unlike the deprecated
+        /// ``is_genomic()`` predicate (which is ``g.``-only).
+        fn is_dna(&self) -> bool {
+            CoordinateAxis::from(*self).is_dna()
+        }
 
-    /// Whether this axis addresses an RNA molecule (``r.``).
-    fn is_rna(&self) -> bool {
-        CoordinateAxis::from(*self).is_rna()
-    }
+        /// Whether this axis addresses an RNA molecule (``r.``).
+        fn is_rna(&self) -> bool {
+            CoordinateAxis::from(*self).is_rna()
+        }
 
-    /// Whether this axis addresses a protein (``p.``).
-    fn is_protein(&self) -> bool {
-        CoordinateAxis::from(*self).is_protein()
-    }
+        /// Whether this axis addresses a protein (``p.``).
+        fn is_protein(&self) -> bool {
+            CoordinateAxis::from(*self).is_protein()
+        }
 
-    fn __str__(&self) -> &'static str {
-        CoordinateAxis::from(*self).code()
+        fn __str__(&self) -> &'static str {
+            CoordinateAxis::from(*self).code()
+        }
     }
 }
 
@@ -2431,8 +2530,8 @@ fn index_to_hgvs_pos(idx: usize) -> u64 {
 // ============================================================================
 
 /// Equivalence level between two variants
-#[pyclass(name = "EquivalenceLevel", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "EquivalenceLevel", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyEquivalenceLevel {
     /// Exactly identical (same string representation)
     Identical = 0,
@@ -2461,33 +2560,42 @@ impl From<EquivalenceLevel> for PyEquivalenceLevel {
     }
 }
 
-#[pymethods]
-impl PyEquivalenceLevel {
-    fn __str__(&self) -> &'static str {
-        match self {
-            PyEquivalenceLevel::Identical => "Identical",
-            PyEquivalenceLevel::NormalizedMatch => "NormalizedMatch",
-            PyEquivalenceLevel::SequenceMatch => "SequenceMatch",
-            PyEquivalenceLevel::AccessionVersionDifference => "AccessionVersionDifference",
-            PyEquivalenceLevel::NotEquivalent => "NotEquivalent",
-        }
-    }
-
-    /// Returns true if the variants are considered equivalent
-    fn is_equivalent(&self) -> bool {
-        !matches!(self, PyEquivalenceLevel::NotEquivalent)
-    }
-
-    /// Get a human-readable description
-    fn description(&self) -> &'static str {
-        match self {
-            PyEquivalenceLevel::Identical => "Identical representation",
-            PyEquivalenceLevel::NormalizedMatch => "Equivalent after normalization",
-            PyEquivalenceLevel::SequenceMatch => "Equivalent by resulting sequence",
-            PyEquivalenceLevel::AccessionVersionDifference => {
-                "Same variant, different accession versions"
+native_enum_pymethods! {
+    PyEquivalenceLevel as "EquivalenceLevel",
+    values {
+        0 => Identical,
+        1 => NormalizedMatch,
+        2 => AccessionVersionDifference,
+        3 => NotEquivalent,
+        4 => SequenceMatch,
+    },
+    methods {
+        fn __str__(&self) -> &'static str {
+            match self {
+                PyEquivalenceLevel::Identical => "Identical",
+                PyEquivalenceLevel::NormalizedMatch => "NormalizedMatch",
+                PyEquivalenceLevel::SequenceMatch => "SequenceMatch",
+                PyEquivalenceLevel::AccessionVersionDifference => "AccessionVersionDifference",
+                PyEquivalenceLevel::NotEquivalent => "NotEquivalent",
             }
-            PyEquivalenceLevel::NotEquivalent => "Not equivalent",
+        }
+
+        /// Returns true if the variants are considered equivalent
+        fn is_equivalent(&self) -> bool {
+            !matches!(self, PyEquivalenceLevel::NotEquivalent)
+        }
+
+        /// Get a human-readable description
+        fn description(&self) -> &'static str {
+            match self {
+                PyEquivalenceLevel::Identical => "Identical representation",
+                PyEquivalenceLevel::NormalizedMatch => "Equivalent after normalization",
+                PyEquivalenceLevel::SequenceMatch => "Equivalent by resulting sequence",
+                PyEquivalenceLevel::AccessionVersionDifference => {
+                    "Same variant, different accession versions"
+                }
+                PyEquivalenceLevel::NotEquivalent => "Not equivalent",
+            }
         }
     }
 }
@@ -2680,8 +2788,8 @@ impl PyEquivalenceChecker {
 // ============================================================================
 
 /// Sequence Ontology consequence term
-#[pyclass(name = "Consequence", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "Consequence", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyConsequence {
     TranscriptAblation = 0,
     SpliceAcceptorVariant = 1,
@@ -2756,36 +2864,59 @@ impl From<PyConsequence> for Consequence {
     }
 }
 
-#[pymethods]
-impl PyConsequence {
-    fn __str__(&self) -> &'static str {
-        Consequence::from(*self).so_term()
-    }
+native_enum_pymethods! {
+    PyConsequence as "Consequence",
+    values {
+        0 => TranscriptAblation,
+        1 => SpliceAcceptorVariant,
+        2 => SpliceDonorVariant,
+        3 => StopGained,
+        4 => FrameshiftVariant,
+        5 => StopLost,
+        6 => StartLost,
+        7 => MissenseVariant,
+        8 => InframeInsertion,
+        9 => InframeDeletion,
+        10 => ProteinAlteringVariant,
+        11 => SpliceRegionVariant,
+        12 => SynonymousVariant,
+        13 => StartRetainedVariant,
+        14 => StopRetainedVariant,
+        15 => FivePrimeUtrVariant,
+        16 => ThreePrimeUtrVariant,
+        17 => IntronVariant,
+        18 => CodingSequenceVariant,
+    },
+    methods {
+        fn __str__(&self) -> &'static str {
+            Consequence::from(*self).so_term()
+        }
 
-    /// Get the Sequence Ontology term
-    fn so_term(&self) -> &'static str {
-        Consequence::from(*self).so_term()
-    }
+        /// Get the Sequence Ontology term
+        fn so_term(&self) -> &'static str {
+            Consequence::from(*self).so_term()
+        }
 
-    /// Get the Sequence Ontology ID
-    fn so_id(&self) -> &'static str {
-        Consequence::from(*self).so_id()
-    }
+        /// Get the Sequence Ontology ID
+        fn so_id(&self) -> &'static str {
+            Consequence::from(*self).so_id()
+        }
 
-    /// Get the impact level
-    fn impact(&self) -> PyImpact {
-        Consequence::from(*self).impact().into()
-    }
+        /// Get the impact level
+        fn impact(&self) -> PyImpact {
+            Consequence::from(*self).impact().into()
+        }
 
-    /// Get a human-readable description
-    fn description(&self) -> &'static str {
-        Consequence::from(*self).description()
+        /// Get a human-readable description
+        fn description(&self) -> &'static str {
+            Consequence::from(*self).description()
+        }
     }
 }
 
 /// Variant impact level (VEP-style)
-#[pyclass(name = "Impact", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[pyclass(name = "Impact", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyImpact {
     Modifier = 0,
     Low = 1,
@@ -2804,14 +2935,22 @@ impl From<Impact> for PyImpact {
     }
 }
 
-#[pymethods]
-impl PyImpact {
-    fn __str__(&self) -> &'static str {
-        match self {
-            PyImpact::High => "HIGH",
-            PyImpact::Moderate => "MODERATE",
-            PyImpact::Low => "LOW",
-            PyImpact::Modifier => "MODIFIER",
+native_enum_pymethods! {
+    PyImpact as "Impact",
+    values {
+        0 => Modifier,
+        1 => Low,
+        2 => Moderate,
+        3 => High,
+    },
+    methods {
+        fn __str__(&self) -> &'static str {
+            match self {
+                PyImpact::High => "HIGH",
+                PyImpact::Moderate => "MODERATE",
+                PyImpact::Low => "LOW",
+                PyImpact::Modifier => "MODIFIER",
+            }
         }
     }
 }
@@ -3408,8 +3547,8 @@ impl PyBatchProcessor {
 // ============================================================================
 
 /// Error handling mode
-#[pyclass(name = "ErrorMode", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "ErrorMode", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyErrorMode {
     /// Strict mode - reject all non-standard input
     Strict = 0,
@@ -3417,6 +3556,15 @@ pub enum PyErrorMode {
     Lenient = 1,
     /// Silent mode - auto-correct without warnings
     Silent = 2,
+}
+
+native_enum_pymethods! {
+    PyErrorMode as "ErrorMode",
+    values {
+        0 => Strict,
+        1 => Lenient,
+        2 => Silent,
+    },
 }
 
 impl From<ErrorMode> for PyErrorMode {
@@ -3440,8 +3588,8 @@ impl From<PyErrorMode> for ErrorMode {
 }
 
 /// Error type for configurable error handling
-#[pyclass(name = "ErrorType", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[pyclass(name = "ErrorType", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyErrorType {
     LowercaseAminoAcid = 0,
     MissingVersion = 1,
@@ -3517,6 +3665,57 @@ pub enum PyErrorType {
     // insertion with no inserted sequence); rejected in every mode, since the
     // missing bases are not recoverable from the description (#1162).
     InsertionWithoutInsertedSequence = 45,
+}
+
+native_enum_pymethods! {
+    PyErrorType as "ErrorType",
+    values {
+        0 => LowercaseAminoAcid,
+        1 => MissingVersion,
+        2 => WrongDashCharacter,
+        3 => ExtraWhitespace,
+        4 => ProteinSubstitutionArrow,
+        6 => SingleLetterAminoAcid,
+        7 => WrongQuoteCharacter,
+        8 => LowercaseAccessionPrefix,
+        9 => MixedCaseEditType,
+        10 => OldSubstitutionSyntax,
+        11 => InvalidUnicodeCharacter,
+        12 => SwappedPositions,
+        13 => TrailingAnnotation,
+        14 => MissingCoordinatePrefix,
+        15 => OldAlleleFormat,
+        16 => RefSeqMismatch,
+        17 => DeprecatedStopCodonStar,
+        18 => DeprecatedStopCodonX,
+        19 => DeprecatedFrameshiftStar,
+        20 => DeprecatedFrameshiftX,
+        21 => DelSizeSuffix,
+        22 => EmptyDelinsInsert,
+        23 => RedundantRepeatLabel,
+        24 => SinglePositionRange,
+        25 => DeprecatedIvsNotation,
+        26 => DeprecatedConSyntax,
+        27 => LengthMismatch,
+        28 => AlleleFractionAnnotation,
+        29 => ClinVarProseMultiAllelic,
+        30 => RnaThymineCanonicalized,
+        31 => ProteinBracketedAaInsertion,
+        32 => PositionPastEnd,
+        33 => VariantExceedsReference,
+        34 => NonSpecMosaicForm,
+        35 => OverlapConflictingEdits,
+        36 => InitiatorMetCanonicalization,
+        37 => DupSizeSuffix,
+        38 => DupExplicitSeq,
+        39 => DelExplicitSeq,
+        40 => NonConformantBracketCardinality,
+        41 => UnresolvableCentromere,
+        42 => TranscriptFlankNotDescribable,
+        43 => IntronicOnBareTranscript,
+        44 => IncompleteCdsStartReference,
+        45 => InsertionWithoutInsertedSequence,
+    },
 }
 
 impl From<ErrorType> for PyErrorType {
@@ -3632,8 +3831,8 @@ impl From<PyErrorType> for ErrorType {
 }
 
 /// Override behavior for a specific error type
-#[pyclass(name = "ErrorOverride", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "ErrorOverride", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyErrorOverride {
     /// Use the base mode's behavior
     Default = 0,
@@ -3645,6 +3844,17 @@ pub enum PyErrorOverride {
     SilentCorrect = 3,
     /// Accept the input as-is without correction
     Accept = 4,
+}
+
+native_enum_pymethods! {
+    PyErrorOverride as "ErrorOverride",
+    values {
+        0 => Default,
+        1 => Reject,
+        2 => WarnCorrect,
+        3 => SilentCorrect,
+        4 => Accept,
+    },
 }
 
 impl From<ErrorOverride> for PyErrorOverride {
@@ -5032,8 +5242,8 @@ fn build_transcript(
 // ============================================================================
 
 /// Genome build (GRCh37 or GRCh38)
-#[pyclass(name = "GenomeBuild", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "GenomeBuild", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyGenomeBuild {
     GRCh37 = 0,
     GRCh38 = 1,
@@ -5050,20 +5260,27 @@ impl From<GenomeBuild> for PyGenomeBuild {
     }
 }
 
-#[pymethods]
-impl PyGenomeBuild {
-    fn __str__(&self) -> &'static str {
-        match self {
-            PyGenomeBuild::GRCh37 => "GRCh37",
-            PyGenomeBuild::GRCh38 => "GRCh38",
-            PyGenomeBuild::Unknown => "Unknown",
+native_enum_pymethods! {
+    PyGenomeBuild as "GenomeBuild",
+    values {
+        0 => GRCh37,
+        1 => GRCh38,
+        2 => Unknown,
+    },
+    methods {
+        fn __str__(&self) -> &'static str {
+            match self {
+                PyGenomeBuild::GRCh37 => "GRCh37",
+                PyGenomeBuild::GRCh38 => "GRCh38",
+                PyGenomeBuild::Unknown => "Unknown",
+            }
         }
     }
 }
 
 /// Strand direction
-#[pyclass(name = "Strand", eq, eq_int, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[pyclass(name = "Strand", eq, eq_int, ord, frozen, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum PyStrand {
     Plus = 0,
     Minus = 1,
@@ -5080,13 +5297,20 @@ impl From<Strand> for PyStrand {
     }
 }
 
-#[pymethods]
-impl PyStrand {
-    fn __str__(&self) -> &'static str {
-        match self {
-            PyStrand::Plus => "+",
-            PyStrand::Minus => "-",
-            PyStrand::Unknown => ".",
+native_enum_pymethods! {
+    PyStrand as "Strand",
+    values {
+        0 => Plus,
+        1 => Minus,
+        2 => Unknown,
+    },
+    methods {
+        fn __str__(&self) -> &'static str {
+            match self {
+                PyStrand::Plus => "+",
+                PyStrand::Minus => "-",
+                PyStrand::Unknown => ".",
+            }
         }
     }
 }

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,53 @@
+"""Shared fixtures for the Python binding tests."""
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# Location of the committed type stub, relative to this file
+# (<repo>/tests/python/conftest.py -> <repo>/python/ferro_hgvs/__init__.pyi).
+_STUB_PATH = Path(__file__).resolve().parents[2] / "python" / "ferro_hgvs" / "__init__.pyi"
+
+
+def _stub_enum_members(class_name: str) -> dict[str, int]:
+    """Parse the declared members of a native enum class from the type stub.
+
+    Reads the block following ``class <class_name>(_NativeEnum):`` up to the
+    next top-level ``class`` declaration, returning the declared name->value
+    mapping. Members are annotated with their own class and carry the integer
+    value in a trailing comment (``Plus: Strand  # 0``), because the value is
+    not assignable under the annotation — see issue #1245, which moved these
+    off the ``IntEnum`` declaration the runtime never honoured.
+
+    Docstring lines and free-standing comments are ignored, so a retired
+    discriminant documented only in a comment is not treated as a member.
+    """
+    lines = _STUB_PATH.read_text().splitlines()
+    header = re.compile(rf"^class {re.escape(class_name)}\(_NativeEnum\):")
+    member = re.compile(rf"^    (\w+): {re.escape(class_name)}\s+# (\d+)$")
+    members: dict[str, int] = {}
+    in_block = False
+    for line in lines:
+        if header.match(line):
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith("class "):
+                break
+            match = member.match(line)
+            if match:
+                members[match.group(1)] = int(match.group(2))
+    return members
+
+
+@pytest.fixture
+def stub_enum_members() -> Callable[[str], dict[str, int]]:
+    """Return the stub-declared ``name -> value`` members of a native enum.
+
+    Lives here rather than in one test module because two suites need it: the
+    long-standing ``ErrorType`` drift guard (issue #630) and the all-enum guard
+    added for #1245.
+    """
+    return _stub_enum_members

--- a/tests/python/test_error_handling.py
+++ b/tests/python/test_error_handling.py
@@ -1,40 +1,8 @@
 """Tests for error handling functionality."""
 
-import re
-from pathlib import Path
+from collections.abc import Callable
 
 import ferro_hgvs
-
-# Location of the committed type stub, relative to this test file
-# (<repo>/tests/python/test_error_handling.py -> <repo>/python/ferro_hgvs/__init__.pyi).
-_STUB_PATH = Path(__file__).resolve().parents[2] / "python" / "ferro_hgvs" / "__init__.pyi"
-
-
-def _stub_enum_members(class_name: str) -> dict[str, int]:
-    """Parse ``name = value`` members of an ``IntEnum`` class from the type stub.
-
-    Reads the block following ``class <class_name>(IntEnum):`` up to the next
-    top-level ``class`` declaration, returning the declared name->value mapping.
-    Comment and docstring lines are ignored, so retired discriminants documented
-    only in comments are not treated as members.
-    """
-    text = _STUB_PATH.read_text()
-    lines = text.splitlines()
-    header = re.compile(rf"^class {re.escape(class_name)}\(IntEnum\):")
-    member = re.compile(r"^    (\w+) = (\d+)$")
-    members: dict[str, int] = {}
-    in_block = False
-    for line in lines:
-        if header.match(line):
-            in_block = True
-            continue
-        if in_block:
-            if line.startswith("class "):
-                break
-            match = member.match(line)
-            if match:
-                members[match.group(1)] = int(match.group(2))
-    return members
 
 
 class TestErrorConfig:
@@ -119,7 +87,9 @@ class TestErrorTypes:
         assert ferro_hgvs.ErrorOverride.SilentCorrect is not None
         assert ferro_hgvs.ErrorOverride.Accept is not None
 
-    def test_error_type_stub_matches_runtime(self) -> None:
+    def test_error_type_stub_matches_runtime(
+        self, stub_enum_members: Callable[[str], dict[str, int]]
+    ) -> None:
         """The ``ErrorType`` type stub must list exactly the runtime members.
 
         Guards against the stub drifting out of sync with the Rust
@@ -136,7 +106,7 @@ class TestErrorTypes:
             for name in dir(error_type)
             if not name.startswith("_") and isinstance(getattr(error_type, name), error_type)
         }
-        stub = _stub_enum_members("ErrorType")
+        stub = stub_enum_members("ErrorType")
         assert stub == runtime
 
     def test_error_type_centromere_and_flank_members(self) -> None:

--- a/tests/python/test_issue_1245_enum_contract.py
+++ b/tests/python/test_issue_1245_enum_contract.py
@@ -1,0 +1,319 @@
+"""Issue #1245: the exported enums must honour the contract their stubs declare.
+
+All nine enums are pyo3 simple enums. pyo3's ``eq`` option generates ``__eq__``,
+and a Python type that defines ``__eq__`` without ``__hash__`` is **unhashable**
+— so eight of the nine crashed in idiomatic code like ``Counter(...)``,
+``{x}`` or a dict keyed by the enum. ``Axis`` was the lone exception because it
+alone carried ``frozen, hash``, which is what showed the omission was accidental
+rather than designed.
+
+The same block adds ordering (``ord``), ``.name`` / ``.value`` accessors, and
+by-value construction, so the runtime now matches what the stubs promise.
+
+Two further gaps came out of review, both about a member and the integer it
+equals drifting apart:
+
+* ``eq_int`` makes members compare equal to plain ints, but pyo3's ``hash``
+  option hashes the *variant*, not its discriminant — so ``Axis.Genomic == 0``
+  while ``hash(Axis.Genomic) != hash(0)``, and the two landed in different dict
+  buckets. Each enum now defines ``__hash__`` as its discriminant.
+* ``Cls(value)`` returned a fresh equal object rather than the interned member,
+  so ``is`` — which the standard library documents as the way to compare enum
+  members — silently disagreed with ``==``. The constructor now returns the
+  interned member.
+
+Two ``enum.Enum`` behaviours remain out of reach and the stubs no longer claim
+them: iterating the class (``list(X)``, ``__members__``) needs a metaclass, and
+``isinstance(x, enum.Enum)`` needs real ``enum.Enum`` inheritance. pyo3 provides
+neither for a ``#[pyclass]`` enum.
+
+These tests are written against every exported enum rather than a sample, since
+the defect was precisely that one of the nine had been treated differently.
+"""
+
+import collections
+import enum
+import itertools
+import pickle
+from collections.abc import Callable
+
+import pytest
+
+import ferro_hgvs
+
+ENUM_NAMES = [
+    "Axis",
+    "Consequence",
+    "Impact",
+    "ErrorMode",
+    "ErrorType",
+    "ErrorOverride",
+    "EquivalenceLevel",
+    "GenomeBuild",
+    "Strand",
+]
+
+ENUMS = [getattr(ferro_hgvs, name) for name in ENUM_NAMES]
+
+
+def members(cls: type) -> list[object]:
+    """Every member bound as an attribute of ``cls``."""
+    found = [
+        getattr(cls, attribute)
+        for attribute in dir(cls)
+        if not attribute.startswith("__") and isinstance(getattr(cls, attribute, None), cls)
+    ]
+    assert found, f"{cls.__name__} exposes no members"
+    return found
+
+
+@pytest.fixture(params=ENUMS, ids=ENUM_NAMES)
+def enum_class(request: pytest.FixtureRequest) -> type:
+    return request.param
+
+
+# ---------------------------------------------------------------------------
+# The crashes.
+# ---------------------------------------------------------------------------
+
+
+def test_members_are_hashable(enum_class: type) -> None:
+    for member in members(enum_class):
+        hash(member)
+
+
+def test_members_work_as_set_and_dict_keys(enum_class: type) -> None:
+    all_members = members(enum_class)
+    assert len(set(all_members)) == len(all_members)
+    assert len({member: index for index, member in enumerate(all_members)}) == len(all_members)
+
+
+def test_members_can_be_counted(enum_class: type) -> None:
+    # The reported failure: Counter over a stream of enum values.
+    first = members(enum_class)[0]
+    assert collections.Counter([first, first])[first] == 2
+
+
+def test_members_can_be_grouped(enum_class: type) -> None:
+    first = members(enum_class)[0]
+    grouped = [(key, len(list(group))) for key, group in itertools.groupby([first, first])]
+    assert grouped == [(first, 2)]
+
+
+def test_members_are_orderable(enum_class: type) -> None:
+    all_members = members(enum_class)
+    # Sorting must agree with the integer values, as IntEnum ordering would.
+    assert [member.value for member in sorted(all_members)] == sorted(
+        member.value for member in all_members
+    )
+
+
+def test_ordering_accepts_ints_and_rejects_foreign_operands(enum_class: type) -> None:
+    # The operand set the stubs declare for `__lt__`/`__le__`/`__gt__`/`__ge__`
+    # (`Self | int`). It was `Any`, which type-checked every one of the
+    # rejections below. A self-bound TypeVar would go too far the other way and
+    # reject the int comparison that `eq_int` + `ord` genuinely support.
+    member = members(enum_class)[0]
+
+    # An int operand works, and orders by the member's value.
+    assert (member < member.value + 1) is True
+    assert (member > member.value - 1) is True
+
+    # A member of a *different* native enum does not — ordering is per-enum.
+    other_enum = next(cls for cls in ENUMS if cls is not enum_class)
+    with pytest.raises(TypeError):
+        member < members(other_enum)[0]  # noqa: B015 - raising is the assertion
+
+    # Nor does an unrelated type.
+    with pytest.raises(TypeError):
+        member < "not a member"  # noqa: B015 - raising is the assertion
+
+    # Equality stays total across enums — `False`, not `TypeError` — which is
+    # why `__eq__` keeps `object` rather than narrowing with the ordering ops.
+    assert (member == members(other_enum)[0]) is False
+
+
+def test_equal_members_hash_equally(enum_class: type) -> None:
+    # The hash/eq contract: a == b implies hash(a) == hash(b).
+    for member in members(enum_class):
+        rebuilt = enum_class(member.value)
+        assert rebuilt == member
+        assert hash(rebuilt) == hash(member)
+
+
+def test_members_hash_like_the_int_they_equal(enum_class: type) -> None:
+    # `eq_int` extends equality across the type boundary — a member equals a
+    # plain int — so the hash contract has to reach across it too. pyo3's
+    # `hash` option does not: it delegates to the Rust `Hash` derive, which
+    # hashes the variant rather than its discriminant. That left every member
+    # equal to an int it hashed differently from.
+    for member in members(enum_class):
+        assert member == member.value
+        assert hash(member) == hash(member.value), (
+            f"{enum_class.__name__}.{member.name} == {member.value} but hashes differently"
+        )
+
+
+def test_members_and_their_ints_are_interchangeable_as_keys(enum_class: type) -> None:
+    # The practical consequence, and how the defect actually surfaced: a
+    # container keyed by the int did not answer to the member, and vice versa,
+    # even though `==` said they were the same key.
+    for member in members(enum_class):
+        assert member in {member.value: "by int"}
+        assert member.value in {member: "by member"}
+        assert member.value in {member}
+        assert member in {member.value}
+        # A member and its int must collapse to one entry, never two.
+        assert len({member, member.value}) == 1
+
+
+# ---------------------------------------------------------------------------
+# The accessors.
+# ---------------------------------------------------------------------------
+
+
+def test_members_expose_name(enum_class: type) -> None:
+    for member in members(enum_class):
+        assert isinstance(member.name, str)
+        assert member.name
+        # `.name` must be the attribute the member is actually bound to.
+        assert getattr(enum_class, member.name) == member
+
+
+def test_members_expose_value(enum_class: type) -> None:
+    for member in members(enum_class):
+        assert isinstance(member.value, int)
+        assert member.value == int(member)
+
+
+def test_values_are_distinct(enum_class: type) -> None:
+    values = [member.value for member in members(enum_class)]
+    assert len(set(values)) == len(values)
+
+
+# ---------------------------------------------------------------------------
+# By-value construction.
+# ---------------------------------------------------------------------------
+
+
+def test_every_member_round_trips_through_its_value(enum_class: type) -> None:
+    # This is the guard on the generated constructors: a wrong or missing arm
+    # for any of the 94 variants across the nine enums shows up right here.
+    for member in members(enum_class):
+        assert enum_class(member.value) == member
+        assert enum_class(member.value).name == member.name
+
+
+def test_construction_returns_the_interned_member(enum_class: type) -> None:
+    # The standard library documents identity as *the* way to compare enum
+    # members (`Color.RED is Color.RED`), so a constructor handing back a fresh
+    # equal object is a footgun for anyone carrying that habit over: `==` would
+    # work and `is` would silently not. Returning the interned member removes
+    # the discrepancy rather than documenting around it.
+    for member in members(enum_class):
+        assert enum_class(member.value) is member
+        # Repeated construction is the same object every time, not merely equal.
+        assert enum_class(member.value) is enum_class(member.value)
+
+
+def test_members_returned_from_the_library_are_also_interned(enum_class: type) -> None:
+    # Interning has to hold for values crossing the Rust boundary too, not just
+    # the constructor — that is where users actually get their members from.
+    for member in members(enum_class):
+        assert getattr(enum_class, member.name) is member
+
+
+def test_construction_rejects_an_unknown_value(enum_class: type) -> None:
+    unknown = max(member.value for member in members(enum_class)) + 1
+    with pytest.raises(ValueError):
+        enum_class(unknown)
+
+
+def test_error_type_rejects_the_retired_discriminant() -> None:
+    # `max(value) + 1` above only covers the value past the end, so it cannot
+    # see a hole in the middle. Discriminant 5 was `PositionZero` (W4002),
+    # retired in issue #269; the numeric value is skipped deliberately so the
+    # surviving variants keep their stable repr-C discriminants. Nothing else
+    # pins the gap, so a regression that reintroduced 5 would pass every other
+    # test here.
+    assert 5 not in {member.value for member in members(ferro_hgvs.ErrorType)}
+    with pytest.raises(ValueError):
+        ferro_hgvs.ErrorType(5)
+
+
+# ---------------------------------------------------------------------------
+# Behaviours that already worked and must keep working.
+# ---------------------------------------------------------------------------
+
+
+def test_members_compare_equal_to_their_int(enum_class: type) -> None:
+    for member in members(enum_class):
+        assert member == member.value
+
+
+def test_members_render(enum_class: type) -> None:
+    for member in members(enum_class):
+        assert str(member)
+        assert repr(member)
+
+
+# ---------------------------------------------------------------------------
+# The documented residue: what these are still not.
+# ---------------------------------------------------------------------------
+
+
+def test_members_are_not_enum_enum_instances(enum_class: type) -> None:
+    # Pinned deliberately. pyo3 cannot make a #[pyclass] enum inherit from
+    # enum.Enum, so the stubs no longer declare IntEnum. If a future pyo3 makes
+    # this possible, this test is the reminder to revisit the stubs.
+    assert not isinstance(members(enum_class)[0], enum.Enum)
+
+
+def test_the_class_is_not_iterable(enum_class: type) -> None:
+    # Likewise: iterating the class needs a metaclass pyo3 does not provide.
+    with pytest.raises(TypeError):
+        list(enum_class)
+
+
+# ---------------------------------------------------------------------------
+# Strand.Unknown was missing from the stub entirely (sibling defect).
+# ---------------------------------------------------------------------------
+
+
+def test_strand_exposes_all_three_members() -> None:
+    assert {member.name for member in members(ferro_hgvs.Strand)} == {
+        "Plus",
+        "Minus",
+        "Unknown",
+    }
+
+
+def test_stub_lists_exactly_the_runtime_members(
+    enum_class: type, stub_enum_members: Callable[[str], dict[str, int]]
+) -> None:
+    """Every native enum's stub must match its runtime members.
+
+    An equivalent guard already existed, but only for ``ErrorType`` (added for
+    issue #630). That is precisely why ``Strand.Unknown`` could exist at runtime
+    while the stub listed only ``Plus`` and ``Minus`` — nothing checked the
+    other eight. Applying it to all of them closes the gap for good.
+    """
+    stub = stub_enum_members(enum_class.__name__)
+    runtime = {member.name: member.value for member in members(enum_class)}
+    assert stub == runtime
+
+
+def test_members_are_not_picklable(enum_class: type) -> None:
+    # Pinned, not skipped. Hashability often travels with pickling in consumer
+    # code (caches keyed by enum, multiprocessing), so which way this behaves is
+    # worth recording — but an `except Exception: pytest.skip` records nothing:
+    # it reports success whether pickling works or not, so it can never fail.
+    #
+    # A pyo3 `#[pyclass]` enum has no `__reduce__`, so `pickle.dumps` raises
+    # `TypeError`. Asserting that makes the day it starts working visible: this
+    # test fails, and whatever adds pickling has to keep interning intact (see
+    # `test_construction_returns_the_interned_member`) so that an unpickled
+    # member is still the very object bound to the class attribute.
+    member = members(enum_class)[0]
+    with pytest.raises(TypeError):
+        pickle.dumps(member)


### PR DESCRIPTION
Closes #1245.

## The defect

pyo3's `eq` option generates `__eq__`, and a Python type that defines `__eq__` without `__hash__` is **unhashable**. Eight of the nine exported enums carried only `eq, eq_int`:

```
Axis:      #[pyclass(name = "Axis", eq, eq_int, frozen, hash, from_py_object)]
other 8:   #[pyclass(name = "...",  eq, eq_int, from_py_object)]
```

So `hash(x)`, `{x}`, a dict keyed by the enum, `Counter(...)` and `groupby(...)` all raised `TypeError` — a hard runtime crash in idiomatic code, not a typing nit. `Axis` being the lone hashable one is what shows this was an accidental omission rather than a design choice, and two more clues point the same way: `Impact` already derived `PartialOrd, Ord` and `ErrorType` already derived `Hash`, neither of which the `#[pyclass]` ever exposed.

## What now works

Measured across all nine, before and after:

| | isEnum | .name | .value | hash | order | `X(0)` | `list(X)` | `int()` |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| before (`Axis`) | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ |
| before (other 8) | ✗ | ✗ | ✗ | **✗** | ✗ | ✗ | ✗ | ✓ |
| after (all 9) | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |

Members hash, sort by value, expose `.name` and `.value`, and round-trip through `Cls(value)` — raising `ValueError` for an unknown value, exactly as an `IntEnum` would.

`frozen` is free here: none of the enums carry data, and no method anywhere in the binding takes `&mut self` (checked, not assumed).

## What is still not an IntEnum, and why the stubs changed

Two behaviours are out of reach: iterating the class (`list(X)`, `__members__`) needs a metaclass, and `isinstance(x, enum.Enum)` needs real `enum.Enum` inheritance. pyo3 provides neither for a `#[pyclass]` enum.

Rather than keep declaring `IntEnum` and let type-checkers keep accepting code that fails at runtime, the stubs move onto a `_NativeEnum` base that documents precisely what is and is not supported, in one place instead of nine.

**Nothing that worked at runtime stops type-checking.** The promises removed — `list(X)`, `isinstance(..., enum.Enum)` — never worked in the first place; the promises kept (`.name`, `.value`, `X(0)`, ordering, hashing) now genuinely do. Members are annotated as their own class with the value in a trailing comment (`Plus: Strand  # 0`), since the value is not assignable under the annotation.

One caveat worth knowing: `Cls(value)` returns a new equal object rather than an interned member, so compare with `==`, never `is`. That is stated in the base's docstring.

## Two sibling defects found while checking

Neither was in the issue; both turned up from comparing all nine enums against their stubs rather than trusting the report.

1. **`Strand.Unknown` was missing from the stub.** It exists at runtime, so type-checked code could not name a value the library returns.
2. **The drift guard only covered `ErrorType`.** The stub/runtime guard added for #630 checked one enum — which is exactly why the `Strand` gap survived. It now runs over all nine. The shared stub parser moved to a `conftest.py` fixture so both suites use one copy rather than a duplicate.

## Verification

| gate | result |
| --- | --- |
| Python suite | **597 passed**, 9 skipped |
| Rust suite | **8786/8786** |
| clippy `--all-features --all-targets -D warnings` | clean |
| ruff check / ruff format / mypy | clean |
| `cargo fmt --all` | clean |

TDD confirmed both ways against a locally built wheel: with the Rust change reverted, **106 of the new tests fail**; with it applied, all pass.

The new tests are parametrised over *every* exported enum rather than a sample, because the defect was precisely that one of the nine had been treated differently. `test_every_member_round_trips_through_its_value` is the guard on the generated constructors — a wrong or missing arm in any of the 94 variants shows up there.

Two tests deliberately pin the *residue* — that members are not `enum.Enum` instances and the classes are not iterable — so if a future pyo3 makes those possible, the failing test is the reminder to revisit the stubs.

## Observed, not fixed

The 9 skips are a pickling probe: none of the enums are picklable. The issue does not ask for it and it is out of scope here, so the test records the current behaviour by skipping rather than asserting either way. Worth a follow-up issue if consumers hit it (caches keyed by enum, multiprocessing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python-exposed enums now provide `.name` and `.value` properties.
  * Enums support construction from valid integer values, ordering, hashing, and use in dictionaries and sets.
  * Added the `Strand.Unknown` enum member.

* **Bug Fixes**
  * Improved consistency between runtime enum behavior and published Python type information.
  * Added validation for invalid and retired enum values.
  * Preserved sparse numeric values for applicable error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->