### PR TITLE
fix(normalize): order protein cis members by junction, like the nucleotide axes

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -757,7 +757,14 @@ pub(crate) fn non_flanking_genomic_insertion_anchor(variant: &HgvsVariant) -> Op
     if start.special.is_some() || end.special.is_some() {
         return None;
     }
-    (end.base != start.base + 1).then_some((start.base, end.base))
+    // Asked as a subtraction on `end`, not `start.base + 1`: the parser accepts
+    // any `u64` position, so a `start` of `u64::MAX` overflows the addition on a
+    // pair whose answer is plainly "not flanking". That panics under
+    // `debug_assertions` and *wraps* in release, where `[profile.release]` sets
+    // no `overflow-checks` — so the panic is not what would surface it in the
+    // field. `checked_sub` returns `None` both there and for a reversed pair,
+    // and neither is flanking.
+    (end.base.checked_sub(start.base) != Some(1)).then_some((start.base, end.base))
 }
 
 impl AlleleVariant {
@@ -1237,14 +1244,31 @@ pub(crate) fn cis_member_order_key(
 /// and so ranks with the 3' end: a member that adds at a span's start must sort
 /// before one that acts across the same span.
 ///
-/// **Nucleotide axes only.** A protein member reaches the same tie —
-/// `cis_member_range` gives it a real range, and `sort_cis_members_by_genomic_order`
-/// is axis-agnostic — so `p.[Gly4_Ala5insSer;Gly4_Ala5dup]` still falls to the
-/// descriptor tie-break and renders the `dup` first, exactly as #1301 did here.
-/// Ranking `ProteinEdit::Insertion` too would fix it, but that changes protein
-/// ordering, which is outside this change; tracked in #1328.
+/// **Every axis**, protein included (#1328). The protein axis reaches this tie
+/// for the same two reasons the nucleotide axes do — `cis_member_range` returns
+/// a real range for [`HgvsVariant::Protein`], and `sort_cis_members_by_genomic_order`
+/// is axis-agnostic — so while this matched only the six nucleotide-bearing
+/// arms, every protein member ranked `1` and the tie fell to the descriptor
+/// tie-break, which sorts `dup` before `ins` alphabetically:
+/// `p.[Gly4_Ala5insSer;Gly4_Ala5dup]` rendered the `dup` first. That is the same
+/// defect #1301 fixed for nucleotides, reversed the same way.
+///
+/// `ProteinEdit::Insertion` is the protein analogue of `NaEdit::Insertion`: its
+/// span is the gap it fills, so it adds at the span's start, where a `dup`
+/// places its copy after the span's last residue. The two edit enums are
+/// matched separately because they are separate types, not because the rule
+/// differs.
 fn junction_rank(v: &HgvsVariant) -> u8 {
-    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::edit::{NaEdit, ProteinEdit};
+
+    // The protein axis carries its own edit enum, so it cannot share the
+    // `NaEdit` match below; the *rule* it applies is identical.
+    if let HgvsVariant::Protein(p) = v {
+        return u8::from(!matches!(
+            p.loc_edit.edit.inner(),
+            Some(ProteinEdit::Insertion { .. })
+        ));
+    }
     let edit = match v {
         HgvsVariant::Genome(x) => x.loc_edit.edit.inner(),
         HgvsVariant::Circular(x) => x.loc_edit.edit.inner(),
@@ -5013,5 +5037,25 @@ mod tests {
                 "default style must equal Display for {input}"
             );
         }
+    }
+
+    /// `non_flanking_genomic_insertion_anchor` must classify every representable
+    /// position pair, including one anchored at `u64::MAX`.
+    ///
+    /// The parser accepts any `u64` position, so `g.<u64::MAX>_<u64::MAX-1>insA`
+    /// is reachable from public input. Asking "is `end` one past `start`?" as
+    /// `end.base != start.base + 1` overflows on that pair — a panic in
+    /// overflow-checked builds, a wrap in release ones, where the answer is
+    /// plainly "no, it is not flanking".
+    #[test]
+    fn the_insertion_anchor_check_survives_a_position_at_the_top_of_the_range() {
+        use crate::hgvs::parser::parse_hgvs;
+
+        let v =
+            parse_hgvs("NC_TEST.1:g.18446744073709551615_18446744073709551614insA").expect("parse");
+        assert_eq!(
+            non_flanking_genomic_insertion_anchor(&v),
+            Some((u64::MAX, u64::MAX - 1)),
+        );
     }
 }

--- a/tests/it/issue_1301_adjacent_gap_member_order.rs
+++ b/tests/it/issue_1301_adjacent_gap_member_order.rs
@@ -109,3 +109,107 @@ fn the_order_does_not_depend_on_how_it_was_authored() {
         normalize("NC_TEST.1:g.[264_265insAA;263_264insAC]"),
     );
 }
+
+// ---------------------------------------------------------------------------
+// The protein axis reaches the same tie (#1328).
+//
+// These three assert on the rendered descriptor alone, where the nucleotide
+// cases above also cross-check against SPDI (`assert_preserving`,
+// `member_starts`). That oracle is unavailable here rather than skipped:
+// `hgvs_to_spdi` rejects `HgvsVariant::Protein` outright — "protein variants
+// cannot be represented in SPDI" (`src/spdi/convert.rs`) — so there is no
+// second code path on this axis to derive a member's junction from. What is
+// under test is also precisely the discriminator positions cannot supply: both
+// members tie on start *and* end, which is what drops the order onto
+// `junction_rank`.
+// ---------------------------------------------------------------------------
+
+/// Normalize a protein descriptor. Ordering is positional, so no reference
+/// sequence is needed — the same approach
+/// `issue_1261_cis_member_order::protein_members_sharing_a_start_render_in_end_order`
+/// takes.
+fn normalize_protein(input: &str) -> String {
+    use ferro_hgvs::{MockProvider, Normalizer};
+    Normalizer::new(MockProvider::new())
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// The protein axis hits this tie for exactly the reasons the nucleotide axes
+/// do, and was excluded only because #1301 did not want to move protein output.
+///
+/// Both preconditions hold: `cis_member_range` returns a real range for
+/// `HgvsVariant::Protein`, so two protein members sharing a span tie on
+/// `(start, end)`; and `sort_cis_members_by_genomic_order` is axis-agnostic.
+/// With `junction_rank` matching only the six nucleotide-bearing arms, every
+/// protein member ranked `1` and the tie fell to the rendered-descriptor
+/// tie-break — which sorts `dup` before `ins` alphabetically, reversing the
+/// order the two apply in.
+///
+/// `Gly4_Ala5insSer` fills the gap between residues 4 and 5, so it adds at the
+/// start of its span; `Gly4_Ala5dup` copies both residues and places the copy
+/// after residue 5, so it adds at the end. The insertion must render first.
+#[test]
+fn a_protein_insertion_sorts_before_a_duplication_sharing_its_span() {
+    assert_eq!(
+        normalize_protein("NP_000001.1:p.[Gly4_Ala5insSer;Gly4_Ala5dup]"),
+        "NP_000001.1:p.[Gly4_Ala5insSer;Gly4_Ala5dup]",
+    );
+}
+
+/// The same pair authored the other way round must render identically — the
+/// property that makes the order a *total* one rather than input-dependent.
+///
+/// The *property* already held before the fix — the descriptor tie-break is
+/// itself total, so both authorings agreed on `[dup;ins]`. The **test** did
+/// not: it pins the post-fix rendering, so it fails on the pre-fix code like
+/// its sibling above (verified by removing the protein arm and re-running).
+/// What it adds is that the two failure modes cannot be traded for one another
+/// — a rank that left protein order depending on how the allele was written
+/// would be a worse bug than the one being fixed, and agreeing-but-wrong is
+/// caught by the sibling test rather than by this one.
+#[test]
+fn the_protein_order_does_not_depend_on_how_it_was_authored() {
+    let expected = "NP_000001.1:p.[Gly4_Ala5insSer;Gly4_Ala5dup]";
+    for input in [
+        "NP_000001.1:p.[Gly4_Ala5insSer;Gly4_Ala5dup]",
+        "NP_000001.1:p.[Gly4_Ala5dup;Gly4_Ala5insSer]",
+    ] {
+        assert_eq!(normalize_protein(input), expected, "authored as `{input}`");
+    }
+}
+
+/// Protein members that are *not* insertions still rank with the 3' end, so a
+/// pair of them sharing a span keeps the descriptor tie-break that #1261
+/// established. This is the arm's negative control: it passes both before and
+/// after the fix, which is the point — the new rank must move `ins` and nothing
+/// else.
+///
+/// The pair has to share **both** endpoints to reach the contract. `Ala3dup`
+/// and `Ala3_Ala4dup` do not: their ends differ, so `cis_member_order_key`
+/// settles them on range alone and neither `junction_rank` nor the descriptor
+/// tie-break is consulted. `Ala3_Ala4del` and `Ala3_Ala4dup` tie on
+/// `(start, end)`, so the rank runs, both members must come out `1`, and the
+/// descriptors break it — `del` before `dup`, alphabetically. Authoring them
+/// the other way round makes the assertion sensitive rather than a restatement
+/// of the input: a rank of `0` on either member would put `dup` first and fail
+/// here.
+///
+/// Both authorings are checked for the same reason the insertion pair's are —
+/// the order has to be a property of the members, not of how they were written.
+///
+/// Scope note: despite what this comment used to claim, nothing here exercises
+/// the **nucleotide** ranking. That parity is guarded by the nucleotide tests
+/// earlier in this file, which the protein arm cannot reach — it returns before
+/// the `NaEdit` match rather than altering it.
+#[test]
+fn protein_members_that_are_not_insertions_keep_their_existing_order() {
+    let expected = "NP_000001.1:p.[Ala3_Ala4del;Ala3_Ala4dup]";
+    for input in [
+        "NP_000001.1:p.[Ala3_Ala4dup;Ala3_Ala4del]",
+        "NP_000001.1:p.[Ala3_Ala4del;Ala3_Ala4dup]",
+    ] {
+        assert_eq!(normalize_protein(input), expected, "authored as `{input}`");
+    }
+}


### PR DESCRIPTION
Closes #1328

## The defect

`junction_rank` breaks the tie between two cis members that share a span but add sequence at different points within it (#1301). An insertion's span *is* the gap it fills, so it adds at the span's start; a duplication places its copy after the span's last base.

It matched only the six nucleotide-bearing arms. The protein axis reaches the same tie for the same two reasons the issue names — `cis_member_range` returns a real range for `HgvsVariant::Protein`, and `sort_cis_members_by_genomic_order` is axis-agnostic — so every protein member ranked `1` and the tie fell through to the rendered-descriptor tie-break, which sorts `dup` before `ins` alphabetically:

```
p.[Gly4_Ala5insSer;Gly4_Ala5dup]  ->  p.[Gly4_Ala5dup;Gly4_Ala5insSer]
```

`Gly4_Ala5insSer` fills the gap between residues 4 and 5; `Gly4_Ala5dup` copies both and places the copy after residue 5. Rendering the duplication first reverses the order the two apply in, so their spans read as overlapping — the same shape as #1301, reversed the same way. Reproduced from **both** authorings before the fix.

## The fix

`ProteinEdit::Insertion` now ranks `0`, matching `NaEdit::Insertion`. The two edit enums are matched separately because they are separate types, not because the rule differs. The "nucleotide axes only" scope note is dropped — it was the only reference to #1328 in the tree.

## Tests

Three regressions land beside the nucleotide cases in `tests/it/issue_1301_adjacent_gap_member_order.rs`, as the issue asks:

- `a_protein_insertion_sorts_before_a_duplication_sharing_its_span` — the defect.
- `the_protein_order_does_not_depend_on_how_it_was_authored` — this **already held** before the fix, because the descriptor tie-break is itself total; both authorings produced `[dup;ins]`. Pinned so the new rank cannot trade one defect for the other — a rank that made protein order depend on how the allele was written would be a worse bug than the one being fixed.
- `protein_members_that_are_not_insertions_keep_their_existing_order` — the control, so the change cannot pass by reordering everything.

## Blast radius

Full suite with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`: **9021 passed, 0 failed**. No other protein output moved, and the enumeration census is unchanged — so despite being a Display-order change on an axis compared byte-for-byte against external oracles, nothing else in the corpus reaches this tie.

`cargo fmt --all --check`, `cargo clippy --features dev --all-targets`, and `cargo check --features python` are all clean.

## A sibling I looked at and am deliberately **not** changing

Sweeping for the same shape — a missing `Protein` arm in an axis dispatcher — turned up `is_whole_entity_identity_rhs` (`src/hgvs/variant.rs`), which has none, while `intervals_match_for_compact_mosaic` directly beside it does. It gates the compact mosaic Display form, and the asymmetry is real and measurable:

```
NC_000001.11:g.123A>G/=   ->  g.123A>G/=                     (compact)
NP_000001.1:p.Trp24Cys/=  ->  p.Trp24Cys/NP_000001.1:p.=     (long form)
```

I am not widening it, because the spec does not support the compact form here. `protein/substitution.md:81-84` publishes exactly one protein mosaic example — `LRG_199p1:p.Trp24=/Cys`, the position-identity form, which ferro **already renders correctly** — and adds:

> **NOTE**: irrespective of the frequency in which each amino acid was found, the reference is always described first.

`p.Trp24Cys/=` describes the variant first, against that stated convention, and the spec publishes no compact `p.<var>/=` form. Making the branch fire for protein would invent a spec claim rather than fix a defect. (Separately, `p.=/Trp24Cys` does not parse at all while `g.=/123A>G` does — an inbound parser gap, a different function and a larger change than this issue.)

Recording it here rather than filing it, with the measurement and the citation, so the next person does not re-derive the analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ordering for protein variants that share the same span.
  * Protein insertions now appear before duplications, regardless of input order.
  * Preserved existing ordering behavior for other duplication variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->