### PR TITLE
fix(normalize): keep a moved member's junction payload in phase

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3120,11 +3120,12 @@ fn blocks_sibling_shift(edit: &NaEdit) -> bool {
 /// live list keeps the pass independent of member order.
 ///
 /// [`ShuffleDirection::FivePrime`]: crate::normalize::ShuffleDirection
-pub(crate) fn clamp_sibling_crossing_shifts(
+pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
     before: &[HgvsVariant],
     after: &mut [HgvsVariant],
     phase: AllelePhase,
     uncertain: bool,
+    provider: &P,
 ) {
     // An uncertain allele — `g.[(…)]` — asserts only that the members are in
     // cis, not where they sit, so repositioning one states something the input
@@ -3242,7 +3243,13 @@ pub(crate) fn clamp_sibling_crossing_shifts(
             continue;
         };
         if pull != 0 {
-            translate_member(&mut after[i], -pull, kind, a);
+            // A duplication blocks a sibling's shift without claiming bases, so
+            // it reaches this pass too — and its payload is read from under its
+            // own span, so it cannot simply be slid (#1280, #1292).
+            match a.junction {
+                Some(_) => translate_junction_member(&mut after[i], -pull, kind, a, provider),
+                None => translate_member(&mut after[i], -pull, kind, a),
+            }
         }
     }
 }
@@ -3506,7 +3513,7 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         // Never move past where the junction started.
         let delta = (limit - after_junction).max(before_junction - after_junction);
         if delta != 0 {
-            translate_member(&mut after[i], delta, kind, a);
+            translate_junction_member(&mut after[i], delta, kind, a, provider);
         }
     }
 }
@@ -3812,7 +3819,7 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
         };
         // The copy lands at the junction 3' of the duplicated span, which is
         // the gap `[end, end + 1]`.
-        respell_at_gap(&mut members[i], kind, dup, edit);
+        respell_at_gap(&mut members[i], kind, dup, dup.end, edit);
     }
 }
 
@@ -3935,28 +3942,13 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         let Some(span) = spans[target].as_ref() else {
             continue;
         };
+        // The merged payload belongs at the junction the group shares, which is
+        // not `span.end` when the target member is spelled as an insertion.
         let Some(junction) = span.junction else {
             continue;
         };
-        // `respell_at_gap` places the edit over `[span.end, span.end + 1]`, so
-        // hand it a span whose `end` is the shared junction rather than the
-        // member's own. For a `Duplication` the two coincide (`junction_of`
-        // returns its `end`), but for an `Insertion` the junction is its
-        // `start`, so `span.end` sits one base 3' of it. `respell_at_gap`
-        // cannot catch that: it checks the result landed on the gap it was
-        // given, not that the gap was the right one.
-        let gap = MemberSpan {
-            accession: span.accession.clone(),
-            provider_key: span.provider_key.clone(),
-            region: span.region,
-            start: junction,
-            end: junction,
-            claims_bases: span.claims_bases,
-            blocks_shift: span.blocks_shift,
-            junction: Some(junction),
-        };
         let before = members[target].clone();
-        respell_at_gap(&mut members[target], kind, &gap, edit);
+        respell_at_gap(&mut members[target], kind, span, junction, edit);
         if members[target] == before {
             continue; // the re-spell did not take; leave the group alone
         }
@@ -3972,6 +3964,125 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         index += 1;
         keep
     });
+}
+
+/// The payload an equivalent junction-inserting member carries at `to`, given
+/// that it carries `payload` at `from`.
+///
+/// A member that adds sequence at a junction denotes those bases *at that
+/// junction*, so the same payload spelled one position over denotes a different
+/// sequence. The two agree only under a rotation, and only when the base being
+/// stepped over is the one the rotation brings around:
+///
+/// ```text
+/// insert P at junction j  ==  insert (ref[j] ++ P[..n-1]) at junction j - 1
+///                             only when P[n-1] == ref[j]
+/// ```
+///
+/// with the mirror image 3'. A multi-position move composes single steps, which
+/// is why a payload can rotate through more than its own length.
+///
+/// `None` when some step is not payload-preserving, or the reference cannot be
+/// read — the caller's signal to leave the member where it is rather than emit
+/// a description of different bases.
+fn payload_at_junction<P: ReferenceProvider>(
+    payload: &[Base],
+    from: i64,
+    to: i64,
+    key: &str,
+    provider: &P,
+) -> Option<Vec<Base>> {
+    let base_at = |position: i64| -> Option<Base> {
+        let (start, end) = (
+            u64::try_from(position.checked_sub(1)?).ok()?,
+            u64::try_from(position).ok()?,
+        );
+        let read = provider.get_sequence(key, start, end).ok()?;
+        let mut chars = read.chars();
+        let base = Base::from_char(chars.next()?)?;
+        chars.next().is_none().then_some(base)
+    };
+    let mut rotated = payload.to_vec();
+    let mut junction = from;
+    while junction > to {
+        // 5' by one: the payload's last base is the one it steps back over.
+        if *rotated.last()? != base_at(junction)? {
+            return None;
+        }
+        rotated.rotate_right(1);
+        junction -= 1;
+    }
+    while junction < to {
+        // 3' by one: the payload's first base is the one it steps over.
+        if *rotated.first()? != base_at(junction + 1)? {
+            return None;
+        }
+        rotated.rotate_left(1);
+        junction += 1;
+    }
+    Some(rotated)
+}
+
+/// Move a junction-occupying member `delta` positions along its axis, keeping
+/// the bases it adds unchanged.
+///
+/// [`translate_member`] alone is not enough for these members, because a
+/// spelling can be position-dependent: a `Duplication` reads its payload from
+/// the reference **under its own span**, so translating the span silently
+/// rewrites what the member copies. On `g.[263_264insAC;265del]` that turned a
+/// clamped `g.265_266dup` (payload `CA`) into `g.263_264dup` (payload `AA`) and
+/// dropped the inserted `C` from the allele (#1292); the same rewrite corrupts
+/// a repeat demoted to a duplication that the clamp then pulls back (#1280).
+///
+/// So the payload is rotated into phase at the destination first, and the
+/// member is re-spelled as a plain insertion carrying it whenever the
+/// translated spelling would denote something else. A move whose payload cannot
+/// be rotated, read, or re-spelled leaves the member untouched: an unclamped
+/// crossing is the defect this pass is repairing, but a corrupted payload is a
+/// worse one.
+fn translate_junction_member<P: ReferenceProvider>(
+    variant: &mut HgvsVariant,
+    delta: i64,
+    kind: CisKind,
+    from: &MemberSpan,
+    provider: &P,
+) {
+    let (Some(junction), Some(payload)) = (
+        from.junction,
+        junction_payload(variant, kind, from, provider),
+    ) else {
+        return;
+    };
+    let destination = junction + delta;
+    let Some(moved) = payload_at_junction(
+        &payload,
+        junction,
+        destination,
+        &from.provider_key,
+        provider,
+    ) else {
+        return;
+    };
+
+    let original = variant.clone();
+    translate_member(variant, delta, kind, from);
+    if *variant == original {
+        return; // the translation was refused; nothing to repair
+    }
+    let landed = member_span(variant, kind)
+        .filter(|s| s.junction == Some(destination))
+        .and_then(|s| junction_payload(variant, kind, &s, provider));
+    if landed.as_deref() == Some(moved.as_slice()) {
+        return; // the spelling still denotes the same bases
+    }
+    let edit = NaEdit::Insertion {
+        sequence: InsertedSequence::Literal(Sequence::new(moved)),
+    };
+    let translated = variant.clone();
+    respell_at_gap(variant, kind, from, destination, edit);
+    if *variant == translated {
+        *variant = original;
+    }
 }
 
 /// Whether two junction payloads may be reordered without changing what the
@@ -4023,12 +4134,23 @@ fn junction_payload<P: ReferenceProvider>(
     }
 }
 
-/// Replace a genomic member with `edit` over the gap `[span.end, span.end + 1]`.
+/// Replace a genomic member with `edit` over the gap `[junction, junction + 1]`.
 ///
-/// Reverts unless the result reads back exactly as intended.
-fn respell_at_gap(variant: &mut HgvsVariant, kind: CisKind, span: &MemberSpan, edit: NaEdit) {
+/// The junction is passed rather than read off `span`, because where it sits
+/// depends on the spelling: `span.end` is the junction for a duplication, but
+/// one position past it for an insertion, whose span is the gap itself.
+///
+/// Reverts unless the result reads back exactly as intended. `span` is used
+/// only to check the result landed on the same region.
+fn respell_at_gap(
+    variant: &mut HgvsVariant,
+    kind: CisKind,
+    span: &MemberSpan,
+    junction: i64,
+    edit: NaEdit,
+) {
     let original = variant.clone();
-    let (gap_start, gap_end) = (span.end, span.end + 1);
+    let (gap_start, gap_end) = (junction, junction + 1);
     let (Ok(start), Ok(end)) = (u64::try_from(gap_start), u64::try_from(gap_end)) else {
         return;
     };

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2634,6 +2634,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 &mut result,
                 allele.phase,
                 allele.uncertain,
+                &self.provider,
             );
             // Third: an insertion or duplication consumes no base, so the clamp
             // above leaves it alone — but its *junction* shifts through a tract

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -54,10 +54,10 @@
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1292, in the insertion/deletion cancellation path. It
-//!   found #1286, #1287 and #1290 first, all now fixed, each masked behind the
-//!   one before it; see its doc comment for the history and the live
-//!   reproduction.
+//!   because it finds #1296, a repeat that is not a barrier to a sibling's 3'
+//!   shift. It found #1286, #1287, #1290 and #1292 first, all now fixed, each
+//!   masked behind the one before it; see its doc comment for the history and
+//!   the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -779,23 +779,32 @@ proptest! {
     /// ```
     ///
     /// #1290 followed and is also fixed — a junction shifting past *another
-    /// junction*, reordering two insertions. The live failure is now the fourth
-    /// it has found, #1292, in the insertion/deletion **cancellation** path:
+    /// junction*, reordering two insertions. So is #1292, a duplication whose
+    /// payload was rewritten when a clamp translated it. The live failure is
+    /// the fifth it has found, **#1296**: a `Repeat` claims the bases under its
+    /// tract but does not report that it does, so it is no barrier to a
+    /// sibling's 3' shift and the pair ends up overlapping.
     ///
     /// ```text
-    /// core "GCAAATAACATCCAGA", insert "AC" after index 6, delete index 8
-    ///   g.[263_264insAC;265del] -> g.265delinsAA
-    ///     intended  T A A C A A T
-    ///     emitted   T A A A A A T      <- the inserted C is gone
+    /// core "AAAAAAATAATCGCAACAGAAG", delete index 15 and 16, insert "AA" after 17
+    ///   g.[272_273del;274_275insAA] -> g.[273_274del;274A[3]]
+    ///     both members claim 274 — the apply oracle declines the output
     /// ```
     ///
-    /// Each of the four was masked behind the one before it, which is the point
+    /// Each of the five was masked behind the one before it, which is the point
     /// of keeping this committed rather than deleting it until it can pass.
     ///
-    /// Enabling this test is #1292's acceptance criterion — do not weaken it to
-    /// make it pass.
+    /// Enabling this test was #1292's acceptance criterion. #1292 itself is
+    /// fixed and pinned — by `issue_1292_junction_payload_rotation` and by the
+    /// `99d5d382` seed below, which now replays green — but the criterion could
+    /// not be met with it, because the property's next two failures were behind
+    /// it. Enabling now belongs to #1296 and, behind that, **#1297**. Both of
+    /// their seeds are committed below, so taking the ignore off replays them
+    /// immediately — which is what should gate taking it off.
+    ///
+    /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1292, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1296, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -995,12 +1004,12 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1292: the insertion's payload is lost against the deletion in the
-    // cancellation path, so the output denotes a different sequence.
+    // #1296: the repeat claims the bases under its tract without reporting it,
+    // so it is no barrier to the sibling's 3' shift and the pair overlaps.
     let (core, input, issue) = (
-        "GCAAATAACATCCAGA",
-        "NC_TEST.1:g.[263_264insAC;265del]",
-        "#1292",
+        "AAAAAAATAATCGCAACAGAAG",
+        "NC_TEST.1:g.[272_273del;274_275insAA]",
+        "#1296",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1292_junction_payload_rotation.rs
+++ b/tests/it/issue_1292_junction_payload_rotation.rs
@@ -1,0 +1,83 @@
+//! Moving a junction-occupying member must not rewrite the bases it adds.
+//!
+//! A member that adds sequence at a junction denotes its payload *at that
+//! junction*. Two of the sibling-repair passes move such a member, and a
+//! `Duplication` reads its payload from the reference **under its own span** —
+//! so sliding the span silently changes what the member copies:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "GCAAATAACATCCAGA" + ("ACGT" x 64)
+//! g.[263_264insAC;265del]
+//!   per-member ->  g.[265_266dup;265del]      dup payload "CA"
+//!   clamped    ->  g.[263_264dup;265del]      payload silently became "AA"
+//!   merged     ->  g.265delinsAA              the inserted C is gone
+//!
+//!   intended  T A A C A A T
+//!   emitted   T A A A A A T
+//! ```
+//!
+//! The repair is to rotate the payload into phase at the destination:
+//!
+//! ```text
+//! insert P at junction j  ==  insert (ref[j] ++ P[..n-1]) at junction j - 1
+//!                             only when P[n-1] == ref[j]
+//! ```
+//!
+//! and to re-spell the member as a plain insertion carrying it whenever the
+//! translated spelling would denote something else. #1292 is that defect at
+//! `clamp_sibling_crossing_junctions`; #1280 is the same root cause reached
+//! through `demote_repeats_spanning_siblings`, whose duplication is then pulled
+//! back by the very same clamp.
+//!
+//! The rotation is what makes this safe in a tandem repeat. #1280 records an
+//! attempted fix — demote the repeat to an insertion carrying its **literal**
+//! payload — that was reverted precisely because it skipped the rotation:
+//! invisible in a homopolymer, wrong in a `(CAG)` tract. The last test here is
+//! that counterexample.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+#[test]
+fn a_clamped_duplication_keeps_the_bases_it_copies() {
+    // #1292. The inserted `AC` cancels against the deleted `C`, leaving one
+    // added `A`; the payload must survive being pulled back two positions.
+    let output = assert_padded_preserving("GCAAATAACATCCAGA", "NC_TEST.1:g.[263_264insAC;265del]");
+    assert_eq!(output, "NC_TEST.1:g.266dup");
+}
+
+#[test]
+fn a_demoted_repeat_keeps_its_payload_when_the_clamp_pulls_it_back() {
+    // #1280 (1). An insertion grows a nine-`T` tract; the repeat is demoted to
+    // a duplication over the tract's 3'-most bases, which reaches across the
+    // substituted base, and the junction clamp then pulls it back.
+    let output = assert_padded_preserving(
+        "CTTTTTTTTTAATATATTTTG",
+        "NC_TEST.1:g.[259_260insTTTTT;262T>A]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.263_267dup");
+}
+
+#[test]
+fn the_pulled_back_payload_does_not_pick_up_a_flanking_base() {
+    // #1280 (2). The same shape with a `GC` run 5' of the tract, which is what
+    // made the corruption visible: the translated duplication read a `C` from
+    // outside the tract and emitted `g.272delinsCTTTTA` — a base that appears
+    // nowhere in the sequence the input denotes.
+    let output = assert_padded_preserving(
+        "CGCGCGCGCGCTTTTTTTTTAATATATTTTG",
+        "NC_TEST.1:g.[269_270insTTTTT;272T>A]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.273_277dup");
+}
+
+#[test]
+fn a_tandem_repeat_keeps_the_duplication_spelling() {
+    // #1280's counterexample, and the reason the payload is *rotated* rather
+    // than carried literally. A duplication is phase-correct by construction
+    // where it already sits, so a member that does not have to move keeps it.
+    let output = assert_padded_preserving(
+        "CTTTTCAGCAGCAGCAGCAGCAGTTTTG",
+        "NC_TEST.1:g.[268_269insAGCAGC;262del]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.[262del;274_279dup]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -168,6 +168,7 @@ mod issue_1281_reducing_member_shift;
 mod issue_1286_shared_junction_merge;
 mod issue_1287_repeat_span_junction;
 mod issue_1290_junction_crosses_junction;
+mod issue_1292_junction_payload_rotation;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -4,9 +4,16 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-# The three cases the IndelHaplotype model found. The first two are filtered by
+# The cases the IndelHaplotype model has found. The first two are filtered by
 # the strategy today (#1260/#1262 adjacent-gap insertions, and events cancelling
-# to no net change) and are re-rejected rather than re-run. The third is #1287.
+# to no net change) and are re-rejected rather than re-run. #1287 and #1292 are
+# fixed and replay green. #1296 and #1297 are not yet fixed and are the reason
+# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d, so
+# they are recorded here rather than running: they replay the moment it is
+# enabled, which is what should gate enabling it.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
+cc 99d5d382a1a8f00844864743b0bed0ae12fe2bb8a21b902c99963e8902ab9f11 # #1292; shrinks to haplotype = IndelHaplotype { core: "GCAAATAACATCCAGA", events: [Insert { index: 6, bases: "AC" }, Delete { index: 8 }] }
+cc d327f0bf8cf0b8efddb73821bcc4e210ec3c32c5df034d9d4607833b24a588d2 # #1296; shrinks to haplotype = IndelHaplotype { core: "AAAAAAATAATCGCAACAGAAG", events: [Insert { index: 15, bases: "A" }, Delete { index: 16 }, Insert { index: 17, bases: "AC" }] }
+cc a88766af1b7adaab791aaf8fda16997a3c66fe0d265cb1a57d9488f22a67ef5d # #1297; shrinks to haplotype = IndelHaplotype { core: "GCATGAAAAT", events: [Insert { index: 4, bases: "AA" }, Delete { index: 6 }, Insert { index: 7, bases: "A" }] }


### PR DESCRIPTION
Closes #1292. Closes #1280.

A cis member that adds sequence at a junction denotes its payload *at that junction*. Two sibling-repair passes move such a member, and a `Duplication` reads its payload from the reference **under its own span** — so sliding the span silently rewrites what the member copies.

```
g.[263_264insAC;265del]     on ("ACGT"x64) + "GCAAATAACATCCAGA" + ("ACGT"x64)
  per-member ->  g.[265_266dup;265del]      dup payload "CA"
  clamped    ->  g.[263_264dup;265del]      payload silently became "AA"
  merged     ->  g.265delinsAA              the inserted C is gone

  intended  T A A C A A T
  emitted   T A A A A A T
```

Traced live on `clamp_sibling_crossing_junctions` → `translate_member`, whose `landed` check verifies position and region but never that the member still denotes the same bases.

## The fix

Rotate the payload into phase at the destination, and re-spell the member as a plain insertion carrying it whenever the translated spelling would denote something else:

```
insert P at junction j  ==  insert (ref[j] ++ P[..n-1]) at junction j - 1
                            only when P[n-1] == ref[j]
```

applied one position at a time, so a multi-position move is the composition — which is also why a payload can rotate through more than its own length. On the trace above: `"CA"` at 266 → 265 needs `P[1]=='A' == ref[266]` ✓ giving `"AC"`; 265 → 264 needs `'C' == ref[265]` ✓ giving `"CA"` at 264. A move whose payload cannot be rotated, read, or re-spelled leaves the member where it is — an unclamped crossing is the defect the pass is repairing, but a corrupted payload is a worse one.

**A shared helper, not a per-call-site repair**, because the same rewrite is reachable from both passes that translate a member: `clamp_sibling_crossing_junctions` (#1292) and `clamp_sibling_crossing_shifts`, which a duplication reaches because it blocks a sibling's shift without claiming bases.

## Why this closes #1280 without touching its placement

#1280 is the same root cause arrived at through `demote_repeats_spanning_siblings`: its duplication over the tract's 3'-most bases is then pulled back by the very same junction clamp, which corrupted the payload. Both of its reproductions are fixed here, so its "compute the placement subject to the sibling barrier" suggestion is not needed — a duplication is phase-correct where it already sits, and the clamp now moves it correctly:

```
(1)  g.[259_260insTTTTT;262T>A]   ->  g.263_267dup          was g.262delinsCTTTTA
(2)  g.[269_270insTTTTT;272T>A]   ->  g.273_277dup          was g.272delinsCTTTTA
```

(Both re-expressed on the padded synthetic contig; case (2) is the one whose output carried a `C` that appears nowhere in the sequence the input denotes.)

Rotating rather than carrying the payload literally is exactly what makes this safe in a tandem repeat. #1280 records an attempted fix — demote the repeat to an insertion carrying its **literal** payload — that was reverted because it skipped the rotation: invisible in a homopolymer, wrong in a `(CAG)` tract. That counterexample is pinned as a test here, and still keeps its duplication spelling:

```
g.[268_269insAGCAGC;262del]  ->  g.[262del;274_279dup]
```

## Also in this PR

A latent off-by-one in the same helper. `respell_at_gap` placed its edit at `[span.end, span.end + 1]`, which is the junction for a duplication but one position **past** it for an insertion, whose span is the gap itself — so `coalesce_members_at_one_junction` would have placed a merged payload one position 3' of the junction its group shares, whenever the target member was spelled as an insertion. Invisible in the poly-A cases the pass has tests for. It now takes the junction explicitly.

## The acceptance criterion, and why it is not met literally

#1292's stated acceptance criterion was removing `#[ignore]` from `cis_allele_confluence_proptest::an_indel_haplotype_normalizes_to_its_own_sequence`. **The property still fails**, and not on #1292: its next two failures were masked behind this one, which is the fifth and sixth instance of that pattern in this stack (#1286 → #1287 → #1290 → #1292 → …).

- **#1296** — a `Repeat` claims the bases under its tract but does not report that it does, so it is no barrier to a sibling's 3' shift and the pair overlaps. Found at the property's committed 512-case budget once #1292 was fixed. A verified one-line fix exists; filed separately rather than folded in here.
- **#1297** — a cancelled member left as an identity member (`265=`) overlapping the repeat that absorbed it. Found at 30,000 cases with #1292 and #1296 both fixed.

Both are **pre-existing** — verified by reverting `src/normalize/{merge,mod}.rs` to this branch's parent and re-running, not by `git stash`. #1297 is *silently wrong* on the parent (`g.[261_262dup;265=]`, a `G` that is not in the input's sequence) and becomes a loud overlap here, so this PR improves its failure mode.

So the ignore stays, its reason now names #1296, and the property's doc comment records that #1292 is fixed and pinned by other means. #1292 is closed on that evidence: its reproduction is fixed, `tests/it/issue_1292_junction_payload_rotation.rs` pins it, and its proptest seed `99d5d382` is committed and replays green. Enabling the property belongs to #1297, which says so. Deliberately **not** weakened to make it pass.

## Verification

- `cargo nextest run --features dev` — **8920 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8920 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- `cis_junction_crossing_shift::no_two_member_allele_normalizes_to_a_different_sequence` — the 276,480-case sweep holds its residual at **0**, the measurement that killed the reverted attempts in #1279/#1280
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine. Watching the nightly.
