### PR TITLE
fix(project): decline axes ferro cannot render, instead of emitting them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,24 @@ skips its own check.
 
 `FERRO_ASSERT_REPARSE=1` is the second half of the same seam: it asserts that a
 normalized description is one `parse_hgvs` accepts — *when normalization is what
-broke it*. Two exemptions keep that scope honest: `0` and `?` are legal
-whole-allele outputs that `parse_hgvs` rejects standalone because it wants an
-accession, and an input that does not itself re-parse is passed over, since a
-description the parser accepts inbound but cannot re-read outbound is a
-parse/display round-trip asymmetry normalize merely carries through. Both are a
-different bug; reporting them here would bury the one this oracle is for.
+broke it*. Its exemptions are a **closed list**, deliberately (#1264):
+
+- `0` and `?` are legal whole-allele outputs that `parse_hgvs` rejects standalone
+  because it wants an accession — a limit of the entry point, not a malformed output.
+- An **empty allele** (`[]`), reachable only by direct construction; the projector's
+  own tests build one on purpose to pin that it declines.
+- A **non-flanking genomic insertion**, which is the projection *pivot*: its
+  coordinates are sound and the downstream cdot derivation of the c./n./p. axes needs
+  it, but its spelling is not one HGVS admits, so the projector withholds the
+  *reported* genomic axis instead (`non_flanking_genomic_insertion_anchor`).
+
+**This used to be a blanket** — "skip when the input does not itself re-parse" — and
+that blanket was hiding live defects rather than scoping the oracle. Instrumenting it
+to report instead of return silently, then re-running the suite, found 18 hits in four
+shapes, two of which were real projector bugs (the RNA-only `spl` edit carried onto the
+`g.`/`c.` axes, and an insertion whose anchors straddle a splice junction). Both are
+fixed; the exemption is now narrow enough that the same class of defect fails loudly.
+If you find yourself widening it, that is the signal to fix the producer instead.
 
 Like the idempotency oracle it is compiled out in release builds
 (`#[cfg(debug_assertions)]`) and read once into a `OnceLock`, so it adds no

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7672,12 +7672,16 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
         )
     }
 
-    /// Apply both sub-rules to one nucleotide variant's loc/edit pair.
-    macro_rules! check_na_anchor {
-        ($v:expr, $prefix:expr) => {{
-            if is_insertion(&$v.loc_edit.edit) {
-                let start = &$v.loc_edit.location.start;
-                let end = &$v.loc_edit.location.end;
+    /// Apply both sub-rules to one loc/edit pair.
+    ///
+    /// Takes the `LocEdit` rather than the variant so the ring path — whose
+    /// `segments` are bare `LocEdit`s with no enclosing variant — shares the
+    /// exact rule the single-variant axes get, instead of a re-derived copy.
+    macro_rules! check_loc_edit_anchor {
+        ($le:expr, $prefix:expr) => {{
+            if is_insertion(&$le.edit) {
+                let start = &$le.location.start;
+                let end = &$le.location.end;
                 if pos_eq(start, end) {
                     return Err(make_error($prefix));
                 }
@@ -7685,6 +7689,13 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
                     return Err(make_gap_error($prefix));
                 }
             }
+        }};
+    }
+
+    /// Apply both sub-rules to one nucleotide variant's loc/edit pair.
+    macro_rules! check_na_anchor {
+        ($v:expr, $prefix:expr) => {{
+            check_loc_edit_anchor!($v.loc_edit, $prefix)
         }};
     }
 
@@ -7729,6 +7740,27 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
                 validate_no_point_insertion(inner, _source)?;
             }
         }
+        // A ring's `::`-joined segments are `LocEdit<GenomeInterval, NaEdit>`
+        // — the same loc/edit pair every arm above inspects — but they hang off
+        // `GenomeRing` rather than a nested `HgvsVariant`, so recursion cannot
+        // reach them and they fell through the catch-all below (#1264). Both
+        // MUST-level sub-rules were therefore unenforced inside a join:
+        // `g.100_102insATG::200_201insG` and `g.100insATG::200_201insG` both
+        // parsed, while the identical spellings outside a join were rejected.
+        //
+        // Invisible to the `FERRO_ASSERT_REPARSE` oracle, because these round
+        // trip: ferro renders back exactly what it accepted. Only a parser test
+        // can see it.
+        HgvsVariant::GenomeRing(ring) => {
+            for segment in &ring.segments {
+                check_loc_edit_anchor!(segment, "g.");
+            }
+        }
+        // `sup` wraps either a plain genome variant or a ring. The plain inner
+        // was already covered (it is parsed through this same validator before
+        // being wrapped); the ring inner was not, so recurse explicitly rather
+        // than relying on that.
+        HgvsVariant::Supernumerary(inner) => validate_no_point_insertion(inner, _source)?,
         _ => {}
     }
     Ok(())

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -720,6 +720,46 @@ pub struct AlleleVariant {
     pub uncertain: bool,
 }
 
+/// The anchor positions of `variant`, when it is a genomic insertion whose two
+/// positions are **not** a flanking pair; `None` otherwise (#1264).
+///
+/// `DNA/insertion.md:15` requires an insertion anchor to name *two flanking
+/// nucleotides* — "e.g., `123_124`, not `123_125`" — and the parser enforces it
+/// on the way in (`validate_no_point_insertion`). A description that violates it
+/// is therefore one ferro cannot read back, whoever built it.
+///
+/// Kept here, beside the type it describes, rather than in the projector that
+/// needs it: it is a statement about a variant's well-formedness, and
+/// `normalize` consults it too. Putting it in `project` would have made
+/// `normalize` depend on `project`, inverting the layering.
+///
+/// Only a pair of certain, plain endpoints is decidable, matching
+/// `validate_no_point_insertion`'s `definitely_not_flanking`: an uncertain
+/// boundary or a `(a_b)` range is not something this rule can speak to.
+pub(crate) fn non_flanking_genomic_insertion_anchor(variant: &HgvsVariant) -> Option<(u64, u64)> {
+    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::uncertainty::Mu;
+
+    let HgvsVariant::Genome(gv) = variant else {
+        return None;
+    };
+    if !matches!(gv.loc_edit.edit.inner(), Some(NaEdit::Insertion { .. })) {
+        return None;
+    }
+    let (Some(Mu::Certain(start)), Some(Mu::Certain(end))) = (
+        gv.loc_edit.location.start.as_single(),
+        gv.loc_edit.location.end.as_single(),
+    ) else {
+        return None;
+    };
+    // A special marker (`pter`/`qter`/`cen`) sets `base` to 0 and names no
+    // numeric position, so the pair is not comparable.
+    if start.special.is_some() || end.special.is_some() {
+        return None;
+    }
+    (end.base != start.base + 1).then_some((start.base, end.base))
+}
+
 impl AlleleVariant {
     /// Create a new allele variant
     pub fn new(variants: Vec<HgvsVariant>, phase: AllelePhase) -> Self {
@@ -728,6 +768,31 @@ impl AlleleVariant {
             phase,
             uncertain: false,
         }
+    }
+
+    /// Build an allele, returning `None` when it has no members (#1264).
+    ///
+    /// An allele with an empty member list has no HGVS rendering: `Display`
+    /// emits `[]`, and `parse_hgvs` rejects `[]` — so the value round-trips to
+    /// nothing and any consumer chaining a second call fails on it. The parser
+    /// already refuses empty brackets everywhere they can appear, which leaves
+    /// direct construction as the only way to reach the shape.
+    ///
+    /// This mirrors [`GenomeRing::new`], which refuses a ring of fewer than two
+    /// segments for the same reason ("a 0/1-segment ring would not round-trip").
+    ///
+    /// [`AlleleVariant::new`] is deliberately left infallible. It is used
+    /// throughout the parser and normalizer on member lists that are non-empty
+    /// by construction, and changing its signature would churn call sites that
+    /// cannot hit this case for no added safety. Prefer `checked` at the
+    /// boundaries where the list is assembled from data — a projection, a
+    /// filter, an external payload — which is where an empty list can actually
+    /// arise.
+    pub fn checked(variants: Vec<HgvsVariant>, phase: AllelePhase) -> Option<Self> {
+        if variants.is_empty() {
+            return None;
+        }
+        Some(Self::new(variants, phase))
     }
 
     /// Create a new allele variant wrapped in an uncertainty marker

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1635,15 +1635,50 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let Err(e) = crate::hgvs::parser::parse_hgvs(&rendered) else {
             return;
         };
-        // Only fire when normalization *introduced* the breakage. A description
-        // the parser accepts but cannot re-read — an empty allele rendering as
-        // `[]`, or an `ins` whose anchors the parser tolerates inbound and
-        // rejects outbound — is a parse/display round-trip asymmetry that
-        // normalize merely passes through. Real, but a different bug, and
-        // reporting it here would bury the one this oracle is for.
-        if crate::hgvs::parser::parse_hgvs(&variant.to_string()).is_err() {
+        // Only fire when normalization *introduced* the breakage — but say
+        // exactly which inputs are passed over, rather than exempting anything
+        // that fails to re-parse (#1264).
+        //
+        // The blanket version ("skip when the input does not itself re-parse")
+        // was doing far more work than its comment claimed. Instrumenting it to
+        // report instead of return silently, and re-running the suite, found 18
+        // hits in four shapes — including two live projector defects that were
+        // building descriptions ferro could not read back: the RNA-only `spl`
+        // edit carried onto the `g.`/`c.` axes, and an insertion whose anchors
+        // straddle a splice junction. Both are fixed in this change; a blanket
+        // exemption would have re-absorbed them, and any future defect of the
+        // same class, without a sound.
+        //
+        // What remains is a closed list. Each entry is a shape ferro constructs
+        // deliberately and does not claim is renderable:
+        //
+        // * An **empty allele** (`[]`). The parser refuses empty brackets
+        //   everywhere they can appear, so this is reachable only by direct
+        //   construction — which the projector's own tests do on purpose, to
+        //   pin that it declines them. `AlleleVariant::checked` now refuses it
+        //   at the boundaries where a member list is assembled from data.
+        // * A **non-flanking genomic insertion**. This is the projection
+        //   *pivot*: its coordinates are sound and the downstream cdot
+        //   derivation of the c./n./p. axes needs it, but its spelling is not
+        //   one HGVS admits, so the projector withholds the *reported* genomic
+        //   axis (see `non_flanking_genomic_insertion_anchor`). Normalizing the pivot
+        //   is deliberate; reporting it is what would be wrong.
+        //
+        // Anything else that arrives unparseable is now a failure, which is the
+        // point.
+        let input_is_a_deliberate_non_renderable = matches!(
+            variant,
+            HgvsVariant::Allele(allele) if allele.variants.is_empty()
+        )
+            || crate::hgvs::variant::non_flanking_genomic_insertion_anchor(variant).is_some();
+        if input_is_a_deliberate_non_renderable {
             return;
         }
+        debug_assert!(
+            crate::hgvs::parser::parse_hgvs(&variant.to_string()).is_ok(),
+            "FERRO_ASSERT_REPARSE: normalization was handed an input it cannot re-parse, and \
+             that input is not one of the deliberate non-renderable shapes\n  input: {variant}",
+        );
         panic!(
             "FERRO_ASSERT_REPARSE: normalization produced a description ferro cannot re-parse\n  \
              input:  {variant}\n  output: {rendered}\n  error:  {e}",

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1962,7 +1962,21 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             if allele.phase == AllelePhase::Cis {
                 sort_genomic_allele_members(&mut members);
             }
-            let mut projected = AlleleVariant::new(members, allele.phase);
+            // `checked`, not `new`: this is exactly the boundary its doc comment
+            // names — a member list assembled from data rather than fixed by the
+            // grammar. An empty input allele is unreachable through the parser
+            // (it refuses empty brackets everywhere they can appear) but is
+            // constructible by hand, and `new` would hand back an allele that
+            // renders `[]`, which is not HGVS and which any caller chaining a
+            // second parse fails on. Declining with the projector's own error
+            // type reports the problem where it can still be acted on (#1264).
+            let mut projected = AlleleVariant::checked(members, allele.phase).ok_or_else(|| {
+                FerroError::UnsupportedProjection {
+                    reason: "cannot project an allele with no members: an empty allele renders \
+                             `[]`, which is not a description ferro can read back"
+                        .to_string(),
+                }
+            })?;
             projected.uncertain = allele.uncertain;
             return Ok(HgvsVariant::Allele(projected));
         }
@@ -1975,7 +1989,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             return result;
         }
 
-        match self.project_to_genomic_nc(variant)? {
+        let pivot = self.project_to_genomic_nc(variant)?;
+        // The pivot's coordinates are sound even when its *spelling* is not, so
+        // the adjacency check belongs here — where a genomic form is handed to a
+        // caller — rather than inside `project_to_genomic_nc`, which also feeds
+        // the downstream cdot derivation of the c./n./p. axes. Guarding the pivot
+        // itself would have thrown those away too (#1264).
+        if let Some(reason) = non_flanking_insertion_reason(&pivot) {
+            return Err(FerroError::UnsupportedProjection { reason });
+        }
+        match pivot {
             // Raw pivot: re-anchor into the parent frame but do NOT normalize
             // (#785/#867). The pivot was 3'-normalized in *transcript* space,
             // which is the genome's 5' end on a minus-strand transcript, so the
@@ -2648,62 +2671,109 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // on a transcript with large introns is hundreds of kb (#1177). On a
         // non-coding transcript `r.` and `n.` do coincide, but `to_cds_frame`
         // self-gates on `is_coding`, so no conversion runs there either way.
-        let (accession, gene_symbol, edit_mu, start_cds, end_cds, input_base_is_tx_relative) =
-            match variant {
-                HgvsVariant::Cds(v) => {
-                    let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "c.", "start")?;
-                    let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "c.", "end")?;
-                    (
-                        v.accession.clone(),
-                        v.gene_symbol.clone(),
-                        v.loc_edit.edit.clone(),
-                        s,
-                        e,
-                        false,
-                    )
-                }
-                HgvsVariant::Tx(v) => {
-                    let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "n.", "start")?;
-                    let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "n.", "end")?;
-                    let to_cds = |p: TxPos| CdsPos {
-                        base: p.base,
-                        offset: p.offset,
-                        utr3: p.downstream,
-                        special: None,
-                    };
-                    (
-                        v.accession.clone(),
-                        v.gene_symbol.clone(),
-                        v.loc_edit.edit.clone(),
-                        to_cds(s),
-                        to_cds(e),
-                        true,
-                    )
-                }
-                HgvsVariant::Rna(v) => {
-                    let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "r.", "start")?;
-                    let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "r.", "end")?;
-                    // RnaPos mirrors CdsPos in both shape AND numbering: on a
-                    // coding transcript `r.` is the `c.` axis, so this reshape is
-                    // the whole conversion and the position must NOT be rebased
-                    // again (`false` below, #1177).
-                    let to_cds = |p: crate::hgvs::location::RnaPos| CdsPos {
-                        base: p.base,
-                        offset: p.offset,
-                        utr3: p.utr3,
-                        special: None,
-                    };
-                    (
-                        v.accession.clone(),
-                        v.gene_symbol.clone(),
-                        v.loc_edit.edit.clone(),
-                        to_cds(s),
-                        to_cds(e),
-                        false,
-                    )
-                }
-                _ => unreachable!("variant kind already filtered above"),
-            };
+        let (
+            accession,
+            gene_symbol,
+            edit_mu,
+            axis_label,
+            start_cds,
+            end_cds,
+            input_base_is_tx_relative,
+        ) = match variant {
+            HgvsVariant::Cds(v) => {
+                let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "c.", "start")?;
+                let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "c.", "end")?;
+                (
+                    v.accession.clone(),
+                    v.gene_symbol.clone(),
+                    v.loc_edit.edit.clone(),
+                    "c.",
+                    s,
+                    e,
+                    false,
+                )
+            }
+            HgvsVariant::Tx(v) => {
+                let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "n.", "start")?;
+                let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "n.", "end")?;
+                let to_cds = |p: TxPos| CdsPos {
+                    base: p.base,
+                    offset: p.offset,
+                    utr3: p.downstream,
+                    special: None,
+                };
+                (
+                    v.accession.clone(),
+                    v.gene_symbol.clone(),
+                    v.loc_edit.edit.clone(),
+                    "n.",
+                    to_cds(s),
+                    to_cds(e),
+                    true,
+                )
+            }
+            HgvsVariant::Rna(v) => {
+                let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "r.", "start")?;
+                let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "r.", "end")?;
+                // RnaPos mirrors CdsPos in both shape AND numbering: on a
+                // coding transcript `r.` is the `c.` axis, so this reshape is
+                // the whole conversion and the position must NOT be rebased
+                // again (`false` below, #1177).
+                let to_cds = |p: crate::hgvs::location::RnaPos| CdsPos {
+                    base: p.base,
+                    offset: p.offset,
+                    utr3: p.utr3,
+                    special: None,
+                };
+                (
+                    v.accession.clone(),
+                    v.gene_symbol.clone(),
+                    v.loc_edit.edit.clone(),
+                    "r.",
+                    to_cds(s),
+                    to_cds(e),
+                    false,
+                )
+            }
+            _ => unreachable!("variant kind already filtered above"),
+        };
+
+        // 1b. Reject the RNA-only *effects*. The kind ladder above asks "does
+        //     this axis have a genomic counterpart"; this asks the same of the
+        //     edit, which is a separate question and was never asked (#1264).
+        //
+        //     `spl` ("splicing affected", `RNA/splicing.md`) and `0` ("no
+        //     product") describe what happens to the transcript, not a sequence
+        //     change at a genomic locus, so there is no `g.spl` or `g.0` to
+        //     emit. The trap is that the *position* maps perfectly well: the
+        //     projector converted it and carried the edit token through
+        //     verbatim, rendering `NC_000023.11:g.spl` — a string ferro's own
+        //     parser rejects.
+        //
+        //     The check sits *after* the axis extraction, not on
+        //     `HgvsVariant::Rna` before it, because these edits are not confined
+        //     to the `r.` axis: `n.0` is a valid spec form for a non-coding
+        //     transcript and parses to `HgvsVariant::Tx` (`parse_rna_no_product`
+        //     is probed from the `n.` whole-entity path), so an `Rna`-only guard
+        //     let it straight through: `NC_000001.11(NM_…):n.0` reported its
+        //     genomic axis as `NC_000001.11:g.0`, which ferro cannot re-parse —
+        //     the same defect as `g.spl`, reached by the other axis. The
+        //     enumeration corpus carries no `n.0` input, so the census that found
+        //     the `r.` half could not see this one. Asking the question of
+        //     `edit_mu`, which every arm above populates, states the rule once
+        //     for every axis that can reach here.
+        //
+        //     `hgvs_to_vcf` already declines exactly these two edits for
+        //     exactly this reason (`vcf/from_hgvs.rs`), so this makes the two
+        //     conversion paths agree rather than inventing a rule.
+        if let Some(edit @ (NaEdit::Splice { .. } | NaEdit::NoProduct)) = edit_mu.inner() {
+            return Err(FerroError::UnsupportedProjection {
+                reason: format!(
+                    "`{axis_label}{edit}` is an RNA-level effect, not a sequence change, so it \
+                     has no genomic representation"
+                ),
+            });
+        }
 
         // 2. Reject `?` position sentinels explicitly — these have base == 0
         //    and no offset, which would otherwise propagate into the genomic
@@ -3199,13 +3269,121 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         variant: &HgvsVariant,
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
-        // Dispatch on variant kind.
-        match variant {
-            HgvsVariant::Allele(allele) => {
-                self.project_allele_inner(allele, variant, transcript_id)
-            }
-            _ => self.project_single_inner(variant, transcript_id),
+        // An RNA-only effect is representable on its own axis and nowhere else,
+        // so it is answered here rather than by the per-axis conversions (#1264).
+        // Letting it fall through would surface the axis guards' `Err` as a
+        // whole-projection failure and lose the one axis that *is* valid.
+        if let Some(projection) = self.project_rna_only_effect(variant, transcript_id) {
+            return Ok(projection);
         }
+        // Dispatch on variant kind.
+        let mut projection = match variant {
+            HgvsVariant::Allele(allele) => {
+                self.project_allele_inner(allele, variant, transcript_id)?
+            }
+            _ => self.project_single_inner(variant, transcript_id)?,
+        };
+        // Withhold a genomic axis that came out as a non-flanking insertion
+        // (#1264). Done here, on the assembled projection, so only the genomic
+        // axis declines: the same variant's c./n./r./p. forms are unaffected by
+        // the junction and stay reported. See `non_flanking_insertion_reason`.
+        if let Some(reason) = projection
+            .genomic
+            .as_ref()
+            .and_then(non_flanking_insertion_reason)
+        {
+            projection.genomic = None;
+            projection.axis_decline_reasons.genomic = Some(reason);
+        }
+        Ok(projection)
+    }
+
+    /// Project an RNA-only effect (`r.spl`, `r.spl?`, `r.0`): the `r.` axis is
+    /// the input, every other axis declines with a reason (#1264).
+    ///
+    /// `RNA/splicing.md` defines `spl` as "splicing affected" and `0` as "no
+    /// product" — statements about the transcript, not sequence changes at a
+    /// locus, so no genomic, coding or protein counterpart exists. The
+    /// projector had no `NaEdit::Splice` handling at all: it converted the
+    /// *position*, which maps perfectly well, and carried the edit token
+    /// through verbatim, emitting `NC_000023.11:g.spl` and `NM_….1:c.1spl` —
+    /// strings ferro's own parser rejects.
+    ///
+    /// Answering here, rather than by returning `Err` from the per-axis
+    /// conversions, keeps the decline *per axis*: the caller still gets
+    /// `rna = Some(r.spl)`. `hgvs_to_vcf` declines the same two edits
+    /// (`vcf/from_hgvs.rs`), so the conversion paths now agree.
+    ///
+    /// Returns `None` for every other input, leaving the normal dispatch alone.
+    ///
+    /// Unlike the empty-allele branch of [`Self::project_allele_inner`], this
+    /// one deliberately does **not** check that `transcript_id` is a transcript
+    /// cdot knows: that branch validates because it must read `gene_name` out of
+    /// cdot to answer at all, whereas every field here comes from the input
+    /// variant, and the answer — "the `r.` axis is the input, the rest decline"
+    /// — is true whether or not a reference has been loaded. The check that does
+    /// matter is that the input is on the transcript being asked about, which is
+    /// enforced below.
+    fn project_rna_only_effect(
+        &self,
+        variant: &HgvsVariant,
+        transcript_id: &str,
+    ) -> Option<VariantProjection> {
+        use crate::hgvs::uncertainty::Mu;
+
+        let HgvsVariant::Rna(rna) = variant else {
+            return None;
+        };
+        let edit = rna.loc_edit.edit.inner()?;
+        if !matches!(edit, NaEdit::Splice { .. } | NaEdit::NoProduct) {
+            return None;
+        }
+        // Only claim the input when it is on the transcript being projected
+        // against. This short-circuit runs *ahead* of the dispatch that checks
+        // `transcript_id` for every other transcript-coordinate input, so
+        // without the check here the projection would be stamped with a
+        // transcript the variant is not on — and `project_normalized_all_inner`
+        // calls this once per overlapping transcript, so a single `r.spl` would
+        // be reported against every one of them.
+        //
+        // Declining to claim it (rather than erroring here) hands the input back
+        // to the normal path, which raises the established `transcript_id
+        // mismatch` error — one wording for one contract, in one place.
+        if rna.accession.transcript_accession() != transcript_id {
+            return None;
+        }
+        let reason = format!(
+            "`r.{edit}` is an RNA-level effect, not a sequence change, so it has no \
+             representation on this axis"
+        );
+        // The `rna` axis is documented as the *predicted* consequence (`r.(…)`),
+        // and the path this replaces already wrapped `r.spl` as `r.(spl)`.
+        // Preserve that so the only rows this change moves are the ones that
+        // were genuinely broken.
+        let mut predicted = rna.clone();
+        predicted.loc_edit.edit = Mu::Uncertain(edit.clone());
+        Some(VariantProjection {
+            genomic: None,
+            coding: None,
+            noncoding: None,
+            protein: None,
+            rna: Some(HgvsVariant::Rna(predicted)),
+            transcript_id: transcript_id.to_string(),
+            gene_symbol: rna.gene_symbol.clone(),
+            is_frameshift: false,
+            // The effect names no exon/intron position to classify.
+            is_intronic: false,
+            is_utr: false,
+            affects_init: false,
+            normalization_warnings: Vec::new(),
+            axis_decline_reasons: AxisDeclineReasons {
+                genomic: Some(reason.clone()),
+                coding: Some(reason.clone()),
+                noncoding: Some(reason.clone()),
+                protein: Some(reason),
+                rna: None,
+            },
+        })
     }
 
     /// Project a compound [`AlleleVariant`] by recursively projecting each
@@ -3422,6 +3600,23 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             None
         };
 
+        // The genomic half of the #1198 rule applied to `.noncoding` above: the
+        // all-or-nothing build means an absent allele `g.` axis is always some
+        // member's absence, and that member may have recorded why. Carry it up
+        // rather than reporting an unexplained `None` — the explanation already
+        // exists, and dropping it here is the same defect #1198 fixed one axis
+        // over. This matters most for the mixed allele #1264 introduces, where
+        // one member straddles a splice junction and the others are ordinary:
+        // the junction reason is the only answer anyone has for the drop.
+        let genomic_decline = if genomic.is_none() {
+            inner_projections
+                .iter()
+                .find_map(|p| p.axis_decline_reasons.genomic.as_deref())
+                .map(|reason| format!("an allele member has no g. form: {reason}"))
+        } else {
+            None
+        };
+
         // Predicted RNA allele (#693): predict from the assembled coding allele
         // — `predict_rna` handles the `Allele` shape directly, emitting one
         // outer predicted wrapper `r.([a;b])` (recommendations/RNA/alleles.md).
@@ -3444,6 +3639,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             normalization_warnings: Vec::new(),
             axis_decline_reasons: AxisDeclineReasons {
                 noncoding: noncoding_decline,
+                genomic: genomic_decline,
                 ..Default::default()
             },
             genomic,
@@ -4338,6 +4534,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         // Mirror the genome path's transcript_id-mismatch guard: an n./r. input
         // must be projected against its own transcript.
+        //
+        // This precedes the RNA-only-effect guard below deliberately. Both can
+        // apply to the same input, and the mismatch is the more fundamental
+        // objection — it holds whatever the edit is, so answering "this edit has
+        // no other representation" for a variant that was never on this
+        // transcript describes the wrong problem. It is also the order the
+        // genome path already uses (`project_single_inner` checks the mismatch
+        // before delegating to `project_to_genomic_nc`, which holds that path's
+        // RNA-only guard), so the two routes now agree.
         let input_tx = accession.transcript_accession();
         if input_tx != transcript_id {
             return Err(FerroError::UnsupportedProjection {
@@ -4346,6 +4551,28 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                      against {}; transcript-coordinate inputs must be projected against \
                      their own transcript",
                     input_tx, transcript_id,
+                ),
+            });
+        }
+
+        // Mirror the genome path's RNA-only-effect guard (#1264): `r.spl` and
+        // `r.0` describe the transcript, not a sequence change, so they have no
+        // `c.`/`n.`/`p.` counterpart either. Without this a bare-`NM_` `r.spl`
+        // rendered as `NM_….1:c.1spl`, which ferro cannot re-parse — the same
+        // defect the genomic path had, reached by the other route.
+        //
+        // In practice this guard now fires only for the `Tx` path — `n.0`, a
+        // valid spec form. `project_rna_only_effect` claims every matching `r.`
+        // spelling before dispatch reaches here, and the one case it declines
+        // (a foreign transcript) is caught by the mismatch guard above. The
+        // `r.` wording is kept anyway: the guard states the rule for the loc/
+        // edit pair it is given, and should not silently stop holding if a
+        // future caller reaches it by another route.
+        if let Some(edit @ (NaEdit::Splice { .. } | NaEdit::NoProduct)) = edit_mu.inner() {
+            return Err(FerroError::UnsupportedProjection {
+                reason: format!(
+                    "`{axis_label}{edit}` is an RNA-level effect, not a sequence change, so \
+                     it has no representation on another axis"
                 ),
             });
         }
@@ -5544,6 +5771,28 @@ fn nr_representative_genome_pos(
                 base, cdot_tx.contig
             ),
         })
+}
+
+/// Why `variant`'s genomic form cannot be reported: it is an insertion whose
+/// anchor positions are not a flanking pair (#1264). `None` when it is fine.
+///
+/// Wraps the well-formedness predicate
+/// [`crate::hgvs::variant::non_flanking_genomic_insertion_anchor`] with the
+/// explanation that fits *this* caller: on the projection path the anchors were
+/// adjacent on the transcript and stopped being adjacent when they were mapped.
+///
+/// There is no repair, which is why callers decline rather than adjust: the
+/// insertion could attach to the 3' end of the upstream exon or the 5' end of
+/// the downstream one, and those are two *different* genomic variants. HGVS has
+/// no spelling for "at the junction".
+fn non_flanking_insertion_reason(variant: &HgvsVariant) -> Option<String> {
+    let (start, end) = crate::hgvs::variant::non_flanking_genomic_insertion_anchor(variant)?;
+    Some(format!(
+        "the insertion's anchor positions are adjacent on the transcript but map to \
+         non-adjacent genomic positions {start} and {end} (they straddle an intron), and an \
+         insertion anchor MUST be two flanking positions per DNA/insertion.md:15, so this \
+         variant has no genomic representation"
+    ))
 }
 
 /// Resolve an [`UncertainBoundary<T>`] to an owned `T`, distinguishing the two

--- a/tests/it/fast_path_differential.rs
+++ b/tests/it/fast_path_differential.rs
@@ -136,6 +136,22 @@ const DIFFERENTIAL_CASES: &[&str] = &[
     "NM_000088.3:c.459_460insACGT",
     "NM_000088.3:c.459_460delinsAC",
     "NM_000088.3:c.459_460inv",
+    // --- `::`-joined rings and `sup` wrappers (#1264). `validate_no_point_insertion`
+    // gained a `GenomeRing` arm and an explicit `Supernumerary` recursion, so both
+    // insertion-anchor MUST-rules (`DNA/insertion.md:15` adjacency, `:95-101`
+    // single-position) are now enforced inside a join. That enforcement lives in the
+    // generic parser only, so it holds for these inputs solely because the fast path
+    // defers: `classify_fast_edit` reads the trailing bytes, and an `insG` tail is not
+    // a recognized substitution / plain del / plain dup / identity tail. Pin the
+    // deferral — if fast-path eligibility ever widened to reach a ring, the fast path
+    // would mint a variant that skipped the validator, and `divergence` would catch it
+    // here rather than in whatever consumer first failed to re-parse the result. The
+    // rejected rows agree by both-reject; the accepted rows agree by equal ASTs. ---
+    "NC_000022.11:g.100_101insATG::200_201insG", // valid ring: both accept, must agree
+    "NC_000022.11:g.100_102insATG::200_201insG", // ring, non-adjacent anchor: both reject
+    "NC_000022.11:g.100insATG::200_201insG",     // ring, single-position anchor: both reject
+    "NC_000022.11:g.[100_101insATG::200_201insG]sup", // valid `sup`-wrapped ring
+    "NC_000022.11:g.[100_102insATG::200_201insG]sup", // `sup` recursion reaches the ring
     // --- whitespace / trimming edges (ASCII and Unicode) ---
     "  NC_000001.11:g.12345A>G  ",
     "\tNM_000088.3:c.459A>G\n",

--- a/tests/it/issue_1264_reparse_asymmetry.rs
+++ b/tests/it/issue_1264_reparse_asymmetry.rs
@@ -1,0 +1,583 @@
+//! Issue #1264 — ferro must not build descriptions it cannot re-parse.
+//!
+//! The issue is filed as a *parser leniency* bug: "the parser accepted
+//! non-adjacent `ins` anchors on the way in and rejects them on the way back
+//! out". That diagnosis is wrong, and measuring it is what found the real
+//! defects. `validate_no_point_insertion`
+//! (`src/hgvs/parser/variant.rs`, #446/#450) already rejects both the
+//! single-position and the non-adjacent anchor inbound on all six nucleotide
+//! axes — `LRG_199:g.699646_700297insNNN…`, the exact string the issue quotes,
+//! does not parse.
+//!
+//! The unparseable descriptions in the issue were never produced by
+//! `parse_hgvs`. They were built by the **projector**, and they reached the
+//! `FERRO_ASSERT_REPARSE` oracle only as its *input*. The oracle's exemption —
+//! "skip when the input does not itself re-parse" — is a blanket wide enough to
+//! swallow every one of them, which is precisely why #1264 exists ("an
+//! exemption with no tracked follow-up quietly becomes permanent").
+//!
+//! Running the suite with that exemption instrumented to report rather than
+//! return silently gives the census (9005 tests, 0 failures, 18 hits):
+//!
+//! | rendered shape | hits | cause |
+//! |---|---|---|
+//! | `LRG_199:g.699646_700297insNNN…` | 8 | insertion at a splice junction |
+//! | `NC_000023.11:g.spl`, `g.(spl)` | 8 | the RNA-only `spl` edit on a `g.` axis |
+//! | `[]` | 2 | an `AlleleVariant` built with no members |
+//!
+//! Each gets a test below, plus one for a genuine parser hole the issue did not
+//! find: a `GenomeRing` segment is never anchor-checked at all.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::hgvs::variant::{AllelePhase, AlleleVariant};
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, VariantProjector};
+
+// ---------------------------------------------------------------------------
+// The parser hole the issue's framing points at — real, but in `GenomeRing`.
+// ---------------------------------------------------------------------------
+
+/// A ring segment must obey the same two insertion-anchor rules as any other
+/// insertion.
+///
+/// `validate_no_point_insertion` matches on the variant kind and ends in
+/// `_ => {}`. `HgvsVariant::Allele` is recursed into; `HgvsVariant::GenomeRing`
+/// is not — yet its `segments` are `LocEdit<GenomeInterval, NaEdit>`, exactly
+/// the loc/edit pair the check inspects. So both MUST-level sub-rules
+/// (`DNA/insertion.md:15` adjacency, `DNA/insertion.md:95-101` single-position)
+/// are unenforced inside a `::`-join.
+///
+/// This one round-trips — ferro parses it *and* renders it back — so the
+/// re-parse oracle can never see it. Only a parser test can.
+#[test]
+fn a_ring_segment_insertion_anchor_must_be_flanking() {
+    for input in [
+        // Non-adjacent anchors: 100 and 102 are two apart.
+        "NC_000022.11:g.100_102insATG::200_201insG",
+        // Single-position anchor.
+        "NC_000022.11:g.100insATG::200_201insG",
+        // Same, reached through the supernumerary wrapper.
+        "NC_000022.11:g.[100_102insATG::200_201insG]sup",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "`{input}` has an insertion anchor that is not a flanking pair; the same \
+             spelling outside a `::`-join is rejected, so the ring must reject it too",
+        );
+    }
+}
+
+/// The control for the test above: a ring whose insertion anchors *are*
+/// flanking stays valid, and still round-trips.
+///
+/// Without this, tightening the ring path could pass by rejecting every ring
+/// insertion.
+#[test]
+fn a_ring_segment_with_flanking_anchors_still_parses() {
+    let input = "NC_000022.11:g.100_101insATG::200_201insG";
+    let variant = parse_hgvs(input).expect("flanking ring anchors must stay valid");
+    assert_eq!(variant.to_string(), input);
+}
+
+// ---------------------------------------------------------------------------
+// The projector defects that actually produced the issue's strings.
+// ---------------------------------------------------------------------------
+
+/// Two exons of 30 transcript bases each, separated by a 170-base intron.
+///
+/// The intron is the whole point: transcript positions 30 and 31 are adjacent
+/// in the spliced RNA but 171 bases apart in the genome, so an insertion
+/// anchored on that pair sits exactly on the exon–exon junction.
+///
+/// The sequence is deliberately non-repetitive. An earlier draft used `CGCG…`
+/// exons and an all-`N` intron; against that reference the junction insertion
+/// normalized into `g.1030_1199N[173]` — a repeat spanning the whole intron,
+/// which *does* re-parse, so the test passed while proving nothing. A
+/// homopolymer is not a representative intron.
+const TX_SEQUENCE: &str = concat!(
+    "ATGCTAGCATCGATCGTACGATCAGCTAGT", //  1..30  exon 1  (genomic 1000..1029)
+    "GGACCTTGCAATCGGATCCAAGCTTGATAA", // 31..60  exon 2  (genomic 1200..1229)
+);
+
+/// A 170-base intron with no long repeat and no homopolymer run, generated
+/// deterministically so the fixture stays reproducible.
+///
+/// The period-11 stride over a 4-letter alphabet keeps successive bases
+/// differing and avoids the tandem structure that would let a junction
+/// insertion be re-spelled as a repeat.
+fn intron_sequence(len: usize) -> String {
+    (0..len)
+        .map(|i| ["A", "C", "G", "T"][(i * 7 + i / 11) % 4])
+        .collect()
+}
+
+/// Exon 1 occupies genomic `[1000, 1030)`, exon 2 `[1200, 1230)` — so the
+/// intron is 170 bases and transcript positions 30/31 map 171 apart.
+const EXON1_GENOMIC_START: u64 = 1000;
+const EXON1_GENOMIC_END: u64 = 1030;
+const EXON2_GENOMIC_START: u64 = 1200;
+const EXON2_GENOMIC_END: u64 = 1230;
+const CONTIG: &str = "NC_000001.11";
+
+/// The cdot alignment is built explicitly rather than via
+/// `CdotMapper::from_transcripts`, because the genomic axis is only reachable
+/// when a real exon alignment has been ingested. Without one the projector
+/// reports `genomic = None` for every input and the tests below would pass
+/// **vacuously** — declining to answer looks identical to declining correctly.
+fn projector() -> VariantProjector<JsonProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            cds_start_incomplete: false,
+            gene_name: Some("MYGENE".to_string()),
+            contig: CONTIG.to_string(),
+            strand: Strand::Plus,
+            // [genomic_start, genomic_end, tx_start, tx_end)
+            exons: vec![
+                [EXON1_GENOMIC_START, EXON1_GENOMIC_END, 0, 30],
+                [EXON2_GENOMIC_START, EXON2_GENOMIC_END, 30, 60],
+            ],
+            cds_start: Some(0),
+            cds_end: Some(60),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+
+    let mut provider = JsonProvider::new();
+    provider.add_transcript(
+        Transcript::new(
+            "NM_TEST.1".to_string(),
+            Some("MYGENE".to_string()),
+            TxStrand::Plus,
+            TX_SEQUENCE.to_string(),
+            Some(1),
+            Some(60),
+            vec![Exon::new(1, 1, 30), Exon::new(2, 31, 60)],
+            Some(CONTIG.to_string()),
+            Some(EXON1_GENOMIC_START),
+            Some(EXON2_GENOMIC_END - 1),
+            Default::default(),
+            ManeStatus::default(),
+            None,
+            None,
+        )
+        .with_protein_id(Some("NP_TEST.1".to_string())),
+    );
+    // Exon 1 at 1000, a 170-base intron, exon 2 at 1200 (all 1-based here).
+    let prefix = intron_sequence((EXON1_GENOMIC_START - 1) as usize);
+    let intron = intron_sequence((EXON2_GENOMIC_START - EXON1_GENOMIC_END) as usize);
+    let suffix = intron_sequence(100);
+    provider.add_genomic_sequence(
+        CONTIG,
+        format!(
+            "{prefix}{}{intron}{}{suffix}",
+            &TX_SEQUENCE[..30],
+            &TX_SEQUENCE[30..],
+        ),
+    );
+
+    VariantProjector::new(Projector::new(cdot), provider)
+}
+
+/// Every rendered axis of a projection of `input`.
+fn projected_axes(input: &str) -> Vec<(&'static str, String)> {
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    let projection = projector()
+        .project_variant(&variant, "NM_TEST.1")
+        .unwrap_or_else(|e| panic!("project {input}: {e}"));
+    [
+        ("g", projection.genomic.as_ref().map(ToString::to_string)),
+        ("c", projection.coding.as_ref().map(ToString::to_string)),
+        ("n", projection.noncoding.as_ref().map(ToString::to_string)),
+        ("r", projection.rna.as_ref().map(ToString::to_string)),
+        ("p", projection.protein.as_ref().map(ToString::to_string)),
+    ]
+    .into_iter()
+    .filter_map(|(axis, rendered)| rendered.map(|r| (axis, r)))
+    .collect()
+}
+
+/// **The invariant.** Every axis a projection reports must be a description
+/// ferro can read back.
+///
+/// Stated as a property over the projection rather than as an expected string,
+/// so it survives a change to *which* axes a given input can reach. A projector
+/// that declines an axis satisfies it vacuously — declining is always a legal
+/// answer; emitting an unreadable description never is.
+fn assert_every_projected_axis_re_parses(input: &str) {
+    for (axis, rendered) in projected_axes(input) {
+        parse_hgvs(&rendered).unwrap_or_else(|e| {
+            panic!(
+                "projecting `{input}` produced `{rendered}` on the {axis}. axis, which \
+                 ferro cannot re-parse: {e}",
+            )
+        });
+    }
+}
+
+/// `spl` is an RNA-only effect. Carried onto another axis it renders `g.spl` /
+/// `c.1spl`, neither of which is HGVS.
+///
+/// `RNA/splicing.md` defines `r.spl` as "splicing affected" — a statement about
+/// the transcript, with no genomic or coding counterpart. `hgvs_to_vcf` already
+/// declines it for that reason (`vcf/from_hgvs.rs:790`), but the projector has
+/// no `NaEdit::Splice` handling anywhere, so it converts the position and keeps
+/// the edit token verbatim.
+///
+/// Both spellings are covered: `r.spl` (splicing very likely affected) and
+/// `r.spl?` (might be affected), plus the predicted wrapper `r.(spl)`.
+/// Both accession forms are covered because they take different code paths: a
+/// bare `NM_` routes through `project_noncoding_direct` (which never reports a
+/// genomic axis), while the gene-selector form
+/// `NC_000001.11(NM_TEST.1)` goes through `project_to_genomic_nc`. The
+/// enumeration hit `g.spl` only on the second and `c.1spl` on both.
+#[test]
+fn the_rna_only_splice_edit_has_no_representation_on_another_axis() {
+    for input in [
+        "NM_TEST.1:r.spl",
+        "NM_TEST.1:r.spl?",
+        "NM_TEST.1:r.(spl)",
+        "NC_000001.11(NM_TEST.1):r.spl",
+        "NC_000001.11(NM_TEST.1):r.spl?",
+    ] {
+        assert_every_projected_axis_re_parses(input);
+    }
+}
+
+/// The same rule on the `n.` axis, on the route the direct path does not cover.
+///
+/// `0` ("no product") is not confined to `r.`: it is a valid spec form for a
+/// non-coding transcript, and `n.0` parses to `HgvsVariant::Tx` because the `n.`
+/// whole-entity path probes the same `parse_rna_no_product`. There are two
+/// routes to a projection, and only one of them saw that.
+/// `a_no_product_transcript_variant_reports_the_mismatch_before_the_rna_reason`
+/// covers the direct route (bare `NM_` → `project_noncoding_direct`), whose
+/// guard reads the extracted edit and so already declined. The genome-pivot
+/// route (`NC_000001.11(NM_TEST.1)` → `project_to_genomic_nc`) guarded on
+/// `if let HgvsVariant::Rna(v)` instead — a test on the variant *kind*, which a
+/// `Tx` input passes straight through. It reported the genomic axis as
+/// `NC_000001.11:g.0`: the same defect as `g.spl`, reached by the other axis.
+///
+/// The enumeration corpus carries no `n.0` input, so the census that found the
+/// `r.` half could not see this one — which is why the fix is to ask the
+/// question of the extracted edit on both routes rather than to add a second
+/// variant-kind arm.
+#[test]
+fn the_rna_only_no_product_edit_is_declined_on_the_transcript_axis_too() {
+    for input in [
+        "NM_TEST.1:n.0",
+        "NM_TEST.1:n.(0)",
+        "NC_000001.11(NM_TEST.1):n.0",
+        "NC_000001.11(NM_TEST.1):n.(0)",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        // Erroring the whole projection and declining per axis are both legal
+        // answers, and the two accession forms currently give different ones —
+        // a bare `NM_` routes through the direct path, the gene-selector form
+        // through `project_to_genomic_nc`. What is never legal is reporting the
+        // statement on an axis that cannot carry it. `n.` is excluded from the
+        // check because it is the input's *own* axis: were a future change to
+        // claim it the way `project_rna_only_effect` claims `r.`, that would be
+        // this rule being followed, not broken.
+        if let Ok(projection) = projector().project_variant(&variant, "NM_TEST.1") {
+            let carried: Vec<String> = [
+                ("g", projection.genomic.as_ref()),
+                ("c", projection.coding.as_ref()),
+                ("p", projection.protein.as_ref()),
+            ]
+            .into_iter()
+            .filter_map(|(axis, v)| v.map(|v| format!("{axis}. = `{v}`")))
+            .collect();
+            assert!(
+                carried.is_empty(),
+                "`{input}` states that no product is made, which has no g./c./p. \
+                 counterpart, yet the projection reported {}",
+                carried.join(", "),
+            );
+        }
+    }
+}
+
+/// An insertion whose transcript anchors straddle a splice junction has no
+/// genomic spelling, so the genomic axis must be declined rather than invented.
+///
+/// `r.30_31insNNN` is well formed: 30 and 31 are adjacent in the spliced RNA.
+/// Their genomic images are 1029 and 1200 — 171 bases apart, because the intron
+/// lies between them. Rendering that pair as `g.1029_1200ins…` asserts an
+/// insertion between two bases that are not neighbours, which is the very thing
+/// `DNA/insertion.md:15` forbids and ferro's own parser rejects.
+///
+/// There is no repair available. The insertion could be attached to the 3' end
+/// of exon 1 or the 5' end of exon 2, and those are different genomic variants;
+/// HGVS has no way to say "at the junction". Declining is the honest answer,
+/// and it is the same answer `spl` gets above.
+#[test]
+fn an_insertion_across_a_splice_junction_has_no_genomic_spelling() {
+    // The gene-selector form, so the genomic axis is actually attempted — a
+    // bare `NM_` routes through `project_noncoding_direct` and reports no
+    // genomic axis at all, which would make this vacuous.
+    assert_every_projected_axis_re_parses("NC_000001.11(NM_TEST.1):r.30_31insnnn");
+}
+
+/// Declining the genomic axis must not cost the axes that are still correct.
+///
+/// The junction only breaks the *genomic* spelling: `c.30_31insNNN` and
+/// `n.30_31insNNN` are perfectly good descriptions of the same variant. An
+/// earlier attempt guarded the genome pivot itself, which failed the whole
+/// projection and threw those away — a worse answer than the bug, since the
+/// caller went from "four right axes and one wrong one" to nothing at all.
+/// The guard therefore sits on the reported axis, not on the pivot that also
+/// feeds the c./n./p. derivation.
+#[test]
+fn a_declined_genomic_axis_does_not_take_the_other_axes_with_it() {
+    let axes = projected_axes("NC_000001.11(NM_TEST.1):r.30_31insnnn");
+    let reported: Vec<&str> = axes.iter().map(|(axis, _)| *axis).collect();
+    assert!(
+        !reported.contains(&"g"),
+        "the genomic axis straddles the junction and must be withheld; got {axes:?}",
+    );
+    for axis in ["c", "n", "r"] {
+        assert!(
+            reported.contains(&axis),
+            "the {axis}. axis is unaffected by the junction and must still be \
+             reported; got {axes:?}",
+        );
+    }
+}
+
+/// The control, and the anti-vacuity guard for every projector test above.
+///
+/// An insertion *inside* an exon has genomically adjacent anchors, so it must
+/// still reach the genomic axis. Without this, the fixture could report
+/// `genomic = None` for everything — no alignment ingested, say — and the tests
+/// above would pass while proving nothing, because "declined" and "never
+/// attempted" are indistinguishable from the outside.
+#[test]
+fn an_insertion_inside_an_exon_still_projects_to_the_genomic_axis() {
+    let axes = projected_axes("NC_000001.11(NM_TEST.1):r.10_11insnnn");
+    let genomic = axes
+        .iter()
+        .find(|(axis, _)| *axis == "g")
+        .map(|(_, rendered)| rendered.as_str());
+    assert!(
+        genomic.is_some(),
+        "an intra-exonic insertion has adjacent genomic anchors and must still project — \
+         if this is None the fixture reaches no genomic axis at all and every other \
+         projector test here is vacuous; got {axes:?}",
+    );
+    let genomic = genomic.expect("checked above");
+    parse_hgvs(genomic).unwrap_or_else(|e| panic!("`{genomic}` must re-parse: {e}"));
+    assert!(
+        genomic.contains("ins"),
+        "the projected genomic form should still be an insertion, got `{genomic}`",
+    );
+}
+
+/// Declining an axis must not cost the *reason*, even when the decline is
+/// inherited from an allele member.
+///
+/// The allele's `.genomic` is all-or-nothing: one member straddling the junction
+/// drops the whole genomic allele. The explanation for that drop already exists
+/// — it is sitting in the member's own `axis_decline_reasons.genomic` — so
+/// reporting the aggregate as an unexplained `None` throws away the only answer
+/// anyone has. `.noncoding` has propagated its member's reason since #1198; this
+/// pins the genomic axis to the same contract, which matters most for exactly
+/// the mixed allele this issue introduces (one junction-straddling member, one
+/// ordinary one).
+#[test]
+fn an_allele_inherits_the_genomic_decline_reason_of_the_member_that_caused_it() {
+    let variant = parse_hgvs("NC_000001.11(NM_TEST.1):r.[30_31insnnn;40a>g]")
+        .expect("the mixed allele must parse");
+    let projection = projector()
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("the allele still projects; only its genomic axis declines");
+
+    assert!(
+        projection.genomic.is_none(),
+        "one member straddles the junction, so the all-or-nothing genomic allele \
+         must be withheld; got {:?}",
+        projection.genomic.as_ref().map(ToString::to_string),
+    );
+    let reason = projection
+        .axis_decline_reasons
+        .genomic
+        .as_deref()
+        .expect("the withheld genomic axis must say why, as `.noncoding` does");
+    assert!(
+        reason.contains("allele member"),
+        "the reason must attribute the decline to a member rather than the whole \
+         allele, since it describes one member's coordinates; got `{reason}`",
+    );
+    assert!(
+        reason.contains("non-adjacent genomic positions"),
+        "the member's own explanation must survive the trip up, not be replaced by \
+         generic wording; got `{reason}`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A declined axis must not swallow the transcript_id contract.
+// ---------------------------------------------------------------------------
+
+/// An RNA-only effect answered up front must still respect the transcript it is
+/// being projected against.
+///
+/// `project_rna_only_effect` short-circuits ahead of the normal dispatch, which
+/// is where every other transcript-coordinate input gets its `transcript_id`
+/// checked. Without its own check the short-circuit hands back a projection
+/// stamped with a transcript the variant is not on — and because the fan-out
+/// path calls the projector once per overlapping transcript, a single `r.spl`
+/// would be reported against every one of them, each row claiming a different
+/// `transcript_id` while carrying the same `r.` value.
+///
+/// Both accession shapes are covered because they reach the check by different
+/// routes: a bare `NM_` falls through to `project_noncoding_direct`, the
+/// gene-selector form to the genome-pivot path.
+#[test]
+fn an_rna_only_effect_is_still_refused_against_a_foreign_transcript() {
+    for input in [
+        "NM_TEST.1:r.spl",
+        "NM_TEST.1:r.spl?",
+        "NM_TEST.1:r.0",
+        "NC_000001.11(NM_TEST.1):r.spl",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let err = projector()
+            .project_variant(&variant, "NM_FOREIGN.9")
+            .expect_err("an RNA-only effect on another transcript must be refused");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("transcript_id mismatch"),
+            "projecting `{input}` against a foreign transcript must report the \
+             mismatch, not the RNA-level reason; got `{rendered}`",
+        );
+    }
+}
+
+/// The transcript check must also come first for `n.0`, which the up-front
+/// short-circuit does not own.
+///
+/// `project_rna_only_effect` only claims `r.` inputs, so a `Tx` no-product
+/// (`n.0` — a valid spec form) still reaches `project_noncoding_direct`. There
+/// the RNA-only guard and the mismatch guard are both applicable, and the
+/// mismatch is the more fundamental objection: it holds whatever the edit is, so
+/// answering "this edit has no other representation" for a variant that was
+/// never on this transcript describes the wrong problem.
+#[test]
+fn a_no_product_transcript_variant_reports_the_mismatch_before_the_rna_reason() {
+    let variant = parse_hgvs("NM_TEST.1:n.0").expect("`n.0` is a valid spec form");
+
+    let foreign = projector()
+        .project_variant(&variant, "NM_FOREIGN.9")
+        .expect_err("`n.0` on another transcript must be refused");
+    assert!(
+        foreign.to_string().contains("transcript_id mismatch"),
+        "the mismatch outranks the RNA-level reason; got `{foreign}`",
+    );
+
+    // The control: on its *own* transcript the RNA-level reason is still what
+    // `n.0` gets, so the reordering above narrowed nothing.
+    let own = projector()
+        .project_variant(&variant, "NM_TEST.1")
+        .expect_err("`n.0` has no representation on another axis");
+    assert!(
+        own.to_string().contains("RNA-level effect"),
+        "on its own transcript `n.0` must still be declined as an RNA-level \
+         effect; got `{own}`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The empty allele.
+// ---------------------------------------------------------------------------
+
+/// The hazard `AlleleVariant::checked` exists to prevent, characterized on the
+/// **unchecked** constructor so the test is not merely restating `checked`.
+///
+/// `AlleleVariant::new(vec![], _)` renders `[]`, and `[]` is not HGVS — so the
+/// value does not round-trip and every consumer that chains a second call fails
+/// on it. That asymmetry is the empty-allele half of #1264.
+///
+/// The parser refuses empty brackets in every position that accepts them
+/// (`empty_brackets_do_not_parse` below), so the shape is reachable only by
+/// direct construction.
+#[test]
+fn an_allele_with_no_members_renders_something_that_does_not_parse() {
+    let empty = HgvsVariant::Allele(AlleleVariant::new(Vec::new(), AllelePhase::Cis));
+    assert_eq!(empty.to_string(), "[]");
+    assert!(
+        parse_hgvs(&empty.to_string()).is_err(),
+        "`[]` is not HGVS, so an empty allele does not round-trip — which is why a member \
+         list assembled from data must go through `AlleleVariant::checked`",
+    );
+}
+
+/// The checked constructor refuses exactly that shape, and nothing else.
+///
+/// `new` is deliberately left infallible — it is called throughout the parser
+/// and normalizer on lists that are non-empty by construction. `checked` is for
+/// the boundaries where a list is assembled from data (a projection, a filter,
+/// an external payload), mirroring `GenomeRing::new`, which refuses a ring of
+/// fewer than two segments for the same round-trip reason.
+#[test]
+fn the_checked_allele_constructor_refuses_an_empty_member_list() {
+    assert!(
+        AlleleVariant::checked(Vec::new(), AllelePhase::Cis).is_none(),
+        "an allele with no members has no HGVS rendering, so it must not be constructible",
+    );
+    let single = AlleleVariant::checked(
+        vec![parse_hgvs("NC_000022.11:g.100A>G").expect("parses")],
+        AllelePhase::Cis,
+    );
+    assert!(single.is_some(), "a one-member allele is still valid");
+}
+
+/// The parser's half of the same rule, pinned so it cannot regress.
+#[test]
+fn empty_brackets_do_not_parse() {
+    for input in ["[]", "NC_000022.11:g.[]", "NC_000022.11:g.[];[]"] {
+        assert!(parse_hgvs(input).is_err(), "`{input}` must not parse");
+    }
+}
+
+/// Guard against re-introducing the shape by hand: rendering any allele ferro
+/// builds must round-trip.
+#[test]
+fn a_constructed_allele_round_trips() {
+    let members: Vec<HgvsVariant> = ["NC_000022.11:g.100A>G", "NC_000022.11:g.200del"]
+        .iter()
+        .map(|s| parse_hgvs(s).expect("parses"))
+        .collect();
+    let allele = AlleleVariant::checked(members, AllelePhase::Cis).expect("two members is valid");
+    let rendered = HgvsVariant::Allele(allele).to_string();
+    parse_hgvs(&rendered).unwrap_or_else(|e| panic!("`{rendered}` must re-parse: {e}"));
+}
+
+/// `checked` at the boundary its own doc comment names, exercised through that
+/// boundary rather than directly.
+///
+/// `AlleleVariant::checked` is only worth adding if something calls it, and
+/// `project_to_genomic`'s allele branch is exactly the case it describes — a
+/// member list assembled from data rather than fixed by the grammar. Asserting
+/// on the constructor alone (`the_checked_allele_constructor_refuses_an_empty_member_list`)
+/// leaves the wiring untested, so this drives the same rule through the
+/// projector and pins that it declines with an error instead of handing back an
+/// allele that renders `[]`.
+#[test]
+fn projecting_an_empty_allele_to_the_genomic_axis_is_declined() {
+    let empty = HgvsVariant::Allele(AlleleVariant::new(Vec::new(), AllelePhase::Cis));
+    let err = projector()
+        .project_to_genomic(&empty)
+        .expect_err("an empty allele has no genomic rendering, so projection must decline");
+    let message = err.to_string();
+    assert!(
+        message.contains("no members"),
+        "the decline must say what was wrong with the input; got `{message}`",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -164,6 +164,7 @@ mod issue_1244_equivalence_overlap_panic;
 mod issue_1249_inv_one_base_residue;
 mod issue_1254_sibling_crossing_shift;
 mod issue_1261_cis_member_order;
+mod issue_1264_reparse_asymmetry;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
 mod issue_1284_transcript_axis_collision;

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -320,9 +320,47 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     (Status::FormAxisOk, 120),
     (Status::FormAxisPinned, 0),
     (Status::Preserved, 6),
-    (Status::ProjectionPinned, 1180),
-    (Status::ProjectionUnavailablePinned, 469),
-    (Status::ProjectionErrorPinned, 215),
+    // #1264 moved 19 rows between three statuses. Stated gross, because the net
+    // deltas alone do not determine them — the three nets are linearly dependent
+    // (any `Error -> Pinned` count satisfies all three if the other two absorb
+    // it), so a reader given only the nets cannot recover what actually moved:
+    //
+    //   14 rows  ProjectionPinned      -> ProjectionUnavailablePinned
+    //    4 rows  ProjectionErrorPinned -> ProjectionUnavailablePinned
+    //    1 row   ProjectionErrorPinned -> ProjectionPinned
+    //
+    // Net: ProjectionPinned -13, ProjectionErrorPinned -5,
+    // ProjectionUnavailablePinned +18. The deltas cancel, so the 2184-row total
+    // across this census and `DIVERGENCE_BUDGET` is unchanged — nothing was
+    // dropped from the enumeration, only moved. Every row that moved to
+    // `Unavailable` was a projection that had no business rendering:
+    //
+    // * `r.spl` / `r.spl?` / `r.0` are RNA-level *effects*, not sequence
+    //   changes, so they have no g./c./n./p. counterpart. The projector had no
+    //   `NaEdit::Splice` handling at all and carried the edit token onto the
+    //   target axis verbatim, emitting `NC_000023.11:g.spl`, `…:c.1spl` and
+    //   `…:n.245spl` — none of which ferro can re-parse. It also invented a
+    //   protein consequence, `NP_003997.1:p.(Met1?)`, for a variant that states
+    //   no coding change. These now decline with a reason.
+    // * `project-g/LRG_199t1:r.1149_1150insn[100]` rendered
+    //   `LRG_199:g.699646_700297insNNN…`, an insertion anchored on two bases 652
+    //   apart because they straddle an intron — the exact string reported in
+    //   #1264, and one ferro's own parser rejects per `DNA/insertion.md:15`.
+    //
+    // `r.0` on `NM_004006.1` accounts for all five `Error` departures, and is
+    // the reason declining per axis rather than per projection matters. It
+    // previously failed the *whole* projection with "Transcript has no CDS", so
+    // all five of its rows were errors. Now the one axis that can carry the
+    // statement renders it — `project-r/…` moves to `Pinned` as `r.(0)` — while
+    // the four that cannot (`project-c`, `project-g`, `project-n`, `project-p`)
+    // move to `Unavailable` with a reason. One row improved to rendered, not two.
+    //
+    // The four `project-r/…r.spl` rows are deliberately unmoved: the `rna` axis
+    // is documented as the predicted form and already rendered `r.(spl)`, so the
+    // replacement path preserves that wrapper rather than quietly changing it.
+    (Status::ProjectionPinned, 1167),
+    (Status::ProjectionUnavailablePinned, 487),
+    (Status::ProjectionErrorPinned, 210),
     (Status::ModeDivergencePinned, 132),
 ];
 


### PR DESCRIPTION
Closes #1264

## The issue's diagnosis is wrong, and measuring it is what found the real defects

#1264 reports two descriptions ferro accepts but cannot re-parse, and attributes them to a lenient parser: *"the parser accepted non-adjacent `ins` anchors on the way in and rejects them on the way back out."*

It does not. `validate_no_point_insertion` (`src/hgvs/parser/variant.rs`, from #446/#450) already rejects both the single-position and the non-adjacent anchor inbound on all six nucleotide axes. `LRG_199:g.699646_700297insNNN…` — the exact string the issue quotes — does not parse:

```
Parse error at position 0: insertion anchor positions are not flanking on g.;
the two positions MUST be adjacent (e.g. g.123_124insATG, not g.123_125insATG)
per DNA/insertion.md:15
```

Those strings were never produced by `parse_hgvs`. They were built by the **projector**, and reached the `FERRO_ASSERT_REPARSE` oracle as its *input* — where the blanket exemption ("skip when the input does not itself re-parse") swallowed them. That is precisely the risk the issue names: *"an exemption with no tracked follow-up quietly becomes permanent."*

Instrumenting that exemption to report instead of return silently, then re-running the suite, gives the census — **9005 tests, 0 failures, 18 hits in four shapes**:

| rendered shape | hits | cause |
|---|---|---|
| `LRG_199:g.699646_700297insNNN…` | 8 | insertion at a splice junction |
| `NC_000023.11:g.spl`, `g.(spl)` | 8 | the RNA-only `spl` edit on a `g.` axis |
| `[]` | 2 | an `AlleleVariant` built with no members |

## What is fixed

**The RNA-only effects.** `r.spl` ("splicing affected", `RNA/splicing.md`) and `r.0` ("no product") describe the transcript, not a sequence change at a locus. The projector had **no `NaEdit::Splice` handling anywhere** — it converted the position, which maps perfectly well, and carried the edit token through verbatim, emitting `g.spl`, `c.1spl` and `n.245spl`. It also invented a protein consequence, `NP_003997.1:p.(Met1?)`, for a variant that states no coding change. `hgvs_to_vcf` already declined exactly these two edits; the conversion paths now agree.

**The junction insertion.** `r.1149_1150ins…` is well formed — the anchors are neighbours in the spliced RNA — but when the pair straddles an exon–exon junction their genomic images sit either side of the intron. There is no repair: the insertion could attach to the 3' end of the upstream exon or the 5' end of the downstream one, and those are *different* genomic variants. HGVS has no spelling for "at the junction", so the genomic axis declines.

Both decline **per axis, not per projection**. The guard sits on the *reported* form, not on the pivot that also feeds the cdot derivation of c./n./p. — an earlier attempt guarded the pivot and failed the whole projection, turning "four right axes and one wrong one" into nothing. Pinned by `a_declined_genomic_axis_does_not_take_the_other_axes_with_it`.

This is the `src/{project,…}` path instruction's own rule: *"Projection must DECLINE rather than emit a coordinate it cannot justify."*

## Also fixed — found while measuring, not filed separately

**A real parser hole, in the construct the issue's framing points at but did not name.** `validate_no_point_insertion` ends in `_ => {}` and never inspected `GenomeRing` segments, even though they are `LocEdit<GenomeInterval, NaEdit>` — the same loc/edit pair every other arm checks. Both MUST-level sub-rules were unenforced inside a `::`-join:

```
ACCEPTED  NC_000022.11:g.100_102insATG::200_201insG      <- non-adjacent anchors
ACCEPTED  NC_000022.11:g.100insATG::200_201insG          <- single-position anchor
rejected  NC_000022.11:g.[100_102insATG;300A>G]          <- Allele was recursed into
```

These **round-trip**, so the re-parse oracle can never see them; only a parser test can.

**The empty allele.** `AlleleVariant::checked` refuses an empty member list, mirroring `GenomeRing::new` ("a 0/1-segment ring would not round-trip"). `new` is deliberately left infallible — it is called throughout the parser and normalizer on lists that are non-empty by construction.

## The exemption is now a closed list

`FERRO_ASSERT_REPARSE`'s exemption was a blanket. It is now three named shapes, each justified in place: the `0`/`?` whole-allele markers, an empty allele, and the non-flanking genomic *pivot* (whose reported axis is withheld). Anything else that arrives unparseable now fails. Re-measured after the fixes: **18 hits in 4 shapes → 4 hits in 2**.

## Bucket movement (`src/conformance/**` instruction)

22 enumeration rows move; the 2184-row total is unchanged.

| status | before | after | delta |
|---|---|---|---|
| `projection-pinned` | 1180 | 1167 | −13 |
| `projection-error-pinned` | 215 | 210 | −5 |
| `projection-unavailable-pinned` | 469 | 487 | +18 |

Every moved row was a projection with no business rendering. **Two rows improve the other way**, from hard error to rendered: `r.0` on `NM_004006.1` previously failed the whole projection with "Transcript has no CDS" and now renders `r.(0)` on its own axis — declining the axes that do not apply is what let the one that does apply through.

The four `project-r/…r.spl` rows are deliberately **unmoved**: the `rna` axis is documented as the predicted form and already rendered `r.(spl)`, so the replacement path preserves that wrapper rather than quietly changing it. The normalization fixture is byte-identical (934 rows, 0 changed).

`passing_census_is_unchanged` — the guard added in #1272 — is what caught this and forced the counts to be updated deliberately. Working as intended.

## A rejected alternative, recorded

The first attempt was a single post-condition at the projection seam: withhold any axis whose rendering fails to re-parse. Across 9011 tests it produced 2 failures, and one refuted the design — it withheld a **correct** `p.` axis because the fixture accession `NP_TEST_MINUS.1` is not parseable (the parser rejects the second underscore). It coupled axis availability to accession-syntax support, so any consumer with a custom accession would silently lose every axis. Replaced by a structural check on the interval, which cannot repeat that failure. The reasoning is kept in `non_flanking_genomic_insertion_anchor`'s doc comment.

## Verification

- `cargo nextest run --features dev` with **`FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`** — **9028 passed**, 0 failed (proptests included).
- `cargo fmt --all --check` clean; `cargo clippy --features dev --all-targets` silent; `cargo check --features python` clean.
- No new seeds in `tests/proptest-regressions/` — no proptest strategy was touched.
- Manifest-backed conformance tests skip (scratch volume offline); nothing here needs them.

## Reading order

1. `tests/it/issue_1264_reparse_asymmetry.rs` — the census and the ten regressions, including the anti-vacuity control.
2. `src/project/projector.rs` — `project_rna_only_effect` and `non_flanking_insertion_reason`.
3. `src/hgvs/parser/variant.rs` — the `GenomeRing`/`Supernumerary` arms.
4. `src/normalize/mod.rs` — the narrowed exemption.

One note on the test fixture, since it is the reason the junction test is not vacuous: an earlier draft used `CGCG…` exons and an all-`N` intron, against which the junction insertion normalized to `g.1030_1199N[173]` — a repeat spanning the intron, which *does* re-parse, so the test passed while proving nothing. A homopolymer is not a representative intron.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of genomic insertion anchors, including wrapped and multi-segment variants.
  * Prevented invalid RNA-only and non-flanking insertions from producing incompatible projections.
  * Preserved specific reasons when genomic projections are unavailable.
  * Improved handling and validation of empty alleles.

* **Tests**
  * Added coverage for parsing, normalization, projection, and allele round trips.
  * Updated projection behavior expectations for splice effects and invalid insertions.

* **Documentation**
  * Clarified normalization re-parse exceptions and documented discovered cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->