### PR TITLE
fix(normalize): let a repeat claim the bases under its tract

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3054,10 +3054,10 @@ fn member_span(v: &HgvsVariant, kind: CisKind) -> Option<MemberSpan> {
 /// span are what it copies; `blocks_sibling_shift` carries that, keeping this
 /// predicate to the narrower "consumes bases" question its name asks.
 ///
-/// `Repeat`/`MultiRepeat` are the one deliberate omission: a repeat does claim
-/// the bases under its tract, but making it say so changes clamp and barrier
-/// behaviour across the whole repeat corpus at once. That is tracked in #1269,
-/// with `demote_repeats_spanning_siblings` standing in until it is measured.
+/// `Repeat`/`MultiRepeat` claim the bases under their tract too: `g.1_9T[7]`
+/// covers positions 1–9 whatever copy count it asserts. They were excluded until
+/// the change could be measured (#1269), which left a repeat invisible as a
+/// barrier and let a sibling's 3' shift land inside its tract (#1296).
 fn claims_reference_bases(edit: &NaEdit) -> bool {
     matches!(
         edit,
@@ -3067,6 +3067,8 @@ fn claims_reference_bases(edit: &NaEdit) -> bool {
             | NaEdit::NPaddedDeletion { .. }
             | NaEdit::Delins { .. }
             | NaEdit::Inversion { .. }
+            | NaEdit::Repeat { .. }
+            | NaEdit::MultiRepeat { .. }
     )
 }
 
@@ -3281,11 +3283,16 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
 /// have taken had B2 declined, and it is exactly equivalent — B2 only re-writes
 /// notation, never the bases removed.
 ///
-/// Restoring the deletion is what lets the rest of the pipeline finish the job.
-/// [`clamp_sibling_crossing_shifts`] can then see a real span to pull back, and
-/// the caller's next merge pass coalesces the members. `g.[1_2del;4del]` ends up
-/// as `g.1_9T[6]` — one member, three bases removed from the tract, repeat
-/// notation restored now that there is no sibling to span.
+/// Restoring the deletion is what lets the rest of the pipeline finish the job:
+/// the member is back to a span the caller's next merge pass can coalesce with
+/// its sibling. `g.[1_2del;4del]` ends up as `g.1_9T[6]` — one member, three
+/// bases removed from the tract, repeat notation restored now that there is no
+/// sibling to span.
+///
+/// Visibility to [`clamp_sibling_crossing_shifts`] is no longer part of that:
+/// since #1296 a repeat reports that it claims the bases under its tract, so
+/// the clamp sees the widened span whether or not this pass has run. What this
+/// pass still supplies is the *narrower, coalescible* spelling.
 ///
 /// Runs before the clamp, so the clamp sees the deletion rather than the
 /// repeat. Members whose pre-normalization form was not a plain deletion are

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -54,10 +54,10 @@
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1296, a repeat that is not a barrier to a sibling's 3'
-//!   shift. It found #1286, #1287, #1290 and #1292 first, all now fixed, each
-//!   masked behind the one before it; see its doc comment for the history and
-//!   the live reproduction.
+//!   because it finds #1297, a cancelled member left as an identity member
+//!   overlapping the repeat that absorbed it. It found #1286, #1287, #1290,
+//!   #1292 and #1296 first, all now fixed, each masked behind the one before
+//!   it; see its doc comment for the history and the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -779,32 +779,35 @@ proptest! {
     /// ```
     ///
     /// #1290 followed and is also fixed — a junction shifting past *another
-    /// junction*, reordering two insertions. So is #1292, a duplication whose
-    /// payload was rewritten when a clamp translated it. The live failure is
-    /// the fifth it has found, **#1296**: a `Repeat` claims the bases under its
-    /// tract but does not report that it does, so it is no barrier to a
-    /// sibling's 3' shift and the pair ends up overlapping.
+    /// junction*, reordering two insertions. So are #1292, a duplication whose
+    /// payload was rewritten when a clamp translated it, and #1296, a repeat
+    /// that did not report claiming the bases under its tract. The live failure
+    /// is the sixth it has found, **#1297**: a member that cancelled is left as
+    /// an identity member, overlapping the repeat that absorbed it.
     ///
     /// ```text
-    /// core "AAAAAAATAATCGCAACAGAAG", delete index 15 and 16, insert "AA" after 17
-    ///   g.[272_273del;274_275insAA] -> g.[273_274del;274A[3]]
-    ///     both members claim 274 — the apply oracle declines the output
+    /// core "GCATGAAAAT", insert "AA" after 4, delete index 6, insert "A" after 7
+    ///   g.[261_262insAA;263del;264_265insA] -> g.[262_265A[6];265=]
+    ///     the repeat alone is right; the `265=` residue overlaps it
     /// ```
     ///
-    /// Each of the five was masked behind the one before it, which is the point
+    /// Each of the six was masked behind the one before it, which is the point
     /// of keeping this committed rather than deleting it until it can pass.
     ///
-    /// Enabling this test was #1292's acceptance criterion. #1292 itself is
-    /// fixed and pinned — by `issue_1292_junction_payload_rotation` and by the
-    /// `99d5d382` seed below, which now replays green — but the criterion could
-    /// not be met with it, because the property's next two failures were behind
-    /// it. Enabling now belongs to #1296 and, behind that, **#1297**. Both of
-    /// their seeds are committed below, so taking the ignore off replays them
-    /// immediately — which is what should gate taking it off.
+    /// Enabling this test was #1292's acceptance criterion. #1292 is fixed and
+    /// pinned — by `issue_1292_junction_payload_rotation` and by the `99d5d382`
+    /// seed below, which replays green — but the criterion could not be met
+    /// with it, because the property's next two failures were behind it.
+    /// Enabling now belongs to **#1297**, whose seed `a88766af` is committed
+    /// below — so taking the ignore off replays it immediately, which is what
+    /// should gate taking it off. Absent that seed this passes the 512-case
+    /// budget and fails a 30,000-case soak on the same shape, so switching it
+    /// on would make a green CI a matter of the budget rather than of the
+    /// property holding.
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1296, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1297, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1004,12 +1007,12 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1296: the repeat claims the bases under its tract without reporting it,
-    // so it is no barrier to the sibling's 3' shift and the pair overlaps.
+    // #1297: a member that cancelled is left behind as an identity member,
+    // overlapping the repeat that absorbed it.
     let (core, input, issue) = (
-        "AAAAAAATAATCGCAACAGAAG",
-        "NC_TEST.1:g.[272_273del;274_275insAA]",
-        "#1296",
+        "GCATGAAAAT",
+        "NC_TEST.1:g.[261_262insAA;263del;264_265insA]",
+        "#1297",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1296_repeat_claims_its_bases.rs
+++ b/tests/it/issue_1296_repeat_claims_its_bases.rs
@@ -1,0 +1,52 @@
+//! A repeat claims the bases under its tract, and must say so.
+//!
+//! `claims_reference_bases` is how every sibling-repair pass asks "can this
+//! member collide with that one". It excluded `NaEdit::Repeat`, so a repeat was
+//! invisible as a barrier — and it has no junction either, so the junction rule
+//! did not see it. A sibling deletion could 3'-shift straight into the tract:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "AAAAAAATAATCGCAACAGAAG" + ("ACGT" x 64)
+//! g.[272_273del;274_275insAA]  ->  g.[273_274del;274A[3]]
+//!   both members claim 274 — the apply oracle declines the output
+//! ```
+//!
+//! The exclusion was deliberate and tracked by #1269: a repeat that says it
+//! claims its bases becomes a barrier everywhere at once, and that had not been
+//! measured. #1296 is the defect it left behind, so the measurement is here.
+//!
+//! It does **not** make the two passes that stood in for it redundant. Disabling
+//! `demote_repeats_spanning_siblings` with the predicate corrected fails 12
+//! tests including both committed sweeps, and disabling
+//! `respell_colliding_duplications` fails two more. Correcting the predicate
+//! removes the reason a *third* workaround would have been needed, not the two
+//! that exist.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+const CORE: &str = "AAAAAAATAATCGCAACAGAAG";
+
+#[test]
+fn a_deletion_does_not_shift_into_a_repeats_tract() {
+    // #1296. The deletion of `AC` at 272_273 may 3'-shift to 273_274 on its
+    // own — `AC` and `CA` leave the same bases behind — but 274 is where the
+    // insertion's repeat starts, so the shift must stop.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[272_273del;274_275insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[272_273del;274A[3]]");
+}
+
+#[test]
+fn the_three_member_form_reaches_the_same_result() {
+    // The shape the confluence property actually generated, before it reduced
+    // to the pair above: two single-base deletions that merge first.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[272del;273del;274_275insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[272_273del;274A[3]]");
+}
+
+#[test]
+fn a_deletion_clear_of_the_tract_still_shifts() {
+    // The guard on the barrier: a repeat bounds a sibling that would land in
+    // its tract, and nothing else. This deletion never reaches 274.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[272del;274_275insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[272del;274A[3]]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -169,6 +169,7 @@ mod issue_1286_shared_junction_merge;
 mod issue_1287_repeat_span_junction;
 mod issue_1290_junction_crosses_junction;
 mod issue_1292_junction_payload_rotation;
+mod issue_1296_repeat_claims_its_bases;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -7,10 +7,10 @@
 # The cases the IndelHaplotype model has found. The first two are filtered by
 # the strategy today (#1260/#1262 adjacent-gap insertions, and events cancelling
 # to no net change) and are re-rejected rather than re-run. #1287 and #1292 are
-# fixed and replay green. #1296 and #1297 are not yet fixed and are the reason
-# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d, so
-# they are recorded here rather than running: they replay the moment it is
-# enabled, which is what should gate enabling it.
+# fixed and replay green, as does #1296. #1297 is not yet fixed and is the
+# reason `an_indel_haplotype_normalizes_to_its_own_sequence` is still
+# `#[ignore]`d, so it is recorded here rather than running: it replays the
+# moment the test is enabled, which is what should gate enabling it.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }


### PR DESCRIPTION
Closes #1296. Closes #1269.

`claims_reference_bases` is how every sibling-repair pass asks "can this member collide with that one", and it excluded `NaEdit::Repeat`. A repeat has no junction either, so the junction rule did not see it. A sibling deletion could 3'-shift straight into a tract:

```
reference  ("ACGT" x 64) + "AAAAAAATAATCGCAACAGAAG" + ("ACGT" x 64)
in   NC_TEST.1:g.[272_273del;274_275insAA]
out  NC_TEST.1:g.[273_274del;274A[3]]
```

`273_274del` claims 273 and 274; `274A[3]` claims 274. The pair overlaps and the apply oracle declines the output. The deletion of `AC` at `272_273` may legitimately 3'-shift to `273_274` on its own — `AC` and `CA` leave the same bases behind — but 274 is where the repeat's tract starts, so the shift has to stop.

## This is #1269's measurement, not a new judgement

The exclusion was deliberate, documented in the predicate's own doc comment, and tracked by #1269, which asked for exactly this:

> Flip the predicate behind a measurement rather than a judgement: add `Repeat`/`MultiRepeat`, run the two committed sweeps plus the full suite, and see whether the two workaround passes become dead code or merely redundant.

#1296 is the defect the exclusion left behind, so the measurement is here. The corpus survives unchanged: full suite green, both committed sweeps green, and `cis_junction_crossing_shift`'s 276,480-case sweep holds its residual at **0**.

## The workarounds do not become dead code

#1269's other question, answered by disabling each pass with the predicate corrected:

| pass disabled | result |
| --- | --- |
| `demote_repeats_spanning_siblings` | **12 tests fail**, including `repeat_span_sibling_overlap::no_two_member_allele_normalizes_to_overlapping_members` and `cis_junction_crossing_shift::no_two_member_allele_normalizes_to_a_different_sequence` — both committed sweeps |
| `respell_colliding_duplications` | **2 tests fail** (`normalize_reparse_invariant::a_del_beside_a_dup_re_spells_instead_of_colliding`, `…::every_sibling_pass_is_idempotent_on_a_compound_allele`) |

So correcting the predicate removes the reason a *third* workaround would have been wanted — #1296 is precisely that third shape — not the two that exist. Both keep their passes, their tests and their comments. #1269 asked for this to be documented either way; the answer is recorded in the new test module's header and in the commit message.

## Also in this PR

`claims_reference_bases`'s doc comment was glued to the front of `blocks_sibling_shift`'s, in one contiguous `///` run above the latter. So the function it described carried no doc at all and rustdoc rendered both paragraphs under the wrong name. Moved onto the function it describes; the `#1269` paragraph is rewritten in place since the omission it recorded is what this PR removes.

## The confluence property

Still `#[ignore]`d, and the reason moves on: with #1296 fixed its next failure is **#1297** (a cancelled member left as an identity member, overlapping the repeat that absorbed it). The ignore reason, the module docs, the property's doc comment and the seed-file header all now say #1297, and #1297's seed `a88766af` is committed, so taking the ignore off replays it immediately — which is what should gate taking it off.

## Verification

- `cargo nextest run --features dev` — **8923 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8923 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine. Watching the nightly.

Stacked on #1298.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of complex insertions, duplications, repeats, and deletions across neighboring junctions.
  * Preserved inserted sequence content and authored ordering during coordinate shifts.
  * Combined compatible insertions targeting the same junction while keeping distinct changes separate.
  * Prevented deletions from incorrectly shifting into repeat regions.

* **Tests**
  * Added extensive regression coverage to verify sequence preservation, stable normalization, and correct repeat and junction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->