### PR TITLE
fix(normalize): stop a cis member's shift at a sibling's bases

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1553,6 +1553,247 @@ pub(crate) fn coalesce_protein_adjacent_changes(
     }
 }
 
+// ----------------------------------------------------------------------------
+// Sibling-crossing shift clamp (#1254)
+// ----------------------------------------------------------------------------
+
+/// A cis member's span on the shared coordinate axis, copied out of the
+/// variant so the caller can mutate the member afterwards.
+struct MemberSpan {
+    accession: String,
+    region: Region,
+    start: i64,
+    end: i64,
+    /// Whether the edit consumes the reference bases under its span.
+    claims_bases: bool,
+}
+
+/// Read a member's span for the clamp pass, or `None` for a member this pass
+/// cannot place (wrong kind, uncertain edit, offset / special position).
+fn member_span(v: &HgvsVariant, kind: CisKind) -> Option<MemberSpan> {
+    let (accession, region, start, end, edit) = cis_axis_parts(v, kind)?;
+    Some(MemberSpan {
+        accession: accession.full(),
+        region,
+        start,
+        end,
+        claims_bases: claims_reference_bases(edit),
+    })
+}
+
+/// Whether an edit consumes the reference bases under its span.
+///
+/// Substitutions, deletions, delins and inversions replace or remove the bases
+/// they cover, so a shift that carries one of them over another's bases changes
+/// what the allele denotes. Insertions and duplications add sequence at a
+/// junction without consuming a base, so a member landing flush against one is
+/// the *adjacency* the collapse pass is meant to catch (#999, #1135) — they are
+/// neither clamped nor treated as barriers.
+fn claims_reference_bases(edit: &NaEdit) -> bool {
+    matches!(
+        edit,
+        NaEdit::Substitution { .. }
+            | NaEdit::Deletion { .. }
+            | NaEdit::Delins { .. }
+            | NaEdit::Inversion { .. }
+    )
+}
+
+/// The [`CisKind`] this pass serves, or `None` for a variant kind it does not.
+fn cis_kind_of(variant: &HgvsVariant) -> Option<CisKind> {
+    match variant {
+        HgvsVariant::Genome(_) => Some(CisKind::Genome),
+        HgvsVariant::Mt(_) => Some(CisKind::Mt),
+        HgvsVariant::Cds(_) => Some(CisKind::Cds),
+        HgvsVariant::Tx(_) => Some(CisKind::Tx),
+        HgvsVariant::Rna(_) => Some(CisKind::Rna),
+        _ => None,
+    }
+}
+
+/// Pull back any cis member whose shift carried it over a sibling's bases.
+///
+/// The 3' rule (`general.md:41`) is stated per description, with no
+/// allele-awareness, so a member is shifted to its *standalone* most-3'
+/// position. When a sibling edits a base inside the tract the member rotates
+/// through, that is not meaning-preserving: the member leapfrogs the sibling
+/// and the pair now describes a different sequence. `g.[3_4del;9del]` over
+/// `TAATATATATAATATATATT` shifted `3_4del` to `10_11del`, straight past the
+/// `9del`, and the two then merged to `g.12_14del` — a well-formed,
+/// warning-free description of *different* bases (#1254).
+///
+/// The invariant this restores: a member's **sweep window** — every position
+/// between its pre-shift and post-shift span — must contain no base claimed by
+/// another member. A shift is a rotation, so within a window no sibling edits,
+/// every position in it describes the same sequence; the members then sit on
+/// disjoint windows and compose exactly as the input did. Stopping at the last
+/// position before the nearest sibling base is the most 3' choice that keeps
+/// that true, which leaves the member *adjacent* to its sibling rather than
+/// past it — and the caller's next merge pass coalesces the two
+/// (`delins.md:16`). For the case above the clamp yields `[7_8del;9del]`, which
+/// merges to `g.7_9del`: three contiguous deleted bases, the same sequence the
+/// input denotes.
+///
+/// Both shift directions are handled — [`ShuffleDirection::FivePrime`] crosses
+/// siblings the same way, in the other direction.
+///
+/// `before` is the member list as it entered per-member normalization and
+/// supplies both the pull-back floor and the barrier positions; `after` is the
+/// shifted list, mutated in place. The two must be index-aligned. Barriers are
+/// read from a snapshot of `after` as well, so a sibling that shifted *into*
+/// this member's window also blocks; taking them from snapshots rather than the
+/// live list keeps the pass independent of member order.
+///
+/// [`ShuffleDirection::FivePrime`]: crate::normalize::ShuffleDirection
+pub(crate) fn clamp_sibling_crossing_shifts(
+    before: &[HgvsVariant],
+    after: &mut [HgvsVariant],
+    phase: AllelePhase,
+    uncertain: bool,
+) {
+    // An uncertain allele — `g.[(…)]` — asserts only that the members are in
+    // cis, not where they sit, so repositioning one states something the input
+    // did not. Every neighbouring transform in `normalize_allele` gates on this.
+    if phase != AllelePhase::Cis || uncertain || after.len() < 2 || before.len() != after.len() {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&after[0]) else {
+        return;
+    };
+    let pre: Vec<Option<MemberSpan>> = before.iter().map(|v| member_span(v, kind)).collect();
+    let post: Vec<Option<MemberSpan>> = after.iter().map(|v| member_span(v, kind)).collect();
+
+    for i in 0..after.len() {
+        let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
+            continue;
+        };
+        if !b.claims_bases || !a.claims_bases || b.region != a.region {
+            continue;
+        }
+        // Only a pure translation is a rotation. A member whose span length
+        // changed (an `ins` canonicalised to a `dup`, a `delins` reduced) is
+        // not something this pass can reason about positionally.
+        let delta = a.start - b.start;
+        if delta == 0 || a.end - b.end != delta {
+            continue;
+        }
+        // Every sibling span, from either snapshot, that shares this member's
+        // coordinate line and claims bases of its own.
+        let siblings: Vec<&MemberSpan> = (0..pre.len())
+            .filter(|&j| j != i)
+            .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
+            .flatten()
+            .filter(|s| s.claims_bases && s.region == a.region && s.accession == a.accession)
+            .collect();
+
+        let pull = if delta > 0 {
+            // 3'-shift: the window is `[b.start, a.end]`. A sibling starting
+            // beyond this member's original end but at or before its new end
+            // was rotated over; stop one position short of the nearest.
+            siblings
+                .iter()
+                .map(|s| s.start)
+                .filter(|&start| start > b.end && start <= a.end)
+                .min()
+                .map(|start| a.end - (start - 1))
+        } else {
+            // 5'-shift: mirror image, window `[a.start, b.end]`.
+            siblings
+                .iter()
+                .map(|s| s.end)
+                .filter(|&end| end < b.start && end >= a.start)
+                .max()
+                .map(|end| a.start - (end + 1))
+        };
+        // Never move past where the member started: those positions were not
+        // reachable by this shift and are not equivalent to it.
+        let Some(pull) = pull.map(|p| {
+            if delta > 0 {
+                p.min(delta)
+            } else {
+                p.max(delta)
+            }
+        }) else {
+            continue;
+        };
+        if pull != 0 {
+            translate_member(&mut after[i], -pull, kind, a);
+        }
+    }
+}
+
+/// Move `variant`'s span `delta` positions along its axis (negative is 5').
+///
+/// Reverts and leaves the variant untouched unless the result lands exactly
+/// where intended on the *same* region — the guard against an axis whose
+/// integer coordinate is not simply translatable (a `c.` span that would cross
+/// into the 5'UTR or `*`-region, a genomic base that would underflow).
+fn translate_member(variant: &mut HgvsVariant, delta: i64, kind: CisKind, from: &MemberSpan) {
+    let original = variant.clone();
+    let moved = match variant {
+        HgvsVariant::Genome(g) => {
+            translate_interval(&mut g.loc_edit.location, |p: &mut GenomePos| {
+                shift_unsigned(&mut p.base, delta)
+            })
+        }
+        HgvsVariant::Mt(m) => translate_interval(&mut m.loc_edit.location, |p: &mut GenomePos| {
+            shift_unsigned(&mut p.base, delta)
+        }),
+        HgvsVariant::Cds(c) => translate_interval(&mut c.loc_edit.location, |p: &mut CdsPos| {
+            shift_signed(&mut p.base, delta)
+        }),
+        HgvsVariant::Tx(t) => translate_interval(&mut t.loc_edit.location, |p: &mut TxPos| {
+            shift_signed(&mut p.base, delta)
+        }),
+        HgvsVariant::Rna(r) => translate_interval(&mut r.loc_edit.location, |p: &mut RnaPos| {
+            shift_signed(&mut p.base, delta)
+        }),
+        _ => false,
+    };
+    let landed = moved
+        && member_span(variant, kind).is_some_and(|s| {
+            s.region == from.region && s.start == from.start + delta && s.end == from.end + delta
+        });
+    if !landed {
+        *variant = original;
+    }
+}
+
+/// Apply `step` to both certain endpoints of an interval, refusing any
+/// boundary this pass cannot move (uncertain, unknown, or a range endpoint).
+fn translate_interval<T>(interval: &mut Interval<T>, mut step: impl FnMut(&mut T) -> bool) -> bool {
+    let mut moved = true;
+    for boundary in [&mut interval.start, &mut interval.end] {
+        match boundary {
+            UncertainBoundary::Single(Mu::Certain(pos)) => moved &= step(pos),
+            _ => return false,
+        }
+    }
+    moved
+}
+
+/// Shift a 1-based unsigned coordinate, refusing a move off the 5' end.
+fn shift_unsigned(base: &mut u64, delta: i64) -> bool {
+    match base.checked_add_signed(delta) {
+        Some(shifted) if shifted >= 1 => {
+            *base = shifted;
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Shift a signed axis coordinate, refusing a move onto the non-existent `0`.
+fn shift_signed(base: &mut i64, delta: i64) -> bool {
+    match base.checked_add(delta) {
+        Some(shifted) if shifted != 0 => {
+            *base = shifted;
+            true
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2275,11 +2275,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
             let mut result: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
             let mut pass_warnings: Vec<NormalizationWarning> = Vec::new();
-            for v in merged_split {
-                let (r, warnings) = self.normalize_core(&v)?;
+            for v in &merged_split {
+                let (r, warnings) = self.normalize_core(v)?;
                 pass_warnings.extend(warnings);
                 result.push(r);
             }
+
+            // The per-member shift above is sibling-unaware: each member goes to
+            // its standalone most-3' position, which can carry it clear over a
+            // sibling's bases and make the pair denote a different sequence
+            // (#1254). Pull any such member back to the last position before the
+            // sibling — still the most 3' placement that keeps the members on
+            // disjoint windows, and now merely *adjacent*, so the next pass's
+            // merge coalesces the two.
+            merge::clamp_sibling_crossing_shifts(
+                &merged_split,
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+            );
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/tests/it/issue_1254_sibling_crossing_shift.rs
+++ b/tests/it/issue_1254_sibling_crossing_shift.rs
@@ -1,0 +1,269 @@
+//! Regression coverage for issue #1254 — a cis member's 3'-shift must not
+//! carry it over a sibling's bases.
+//!
+//! The per-member 3'-shift is sibling-unaware: each member goes to its
+//! *standalone* most-3' position. When a sibling edits a base inside the tract
+//! the member rotates through, the member leapfrogs it and the pair describes a
+//! different sequence:
+//!
+//! ```text
+//! reference   TAATATATATAATATATATT
+//! input       TEMPLATE:g.[3_4del;9del]
+//! was      -> TEMPLATE:g.12_14del      applied: TAATATATATATATATT
+//! input applied                                 TAATATTAATATATATT   ← different
+//! now      -> TEMPLATE:g.7_9del        applied: TAATATTAATATATATT
+//! ```
+//!
+//! `3_4del` shifted to `10_11del`, straight past the `9del`; the two were then
+//! adjacent and merged to `9_11del`, which shifted on to `12_14del`. Nothing
+//! about that output invites suspicion — one well-formed member, no overlap, no
+//! warning — so the corruption is silent.
+//!
+//! Every assertion here is against an **independently applied** reference
+//! sequence, reconstructed from SPDI triples rather than from the normalizer.
+//! Asserting `normalize(input) == normalize(output)` cannot catch this class: it
+//! normalizes both sides, so it passed on the broken behavior.
+
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{
+    parse_hgvs, HgvsVariant, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection,
+};
+
+/// The reported reference: an `(AT)` tract that ends at position 11, where
+/// `11=A, 12=A` breaks the repeat.
+const TEMPLATE: &str = "TAATATATATAATATATATT";
+
+fn provider(seq: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", seq.to_string());
+    provider
+}
+
+fn normalize(seq: &str, input: &str) -> String {
+    normalize_in(seq, input, ShuffleDirection::ThreePrime)
+}
+
+fn normalize_in(seq: &str, input: &str, direction: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(seq),
+        NormalizeConfig::default().with_direction(direction),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+/// Apply `descriptor` to `seq` **independently of the normalizer**, by
+/// converting each member to its SPDI triple and splicing the reference.
+///
+/// Returns `None` when a member cannot be converted, when a stated deletion
+/// disagrees with the reference, or when two members claim the same base — an
+/// overlapping description has no single well-defined resulting sequence, and
+/// silently double-splicing one would invent a sequence neither side denotes.
+fn apply(seq: &str, descriptor: &str) -> Option<String> {
+    let provider = provider(seq);
+    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let mut triples = Vec::with_capacity(members.len());
+    for member in &members {
+        triples.push(hgvs_to_spdi(member, &provider).ok()?);
+    }
+    // 3'→5' so an applied splice never shifts a later one's coordinates.
+    triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+    let reference = seq.as_bytes();
+    let mut edited = reference.to_vec();
+    let mut claimed_from = reference.len();
+    for triple in &triples {
+        let start = usize::try_from(triple.position).ok()?;
+        let end = start.checked_add(triple.deletion.len())?;
+        if end > reference.len() || end > claimed_from {
+            return None; // out of bounds, or overlapping the member 3' of it
+        }
+        if !reference[start..end].eq_ignore_ascii_case(triple.deletion.as_bytes()) {
+            return None;
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+        claimed_from = start;
+    }
+    String::from_utf8(edited).ok()
+}
+
+/// Assert that `input` normalizes to `expected` *and* that both denote the same
+/// sequence when applied to `seq`.
+fn assert_normalizes_preserving(seq: &str, input: &str, expected: &str) {
+    let actual = normalize(seq, input);
+    assert_eq!(actual, expected, "normalizing {input}");
+    let from_input = apply(seq, input).expect("input applies");
+    let from_output = apply(seq, &actual).unwrap_or_else(|| {
+        panic!("{actual} has no well-defined resulting sequence (overlapping or unconvertible)")
+    });
+    assert_eq!(
+        from_output, from_input,
+        "{input} -> {actual} changed the sequence"
+    );
+}
+
+#[test]
+fn separated_deletions_do_not_merge_into_a_different_deletion() {
+    // The reported case. `3_4del` may 3'-shift only as far as `7_8del`, which
+    // stops one base short of the `9del`; the two are then adjacent (no
+    // intervening nucleotide) and merge into one three-base deletion.
+    assert_normalizes_preserving(TEMPLATE, "TEMPLATE:g.[3_4del;9del]", "TEMPLATE:g.7_9del");
+}
+
+#[test]
+fn separated_deletions_with_a_downstream_substitution_stay_well_formed() {
+    // The three-member variant of the same input. It used to expose the
+    // corruption *visibly*, as the overlapping `g.[12_14del;13T>A]`; with the
+    // shift clamped, the deletion lands where it belongs and the substitution
+    // is untouched.
+    assert_normalizes_preserving(
+        TEMPLATE,
+        "TEMPLATE:g.[3_4del;9del;13T>A]",
+        "TEMPLATE:g.[7_9del;13T>A]",
+    );
+}
+
+#[test]
+fn every_spelling_of_the_variant_reaches_one_canonical_form() {
+    // Confluence: the pre-shifted, the shifted-and-adjacent, the already-merged
+    // and the reordered spellings are one variant and must share a key.
+    for input in [
+        "TEMPLATE:g.[3_4del;9del]",
+        "TEMPLATE:g.[7_8del;9del]",
+        "TEMPLATE:g.[9del;3_4del]",
+        "TEMPLATE:g.7_9del",
+    ] {
+        assert_normalizes_preserving(TEMPLATE, input, "TEMPLATE:g.7_9del");
+    }
+}
+
+#[test]
+fn a_deletion_does_not_shift_onto_a_substituted_base() {
+    // A deletion inside a homopolymer whose 3'-most standalone position is the
+    // substituted base itself. Clamped to `8del`, it is adjacent to `9A>G` and
+    // the two render as one delins (`delins.md:16`). This previously emitted the
+    // overlapping `g.[9A>G;9del]`.
+    assert_normalizes_preserving(
+        "GGGAAAAAAGGG",
+        "TEMPLATE:g.[4del;9A>G]",
+        "TEMPLATE:g.8_9delinsG",
+    );
+}
+
+#[test]
+fn a_member_that_cannot_reach_its_sibling_still_shifts_fully() {
+    // Negative control against over-clamping: `4del` 3'-shifts through the A-run
+    // to `9del`, and the substitution at `11` is two bases beyond it — never
+    // inside the swept window — so the shift must complete and the two must stay
+    // separate members, separated by the unchanged `10G` (`general.md:34`).
+    assert_normalizes_preserving(
+        "GGGAAAAAAGCG",
+        "TEMPLATE:g.[4del;11C>T]",
+        "TEMPLATE:g.[9del;11C>T]",
+    );
+}
+
+#[test]
+fn a_five_prime_shift_does_not_cross_a_sibling_either() {
+    // The mirror image. Under `ShuffleDirection::FivePrime`, `9_10del` rotates
+    // 5' through the same `(AT)` tract and its standalone 5'-most position is
+    // past the `5del`. Clamped to `6_7del` it is adjacent to the `5del`, and the
+    // two merge into `g.5_7del`. This previously emitted `g.1_3del`, which
+    // denotes `TATATATAATATATATT` where the input denotes `TAATTATAATATATATT`.
+    let input = "TEMPLATE:g.[5del;9_10del]";
+    let actual = normalize_in(TEMPLATE, input, ShuffleDirection::FivePrime);
+    assert_eq!(actual, "TEMPLATE:g.5_7del");
+    assert_eq!(
+        apply(TEMPLATE, &actual).expect("output applies"),
+        apply(TEMPLATE, input).expect("input applies"),
+    );
+}
+
+#[test]
+fn an_insertion_landing_flush_against_a_substitution_still_collapses() {
+    // Negative control for the #999 rule the clamp must not disturb: an
+    // insertion claims no reference base, so a member landing flush against one
+    // is adjacency, not a crossing. `305_306insC` 3'-shifts to a dup at 306 and
+    // coalesces with `307G>T`.
+    let mut seq = vec![b'A'; 1000];
+    for (i, b) in "CATCCTCGCTCCT".bytes().enumerate() {
+        seq[299 + i] = b;
+    }
+    let seq = String::from_utf8(seq).unwrap();
+    assert_eq!(
+        normalize(&seq, "TEMPLATE:g.[305_306insC;307G>T]"),
+        "TEMPLATE:g.307delinsCT"
+    );
+}
+
+#[test]
+fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
+    // The class, not the instance. Every two-member cis allele of a deletion
+    // plus a downstream deletion or substitution, over every 4^10 window of a
+    // deterministic set of 10-mers, checked by applying both sides to the
+    // reference. Before the clamp this sweep reported 2,244 silent
+    // sequence-changing normalizations (well-formed, warning-free, disjoint
+    // output) out of 445,148; over-clamping would show up as a canonical-form
+    // change in the pinned cases above.
+    let mut checked = 0usize;
+    let mut mismatched: Vec<String> = Vec::new();
+
+    for seed in 0..64u32 {
+        // Deterministic 20-mers over {A,T} — the alphabet that builds the long
+        // alternating tracts a shift can travel through — and over {A,C,G,T}.
+        for alphabet in [b"AT".as_slice(), b"ACGT".as_slice()] {
+            let mut state = u64::from(seed).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+            let seq: String = (0..20)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    alphabet[(state % alphabet.len() as u64) as usize] as char
+                })
+                .collect();
+
+            for first_start in 1..=14usize {
+                for first_len in 1..=2usize {
+                    let first_end = first_start + first_len - 1;
+                    let first = if first_len == 1 {
+                        format!("{first_start}del")
+                    } else {
+                        format!("{first_start}_{first_end}del")
+                    };
+                    // Leave at least one unchanged base between the members, so
+                    // every case starts out as a genuinely separated pair.
+                    for second_start in first_end + 2..=19usize {
+                        let base = seq.as_bytes()[second_start - 1] as char;
+                        let alt = if base == 'A' { 'G' } else { 'A' };
+                        for second in [
+                            format!("{second_start}del"),
+                            format!("{second_start}{base}>{alt}"),
+                        ] {
+                            let input = format!("TEMPLATE:g.[{first};{second}]");
+                            let output = normalize(&seq, &input);
+                            let (Some(want), Some(got)) =
+                                (apply(&seq, &input), apply(&seq, &output))
+                            else {
+                                continue; // unconvertible, or a flagged overlap
+                            };
+                            checked += 1;
+                            if want != got && mismatched.len() < 10 {
+                                mismatched.push(format!(
+                                    "{seq}: {input} -> {output} (want {want}, got {got})"
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(checked > 10_000, "sweep covered too little: {checked}");
+    assert!(
+        mismatched.is_empty(),
+        "sequence-changing normalizations in {checked} cases: {mismatched:#?}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -153,6 +153,7 @@ mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
 mod issue_1217_mito_terminus_insertion_clamp;
+mod issue_1254_sibling_crossing_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -4290,17 +4290,22 @@ mod comprehensive_normalization_tests {
 
         #[test]
         fn test_compact_allele_notation() {
-            // Compact allele notation with accession before bracket
-            // NM_TEST.1:c.[4del;9A>G] format
+            // Compact allele notation with accession before bracket.
+            // `c.4del` sits in the A-run `c.4..9` and 3'-shifts within it, but
+            // `c.9` is the substituted base — so the shift stops at `c.8`
+            // (#1254) instead of landing on top of the substitution. The two are
+            // then adjacent with no intervening nucleotide, which HGVS requires
+            // to render as one edit (`delins.md:16`): delete `c.8_9` (`AA`),
+            // insert the substituted `G`.
+            //
+            // Before #1254 this shifted clear onto the sibling and emitted the
+            // overlapping `c.[9A>G;9del]` — two members claiming `c.9`, which
+            // ferro itself flags as an overlap conflict and which denotes a
+            // different sequence than the input.
             let seq = "GGGAAAAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.[4del;9A>G]");
-            // Should normalize the variants
-            assert!(
-                result.contains("del") && result.contains("A>G"),
-                "Compact allele should normalize both variants, got: {}",
-                result
-            );
+            assert_eq!(result, "NM_TEST.1:c.8_9delinsG");
         }
     }
 }


### PR DESCRIPTION
Closes #1254.

## The defect

`g.[3_4del;9del]` over `TAATATATATAATATATATT` normalized to `g.12_14del`, which denotes different bases than the input — silently, with no overlap and no warning to detect it.

```
input applied   TAATATTAATATATATT
output applied  TAATATATATATATATT     ← differs at result positions 7-8
```

The issue frames this as a bad merge. Tracing it, the merge is the symptom and the **3'-shift is the defect**:

| pass | members | note |
| --- | --- | --- |
| in | `[3_4del; 9del]` | separated by four unchanged bases (5-8) |
| 1 | `[9del; 10_11del]` | `3_4del` shifted to its standalone most-3' position — **clear over the `9del`** |
| 2 | `9_11del` | now adjacent, so they merge — but `{9,10,11}` was never equivalent to `{3,4,9}` |
| 3 | `12_14del` | the merged deletion shifts on |

Equivalence broke at pass 1, before the merge ran. The per-member shift (`normalize_core`, inside the `normalize_allele` fixed-point loop) sees only its own member: `boundary.rs` supplies reference/exon/CDS bounds, never a sibling's position. So `3_4del` rotated through the `(AT)` tract and straight past the base its sibling deletes.

This is also why the sibling clamp in #1236 does not catch it. That clamp fires on an **overlap** (`end >= next_start`); here the member leapfrogs entirely and the two are never overlapping. #1254 reaches that clamp with an already-corrupted member list, which is where part of its "32/32 regressions survive the gate" count comes from.

## The fix

Clamp a member's shift so its **sweep window** — every position between its pre-shift and post-shift span — contains no base another member claims.

A shift is a rotation, so within a window no sibling edits, every position in it describes the same sequence; the members then sit on disjoint windows and compose exactly as the input did. Stopping one position short of the nearest sibling base is the most 3' placement that keeps that true — and it leaves the member *adjacent* to its sibling rather than past it, so the loop's next merge pass coalesces the two per `delins.md:16`.

For the reported case: `3_4del` clamps to `7_8del`, which is adjacent to `9del`, and the two merge to **`g.7_9del`** — three contiguous deleted bases, exactly the sequence the input denotes.

Brute-forcing every 3-position deletion set over that reference confirms `{7,8,9}` is in the input's equivalence class and `{12,13,14}` is not. `7_9del` is also the most 3' *contiguous* member of that class, so nothing is given up by stopping at the sibling.

Both shift directions are clamped. Under `ShuffleDirection::FivePrime` the mirror-image case `g.[5del;9_10del]` produced `g.1_3del` (denoting `TATATATAATATATATT` against the input's `TAATTATAATATATATT`) and now produces `g.5_7del`.

Insertions and duplications claim no reference base, so they are neither clamped nor treated as barriers — a member landing flush against one is the *adjacency* #999 and #1135 rely on, not a crossing. That boundary is pinned by a test.

## Scope, measured

An exhaustive two-member sweep — a deletion plus a downstream deletion or substitution, over deterministic 20-mers on `{A,T}` and `{A,C,G,T}` — applying **both sides to the reference** independently of the normalizer:

| | before | after |
| --- | --- | --- |
| cases checked | 445,148 | 445,148 |
| silent sequence-changing normalizations | **2,244** | **0** |

"Silent" is the filter the issue asks for: warning-free output whose members are disjoint, i.e. nothing a consumer could reject. Counting the visible failures too (overlapping outputs — the #1234 class) the before-figure is 11,842.

## It also resolves the visible variant

The three-member case that #1234 / PR #1236 tracks:

| input | main | PR #1236 | here |
| --- | --- | --- | --- |
| `g.[3_4del;9del;13T>A]` | `g.[12_14del;13T>A]` — overlapping | `g.10_13delinsA` — wrong sequence | `g.[7_9del;13T>A]` ✅ |

Same root cause, so clamping the crossing fixes both the silent and the visible shape. This PR is independent of #1236/#1237/#1239/#1240 and based on `main`; it touches `merge.rs` near where #1236 adds its own clamp, so whichever lands second will need a small reconciliation.

## Confluence

All four spellings of the variant now reach one key — the failure mode #1229–#1235 track:

| spelling | before | after |
| --- | --- | --- |
| `g.[3_4del;9del]` | `g.12_14del` ❌ | `g.7_9del` |
| `g.[9del;3_4del]` | `g.12_14del` ❌ | `g.7_9del` |
| `g.[7_8del;9del]` | `g.12_14del` ❌ | `g.7_9del` |
| `g.7_9del` | `g.7_9del` | `g.7_9del` |

## The change

- `src/normalize/merge.rs` — `clamp_sibling_crossing_shifts`, plus `member_span` / `cis_kind_of` / `claims_reference_bases` and a small position-translation helper. The translation verifies it landed exactly where intended on the same region and otherwise reverts, so an axis that is not simply translatable (a `c.` span that would cross into the 5'UTR or `*`-region, a genomic base that would underflow) is left alone rather than mangled.
- `src/normalize/mod.rs` — call it in the `normalize_allele` fixed-point loop, right after per-member normalization, gated on cis and not-uncertain like every neighbouring transform.

The pass only reads positions — no provider, no sequence fetch — because the rotation argument is what makes it sound. The evidence that the argument holds is the sweep above, which is reference-backed.

## One existing test changed

`test_compact_allele_notation` asserted only that the output contained `"del"` and `"A>G"`. It was passing on `c.[9A>G;9del]` — two members claiming `c.9`, which ferro itself flags as an overlap conflict and which denotes a different sequence than the input. With the shift clamped it becomes `c.8_9delinsG` (adjacent changes as one edit), so the assertion is now an equality on that string, with the history recorded in the comment.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **8794/8794** |
| `FERRO_ASSERT_IDEMPOTENT=1` full suite | **8793/8793** |
| conformance axes (`FERRO_MANIFEST`, real prepared reference) | **306/306** |
| `cargo clippy --all-features --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |

New tests in `tests/it/issue_1254_sibling_crossing_shift.rs`: the reported case, the three-member case, the four-spelling confluence check, a deletion shifting onto a substituted base, the 5'-direction mirror, and the exhaustive sweep — plus two negative controls (a member that cannot reach its sibling must still shift fully; an insertion landing flush must still collapse per #999) that guard against over-clamping.

Every assertion applies the descriptor to the reference **independently of the normalizer**, via SPDI triples. As the issue notes, `check(input, normalize(input))` cannot catch this class — it normalizes both sides, so it passed on the broken behavior. The `apply` helper also refuses an overlapping description rather than double-splicing one, so a malformed output fails the test instead of quietly producing a sequence neither side denotes.

## Reading order

`clamp_sibling_crossing_shifts` in `src/normalize/merge.rs` (the sweep-window rule), then its call site in `src/normalize/mod.rs`, then the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of multi-part variants to prevent sibling changes from crossing or incorrectly merging.
  * Preserved sequence accuracy when shifting deletions, substitutions, and insertions.
  * Ensured consistent canonical output across equivalent variant spellings and shuffle directions.

* **Tests**
  * Added comprehensive regression coverage for sibling-crossing shifts, compact allele notation, boundary cases, and sequence preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->