### PR TITLE
fix(normalize): stop a repeat's tract swallowing a sibling's junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3332,14 +3332,33 @@ pub(crate) fn demote_repeats_spanning_siblings(
         if length <= 0 || start < a.start || b.region != a.region {
             continue;
         }
-        // Does the tract actually span a sibling's bases? Both snapshots, so a
+        // Does the tract actually swallow a sibling? Both snapshots, so a
         // sibling that moved into the tract counts too.
-        let spans_sibling = (0..pre.len())
-            .filter(|&j| j != i)
-            .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
-            .flatten()
-            .filter(|s| s.claims_bases && s.region == a.region && s.accession == a.accession)
+        //
+        // Two ways to be swallowed. A sibling that *claims bases* is swallowed
+        // when its span meets the tract. A sibling that claims none is still
+        // swallowed when its **junction** falls strictly inside the tract
+        // (#1287): a copy count over `1_9` cannot express another member adding
+        // sequence in the middle of those nine bases, so the pair overlaps. The
+        // 3' end is exclusive on purpose — a junction at `a.end` is flush against
+        // the tract rather than inside it, which is the adjacency the collapse
+        // pass exists to catch (#999, #1135), and the same strictness
+        // `detect_insertion_overlaps` uses for an interior junction (#1276).
+        let siblings = || {
+            (0..pre.len())
+                .filter(|&j| j != i)
+                .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
+                .flatten()
+                .filter(|s| s.region == a.region && s.accession == a.accession)
+        };
+        let spans_sibling_bases = siblings()
+            .filter(|s| s.claims_bases)
             .any(|s| s.start <= a.end && s.end >= a.start);
+        let spans_sibling_junction = siblings()
+            .filter(|s| !s.claims_bases)
+            .filter_map(|s| s.junction)
+            .any(|junction| junction >= a.start && junction < a.end);
+        let spans_sibling = spans_sibling_bases || spans_sibling_junction;
         if !spans_sibling {
             continue;
         }

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -54,9 +54,9 @@
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1287, an unfixed defect in the #1269
-//!   `claims_reference_bases` family. It found #1286 first, now fixed; see its
-//!   doc comment for the history and the live reproduction.
+//!   because it finds #1290, a junction shifting past another junction. It
+//!   found #1286 and #1287 first, both now fixed; see its doc comment for the
+//!   history and the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -764,36 +764,37 @@ proptest! {
     /// A length-changing haplotype normalizes to something that denotes it, is
     /// a fixed point, and renders disjoint members in ascending order.
     ///
-    /// **`#[ignore]`d: this currently fails, and the failures are real.** Run it
+    /// **`#[ignore]`d: this currently fails, and the failure is real.** Run it
     /// with `cargo test --features dev -- --ignored an_indel_haplotype`.
     ///
-    /// It is committed rather than withheld because it earned its place
-    /// immediately — the first two runs found two defects that no committed
-    /// sweep reaches, filed as #1286 and #1287:
+    /// It is committed rather than withheld because it keeps earning its place.
+    /// Its first two runs found #1286 and #1287, both since fixed:
     ///
     /// ```text
-    /// #1286 (FIXED): core "AAAAAA", insert A after index 1 and after index 2
-    ///   g.[258_259insA;259_260insA] -> g.[263dup;263dup]
-    ///     two dup members at one junction (both interbase 263)
-    ///   now merged by `coalesce_members_at_one_junction` into g.257_263A[9];
-    ///   regression-tested in `issue_1286_shared_junction_merge.rs`
-    ///
-    /// #1287 (LIVE): core "ATACAGAAAATCAGGGCATA", insert GA after 4, AA after 6
-    ///   g.[261_262insGA;263_264insAA] -> g.[262_263dup;263_266A[6]]
-    ///     the dup's junction (263) sits inside the repeat's span (262-266)
+    /// #1286  g.[258_259insA;259_260insA] -> g.[263dup;263dup]
+    ///          two dup members at one junction              (fixed)
+    /// #1287  g.[261_262insGA;263_264insAA] -> g.[262_263dup;263_266A[6]]
+    ///          the dup's junction inside the repeat's span  (fixed)
     /// ```
     ///
-    /// Both are the `claims_reference_bases` family (#1269): a duplication and a
-    /// repeat report that they claim no bases, so the sibling clamps skip them
-    /// and two members settle onto the same span. #1259 addressed part of this
-    /// with `demote_repeats_spanning_siblings`; these shapes are past it.
+    /// With those closed it immediately surfaced a third, #1290 — a junction
+    /// shifting past *another junction*, which reorders two insertions and
+    /// changes the sequence:
     ///
-    /// Enabling this test is the acceptance criterion for what remains — #1287,
-    /// and whatever the property surfaces after it, pinned one at a time by
-    /// `the_ignored_indel_property_still_finds_its_defect`. Do not weaken it to
+    /// ```text
+    /// core "ATACAGAAAATCAGGGCATA"
+    ///   g.[263_264insA;265_266insC] -> g.[265_266insC;266dup]
+    ///     intended  G A A A A C A T
+    ///     emitted   G A A A C A A T      <- the inserted A crossed the C
+    /// ```
+    ///
+    /// Verified pre-existing: identical output on the base of #1287's branch,
+    /// so it was merely masked behind the two overlap defects.
+    ///
+    /// Enabling this test is #1290's acceptance criterion — do not weaken it to
     /// make it pass.
     #[test]
-    #[ignore = "finds a real unfixed defect in the #1269 dup/repeat family (#1287); see doc comment"]
+    #[ignore = "finds #1290, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -993,11 +994,12 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1287: the dup's junction (263) lands inside the repeat's span (262-266).
+    // #1290: the first insertion's junction shifts past the second's, which
+    // reorders the two payloads and changes the sequence.
     let (core, input, issue) = (
         "ATACAGAAAATCAGGGCATA",
-        "NC_TEST.1:g.[261_262insGA;263_264insAA]",
-        "#1287",
+        "NC_TEST.1:g.[263_264insA;265_266insC]",
+        "#1290",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/common/synthetic.rs
+++ b/tests/it/common/synthetic.rs
@@ -3,7 +3,8 @@
 //! See `docs/superpowers/specs/2026-05-01-A7-ins-shift-coverage-matrix-design.md`.
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
-use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
 
 /// 256 bases of padding to ensure the normalizer's 100bp window stays in
 /// bounds on either side of any test variant.
@@ -328,6 +329,59 @@ pub fn normalize_to_string(provider: MockProvider, input: &str) -> String {
         .normalize(&variant)
         .unwrap_or_else(|e| panic!("Normalization failed for '{}': {}", input, e));
     format!("{}", normalized)
+}
+
+/// Normalize `input` against the padded synthetic genomic contig built from
+/// `core`, assert the result denotes the same bases the input did, and return
+/// the rendered output.
+///
+/// The comparison is projected through [`hgvs_to_spdi`] rather than the
+/// normalizer's own applier, so a pass that silently changed the sequence shows
+/// up here even when every encoding agrees with every other. Members that
+/// overlap have no resulting sequence at all, which this reports as a failure
+/// rather than as equality — that is the shape most of the cis-allele issue
+/// regressions are about.
+pub fn assert_padded_preserving(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None; // overlapping members
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+
+    let from_input = denote(input).expect("input applies");
+    let from_output = denote(&output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
 }
 
 fn reverse_complement(seq: &str) -> String {

--- a/tests/it/issue_1286_shared_junction_merge.rs
+++ b/tests/it/issue_1286_shared_junction_merge.rs
@@ -29,56 +29,7 @@
 //! re-canonicalises it to a `dup` or a repeat where the reference permits.
 
 use crate::common::cis_apply_oracle::{apply, assert_normalizes_preserving, normalize};
-use crate::common::synthetic::{padded, SyntheticBuilder};
-use ferro_hgvs::spdi::hgvs_to_spdi;
-use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
-
-/// Normalize against the padded synthetic contig and assert the result denotes
-/// the same bases the input did — through `hgvs_to_spdi`, a different code path
-/// from the normalizer.
-fn assert_padded_preserving(core: &str, input: &str) -> String {
-    let provider = SyntheticBuilder::genomic(core).build();
-    let normalizer = Normalizer::new(provider.clone());
-    let reference = padded(core);
-    let variant = parse_hgvs(input).expect("parse");
-    let output = normalizer
-        .normalize(&variant)
-        .expect("normalize")
-        .to_string();
-
-    let denote = |descriptor: &str| -> Option<String> {
-        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
-            HgvsVariant::Allele(allele) => allele.variants.clone(),
-            single => vec![single],
-        };
-        let mut triples = Vec::new();
-        for member in &members {
-            triples.push(hgvs_to_spdi(member, &provider).ok()?);
-        }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
-        let mut edited = reference.as_bytes().to_vec();
-        let mut claimed = reference.len();
-        for triple in &triples {
-            let start = usize::try_from(triple.position).ok()?;
-            let end = start.checked_add(triple.deletion.len())?;
-            if end > claimed {
-                return None; // overlapping members
-            }
-            edited.splice(start..end, triple.insertion.bytes());
-            claimed = start;
-        }
-        String::from_utf8(edited).ok()
-    };
-
-    let from_input = denote(input).expect("input applies");
-    let from_output = denote(&output)
-        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
-    assert_eq!(
-        from_output, from_input,
-        "`{input}` -> `{output}` changed the sequence"
-    );
-    output
-}
+use crate::common::synthetic::assert_padded_preserving;
 
 #[test]
 fn two_insertions_reaching_one_junction_merge() {

--- a/tests/it/issue_1287_repeat_span_junction.rs
+++ b/tests/it/issue_1287_repeat_span_junction.rs
@@ -1,0 +1,61 @@
+//! A repeat's tract must not swallow a sibling's **junction**.
+//!
+//! `demote_repeats_spanning_siblings` re-spells a repeat back to the plain edit
+//! it grew from when the tract-wide span it canonicalised to would cover a
+//! sibling. It asked only whether a sibling *claims bases*:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "ATACAGAAAATCAGGGCATA" + ("ACGT" x 64)
+//! g.[261_262insGA;263_264insAA]  ->  g.[262_263dup;263_266A[6]]
+//! ```
+//!
+//! The duplication claims no bases — it occupies the junction at 263 — so the
+//! demotion did not fire, and the repeat kept a span (262-266) containing that
+//! junction. The two members overlap, and the pair has no well-defined resulting
+//! sequence: `parse_hgvs` accepts the output, the SPDI apply oracle declines it.
+//!
+//! A copy count over `262_266` cannot express another member adding sequence in
+//! the middle of those bases, so a junction strictly inside the tract is
+//! swallowed exactly as claimed bases are. The 3' end stays exclusive: a
+//! junction at the tract's end is *flush against* it rather than inside it,
+//! which is the adjacency the collapse pass exists to catch (#999, #1135) — the
+//! same strictness `detect_insertion_overlaps` uses for an interior junction
+//! (#1276).
+
+use crate::common::cis_apply_oracle::assert_normalizes_preserving;
+use crate::common::synthetic::assert_padded_preserving;
+
+#[test]
+fn a_repeat_does_not_swallow_a_siblings_junction() {
+    // #1287. Demoted, the repeat becomes a duplication that clears the sibling.
+    let output = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[261_262insGA;263_264insAA]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.[262_263dup;265_266dup]");
+}
+
+#[test]
+fn the_demotion_does_not_depend_on_the_authored_order() {
+    let forward = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[261_262insGA;263_264insAA]",
+    );
+    let reverse = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[263_264insAA;261_262insGA]",
+    );
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn a_lone_insertion_still_reaches_repeat_notation() {
+    // The guard that keeps the demotion from firing when there is no sibling to
+    // swallow: a lone insertion inside a tract must still canonicalise to a
+    // copy count, which is what `repeated.md` B2 asks for.
+    assert_normalizes_preserving(
+        "TTTTTTTTTAATATATTTTA",
+        "TEMPLATE:g.2_3insTT",
+        "TEMPLATE:g.1_9T[11]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -166,6 +166,7 @@ mod issue_1261_cis_member_order;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
 mod issue_1286_shared_junction_merge;
+mod issue_1287_repeat_span_junction;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
> Stacked on #1289 → #1288 → #1285 → #1259. Base retargets as those merge.

Closes #1287.

```
reference  ("ACGT" x 64) + "ATACAGAAAATCAGGGCATA" + ("ACGT" x 64)
g.[261_262insGA;263_264insAA]  ->  g.[262_263dup;263_266A[6]]
```

Interbase spans of the output are `(263, 263)` and `(262, 266)` — the duplication's junction sits inside the repeat's span. The members overlap and the pair has no well-defined resulting sequence: `parse_hgvs` accepts the output, the SPDI apply oracle declines it while the input applies fine.

## Fix

`demote_repeats_spanning_siblings` exists for exactly this shape — a repeat's tract-wide span swallowing a sibling — but it asked only whether a sibling **claims bases**. A duplication claims none; it occupies a junction. So the demotion never fired and the repeat kept a span containing that junction.

A copy count over `262_266` cannot express another member adding sequence in the middle of those bases, so a junction strictly inside the tract is swallowed exactly as claimed bases are. Count it.

**The 3' end stays exclusive.** A junction at the tract's end is *flush against* it rather than inside it, which is the adjacency the collapse pass exists to catch (#999, #1135) — the same strictness `detect_insertion_overlaps` uses for an interior junction (#1276). Demoted, the repeat becomes a duplication that clears the sibling: `g.[262_263dup;265_266dup]`.

## A third defect fell out — filed as #1290

The `IndelHaplotype` confluence property added in #1285 found #1286 and #1287. With both closed it immediately surfaced a third:

```
core "ATACAGAAAATCAGGGCATA"
g.[263_264insA;265_266insC]  ->  g.[265_266insC;266dup]
  intended  G A A A A C A T
  emitted   G A A A C A A T      <- the inserted A crossed the C's junction
```

An insertion's junction shifts 3' **past another insertion's junction**, reordering the two payloads. Both members survive and land on *different* junctions, so there is no overlap to detect — the output is well-formed, disjoint and warning-free, and simply denotes different bases. The quietest member of the family.

**Verified pre-existing**, not introduced here: identical output on this branch's base, before any of the #1286/#1287 work. It was masked behind the two overlap defects, which the property hit first.

`clamp_sibling_crossing_junctions` bounds a junction against a sibling's *bases*, and both members here have none — so nothing is a barrier to anything. That is the junction-versus-junction case of the family #1276/#1277, #1286 and #1287 all belong to.

The property therefore stays `#[ignore]`d, with #1290's reproduction and the now-fixed history in its doc comment. Enabling it is #1290's acceptance criterion.

## Tests

`tests/it/issue_1287_repeat_span_junction.rs`, 3 tests, generated programmatically: the reproduction, order-independence, and a guard that a **lone** insertion inside a tract still reaches repeat notation (`repeated.md` B2) — the demotion must not fire when there is no sibling to swallow.

The sequence check projects through `hgvs_to_spdi`, a different code path from the normalizer's own applier.

## Verification

- 8902 pass; 8902 pass again under `FERRO_ASSERT_IDEMPOTENT=1` with `FERRO_ASSERT_REPARSE=1`.
- The 276,480-case sweep still passes with its residual pinned at 0.
- `cargo fmt --all` and `cargo clippy --features dev --all-targets -- -D warnings` clean.
- Commit is signed.

Not run: the manifest-backed conformance axis tests — no reference volume mounted locally, so they skip. Worth watching the nightly.
