### PR TITLE
fix(normalize): bound a commuting sibling at the junction it settles on

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3511,36 +3511,75 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         // `265dup`, which reported the payload `GA` rather than `A`. `GA`
         // commutes with this member's `GA`, so the barrier vanished and the
         // member swept past it (#1304).
+        // Commuting payloads are exempt from the barrier, but only as far as the
+        // sibling's **settled** junction. Commuting says `p ++ q == q ++ p` — the
+        // two payloads have no observable order *once they meet*. It says
+        // nothing about a member sweeping past a sibling that stays put and
+        // landing beyond it, where reference bases now separate them differently:
+        //
+        //     core "CAGAAGATGAATAA"
+        //     g.[263_264insTG;264_265insTG]
+        //       the second member does not move; the first 3'-shifts 263 -> 265
+        //       intended  A T G T T G G
+        //       emitted   A T T G T G G          (#1308)
+        //
+        // So a commuting sibling bounds this member at the junction it settles
+        // on — landing *on* it is what lets the pair merge (#1286) — and only
+        // its post-normalization position counts, since where it started is
+        // exactly the order that commuting makes unobservable. A sibling whose
+        // payload does not commute keeps the stricter rule above: one short, and
+        // from either snapshot.
         let payload = junction_payload(&after[i], kind, a, provider);
         let across_junctions = (0..pre.len())
             .filter(|&j| j != i)
             .flat_map(|j| {
                 [
-                    (&before[j], pre[j].as_ref()),
-                    (&post_snapshot[j], post[j].as_ref()),
+                    (false, &before[j], pre[j].as_ref()),
+                    (true, &post_snapshot[j], post[j].as_ref()),
                 ]
             })
-            .filter_map(|(variant, span)| span.map(|s| (variant, s)))
-            .filter(|(_, s)| !s.claims_bases && s.region == a.region && s.accession == a.accession)
-            .filter(|(variant, s)| {
-                let blocks = match (&payload, junction_payload(variant, kind, s, provider)) {
-                    (Some(mine), Some(theirs)) => !payloads_commute(mine, &theirs),
+            .filter_map(|(settled, variant, span)| span.map(|s| (settled, variant, s)))
+            .filter(|(_, _, s)| {
+                !s.claims_bases && s.region == a.region && s.accession == a.accession
+            })
+            .filter_map(|(settled, variant, s)| {
+                let junction = s.junction?;
+                if junction <= before_junction || junction > after_junction {
+                    return None;
+                }
+                let commutes = match (&payload, junction_payload(variant, kind, s, provider)) {
+                    (Some(mine), Some(theirs)) => payloads_commute(mine, &theirs),
                     // A payload that cannot be read blocks: refusing to cross is
                     // the conservative answer when the reordering cannot be
                     // shown to be harmless.
-                    _ => true,
+                    _ => false,
                 };
-                blocks && s.junction.is_some()
-            })
-            .filter_map(|(_, s)| s.junction)
-            .filter(|&j| j > before_junction && j <= after_junction)
-            .map(|j| j - 1);
+                match commutes {
+                    // Where it settles, and it may be met rather than only
+                    // approached. Its pre-normalization position is exactly the
+                    // order commuting makes unobservable, so it is not a bound.
+                    true => settled.then_some(junction),
+                    false => Some(junction - 1),
+                }
+            });
         let limit = onto_bases.chain(across_junctions).min();
         let Some(limit) = limit else {
             continue;
         };
-        // Never move past where the junction started.
-        let delta = (limit - after_junction).max(before_junction - after_junction);
+        // Never move past where the junction started, and never onto a junction
+        // this member's payload is out of phase with: the walk back finds the
+        // most 3' position it can legally occupy. `before_junction` always can,
+        // since that is where the shift began.
+        let ceiling = limit.max(before_junction).min(after_junction);
+        let Some(payload) = payload.as_ref() else {
+            continue;
+        };
+        let Some(destination) = (before_junction..=ceiling).rev().find(|&j| {
+            payload_at_junction(payload, after_junction, j, &a.provider_key, provider).is_some()
+        }) else {
+            continue;
+        };
+        let delta = destination - after_junction;
         if delta != 0 {
             translate_junction_member(&mut after[i], delta, kind, a, provider);
         }

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,9 +60,9 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1308, two equal-payload insertions at adjacent gaps
-//!   that both shift 3' and denote different bases. It found #1286, #1287,
-//!   #1290, #1292, #1296, #1301, #1304 and #1297 first, all now fixed, each
+//!   because it finds #1312, equal-payload insertions at adjacent gaps merging
+//!   out of phase with the base between them. It found #1286, #1287, #1290,
+//!   #1292, #1296, #1301, #1304, #1297 and #1308 first, all now fixed, each
 //!   masked behind the one before it; see its doc comment for the history and
 //!   the live reproduction.
 //!
@@ -788,29 +788,30 @@ proptest! {
     /// sharing a span rendered out of order; #1304, a junction barrier reading a
     /// moved sibling's payload from the wrong snapshot; and #1297, a member that
     /// cancelled and was left as an identity member overlapping the repeat that
-    /// absorbed it. The live failure is the ninth it has found, **#1308**:
+    /// absorbed it, and #1308, a commuting payload sweeping past a sibling that
+    /// stays put. The live failure is the tenth it has found, **#1312**:
     ///
     /// ```text
-    /// core "CAGAAGATGAATAA", insert "TG" after index 6 and after index 7
-    ///   g.[263_264insTG;264_265insTG] -> g.[264_265insTG;264_265dup]
-    ///     intended  C A G A A G A T G T T G G A A T A A
-    ///     emitted   C A G A A G A T T G G T G A A T A A
+    /// core "TAAAACCA", insert "AC" after index 3 and after index 4
+    ///   g.[260_261insAC;261_262insAC] -> g.261_262insACCA
+    ///     intended  T A A A A C A A C C C A
+    ///     emitted   T A A A A A C C A C C A
     /// ```
     ///
-    /// Both insertions moved one position 3', which is only equivalent when the
-    /// base they step over is in phase with them. Their payloads are equal, so
-    /// they commute and the junction clamp permits the crossing — but commuting
-    /// governs the two payloads' order relative to *each other*, not their phase
-    /// against the reference.
+    /// `AC` is out of phase with the `A` between the two gaps, so neither member
+    /// may move onto the other's junction — yet they merge there anyway, with a
+    /// payload that is neither concatenation nor rotation. This one survives the
+    /// 512-case budget below and is only reachable in a soak, which is exactly
+    /// why enabling the test on that budget would prove nothing.
     ///
-    /// Each of the eight was masked behind the one before it, which is the point
+    /// Each of the nine was masked behind the one before it, which is the point
     /// of keeping this committed rather than deleting it until it can pass.
     ///
     /// Enabling this test was #1292's acceptance criterion. #1292 is fixed and
     /// pinned — by `issue_1292_junction_payload_rotation` and by the `99d5d382`
     /// seed below, which replays green — but the criterion could not be met
     /// with it, because the property's next two failures were behind it.
-    /// Enabling now belongs to **#1308**, whose seed `03577f14` is committed
+    /// Enabling now belongs to **#1312**, whose seed `958acf3e` is committed
     /// below — so taking the ignore off replays it immediately, which is what
     /// should gate taking it off. Absent that seed this passes the 512-case
     /// budget and fails a 30,000-case soak on the same shape, so switching it
@@ -819,7 +820,7 @@ proptest! {
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1308, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1312, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1019,13 +1020,13 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1308: two equal payloads commute, so the junction clamp lets both step
-    // 3' -- but the base they step over is out of phase with them, so the
-    // output denotes a different sequence.
+    // #1312: `AC` is out of phase with the `A` between the two gaps, so neither
+    // member may move onto the other's junction -- yet they merge there anyway,
+    // with a payload that is neither concatenation nor rotation.
     let (core, input, issue) = (
-        "CAGAAGATGAATAA",
-        "NC_TEST.1:g.[263_264insTG;264_265insTG]",
-        "#1308",
+        "TAAAACCA",
+        "NC_TEST.1:g.[260_261insAC;261_262insAC]",
+        "#1312",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1308_commuting_payload_phase.rs
+++ b/tests/it/issue_1308_commuting_payload_phase.rs
@@ -1,0 +1,112 @@
+//! Commuting payloads may meet, but not sweep past a sibling that stays put.
+//!
+//! `clamp_sibling_crossing_junctions` exempts a sibling whose payload
+//! *commutes* with this member's: `p ++ q == q ++ p` means the two have no
+//! observable order, so letting them reach one junction is better than keeping
+//! them apart — they merge into a single member (#1286).
+//!
+//! That reasoning is about the order of the two payloads **relative to each
+//! other**, once they meet. It says nothing about a member sweeping past a
+//! sibling that does not move and landing beyond it, where different reference
+//! bases now separate them:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "CAGAAGATGAATAA" + ("ACGT" x 64)
+//! g.[263_264insTG;264_265insTG]
+//!   the second member does not move; the first 3'-shifts 263 -> 265
+//!
+//!   intended  C A G A A G A T G T T G G A A T A A
+//!   emitted   C A G A A G A T T G G T G A A T A A
+//! ```
+//!
+//! Two well-formed members on distinct junctions, disjoint and in order — and
+//! denoting different bases. So a commuting sibling bounds this member at the
+//! junction it **settles** on, and only its post-normalization position counts,
+//! since where it started is exactly the order commuting makes unobservable.
+//!
+//! Landing on that bound can still be out of phase, and then the member may not
+//! go there either. The clamp walks back from the bound to the most 3' junction
+//! this member's payload is in phase with — `before_junction` always is, since
+//! that is where the shift began.
+//!
+//! **Not fully solved by this: see #1312.** When the payload is out of phase
+//! with the base between the two gaps, something downstream still merges them
+//! at one junction with a payload that is neither concatenation nor rotation.
+//! That case is pre-existing and denotes the same wrong sequence before and
+//! after this change.
+
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+/// Normalize and assert the output denotes the input's bases, projected through
+/// `hgvs_to_spdi` rather than the normalizer's own applier.
+fn assert_padded_preserving(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None;
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+
+    let from_input = denote(input).expect("input applies");
+    let from_output = denote(&output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
+}
+
+#[test]
+fn a_commuting_payload_does_not_sweep_past_a_sibling_that_stays() {
+    // #1308. `264_265insTG` does not move, so the first member may not shift
+    // from 263 to 265 across it.
+    let output =
+        assert_padded_preserving("CAGAAGATGAATAA", "NC_TEST.1:g.[263_264insTG;264_265insTG]");
+    assert_eq!(output, "NC_TEST.1:g.265_266insTTGG");
+}
+
+#[test]
+fn commuting_payloads_that_settle_together_still_merge() {
+    // The guard on the bound. Both members shift to the same junction in a
+    // poly-A tract, so the exemption must still let them meet and merge — one
+    // member, not two. Bounding at the sibling's *pre* junction would split it.
+    let output = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    assert_eq!(output, "NC_TEST.1:g.257_263A[9]");
+}
+
+#[test]
+fn three_commuting_payloads_still_reach_one_member() {
+    let output = assert_padded_preserving(
+        "AAAAAA",
+        "NC_TEST.1:g.[258_259insA;259_260insA;260_261insA]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.257_263A[10]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -174,6 +174,7 @@ mod issue_1297_cancelled_identity_member;
 mod issue_129_mt_circular_wraparound;
 mod issue_1301_adjacent_gap_member_order;
 mod issue_1304_junction_barrier_snapshot;
+mod issue_1308_commuting_payload_phase;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -8,11 +8,11 @@
 # are fixed and replay green; the second seed is still rejected by the strategy,
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
-# was removed in #1294, so it runs now.) #1297 is fixed too. #1308 is
-# not yet fixed and is the reason
-# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d, so
-# it is recorded here rather than running: it replays the moment the test is
-# enabled, which is what should gate enabling it.
+# was removed in #1294, so it runs now.) #1297 and #1308 are fixed too, and all
+# of the above now replay green. #1312 is not yet fixed and is the reason
+# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
+# is the one seed here that still fails, which is what should gate enabling the
+# test.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -20,3 +20,4 @@ cc 99d5d382a1a8f00844864743b0bed0ae12fe2bb8a21b902c99963e8902ab9f11 # #1292; shr
 cc d327f0bf8cf0b8efddb73821bcc4e210ec3c32c5df034d9d4607833b24a588d2 # #1296; shrinks to haplotype = IndelHaplotype { core: "AAAAAAATAATCGCAACAGAAG", events: [Insert { index: 15, bases: "A" }, Delete { index: 16 }, Insert { index: 17, bases: "AC" }] }
 cc a88766af1b7adaab791aaf8fda16997a3c66fe0d265cb1a57d9488f22a67ef5d # #1297; shrinks to haplotype = IndelHaplotype { core: "GCATGAAAAT", events: [Insert { index: 4, bases: "AA" }, Delete { index: 6 }, Insert { index: 7, bases: "A" }] }
 cc 03577f141460793dd01977d320da2524039646462483ad1e6df70eb4426e8213 # #1308; shrinks to haplotype = IndelHaplotype { core: "CAGAAGATGAATAA", events: [Insert { index: 6, bases: "TG" }, Insert { index: 7, bases: "TG" }] }
+cc 958acf3ea2005efa9eafd738606d0fd1d6bb0f586c918b926fd4d79d052f8d99 # #1312; shrinks to haplotype = IndelHaplotype { core: "TAAAACCA", events: [Insert { index: 3, bases: "AC" }, Insert { index: 4, bases: "AC" }] }


### PR DESCRIPTION
Closes #1308.

`clamp_sibling_crossing_junctions` exempts a sibling whose payload **commutes** with this member's, because `p ++ q == q ++ p` means the two have no observable order — and letting them reach one junction is better than keeping them apart, since they then merge into a single member (#1286).

That reasoning covers the order of the two payloads relative to *each other, once they meet*. It does not cover a member sweeping past a sibling that **stays put** and landing beyond it, where different reference bases now separate them:

```
reference  ("ACGT" x 64) + "CAGAAGATGAATAA" + ("ACGT" x 64)
in   NC_TEST.1:g.[263_264insTG;264_265insTG]
       the second member does not move; the first 3'-shifts 263 -> 265
out  NC_TEST.1:g.[264_265insTG;264_265dup]

  intended  C A G A A G A T G T T G G A A T A A
  emitted   C A G A A G A T T G G T G A A T A A
```

Silent: two well-formed members on distinct junctions, disjoint, in order, a fixed point, and the SPDI oracle applies it cleanly.

## The fix

Two parts.

1. **A commuting sibling bounds this member at the junction it *settles* on**, and may be met rather than only approached — landing on it is what lets the pair merge. Only its post-normalization position counts, since where it *started* is exactly the order commuting makes unobservable. Bounding at its pre-normalization junction instead would split `g.[258_259insA;259_260insA]` back into two members, which is what the exemption exists to avoid — pinned as a test, along with the three-insertion case.
2. **Landing on that bound can itself be out of phase.** The clamp walks back from the bound to the most 3' junction this member's payload is in phase with, reusing `payload_at_junction`'s rotation rule from #1298. `before_junction` always qualifies — that is where the shift began — so the walk terminates.

```
after:  NC_TEST.1:g.265_266insTTGG
```

A non-commuting sibling keeps the stricter rule: one position short, and from either snapshot.

## What this does **not** fix

**#1312**, filed from this work. When the payload is out of phase with the base *between* the two gaps, something downstream still merges the pair at one junction with a payload that is neither concatenation nor rotation:

```
core "TAAAACCA"
in   NC_TEST.1:g.[260_261insAC;261_262insAC]
out  NC_TEST.1:g.261_262insACCA
  intended  T A A A A C A A C C C A
  emitted   T A A A A A C C A C C A
```

**Pre-existing and unchanged in effect** — verified by reverting `src/normalize/merge.rs` to this branch's parent, where the same input emits `g.[261_262insAC;261_262dup]`, denoting the *same wrong sequence*. So this PR changes that case from two wrong members to one wrong member without correcting it, and #1312 says so explicitly. The new test module's header says so too.

## The confluence property

**It passes its committed 512-case budget for the first time** — all nine committed seeds replay green. It fails a 60,000-case soak on #1312, so it **stays `#[ignore]`d** and the reason names #1312. Enabling it on a budget that cannot reach the known-failing shape would prove nothing.

Ninth in the chain, each masked behind the one before it: #1286 → #1287 → #1290 → #1292 → #1296 → #1301 → #1304 → #1297 → #1308 → #1312.

## Verification

- `cargo nextest run --features dev` — **8934 pass**, 0 fail
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8934 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1309.
