### PR TITLE
fix(normalize): stop a repeat's tract span from swallowing a sibling

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1722,6 +1722,175 @@ pub(crate) fn clamp_sibling_crossing_shifts(
     }
 }
 
+/// Re-spell as a plain deletion any cis member whose repeat notation spans a
+/// sibling's bases.
+///
+/// `deletion_to_repeat` (`repeated.md` B2) re-expresses a deletion inside a
+/// tandem tract as a copy count over the **whole tract**, not over the deleted
+/// bases: on a nine-`T` run, `g.1_2del` becomes `g.1_9T[7]`. That widened span
+/// is correct for a lone variant, but in a cis allele it can swallow a sibling
+/// — `g.[1_2del;4del]` emitted `g.[1_9T[7];9del]`, where `9del` sits inside
+/// `1_9`. Overlapping members are malformed, and the pair denotes a different
+/// sequence than the input.
+///
+/// The conversion happens per member, deep inside `normalize_na_edit`, with no
+/// sibling context reaching it, so the decision is undone here instead: the
+/// repeat is re-spelled as the equivalent 3'-most deletion of the same number
+/// of bases, ending where the tract ends. That is the form the member would
+/// have taken had B2 declined, and it is exactly equivalent — B2 only re-writes
+/// notation, never the bases removed.
+///
+/// Restoring the deletion is what lets the rest of the pipeline finish the job.
+/// [`clamp_sibling_crossing_shifts`] can then see a real span to pull back, and
+/// the caller's next merge pass coalesces the members. `g.[1_2del;4del]` ends up
+/// as `g.1_9T[6]` — one member, three bases removed from the tract, repeat
+/// notation restored now that there is no sibling to span.
+///
+/// Runs before the clamp, so the clamp sees the deletion rather than the
+/// repeat. Members whose pre-normalization form was not a plain deletion are
+/// left alone: without a deleted-base count there is nothing to re-spell to.
+pub(crate) fn demote_repeats_spanning_siblings(
+    before: &[HgvsVariant],
+    after: &mut [HgvsVariant],
+    phase: AllelePhase,
+    uncertain: bool,
+) {
+    if phase != AllelePhase::Cis || uncertain || after.len() < 2 || before.len() != after.len() {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&after[0]) else {
+        return;
+    };
+    let pre: Vec<Option<MemberSpan>> = before.iter().map(|v| member_span(v, kind)).collect();
+    let post: Vec<Option<MemberSpan>> = after.iter().map(|v| member_span(v, kind)).collect();
+
+    for i in 0..after.len() {
+        let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
+            continue;
+        };
+        // Only a repeat that grew out of a plain deletion is re-spellable.
+        if !matches!(
+            cis_axis_parts(&after[i], kind).map(|(_, _, _, _, e)| e),
+            Some(NaEdit::Repeat { .. })
+        ) || !matches!(
+            cis_axis_parts(&before[i], kind).map(|(_, _, _, _, e)| e),
+            Some(NaEdit::Deletion { .. })
+        ) {
+            continue;
+        }
+        let deleted = b.end - b.start + 1;
+        // The equivalent deletion is the 3'-most `deleted` bases of the tract.
+        let start = a.end - deleted + 1;
+        if deleted <= 0 || start < a.start || b.region != a.region {
+            continue;
+        }
+        // Does the tract actually span a sibling's bases? Both snapshots, so a
+        // sibling that moved into the tract counts too.
+        let spans_sibling = (0..pre.len())
+            .filter(|&j| j != i)
+            .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
+            .flatten()
+            .filter(|s| s.claims_bases && s.region == a.region && s.accession == a.accession)
+            .any(|s| s.start <= a.end && s.end >= a.start);
+        if !spans_sibling {
+            continue;
+        }
+        respell_as_deletion(&mut after[i], kind, a.region, start, a.end);
+    }
+}
+
+/// Replace `variant`'s edit with a plain deletion over `[start, end]`.
+///
+/// Reverts on any axis this pass cannot rewrite, or if the result does not land
+/// exactly where intended on the same region.
+fn respell_as_deletion(
+    variant: &mut HgvsVariant,
+    kind: CisKind,
+    region: Region,
+    start: i64,
+    end: i64,
+) {
+    let original = variant.clone();
+    let placed = match variant {
+        HgvsVariant::Genome(g) => place_genome(&mut g.loc_edit, start, end),
+        HgvsVariant::Mt(m) => place_genome(&mut m.loc_edit, start, end),
+        HgvsVariant::Cds(c) => place_signed(&mut c.loc_edit, start, end, |p: &mut CdsPos, v| {
+            p.base = v;
+        }),
+        HgvsVariant::Tx(t) => place_signed(&mut t.loc_edit, start, end, |p: &mut TxPos, v| {
+            p.base = v;
+        }),
+        HgvsVariant::Rna(r) => place_signed(&mut r.loc_edit, start, end, |p: &mut RnaPos, v| {
+            p.base = v;
+        }),
+        _ => false,
+    };
+    let landed = placed
+        && member_span(variant, kind)
+            .is_some_and(|s| s.region == region && s.start == start && s.end == end);
+    if !landed {
+        *variant = original;
+    }
+}
+
+/// Set a genomic `LocEdit` to a plain deletion over `[start, end]`.
+fn place_genome(loc_edit: &mut LocEdit<Interval<GenomePos>, NaEdit>, start: i64, end: i64) -> bool {
+    let (Ok(start), Ok(end)) = (u64::try_from(start), u64::try_from(end)) else {
+        return false;
+    };
+    if !set_endpoints(
+        &mut loc_edit.location,
+        |p: &mut GenomePos, v: u64| p.base = v,
+        start,
+        end,
+    ) {
+        return false;
+    }
+    loc_edit.edit = Mu::Certain(NaEdit::Deletion {
+        sequence: None,
+        length: None,
+    });
+    true
+}
+
+/// Set a signed-axis `LocEdit` to a plain deletion over `[start, end]`.
+fn place_signed<P, L>(
+    loc_edit: &mut LocEdit<Interval<P>, NaEdit>,
+    start: i64,
+    end: i64,
+    assign: L,
+) -> bool
+where
+    L: Fn(&mut P, i64) + Copy,
+{
+    if start == 0 || end == 0 {
+        return false; // no `c.0` / `n.0` position exists
+    }
+    if !set_endpoints(&mut loc_edit.location, assign, start, end) {
+        return false;
+    }
+    loc_edit.edit = Mu::Certain(NaEdit::Deletion {
+        sequence: None,
+        length: None,
+    });
+    true
+}
+
+/// Assign both certain endpoints of an interval, refusing anything else.
+fn set_endpoints<P, V, L>(interval: &mut Interval<P>, assign: L, start: V, end: V) -> bool
+where
+    L: Fn(&mut P, V),
+    V: Copy,
+{
+    for (boundary, value) in [(&mut interval.start, start), (&mut interval.end, end)] {
+        match boundary {
+            UncertainBoundary::Single(Mu::Certain(pos)) => assign(pos, value),
+            _ => return false,
+        }
+    }
+    true
+}
+
 /// Move `variant`'s span `delta` positions along its axis (negative is 5').
 ///
 /// Reverts and leaves the variant untouched unless the result lands exactly

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2281,13 +2281,26 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 result.push(r);
             }
 
-            // The per-member shift above is sibling-unaware: each member goes to
-            // its standalone most-3' position, which can carry it clear over a
-            // sibling's bases and make the pair denote a different sequence
-            // (#1254). Pull any such member back to the last position before the
-            // sibling — still the most 3' placement that keeps the members on
-            // disjoint windows, and now merely *adjacent*, so the next pass's
-            // merge coalesces the two.
+            // Two sibling-unaware decisions were taken per member above, and
+            // both are corrected here, in this order.
+            //
+            // First: a deletion inside a tandem tract is re-spelled as a copy
+            // count over the *whole tract* (`g.1_2del` -> `g.1_9T[7]` on a
+            // nine-base run), and that widened span can swallow a sibling. Undo
+            // it before the clamp runs, so the clamp sees a deletion span it can
+            // pull back rather than a repeat it would skip.
+            merge::demote_repeats_spanning_siblings(
+                &merged_split,
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+            );
+            // Second: each member went to its standalone most-3' position, which
+            // can carry it clear over a sibling's bases and make the pair denote
+            // a different sequence (#1254). Pull any such member back to the last
+            // position before the sibling — still the most 3' placement that
+            // keeps the members on disjoint windows, and now merely *adjacent*,
+            // so the next pass's merge coalesces the two.
             merge::clamp_sibling_crossing_shifts(
                 &merged_split,
                 &mut result,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -331,6 +331,7 @@ mod reject_single_position_insertion;
 mod reject_u_in_dna;
 mod repeat_count_trans;
 mod repeat_deln_uncertain_range;
+mod repeat_span_sibling_overlap;
 mod repeat_tract_maximization;
 mod rna_coding_consistency;
 mod rna_spl_marker;

--- a/tests/it/repeat_span_sibling_overlap.rs
+++ b/tests/it/repeat_span_sibling_overlap.rs
@@ -1,0 +1,267 @@
+//! A repeat's tract-wide span must not swallow a cis sibling.
+//!
+//! `deletion_to_repeat` (`repeated.md` B2) re-expresses a deletion inside a
+//! tandem tract as a copy count over the **whole tract**, not over the deleted
+//! bases. On a nine-`T` run, `g.1_2del` becomes `g.1_9T[7]` — correct for a lone
+//! variant, wrong the moment a cis sibling lives inside that tract:
+//!
+//! ```text
+//! reference   TTTTTTTTTAATATATTTTA        (positions 1-9 are T)
+//! input       TEMPLATE:g.[1_2del;4del]
+//! was      -> TEMPLATE:g.[1_9T[7];9del]   `9del` sits inside `1_9`
+//! now      -> TEMPLATE:g.1_9T[6]
+//! ```
+//!
+//! The conversion runs per member, deep inside `normalize_na_edit`, with no
+//! sibling context reaching it, so the widened span is undone in the allele loop
+//! instead: the repeat is re-spelled as the equivalent 3'-most deletion, the
+//! sibling-crossing clamp pulls it back, and the merge finishes the job. Repeat
+//! notation is restored once the members have coalesced and there is no sibling
+//! left to span.
+//!
+//! This is the residual left by #1254 and #1234, which fixed the *shift* into a
+//! sibling but not the *span expansion* over one — `NaEdit::Repeat` claims no
+//! reference bases as far as the clamp is concerned, so it skipped these. It is
+//! pre-existing on `main` and independent of both.
+
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{
+    parse_hgvs, HgvsVariant, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection,
+};
+
+/// Nine `T` at positions 1-9, then `AA` breaking the run.
+const TRACT: &str = "TTTTTTTTTAATATATTTTA";
+
+fn provider(seq: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", seq.to_string());
+    provider
+}
+
+fn normalize(seq: &str, input: &str) -> String {
+    normalize_in(seq, input, ShuffleDirection::ThreePrime)
+}
+
+fn normalize_in(seq: &str, input: &str, direction: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(seq),
+        NormalizeConfig::default().with_direction(direction),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+/// Apply `descriptor` to `seq` **independently of the normalizer**, via SPDI
+/// triples. Returns `None` for an unconvertible or overlapping description —
+/// an overlap has no single well-defined resulting sequence, so it must fail a
+/// test rather than be double-spliced into a sequence neither side denotes.
+fn apply(seq: &str, descriptor: &str) -> Option<String> {
+    let provider = provider(seq);
+    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let mut triples = Vec::with_capacity(members.len());
+    for member in &members {
+        triples.push(hgvs_to_spdi(member, &provider).ok()?);
+    }
+    triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+    let reference = seq.as_bytes();
+    let mut edited = reference.to_vec();
+    let mut claimed_from = reference.len();
+    for triple in &triples {
+        let start = usize::try_from(triple.position).ok()?;
+        let end = start.checked_add(triple.deletion.len())?;
+        if end > reference.len() || end > claimed_from {
+            return None;
+        }
+        if !reference[start..end].eq_ignore_ascii_case(triple.deletion.as_bytes()) {
+            return None;
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+        claimed_from = start;
+    }
+    String::from_utf8(edited).ok()
+}
+
+/// Assert `input` normalizes to `expected` and that both denote one sequence.
+fn assert_normalizes_preserving(seq: &str, input: &str, expected: &str) {
+    let actual = normalize(seq, input);
+    assert_eq!(actual, expected, "normalizing {input}");
+    let from_input = apply(seq, input).expect("input applies");
+    let from_output = apply(seq, &actual)
+        .unwrap_or_else(|| panic!("{actual} has no well-defined resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "{input} -> {actual} changed the sequence"
+    );
+}
+
+#[test]
+fn two_deletions_in_one_tract_reach_a_single_repeat() {
+    // The reported case. Three bases leave the nine-`T` tract, so the whole
+    // allele is one repeat of six copies — not a seven-copy repeat with a
+    // stray deletion inside it.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1_2del;4del]", "TEMPLATE:g.1_9T[6]");
+}
+
+#[test]
+fn three_deletions_in_one_tract_reach_the_same_repeat() {
+    // Same total, spelled as three single-base members.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1del;5del;9del]", "TEMPLATE:g.1_9T[6]");
+}
+
+#[test]
+fn a_substitution_inside_the_tract_blocks_the_repeat_form() {
+    // A substituted base inside the tract cannot be described by a copy count,
+    // so the deletion stays a deletion, clamps against the substitution, and
+    // the two coalesce.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1_2del;4T>A]", "TEMPLATE:g.2_4delinsA");
+}
+
+#[test]
+fn a_substitution_at_the_tract_end_blocks_it_too() {
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1_2del;9T>A]", "TEMPLATE:g.7_9delinsA");
+}
+
+#[test]
+fn the_repeat_and_deletion_spellings_reach_one_canonical_form() {
+    // Confluence. `[1_2del;4T>A]` used to reach the overlapping
+    // `[1_9T[7];4T>A]` while `[2_3del;4T>A]` — the same variant, already at the
+    // clamp position — reached `2_4delinsA`. Both now land on the latter.
+    for input in ["TEMPLATE:g.[1_2del;4T>A]", "TEMPLATE:g.[2_3del;4T>A]"] {
+        assert_normalizes_preserving(TRACT, input, "TEMPLATE:g.2_4delinsA");
+    }
+}
+
+#[test]
+fn a_lone_deletion_still_becomes_a_repeat() {
+    // Negative control: with no sibling there is nothing to span, so B2 applies
+    // exactly as before. Guards against "fixing" this by disabling the repeat
+    // form for deletions.
+    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_2del"), "TEMPLATE:g.1_9T[7]");
+    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_3del"), "TEMPLATE:g.1_9T[6]");
+}
+
+#[test]
+fn a_sibling_outside_the_tract_leaves_the_repeat_alone() {
+    // Negative control: `10A>G` is past the tract's last base (9), so the
+    // repeat span claims nothing the sibling claims and must survive.
+    assert_normalizes_preserving(
+        TRACT,
+        "TEMPLATE:g.[1_2del;10A>G]",
+        "TEMPLATE:g.[1_9T[7];10A>G]",
+    );
+}
+
+#[test]
+fn a_short_tract_with_a_clear_sibling_keeps_its_repeat() {
+    // Negative control on a four-base tract (`T` at 4-7): `5_6del` becomes
+    // `4_7T[2]`, and the substitution at 8 is outside it.
+    assert_normalizes_preserving(
+        "ACGTTTTACGTACGTACGTA",
+        "TEMPLATE:g.[5_6del;8A>G]",
+        "TEMPLATE:g.[4_7T[2];8A>G]",
+    );
+}
+
+#[test]
+fn a_five_prime_shuffle_is_unaffected() {
+    // B2 is gated on 3' shuffle, so under FivePrime no repeat is produced and
+    // this pass has nothing to undo.
+    let out = normalize_in(
+        TRACT,
+        "TEMPLATE:g.[1_2del;4del]",
+        ShuffleDirection::FivePrime,
+    );
+    assert!(
+        !out.contains('['),
+        "5' shuffle should not produce repeat notation, got {out}"
+    );
+    assert_eq!(
+        apply(TRACT, &out).expect("output applies"),
+        apply(TRACT, "TEMPLATE:g.[1_2del;4del]").expect("input applies"),
+    );
+}
+
+#[test]
+fn no_two_member_allele_normalizes_to_overlapping_members() {
+    // The class. Every two-member cis allele of a deletion plus a downstream
+    // deletion or substitution, over deterministic 20-mers, in both shuffle
+    // directions — checked for overlapping output *and* for sequence
+    // preservation against an independently applied reference.
+    //
+    // Overlapping outputs across this sweep: 2,578 before the sibling-crossing
+    // clamp, 526 after it (all of them this repeat-span class), 0 now.
+    let mut checked = 0usize;
+    let mut overlapping: Vec<String> = Vec::new();
+    let mut changed: Vec<String> = Vec::new();
+
+    for seed in 0..64u32 {
+        for alphabet in [b"AT".as_slice(), b"ACGT".as_slice()] {
+            let mut state = u64::from(seed).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+            let seq: String = (0..20)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    alphabet[(state % alphabet.len() as u64) as usize] as char
+                })
+                .collect();
+
+            for first_start in 1..=14usize {
+                for first_len in 1..=2usize {
+                    let first_end = first_start + first_len - 1;
+                    let first = if first_len == 1 {
+                        format!("{first_start}del")
+                    } else {
+                        format!("{first_start}_{first_end}del")
+                    };
+                    for second_start in first_end + 2..=19usize {
+                        let base = seq.as_bytes()[second_start - 1] as char;
+                        let alt = if base == 'A' { 'G' } else { 'A' };
+                        for second in [
+                            format!("{second_start}del"),
+                            format!("{second_start}{base}>{alt}"),
+                        ] {
+                            for direction in
+                                [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                            {
+                                let input = format!("TEMPLATE:g.[{first};{second}]");
+                                let output = normalize_in(&seq, &input, direction);
+                                checked += 1;
+                                let Some(want) = apply(&seq, &input) else {
+                                    continue; // unconvertible input
+                                };
+                                match apply(&seq, &output) {
+                                    // `apply` declines an overlapping output, so
+                                    // `None` here is the overlap signal.
+                                    None if overlapping.len() < 10 => {
+                                        overlapping.push(format!("{seq}: {input} -> {output}"));
+                                    }
+                                    None => {}
+                                    Some(got) if got != want && changed.len() < 10 => {
+                                        changed.push(format!(
+                                            "{seq}: {input} -> {output} (want {want}, got {got})"
+                                        ));
+                                    }
+                                    Some(_) => {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(checked > 100_000, "sweep covered too little: {checked}");
+    assert!(
+        overlapping.is_empty(),
+        "overlapping or unconvertible output in {checked} cases: {overlapping:#?}"
+    );
+    assert!(
+        changed.is_empty(),
+        "sequence-changing normalizations in {checked} cases: {changed:#?}"
+    );
+}


### PR DESCRIPTION
**Stacked on #1256** (which is stacked on #1255) — base is `test/issue-1234-cis-shift-coverage`. Review and merge #1255 → #1256 → this.

No issue filed for this, per instruction. It was found while measuring the residual of #1255's clamp, and is documented in #1256's module header as a known out-of-scope defect. This PR closes it out.

## The defect

`deletion_to_repeat` (`repeated.md` B2) re-expresses a deletion inside a tandem tract as a copy count over the **whole tract**, not over the deleted bases:

```
reference   TTTTTTTTTAATATATTTTA        positions 1-9 are T
g.1_2del                ->  g.1_9T[7]   correct for a lone variant
g.[1_2del;4del]         ->  g.[1_9T[7];9del]
                                        ^ 9del sits inside 1_9
```

Overlapping members are malformed — a base cannot be both deleted and part of a copy count — and the pair denotes a different sequence than the input.

This is the residual #1255 left behind, and it is a genuinely different mechanism. #1255 stops a member *shifting into* a sibling; here the span *expands over* one without moving. `NaEdit::Repeat` claims no reference bases as far as `claims_reference_bases` is concerned, and the expansion is not a translation, so the clamp skipped these on both counts. Pre-existing on `main`, independent of #1255 and #1256 — verified by running the probe against `origin/main`'s source, which produces the identical wrong output.

## The fix

The conversion happens in `normalize_na_edit`, four levels below the allele loop (`normalize_core` → `normalize_dispatch` → axis normalizer → `normalize_na_edit`), and nothing about siblings reaches it. Threading a barrier down five axis paths would be a large change for a narrow rule, so the decision is undone in the loop instead.

A repeat that (a) grew from a plain deletion and (b) whose tract span covers a sibling's bases is re-spelled as the equivalent **3'-most deletion of the same length**. B2 only rewrites notation — it never changes which bases are removed — so the re-spelling is exact, and the deleted count comes from the member's own pre-normalization span rather than being recomputed from the reference.

Re-spelling is what lets the rest of the pipeline finish the job. It runs **before** the clamp, so the clamp now has a real span to pull back, and the merge coalesces from there:

```
[1_2del; 4del]          input
[8_9del; 4del]          repeat re-spelled as its 3'-most deletion
[2_3del; 4del]          clamped at the sibling (#1255)
 2_4del                 merged
 1_9T[6]                repeat notation restored — no sibling left to span
```

Three bases gone from a nine-base tract, which is what the input says.

## Results

| input | before | after |
| --- | --- | --- |
| `g.[1_2del;4del]` | `g.[1_9T[7];9del]` ❌ | `g.1_9T[6]` |
| `g.[1del;5del;9del]` | `g.[1_9T[7];9del]` ❌ | `g.1_9T[6]` |
| `g.[1_2del;4T>A]` | `g.[1_9T[7];4T>A]` ❌ | `g.2_4delinsA` |
| `g.[1_2del;9T>A]` | `g.[1_9T[7];9T>A]` ❌ | `g.7_9delinsA` |
| `g.[1_2del;10A>G]` | `g.[1_9T[7];10A>G]` ✅ | unchanged — sibling is past the tract |
| `g.1_2del` | `g.1_9T[7]` ✅ | unchanged — no sibling to span |

It also restores confluence: `g.[1_2del;4T>A]` and `g.[2_3del;4T>A]` are the same variant, and used to reach an overlapping repeat and a clean delins respectively. Both now reach `g.2_4delinsA`.

## Scope, measured

Overlapping normalized outputs across 143,360 two-member cis alleles, both shuffle directions:

| build | overlapping outputs |
| --- | --- |
| `main` | 2,578 |
| \+ #1255 sibling-crossing clamp | 526 |
| **\+ this PR** | **0** |

The 526 were entirely this class. The sweep is committed as `no_two_member_allele_normalizes_to_overlapping_members` and checks sequence preservation as well as non-overlap, against an independently applied reference.

> **Scope of that "0".** The sweep generates a **deletion** as the first member. It does not cover a `dup` or `ins` first member, which reach the same tracts and produce the same malformed shape — `g.[1_2dup;4T>A]` still emits the overlapping `g.[1_9T[11];4T>A]` after this PR, because the demotion below only re-spells repeats grown from a deletion. So "0" means *the deletion-first class is closed*, not *the overlap class is closed*. #1258 stacks on this branch, widens the demotion to `dup`/`ins`, adds a junction clamp for insertion-like members, and takes the widened 276,480-case sweep to 0 overlapping.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **8812/8812** |
| `FERRO_ASSERT_IDEMPOTENT=1` full suite | **8812/8812** |
| `cargo clippy --all-features --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| new tests against the branch without the fix | 6 of 10 fail, 4 negative controls pass |

Idempotency deserves a specific note: making output depend on sibling context is exactly the kind of change that can break `norm(norm(x)) == norm(x)`, because pass 2 sees an already-normalized member set. The oracle run above covers it, and the design reason it holds is that the re-spelling only fires while a sibling is still present — once the members merge, the single remaining member canonicalises to a repeat and stays there.

**Not run: the reference-backed conformance axes.** Both the scratch and backup reference volumes are offline on this machine right now, so `FERRO_MANIFEST` tests skipped. Unlike #1256 this PR does change source, so that is a real gap rather than one inherited from a parent — the nightly reference job should be checked before merge.

## Reading order

`demote_repeats_spanning_siblings` in `src/normalize/merge.rs`, then its call site in `src/normalize/mod.rs` (note it runs before the clamp, and why), then the tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of repeat-formatted deletions when neighboring edits are present.
  * Prevented repeat spans from incorrectly absorbing sibling edits.
  * Preserved sequence-equivalent results across normalization and shuffle directions.
  * Improved convergence to consistent canonical representations for overlapping repeat/deletion spellings.

* **Tests**
  * Added comprehensive coverage for sibling overlaps, substitutions, multi-deletion alleles, and randomized scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->