### PR TITLE
fix(normalize): merge cis members that settle on one junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3751,6 +3751,185 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
     }
 }
 
+/// Coalesce cis members that settled onto **one junction** into a single
+/// insertion carrying their combined payload.
+///
+/// A member that consumes no base occupies the interbase junction where its
+/// added sequence lands. Two of them can shift onto the same junction from
+/// distinct starting points — two one-base insertions at adjacent gaps inside a
+/// homopolymer both travel to the tract's 3'-most junction:
+///
+/// ```text
+/// reference  ("ACGT" x 64) + "AAAAAA" + ("ACGT" x 64)   poly-A run at 257-263
+/// g.[258_259insA;259_260insA]  ->  g.[263dup;263dup]
+/// ```
+///
+/// That output claims one position twice, so it has no well-defined resulting
+/// sequence — `parse_hgvs` accepts it, and the SPDI apply oracle declines it
+/// (#1286). Nothing upstream prevents it: the sibling clamps bound a member
+/// against a sibling's *bases*, and neither of these has any.
+///
+/// It cannot be repaired downstream either. The sequence-first canonicalization
+/// would derive the correct single member, but it runs *after* the per-member
+/// pipeline and derives from the allele's resulting sequence — which an
+/// overlapping allele does not have. It declines, so the corruption survives the
+/// one pass that would have merged it.
+///
+/// So merge here, before that pass sees it. Both members add their payload at
+/// the same interbase point, so one insertion carrying the concatenation denotes
+/// exactly what the pair denoted. Re-spelling as an `Insertion` rather than a
+/// wider `Duplication` is the same choice `respell_colliding_duplications`
+/// makes: an insertion's payload is a literal and is correct wherever it lands,
+/// whereas `g.262_263dup` would only be equivalent when `ref[262] == ref[263]`.
+/// The next pass re-canonicalises it to a `dup` or a repeat where the reference
+/// permits.
+///
+/// **Only when every colliding payload is identical.** Concatenation is
+/// otherwise order-dependent, and the order is exactly what the shift destroyed:
+/// two insertions that were at distinct junctions had a defined order, and once
+/// they share a junction they do not. Equal payloads make the concatenation
+/// order-independent, so the repair is unambiguous. A differing-payload
+/// collision is left for the overlap detector to report rather than guessed at.
+///
+/// Genomic axes only, matching `respell_colliding_duplications` — the
+/// transcript axes need a coordinate conversion this does not carry.
+pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
+    members: &mut Vec<HgvsVariant>,
+    phase: AllelePhase,
+    uncertain: bool,
+    provider: &P,
+) {
+    if phase != AllelePhase::Cis || uncertain || members.len() < 2 {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&members[0]) else {
+        return;
+    };
+    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
+        return;
+    }
+    let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
+
+    // Group by (accession, region, junction). Only members that occupy a
+    // junction and claim no bases participate.
+    let mut groups: Vec<(usize, Vec<usize>)> = Vec::new();
+    for i in 0..members.len() {
+        let Some(span) = spans[i].as_ref() else {
+            continue;
+        };
+        if span.claims_bases {
+            continue;
+        }
+        let Some(junction) = span.junction else {
+            continue;
+        };
+        match groups.iter_mut().find(|(first, _)| {
+            spans[*first].as_ref().is_some_and(|s| {
+                s.junction == Some(junction)
+                    && s.region == span.region
+                    && s.accession == span.accession
+            })
+        }) {
+            Some((_, members_at)) => members_at.push(i),
+            None => groups.push((i, vec![i])),
+        }
+    }
+
+    let mut remove: Vec<usize> = Vec::new();
+    for (_, at) in &groups {
+        if at.len() < 2 {
+            continue;
+        }
+        let payloads: Option<Vec<Vec<Base>>> = at
+            .iter()
+            .map(|&i| junction_payload(&members[i], kind, spans[i].as_ref()?, provider))
+            .collect();
+        let Some(payloads) = payloads else {
+            continue;
+        };
+        // Order-independence guard: every payload identical.
+        if payloads.windows(2).any(|pair| pair[0] != pair[1]) {
+            continue;
+        }
+        let combined: Vec<Base> = payloads.concat();
+        let edit = NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::new(combined)),
+        };
+        let target = at[0];
+        let Some(span) = spans[target].as_ref() else {
+            continue;
+        };
+        let Some(junction) = span.junction else {
+            continue;
+        };
+        // `respell_at_gap` places the edit over `[span.end, span.end + 1]`, so
+        // hand it a span whose `end` is the shared junction rather than the
+        // member's own. For a `Duplication` the two coincide (`junction_of`
+        // returns its `end`), but for an `Insertion` the junction is its
+        // `start`, so `span.end` sits one base 3' of it. `respell_at_gap`
+        // cannot catch that: it checks the result landed on the gap it was
+        // given, not that the gap was the right one.
+        let gap = MemberSpan {
+            accession: span.accession.clone(),
+            provider_key: span.provider_key.clone(),
+            region: span.region,
+            start: junction,
+            end: junction,
+            claims_bases: span.claims_bases,
+            blocks_shift: span.blocks_shift,
+            junction: Some(junction),
+        };
+        let before = members[target].clone();
+        respell_at_gap(&mut members[target], kind, &gap, edit);
+        if members[target] == before {
+            continue; // the re-spell did not take; leave the group alone
+        }
+        remove.extend(at.iter().skip(1).copied());
+    }
+    if remove.is_empty() {
+        return;
+    }
+    remove.sort_unstable();
+    let mut index = 0;
+    members.retain(|_| {
+        let keep = !remove.contains(&index);
+        index += 1;
+        keep
+    });
+}
+
+/// The bases a junction-occupying member adds, or `None` when they cannot be
+/// determined without guessing.
+///
+/// A `Duplication` copies the reference under its own span, so its payload is
+/// read from the provider. An `Insertion` carries a literal. Every other shape —
+/// an unspecified count, a bracketed range, a `DupIns` — has no single literal
+/// payload to concatenate, so the caller declines to merge it.
+fn junction_payload<P: ReferenceProvider>(
+    variant: &HgvsVariant,
+    kind: CisKind,
+    span: &MemberSpan,
+    provider: &P,
+) -> Option<Vec<Base>> {
+    match cis_axis_parts(variant, kind).map(|(_, _, _, _, edit)| edit)? {
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(literal),
+        } => Some(literal.bases().to_vec()),
+        NaEdit::Duplication { .. } => {
+            let (from, to) = (
+                u64::try_from(span.start - 1).ok()?,
+                u64::try_from(span.end).ok()?,
+            );
+            let copied = provider.get_sequence(&span.provider_key, from, to).ok()?;
+            if copied.len() as i64 != span.end - span.start + 1 {
+                return None;
+            }
+            copied.chars().map(Base::from_char).collect()
+        }
+        _ => None,
+    }
+}
+
 /// Replace a genomic member with `edit` over the gap `[span.end, span.end + 1]`.
 ///
 /// Reverts unless the result reads back exactly as intended.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2664,6 +2664,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 allele.uncertain,
                 &self.provider,
             );
+            // Last: two junction-occupying members that settled on the SAME
+            // junction. The clamps above bound a member against a sibling's
+            // bases, and an insertion or duplication has none, so a pair can
+            // land on one interbase and claim it twice (#1286). Merge them into
+            // one insertion carrying both payloads. This must happen here rather
+            // than in the sequence-first pass, which derives from the allele's
+            // resulting sequence — an overlapping allele has none, so that pass
+            // declines exactly the input it would have fixed.
+            merge::coalesce_members_at_one_junction(
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+                &self.provider,
+            );
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -54,9 +54,9 @@
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds unfixed defects in the #1269 `claims_reference_bases`
-//!   family, filed as #1286 and #1287; see its doc comment for both
-//!   reproductions.
+//!   because it finds #1287, an unfixed defect in the #1269
+//!   `claims_reference_bases` family. It found #1286 first, now fixed; see its
+//!   doc comment for the history and the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -769,14 +769,16 @@ proptest! {
     ///
     /// It is committed rather than withheld because it earned its place
     /// immediately — the first two runs found two defects that no committed
-    /// sweep reaches, now filed as #1286 and #1287:
+    /// sweep reaches, filed as #1286 and #1287:
     ///
     /// ```text
-    /// #1286: core "AAAAAA", insert A after index 1 and after index 2
+    /// #1286 (FIXED): core "AAAAAA", insert A after index 1 and after index 2
     ///   g.[258_259insA;259_260insA] -> g.[263dup;263dup]
     ///     two dup members at one junction (both interbase 263)
+    ///   now merged by `coalesce_members_at_one_junction` into g.257_263A[9];
+    ///   regression-tested in `issue_1286_shared_junction_merge.rs`
     ///
-    /// #1287: core "ATACAGAAAATCAGGGCATA", insert GA after 4, AA after 6
+    /// #1287 (LIVE): core "ATACAGAAAATCAGGGCATA", insert GA after 4, AA after 6
     ///   g.[261_262insGA;263_264insAA] -> g.[262_263dup;263_266A[6]]
     ///     the dup's junction (263) sits inside the repeat's span (262-266)
     /// ```
@@ -786,10 +788,12 @@ proptest! {
     /// and two members settle onto the same span. #1259 addressed part of this
     /// with `demote_repeats_spanning_siblings`; these shapes are past it.
     ///
-    /// Enabling this test is the acceptance criterion for #1286 and #1287 — do
-    /// not weaken it to make it pass.
+    /// Enabling this test is the acceptance criterion for what remains — #1287,
+    /// and whatever the property surfaces after it, pinned one at a time by
+    /// `the_ignored_indel_property_still_finds_its_defect`. Do not weaken it to
+    /// make it pass.
     #[test]
-    #[ignore = "finds real unfixed defects in the #1269 dup/repeat family; see doc comment"]
+    #[ignore = "finds a real unfixed defect in the #1269 dup/repeat family (#1287); see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -915,43 +919,92 @@ fn adjacent_gap_insertions_are_a_known_gap() {
     );
 }
 
-/// Pins the two defects that keep `an_indel_haplotype_normalizes_to_its_own_sequence`
-/// `#[ignore]`d, so fixing either one fails here and names the ignore to drop.
+/// The three clauses of `an_indel_haplotype_normalizes_to_its_own_sequence`,
+/// evaluated on one hand-written case instead of over the strategy: the output
+/// denotes the input's sequence, normalization is a fixed point, and the members
+/// render disjoint and ascending.
 ///
-/// Its doc comment records both reproductions, but a doc comment does not run:
-/// #1286 or #1287 could be fixed and the property would simply stay ignored,
-/// which is the coverage-that-reads-wider-than-it-is complaint in #1268/#1283.
-/// This is the same guard `adjacent_gap_insertions_are_a_known_gap` gives the
-/// two shapes the model holds back.
+/// `Ok(())` means the property holds for `input` against `core`; `Err` names the
+/// clause that fails. [`the_ignored_indel_property_still_finds_its_defect`]
+/// asserts `Err`, so fixing the pinned defect turns it red.
 ///
-/// Asserted on the *shape* of the defect — two members settling onto one span,
-/// or one member's junction landing inside another's — rather than on the
-/// rendered strings, so an unrelated re-spelling does not fail it while the
-/// defect stands.
-#[test]
-fn the_ignored_indel_property_still_finds_its_two_defects() {
-    for (core, input, issue) in [
-        ("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]", "#1286"),
-        (
-            "ATACAGAAAATCAGGGCATA",
-            "NC_TEST.1:g.[261_262insGA;263_264insAA]",
-            "#1287",
-        ),
-    ] {
-        let provider = SyntheticBuilder::genomic(core).build();
-        let normalizer = Normalizer::new(provider.clone());
-        let normalized = normalize(&normalizer, input);
-        let spans = interbase_spans(&normalized, &provider)
-            .expect("every normalized member converts to SPDI");
-        assert!(
-            spans
-                .windows(2)
-                .any(|pair| pair[0] == pair[1] || pair[1].0 < pair[0].1),
-            "{issue} appears fixed — `{input}` -> `{normalized}` now renders disjoint \
-             members {spans:?}. Re-run `an_indel_haplotype_normalizes_to_its_own_sequence` \
-             with `--ignored`, and drop its `#[ignore]` once both are fixed."
-        );
+/// Stated over the property's own clauses rather than over a defect's *shape*
+/// because the shapes differ: #1286 and #1287 rendered overlapping members,
+/// while later defects change the sequence or break the fixed point instead. A
+/// shape-specific assertion would have to be rewritten for each one, and — worse
+/// — would report a defect as fixed while the property still failed on it some
+/// other way.
+fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+
+    // The pinned inputs are well-formed by construction, so an input that does
+    // not itself denote a sequence is a broken pin rather than a property
+    // failure — panic rather than report it as the defect still standing.
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let intended = resulting_sequence(&parsed, &provider, &reference)
+        .unwrap_or_else(|e| panic!("pinned input `{input}` has no resulting sequence: {e}"));
+
+    let normalized = normalize(&normalizer, input);
+
+    let applied = resulting_sequence(&normalized, &provider, &reference)
+        .map_err(|e| format!("`{input}` -> `{normalized}` has no resulting sequence: {e}"))?;
+    if applied != intended {
+        return Err(format!(
+            "`{input}` -> `{normalized}` does not denote the input's sequence"
+        ));
     }
+
+    let once = normalized.to_string();
+    let twice = normalize(&normalizer, &once).to_string();
+    if twice != once {
+        return Err(format!(
+            "`{once}` is not a fixed point: it normalizes to `{twice}`"
+        ));
+    }
+
+    let spans = interbase_spans(&normalized, &provider)
+        .map_err(|e| format!("`{input}` -> `{normalized}` has no interbase spans: {e}"))?;
+    for pair in spans.windows(2) {
+        let ((_, previous_end), (start, _)) = (pair[0], pair[1]);
+        if start < previous_end {
+            return Err(format!(
+                "`{input}` -> `{normalized}`: member at interbase {start} overlaps or does not \
+                 follow the previous member ending at {previous_end}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Pins the defect that currently keeps `an_indel_haplotype_normalizes_to_its_own_sequence`
+/// `#[ignore]`d, so fixing it fails here and names the ignore to revisit.
+///
+/// The property's doc comment records the reproduction, but a doc comment does
+/// not run: the live defect could be fixed and the property would simply stay
+/// ignored, which is the coverage-that-reads-wider-than-it-is complaint in
+/// #1268/#1283. This is the same guard `adjacent_gap_insertions_are_a_known_gap`
+/// gives the two shapes the model holds back.
+///
+/// One row, not a list: the property stops at its first failure, so only the
+/// *live* blocker is observable here. Each fix moves this pin to whatever the
+/// property surfaces next, and the ignore comes off when there is nothing left
+/// to pin.
+#[test]
+fn the_ignored_indel_property_still_finds_its_defect() {
+    // #1287: the dup's junction (263) lands inside the repeat's span (262-266).
+    let (core, input, issue) = (
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[261_262insGA;263_264insAA]",
+        "#1287",
+    );
+    assert!(
+        indel_property_holds(core, input).is_err(),
+        "{issue} appears fixed — the property now holds for `{input}`. Re-run \
+         `an_indel_haplotype_normalizes_to_its_own_sequence` with `--ignored`, pin whatever \
+         it finds next here, and drop its `#[ignore]` once it finds nothing."
+    );
 }
 
 /// Non-vacuity guard for the indel model: it must actually produce deletions,

--- a/tests/it/issue_1286_shared_junction_merge.rs
+++ b/tests/it/issue_1286_shared_junction_merge.rs
@@ -1,0 +1,129 @@
+//! Two cis members that settle on one junction must merge, not claim it twice.
+//!
+//! A member that consumes no base occupies the interbase junction where its
+//! payload lands. Two of them can reach the same junction from distinct starting
+//! points — two one-base insertions at adjacent gaps inside a homopolymer both
+//! travel to the tract's 3'-most junction:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "AAAAAA" + ("ACGT" x 64)   poly-A run at 257-263
+//! g.[258_259insA;259_260insA]  ->  g.[263dup;263dup]
+//! ```
+//!
+//! `parse_hgvs` **accepts** that, so `FERRO_ASSERT_REPARSE` does not catch it,
+//! while the SPDI apply oracle correctly declines it — two members claiming one
+//! position have no well-defined resulting sequence.
+//!
+//! Nothing upstream prevented it: the sibling clamps bound a member against a
+//! sibling's *bases*, and neither of these has any. And nothing downstream could
+//! repair it: the sequence-first canonicalization would derive the correct single
+//! member, but it runs after the per-member pipeline and derives from the
+//! allele's resulting sequence — which an overlapping allele does not have. It
+//! declines, so the corruption survives the one pass that would have merged it.
+//! Traced: the pass is entered with `[263dup;263dup]` and exits without
+//! deriving.
+//!
+//! `coalesce_members_at_one_junction` merges them before that pass runs. Both add
+//! their payload at the same interbase point, so one insertion carrying the
+//! concatenation denotes exactly what the pair denoted; the next pass
+//! re-canonicalises it to a `dup` or a repeat where the reference permits.
+
+use crate::common::cis_apply_oracle::{apply, assert_normalizes_preserving, normalize};
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+/// Normalize against the padded synthetic contig and assert the result denotes
+/// the same bases the input did — through `hgvs_to_spdi`, a different code path
+/// from the normalizer.
+fn assert_padded_preserving(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+    let variant = parse_hgvs(input).expect("parse");
+    let output = normalizer
+        .normalize(&variant)
+        .expect("normalize")
+        .to_string();
+
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None; // overlapping members
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+
+    let from_input = denote(input).expect("input applies");
+    let from_output = denote(&output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
+}
+
+#[test]
+fn two_insertions_reaching_one_junction_merge() {
+    // #1286. Seven A at 257-263 plus two inserted A is a nine-A run, which
+    // canonicalises to the repeat spelling.
+    let output = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    assert_eq!(output, "NC_TEST.1:g.257_263A[9]");
+}
+
+#[test]
+fn the_merge_is_independent_of_the_authored_order() {
+    let forward = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    let reverse = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[259_260insA;258_259insA]");
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn three_insertions_reaching_one_junction_merge() {
+    // The group is not limited to pairs.
+    let output = assert_padded_preserving(
+        "AAAAAA",
+        "NC_TEST.1:g.[258_259insA;259_260insA;260_261insA]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.257_263A[10]");
+}
+
+#[test]
+fn insertions_at_distinct_junctions_are_left_alone() {
+    // The pass must fire on a *shared* junction only. These two land in
+    // different tracts and stay two members.
+    let seq = "ACGTTTTTTACGTAAAAAAACGT";
+    let output = normalize(seq, "TEMPLATE:g.[5_6insT;15_16insA]");
+    assert!(
+        output.starts_with("TEMPLATE:g.["),
+        "two disjoint insertions must stay two members, got `{output}`"
+    );
+    assert_eq!(
+        apply(seq, "TEMPLATE:g.[5_6insT;15_16insA]"),
+        apply(seq, &output),
+        "sequence changed"
+    );
+}
+
+#[test]
+fn a_single_insertion_is_untouched() {
+    // No group, nothing to merge — the ordinary path must be unaffected.
+    assert_normalizes_preserving("ACGTTTTTTACGT", "TEMPLATE:g.5_6insT", "TEMPLATE:g.9dup");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -165,6 +165,7 @@ mod issue_1254_sibling_crossing_shift;
 mod issue_1261_cis_member_order;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
+mod issue_1286_shared_junction_merge;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
> Stacked on #1288 → #1285 → #1259. Base retargets as those merge.

Closes #1286.

```
reference  ("ACGT" x 64) + "AAAAAA" + ("ACGT" x 64)   poly-A run at 257-263
g.[258_259insA;259_260insA]  ->  g.[263dup;263dup]
```

Two members claiming one position have no well-defined resulting sequence. `parse_hgvs` **accepts** the output, so `FERRO_ASSERT_REPARSE` does not catch it; the SPDI apply oracle declines it while the input applies fine.

## Why neither existing layer catches it

**Nothing upstream prevents it.** The sibling clamps bound a member against a sibling's *bases*. A member that consumes no base occupies the interbase junction where its payload lands, and neither of these has bases for the other to land on — so both are free to travel to the tract's 3'-most junction and settle there together.

**Nothing downstream repairs it.** The sequence-first canonicalization would derive the correct single member, but it runs *after* the per-member pipeline and derives from the allele's **resulting sequence** — which an overlapping allele does not have. I traced this rather than assuming: the pass is entered with `[263dup;263dup]` and exits without deriving. So the corruption survives the one pass that would have merged it.

That is the shape of the bug: a catch-22 between the layer that could have prevented it and the layer that could have fixed it.

## Fix

`coalesce_members_at_one_junction`, running last in the sibling-repair sequence in `normalize_allele`. Both members add their payload at the same interbase point, so one insertion carrying the concatenation denotes exactly what the pair denoted.

Re-spelling as an `Insertion` rather than a wider `Duplication` is the choice `respell_colliding_duplications` already makes: an insertion's payload is a literal and is correct wherever it lands, whereas `g.262_263dup` would be equivalent only when `ref[262] == ref[263]`. The next pass re-canonicalises it where the reference permits — here to `g.257_263A[9]`, the nine-A run.

**Merged only when every colliding payload is identical.** Concatenation is otherwise order-dependent, and the order is exactly what the shift destroyed: two insertions at distinct junctions had a defined order, and once they share a junction they do not. Equal payloads make the concatenation order-independent, so the repair is unambiguous. A differing-payload collision is left for the overlap detector to report rather than guessed at — if one turns out to be reachable, that is a separate issue with a separate answer.

Genomic axes only, matching `respell_colliding_duplications`; the transcript axes need a coordinate conversion this does not carry.

## Tests

`tests/it/issue_1286_shared_junction_merge.rs`, 5 tests, generated programmatically. The reproduction, order-independence, a **three**-member group (the pass is not limited to pairs), and two guards: insertions at distinct junctions stay two members, and a lone insertion is untouched.

The sequence check goes through `hgvs_to_spdi` — a different projection and applier from the normalizer's own — so a canonicalization that silently altered the sequence shows up even when the string looks plausible.

## Not addressed

**#1287 is still open** and was probed against this branch: `g.[261_262insGA;263_264insAA]` → `g.[262_263dup;263_266A[6]]`, unchanged. That is a *different* overlap — a junction falling inside a `Repeat`'s tract span, not two members sharing one junction — and it needs `Repeat` in the `blocks_sibling_shift` predicate, which is #1269's question. Next in the stack.

## Verification

- 8899 pass; 8899 pass again under `FERRO_ASSERT_IDEMPOTENT=1` with `FERRO_ASSERT_REPARSE=1`.
- The 276,480-case sweep still passes with its residual pinned at 0 (from #1288).
- `cargo fmt --all` and `cargo clippy --features dev --all-targets -- -D warnings` clean.
- Commit is signed.

Not run: the manifest-backed conformance axis tests — no reference volume mounted locally, so they skip. Worth watching the nightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variant normalization when duplications and insertions cross neighboring substitutions or deletions.
  * Corrected shifting behavior around reference-consuming boundaries.
  * Combined identical insertions that resolve to the same genomic junction while preserving distinct insertions separately.
  * Improved handling of insertion and duplication payloads from literals or reference sequences.
* **Tests**
  * Expanded coverage for cis insertions, duplication shifts, junction merging, sequence preservation, and normalization consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->