### PR TITLE
fix(normalize): stop an insertion's junction crossing a sibling

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1768,20 +1768,34 @@ pub(crate) fn demote_repeats_spanning_siblings(
         let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
             continue;
         };
-        // Only a repeat that grew out of a plain deletion is re-spellable.
+        // Only a repeat is re-spellable, and only back into the kind of edit it
+        // grew out of.
         if !matches!(
             cis_axis_parts(&after[i], kind).map(|(_, _, _, _, e)| e),
             Some(NaEdit::Repeat { .. })
-        ) || !matches!(
-            cis_axis_parts(&before[i], kind).map(|(_, _, _, _, e)| e),
-            Some(NaEdit::Deletion { .. })
         ) {
             continue;
         }
-        let deleted = b.end - b.start + 1;
-        // The equivalent deletion is the 3'-most `deleted` bases of the tract.
-        let start = a.end - deleted + 1;
-        if deleted <= 0 || start < a.start || b.region != a.region {
+        let Some(source) = cis_axis_parts(&before[i], kind).and_then(|(_, _, _, _, e)| match e {
+            // A deletion removes the bases under its span.
+            NaEdit::Deletion { .. } => Some((RepeatSource::Removed, b.end - b.start + 1)),
+            // A duplication adds a copy of the bases under its span.
+            NaEdit::Duplication { .. } => Some((RepeatSource::Added, b.end - b.start + 1)),
+            // An insertion adds its own sequence at a junction; its span is the
+            // gap, so the length has to come from the sequence itself.
+            NaEdit::Insertion { sequence } => sequence
+                .len()
+                .and_then(|n| i64::try_from(n).ok())
+                .map(|n| (RepeatSource::Added, n)),
+            _ => None,
+        }) else {
+            continue;
+        };
+        let (source, length) = source;
+        // Either way the equivalent edit sits on the 3'-most `length` bases of
+        // the tract: removing them, or duplicating them.
+        let start = a.end - length + 1;
+        if length <= 0 || start < a.start || b.region != a.region {
             continue;
         }
         // Does the tract actually span a sibling's bases? Both snapshots, so a
@@ -1795,34 +1809,175 @@ pub(crate) fn demote_repeats_spanning_siblings(
         if !spans_sibling {
             continue;
         }
-        respell_as_deletion(&mut after[i], kind, a.region, start, a.end);
+        respell_as(&mut after[i], kind, a.region, start, a.end, source);
     }
 }
 
-/// Replace `variant`'s edit with a plain deletion over `[start, end]`.
+/// Pull back any cis member whose *junction* was carried over a sibling's bases.
+///
+/// [`clamp_sibling_crossing_shifts`] governs edits that consume the bases under
+/// their span. An insertion or duplication consumes none — it adds sequence at
+/// the junction between two bases — so it is excluded there, and deliberately:
+/// a member landing flush against one is the adjacency the collapse pass exists
+/// to catch (#999, #1135).
+///
+/// It can still cross. The junction itself 3'-shifts through a tract, and when
+/// a sibling substitutes or deletes a base inside that tract, moving the
+/// junction past it changes what the allele denotes:
+///
+/// ```text
+/// reference    ACAAAAAAAACGTACGTACG        A-run at 3-10
+/// g.[2_3insA;5A>G]  ->  g.[5A>G;10dup]     junction moved from 2|3 to 10|11
+/// input applied     ACAAAGAAAAACGTACGTACG
+/// output applied    ACAAGAAAAAACGTACGTACG  ← the substituted base moved
+/// ```
+///
+/// No overlap, no warning, well-formed — and wrong. The constraint is that the
+/// junction may reach a sibling's 5' edge but not pass it: for a sibling
+/// claiming `[s, e]`, a 3'-shifted junction must stay at or below `s - 1`, and
+/// a 5'-shifted one at or above `e`. That is exactly the adjacency #999 needs —
+/// its insertion lands at `306|307` against a substitution at `307`, which is
+/// the last position the rule permits — so the collapse still fires.
+///
+/// A junction sits immediately 3' of one position: `end` for a duplication
+/// (the copy follows the duplicated bases), `start` for an insertion (whose
+/// span is the gap `start_end`).
+pub(crate) fn clamp_sibling_crossing_junctions(
+    before: &[HgvsVariant],
+    after: &mut [HgvsVariant],
+    phase: AllelePhase,
+    uncertain: bool,
+) {
+    if phase != AllelePhase::Cis || uncertain || after.len() < 2 || before.len() != after.len() {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&after[0]) else {
+        return;
+    };
+    let pre: Vec<Option<MemberSpan>> = before.iter().map(|v| member_span(v, kind)).collect();
+    let post: Vec<Option<MemberSpan>> = after.iter().map(|v| member_span(v, kind)).collect();
+
+    for i in 0..after.len() {
+        let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
+            continue;
+        };
+        let (Some(before_junction), Some(after_junction)) = (
+            cis_axis_parts(&before[i], kind).and_then(|(_, _, s, e, edit)| junction_of(edit, s, e)),
+            cis_axis_parts(&after[i], kind).and_then(|(_, _, s, e, edit)| junction_of(edit, s, e)),
+        ) else {
+            continue;
+        };
+        if before_junction == after_junction || b.region != a.region {
+            continue;
+        }
+        let siblings: Vec<&MemberSpan> = (0..pre.len())
+            .filter(|&j| j != i)
+            .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
+            .flatten()
+            .filter(|s| s.claims_bases && s.region == a.region && s.accession == a.accession)
+            .collect();
+
+        // 3' only, and the 5' case is genuinely unsolved rather than merely
+        // unwritten. A duplication's span and its junction move together under a
+        // 5' shift, so bounding the junction there mis-places the copy: a mirror
+        // of the rule below was measured to turn 80 previously-correct outputs
+        // into silently wrong ones, and was removed as defective rather than
+        // deferred.
+        //
+        // A 5' junction *does* cross, in a shape this rule would not have caught
+        // anyway — when the sibling is **upstream** and the junction travels
+        // toward it (`g.[4A>G;9dup]` under 5' shuffle emits `g.4_5insG`, which
+        // denotes different bases). That is pre-existing and untouched here; see
+        // `a_five_prime_junction_with_an_upstream_sibling_is_a_known_gap`.
+        if after_junction < before_junction {
+            continue;
+        }
+        // The junction crossed a sibling if it started 5' of the sibling's
+        // first base and ended at or past it.
+        let limit = siblings
+            .iter()
+            .filter(|s| s.start > before_junction && s.start <= after_junction)
+            .map(|s| s.start - 1)
+            .min();
+        let Some(limit) = limit else {
+            continue;
+        };
+        // Never move past where the junction started.
+        let delta = (limit - after_junction).max(before_junction - after_junction);
+        if delta != 0 {
+            translate_member(&mut after[i], delta, kind, a);
+        }
+    }
+}
+
+/// The position a junction-inserting edit sits immediately 3' of, or `None` for
+/// an edit that is not junction-inserting.
+fn junction_of(edit: &NaEdit, start: i64, end: i64) -> Option<i64> {
+    match edit {
+        // The copy follows the duplicated bases.
+        NaEdit::Duplication { .. } => Some(end),
+        // The span is the gap `start_end`, so the sequence lands after `start`.
+        NaEdit::Insertion { .. } => Some(start),
+        _ => None,
+    }
+}
+
+/// Which plain edit a tract-wide repeat was standing in for.
+#[derive(Clone, Copy)]
+enum RepeatSource {
+    /// The tract lost copies — re-spell as a deletion.
+    Removed,
+    /// The tract gained copies — re-spell as a duplication.
+    Added,
+}
+
+impl RepeatSource {
+    fn edit(self) -> NaEdit {
+        match self {
+            RepeatSource::Removed => NaEdit::Deletion {
+                sequence: None,
+                length: None,
+            },
+            RepeatSource::Added => NaEdit::Duplication {
+                sequence: None,
+                length: None,
+                uncertain_extent: None,
+            },
+        }
+    }
+}
+
+/// Replace `variant`'s edit with `source`'s plain form over `[start, end]`.
 ///
 /// Reverts on any axis this pass cannot rewrite, or if the result does not land
 /// exactly where intended on the same region.
-fn respell_as_deletion(
+fn respell_as(
     variant: &mut HgvsVariant,
     kind: CisKind,
     region: Region,
     start: i64,
     end: i64,
+    source: RepeatSource,
 ) {
     let original = variant.clone();
     let placed = match variant {
-        HgvsVariant::Genome(g) => place_genome(&mut g.loc_edit, start, end),
-        HgvsVariant::Mt(m) => place_genome(&mut m.loc_edit, start, end),
-        HgvsVariant::Cds(c) => place_signed(&mut c.loc_edit, start, end, |p: &mut CdsPos, v| {
-            p.base = v;
-        }),
-        HgvsVariant::Tx(t) => place_signed(&mut t.loc_edit, start, end, |p: &mut TxPos, v| {
-            p.base = v;
-        }),
-        HgvsVariant::Rna(r) => place_signed(&mut r.loc_edit, start, end, |p: &mut RnaPos, v| {
-            p.base = v;
-        }),
+        HgvsVariant::Genome(g) => place_genome(&mut g.loc_edit, start, end, source),
+        HgvsVariant::Mt(m) => place_genome(&mut m.loc_edit, start, end, source),
+        HgvsVariant::Cds(c) => {
+            place_signed(&mut c.loc_edit, start, end, source, |p: &mut CdsPos, v| {
+                p.base = v;
+            })
+        }
+        HgvsVariant::Tx(t) => {
+            place_signed(&mut t.loc_edit, start, end, source, |p: &mut TxPos, v| {
+                p.base = v;
+            })
+        }
+        HgvsVariant::Rna(r) => {
+            place_signed(&mut r.loc_edit, start, end, source, |p: &mut RnaPos, v| {
+                p.base = v;
+            })
+        }
         _ => false,
     };
     let landed = placed
@@ -1833,8 +1988,13 @@ fn respell_as_deletion(
     }
 }
 
-/// Set a genomic `LocEdit` to a plain deletion over `[start, end]`.
-fn place_genome(loc_edit: &mut LocEdit<Interval<GenomePos>, NaEdit>, start: i64, end: i64) -> bool {
+/// Set a genomic `LocEdit` to `source`'s plain form over `[start, end]`.
+fn place_genome(
+    loc_edit: &mut LocEdit<Interval<GenomePos>, NaEdit>,
+    start: i64,
+    end: i64,
+    source: RepeatSource,
+) -> bool {
     let (Ok(start), Ok(end)) = (u64::try_from(start), u64::try_from(end)) else {
         return false;
     };
@@ -1846,18 +2006,16 @@ fn place_genome(loc_edit: &mut LocEdit<Interval<GenomePos>, NaEdit>, start: i64,
     ) {
         return false;
     }
-    loc_edit.edit = Mu::Certain(NaEdit::Deletion {
-        sequence: None,
-        length: None,
-    });
+    loc_edit.edit = Mu::Certain(source.edit());
     true
 }
 
-/// Set a signed-axis `LocEdit` to a plain deletion over `[start, end]`.
+/// Set a signed-axis `LocEdit` to `source`'s plain form over `[start, end]`.
 fn place_signed<P, L>(
     loc_edit: &mut LocEdit<Interval<P>, NaEdit>,
     start: i64,
     end: i64,
+    source: RepeatSource,
     assign: L,
 ) -> bool
 where
@@ -1869,10 +2027,7 @@ where
     if !set_endpoints(&mut loc_edit.location, assign, start, end) {
         return false;
     }
-    loc_edit.edit = Mu::Certain(NaEdit::Deletion {
-        sequence: None,
-        length: None,
-    });
+    loc_edit.edit = Mu::Certain(source.edit());
     true
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2307,6 +2307,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 allele.phase,
                 allele.uncertain,
             );
+            // Third: an insertion or duplication consumes no base, so the clamp
+            // above leaves it alone — but its *junction* shifts through a tract
+            // too, and carrying it past a base a sibling edits changes what the
+            // allele denotes. Bound the junction at the sibling's 5' edge, which
+            // is still flush against it, so the #999 collapse keeps firing.
+            merge::clamp_sibling_crossing_junctions(
+                &merged_split,
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+            );
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -1,0 +1,352 @@
+//! An insertion or duplication must not carry its junction over a sibling.
+//!
+//! The sibling-crossing clamp governs edits that consume the bases under their
+//! span. An insertion or duplication consumes none — it adds sequence at the
+//! junction between two bases — so it is excluded there, deliberately: a member
+//! landing flush against one is the adjacency the collapse pass exists to catch
+//! (#999, #1135).
+//!
+//! It can still cross. The junction 3'-shifts through a tract like anything
+//! else, and moving it past a base a sibling edits changes what the allele
+//! denotes:
+//!
+//! ```text
+//! reference    ACAAAAAAAACGTACGTACG        A-run at 3-10
+//! g.[2_3insA;5A>G]  ->  g.[5A>G;10dup]     junction moved 2|3 -> 10|11
+//! input applied     ACAAAGAAAAACGTACGTACG
+//! output applied    ACAAGAAAAAACGTACGTACG  ← the substituted base moved
+//! ```
+//!
+//! Well-formed, disjoint, warning-free, and wrong — the silent shape.
+//!
+//! The same defect reaches the repeat path. A `dup` or `ins` inside a tandem
+//! tract canonicalises to a copy count over the **whole tract**, and that span
+//! can swallow a sibling outright:
+//!
+//! ```text
+//! reference    TTTTTTTTTAATATATTTTA
+//! g.[1_2dup;4T>A]  ->  g.[1_9T[11];4T>A]   `4T>A` sits inside `1_9`
+//! ```
+//!
+//! The demotion pass re-spelled only repeats that grew from a *deletion*, so
+//! these were left. Both are fixed here: the demotion covers `dup`/`ins`-grown
+//! repeats too, and the junction is then bounded at the sibling's 5' edge —
+//! still flush against it, so the #999 collapse keeps firing.
+
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{
+    parse_hgvs, HgvsVariant, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection,
+};
+
+/// Nine `T` at positions 1-9 — a tract long enough to canonicalise to a repeat.
+const TRACT: &str = "TTTTTTTTTAATATATTTTA";
+
+/// An `A`-run at positions 3-10 — long enough for a junction to travel, short
+/// enough that a two-copy insertion does not reach repeat notation.
+const RUN: &str = "ACAAAAAAAACGTACGTACG";
+
+fn provider(seq: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", seq.to_string());
+    provider
+}
+
+fn normalize(seq: &str, input: &str) -> String {
+    normalize_in(seq, input, ShuffleDirection::ThreePrime)
+}
+
+fn normalize_in(seq: &str, input: &str, direction: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(seq),
+        NormalizeConfig::default().with_direction(direction),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+/// Apply `descriptor` to `seq` independently of the normalizer, via SPDI
+/// triples. `None` for an unconvertible or overlapping description.
+fn apply(seq: &str, descriptor: &str) -> Option<String> {
+    let provider = provider(seq);
+    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let mut triples = Vec::with_capacity(members.len());
+    for member in &members {
+        triples.push(hgvs_to_spdi(member, &provider).ok()?);
+    }
+    triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+    let reference = seq.as_bytes();
+    let mut edited = reference.to_vec();
+    let mut claimed_from = reference.len();
+    for triple in &triples {
+        let start = usize::try_from(triple.position).ok()?;
+        let end = start.checked_add(triple.deletion.len())?;
+        if end > reference.len() || end > claimed_from {
+            return None;
+        }
+        if !reference[start..end].eq_ignore_ascii_case(triple.deletion.as_bytes()) {
+            return None;
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+        claimed_from = start;
+    }
+    String::from_utf8(edited).ok()
+}
+
+fn assert_normalizes_preserving(seq: &str, input: &str, expected: &str) {
+    let actual = normalize(seq, input);
+    assert_eq!(actual, expected, "normalizing {input}");
+    let from_input = apply(seq, input).expect("input applies");
+    let from_output = apply(seq, &actual)
+        .unwrap_or_else(|| panic!("{actual} has no well-defined resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "{input} -> {actual} changed the sequence"
+    );
+}
+
+#[test]
+fn an_insertion_does_not_shift_past_a_substituted_base() {
+    // The junction may travel the `A`-run only as far as the base before the
+    // substitution; clamped there it is flush against it, and the two coalesce.
+    assert_normalizes_preserving(RUN, "TEMPLATE:g.[2_3insA;5A>G]", "TEMPLATE:g.5_6insG");
+}
+
+#[test]
+fn a_duplication_does_not_shift_past_a_substituted_base() {
+    assert_normalizes_preserving(RUN, "TEMPLATE:g.[4dup;7A>G]", "TEMPLATE:g.7_8insG");
+}
+
+#[test]
+fn a_repeat_grown_from_a_duplication_does_not_span_a_sibling() {
+    // `1_2dup` canonicalised to `1_9T[11]`, whose span covers the substituted
+    // base at 4. Demoted back to a duplication, clamped, then coalesced.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1_2dup;4T>A]", "TEMPLATE:g.5_6insAT");
+}
+
+#[test]
+fn a_repeat_grown_from_a_duplication_does_not_span_a_deletion() {
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1_2dup;4del]", "TEMPLATE:g.9dup");
+}
+
+#[test]
+fn a_repeat_grown_from_an_insertion_does_not_span_a_sibling() {
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[2_3insTT;5T>A]", "TEMPLATE:g.6_7insAT");
+}
+
+#[test]
+fn a_lone_duplication_still_reaches_repeat_notation() {
+    // Negative control: no sibling, nothing to span, so the tract-wide repeat
+    // is exactly right and must survive.
+    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_2dup"), "TEMPLATE:g.1_9T[11]");
+}
+
+#[test]
+fn an_insertion_may_still_land_flush_against_its_sibling() {
+    // Negative control for #999, the rule this clamp must not break. The
+    // inserted `C` 3'-shifts to a dup at 306, landing at the junction
+    // `306|307` — the last position the clamp permits, since `307G>T` claims
+    // base 307 and the junction has not passed it. The two then coalesce.
+    let mut seq = vec![b'A'; 1000];
+    for (i, b) in "CATCCTCGCTCCT".bytes().enumerate() {
+        seq[299 + i] = b;
+    }
+    let seq = String::from_utf8(seq).unwrap();
+    assert_eq!(
+        normalize(&seq, "TEMPLATE:g.[305_306insC;307G>T]"),
+        "TEMPLATE:g.307delinsCT"
+    );
+}
+
+#[test]
+fn an_insertion_reaching_the_end_of_its_run_still_collapses() {
+    // Negative control: the junction travels the whole `A`-run and lands flush
+    // against `11C>G`, which is outside the run — no crossing, so the two
+    // coalesce exactly as before.
+    assert_normalizes_preserving(RUN, "TEMPLATE:g.[2_3insA;11C>G]", "TEMPLATE:g.11delinsAG");
+}
+
+#[test]
+fn no_two_member_allele_normalizes_to_a_different_sequence() {
+    // The widened class. The sweep in `repeat_span_sibling_overlap.rs` uses a
+    // deletion as the first member; this one adds duplications and insertions,
+    // which reach the same tracts through the junction rather than through a
+    // consumed span.
+    //
+    // Two failure modes are counted separately: an *overlapping* output, which
+    // a consumer can at least reject, and a *sequence-changing* one, which is
+    // silent. Before this fix the same sweep reported 1,318 of the first and
+    // 1,033 of the second; it now reports 0 and 74.
+    //
+    // Those 74 are a **known, separate residual**, excluded from the assertion
+    // below and characterised in
+    // `a_five_prime_duplication_beside_a_deletion_is_a_known_residual`. They are
+    // exactly the cases that already failed before this change — verified by
+    // diffing the failing-case sets, which found zero newly-failing cases — so
+    // nothing here regressed to reach 0/74.
+    let mut checked = 0usize;
+    let mut overlapping: Vec<String> = Vec::new();
+    let mut changed: Vec<String> = Vec::new();
+
+    for seed in 0..48u32 {
+        for alphabet in [b"AT".as_slice(), b"ACGT".as_slice()] {
+            let mut state = u64::from(seed).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+            let seq: String = (0..20)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    alphabet[(state % alphabet.len() as u64) as usize] as char
+                })
+                .collect();
+
+            for first_start in 2..=13usize {
+                for first_len in 1..=2usize {
+                    let first_end = first_start + first_len - 1;
+                    let span = if first_len == 1 {
+                        format!("{first_start}")
+                    } else {
+                        format!("{first_start}_{first_end}")
+                    };
+                    let inserted = &seq[first_start - 1..first_end];
+                    let firsts = [
+                        format!("{span}del"),
+                        format!("{span}dup"),
+                        format!("{first_start}_{}ins{inserted}", first_start + 1),
+                    ];
+                    for first in firsts {
+                        for second_start in first_end + 2..=19usize {
+                            let base = seq.as_bytes()[second_start - 1] as char;
+                            let alt = if base == 'A' { 'G' } else { 'A' };
+                            for second in [
+                                format!("{second_start}del"),
+                                format!("{second_start}{base}>{alt}"),
+                            ] {
+                                for direction in
+                                    [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                                {
+                                    let input = format!("TEMPLATE:g.[{first};{second}]");
+                                    let output = normalize_in(&seq, &input, direction);
+                                    checked += 1;
+                                    let Some(want) = apply(&seq, &input) else {
+                                        continue;
+                                    };
+                                    // The known residual, excluded from the
+                                    // sequence-preservation assertion only —
+                                    // it must still never overlap.
+                                    let known_residual = first.ends_with("dup")
+                                        && second.ends_with("del")
+                                        && direction == ShuffleDirection::FivePrime;
+                                    match apply(&seq, &output) {
+                                        None if overlapping.len() < 10 => {
+                                            overlapping.push(format!("{seq}: {input} -> {output}"))
+                                        }
+                                        None => {}
+                                        Some(got)
+                                            if got != want
+                                                && !known_residual
+                                                && changed.len() < 10 =>
+                                        {
+                                            changed.push(format!(
+                                                "{seq}: {input} [{direction:?}] -> {output} (want {want}, got {got})"
+                                            ));
+                                        }
+                                        Some(_) => {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(checked > 100_000, "sweep covered too little: {checked}");
+    assert!(
+        overlapping.is_empty(),
+        "overlapping or unconvertible output in {checked} cases: {overlapping:#?}"
+    );
+    assert!(
+        changed.is_empty(),
+        "sequence-changing normalizations in {checked} cases: {changed:#?}"
+    );
+}
+
+#[test]
+fn a_five_prime_duplication_beside_a_deletion_is_a_known_residual() {
+    // Characterising the one shape the sweep above excludes, so the boundary of
+    // this fix is written down rather than implied by an exclusion.
+    //
+    // Under 5' shuffle, a duplication whose sibling is a deletion can still
+    // normalize to a different sequence. The mechanism is *not* a junction
+    // crossing — it is the merge cancelling part of the duplicated sequence
+    // against the deletion and emitting a shorter duplication:
+    //
+    //   reference        TTATTTAAATAAAAATAAAA
+    //   g.[6_7dup;9del]  applies to  TTATTTATAATAAAAATAAAA
+    //   normalizes to    g.4dup      TTATTTTAAATAAAAATAAAA   ← different
+    //
+    // The duplicated `TA` and the deleted `A` partly cancel, and what survives
+    // is emitted as a one-base duplication in the wrong place. That is a defect in the
+    // duplication/deletion cancellation path, distinct from the junction rule
+    // this file is about, and it is pre-existing — every case in this class
+    // fails identically before this change.
+    //
+    // The junction clamp is 3'-only for a related reason: an attempted 5' mirror
+    // turned 80 correct outputs of this shape into wrong ones, because a
+    // duplication's span and its junction move together under a 5' shift. It was
+    // removed as defective, not deferred — see
+    // `a_five_prime_junction_with_an_upstream_sibling_is_a_known_gap` for the 5'
+    // crossing that does exist and that the mirror would not have fixed.
+    let seq = "TTATTTAAATAAAAATAAAA";
+    let input = "TEMPLATE:g.[6_7dup;9del]";
+    let actual = normalize_in(seq, input, ShuffleDirection::FivePrime);
+
+    // Pinned as *currently wrong*, so that fixing it fails this test loudly and
+    // whoever fixes it updates the boundary above.
+    assert_eq!(actual, "TEMPLATE:g.4dup", "residual shape changed");
+    assert_ne!(
+        apply(seq, &actual).expect("output applies"),
+        apply(seq, input).expect("input applies"),
+        "the residual is fixed — update this test and re-enable the shape in the sweep"
+    );
+}
+
+#[test]
+fn a_five_prime_junction_with_an_upstream_sibling_is_a_known_gap() {
+    // A blind spot in the sweep above, written down so it is not mistaken for
+    // coverage.
+    //
+    // The sweep always places the sibling **downstream** of the first member.
+    // Under 5' shuffle the member therefore travels *away* from its sibling and
+    // can never cross it, so the sweep cannot see a 5' junction crossing at all.
+    // It exists: put the sibling upstream and the junction runs straight over
+    // it.
+    //
+    //   reference        ACAAAAAAAACGTACGTACG        A-run at 3-10
+    //   g.[4A>G;9dup]    applies to  ACAGAAAAAAACGTACGTACG
+    //   normalizes to    g.4_5insG   ACAAGAAAAAACGTACGTACG   ← different
+    //
+    // Pre-existing, and identical on the parent branch — this PR neither fixes
+    // nor worsens it. The 3'-only clamp does not apply, and the removed 5'
+    // mirror would not have caught it either: it bounded the junction against a
+    // sibling the member was moving away from, not one it was moving toward.
+    let seq = "ACAAAAAAAACGTACGTACG";
+    for (input, current) in [
+        ("TEMPLATE:g.[4A>G;9dup]", "TEMPLATE:g.4_5insG"),
+        ("TEMPLATE:g.[4A>G;9_10insA]", "TEMPLATE:g.4_5insG"),
+        ("TEMPLATE:g.[5A>G;10dup]", "TEMPLATE:g.[3dup;5A>G]"),
+    ] {
+        let actual = normalize_in(seq, input, ShuffleDirection::FivePrime);
+        assert_eq!(actual, current, "known-gap shape changed for {input}");
+        assert_ne!(
+            apply(seq, &actual).expect("output applies"),
+            apply(seq, input).expect("input applies"),
+            "{input} is fixed — update this test and widen the sweep to \
+             upstream siblings"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -34,6 +34,7 @@ mod breakpoint_insertion;
 mod build_transcript_library_parity;
 mod bulk_fixture_tests;
 mod cds_utr3_crossing_shift_idempotency;
+mod cis_junction_crossing_shift;
 mod civic_validation;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;


### PR DESCRIPTION
**Stacked on #1257** (→ #1256 → #1255). Merge order: #1255 → #1256 → #1257 → this.

Closes out **item 1** of the session retro; **item 2** is handled by an edit to #1257's description.

## What was left

#1257 stops a *deletion* that canonicalises into a whole-tract repeat from swallowing a cis sibling. It re-spells only repeats grown from a deletion, so the two sibling converters — `insertion_to_repeat` and `duplication_to_repeat` — were untouched. Probing them confirmed the identical malformed shape:

```
reference          TTTTTTTTTAATATATTTTA
g.[1_2dup;4T>A]  -> g.[1_9T[11];4T>A]     `4T>A` sits inside `1_9`
g.[2_3insTT;5T>A]-> g.[1_9T[11];5T>A]
```

Probing further turned up a **second, larger** shape that has nothing to do with repeats. An insertion or duplication consumes no reference base, so `clamp_sibling_crossing_shifts` excludes it — deliberately, because a member landing flush against one is the adjacency #999 and #1135 depend on. But its **junction** shifts through a tract like anything else, and carrying it past a base a sibling edits changes what the allele denotes:

```
reference          ACAAAAAAAACGTACGTACG        A-run at 3-10
g.[2_3insA;5A>G] -> g.[5A>G;10dup]             junction moved 2|3 -> 10|11
input applied      ACAAAGAAAAACGTACGTACG
output applied     ACAAGAAAAAACGTACGTACG       ← the substituted base moved
```

Disjoint, warning-free, well-formed, wrong. The silent shape, for insertion-like edits.

## The fix

**Demotion widened.** A repeat grown from a `dup` or `ins` is re-spelled as the equivalent 3'-most **duplication** (the deletion case re-spells to a deletion). Length comes from the member's own pre-normalization form — span length for a `dup`, sequence length for an `ins`.

**Junction clamp.** An insertion-like member's junction may reach a sibling's 5' edge but not pass it. For a sibling claiming `[s, e]`, a 3'-shifted junction stops at `s - 1`. That bound *is* the #999 adjacency — its insertion lands at `306|307` against a substitution at `307`, the last position the rule permits — so the collapse still fires. Verified by brute force that `s - 1` is exactly the 3'-most sequence-preserving junction, not a conservative under-shift.

A junction sits immediately 3' of one position: `end` for a duplication, `start` for an insertion (whose span is the gap).

## Measured

276,480 two-member cis alleles — `del`/`dup`/`ins` first member × `del`/`sub` sibling × both shuffle directions — applying both sides to the reference independently of the normalizer:

| first member | overlapping before → after | sequence-changed before → after |
| --- | --- | --- |
| `del` | 0 → 0 | 0 → 0 |
| `dup` + `sub` | 316 → **0** | 554 → **0** |
| `dup` + `del` | 370 → **0** | 151 → 74 |
| `ins` + `sub` | 316 → **0** | 328 → **0** |
| `ins` + `del` | 316 → **0** | 0 → 0 |
| **total** | **1,318 → 0** | **1,033 → 74** |

Diffing the failing-case sets: **zero newly-failing cases**. The 74 are a strict subset of what already failed, so nothing regressed to reach this.

## The clamp is 3'-only — and the 5' case is unsolved, not merely unwritten

I wrote the 5' mirror first. It measured **worse than useless**: it fixed cases but turned **80 previously-correct** outputs into silently wrong ones, because a duplication's span and its junction move together under a 5' shift, so bounding the junction mis-places the copy. Net counts favoured shipping it (2,351 bad → 154). Introducing new silent corruption does not, and that is precisely the trade I argued against when closing #1236. It was **removed as defective**, not deferred. Removing it took the residual from 154 to 74 and the regressions from 80 to 0.

A 5' junction **does** cross, in a shape that mirror would not have caught either — when the sibling is **upstream** and the junction travels toward it:

```
reference        ACAAAAAAAACGTACGTACG        A-run at 3-10
g.[4A>G;9dup]    applies to  ACAGAAAAAAACGTACGTACG
normalizes to    g.4_5insG   ACAAGAAAAAACGTACGTACG   ← different
```

**The sweep in this PR cannot see that**, and that is worth stating plainly: it always places the sibling *downstream* of the first member, so under 5' shuffle the member travels away from its sibling and can never cross it. Three hand-built upstream cases fail, identically on #1257 and on this branch — pre-existing, neither fixed nor worsened here, and pinned as currently-wrong by `a_five_prime_junction_with_an_upstream_sibling_is_a_known_gap` so the blind spot is recorded rather than implied by an unqualified "0".

## The 74 residual

One shape, characterised rather than waved at: a 5'-shuffled duplication beside a deletion, where the merge cancels part of the duplicated sequence against the deletion and emits a shorter duplication in the wrong place.

```
reference        TTATTTAAATAAAAATAAAA
g.[6_7dup;9del]  applies to  TTATTTATAATAAAAATAAAA
normalizes to    g.4dup      TTATTTTAAATAAAAATAAAA   ← different
```

Distinct mechanism from the junction rule (it is the dup/deletion cancellation path, #1135 territory), pre-existing, and **pinned as currently-wrong** by `a_five_prime_duplication_beside_a_deletion_is_a_known_residual` — so whoever fixes it gets a loud failure and a pointer to re-enable the shape in the sweep. The sweep excludes it from the sequence assertion only; it must still never overlap.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **8822/8822** |
| `FERRO_ASSERT_IDEMPOTENT=1` full suite | **8822/8822** |
| `cargo clippy --all-features --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |

#999 and #1135 pass unchanged, which is the load-bearing check — both depend on an insertion shifting to become flush with a neighbour, and the junction rule is built to permit exactly that.

**Not run: reference-backed conformance.** Both reference volumes are offline on this machine. This PR changes source, so that is a real gap — check the nightly reference job before merge, same caveat as #1257.

## Reading order

`clamp_sibling_crossing_junctions` in `src/normalize/merge.rs` (the junction rule and why it is 3'-only), then the widened `demote_repeats_spanning_siblings` above it, then the call sites in `src/normalize/mod.rs`, then the tests.

