### PR TITLE
fix(normalize): let a duplication cover the identity member inside it

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4396,9 +4396,28 @@ fn translate_junction_member<P: ReferenceProvider>(
 ///   the repeat alone denotes the input; the `265=` residue overlaps it
 /// ```
 ///
-/// Only the identity member is dropped, and only when a sibling *claims* the
-/// bases under it — a sibling that merely adds sequence at a junction inside it
-/// contradicts nothing.
+/// Only the identity member is dropped, and only when a sibling's span *covers*
+/// it under [`blocks_sibling_shift`] — a sibling that merely adds sequence at a
+/// junction inside it contradicts nothing.
+///
+/// `blocks_sibling_shift` rather than `claims_reference_bases`, because a
+/// duplication covers the positions it copies without consuming them (#1321):
+///
+/// ```text
+/// g.[261_262insGA;262_263insA;263del]  ->  g.[262_263dup;263=]
+///   `262_263dup` alone denotes the input; the `263=` overlaps it
+/// ```
+///
+/// That is #1297's shape one spelling over, and the two predicates differ by
+/// exactly the case that matters — `blocks_sibling_shift` is
+/// `claims_reference_bases` plus `Duplication`/`DupIns`, which are barriers
+/// precisely because they read their payload from the reference under their own
+/// span. Naming those positions is what makes an identity member inside them
+/// redundant.
+///
+/// Insertions stay out of it under either predicate, and must: an insertion's
+/// span *is* the gap it occupies, so `g.264_265insA` nominally covers position
+/// 264 while changing nothing there.
 pub(crate) fn drop_identity_members_covered_by_siblings(
     members: &mut Vec<HgvsVariant>,
     phase: AllelePhase,
@@ -4425,7 +4444,7 @@ pub(crate) fn drop_identity_members_covered_by_siblings(
             };
             (0..members.len()).filter(|&j| j != i).any(|j| {
                 spans[j].as_ref().is_some_and(|s| {
-                    s.claims_bases
+                    s.blocks_shift
                         && s.region == span.region
                         && s.accession == span.accession
                         && s.start <= span.start

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,11 +60,11 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1321, a cancelled identity member surviving inside a
-//!   duplication's span. It found #1286, #1287, #1290, #1292, #1296, #1301,
-//!   #1304, #1297, #1308, #1312, #1316 and #1320 first, all now fixed, each
-//!   masked behind the one before it; see its doc comment for the history and
-//!   the live reproduction.
+//!   because it finds #1323, a three-member allele losing its deletion and
+//!   denoting the wrong sequence. It found #1286, #1287, #1290, #1292, #1296,
+//!   #1301, #1304, #1297, #1308, #1312, #1316, #1320 and #1321 first, all now
+//!   fixed, each masked behind the one before it; see its doc comment for the
+//!   history and the live reproduction.
 //!
 //! Neither restriction is silent: both are named, pinned, and fail loudly when
 //! the underlying issue is fixed (#1268/#1283's complaint about coverage that
@@ -808,20 +808,22 @@ proptest! {
     /// deletion and placed the repeats at 259; #1313 and #1317 moved both before
     /// #1316 itself was fixed.)
     ///
-    /// The live failure is the thirteenth, **#1321**:
+    /// The live failure is the fourteenth, **#1323**:
     ///
     /// ```text
-    /// core "TCCCAGAAAAT", insert "GA" after 4, "A" after 5, delete index 6
-    ///   g.[261_262insGA;262_263insA;263del] -> g.[262_263dup;263=]
-    ///     the dup spans 262-263; the identity member names 263, inside it
+    /// core "CAGGGATCAT", delete index 3, insert "GA" after 4, insert "GA" after 5
+    ///   g.[260del;261_262insGA;262_263insGA] -> g.[261_262dup;262dup]
+    ///     intended  C A G G G A A G A T C A T
+    ///     emitted   C A G G G A G A A T C A T
     /// ```
     ///
-    /// #1297's shape one spelling over: `drop_identity_members_covered_by_siblings`
-    /// drops a cancelled member only when a sibling *claims the bases* under it,
-    /// and a duplication claims none. Verified pre-existing — the parent of
-    /// #1320's fix emits the identical output.
+    /// The deletion is dropped, the two duplications overlap at 262, and the
+    /// result denotes different bases. The first chain defect that is
+    /// **sequence-changing** rather than a rendering or ordering fault — every
+    /// one since #1304 has preserved the sequence. Verified pre-existing: the
+    /// parent of #1321's fix emits the identical output.
     ///
-    /// Each of the thirteen was masked behind the one before it, which is the
+    /// Each of the fourteen was masked behind the one before it, which is the
     /// point of keeping this committed rather than deleting it until it passes.
     ///
     /// Enabling this test was #1292's acceptance criterion, then #1316's; both
@@ -829,20 +831,21 @@ proptest! {
     /// `issue_1316_coincident_tract_repeats` and by the `99d5d382` and
     /// `23c33174` seeds below. Neither could carry the criterion, because the
     /// property's next failure was always behind it. Enabling now belongs to
-    /// **#1321**, whose seed `467e0a71` is committed below — so taking the
+    /// **#1323**, whose seed `ff4eca54` is committed below — so taking the
     /// ignore off replays it immediately and turns CI red, which is exactly what
     /// should gate taking it off.
     ///
-    /// A caution about soak depth, learned twice here. With #1316 fixed this
-    /// passed 200,000 cases and then failed a 1,000,000-case run at 27,633
-    /// successes (#1320); with #1320 fixed it failed another 1,000,000-case run
-    /// at 114,694 (#1321). Each fix pushes the next failure roughly four times
-    /// deeper, so a clean soak at one depth is not evidence about the next, and
-    /// it is certainly not evidence the chain has ended.
+    /// A caution about soak depth, and about reading a trend into it. With
+    /// #1316 fixed this passed 200,000 cases and then failed a 1,000,000-case
+    /// run at 27,633 successes (#1320); with #1320 fixed, at 114,694 (#1321);
+    /// with #1321 fixed, at 143,034 (#1323). The 4x jump did not repeat — the
+    /// last step is 1.25x — so depth is not trending predictably and cannot be
+    /// used to forecast an end. A clean soak at one depth says nothing about the
+    /// next, and is certainly not evidence the chain has ended.
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1321, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1323, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1042,15 +1045,14 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1321: a cancelled identity member survives inside a duplication's span,
-    // because `drop_identity_members_covered_by_siblings` drops one only when a
-    // sibling *claims the bases* under it and a duplication claims none --
-    // #1297's shape one spelling over. Moved here from #1320, which this change
-    // fixes.
+    // #1323: a three-member allele loses its deletion and denotes the wrong
+    // sequence as two overlapping duplications. The first chain defect that is
+    // sequence-changing rather than a rendering or ordering fault. Moved here
+    // from #1321, which this change fixes.
     let (core, input, issue) = (
-        "TCCCAGAAAAT",
-        "NC_TEST.1:g.[261_262insGA;262_263insA;263del]",
-        "#1321",
+        "CAGGGATCAT",
+        "NC_TEST.1:g.[260del;261_262insGA;262_263insGA]",
+        "#1323",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/common/synthetic.rs
+++ b/tests/it/common/synthetic.rs
@@ -359,7 +359,12 @@ pub fn assert_padded_preserving(core: &str, input: &str) -> String {
         for member in &members {
             triples.push(hgvs_to_spdi(member, &provider).ok()?);
         }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        // 3'-to-5', and at a tied position the *longer* deletion first. A
+        // deletion and an insertion can both touch one interbase (`262_263insA`
+        // and `263del`); applying the zero-width one first leaves `claimed` at
+        // that interbase and makes the deletion look like it overruns, so this
+        // applier would report a legal input as having no resulting sequence.
+        triples.sort_by_key(|t| std::cmp::Reverse((t.position, t.deletion.len())));
         let mut edited = reference.as_bytes().to_vec();
         let mut claimed = reference.len();
         for triple in &triples {
@@ -381,6 +386,35 @@ pub fn assert_padded_preserving(core: &str, input: &str) -> String {
         from_output, from_input,
         "`{input}` -> `{output}` changed the sequence"
     );
+
+    // Denoting the same bases is not enough: the members must also render
+    // disjoint and ascending. An overlapping pair that happens to apply to the
+    // right sequence is still malformed, and that is the shape most of the
+    // cis-allele regressions are about.
+    let members: Vec<HgvsVariant> = match parse_hgvs(&output).expect("output parses") {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let spans: Vec<(u64, u64)> = members
+        .iter()
+        .map(|member| {
+            let triple = hgvs_to_spdi(member, &provider).expect("member has an SPDI");
+            (
+                triple.position,
+                triple.position + triple.deletion.len() as u64,
+            )
+        })
+        .collect();
+    for (index, pair) in spans.windows(2).enumerate() {
+        assert!(
+            pair[0] != pair[1] && pair[1].0 >= pair[0].1,
+            "`{input}` -> `{output}`: member {} at interbase {} overlaps or does not \
+             follow the previous member ending at {} (spans {spans:?})",
+            index + 1,
+            pair[1].0,
+            pair[0].1
+        );
+    }
     output
 }
 

--- a/tests/it/issue_1321_identity_inside_a_duplication.rs
+++ b/tests/it/issue_1321_identity_inside_a_duplication.rs
@@ -1,0 +1,75 @@
+//! A duplication covers the positions it copies, so an identity member inside
+//! its span is a residue to drop.
+//!
+//! `drop_identity_members_covered_by_siblings` removes a member that cancelled
+//! to `=` while a sibling grew over the bases it names (#1297). It gates on
+//! `claims_reference_bases`, which deliberately excludes `Duplication` — a dup
+//! adds a copy at a junction and consumes nothing — so a duplication that grew
+//! across the cancelled member's position did not count:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "TCCCAGAAAAT" + ("ACGT" x 64)
+//!
+//! g.[261_262insGA;262_263insA;263del]  ->  g.[262_263dup;263=]
+//!   the dup spans 262-263 and the identity member names 263, inside it
+//! ```
+//!
+//! `g.262_263dup` on its own already denotes the input — it copies `G` at 262
+//! and `A` at 263, giving `CAGA` + `GA` + `AAAT`, which is exactly what the
+//! three input members describe. The `263=` adds nothing and overlaps, so the
+//! pair violates #1235's second criterion.
+//!
+//! This is #1297's shape one spelling over, and the gate widens from
+//! `claims_reference_bases` to `blocks_sibling_shift` — the predicate that is
+//! already "claims bases, plus a duplication", and which exists because a
+//! duplication reads its payload from the reference under its own span. A
+//! duplication therefore *names* the positions it copies even though it consumes
+//! none of them, which is exactly the property that makes an identity member
+//! inside it redundant (#1321).
+//!
+//! Insertions stay excluded, and must: an insertion's span is the gap it sits
+//! in, so `g.264_265insA` nominally covers position 264 while contradicting
+//! nothing there. `blocks_sibling_shift` excludes them for the same reason
+//! `claims_reference_bases` did.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// The core the proptest shrank to, and the reference the seed describes.
+const CORE: &str = "TCCCAGAAAAT";
+
+#[test]
+fn an_identity_member_inside_a_duplication_is_dropped() {
+    // #1321. The seed's own case. `262_263dup` alone denotes the input; the
+    // `263=` it was left beside adds nothing and overlaps it.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[261_262insGA;262_263insA;263del]");
+    assert_eq!(output, "NC_TEST.1:g.262_263dup");
+}
+
+#[test]
+fn an_identity_member_beside_an_unrelated_deletion_survives() {
+    // The guard #1297 installed and this must not weaken. An identity member is
+    // real information when nothing covers it: `g.[1002=;1005del]` keeps both,
+    // and dropping identities outright would lose what the `=` records.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[258=;260del]");
+    assert!(
+        output.contains("258="),
+        "an uncovered identity member must survive: `{output}`"
+    );
+}
+
+#[test]
+fn an_identity_member_beside_an_insertion_survives() {
+    // The reason the gate cannot simply be "a sibling's span covers it". An
+    // insertion's span is the gap it occupies, so `259_260insG` nominally spans
+    // 259-260 while changing nothing at 259 — it contradicts an identity there,
+    // and `blocks_sibling_shift` excludes it exactly as `claims_reference_bases`
+    // did.
+    // The identity sits *inside* the insertion's nominal span, which is the
+    // case the paragraph above is about — an identity outside it was never at
+    // risk from this gate and so proves nothing.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[259=;259_260insG]");
+    assert!(
+        output.contains("259="),
+        "an insertion must not drop an identity member inside its span: `{output}`"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -178,6 +178,7 @@ mod issue_1308_commuting_payload_phase;
 mod issue_1312_landed_payload_commutes;
 mod issue_1316_coincident_tract_repeats;
 mod issue_1320_dup_spans_sibling_junction;
+mod issue_1321_identity_inside_a_duplication;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -9,16 +9,18 @@
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
 # was removed in #1294, so it runs now.) #1297, #1308 and #1312 are fixed
-# too, and so are #1316 and #1320 — all of the above now replay green. #1321 is
-# not yet fixed and is the reason `an_indel_haplotype_normalizes_to_its_own_sequence`
-# is still `#[ignore]`d — it is the one seed here that still fails, which is what
-# should gate enabling the test.
+# too, and so are #1316, #1320 and #1321 — all of the above now replay green.
+# #1323 is not yet fixed and is the reason
+# `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
+# is the one seed here that still fails, which is what should gate enabling the
+# test. It is also the first of the chain that is sequence-changing rather than a
+# rendering or ordering fault.
 #
-# On soak depth: #1320 was found at 27,633 successes by a 1,000,000-case run that
-# a 200,000-case run had just passed; #1321 at 114,694 successes by another
-# 1,000,000-case run. Each fix pushes the next failure deeper, so a clean soak at
-# one depth says nothing about the next. Note also that the soak's shell exit
-# code is `tail`'s, not the test's — an appended seed here is the reliable signal.
+# On soak depth, and on not reading a trend into it: #1320 was found at 27,633
+# successes by a 1,000,000-case run that a 200,000-case run had just passed;
+# #1321 at 114,694; #1323 at 143,034. The 4x jump did not repeat, so depth cannot
+# forecast an end. Note also that the soak's shell exit code is `tail`'s, not the
+# test's — an appended seed here is the reliable signal.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -30,3 +32,4 @@ cc 958acf3ea2005efa9eafd738606d0fd1d6bb0f586c918b926fd4d79d052f8d99 # #1312; shr
 cc 23c331742c910e4d748997c1e4e9d988fe3b4d032c3f60b1e995c9d052f3c720 # #1316; shrinks to haplotype = IndelHaplotype { core: "ACAGCCAGTCAGCGCATCAG", events: [Insert { index: 1, bases: "AA" }, Insert { index: 2, bases: "AA" }] }
 cc 2521c7200c3f735e03b752af83fb12c21c0e903ee3c7a42454dbe8f68f62b08d # #1320; shrinks to haplotype = IndelHaplotype { core: "AACAGTAAAATAT", events: [Insert { index: 6, bases: "AC" }, Insert { index: 8, bases: "AA" }, Insert { index: 9, bases: "AA" }] }
 cc 467e0a71b3d82df45d32757cbea6276e3853cc2bcfa505b23e946ac5513d57b2 # #1321; shrinks to haplotype = IndelHaplotype { core: "TCCCAGAAAAT", events: [Insert { index: 4, bases: "GA" }, Delete { index: 5 }, Insert { index: 6, bases: "GA" }] }
+cc ff4eca544f5524a5164ea91fe2bd0ab9f777f8bc2c86180ecae1aa19ee46aaa1 # #1323; shrinks to haplotype = IndelHaplotype { core: "CAGGGATCAT", events: [Delete { index: 3 }, Insert { index: 4, bases: "GA" }, Insert { index: 5, bases: "GA" }] }


### PR DESCRIPTION
Closes #1321.

## The defect

```text
reference  ("ACGT" x 64) + "TCCCAGAAAAT" + ("ACGT" x 64)

g.[261_262insGA;262_263insA;263del]  ->  g.[262_263dup;263=]
```

`262_263dup` spans 262–263 and `263=` names position 263, inside it. The pair overlaps, which #1235's second criterion forbids.

`g.262_263dup` **on its own already denotes the input** — it copies `G` at 262 and `A` at 263, giving `CAGA` + `GA` + `AAAT`, exactly what the three input members describe between them. So the `263=` is a pure residue: it adds no information and creates the overlap.

## Root cause

`drop_identity_members_covered_by_siblings` exists for precisely this shape (#1297): a `del` and an `ins` merge into a `delins` restating the reference, cancel to `=`, and the member that absorbed the change grows over it.

It gated on `claims_reference_bases`, which **deliberately excludes `Duplication`** — a dup adds a copy at a junction and consumes nothing. So a duplication that grew across the cancelled member's position did not count as covering it, and the residue survived. #1297's shape, one spelling over.

## The fix

The gate widens from `claims_reference_bases` to **`blocks_sibling_shift`**.

Those two predicates differ by exactly the case that matters: `blocks_sibling_shift` is `claims_reference_bases` plus `Duplication`/`DupIns`. Those are barriers precisely because they read their payload from the reference *under their own span* — and naming those positions is what makes an identity member inside them redundant, whether or not the bases are consumed.

**Insertions stay excluded under either predicate, and must.** An insertion's span *is* the gap it occupies, so `g.264_265insA` nominally covers position 264 while changing nothing there — dropping an identity member on that basis would be wrong. Pinned as a test.

The other guard #1297 installed is also pinned: an identity member nothing covers is real information, so `g.[1002=;1005del]` keeps both. Dropping identities outright would lose what the `=` records.

## Tests

`tests/it/issue_1321_identity_inside_a_duplication.rs`, three cases — the seed's own reproduction, the uncovered-identity guard, and the insertion-sibling guard. The helper asserts the invariant (members disjoint and ascending, mirroring the property's own check) as well as sequence preservation through `hgvs_to_spdi`.

One helper detail worth flagging for the next module in this family: its applier sorts 3'-to-5' and, **at a tied position, takes the longer deletion first**. The pinned input has a deletion and an insertion that both touch interbase 262 (`262_263insA` and `263del`); applying the zero-width one first leaves `claimed` at 262 and makes the deletion look like it overruns, so the applier reported a legal input as having no resulting sequence. That cost a false failure here and the same shape will recur.

## Verification

- `cargo nextest run --features dev` — **8967 passed, 0 failed**
- Same under `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` — 8967 passed
- `cargo fmt --all` + `cargo clippy --features dev --all-targets -- -D warnings` — clean
- All fourteen committed confluence seeds replay green, including #1321's `467e0a71`
- Failure output checked for `SIGABRT`/`SIGSEGV`/`TIMEOUT`/`LEAK`, not just `FAIL`, and reconciled against nextest's own failed count
- Commit signed

## What the property finds next

`the_ignored_indel_property_still_finds_its_defect` pins the property's *live* blocker and asserts it still fails, so fixing one turns that test red by design. Its pin moves from #1321 to **#1323** here.

With this fix the property fails a 1,000,000-case soak at **143,034 successes** on #1323:

```text
g.[260del;261_262insGA;262_263insGA]  ->  g.[261_262dup;262dup]
  intended  C A G G G A A G A T C A T
  emitted   C A G G G A G A A T C A T
```

The deletion is dropped, the duplications overlap at 262, and the result denotes different bases. That makes #1323 the **first chain defect since #1304 that is sequence-changing** rather than a rendering or ordering fault — a more severe class than #1301, #1316, #1320 or #1321. Verified pre-existing.

On depth, since it is the only measure of how close the chain is to ending: #1320 surfaced at 27,633 successes, #1321 at 114,694, #1323 at 143,034. **The 4x jump did not repeat** — the last step is 1.25x — so depth is not trending predictably and should not be used to forecast an end.
