### PR TITLE
test(normalize): strengthen the cis-allele test oracles to their stated contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ description the parser accepts inbound but cannot re-read outbound is a
 parse/display round-trip asymmetry normalize merely carries through. Both are a
 different bug; reporting them here would bury the one this oracle is for.
 
+Like the idempotency oracle it is compiled out in release builds
+(`#[cfg(debug_assertions)]`) and read once into a `OnceLock`, so it adds no
+release-build cost and a disabled debug run pays only one atomic load.
+
 ```bash
 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev
 ```

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -85,7 +85,7 @@ fn a_repeat_grown_from_an_insertion_does_not_span_a_sibling() {
 fn a_lone_duplication_still_reaches_repeat_notation() {
     // Negative control: no sibling, nothing to span, so the tract-wide repeat
     // is exactly right and must survive.
-    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_2dup"), "TEMPLATE:g.1_9T[11]");
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.1_2dup", "TEMPLATE:g.1_9T[11]");
 }
 
 #[test]
@@ -342,24 +342,12 @@ fn a_deletion_does_not_shift_across_an_insertion_junction() {
         "TEMPLATE:g.[259del;259_260insC]",
         "TEMPLATE:g.259delinsC",
     ] {
-        let actual = normalize(&seq, input);
-        assert_eq!(actual, "TEMPLATE:g.259A>C", "normalizing {input}");
-        assert_eq!(
-            apply(&seq, &actual).expect("output applies"),
-            apply(&seq, input).expect("input applies"),
-            "{input} -> {actual} changed the sequence"
-        );
+        assert_normalizes_preserving(&seq, input, "TEMPLATE:g.259A>C");
     }
 
     // A junction further into the tract clamps to that junction instead.
-    let input = "TEMPLATE:g.[258del;261_262insC]";
-    let actual = normalize(&seq, input);
-    assert_eq!(actual, "TEMPLATE:g.261A>C");
-    assert_eq!(
-        apply(&seq, &actual).expect("output applies"),
-        apply(&seq, input).expect("input applies"),
-    );
+    assert_normalizes_preserving(&seq, "TEMPLATE:g.[258del;261_262insC]", "TEMPLATE:g.261A>C");
 
     // Negative control: with no sibling the deletion still shifts fully.
-    assert_eq!(normalize(&seq, "TEMPLATE:g.258del"), "TEMPLATE:g.263del");
+    assert_normalizes_preserving(&seq, "TEMPLATE:g.258del", "TEMPLATE:g.263del");
 }

--- a/tests/it/issue_1254_sibling_crossing_shift.rs
+++ b/tests/it/issue_1254_sibling_crossing_shift.rs
@@ -25,7 +25,8 @@
 //! normalizes both sides, so it passed on the broken behavior.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, normalize, normalize_in, sweep_sequences,
+    apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize,
+    sweep_sequences,
 };
 use ferro_hgvs::ShuffleDirection;
 
@@ -101,12 +102,11 @@ fn a_five_prime_shift_does_not_cross_a_sibling_either() {
     // past the `5del`. Clamped to `6_7del` it is adjacent to the `5del`, and the
     // two merge into `g.5_7del`. This previously emitted `g.1_3del`, which
     // denotes `TATATATAATATATATT` where the input denotes `TAATTATAATATATATT`.
-    let input = "TEMPLATE:g.[5del;9_10del]";
-    let actual = normalize_in(TEMPLATE, input, ShuffleDirection::FivePrime);
-    assert_eq!(actual, "TEMPLATE:g.5_7del");
-    assert_eq!(
-        apply(TEMPLATE, &actual).expect("output applies"),
-        apply(TEMPLATE, input).expect("input applies"),
+    assert_normalizes_preserving_in(
+        TEMPLATE,
+        "TEMPLATE:g.[5del;9_10del]",
+        "TEMPLATE:g.5_7del",
+        ShuffleDirection::FivePrime,
     );
 }
 

--- a/tests/it/issue_1254_sibling_crossing_shift.rs
+++ b/tests/it/issue_1254_sibling_crossing_shift.rs
@@ -126,8 +126,16 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
     // reported silent sequence-changing normalizations — well-formed,
     // warning-free, disjoint output — in the low thousands; over-clamping would
     // show up as a canonical-form change in the pinned cases above.
+    //
+    // Two failure modes are counted separately, matching the sibling sweep in
+    // `cis_junction_crossing_shift.rs`: an *input* that does not apply is a case
+    // this sweep cannot speak for and is skipped, while an *output* that does
+    // not apply is a failure — an overlapping or unconvertible normalization is
+    // precisely the defect the sweep exists to catch, and folding it into
+    // `skipped` let it pass silently.
     let mut enumerated = 0usize;
     let mut skipped = 0usize;
+    let mut overlapping: Vec<String> = Vec::new();
     let mut mismatched: Vec<String> = Vec::new();
 
     for seq in sweep_sequences(64) {
@@ -156,9 +164,14 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
                         // change in the skip rate trips a coverage floor
                         // for a reason unrelated to coverage.
                         enumerated += 1;
-                        let (Some(want), Some(got)) = (apply(&seq, &input), apply(&seq, &output))
-                        else {
-                            skipped += 1; // unconvertible, or a flagged overlap
+                        let Some(want) = apply(&seq, &input) else {
+                            skipped += 1; // the input itself is unconvertible
+                            continue;
+                        };
+                        let Some(got) = apply(&seq, &output) else {
+                            if overlapping.len() < 10 {
+                                overlapping.push(format!("{seq}: {input} -> {output}"));
+                            }
                             continue;
                         };
                         if want != got && mismatched.len() < 10 {
@@ -182,8 +195,12 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
     );
     assert!(
         skipped * 10 < enumerated,
-        "too many cases skipped as unconvertible or overlapping: \
-         {skipped} of {enumerated}"
+        "too many cases skipped as unconvertible: {skipped} of {enumerated}"
+    );
+    assert!(
+        overlapping.is_empty(),
+        "overlapping or unconvertible output in {enumerated} enumerated cases: \
+         {overlapping:#?}"
     );
     assert!(
         mismatched.is_empty(),

--- a/tests/it/normalize_reparse_invariant.rs
+++ b/tests/it/normalize_reparse_invariant.rs
@@ -80,19 +80,24 @@ fn a_del_beside_a_dup_re_spells_instead_of_colliding() {
 }
 
 /// Apply `descriptor` to the synthetic reference independently of the
-/// normalizer, via SPDI triples, and return a 20-base window at 0-based 254.
+/// normalizer, via SPDI triples, and return the **whole** resulting sequence.
 ///
 /// Delegates to the shared oracle rather than re-deriving the splice walk: that
 /// walk is what makes "declines an overlapping description" true, and it is
 /// already the single copy the sibling-crossing tests rest on.
+///
+/// The full sequence, not a window around the core. This previously returned
+/// `skip(254).take(20)`, which is narrower than the contract its caller states
+/// ("changed the sequence"): the cases here change length, so a member that
+/// shifted out of the window, or content pushed past its end, compared equal
+/// while the sequences differed.
 fn applied(core: &str, descriptor: &str) -> String {
     let provider = SyntheticBuilder::genomic(core).build();
     let reference = padded(core);
-    let edited = crate::common::cis_apply_oracle::apply_with(&provider, &reference, descriptor)
+    crate::common::cis_apply_oracle::apply_with(&provider, &reference, descriptor)
         .unwrap_or_else(|| {
             panic!("`{descriptor}` has no well-defined resulting sequence (overlapping or unconvertible)")
-        });
-    edited.chars().skip(254).take(20).collect()
+        })
 }
 
 /// The invariant itself, over the cases that already satisfy it — so the

--- a/tests/it/repeat_span_sibling_overlap.rs
+++ b/tests/it/repeat_span_sibling_overlap.rs
@@ -25,7 +25,7 @@
 //! pre-existing on `main` and independent of both.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, normalize, normalize_in, sweep_sequences,
+    apply, assert_normalizes_preserving, normalize_in, sweep_sequences,
 };
 use ferro_hgvs::ShuffleDirection;
 
@@ -74,8 +74,8 @@ fn a_lone_deletion_still_becomes_a_repeat() {
     // Negative control: with no sibling there is nothing to span, so B2 applies
     // exactly as before. Guards against "fixing" this by disabling the repeat
     // form for deletions.
-    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_2del"), "TEMPLATE:g.1_9T[7]");
-    assert_eq!(normalize(TRACT, "TEMPLATE:g.1_3del"), "TEMPLATE:g.1_9T[6]");
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.1_2del", "TEMPLATE:g.1_9T[7]");
+    assert_normalizes_preserving(TRACT, "TEMPLATE:g.1_3del", "TEMPLATE:g.1_9T[6]");
 }
 
 #[test]


### PR DESCRIPTION
Four assertions in the cis-allele test suite claimed more than they checked. Each is fixed in its own commit; no production code changes and no expectation changes.

### 1. The two-member sweep counted an overlapping output as skipped

`shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep` destructured both applies at once, so an *output* with no well-defined resulting sequence landed in `skipped` next to an input the sweep genuinely cannot speak for. An overlapping normalization — two members claiming one base — is precisely the defect the sweep exists to catch. The sibling sweep in `cis_junction_crossing_shift.rs` already separates the two; this brings the pair back into step.

### 2. The re-parse invariant compared a 20-base window

`applied` returned `edited.chars().skip(254).take(20)` while its caller asserted the normalization "changed the sequence". These cases change length, so content can move out of the window or be pushed past its end and still compare equal. Now returns the full resulting sequence.

### 3. Negative controls asserted only the rendered string

The point of these controls is that the unclamped path is still correct, and correctness includes denoting the same bases. They now go through `assert_normalizes_preserving`, which the positive cases in the same files already use. Two sites that hand-rolled the preservation half inline (one dropping its failure message) now call the helper too.

### 4. CLAUDE.md omitted the re-parse oracle's debug-only gating

The idempotency section states it; the re-parse section, describing the same seam, did not. Verified against `reparse_self_check_enabled` in `src/normalize/mod.rs`.

## Verification

8906/8906 tests pass; clippy `-D warnings` and fmt clean. No case in the 128-sequence corpus trips the new overlapping-output assertion, and every pinned re-parse case still passes with the full-sequence comparison — so these strengthen the guards without moving any result.

## Provenance and scope

These were flagged by CodeRabbit on #1285 against a pre-rebase diff base. That PR no longer touches these files, so they were triaged out of it and verified independently here.

One related item is deliberately **not** here: `issue_1254_sibling_crossing_shift.rs` still hand-rolls the 5' preservation assertion. The direction-aware `assert_normalizes_preserving_in` helper it needs is added by #1285, so converting that site here would guarantee a conflict. It follows once #1285 lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened normalization regression coverage to verify that sequence content is preserved across duplication, deletion, insertion, and repeat-boundary cases.
  * Expanded invariant checks to cover complete generated sequences, including length and out-of-range differences.
  * Improved test reporting by distinguishing conversion failures, overlapping outputs, and sequence mismatches.
* **Documentation**
  * Clarified that the normalization debug check is disabled in release builds and optimized for minimal overhead in debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->