### PR TITLE
fix(normalize): cis member ordering and a repositioned member's clamp

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -950,7 +950,7 @@ enum SelfCancellingAxis {
 /// The genome/mito axes never carry a region flag and rarely an
 /// offset, but we include both for uniformity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct SelfCancellingPoint {
+pub(crate) struct SelfCancellingPoint {
     region: bool,
     base: i64,
     offset: i64,
@@ -1112,52 +1112,80 @@ fn rna_simple_range(interval: &crate::hgvs::interval::RnaInterval) -> Option<Sel
 /// cis-allele members in genomic (coordinate) order regardless of the order
 /// they were written (#1098).
 ///
-/// The key is `(accession, region, base, offset, descriptor)`:
+/// The key is `(accession, start, end, descriptor)`, with `start` and `end`
+/// each spelled `(region, base, offset)`:
 ///
 /// - `accession` groups members by molecule first. A bracketed cis allele is
 ///   normally single-accession, so this is constant in the common case; for a
 ///   mixed-accession allele it at least keeps members grouped and
 ///   deterministic.
-/// - `(region, base, offset)` is the member's canonical **start** point in the
-///   same "region + base + offset" coordinate the self-cancelling detector
-///   uses, so 5'UTR sorts before CDS-proper before 3'UTR and intronic offsets
-///   sort within their anchor. Members whose start cannot be resolved to a
-///   definite point (uncertain/unknown positions, or a non-positional arm)
-///   get a max sentinel so they sort last, still deterministically.
+/// - `(region, base, offset)` is a canonical point in the same "region + base +
+///   offset" coordinate the self-cancelling detector uses, so 5'UTR sorts
+///   before CDS-proper before 3'UTR and intronic offsets sort within their
+///   anchor. Members whose location cannot be resolved to a definite range
+///   (uncertain/unknown positions, or a non-positional arm) get a max sentinel
+///   so they sort last, still deterministically.
+/// - The **end** breaks a tie on the start (#1261). Two members that share a
+///   start are the ones whose rendered order was previously decided by the
+///   descriptor, which is arbitrary with respect to where they sit: a
+///   duplication places its copy at the junction *after* its last base, so
+///   `258dup` and `258_259dup` share a start but occupy interbase 258 and 259
+///   respectively, and `"258_259dup" < "258dup"` lexically rendered them
+///   descending. Ordering by the end puts them in junction order.
+///
+///   This cannot reorder members whose spans do not overlap: for those, `a < c`
+///   implies `b < c` (else the spans meet), so start-order, end-order and
+///   junction-order already agree. Overlapping members do not reach the sort at
+///   all — `normalize_allele` skips it when an `OverlapConflict` was warned,
+///   since reordering is only meaning-preserving for disjoint members.
 /// - `descriptor` (the member's rendered HGVS string) is the final tie-break.
-///   It makes the order **total**: two members that share a start point still
-///   get distinct keys, so the sort result never depends on input order. This
-///   is why a total order is used rather than a stable sort keyed on the start
-///   alone — the latter would leave same-start members in input order, which
+///   It makes the order **total**: two members sharing both endpoints still get
+///   distinct keys, so the sort result never depends on input order. This is
+///   why a total order is used rather than a stable sort keyed on position
+///   alone — the latter would leave same-position members in input order, which
 ///   is the exact order-dependence #1098 is about.
-pub(crate) fn cis_member_order_key(v: &HgvsVariant) -> (String, bool, i64, i64, String) {
+pub(crate) fn cis_member_order_key(
+    v: &HgvsVariant,
+) -> (String, SelfCancellingPoint, SelfCancellingPoint, String) {
     let accession = v.accession().map(Accession::full).unwrap_or_default();
     let descriptor = format!("{v}");
-    let (region, base, offset) = match cis_member_start_point(v) {
-        Some(p) => (p.region, p.base, p.offset),
-        None => (true, i64::MAX, i64::MAX),
-    };
-    (accession, region, base, offset, descriptor)
+    // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
+    // field order, which is exactly the comparison this key wants, so the points
+    // go in whole rather than flattened into six scalars.
+    let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
+    let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
+    (accession, start, end, descriptor)
 }
 
-/// Canonical **start** point of a cis-allele member's location, or `None` when
-/// the member has no definite positional start (uncertain/unknown positions,
-/// or a non-positional arm such as a null/unknown-allele marker). Reuses the
-/// per-axis range extractors that back the self-cancelling detector.
-fn cis_member_start_point(v: &HgvsVariant) -> Option<SelfCancellingPoint> {
+/// Canonical **start and end** points of a cis-allele member's location, or
+/// `None` when the member has no definite positional range (uncertain/unknown
+/// positions, or a non-positional arm such as a null/unknown-allele marker).
+/// Reuses the per-axis range extractors that back the self-cancelling detector.
+///
+/// The end is what breaks a start tie in [`cis_member_order_key`]; see that
+/// function's docs for why the start alone is not a sufficient discriminator.
+fn cis_member_range(v: &HgvsVariant) -> Option<SelfCancellingRange> {
     match v {
-        HgvsVariant::Genome(x) => genome_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Cds(x) => cds_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Tx(x) => tx_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Rna(x) => rna_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Mt(x) => genome_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Circular(x) => genome_simple_range(&x.loc_edit.location).map(|r| r.0),
-        HgvsVariant::Protein(x) => x
-            .loc_edit
-            .location
-            .start
-            .inner()
-            .map(|p| SelfCancellingPoint::new(false, p.number as i64, 0)),
+        HgvsVariant::Genome(x) => genome_simple_range(&x.loc_edit.location),
+        HgvsVariant::Cds(x) => cds_simple_range(&x.loc_edit.location),
+        HgvsVariant::Tx(x) => tx_simple_range(&x.loc_edit.location),
+        HgvsVariant::Rna(x) => rna_simple_range(&x.loc_edit.location),
+        HgvsVariant::Mt(x) => genome_simple_range(&x.loc_edit.location),
+        HgvsVariant::Circular(x) => genome_simple_range(&x.loc_edit.location),
+        // The protein axis needs the end for the same reason the nucleotide
+        // axes do: `p.Ala3dup` and `p.Ala3_Ala4dup` share a start, so without it
+        // their order falls to the descriptor tie-break that #1261 is about.
+        // A point location carries `end == start`, so this is the start for
+        // everything that is not a range; an absent end degrades to the start
+        // rather than dropping the member to the sort's max sentinel.
+        HgvsVariant::Protein(x) => {
+            let point = |p: &crate::hgvs::location::ProtPos| {
+                SelfCancellingPoint::new(false, p.number as i64, 0)
+            };
+            let start = x.loc_edit.location.start.inner().map(point)?;
+            let end = x.loc_edit.location.end.inner().map(point).unwrap_or(start);
+            Some((start, end))
+        }
         _ => None,
     }
 }

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2880,11 +2880,30 @@ pub(crate) fn clamp_sibling_crossing_shifts(
         if !b.claims_bases || !a.claims_bases || b.region != a.region {
             continue;
         }
-        // Only a pure translation is a rotation. A member whose span length
-        // changed (an `ins` canonicalised to a `dup`, a `delins` reduced) is
-        // not something this pass can reason about positionally.
+        // A member that did not move cannot have crossed anything.
         let delta = a.start - b.start;
-        if delta == 0 || a.end - b.end != delta {
+        if delta == 0 {
+            continue;
+        }
+        // A pure translation is the clear case: the whole span rotated.
+        //
+        // A member that *shrank* while its start moved is admitted too (#1281).
+        // Merging an adjacent substitution and deletion yields a `delins` that
+        // reduces to a plain deletion and shifts in the same pass — `g.
+        // 9_10delinsA` becomes `g.1del` on a nine-`T` tract, where `delta` is -8
+        // at the start but -9 at the end. Refusing that let the member cross
+        // eight positions unchecked, straight onto a `1del` sibling, and
+        // `g.[1del;9_10delinsA]` emitted `g.[1del;1del]` — two members claiming
+        // one base, which the apply oracle declines. It still swept a window
+        // this pass can bound, and the cap below keeps the pull inside it.
+        //
+        // A member that *grew* is still refused. An insertion canonicalising to
+        // a duplication moves its span and its junction together, so bounding
+        // the span mis-places the copy — measured on the 5' sweep, that turns
+        // correct outputs into silently wrong ones (#1266, #1279).
+        let translated = a.end - b.end == delta;
+        let shrank = a.end - a.start < b.end - b.start;
+        if !translated && !shrank {
             continue;
         }
         // Every sibling, from either snapshot, that shares this member's

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2530,13 +2530,44 @@ impl<P: ReferenceProvider> Normalizer<P> {
             );
             let merged_raw =
                 merge::merge_consecutive_edits(pre_collapsed, allele.phase, &self.provider);
-            let merged_split: Vec<HgvsVariant> = if is_cis {
-                merged_raw
-                    .into_iter()
-                    .flat_map(|v| self.canonical_split_for_variant(v))
-                    .collect()
+            // `canonical_split_for_variant` is the sequence-first
+            // canonicalization (#1237), and like `normalize_core` below it acts
+            // on one member with no sibling context. It can *reposition* a
+            // member, not merely re-spell it: on a nine-`T` tract
+            // `g.9_10delinsA` reduces to `g.1del` under a 5' shuffle, an
+            // eight-position move. The sibling passes take their "before"
+            // snapshot to decide what crossed what, so a snapshot taken *after*
+            // this step shows no movement and they let the member sit wherever
+            // it landed — including on top of a sibling (#1281).
+            //
+            // So record, per surviving member, the member it came from. A
+            // one-for-one rewrite is a repositioning of the same member, and
+            // its origin span is what the clamp needs. A genuine split into
+            // several pieces has no single origin span per piece — the pieces
+            // partition the original between them — so each piece stands for
+            // itself, exactly as before.
+            let (merged_split, pre_split): (Vec<HgvsVariant>, Vec<HgvsVariant>) = if is_cis {
+                let mut split = Vec::with_capacity(merged_raw.len());
+                let mut origins = Vec::with_capacity(merged_raw.len());
+                for variant in merged_raw {
+                    let origin = variant.clone();
+                    let pieces = self.canonical_split_for_variant(variant);
+                    if pieces.len() == 1 {
+                        origins.push(origin);
+                    } else {
+                        origins.extend(pieces.iter().cloned());
+                    }
+                    split.extend(pieces);
+                }
+                (split, origins)
             } else {
-                merged_raw
+                // Non-cis has no origin snapshot to build: all three sibling
+                // passes below return early on `phase != AllelePhase::Cis`, so
+                // cloning the member list here would be pure waste on the
+                // normalization hot path. All three also refuse a `before` whose
+                // length differs from `after`, so an empty snapshot stays safe
+                // if that phase gate ever moves.
+                (merged_raw, Vec::new())
             };
 
             let mut result: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
@@ -2557,7 +2588,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // it before the clamp runs, so the clamp sees a deletion span it can
             // pull back rather than a repeat it would skip.
             merge::demote_repeats_spanning_siblings(
-                &merged_split,
+                &pre_split,
                 &mut result,
                 allele.phase,
                 allele.uncertain,
@@ -2568,8 +2599,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // position before the sibling — still the most 3' placement that
             // keeps the members on disjoint windows, and now merely *adjacent*,
             // so the next pass's merge coalesces the two.
+            // `pre_split`, not `merged_split`: a member repositioned by the
+            // canonicalization above must be measured from where it started,
+            // not from where that step already put it (#1281).
             merge::clamp_sibling_crossing_shifts(
-                &merged_split,
+                &pre_split,
                 &mut result,
                 allele.phase,
                 allele.uncertain,
@@ -2580,7 +2614,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // allele denotes. Bound the junction at the sibling's 5' edge, which
             // is still flush against it, so the #999 collapse keeps firing.
             merge::clamp_sibling_crossing_junctions(
-                &merged_split,
+                &pre_split,
                 &mut result,
                 allele.phase,
                 allele.uncertain,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -11322,11 +11322,13 @@ mod tests {
         let key_sub = cis_member_order_key(&sub);
         let key_del = cis_member_order_key(&del);
 
-        // Same accession and same start point (region/base/offset)...
+        // Same accession, same start point, and — since both are one base wide
+        // — the same end point too, so every positional field of the key ties
+        // and only the descriptor can separate them (#1261 added the end).
         assert_eq!(
-            (&key_sub.0, key_sub.1, key_sub.2, key_sub.3),
-            (&key_del.0, key_del.1, key_del.2, key_del.3),
-            "the two members must share their start-point portion of the key"
+            (&key_sub.0, key_sub.1, key_sub.2),
+            (&key_del.0, key_del.1, key_del.2),
+            "the two members must share the whole positional portion of the key"
         );
         // ...but distinct keys overall, via the rendered-descriptor tie-break.
         assert_ne!(

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -8,8 +8,10 @@
 //!
 //! `normalize_idempotency_proptest` already fuzzes confluence for *homopolymer
 //! boundary* spellings of a single edit. This file covers the cis-allele case:
-//! one haplotype spelled as separate substitutions, as one spanning delins, and
-//! as runs grouped into delins members must all reach one form.
+//! several encodings of one haplotype must all reach one form. Two models
+//! generate those haplotypes — a substitution-only one and a length-changing
+//! one — with different encoding sets and different reach; see **Two models**
+//! below for what each can and cannot assert.
 //!
 //! Cases are **valid by construction** — the encodings are generated from a
 //! chosen set of changed positions over a known core, so each one provably
@@ -27,15 +29,38 @@
 //! oracle: `check()` normalizes both sides, so comparing a normalized result
 //! against anything returns `Identical` tautologically.
 //!
-//! **Scope: substitution-only, and so length-preserving.** Every generated
-//! haplotype replaces bases in place, which means no encoding and no normalized
-//! output can contain a bare `del`, `ins` or `dup`. That bounds what this file
-//! can reach: `shift_pieces_three_prime` only moves a piece for which
-//! `is_pure_indel()` holds, so the sibling clamp of #1234 — where a member's
-//! 3'-shift runs over a neighbour — is unreachable from here, and #1231/#1232/
-//! #1233's indel-bearing shapes are not covered. Extending the model to
-//! reference/alternate edit pairs reaches those; that work belongs with the
-//! normalizer fixes it depends on and is tracked separately.
+//! **Two models.** The original `Haplotype` is substitution-only and so
+//! length-preserving: no encoding and no normalized output can contain a bare
+//! `del`, `ins` or `dup`. That bounded what this file could reach —
+//! `shift_pieces_three_prime` only moves a piece for which `is_pure_indel()`
+//! holds, so the sibling clamp of #1234 was unreachable from here, and
+//! #1231/#1232/#1233's indel-bearing shapes were not covered.
+//!
+//! `IndelHaplotype` closes that gap: single-base deletions and one- or two-base
+//! insertions, which do reach the shifting machinery. It is deliberately a
+//! second model rather than a widening of the first — the substitution corpus
+//! is tuned (see `core_strategy` and the non-vacuity guard) and runs at the
+//! soak's 125k cases, and mixing the two would blur which shapes a failure came
+//! from.
+//!
+//! What the indel model can assert today is narrower than what it should:
+//!
+//! - The **spanning-delins comparison is held back**. A length-changing
+//!   haplotype and its spanning `delins` reach two fixed points in general, not
+//!   in two edge cases — the derivation reaches the *same* piece set from both
+//!   spellings, and only the input-relative gates in `canonicalize_from_sequence`
+//!   (the `changed_columns_of_edits` bound and the `input_separator_gaps` veto)
+//!   decide differently, because both are measured against how the input
+//!   happened to be written. Tracked by #1260 and #1262 and pinned by
+//!   `adjacent_gap_insertions_are_a_known_gap`.
+//! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
+//!   because it finds unfixed defects in the #1269 `claims_reference_bases`
+//!   family, filed as #1286 and #1287; see its doc comment for both
+//!   reproductions.
+//!
+//! Neither restriction is silent: both are named, pinned, and fail loudly when
+//! the underlying issue is fixed (#1268/#1283's complaint about coverage that
+//! reads wider than it is).
 //!
 //! Axis scope: the genomic axis, matching where the sequence-first
 //! canonicalization is enabled. Extending this to `c.`/`n.`/`r.` should follow
@@ -520,5 +545,449 @@ fn the_strategy_generates_every_shape_the_properties_depend_on() {
     panic!(
         "strategy never produced every required shape \
          (adjacent={adjacent}, separated={separated}, three_encodings={three_encodings})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Length-changing haplotypes (#1235 criterion 1, beyond substitutions)
+// ---------------------------------------------------------------------------
+
+/// One length-changing event on the core: a single-base deletion, or an
+/// insertion of one or two bases at the gap *after* an index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Event {
+    /// Delete `core[index]`.
+    Delete { index: usize },
+    /// Insert `bases` into the gap between `core[index]` and `core[index + 1]`.
+    ///
+    /// A `&'static str` payload rather than a `([char; 2], len)` pair: the
+    /// latter made a `len` past the array's end constructible, and `inserted()`
+    /// would then slice out of bounds.
+    Insert { index: usize, bases: &'static str },
+}
+
+impl Event {
+    fn index(&self) -> usize {
+        match self {
+            Event::Delete { index } | Event::Insert { index, .. } => *index,
+        }
+    }
+
+    fn inserted(&self) -> &'static str {
+        match self {
+            Event::Delete { .. } => "",
+            Event::Insert { bases, .. } => bases,
+        }
+    }
+}
+
+/// A haplotype built from length-changing events.
+///
+/// The substitution model above cannot reach a bare `del`, `ins` or `dup`, and
+/// so cannot reach the shifting machinery at all: `shift_pieces_three_prime`
+/// only moves a piece for which `is_pure_indel()` holds. This model reaches it.
+#[derive(Debug, Clone)]
+struct IndelHaplotype {
+    core: String,
+    /// Ascending by index, never two events on the same index.
+    events: Vec<Event>,
+}
+
+impl IndelHaplotype {
+    /// The core with every event applied — computed without the normalizer, so
+    /// it can detect a canonicalization that silently altered the sequence.
+    fn intended_sequence(&self) -> String {
+        let mut out = String::new();
+        for (index, base) in self.core.chars().enumerate() {
+            let deleted = self
+                .events
+                .iter()
+                .any(|e| matches!(e, Event::Delete { index: i } if *i == index));
+            if !deleted {
+                out.push(base);
+            }
+            for event in &self.events {
+                if matches!(event, Event::Insert { index: i, .. } if *i == index) {
+                    out.push_str(event.inserted());
+                }
+            }
+        }
+        out
+    }
+
+    /// The member string for one event.
+    fn member(event: &Event) -> String {
+        match event {
+            Event::Delete { index } => format!("{}del", hgvs_position(*index)),
+            Event::Insert { index, .. } => format!(
+                "{}_{}ins{}",
+                hgvs_position(*index),
+                hgvs_position(*index) + 1,
+                event.inserted()
+            ),
+        }
+    }
+
+    /// One member per event: `g.[261del;265_266insAC]`.
+    fn as_separate_members(&self) -> String {
+        let members: Vec<String> = self.events.iter().map(Self::member).collect();
+        render_members(&members)
+    }
+
+    /// The same members authored in descending order — the input the
+    /// order-independence property compares against. Shares `member` with
+    /// `as_separate_members` so the two cannot drift.
+    fn as_separate_members_reversed(&self) -> String {
+        let members: Vec<String> = self.events.iter().rev().map(Self::member).collect();
+        render_members(&members)
+    }
+
+    /// One delins spanning the first to the last affected base, carrying the
+    /// unchanged interior through: the same haplotype, spelled as one member.
+    fn as_spanning_delins(&self) -> String {
+        let first = self.events.first().expect("non-empty").index();
+        let last = self.events.last().expect("non-empty").index();
+        let mut replacement = String::new();
+        for (index, base) in self.core.chars().enumerate() {
+            if index < first || index > last {
+                continue;
+            }
+            let deleted = self
+                .events
+                .iter()
+                .any(|e| matches!(e, Event::Delete { index: i } if *i == index));
+            if !deleted {
+                replacement.push(base);
+            }
+            for event in &self.events {
+                if matches!(event, Event::Insert { index: i, .. } if *i == index) {
+                    replacement.push_str(event.inserted());
+                }
+            }
+        }
+        if replacement.is_empty() {
+            return format!(
+                "NC_TEST.1:g.{}_{}del",
+                hgvs_position(first),
+                hgvs_position(last)
+            );
+        }
+        format!(
+            "NC_TEST.1:g.{}_{}delins{replacement}",
+            hgvs_position(first),
+            hgvs_position(last)
+        )
+    }
+
+    fn encodings(&self) -> Vec<String> {
+        let mut out = Vec::with_capacity(2);
+        for encoding in [self.as_separate_members(), self.as_spanning_delins()] {
+            if !out.contains(&encoding) {
+                out.push(encoding);
+            }
+        }
+        out
+    }
+
+    /// Whether two insertions sit at **adjacent gaps** — the one shape this
+    /// model must currently exclude, tracked by #1260 and #1262.
+    ///
+    /// Excluded, not silently skipped: `adjacent_gap_insertions_are_a_known_gap`
+    /// below pins the shape as currently-broken, so fixing either issue fails
+    /// that test loudly and this filter comes out at the same time.
+    fn has_adjacent_gap_insertions(&self) -> bool {
+        self.events.windows(2).any(|pair| {
+            matches!(pair[0], Event::Insert { .. })
+                && matches!(pair[1], Event::Insert { .. })
+                && pair[1].index() == pair[0].index() + 1
+        })
+    }
+}
+
+fn indel_haplotype_strategy() -> impl Strategy<Value = IndelHaplotype> {
+    core_strategy().prop_flat_map(|core| {
+        let length = core.len();
+        // Leave the first and last base alone so an event never sits against
+        // the core/padding seam, where a shift would leave the modelled region.
+        prop::collection::btree_set(1..length.saturating_sub(1), 2..=3).prop_flat_map(
+            move |indices| {
+                let core = core.clone();
+                let indices: Vec<usize> = indices.into_iter().collect();
+                let kinds = prop::collection::vec(0..4usize, indices.len());
+                let payloads = prop::collection::vec((0..4usize, 0..4usize), indices.len());
+                (kinds, payloads)
+                    .prop_map(move |(kinds, payloads)| {
+                        // One- and two-base payloads over the full alphabet.
+                        const ONE: [&str; 4] = ["A", "C", "G", "T"];
+                        const TWO: [&str; 4] = ["AA", "AC", "GA", "TG"];
+                        let events = indices
+                            .iter()
+                            .zip(kinds.iter())
+                            .zip(payloads.iter())
+                            .map(|((index, kind), (first, second))| match kind {
+                                0 | 1 => Event::Delete { index: *index },
+                                2 => Event::Insert {
+                                    index: *index,
+                                    bases: ONE[*first],
+                                },
+                                _ => Event::Insert {
+                                    index: *index,
+                                    bases: TWO[*second],
+                                },
+                            })
+                            .collect();
+                        IndelHaplotype {
+                            core: core.clone(),
+                            events,
+                        }
+                    })
+                    .prop_filter(
+                        "two insertions at adjacent gaps: #1260 / #1262 (see module docs)",
+                        |haplotype| !haplotype.has_adjacent_gap_insertions(),
+                    )
+                    // A haplotype whose events cancel denotes the reference itself.
+                    // That is a real HGVS question (`=` and the self-cancelling
+                    // merge, #1135) but not a *confluence* one: the spanning-delins
+                    // encoding of a no-change region is degenerate, so the model
+                    // would be comparing two spellings of "nothing happened".
+                    .prop_filter("events cancel to no net change", |haplotype| {
+                        haplotype.intended_sequence() != haplotype.core
+                    })
+            },
+        )
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 512, ..ProptestConfig::default() })]
+
+    /// A length-changing haplotype normalizes to something that denotes it, is
+    /// a fixed point, and renders disjoint members in ascending order.
+    ///
+    /// **`#[ignore]`d: this currently fails, and the failures are real.** Run it
+    /// with `cargo test --features dev -- --ignored an_indel_haplotype`.
+    ///
+    /// It is committed rather than withheld because it earned its place
+    /// immediately — the first two runs found two defects that no committed
+    /// sweep reaches, now filed as #1286 and #1287:
+    ///
+    /// ```text
+    /// #1286: core "AAAAAA", insert A after index 1 and after index 2
+    ///   g.[258_259insA;259_260insA] -> g.[263dup;263dup]
+    ///     two dup members at one junction (both interbase 263)
+    ///
+    /// #1287: core "ATACAGAAAATCAGGGCATA", insert GA after 4, AA after 6
+    ///   g.[261_262insGA;263_264insAA] -> g.[262_263dup;263_266A[6]]
+    ///     the dup's junction (263) sits inside the repeat's span (262-266)
+    /// ```
+    ///
+    /// Both are the `claims_reference_bases` family (#1269): a duplication and a
+    /// repeat report that they claim no bases, so the sibling clamps skip them
+    /// and two members settle onto the same span. #1259 addressed part of this
+    /// with `demote_repeats_spanning_siblings`; these shapes are past it.
+    ///
+    /// Enabling this test is the acceptance criterion for #1286 and #1287 — do
+    /// not weaken it to make it pass.
+    #[test]
+    #[ignore = "finds real unfixed defects in the #1269 dup/repeat family; see doc comment"]
+    fn an_indel_haplotype_normalizes_to_its_own_sequence(
+        haplotype in indel_haplotype_strategy()
+    ) {
+        let provider = SyntheticBuilder::genomic(&haplotype.core).build();
+        let normalizer = Normalizer::new(provider.clone());
+        let reference = padded(&haplotype.core);
+        let intended = padded(&haplotype.intended_sequence());
+
+        let input = haplotype.as_separate_members();
+        let normalized = normalize(&normalizer, &input);
+
+        let applied = resulting_sequence(&normalized, &provider, &reference)?;
+        prop_assert_eq!(
+            &applied,
+            &intended,
+            "`{}` -> `{}` does not denote the haplotype's sequence",
+            input, normalized
+        );
+
+        let twice = normalize(&normalizer, &normalized.to_string()).to_string();
+        prop_assert_eq!(
+            &twice,
+            &normalized.to_string(),
+            "`{}` is not a fixed point",
+            normalized
+        );
+
+        let spans = interbase_spans(&normalized, &provider)?;
+        for pair in spans.windows(2) {
+            let ((_, previous_end), (start, _)) = (pair[0], pair[1]);
+            prop_assert!(
+                start >= previous_end,
+                "`{}` -> `{}`: member at interbase {} overlaps or does not follow the \
+                 previous member ending at {}",
+                input, normalized, start, previous_end
+            );
+        }
+    }
+
+    /// The rendered form does not depend on the order the members were authored
+    /// in — #1098's contract, and the confluence this model *can* check without
+    /// the delins spelling.
+    #[test]
+    fn an_indel_haplotype_is_authored_order_independent(
+        haplotype in indel_haplotype_strategy()
+    ) {
+        let provider = SyntheticBuilder::genomic(&haplotype.core).build();
+        let normalizer = Normalizer::new(provider);
+        let forward = haplotype.as_separate_members();
+        let reversed = haplotype.as_separate_members_reversed();
+        prop_assume!(forward != reversed);
+        prop_assert_eq!(
+            normalize(&normalizer, &forward).to_string(),
+            normalize(&normalizer, &reversed).to_string(),
+            "authored order changed the result:\n  {}\n  {}",
+            forward, reversed
+        );
+    }
+}
+
+/// Pins the shapes the indel model holds back, so neither the filter nor the
+/// missing spanning-delins comparison becomes permanent by inattention.
+///
+/// Both are **currently broken**, and this test asserts they still are. Fixing
+/// #1260 or #1262 fails it, which is the prompt to drop
+/// `has_adjacent_gap_insertions` and to restore the delins encoding to
+/// `an_indel_haplotype_normalizes_to_its_own_sequence`'s comparison set.
+///
+/// The two rows are not two edge cases. They are the general behaviour of
+/// "length-changing members versus the spanning delins": the derivation reaches
+/// the *same* piece set from both spellings, and only the input-relative gates
+/// in `canonicalize_from_sequence` — the `changed_columns_of_edits` bound and
+/// the `input_separator_gaps` veto — decide differently, because both are
+/// measured against how the input happened to be written.
+#[test]
+fn adjacent_gap_insertions_are_a_known_gap() {
+    let provider = SyntheticBuilder::genomic("AAAAAA").build();
+    let normalizer = Normalizer::new(provider);
+    let normalize_str = |input: &str| normalize(&normalizer, input).to_string();
+
+    // #1260, driven through the model itself so the held-back
+    // `as_spanning_delins` encoding stays exercised rather than rotting: two
+    // insertions of one base at adjacent gaps in a poly-A run.
+    let haplotype = IndelHaplotype {
+        core: "AAAAAA".to_string(),
+        events: vec![
+            Event::Insert {
+                index: 1,
+                bases: "C",
+            },
+            Event::Insert {
+                index: 2,
+                bases: "C",
+            },
+        ],
+    };
+    assert!(
+        haplotype.has_adjacent_gap_insertions(),
+        "the pinned haplotype must be the shape the strategy filters out"
+    );
+    let encodings = haplotype.encodings();
+    assert_eq!(
+        encodings.len(),
+        2,
+        "the pinned haplotype must have two distinct encodings, got {encodings:?}"
+    );
+    let normalized: Vec<String> = encodings.iter().map(|e| normalize_str(e)).collect();
+    assert_ne!(
+        normalized[0], normalized[1],
+        "#1260 appears fixed — drop `has_adjacent_gap_insertions` from \
+         `indel_haplotype_strategy` and restore the delins comparison to \
+         `an_indel_haplotype_normalizes_to_its_own_sequence`"
+    );
+
+    // #1262: a substitution and a deletion against the spanning delins. Spelled
+    // literally because the indel model has no substitution event.
+    let split = normalize_str("NC_TEST.1:g.[258A>C;260del]");
+    let spanning = normalize_str("NC_TEST.1:g.258_260delinsCA");
+    assert_ne!(
+        split, spanning,
+        "#1262 appears fixed — restore the delins comparison in \
+         `an_indel_haplotype_normalizes_to_its_own_sequence`"
+    );
+}
+
+/// Pins the two defects that keep `an_indel_haplotype_normalizes_to_its_own_sequence`
+/// `#[ignore]`d, so fixing either one fails here and names the ignore to drop.
+///
+/// Its doc comment records both reproductions, but a doc comment does not run:
+/// #1286 or #1287 could be fixed and the property would simply stay ignored,
+/// which is the coverage-that-reads-wider-than-it-is complaint in #1268/#1283.
+/// This is the same guard `adjacent_gap_insertions_are_a_known_gap` gives the
+/// two shapes the model holds back.
+///
+/// Asserted on the *shape* of the defect — two members settling onto one span,
+/// or one member's junction landing inside another's — rather than on the
+/// rendered strings, so an unrelated re-spelling does not fail it while the
+/// defect stands.
+#[test]
+fn the_ignored_indel_property_still_finds_its_two_defects() {
+    for (core, input, issue) in [
+        ("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]", "#1286"),
+        (
+            "ATACAGAAAATCAGGGCATA",
+            "NC_TEST.1:g.[261_262insGA;263_264insAA]",
+            "#1287",
+        ),
+    ] {
+        let provider = SyntheticBuilder::genomic(core).build();
+        let normalizer = Normalizer::new(provider.clone());
+        let normalized = normalize(&normalizer, input);
+        let spans = interbase_spans(&normalized, &provider)
+            .expect("every normalized member converts to SPDI");
+        assert!(
+            spans
+                .windows(2)
+                .any(|pair| pair[0] == pair[1] || pair[1].0 < pair[0].1),
+            "{issue} appears fixed — `{input}` -> `{normalized}` now renders disjoint \
+             members {spans:?}. Re-run `an_indel_haplotype_normalizes_to_its_own_sequence` \
+             with `--ignored`, and drop its `#[ignore]` once both are fixed."
+        );
+    }
+}
+
+/// Non-vacuity guard for the indel model: it must actually produce deletions,
+/// insertions, and haplotypes mixing the two, or the properties above are
+/// asserting over a corpus narrower than they read as covering (#1268/#1283).
+#[test]
+fn the_indel_strategy_generates_every_shape_the_properties_depend_on() {
+    use proptest::strategy::ValueTree;
+    use proptest::test_runner::TestRunner;
+
+    let mut runner = TestRunner::deterministic();
+    let (mut deletion, mut insertion, mut mixed, mut multi_base) = (false, false, false, false);
+    for _ in 0..512 {
+        let haplotype = indel_haplotype_strategy()
+            .new_tree(&mut runner)
+            .expect("strategy produces a value")
+            .current();
+        let deletes = haplotype
+            .events
+            .iter()
+            .filter(|e| matches!(e, Event::Delete { .. }))
+            .count();
+        let inserts = haplotype.events.len() - deletes;
+        deletion |= deletes > 0;
+        insertion |= inserts > 0;
+        mixed |= deletes > 0 && inserts > 0;
+        multi_base |= haplotype
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::Insert { bases, .. } if bases.len() == 2));
+        if deletion && insertion && mixed && multi_base {
+            return;
+        }
+    }
+    panic!(
+        "indel strategy never produced every required shape (deletion={deletion}, \
+         insertion={insertion}, mixed={mixed}, multi_base={multi_base})"
     );
 }

--- a/tests/it/common/cis_apply_oracle.rs
+++ b/tests/it/common/cis_apply_oracle.rs
@@ -162,6 +162,44 @@ pub fn apply_with<P: ReferenceProvider + ?Sized>(
     String::from_utf8(edited).ok()
 }
 
+/// The half-open interbase spans of `descriptor`'s members, in the order they
+/// are rendered.
+///
+/// Spans come from `hgvs_to_spdi` rather than the printed HGVS endpoints
+/// because the two disagree for the edits that consume no base: `a_b ins` names
+/// two positions while occupying the junction at `a`, and `a_b dup` places its
+/// copy at the junction *after* `b`. Interbase coordinates are the frame the
+/// ordering and disjointness contracts are actually stated in — reading the
+/// printed endpoints instead is what let #1261 render as ascending.
+pub fn member_interbase_spans(seq: &str, descriptor: &str) -> Vec<(u64, u64)> {
+    let template = provider(seq);
+    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).expect("parse") {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    members
+        .iter()
+        .map(|member| {
+            let triple = hgvs_to_spdi(member, &template)
+                .unwrap_or_else(|e| panic!("`{descriptor}`: member `{member}` has no SPDI: {e}"));
+            (
+                triple.position,
+                triple.position + triple.deletion.len() as u64,
+            )
+        })
+        .collect()
+}
+
+/// Assert that `descriptor`'s members are rendered in ascending interbase
+/// order (#1098's contract, and #1235's second acceptance criterion).
+pub fn assert_members_ascending(seq: &str, descriptor: &str) {
+    let spans = member_interbase_spans(seq, descriptor);
+    assert!(
+        spans.windows(2).all(|pair| pair[0] <= pair[1]),
+        "`{descriptor}` renders its members out of order: interbase spans {spans:?}"
+    );
+}
+
 /// Assert that `input` normalizes to `expected` *and* that both denote the same
 /// sequence when applied to `seq`.
 pub fn assert_normalizes_preserving(seq: &str, input: &str, expected: &str) {

--- a/tests/it/common/cis_apply_oracle.rs
+++ b/tests/it/common/cis_apply_oracle.rs
@@ -8,11 +8,15 @@
 //! [`apply_with`] is the load-bearing piece: its `claimed_from` walk is what
 //! makes "declines an overlapping description" true, and every
 //! sequence-preservation assertion in `cis_junction_crossing_shift.rs`,
-//! `issue_1234_sibling_clamped_shift.rs`, `issue_1254_sibling_crossing_shift.rs`
-//! and `repeat_span_sibling_overlap.rs` rests on it. It lives here rather than
+//! `issue_1234_sibling_clamped_shift.rs`, `issue_1254_sibling_crossing_shift.rs`,
+//! `issue_1261_cis_member_order.rs`, `issue_1281_reducing_member_shift.rs` and
+//! `repeat_span_sibling_overlap.rs` rests on it. It lives here rather than
 //! being copied into each of them so a change cannot silently weaken one file's
 //! oracle while the others keep their own version — it is generic over the
 //! provider so the `JsonProvider`-backed file shares it too.
+//!
+//! [`assert_normalizes_preserving`] and [`assert_normalizes_preserving_in`] are
+//! the assertion half of that, one per shuffle direction, for the same reason.
 //!
 //! [`sweep_sequences`] is here for the same reason: the three exhaustive sweeps
 //! assert case-count floors, and one of them an exact residual count, over the
@@ -200,11 +204,26 @@ pub fn assert_members_ascending(seq: &str, descriptor: &str) {
     );
 }
 
-/// Assert that `input` normalizes to `expected` *and* that both denote the same
-/// sequence when applied to `seq`.
+/// Assert that `input` normalizes to `expected` in the default 3' direction
+/// *and* that both denote the same sequence when applied to `seq`.
 pub fn assert_normalizes_preserving(seq: &str, input: &str, expected: &str) {
-    let actual = normalize(seq, input);
-    assert_eq!(actual, expected, "normalizing {input}");
+    assert_normalizes_preserving_in(seq, input, expected, ShuffleDirection::ThreePrime);
+}
+
+/// Assert that `input` normalizes to `expected` in `direction` *and* that both
+/// denote the same sequence when applied to `seq`.
+///
+/// The 5' direction gets the same single home as the 3' one for the reason
+/// [`apply_with`] does: a hand-rolled copy per file is a way for one file's
+/// assertion to weaken while the others keep theirs.
+pub fn assert_normalizes_preserving_in(
+    seq: &str,
+    input: &str,
+    expected: &str,
+    direction: ShuffleDirection,
+) {
+    let actual = normalize_in(seq, input, direction);
+    assert_eq!(actual, expected, "normalizing {input} in {direction:?}");
     let from_input = apply(seq, input).expect("input applies");
     let from_output = apply(seq, &actual).unwrap_or_else(|| {
         panic!("{actual} has no well-defined resulting sequence (overlapping or unconvertible)")

--- a/tests/it/issue_1261_cis_member_order.rs
+++ b/tests/it/issue_1261_cis_member_order.rs
@@ -1,0 +1,125 @@
+//! A normalized cis allele renders its members in ascending coordinate order.
+//!
+//! `sort_cis_members_by_genomic_order` (#1098) exists to make the rendered order
+//! canonical and input-order-independent, and it keys on
+//! `cis_member_order_key`. That key's only positional discriminator was the
+//! member's **start**; when two members shared a start it fell through to a
+//! lexical compare of the rendered descriptor, which is arbitrary with respect
+//! to where the members actually sit:
+//!
+//! ```text
+//! reference   ("ACGT" x 64) + "CAGTATGCAGGCAA" + ("ACGT" x 64)
+//! in   g.[258_259insA;259_260insAG]
+//! out  g.[258_259dup;258dup]          <- descending
+//! ```
+//!
+//! Both members start at 258, so every positional field tied and
+//! `"258_259dup" < "258dup"` decided it (`_` is 0x5F, `d` is 0x64). But a
+//! duplication places its copy at the junction *after* its last base, so those
+//! two sit at interbase 259 and 258 respectively — ordered by their **end**,
+//! the one field the key omitted.
+//!
+//! This is the ordering-key twin of #1276/#1277, which found the same blind spot
+//! in the overlap detector: a duplication occupies a junction, not just a span.
+//!
+//! The fix adds the member's end to the key between the offset and the
+//! descriptor. Members whose spans do not overlap already agree on start-order,
+//! end-order and junction-order, so this can only reorder members that share a
+//! start — which is precisely the case the descriptor tie-break was deciding
+//! arbitrarily. The descriptor stays as the final tie-break, so the key remains
+//! total and the result input-order-independent.
+//!
+//! The sequence is correct on both sides here; this is an ordering violation
+//! only, so every assertion below pairs the order check with the apply oracle.
+
+use crate::common::cis_apply_oracle::{apply, assert_members_ascending, normalize};
+
+/// `("ACGT" x 64) + core + ("ACGT" x 64)`, so `core[i]` is at 1-based position
+/// `257 + i`. Padding keeps every shift well away from a contig boundary.
+fn padded(core: &str) -> String {
+    format!("{}{}{}", "ACGT".repeat(64), core, "ACGT".repeat(64))
+}
+
+/// Assert that `input` normalizes to members in ascending interbase order and
+/// that normalization preserved the denoted sequence.
+fn assert_ordered_and_preserving(core: &str, input: &str) -> String {
+    let seq = padded(core);
+    let output = normalize(&seq, input);
+    assert_members_ascending(&seq, &output);
+    // Both sides are unwrapped rather than compared as `Option`s: `apply`
+    // declines an overlapping description, and `assert_eq!(None, None)` would
+    // report preservation it never checked.
+    let from_input = apply(&seq, input).expect("input applies");
+    let from_output = apply(&seq, &output).unwrap_or_else(|| {
+        panic!("`{input}` normalized to `{output}`, which has no well-defined resulting sequence")
+    });
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
+}
+
+#[test]
+fn two_duplications_sharing_a_start_render_in_junction_order() {
+    // The #1261 reproduction. `258dup` sits at interbase 258 and `258_259dup`
+    // at 259, so the narrower one must come first.
+    let output =
+        assert_ordered_and_preserving("CAGTATGCAGGCAA", "TEMPLATE:g.[258_259insA;259_260insAG]");
+    assert_eq!(output, "TEMPLATE:g.[258dup;258_259dup]");
+}
+
+#[test]
+fn the_rendered_order_does_not_depend_on_the_authored_order() {
+    // The whole point of #1098's sort. Both spellings must reach one string.
+    let forward =
+        assert_ordered_and_preserving("CAGTATGCAGGCAA", "TEMPLATE:g.[258_259insA;259_260insAG]");
+    let reverse =
+        assert_ordered_and_preserving("CAGTATGCAGGCAA", "TEMPLATE:g.[259_260insAG;258_259insA]");
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn members_with_distinct_starts_are_unaffected() {
+    // Non-overlapping spans already agree on start- and end-order, so adding
+    // the end to the key must not move them. Authored both ways round.
+    for input in ["TEMPLATE:g.[258A>C;266G>T]", "TEMPLATE:g.[266G>T;258A>C]"] {
+        let output = assert_ordered_and_preserving("CAGTATGCAGGCAA", input);
+        assert_eq!(output, "TEMPLATE:g.[258A>C;266G>T]");
+    }
+}
+
+#[test]
+fn a_duplication_beside_a_later_substitution_keeps_its_place() {
+    // A dup's junction is its end, which for a disjoint sibling is still 5' of
+    // that sibling's start — so the dup stays first.
+    let output = assert_ordered_and_preserving("CAGTATGCAGGCAA", "TEMPLATE:g.[266G>T;258_259dup]");
+    assert!(
+        output.starts_with("TEMPLATE:g.[258"),
+        "the duplication must render first, got `{output}`"
+    );
+}
+
+#[test]
+fn protein_members_sharing_a_start_render_in_end_order() {
+    // The protein axis has the same shared-start shape: `p.Ala3dup` and
+    // `p.Ala3_Ala4dup` both start at residue 3. Ordering by end puts the
+    // narrower first, matching the nucleotide axes. No reference needed —
+    // ordering is positional, so a bare parse/normalize round trip shows it.
+    use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+    let normalizer = Normalizer::new(MockProvider::new());
+    for input in [
+        "NP_000001.1:p.[Ala3_Ala4dup;Ala3dup]",
+        "NP_000001.1:p.[Ala3dup;Ala3_Ala4dup]",
+    ] {
+        let variant = parse_hgvs(input).expect("parse");
+        let output = normalizer
+            .normalize(&variant)
+            .expect("normalize")
+            .to_string();
+        assert_eq!(
+            output, "NP_000001.1:p.[Ala3dup;Ala3_Ala4dup]",
+            "authored as `{input}`"
+        );
+    }
+}

--- a/tests/it/issue_1281_reducing_member_shift.rs
+++ b/tests/it/issue_1281_reducing_member_shift.rs
@@ -1,0 +1,108 @@
+//! A cis member that *reduces* while it shifts must still be clamped at its
+//! siblings.
+//!
+//! `clamp_sibling_crossing_shifts` compares each member's pre- and post-
+//! normalization span and pulls back one that rotated over a sibling. It
+//! admitted only a **pure translation** — `a.end - b.end == delta` — and skipped
+//! anything whose span length changed, on the grounds that a length change is
+//! not a rotation this pass can reason about positionally.
+//!
+//! A member can do both at once. When an adjacent substitution and deletion
+//! merge, the resulting `delins` reduces to a plain deletion *and* 5'-shifts
+//! through the tract in the same pass:
+//!
+//! ```text
+//! reference        TTTTTTTTTAATATATTTTAATAT      nine-T tract at 1-9
+//! g.9_10delinsA -> g.1del                        span 9..10 becomes 1..1
+//! ```
+//!
+//! `delta` is -8 at the start but -9 at the end, so the guard rejected it and
+//! the member crossed eight positions unchecked — straight over a `1del`
+//! sibling and onto it:
+//!
+//! ```text
+//! g.[1del;9_10delinsA]  ->  g.[1del;1del]        two members claiming base 1
+//! ```
+//!
+//! `parse_hgvs` accepts that output, so `FERRO_ASSERT_REPARSE` does not catch
+//! it; the SPDI apply oracle correctly declines it (`None`) while the input
+//! applies fine. #1281 reported it at three members, which is simply the
+//! shortest route from clean input to such a member — the sub/del pair has to
+//! merge before it can reduce.
+//!
+//! The fix admits a member that **shrank** while its start moved, alongside the
+//! pure translation. Both sweep a window this pass can bound, and the existing
+//! cap ("never move past where the member started") still applies. A member
+//! that *grew* is still refused: an insertion canonicalising to a duplication
+//! moves its span and its junction together, and bounding that mis-places the
+//! copy (#1266, #1279).
+//!
+//! Clamped at the sibling, the member lands merely adjacent to it, and the next
+//! pass's merge coalesces the two into the correct single deletion —
+//! `g.[1del;9_10delinsA]` -> `g.1_2del` under the 5' shuffle these cases use.
+//! Fed that adjacent pair directly and shuffled 3' instead, the merge reaches
+//! the same two-base deletion, which on this nine-`T` tract the repeat path
+//! spells `g.[1del;2del]` -> `g.1_9T[7]`.
+
+use crate::common::cis_apply_oracle::{
+    assert_normalizes_preserving, assert_normalizes_preserving_in,
+};
+use ferro_hgvs::ShuffleDirection;
+
+/// Nine `T` at 1-9 — long enough for a reduced member to shift a clear eight
+/// positions before reaching the sibling at position 1.
+const TRACT: &str = "TTTTTTTTTAATATATTTTAATAT";
+
+/// Assert 5'-shuffled `input` normalizes to `expected` and denotes the same
+/// bases, through the oracle's shared direction-aware assertion.
+fn assert_five_prime_preserving(seq: &str, input: &str, expected: &str) {
+    assert_normalizes_preserving_in(seq, input, expected, ShuffleDirection::FivePrime);
+}
+
+#[test]
+fn a_reducing_member_does_not_shift_onto_a_sibling() {
+    // The minimal shape: two members, the second reduces 9_10 -> 1 as it shifts.
+    assert_five_prime_preserving(TRACT, "TEMPLATE:g.[1del;9_10delinsA]", "TEMPLATE:g.1_2del");
+}
+
+#[test]
+fn the_three_member_allele_from_the_issue_keeps_its_substitution() {
+    // #1281 as filed. The `9T>A`/`11del` pair merges, then reduces and shifts.
+    assert_five_prime_preserving(TRACT, "TEMPLATE:g.[1del;9T>A;11del]", "TEMPLATE:g.1_2del");
+}
+
+#[test]
+fn the_second_three_member_allele_from_the_issue_keeps_its_substitution() {
+    // Pin the settled spelling, not merely the absence of the broken one:
+    // `g.[4del;4del]` before the fix, the coalesced two-base deletion after.
+    assert_five_prime_preserving(
+        "TTATTTAAATAAAAATAAAATTTT",
+        "TEMPLATE:g.[4del;6T>A;8del]",
+        "TEMPLATE:g.4_5del",
+    );
+}
+
+#[test]
+fn the_clamped_member_still_coalesces_with_its_sibling() {
+    // The clamp leaves the two merely adjacent; the merge must then close them
+    // into one deletion rather than leaving `[1del;2del]` standing.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1del;2del]", "TEMPLATE:g.1_9T[7]");
+}
+
+#[test]
+fn a_reducing_member_with_no_sibling_in_its_path_is_untouched() {
+    // The relaxation must not pull back a member that crossed nothing: with the
+    // sibling far 3' of the tract, the reduced member keeps its 5'-most spot.
+    assert_five_prime_preserving(
+        TRACT,
+        "TEMPLATE:g.[9_10delinsA;20A>C]",
+        "TEMPLATE:g.[1del;20A>C]",
+    );
+}
+
+#[test]
+fn the_three_prime_direction_is_unchanged() {
+    // 3' already reached the correct answer through the repeat path; the
+    // relaxation must not disturb it.
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.[1del;9T>A;11del]", "TEMPLATE:g.1_9T[7]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -160,6 +160,7 @@ mod issue_1234_sibling_clamped_shift;
 mod issue_1235_cis_allele_confluence;
 mod issue_1244_equivalence_overlap_panic;
 mod issue_1254_sibling_crossing_shift;
+mod issue_1261_cis_member_order;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -161,6 +161,7 @@ mod issue_1235_cis_allele_confluence;
 mod issue_1244_equivalence_overlap_panic;
 mod issue_1254_sibling_crossing_shift;
 mod issue_1261_cis_member_order;
+mod issue_1281_reducing_member_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -1,0 +1,12 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+# The three cases the IndelHaplotype model found. The first two are filtered by
+# the strategy today (#1260/#1262 adjacent-gap insertions, and events cancelling
+# to no net change) and are re-rejected rather than re-run. The third is #1287.
+cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
+cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
+cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }


### PR DESCRIPTION
> Stacked on #1259. Base retargets to `main` when that merges.

Closes #1261. Closes #1281.

Two of the four defects standing between #1235 and closure, plus the confluence-generator extension #1260/#1261 ask for. #1235 itself stays open — see [What is left](#what-is-left).

## #1261 — members rendered in descending order

`sort_cis_members_by_genomic_order` (#1098) keys on `cis_member_order_key`, whose only positional discriminator was the member's **start**. When two members shared a start it fell through to a lexical compare of the rendered descriptor, which is arbitrary with respect to where those members actually sit:

```
reference   ("ACGT" x 64) + "CAGTATGCAGGCAA" + ("ACGT" x 64)
in   g.[258_259insA;259_260insAG]
out  g.[258_259dup;258dup]          <- descending
```

Both start at 258, so every positional field tied and `"258_259dup" < "258dup"` decided it (`_` is 0x5F, `d` is 0x64). A duplication places its copy at the junction *after* its last base, so those two occupy interbase 259 and 258 — ordered by their **end**, the one field the key omitted. The same blind spot #1276/#1277 found in the overlap detector, one layer up.

The fix adds the end to the key, on every axis including protein — `p.[Ala3dup;Ala3_Ala4dup]` has the identical shared-start shape and is covered by its own test. It cannot reorder members whose spans do not overlap: there `a < c` implies `b < c`, so start-, end- and junction-order already agree. Overlapping members never reach the sort — `normalize_allele` skips it when an `OverlapConflict` was warned. The descriptor stays the final tie-break, so the key remains total and the result input-order-independent.

Verified the sort was genuinely running first (output is input-order-independent), so this is the tie-break and not a skipped pass.

## #1281 — two members claiming one base

Reported as a three-member allele losing a substitution. It needs only **two**, and three is simply the shortest route from clean input — the adjacent sub/del pair has to merge before it can reduce:

```
reference             TTTTTTTTTAATATATTTTAATAT   nine-T tract at 1-9
g.[1del;9_10delinsA]  ->  g.[1del;1del]
g.[1del;9T>A;11del]   ->  g.[1del;1del]          <- as filed
```

`parse_hgvs` accepts that, so `FERRO_ASSERT_REPARSE` does not catch it; the SPDI apply oracle declines it while the input applies fine.

**Two causes, both required.** Traced with per-pass instrumentation:

```
pre_collapsed  1del | 9_10delinsA
merged_split   1del | 1del          <- the move happens here
```

1. **The snapshot.** `canonical_split_for_variant` (the #1237 sequence-first canonicalization) acts on one member with no sibling context, and it *repositions* rather than merely re-spells: `g.9_10delinsA` reduces to `g.1del`, an eight-position move. The sibling passes took their "before" snapshot **after** that step, so they saw `1del -> 1del`, concluded nothing had moved, and left the member where it landed. Now each surviving member records its origin, and **all three** sibling passes read it — `demote_repeats_spanning_siblings` and `clamp_sibling_crossing_junctions` had the same stale-snapshot exposure, so fixing only the span clamp would have left the junction clamp measuring from wherever the canonicalization put the member. A one-for-one rewrite is a repositioning of the same member, so its origin span is what the clamp needs; a genuine split into several pieces has no single origin span per piece, so each piece stands for itself exactly as before.

2. **The guard.** `clamp_sibling_crossing_shifts` admitted only a pure translation. This member shrinks as it moves — delta is −8 at the start, −9 at the end — so it was refused even once the snapshot showed the movement. Admit a member that shrank while its start moved; it still sweeps a window this pass can bound, and the existing cap keeps the pull inside it. A member that **grew** is still refused: an insertion canonicalising to a duplication moves its span and its junction together, and bounding the span mis-places the copy (#1266, #1279).

Clamped at the sibling the member lands merely adjacent, and the next pass coalesces the pair into the correct single deletion — `g.[1del;2del]` -> `g.1_2del`.

## Confluence generator: length-changing members

The #1238 property test is substitution-only and so length-preserving, which put the shifting machinery out of reach entirely (`shift_pieces_three_prime` only moves a piece for which `is_pure_indel()` holds). That is the exclusion #1260 and #1261 record as needing relaxation. `IndelHaplotype` adds single-base deletions and one/two-base insertions.

It found two defects on its first two runs, neither previously filed and neither reachable by any committed sweep:

```
core "AAAAAA", insert A after index 1 and after index 2
  -> g.[263dup;263dup]             two members claiming one base
core "ATACAGAAAATCAGGGCATA", insert GA after 4, AA after 6
  -> g.[262_263dup;263_266A[6]]    dup and repeat spans overlap
```

Both are the `claims_reference_bases` family (#1269): a duplication and a repeat report claiming no bases, so the sibling clamps skip them and two members settle onto one span. Filed as **#1286** (two dup members at one junction) and **#1287** (a dup's junction inside a repeat's tract span) — separate issues because the mechanisms differ, and #1287 specifically implicates #1259's `demote_repeats_spanning_siblings`.

Consequently the property that catches them is committed `#[ignore]`d with both reproductions in its doc comment; enabling it is the acceptance criterion for that work. Active instead: sequence-preservation, fixed-point and disjoint/ascending over the separate-member spelling, authored-order independence, and a non-vacuity guard that the model really produces deletions, insertions, mixed haplotypes and multi-base payloads.

Neither restriction is silent — `adjacent_gap_insertions_are_a_known_gap` pins both held-back shapes as currently-broken and drives #1260's through the model itself, so fixing either fails loudly and names what to re-enable. That is #1268/#1283's complaint about coverage reading wider than it is.

## What is left

**#1260 and #1262 are one cause, not two, and it is not local.** Both issues filed hypotheses they noted could not be checked against `main`. Traced now that #1237 has merged, both are confirmed and both reduce to the same thing:

- The derivation reaches the **same piece set from both spellings** — it is already confluent.
- The divergence is entirely in the **input-relative gates**. #1260 refuses via the column bound (`3 > 2` for the two-insertion spelling; `3 > 3` admits the delins one); #1262 refuses via the separator veto, whose `pieces.len() < edits.len()` precondition is never true for a one-member spelling, so a single delins is never checked at all.
- The derivation produces the **over-merged** form. The gates are the only thing rescuing the split form, and only when the author happened to write it that way. So making the gates spelling-independent does not fix this — it picks the over-merged answer for everyone.

It is also not two edge shapes: the generator hits it constantly, including on plain `del`+`ins` pairs, because it is the general behaviour of "length-changing members versus the spanning delins".

Fixing it means making the derivation prefer the split form: `general.md:56` prioritisation (substitution > deletion > delins) for #1262, and for #1260 a **two-gap** alignment — insertion, retained base, insertion — which `best_alignment`'s single-gap restriction cannot express. That restriction and the "stays delins" corpus (#1034, #1040, #182, #422) are documented as deliberate and load-bearing, so this belongs in its own PR with its own measurement.

## Review pass

A CodeRabbit-style self-review was applied before this was opened; nine findings, all fixed, amended into the commit each belongs to (no fixup commits). The substantive ones:

- **The origin snapshot now reaches all three sibling passes**, not just the span clamp — see #1281 above. Measured: suite green and the pinned 74-case residual unmoved.
- **The protein axis gets its real end.** `cis_member_range` had been returning the start twice for `HgvsVariant::Protein`, so the fix reached six of seven arms and protein kept the defect. Verified non-vacuous — reverting that one line makes `p.[Ala3dup;Ala3_Ala4dup]` render descending.
- **`cis_member_order_key` returns `(String, SelfCancellingPoint, SelfCancellingPoint, String)`** rather than a flattened eight-field tuple. `SelfCancellingPoint` already derives `Ord` over `(region, base, offset)`, so the sort order is identical and the call site is legible.
- **A weak test assertion replaced.** One #1281 case asserted `!output.contains("4del;4del")` — true of any *other* malformed pair too. Now pins `g.4_5del`.
- **No member-list clone on the non-cis path**, which never reads the snapshot.
- Plus four nitpicks: shared member rendering between the two encoding helpers, `Event::Insert`'s payload changed from `([char; 2], len)` (which made an out-of-bounds `len` constructible) to `&'static str`, a shadowed binding, and a stale module-doc opener.

Each of the four commits builds and tests standalone, so bisect still works.

## Verification

- 8893 pass; 8893 pass again under `FERRO_ASSERT_IDEMPOTENT=1` with `FERRO_ASSERT_REPARSE=1`.
- The `#[ignore]`d property still reproduces #1287 when run with `-- --ignored`, so the pin is live rather than quietly passing.
- The 276,480-case sweep in `cis_junction_crossing_shift` holds its pinned 74-case #1266 residual **exactly**, so no previously-correct output became wrong. That is the measurement the attempted fixes in #1279 and #1280 failed, and the reason the clamp relaxation here is restricted to members that shrank.
- `cargo fmt --all` and `cargo clippy --features dev --all-targets -- -D warnings` clean.
- All four commits are signed.

Not run: the manifest-backed conformance axis tests — no reference volume mounted locally, so they skip. Worth watching the nightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cis-allele normalization across genomic, mitochondrial, transcript, RNA, CDS, and protein coordinates.
  * Corrected ordering for variants sharing the same start position.
  * Prevented shifted variants from crossing sibling spans or junctions, including shrinking spans.
  * Improved repeat, duplication, insertion, and deletion normalization.
  * Preserved applied sequence results through complex normalization scenarios.

* **Tests**
  * Added extensive regression, confluence, ordering, and sequence-preservation coverage for cis-allele normalization.
  * Added coverage for protein variants, adjacent gaps, spanning indels, and multi-base insertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->