### PR TITLE
fix(normalize): order two members sharing a span by where they add sequence

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1146,7 +1146,7 @@ fn rna_simple_range(interval: &crate::hgvs::interval::RnaInterval) -> Option<Sel
 ///   is the exact order-dependence #1098 is about.
 pub(crate) fn cis_member_order_key(
     v: &HgvsVariant,
-) -> (String, SelfCancellingPoint, SelfCancellingPoint, String) {
+) -> (String, SelfCancellingPoint, SelfCancellingPoint, u8, String) {
     let accession = v.accession().map(Accession::full).unwrap_or_default();
     let descriptor = format!("{v}");
     // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
@@ -1154,7 +1154,42 @@ pub(crate) fn cis_member_order_key(
     // go in whole rather than flattened into six scalars.
     let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
     let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
-    (accession, start, end, descriptor)
+    (accession, start, end, junction_rank(v), descriptor)
+}
+
+/// Where within its own span a member adds sequence: `0` at the span's start,
+/// `1` at its end.
+///
+/// Breaks a tie that [`cis_member_order_key`]'s `end` cannot (#1301). An
+/// insertion's span *is* the gap it fills, so `264_265insCA` adds at interbase
+/// 264; a duplication places its copy after its last base, so `264_265dup` adds
+/// at 265. The two share both endpoints, and without this the order fell to the
+/// descriptor tie-break, which sorts `264_265dup` first — the reverse of the
+/// order the members apply in, so the pair rendered out of order and their
+/// interbase spans read as overlapping.
+///
+/// Everything that consumes the bases under its span occupies the whole of it
+/// and so ranks with the 3' end: a member that adds at a span's start must sort
+/// before one that acts across the same span.
+///
+/// **Nucleotide axes only.** A protein member reaches the same tie —
+/// `cis_member_range` gives it a real range, and `sort_cis_members_by_genomic_order`
+/// is axis-agnostic — so `p.[Gly4_Ala5insSer;Gly4_Ala5dup]` still falls to the
+/// descriptor tie-break and renders the `dup` first, exactly as #1301 did here.
+/// Ranking `ProteinEdit::Insertion` too would fix it, but that changes protein
+/// ordering, which is outside this change; tracked in #1328.
+fn junction_rank(v: &HgvsVariant) -> u8 {
+    use crate::hgvs::edit::NaEdit;
+    let edit = match v {
+        HgvsVariant::Genome(x) => x.loc_edit.edit.inner(),
+        HgvsVariant::Circular(x) => x.loc_edit.edit.inner(),
+        HgvsVariant::Mt(x) => x.loc_edit.edit.inner(),
+        HgvsVariant::Cds(x) => x.loc_edit.edit.inner(),
+        HgvsVariant::Tx(x) => x.loc_edit.edit.inner(),
+        HgvsVariant::Rna(x) => x.loc_edit.edit.inner(),
+        _ => None,
+    };
+    u8::from(!matches!(edit, Some(NaEdit::Insertion { .. })))
 }
 
 /// Canonical **start and end** points of a cis-allele member's location, or

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -58,10 +58,10 @@
 //!   used to carry a second one citing them — a filter excluding two insertions
 //!   at adjacent gaps — which #1294 removed after re-measuring: neither #1260
 //!   nor #1262 is about overlapping members, so the citation did not describe
-//!   the shape it was excluding. What that shape actually hits is #1301.
+//!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
 //!   because it finds #1297, a cancelled member left as an identity member
-//!   overlapping the repeat that absorbed it. It found #1286, #1287, #1290,
+//!   overlapping the repeat that absorbed it, and #1304 behind it. It found #1286, #1287, #1290,
 //!   #1292 and #1296 first, all now fixed, each masked behind the one before
 //!   it; see its doc comment for the history and the live reproduction.
 //!
@@ -807,10 +807,10 @@ proptest! {
     /// on would make a green CI a matter of the budget rather than of the
     /// property holding.
     ///
-    /// **#1301** is behind it, and reachable at the first generated case since
-    /// #1294 dropped the adjacent-gap-insertion filter from the strategy: two
-    /// insertions at adjacent gaps reach a duplication and an insertion that
-    /// denote the right bases but overlap and are rendered out of order.
+    /// **#1304** is behind it: two insertions at adjacent gaps plus a deletion
+    /// denote the wrong bases, silently. It became reachable once #1301 fixed
+    /// the ordering of two members sharing a span, which is what that shape used
+    /// to fail on first.
     ///
     /// Expect the reported minimal case to name that shape rather than #1297's.
     /// #1297's seed is the one that fails, but with the filter gone its shrink

--- a/tests/it/issue_1301_adjacent_gap_member_order.rs
+++ b/tests/it/issue_1301_adjacent_gap_member_order.rs
@@ -1,0 +1,111 @@
+//! Two members that share a span but add sequence at different junctions must
+//! render in junction order.
+//!
+//! `cis_member_order_key` broke a start tie with the member's **end** (#1261).
+//! That is not enough for two members whose spans are identical:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
+//! g.[263_264insAC;264_265insAA]  ->  g.[264_265dup;264_265insCA]
+//! ```
+//!
+//! `264_265insCA` fills the gap `264|265`, so it adds at interbase 264;
+//! `264_265dup` places its copy after its last base, so it adds at 265. Both
+//! span `264_265`, so start and end tie and the order fell to the descriptor
+//! tie-break — which sorts `264_265dup` first, the reverse of the order the two
+//! apply in. The pair then rendered out of order and their interbase spans read
+//! as overlapping, which is #1235's second acceptance criterion.
+//!
+//! The sequence was never wrong here: both members applied denote the input's
+//! bases. What was wrong is the rendering. `junction_rank` adds the missing
+//! discriminator — a member adding at its span's *start* sorts before one acting
+//! across the whole span.
+
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+const CORE: &str = "GCATGAAAAT";
+
+fn normalize(input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    Normalizer::new(provider)
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// The interbase start of each member, in rendered order, via `hgvs_to_spdi` —
+/// a different code path from the ordering key under test.
+fn member_starts(descriptor: &str) -> Vec<u64> {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).expect("parse") {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    members
+        .iter()
+        .map(|member| {
+            hgvs_to_spdi(member, &provider)
+                .expect("member converts to SPDI")
+                .position
+        })
+        .collect()
+}
+
+/// Assert the output denotes the input's bases, so an ordering test cannot pass
+/// by rendering a *wrong* pair tidily.
+fn assert_preserving(input: &str, output: &str) {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    let reference = padded(CORE);
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None;
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+    assert_eq!(
+        denote(output).expect("output applies"),
+        denote(input).expect("input applies"),
+        "`{input}` -> `{output}` changed the sequence"
+    );
+}
+
+#[test]
+fn an_insertion_sorts_before_a_duplication_sharing_its_span() {
+    let input = "NC_TEST.1:g.[263_264insAC;264_265insAA]";
+    let output = normalize(input);
+    assert_eq!(output, "NC_TEST.1:g.[264_265insCA;264_265dup]");
+    assert_preserving(input, &output);
+
+    let starts = member_starts(&output);
+    assert!(
+        starts.windows(2).all(|pair| pair[0] <= pair[1]),
+        "`{output}` renders its members out of interbase order: {starts:?}"
+    );
+}
+
+#[test]
+fn the_order_does_not_depend_on_how_it_was_authored() {
+    assert_eq!(
+        normalize("NC_TEST.1:g.[263_264insAC;264_265insAA]"),
+        normalize("NC_TEST.1:g.[264_265insAA;263_264insAC]"),
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -171,6 +171,7 @@ mod issue_1290_junction_crosses_junction;
 mod issue_1292_junction_payload_rotation;
 mod issue_1296_repeat_claims_its_bases;
 mod issue_129_mt_circular_wraparound;
+mod issue_1301_adjacent_gap_member_order;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1301.

`cis_member_order_key` breaks a start tie with the member's **end** (#1261). That is not enough for two members whose spans are *identical*:

```
reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
in   NC_TEST.1:g.[263_264insAC;264_265insAA]
out  NC_TEST.1:g.[264_265dup;264_265insCA]      <- before
out  NC_TEST.1:g.[264_265insCA;264_265dup]      <- after
```

`264_265insCA` fills the gap `264|265`, so it adds at interbase **264**; `264_265dup` places its copy after its last base, so it adds at **265**. Both span `264_265`, so start and end tie and the order fell through to the descriptor tie-break — which sorts `264_265dup` first, the reverse of the order the two apply in. The pair rendered out of order and their interbase spans read as overlapping, which is #1235's second acceptance criterion.

## What was and was not wrong

**The sequence was never wrong.** Both members applied denote the input's bases, before and after. What was wrong is the rendering, so the new test asserts the ordering *and* re-applies the output through `hgvs_to_spdi` — an ordering test that could pass by tidily rendering a wrong pair would be worse than none.

`junction_rank` adds the missing discriminator: a member adding at its span's **start** (an insertion, whose span is the gap it fills) sorts before one acting across the whole span. Everything that consumes the bases under its span ranks with the 3' end.

## Reachability

This shape only became reachable in #1302, which dropped the generator filter that had been excluding adjacent-gap insertions — the filter was hiding it under a citation (#1260 / #1262) that did not describe it.

## What is behind it

Fixing the ordering unmasks **#1304**, filed from this work: the same two-insertion shape *with a deletion added* denotes the wrong bases, silently.

```
in   NC_TEST.1:g.[260_261insGA;261_262insA;264del]
out  NC_TEST.1:g.[261_262insA;261_262dup;265del]
  intended  G C A T G A G A A A A T
  emitted   G C A T G A A G A A A T
```

**Pre-existing**, verified by reverting `src/hgvs/variant.rs` to this branch's parent and re-running: the same two members in the opposite order denote the same wrong sequence. So this change neither causes nor masks it — it only stops that shape failing on the ordering check first. The confluence property's doc comment now names #1304 as what sits behind #1297.

That is the seventh defect this property has surfaced, each masked behind the one before it: #1286 → #1287 → #1290 → #1292 → #1296 → #1301 → #1304.

## Verification

- `cargo nextest run --features dev` — **8925 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8925 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1302.
