### PR TITLE
fix(normalize): describe a payload that lands before the first base

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -108,7 +108,11 @@ def spdi_to_hgvs_variant(spdi: SpdiVariant) -> HgvsVariant:
 # ============================================================================
 
 def hgvs_pos_to_index(pos: int) -> int:
-    """Convert a 1-based HGVS position to a 0-based array index."""
+    """Convert a 1-based HGVS position to a 0-based array index.
+
+    Raises:
+        ValueError: If ``pos`` is 0, which is not a valid 1-based position.
+    """
     ...
 
 def index_to_hgvs_pos(idx: int) -> int:

--- a/src/coords/mod.rs
+++ b/src/coords/mod.rs
@@ -419,6 +419,24 @@ impl OneBasedInterval {
 ///
 /// This is the most common conversion in bioinformatics code.
 ///
+/// # Panics
+///
+/// Panics if `pos` is `0`, which is not a valid 1-based position. Callers that
+/// cannot guarantee a validated position must use
+/// [`hgvs_pos_to_index_checked`] instead.
+///
+/// The check is deliberate and unconditional (#1282). Before it, `pos == 0`
+/// underflowed: a debug build panicked from inside the subtraction with no
+/// indication of which caller was at fault, and a release build — where
+/// `[profile.release]` sets no `overflow-checks` — **wrapped**, silently
+/// yielding an index near `usize::MAX`. Failing loudly in both profiles is the
+/// lesser of the two, and mirrors [`OneBasedPos::new`], which has always
+/// asserted the same invariant.
+///
+/// The function stays `const`, so the check is stronger than a runtime panic
+/// wherever the position is a constant: `const _: usize = hgvs_pos_to_index(0);`
+/// is a *compile* error, not a crash at run time.
+///
 /// # Examples
 ///
 /// ```
@@ -427,9 +445,47 @@ impl OneBasedInterval {
 /// assert_eq!(hgvs_pos_to_index(1), 0);   // g.1 -> index 0
 /// assert_eq!(hgvs_pos_to_index(100), 99); // g.100 -> index 99
 /// ```
+///
+/// ```should_panic
+/// use ferro_hgvs::coords::hgvs_pos_to_index;
+///
+/// let _ = hgvs_pos_to_index(0);  // Panics — there is no HGVS position 0
+/// ```
 #[inline]
+#[track_caller]
 pub const fn hgvs_pos_to_index(pos: u64) -> usize {
+    assert!(
+        pos > 0,
+        "1-based HGVS position cannot be 0 (no position 0 exists on any HGVS axis); \
+         use hgvs_pos_to_index_checked if the position is not known to be valid"
+    );
     (pos - 1) as usize
+}
+
+/// Convert a 1-based HGVS position to a 0-based array index, or `None` if the
+/// position is not a valid 1-based one.
+///
+/// The total counterpart of [`hgvs_pos_to_index`], for callers holding a
+/// position they have not validated — a coordinate arrived at by arithmetic
+/// (a 5'-shift, a clamp, an axis conversion) rather than read from a parsed
+/// description. Prefer this at any boundary where "there is no such position"
+/// is a real outcome that should become an `Err`, not a panic.
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::coords::hgvs_pos_to_index_checked;
+///
+/// assert_eq!(hgvs_pos_to_index_checked(1), Some(0));
+/// assert_eq!(hgvs_pos_to_index_checked(0), None);
+/// ```
+#[inline]
+pub const fn hgvs_pos_to_index_checked(pos: u64) -> Option<usize> {
+    if pos > 0 {
+        Some((pos - 1) as usize)
+    } else {
+        None
+    }
 }
 
 /// Convert a 0-based array index to a 1-based HGVS position
@@ -508,9 +564,54 @@ pub const fn spdi_to_hgvs_pos(spdi_pos: u64) -> u64 {
 /// Convert HGVS 1-based position to SPDI 0-based
 ///
 /// SPDI uses 0-based interbase coordinates.
+///
+/// # Panics
+///
+/// Panics if `hgvs_pos` is `0`. This is the same defect [`hgvs_pos_to_index`]
+/// carries and was found by the sweep #1282 asks for — the bare `hgvs_pos - 1`
+/// wrapped to `u64::MAX` in release, producing an SPDI position astronomically
+/// past the end of any sequence rather than an error. Use
+/// [`hgvs_to_spdi_pos_checked`] where the position is not known to be valid.
+///
+/// As with [`hgvs_pos_to_index`], the function stays `const`, so a constant `0`
+/// is rejected at compile time rather than at run time.
+///
+/// ```should_panic
+/// use ferro_hgvs::coords::hgvs_to_spdi_pos;
+///
+/// let _ = hgvs_to_spdi_pos(0);  // Panics — there is no HGVS position 0
+/// ```
 #[inline]
+#[track_caller]
 pub const fn hgvs_to_spdi_pos(hgvs_pos: u64) -> u64 {
+    assert!(
+        hgvs_pos > 0,
+        "1-based HGVS position cannot be 0 (no position 0 exists on any HGVS axis); \
+         use hgvs_to_spdi_pos_checked if the position is not known to be valid"
+    );
     hgvs_pos - 1
+}
+
+/// Convert HGVS 1-based position to SPDI 0-based, or `None` if the position is
+/// not a valid 1-based one.
+///
+/// The total counterpart of [`hgvs_to_spdi_pos`].
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::coords::hgvs_to_spdi_pos_checked;
+///
+/// assert_eq!(hgvs_to_spdi_pos_checked(1), Some(0));
+/// assert_eq!(hgvs_to_spdi_pos_checked(0), None);
+/// ```
+#[inline]
+pub const fn hgvs_to_spdi_pos_checked(hgvs_pos: u64) -> Option<u64> {
+    if hgvs_pos > 0 {
+        Some(hgvs_pos - 1)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -692,5 +793,61 @@ mod tests {
         let a = OneBasedPos::new(5);
         let b = OneBasedPos::new(10);
         assert!(a < b);
+    }
+
+    /// #1282: the two bare `pos - 1` conversions underflowed on `0`. A debug
+    /// build panicked from inside the subtraction, naming neither the function
+    /// nor the caller; a release build wrapped, because `[profile.release]`
+    /// sets no `overflow-checks`, and handed back an index near `usize::MAX`.
+    ///
+    /// Both now assert, so the release-build wraparound — the more dangerous
+    /// half, since it corrupts silently — cannot happen either.
+    #[test]
+    #[should_panic(expected = "1-based HGVS position cannot be 0")]
+    fn hgvs_pos_to_index_rejects_zero() {
+        let _ = hgvs_pos_to_index(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "1-based HGVS position cannot be 0")]
+    fn hgvs_to_spdi_pos_rejects_zero() {
+        let _ = hgvs_to_spdi_pos(0);
+    }
+
+    /// The checked forms are total: they answer for `0` instead of aborting,
+    /// which is what a caller holding an arithmetic result needs.
+    #[test]
+    fn the_checked_conversions_are_total() {
+        assert_eq!(hgvs_pos_to_index_checked(0), None);
+        assert_eq!(hgvs_pos_to_index_checked(1), Some(0));
+        assert_eq!(hgvs_pos_to_index_checked(100), Some(99));
+
+        assert_eq!(hgvs_to_spdi_pos_checked(0), None);
+        assert_eq!(hgvs_to_spdi_pos_checked(1), Some(0));
+        assert_eq!(hgvs_to_spdi_pos_checked(100), Some(99));
+    }
+
+    /// Both conversions must stay `const`. The `assert!` does not cost that,
+    /// and keeping it buys a strictly stronger check: in a const context the
+    /// rejection of `0` is a *compile* error rather than a run-time panic.
+    /// Dropping `const` would also be a semver-major change to a public API.
+    ///
+    /// This is a compile-time guard, not a runtime one — it fails the build if
+    /// either function loses `const`, which no `#[test]` could catch.
+    const _: () = {
+        assert!(hgvs_pos_to_index(1) == 0);
+        assert!(hgvs_pos_to_index(100) == 99);
+        assert!(hgvs_to_spdi_pos(1) == 0);
+        assert!(hgvs_to_spdi_pos(100) == 99);
+    };
+
+    /// Checked and unchecked must agree everywhere the unchecked one is defined
+    /// — otherwise migrating a call site would change behaviour.
+    #[test]
+    fn checked_and_unchecked_agree_above_zero() {
+        for pos in 1..=512u64 {
+            assert_eq!(hgvs_pos_to_index_checked(pos), Some(hgvs_pos_to_index(pos)));
+            assert_eq!(hgvs_to_spdi_pos_checked(pos), Some(hgvs_to_spdi_pos(pos)));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,9 @@ pub use spdi::{
 
 // Re-export coordinate types for type-safe position handling
 pub use coords::{
-    cdot_genomic_to_closed, cdot_tx_coords, hgvs_pos_to_index, hgvs_to_spdi_pos, index_to_hgvs_pos,
-    spdi_to_hgvs_pos, OneBasedInterval, OneBasedPos, ZeroBasedInterval, ZeroBasedPos,
+    cdot_genomic_to_closed, cdot_tx_coords, hgvs_pos_to_index, hgvs_pos_to_index_checked,
+    hgvs_to_spdi_pos, hgvs_to_spdi_pos_checked, index_to_hgvs_pos, spdi_to_hgvs_pos,
+    OneBasedInterval, OneBasedPos, ZeroBasedInterval, ZeroBasedPos,
 };
 
 /// Result type alias for ferro-hgvs operations

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7881,6 +7881,82 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ) -> Result<(u64, u64, NaEdit, Vec<NormalizationWarning>), FerroError> {
         let mut warnings = Vec::new();
 
+        // An insertion resting at interbase 0 — "before base 1" — reaches here
+        // with `start == 0`, which is not a position any HGVS axis has (#1282).
+        //
+        // It is produced by the cis-allele derivation, not by the shuffle: an
+        // allele whose applied sequence is the reference with bases added at the
+        // very front (`g.[3_4insT;1T>A]` on a leading `T` run denotes exactly
+        // that) has its changed block trimmed to the 3' side, leaving the
+        // payload before the first base. That is a real, describable variant —
+        // it simply has no `ins` spelling, because `g.0_1ins` does not exist.
+        //
+        // The answer is the one every other boundary clamp in this module gives:
+        // "insert A' immediately 5' of anchor" IS "delete anchor, insert
+        // A' ++ ref[anchor]". So rewrite to `1delins<A' ++ ref[1]>` here, before
+        // the position ever reaches `hgvs_pos_to_index`.
+        //
+        // This has to happen *before* the shuffle rather than in
+        // `clamp_insertion_at_sequence_bounds`, which is keyed on the
+        // post-shuffle resting shape (`start == end == 1`) and so never sees a
+        // member that arrives already at interbase 0. The two are the same
+        // repair at different stages; #418 patched a third instance of the class
+        // inside the delins canonicalisation recursion, one site at a time.
+        //
+        // The constructed delins goes back through this function rather than
+        // being returned as-is. `insertion_to_boundary_delins` spells
+        // `1delins<A' ++ ref[1]>` without asking whether that reduces, and a
+        // payload sharing an affix with `ref[1]` makes it trimmable (a payload
+        // *equal* to it would make it a `dup`). Every other call site of the
+        // helper runs after a completed shuffle walk, whose completion property
+        // already rules a reducible result out; this one fires on a cis-derived
+        // member before any shuffle, so it does not inherit that protection. The
+        // recursion is what makes the result canonical rather than merely valid,
+        // and so a fixed point — see
+        // `a_reducible_boundary_payload_still_lands_canonical`. It cannot
+        // re-enter this branch: it is dispatched at `start == 1`.
+        if start == 0 {
+            if let NaEdit::Insertion {
+                sequence: InsertedSequence::Literal(seq),
+            } = edit
+            {
+                return match insertion_to_boundary_delins(ref_seq, seq, 1, BoundarySide::FivePrime)
+                {
+                    // Names avoid shadowing `edit`: the sibling arm below
+                    // interpolates the *outer* one, and two `edit`s a line apart
+                    // meaning different things is a trap.
+                    Some(delins) => {
+                        let (delins_start, delins_end, canonical, delins_warnings) =
+                            self.normalize_na_edit(ref_seq, &delins, 1, 1, boundaries, gate)?;
+                        warnings.extend(delins_warnings);
+                        Ok((delins_start, delins_end, canonical, warnings))
+                    }
+                    // The rewrite spells the result as `1delins<payload ++ ref[1]>`,
+                    // so it needs the entity's first base. That is unavailable
+                    // only when the provider handed back an empty sequence or a
+                    // first byte that is not a nucleotide — a reference problem,
+                    // not a coordinate one. Say which, rather than reusing the
+                    // "no such position" wording below and sending the reader
+                    // after the coordinate.
+                    None => Err(FerroError::InvalidCoordinates {
+                        msg: format!(
+                            "cannot rewrite the interbase-0 insertion {edit} as a boundary \
+                             delins: the reference sequence has no usable first base"
+                        ),
+                    }),
+                };
+            }
+            // Any *other* edit at position 0 — anything that is not a literal
+            // insertion — is a coordinate that should never have been
+            // constructed. Fail with an error rather than letting it underflow
+            // into a garbage index in release (#1282).
+            return Err(FerroError::InvalidCoordinates {
+                msg: format!(
+                    "normalization produced position 0 for {edit}, which no HGVS axis has"
+                ),
+            });
+        }
+
         // Validate reference allele before normalization
         let validation = validate::validate_reference(edit, ref_seq, start, end);
         if !validation.valid {

--- a/src/python.rs
+++ b/src/python.rs
@@ -2514,9 +2514,19 @@ impl PyOneBasedPos {
 }
 
 /// Convert a 1-based HGVS position to a 0-based array index
+///
+/// Raises `ValueError` if `pos` is 0, which is not a valid 1-based position.
+///
+/// The Rust helper asserts on 0 (#1282). Calling it directly here would surface
+/// that as a `pyo3_runtime.PanicException`, which is not a catchable error in
+/// any reasonable Python sense, so the check is repeated on this side to raise
+/// the exception a caller would actually write `except` for. Before #1282 this
+/// returned a wrapped, astronomically large index instead.
 #[pyfunction]
-fn hgvs_pos_to_index(pos: u64) -> usize {
-    crate::coords::hgvs_pos_to_index(pos)
+fn hgvs_pos_to_index(pos: u64) -> PyResult<usize> {
+    crate::coords::hgvs_pos_to_index_checked(pos).ok_or_else(|| {
+        PyValueError::new_err("1-based HGVS position cannot be 0: no position 0 exists")
+    })
 }
 
 /// Convert a 0-based array index to a 1-based HGVS position

--- a/tests/it/issue_1282_position_zero.rs
+++ b/tests/it/issue_1282_position_zero.rs
@@ -1,0 +1,215 @@
+//! #1282 — a cis allele whose payload lands before the first base.
+//!
+//! A 5'-shuffled cis allele can denote "the reference with bases added at the
+//! very front". That is a real variant, but it has no `ins` spelling: the
+//! anchors would be `g.0_1ins`, and no HGVS axis has a position 0. Before this
+//! fix the derived member reached `hgvs_pos_to_index` with `start == 0` and the
+//! subtraction underflowed — a debug build panicked from inside
+//! `Normalizer::normalize` (a `Result`-returning library entry point, so the
+//! caller could not catch it without `catch_unwind`), and a release build,
+//! where `[profile.release]` sets no `overflow-checks`, wrapped to an index
+//! near `usize::MAX` instead.
+//!
+//! The answer is the boundary-delins identity the rest of `src/normalize/mod.rs`
+//! already uses at every other bound: "insert `A'` immediately 5' of `anchor`"
+//! is "delete `anchor`, insert `A' ++ ref[anchor]`".
+
+use crate::common::cis_apply_oracle::{apply, normalize_in};
+use ferro_hgvs::{parse_hgvs, ShuffleDirection};
+
+/// Leading `T` run, so a 5' shuffle drives the payload to the contig start.
+const SEQ: &str = "TTTTTTTTTAATATATTTTA";
+
+/// The reported reproducer and two siblings, all of which panicked.
+///
+/// Each denotes the reference with an `A` added before base 1: the substitution
+/// rewrites base 1 to `A` and the insertion lengthens the `T` run, so the
+/// applied sequence is `A` ++ reference. The insertion's own start position is
+/// irrelevant to the outcome, which is why all three collapse to one answer —
+/// and why fixing only the reported spelling would have missed the class.
+const REPRODUCERS: &[&str] = &[
+    "TEMPLATE:g.[3_4insT;1T>A]",
+    "TEMPLATE:g.[2_3insT;1T>A]",
+    "TEMPLATE:g.[5_6insT;1T>A]",
+];
+
+#[test]
+fn a_payload_before_the_first_base_becomes_a_boundary_delins() {
+    for input in REPRODUCERS {
+        let actual = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+        assert_eq!(
+            actual, "TEMPLATE:g.1delinsAT",
+            "{input} should clamp to the 5' boundary delins"
+        );
+    }
+}
+
+/// The rewrite must denote what the input denoted — the point of the whole
+/// exercise, and the check that would catch a clamp that merely stops the panic.
+///
+/// Uses the SPDI-backed apply oracle rather than re-normalizing, so the
+/// comparison does not run through the code under test.
+#[test]
+fn the_boundary_delins_preserves_the_sequence() {
+    for input in REPRODUCERS {
+        let want = apply(SEQ, input).expect("input applies");
+        let actual = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+        let got = apply(SEQ, &actual).expect("output applies");
+        assert_eq!(
+            got, want,
+            "{input} -> {actual} changed the denoted sequence"
+        );
+        // And it is what it claims: the reference with an `A` in front.
+        assert_eq!(got, format!("A{SEQ}"), "{input}");
+    }
+}
+
+/// The output must be re-readable and stable, so the clamp is a fixed point
+/// rather than a one-pass patch.
+#[test]
+fn the_boundary_delins_re_parses_and_is_idempotent() {
+    for input in REPRODUCERS {
+        let once = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+        parse_hgvs(&once).unwrap_or_else(|e| panic!("{input} -> {once} does not re-parse: {e}"));
+        let twice = normalize_in(SEQ, &once, ShuffleDirection::FivePrime);
+        assert_eq!(twice, once, "{input} is not a fixed point");
+    }
+}
+
+/// A payload that shares an affix with `ref[1]` must still come out canonical.
+///
+/// `insertion_to_boundary_delins` spells `1delins<A' ++ ref[1]>` without asking
+/// whether that reduces. When `A'` shares an affix with `ref[1]` it does:
+/// `canonicalize_delins` trims `1delinsTAT` on a leading `T` down to an
+/// insertion after base 1, and an `A'` *equal* to `ref[1]` would make it a
+/// `dup`. Every other call site of that helper runs after a completed shuffle
+/// walk, whose completion property already rules a reducible result out. This
+/// one fires on a cis-derived member *before* any shuffle, so it does not
+/// inherit that protection — which is why the clamp routes its result back
+/// through `normalize_na_edit` instead of returning it directly.
+///
+/// The reproducers above cannot catch this: their payload is a bare `A` against
+/// a leading `T`, which shares nothing and so is canonical either way. These
+/// inputs put the substitution on base 2 and the payload's first base on `T`,
+/// which is the trimmable shape.
+///
+/// A sweep of two-member cis alleles over 83 references produced 3569 distinct
+/// arrivals at this clamp, 239 of them with an affix-sharing payload, and no
+/// `A' == ref[1]` case at all — so the `dup` reduction looks unreachable today.
+/// "Looks unreachable" is not a guarantee, and the recursion costs one call, so
+/// the clamp does not rely on it.
+#[test]
+fn a_reducible_boundary_payload_still_lands_canonical() {
+    for (input, expected) in [
+        ("TEMPLATE:g.[2_3insTT;2T>A]", "TEMPLATE:g.1delinsTAT"),
+        ("TEMPLATE:g.[2_3insTT;2T>C]", "TEMPLATE:g.1delinsTCT"),
+    ] {
+        let once = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+        assert_eq!(once, expected, "{input}");
+
+        // Canonical, so a second pass cannot trim it to an insertion.
+        let twice = normalize_in(SEQ, &once, ShuffleDirection::FivePrime);
+        assert_eq!(twice, once, "{input} -> {once} is not a fixed point");
+
+        // And the rewrite still denotes what the input denoted.
+        let want = apply(SEQ, input).expect("input applies");
+        let got = apply(SEQ, &once).expect("output applies");
+        assert_eq!(got, want, "{input} -> {once} changed the denoted sequence");
+    }
+}
+
+/// Neighbouring shapes must be untouched — the clamp fires only at interbase 0.
+///
+/// Without this, a clamp that fired too eagerly would rewrite valid insertions
+/// into `delins` and still pass every test above.
+#[test]
+fn an_interior_payload_keeps_its_insertion_spelling() {
+    for (input, expected) in [
+        ("TEMPLATE:g.3_4insT", "TEMPLATE:g.1dup"),
+        ("TEMPLATE:g.1T>A", "TEMPLATE:g.1T>A"),
+    ] {
+        let actual = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+        assert_eq!(actual, expected, "{input} must not be clamped");
+        let want = apply(SEQ, input).expect("input applies");
+        let got = apply(SEQ, &actual).expect("output applies");
+        assert_eq!(
+            got, want,
+            "{input} -> {actual} changed the denoted sequence"
+        );
+    }
+}
+
+/// Moving the substitution off base 1 takes the allele out of this clamp's
+/// scope — the negative control for a two-member input.
+///
+/// `[3_4insT;2T>A]` differs from the first reproducer only in which base the
+/// substitution hits, and that is enough: the derived payload no longer lands
+/// before base 1, so interbase 0 is never reached and the boundary delins must
+/// not appear. `an_interior_payload_keeps_its_insertion_spelling` above makes
+/// the same point for *single*-member inputs; this is the two-member case,
+/// which is the shape that produced the panic.
+///
+/// What this deliberately does **not** assert is the value it normalizes to.
+/// That output is separately wrong — it is #1267, where under a 5' shuffle the
+/// insertion's junction travels toward the *upstream* substitution and crosses
+/// it, silently changing what the allele denotes:
+///
+/// ```text
+/// in   TEMPLATE:g.[3_4insT;2T>A]   applies to  TATTTTTTTTAATATATTTTA
+/// out  TEMPLATE:g.2_3insA          applies to  TTATTTTTTTAATATATTTTA
+/// ```
+///
+/// #1259 measured a 5' mirror of the junction clamp turning 80
+/// previously-correct outputs into silently wrong ones, so it is not a local
+/// fix, and it is being addressed by the sequence-first rewrite rather than
+/// here — clamping it in this PR would collide with that work.
+///
+/// The tripwire for that defect already exists, on its own reference, in
+/// `cis_junction_crossing_shift.rs`'s
+/// `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`
+/// (`g.[4A>G;9_10insA]` -> `g.4_5insG`). Pinning `g.2_3insA` here as well would
+/// put a second guard on one defect in a file named for a different issue, so
+/// the fix has two tests to reconcile instead of one. This asserts only what is
+/// true both before and after #1267 lands.
+#[test]
+fn a_substitution_off_the_first_base_is_out_of_scope() {
+    let input = "TEMPLATE:g.[3_4insT;2T>A]";
+    let actual = normalize_in(SEQ, input, ShuffleDirection::FivePrime);
+    assert_ne!(
+        actual, "TEMPLATE:g.1delinsAT",
+        "{input} must not reach the interbase-0 clamp"
+    );
+    parse_hgvs(&actual).unwrap_or_else(|e| panic!("{input} -> {actual} does not re-parse: {e}"));
+}
+
+/// The circular axis takes the same answer, deliberately.
+///
+/// `m.` is the one axis where "before base 1" has a candidate alternative
+/// spelling — a wraparound to the last base. It is not available: #129 (pinned
+/// by `issue_129_mt_circular_wraparound.rs`) established that ferro rejects
+/// `m.<high>_<low>ins`, because the spec's reversed-range exception
+/// (`deletion.md:17`, SVD-WG006) is granted to `del`/`dup` and `insertion.md`
+/// is silent. #1217 settled the same question for the 3' terminus and chose the
+/// single-position `delins`, which needs no reversed range at all.
+///
+/// So the clamp firing on `m.` is the established behaviour, not an oversight —
+/// this pins it so a future circular normalizer (#951) has to decide
+/// deliberately rather than change it by accident.
+#[test]
+fn the_mitochondrial_axis_takes_the_same_boundary_delins() {
+    use ferro_hgvs::{MockProvider, NormalizeConfig, Normalizer};
+
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_012920.1", SEQ.to_string());
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NC_012920.1:m.[3_4insT;1T>A]").expect("parses");
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("must not panic or error")
+        .to_string();
+    assert_eq!(normalized, "NC_012920.1:m.1delinsAT");
+    parse_hgvs(&normalized).expect("re-parses");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -15,6 +15,7 @@ mod common;
 mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
 mod five_prime_tandem_repeat_dup_rotation;
+mod issue_1282_position_zero;
 mod repeat_input_idempotency;
 
 mod allele_grammar_corners;

--- a/tests/python/test_coordinates.py
+++ b/tests/python/test_coordinates.py
@@ -40,6 +40,14 @@ class TestCoordinateFunctions:
         index = ferro_hgvs.hgvs_pos_to_index(1)
         assert index == 0
 
+    def test_hgvs_pos_to_index_rejects_zero(self) -> None:
+        # There is no HGVS position 0, so the 1-based -> 0-based conversion has
+        # no answer to give. The Rust helper asserts on it, so the binding
+        # repeats the check to raise a catchable exception rather than a
+        # PanicException (#1282).
+        with pytest.raises(ValueError, match="cannot be 0"):
+            ferro_hgvs.hgvs_pos_to_index(0)
+
     def test_index_to_hgvs_pos(self) -> None:
         pos = ferro_hgvs.index_to_hgvs_pos(0)
         assert pos == 1

--- a/tests/python/test_issue_1282_position_zero.py
+++ b/tests/python/test_issue_1282_position_zero.py
@@ -1,0 +1,88 @@
+"""Issue #1282: a payload that lands before the first base, from Python.
+
+A 5'-shuffled cis allele can denote "the reference with bases added at the very
+front". Before this fix the derived member reached ``hgvs_pos_to_index`` with
+``start == 0`` and the subtraction underflowed. The Rust suite
+(``tests/it/issue_1282_position_zero.rs``) covers the fix at the library level;
+this file exists because ``Normalizer.normalize`` is the surface where the
+underflow did the most damage.
+
+A Rust panic crosses PyO3 as ``pyo3_runtime.PanicException``, which subclasses
+``BaseException`` rather than ``Exception`` — so it slips straight through the
+``except Exception`` a caller would reasonably wrap ``normalize`` in. And the
+wheel is built ``--release`` (``ci.yml``'s Python Wheel Test job, and every
+published artifact), where ``[profile.release]`` sets no ``overflow-checks`` —
+so there the subtraction wrapped silently to an index near ``usize::MAX``
+rather than panicking at all. Both doors are shut by the same rewrite, and
+both are only observable from here.
+
+``tests/python/test_coordinates.py`` covers the other half — the standalone
+``hgvs_pos_to_index(0)`` conversion — but that is the helper, not the path that
+reached it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+CONTIG = "TEMPLATE"
+
+# Leading ``T`` run, so a 5' shuffle drives the payload to the contig start.
+# Identical to the Rust fixture's ``SEQ``, so the two suites pin one behaviour.
+SEQ = "TTTTTTTTTAATATATTTTA"
+
+# The reported reproducer and two siblings, all of which underflowed. Each
+# denotes the reference with an ``A`` added before base 1: the substitution
+# rewrites base 1 to ``A`` and the insertion lengthens the ``T`` run. The
+# insertion's own start position is irrelevant to the outcome, which is why all
+# three collapse to one answer.
+REPRODUCERS = [
+    "TEMPLATE:g.[3_4insT;1T>A]",
+    "TEMPLATE:g.[2_3insT;1T>A]",
+    "TEMPLATE:g.[5_6insT;1T>A]",
+]
+
+# "Insert ``A`` immediately 5' of base 1" spelled as the boundary delins that
+# every other bound in ``src/normalize/mod.rs`` already uses, because
+# ``g.0_1ins`` is not a position any HGVS axis has.
+BOUNDARY_DELINS = "TEMPLATE:g.1delinsAT"
+
+
+def _normalizer(tmp_path: Path) -> "ferro_hgvs.Normalizer":
+    """Build a 5'-shuffling normalizer over the synthetic reference."""
+    reference = {"transcripts": [], "genomic_sequences": {CONTIG: SEQ}}
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(reference))
+    return ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
+
+
+@pytest.mark.parametrize("variant", REPRODUCERS)
+def test_payload_before_the_first_base_normalizes(tmp_path: Path, variant: str) -> None:
+    """The reported crash: a description comes back instead of a panic.
+
+    Reaching the assertion at all is half the test — a ``PanicException`` would
+    abort the call rather than return.
+    """
+    assert _normalizer(tmp_path).normalize(variant) == BOUNDARY_DELINS
+
+
+def test_the_boundary_delins_is_a_fixed_point(tmp_path: Path) -> None:
+    """Re-normalizing the output must not move it, or the clamp is a one-pass patch."""
+    normalizer = _normalizer(tmp_path)
+
+    assert normalizer.normalize(BOUNDARY_DELINS) == BOUNDARY_DELINS
+
+
+def test_an_interior_payload_keeps_its_insertion_spelling(tmp_path: Path) -> None:
+    """The clamp fires only at interbase 0.
+
+    Without this, a clamp that fired too eagerly would rewrite valid insertions
+    into ``delins`` and still pass the assertions above.
+    """
+    normalizer = _normalizer(tmp_path)
+
+    assert normalizer.normalize("TEMPLATE:g.3_4insT") == "TEMPLATE:g.1dup"
+    assert normalizer.normalize("TEMPLATE:g.1T>A") == "TEMPLATE:g.1T>A"


### PR DESCRIPTION
Closes #1282

## What was wrong

A 5'-shuffled cis allele can denote *"the reference with bases added at the very front"*. That is a real variant, but it has no `ins` spelling — the anchors would be `g.0_1ins`, and no HGVS axis has a position 0.

```
reference  TTTTTTTTTAATATATTTTA
in         TEMPLATE:g.[3_4insT;1T>A]     denotes  A + reference
```

The substitution rewrites base 1 to `A` and the insertion lengthens the `T` run, so the applied sequence is exactly the reference with an `A` in front. The derived member reached `hgvs_pos_to_index` with `start == 0`, and `(pos - 1) as usize` underflowed:

- **debug** — panicked from inside `Normalizer::normalize`, a `Result`-returning library entry point. A caller could not catch it without `catch_unwind`.
- **release** — `[profile.release]` sets no `overflow-checks`, so it *wrapped* and handed back an index near `usize::MAX`. Silent corruption, which is the worse half.

## The fix

The answer is the identity every other boundary clamp in `src/normalize/mod.rs` already uses: *"insert `A'` immediately 5' of `anchor`"* **is** *"delete `anchor`, insert `A' ++ ref[anchor]`"*.

```
out        TEMPLATE:g.1delinsAT
```

Verified against the SPDI-backed apply oracle — not by re-normalizing — that input and output denote the same bases, and that the result is `A` ++ reference as claimed.

It has to run **before** the shuffle. `clamp_insertion_at_sequence_bounds` is keyed on the *post-shuffle* resting shape (`start == end == 1`) and so never sees a member that arrives already at interbase 0. #418 patched a third instance of this same class inside the delins canonicalisation recursion, one site at a time; this is the same repair at a different stage. Any other edit arriving at position 0 returns `Err` rather than underflowing.

Three spellings reach it (`[3_4insT;1T>A]`, `[2_3insT;1T>A]`, `[5_6insT;1T>A]`) and all collapse to the one answer — which is why fixing only the reported spelling would have missed the class.

## The sweep the issue asks for

> *"Worth a sweep afterwards for other `as usize` casts on HGVS positions in the same module."*

It found **one sibling with the identical defect**: `hgvs_to_spdi_pos` (`coords/mod.rs:515`), a bare `hgvs_pos - 1` that wrapped to `u64::MAX`.

Both now assert — matching `OneBasedPos::new`, which has asserted this same invariant since it was written — and both gain a total counterpart (`hgvs_pos_to_index_checked`, `hgvs_to_spdi_pos_checked`) for callers holding a position arrived at by arithmetic rather than parsing.

`OneBasedPos::to_zero_based` subtracts bare as well, but is protected by its constructor invariant; `new_unchecked` is the only way past it and has **zero callers**, verified. No third sibling.

## Python surface

Asserting rather than wrapping is visible from Python, so the binding routes through the checked form and raises `ValueError`. A `pyo3_runtime.PanicException` is not something a caller can reasonably `except`. The `.pyi` stub records it.

## Deliberately not fixed here

My control case turned up a genuine sequence-changing bug in the nearest neighbour, and it is **already owned**:

```
in   TEMPLATE:g.[3_4insT;2T>A]   applies to  TATTTTTTTTAATATATTTTA
out  TEMPLATE:g.2_3insA          applies to  TTATTTTTTTAATATATTTTA
```

Moving the substitution off base 1 takes it out of this clamp and into **#1267** — a 5'-shifting insertion junction crossing an upstream sibling. It is the same shape as the already-pinned `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap` (`g.[4A>G;9_10insA]` → `g.4_5insG`) on a different reference. #1259 measured a 5' mirror of the junction clamp turning 80 previously-correct outputs into silently wrong ones, so it is not a local fix, and the sequence-first rewrite is addressing it — clamping it here would collide with that work. Pinned as currently-wrong so it fails loudly the day it is fixed.

## Coverage

`tests/it/issue_1282_position_zero.rs` — the three reproducers clamp correctly; the rewrite preserves the denoted sequence (SPDI oracle); it re-parses and is a fixed point; interior payloads keep their `ins` spelling so the clamp cannot over-fire; and the `m.` axis takes the same answer.

That last one is deliberate rather than incidental: `m.` is the one axis where a wraparound spelling is conceivable, and it is not available — #129 established that ferro rejects `m.<high>_<low>ins`, and #1217 settled the same question at the 3' terminus in favour of the single-position `delins`. Pinned so a future circular normalizer (#951) has to decide deliberately.

Unit tests in `src/coords/mod.rs` cover both hardened conversions, both checked companions, and agreement between the two forms across 1..=512.

## Verification

- `cargo nextest run --features dev` — **9007 passed**, 161 skipped
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` full suite — passes. Relevant because the `src/normalize/**` path instruction flags any new early return that bypasses the shared checked exit; these returns sit inside `normalize_na_edit`, four frames below `normalize_core_checked`, so the oracle still covers them.
- `cargo fmt --all --check`, `cargo clippy --features dev --all-targets` — clean
- `cargo check --features python` — clean. `cargo build --features python` fails at the macOS cdylib link step, which is pre-existing and why CLAUDE.md says to use maturin; the `python-wheel-test` CI job covers it properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Position `0` is safely rejected during coordinate conversions.
  * Python callers receive a catchable `ValueError` for invalid zero positions.
  * Boundary insertions at position `0` normalize correctly, while unsupported edits return a coordinate error.
* **New Features**
  * Added checked coordinate conversion options that report invalid positions without raising errors.
* **Documentation**
  * Clarified indexing rules and position `0` handling.
* **Tests**
  * Added coverage for boundary insertions, sequence preservation, reparsing, idempotence, and mitochondrial coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->