### PR TITLE
fix(normalize): repair del+dup collisions on the non-coding axis

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4011,10 +4011,22 @@ fn shift_signed(base: &mut i64, delta: i64) -> bool {
 /// (`g.[261_262del;262_263insA;…]` reduces to `g.[261del;…]`), so the loop has
 /// to see the re-spelled form to settle on that reduction.
 ///
-/// Genomic axes only. On `c.`/`n.`/`r.` the 1-based coordinate is not a direct
-/// offset into the fetched sequence, and the conversion this would need already
-/// exists only inside `collapse_overlapping_cis_edits`; rather than duplicate
-/// it, a transcript-axis collision is left alone.
+/// Runs on every axis whose 1-based coordinate is a direct offset into the
+/// sequence the provider serves — the genomic axes and `n.`.
+///
+/// That is the whole requirement, because the pass reads the duplicated bases
+/// over the member's own coordinates. `axis_frame` states which axes qualify:
+/// it returns `delta: 0` for `Genome`, `Mt` **and** `Tx`, since a non-coding
+/// transcript's positions index its sequence directly, exactly as a contig's
+/// do. The original gate said "genomic axes only", which was over-broad — it
+/// grouped `n.` with the CDS-relative axes it does not resemble (#1284).
+///
+/// `c.` and `r.` are still refused. Those are CDS-relative (`delta:
+/// cds_start - 1`) and the axis has no zero, so `c.-1` is `cds_start - 1`
+/// rather than `cds_start - 2`: a single delta is off by one below the CDS
+/// start, and applying one naively was measured to re-spell a duplication from
+/// the wrong bases and to move answers that were already correct. That
+/// conversion is the remaining half of #1284 and is not attempted here.
 pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
     members: &mut [HgvsVariant],
     phase: AllelePhase,
@@ -4027,7 +4039,10 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
     let Some(kind) = cis_kind_of(&members[0]) else {
         return;
     };
-    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
+    // `Tx` belongs here and `Cds`/`Rna` do not: see the doc comment. The test
+    // is "does this axis index the served sequence directly", which is exactly
+    // the axes `axis_frame` gives `delta: 0`.
+    if !matches!(kind, CisKind::Genome | CisKind::Mt | CisKind::Tx) {
         return;
     }
     let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
@@ -4588,9 +4603,27 @@ fn respell_at_gap(
                 start,
                 end,
             ) && {
-                m.loc_edit.edit = Mu::Certain(edit);
+                m.loc_edit.edit = Mu::Certain(edit.clone());
                 true
             }
+        }
+        // `n.` is a signed axis with no zero, so a gap that would name `n.0` is
+        // refused — the same guard `place_signed` applies for `respell_as`.
+        // Otherwise it behaves exactly as the genomic arms: the position is a
+        // direct offset into the transcript sequence (see the doc comment).
+        HgvsVariant::Tx(t) => {
+            gap_start != 0
+                && gap_end != 0
+                && set_endpoints(
+                    &mut t.loc_edit.location,
+                    |p: &mut TxPos, v: i64| p.base = v,
+                    gap_start,
+                    gap_end,
+                )
+                && {
+                    t.loc_edit.edit = Mu::Certain(edit);
+                    true
+                }
         }
         _ => false,
     };

--- a/tests/it/issue_1284_transcript_axis_collision.rs
+++ b/tests/it/issue_1284_transcript_axis_collision.rs
@@ -1,0 +1,114 @@
+//! The del+dup collision repair reaches the non-coding transcript axis.
+//!
+//! `respell_colliding_duplications` (#1259) resolves the #1263 collision: a
+//! duplication whose junction lands inside a sibling's span, which ferro's own
+//! parser rejects as a self-cancelling allele. It was gated to
+//! `CisKind::Genome | CisKind::Mt`, so on the transcript axes `normalize` still
+//! emitted a description `parse_hgvs` refuses:
+//!
+//! ```text
+//! reference   ATGGCAACAGCGTAAACGGCTAGCTAGCTA        (the g. motif at n.4)
+//! in    n.[7_8del;9_10insA;11delinsAC]
+//! out   n.[8_9del;9dup;10_11insA]
+//!       Parse error: Self-cancelling allele: variants at index 0 (del) and
+//!       1 (dup) describe overlapping reference positions
+//! ```
+//!
+//! #1284 records why lifting that gate looked hard: the repair reads the
+//! duplicated bases straight out of the provider over the member's own
+//! coordinates, and the `c.` axis does not index the transcript sequence —
+//! `c.-1` is `cds_start - 1`, not `cds_start - 2`, so a naive `delta` is off by
+//! one below the CDS start, and wiring it up that way was tried and reverted.
+//!
+//! That blocker is specific to the **CDS-relative** axes. `n.` is
+//! transcript-relative: `axis_frame` already returns `delta: 0` for
+//! `CisKind::Tx`, exactly as it does for the genomic axes, so the member's
+//! coordinates index the fetched sequence directly and the repair needs no
+//! conversion at all. Admitting `Tx` therefore closes the whole non-coding
+//! transcript axis without touching the discontinuity.
+//!
+//! `c.` and `r.` are still refused, and #1284 stays open for them.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// A transcript carrying the `GCAACAGCGTAAAC` motif of the genomic #1263
+/// reproducer at position 4, so the `n.` and `g.` cases describe the same bases.
+const TX: &str = "ATGGCAACAGCGTAAACGGCTAGCTAGCTA";
+
+fn normalize(provider: &MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider.clone());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse `{input}`: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize `{input}`: {e}"))
+        .to_string()
+}
+
+/// Assert `input` normalizes to `expected`, that the result is one the parser
+/// accepts, and that it is a fixed point.
+///
+/// The re-parse is the load-bearing half: the defect is not a wrong spelling
+/// but an **unparseable** one, so a test that only compared strings would still
+/// pass against the broken output if someone pinned it.
+fn assert_repairs_to(provider: &MockProvider, input: &str, expected: &str) {
+    let once = normalize(provider, input);
+    assert_eq!(once, expected, "normalizing `{input}`");
+    let reparsed = parse_hgvs(&once)
+        .unwrap_or_else(|e| panic!("`{input}` -> `{once}`, which ferro cannot re-parse: {e}"));
+    let twice = Normalizer::new(provider.clone())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalizing `{once}`: {e}"))
+        .to_string();
+    assert_eq!(twice, once, "`{input}` -> `{once}` is not a fixed point");
+}
+
+#[test]
+fn a_noncoding_del_dup_collision_is_repaired() {
+    // The #1284 reproduction on the axis that needs no coordinate conversion.
+    let provider = SyntheticBuilder::noncoding(TX, Strand::Plus).build();
+    assert_repairs_to(
+        &provider,
+        "NR_TEST.1:n.[7_8del;9_10insA;11delinsAC]",
+        "NR_TEST.1:n.[8del;10_11insA]",
+    );
+}
+
+#[test]
+fn the_repair_preserves_the_sequence_the_allele_denotes() {
+    // The repair rewrites the members, so the binding check is not the spelling
+    // but the bases: applied to the transcript, input and output must agree.
+    // `apply_with` converts each member through `hgvs_to_spdi` — a different
+    // code path from the repair — and declines an overlapping description, so
+    // the pre-fix output has no resulting sequence at all rather than a wrong
+    // one.
+    let provider = SyntheticBuilder::noncoding(TX, Strand::Plus).build();
+    for input in [
+        "NR_TEST.1:n.[7_8del;9_10insA;11delinsAC]",
+        "NR_TEST.1:n.[7_8del;11delinsAC]",
+    ] {
+        let output = normalize(&provider, input);
+        let from_input = crate::common::cis_apply_oracle::apply_with(&provider, TX, input)
+            .unwrap_or_else(|| panic!("`{input}` does not apply"));
+        let from_output = crate::common::cis_apply_oracle::apply_with(&provider, TX, &output)
+            .unwrap_or_else(|| {
+                panic!("`{input}` -> `{output}`, which has no well-defined resulting sequence")
+            });
+        assert_eq!(
+            from_output, from_input,
+            "`{input}` -> `{output}` changed the sequence"
+        );
+    }
+}
+
+#[test]
+fn the_simple_two_member_collision_is_repaired_too() {
+    // The shorter route to the same collision, without the middle insertion.
+    let provider = SyntheticBuilder::noncoding(TX, Strand::Plus).build();
+    assert_repairs_to(
+        &provider,
+        "NR_TEST.1:n.[7_8del;11delinsAC]",
+        "NR_TEST.1:n.[8C>G;10del]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -165,6 +165,7 @@ mod issue_1254_sibling_crossing_shift;
 mod issue_1261_cis_member_order;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
+mod issue_1284_transcript_axis_collision;
 mod issue_1286_shared_junction_merge;
 mod issue_1287_repeat_span_junction;
 mod issue_1290_junction_crosses_junction;


### PR DESCRIPTION
Closes part of #1284 — the `n.` axis. `c.` and `r.` are deliberately left, and the issue stays open for them.

## The defect

`respell_colliding_duplications` (#1259) resolves the #1263 collision — a duplication whose junction lands inside a sibling's span, which ferro's own parser rejects. It was gated to `CisKind::Genome | CisKind::Mt`, so on the transcript axes normalization emitted a description it cannot read back:

```text
reference   ATGGCAACAGCGTAAACGGCTAGCTAGCTA
in    n.[7_8del;9_10insA;11delinsAC]
out   n.[8_9del;9dup;10_11insA]
      Parse error: Self-cancelling allele: variants at index 0 (del) and 1 (dup)
      describe overlapping reference positions
```

The same edit on `g.` reaches `g.[261del;263_264insA]` and is a fixed point — pinned as one by `every_sibling_pass_is_idempotent_on_a_compound_allele`. Only the axis differed.

## Why `n.` and not `c.`/`r.`

#1284's "why the obvious extension does not work" is about the CDS-start discontinuity: the pass reads the duplicated bases over the member's own coordinates, and on a CDS-relative axis those do not index the served sequence — `c.-1` is `cds_start - 1`, not `cds_start - 2`, so a single delta is off by one below the CDS start. That was tried and reverted.

That blocker is specific to the CDS-relative axes. `n.` is transcript-relative: `axis_frame` already returns `delta: 0` for `CisKind::Tx`, exactly as for the genomic axes. So the whole non-coding axis is reachable with **no conversion at all**, and the original "genomic axes only" gate was over-broad — it grouped `n.` with axes it does not resemble.

## Two gates, not one

Worth knowing for whoever does `c.`/`r.`: the visible kind check is not the only gate. `respell_at_gap` also matched only `Genome`/`Mt` and silently reverted everything else, so lifting the first alone changed nothing — the tests still failed, byte-identically. Its new `Tx` arm refuses a gap that would name `n.0`, the guard `place_signed` already applies for `respell_as` on the same axis.

## Verification

8909 pass, and **8909 with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`**. That matters here specifically: #1284 warns that #1259 armed the re-parse oracle on an invariant known-false for the transcript axes, so a future transcript-axis test would panic and abort the run rather than fail with a diff. This narrows that exposure to `c.`/`r.`.

The new tests assert the output re-parses and is a fixed point, not just that it matches a string — the defect is an unparseable spelling, so a string-only test would still pass if someone pinned the broken output. One test checks sequence preservation through `hgvs_to_spdi`, a different code path from the repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variant normalization for transcript-relative (`n.`) duplication and deletion collisions.
  * Transcript duplications are now converted to equivalent literal insertions when sequence information is available.
  * Added validation for signed transcript coordinates, including rejection of invalid `n.0` endpoints.
  * Preserved compatibility and sequence accuracy across repeated normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->