### PR TITLE
fix(normalize): test commuting against the payload a member lands with

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3547,11 +3547,36 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
                 if junction <= before_junction || junction > after_junction {
                     return None;
                 }
-                let commutes = match (&payload, junction_payload(variant, kind, s, provider)) {
-                    (Some(mine), Some(theirs)) => payloads_commute(mine, &theirs),
-                    // A payload that cannot be read blocks: refusing to cross is
-                    // the conservative answer when the reordering cannot be
-                    // shown to be harmless.
+                // Commuting is tested against the payload this member would
+                // carry **at that junction**, not the one it carries now. The
+                // two differ: landing there rotates the payload into phase, and
+                // a rotation is exactly what can destroy the identity —
+                // `260_261insAC` moved onto junction 261 becomes `insCA`, and
+                // `CA` does not commute with the `AC` already sitting there,
+                // though `AC` and `AC` did. Sharing a junction with a payload it
+                // does not commute with leaves the pair's order undefined, and
+                // the merge downstream concatenates them in rendered order:
+                // `g.[260_261insAC;261_262insAC]` became `g.261_262insACCA`,
+                // denoting different bases (#1312).
+                let commutes = match (
+                    payload
+                        .as_ref()
+                        .and_then(|mine| {
+                            payload_at_junction(
+                                mine,
+                                after_junction,
+                                junction,
+                                &a.provider_key,
+                                provider,
+                            )
+                        })
+                        .as_deref(),
+                    junction_payload(variant, kind, s, provider),
+                ) {
+                    (Some(landed), Some(theirs)) => payloads_commute(landed, &theirs),
+                    // A payload that cannot be read, or cannot legally reach the
+                    // junction, blocks: refusing to cross is the conservative
+                    // answer when the reordering cannot be shown to be harmless.
                     _ => false,
                 };
                 match commutes {

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,11 +60,11 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1312, equal-payload insertions at adjacent gaps merging
-//!   out of phase with the base between them. It found #1286, #1287, #1290,
-//!   #1292, #1296, #1301, #1304, #1297 and #1308 first, all now fixed, each
-//!   masked behind the one before it; see its doc comment for the history and
-//!   the live reproduction.
+//!   because it finds #1316, two adjacent-gap insertions each re-spelling as
+//!   the same tract-wide repeat. It found #1286, #1287, #1290, #1292, #1296,
+//!   #1301, #1304, #1297, #1308 and #1312 first, all now fixed, each masked
+//!   behind the one before it; see its doc comment for the history and the live
+//!   reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -788,30 +788,36 @@ proptest! {
     /// sharing a span rendered out of order; #1304, a junction barrier reading a
     /// moved sibling's payload from the wrong snapshot; and #1297, a member that
     /// cancelled and was left as an identity member overlapping the repeat that
-    /// absorbed it, and #1308, a commuting payload sweeping past a sibling that
-    /// stays put. The live failure is the tenth it has found, **#1312**:
+    /// absorbed it; #1308, a commuting payload sweeping past a sibling that
+    /// stays put; and #1312, commuting tested against a payload the member no
+    /// longer carries once it lands. The live failure is the eleventh it has
+    /// found, **#1316**:
     ///
     /// ```text
-    /// core "TAAAACCA", insert "AC" after index 3 and after index 4
-    ///   g.[260_261insAC;261_262insAC] -> g.261_262insACCA
-    ///     intended  T A A A A C A A C C C A
-    ///     emitted   T A A A A A C C A C C A
+    /// core "CAGCCAGTCAGCGCATCAG", insert "AA" after 4 and 5, delete index 12
+    ///   g.[261_262insAA;262_263insAA;269del] -> g.[262A[3];262A[3];269del]
+    ///     two identical repeats over one tract
     /// ```
     ///
-    /// `AC` is out of phase with the `A` between the two gaps, so neither member
-    /// may move onto the other's junction — yet they merge there anyway, with a
-    /// payload that is neither concatenation nor rotation. This one survives the
-    /// 512-case budget below and is only reachable in a soak, which is exactly
-    /// why enabling the test on that budget would prove nothing.
+    /// The seed's own shrink is smaller than that and drops the deletion
+    /// entirely — `core "ACAGCCAGTCAGCGCATCAG"` with `insAA` after 1 and 2,
+    /// giving `g.[257A[3];259A[3]]` — so the deletion is incidental to the
+    /// defect. The three-event form is kept here because it is the shape #1316
+    /// was filed from.
     ///
-    /// Each of the nine was masked behind the one before it, which is the point
+    /// The repeat-form analogue of #1286, which fixed the same shape spelled as
+    /// duplications. It survives the 512-case budget below and is only reachable
+    /// in a soak, which is exactly why enabling the test on that budget would
+    /// prove nothing.
+    ///
+    /// Each of the ten was masked behind the one before it, which is the point
     /// of keeping this committed rather than deleting it until it can pass.
     ///
     /// Enabling this test was #1292's acceptance criterion. #1292 is fixed and
     /// pinned — by `issue_1292_junction_payload_rotation` and by the `99d5d382`
     /// seed below, which replays green — but the criterion could not be met
     /// with it, because the property's next two failures were behind it.
-    /// Enabling now belongs to **#1312**, whose seed `958acf3e` is committed
+    /// Enabling now belongs to **#1316**, whose seed `23c33174` is committed
     /// below — so taking the ignore off replays it immediately, which is what
     /// should gate taking it off. Absent that seed this passes the 512-case
     /// budget and fails a 30,000-case soak on the same shape, so switching it
@@ -820,7 +826,7 @@ proptest! {
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1312, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1316, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1020,13 +1026,13 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1312: `AC` is out of phase with the `A` between the two gaps, so neither
-    // member may move onto the other's junction -- yet they merge there anyway,
-    // with a payload that is neither concatenation nor rotation.
+    // #1316: two identical repeats settle over one tract and the deletion is
+    // dropped -- the repeat-form analogue of #1286, which fixed the same shape
+    // spelled as duplications.
     let (core, input, issue) = (
-        "TAAAACCA",
-        "NC_TEST.1:g.[260_261insAC;261_262insAC]",
-        "#1312",
+        "CAGCCAGTCAGCGCATCAG",
+        "NC_TEST.1:g.[261_262insAA;262_263insAA;269del]",
+        "#1316",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1308_commuting_payload_phase.rs
+++ b/tests/it/issue_1308_commuting_payload_phase.rs
@@ -29,11 +29,9 @@
 //! this member's payload is in phase with — `before_junction` always is, since
 //! that is where the shift began.
 //!
-//! **Not fully solved by this: see #1312.** When the payload is out of phase
-//! with the base between the two gaps, something downstream still merges them
-//! at one junction with a payload that is neither concatenation nor rotation.
-//! That case is pre-existing and denotes the same wrong sequence before and
-//! after this change.
+//! The bound must be tested against the payload this member would carry **at**
+//! that junction, not the one it carries now — landing there rotates it, and a
+//! rotation can destroy the commuting identity. That half is #1312.
 
 use crate::common::synthetic::{padded, SyntheticBuilder};
 use ferro_hgvs::spdi::hgvs_to_spdi;
@@ -90,7 +88,10 @@ fn a_commuting_payload_does_not_sweep_past_a_sibling_that_stays() {
     // from 263 to 265 across it.
     let output =
         assert_padded_preserving("CAGAAGATGAATAA", "NC_TEST.1:g.[263_264insTG;264_265insTG]");
-    assert_eq!(output, "NC_TEST.1:g.265_266insTTGG");
+    // The input's own spelling. Landing on the sibling's junction would rotate
+    // this member's `TG` into `GT`, which does not commute with the `TG` already
+    // there, so the pair stays apart rather than merging (#1312).
+    assert_eq!(output, "NC_TEST.1:g.[263_264insTG;264_265insTG]");
 }
 
 #[test]

--- a/tests/it/issue_1312_landed_payload_commutes.rs
+++ b/tests/it/issue_1312_landed_payload_commutes.rs
@@ -1,0 +1,89 @@
+//! Commuting is tested against the payload a member would carry **at** the
+//! junction it lands on, not the one it carries now.
+//!
+//! `clamp_sibling_crossing_junctions` lets a member meet a sibling whose payload
+//! commutes with its own, because sharing a junction is well-defined there and
+//! the pair then merges (#1286, #1308). Landing rotates the payload into phase —
+//! and a rotation is exactly what can destroy the commuting identity:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "TAAAACCA" + ("ACGT" x 64)
+//! g.[260_261insAC;261_262insAC]
+//!   `AC` and `AC` commute, so the first member was allowed onto junction 261
+//!   at 261 its payload is `CA`, and `CA ++ AC != AC ++ CA`
+//!
+//!   intended  T A A A A C A A C C C A
+//!   emitted   T A A A A A C C A C C A
+//! ```
+//!
+//! Two members then share a junction with no defined order between them, and the
+//! merge downstream concatenates them in *rendered* order — producing `ACCA`,
+//! which is neither payload nor any rotation of the pair.
+//!
+//! Testing the landed payload keeps them apart: the bound falls back to one
+//! position short, and the allele renders as its input does.
+
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+/// Normalize and assert the output denotes the input's bases, projected through
+/// `hgvs_to_spdi` rather than the normalizer's own applier.
+fn assert_padded_preserving(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let normalizer = Normalizer::new(provider.clone());
+    let reference = padded(core);
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let denote = |descriptor: &str| -> Option<String> {
+        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        let mut triples = Vec::new();
+        for member in &members {
+            triples.push(hgvs_to_spdi(member, &provider).ok()?);
+        }
+        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        let mut edited = reference.as_bytes().to_vec();
+        let mut claimed = reference.len();
+        for triple in &triples {
+            let start = usize::try_from(triple.position).ok()?;
+            let end = start.checked_add(triple.deletion.len())?;
+            if end > claimed {
+                return None;
+            }
+            edited.splice(start..end, triple.insertion.bytes());
+            claimed = start;
+        }
+        String::from_utf8(edited).ok()
+    };
+
+    let from_input = denote(input).expect("input applies");
+    let from_output = denote(&output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` changed the sequence"
+    );
+    output
+}
+
+#[test]
+fn a_rotation_that_breaks_commuting_keeps_the_pair_apart() {
+    // #1312. `AC` at 260 becomes `CA` at 261, which does not commute with the
+    // `AC` already there, so the member may not land on that junction.
+    let output = assert_padded_preserving("TAAAACCA", "NC_TEST.1:g.[260_261insAC;261_262insAC]");
+    assert_eq!(output, "NC_TEST.1:g.[260_261insAC;261_262insAC]");
+}
+
+#[test]
+fn a_rotation_that_preserves_commuting_still_lets_them_merge() {
+    // The guard. In a poly-A tract every rotation of `A` is `A`, so the landed
+    // payload still commutes and the pair merges into one member.
+    let output = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    assert_eq!(output, "NC_TEST.1:g.257_263A[9]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -175,6 +175,7 @@ mod issue_129_mt_circular_wraparound;
 mod issue_1301_adjacent_gap_member_order;
 mod issue_1304_junction_barrier_snapshot;
 mod issue_1308_commuting_payload_phase;
+mod issue_1312_landed_payload_commutes;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -8,11 +8,11 @@
 # are fixed and replay green; the second seed is still rejected by the strategy,
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
-# was removed in #1294, so it runs now.) #1297 and #1308 are fixed too, and all
-# of the above now replay green. #1312 is not yet fixed and is the reason
-# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
-# is the one seed here that still fails, which is what should gate enabling the
-# test.
+# was removed in #1294, so it runs now.) #1297, #1308 and #1312 are fixed
+# too, and all of the above now replay green. #1316 is not yet fixed and is the
+# reason `an_indel_haplotype_normalizes_to_its_own_sequence` is still
+# `#[ignore]`d — it is the one seed here that still fails, which is what should
+# gate enabling the test.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -21,3 +21,4 @@ cc d327f0bf8cf0b8efddb73821bcc4e210ec3c32c5df034d9d4607833b24a588d2 # #1296; shr
 cc a88766af1b7adaab791aaf8fda16997a3c66fe0d265cb1a57d9488f22a67ef5d # #1297; shrinks to haplotype = IndelHaplotype { core: "GCATGAAAAT", events: [Insert { index: 4, bases: "AA" }, Delete { index: 6 }, Insert { index: 7, bases: "A" }] }
 cc 03577f141460793dd01977d320da2524039646462483ad1e6df70eb4426e8213 # #1308; shrinks to haplotype = IndelHaplotype { core: "CAGAAGATGAATAA", events: [Insert { index: 6, bases: "TG" }, Insert { index: 7, bases: "TG" }] }
 cc 958acf3ea2005efa9eafd738606d0fd1d6bb0f586c918b926fd4d79d052f8d99 # #1312; shrinks to haplotype = IndelHaplotype { core: "TAAAACCA", events: [Insert { index: 3, bases: "AC" }, Insert { index: 4, bases: "AC" }] }
+cc 23c331742c910e4d748997c1e4e9d988fe3b4d032c3f60b1e995c9d052f3c720 # #1316; shrinks to haplotype = IndelHaplotype { core: "ACAGCCAGTCAGCGCATCAG", events: [Insert { index: 1, bases: "AA" }, Insert { index: 2, bases: "AA" }] }


### PR DESCRIPTION
Closes #1312.

`clamp_sibling_crossing_junctions` lets a member meet a sibling whose payload **commutes** with its own: sharing a junction is well-defined there, and the pair then merges (#1286, #1308).

It tested commuting against the payload the member carries **now**. Landing on that junction rotates the payload into phase — and a rotation is exactly what can destroy the identity:

```
reference  ("ACGT" x 64) + "TAAAACCA" + ("ACGT" x 64)
in   NC_TEST.1:g.[260_261insAC;261_262insAC]

  `AC` and `AC` commute, so the first member was allowed onto junction 261
  at 261 its payload is `CA`, and `CA ++ AC != AC ++ CA`

out  NC_TEST.1:g.261_262insACCA
  intended  T A A A A C A A C C C A
  emitted   T A A A A A C C A C C A
```

Two members then shared a junction with **no order defined between them**, and the merge downstream concatenated them in *rendered* order — producing `ACCA`, which is neither payload nor any rotation of the pair. Silent: one well-formed member, a fixed point, parses, applies cleanly.

## The fix

Rotate first, then test. The commuting check now runs against `payload_at_junction(mine, …, junction, …)` — what this member would actually carry there. When that does not commute, the bound falls back to one position short, exactly as for any non-commuting sibling, and the pair stays apart.

```
after:  NC_TEST.1:g.[260_261insAC;261_262insAC]     (the input's own spelling)
```

This is a hole in **my own #1308 fix**, which introduced the "land on the sibling's settled junction" rule without re-checking commuting after the rotation that landing implies.

## One expectation updated

`issue_1308_commuting_payload_phase::a_commuting_payload_does_not_sweep_past_a_sibling_that_stays` expected `g.265_266insTTGG`; it now expects the input spelling `g.[263_264insTG;264_265insTG]`. `TG` landing on the sibling's junction becomes `GT`, which does not commute with the `TG` already there, so the merge this rule refuses no longer happens. The form it replaced was sequence-correct but reached through a landing that is not generally sound. That test is from #1313, not a long-standing blessed expectation.

The guard is pinned alongside it: in a poly-A tract every rotation of `A` is `A`, so the landed payload still commutes and `g.[258_259insA;259_260insA]` still merges to `g.257_263A[9]`.

## What is behind it

**#1316**, filed from this work: two adjacent-gap insertions each re-spell as the *same* tract-wide repeat, giving `g.[259A[3];259A[3]]` — two identical members over one tract, with the allele's deletion gone. It is the repeat-form analogue of #1286, which fixed the same shape spelled as duplications. Loud (the apply oracle declines it), and reachable only in a soak.

Tenth in the chain, each masked behind the one before it: #1286 → #1287 → #1290 → #1292 → #1296 → #1301 → #1304 → #1297 → #1308 → #1312 → #1316.

## Verification

- `cargo nextest run --features dev` — **8936 pass**, 0 fail, **0 aborts** (checked for `SIGABRT`/`SIGSEGV`/`TIMEOUT`, not just `FAIL`)
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 …` — 8936 pass under both oracles
- `cargo fmt --all` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- The 276,480-case sweep holds its residual at 0
- Commit is signed

Conformance axis tests were **not** run: they need the prepared reference, and both `/Volumes/scratch-00001` and `/Volumes/backup-00001` are absent on this machine.

Stacked on #1313.
