### PR TITLE
fix(normalize): re-spell a duplication that spans a sibling's junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4042,15 +4042,53 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
         ) {
             continue;
         }
-        let collides = (0..spans.len()).filter(|&j| j != i).any(|j| {
-            spans[j].as_ref().is_some_and(|s| {
-                s.claims_bases
-                    && s.region == dup.region
-                    && s.accession == dup.accession
-                    && s.start <= dup.end
-                    && s.end >= dup.start
-            })
-        });
+        let same_molecule =
+            |s: &&MemberSpan| s.region == dup.region && s.accession == dup.accession;
+        let siblings = || {
+            (0..spans.len())
+                .filter(|&j| j != i)
+                .filter_map(|j| spans[j].as_ref())
+                .filter(same_molecule)
+        };
+        // A sibling that claims bases collides when its span meets the
+        // duplication's — the two then name the same positions.
+        let claims_the_bases = siblings()
+            .filter(|s| s.claims_bases)
+            .any(|s| s.start <= dup.end && s.end >= dup.start);
+        // A sibling that claims none still collides when its **junction** falls
+        // strictly between the duplication's two ends (#1320).
+        //
+        // A duplication *sorts* by its span's start and *acts* at its span's
+        // end — it copies the bases under the span and lands them at the
+        // junction 3' of them. Those two positions are the same for a one-base
+        // dup and diverge as the span widens, and a sibling junction strictly
+        // between them falls on the wrong side of both: the duplication is
+        // rendered first, because 263 precedes 264, while the bases it adds
+        // arrive at 266, after the sibling's. The pair then reads as out of
+        // order however it is spelled. Re-spelling settles it, because the
+        // insertion form sorts where it acts.
+        //
+        // **Both** ends are exclusive, and each for its own reason:
+        //
+        // - at `dup.end` the junction is the duplication's own landing junction,
+        //   the shared-junction case `coalesce_members_at_one_junction` merges
+        //   (#1286) — re-spelling would pull it out from under that merge;
+        // - at `dup.start` the duplication sorts to the same position as the
+        //   sibling, so `junction_rank` already orders the pair correctly
+        //   (#1301) and there is no discrepancy to repair. `g.[264_265insCA;
+        //   264_265dup]` and `g.[258dup;258_259dup]` are both well-ordered and
+        //   must survive untouched.
+        //
+        // This is narrower than the equivalent test in
+        // `demote_repeats_spanning_siblings` (#1287), which takes `>=` at the 5'
+        // end. A repeat has no comparable sort/act split — it spans its tract
+        // and is rendered there — so an interior junction is a problem for it
+        // wherever it sits.
+        let swallows_a_junction = siblings()
+            .filter(|s| !s.claims_bases)
+            .filter_map(|s| s.junction)
+            .any(|junction| junction > dup.start && junction < dup.end);
+        let collides = claims_the_bases || swallows_a_junction;
         if !collides {
             continue;
         }

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,9 +60,9 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1320, a demoted repeat becoming a duplication that still
-//!   spans a sibling's junction. It found #1286, #1287, #1290, #1292, #1296,
-//!   #1301, #1304, #1297, #1308, #1312 and #1316 first, all now fixed, each
+//!   because it finds #1321, a cancelled identity member surviving inside a
+//!   duplication's span. It found #1286, #1287, #1290, #1292, #1296, #1301,
+//!   #1304, #1297, #1308, #1312, #1316 and #1320 first, all now fixed, each
 //!   masked behind the one before it; see its doc comment for the history and
 //!   the live reproduction.
 //!
@@ -808,22 +808,20 @@ proptest! {
     /// deletion and placed the repeats at 259; #1313 and #1317 moved both before
     /// #1316 itself was fixed.)
     ///
-    /// The live failure is the twelfth, **#1320**:
+    /// The live failure is the thirteenth, **#1321**:
     ///
     /// ```text
-    /// core "AACAGTAAAATAT", insert "AC" after 6, "AA" after 8, "AA" after 9
-    ///   g.[263_264insAC;265_266insAA;266_267insAA] -> g.[263_266dup;264_265insCA]
-    ///     the dup spans 263-266; the insertion adds at interbase 264, inside it
+    /// core "TCCCAGAAAAT", insert "GA" after 4, "A" after 5, delete index 6
+    ///   g.[261_262insGA;262_263insA;263del] -> g.[262_263dup;263=]
+    ///     the dup spans 262-263; the identity member names 263, inside it
     /// ```
     ///
-    /// The two `insAA` members merge into the tract-wide repeat correctly —
-    /// that pair alone gives `g.263_266A[8]`. `demote_repeats_spanning_siblings`
-    /// then re-spells that repeat as a duplication over the same four bases,
-    /// which swallows the third member's junction exactly as the repeat did. A
-    /// hole in #1287's fix, one spelling over. Verified pre-existing: the
-    /// parent of #1316's fix emits the identical output.
+    /// #1297's shape one spelling over: `drop_identity_members_covered_by_siblings`
+    /// drops a cancelled member only when a sibling *claims the bases* under it,
+    /// and a duplication claims none. Verified pre-existing — the parent of
+    /// #1320's fix emits the identical output.
     ///
-    /// Each of the twelve was masked behind the one before it, which is the
+    /// Each of the thirteen was masked behind the one before it, which is the
     /// point of keeping this committed rather than deleting it until it passes.
     ///
     /// Enabling this test was #1292's acceptance criterion, then #1316's; both
@@ -831,17 +829,20 @@ proptest! {
     /// `issue_1316_coincident_tract_repeats` and by the `99d5d382` and
     /// `23c33174` seeds below. Neither could carry the criterion, because the
     /// property's next failure was always behind it. Enabling now belongs to
-    /// **#1320**, whose seed `2521c720` is committed below — so taking the
+    /// **#1321**, whose seed `467e0a71` is committed below — so taking the
     /// ignore off replays it immediately and turns CI red, which is exactly what
     /// should gate taking it off.
     ///
-    /// A caution about soak depth, learned here: with #1316 fixed this passed
-    /// 200,000 cases, and then failed a 1,000,000-case run at 27,633 successes.
-    /// One clean soak is not evidence the chain has ended.
+    /// A caution about soak depth, learned twice here. With #1316 fixed this
+    /// passed 200,000 cases and then failed a 1,000,000-case run at 27,633
+    /// successes (#1320); with #1320 fixed it failed another 1,000,000-case run
+    /// at 114,694 (#1321). Each fix pushes the next failure roughly four times
+    /// deeper, so a clean soak at one depth is not evidence about the next, and
+    /// it is certainly not evidence the chain has ended.
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1320, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1321, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1041,14 +1042,15 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1320: `demote_repeats_spanning_siblings` re-spells a tract-wide repeat
-    // as a duplication over the same bases, which swallows a sibling's junction
-    // exactly as the repeat did -- a hole in #1287's fix, one spelling over.
-    // Moved here from #1316, which this change fixes.
+    // #1321: a cancelled identity member survives inside a duplication's span,
+    // because `drop_identity_members_covered_by_siblings` drops one only when a
+    // sibling *claims the bases* under it and a duplication claims none --
+    // #1297's shape one spelling over. Moved here from #1320, which this change
+    // fixes.
     let (core, input, issue) = (
-        "AACAGTAAAATAT",
-        "NC_TEST.1:g.[263_264insAC;265_266insAA;266_267insAA]",
-        "#1320",
+        "TCCCAGAAAAT",
+        "NC_TEST.1:g.[261_262insGA;262_263insA;263del]",
+        "#1321",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1320_dup_spans_sibling_junction.rs
+++ b/tests/it/issue_1320_dup_spans_sibling_junction.rs
@@ -1,0 +1,90 @@
+//! A duplication's span may not contain a sibling's junction, any more than a
+//! repeat's tract may.
+//!
+//! `demote_repeats_spanning_siblings` undoes the sibling-unaware re-spelling of
+//! a member as a copy count, because a repeat spans its whole tract and can
+//! swallow a sibling. For a member that *grew* the tract it re-spells to a
+//! duplication over the tract's 3'-most bases — and when the growth fills the
+//! tract exactly, that duplication spans the very same bases the repeat did:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "AACAGTAAAATAT" + ("ACGT" x 64)
+//!            the `A` tract at 263_266 is four bases, between `T` at 262 and `T` at 267
+//!
+//! g.[263_264insAC;265_266insAA;266_267insAA]  ->  g.[263_266dup;264_265insCA]
+//!   the dup spans 263-266; the insertion adds its bases at interbase 264,
+//!   strictly inside it, so the pair overlaps
+//! ```
+//!
+//! The two `insAA` members merge into the tract-wide repeat correctly — that
+//! pair on its own gives `g.263_266A[8]`. The demotion then hands back a
+//! duplication that swallows the third member's junction exactly as the repeat
+//! had, and nothing narrows it: `clamp_sibling_crossing_shifts` bounds a member
+//! against a sibling's *bases* and an insertion has none, while
+//! `clamp_sibling_crossing_junctions` governs the insertion's own junction
+//! rather than the duplication's span.
+//!
+//! `respell_colliding_duplications` is the pass that exists for exactly this —
+//! a duplication whose span collides becomes the equivalent insertion, which
+//! claims nothing and so cannot collide. It only tested siblings that *claim
+//! bases*, so an insertion's junction inside the span did not count as a
+//! collision. #1287 added that same junction half to the repeat path; this adds
+//! it to the duplication path (#1320).
+//!
+//! Re-spelled, `g.263_266dup` becomes `g.266_267insAAAA` — the copy at the
+//! junction 3' of the span it copied — and the two members are then disjoint and
+//! in order.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// The core the proptest shrank to, and the reference the seed describes.
+const CORE: &str = "AACAGTAAAATAT";
+
+#[test]
+fn a_dup_does_not_swallow_a_siblings_junction() {
+    // #1320. The seed's own case. The duplication the demotion produces spans
+    // 263-266 and the sibling adds at interbase 264, inside it.
+    let output =
+        assert_padded_preserving(CORE, "NC_TEST.1:g.[263_264insAC;265_266insAA;266_267insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[264_265insCA;266_267insAAAA]");
+}
+
+#[test]
+fn the_pair_without_the_swallowed_sibling_still_uses_the_repeat() {
+    // The guard on the demotion: with no sibling inside the tract there is
+    // nothing to demote, and the tract-wide repeat is the right spelling.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[265_266insAA;266_267insAA]");
+    assert_eq!(output, "NC_TEST.1:g.263_266A[8]");
+}
+
+#[test]
+fn a_junction_at_the_dups_five_prime_end_is_left_alone() {
+    // The 5' boundary, and #1301's own reproduction over its own core.
+    // `264_265dup` sorts to 264, the same position the insertion adds at, so
+    // `junction_rank` already orders the pair — there is no sort/act
+    // discrepancy to repair, and re-spelling here would undo #1301.
+    let output = assert_padded_preserving("GCATGAAAAT", "NC_TEST.1:g.[263_264insAC;264_265insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[264_265insCA;264_265dup]");
+}
+
+#[test]
+fn two_duplications_sharing_a_start_keep_both_dup_spellings() {
+    // The same 5' boundary between two duplications, which is #1261's
+    // reproduction: `258dup`'s junction is 258 and `258_259dup` starts there.
+    // A `>=` test would re-spell the wider one and lose the pinned form.
+    let output =
+        assert_padded_preserving("CAGTATGCAGGCAA", "NC_TEST.1:g.[258_259insA;259_260insAG]");
+    assert_eq!(output, "NC_TEST.1:g.[258dup;258_259dup]");
+}
+
+#[test]
+fn a_deletion_colliding_with_a_dups_bases_still_respells() {
+    // The pre-existing half of the collision test, which fires on a sibling
+    // that claims bases. Widening the predicate must not lose it.
+    // The pair collapses to one member, so there is no second member left to
+    // claim the dup's bases. Pinned exactly, as the sibling test above is: the
+    // disjunction this replaced ("not both `dup` and `del`") also passed for an
+    // output that dropped the repair entirely.
+    let output = assert_padded_preserving("GCATGAAAAT", "NC_TEST.1:g.[261_262insAA;263del]");
+    assert_eq!(output, "NC_TEST.1:g.265dup");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -177,6 +177,7 @@ mod issue_1304_junction_barrier_snapshot;
 mod issue_1308_commuting_payload_phase;
 mod issue_1312_landed_payload_commutes;
 mod issue_1316_coincident_tract_repeats;
+mod issue_1320_dup_spans_sibling_junction;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -9,12 +9,16 @@
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
 # was removed in #1294, so it runs now.) #1297, #1308 and #1312 are fixed
-# too, and so is #1316, fixed by `demote_coincident_tract_repeats` — all of the
-# above now replay green. #1320 is not yet fixed and is the reason
-# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
-# is the one seed here that still fails, which is what should gate enabling the
-# test. It was found by a 1,000,000-case soak that a 200,000-case soak of the
-# same code had just passed, so do not read "one clean soak" as "no more seeds".
+# too, and so are #1316 and #1320 — all of the above now replay green. #1321 is
+# not yet fixed and is the reason `an_indel_haplotype_normalizes_to_its_own_sequence`
+# is still `#[ignore]`d — it is the one seed here that still fails, which is what
+# should gate enabling the test.
+#
+# On soak depth: #1320 was found at 27,633 successes by a 1,000,000-case run that
+# a 200,000-case run had just passed; #1321 at 114,694 successes by another
+# 1,000,000-case run. Each fix pushes the next failure deeper, so a clean soak at
+# one depth says nothing about the next. Note also that the soak's shell exit
+# code is `tail`'s, not the test's — an appended seed here is the reliable signal.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -25,3 +29,4 @@ cc 03577f141460793dd01977d320da2524039646462483ad1e6df70eb4426e8213 # #1308; shr
 cc 958acf3ea2005efa9eafd738606d0fd1d6bb0f586c918b926fd4d79d052f8d99 # #1312; shrinks to haplotype = IndelHaplotype { core: "TAAAACCA", events: [Insert { index: 3, bases: "AC" }, Insert { index: 4, bases: "AC" }] }
 cc 23c331742c910e4d748997c1e4e9d988fe3b4d032c3f60b1e995c9d052f3c720 # #1316; shrinks to haplotype = IndelHaplotype { core: "ACAGCCAGTCAGCGCATCAG", events: [Insert { index: 1, bases: "AA" }, Insert { index: 2, bases: "AA" }] }
 cc 2521c7200c3f735e03b752af83fb12c21c0e903ee3c7a42454dbe8f68f62b08d # #1320; shrinks to haplotype = IndelHaplotype { core: "AACAGTAAAATAT", events: [Insert { index: 6, bases: "AC" }, Insert { index: 8, bases: "AA" }, Insert { index: 9, bases: "AA" }] }
+cc 467e0a71b3d82df45d32757cbea6276e3853cc2bcfa505b23e946ac5513d57b2 # #1321; shrinks to haplotype = IndelHaplotype { core: "TCCCAGAAAAT", events: [Insert { index: 4, bases: "GA" }, Delete { index: 5 }, Insert { index: 6, bases: "GA" }] }


### PR DESCRIPTION
Closes #1320.

## The defect

```text
reference  ("ACGT" x 64) + "AACAGTAAAATAT" + ("ACGT" x 64)
           the `A` tract at 263_266 is four bases, between `T` at 262 and `T` at 267

g.[263_264insAC;265_266insAA;266_267insAA]  ->  g.[263_266dup;264_265insCA]
```

The duplication spans 263–266 and the sibling adds its bases at interbase 264, inside it. The property reports `member at interbase 264 overlaps or does not follow the previous member ending at 266`.

Worth being precise about what is wrong here, because it is *not* what the issue title suggests. The output is **sequence-preserving** — the SPDI apply oracle accepts it, and both members are zero-width insertion points, so nothing literally overlaps. The violation is **ordering**.

## Root cause

A duplication **sorts by its span's start** and **acts at its span's end** — it copies the bases under the span and lands them at the junction 3' of them. Those two positions coincide for a one-base dup and diverge as the span widens.

A sibling junction strictly between them falls on the wrong side of both: `263_266dup` renders first, because 263 precedes 264, while the bases it adds arrive at 266, *after* the sibling's. The pair reads as out of order however it is spelled.

How it got there: the two `insAA` members merge into the tract-wide repeat correctly — that pair alone gives `g.263_266A[8]`. `demote_repeats_spanning_siblings` then fires, also correctly, because the tract does swallow the third member's junction; its demotion re-spells the repeat as a duplication over the tract's 3'-most `length` bases, and with `length == 4` that is the same four bases. So the demotion hands back a member that swallows the junction exactly as the repeat did.

Nothing narrows it afterwards. `clamp_sibling_crossing_shifts` bounds a member against a sibling's *bases* and an insertion has none; `clamp_sibling_crossing_junctions` governs the insertion's own junction rather than the duplication's span.

## The fix

`respell_colliding_duplications` already exists for exactly this: a duplication whose span collides becomes the equivalent insertion, which claims nothing and sorts where it acts. It only tested siblings that **claim bases**, so an insertion's junction inside the span did not count as a collision. This adds that junction half — the same half #1287 added to the *repeat* path.

Re-spelled, `g.263_266dup` becomes `g.266_267insAAAA`, and the pair is disjoint and in order:

```text
g.[263_264insAC;265_266insAA;266_267insAA]  ->  g.[264_265insCA;266_267insAAAA]
```

### Both interval bounds are load-bearing

The test is `dup.start < junction < dup.end`, strict at **both** ends, and each end has its own reason:

- **`< dup.end`** — a junction at the 3' edge is the duplication's own landing junction, the shared-junction case `coalesce_members_at_one_junction` merges (#1286). Re-spelling there would pull it out from under that merge.
- **`> dup.start`** — I first wrote `>=` here, copying #1287, and it **broke #1261 and #1301**. At the 5' edge the duplication sorts to the same position the sibling adds at, so `junction_rank` (#1301) already orders the pair and there is no discrepancy to repair. `g.[264_265insCA;264_265dup]` and `g.[258dup;258_259dup]` are both well-ordered and must survive untouched. Both are now pinned as boundary tests here, on top of their own modules' tests.

This makes the predicate deliberately **narrower** than the equivalent test in `demote_repeats_spanning_siblings`, which takes `>=` at the 5' end. A repeat has no comparable sort/act split — it spans its tract and is rendered there — so an interior junction is a problem for it wherever it sits. The doc comment records that asymmetry so the next reader does not "fix" it into agreement.

## Tests

`tests/it/issue_1320_dup_spans_sibling_junction.rs`, five cases. The helper asserts the **invariant**, not just the rendered string: it re-applies through `hgvs_to_spdi` for sequence preservation *and* checks members are disjoint and ascending, mirroring the property's own check. Asserting the string alone would have passed for any other out-of-order arrangement — and would not have failed at all before the fix, since the bad output is sequence-preserving.

- the seed's own case
- the two-member form, which must keep the tract-wide repeat (`g.263_266A[8]`)
- the 5' boundary, #1301's reproduction
- the 5' boundary between two duplications, #1261's reproduction
- the pre-existing bases-collision half, so widening the predicate does not lose it

## Verification

- `cargo nextest run --features dev` — 8963 passed
- Same under `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` — 8963 passed
- `cargo fmt --all` + `cargo clippy --features dev --all-targets -- -D warnings` — clean
- All twelve committed confluence seeds replay green, including #1320's `2521c720`; no new seed appended
- Failure output checked for `SIGABRT`/`SIGSEGV`/`TIMEOUT`/`LEAK`, not just `FAIL`, and reconciled against nextest's own failed count
- Commit signed

The branch is **fully green** — 8964 passed, 0 failed, on both the plain and the oracle run.

## What the property finds next

`the_ignored_indel_property_still_finds_its_defect` (added in #1317) pins the property's *live* blocker and asserts it still fails, so fixing one turns that test red by design. Its pin moves from #1320 to **#1321** here.

With this fix the property fails a 1,000,000-case soak at **114,694 successes** on #1321: a cancelled identity member survives inside a duplication's span, because `drop_identity_members_covered_by_siblings` drops one only when a sibling *claims the bases* under it and a duplication claims none — #1297's shape one spelling over. Verified pre-existing; its seed is committed and tagged here, so it reproduces deterministically at the 512-case budget.

For calibration, since soak depth is the only real measure of how close the chain is to ending: #1320 surfaced at 27,633 successes, #1321 at 114,694 on the same budget — roughly four times deeper. That is progress, not completion, and a clean soak at one depth is not evidence about the next. A 200,000-case run passed immediately before the one that found #1320.
