### PR TITLE
fix(normalize): combine two repeats that grew one tract

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2,7 +2,7 @@
 //!
 //! See `docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md`.
 
-use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, RepeatCount, Sequence};
 use crate::hgvs::interval::{Interval, UncertainBoundary};
 use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::uncertainty::Mu;
@@ -3377,6 +3377,168 @@ pub(crate) fn demote_repeats_spanning_siblings(
             continue;
         }
         respell_as(&mut after[i], kind, a.region, start, a.end, source);
+    }
+}
+
+/// The bases a repeat added to its own tract, spelled as an insertion payload,
+/// together with the unit it repeats.
+///
+/// A tract is tandem, so appending the added bases at its 3' end is just the
+/// unit repeated — and the 3' end is where the tract's own shift rule places
+/// them anyway. `g.262A[3]` over the one-base `A` at 262 added two copies, so
+/// its payload is `AA` and its junction is 262.
+///
+/// `None` unless the repeat is a plain exact count over a whole number of units
+/// that actually grew: a genotype count (`A[6][1]`), an inexact count, a VEP
+/// trailing sequence, a partial unit, or a tract that lost copies all describe
+/// something this equivalence does not cover, and fabricating a payload for
+/// them would state bases nothing asserted.
+fn repeat_growth_as_insertion(
+    variant: &HgvsVariant,
+    kind: CisKind,
+    span: &MemberSpan,
+) -> Option<(Vec<Base>, Vec<Base>)> {
+    let NaEdit::Repeat {
+        sequence: Some(unit),
+        count: RepeatCount::Exact(count),
+        additional_counts,
+        trailing: None,
+    } = cis_axis_parts(variant, kind)?.4
+    else {
+        return None;
+    };
+    if !additional_counts.is_empty() {
+        return None;
+    }
+    let unit = unit.bases();
+    let unit_len = i64::try_from(unit.len()).ok()?;
+    let tract = span.end - span.start + 1;
+    if unit_len <= 0 || tract <= 0 || tract % unit_len != 0 {
+        return None;
+    }
+    let added = i64::try_from(*count).ok()? * unit_len - tract;
+    if added <= 0 {
+        return None;
+    }
+    let payload: Vec<Base> = unit
+        .iter()
+        .copied()
+        .cycle()
+        .take(usize::try_from(added).ok()?)
+        .collect();
+    Some((payload, unit.to_vec()))
+}
+
+/// Re-spell two or more repeats that grew the *same* tract as the insertions
+/// they stand for, so the junction merge can combine their copies.
+///
+/// Each member is re-spelled per member, with no sibling context, and a member
+/// that grows a tract is spelled as a copy count over the whole tract. Two
+/// members that grew one tract therefore both name it, and the pair claims it
+/// twice — an overlap with no resulting sequence at all:
+///
+/// ```text
+/// reference  ("ACGT" x 64) + "CAGCCAGTCAGCGCATCAG" + ("ACGT" x 64)
+///            the `A` at 262 is a one-base tract, between `C` at 261 and `G` at 263
+///
+/// g.[261_262insAA;262_263insAA]  ->  g.[262A[3];262A[3]]
+///   each member grew the tract to three, and says so over the same one base
+/// ```
+///
+/// This is the repeat-form analogue of #1286, and nothing else catches it. A
+/// repeat has no junction (`junction_of` returns `None` for `NaEdit::Repeat`),
+/// so [`coalesce_members_at_one_junction`] never considers the pair; and
+/// [`demote_repeats_spanning_siblings`] re-spells a repeat back into a deletion
+/// or a duplication *over the tract*, neither of which can express two bases
+/// added to a one-base tract — it declines exactly this shape.
+///
+/// A repeat's growth is expressible, as an insertion at the tract's 3' junction.
+/// Emitting that gives both members a junction and the existing merge finishes
+/// the job: `g.262_263insAA` twice, coalesced to `insAAAA`, re-spelled `g.262A[5]`
+/// on the next pass (#1316).
+///
+/// Only a whole *group* sharing one tract is re-spelled, and only when every
+/// member of it yields a payload — a lone repeat is the correct spelling for a
+/// member with no sibling on its tract, and half a group demoted would trade one
+/// overlap for another. Requiring a shared unit as well as a shared span makes
+/// the payloads powers of one word, so they commute and the coalesce below
+/// cannot decline on order-ambiguity after this pass has already rewritten them.
+///
+/// Runs late, immediately before that coalesce, and **not** inside
+/// [`demote_repeats_spanning_siblings`] despite the kinship: the demotion there
+/// preserves the barrier a repeat presents to a sibling's shift, because a
+/// deletion and a duplication both still block one. An insertion claims no
+/// bases and blocks nothing, so demoting early released a sibling deletion that
+/// #1296 had deliberately clamped out of the tract. Two repeats on one tract
+/// have no such barrier to preserve — they occupy the same bases — so the
+/// rewrite is safe here and only here.
+pub(crate) fn demote_coincident_tract_repeats(
+    members: &mut [HgvsVariant],
+    phase: AllelePhase,
+    uncertain: bool,
+) {
+    if phase != AllelePhase::Cis || uncertain || members.len() < 2 {
+        return;
+    }
+    let Some(kind) = cis_kind_of(&members[0]) else {
+        return;
+    };
+    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
+        return;
+    }
+    let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
+    // A member participates only if it is a repeat that grew its tract by a
+    // whole number of units; `growth` carries the payload and the unit.
+    let growth: Vec<Option<(Vec<Base>, Vec<Base>)>> = (0..members.len())
+        .map(|i| {
+            let span = spans[i].as_ref()?;
+            repeat_growth_as_insertion(&members[i], kind, span)
+        })
+        .collect();
+
+    // Group by the tract itself — accession, region, span — plus the unit.
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for i in 0..members.len() {
+        let (Some(span), Some((_, unit))) = (spans[i].as_ref(), growth[i].as_ref()) else {
+            continue;
+        };
+        match groups.iter_mut().find(|at| {
+            let first = at[0];
+            spans[first].as_ref().is_some_and(|s| {
+                s.accession == span.accession
+                    && s.region == span.region
+                    && s.start == span.start
+                    && s.end == span.end
+            }) && growth[first].as_ref().is_some_and(|(_, u)| u == unit)
+        }) {
+            Some(at) => at.push(i),
+            None => groups.push(vec![i]),
+        }
+    }
+
+    for at in &groups {
+        if at.len() < 2 {
+            continue;
+        }
+        // All or nothing. `respell_at_gap` reverts a member it cannot place, and
+        // a group left half re-spelled is one insertion overlapping one repeat —
+        // the same defect in a new spelling, and one no later pass looks for.
+        let originals: Vec<HgvsVariant> = at.iter().map(|&i| members[i].clone()).collect();
+        let rewritten = at.iter().enumerate().all(|(slot, &i)| {
+            let (Some(span), Some((payload, _))) = (spans[i].as_ref(), growth[i].as_ref()) else {
+                return false;
+            };
+            let edit = NaEdit::Insertion {
+                sequence: InsertedSequence::Literal(Sequence::new(payload.clone())),
+            };
+            respell_at_gap(&mut members[i], kind, span, span.end, edit);
+            members[i] != originals[slot]
+        });
+        if !rewritten {
+            for (slot, &i) in at.iter().enumerate() {
+                members[i] = originals[slot].clone();
+            }
+        }
     }
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2666,6 +2666,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 allele.uncertain,
                 &self.provider,
             );
+            // Then, so the coalesce below can see them: two members that each
+            // grew the SAME tract are both spelled as a copy count over it, and
+            // a repeat carries no junction — so the pair claims one tract twice
+            // and the coalesce never considers it (#1316). Re-spell each as the
+            // insertion it stands for, which restores the junction. Deliberately
+            // after the clamps rather than inside
+            // `demote_repeats_spanning_siblings`: an insertion blocks no
+            // sibling's shift, so demoting a repeat before the clamps would
+            // release a sibling that #1296 clamped out of its tract.
+            merge::demote_coincident_tract_repeats(&mut result, allele.phase, allele.uncertain);
             // Last: two junction-occupying members that settled on the SAME
             // junction. The clamps above bound a member against a sibling's
             // bases, and an insertion or duplication has none, so a pair can

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,11 +60,11 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1316, two adjacent-gap insertions each re-spelling as
-//!   the same tract-wide repeat. It found #1286, #1287, #1290, #1292, #1296,
-//!   #1301, #1304, #1297, #1308 and #1312 first, all now fixed, each masked
-//!   behind the one before it; see its doc comment for the history and the live
-//!   reproduction.
+//!   because it finds #1320, a demoted repeat becoming a duplication that still
+//!   spans a sibling's junction. It found #1286, #1287, #1290, #1292, #1296,
+//!   #1301, #1304, #1297, #1308, #1312 and #1316 first, all now fixed, each
+//!   masked behind the one before it; see its doc comment for the history and
+//!   the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -790,8 +790,7 @@ proptest! {
     /// cancelled and was left as an identity member overlapping the repeat that
     /// absorbed it; #1308, a commuting payload sweeping past a sibling that
     /// stays put; and #1312, commuting tested against a payload the member no
-    /// longer carries once it lands. The live failure is the eleventh it has
-    /// found, **#1316**:
+    /// longer carries once it lands. The eleventh and last was **#1316**:
     ///
     /// ```text
     /// core "CAGCCAGTCAGCGCATCAG", insert "AA" after 4 and 5, delete index 12
@@ -799,34 +798,50 @@ proptest! {
     ///     two identical repeats over one tract
     /// ```
     ///
-    /// The seed's own shrink is smaller than that and drops the deletion
-    /// entirely — `core "ACAGCCAGTCAGCGCATCAG"` with `insAA` after 1 and 2,
-    /// giving `g.[257A[3];259A[3]]` — so the deletion is incidental to the
-    /// defect. The three-event form is kept here because it is the shape #1316
-    /// was filed from.
+    /// The seed's own shrink is smaller than that and carries no deletion at
+    /// all — `core "ACAGCCAGTCAGCGCATCAG"` with `insAA` after 1 and 2 — so the
+    /// deletion was incidental to the defect. The three-event form is kept here
+    /// because it is the shape #1316 was filed from.
     ///
     /// The repeat-form analogue of #1286, which fixed the same shape spelled as
-    /// duplications. It survives the 512-case budget below and is only reachable
-    /// in a soak, which is exactly why enabling the test on that budget would
-    /// prove nothing.
+    /// duplications. (The output recorded when it was filed also lost the
+    /// deletion and placed the repeats at 259; #1313 and #1317 moved both before
+    /// #1316 itself was fixed.)
     ///
-    /// Each of the ten was masked behind the one before it, which is the point
-    /// of keeping this committed rather than deleting it until it can pass.
+    /// The live failure is the twelfth, **#1320**:
     ///
-    /// Enabling this test was #1292's acceptance criterion. #1292 is fixed and
-    /// pinned — by `issue_1292_junction_payload_rotation` and by the `99d5d382`
-    /// seed below, which replays green — but the criterion could not be met
-    /// with it, because the property's next two failures were behind it.
-    /// Enabling now belongs to **#1316**, whose seed `23c33174` is committed
-    /// below — so taking the ignore off replays it immediately, which is what
-    /// should gate taking it off. Absent that seed this passes the 512-case
-    /// budget and fails a 30,000-case soak on the same shape, so switching it
-    /// on would make a green CI a matter of the budget rather than of the
-    /// property holding.
+    /// ```text
+    /// core "AACAGTAAAATAT", insert "AC" after 6, "AA" after 8, "AA" after 9
+    ///   g.[263_264insAC;265_266insAA;266_267insAA] -> g.[263_266dup;264_265insCA]
+    ///     the dup spans 263-266; the insertion adds at interbase 264, inside it
+    /// ```
+    ///
+    /// The two `insAA` members merge into the tract-wide repeat correctly —
+    /// that pair alone gives `g.263_266A[8]`. `demote_repeats_spanning_siblings`
+    /// then re-spells that repeat as a duplication over the same four bases,
+    /// which swallows the third member's junction exactly as the repeat did. A
+    /// hole in #1287's fix, one spelling over. Verified pre-existing: the
+    /// parent of #1316's fix emits the identical output.
+    ///
+    /// Each of the twelve was masked behind the one before it, which is the
+    /// point of keeping this committed rather than deleting it until it passes.
+    ///
+    /// Enabling this test was #1292's acceptance criterion, then #1316's; both
+    /// are fixed and pinned, by `issue_1292_junction_payload_rotation` and
+    /// `issue_1316_coincident_tract_repeats` and by the `99d5d382` and
+    /// `23c33174` seeds below. Neither could carry the criterion, because the
+    /// property's next failure was always behind it. Enabling now belongs to
+    /// **#1320**, whose seed `2521c720` is committed below — so taking the
+    /// ignore off replays it immediately and turns CI red, which is exactly what
+    /// should gate taking it off.
+    ///
+    /// A caution about soak depth, learned here: with #1316 fixed this passed
+    /// 200,000 cases, and then failed a 1,000,000-case run at 27,633 successes.
+    /// One clean soak is not evidence the chain has ended.
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1316, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1320, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1026,13 +1041,14 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1316: two identical repeats settle over one tract and the deletion is
-    // dropped -- the repeat-form analogue of #1286, which fixed the same shape
-    // spelled as duplications.
+    // #1320: `demote_repeats_spanning_siblings` re-spells a tract-wide repeat
+    // as a duplication over the same bases, which swallows a sibling's junction
+    // exactly as the repeat did -- a hole in #1287's fix, one spelling over.
+    // Moved here from #1316, which this change fixes.
     let (core, input, issue) = (
-        "CAGCCAGTCAGCGCATCAG",
-        "NC_TEST.1:g.[261_262insAA;262_263insAA;269del]",
-        "#1316",
+        "AACAGTAAAATAT",
+        "NC_TEST.1:g.[263_264insAC;265_266insAA;266_267insAA]",
+        "#1320",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1316_coincident_tract_repeats.rs
+++ b/tests/it/issue_1316_coincident_tract_repeats.rs
@@ -1,0 +1,79 @@
+//! A repeat that grew its tract by more bases than the tract holds is still
+//! demotable — as an insertion, not a duplication.
+//!
+//! [`demote_repeats_spanning_siblings`] undoes the sibling-unaware re-spelling
+//! of a member as a copy count, because a repeat spans its whole tract and so
+//! hides the member from every junction-based pass. It re-spells back into the
+//! edit the member grew out of: a deletion, or a duplication of the tract's
+//! 3'-most bases.
+//!
+//! Neither fits when a member *added* more bases than the reference tract holds:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "CAGCCAGTCAGCGCATCAG" + ("ACGT" x 64)
+//!            the `A` at 262 is a one-base tract, between `C` at 261 and `G` at 263
+//!
+//! g.[261_262insAA;262_263insAA]
+//!   each member alone grows that tract to three, and is spelled `g.262A[3]`
+//!   the demotion wants `g.261_262dup` — two bases of a one-base tract
+//! ```
+//!
+//! So the pass bailed and both members stayed repeats. A repeat carries no
+//! junction (`junction_of` returns `None` for `NaEdit::Repeat`), so
+//! `coalesce_members_at_one_junction` never saw them either, and the allele
+//! rendered as two identical members claiming one tract — an overlap the SPDI
+//! apply oracle declines (#1316).
+//!
+//! The one-base payload escaped only by the spelling it happened to get:
+//! `g.261_262insA` normalizes to `g.262dup`, a duplication, which *does* carry a
+//! junction, so the pair coalesced and re-spelled as one repeat.
+//!
+//! The added bases are expressible — as an insertion at the tract's 3' junction.
+//! Emitting that gives both members a junction, and the existing merge finishes
+//! the job: `g.262_263insAA` twice, coalesced to `insAAAA`, re-spelled `g.262A[5]`.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// The core the proptest shrank to, and the reference the seed describes.
+const CORE: &str = "CAGCCAGTCAGCGCATCAG";
+
+#[test]
+fn two_insertions_growing_one_tract_combine_their_copies() {
+    // #1316. Both members grow the one-base `A` tract at 262 by two, so the
+    // tract holds five copies — one member, not the same member twice.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[261_262insAA;262_263insAA]");
+    assert_eq!(output, "NC_TEST.1:g.262A[5]");
+}
+
+#[test]
+fn the_seeds_deletion_survives_the_combination() {
+    // The proptest's own case, which carries a distant deletion. It is outside
+    // the tract and must come through untouched.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[261_262insAA;262_263insAA;269del]");
+    assert_eq!(output, "NC_TEST.1:g.[262A[5];269del]");
+}
+
+#[test]
+fn a_one_base_payload_still_reaches_the_same_form() {
+    // The shape that already worked, via the `dup` spelling rather than the
+    // demotion. Pinned so the two routes stay in agreement.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[261_262insA;262_263insA]");
+    assert_eq!(output, "NC_TEST.1:g.262A[3]");
+}
+
+#[test]
+fn a_multi_base_unit_combines_the_same_way() {
+    // The unit is read off the repeat rather than assumed to be one base: the
+    // `CA` at 259_260 is a one-copy tract, and each member adds two copies of
+    // it. The payload is the unit repeated, not the tract's first base.
+    let output = assert_padded_preserving("TTCAGG", "NC_TEST.1:g.[258_259insCACA;260_261insCACA]");
+    assert_eq!(output, "NC_TEST.1:g.259_260CA[5]");
+}
+
+#[test]
+fn a_lone_repeat_growing_past_its_tract_is_left_alone() {
+    // The guard: with no sibling to span, the repeat spelling is correct and
+    // must survive. Demoting unconditionally would undo B2 for every member.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.261_262insAA");
+    assert_eq!(output, "NC_TEST.1:g.262A[3]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -176,6 +176,7 @@ mod issue_1301_adjacent_gap_member_order;
 mod issue_1304_junction_barrier_snapshot;
 mod issue_1308_commuting_payload_phase;
 mod issue_1312_landed_payload_commutes;
+mod issue_1316_coincident_tract_repeats;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -9,10 +9,12 @@
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
 # was removed in #1294, so it runs now.) #1297, #1308 and #1312 are fixed
-# too, and all of the above now replay green. #1316 is not yet fixed and is the
-# reason `an_indel_haplotype_normalizes_to_its_own_sequence` is still
-# `#[ignore]`d — it is the one seed here that still fails, which is what should
-# gate enabling the test.
+# too, and so is #1316, fixed by `demote_coincident_tract_repeats` — all of the
+# above now replay green. #1320 is not yet fixed and is the reason
+# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
+# is the one seed here that still fails, which is what should gate enabling the
+# test. It was found by a 1,000,000-case soak that a 200,000-case soak of the
+# same code had just passed, so do not read "one clean soak" as "no more seeds".
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -22,3 +24,4 @@ cc a88766af1b7adaab791aaf8fda16997a3c66fe0d265cb1a57d9488f22a67ef5d # #1297; shr
 cc 03577f141460793dd01977d320da2524039646462483ad1e6df70eb4426e8213 # #1308; shrinks to haplotype = IndelHaplotype { core: "CAGAAGATGAATAA", events: [Insert { index: 6, bases: "TG" }, Insert { index: 7, bases: "TG" }] }
 cc 958acf3ea2005efa9eafd738606d0fd1d6bb0f586c918b926fd4d79d052f8d99 # #1312; shrinks to haplotype = IndelHaplotype { core: "TAAAACCA", events: [Insert { index: 3, bases: "AC" }, Insert { index: 4, bases: "AC" }] }
 cc 23c331742c910e4d748997c1e4e9d988fe3b4d032c3f60b1e995c9d052f3c720 # #1316; shrinks to haplotype = IndelHaplotype { core: "ACAGCCAGTCAGCGCATCAG", events: [Insert { index: 1, bases: "AA" }, Insert { index: 2, bases: "AA" }] }
+cc 2521c7200c3f735e03b752af83fb12c21c0e903ee3c7a42454dbe8f68f62b08d # #1320; shrinks to haplotype = IndelHaplotype { core: "AACAGTAAAATAT", events: [Insert { index: 6, bases: "AC" }, Insert { index: 8, bases: "AA" }, Insert { index: 9, bases: "AA" }] }


### PR DESCRIPTION
Closes #1316.

## The defect

A member that grows a tandem tract is re-spelled as a copy count over the whole tract — per member, with no sibling context. Two members that grew the *same* tract therefore both name it, and the pair claims it twice:

```text
reference  ("ACGT" x 64) + "CAGCCAGTCAGCGCATCAG" + ("ACGT" x 64)
           the `A` at 262 is a one-base tract, between `C` at 261 and `G` at 263

g.[261_262insAA;262_263insAA]  ->  g.[262A[3];262A[3]]
```

Both members overlap on that one base, so the allele has no resulting sequence at all and the SPDI apply oracle declines it.

Note the output has moved since the issue was filed: it recorded `g.[259A[3];259A[3]]` with the seed's `269del` gone entirely. #1313 and #1317 fixed both of those before this change; what remained is the coincident pair above. The seed's full form now normalizes to `g.[262A[5];269del]`, and the deletion is pinned by a test.

## Why nothing caught it

Two passes could have, and neither applies:

- **`coalesce_members_at_one_junction`** merges members that settle on one junction. A repeat has no junction — `junction_of` returns `None` for `NaEdit::Repeat` — so the pair was never considered.
- **`demote_repeats_spanning_siblings`** exists to undo exactly this sibling-unaware re-spelling. It re-spells a repeat back into a deletion or a duplication *over the tract*, and neither can express two bases added to a one-base tract, so it declined at its `start < a.start` guard. Instrumented and confirmed: the pass reaches both members, computes `source=Added length=2 start=261 a.start=262`, and bails there.

The one-base payload escaped only by the spelling it happened to get. `g.[261_262insA;262_263insA]` normalizes each member to `g.262dup`, and a duplication *does* carry a junction, so that pair coalesced and came out as one `g.262A[3]`. Same shape, different spelling, different outcome — pinned as a test so the two routes stay in agreement.

## The fix

A repeat's growth *is* expressible, as an insertion at the tract's 3' junction — which is where the tract's own shift rule puts it anyway. `demote_coincident_tract_repeats` emits that for a group of two or more repeats sharing one tract, restoring the junction and letting the existing merge finish the job: `g.262_263insAA` twice, coalesced to `insAAAA`, re-spelled `g.262A[5]` on the next pass.

Scoping:

- **Group must share the span *and* the unit**, so the payloads are powers of one word and therefore commute — the coalesce below cannot then decline on order-ambiguity after this pass has already rewritten them.
- **Only exact counts over whole units that actually grew.** A genotype count (`A[6][1]`), an inexact count, a VEP trailing sequence, a partial unit, or a tract that lost copies all decline; fabricating a payload for them would state bases nothing asserted.
- **All-or-nothing per group.** `respell_at_gap` reverts a member it cannot place, and a half-rewritten group is one insertion overlapping one repeat — the same defect in a spelling no later pass looks for.
- **A lone repeat is untouched**, since it is the correct spelling with no sibling on its tract.

### Why it is a separate pass, and why it runs late

It is deliberately *not* folded into `demote_repeats_spanning_siblings`, despite the kinship. That pass's demotions preserve the barrier a repeat presents to a sibling's shift: a deletion and a duplication both still block one. An insertion claims no bases and blocks nothing.

This was measured, not assumed. Extending `demote_repeats_spanning_siblings` to emit the insertion fixed #1316 and broke two of #1296's own tests — `g.[272_273del;274_275insAA]` became `g.273C>A` instead of `g.[272_273del;274A[3]]`. That output is sequence-preserving (the preservation check passed; only the string assertion fired), and arguably more reduced, but it is reached by dissolving the barrier #1296 installed rather than by agreeing with it. Running the rewrite after the clamps instead leaves #1296 untouched: by then the deletion has been pulled back clear of the tract, so the repeat no longer spans a sibling and is not rewritten.

Two repeats on one tract have no such barrier to preserve — they occupy the same bases — so the rewrite is safe there, and only there.

## The property does NOT now pass — and that is the point

`an_indel_haplotype_normalizes_to_its_own_sequence` has found twelve defects, each masked behind the one before it:

#1286 -> #1287 -> #1290 -> #1292 -> #1296 -> #1301 -> #1304 -> #1297 -> #1308 -> #1312 -> **#1316** -> **#1320**

Eleven are fixed. With #1316 fixed the property passed a **200,000-case soak** — the first it had ever survived — and then **failed a 1,000,000-case run at 27,633 successes** on a twelfth, now filed as **#1320**:

```text
core "AACAGTAAAATAT", insert "AC" after 6, "AA" after 8, "AA" after 9
  g.[263_264insAC;265_266insAA;266_267insAA] -> g.[263_266dup;264_265insCA]
    the dup spans 263-266; the insertion adds at interbase 264, inside it
```

The two `insAA` members merge into the tract-wide repeat correctly — that pair alone gives `g.263_266A[8]`, which is this PR's fix working. `demote_repeats_spanning_siblings` then re-spells that repeat as a duplication over the same four bases, and the duplication swallows the third member's junction exactly as the repeat did. A hole in #1287's fix, one spelling over.

**#1320 is pre-existing.** Verified by A/B: reverting `src/normalize/merge.rs` and `src/normalize/mod.rs` to this commit's parent and re-running the same input gives the identical wrong output. This PR neither causes nor worsens it.

Its seed is committed and tagged here, so it now reproduces **deterministically at the 512-case budget** — taking the `#[ignore]` off would turn CI red immediately. The attribute therefore stays, pointed at #1320.

I had earlier read the clean 200k soak as evidence the chain had ended, and said so. It was not. That caution is now recorded in the test's doc comment, because it nearly cost the `#[ignore]` gate.

## Verification

- `cargo nextest run --features dev` — **8941 passed**, 0 failed (8936 baseline + 5 new tests)
- Same suite under `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` — 8941 passed
- **Conformance axis run** against the blessed prepared reference (`FERRO_MANIFEST` set): all axis tests pass — `mutalyzer_normalize_tests` (`axis_normalized`, `axis_genomic`, `axis_noncoding`, `axis_errors`, `axis_infos`, `axis_protein_description`, `axis_rna_description`, `axis_coding_protein_descriptions`, and both idempotency axes), `biocommons_normalize_tests`, `hgvs_rs_projection_tests`. `comparator_provenance_reference_identity_matches_live` passes, so the reference is the one the baselines were blessed against.
- `cargo fmt --all` + `cargo clippy --features dev --all-targets -- -D warnings` — clean
- The 276,480-case sweep `cis_junction_crossing_shift::no_two_member_allele_normalizes_to_a_different_sequence` holds its residual at **0** (asserted in-test against `KNOWN_FIVE_PRIME_DUP_DEL_RESIDUAL`)
- Confluence property: committed seeds replay green; 60k and 200k soaks both pass
- Failure output was checked for `SIGABRT`/`SIGSEGV`/`TIMEOUT`/`LEAK`, not just `FAIL`, and reconciled against nextest's own failed count
- Commit is signed

Pre-existence: the defect was reproduced on the parent (`c2696b1`) before any source change, and the two new failing tests were confirmed red there and green after.

Conformance was initially unavailable (both reference volumes unmounted); the backup volume was mounted later in the session and the axis run above is the result. It is the first conformance coverage this stack has had.

## Stack

Branches off `fix/issue-1312-out-of-phase-merge` (#1317), so it is link 13 of the chain and 3 commits behind `main` like the rest. It needs to be included in the pending stack rebase.
