### PR TITLE
fix(normalize): read a junction barrier's payload from its own snapshot

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3424,6 +3424,15 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
     };
     let pre: Vec<Option<MemberSpan>> = before.iter().map(|v| member_span(v, kind)).collect();
     let post: Vec<Option<MemberSpan>> = after.iter().map(|v| member_span(v, kind)).collect();
+    // The members `post` was measured from. The loop below translates `after`
+    // in place, so by the time member `i` inspects a sibling `j < i` that has
+    // already moved, `after[j]` no longer matches `post[j]` — pairing them
+    // reads a duplication's payload from bases under a span it has left, which
+    // is the #1304 mismatch one iteration later rather than one snapshot over.
+    // Keeping the pair together also keeps the barrier evaluated against the
+    // state the whole pass started from, so the result does not depend on the
+    // order the members happen to be visited in.
+    let post_snapshot: Vec<HgvsVariant> = after.to_vec();
 
     for i in 0..after.len() {
         let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
@@ -3494,14 +3503,27 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         // would leave the three-insertion case at two members for the same
         // reason, since a merged `AA` is not *equal* to a remaining `A` even
         // though it commutes with it.
+        // Each span is carried with the variant it was read from. A duplication
+        // reads its payload from the reference *under its own span*, so pairing
+        // the post-normalization edit with the pre-normalization span reads
+        // bases belonging to neither: `g.[260_261insGA;261_262insA;264del]` had
+        // the sibling's `insA` span measured against its own normalized
+        // `265dup`, which reported the payload `GA` rather than `A`. `GA`
+        // commutes with this member's `GA`, so the barrier vanished and the
+        // member swept past it (#1304).
         let payload = junction_payload(&after[i], kind, a, provider);
         let across_junctions = (0..pre.len())
             .filter(|&j| j != i)
-            .flat_map(|j| [(j, pre[j].as_ref()), (j, post[j].as_ref())])
-            .filter_map(|(j, span)| span.map(|s| (j, s)))
+            .flat_map(|j| {
+                [
+                    (&before[j], pre[j].as_ref()),
+                    (&post_snapshot[j], post[j].as_ref()),
+                ]
+            })
+            .filter_map(|(variant, span)| span.map(|s| (variant, s)))
             .filter(|(_, s)| !s.claims_bases && s.region == a.region && s.accession == a.accession)
-            .filter(|(j, s)| {
-                let blocks = match (&payload, junction_payload(&after[*j], kind, s, provider)) {
+            .filter(|(variant, s)| {
+                let blocks = match (&payload, junction_payload(variant, kind, s, provider)) {
                     (Some(mine), Some(theirs)) => !payloads_commute(mine, &theirs),
                     // A payload that cannot be read blocks: refusing to cross is
                     // the conservative answer when the reordering cannot be

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -61,7 +61,7 @@
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
 //!   because it finds #1297, a cancelled member left as an identity member
-//!   overlapping the repeat that absorbed it, and #1304 behind it. It found #1286, #1287, #1290,
+//!   overlapping the repeat that absorbed it. It found #1286, #1287, #1290,
 //!   #1292 and #1296 first, all now fixed, each masked behind the one before
 //!   it; see its doc comment for the history and the live reproduction.
 //!
@@ -807,10 +807,9 @@ proptest! {
     /// on would make a green CI a matter of the budget rather than of the
     /// property holding.
     ///
-    /// **#1304** is behind it: two insertions at adjacent gaps plus a deletion
-    /// denote the wrong bases, silently. It became reachable once #1301 fixed
-    /// the ordering of two members sharing a span, which is what that shape used
-    /// to fail on first.
+    /// #1301 and #1304 sat between #1297 and this test in turn, and are both
+    /// fixed: two members sharing a span rendered out of order, and a junction
+    /// barrier that read a moved sibling's payload from the wrong snapshot.
     ///
     /// Expect the reported minimal case to name that shape rather than #1297's.
     /// #1297's seed is the one that fails, but with the filter gone its shrink

--- a/tests/it/issue_1304_junction_barrier_snapshot.rs
+++ b/tests/it/issue_1304_junction_barrier_snapshot.rs
@@ -1,0 +1,61 @@
+//! A junction barrier must read its sibling's payload from the snapshot the
+//! span came from.
+//!
+//! `clamp_sibling_crossing_junctions` compares this member's payload against
+//! each sibling's to decide whether crossing is observable — commuting payloads
+//! may cross, others may not (#1290). It considers each sibling from *both*
+//! snapshots, before and after per-member normalization, so a sibling that moved
+//! still counts as a barrier where it started.
+//!
+//! It read every payload off the **after** variant, including for spans taken
+//! from the **before** snapshot. A duplication reads its payload from the
+//! reference under its own span, so that pairing reads bases belonging to
+//! neither:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
+//! g.[260_261insGA;261_262insA;264del]
+//!   per-member ->  g.[261_262dup;265dup;265del]
+//!   the `insA` sibling's *before* span 261_262 measured against its *after*
+//!   `265dup` reports the payload `GA`, not `A`
+//!
+//!   intended  G C A T G A G A A A A T
+//!   emitted   G C A T G A A G A A A T
+//! ```
+//!
+//! `GA` commutes with this member's own `GA`, so the barrier vanished and the
+//! `insGA` junction swept from 260 past the sibling at 261 — reordering the two
+//! insertions and denoting different bases, with both members well-formed and
+//! disjoint. Nothing else catches it.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+const CORE: &str = "GCATGAAAAT";
+
+#[test]
+fn a_moved_sibling_still_bars_the_crossing_it_started_at() {
+    // #1304. The `insGA` junction may not sweep from 260 past the `insA` at
+    // 261: the payloads do not commute, so their order is observable.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[260_261insGA;261_262insA;264del]");
+    assert_eq!(output, "NC_TEST.1:g.[260_261insGA;261_262insA;265del]");
+}
+
+#[test]
+fn the_pair_alone_is_barred_too() {
+    // Without the deletion, so the barrier is the only thing under test.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[260_261insGA;261_262insA]");
+    assert_eq!(output, "NC_TEST.1:g.[260_261insGA;261_262insA]");
+}
+
+#[test]
+fn each_insertion_alone_still_shifts_to_its_own_most_three_prime_form() {
+    // The guard: the barrier is a *sibling* effect. On its own each member
+    // still reaches its standalone 3'-most spelling, so the clamp is not
+    // suppressing the 3' rule.
+    for (input, expected) in [
+        ("NC_TEST.1:g.260_261insGA", "NC_TEST.1:g.261_262dup"),
+        ("NC_TEST.1:g.261_262insA", "NC_TEST.1:g.265dup"),
+    ] {
+        assert_eq!(assert_padded_preserving(CORE, input), expected);
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -172,6 +172,7 @@ mod issue_1292_junction_payload_rotation;
 mod issue_1296_repeat_claims_its_bases;
 mod issue_129_mt_circular_wraparound;
 mod issue_1301_adjacent_gap_member_order;
+mod issue_1304_junction_barrier_snapshot;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1304.

`clamp_sibling_crossing_junctions` compares this member's payload against each sibling's to decide whether a crossing is observable — commuting payloads may cross, others may not (#1290). It considers each sibling from **both** snapshots, before and after per-member normalization, so a sibling that moved still counts as a barrier where it started.

It read every payload off the **after** variant, including for spans taken from the **before** snapshot. A duplication reads its payload from the reference *under its own span*, so that pairing reads bases belonging to neither:

```
reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
in   NC_TEST.1:g.[260_261insGA;261_262insA;264del]
  per-member ->  g.[261_262dup;265dup;265del]

the `insA` sibling's *before* span 261_262 measured against its *after*
`265dup` reports the payload `GA`, not `A`
```

`GA` commutes with this member's own `GA`, so the barrier vanished and the `insGA` junction swept from 260 straight past the sibling at 261:

```
out  NC_TEST.1:g.[261_262insA;261_262dup;265del]
  intended  G C A T G A G A A A A T
  emitted   G C A T G A A G A A A T
```

Silent: both members well-formed, disjoint, in order, a fixed point, and the SPDI oracle applies it cleanly. Neither `FERRO_ASSERT_REPARSE` nor `FERRO_ASSERT_IDEMPOTENT` can see it.

## The fix

Carry each span with the variant it was read from, so a before-span is measured against the before-edit. Two lines: the `flat_map` pairs `(&before[j], pre[j])` and `(&after[j], post[j])` instead of `j` alone, and the payload lookup uses that variant.

```
after:  NC_TEST.1:g.[260_261insGA;261_262insA;265del]
```

The two insertions hold their authored junction order and the deletion 3'-shifts alone.

## Scope

The bug is specific to the payload comparison. `onto_bases` in the same pass reads only span geometry, and `let payload = junction_payload(&after[i], kind, a, provider)` was already consistent — `a` is `post[i]`.

The new test also pins the guard: each insertion **alone** still reaches its standalone 3'-most spelling (`g.261_262dup`, `g.265dup`), so the barrier is a sibling effect and not a suppression of the 3' rule.

## Where this sits

Seventh in the chain the confluence property has surfaced, each masked behind the one before it: #1286 → #1287 → #1290 → #1292 → #1296 → #1301 → #1304. With this fixed the property's next failure is **#1297** again — a cancelled member left as an identity member overlapping the repeat that absorbed it — which is the last one before it can be enabled.

## Verification

- `cargo nextest run --features dev` — **8928 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8928 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1305.
