### PR TITLE
fix(liftover): return an error for position 0 instead of panicking

### DIFF
--- a/src/liftover/lift.rs
+++ b/src/liftover/lift.rs
@@ -14,7 +14,7 @@
 //! For type-safe coordinate handling, see [`crate::coords`].
 
 use super::chain::ChainFile;
-use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
+use crate::coords::{hgvs_pos_to_index_checked, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::reference::transcript::GenomeBuild;
 use std::path::Path;
@@ -127,6 +127,14 @@ impl Liftover {
     /// Lift a single position from one build to another.
     ///
     /// Positions are 1-based (HGVS convention).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FerroError::InvalidCoordinates`] if `pos` is `0` — there is no
+    /// 1-based position 0 — if the build pair is not one this instance carries
+    /// chains for, if no chain covers `contig:pos`, or if the position falls in
+    /// an alignment gap. All four share the one variant, so callers that need to
+    /// tell them apart have only the message.
     pub fn lift(
         &self,
         from: GenomeBuild,
@@ -136,8 +144,11 @@ impl Liftover {
     ) -> Result<LiftoverResult, FerroError> {
         let chain_file = self.get_chain_file(from, to)?;
 
-        // Convert from 1-based HGVS to 0-based for chain operations
-        let pos_0based = hgvs_pos_to_index(pos) as u64;
+        // Convert from 1-based HGVS to 0-based for chain operations. `pos` is a
+        // raw `u64` off a public API — the web service hands one straight from
+        // the query string — so it is not known to be a valid 1-based position
+        // and the conversion has to be the checked one (#1282).
+        let pos_0based = position_to_index(contig, pos)?;
 
         // Find chains covering this position
         let chains = chain_file.find_chains(contig, pos_0based);
@@ -196,6 +207,11 @@ impl Liftover {
     }
 
     /// Lift an interval from one build to another.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FerroError::InvalidCoordinates`] if either endpoint is `0`, or
+    /// if the build pair is not one this instance carries chains for.
     pub fn lift_interval(
         &self,
         from: GenomeBuild,
@@ -206,9 +222,11 @@ impl Liftover {
     ) -> Result<IntervalLiftoverResult, FerroError> {
         let chain_file = self.get_chain_file(from, to)?;
 
-        // Convert 1-based HGVS positions to 0-based for chain operations
-        let start_0based = hgvs_pos_to_index(start) as u64;
-        let end_0based = hgvs_pos_to_index(end) as u64;
+        // Convert 1-based HGVS positions to 0-based for chain operations. Both
+        // endpoints are unvalidated, so both take the checked conversion —
+        // guarding only `start` would still panic on `lift_interval(.., 10001, 0)`.
+        let start_0based = position_to_index(contig, start)?;
+        let end_0based = position_to_index(contig, end)?;
 
         // Find chains covering the start and end
         let start_chains = chain_file.find_chains(contig, start_0based);
@@ -298,6 +316,28 @@ impl Liftover {
     }
 }
 
+/// Convert a caller-supplied 1-based position to a 0-based chain index, or an
+/// error naming the offending coordinate.
+///
+/// Shared by [`Liftover::lift`] and [`Liftover::lift_interval`] so the three
+/// call sites cannot drift apart — the failure mode this guards against is
+/// exactly one endpoint keeping the unchecked conversion.
+fn position_to_index(contig: &str, pos: u64) -> Result<u64, FerroError> {
+    hgvs_pos_to_index_checked(pos)
+        .map(|idx| idx as u64)
+        .ok_or_else(|| FerroError::InvalidCoordinates {
+            // Report `pos` rather than the literal `0`. Zero is the only value
+            // `hgvs_pos_to_index_checked` refuses today, so the two read the
+            // same — but a hardcoded `0` becomes a lie the moment that function
+            // grows a second refusal, and an error message that names a value
+            // the caller did not pass is worse than one that names none.
+            msg: format!(
+                "liftover position must be 1-based, but got {pos} for contig {contig}: \
+                 no position 0 exists on any HGVS axis"
+            ),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,6 +375,44 @@ mod tests {
         let result = liftover.lift(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", 1);
 
         assert!(result.is_err());
+    }
+
+    /// Position `0` must be refused, not panic.
+    ///
+    /// `lift` takes a raw `u64` on a `pub` API and converts it with
+    /// `hgvs_pos_to_index`, which asserts on `0` (#1282). The web service reaches
+    /// here with an unvalidated position — `parse_genomic_position` accepts
+    /// `chr7:0` — so leaving the bare conversion in place turns a malformed
+    /// request into a panicked handler task rather than a 200 with an error body.
+    ///
+    /// #1282 asked for exactly this: guard the conversion and return an error,
+    /// rather than relying on callers never producing a zero.
+    #[test]
+    fn lift_rejects_position_zero() {
+        let liftover = Liftover::one_way(test_chain_file());
+        let err = liftover
+            .lift(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", 0)
+            .expect_err("position 0 must be an error, not a panic");
+        assert!(
+            matches!(err, FerroError::InvalidCoordinates { .. }),
+            "expected InvalidCoordinates, got {err:?}"
+        );
+    }
+
+    /// Both endpoints of an interval get the same guard — a start of `0` and an
+    /// end of `0` are each rejected, so fixing only the start would still panic.
+    #[test]
+    fn lift_interval_rejects_position_zero_at_either_end() {
+        let liftover = Liftover::one_way(test_chain_file());
+        for (start, end) in [(0u64, 10100u64), (10001, 0)] {
+            let err = liftover
+                .lift_interval(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", start, end)
+                .unwrap_err();
+            assert!(
+                matches!(err, FerroError::InvalidCoordinates { .. }),
+                "expected InvalidCoordinates for ({start}, {end}), got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/it/issue_1334_liftover_position_zero.rs
+++ b/tests/it/issue_1334_liftover_position_zero.rs
@@ -1,0 +1,137 @@
+//! #1334 — liftover must refuse position `0` rather than panic on it.
+//!
+//! `Liftover::lift` and `Liftover::lift_interval` take raw `u64` positions on a
+//! `pub` API. The web service reaches them with an unvalidated value —
+//! `parse_genomic_position` in `src/service/handlers/liftover.rs` parses with a
+//! bare `pos_part.parse::<u64>()` and applies no lower bound, so `chr7:0` yields
+//! `Ok(("chr7", 0))` — and the `ferro liftover` CLI reaches `lift` the same way.
+//!
+//! Since #1282 made `hgvs_pos_to_index` assert on `0`, that input panicked: in
+//! the service it killed the handler task and dropped the connection, where
+//! before #1282 it had wrapped to an index near `usize::MAX` in release (the
+//! release profile sets no `overflow-checks`), found no chains, and rendered a
+//! graceful error body. Neither is acceptable; #1282 asked for the guard:
+//!
+//! > Guard the conversion (return `None`/`Err` for `pos < 1`) rather than
+//! > relying on callers never producing a zero.
+//!
+//! This file pins the guarded behaviour from *outside* the crate, which is where
+//! the offending callers live — the in-module unit tests in `src/liftover/lift.rs`
+//! exercise the same paths but cannot show that the failure is reachable and
+//! catchable across the public API boundary.
+//!
+//! There is no oracle movement to report: liftover is chain-file arithmetic, not
+//! an HGVS description, so no reference oracle (biocommons hgvs, Mutalyzer,
+//! VariantValidator) has an opinion about it. For every position these entry
+//! points previously answered — every `pos >= 1` — the answer is byte-identical;
+//! the only inputs whose behaviour moves are the ones that used to panic.
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::liftover::{ChainFile, Liftover};
+use ferro_hgvs::reference::transcript::GenomeBuild;
+
+/// A single 1:1 chain covering target `chr1:10001..20000` (1-based inclusive),
+/// mapping onto query `chr1:10051..20150` with a 100 bp offset introduced by the
+/// gap between the two 5000 bp blocks.
+///
+/// Built inline rather than read from a fixture so the corpus stays generated
+/// rather than committed.
+const CHAIN: &str =
+    "chain 1000 chr1 1000000 + 10000 20000 chr1 1000100 + 10050 20150 1\n5000\n5000\n\n";
+
+fn liftover() -> Liftover {
+    Liftover::one_way(ChainFile::parse(CHAIN.as_bytes()).expect("chain parses"))
+}
+
+/// The reported reproducer: `lift` with `pos == 0`.
+///
+/// Pins the *new* output — a returned `InvalidCoordinates` naming the offending
+/// coordinate and contig — rather than merely "is an error", so a future change
+/// that swaps the variant or drops the coordinate from the message fails here.
+#[test]
+fn lift_returns_invalid_coordinates_for_position_zero() {
+    let err = liftover()
+        .lift(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr7", 0)
+        .expect_err("position 0 must be an error, not a panic");
+
+    let FerroError::InvalidCoordinates { msg } = &err else {
+        panic!("expected InvalidCoordinates, got {err:?}");
+    };
+    assert!(
+        msg.contains("chr7"),
+        "error must name the contig the caller passed: {msg}"
+    );
+    assert!(
+        msg.contains("1-based"),
+        "error must say what was wrong with the position: {msg}"
+    );
+}
+
+/// Both interval endpoints carry the same guard.
+///
+/// This is the case a partial fix loses: guarding only `start` leaves
+/// `lift_interval(.., 10001, 0)` converting `end` with the panicking helper, and
+/// every test that only ever zeroes the start still passes.
+#[test]
+fn lift_interval_returns_invalid_coordinates_for_a_zero_at_either_end() {
+    for (start, end) in [(0u64, 10100u64), (10001, 0), (0, 0)] {
+        let err = liftover()
+            .lift_interval(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", start, end)
+            .expect_err("a zero endpoint must be an error, not a panic");
+        assert!(
+            matches!(err, FerroError::InvalidCoordinates { .. }),
+            "expected InvalidCoordinates for ({start}, {end}), got {err:?}"
+        );
+    }
+}
+
+/// The negative control: positions the guard must not touch still lift to the
+/// coordinates they lifted to before it existed.
+///
+/// Without this, a guard that rejected far more than `0` — say `pos <= 1`, or
+/// every position — would satisfy both tests above and silently break liftover.
+#[test]
+fn valid_positions_still_lift_to_their_previous_coordinates() {
+    let liftover = liftover();
+
+    // First base of the chain's first block: 1:1, no gap offset yet.
+    let first = liftover
+        .lift(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", 10001)
+        .expect("the first covered base lifts");
+    assert_eq!(first.source_pos, 10001);
+    assert_eq!(first.target_contig, "chr1");
+    assert_eq!(first.target_pos, 10051);
+    assert!(!first.in_gap);
+
+    // An interval wholly inside that block lifts both endpoints the same way.
+    let interval = liftover
+        .lift_interval(
+            GenomeBuild::GRCh37,
+            GenomeBuild::GRCh38,
+            "chr1",
+            10001,
+            10100,
+        )
+        .expect("a covered interval lifts");
+    assert_eq!(interval.source_interval, (10001, 10100));
+    assert_eq!(interval.target_interval, Some((10051, 10150)));
+
+    // And position 1 — the smallest position that exists — still reaches the
+    // chain lookup and fails there as "no chain covers this", not at the guard.
+    //
+    // Both failures are spelled `InvalidCoordinates`, so the discriminator has
+    // to be the message: the uncovered path names the chain lookup, the guard
+    // names the 1-based convention. That shared variant is pre-existing and out
+    // of scope here; what matters is that the guard did not swallow position 1.
+    let err = liftover
+        .lift(GenomeBuild::GRCh37, GenomeBuild::GRCh38, "chr1", 1)
+        .expect_err("position 1 is outside the chain");
+    let FerroError::InvalidCoordinates { msg } = &err else {
+        panic!("expected InvalidCoordinates, got {err:?}");
+    };
+    assert!(
+        msg.contains("No chain found"),
+        "position 1 is valid; it must fail at the chain lookup, not at the \
+         1-based guard: {msg}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -185,6 +185,7 @@ mod issue_1320_dup_spans_sibling_junction;
 mod issue_1321_identity_inside_a_duplication;
 mod issue_1323_shared_junction_order;
 mod issue_132_cyclic_rotation_insertion;
+mod issue_1334_liftover_position_zero;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
#1331 has landed, so this is no longer stacked — the branch is rebased onto `main` and the diff is a single commit touching only `src/liftover/lift.rs`.

Closes #1334

## Why

#1331 makes `hgvs_pos_to_index` assert on `0` rather than wrap to a near-`usize::MAX` index. That is the right call, but it added `hgvs_pos_to_index_checked` and wired it into exactly one consumer — the PyO3 binding — leaving the Rust call sites on the panicking path. One of them takes unvalidated external input.

`src/service/handlers/liftover.rs` `parse_genomic_position` parses with a bare `pos_part.parse::<u64>()` and applies no lower bound, so a request for `chr7:0` yields `Ok(("chr7", 0))`. That reaches `Liftover::lift`, which converted with `hgvs_pos_to_index(pos)`.

- **Before #1331:** wrapped to a huge index in release (`[profile.release]` sets no `overflow-checks`), `find_chains` returned empty, handler produced a 200 with an `error` field.
- **After #1331:** panics, killing the handler task and dropping the connection.

`lift_interval` has the same problem on *both* endpoints, and the `ferro liftover` CLI reaches `lift` the same way.

This is what #1282 asked for in the first place:

> Guard the conversion (return `None`/`Err` for `pos < 1`) rather than relying on callers never producing a zero.

## What changed

All three conversions now go through a shared `position_to_index` helper backed by `hgvs_pos_to_index_checked`. `lift` and `lift_interval` already return `Result<_, FerroError>`, so there is no signature change, and the handler's existing `Err` arm renders the result as the same graceful response it produced before #1331.

The helper is shared rather than inlined three times deliberately: the failure mode being guarded against is precisely one endpoint keeping the unchecked call, and `lift_interval` panicked on a zero `end` as readily as a zero `start`.

## Testing

Two tests in `src/liftover/lift.rs`, both confirmed to **fail without the fix** — they panic at `lift.rs:149` and `lift.rs:226`, the exact conversion sites — and pass with it:

- `lift_rejects_position_zero`
- `lift_interval_rejects_position_zero_at_either_end` (covers a zero `start` *and* a zero `end`, so fixing only one endpoint still fails)

Both assert the specific `FerroError::InvalidCoordinates` variant rather than merely that an error occurred.

Plus a pinned integration regression, `tests/it/issue_1334_liftover_position_zero.rs`, which exercises the same guard across the crate boundary — which is where the offending callers (the web service handler and the CLI) actually live:

- `lift_returns_invalid_coordinates_for_position_zero` — pins the *new* output, not just "is an error": the message names the caller's contig and the 1-based convention.
- `lift_interval_returns_invalid_coordinates_for_a_zero_at_either_end` — `(0, 10100)`, `(10001, 0)` and `(0, 0)`.
- `valid_positions_still_lift_to_their_previous_coordinates` — the negative control. `chr1:10001 -> chr1:10051` and the interval `10001_10100 -> 10051_10150` still lift to the coordinates hand-derived from the chain header, and position 1 still fails at the chain lookup (`No chain found`) rather than at the new guard. Without it, a guard that rejected `pos <= 1` — or everything — would satisfy the two tests above.

The chain is built programmatically from an inline string; no fixture is committed. The test resolves no `FERRO_MANIFEST`, so it runs on PR CI rather than only in the nightly.

### Movement relative to the reference oracles

**Neither toward nor away — no oracle has an opinion here.** Liftover is UCSC chain-file arithmetic, not an HGVS description, so biocommons hgvs, Mutalyzer and VariantValidator have nothing to say about `Liftover::lift`. For every input these entry points previously *answered* — every `pos >= 1` — the output is byte-identical, which `valid_positions_still_lift_to_their_previous_coordinates` pins. The only inputs whose behaviour moves are the ones that panicked (post-#1331) or wrapped to a near-`usize::MAX` index (pre-#1331); both are replaced by a returned `Err`.

Full suite: 9024 passed, 0 failed. `cargo fmt --check` and `clippy --all-targets -- -D warnings` clean.

## Not in scope

#1334 also lists position-to-index conversions that #1282's sweep did not reach — `src/normalize/validate.rs:194,353,559,584`, `src/normalize/rules.rs:436,454`, `src/benchmark/cache.rs:653,1229,2762`. Those take positions from parsed, validated variants rather than raw external input, so they are lower risk than the liftover path and are left for a separate audit rather than widening this PR. They remain tracked on the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Liftover conversions now safely reject invalid zero-valued coordinates instead of potentially failing unexpectedly.
  * Error messages identify the affected contig and coordinate.
* **Documentation**
  * Added documentation describing invalid-coordinate errors.
* **Tests**
  * Added coverage for invalid single-position and interval endpoint conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
