### PR TITLE
fix(normalize): unify the complement helpers and case-fold the delins path

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -14,6 +14,7 @@ use crate::normalize::boundary::Boundaries;
 use crate::normalize::config::ShuffleDirection;
 use crate::normalize::shuffle::shuffle;
 use crate::reference::ReferenceProvider;
+use crate::sequence::complement_base;
 
 /// Coordinate-system region used as the merge-eligibility key.
 ///
@@ -2333,37 +2334,6 @@ fn canonical_base_byte(base: u8) -> u8 {
         b'U' => b'T',
         other => other,
     }
-}
-
-/// Watson-Crick complement of an IUPAC base, case-insensitive, as uppercase.
-/// `None` for a byte that is not a recognised base.
-///
-/// Matched here rather than delegated to [`crate::sequence::reverse_complement`],
-/// which is a *display* helper: its fallback arm is `other => other`, so it
-/// passes an unrecognised byte through unchanged. Routing through it made this
-/// function total — it could not return `None`, so the `?` refusals at the call
-/// sites were unreachable, and a byte that is not a base would have been
-/// "complemented" to itself and folded into an inversion instead of declining
-/// the edit. Enumerating the set is what makes that refusal real.
-fn complement_base(base: u8) -> Option<u8> {
-    Some(match base.to_ascii_uppercase() {
-        b'A' => b'T',
-        b'T' | b'U' => b'A',
-        b'G' => b'C',
-        b'C' => b'G',
-        b'R' => b'Y',
-        b'Y' => b'R',
-        b'S' => b'S',
-        b'W' => b'W',
-        b'K' => b'M',
-        b'M' => b'K',
-        b'B' => b'V',
-        b'V' => b'B',
-        b'D' => b'H',
-        b'H' => b'D',
-        b'N' => b'N',
-        _ => return None,
-    })
 }
 
 /// Trim the common prefix and suffix of the reference and result blocks.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -8416,15 +8416,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             ));
                         }
                         // Not a base we can complement into a typed
-                        // substitution. Unreachable as written:
-                        // `shorten_inversion` yields a one-base residue only
-                        // for a base whose complement differs from it, which
-                        // `complement` answers only for the IUPAC alphabet
-                        // `Base` models — a byte outside it is left unchanged,
-                        // reads as self-complementary, and collapses to
-                        // identity before reaching here. Kept as a defensive
-                        // fallback: leave the inversion as authored rather than
-                        // assert or invent an edit.
+                        // substitution. **Reachable since #1318**, and the
+                        // comment here used to say the opposite.
+                        //
+                        // The old justification was that an unmodelled byte was
+                        // returned unchanged by `complement`, so it read as
+                        // self-complementary and collapsed to identity before
+                        // reaching here. `complement_base` answers `None` for
+                        // such a byte instead, so `is_self_complementary` is
+                        // now `false` for it and `shorten_inversion` hands back
+                        // a one-base residue rather than `None` — measured:
+                        // `shorten_inversion(b"X", 0, 1)` was `None`, is now
+                        // `Some((0, 1))`.
+                        //
+                        // Landing here is the right outcome: leave the
+                        // inversion as authored rather than claim an identity
+                        // for a byte we cannot complement, which is the #1249
+                        // class of silent loss. Emitting nothing typed is a
+                        // refusal, not a fallback nobody reaches.
                         return Ok((start, end, canonicalize_edit(edit), warnings));
                     }
                     return Ok((

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -23,6 +23,7 @@ use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::hgvs::edit::{InsertedPart, InsertedSequence, NaEdit, Sequence};
 use crate::reference::ReferenceProvider;
+use crate::sequence::complement_base;
 
 /// Check if an edit type needs normalization
 ///
@@ -114,15 +115,21 @@ pub fn insertion_is_duplication(ref_seq: &[u8], pos: u64, inserted_seq: &[u8]) -
 
     // Check if sequence before the insertion point matches the inserted sequence
     // (this would be a duplication of the preceding sequence)
+    //
+    // Case-insensitive on both sides (#1318): `ref_seq` may be soft-masked while
+    // `inserted_seq` comes from the author's upper-case description, and a raw
+    // byte test then reports "not a duplication" for one that is — the same
+    // class of miss the delins path carried, measured on `acgtacgt` + `ACGT`.
     if pos_idx >= ins_len && pos_idx <= ref_seq.len() {
         let before_start = pos_idx - ins_len;
-        if ref_seq[before_start..pos_idx] == inserted_seq[..] {
+        if ref_seq[before_start..pos_idx].eq_ignore_ascii_case(inserted_seq) {
             return true;
         }
     }
 
     // Also check if sequence after matches (for 5' duplications)
-    if pos_idx + ins_len <= ref_seq.len() && ref_seq[pos_idx..pos_idx + ins_len] == inserted_seq[..]
+    if pos_idx + ins_len <= ref_seq.len()
+        && ref_seq[pos_idx..pos_idx + ins_len].eq_ignore_ascii_case(inserted_seq)
     {
         return true;
     }
@@ -894,67 +901,28 @@ pub(crate) fn deletion_to_repeat(
     })
 }
 
-/// Get the complement of a nucleotide, over the whole IUPAC alphabet that
-/// [`crate::hgvs::edit::Base`] models.
-///
-/// Ambiguity codes complement by complementing their member set: `R` (A/G)
-/// becomes `Y` (C/T), `B` (not A) becomes `V` (not T), and so on. `W` (A/T),
-/// `S` (C/G) and `N` are the only genuinely self-complementary symbols.
-///
-/// Modelling the ambiguity codes matters because callers ask
-/// [`is_self_complementary`] whether "inverting this base changes nothing".
-/// Mapping an unmodelled symbol to itself made that test lie: `R` looked
-/// self-complementary, so an inversion resolving to a lone `R` was silently
-/// discarded as identity even though its reverse complement is `Y`.
-///
-/// The complement is returned uppercase regardless of input case, matching the
-/// long-standing behaviour for A/C/G/T/U. Bytes outside the alphabet are still
-/// returned unchanged — there is no meaningful complement to report for them.
-fn complement(base: u8) -> u8 {
-    match base {
-        b'A' | b'a' => b'T',
-        b'T' | b't' => b'A',
-        b'G' | b'g' => b'C',
-        b'C' | b'c' => b'G',
-        b'U' | b'u' => b'A', // RNA
-        // IUPAC ambiguity codes, complemented member-set-wise.
-        b'R' | b'r' => b'Y', // A/G  -> C/T
-        b'Y' | b'y' => b'R', // C/T  -> A/G
-        b'K' | b'k' => b'M', // G/T  -> A/C
-        b'M' | b'm' => b'K', // A/C  -> G/T
-        b'B' | b'b' => b'V', // C/G/T -> A/C/G
-        b'V' | b'v' => b'B', // A/C/G -> C/G/T
-        b'D' | b'd' => b'H', // A/G/T -> A/C/T
-        b'H' | b'h' => b'D', // A/C/T -> A/G/T
-        // Self-complementary: W (A/T), S (C/G), N (any).
-        b'W' | b'w' => b'W',
-        b'S' | b's' => b'S',
-        b'N' | b'n' => b'N',
-        _ => base, // Not a nucleotide we model.
-    }
-}
-
 /// True when `last` is the complement of `first`, i.e. inverting the pair
 /// changes nothing.
 ///
-/// Compares case-insensitively. [`complement`] always answers uppercase, so a
-/// raw `complement(x) == y` test silently fails for soft-masked reference bases:
-/// `complement(b'a')` is `b'T'`, which never equals `b't'`. Reference sequences
-/// really do arrive soft-masked (see
-/// `issue_1235_cis_allele_confluence::soft_masked_reference_yields_the_same_canonical_form`),
-/// so every complement comparison in the inversion-shortening path goes through
-/// here and treats `a` exactly like `A`.
+/// Both sides fold case, and an unmodelled byte on either side answers `false`
+/// — both properties come from [`complement_base`], which is now the crate's
+/// single byte-level complement (#1318). This used to work around a local
+/// helper whose fallback returned unmodelled bytes unchanged; with that helper
+/// gone the wrapper is a thin, honest comparison.
 fn is_complementary_pair(first: u8, last: u8) -> bool {
-    let first = first.to_ascii_uppercase();
-    complement(first) == last.to_ascii_uppercase()
+    // `complement_base` never answers with an unmodelled byte, so if `last` is
+    // one the comparison is false — which is the wanted behaviour, and the
+    // reason this does not need a separate "is `last` a base?" test.
+    complement_base(first) == Some(last.to_ascii_uppercase())
 }
 
 /// True when inverting `base` on its own changes nothing, i.e. it is one of the
 /// self-complementary symbols `W` (A/T), `S` (C/G) and `N`.
 ///
-/// Bytes outside the modelled alphabet answer `true` as well, because
-/// [`complement`] returns them unchanged — there is no complement to substitute
-/// in, so the caller must not describe one.
+/// A byte outside the modelled alphabet answers **`false`**, not `true`: there
+/// is no complement to report, so "inverting it changes nothing" is not a claim
+/// this can make. The previous helper returned such bytes unchanged, which made
+/// every unmodelled symbol look self-complementary — the #1249 trap.
 fn is_self_complementary(base: u8) -> bool {
     is_complementary_pair(base, base)
 }
@@ -975,7 +943,7 @@ pub fn complementary_substitution(
     }
     Some((
         Base::from_char(base as char)?,
-        Base::from_char(complement(base) as char)?,
+        Base::from_char(complement_base(base)? as char)?,
     ))
 }
 
@@ -1214,7 +1182,7 @@ pub fn decompose_delins(
     let mut has_identity = false;
     let mut i = 0;
     while i < n {
-        if deleted[i] == inserted_seq[i] {
+        if deleted[i].eq_ignore_ascii_case(&inserted_seq[i]) {
             // Identity position: record the unchanged ref byte so the caller
             // can rebuild a codon-frame triplet's alt sequence (issue #165),
             // and let it bound the maximal contiguous run. Abandon the whole
@@ -1234,9 +1202,18 @@ pub fn decompose_delins(
         }
 
         // Maximal contiguous run of mismatches `[run_start, run_end)`.
+        //
+        // Case-insensitive for the same reason as the identity test above, and
+        // it must be: this is the same rule written twice, and folding case in
+        // only one of them is worse than folding it in neither. On a
+        // soft-masked reference the run would swallow positions that the test
+        // above calls identities, so `has_identity` never became true and the
+        // final gate returned `None` for a span whose uppercase twin decomposes
+        // — defeating the fix above for exactly the input it targets (#1318).
+        let run_end_differs = |k: usize| !deleted[k].eq_ignore_ascii_case(&inserted_seq[k]);
         let run_start = i;
         let mut run_end = i + 1;
-        while run_end < n && deleted[run_end] != inserted_seq[run_end] {
+        while run_end < n && run_end_differs(run_end) {
             run_end += 1;
         }
 
@@ -1344,7 +1321,15 @@ pub fn canonicalize_delins(
 
     // 1. Identity (insert == deleted reference). Caught at full range; trimming
     //    would otherwise consume the entire range and lose this classification.
-    if deleted == inserted_seq {
+    //
+    //    Case-insensitive (#1318): on a soft-masked reference `deleted` arrives
+    //    lower-case while `inserted_seq` comes from the author's upper-case
+    //    description, so a raw byte test missed an identity that is one. That
+    //    is not merely a mis-classification — the range then fell through to
+    //    the trimming below, which now consumes it entirely, and the pure-
+    //    insertion branch's `debug_assert!("Identity case caught above")` is
+    //    exactly the claim this step has to make true.
+    if deleted.eq_ignore_ascii_case(inserted_seq) {
         return DelinsCanonical::Identity;
     }
 
@@ -1355,7 +1340,10 @@ pub fn canonicalize_delins(
     //    sub > del > inv > dup > ins priority.
     if inserted_seq.len() == 2 * deleted.len() {
         let (first_half, second_half) = inserted_seq.split_at(deleted.len());
-        if first_half == deleted && second_half == deleted {
+        // Case-insensitive for the same reason as step 1 (#1318): a
+        // soft-masked reference must classify as a duplication exactly when the
+        // upper-case one does.
+        if first_half.eq_ignore_ascii_case(deleted) && second_half.eq_ignore_ascii_case(deleted) {
             return DelinsCanonical::Duplication { start, end };
         }
     }
@@ -1445,13 +1433,26 @@ pub fn canonicalize_delins(
 /// cannot consume more than `min(deleted.len(), inserted.len())` bytes from
 /// either side (so the two regions never overlap on either string).
 fn shared_affix_lengths(deleted: &[u8], inserted: &[u8]) -> (usize, usize) {
+    // Case-insensitive on both sides (#1318): on a soft-masked reference
+    // `deleted` arrives lower-case while `inserted` comes from the author's
+    // upper-case description, so a raw byte test found no shared affix for
+    // sequences that are identical. That mattered beyond a missed trim — it left
+    // a palindromic delins untrimmed on the way into the inversion branch, whose
+    // `expect` assumes trimming has already handled the collapse-to-identity
+    // case, and the mismatch panicked.
+    let same = |a: u8, b: u8| a.eq_ignore_ascii_case(&b);
     let max_total = deleted.len().min(inserted.len());
     let mut k = 0;
-    while k < max_total && deleted[k] == inserted[k] {
+    while k < max_total && same(deleted[k], inserted[k]) {
         k += 1;
     }
     let mut l = 0;
-    while k + l < max_total && deleted[deleted.len() - 1 - l] == inserted[inserted.len() - 1 - l] {
+    while k + l < max_total
+        && same(
+            deleted[deleted.len() - 1 - l],
+            inserted[inserted.len() - 1 - l],
+        )
+    {
         l += 1;
     }
     (k, l)
@@ -1460,14 +1461,19 @@ fn shared_affix_lengths(deleted: &[u8], inserted: &[u8]) -> (usize, usize) {
 /// Bytewise reverse-complement equality check.
 ///
 /// Returns true iff `inserted` is the reverse complement of `deleted`, both
-/// of equal length. Allocation-free; uses the existing `complement()` helper.
+/// of equal length, comparing case-insensitively on **both** sides.
+///
+/// Allocation-free. Folding case matters here for the same reason it does in
+/// [`is_complementary_pair`]: on a soft-masked reference `deleted` arrives
+/// lower-case while `inserted` comes from the author's upper-case description
+/// (#1318).
 fn is_revcomp(deleted: &[u8], inserted: &[u8]) -> bool {
     deleted.len() == inserted.len()
         && deleted
             .iter()
             .rev()
             .zip(inserted.iter())
-            .all(|(d, i)| complement(*d) == *i)
+            .all(|(d, i)| complement_base(*d) == Some(i.to_ascii_uppercase()))
 }
 
 /// Check if a duplication in a homopolymer should become repeat notation
@@ -4132,11 +4138,15 @@ mod tests {
 
     #[test]
     fn test_complement() {
-        assert_eq!(complement(b'A'), b'T');
-        assert_eq!(complement(b'T'), b'A');
-        assert_eq!(complement(b'G'), b'C');
-        assert_eq!(complement(b'C'), b'G');
-        assert_eq!(complement(b'N'), b'N'); // N stays N
+        assert_eq!(complement_base(b'A'), Some(b'T'));
+        assert_eq!(complement_base(b'T'), Some(b'A'));
+        assert_eq!(complement_base(b'G'), Some(b'C'));
+        assert_eq!(complement_base(b'C'), Some(b'G'));
+        assert_eq!(complement_base(b'N'), Some(b'N')); // N stays N
+                                                       // The contract that replaced the old `_ => base` fallback (#1318): an
+                                                       // unmodelled byte has no complement to report, so callers cannot mistake
+                                                       // "no answer" for "self-complementary".
+        assert_eq!(complement_base(b'X'), None);
     }
 
     #[test]
@@ -4203,21 +4213,21 @@ mod tests {
             (b'H', b'D'), // A/C/T -> A/G/T
         ] {
             assert_eq!(
-                complement(base),
-                expected,
+                complement_base(base),
+                Some(expected),
                 "complement({}) should be {}",
                 base as char,
                 expected as char
             );
             // Lowercase complements to the same uppercase symbol as A/C/G/T/U do.
-            assert_eq!(complement(base.to_ascii_lowercase()), expected);
+            assert_eq!(complement_base(base.to_ascii_lowercase()), Some(expected));
         }
 
         // Only W, S and N are genuinely self-complementary.
         for base in *b"WSN" {
             assert_eq!(
-                complement(base),
-                base,
+                complement_base(base),
+                Some(base),
                 "{} is self-complementary",
                 base as char
             );
@@ -4316,6 +4326,173 @@ mod tests {
         // a soft-masked non-self-complementary centre still survives.
         assert_eq!(shorten_inversion(b"awt", 0, 3), None);
         assert_eq!(shorten_inversion(b"art", 0, 3), Some((1, 2)));
+    }
+
+    /// The delins path must answer identically for a soft-masked reference and
+    /// the same sequence uppercased (#1318).
+    ///
+    /// #1250 fixed the *inversion-shortening* comparisons and was deliberately
+    /// scope-limited; the delins→inv typing path kept its raw byte tests. On a
+    /// soft-masked reference `deleted` arrives lowercase while `inserted` comes
+    /// from the author's uppercase description, so `is_revcomp` and the
+    /// shared-affix/identity comparisons all saw a mismatch that is not one.
+    ///
+    /// Parity between the two cases is the assertion, rather than a pinned
+    /// output shape: whatever the canonical form of a given delins is, the
+    /// reference's masking must not change it.
+    #[test]
+    fn canonicalize_delins_treats_soft_masked_bases_like_uppercase() {
+        // (reference, start, end, inserted) — each exercises a different one of
+        // the case-sensitive comparison sites.
+        let cases: &[(&[u8], usize, usize, &[u8])] = &[
+            // is_revcomp: `atgcat` reverse-complements to `ATGCAT`, so this is
+            // an inversion — but only if the comparison folds case.
+            (b"atgcat", 0, 6, b"ATGCAT"),
+            // A longer revcomp that survives outer-pair shortening.
+            (b"aggcct", 0, 6, b"AGGCCT"),
+            // The Duplication branch (`inserted_seq.len() == 2 * deleted.len()`),
+            // which is checked before trimming and has its own pair of
+            // comparisons. Nothing above reaches it: every other case here has
+            // an insert the same length as the deleted range, so the branch's
+            // length gate is false and its case-folding is never exercised.
+            (b"acgt", 0, 4, b"ACGTACGT"),
+            // shared_affix_lengths: a shared prefix/suffix that differs only in
+            // case must still be trimmed.
+            (b"acgtacgt", 0, 8, b"ACGTTTGT"),
+            // The identity-run detector inside the decomposition loop.
+            (b"acgtacgt", 0, 8, b"ACGAACGT"),
+            // Whole-range identity: insert equals the deleted reference, modulo
+            // case.
+            (b"acgtacgt", 0, 8, b"ACGTACGT"),
+            // A plain substitution reached through the trimming path.
+            (b"acgt", 0, 4, b"ACTT"),
+        ];
+        for (lower, start, end, inserted) in cases {
+            let upper: Vec<u8> = lower.to_ascii_uppercase();
+            assert_eq!(
+                canonicalize_delins(lower, *start, *end, inserted),
+                canonicalize_delins(&upper, *start, *end, inserted),
+                "`{}` and `{}` with insert `{}` must canonicalize identically",
+                std::str::from_utf8(lower).unwrap(),
+                std::str::from_utf8(&upper).unwrap(),
+                std::str::from_utf8(inserted).unwrap(),
+            );
+        }
+    }
+
+    /// `decompose_delins` must hold the same soft-mask parity, and did not.
+    ///
+    /// The identity test at the top of its loop was case-folded while the
+    /// mismatch-run scan below it was not — the same rule written twice, fixed
+    /// in one copy. On a soft-masked reference the run then swallowed positions
+    /// that the identity test calls identities, so `has_identity` never became
+    /// true and the function's final gate returned `None` for a span whose
+    /// uppercase twin decomposes. Measured before the fix:
+    /// `decompose_delins(b"acgt", 0, 4, b"TCGA")` was `None` against
+    /// `Some(4)` for `b"ACGT"`.
+    #[test]
+    fn decompose_delins_treats_soft_masked_bases_like_uppercase() {
+        let cases: &[(&[u8], &[u8])] = &[
+            // An identity sitting *inside* what the run scan saw as a mismatch
+            // run — the shape the unfixed copy swallowed.
+            (b"acgt", b"TCGA"),
+            (b"acgtac", b"TCGTAC"),
+            // A palindrome, so the inversion branch is reached on both sides.
+            (b"atgcat", b"TTGCAA"),
+        ];
+        for (lower, inserted) in cases {
+            let upper: Vec<u8> = lower.to_ascii_uppercase();
+            assert_eq!(
+                decompose_delins(lower, 0, lower.len(), inserted),
+                decompose_delins(&upper, 0, upper.len(), inserted),
+                "`{}` and `{}` with insert `{}` must decompose identically",
+                std::str::from_utf8(lower).unwrap(),
+                std::str::from_utf8(&upper).unwrap(),
+                std::str::from_utf8(inserted).unwrap(),
+            );
+        }
+    }
+
+    /// The same parity for the insertion→duplication test, which compares a
+    /// reference slice against the author's inserted sequence and so carried
+    /// the identical defect: `insertion_is_duplication(b"acgtacgt", 4, b"ACGT")`
+    /// answered `false` where the uppercase reference answered `true`, silently
+    /// leaving a duplication spelled as an insertion.
+    #[test]
+    fn insertion_is_duplication_treats_soft_masked_bases_like_uppercase() {
+        for (lower, pos, inserted) in [
+            (&b"acgtacgt"[..], 4u64, &b"ACGT"[..]), // 3' duplication
+            (&b"aaggtt"[..], 2u64, &b"AA"[..]),     // 5' duplication
+        ] {
+            let upper: Vec<u8> = lower.to_ascii_uppercase();
+            assert_eq!(
+                insertion_is_duplication(lower, pos, inserted),
+                insertion_is_duplication(&upper, pos, inserted),
+                "`{}` at {pos} with insert `{}` must classify identically",
+                std::str::from_utf8(lower).unwrap(),
+                std::str::from_utf8(inserted).unwrap(),
+            );
+        }
+    }
+
+    /// Unifying on `complement_base` changed what happens to a byte outside the
+    /// modelled alphabet, and that change is deliberate — pinned here so it is a
+    /// decision rather than a side effect.
+    ///
+    /// `complement` returned such a byte unchanged, so it read as
+    /// self-complementary and an inversion over it collapsed to identity — the
+    /// #1249 class of silent loss. `complement_base` answers `None`, so the span
+    /// survives as a residue and the caller leaves the inversion as authored
+    /// rather than claiming an identity it cannot justify.
+    #[test]
+    fn an_unmodelled_byte_no_longer_reads_as_self_complementary() {
+        assert!(!is_self_complementary(b'X'));
+        // Was `None` (identity) before #1318; the span now survives.
+        assert_eq!(shorten_inversion(b"X", 0, 1), Some((0, 1)));
+        assert_eq!(shorten_inversion(b"XX", 0, 2), Some((0, 2)));
+        // No typed substitution exists for it, so the caller must refuse.
+        assert_eq!(complementary_substitution(b'X'), None);
+        // The genuinely self-complementary symbols are unaffected.
+        for base in *b"WSN" {
+            assert!(is_self_complementary(base), "{} ", base as char);
+        }
+        // And a real complementary pair still collapses.
+        assert_eq!(shorten_inversion(b"AT", 0, 2), None);
+    }
+
+    /// The headline case, spelled out: a soft-masked delins that genuinely *is*
+    /// a reverse complement must be typed as an inversion.
+    ///
+    /// `atgc` deliberately, not a palindrome like `aggcct`: a palindrome is its
+    /// own reverse complement, so the insert equals the deleted bases and the
+    /// *identity* branch is the correct answer — such a case cannot show that
+    /// inversion typing works.
+    #[test]
+    fn a_soft_masked_delins_that_is_a_revcomp_is_typed_as_an_inversion() {
+        assert!(
+            matches!(
+                canonicalize_delins(b"atgc", 0, 4, b"GCAT"),
+                DelinsCanonical::Inversion { .. }
+            ),
+            "a lowercase reference whose delins is a true reverse complement \
+             must still be recognised as an inversion",
+        );
+        // The upper-case reference must of course agree.
+        assert_eq!(
+            canonicalize_delins(b"atgc", 0, 4, b"GCAT"),
+            canonicalize_delins(b"ATGC", 0, 4, b"GCAT"),
+        );
+    }
+
+    /// `is_revcomp` itself, at the byte level.
+    #[test]
+    fn is_revcomp_folds_case_on_both_sides() {
+        assert!(is_revcomp(b"atgcat", b"ATGCAT"));
+        assert!(is_revcomp(b"ATGCAT", b"atgcat"));
+        assert!(is_revcomp(b"atgcat", b"atgcat"));
+        // Still discriminating — this is not a fold that makes everything true.
+        assert!(!is_revcomp(b"atgcat", b"ATGCAA"));
+        assert!(!is_revcomp(b"acgt", b"ACG"));
     }
 
     #[test]

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -25,6 +25,63 @@ pub fn reverse_complement(seq: &str) -> String {
     seq.chars().rev().map(complement_char).collect()
 }
 
+/// Complement one base, folding case and refusing anything outside the modelled
+/// alphabet. **The single byte-level complement for the crate** (#1318).
+///
+/// Two properties, and both matter:
+///
+/// * **Case-folding.** The input is upper-cased before matching and the answer
+///   is always upper-case, so a soft-masked reference byte compares equal to the
+///   same base written in upper case. Reference FASTAs are routinely
+///   soft-masked and those bytes reach normalization (see
+///   `issue_1235_cis_allele_confluence::soft_masked_reference_yields_the_same_canonical_form`).
+/// * **`None` for an unmodelled byte.** There is no complement to report for
+///   `X`, so callers cannot mistake "no answer" for "self-complementary". That
+///   confusion is exactly what produced #1249: a helper whose fallback returned
+///   the byte unchanged made `complement(b'w') == b'w'` true for *every*
+///   unmodelled symbol, and an inversion resolving to one was silently
+///   discarded as identity, or emitted as the degenerate `<pos>W>W`.
+///
+/// This replaces the two byte-level helpers that disagreed on exactly those
+/// axes: `normalize::rules::complement` (upper-cased, but returned unmodelled
+/// bytes unchanged — the one with the bugs) and
+/// `normalize::merge::complement_base` (this contract, and the one that never
+/// had a bug, so its behaviour is what survived).
+///
+/// [`complement_char`] keeps a **deliberately different** contract: it preserves
+/// case and passes unmodelled characters through, because it backs
+/// [`reverse_complement`], whose job is to render a sequence a caller will read
+/// back. Rendering must not silently upper-case a soft-masked region or drop a
+/// byte it does not model. That is a display concern; this is a comparison
+/// concern, and collapsing the two would break one of them.
+pub(crate) fn complement_base(base: u8) -> Option<u8> {
+    Some(match base.to_ascii_uppercase() {
+        b'A' => b'T',
+        b'T' | b'U' => b'A',
+        b'G' => b'C',
+        b'C' => b'G',
+        b'R' => b'Y',
+        b'Y' => b'R',
+        b'S' => b'S',
+        b'W' => b'W',
+        b'K' => b'M',
+        b'M' => b'K',
+        b'B' => b'V',
+        b'V' => b'B',
+        b'D' => b'H',
+        b'H' => b'D',
+        b'N' => b'N',
+        _ => return None,
+    })
+}
+
+/// Case-**preserving** complement of one character; unmodelled characters pass
+/// through unchanged.
+///
+/// See [`complement_base`] for why this contract differs from the comparison
+/// helper rather than sharing it: this one backs [`reverse_complement`], which
+/// renders a sequence for a caller to read, so it must not upper-case a
+/// soft-masked region or drop bytes it does not model.
 fn complement_char(c: char) -> char {
     match c {
         'A' => 'T',

--- a/tests/it/issue_1318_soft_masked_delins.rs
+++ b/tests/it/issue_1318_soft_masked_delins.rs
@@ -1,0 +1,233 @@
+//! Issue #1318 — the delins path must not depend on the reference's masking.
+//!
+//! #1250 case-folded the *inversion-shortening* comparisons and was
+//! deliberately scope-limited; the delins→inv typing path kept its raw byte
+//! tests. On a soft-masked reference `deleted` arrives lowercase while
+//! `inserted` comes from the author's upper-case description, so those tests
+//! saw a mismatch that is not one.
+//!
+//! The consequence is worse than a mis-typing. Two comparisons on the same path
+//! disagreed about case:
+//!
+//! - `is_revcomp` complements through `complement()`, which folds to
+//!   upper-case, so lower-case deleted vs upper-case inserted compared **equal**;
+//! - `shared_affix_lengths` compares raw bytes, so the same pair shared **no**
+//!   prefix or suffix and nothing was trimmed.
+//!
+//! A palindromic delins therefore entered the inversion branch with an
+//! untrimmed range, `shorten_inversion` (correctly case-folding since #1250)
+//! collapsed it to nothing, and the branch's `expect` — whose stated invariant
+//! is that trimming has already handled that case — **panicked**.
+//!
+//! Reference FASTAs are routinely soft-masked, and soft-masked bytes reach
+//! normalization in this codebase (`issue_1235_cis_allele_confluence.rs::
+//! soft_masked_reference_yields_the_same_canonical_form`), so this is reachable
+//! from ordinary input.
+
+use std::io::Write;
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+
+/// Positions 29..34 are `CACGTG` and 35..40 are `CAATTG` — both palindromes, so
+/// both are their own reverse complement.
+const SEQ: &str = concat!(
+    "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCG",
+    "TACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA"
+);
+
+fn provider_for(sequence: &str) -> JsonProvider {
+    let n = sequence.len() as u64;
+    let json = serde_json::json!({
+        "version": "1.0",
+        "transcripts": [{
+            "id": "TEMPLATE-gene.1",
+            "chromosome": "TEMPLATE",
+            "strand": "+",
+            "sequence": sequence,
+            "cds_start": 1,
+            "cds_end": n - (n % 3),
+            "genomic_start": 1,
+            "genomic_end": n,
+            "protein_id": "TEMPLATE-gene.1",
+            "exons": [{"number": 1, "start": 1, "end": n,
+                       "genomic_start": 1, "genomic_end": n}],
+        }],
+        "genomic_sequences": {"TEMPLATE": sequence},
+    });
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    write!(f, "{json}").expect("write json");
+    JsonProvider::from_json(f.path()).expect("load reference")
+}
+
+fn normalize_with(sequence: &str, input: &str) -> String {
+    let normalizer = Normalizer::new(provider_for(sequence));
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse `{input}`: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize `{input}`: {e}"))
+        .to_string()
+}
+
+/// The crash. A palindromic delins over a soft-masked span.
+///
+/// On an upper-case reference the insert equals the deleted bases and the
+/// identity branch answers immediately; on the lower-case one the byte
+/// comparison misses that, and the range reaches the inversion branch untrimmed.
+#[test]
+fn a_palindromic_delins_on_a_soft_masked_reference_does_not_panic() {
+    // `CACGTG` at 29..34 and `CAATTG` at 35..40 are both palindromes. Each
+    // insert equals the deleted bases modulo case, so the canonical form is the
+    // identity — which is the answer the uppercase reference already gave, and
+    // the one the soft-masked reference panicked instead of giving.
+    for (input, expected) in [
+        ("TEMPLATE:g.29_34delinsCACGTG", "TEMPLATE:g.29_34="),
+        ("TEMPLATE:g.35_40delinsCAATTG", "TEMPLATE:g.35_40="),
+    ] {
+        let masked = normalize_with(&SEQ.to_lowercase(), input);
+        // Pin the output, not merely parity: two equally-wrong answers would
+        // satisfy a parity check, and the whole class of defect here is one
+        // comparison folding case while its sibling does not.
+        assert_eq!(masked, expected, "canonical form of `{input}`");
+        let upper = normalize_with(SEQ, input);
+        assert_eq!(
+            masked, upper,
+            "soft-masking must not change the canonical form of `{input}`"
+        );
+    }
+}
+
+/// The spread of shapes, each reaching a different one of the case-sensitive
+/// comparison sites, with its canonical form pinned.
+///
+/// Two assertions per case, and both are needed. The pinned output is the
+/// primary check — it is what a parity-only test cannot give, since masked and
+/// unmasked can be equally wrong. The parity assertion is the supplementary
+/// one: it says the *reason* the output is right is not "the uppercase path
+/// happens to agree today".
+///
+/// The eight cases land on eight distinct canonical shapes — identity, `inv`,
+/// three different single substitutions, a two-member decomposition, and a
+/// `dup` — which is how you can tell the table exercises separate branches
+/// rather than eight spellings of one.
+#[test]
+fn soft_masking_never_changes_the_canonical_form_of_a_delins() {
+    for (input, expected) in [
+        // Palindromes — the inversion branch, which for a palindrome reduces to
+        // the identity.
+        ("TEMPLATE:g.29_34delinsCACGTG", "TEMPLATE:g.29_34="),
+        ("TEMPLATE:g.35_40delinsCAATTG", "TEMPLATE:g.35_40="),
+        // A true reverse complement that is not an identity: 63..70 is
+        // `TACGTACG`, which is not its own reverse complement, and the insert
+        // is that reverse complement. So `is_revcomp` must fire while the
+        // identity test above it must not — the discrimination a palindrome
+        // cannot show, because for a palindrome the two agree.
+        ("TEMPLATE:g.63_70delinsCGTACGTA", "TEMPLATE:g.63_70inv"),
+        // Shared suffix, then shared prefix, each differing only in case: the
+        // trimming must consume it and leave a bare substitution.
+        ("TEMPLATE:g.29_34delinsCACTTG", "TEMPLATE:g.32G>T"),
+        ("TEMPLATE:g.29_34delinsCTCGTG", "TEMPLATE:g.30A>T"),
+        // A genuine interior identity run flanked by mismatches on both ends:
+        // 29..36 is `CACGTGCA`, and the insert changes only the first and last
+        // base, leaving `ACGTGC` identical in the middle. That is what the
+        // decomposition loop's identity-run detector exists to find, and it is
+        // why the answer is two members rather than one delins; an insert equal
+        // to the whole deleted span never reaches it, because the whole-range
+        // identity test answers first.
+        ("TEMPLATE:g.29_36delinsGACGTGCT", "TEMPLATE:g.[29C>G;36A>T]"),
+        // A duplication (`N -> 2N`), which `canonicalize_delins` classifies
+        // before trimming and with its own pair of comparisons. The 3' shift
+        // moves it off the input's own span, so this also pins that the dup was
+        // typed as a dup rather than trimmed down to an insertion.
+        ("TEMPLATE:g.29_34delinsCACGTGCACGTG", "TEMPLATE:g.31_36dup"),
+        // A plain substitution reached through trimming.
+        ("TEMPLATE:g.29_31delinsCAG", "TEMPLATE:g.31C>G"),
+    ] {
+        let masked = normalize_with(&SEQ.to_lowercase(), input);
+        assert_eq!(masked, expected, "canonical form of `{input}`");
+        let upper = normalize_with(SEQ, input);
+        assert_eq!(
+            masked, upper,
+            "soft-masking must not change the canonical form of `{input}`"
+        );
+    }
+}
+
+/// The mirror-image mixed-case shape: an **r.** description, whose edit
+/// literals are lowercase by convention, against an **uppercase** reference.
+///
+/// Every case above puts the lowercase bytes on the reference side and the
+/// uppercase ones in the description. The RNA axis inverts that — `to_rna`
+/// lowercases the edit literals and maps `t` to `u` — so a comparison that
+/// folds case in only one direction, or that folds case but not the `t`/`u`
+/// spelling, is invisible to the whole table above. Both orientations reach the
+/// same comparison sites, so both must answer the same shapes.
+#[test]
+fn an_rna_description_with_lowercase_payloads_takes_the_same_shapes() {
+    for (input, expected) in [
+        // Identity — the palindrome.
+        (
+            "TEMPLATE-gene.1:r.29_34delinscacgug",
+            "TEMPLATE-gene.1:r.29_34=",
+        ),
+        // Inversion — the non-palindromic reverse complement.
+        (
+            "TEMPLATE-gene.1:r.63_70delinscguacgua",
+            "TEMPLATE-gene.1:r.63_70inv",
+        ),
+        // The interior identity run, decomposing into two substitutions.
+        (
+            "TEMPLATE-gene.1:r.29_36delinsgacgugcu",
+            "TEMPLATE-gene.1:r.[29c>g;36a>u]",
+        ),
+    ] {
+        let upper = normalize_with(SEQ, input);
+        assert_eq!(upper, expected, "canonical form of `{input}`");
+        let masked = normalize_with(&SEQ.to_lowercase(), input);
+        assert_eq!(
+            masked, upper,
+            "soft-masking must not change the canonical form of `{input}`"
+        );
+    }
+}
+
+/// Normalization must be a fixed point on a soft-masked reference, not merely
+/// agree with the uppercase run once.
+///
+/// The parity tests above compare two *first* passes. They would still hold if
+/// masked and unmasked were equally non-idempotent, which is the failure this
+/// class actually produces: a comparison that folds case in one place and not
+/// another can type the first pass one way and the re-read output another. So
+/// this asserts `norm(norm(x)) == norm(x)` against a lowercase reference with
+/// uppercase edit literals — the real mixed-case shape, since HGVS descriptions
+/// are written uppercase and reference FASTAs are routinely soft-masked.
+///
+/// It also re-parses the intermediate, so an unreadable output fails here
+/// rather than surfacing as the second pass's parse error.
+#[test]
+fn normalization_is_idempotent_on_a_soft_masked_reference() {
+    let masked_seq = SEQ.to_lowercase();
+    for input in [
+        "TEMPLATE:g.29_34delinsCACGTG",
+        "TEMPLATE:g.35_40delinsCAATTG",
+        "TEMPLATE:g.63_70delinsCGTACGTA",
+        "TEMPLATE:g.29_34delinsCACTTG",
+        "TEMPLATE:g.29_34delinsCTCGTG",
+        "TEMPLATE:g.29_36delinsGACGTGCT",
+        "TEMPLATE:g.29_34delinsCACGTGCACGTG",
+        "TEMPLATE:g.29_31delinsCAG",
+        // The inverse orientation: lowercase `r.` payloads (with `u` for `t`)
+        // against the same soft-masked reference.
+        "TEMPLATE-gene.1:r.29_34delinscacgug",
+        "TEMPLATE-gene.1:r.63_70delinscguacgua",
+        "TEMPLATE-gene.1:r.29_36delinsgacgugcu",
+    ] {
+        let once = normalize_with(&masked_seq, input);
+        parse_hgvs(&once)
+            .unwrap_or_else(|e| panic!("`{input}` -> `{once}` does not re-parse: {e}"));
+        let twice = normalize_with(&masked_seq, &once);
+        assert_eq!(
+            twice, once,
+            "`{input}` -> `{once}` is not a fixed point on a soft-masked reference"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -181,6 +181,7 @@ mod issue_1304_junction_barrier_snapshot;
 mod issue_1308_commuting_payload_phase;
 mod issue_1312_landed_payload_commutes;
 mod issue_1316_coincident_tract_repeats;
+mod issue_1318_soft_masked_delins;
 mod issue_1320_dup_spans_sibling_junction;
 mod issue_1321_identity_inside_a_duplication;
 mod issue_1323_shared_junction_order;


### PR DESCRIPTION
Closes #1318

Does all four steps of the issue's suggested shape, including the helper unification.

## The headline: this is a crash fix

The issue frames the delins case-sensitivity as a mis-typing — "a delins that genuinely *is* a reverse complement can fail to be typed as an `inv`". It is worse than that. Two comparisons on the same path disagreed about case:

- `is_revcomp` complements through a helper that folds to upper-case, so lower-case `deleted` vs upper-case `inserted` compared **equal**;
- `shared_affix_lengths` compared raw bytes, so the same pair shared **no** prefix or suffix and nothing was trimmed.

A palindromic delins therefore entered the inversion branch with an untrimmed range, `shorten_inversion` (correctly case-folding since #1250) collapsed it to nothing, and that branch's `expect` — whose stated invariant is that trimming has already handled the collapse-to-identity case — **panicked**:

```
thread '...' panicked at src/normalize/rules.rs:
revcomp delins cannot collapse to identity under shortening;
that case is handled by the Identity / Insertion branches above
```

Reproduced end to end through the public `Normalizer::normalize` on a soft-masked reference (`tests/it/issue_1318_soft_masked_delins.rs`), not just at the internal helper. Reference FASTAs are routinely soft-masked and those bytes reach normalization, so it is reachable from ordinary input.

## Step 1–2: one complement helper

`sequence::complement_base` is now the crate's single byte-level complement. It takes the contract of the one that never had a bug (`normalize::merge::complement_base`): **fold case**, and **return `None`** for a byte outside the modelled alphabet.

`normalize::rules::complement` is deleted. Its `_ => base` arm is the structural cause of #1249 — it made `complement(x) == x` true for every unmodelled symbol, so `is_self_complementary` answered `true` when the honest answer is "there is no complement to report". #1250 worked around that at three call sites; this removes it, so the trap is gone rather than routed around. `is_complementary_pair` / `is_self_complementary` survive as thin wrappers and are now honest — an unmodelled byte answers `false`.

`sequence::complement_char` keeps its **case-preserving** contract, and step 4's requested documentation says why that split is deliberate rather than accidental: it backs `reverse_complement`, which renders a sequence for a caller to read back, so it must not silently upper-case a soft-masked region or drop a byte it does not model. That is a display concern; `complement_base` is a comparison concern.

## Step 3: the delins path folds case — all of it

The issue names `is_revcomp` and the shared-affix / run-detection comparisons. Sweeping the function found the class was wider: **every** deleted-vs-inserted byte comparison in `canonicalize_delins` was raw. All of them now fold:

| site | what it decides |
|---|---|
| step 1 | whole-range identity |
| step 2 | duplication (`N` → `2N`) |
| `shared_affix_lengths` | prefix/suffix trimming |
| interior loop | identity runs within the decomposition |
| `is_revcomp` | inversion typing |

Fixing only the two the issue named would have moved the crash rather than removed it, and did: with trimming corrected, the range was fully consumed and the pure-insertion branch's `debug_assert!("Identity case caught above")` fired next, because step 1 was still raw-byte. That is the reason the sweep is exhaustive.

## Blast radius

Full suite with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`: **9023 passed, 0 failed**. `cargo fmt --all --check`, `cargo clippy --features dev --all-targets`, `cargo check --features python` all clean.

The issue notes that step 3 "changes `delins` recognition, so it wants its own conformance run." It got one: **zero enumeration rows moved and the census is unchanged.** The reason is worth stating rather than reading as "no effect" — the spec corpus is entirely upper-case, so case-folding is a no-op over it. The corpus cannot exercise this change, which is why the new tests carry it.

## Tests

- `tests/it/issue_1318_soft_masked_delins.rs` — the end-to-end crash reproducer, plus a masked-vs-unmasked parity property over shapes that each reach a different comparison site.
- `canonicalize_delins_treats_soft_masked_bases_like_uppercase` — the same parity at the unit level.
- `a_soft_masked_delins_that_is_a_revcomp_is_typed_as_an_inversion` — uses `atgc`/`GCAT` deliberately, **not** a palindrome: a palindrome is its own reverse complement, so the insert equals the deleted bases and *identity* is the correct answer. My first draft used `aggcct` and asserted `Inversion`, which was wrong about the domain, not about the code.
- `is_revcomp_folds_case_on_both_sides` — including negative cases, so the fold cannot pass by making everything true.
- `test_complement` gains `complement_base(b'X') == None`, pinning the contract that replaced `_ => base`.

Parity assertions are stated as masked-vs-unmasked equality rather than pinned output shapes: whatever the canonical form of a given delins is, the reference's masking must not decide it.


## Follow-up from self-review

Three things the first pass missed, each measured rather than argued.

**The delins fix was defeated by its own unfixed twin.** `decompose_delins` case-folded the identity test at the top of its loop but not the mismatch-run scan below it — the same rule written twice, updated in one copy. On a soft-masked reference the run swallowed the very positions the identity test calls identities, so `has_identity` never became true and the function's final gate returned `None` for a span whose uppercase twin decomposes. Measured before: `decompose_delins(b"acgt", 0, 4, b"TCGA")` → `None` against `Some(4)` for `b"ACGT"`. Both now agree, pinned by `decompose_delins_treats_soft_masked_bases_like_uppercase`.

**`insertion_is_duplication` carried the identical defect** and is fixed with it: it compares a reference slice against the author's inserted sequence, so `insertion_is_duplication(b"acgtacgt", 4, b"ACGT")` answered `false` where the uppercase reference answered `true` — silently leaving a duplication spelled as an insertion. Pinned by `insertion_is_duplication_treats_soft_masked_bases_like_uppercase`.

**Unifying on `complement_base` changed what happens to a byte outside the modelled alphabet**, which the description did not call out. `complement` returned such a byte unchanged, so it read as self-complementary and an inversion over it collapsed to identity; `complement_base` answers `None`, so it does not. Measured: `shorten_inversion(b"X", 0, 1)` was `None`, is now `Some((0, 1))`. That makes the "Not a base we can complement" branch in `src/normalize/mod.rs` **reachable**, where its comment claimed it was unreachable *because of the behaviour this PR removes* — the comment is corrected, and the new behaviour is the right one (refusing is better than claiming an identity we cannot justify, the #1249 class). Pinned by `an_unmodelled_byte_no_longer_reads_as_self_complementary`.

Full suite with both oracles: **9052 passed, 0 failed.**

## Review round 2: pinned coverage and the oracle question

**Pinned canonical outputs, not just masked-vs-unmasked parity.** `tests/it/issue_1318_soft_masked_delins.rs` previously asserted only that the two references agree; two equally-wrong answers satisfy that. Each case now pins its canonical form as the primary assertion, keeping parity as the supplementary one. The eight cases land on eight *distinct* shapes — `29_34=`, `35_40=`, `63_70inv`, `32G>T`, `30A>T`, `[29C>G;36A>T]`, `31_36dup`, `31C>G` — which is what shows the table exercises separate branches rather than eight spellings of one.

**Two placeholder cases replaced with the shapes they claimed to be.** The "true reverse complement that is not an identity" entry was a duplicate of the palindrome above it, and the "whole-range identity" entry duplicated another. They are now `g.63_70delinsCGTACGTA` (63..70 is `TACGTACG`, not its own reverse complement, so `is_revcomp` must fire where the identity test must not — the discrimination a palindrome cannot make) and `g.29_36delinsGACGTGCT` (a genuine interior identity run flanked by mismatches, which is what the decomposition loop's run detector exists to find).

**The Duplication branch is now covered.** Every prior case had `inserted_seq.len() == deleted.len()`, so the `N -> 2N` branch's length gate was false and its case-folding was never exercised. Added `(b"acgt", 0, 4, b"ACGTACGT")` to `canonicalize_delins_treats_soft_masked_bases_like_uppercase`, plus `g.29_34delinsCACGTGCACGTG` end-to-end. Verified non-vacuous: reverting just that branch's two comparisons to raw-byte gives `Insertion { after_index: 4, … }` against `Duplication { start: 0, end: 4 }` — precisely the sub > del > inv > dup > ins priority violation the branch's comment warns about.

**Idempotency, and the inverse mixed-case orientation.** `normalization_is_idempotent_on_a_soft_masked_reference` asserts `norm(norm(x)) == norm(x)` against a lowercase reference with uppercase edit literals, and re-parses the intermediate. `an_rna_description_with_lowercase_payloads_takes_the_same_shapes` covers the mirror image — `r.` descriptions, whose literals are lowercase with `u` for `t`, against an *uppercase* reference. Every other case puts the lowercase bytes on the reference side, so a fold that works in one direction only was invisible to the whole table.

**All three integration tests were confirmed to fail against pre-fix production code** (`src/normalize/{rules,merge,mod}.rs` and `src/sequence.rs` reverted to `main`), not merely to pass after it. The palindromic case panics at `rules.rs:1427` on the `expect` this PR's description names.

### Movement relative to the reference oracles

**Toward, for soft-masked references; no movement at all for uppercase ones.** The uppercase path is untouched by the case-folding — every comparison this PR changes already compared equal when both sides were uppercase — so ferro's answer for every input the biocommons / Mutalyzer / hgvs-rs corpora actually contain is byte-identical. Those corpora are uppercase, which is why the whole class went unnoticed. What moves is the soft-masked path, and it moves *onto* the uppercase answer: the parity assertions in `issue_1318_soft_masked_delins.rs` state exactly that, and the uppercase answer is the one the oracles agree with. The one case where the new behaviour is not simply the old uppercase behaviour is the unmodelled-byte change described above (`shorten_inversion(b"X", 0, 1)`: `None` → `Some((0, 1))`), which no oracle covers — none of them accept `X` as a base — and which refuses rather than asserts an identity it cannot justify.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequence normalization for mixed-case and soft-masked DNA bases.
  * Prevented incorrect complement matching for unsupported symbols.
  * Improved handling of inversions, substitutions, duplications, repeats, and delins normalization.
  * Fixed cases where certain palindromic delins inputs could fail unexpectedly.

* **Tests**
  * Added coverage for ambiguity codes, unsupported bases, soft masking, and tandem conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
