### PR TITLE
ci: link the archive builds with mold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,13 @@ jobs:
     name: Build test archive
     runs-on: ubuntu-latest
     env:
+      # Link with mold. Set here rather than in `.cargo/config.toml` so it
+      # applies only to CI and stays visible next to the job that pays for it.
+      # Changing this value changes the cache key, because the key hashes this
+      # file — which is exactly what has to happen: RUSTFLAGS re-fingerprints
+      # every crate, and a cache keyed without it would restore artifacts built
+      # by a different linker and rebuild them all, every run.
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # The Test jobs build and LINK the integration-test binary. With full
       # debuginfo (dev/test profile default `debug = true`) the linked
       # `target/` exhausts the stock runner's ~14 GB free disk and the linker
@@ -353,6 +360,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}-test-archive
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
+      - name: Install mold
+        # A large share of both archive builds is linking, not codegen: this job
+        # links ~8 test binaries into a 93 MB archive, and the soak one links a
+        # single large `it` binary. mold is a drop-in replacement for GNU ld
+        # that parallelizes the link. Installed from apt rather than a
+        # third-party action so there is no unpinned dependency.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          mold --version
       - name: Build test archive
         # Compiles every test binary and packs them with their run metadata.
         run: cargo nextest archive --features dev --archive-file nextest.tar.zst
@@ -382,6 +399,9 @@ jobs:
   test-build-soak:
     name: Build soak archive (optimized)
     runs-on: ubuntu-latest
+    env:
+      # See `test-build` for why this lives here and why it moves the cache key.
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -418,6 +438,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}-soak
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-soak
+      - name: Install mold
+        # A large share of both archive builds is linking, not codegen: this job
+        # links ~8 test binaries into a 93 MB archive, and the soak one links a
+        # single large `it` binary. mold is a drop-in replacement for GNU ld
+        # that parallelizes the link. Installed from apt rather than a
+        # third-party action so there is no unpinned dependency.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          mold --version
       - name: Build soak archive
         # No `--features dev`. That feature pulls in `web-service` (axum, tokio,
         # tower, tracing) and `benchmark` (reqwest, rusqlite, tokio-postgres,


### PR DESCRIPTION
**Result: mold does not pay for itself here. Closing.**

Measured on run [30685719955](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/30685719955), attempt 2 — the cache-warm one. Both jobs compiled exactly **1** crate in that attempt, same as the baseline on #1303, so this is apples-to-apples: the difference is codegen for `ferro-hgvs` plus linking, and nothing else.

Comparing the build step alone:

| build step | GNU ld (#1303) | mold | delta |
| --- | --- | --- | --- |
| `Build test archive` | 58s | 57s | -1s |
| `Build soak archive (optimized)` | 122s | 114s | -8s |
| *`Install mold` step* | - | 15-19s | +15-19s |

Whole-job durations, which is what actually reaches the critical path:

| | GNU ld | mold |
| --- | --- | --- |
| `Build test archive` | 85s | 110s |
| `Build soak archive (optimized)` | 136s | 153s |
| critical path | **175s** | 196s |

mold saves 1-8s of link time and costs 15-19s to install, so it is a net loss of about 21s on the critical path.

## What this establishes

**These builds are codegen-bound, not link-bound.** That is consistent with the other negative result from this campaign: compile time was flat at 61.3s / 69.1s / 61.9s across opt-levels 1 / 2 / 3, which is also what you would expect if codegen of `ferro-hgvs` itself dominates. Two independent measurements now point the same way.

Two reasons mold had little to grab, in hindsight:

- `test-build` already sets `CARGO_PROFILE_TEST_DEBUG=0`. Heavy debug info is exactly what mold is best at chewing through, and it has already been stripped.
- In the warm state these jobs compile one crate, so the remaining time is `ferro-hgvs` codegen — which no linker can touch.

Shipping a cheaper install (a prebuilt tarball instead of apt, ~2s) would make it roughly break-even on `test-build` and about 6s better on the soak archive. That is inside run-to-run noise on these runners, and not worth an extra moving part in CI for.

Recorded rather than silently dropped, so the next person asking "have we tried a faster linker?" has the numbers.
