### PR TITLE
ci: halve the critical path (optimized soak archive, sweeps job, cache fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,76 @@ jobs:
             ${{ runner.os }}-cargo-
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
-  # Build the test binaries and the two generated spec artifacts ONCE, then fan
-  # out: every downstream job consumes this job's `nextest archive`, so the
-  # crate compiles a single time no matter how many shards run.
+  # The two generated spec artifacts, split out of `test-build`.
+  #
+  # These ran as the first two steps of `test-build`, which serialized ~52s of
+  # generation ahead of the ~105s archive compile inside one job. They share
+  # nothing with the archive but the library crate: the generators are `[[bin]]`
+  # targets that read the spec submodule at RUNTIME, and what they emit is a
+  # pair of JSON files the shards download. Running them concurrently with the
+  # archive build takes that serialization off the critical path.
+  #
+  # Generation is itself the gate on the curated overrides — plain generation,
+  # not `--check` — so this job failing means the overrides no longer resolve
+  # against the spec checkout. That signal is now its own job rather than
+  # buried in a build.
+  spec-fixtures:
+    name: Spec fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          # Required here, and ONLY here: the generators harvest HGVS strings
+          # from the vendored spec checkout at runtime.
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-specgen
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-specgen
+      - name: Generate HGVS v21.0 spec fixture
+        run: cargo run --features dev --bin generate_spec_fixture
+      - name: Generate HGVS spec test enumeration
+        run: cargo run --features dev --bin generate_spec_enumeration
+      - name: Stage the generator binaries for the shards
+        # `spec_generator_preconditions` executes these two binaries. The shards
+        # run from the nextest archive with no build state, so they must not
+        # shell out to cargo. Both were built and run by the steps above, so
+        # ship them alongside the fixtures. As `[[bin]]` targets they land in
+        # `target/debug/`, not `target/debug/examples/`.
+        run: |
+          mkdir -p staged-generators
+          cp target/debug/generate_spec_fixture \
+             target/debug/generate_spec_enumeration staged-generators/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: generator-binaries
+          path: staged-generators/
+          retention-days: 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: spec-fixtures
+          path: |
+            tests/fixtures/grammar/hgvs_spec_normalization.json
+            tests/fixtures/grammar/hgvs_spec_enumeration.json
+          retention-days: 1
+
+  # Build the test binaries ONCE, then fan out: `test` and `test-oracle` consume
+  # this job's `nextest archive`, so the crate compiles a single time no matter
+  # how many shards run. (The two generated spec artifacts moved to
+  # `spec-fixtures` above; the soak and sweeps run from the optimized archive
+  # `test-build-soak` produces, not this one.)
   #
   # `--extract-to . --extract-overwrite` in the consumers is load-bearing, not
   # tidiness. 26 call sites across 10 test files resolve the CLI binary with
@@ -247,7 +314,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           lfs: true
-          submodules: true
+          # No `submodules: true`. The spec checkout is read at generator
+          # RUNTIME, in the `spec-fixtures` job — nothing here reads it at
+          # compile time (verified: no `include_str!`/`include_bytes!` under
+          # `src/` or `tests/` names a path below `assets/`).
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -264,44 +334,13 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
-      - name: Generate HGVS v21.0 spec fixture
-        # Gitignored generated artifact, not committed. Generating it here also
-        # validates the curated overrides file — the guard the old `--check`
-        # step provided. Shipped to the shards as an artifact so they never
-        # regenerate it (and so they need no spec submodule).
-        run: cargo run --features dev --bin generate_spec_fixture
-      - name: Generate HGVS spec test enumeration
-        run: cargo run --features dev --bin generate_spec_enumeration
       - name: Build test archive
         # Compiles every test binary and packs them with their run metadata.
         run: cargo nextest archive --features dev --archive-file nextest.tar.zst
-      - name: Stage the generator binaries for the shards
-        # `spec_generator_preconditions` executes these two binaries. They are
-        # `required-features = ["dev"]` bin targets, and the shards run from the
-        # nextest archive with no build state, so they must not shell out to
-        # cargo. Both were already built and run by the generate steps above, so
-        # ship them alongside the archive. As `[[bin]]` targets they land in
-        # `target/debug/`, not `target/debug/examples/`.
-        run: |
-          mkdir -p staged-generators
-          cp target/debug/generate_spec_fixture \
-             target/debug/generate_spec_enumeration staged-generators/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive
           path: nextest.tar.zst
-          retention-days: 1
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: generator-binaries
-          path: staged-generators/
-          retention-days: 1
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: spec-fixtures
-          path: |
-            tests/fixtures/grammar/hgvs_spec_normalization.json
-            tests/fixtures/grammar/hgvs_spec_enumeration.json
           retention-days: 1
 
   # A SECOND archive, built at `opt-level = 3`, for the soak shards only.
@@ -361,7 +400,7 @@ jobs:
   # 2148 / 2181 / 2162 / 2155 across four shards.
   test:
     name: Test (${{ matrix.shard }}/6)
-    needs: test-build
+    needs: [test-build, spec-fixtures]
     runs-on: ubuntu-latest
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"
@@ -398,8 +437,9 @@ jobs:
         run: |
           echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."
       - name: Run Rust tests (shard ${{ matrix.shard }} of 6)
-        # Builds in-shard rather than consuming the archive — see the note on
-        # `test-build` for why the archive is soak-only.
+        # Consumes the standard archive `test-build` produces — see the note
+        # there for why `--extract-to .` is load-bearing. Only the optimized
+        # archive from `test-build-soak` is reserved for `soak` and `sweeps`.
         #
         # Proptests are excluded here and owned entirely by the `soak` job,
         # which runs them at 125k cases per shard instead of 12k. Leaving them
@@ -424,7 +464,7 @@ jobs:
   # run. The deep random coverage lives in the `soak` job below instead.
   test-oracle:
     name: Test oracle (${{ matrix.shard }}/2)
-    needs: test-build
+    needs: [test-build, spec-fixtures]
     runs-on: ubuntu-latest
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+          # Keyed on the workflow file as well as the lockfile. `actions/cache`
+          # SKIPS the save on an exact key hit ("Cache hit occurred on the
+          # primary key ..., not saving cache"), so a key derived from
+          # `Cargo.lock` alone freezes `target/` at whatever the first run for
+          # that lockfile produced. Measured directly: after this job dropped
+          # `--features dev`, the restored cache still held the dev-feature
+          # artifacts, so every run re-compiled reqwest, hyper, criterion and
+          # the rest at opt-level 3 — about 60s, repeated forever rather than
+          # paid once. The build flags live in this file, so hashing it makes
+          # the cache follow them.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}-soak
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
       - name: Build soak archive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,19 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          # Hashed on this workflow file as well as the lockfile, and given a
+          # suffix distinct from `generated-docs`. Two separate bugs met here.
+          #
+          # `actions/cache` skips the save on an exact key hit, so a
+          # lockfile-only key can never refresh once written. And this key was
+          # SHARED with `generated-docs`, which builds in the dev profile,
+          # while this job builds in the test profile where
+          # `CARGO_PROFILE_TEST_DEBUG=0` re-fingerprints every dependency. The
+          # frozen cache therefore satisfied that job and was useless to this
+          # one: measured on run 30684270515, `generated-docs` compiled 3
+          # crates and this job compiled 316 — the entire tree from
+          # `proc-macro2` up — on every single run.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}-test-archive
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Build test archive
@@ -496,7 +508,7 @@ jobs:
   # nothing the plain run did not already check — it just cost ~80s of every CI
   # run. The deep random coverage lives in the `soak` job below instead.
   test-oracle:
-    name: Test oracle (${{ matrix.shard }}/2)
+    name: Test oracle (${{ matrix.shard }}/3)
     needs: [test-build, spec-fixtures]
     runs-on: ubuntu-latest
     env:
@@ -504,7 +516,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -549,7 +561,7 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/2 \
+            --partition hash:${{ matrix.shard }}/3 \
             -E "not test(proptest) and not ($SWEEP_FILTER)"
 
   # 1,000,000-case idempotency soak on every PR, split 8 ways.
@@ -712,7 +724,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          # Its own key, no longer shared with `test-build` — see there. This
+          # job builds examples in the dev profile; that one builds test
+          # binaries with different debug settings, and one cache cannot serve
+          # both.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}-gendocs
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: Verify conformance summary docs are up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,57 @@ jobs:
             tests/fixtures/grammar/hgvs_spec_enumeration.json
           retention-days: 1
 
+  # A SECOND archive, built at `opt-level = 3`, for the soak shards only.
+  #
+  # The soak is compute-bound in a way the other jobs are not: eight shards each
+  # run 125,000 proptest cases, so a constant factor on the code under test is
+  # multiplied a million times over. Measured locally at 5,000 cases, one
+  # confluence property costs 1.90s of user CPU in the test profile against
+  # 0.355s under this one — 5.4x. The other jobs run each test once and would
+  # only pay the longer compile.
+  #
+  # Only the `it` binary is built (`--test it`): every test the soak selects
+  # with `-E 'test(proptest)'` lives there, so compiling the rest of the test
+  # targets at `opt-level = 3` would be pure cost.
+  #
+  # `debug-assertions` and `overflow-checks` stay ON in the profile (see
+  # Cargo.toml) so this buys speed without quietly weakening what the soak
+  # checks — the `#[cfg(debug_assertions)]` oracles and every `debug_assert!`
+  # in the normalizer behave exactly as they do under the test profile.
+  test-build-soak:
+    name: Build soak archive (optimized)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+      - name: Build soak archive
+        run: |
+          cargo nextest archive --features dev --cargo-profile soak --test it \
+            --archive-file nextest-soak.tar.zst
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: nextest-archive-soak
+          path: nextest-soak.tar.zst
+          retention-days: 1
+
   # The suite, split across shards. `--partition hash:K/N` assigns each test to
   # a shard by a hash of its name, so the split is deterministic and stays
   # stable as tests are added. Verified even on this suite: 8646 tests split
@@ -437,7 +488,13 @@ jobs:
   # new territory still gets explored — it just reports instead of blocking.
   soak:
     name: Idempotency soak (${{ matrix.shard }}/8)
-    needs: test-build
+    # Only the optimized archive, NOT `test-build`. Every test the selection
+    # below reaches lives in `tests/it/{cis_allele_confluence,
+    # normalize_idempotency}_proptest.rs`, and neither reads the generated spec
+    # fixture or shells out to the staged generators — so the shards need
+    # neither of those artifacts, and waiting on the job that produces them
+    # would put the dev-profile compile back on the soak's critical path.
+    needs: test-build-soak
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -465,18 +522,7 @@ jobs:
       # `CARGO_BIN_EXE_ferro` paths that break the other shards are never read.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: nextest-archive
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: spec-fixtures
-          path: tests/fixtures/grammar/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: generator-binaries
-          path: target/debug/
-      - name: Restore the executable bit on the staged generators
-        # Artifact upload does not preserve the executable bit.
-        run: chmod +x target/debug/generate_spec_fixture target/debug/generate_spec_enumeration
+          name: nextest-archive-soak
       - name: Soak 125k cases (seed ${{ matrix.seed }})
         env:
           # 8 shards x 125k = 1,000,000 cases per property.
@@ -488,7 +534,7 @@ jobs:
           PROPTEST_MAX_LOCAL_REJECTS: "1000000"
           FERRO_PREBUILT_EXAMPLES: "1"
         run: |
-          cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
+          cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite -E 'test(proptest)'
 
   # The generated-doc `--check` gates. Split out of the old monolithic Test job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,7 +710,15 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The repo has exactly four LFS files
+          # (`git lfs ls-files`): two under `tests/fixtures/bulk/` and two
+          # under `tests/fixtures/validation/`, 149 MB in total. Every
+          # reference to them lives in `benches/benchmarks.rs` and five
+          # `tests/it/*` modules, and `cargo run --example` compiles neither
+          # `tests/` nor `benches/`. Nothing under `examples/` names them or
+          # has a compile-time include at all, and none of the eight paths
+          # the three generators actually read is LFS-tracked (checked with
+          # `git check-attr filter`).
           submodules: true
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The only LFS-tracked paths are
+          # `tests/fixtures/bulk/*.gz` and
+          # `tests/fixtures/validation/*_exhaustive.json.gz` (.gitattributes),
+          # 149 MB read at test RUNTIME by the bulk-fixture and exhaustive
+          # suites. Nothing here reads them: no `include_str!`/`include_bytes!`
+          # names a path under those directories, and this job only compiles.
           # Required here, and ONLY here: the generators harvest HGVS strings
           # from the vendored spec checkout at runtime.
           submodules: true
@@ -313,7 +318,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The only LFS-tracked paths are
+          # `tests/fixtures/bulk/*.gz` and
+          # `tests/fixtures/validation/*_exhaustive.json.gz` (.gitattributes),
+          # 149 MB read at test RUNTIME by the bulk-fixture and exhaustive
+          # suites. Nothing here reads them: no `include_str!`/`include_bytes!`
+          # names a path under those directories, and this job only compiles.
           # No `submodules: true`. The spec checkout is read at generator
           # RUNTIME, in the `spec-fixtures` job — nothing here reads it at
           # compile time (verified: no `include_str!`/`include_bytes!` under
@@ -366,7 +376,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The only LFS-tracked paths are
+          # `tests/fixtures/bulk/*.gz` and
+          # `tests/fixtures/validation/*_exhaustive.json.gz` (.gitattributes),
+          # 149 MB read at test RUNTIME by the bulk-fixture and exhaustive
+          # suites. Nothing here reads them: no `include_str!`/`include_bytes!`
+          # names a path under those directories, and this job only compiles.
           submodules: true
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -385,8 +400,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
       - name: Build soak archive
+        # No `--features dev`. That feature pulls in `web-service` (axum, tokio,
+        # tower, tracing) and `benchmark` (reqwest, rusqlite, tokio-postgres,
+        # futures) — an entire dependency tree compiled at `opt-level = 3` to
+        # produce one test binary that never touches any of it. `tests/it`
+        # gates only 2 of its ~360 modules on the feature and neither the soak
+        # nor the sweeps selects one, so the selections are unchanged: verified
+        # by listing both under each feature set, `test(proptest)` resolves to
+        # 10 tests either way and the sweep filter to 29.
         run: |
-          cargo nextest archive --features dev --cargo-profile soak --test it \
+          cargo nextest archive --cargo-profile soak --test it \
             --archive-file nextest-soak.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -571,7 +594,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The 149 MB of LFS fixtures
+          # (`tests/fixtures/bulk/*.gz`,
+          # `tests/fixtures/validation/*_exhaustive.json.gz`) are read only by
+          # the bulk-fixture and exhaustive suites, which this job never
+          # selects — verified against every module it runs.
           persist-credentials: false
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       # Safe to run from the archive: this job runs ONLY the proptest modules,
@@ -631,7 +658,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          lfs: true
+          # No `lfs: true`. The 149 MB of LFS fixtures
+          # (`tests/fixtures/bulk/*.gz`,
+          # `tests/fixtures/validation/*_exhaustive.json.gz`) are read only by
+          # the bulk-fixture and exhaustive suites, which this job never
+          # selects — verified against every module it runs.
           persist-credentials: false
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,21 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The three exhaustive-sweep modules, owned by the `sweeps` job and excluded
+  # from the `test` / `test-oracle` partitions. Defined once here because the
+  # filter has to appear identically in three places and GitHub Actions has no
+  # YAML anchors — a copy that drifts would either double-run a sweep or, far
+  # worse, drop one from CI entirely.
+  #
+  # The invariant to preserve is that the two selections PARTITION the suite —
+  # the absolute counts drift as tests are added, the sum must not. Verified
+  # against this base: `not test(proptest)` selects 8907, adding
+  # `and not (SWEEP_FILTER)` selects 8878, and the filter itself selects the
+  # remaining 29. 8878 + 29 == 8907, so nothing falls between the two jobs and
+  # nothing is run twice.
+  SWEEP_FILTER: >-
+    test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap)
+    + test(issue_1254_sibling_crossing_shift)
 
 jobs:
   abi3-floor-consistency:
@@ -399,7 +414,8 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/6 -E 'not test(proptest)'
+            --partition hash:${{ matrix.shard }}/6 \
+            -E "not test(proptest) and not ($SWEEP_FILTER)"
 
   # The idempotency oracle re-run. Deliberately EXCLUDES the proptest modules:
   # their own property already *is* `norm(norm(x)) == norm(x)`, which is exactly
@@ -460,7 +476,8 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/2 -E 'not test(proptest)'
+            --partition hash:${{ matrix.shard }}/2 \
+            -E "not test(proptest) and not ($SWEEP_FILTER)"
 
   # 1,000,000-case idempotency soak on every PR, split 8 ways.
   #
@@ -537,6 +554,59 @@ jobs:
           cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite -E 'test(proptest)'
 
+  # The three exhaustive-sweep modules, moved off the `test` / `test-oracle`
+  # partitions and onto the optimized archive.
+  #
+  # These were the whole workflow's critical path. `--partition hash:K/N` splits
+  # by a hash of the test NAME, which balances shards by count and is blind to
+  # cost — and all three sweeps happened to hash into the same shard. Measured
+  # on run 30681684032, with everything else in those jobs under 4s:
+  #
+  #                                            Test (3/6)   Test oracle (1/2)
+  #   cis_junction_crossing_shift                    118s                183s
+  #   repeat_span_sibling_overlap                     66s                121s
+  #   issue_1254_sibling_crossing_shift               30s                 78s
+  #
+  # They are exhaustive cross-products — the first is a six-deep nest of roughly
+  # 276,000 cases — so they are compute-bound in exactly the way the soak is,
+  # and they benefit from the optimized archive even more (user CPU, oracles on,
+  # 3 reps, spread under 2%):
+  #
+  #   cis_junction_crossing_shift        71.06s -> 8.55s   8.3x
+  #   repeat_span_sibling_overlap        40.44s -> 5.29s   7.6x
+  #   issue_1254_sibling_crossing_shift  20.14s -> 2.32s   8.7x
+  #
+  # They cost nothing extra to build: all three live in `tests/it/`, so they are
+  # already inside the archive `test-build-soak` produces for the soak.
+  #
+  # Running them ONLY here, with both oracles on, loses no coverage. The oracles
+  # add assertions at `normalize_core_checked`'s exit and change no behaviour, so
+  # an oracle-on run strictly subsumes the oracle-off one the `test` shards were
+  # doing. Verified archive-safe the same way the soak is: none of the three
+  # modules, nor `common::cis_apply_oracle`, reads `CARGO_BIN_EXE_ferro`.
+  sweeps:
+    name: Exhaustive sweeps
+    needs: test-build-soak
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive-soak
+      - name: Run the exhaustive sweeps with the normalization self-checks
+        env:
+          FERRO_ASSERT_IDEMPOTENT: "1"
+          FERRO_ASSERT_REPARSE: "1"
+          FERRO_PREBUILT_EXAMPLES: "1"
+        run: |
+          cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite \
+            -E "$SWEEP_FILTER"
+
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.
   generated-docs:
@@ -586,7 +656,7 @@ jobs:
   test-required:
     name: Test
     runs-on: ubuntu-latest
-    needs: [test, test-oracle, soak, generated-docs]
+    needs: [test, test-oracle, soak, sweeps, generated-docs]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
     if: always()
@@ -596,10 +666,12 @@ jobs:
           echo "test            = ${{ needs.test.result }}"
           echo "test-oracle     = ${{ needs.test-oracle.result }}"
           echo "soak            = ${{ needs.soak.result }}"
+          echo "sweeps          = ${{ needs.sweeps.result }}"
           echo "generated-docs  = ${{ needs.generated-docs.result }}"
           if [ "${{ needs.test.result }}" != "success" ] \
             || [ "${{ needs.test-oracle.result }}" != "success" ] \
             || [ "${{ needs.soak.result }}" != "success" ] \
+            || [ "${{ needs.sweeps.result }}" != "success" ] \
             || [ "${{ needs.generated-docs.result }}" != "success" ]; then
             echo "::error::one or more test jobs did not succeed"
             exit 1

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -67,7 +67,17 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+          # Keyed on the workflow file as well as the lockfile. `actions/cache`
+          # SKIPS the save on an exact key hit ("Cache hit occurred on the
+          # primary key ..., not saving cache"), so a key derived from
+          # `Cargo.lock` alone freezes `target/` at whatever the first run for
+          # that lockfile produced. Measured directly: after this job dropped
+          # `--features dev`, the restored cache still held the dev-feature
+          # artifacts, so every run re-compiled reqwest, hyper, criterion and
+          # the rest at opt-level 3 — about 60s, repeated forever rather than
+          # paid once. The build flags live in this file, so hashing it makes
+          # the cache follow them.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/nightly-soak.yml') }}-soak
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
       - name: Build soak archive

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -33,18 +33,22 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  soak:
-    name: Unseeded soak (${{ matrix.shard }}/8)
+  # One optimized build, fanned out to all eight shards.
+  #
+  # Each shard used to run `cargo nextest run` directly, so every one of the
+  # eight compiled the whole test suite from scratch AND ran both spec
+  # generators first — eight full builds, and ~52s of fixture generation per
+  # shard for an artifact no proptest module reads. This mirrors what PR CI's
+  # `test-build-soak` does instead: build once, archive the `it` binary, and let
+  # the shards download it.
+  #
+  # `--cargo-profile soak` matters more here than anywhere: measured at 5,000
+  # cases, a confluence property costs 1.90s of user CPU in the test profile
+  # against 0.355s under this one, and `debug-assertions` / `overflow-checks`
+  # stay on so nothing the soak checks is weakened.
+  build:
+    name: Build soak archive (optimized)
     runs-on: ubuntu-latest
-    strategy:
-      # Let every shard finish: with independent random streams, one shard
-      # failing says nothing about the others, and the extra failures are
-      # additional evidence rather than noise.
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
-    env:
-      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -63,19 +67,50 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
-      - name: Generate HGVS v21.0 spec fixture
-        run: cargo run --features dev --bin generate_spec_fixture
-      - name: Generate HGVS spec test enumeration
-        run: cargo run --features dev --bin generate_spec_enumeration
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+      - name: Build soak archive
+        run: |
+          cargo nextest archive --features dev --cargo-profile soak --test it \
+            --archive-file nextest-soak.tar.zst
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: nextest-archive-soak
+          path: nextest-soak.tar.zst
+          retention-days: 1
+
+  soak:
+    name: Unseeded soak (${{ matrix.shard }}/8)
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      # Let every shard finish: with independent random streams, one shard
+      # failing says nothing about the others, and the extra failures are
+      # additional evidence rather than noise.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      # Still checked out, for two reasons the archive does not cover: proptest
+      # writes its shrunk case under `tests/proptest-regressions/`, and the
+      # capture step below reads that tree.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive-soak
       - name: Soak 125k unseeded cases
         # No PROPTEST_RNG_SEED: each shard, each night, draws a fresh stream.
         env:
           PROPTEST_CASES: "125000"
           PROPTEST_MAX_LOCAL_REJECTS: "1000000"
-        run: cargo nextest run --features dev -E 'test(proptest)'
+        run: |
+          cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite -E 'test(proptest)'
       - name: Capture the failing seed
         # proptest writes the shrunk case to its persistence file. Surfacing it
         # here means the reproducer is in the run log even if the artifact is

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -71,8 +71,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
       - name: Build soak archive
+        # No `--features dev` — see the same step in ci.yml. The feature drags
+        # `web-service` and `benchmark` into an `opt-level = 3` build for a
+        # binary that uses neither, and `test(proptest)` resolves to the same
+        # 10 tests with or without it.
         run: |
-          cargo nextest archive --features dev --cargo-profile soak --test it \
+          cargo nextest archive --cargo-profile soak --test it \
             --archive-file nextest-soak.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,3 +355,10 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.flate2]
 opt-level = 3
+
+[profile.soak]
+inherits = "test"
+opt-level = 3
+debug = false
+debug-assertions = true
+overflow-checks = true


### PR DESCRIPTION
Stacked on #1300. Seven commits, each one measured change to `.github/workflows/`, cutting CI's critical path roughly in half.

## Headline

Measured on **job durations**, not workflow wall clock. Wall clock includes GitHub's runner queue, which varies enormously — one run in this series sat 295s in a queue before its build even started and looked like a 525s regression when its compute was actually an improvement. Critical path = slowest build + the slowest job that depends on it.

| | buildTest | buildSoak | slowestTest | slowestSoak | **critical path** |
| --- | --- | --- | --- | --- | --- |
| `main` | 194s | - | 227s | 271s | **421s** |
| + optimized soak archive | 181s | 259s | 211s | 49s | 392s |
| + sweeps job | 190s | 183s | 65s | 47s | 255s |
| + spec split | 152s | 196s | 89s | 52s | 248s |
| + LFS / feature trim | 132s | 178s | 78s | 40s | 218s |
| + cache keys | 123s | 155s | 70s | 42s | 197s |
| + LFS in generated-docs, **cache-warm** | **85s** | **136s** | 75s | 39s | **175s** |

**421s -> 175s, 2.4x.** The last row is the first run in which every re-keyed cache actually restored something matching what it builds — `Build test archive` compiles **1** crate there, against 316 before.

## Suggested reading order

1. **`ci(soak): build the soak shards from an optimized archive`** — the premise everything else builds on. The soak runs 1,000,000 proptest cases across 8 shards, so a constant factor on the code under test is multiplied a million times over. A `[profile.soak]` at `opt-level = 3` costs one extra compile and takes a property from 1.90s to 0.355s of user CPU at 5,000 cases. `debug-assertions` and `overflow-checks` stay **on**, so this is speed only, not a quieter build.

2. **`ci: run the exhaustive sweeps from the optimized archive`** — the biggest single win. `--partition hash:K/N` splits by test *name*, so it balances shards by count and is blind to cost; all three exhaustive-sweep tests happened to hash into the same shard. They gain even more from optimization than the soak does (8.3x / 7.6x / 8.7x), and they cost nothing extra to build because they already live in `tests/it/`.

3. **`ci: split spec generation out, and build the nightly soak once`** — two serialization fixes. The spec generators ran as `test-build`'s first two steps, ahead of the archive compile. And each of the nightly's 8 shards was compiling the whole suite from scratch *and* running both generators first, for an artifact no proptest module reads.

4. **`ci: stop fetching LFS and dev features where nothing reads them`**, **`ci: stop fetching LFS in generated-docs`** — 149 MB of LFS fixtures fetched by six jobs that never read them, and `--features dev` dragging `web-service` and `benchmark` into an `opt-level = 3` build.

5. **`ci: let the soak cache follow the build flags`**, **`ci: give test-build its own cache key, and split the oracle three ways`** — the subtlest bug here, worth reading closely. See below.

## The cache bug

`actions/cache` **skips the save on an exact key hit** — the log says so outright: `Cache hit occurred on the primary key ..., not saving cache`. A key derived from `Cargo.lock` alone is therefore frozen at whatever the *first* run for that lockfile wrote, and no later run can refresh it.

`test-build` compounded that by *sharing* its key with `generated-docs`. The two need different artifacts: `generated-docs` runs `cargo run --example` in the dev profile, while `test-build` archives test binaries under `CARGO_PROFILE_TEST_DEBUG=0`, which re-fingerprints every dependency. One frozen cache served the first and was useless to the second. Measured on run 30684270515: `generated-docs` compiled 3 crates, `test-build` compiled **316** — the whole tree from `proc-macro2` up — on every single run.

Each cache now hashes its workflow file into the key and carries a distinct suffix. The effect is visible directly in the logs: `Build test archive` went from 316 `Compiling` lines to **1**, and from 194s on `main` to **85s**.

Note that the first run after any key change is a miss — it restores from the lockfile-only `restore-key`, rebuilds, and *saves*. The run after that is the one that benefits. Both are in this PR's history if you want to see the shape.

## What is deliberately not changed

- **Coverage.** The sweeps run only in the new job, with both oracles on — those add assertions at `normalize_core_checked`'s single exit and change no behaviour, so an oracle-on run strictly subsumes the oracle-off one the `test` shards were doing. The filter is exact and defined once: `not test(proptest)` selects 8896 tests, `and not (SWEEP_FILTER)` selects 8867, and the filter alone selects the remaining 29.
- **`test` and `test-oracle` keep `lfs: true`**, and must. `clinvar_hgvs_tests`, `cmrg_exhaustive_tests` and `paraphase_exhaustive_tests` print `Skipping: ... not found` and return **green** when the fixtures are absent. Dropping LFS there would not redden CI; it would silently delete coverage while making the job look faster.
- **Dependency features.** The expensive tree (`reqwest` → hyper, rustls, async-compression) is an unconditional dependency, so no feature flag reaches it. Making it optional is a library change, out of scope here.

## Rejected after measurement

- **Lowering the opt-level.** Compile time is flat: 61.3s / 69.1s / 61.9s at opt-levels 1 / 2 / 3. There is no tradeoff curve.
- **One optimized archive for every job.** `opt-level = 3` for `it` alone (62s) already costs about what the dev profile costs for all 46 targets (66s), so merging the two builds would make the graph worse.
- **Caching the synthetic provider per proptest case.** Measured at ~1us per case, about 1.4% of a property, with a near-zero hit rate besides.

## Follow-ups not taken here

- A faster linker (lld/mold) for the two archive builds. The only untested idea with real upside, but `RUSTFLAGS` is not in the cache key, so measuring it honestly needs two runs.
- `Build` (168s) and `Python Wheel Test` (146s) are off the critical path — optimizing them saves runner minutes, not wall clock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded continuous integration coverage with additional test and oracle shards.
  * Added dedicated exhaustive sweep validation with normalization checks.
  * Improved test artifact reuse across standard, optimized, and soak runs.

* **Chores**
  * Optimized nightly soak testing across eight shards running 125,000 cases each.
  * Added a dedicated soak build profile for faster, more efficient test execution.
  * Updated required-status validation to include exhaustive sweeps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->