### PR TITLE
test(normalize): pin the overlapping shape of the sibling-crossing shift

### DIFF
--- a/tests/it/issue_1234_sibling_clamped_shift.rs
+++ b/tests/it/issue_1234_sibling_clamped_shift.rs
@@ -1,0 +1,233 @@
+//! #1234 — a cis member's 3'-shift must stop at a sibling, not cross it.
+//!
+//! `Normalizer::normalize` 3'-shifted each cis-allele member to its
+//! *standalone* most-3' position, ignoring its siblings. A deletion with a
+//! downstream substitution therefore shifted **into** the substituted position,
+//! emitting an allele whose two members overlap. That is malformed — a base
+//! cannot be both deleted and substituted — and ferro itself read the result as
+//! a different sequence, silently swallowing the substitution.
+//!
+//! The spec says nothing about how 3'-shifting interacts with siblings (the
+//! only text that ever addressed it, SVD-WG010, was rejected), but a
+//! description must not change the sequence it denotes, and `general.md:58`
+//! forbids a description that removes part of the reference and replaces it
+//! with part of the same sequence.
+//!
+//! ## Where the fix lives
+//!
+//! These cases are fixed by the sweep-window clamp added for #1254
+//! (`merge::clamp_sibling_crossing_shifts`), not by a clamp of their own. #1234
+//! and #1254 are one defect seen from two sides: #1234 is the shape where the
+//! shifted member lands *on top of* a sibling, so the damage is visible as an
+//! overlap; #1254 is the shape where it clears the sibling entirely, so the
+//! damage is silent. Preventing the crossing upstream resolves both.
+//!
+//! That was measured rather than assumed. Every test in this file passed
+//! against #1254's fix with the overlap-based clamp originally proposed for
+//! #1234 entirely absent, and across 143,360 two-member cis alleles the two
+//! together left exactly the same 526 overlapping outputs as #1254 alone —
+//! against 1,444 for the overlap clamp alone and 2,578 unfixed. So the coverage
+//! is kept here and the second clamp was dropped.
+//!
+//! The 526 residual is a *different* defect: a deletion canonicalised into a
+//! whole-tract repeat (`g.[1_2del;4del]` -> `g.[1_9T[7];9del]`) that overlaps
+//! its sibling. `NaEdit::Repeat` claims no reference bases as far as the clamp
+//! is concerned, so it is out of scope here and not regressed by it.
+
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+use std::io::Write;
+
+const SEQ: &str = concat!(
+    "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCG",
+    "TACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA"
+);
+
+fn provider() -> JsonProvider {
+    let n = SEQ.len() as u64;
+    let json = serde_json::json!({
+        "version": "1.0",
+        "transcripts": [{
+            "id": "TEMPLATE-gene.1",
+            "chromosome": "TEMPLATE",
+            "strand": "+",
+            "sequence": SEQ,
+            "cds_start": 1,
+            "cds_end": n - (n % 3),
+            "genomic_start": 1,
+            "genomic_end": n,
+            "protein_id": "TEMPLATE-gene.1",
+            "exons": [{
+                "number": 1, "start": 1, "end": n,
+                "genomic_start": 1, "genomic_end": n
+            }]
+        }],
+        "genomic_sequences": { "TEMPLATE": SEQ }
+    });
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    write!(f, "{json}").expect("write json");
+    JsonProvider::from_json(f.path()).expect("load reference")
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(provider());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// The reported case. Reference `CACCA` at 4-8: deleting 4-6 leaves the `C` at
+/// 7 and the substituted `A` at 8. The deletion's standalone 3'-most position
+/// is `6_8`, which collides with the substitution; clamped at `5_7` it is
+/// adjacent to it instead, and the two coalesce into one delins.
+#[test]
+fn deletion_shift_stops_before_a_sibling_substitution() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}
+
+/// The same variant spelled with the deletion already at the clamp position
+/// reaches the same string — it did so before #1254's fix too, which is what
+/// made the unclamped output detectably wrong rather than merely
+/// non-canonical.
+#[test]
+fn the_clamped_spelling_reaches_the_same_string() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[5_7del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}
+
+/// A lone deletion has no sibling to clamp against and must still reach its
+/// standalone 3'-most position. Guards against "fixing" the clamp by disabling
+/// the shift.
+#[test]
+fn a_lone_deletion_still_shifts_to_its_three_prime_most_position() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.4_6del"),
+        "TEMPLATE:g.6_8del"
+    );
+}
+
+/// Members far apart must be untouched by the clamp: the deletion still shifts
+/// fully because its sibling is nowhere near.
+#[test]
+fn a_distant_sibling_does_not_clamp_the_shift() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;60G>C]"),
+        "TEMPLATE:g.[6_8del;60G>C]"
+    );
+}
+
+/// The invariant behind the fix: no normalized cis allele may contain
+/// overlapping or out-of-order members.
+#[test]
+fn normalized_cis_members_never_overlap() {
+    use ferro_hgvs::hgvs::variant::HgvsVariant;
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[4_6del;60G>C]",
+        "TEMPLATE:g.[4_6del;9G>T]",
+    ];
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let HgvsVariant::Allele(allele) = &normalized else {
+            continue; // collapsed to one member: trivially disjoint
+        };
+        let mut previous_end: Option<i64> = None;
+        for member in &allele.variants {
+            let HgvsVariant::Genome(g) = member else {
+                continue;
+            };
+            let interval = &g.loc_edit.location;
+            let (Some(start), Some(end)) = (interval.start.inner(), interval.end.inner()) else {
+                continue;
+            };
+            let (start, end) = (start.base as i64, end.base as i64);
+            if let Some(previous) = previous_end {
+                assert!(
+                    start > previous,
+                    "`{input}` -> `{normalized}`: member at {start} overlaps the previous \
+                     member ending at {previous}"
+                );
+            }
+            previous_end = Some(end);
+        }
+    }
+}
+
+/// Normalization must never change the resulting sequence. `EquivalenceChecker`
+/// read the old overlapping output as a plain `6_8del` — a *different* variant
+/// — so this is the check that actually catches the corruption.
+///
+/// Note this is a weaker oracle than the one in
+/// `issue_1254_sibling_crossing_shift.rs`, which applies both descriptors to
+/// the reference itself: `check` normalizes both sides, so it cannot catch a
+/// corruption that survives normalization. It is kept because it pins the
+/// specific `EquivalenceChecker` misreading that #1234 reported.
+#[test]
+fn normalization_preserves_the_resulting_sequence() {
+    use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+
+    let inputs = [
+        "TEMPLATE:g.[4_6del;8A>T]",
+        "TEMPLATE:g.[5_7del;8A>T]",
+        "TEMPLATE:g.[4_6del;60G>C]",
+        "TEMPLATE:g.[4_6del;9G>T]",
+    ];
+    let checker = EquivalenceChecker::new(provider());
+    let normalizer = Normalizer::new(provider());
+    for input in inputs {
+        let parsed = parse_hgvs(input).expect("parse");
+        let normalized = normalizer.normalize(&parsed).expect("normalize");
+        let level = checker.check(&parsed, &normalized).expect("check").level;
+        assert!(
+            matches!(
+                level,
+                EquivalenceLevel::Identical
+                    | EquivalenceLevel::NormalizedMatch
+                    | EquivalenceLevel::SequenceMatch
+            ),
+            "`{input}` -> `{normalized}` changed the resulting sequence ({level:?})"
+        );
+    }
+}
+
+/// An uncertain allele — `g.[( … )]` — asserts only that its members are in
+/// cis, not where they sit. Rewriting a member's position drops the predicted
+/// marker and states something the input deliberately did not.
+///
+/// Every transform in `normalize_allele` gates on this flag, and the clamp
+/// must too: an ungated clamp collapsed `g.[(4_6del;8A>T)]` to a bare
+/// `g.5_8delinsT`, so the parentheses vanished and a prediction became an
+/// assertion. The flag is always false for protein but genuinely reachable for
+/// a DNA `g.[( … )]`, so it has to be checked. Skipping the clamp leaves the
+/// members overlapping, which is the correct trade here — the input asserts
+/// nothing about where they sit, and the overlap stays visible to a consumer.
+#[test]
+fn an_uncertain_allele_keeps_its_predicted_marker() {
+    let normalized = normalize_to_string("TEMPLATE:g.[(4_6del;8A>T)]");
+    assert!(
+        normalized.contains('('),
+        "the predicted marker must survive normalization, got `{normalized}`"
+    );
+    assert_eq!(normalized, "TEMPLATE:g.[(6_8del;8A>T)]");
+}
+
+/// The certain spelling of the same allele is unaffected — the uncertainty
+/// gate must not disable the clamp generally.
+#[test]
+fn the_certain_spelling_of_that_allele_still_clamps() {
+    assert_eq!(
+        normalize_to_string("TEMPLATE:g.[4_6del;8A>T]"),
+        "TEMPLATE:g.5_8delinsT"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -153,6 +153,7 @@ mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
 mod issue_1210_repeat_gate_tract_span;
 mod issue_1217_mito_terminus_insertion_clamp;
+mod issue_1234_sibling_clamped_shift;
 mod issue_1254_sibling_crossing_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
Closes #1234.

**Stacked on #1255** — base is `fix/issue-1254-separated-deletion-merge`, so review that first and merge it first. This PR adds **tests only**; `git diff` against #1255 touches no source file.

It supersedes #1236, which I'm closing. The rationale is below, because "close the PR, keep its tests" needs to be justified rather than asserted.

## #1234 and #1254 are one defect

A cis member is 3'-shifted to its *standalone* most-3' position, with no awareness of its siblings. When a sibling edits a base inside the tract the member rotates through, the member moves over it. Two shapes result:

| shape | example | how it fails |
| --- | --- | --- |
| **#1234** — lands *on top of* a sibling | `g.[4_6del;8A>T]` → `g.[6_8del;8A>T]` | overlapping members — malformed, and a consumer can reject it |
| **#1254** — clears the sibling entirely | `g.[3_4del;9del]` → `g.12_14del` | well-formed, warning-free, disjoint — and denotes different bases |

Same cause, different visibility. #1255 prevents the crossing itself, which resolves both — so these cases need coverage, not a second clamp.

## The measurement

I did not assume the subsumption. Three checks:

**1. #1236's tests pass without #1236's code.** All eight tests in this file pass against #1255 with the overlap-based clamp entirely absent.

**2. #1236 adds nothing on top.** Overlapping normalized outputs across 143,360 two-member cis alleles, both shuffle directions:

| build | overlapping outputs |
| --- | --- |
| `main` | 2,578 |
| #1236 alone | 1,444 (−44%) |
| **#1255 alone** | **526 (−80%)** |
| #1255 + #1236 stacked | **526 — unchanged** |

#1255 beats #1236 on #1236's own metric, and stacking contributes zero. The stacked build was actually constructed and is green (8,810 tests), so this is a measurement, not an inference — the two are compatible, but the second clamp changes no output.

**3. Both converge on the same string independently.** #1236 re-blessed `test_compact_allele_notation` to `c.8_9delinsG`; #1255 produces `c.8_9delinsG` by a different route.

Closing #1236 therefore drops ~520 lines — including the 303-line `verify.rs` — that provably change no output, while this PR keeps its review value.

## What the residual 526 is

A *different* defect, pre-existing on `main` and untouched by either PR: a deletion canonicalised into a whole-tract repeat that overlaps its sibling.

```
g.[1_2del;4del]  ->  g.[1_9T[7];9del]
```

`NaEdit::Repeat` is not in `claims_reference_bases` — the predicate is byte-identical in #1236 and #1255 — so neither clamp sees it. Out of scope here, and recorded so the 526 is not mistaken for residual #1234 damage.

## The eight tests

Three fail on `main`: `deletion_shift_stops_before_a_sibling_substitution`, `the_certain_spelling_of_that_allele_still_clamps`, `normalized_cis_members_never_overlap`. The other five are negative controls that must pass both before and after — a lone deletion still shifting fully, a distant sibling not clamping, and so on.

Two notes carried into the doc comments:

- `normalization_preserves_the_resulting_sequence` **passes on `main`**, so it is a negative control, not a regression pin. `EquivalenceChecker::check` normalizes both sides, so it cannot catch a corruption that survives normalization. It is kept because it pins the specific misreading #1234 reported; the stronger oracle — applying both descriptors to the reference itself via SPDI triples — lives in #1255's tests.
- `an_uncertain_allele_keeps_its_predicted_marker` documents a deliberate trade. `g.[(4_6del;8A>T)]` skips the clamp and keeps its overlapping members, because the input asserts only that the members are in cis; rewriting a position would drop the parentheses and turn a prediction into an assertion. The overlap stays visible to a consumer, which is the right side to err on.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **8802/8802** |
| `FERRO_ASSERT_IDEMPOTENT=1` full suite | **8802/8802** |
| `cargo clippy --all-features --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| the eight tests against `origin/main` source | 3 fail, 5 negative controls pass |

Reference-backed conformance was run on #1255 (306/306 axes against the prepared reference) and is not re-run here: this branch has a zero-byte source delta from #1255, so the result carries over unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for correct 3’-shift clamping when cis allele members would otherwise overlap.
  * Added validation for normalization output, sequence preservation, uncertain allele markers, distant siblings, and standalone deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->