### PR TITLE
fix(normalize): order a shared junction's payloads by where they came from

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4163,6 +4163,7 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
 /// Genomic axes only, matching `respell_colliding_duplications` — the
 /// transcript axes need a coordinate conversion this does not carry.
 pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
+    before: &[HgvsVariant],
     members: &mut Vec<HgvsVariant>,
     phase: AllelePhase,
     uncertain: bool,
@@ -4204,10 +4205,35 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         }
     }
 
+    // Where each member sat *before* this pass's per-member normalization, used
+    // to order a group whose payloads do not commute. Aligned by index with
+    // `members`: the caller builds both from one list and every pass between
+    // mutates in place, so `before[i]` is member `i`'s origin. An empty or
+    // mismatched snapshot disables the ordering rather than mis-attributing it.
+    let origins: Vec<Option<(i64, i64)>> = if before.len() == members.len() {
+        before
+            .iter()
+            .map(|v| member_span(v, kind).map(|s| (s.start, s.end)))
+            .collect()
+    } else {
+        vec![None; members.len()]
+    };
+
     let mut remove: Vec<usize> = Vec::new();
     for (_, at) in &groups {
         if at.len() < 2 {
             continue;
+        }
+        // Concatenate in the order the members *came from*, not the order they
+        // happen to sit in now. Two members can reach one junction without
+        // either crossing the other — a collapse can create one there while a
+        // sibling re-spells into it in place — and then the rendered order is
+        // an artefact of their spans rather than of what the allele means
+        // (#1323). Their origins are what the input actually said.
+        let mut at: Vec<usize> = at.clone();
+        let ordered_by_origin = at.iter().all(|&i| origins[i].is_some());
+        if ordered_by_origin {
+            at.sort_by_key(|&i| (origins[i], i));
         }
         let payloads: Option<Vec<Vec<Base>>> = at
             .iter()
@@ -4216,17 +4242,27 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
         let Some(payloads) = payloads else {
             continue;
         };
-        // Order-independence guard: every pair must commute, so the
-        // concatenation below does not depend on the order the members happen
-        // to be in. The same predicate `clamp_sibling_crossing_junctions` uses
-        // to decide whether they were allowed to meet here at all.
-        if payloads.iter().enumerate().any(|(x, left)| {
-            payloads[x + 1..]
-                .iter()
-                .any(|right| !payloads_commute(left, right))
-        }) {
+        // Order-independence guard, needed only when the origins could not
+        // supply an order. Commuting payloads (`p ++ q == q ++ p`) concatenate
+        // the same either way, so this is exactly the case where "whatever
+        // order they happen to be in" is safe — and it is the same predicate
+        // `clamp_sibling_crossing_junctions` uses to decide whether the two were
+        // allowed to meet here at all.
+        //
+        // With origins available the guard is unnecessary rather than merely
+        // relaxed: a commuting group reaches the same concatenation under
+        // either ordering, so ordering by origin subsumes the old behaviour
+        // instead of overriding it.
+        if !ordered_by_origin
+            && payloads.iter().enumerate().any(|(x, left)| {
+                payloads[x + 1..]
+                    .iter()
+                    .any(|right| !payloads_commute(left, right))
+            })
+        {
             continue;
         }
+        let at = &at;
         let combined: Vec<Base> = payloads.concat();
         let edit = NaEdit::Insertion {
             sequence: InsertedSequence::Literal(Sequence::new(combined)),

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2685,6 +2685,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // resulting sequence — an overlapping allele has none, so that pass
             // declines exactly the input it would have fixed.
             merge::coalesce_members_at_one_junction(
+                &pre_split,
                 &mut result,
                 allele.phase,
                 allele.uncertain,

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -60,9 +60,9 @@
 //!   nor #1262 is about overlapping members, so the citation did not describe
 //!   the shape it was excluding. What that shape hit was #1301, now fixed.
 //! - `an_indel_haplotype_normalizes_to_its_own_sequence` is `#[ignore]`d
-//!   because it finds #1323, a three-member allele losing its deletion and
-//!   denoting the wrong sequence. It found #1286, #1287, #1290, #1292, #1296,
-//!   #1301, #1304, #1297, #1308, #1312, #1316, #1320 and #1321 first, all now
+//!   because it finds #1325, a repeat whose growth exceeds its tract swallowing
+//!   a sibling's junction. It found #1286, #1287, #1290, #1292, #1296, #1301,
+//!   #1304, #1297, #1308, #1312, #1316, #1320, #1321 and #1323 first, all now
 //!   fixed, each masked behind the one before it; see its doc comment for the
 //!   history and the live reproduction.
 //!
@@ -808,22 +808,21 @@ proptest! {
     /// deletion and placed the repeats at 259; #1313 and #1317 moved both before
     /// #1316 itself was fixed.)
     ///
-    /// The live failure is the fourteenth, **#1323**:
+    /// The live failure is the sixteenth, **#1325**:
     ///
     /// ```text
-    /// core "CAGGGATCAT", delete index 3, insert "GA" after 4, insert "GA" after 5
-    ///   g.[260del;261_262insGA;262_263insGA] -> g.[261_262dup;262dup]
-    ///     intended  C A G G G A A G A T C A T
-    ///     emitted   C A G G G A G A A T C A T
+    /// core "GATCATAAATTCAGC", insert "AA" after 5, "AA" after 6, "C" after 7
+    ///   g.[262_263insAA;263_264insAA;264_265insC] -> g.[263_265A[7];264_265insC]
+    ///     the insertion adds at 264, strictly inside the tract 263-265
     /// ```
     ///
-    /// The deletion is dropped, the two duplications overlap at 262, and the
-    /// result denotes different bases. The first chain defect that is
-    /// **sequence-changing** rather than a rendering or ordering fault — every
-    /// one since #1304 has preserved the sequence. Verified pre-existing: the
-    /// parent of #1321's fix emits the identical output.
+    /// The other branch of #1316's hole: a repeat that grew its tract by more
+    /// bases than the tract holds has no duplication form, so
+    /// `demote_repeats_spanning_siblings` declines at its `start < a.start`
+    /// guard and the tract keeps the sibling's junction. Verified pre-existing —
+    /// the parent of #1323's fix emits the identical output.
     ///
-    /// Each of the fourteen was masked behind the one before it, which is the
+    /// Each of the sixteen was masked behind the one before it, which is the
     /// point of keeping this committed rather than deleting it until it passes.
     ///
     /// Enabling this test was #1292's acceptance criterion, then #1316's; both
@@ -831,21 +830,21 @@ proptest! {
     /// `issue_1316_coincident_tract_repeats` and by the `99d5d382` and
     /// `23c33174` seeds below. Neither could carry the criterion, because the
     /// property's next failure was always behind it. Enabling now belongs to
-    /// **#1323**, whose seed `ff4eca54` is committed below — so taking the
+    /// **#1325**, whose seed `4c6fab93` is committed below — so taking the
     /// ignore off replays it immediately and turns CI red, which is exactly what
     /// should gate taking it off.
     ///
     /// A caution about soak depth, and about reading a trend into it. With
     /// #1316 fixed this passed 200,000 cases and then failed a 1,000,000-case
-    /// run at 27,633 successes (#1320); with #1320 fixed, at 114,694 (#1321);
-    /// with #1321 fixed, at 143,034 (#1323). The 4x jump did not repeat — the
-    /// last step is 1.25x — so depth is not trending predictably and cannot be
-    /// used to forecast an end. A clean soak at one depth says nothing about the
-    /// next, and is certainly not evidence the chain has ended.
+    /// run at 27,633 successes (#1320); then at 114,694 (#1321), 143,034
+    /// (#1323) and 132,216 (#1325). The early 4x jump did not continue — the
+    /// last three sit in one band — so depth has plateaued rather than trending
+    /// toward an end, and it cannot be used to forecast one. A clean soak at one
+    /// depth says nothing about the next.
     ///
     /// Do not weaken it to make it pass.
     #[test]
-    #[ignore = "finds #1323, a real unfixed defect; see doc comment"]
+    #[ignore = "finds #1325, a real unfixed defect; see doc comment"]
     fn an_indel_haplotype_normalizes_to_its_own_sequence(
         haplotype in indel_haplotype_strategy()
     ) {
@@ -1045,14 +1044,14 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// to pin.
 #[test]
 fn the_ignored_indel_property_still_finds_its_defect() {
-    // #1323: a three-member allele loses its deletion and denotes the wrong
-    // sequence as two overlapping duplications. The first chain defect that is
-    // sequence-changing rather than a rendering or ordering fault. Moved here
-    // from #1321, which this change fixes.
+    // #1325: a repeat whose growth exceeds its tract has no duplication form,
+    // so `demote_repeats_spanning_siblings` declines and the tract swallows a
+    // sibling's junction. The other branch of #1316's hole. Moved here from
+    // #1323, which this change fixes.
     let (core, input, issue) = (
-        "CAGGGATCAT",
-        "NC_TEST.1:g.[260del;261_262insGA;262_263insGA]",
-        "#1323",
+        "GATCATAAATTCAGC",
+        "NC_TEST.1:g.[262_263insAA;263_264insAA;264_265insC]",
+        "#1325",
     );
     assert!(
         indel_property_holds(core, input).is_err(),

--- a/tests/it/issue_1323_shared_junction_order.rs
+++ b/tests/it/issue_1323_shared_junction_order.rs
@@ -1,0 +1,68 @@
+//! Two members that arrive at one junction are ordered by where they came
+//! from, not by how they happen to be spelled.
+//!
+//! [`coalesce_members_at_one_junction`] merges members that settle on one
+//! interbase (#1286). It required their payloads to **commute**, as an
+//! order-independence guard: `p ++ q == q ++ p` means the concatenation cannot
+//! depend on the order the members happen to be in. When they do not commute it
+//! declined, leaving the pair sharing a junction with no defined order:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "CAGGGATCAT" + ("ACGT" x 64)
+//!            G at 259-261, A at 262, T at 263
+//!
+//! g.[260del;261_262insGA;262_263insGA]  ->  g.[261_262dup;262dup]
+//!   intended  C A G G G A A G A T C A T
+//!   emitted   C A G G G A G A A T C A T
+//! ```
+//!
+//! Both members occupy junction 262 — `262dup` carrying `A`, `261_262dup`
+//! carrying `GA` — and the renderer concatenates them in span order, giving
+//! `GA ++ A` where the input means `A ++ GA`.
+//!
+//! Neither member *moved* to reach that junction, so
+//! `clamp_sibling_crossing_junctions` never saw a crossing to bound: `261del`
+//! and `261_262insGA` collapsed into `261delinsGA` (which canonicalizes to
+//! `262dup`, absorbing the deletion — it is not dropped), while
+//! `262_263insGA` re-spelled to `261_262dup` in place.
+//!
+//! Separating them is not available. Moving `261_262dup` back to junction 261
+//! is a legal rotation — its last base `A` equals `ref[262]` — but the resulting
+//! `[261_262insAG;262dup]` denotes `GAGAAT`, not `GAAGAT`. Both members belong
+//! at 262; only their order is wrong.
+//!
+//! The order is recoverable from the `before` snapshot the sibling passes
+//! already take: `261delinsGA` sat at 261 and `262_263insGA` at 262, so the
+//! 5'-most original contributes its payload first (#1323).
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// The core the proptest shrank to, and the reference the seed describes.
+const CORE: &str = "CAGGGATCAT";
+
+#[test]
+fn two_members_reaching_one_junction_keep_their_original_order() {
+    // #1323. The seed's own case. Both members land on junction 262 and the
+    // pair must concatenate 5'-most-original first: `A ++ GA`, not `GA ++ A`.
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[260del;261_262insGA;262_263insGA]");
+    assert_eq!(output, "NC_TEST.1:g.262_263insAGA");
+}
+
+#[test]
+fn a_commuting_pair_still_merges_as_before() {
+    // The guard on the relaxed order-independence test. In a poly-A tract every
+    // payload is a power of `A`, so both orders agree and the merge is the one
+    // #1286 installed — ordering by origin must not disturb it.
+    let output = assert_padded_preserving("AAAAAA", "NC_TEST.1:g.[258_259insA;259_260insA]");
+    assert_eq!(output, "NC_TEST.1:g.257_263A[9]");
+}
+
+#[test]
+fn a_non_commuting_pair_that_can_be_kept_apart_still_is() {
+    // #1312's case, which the clamp resolves by keeping the two members on
+    // distinct junctions. That must keep happening: merging is the repair for a
+    // pair that *cannot* be separated, not a licence to fold together members
+    // the clamp already ordered.
+    let output = assert_padded_preserving("TAAAACCA", "NC_TEST.1:g.[260_261insAC;261_262insAC]");
+    assert_eq!(output, "NC_TEST.1:g.[260_261insAC;261_262insAC]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -179,6 +179,7 @@ mod issue_1312_landed_payload_commutes;
 mod issue_1316_coincident_tract_repeats;
 mod issue_1320_dup_spans_sibling_junction;
 mod issue_1321_identity_inside_a_duplication;
+mod issue_1323_shared_junction_order;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/proptest-regressions/cis_allele_confluence_proptest.txt
+++ b/tests/proptest-regressions/cis_allele_confluence_proptest.txt
@@ -9,18 +9,18 @@
 # whose remaining filter drops haplotypes whose events cancel to no net change.
 # (The adjacent-gap-insertion filter that used to reject the first seed as well
 # was removed in #1294, so it runs now.) #1297, #1308 and #1312 are fixed
-# too, and so are #1316, #1320 and #1321 — all of the above now replay green.
-# #1323 is not yet fixed and is the reason
+# too, and so are #1316, #1320, #1321 and #1323 — all of the above now replay
+# green. #1325 is not yet fixed and is the reason
 # `an_indel_haplotype_normalizes_to_its_own_sequence` is still `#[ignore]`d — it
 # is the one seed here that still fails, which is what should gate enabling the
-# test. It is also the first of the chain that is sequence-changing rather than a
-# rendering or ordering fault.
+# test.
 #
 # On soak depth, and on not reading a trend into it: #1320 was found at 27,633
 # successes by a 1,000,000-case run that a 200,000-case run had just passed;
-# #1321 at 114,694; #1323 at 143,034. The 4x jump did not repeat, so depth cannot
-# forecast an end. Note also that the soak's shell exit code is `tail`'s, not the
-# test's — an appended seed here is the reliable signal.
+# then #1321 at 114,694, #1323 at 143,034, #1325 at 132,216. The early 4x jump
+# did not continue and the last three sit in one band, so depth has plateaued
+# and cannot forecast an end. Note also that the soak's shell exit code is
+# `tail`'s, not the test's — an appended seed here is the reliable signal.
 cc e8fb54e331549cd5d7b8d2f8100951aed7db8ab2ffc759df817bd69a7e4eff9a # #1286; shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Insert { index: 1, bases: ['A', 'A'], len: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc e11d211278b3d526443f114ec02b2ec4e1b35df7d4a6024ba0bcc543d52162b3 # shrinks to haplotype = IndelHaplotype { core: "AAAAAA", events: [Delete { index: 1 }, Insert { index: 2, bases: ['A', 'A'], len: 1 }] }
 cc a38727fa5784df80e613e4c9547baccb981621191ad1260871fb5943faf8dce6 # #1287; shrinks to haplotype = IndelHaplotype { core: "ATACAGAAAATCAGGGCATA", events: [Insert { index: 4, bases: ['G', 'A'], len: 2 }, Insert { index: 6, bases: ['A', 'A'], len: 2 }] }
@@ -33,3 +33,4 @@ cc 23c331742c910e4d748997c1e4e9d988fe3b4d032c3f60b1e995c9d052f3c720 # #1316; shr
 cc 2521c7200c3f735e03b752af83fb12c21c0e903ee3c7a42454dbe8f68f62b08d # #1320; shrinks to haplotype = IndelHaplotype { core: "AACAGTAAAATAT", events: [Insert { index: 6, bases: "AC" }, Insert { index: 8, bases: "AA" }, Insert { index: 9, bases: "AA" }] }
 cc 467e0a71b3d82df45d32757cbea6276e3853cc2bcfa505b23e946ac5513d57b2 # #1321; shrinks to haplotype = IndelHaplotype { core: "TCCCAGAAAAT", events: [Insert { index: 4, bases: "GA" }, Delete { index: 5 }, Insert { index: 6, bases: "GA" }] }
 cc ff4eca544f5524a5164ea91fe2bd0ab9f777f8bc2c86180ecae1aa19ee46aaa1 # #1323; shrinks to haplotype = IndelHaplotype { core: "CAGGGATCAT", events: [Delete { index: 3 }, Insert { index: 4, bases: "GA" }, Insert { index: 5, bases: "GA" }] }
+cc 4c6fab93d960d151efaae1712887d2434ede4a2e975eaac181369bd61055889f # #1325; shrinks to haplotype = IndelHaplotype { core: "GATCATAAATTCAGC", events: [Insert { index: 5, bases: "AA" }, Insert { index: 6, bases: "AA" }, Insert { index: 7, bases: "C" }] }


### PR DESCRIPTION
Closes #1323.

## The defect

```text
reference  ("ACGT" x 64) + "CAGGGATCAT" + ("ACGT" x 64)
           G at 259-261, A at 262, T at 263

g.[260del;261_262insGA;262_263insGA]  ->  g.[261_262dup;262dup]

  intended  C A G G G A A G A T C A T
  emitted   C A G G G A G A A T C A T
```

Both members occupy **junction 262** — `262dup` carrying `A`, `261_262dup` carrying `GA` — and the renderer emits them in span order, concatenating `GA ++ A` where the input means `A ++ GA`.

**Correction to the issue as filed.** It says the allele "loses its deletion". It does not: `261del` and `261_262insGA` collapse into `261delinsGA`, which canonicalizes to `262dup`, and `262dup` denotes exactly what that del/ins pair denotes together. The deletion is absorbed by a correct collapse. The fault is the shared-junction ordering alone — the sequence really is wrong, so the severity stands, but the mechanism in the issue title was mine and it was wrong. The issue carries a correcting comment.

## Root cause

Traced with per-pass instrumentation of the merge loop:

```text
pass 0  normalized   [261del; 261_262insGA; 261_262dup]
        respell_dups [261del; 261_262insGA; 262_263insGA]   <- correctly pulled back

pass 1  merged_split [262dup; 262_263insGA]
        pre_split    [261delinsGA; 262_263insGA]
        normalized   [262dup; 261_262dup]                    <- both on junction 262
        (no sibling pass changes anything)
```

Two facts combine, and neither is individually wrong:

- **Neither member moved to reach junction 262.** One was created there by the collapse; the other re-spelled into it in place. `clamp_sibling_crossing_junctions` bounds a member that *crosses* a sibling, so there was no crossing to bound.
- **`coalesce_members_at_one_junction` declined.** Its order-independence guard requires the payloads to commute, and `A ++ GA != GA ++ A`.

So the pair was left sharing a junction with no defined order, and the rendered order — which follows their spans — is an artefact rather than a statement about the allele.

## Separating them is not available

The obvious repair is to pull one back so they no longer share a junction. It changes the sequence. Moving `261_262dup` to junction 261 is a *legal* rotation (its last base `A` equals `ref[262]`), but the resulting `[261_262insAG;262dup]` denotes `GAGAAT`, not `GAAGAT`. Both members genuinely belong at 262. Only their order is wrong.

## The fix

The pass now takes the `pre_split` snapshot the sibling passes already build, and orders the concatenation by **where each member came from**: `261delinsGA` sat at 261 and `262_263insGA` at 262, so the 5'-most origin contributes first — `A ++ GA = AGA`, giving `g.262_263insAGA`, which denotes the input.

This **subsumes** the commuting guard rather than relaxing it. `p ++ q == q ++ p` is precisely the condition under which the two orderings agree, so a commuting group reaches the same concatenation either way. The guard survives as the fallback for a group whose origins are unavailable — an empty or length-mismatched snapshot disables the ordering rather than mis-attributing it.

That is why this did not break the passes that depend on the guard, which was my main worry going in: #1286, #1308, #1312 and #1313 rely on it for the *commuting* case, and that is exactly where the new rule agrees with the old one.

## Tests

`tests/it/issue_1323_shared_junction_order.rs`, three cases, asserting the invariant (members disjoint and ascending) as well as sequence preservation through `hgvs_to_spdi`:

- the seed's own case, now `g.262_263insAGA`
- **#1286's commuting merge still gives `g.257_263A[9]`** — ordering by origin must not disturb it
- **#1312's non-commuting pair is still kept apart** on distinct junctions by the clamp. Merging is the repair for a pair that *cannot* be separated, not a licence to fold together members the clamp already ordered

## Verification

- `cargo nextest run --features dev` — **8970 passed, 0 failed**
- Same under `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` — 8970 passed
- `cargo fmt --all` + `cargo clippy --features dev --all-targets -- -D warnings` — clean
- The 276,480-case sweep holds its residual at 0
- All sixteen committed confluence seeds replay green, including #1323's `ff4eca54`
- Failure output checked for `SIGABRT`/`SIGSEGV`/`TIMEOUT`/`LEAK`, not just `FAIL`
- Commit signed

## What the property finds next

The pin in `the_ignored_indel_property_still_finds_its_defect` moves from #1323 to **#1325**, found by a 1,000,000-case soak at 132,216 successes:

```text
g.[262_263insAA;263_264insAA;264_265insC]  ->  g.[263_265A[7];264_265insC]
```

A repeat whose growth exceeds its tract has no duplication form, so `demote_repeats_spanning_siblings` declines at its `start < a.start` guard and the tract keeps the sibling's junction. **That is the other branch of the hole #1316 fixed for coincident repeats**, and `repeat_growth_as_insertion` — already written for #1316 — is the tool for it. Verified pre-existing.

On depth: #1320 surfaced at 27,633 successes, #1321 at 114,694, #1323 at 143,034, #1325 at 132,216. The early 4x jump did not continue and the last three sit in one band, so depth has **plateaued** rather than trending toward an end. I would not read it as evidence the chain is nearly exhausted.
