### PR TITLE
test(normalize): drop the indel model's adjacent-gap-insertion filter

### DIFF
--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -53,6 +53,12 @@
 //!   decide differently, because both are measured against how the input
 //!   happened to be written. Tracked by #1260 and #1262 and pinned by
 //!   `adjacent_gap_insertions_are_a_known_gap`.
+//!
+//!   This is the **only** restriction those two issues justify. The generator
+//!   used to carry a second one citing them — a filter excluding two insertions
+//!   at adjacent gaps — which #1294 removed after re-measuring: neither #1260
+//!   nor #1262 is about overlapping members, so the citation did not describe
+//!   the shape it was excluding. What that shape actually hits is #1301.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
 //!   because it finds #1297, a cancelled member left as an identity member
 //!   overlapping the repeat that absorbed it. It found #1286, #1287, #1290,
@@ -690,12 +696,12 @@ impl IndelHaplotype {
         out
     }
 
-    /// Whether two insertions sit at **adjacent gaps** — the one shape this
-    /// model must currently exclude, tracked by #1260 and #1262.
+    /// Whether two insertions sit at **adjacent gaps**.
     ///
-    /// Excluded, not silently skipped: `adjacent_gap_insertions_are_a_known_gap`
-    /// below pins the shape as currently-broken, so fixing either issue fails
-    /// that test loudly and this filter comes out at the same time.
+    /// The strategy no longer filters this shape out (#1294). It is kept because
+    /// `adjacent_gap_insertions_are_a_known_gap` uses it to assert that the
+    /// haplotype it pins really is one, so that test cannot drift onto a
+    /// different shape than the one it claims to pin.
     fn has_adjacent_gap_insertions(&self) -> bool {
         self.events.windows(2).any(|pair| {
             matches!(pair[0], Event::Insert { .. })
@@ -742,10 +748,6 @@ fn indel_haplotype_strategy() -> impl Strategy<Value = IndelHaplotype> {
                             events,
                         }
                     })
-                    .prop_filter(
-                        "two insertions at adjacent gaps: #1260 / #1262 (see module docs)",
-                        |haplotype| !haplotype.has_adjacent_gap_insertions(),
-                    )
                     // A haplotype whose events cancel denotes the reference itself.
                     // That is a real HGVS question (`=` and the self-cancelling
                     // merge, #1135) but not a *confluence* one: the spanning-delins
@@ -804,6 +806,18 @@ proptest! {
     /// budget and fails a 30,000-case soak on the same shape, so switching it
     /// on would make a green CI a matter of the budget rather than of the
     /// property holding.
+    ///
+    /// **#1301** is behind it, and reachable at the first generated case since
+    /// #1294 dropped the adjacent-gap-insertion filter from the strategy: two
+    /// insertions at adjacent gaps reach a duplication and an insertion that
+    /// denote the right bases but overlap and are rendered out of order.
+    ///
+    /// Expect the reported minimal case to name that shape rather than #1297's.
+    /// #1297's seed is the one that fails, but with the filter gone its shrink
+    /// is free to walk onto an adjacent-gap pair, which is strictly simpler —
+    /// so the failure output reads as #1301 while the `#[ignore]` reason and the
+    /// seed file both say #1297. Both are accurate; they describe the seed and
+    /// the shrink respectively.
     ///
     /// Do not weaken it to make it pass.
     #[test]
@@ -906,7 +920,7 @@ fn adjacent_gap_insertions_are_a_known_gap() {
     };
     assert!(
         haplotype.has_adjacent_gap_insertions(),
-        "the pinned haplotype must be the shape the strategy filters out"
+        "the pinned haplotype must be an adjacent-gap-insertion one"
     );
     let encodings = haplotype.encodings();
     assert_eq!(

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -4,10 +4,11 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-# The cases the IndelHaplotype model has found. The first two are filtered by
-# the strategy today (#1260/#1262 adjacent-gap insertions, and events cancelling
-# to no net change) and are re-rejected rather than re-run. #1287 and #1292 are
-# fixed and replay green, as does #1296. #1297 is not yet fixed and is the
+# The cases the IndelHaplotype model has found. #1286, #1287, #1292 and #1296
+# are fixed and replay green; the second seed is still rejected by the strategy,
+# whose remaining filter drops haplotypes whose events cancel to no net change.
+# (The adjacent-gap-insertion filter that used to reject the first seed as well
+# was removed in #1294, so it runs now.) #1297 is not yet fixed and is the
 # reason `an_indel_haplotype_normalizes_to_its_own_sequence` is still
 # `#[ignore]`d, so it is recorded here rather than running: it replays the
 # moment the test is enabled, which is what should gate enabling it.


### PR DESCRIPTION
Closes #1294.

`indel_haplotype_strategy` excluded every haplotype with two insertions at adjacent gaps:

```rust
.prop_filter(
    "two insertions at adjacent gaps: #1260 / #1262 (see module docs)",
    |haplotype| !haplotype.has_adjacent_gap_insertions(),
)
```

**The citation does not describe the shape.** Neither #1260 nor #1262 is about overlapping members — both are non-confluence between the separate-member and spanning-`delins` spellings, which is a *different* restriction in the same file and stays exactly as it is. #1294 suspected the citation was doing double duty; re-measured, it was.

What the excluded shape actually hits is **#1301**, filed from this measurement: two adjacent-gap insertions reach a duplication and an insertion that denote the right bases but overlap and are rendered out of order.

```
core "GCATGAAAAT"
in   NC_TEST.1:g.[263_264insAC;264_265insAA]
out  NC_TEST.1:g.[264_265dup;264_265insCA]      sequence right, members overlap
```

That is only visible now. On the tip of #1293 the same input emitted `g.[263_264insCA;264_265dup]`, which *silently denotes different bases*; #1298's payload rotation is what turned it into a loud ordering failure. So this shape could not have been re-measured usefully before the stack below it landed — the masking pattern again.

## The measurement

| property | with the filter | without it |
| --- | --- | --- |
| `an_indel_haplotype_is_authored_order_independent` (runs in CI) | passes | **passes 30,000 cases** |
| `an_indel_haplotype_normalizes_to_its_own_sequence` (`#[ignore]`d on #1297) | passes 512, fails 30k on #1297 | reaches #1301 at its first generated case |

So the filter bought nothing for the property that actually runs, while making the corpus narrower than the module doc claimed — the "coverage reads wider than it is" complaint of #1268 / #1283, inverted. Deleted rather than narrowed: there is no sub-shape left that needs excluding for the running property, and hiding #1301 from the ignored one would only re-create the problem this issue is about.

## What is kept

`has_adjacent_gap_insertions` stays. `adjacent_gap_insertions_are_a_known_gap` uses it to assert that the haplotype it pins really is an adjacent-gap one, so that test cannot drift onto a different shape than the one it claims to pin. Its message about "the shape the strategy filters out" is corrected.

The module docs now record that #1260 / #1262 justify exactly one restriction, and the seed-file header no longer claims the first seed is rejected by the strategy — it runs now, and replays green (it is #1286's shape, fixed in #1289).

## Verification

- `cargo nextest run --features dev` — **8923 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8923 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- `an_indel_haplotype_is_authored_order_independent` at 30,000 cases without the filter — pass
- Commit is signed

No `src/` changes: this is a test-coverage PR.

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1299.
