### PR TITLE
test(normalize): use the shared cis-allele apply oracle in three suites

### DIFF
--- a/tests/it/issue_1297_cancelled_identity_member.rs
+++ b/tests/it/issue_1297_cancelled_identity_member.rs
@@ -20,57 +20,9 @@
 //! identity member a sibling *claims the bases of* is a contradiction, and only
 //! that one is dropped.
 
-use crate::common::synthetic::{padded, SyntheticBuilder};
-use ferro_hgvs::spdi::hgvs_to_spdi;
-use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+use crate::common::synthetic::assert_padded_preserving;
 
 const CORE: &str = "GCATGAAAAT";
-
-/// Normalize and assert the output denotes the input's bases. A pair whose
-/// members overlap has no resulting sequence at all, which is how the pre-fix
-/// output failed.
-fn assert_padded_preserving(core: &str, input: &str) -> String {
-    let provider = SyntheticBuilder::genomic(core).build();
-    let normalizer = Normalizer::new(provider.clone());
-    let reference = padded(core);
-    let output = normalizer
-        .normalize(&parse_hgvs(input).expect("parse"))
-        .expect("normalize")
-        .to_string();
-
-    let denote = |descriptor: &str| -> Option<String> {
-        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
-            HgvsVariant::Allele(allele) => allele.variants.clone(),
-            single => vec![single],
-        };
-        let mut triples = Vec::new();
-        for member in &members {
-            triples.push(hgvs_to_spdi(member, &provider).ok()?);
-        }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
-        let mut edited = reference.as_bytes().to_vec();
-        let mut claimed = reference.len();
-        for triple in &triples {
-            let start = usize::try_from(triple.position).ok()?;
-            let end = start.checked_add(triple.deletion.len())?;
-            if end > claimed {
-                return None;
-            }
-            edited.splice(start..end, triple.insertion.bytes());
-            claimed = start;
-        }
-        String::from_utf8(edited).ok()
-    };
-
-    let from_input = denote(input).expect("input applies");
-    let from_output = denote(&output)
-        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
-    assert_eq!(
-        from_output, from_input,
-        "`{input}` -> `{output}` changed the sequence"
-    );
-    output
-}
 
 #[test]
 fn a_cancelled_member_does_not_survive_inside_the_repeat_that_absorbed_it() {

--- a/tests/it/issue_1308_commuting_payload_phase.rs
+++ b/tests/it/issue_1308_commuting_payload_phase.rs
@@ -33,54 +33,7 @@
 //! that junction, not the one it carries now — landing there rotates it, and a
 //! rotation can destroy the commuting identity. That half is #1312.
 
-use crate::common::synthetic::{padded, SyntheticBuilder};
-use ferro_hgvs::spdi::hgvs_to_spdi;
-use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
-
-/// Normalize and assert the output denotes the input's bases, projected through
-/// `hgvs_to_spdi` rather than the normalizer's own applier.
-fn assert_padded_preserving(core: &str, input: &str) -> String {
-    let provider = SyntheticBuilder::genomic(core).build();
-    let normalizer = Normalizer::new(provider.clone());
-    let reference = padded(core);
-    let output = normalizer
-        .normalize(&parse_hgvs(input).expect("parse"))
-        .expect("normalize")
-        .to_string();
-
-    let denote = |descriptor: &str| -> Option<String> {
-        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
-            HgvsVariant::Allele(allele) => allele.variants.clone(),
-            single => vec![single],
-        };
-        let mut triples = Vec::new();
-        for member in &members {
-            triples.push(hgvs_to_spdi(member, &provider).ok()?);
-        }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
-        let mut edited = reference.as_bytes().to_vec();
-        let mut claimed = reference.len();
-        for triple in &triples {
-            let start = usize::try_from(triple.position).ok()?;
-            let end = start.checked_add(triple.deletion.len())?;
-            if end > claimed {
-                return None;
-            }
-            edited.splice(start..end, triple.insertion.bytes());
-            claimed = start;
-        }
-        String::from_utf8(edited).ok()
-    };
-
-    let from_input = denote(input).expect("input applies");
-    let from_output = denote(&output)
-        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
-    assert_eq!(
-        from_output, from_input,
-        "`{input}` -> `{output}` changed the sequence"
-    );
-    output
-}
+use crate::common::synthetic::assert_padded_preserving;
 
 #[test]
 fn a_commuting_payload_does_not_sweep_past_a_sibling_that_stays() {

--- a/tests/it/issue_1312_landed_payload_commutes.rs
+++ b/tests/it/issue_1312_landed_payload_commutes.rs
@@ -23,54 +23,7 @@
 //! Testing the landed payload keeps them apart: the bound falls back to one
 //! position short, and the allele renders as its input does.
 
-use crate::common::synthetic::{padded, SyntheticBuilder};
-use ferro_hgvs::spdi::hgvs_to_spdi;
-use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
-
-/// Normalize and assert the output denotes the input's bases, projected through
-/// `hgvs_to_spdi` rather than the normalizer's own applier.
-fn assert_padded_preserving(core: &str, input: &str) -> String {
-    let provider = SyntheticBuilder::genomic(core).build();
-    let normalizer = Normalizer::new(provider.clone());
-    let reference = padded(core);
-    let output = normalizer
-        .normalize(&parse_hgvs(input).expect("parse"))
-        .expect("normalize")
-        .to_string();
-
-    let denote = |descriptor: &str| -> Option<String> {
-        let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
-            HgvsVariant::Allele(allele) => allele.variants.clone(),
-            single => vec![single],
-        };
-        let mut triples = Vec::new();
-        for member in &members {
-            triples.push(hgvs_to_spdi(member, &provider).ok()?);
-        }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
-        let mut edited = reference.as_bytes().to_vec();
-        let mut claimed = reference.len();
-        for triple in &triples {
-            let start = usize::try_from(triple.position).ok()?;
-            let end = start.checked_add(triple.deletion.len())?;
-            if end > claimed {
-                return None;
-            }
-            edited.splice(start..end, triple.insertion.bytes());
-            claimed = start;
-        }
-        String::from_utf8(edited).ok()
-    };
-
-    let from_input = denote(input).expect("input applies");
-    let from_output = denote(&output)
-        .unwrap_or_else(|| panic!("`{input}` -> `{output}` has no resulting sequence"));
-    assert_eq!(
-        from_output, from_input,
-        "`{input}` -> `{output}` changed the sequence"
-    );
-    output
-}
+use crate::common::synthetic::assert_padded_preserving;
 
 #[test]
 fn a_rotation_that_breaks_commuting_keeps_the_pair_apart() {


### PR DESCRIPTION
Three cis-allele regression suites — `issue_1297_cancelled_identity_member`, `issue_1308_commuting_payload_phase` and `issue_1312_landed_payload_commutes` — each carry a private copy of `assert_padded_preserving`. They predate the shared helper in `tests/it/common/synthetic.rs` and are behind it in two ways that matter:

**The applier's sort is missing a tie-break.** All three sort 3'-to-5' by position alone. At a tied position the *longer* deletion has to be applied first; otherwise a legal input where a deletion and an insertion touch the same interbase — `262_263insA` alongside `263del` — leaves the running cursor at that interbase, the deletion looks like it overruns, and the helper reports a well-formed input as having no resulting sequence.

**They only check the sequence, not the rendering.** The copies assert that the output denotes the input's bases. The shared helper additionally asserts that the output's members render disjoint and ascending. That second property is what most of these regressions are actually about: an overlapping pair that happens to apply to the right sequence is still malformed, and the copies pass it.

This points all three at the shared helper and deletes the copies. No test data, inputs or expectations change — the three suites simply gain the stricter assertion and the tie-break fix.

Found while dual-reviewing the #1288→#1326 cis-allele stack: the shared helper was extracted partway through, and suites added later reintroduced local copies. The improvements above were contributed by #1324's copy and upstreamed there; these three were left behind.

Verified: 8993 tests pass, including under `FERRO_ASSERT_IDEMPOTENT=1` with `FERRO_ASSERT_REPARSE=1`. `cargo fmt` and `clippy --all-features --all-targets -- -D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated shared test validation across multiple integration tests.
  * Removed duplicated test helper implementations while preserving existing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->