### PR TITLE
fix(normalize): drop a cancelled member left inside the one that absorbed it

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4114,6 +4114,73 @@ fn translate_junction_member<P: ReferenceProvider>(
     }
 }
 
+/// Drop a cis member asserting **no change** at a position another member
+/// changes.
+///
+/// An identity member (`265=`) says a position was examined and found
+/// unchanged. That is real information when it stands alone, so `g.[1002=;
+/// 1005del]` keeps both. It is a contradiction when a sibling claims the same
+/// bases, and the pair also overlaps — two members on one position, which
+/// #1235's second criterion forbids and the apply oracle declines.
+///
+/// The shape is not authored, it is derived: a `del` and an `ins` that merge
+/// into a `delins` restating the reference cancel to `=`, and the member that
+/// absorbed the change then grows over it (#1297).
+///
+/// ```text
+/// g.[261_262insAA;263del;264_265insA]  ->  g.[262_265A[6];265=]
+///   the repeat alone denotes the input; the `265=` residue overlaps it
+/// ```
+///
+/// Only the identity member is dropped, and only when a sibling *claims* the
+/// bases under it — a sibling that merely adds sequence at a junction inside it
+/// contradicts nothing.
+pub(crate) fn drop_identity_members_covered_by_siblings(
+    members: &mut Vec<HgvsVariant>,
+    phase: AllelePhase,
+    uncertain: bool,
+) {
+    if phase != AllelePhase::Cis || uncertain || members.len() < 2 {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&members[0]) else {
+        return;
+    };
+    let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
+    let is_identity = |v: &HgvsVariant| {
+        matches!(
+            cis_axis_parts(v, kind).map(|(_, _, _, _, edit)| edit),
+            Some(NaEdit::Identity { .. })
+        )
+    };
+
+    let covered: Vec<bool> = (0..members.len())
+        .map(|i| {
+            let (Some(span), true) = (spans[i].as_ref(), is_identity(&members[i])) else {
+                return false;
+            };
+            (0..members.len()).filter(|&j| j != i).any(|j| {
+                spans[j].as_ref().is_some_and(|s| {
+                    s.claims_bases
+                        && s.region == span.region
+                        && s.accession == span.accession
+                        && s.start <= span.start
+                        && s.end >= span.end
+                })
+            })
+        })
+        .collect();
+    if !covered.iter().any(|&drop| drop) {
+        return;
+    }
+    let mut index = 0;
+    members.retain(|_| {
+        let keep = !covered[index];
+        index += 1;
+        keep
+    });
+}
+
 /// Whether two junction payloads may be reordered without changing what the
 /// allele denotes.
 ///

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2680,6 +2680,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 allele.uncertain,
                 &self.provider,
             );
+            // Last, once every span above has settled: a member that cancelled
+            // to `=` while a sibling grew over the bases it names is a
+            // contradiction, and an overlap (#1297).
+            merge::drop_identity_members_covered_by_siblings(
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+            );
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,10 +60,11 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1297, a cancelled member left as an identity member
-//!   overlapping the repeat that absorbed it. It found #1286, #1287, #1290,
-//!   #1292 and #1296 first, all now fixed, each masked behind the one before
-//!   it; see its doc comment for the history and the live reproduction.
+//!   because it finds #1308, two equal-payload insertions at adjacent gaps
+//!   that both shift 3' and denote different bases. It found #1286, #1287,
+//!   #1290, #1292, #1296, #1301, #1304 and #1297 first, all now fixed, each
+//!   masked behind the one before it; see its doc comment for the history and
+//!   the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -782,45 +783,43 @@ proptest! {
     ///
     /// #1290 followed and is also fixed — a junction shifting past *another
     /// junction*, reordering two insertions. So are #1292, a duplication whose
-    /// payload was rewritten when a clamp translated it, and #1296, a repeat
-    /// that did not report claiming the bases under its tract. The live failure
-    /// is the sixth it has found, **#1297**: a member that cancelled is left as
-    /// an identity member, overlapping the repeat that absorbed it.
+    /// payload was rewritten when a clamp translated it; #1296, a repeat that
+    /// did not report claiming the bases under its tract; #1301, two members
+    /// sharing a span rendered out of order; #1304, a junction barrier reading a
+    /// moved sibling's payload from the wrong snapshot; and #1297, a member that
+    /// cancelled and was left as an identity member overlapping the repeat that
+    /// absorbed it. The live failure is the ninth it has found, **#1308**:
     ///
     /// ```text
-    /// core "GCATGAAAAT", insert "AA" after 4, delete index 6, insert "A" after 7
-    ///   g.[261_262insAA;263del;264_265insA] -> g.[262_265A[6];265=]
-    ///     the repeat alone is right; the `265=` residue overlaps it
+    /// core "CAGAAGATGAATAA", insert "TG" after index 6 and after index 7
+    ///   g.[263_264insTG;264_265insTG] -> g.[264_265insTG;264_265dup]
+    ///     intended  C A G A A G A T G T T G G A A T A A
+    ///     emitted   C A G A A G A T T G G T G A A T A A
     /// ```
     ///
-    /// Each of the six was masked behind the one before it, which is the point
+    /// Both insertions moved one position 3', which is only equivalent when the
+    /// base they step over is in phase with them. Their payloads are equal, so
+    /// they commute and the junction clamp permits the crossing — but commuting
+    /// governs the two payloads' order relative to *each other*, not their phase
+    /// against the reference.
+    ///
+    /// Each of the eight was masked behind the one before it, which is the point
     /// of keeping this committed rather than deleting it until it can pass.
     ///
     /// Enabling this test was #1292's acceptance criterion. #1292 is fixed and
     /// pinned — by `issue_1292_junction_payload_rotation` and by the `99d5d382`
     /// seed below, which replays green — but the criterion could not be met
     /// with it, because the property's next two failures were behind it.
-    /// Enabling now belongs to **#1297**, whose seed `a88766af` is committed
+    /// Enabling now belongs to **#1308**, whose seed `03577f14` is committed
     /// below — so taking the ignore off replays it immediately, which is what
     /// should gate taking it off. Absent that seed this passes the 512-case
     /// budget and fails a 30,000-case soak on the same shape, so switching it
     /// on would make a green CI a matter of the budget rather than of the
     /// property holding.
     ///
-    /// #1301 and #1304 sat between #1297 and this test in turn, and are both
-    /// fixed: two members sharing a span rendered out of order, and a junction
-    /// barrier that read a moved sibling's payload from the wrong snapshot.
-    ///
-    /// Expect the reported minimal case to name that shape rather than #1297's.
-    /// #1297's seed is the one that fails, but with the filter gone its shrink
-    /// is free to walk onto an adjacent-gap pair, which is strictly simpler —
-    /// so the failure output reads as #1301 while the `#[ignore]` reason and the
-    /// seed file both say #1297. Both are accurate; they describe the seed and
-    /// the shrink respectively.
-    ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1297, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1308, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1020,12 +1019,13 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1297: a member that cancelled is left behind as an identity member,
-    // overlapping the repeat that absorbed it.
+    // #1308: two equal payloads commute, so the junction clamp lets both step
+    // 3' -- but the base they step over is out of phase with them, so the
+    // output denotes a different sequence.
     let (core, input, issue) = (
-        "GCATGAAAAT",
-        "NC_TEST.1:g.[261_262insAA;263del;264_265insA]",
-        "#1297",
+        "CAGAAGATGAATAA",
+        "NC_TEST.1:g.[263_264insTG;264_265insTG]",
+        "#1308",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1297_cancelled_identity_member.rs
+++ b/tests/it/issue_1297_cancelled_identity_member.rs
@@ -1,0 +1,98 @@
+//! A member that cancelled to `=` must not be left overlapping the member that
+//! absorbed it.
+//!
+//! An identity member says a position was examined and found unchanged. It is
+//! not authored here — it is derived: a `del` and an `ins` that merge into a
+//! `delins` restating the reference cancel to `=`, and the member that absorbed
+//! the change then grows over the position it names.
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
+//! g.[261_262insAA;263del;264_265insA]  ->  g.[262_265A[6];265=]
+//! ```
+//!
+//! `262_265A[6]` alone denotes the input exactly. The `265=` residue claims a
+//! base the repeat covers, so the pair overlaps and the apply oracle declines
+//! the output — #1235's second acceptance criterion.
+//!
+//! Dropping identity members outright would be wrong. `g.[1002=;1005del]` is a
+//! real description: the `=` records a position that was checked. Only an
+//! identity member a sibling *claims the bases of* is a contradiction, and only
+//! that one is dropped.
+
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+const CORE: &str = "GCATGAAAAT";
+
+/// Normalize and assert the output denotes the input's bases. A pair whose
+/// members overlap has no resulting sequence at all, which is how the pre-fix
+/// output failed.
+fn assert_padded_preserving(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None;
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+
+    let from_input = denote(input).expect("input applies");
+    let from_output = denote(&output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
+}
+
+#[test]
+fn a_cancelled_member_does_not_survive_inside_the_repeat_that_absorbed_it() {
+    // #1297. Three members reduce to one repeat; the `=` left behind by the
+    // cancelling pair must go with them.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[261_262insAA;263del;264_265insA]");
+    assert_eq!(output, "NC_TEST.1:g.262_265A[6]");
+}
+
+#[test]
+fn a_wholly_self_cancelling_allele_still_reports_no_change() {
+    // The guard on the other side: when *everything* cancels there is no
+    // sibling claiming anything, so the identity is the answer and is kept.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[263del;264_265insA]");
+    assert_eq!(output, "NC_TEST.1:g.266_267=");
+}
+
+#[test]
+fn an_identity_member_beside_an_unrelated_deletion_is_kept() {
+    // `=` records a position that was examined. A sibling elsewhere contradicts
+    // nothing, so both members stay — dropping identities outright would lose
+    // real information.
+    let output = assert_padded_preserving("GCATGAAAATCCTTGG", "NC_TEST.1:g.[258=;266del]");
+    assert_eq!(output, "NC_TEST.1:g.[258=;266del]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -170,6 +170,7 @@ mod issue_1287_repeat_span_junction;
 mod issue_1290_junction_crosses_junction;
 mod issue_1292_junction_payload_rotation;
 mod issue_1296_repeat_claims_its_bases;
+mod issue_1297_cancelled_identity_member;
 mod issue_129_mt_circular_wraparound;
 mod issue_1301_adjacent_gap_member_order;
 mod issue_1304_junction_barrier_snapshot;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -8,13 +8,15 @@
 # are fixed and replay green; the second seed is still rejected by the strategy,
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
-# was removed in #1294, so it runs now.) #1297 is not yet fixed and is the
-# reason `an_indel_haplotype_normalizes_to_its_own_sequence` is still
-# `#[ignore]`d, so it is recorded here rather than running: it replays the
-# moment the test is enabled, which is what should gate enabling it.
+# was removed in #1294, so it runs now.) #1297 is fixed too. #1308 is
+# not yet fixed and is the reason
+# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d, so
+# it is recorded here rather than running: it replays the moment the test is
+# enabled, which is what should gate enabling it.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
 cc 99d5d382a1a8f00844864743b0bed0ae12fe2bb8a21b902c99963e8902ab9f11 # #1292; shrinks to haplotype = IndelHaplotype { core: "GCAAATAACATCCAGA", events: [Insert { index: 6, bases: "AC" }, Delete { index: 8 }] }
 cc d327f0bf8cf0b8efddb73821bcc4e210ec3c32c5df034d9d4607833b24a588d2 # #1296; shrinks to haplotype = IndelHaplotype { core: "AAAAAAATAATCGCAACAGAAG", events: [Insert { index: 15, bases: "A" }, Delete { index: 16 }, Insert { index: 17, bases: "AC" }] }
 cc a88766af1b7adaab791aaf8fda16997a3c66fe0d265cb1a57d9488f22a67ef5d # #1297; shrinks to haplotype = IndelHaplotype { core: "GCATGAAAAT", events: [Insert { index: 4, bases: "AA" }, Delete { index: 6 }, Insert { index: 7, bases: "A" }] }
+cc 03577f141460793dd01977d320da2524039646462483ad1e6df70eb4426e8213 # #1308; shrinks to haplotype = IndelHaplotype { core: "CAGAAGATGAATAA", events: [Insert { index: 6, bases: "TG" }, Insert { index: 7, bases: "TG" }] }


### PR DESCRIPTION
Closes #1297.

A `del` and an `ins` that merge into a `delins` restating the reference cancel to `=`. The member that absorbed the change then grows over the position that `=` names, and the pair overlaps:

```
reference  ("ACGT" x 64) + "GCATGAAAAT" + ("ACGT" x 64)
in   NC_TEST.1:g.[261_262insAA;263del;264_265insA]
out  NC_TEST.1:g.[262_265A[6];265=]
```

`262_265A[6]` alone denotes the input exactly — the repeat is right. The `265=` residue claims a base the repeat covers, so the two overlap and the apply oracle declines the output, which is #1235's second acceptance criterion.

Traced, not guessed. The merge loop reaches `[262_263dup;265delinsA]`, the `265delinsA` normalizes to `265=` (correctly — it restates the reference), and the dup then becomes the tract-wide repeat that swallows it.

## Why not just drop identity members

Because `g.[1002=;1005del]` is a real description — the `=` records a position that was examined and found unchanged, and `tests/it/issue_851_compound_utr_projection.rs` asserts exactly that shape. Dropping identities outright would lose real information.

The rule is narrower: an identity member is dropped only when a sibling **claims the bases** under it. That is the case where the two contradict *and* overlap. A sibling that merely adds sequence at a junction inside it contradicts nothing, and a wholly self-cancelling allele has no claiming sibling at all — so `g.[263del;264_265insA]` still reports `g.266_267=`. All three cases are pinned as tests.

The pass runs last in the merge loop, once every span above it has settled.

## Where this sits

Eighth in the chain the confluence property has surfaced, each invisible until its predecessor closed: #1286 → #1287 → #1290 → #1292 → #1296 → #1301 → #1304 → #1297.

Behind it is **#1308**, filed from this work and **verified pre-existing** (identical output on #1306's tip with this fix reverted): two insertions carrying the *same* payload at adjacent gaps both shift one position 3'.

```
in   NC_TEST.1:g.[263_264insTG;264_265insTG]     core "CAGAAGATGAATAA"
out  NC_TEST.1:g.[264_265insTG;264_265dup]
  intended  C A G A A G A T G T T G G A A T A A
  emitted   C A G A A G A T T G G T G A A T A A
```

Equal payloads commute, so `clamp_sibling_crossing_junctions` deliberately permits the crossing — but commuting governs the two payloads' order relative to *each other*, not their phase against the reference base they stepped over. The property stays `#[ignore]`d on it, with its seed committed and the ignore reason naming it.

## Verification

- `cargo nextest run --features dev` — **8931 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8931 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1306.
