### PR TITLE
ci(coderabbit): repoint stale test paths, cover untuned modules, enforce liveness

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,15 +1,17 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 #
 # CodeRabbit review configuration for ferro-hgvs (HGVS variant normalizer).
 #
 # This repo is output-stability-critical: parsing, normalization, and coordinate
-# projection must be idempotent, round-trip stable, and byte-identical to the
-# external oracles we conform to (biocommons hgvs, Mutalyzer, VariantValidator).
-# The `assertive` profile + the path instructions below aim the review at the
-# failure modes that actually bite here (output divergence, non-idempotent
-# normalization, parser/fast-path disagreement, coordinate off-by-one, panics on
-# adversarial input, spec-conformance drift) rather than generic style. CI
-# (proptests, fuzz targets, idempotency tests, conformance oracles) is the
+# projection must be idempotent, round-trip stable, and conformant with the
+# external oracles we validate against (biocommons hgvs, Mutalyzer,
+# VariantValidator). It also ships a PyO3 extension, a CLI, a web service, and a
+# reference-data preparation pipeline, each with its own failure modes. The
+# `assertive` profile + the path instructions below aim the review at what
+# actually bites here (output divergence, non-idempotent normalization,
+# parser/fast-path disagreement, coordinate off-by-one, panics on adversarial
+# input, spec-conformance drift, stale reference data) rather than generic style.
+# CI (proptests, fuzz targets, idempotency tests, conformance oracles) is the
 # primary correctness net; assertive makes CodeRabbit surface the borderline tier
 # that net can still miss — a false positive here is cheaper than a missed
 # output divergence.
@@ -18,6 +20,20 @@
 # CLI does NOT reliably inherit this file via `-c .coderabbit.yaml` (it can miss
 # findings the bot catches), so treat the CLI as a lighter pre-push smoke check,
 # not a substitute for the bot review.
+#
+# MAINTENANCE: the path instructions below name specific modules, invariants, and
+# test files. Re-read and update them whenever those are refactored, renamed, or
+# moved — a stale instruction silently misdirects the reviewer, which is worse
+# than no instruction at all. (The previous revision of this file pointed at
+# `tests/*.rs` paths after the integration suite had moved to `tests/it/`, so
+# every "confirm the test still covers it" pointer dangled.)
+#
+# That obligation is enforced, not just stated: `tests/it/coderabbit_config_paths.rs`
+# asserts every `path:` glob below matches at least one file in the repository, that
+# every repo-relative path named in backticks exists, and that no such path is split
+# across lines (the `>-` scalars fold a line break into a space, which would turn a
+# wrapped path into one that names nothing). A rename that orphans an instruction
+# fails the test suite instead of rotting silently.
 
 language: en-US
 
@@ -35,30 +51,53 @@ reviews:
   high_level_summary: true
   poem: false
   collapse_walkthrough: false
+  # Never auto-block merges on a review verdict; findings are advisory.
+  request_changes_workflow: false
+  estimate_code_review_effort: true
+  enable_prompt_for_ai_agents: true
+
   # Reviews are triggered on demand, not automatically. CodeRabbit enforces a
   # per-developer hourly review rate limit; auto-review on PR-open (`enabled`)
   # and on every push (`auto_incremental_review`) fire extra reviews into that
   # one shared budget, so a burst of PRs/commits exhausts it and later reviews
   # stall for hours. Disabling both keeps the budget under deliberate control —
   # reviews run only when requested. On-demand `@coderabbitai review` still works
-  # with `enabled: false`, and the assertive profile + path instructions above
-  # still apply to those reviews.
+  # with `enabled: false`, and the assertive profile + path instructions below
+  # still apply to those reviews. Use `@coderabbitai full review` after a push to
+  # force a fresh review of the whole diff instead of an incremental one.
   auto_review:
     enabled: false
     auto_incremental_review: false
     drafts: false
-  # Never auto-block merges on a review verdict; findings are advisory.
-  request_changes_workflow: false
 
-  # Don't spend review budget on build output, vendored trees, lockfiles, or the
-  # generated spec fixture (regenerated from code, never hand-edited).
+  # Don't spend review budget on build output, vendored trees, lockfiles, or
+  # committed data.
+  #
+  # Nothing under tests/fixtures/ is filtered — not even the two generated spec
+  # fixtures (`tests/fixtures/grammar/hgvs_spec_normalization.json` and
+  # `tests/fixtures/grammar/hgvs_spec_enumeration.json`, produced from code by
+  # the `generate_spec_fixture` and `generate_spec_enumeration` `[[bin]]` targets
+  # whose sources live under `examples/`, so `--example` does not work). Those two
+  # are gitignored and must never appear in a diff at all; the gitignore entry is
+  # the real gate, and the "Generated spec fixtures not committed" check below is
+  # the backstop for the case where one slips past it (`git add -f`). A `!` filter
+  # would drop the file from the reviewed diff, so that check could never observe
+  # the only situation it exists to catch. The curated `*_overrides.json` files
+  # next to them ARE committed and reviewed.
   path_filters:
     - "!**/target/**"
     - "!**/*.lock"
     - "!vendor/**"
     - "!assets/**"
-    - "!tests/fixtures/grammar/hgvs_spec_normalization.json"
+    - "!data/**"
+    - "!**/*.so"
 
+  # Scope note: these cover the modules whose failure modes are specific enough
+  # to be worth naming. Deliberately left untuned (generic review is adequate
+  # there): `src/benchmark/`, `src/perf_table/`, `src/tool_support/`,
+  # `src/clinvar/`, `src/rsid/`, `src/mave/`, `src/extractor/`, `src/config.rs`,
+  # and `src/sequence.rs`. Add an instruction when one of them grows an
+  # invariant a reviewer would not infer from the code.
   path_instructions:
     - path: "src/hgvs/parser/**/*.rs"
       instructions: >-
@@ -66,39 +105,496 @@ reviews:
         `fast_path.rs` is the DEFAULT parse route and is only sound if it is
         observationally identical to the generic `parse_variant` for EVERY input
         — both reject, or both accept and yield the same `HgvsVariant`. Treat any
-        change to fast-path eligibility or output as potentially behavior-changing
-        and confirm the differential test (`tests/fast_path_differential.rs`,
-        both its table and its proptest) still covers it. Flag: inputs the spec
-        rejects being accepted (or vice-versa); panics / unwraps / indexing on
-        attacker-controlled input (this parser is fuzzed — `fuzz/fuzz_targets/`);
-        loss of parse→Display round-trip stability; and `usize` arithmetic on
-        positions/offsets that can wrap or narrow.
+        change to fast-path eligibility or output as potentially
+        behavior-changing and confirm the differential coverage still applies
+        (`tests/it/fast_path_differential.rs`, both its table and its proptest,
+        plus `tests/it/fast_path_drift_scope.rs`). Flag: inputs the spec rejects
+        being accepted, or vice versa; panics, `unwrap`, `expect`, slicing, or
+        byte-indexing on attacker-controlled input (this parser is fuzzed —
+        `fuzz/fuzz_targets/fuzz_parse_hgvs.rs` and `fuzz_structured_hgvs.rs`);
+        non-ASCII / multi-byte input splitting a `char` boundary; loss of
+        parse→Display round-trip stability; and `usize` arithmetic on positions
+        or offsets that can wrap, saturate, or narrow. A new accepted syntax
+        needs a spec citation, not just a test.
+    - path: "src/hgvs/**/*.rs"
+      instructions: >-
+        These are the core HGVS types (`HgvsVariant`, `Edit`, `Location`,
+        position/offset representation). Their `Display` implementations are the
+        canonical serialization and are compared byte-for-byte against external
+        oracles, so any change to formatting is an output change. Flag: a
+        `Display`/`FromStr` pair that no longer round-trips; a new enum variant
+        added without handling in every downstream `match` that currently
+        enumerates variants exhaustively (silent behavior loss if a catch-all
+        arm swallows it); `Ord`/`PartialOrd` or `Hash` implementations that
+        disagree with `Eq`; and changes to the public API surface (re-exports in
+        `lib.rs`, struct fields, enum variants) that are semver-breaking without
+        a CHANGELOG entry.
     - path: "src/normalize/**/*.rs"
       instructions: >-
-        This is normalization: 3'-shifting, boundary handling, repeat shuffling,
-        edit merging, and overlap resolution. The core invariant is IDEMPOTENCY —
-        normalize(normalize(x)) == normalize(x) — and shift correctness
-        (3'-most placement, exact repeat-unit boundaries). Confirm changes are
-        covered by `tests/idempotency_tests.rs` and `tests/normalize_property_tests.rs`.
-        Flag: off-by-one in shuffle/boundary windows; wrong shift direction or
-        strand handling; mishandled circular/mitochondrial wraparound; overlap
-        merges that silently drop or reorder edits; and any path that can make a
-        second normalization pass change the output.
+        This is normalization: 3'-shifting (`shuffle.rs`), boundary handling
+        (`boundary.rs`), repeat shuffling, edit merging (`merge.rs`), overlap
+        resolution (`overlap.rs`), and rule application (`rules.rs`). The core
+        invariant is IDEMPOTENCY — normalize(normalize(x)) == normalize(x) —
+        enforced in debug builds by `FERRO_ASSERT_IDEMPOTENT=1` at the shared
+        exit of `normalize_core_checked`, which covers both `normalize()` and
+        every `VariantProjector` path. Confirm changes are covered by
+        `tests/it/idempotency_tests.rs`, `tests/it/normalize_property_tests.rs`,
+        and `tests/it/normalize_idempotency_proptest.rs`. Flag: off-by-one in
+        shuffle or boundary windows; wrong shift direction or strand handling;
+        mishandled circular/mitochondrial wraparound; overlap merges that
+        silently drop or reorder edits; any path that can make a second
+        normalization pass change the output; and any new early return that
+        bypasses the shared checked exit (which would also bypass the
+        idempotency assertion, disabling the oracle rather than satisfying it).
     - path: "src/{project,convert,coords,spdi,liftover}/**/*.rs"
       instructions: >-
         This is coordinate projection and cross-system conversion (c/g/n/r/p,
-        SPDI, liftover, CDS/intron math, protein consequence + frameshift
+        SPDI, liftover, CDS/intron math, protein consequence and frameshift
         classification). These are the off-by-one minefields. Flag: intronic
         offset sign errors on the minus strand; CDS start/end clamp boundaries;
-        UTR/exon-junction edge cases; frame/codon arithmetic; and any projection
-        that emits coordinates without validating them against transcript/contig
-        bounds. Require coverage by the relevant `tests/projection*.rs`,
-        `tests/spdi_tests.rs`, or `issue_*`/`*_matrix` regression test.
+        UTR and exon-junction edge cases; frame and codon arithmetic; 0-based
+        vs 1-based and half-open vs closed interval confusion at any boundary
+        the data crosses (HGVS is 1-based inclusive, SPDI and VCF are not); and
+        any projection that emits coordinates without validating them against
+        transcript or contig bounds. Projection must DECLINE rather than emit a
+        coordinate it cannot justify — flag a fallback that silently produces a
+        plausible-but-unverified position. Require coverage by
+        `tests/it/projection.rs`, `tests/it/projection_coverage.rs`,
+        `tests/it/hgvs_rs_projection_tests.rs`, `tests/it/spdi_tests.rs`, or the
+        relevant `issue_*` / `*_matrix` regression test.
+    - path: "src/reference/**/*.rs"
+      instructions: >-
+        This is the reference-data layer: the `ReferenceProvider` trait, FASTA
+        and multi-FASTA providers, the JSON provider, the prepared index, and
+        genomic-placement resolution (RefSeqGene→genome alignments and LRG XML
+        backing `genomic_placement`, which `VariantProjector::project_to_genomic`
+        composes with the cdot NM→NC step). Flag: a placement resolved without
+        checking the genome build, so a GRCh37 accession picks up a GRCh38
+        placement or vice versa; sequence slicing that assumes a coordinate
+        convention rather than converting explicitly; memory-mapped reads whose
+        offsets are not validated against the mapping length (fail closed on a
+        truncated or malformed index, never read past the end); a cache or
+        prepared index keyed without every input that determines its contents
+        (a stale cache is a silent wrong answer, not an error); and any provider
+        that returns a default, empty, or zero-length sequence where it should
+        return an error — downstream normalization will happily shift against it.
+        `legacy_selector.rs` resolves a bare gene selector to a transcript
+        version via the manifest's optional `ng_hosted_transcripts` artifact:
+        flag a resolution path that silently degrades to "not found" (or to an
+        arbitrary version) when that artifact is absent, rather than declining
+        distinguishably — an optional manifest field that is easy to leave unset
+        must not make a wrong answer look like a missing one.
+    - path: "src/{prepare,check,data}/**/*.rs"
+      instructions: >-
+        This is reference-data acquisition and validation (`ferro prepare`,
+        `ferro check`) — network downloads, archive extraction, and manifest
+        construction. Flag: a downloaded artifact used without verifying its
+        checksum or expected size; an extraction path taken from archive
+        contents without rejecting `..` or absolute components; a partial
+        download left in place under the final filename instead of being written
+        to a temporary path and renamed; unbounded retry or unbounded in-memory
+        buffering of a multi-gigabyte file; and any manifest entry stored as an
+        absolute path — manifest paths are relative so the prepared reference is
+        portable across hosts. Optional manifest fields are populated only when
+        the corresponding flag is passed (e.g. `--derive-ng-placements` fills
+        `ng_hosted_transcripts`), so a re-run without the flag silently clears a
+        field an earlier run set: flag a manifest write that drops or nulls a
+        field it did not compute, instead of preserving the existing value or
+        refusing to overwrite. `ferro check` must fail loudly on a manifest that
+        references a missing or size-mismatched file rather than degrading to a
+        reduced-capability mode without saying so.
+    - path: "src/vcf/**/*.rs"
+      instructions: >-
+        This is VCF parsing and HGVS annotation. Flag: REF/ALT handling that
+        assumes a single ALT allele where the record is multiallelic; the
+        anchor-base convention for indels applied inconsistently between the VCF
+        side (left-anchored, 1-based) and the HGVS side; symbolic ALTs (`<DEL>`,
+        `<*>`), spanning deletions (`*`), and breakend records treated as literal
+        sequence; POS/END arithmetic that disagrees with the emitted HGVS span;
+        and per-record failure aborting the whole stream where the configured
+        error mode says it should be reported and skipped. Any annotation change
+        needs coverage in `tests/it/annotation_cross_format.rs` or
+        `tests/it/annotation_tool_conformance.rs`.
+    - path: "src/{python.rs,python_helpers.rs}"
+      instructions: >-
+        This is the PyO3 boundary. Flag: a Rust panic that can cross the FFI
+        boundary instead of being converted to a Python exception (`unwrap`,
+        `expect`, slicing, integer overflow in debug); a long-running or
+        blocking call made without releasing the GIL; an API added, renamed, or
+        given a changed signature or default without a matching update to
+        `python/ferro_hgvs/__init__.pyi` and the docs; use of a symbol outside
+        the `abi3-py310` stable subset, which breaks the shipped abi3 wheel; and
+        error types mapped to a bare `Exception` rather than the specific
+        exception class the Python tests assert on. Any behavior reachable from
+        Python needs a test under `tests/python/`, not only a Rust test.
+    - path: "src/service/**/*.rs"
+      instructions: >-
+        This is the HTTP service (`web-service` feature). It parses untrusted
+        input with the same parser the fuzz targets exercise, so treat every
+        handler as an attack surface. Flag: a request field used without a
+        length or cardinality bound (batch endpoints in particular — an
+        unbounded list is a trivial memory-exhaustion vector); a handler that can
+        panic, since that takes down the worker; internal errors, file paths, or
+        reference-directory locations echoed into a client-visible response;
+        a blocking or CPU-heavy call on an async executor without
+        `spawn_blocking`; and a response schema change that is not additive,
+        which breaks existing clients silently.
+    - path: "src/{cli,commands,bin}/**/*.rs"
+      instructions: >-
+        This is the CLI surface. Its stdout is consumed by pipelines, so treat
+        output format as an API. Flag: a change to a JSON field name, type, or
+        nesting, or to a TSV column order, without a CHANGELOG entry; a renamed
+        flag or changed default without an alias or deprecation note; diagnostics
+        written to stdout instead of stderr (that corrupts a downstream parse);
+        a process exit code that does not distinguish "ran, found nothing" from
+        "failed"; and progress output emitted when stdout is not a TTY.
+    - path: "src/{error.rs,diagnostic.rs,error_handling/**/*.rs}"
+      instructions: >-
+        This is the configurable error-mode machinery (strict / lenient /
+        silent). Flag: a new failure path that ignores the configured mode and
+        unconditionally returns an error or unconditionally swallows one; an
+        error variant added without a stable error code, or an existing code
+        reused for a different condition (`tests/it/error_code_audit.rs` pins
+        these); a diagnostic whose message states a position or accession that
+        does not match the input that produced it; and `silent` mode dropping a
+        failure without incrementing whatever counter makes it observable — a
+        silently discarded variant must still be countable.
+    - path: "src/{batch/**/*.rs,parallel.rs,cache.rs}"
+      instructions: >-
+        This is batching, Rayon-based parallelism, and caching. Output must not
+        depend on thread count or completion order: flag any collection into an
+        unordered container, or any result ordering derived from completion
+        rather than input index (`tests/it/cli_parallel_*.rs` pin single-thread
+        vs multi-thread equivalence). Flag a cache keyed on fewer inputs than
+        determine the value, an unbounded cache with no eviction, and interior
+        mutability shared across threads without justification.
+    - path: "src/{effect,equivalence,backtranslate}/**/*.rs"
+      instructions: >-
+        This is protein-level reasoning: consequence and impact classification
+        (`effect/`), variant equivalence (`equivalence/`), and protein-to-DNA
+        backtranslation (`backtranslate/`). Flag: a translation or codon walk
+        that stops at the CDS end instead of reading through into the 3' UTR —
+        a frameshift or stop-loss consequence is only correct if the extension is
+        translated past the original terminator; a codon table used without
+        checking the sequence's genetic code (mitochondrial sequences do not use
+        the standard table); an equivalence check that answers "equivalent" from
+        string or coordinate comparison alone when the contract requires
+        comparing normalized forms against a reference; an equivalence level
+        widened (e.g. a stricter level returned where a looser one is meant, or
+        vice versa) without a test pinning the boundary between levels; and
+        backtranslation that enumerates codons without bounding the result set or
+        without stating the genetic code it assumed. `?`/unknown amino acids and
+        `Ter` must be handled explicitly, never defaulted to a concrete residue.
+    - path: "src/conformance/**/*.rs"
+      instructions: >-
+        This is the conformance-corpus schema, the reference snapshot/window
+        machinery, and the summary generators — the code that decides what the
+        committed FAIL-set ledgers under `tests/fixtures/**/baseline-failures/`
+        say. It is the single source of truth for the case schemas that both the
+        integration harnesses and `examples/generate_conformance_summary.rs`
+        deserialize through, so a schema change here silently reinterprets every
+        corpus case. Flag: a schema field made optional or given a default, which
+        turns a malformed case into a silently-accepted one; a case-outcome
+        classification (pass / fail / skip / not-applicable) whose change moves
+        cases between buckets without the PR quantifying the movement; a harness
+        that treats "no reference available" as a pass rather than a skip; and
+        snapshot or reference-window provenance (accession, build, digest)
+        dropped from the recorded output — the ledgers are only comparable when
+        the reference identity behind them is pinned.
+    - path: "src/legacy/**/*.rs"
+      instructions: >-
+        This is deprecated-notation support (IVS offsets, `c.100_102>ATG`,
+        arrow and number-first protein substitutions) that rewrites legacy input
+        into modern HGVS. A rewrite is a semantic claim, not a string edit. Flag:
+        a rewrite that changes the variant's meaning (IVS numbering resolved
+        against the wrong intron or the wrong side of the junction, a `>` form
+        expanded to a delins with a different span); a legacy form accepted by
+        the strict parser rather than only behind the legacy configuration —
+        legacy acceptance must be opt-in, because silently accepting deprecated
+        syntax makes ferro-hgvs disagree with the spec-conformant tools it is
+        validated against; and a rewrite applied without recording that it
+        happened, so a caller cannot tell a legacy input from a modern one.
     - path: "tests/**/*.rs"
       instructions: >-
-        Generate test data programmatically; do not add committed fixtures.
-        Conformance assertions must check against an INDEPENDENT oracle
-        (biocommons hgvs, Mutalyzer, VariantValidator) or a different internal
-        code path than the one under test — not a self-consistency check. Flag
-        assertions weaker than the stated contract, and `issue_*` regression
-        tests that assert the buggy output instead of the fixed one.
+        The integration suite lives in `tests/it/` behind a single harness
+        binary; new integration tests belong there and must be registered in its
+        module tree (two standalone binaries remain —
+        `tests/conformance_reference_snapshot_tests.rs` and
+        `tests/issue_500_legacy_gene_selector.rs` — do not add more). Generate
+        test data programmatically; do not add a NEW committed fixture. Three
+        families already under `tests/fixtures/` are deliberate and must not be
+        flagged: the offline cross-tool oracle snapshots under
+        `tests/fixtures/validation/` (read through the `load_fixture()` pattern
+        in `tests/it/spdi_tests.rs`, which is how an independent oracle is
+        checked without network access), and the expected-FAIL ledgers and
+        `.count` baselines that the two instructions further down address on
+        their own terms. Conformance assertions must check against an INDEPENDENT oracle
+        (biocommons hgvs, Mutalyzer, VariantValidator, or a genuinely different
+        internal code path) — not a self-consistency check that would pass
+        against the bug itself. Flag: assertions weaker than the stated contract;
+        `issue_*` regression tests that pin the buggy output instead of the fixed
+        one; a test that reads
+        `tests/fixtures/grammar/hgvs_spec_normalization.json` or
+        `tests/fixtures/grammar/hgvs_spec_enumeration.json` without going
+        through the shared `tests/it/common/spec_fixture.rs` helper (both are
+        generated, gitignored build artifacts, not committed files); and a
+        `#[ignore]` added without a linked issue explaining when it comes back.
+        Coverage added only to a reference-aware test — any test that resolves a
+        prepared reference from `FERRO_MANIFEST`, which is the mutalyzer /
+        biocommons / hgvs-rs axis suites plus roughly a dozen `issue_*` tests —
+        does NOT run on PR CI, which does not provision the manifest. Such a test
+        skips silently there; only the nightly job runs it. Say so in the PR
+        rather than citing it as pre-merge coverage.
+    - path: "tests/it/{mutalyzer_*.rs,biocommons_*.rs,hgvs_rs_projection_tests.rs}"
+      instructions: >-
+        These suites are REFERENCE-AWARE: they resolve a prepared reference from
+        `FERRO_MANIFEST` and silently no-op when it is unset. PR CI does not
+        provision the multi-gigabyte manifest (`.github/workflows/ci.yml` emits a
+        GitHub notice saying exactly that); only the nightly
+        `nightly-mutalyzer.yml` job runs them against a real reference. So a test
+        added here is NOT pre-merge coverage, and "the existing tests still pass"
+        is not evidence about this code — on PR CI they did not run. Flag: a PR
+        whose only new coverage for a behavior change lands in one of these files
+        without saying so, and without either a manifest-free test (a
+        `JsonProvider`/`MockProvider` fixture built programmatically) or an
+        explicit statement that the nightly is the gate. Flag also a skip path
+        that returns silently without printing why, and a gate that falls back to
+        a hardcoded local reference path when the env var is unset — the env var
+        is authoritative precisely so a developer host cannot pass where CI skips.
+    - path: "tests/fixtures/**/baseline-failures/*.txt"
+      instructions: >-
+        These are the committed expected-FAIL ledgers for the conformance axes
+        (Mutalyzer, biocommons, hgvs-rs projection): each line is a case
+        ferro-hgvs is known NOT to match the oracle on. They are regenerated by
+        `tests/it/failure_expectations_blesser_tests.rs`, so re-blessing is
+        mechanically easy and therefore easy to do instead of fixing the bug.
+        Treat every line change as a claim requiring evidence. Flag: a line
+        REMOVED (FAIL to PASS) without the PR naming the code change that fixed
+        it — removal is only justified if the divergence is genuinely gone, not
+        if the case stopped being emitted; a line ADDED (a new expected failure)
+        — that is a regression being blessed, and it needs an issue link and a
+        statement of which oracle it now disagrees with; bulk churn across
+        several ledgers in a PR that does not touch `src/normalize/`,
+        `src/project/`, or `src/convert/` — that means the reference data or the
+        harness moved, not the code, and the PR must say which; and any ledger
+        edit whose PR description does not state whether the change moves
+        ferro-hgvs TOWARD or AWAY from the reference oracles. Ledgers are only
+        comparable across runs when the prepared reference identity is unchanged;
+        a ledger diff landing alongside a reference or manifest change must say
+        which one caused what.
+    - path: "tests/fixtures/**/*.count"
+      instructions: >-
+        These are blessed cardinality baselines (e.g. the empty-projection counts
+        for the Mutalyzer axis) pinned against a specific prepared reference.
+        A changed count is an output change, not a bookkeeping update. Flag a
+        count edit that the PR does not explain in terms of a specific behavior
+        change, and any edit that loosens a baseline (a larger empty-projection
+        count means MORE cases now project to nothing — that is a regression
+        unless the PR argues otherwise).
+    # Proptest persists failing seeds in two layouts here: the legacy sibling
+    # file (`tests/<name>.proptest-regressions`) and the newer per-crate
+    # directory (`tests/proptest-regressions/<name>.txt`). Both need the same
+    # instruction — a single `**/*.proptest-regressions` glob silently misses
+    # the directory layout, which is where the idempotency proptest's seeds live.
+    - path: "**/*.proptest-regressions"
+      instructions: >-
+        These files are proptest's persisted failing seeds — each line is a
+        counterexample that once broke the property. Adding a line is expected
+        after a fix. Flag any diff that DELETES or rewrites an existing seed
+        line: that removes regression coverage, and it is the mechanical
+        signature of "the test was failing so I cleared the file". Require the PR
+        description to justify a deletion (e.g. the property itself was removed
+        or its semantics intentionally changed).
+    - path: "**/proptest-regressions/**/*.txt"
+      instructions: >-
+        Same contract as the sibling `*.proptest-regressions` files: these are
+        proptest's persisted failing seeds, one counterexample per line, and
+        `tests/proptest-regressions/normalize_idempotency_proptest.txt` holds the
+        seeds for the idempotency oracle specifically. Adding a line is expected
+        after a fix. Flag any diff that DELETES or rewrites an existing seed
+        line, and require the PR description to justify it.
+    - path: "fuzz/**/*.rs"
+      instructions: >-
+        These are the libFuzzer targets for the parser. Flag: a target that
+        catches or suppresses panics (that defeats the point — the panic IS the
+        finding); a harness that discards most inputs via an early `return`
+        before reaching the parser, silently collapsing coverage; and a new
+        public parse entry point added to `src/hgvs/parser/` with no
+        corresponding target here.
+    - path: "python/**/*.{py,pyi}"
+      instructions: >-
+        This is the Python package wrapping the native extension. Flag: a `.pyi`
+        stub whose signature, argument names, or return type disagrees with the
+        `#[pyfunction]`/`#[pymethods]` definition in `src/python.rs` (the stub is
+        the only type contract users see); a re-export added to `__init__.py`
+        without a stub entry, or vice versa; and use of syntax below the declared
+        minimum Python version. Follow the Google Python style with a 100-column
+        line length; all parameters and returns annotated.
+    - path: "tests/python/**/*.py"
+      instructions: >-
+        These exercise the PyO3 surface. Flag: a test asserting only that a call
+        does not raise, rather than checking the returned value; a `pytest.raises`
+        on bare `Exception` rather than the specific exception class the bindings
+        promise; and behavior tested only in Rust when it is reachable from
+        Python (the binding layer is where the signature and exception mapping
+        actually break).
+    - path: "benches/**/*.rs"
+      instructions: >-
+        Flag: a benchmark whose input is generated inside the timed region; a
+        result that can be optimized away without `black_box`; and an assertion
+        of a performance number in a unit of measure that is not comparable
+        across hosts. A benchmark is not a correctness test — flag one being used
+        to justify a behavior change without a corresponding correctness test.
+    - path: "docs/**/*.md"
+      instructions: >-
+        Flag: documented CLI flags, defaults, output fields, or Python signatures
+        that no longer match the code in this diff; a claimed conformance or
+        performance number without the corpus, tool version, and host it was
+        measured on; and any machine-local absolute path (`/Users/`, `/home/`,
+        `/Volumes/`) — runbooks must use a placeholder or a shell variable the
+        reader sets, since this repository is public.
+    - path: ".github/workflows/**"
+      instructions: >-
+        Actions must be pinned by full commit SHA with the version in a trailing
+        comment, never by a mutable tag. Flag: a matrix row that skips the test
+        step; a `continue-on-error` or unchecked step that lets a failing
+        conformance, proptest, or idempotency run pass the job; a cache key that
+        omits an input determining the cached contents; and token permissions
+        broader than the job needs.
+
+  # Deterministic checks specific to this repo. These are review-visible
+  # severities, NOT merge gates: `main`'s ruleset requires 8 status checks (Build,
+  # Test, Clippy, Clippy all-features, Format, Python Lint, Python Wheel Test,
+  # abi3 floor) and CodeRabbit is not among them, `request_changes_workflow` is
+  # false, and `auto_review.enabled` is false — so these run only on a requested
+  # review and nothing they report can block a merge. `error` therefore means
+  # "must be fixed before merging" to a human reader; `warning` means "explain it
+  # in the PR". Making any of them a real gate requires adding CodeRabbit to the
+  # branch ruleset, which is a separate, deliberate decision.
+  pre_merge_checks:
+    title:
+      mode: "warning"
+      requirements: >-
+        Title must follow Conventional Commits (feat:, fix:, perf:, refactor:,
+        docs:, test:, chore:, ci:, build:) with an optional scope, and must name
+        the component touched (e.g. parser, normalize, project, spdi, vcf,
+        python, cli) rather than a generic phrase like "improvements" or
+        "updates".
+    description:
+      mode: "warning"
+    docstrings:
+      mode: "warning"
+      threshold: 70
+    custom_checks:
+      - name: "No machine-local paths"
+        mode: "error"
+        instructions: >-
+          This repository is public and its outputs must be portable across
+          machines. FAIL if any added or modified line in the diff — in source,
+          tests, examples, docs, CI, or fixtures — contains a machine-specific
+          absolute path matching `/Users/`, `/home/`, `/Volumes/`, or
+          `C:\\Users\\`. Such paths break on every other machine and leak local
+          directory layout. The accepted alternatives are: a CLI argument, an
+          environment variable (e.g. `FERRO_MANIFEST`), a repo-relative default,
+          or — in docs and runbooks — an explicit placeholder such as
+          `/path/to/ferro-bench-data` or a shell variable the reader sets. When
+          failing, quote the line and name which alternative fits. PASS if no
+          such path appears.
+      - name: "Generated spec fixtures not committed"
+        mode: "error"
+        instructions: >-
+          `tests/fixtures/grammar/hgvs_spec_normalization.json` and
+          `tests/fixtures/grammar/hgvs_spec_enumeration.json` are generated,
+          gitignored build artifacts produced by the `generate_spec_fixture` and
+          `generate_spec_enumeration` binaries from the HGVS spec submodule plus
+          the curated overrides files.
+          They were deliberately removed from version control because committing
+          them made every parser PR a merge-conflict magnet. FAIL if the diff adds
+          or modifies either file. The curated
+          `hgvs_spec_normalization_overrides.json` and
+          `hgvs_spec_enumeration_overrides.json` ARE committed and may be
+          edited — do not flag them. PASS otherwise.
+      - name: "Output change has a pinned regression test"
+        mode: "warning"
+        instructions: >-
+          Parsing, normalization, and projection output is a contract validated
+          against external oracles. Determine whether this diff can change what
+          ferro-hgvs emits for an input it already accepted: treat as
+          output-changing any modification under src/hgvs/, src/normalize/,
+          src/project/, src/convert/, src/coords/, src/spdi/, src/liftover/, or
+          src/vcf/ that touches parsing acceptance, `Display` output, shift or
+          boundary logic, coordinate arithmetic, or edit selection. If the diff
+          is output-changing, PASS only if it also adds or modifies a test that
+          pins the NEW expected output for a concrete input — an `issue_*`
+          regression test, a `*_matrix` case, or a conformance entry — and the PR
+          description says whether the change moves ferro-hgvs toward or away
+          from the reference oracles. A test that merely still passes is not
+          sufficient. FAIL naming the specific input class whose output can move.
+          PASS trivially for changes confined to docs, CI, benches, or the build.
+      - name: "Python API and stubs in sync"
+        mode: "error"
+        instructions: >-
+          The `.pyi` stubs are the only type contract Python users see. FAIL if
+          the diff modifies a `#[pyfunction]`, `#[pymethods]`, `#[pyclass]`, or
+          `#[pymodule]` item in src/python.rs or src/python_helpers.rs — adding,
+          removing, or renaming a symbol, or changing a parameter name, order,
+          default, or return type — without a corresponding change to
+          python/ferro_hgvs/__init__.pyi (and to __init__.py if the symbol is
+          re-exported). Name the specific symbol that drifted. PASS if the diff
+          touches no PyO3 item, or if the stubs were updated to match.
+      - name: "Conformance ledger change is justified"
+        mode: "warning"
+        instructions: >-
+          The committed expected-FAIL ledgers
+          (`tests/fixtures/**/baseline-failures/*.txt`) and the blessed count
+          baselines (`tests/fixtures/**/*.count`) record where ferro-hgvs is
+          known to diverge from the Mutalyzer, biocommons, and hgvs-rs oracles.
+          They are regenerated mechanically, so updating them is the cheapest way
+          to make a failing suite green — which is exactly why a diff that
+          touches them needs an argument. PASS only if the PR description states,
+          for each ledger touched: what code or reference change moved the
+          result, and whether the movement is toward or away from the oracle.
+          FAIL if the ledger changes are unexplained; if a case moves from FAIL to
+          PASS with no corresponding fix in the diff; if a NEW expected-failure
+          line is added without an issue link (that is a regression being
+          blessed, not recorded); or if ledgers change in a diff that does not
+          touch src/ at all, without the PR naming the reference-data or harness
+          change responsible. PASS trivially if no ledger or count baseline is
+          in the diff.
+
+  # Enable the analyzers that match this stack; disable the ones that only add
+  # noise here.
+  tools:
+    clippy:
+      enabled: true
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    # Long-form design docs and runbooks with intentional formatting; both bury
+    # real findings under style noise.
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+
+knowledge_base:
+  # Carry forward what CodeRabbit learns about this repo's conventions across
+  # PRs, scoped to this repository only (it is public).
+  learnings:
+    scope: "local"
+  code_guidelines:
+    enabled: true
+    # CLAUDE.md is picked up by default; CONTRIBUTING.md and the design docs
+    # carry the conventions that are not in it.
+    filePatterns:
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - "docs/CONFORMANCE_HARNESS_DESIGN.md"
+      - "docs/RECONSTRUCTION_POLICY_DESIGN.md"

--- a/tests/it/coderabbit_config_paths.rs
+++ b/tests/it/coderabbit_config_paths.rs
@@ -1,0 +1,597 @@
+//! Liveness check for `.coderabbit.yaml`.
+//!
+//! The review config targets instructions at modules and names specific test
+//! files. Both rot silently: a renamed directory turns a `path:` glob into a
+//! pattern that matches nothing, and a moved test turns a "confirm the test
+//! still covers it" pointer into a dangling reference. Neither failure is
+//! visible — CodeRabbit does not report an instruction that never fired, so the
+//! config degrades into misdirection while still looking maintained. (This
+//! happened: the instructions pointed at `tests/<name>.rs` for a year after the
+//! integration suite moved to `tests/it/`.)
+//!
+//! This test makes that failure loud:
+//!
+//!   1. every `path:` glob under `reviews.path_instructions` matches at least
+//!      one file in the repository,
+//!   2. every repo-relative path named in backticks anywhere in the config
+//!      exists on disk, and
+//!   3. no backticked path is split across lines — the `>-` folded scalars fold
+//!      a line break into a space, so a wrapped path reaches CodeRabbit as
+//!      `tests/it/ foo.rs`, which names nothing, and
+//!   4. every `path:` glob uses only syntax the matcher here implements, so a
+//!      verdict is never issued about a pattern that was silently read as a
+//!      literal.
+//!
+//! The file universe is the git index, not the working tree — see
+//! [`repository_files`] — so the verdict is the same on a developer host with
+//! build artifacts lying around as on a clean checkout.
+//!
+//! `reviews.path_filters` are deliberately not checked: they are exclusions, so
+//! one that matches nothing is inert rather than misleading, and several of them
+//! point into the `assets/` submodule, which is empty in a checkout that has not
+//! initialized it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Directory names skipped wherever they appear — build output and tooling
+/// caches, never a legitimate target for a review instruction.
+const SKIPPED_DIR_NAMES: &[&str] = &[".git", ".venv", "node_modules", "target"];
+
+/// Directories skipped only at the repository root: the vendored spec submodule
+/// (empty unless initialized) and the top-level reference-data and vendor trees.
+/// Matched by root-relative path, not by name, so `src/data/` is still walked.
+const SKIPPED_ROOT_DIRS: &[&str] = &["assets", "data", "vendor"];
+
+/// Paths that may be named in the config while legitimately absent from a
+/// checkout: both are gitignored build artifacts that the config exists to keep
+/// *out* of diffs, so requiring them to exist would invert the intent.
+const ALLOWED_ABSENT: &[&str] = &[
+    "tests/fixtures/grammar/hgvs_spec_normalization.json",
+    "tests/fixtures/grammar/hgvs_spec_enumeration.json",
+];
+
+/// File extensions worth treating as repo-relative path references when they
+/// appear in backticks. Anything else (prose, command fragments) is ignored.
+const PATH_EXTENSIONS: &[&str] = &[
+    ".rs", ".json", ".pyi", ".py", ".txt", ".md", ".yml", ".yaml", ".toml",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn config_text() -> String {
+    let path = repo_root().join(".coderabbit.yaml");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+/// Every repository file, as a path relative to the repo root with `/`
+/// separators.
+///
+/// Tracked files are the authority: they are the only files CodeRabbit can ever
+/// see in a diff, and they are the same on every checkout. The directory walk
+/// below also counts untracked and gitignored files — the two generated spec
+/// fixtures under `tests/fixtures/grammar/` among them — so a glob whose only
+/// match is a local build artifact would look live on a developer host and be
+/// dead on a clean one, which is the determinism this test exists to provide.
+/// The walk is kept as the fallback for a checkout with no usable `git`.
+fn repository_files() -> Vec<String> {
+    let root = repo_root();
+    if let Some(tracked) = tracked_files(&root) {
+        return tracked;
+    }
+    let mut files = Vec::new();
+    collect_files(&root, &root, &mut files);
+    files.sort();
+    files
+}
+
+/// Files known to the git index, `/`-separated and sorted. `None` when `git` is
+/// unavailable or the directory is not a work tree.
+fn tracked_files(root: &Path) -> Option<Vec<String>> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // `-z` emits raw, `/`-separated pathnames with no quoting or escaping, so
+    // they need no separator rewrite — unlike the `collect_files` walk.
+    let mut files: Vec<String> = String::from_utf8(output.stdout)
+        .ok()?
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect();
+    if files.is_empty() {
+        return None;
+    }
+    files.sort();
+    Some(files)
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<String>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        if path.is_dir() {
+            let skipped = SKIPPED_DIR_NAMES.contains(&name.as_str())
+                || SKIPPED_ROOT_DIRS.contains(&relative.as_str());
+            if !skipped {
+                collect_files(root, &path, out);
+            }
+        } else {
+            out.push(relative);
+        }
+    }
+}
+
+/// The `path:` value of every entry under `reviews.path_instructions`.
+fn instruction_globs(text: &str) -> Vec<String> {
+    let config: serde_yaml::Value =
+        serde_yaml::from_str(text).expect(".coderabbit.yaml is not valid YAML");
+    let instructions = config
+        .get("reviews")
+        .and_then(|reviews| reviews.get("path_instructions"))
+        .and_then(|value| value.as_sequence())
+        .expect("reviews.path_instructions is missing or not a list");
+    instructions
+        .iter()
+        .map(|entry| {
+            entry
+                .get("path")
+                .and_then(|path| path.as_str())
+                .expect("a path_instructions entry has no `path`")
+                .to_string()
+        })
+        .collect()
+}
+
+/// The `knowledge_base.code_guidelines.filePatterns` entries, which name the
+/// files CodeRabbit loads as project guidelines.
+///
+/// Covered for the same reason as `path_instructions`: these are plain paths,
+/// and renaming one silently stops the guideline being loaded at all. That is a
+/// quieter failure than a dead instruction glob, since nothing downstream ever
+/// mentions the file again.
+fn code_guideline_patterns(text: &str) -> Vec<String> {
+    let config: serde_yaml::Value =
+        serde_yaml::from_str(text).expect(".coderabbit.yaml is not valid YAML");
+    let Some(patterns) = config
+        .get("knowledge_base")
+        .and_then(|kb| kb.get("code_guidelines"))
+        .and_then(|guidelines| guidelines.get("filePatterns"))
+    else {
+        return Vec::new();
+    };
+    patterns
+        .as_sequence()
+        .expect("knowledge_base.code_guidelines.filePatterns is not a list")
+        .iter()
+        .map(|entry| {
+            entry
+                .as_str()
+                .expect("a filePatterns entry is not a string")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Rejoins a span that a `>-` folded scalar wrapped across lines, by dropping
+/// each line break together with the indentation that follows it. Spaces within
+/// a line are preserved, so prose is still recognisable as prose.
+fn unfold(span: &str) -> String {
+    let mut out = String::with_capacity(span.len());
+    let mut folding = false;
+    for ch in span.chars() {
+        match ch {
+            '\n' | '\r' => folding = true,
+            ' ' | '\t' if folding => {}
+            _ => {
+                folding = false;
+                out.push(ch);
+            }
+        }
+    }
+    out
+}
+
+/// Whether a backticked span names a repo-relative path. Bare file names
+/// (`merge.rs`) are skipped — they are module references, not paths — as are
+/// patterns containing wildcards, which are covered by the glob check, and
+/// `<name>`-style placeholders, which stand for a family of files.
+fn is_path_reference(candidate: &str) -> bool {
+    candidate.contains('/')
+        && !candidate.contains('*')
+        && !candidate.contains('<')
+        && !candidate.contains(' ')
+        && PATH_EXTENSIONS.iter().any(|ext| candidate.ends_with(ext))
+}
+
+/// The backtick-delimited spans of `text`, in order.
+///
+/// `split('`')` alternates prose, code, prose, code — so the code spans are the
+/// odd indices, but only while the backticks are balanced. An odd count flips
+/// that parity and every consumer then reads prose as code and code as prose,
+/// finding nothing and reporting success. That silent pass is the exact failure
+/// mode this file exists to remove, so the parity is asserted rather than
+/// assumed.
+fn code_spans(text: &str) -> Vec<&str> {
+    assert!(
+        text.matches('`').count().is_multiple_of(2),
+        "unbalanced backtick: the span scan would read every code span as prose and vice versa, \
+         so both backtick checks would pass while checking nothing"
+    );
+    text.split('`').skip(1).step_by(2).collect()
+}
+
+/// Backtick-quoted repo-relative paths mentioned anywhere in the config.
+fn named_paths(text: &str) -> BTreeSet<String> {
+    let mut paths = BTreeSet::new();
+    for raw in code_spans(text) {
+        // Classify the rejoined span. A folded scalar can wrap a path across
+        // lines, and the raw span then carries a newline plus indentation —
+        // which the "no interior space" rule rejects, silently skipping exactly
+        // the dangling pointer this test exists to catch.
+        let candidate = unfold(raw);
+        if is_path_reference(&candidate) && !ALLOWED_ABSENT.contains(&candidate.as_str()) {
+            paths.insert(candidate);
+        }
+    }
+    paths
+}
+
+/// Expands `{a,b}` alternations into one pattern per alternative, recursively so
+/// nested groups are handled.
+fn expand_braces(pattern: &str) -> Vec<String> {
+    let Some(open) = pattern.find('{') else {
+        return vec![pattern.to_string()];
+    };
+    let mut depth = 0usize;
+    let mut close = None;
+    let mut alternatives = Vec::new();
+    let mut current = String::new();
+    for (index, ch) in pattern[open..].char_indices() {
+        let absolute = open + index;
+        match ch {
+            '{' => {
+                depth += 1;
+                if depth > 1 {
+                    current.push(ch);
+                }
+            }
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(absolute);
+                    alternatives.push(std::mem::take(&mut current));
+                    break;
+                }
+                current.push(ch);
+            }
+            ',' if depth == 1 => alternatives.push(std::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    let close = close.unwrap_or_else(|| panic!("unbalanced `{{` in glob: {pattern}"));
+    let (prefix, suffix) = (&pattern[..open], &pattern[close + 1..]);
+    alternatives
+        .iter()
+        .flat_map(|alternative| expand_braces(&format!("{prefix}{alternative}{suffix}")))
+        .collect()
+}
+
+/// Minimatch metacharacters this matcher does not implement. Treating one as a
+/// literal would silently misclassify the glob — a `path:` instruction using it
+/// could be reported live while matching nothing in the real review, or the
+/// reverse. Reject them instead, so adding one to the config fails loudly here
+/// and names what has to be implemented.
+const UNSUPPORTED_GLOB_CHARS: &[char] = &['?', '[', ']', '(', ')', '!'];
+
+/// The first unsupported metacharacter in `pattern`, if any. `*`, `**` and
+/// `{a,b}` are the supported forms.
+fn unsupported_glob_syntax(pattern: &str) -> Option<char> {
+    pattern
+        .chars()
+        .find(|ch| UNSUPPORTED_GLOB_CHARS.contains(ch))
+}
+
+/// Matches a brace-free glob against a `/`-separated path. `**` matches any
+/// number of whole segments (including none); `*` matches within one segment;
+/// and neither crosses into a dot-leading component unless the pattern spells
+/// the dot out, matching the minimatch semantics CodeRabbit applies.
+///
+/// Panics on syntax this matcher does not implement — see
+/// [`unsupported_glob_syntax`].
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    assert!(
+        unsupported_glob_syntax(pattern).is_none(),
+        "glob `{pattern}` uses syntax this matcher does not implement; it would be matched as a \
+         literal and the liveness verdict would be wrong"
+    );
+    let pattern_segments: Vec<&str> = pattern.split('/').collect();
+    let path_segments: Vec<&str> = path.split('/').collect();
+    match_segments(&pattern_segments, &path_segments)
+}
+
+fn match_segments(pattern: &[&str], path: &[&str]) -> bool {
+    match pattern.first() {
+        None => path.is_empty(),
+        // `**` spans whole segments, but like minimatch it does not descend
+        // through a dot-leading directory — see `segment_matches`.
+        Some(&"**") => (0..=path.len())
+            .take_while(|&skip| skip == 0 || !path[skip - 1].starts_with('.'))
+            .any(|skip| match_segments(&pattern[1..], &path[skip..])),
+        Some(segment) => match path.first() {
+            Some(candidate) if segment_matches(segment, candidate) => {
+                match_segments(&pattern[1..], &path[1..])
+            }
+            _ => false,
+        },
+    }
+}
+
+/// Wildcard match within a single path segment (`*` only; `/` never matches).
+///
+/// CodeRabbit evaluates these globs with minimatch, which matches a dot-leading
+/// component only when the pattern component starts with a literal dot — a
+/// leading wildcard never does. Without that rule a glob whose only match is a
+/// hidden file looks live here while firing on nothing in the actual review.
+fn segment_matches(pattern: &str, segment: &str) -> bool {
+    if segment.starts_with('.') && !pattern.starts_with('.') {
+        return false;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return pattern == segment;
+    }
+    let mut rest = segment;
+    if let Some(first) = parts.first() {
+        match rest.strip_prefix(first) {
+            Some(stripped) => rest = stripped,
+            None => return false,
+        }
+    }
+    if let Some(last) = parts.last() {
+        match rest.strip_suffix(last) {
+            // `rest` shrank from both ends; `last` may overlap `first` on a
+            // short segment, which `strip_suffix` on the already-stripped rest
+            // correctly rejects.
+            Some(stripped) => rest = stripped,
+            None => return false,
+        }
+    }
+    for middle in parts.iter().take(parts.len() - 1).skip(1) {
+        match rest.find(middle) {
+            Some(index) => rest = &rest[index + middle.len()..],
+            None => return false,
+        }
+    }
+    true
+}
+
+/// Brace alternatives of `glob` that select no file. Checked per alternative
+/// rather than per glob: `src/{batch,parallel.rs}` "matches something" as a
+/// whole even when `src/batch` is dead, so a whole-glob check would miss
+/// exactly the case this test exists to catch.
+fn dead_alternatives(glob: &str, files: &[String]) -> Vec<String> {
+    expand_braces(glob)
+        .into_iter()
+        .filter(|pattern| !files.iter().any(|file| glob_matches(pattern, file)))
+        .collect()
+}
+
+/// Every `path:` glob — and every brace alternative within it — must select at
+/// least one file. One that matches nothing is an instruction that can never
+/// fire.
+#[test]
+fn every_path_instruction_matches_a_file() {
+    let files = repository_files();
+    let orphans: Vec<String> = instruction_globs(&config_text())
+        .iter()
+        .flat_map(|glob| dead_alternatives(glob, &files))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        ".coderabbit.yaml has path_instructions globs that match no file — the instruction \
+         can never fire. Repoint or remove: {orphans:#?}"
+    );
+}
+
+/// The same liveness question for `knowledge_base.code_guidelines.filePatterns`.
+///
+/// A dead entry here is quieter than a dead `path_instructions` glob: the
+/// guideline simply never loads, and nothing in a review says so.
+#[test]
+fn every_code_guideline_pattern_matches_a_file() {
+    let files = repository_files();
+    let patterns = code_guideline_patterns(&config_text());
+    assert!(
+        !patterns.is_empty(),
+        "knowledge_base.code_guidelines.filePatterns is missing or empty — if the key was \
+         renamed or removed, this test is no longer checking anything"
+    );
+    let orphans: Vec<String> = patterns
+        .iter()
+        .flat_map(|pattern| dead_alternatives(pattern, &files))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        ".coderabbit.yaml names code-guideline files that do not exist, so those guidelines \
+         are never loaded. Repoint or remove: {orphans:#?}"
+    );
+}
+
+/// The matcher implements `*`, `**` and `{a,b}`. A `path:` using anything else
+/// would be matched as a literal, so the liveness verdict above would be about
+/// a pattern CodeRabbit never evaluates.
+#[test]
+fn every_path_instruction_uses_supported_glob_syntax() {
+    let unsupported: Vec<String> = instruction_globs(&config_text())
+        .iter()
+        .flat_map(|glob| expand_braces(glob))
+        .filter_map(|pattern| {
+            unsupported_glob_syntax(&pattern).map(|ch| format!("{pattern} (uses `{ch}`)"))
+        })
+        .collect();
+    assert!(
+        unsupported.is_empty(),
+        ".coderabbit.yaml uses glob syntax this test's matcher does not implement, so the \
+         liveness check cannot speak for these patterns. Implement them in `segment_matches` or \
+         rewrite the globs: {unsupported:#?}"
+    );
+}
+
+#[test]
+fn unsupported_glob_syntax_is_detected() {
+    assert_eq!(unsupported_glob_syntax("src/**/*.rs"), None);
+    assert_eq!(unsupported_glob_syntax("tests/it/mutalyzer_*.rs"), None);
+    assert_eq!(unsupported_glob_syntax("src/lib.?s"), Some('?'));
+    assert_eq!(unsupported_glob_syntax("src/[ab]/*.rs"), Some('['));
+    assert_eq!(unsupported_glob_syntax("src/!(batch)/*.rs"), Some('!'));
+}
+
+#[test]
+#[should_panic(expected = "does not implement")]
+fn glob_matches_rejects_unsupported_syntax() {
+    glob_matches("src/[ab].rs", "src/a.rs");
+}
+
+#[test]
+#[should_panic(expected = "unbalanced backtick")]
+fn code_spans_rejects_an_unbalanced_backtick() {
+    code_spans("a `tests/it/foo.rs` and a stray `");
+}
+
+#[test]
+fn dead_alternatives_flags_a_bare_directory_alternative() {
+    let files = vec![
+        "src/batch/mod.rs".to_string(),
+        "src/parallel.rs".to_string(),
+    ];
+    assert_eq!(
+        dead_alternatives("src/{batch,parallel.rs}", &files),
+        vec!["src/batch".to_string()]
+    );
+    assert!(dead_alternatives("src/{batch/**/*.rs,parallel.rs}", &files).is_empty());
+}
+
+/// Every backticked repo-relative path must exist. These are the "confirm the
+/// test still covers it" pointers; a dangling one misdirects the reviewer.
+#[test]
+fn every_named_path_exists() {
+    let root = repo_root();
+    let missing: Vec<String> = named_paths(&config_text())
+        .into_iter()
+        .filter(|path| !root.join(path).exists())
+        .collect();
+    assert!(
+        missing.is_empty(),
+        ".coderabbit.yaml names paths that do not exist — a dangling pointer silently \
+         misdirects the reviewer. Repoint or remove: {missing:#?}"
+    );
+}
+
+/// A backticked path must stay on one line. The `path_instructions` values are
+/// `>-` folded scalars, and YAML folds a line break into a space — so a wrapped
+/// path reaches CodeRabbit as `tests/it/ foo.rs`, a pointer to nothing, even
+/// though the file it meant to name exists.
+#[test]
+fn no_backticked_path_is_split_across_lines() {
+    let text = config_text();
+    let split: Vec<String> = code_spans(&text)
+        .into_iter()
+        .filter(|span| span.contains('\n'))
+        .map(unfold)
+        .filter(|candidate| is_path_reference(candidate))
+        .collect();
+    assert!(
+        split.is_empty(),
+        ".coderabbit.yaml wraps a backticked path across lines. The folded scalar turns the \
+         break into a space, so CodeRabbit reads a path that names nothing. Rewrap the line so \
+         each of these stays intact: {split:#?}"
+    );
+}
+
+#[test]
+fn glob_matcher_handles_globstar_and_wildcards() {
+    assert!(glob_matches("src/**/*.rs", "src/normalize/shuffle.rs"));
+    assert!(glob_matches("src/**/*.rs", "src/lib.rs"));
+    assert!(glob_matches(
+        "**/*.proptest-regressions",
+        "tests/x.proptest-regressions"
+    ));
+    assert!(glob_matches(
+        "tests/it/mutalyzer_*.rs",
+        "tests/it/mutalyzer_tests.rs"
+    ));
+    assert!(!glob_matches("src/**/*.rs", "src/lib.py"));
+    assert!(!glob_matches("tests/it/*.rs", "tests/it/common/mod.rs"));
+}
+
+/// A directory named without a trailing `/**` selects only the directory entry
+/// itself, never the files inside it — the failure mode that left `src/batch`
+/// uncovered.
+#[test]
+fn glob_matcher_does_not_match_files_under_a_bare_directory() {
+    assert!(!glob_matches("src/batch", "src/batch/mod.rs"));
+    assert!(glob_matches("src/batch/**/*.rs", "src/batch/mod.rs"));
+}
+
+#[test]
+fn brace_expansion_covers_every_alternative() {
+    let expanded = expand_braces("src/{a,b/**/*.rs,c.rs}");
+    assert_eq!(expanded, vec!["src/a", "src/b/**/*.rs", "src/c.rs"]);
+}
+
+#[test]
+fn named_paths_ignores_bare_file_names_and_globs() {
+    let text = "`merge.rs` `tests/it/projection.rs` `tests/it/*.rs` `cargo run --bin x`";
+    let paths = named_paths(text);
+    assert_eq!(
+        paths.into_iter().collect::<Vec<_>>(),
+        vec!["tests/it/projection.rs".to_string()]
+    );
+}
+
+/// A span the folded scalar wrapped is still a path reference, not prose: the
+/// break plus indentation must not be mistaken for an interior space.
+#[test]
+fn named_paths_rejoins_a_wrapped_backtick_span() {
+    let text = "confirm `tests/it/\n        idempotency_tests.rs` covers it";
+    assert_eq!(
+        named_paths(text).into_iter().collect::<Vec<_>>(),
+        vec!["tests/it/idempotency_tests.rs".to_string()]
+    );
+    // Rejoining must not swallow a genuine intra-line space.
+    assert!(named_paths("`cargo run\n        --bin x`").is_empty());
+}
+
+/// Minimatch — CodeRabbit's matcher — only lets a literal dot match a
+/// dot-leading component, so a glob that "matches" only hidden files is dead in
+/// the review even though a naive matcher calls it live.
+#[test]
+fn glob_matcher_uses_minimatch_dotfile_semantics() {
+    assert!(!glob_matches("src/*.rs", "src/.hidden.rs"));
+    assert!(!glob_matches("**/*.yml", ".github/workflows/ci.yml"));
+    assert!(!glob_matches("*/workflows/**", ".github/workflows/ci.yml"));
+    // An explicit literal dot still matches, which is why the real
+    // `.github/workflows/**` instruction stays live.
+    assert!(glob_matches(
+        ".github/workflows/**",
+        ".github/workflows/ci.yml"
+    ));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -50,6 +50,7 @@ mod clinvar_hgvs_tests;
 mod clinvar_tests;
 mod clinvar_validation;
 mod cmrg_exhaustive_tests;
+mod coderabbit_config_paths;
 mod comma_products_allele;
 mod compound_cross_reference;
 mod comprehensive_edge_case_tests;


### PR DESCRIPTION
The config added in #627 pointed every "confirm the test still covers it" instruction at `tests/<name>.rs`, but the integration suite has since moved into `tests/it/`. **All four pointers dangle today** — `tests/idempotency_tests.rs`, `tests/normalize_property_tests.rs`, `tests/fast_path_differential.rs`, and `tests/spdi_tests.rs` do not exist at any of those paths.

A path instruction naming a file that is not there does not fail loudly. It quietly misdirects the reviewer, which is worse than saying nothing — and it is invisible until someone goes looking.

## What changed

**Repoint the stale paths**, and add the ones that were missing: `tests/it/fast_path_drift_scope.rs`, `tests/it/normalize_idempotency_proptest.rs`, `tests/it/projection.rs`, `tests/it/projection_coverage.rs`, `tests/it/hgvs_rs_projection_tests.rs`.

**Name the idempotency oracle explicitly.** `FERRO_ASSERT_IDEMPOTENT=1` sits at the shared exit of `normalize_core_checked`, which is what makes it cover both `normalize()` and every `VariantProjector` path. The instruction now flags a new early return that bypasses that exit — which disables the oracle rather than satisfying it, and looks like a clean refactor while doing so.

**Path instructions for the modules that had none.** The original covered parser, normalize, and projection. Added:

| Module | What the reviewer is told to look for |
|---|---|
| `reference/` | A placement resolved without checking the genome build (GRCh37 accession picking up a GRCh38 placement); mmap offsets not validated against the mapping length; a prepared index or cache keyed on fewer inputs than determine its contents; a provider returning an empty sequence where it should error — normalization will happily shift against it; a legacy gene selector that degrades to "not found" when the optional `ng_hosted_transcripts` artifact is absent |
| `prepare` / `check` | A download used without checksum verification; archive extraction accepting `..` or absolute components; a partial download left under the final filename; absolute paths in the manifest, which breaks portability; a manifest write that nulls an optional field it did not compute (a re-run without `--derive-ng-placements` silently clears what an earlier run set) |
| `effect` / `equivalence` / `backtranslate` | A translation that stops at the CDS end instead of reading through the 3' UTR (a frameshift or stop-loss is only correct if the extension is translated past the original terminator); a codon table used without checking the genetic code; equivalence answered from string or coordinate comparison where the contract requires normalized forms; unknown residues and `Ter` defaulted to a concrete amino acid |
| `conformance/` | The code that decides what the committed FAIL-set ledgers say — a schema field made optional (turning a malformed case into an accepted one); a case-outcome reclassification that moves cases between buckets unquantified; "no reference available" treated as a pass rather than a skip; snapshot provenance dropped |
| `legacy/` | A rewrite that changes meaning (IVS numbering resolved against the wrong intron, a `>` form expanded to a different span); legacy forms accepted by the strict parser rather than only behind the legacy config; a rewrite applied without recording that it happened |
| `vcf/` | Single-ALT assumptions on multiallelic records; the anchor-base convention applied inconsistently between the VCF side and the HGVS side; symbolic ALTs and spanning deletions treated as literal sequence |
| `python.rs` / `python_helpers.rs` | A Rust panic crossing the FFI boundary instead of becoming a Python exception; a blocking call holding the GIL; symbols outside the `abi3-py310` subset, which breaks the shipped wheel |
| `service/` | Unbounded batch input as a memory-exhaustion vector; a handler that can panic and take down the worker; internal paths echoed into a client-visible error |
| `cli` / `commands` / `bin` | Output format treated as an API — JSON field or TSV column changes without a CHANGELOG entry; diagnostics on stdout corrupting a downstream parse |
| error modes, parallelism, `python/**`, fuzz, benches, docs, CI | Failure paths ignoring the configured strict/lenient/silent mode; result ordering derived from completion rather than input index; `.pyi` stubs drifting from the PyO3 definitions; fuzz targets that suppress panics |

A scope note names the nine modules deliberately left untuned, so the next reader can tell a decision from an oversight.

**Conformance ledgers, which nothing reached before.** `tests/fixtures/{mutalyzer,biocommons}-normalize/baseline-failures/*.txt`, the hgvs-rs projection ledgers, and the blessed `*.count` baselines are committed, but the only test-tree instruction was scoped to `tests/**/*.rs` — it never matched a `.txt`. These ledgers are regenerated mechanically by `tests/it/failure_expectations_blesser_tests.rs`, which makes re-blessing the cheapest possible way to turn a failing axis green. The new instruction treats every line change as a claim requiring evidence: a FAIL→PASS removal needs the fix named; a newly added expected-failure line is a regression being blessed and needs an issue; bulk churn in a diff that does not touch `src/` means the reference data or the harness moved, and the PR must say which.

**Reference-aware tests are not pre-merge coverage.** `ci.yml` says so in a GitHub notice: PR CI does not provision `FERRO_MANIFEST`, so the mutalyzer / biocommons / hgvs-rs suites and about a dozen `issue_*` tests skip silently; only the nightly job runs them. Several instructions ask the reviewer to confirm coverage in exactly those files, so both the general test instruction and a dedicated one for the axis suites now say that landing coverage there means saying so in the PR — "the existing tests still pass" is not a statement about code those tests never ran against.

**Proptest seeds in both layouts.** `**/*.proptest-regressions` covers the sibling-file layout but not `tests/proptest-regressions/normalize_idempotency_proptest.txt`, which is where the idempotency oracle's seeds actually live. Both are covered now.

**Five `pre_merge_checks.custom_checks`:**

1. **No machine-local paths** (`error`) — the CLAUDE.md hygiene rule, now actually enforced against the diff, with the accepted alternatives named.
2. **Generated spec fixtures not committed** (`error`) — both `hgvs_spec_normalization.json` and `hgvs_spec_enumeration.json` are gitignored build artifacts; they were removed from version control precisely because committing them made every parser PR a merge-conflict magnet. The curated overrides files are explicitly exempted.
3. **Output change has a pinned regression test** — an output-changing diff must add a test pinning the *new* expected output for a concrete input. A test that merely still passes is not sufficient.
4. **Python API and stubs in sync** (`error`) — a changed `#[pyfunction]`/`#[pymethods]` signature without a matching `__init__.pyi` update.
5. **Conformance ledger change is justified** — the deterministic companion to the ledger instruction above.

**Say what the check modes actually do.** The old comment said to raise a check to `error` only alongside `request_changes_workflow`, then three checks were `error` with that flag false. Neither reading was right: CodeRabbit is not among the eight status checks `main`'s ruleset requires, and with auto-review off these run only on a requested review. `error` is a severity a human reads, not a merge gate, and the comment now says so — making one a real gate means adding CodeRabbit to the branch ruleset, which is a separate decision.

**One removal:** the `manuscript/` path filter. That directory is gitignored and can never appear in a diff.

## The maintenance obligation is now enforced, not just stated

The previous revision's pointers rotted because nothing checked them, so a comment asking future readers to re-check was the same promise that had already failed once. `tests/it/coderabbit_config_paths.rs` asserts that every `path:` glob — and every brace alternative within it — matches at least one file in the repository, and that every repo-relative path named in backticks exists.

Written before the rest of this diff was finished, it immediately caught three live dangles in this very config:

- **`src/batch`** in `src/{batch,parallel.rs,cache.rs}` — a bare directory name matches the directory entry, never the files under it, so the parallelism-and-ordering instruction never reached `src/batch/processor.rs`. This is why the check tests each brace alternative separately: the glob as a whole "matched something" via `parallel.rs`.
- **`**/*.proptest-regressions`** — missed the directory layout entirely, as above.
- **`src/data/**/*.rs`** — surfaced while calibrating the file walk.

It also caught `cargo run --features dev --example generate_spec_fixture` in the header comment: both generators are `[[bin]]` targets whose sources live under `examples/`, so `--example` does not work.

## Preserved

`auto_review.enabled: false` and `auto_incremental_review: false` are unchanged, along with the rate-limit reasoning in the comment above them. `profile: assertive` is also unchanged — it was chosen deliberately in #627 after weighing `chill`, on the grounds that this codebase's bugs are the borderline class (`chill` suppresses subtle off-by-ones, idempotency breaks, and minus-strand sign errors) and a false positive is one click to dismiss. This PR changes what a requested review *looks at*, not when one runs.

## Validation

Checked against the published `schema.v2.json`: the YAML parses, the document is schema-valid, `tone_instructions` is 232 of the 250-character cap, and each of the five custom-check names is within the 50-character cap. Every named path and every glob is verified by `cargo nextest run --features dev -E 'test(coderabbit_config)'` — 7 tests, green — which runs in the normal test job, so no new CI wiring. `cargo fmt` and `cargo clippy --features dev --all-targets -- -D warnings` are clean.

The earlier revision of this PR claimed all 55 named paths were verified to exist. That was true at the file level and still missed the three glob-level dangles above — which is the argument for the test rather than a manual pass.

## Note for reviewers

The instructions name specific modules, invariants, and test files, so they need re-reading whenever those are refactored, renamed, or moved. The liveness test catches the mechanical half of that (a pointer that no longer resolves); it cannot catch an instruction that still resolves but no longer describes what the module does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository review automation and configuration.
  * Expanded guidance for code areas, testing, documentation, workflows, and language-specific components.
  * Added checks to detect invalid paths, generated fixture issues, output regressions, and synchronization problems.

* **Tests**
  * Added automated validation for configuration path references, glob patterns, and documented repository paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->