### PR TITLE
fix(normalize): stop a junction shifting past another junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3395,11 +3395,12 @@ pub(crate) fn demote_repeats_spanning_siblings(
 /// A junction sits immediately 3' of one position: `end` for a duplication
 /// (the copy follows the duplicated bases), `start` for an insertion (whose
 /// span is the gap `start_end`).
-pub(crate) fn clamp_sibling_crossing_junctions(
+pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
     before: &[HgvsVariant],
     after: &mut [HgvsVariant],
     phase: AllelePhase,
     uncertain: bool,
+    provider: &P,
 ) {
     if phase != AllelePhase::Cis || uncertain || after.len() < 2 || before.len() != after.len() {
         return;
@@ -3447,13 +3448,58 @@ pub(crate) fn clamp_sibling_crossing_junctions(
         if after_junction < before_junction {
             continue;
         }
-        // The junction crossed a sibling if it started 5' of the sibling's
-        // first base and ended at or past it.
-        let limit = siblings
+        // The junction crossed a base-claiming sibling if it started 5' of the
+        // sibling's first base and ended at or past it.
+        let onto_bases = siblings
             .iter()
             .filter(|s| s.start > before_junction && s.start <= after_junction)
-            .map(|s| s.start - 1)
-            .min();
+            .map(|s| s.start - 1);
+        // It can equally cross another *junction* (#1290). Two junction-
+        // occupying members add their payloads at two interbase points, and
+        // their relative order is the only thing fixing the order of those
+        // payloads — so a junction sweeping past another reorders them and
+        // changes what the allele denotes, while leaving both members
+        // well-formed and disjoint. Nothing else catches it: the overlap
+        // detector sees two distinct junctions, and the clamp above sees a
+        // sibling with no bases to land on.
+        //
+        // Stop one position **short** of the sibling's junction, not at it.
+        // Landing on it makes the two share a junction, which is the case with
+        // no defined payload order at all — `coalesce_members_at_one_junction`
+        // merges that only when the payloads commute, and declines otherwise,
+        // which would leave an overlap here rather than the correct ordered
+        // pair. One short keeps them distinct and in their original order.
+        //
+        // Only a sibling whose payload does not *commute* with this member's.
+        // Two payloads that commute have no observable order, so crossing is
+        // harmless, and letting them settle on one junction is better: they then
+        // merge into a single member (#1286), the canonical form the
+        // sequence-first derivation would also reach. Barring the crossing
+        // unconditionally would split `g.[258_259insA;259_260insA]` into
+        // `g.[262dup;263dup]` — correct, but two members where one will do — and
+        // would leave the three-insertion case at two members for the same
+        // reason, since a merged `AA` is not *equal* to a remaining `A` even
+        // though it commutes with it.
+        let payload = junction_payload(&after[i], kind, a, provider);
+        let across_junctions = (0..pre.len())
+            .filter(|&j| j != i)
+            .flat_map(|j| [(j, pre[j].as_ref()), (j, post[j].as_ref())])
+            .filter_map(|(j, span)| span.map(|s| (j, s)))
+            .filter(|(_, s)| !s.claims_bases && s.region == a.region && s.accession == a.accession)
+            .filter(|(j, s)| {
+                let blocks = match (&payload, junction_payload(&after[*j], kind, s, provider)) {
+                    (Some(mine), Some(theirs)) => !payloads_commute(mine, &theirs),
+                    // A payload that cannot be read blocks: refusing to cross is
+                    // the conservative answer when the reordering cannot be
+                    // shown to be harmless.
+                    _ => true,
+                };
+                blocks && s.junction.is_some()
+            })
+            .filter_map(|(_, s)| s.junction)
+            .filter(|&j| j > before_junction && j <= after_junction)
+            .map(|j| j - 1);
+        let limit = onto_bases.chain(across_junctions).min();
         let Some(limit) = limit else {
             continue;
         };
@@ -3803,12 +3849,16 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
 /// The next pass re-canonicalises it to a `dup` or a repeat where the reference
 /// permits.
 ///
-/// **Only when every colliding payload is identical.** Concatenation is
-/// otherwise order-dependent, and the order is exactly what the shift destroyed:
-/// two insertions that were at distinct junctions had a defined order, and once
-/// they share a junction they do not. Equal payloads make the concatenation
-/// order-independent, so the repair is unambiguous. A differing-payload
-/// collision is left for the overlap detector to report rather than guessed at.
+/// **Only when the colliding payloads commute** (`p ++ q == q ++ p`, see
+/// [`payloads_commute`]). Concatenation is otherwise order-dependent, and the
+/// order is exactly what the shift destroyed: two insertions at distinct
+/// junctions had a defined order, and once they share a junction they do not.
+/// Commuting payloads make the concatenation order-independent, so the repair is
+/// unambiguous.
+///
+/// A non-commuting pair never reaches here: `clamp_sibling_crossing_junctions`
+/// bars precisely that crossing (#1290), so the two stay at distinct junctions
+/// in their original order. The two predicates are deliberately the same one.
 ///
 /// Genomic axes only, matching `respell_colliding_duplications` — the
 /// transcript axes need a coordinate conversion this does not carry.
@@ -3866,8 +3916,15 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         let Some(payloads) = payloads else {
             continue;
         };
-        // Order-independence guard: every payload identical.
-        if payloads.windows(2).any(|pair| pair[0] != pair[1]) {
+        // Order-independence guard: every pair must commute, so the
+        // concatenation below does not depend on the order the members happen
+        // to be in. The same predicate `clamp_sibling_crossing_junctions` uses
+        // to decide whether they were allowed to meet here at all.
+        if payloads.iter().enumerate().any(|(x, left)| {
+            payloads[x + 1..]
+                .iter()
+                .any(|right| !payloads_commute(left, right))
+        }) {
             continue;
         }
         let combined: Vec<Base> = payloads.concat();
@@ -3915,6 +3972,23 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         index += 1;
         keep
     });
+}
+
+/// Whether two junction payloads may be reordered without changing what the
+/// allele denotes.
+///
+/// Exactly when they commute: `p ++ q == q ++ p`. That identity holds if and
+/// only if both are powers of one common word, which is precisely the case
+/// where the order two insertions apply in is unobservable — `A` and `AA` in a
+/// poly-A tract commute, `A` and `C` do not.
+///
+/// Used in two places that must agree. `clamp_sibling_crossing_junctions` bars a
+/// junction from crossing a sibling's only when the payloads do *not* commute,
+/// and `coalesce_members_at_one_junction` merges members sharing a junction only
+/// when they *do* — so a pair is either kept apart and ordered, or allowed
+/// together and merged, never left overlapping.
+fn payloads_commute(left: &[Base], right: &[Base]) -> bool {
+    left.iter().chain(right).eq(right.iter().chain(left))
 }
 
 /// The bases a junction-occupying member adds, or `None` when they cannot be

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2645,6 +2645,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 &mut result,
                 allele.phase,
                 allele.uncertain,
+                &self.provider,
             );
             // Finally, a spelling repair rather than a repositioning: a
             // duplication whose span collides with a sibling's bases becomes

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -54,9 +54,10 @@
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1290, a junction shifting past another junction. It
-//!   found #1286 and #1287 first, both now fixed; see its doc comment for the
-//!   history and the live reproduction.
+//!   because it finds #1292, in the insertion/deletion cancellation path. It
+//!   found #1286, #1287 and #1290 first, all now fixed, each masked behind the
+//!   one before it; see its doc comment for the history and the live
+//!   reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -777,24 +778,24 @@ proptest! {
     ///          the dup's junction inside the repeat's span  (fixed)
     /// ```
     ///
-    /// With those closed it immediately surfaced a third, #1290 — a junction
-    /// shifting past *another junction*, which reorders two insertions and
-    /// changes the sequence:
+    /// #1290 followed and is also fixed — a junction shifting past *another
+    /// junction*, reordering two insertions. The live failure is now the fourth
+    /// it has found, #1292, in the insertion/deletion **cancellation** path:
     ///
     /// ```text
-    /// core "ATACAGAAAATCAGGGCATA"
-    ///   g.[263_264insA;265_266insC] -> g.[265_266insC;266dup]
-    ///     intended  G A A A A C A T
-    ///     emitted   G A A A C A A T      <- the inserted A crossed the C
+    /// core "GCAAATAACATCCAGA", insert "AC" after index 6, delete index 8
+    ///   g.[263_264insAC;265del] -> g.265delinsAA
+    ///     intended  T A A C A A T
+    ///     emitted   T A A A A A T      <- the inserted C is gone
     /// ```
     ///
-    /// Verified pre-existing: identical output on the base of #1287's branch,
-    /// so it was merely masked behind the two overlap defects.
+    /// Each of the four was masked behind the one before it, which is the point
+    /// of keeping this committed rather than deleting it until it can pass.
     ///
-    /// Enabling this test is #1290's acceptance criterion — do not weaken it to
+    /// Enabling this test is #1292's acceptance criterion — do not weaken it to
     /// make it pass.
     #[test]
-    #[ignore = "finds #1290, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1292, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -994,12 +995,12 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1290: the first insertion's junction shifts past the second's, which
-    // reorders the two payloads and changes the sequence.
+    // #1292: the insertion's payload is lost against the deletion in the
+    // cancellation path, so the output denotes a different sequence.
     let (core, input, issue) = (
-        "ATACAGAAAATCAGGGCATA",
-        "NC_TEST.1:g.[263_264insA;265_266insC]",
-        "#1290",
+        "GCAAATAACATCCAGA",
+        "NC_TEST.1:g.[263_264insAC;265del]",
+        "#1292",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1290_junction_crosses_junction.rs
+++ b/tests/it/issue_1290_junction_crosses_junction.rs
@@ -1,0 +1,76 @@
+//! A junction must not shift past another junction.
+//!
+//! `clamp_sibling_crossing_junctions` bounds a member's junction against a
+//! sibling's **bases**. Two junction-occupying members have none, so neither was
+//! a barrier to the other and one could sweep straight past:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "ATACAGAAAATCAGGGCATA" + ("ACGT" x 64)
+//! g.[263_264insA;265_266insC]  ->  g.[265_266insC;266dup]
+//!   intended  G A A A A C A T
+//!   emitted   G A A A C A A T      <- the inserted A crossed the C
+//! ```
+//!
+//! Both members survive and land on *different* junctions, so there is no
+//! overlap to detect: the output is well-formed, disjoint and warning-free, and
+//! simply denotes different bases. The quietest member of the family that
+//! #1276/#1277 (a dup occupying a junction), #1286 (two members on one junction)
+//! and #1287 (a junction inside a repeat's tract) also belong to.
+//!
+//! The barrier stops one position **short** of the sibling's junction. Landing
+//! *on* it makes the two share a junction, which is the case with no defined
+//! payload order at all.
+//!
+//! It applies only when the two payloads do **not commute** (`p ++ q != q ++ p`).
+//! Commuting payloads have no observable order — `A` and `AA` in a poly-A tract —
+//! so crossing is harmless there, and letting them meet is better: they merge
+//! into one member (#1286), which is the canonical form the sequence-first
+//! derivation also reaches. `coalesce_members_at_one_junction` uses the same
+//! predicate, so a pair is either kept apart and ordered, or allowed together
+//! and merged — never left overlapping.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+#[test]
+fn a_junction_does_not_cross_a_non_commuting_junction() {
+    // #1290. The `A` stops one short of the `C`'s junction, keeping the two in
+    // their authored order.
+    let output = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[263_264insA;265_266insC]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.[264dup;265_266insC]");
+}
+
+#[test]
+fn the_barrier_does_not_depend_on_the_authored_order() {
+    let forward = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[263_264insA;265_266insC]",
+    );
+    let reverse = assert_padded_preserving(
+        "ATACAGAAAATCAGGGCATA",
+        "NC_TEST.1:g.[265_266insC;263_264insA]",
+    );
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn commuting_payloads_still_meet_and_merge() {
+    // The guard on the barrier. Two `A` payloads in a poly-A tract commute, so
+    // they are allowed to reach one junction and merge — one member, not two.
+    let output = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    assert_eq!(output, "NC_TEST.1:g.257_263A[9]");
+}
+
+#[test]
+fn a_merged_payload_still_commutes_with_a_remaining_one() {
+    // Three insertions merge to one member only because `A` commutes with the
+    // merged `AA` — an equality test would stop after the first pair and leave
+    // two members.
+    let output = assert_padded_preserving(
+        "AAAAAA",
+        "NC_TEST.1:g.[258_259insA;259_260insA;260_261insA]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.257_263A[10]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -167,6 +167,7 @@ mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
 mod issue_1286_shared_junction_merge;
 mod issue_1287_repeat_span_junction;
+mod issue_1290_junction_crosses_junction;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
> Stacked on #1291 → #1289 → #1288 → #1285 → #1259. Base retargets as those merge.

Closes #1290.

```
reference  ("ACGT" x 64) + "ATACAGAAAATCAGGGCATA" + ("ACGT" x 64)
g.[263_264insA;265_266insC]  ->  g.[265_266insC;266dup]
  intended  G A A A A C A T
  emitted   G A A A C A A T      <- the inserted A crossed the C
```

`clamp_sibling_crossing_junctions` bounds a member's junction against a sibling's **bases**. Two junction-occupying members have none, so neither was a barrier to the other.

Both members survive and land on *different* junctions, so there is no overlap to detect — the output is well-formed, disjoint and warning-free, and simply denotes different bases. The quietest member of the family that #1276/#1277, #1286 and #1287 also belong to. **Pre-existing**: verified identical on this branch's base, before any of the #1286/#1287 work.

## Fix

Bar the crossing, stopping one position **short** of the sibling's junction. Landing *on* it makes the two share a junction, which is the case with no defined payload order at all.

**Only when the payloads do not commute.** `p ++ q == q ++ p` holds exactly when both are powers of one common word — precisely when the order two insertions apply in is unobservable. `A` and `AA` in a poly-A tract commute; `A` and `C` do not.

Commuting payloads are let through *on purpose*: they then meet on one junction and merge into a single member (#1286), which is the canonical form the sequence-first derivation also reaches. Barring unconditionally split `g.[258_259insA;259_260insA]` into `g.[262dup;263dup]` — correct, but two members where one will do.

**Equality is not enough in place of commuting.** Three insertions merge to one only because `A` commutes with the merged `AA`; an equality test stops after the first pair and leaves two members. I hit exactly that while building this, which is why the test below pins it.

`coalesce_members_at_one_junction` now uses the same predicate, so a pair is either kept apart and ordered, or allowed together and merged — never left overlapping. The two rules are deliberately one rule.

`clamp_sibling_crossing_junctions` gains a provider parameter, to read a duplication's payload from the reference.

## Tests

`tests/it/issue_1290_junction_crosses_junction.rs`, 4 tests, generated programmatically: the reproduction, order-independence, and two guards on the commuting rule — that commuting payloads still meet and merge to one member, and that a *merged* payload still commutes with a remaining one (the three-insertion case that an equality test fails).

## A fourth defect — filed as #1292

The `IndelHaplotype` property added in #1285 has now found four defects, each masked behind the one before it: #1286, #1287, #1290, and now **#1292** — the insertion/deletion cancellation path dropping a base from the payload:

```
core "GCAAATAACATCCAGA", insert "AC" after index 6, delete index 8
  g.[263_264insAC;265del] -> g.265delinsAA
    intended  T A A C A A T
    emitted   T A A A A A T      <- the inserted C is gone
```

Same class as #1266's "merge's cancellation path" but for `ins` + `del` with a multi-base payload. The property therefore stays `#[ignore]`d, now with #1292's reproduction; enabling it is that issue's acceptance criterion.

That each defect only became visible once the previous was fixed is the argument for keeping the property committed and failing rather than deleting it until it can pass.

## Verification

- 8906 pass; 8906 pass again under `FERRO_ASSERT_IDEMPOTENT=1` with `FERRO_ASSERT_REPARSE=1`.
- The 276,480-case sweep still passes with its residual pinned at 0.
- `cargo fmt --all` and `cargo clippy --features dev --all-targets -- -D warnings` clean.
- Commit is signed.

Not run: the manifest-backed conformance axis tests — no reference volume mounted locally. Worth watching the nightly.
