### PR TITLE
fix(normalize): repair del+dup collisions on the CDS-relative axes

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -18,16 +18,25 @@ use crate::sequence::complement_base;
 
 /// Coordinate-system region used as the merge-eligibility key.
 ///
-/// Adjacency in the merge pass requires both ends to share a region.
-/// HGVS forbids ranges that span the 5'UTR↔CDS, CDS↔3'UTR (for `c.`/`r.`)
-/// or upstream↔transcript / transcript↔downstream (for `n.`) boundaries
-/// — `c.-1_1`, `c.40_*1`, etc. do not exist as valid range syntax — so
-/// we tag each position with its region and refuse to merge across.
+/// Adjacency in the merge pass requires both ends to share a region, so we
+/// tag each position with its region and refuse to merge across.
+///
 /// The integer `start`/`end` axis is region-local: positive for `Cds` /
 /// `ThreePrimeUtr` / `Tx` / `TxDownstream`, negative for `FivePrimeUtr`
 /// / `TxUpstream`. Adjacency `prev.end + 1 == next.start` works
 /// naturally for all six because the axis is monotonic 5'→3' within
 /// each region (`c.-3 → c.-2 → c.-1` maps to `-3 → -2 → -1`).
+///
+/// That refusal is therefore a **property of this pass's arithmetic, not of
+/// HGVS**: `prev.end + 1 == next.start` is only meaningful within one region,
+/// since `c.-1` and `c.1` are adjacent nucleotides whose axis values differ by
+/// 2. A region-spanning range is perfectly valid nomenclature — the spec writes
+/// `NM_001849.3:c.-1_*1=` (`consultation/SVD-WG001.md:37`) and
+/// `NM_004006.2:c.-244_*2691del` (`consultation/open-issues.md:53`), and
+/// ferro's own parser accepts both. (This comment previously asserted the
+/// opposite, that `c.-1_1` "does not exist as valid range syntax"; corrected
+/// 2026-08-02, and [`respell_at_gap`] now deliberately *emits* such a range
+/// when a repair's junction lands on the CDS start.)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum Region {
     /// `g.` (genomic) and `m.` (mitochondrial) — single axis, no
@@ -1992,9 +2001,16 @@ fn edit_span_union(edits: &[GEdit]) -> Option<(i64, i64)> {
 /// The two facts travel together because both are answered by the same
 /// `cds_start` lookup, and a second provider round-trip to re-answer the other
 /// half would be pure waste on a path that already fetches a window.
+/// Answers per *axis*, which is enough for its one caller because
+/// [`canonicalize_from_sequence`] restricts itself to the positive body region.
+/// The repair passes are not so restricted and must use
+/// [`region_sequence_delta`], which answers per *region* — see its doc comment
+/// for why a per-axis offset cannot be right in the UTRs.
 struct AxisFrame {
     /// Offset between the member axis and the fetched sequence: 0 for
     /// `g.`/`m.`/`n.`, `cds_start - 1` for the CDS-relative `c.`/`r.` axes.
+    ///
+    /// Correct only inside the positive body region; see the note above.
     delta: i64,
     /// Whether positions on this axis carry a **reading frame** — i.e. whether
     /// [`same_codon`] means anything here. True only when the axis is
@@ -2054,6 +2070,153 @@ fn axis_frame<P: ReferenceProvider>(
                 }),
             }
         }
+    }
+}
+
+/// Offset from a member's own **region** axis to the 1-based sequence the
+/// provider serves, or `None` for a region that is not part of that sequence.
+///
+/// `position_on_the_sequence = axis_position + delta`.
+///
+/// # Why this is keyed on `Region` and not on `CisKind`
+///
+/// [`AxisFrame`] answers the same question one level coarser — per *axis* —
+/// and that is all its caller needs, because [`canonicalize_from_sequence`]
+/// restricts itself to the positive body region. The repair passes have no
+/// such restriction: they operate wherever a collision settles, including
+/// both UTRs.
+///
+/// Per-axis is the wrong granularity there, and #1284 records the resulting
+/// dead end. A single `cds_start - 1` for the whole `c.` axis is right at
+/// `c.1` and off by one below it, because the CDS axis has **no zero**:
+/// `c.-1` is `cds_start - 1`, not `cds_start - 2`. Patching that with a sign
+/// test (`axis + delta + 1` when negative) gets the endpoints right and still
+/// leaves the 3'UTR — a third offset entirely, `cds_end` — wrong.
+///
+/// Keyed on the region the discontinuity disappears rather than being patched
+/// across, because each region *is* individually affine onto the transcript:
+///
+/// | region | axis → transcript | delta |
+/// |---|---|---|
+/// | `Genome`, `Tx` | the axis is the sequence | `0` |
+/// | `Cds`, `Rna` (`c.N`) | `cds_start + N - 1` | `cds_start - 1` |
+/// | `FivePrimeUtr` (`c.-N`) | `cds_start - N` | `cds_start` |
+/// | `ThreePrimeUtr` (`c.*N`) | `cds_end + N` | `cds_end` |
+///
+/// and every pass that uses it already groups members within one region, so a
+/// span never straddles two.
+///
+/// `TxUpstream` / `TxDownstream` (`n.-N` / `n.*N`) are refused: those positions
+/// lie outside the transcript the provider serves, so there are no bases to
+/// read at all. That is a genuine refusal, not a missing conversion.
+fn region_sequence_delta<P: ReferenceProvider>(
+    region: Region,
+    provider_key: &str,
+    provider: &P,
+) -> Option<i64> {
+    // `ordered_cds_bounds` for every CDS-relative region, not just
+    // `ThreePrimeUtr`. Reading `cds_start` on its own accepts a record whose
+    // bounds are inverted, and on such a record the `c.` axis is incoherent —
+    // its 5'UTR and 3'UTR halves overlap, so one transcript position carries two
+    // names. Refusing in one region and not the others is the worst of both: the
+    // 3'UTR declined while the 5'UTR and the CDS body silently picked a
+    // spelling, which is precisely what `ordered_cds_bounds`' own doc comment
+    // says this conversion must not do.
+    //
+    // Written as "refuse if inverted" rather than as `ordered_cds_bounds`
+    // directly, because that would also require `cds_end` to be *present*: a
+    // record carrying `cds_start` but no `cds_end` has an unknown 3'UTR yet a
+    // perfectly well-defined `c.N` body, and refusing it would be a new
+    // restriction rather than the guard-parity fix.
+    // Read lazily: `Genome`/`Tx` need no transcript at all, and asking for one
+    // under a genomic accession is a guaranteed miss.
+    let bounds = || -> Option<(Option<i64>, Option<i64>)> {
+        let transcript = provider.get_transcript(provider_key).ok()?;
+        Some((
+            transcript.cds_start.and_then(|v| i64::try_from(v).ok()),
+            transcript.cds_end.and_then(|v| i64::try_from(v).ok()),
+        ))
+    };
+    // Bounds that exist and are the wrong way round. Distinguished from "no CDS
+    // on this record", because the two want opposite answers: absent bounds are
+    // a non-coding transcript, which `Rna` legitimately falls back for; inverted
+    // bounds are a malformed one, which every region must refuse.
+    let inverted = || matches!(bounds(), Some((Some(start), Some(end))) if end < start);
+    let cds_start = || match bounds()? {
+        (Some(start), Some(end)) if end < start => None,
+        (start, _) => start,
+    };
+    match region {
+        Region::Genome | Region::Tx => Some(0),
+        Region::Cds => Some(cds_start()? - 1),
+        // Falls back to transcript-relative when there is no `cds_start` —
+        // either a non-coding transcript, whose `r.` numbers it directly, or a
+        // provider that cannot resolve it. That is the same fallback
+        // `axis_frame` makes and for the same reason: refusing would put every
+        // non-coding `r.` description outside these repairs. `Cds` above
+        // refuses instead, also matching `axis_frame`, because a `c.`
+        // description asserts a CDS this record does not have.
+        //
+        // The fallback must not swallow the *inverted* case, though: `map_or(0)`
+        // on its own turns a refusal into a silent delta of 0, which is the
+        // guess this conversion exists not to make. Absent bounds fall back;
+        // inverted bounds refuse, like every other region here.
+        Region::Rna if inverted() => None,
+        Region::Rna => Some(cds_start().map_or(0, |start| start - 1)),
+        Region::FivePrimeUtr => cds_start(),
+        Region::ThreePrimeUtr => Some(ordered_cds_bounds(provider_key, provider)?.1),
+        Region::TxUpstream | Region::TxDownstream => None,
+    }
+}
+
+/// Both CDS bounds, **refused unless they are ordered**.
+///
+/// `cds_end < cds_start` is a malformed record whose `c.` axis is incoherent:
+/// the 5'UTR and 3'UTR halves overlap, so one transcript position has two
+/// names. On such a record `c.*1` and `c.-10` can denote the same base, and a
+/// conversion that does not refuse simply picks one of the two spellings —
+/// silently, since the result re-parses and so is invisible to the
+/// `FERRO_ASSERT_REPARSE` oracle.
+///
+/// Refusing is not a fix for that ambiguity, which predates this conversion and
+/// is reachable without it; it keeps *this* conversion from being one more
+/// place that resolves it arbitrarily.
+/// `boundary::get_cds_boundaries_with_axis_info` guards the same condition the
+/// same way (`(Some(s), Some(e)) if e >= s`); this applies that precedent here.
+fn ordered_cds_bounds<P: ReferenceProvider>(
+    provider_key: &str,
+    provider: &P,
+) -> Option<(i64, i64)> {
+    let transcript = provider.get_transcript(provider_key).ok()?;
+    let start = i64::try_from(transcript.cds_start?).ok()?;
+    let end = i64::try_from(transcript.cds_end?).ok()?;
+    (end >= start).then_some((start, end))
+}
+
+/// The inverse of [`region_sequence_delta`] for the CDS-relative axes: which
+/// `(region, axis position)` names transcript position `tx`.
+///
+/// Needed because a repair's *junction* can land on a region boundary even
+/// though its span does not. A duplication resting at `c.-1` copies its bases
+/// to the junction between `c.-1` and `c.1` — one interbase point, two
+/// regions — and naming it requires converting through the transcript rather
+/// than adding 1 to an axis value that has no zero to add it to.
+///
+/// `body` is the region name this axis gives the CDS proper: `Region::Cds` on
+/// `c.`, `Region::Rna` on `r.`. Passed in rather than fixed, because the two
+/// axes share every other region name and `member_endpoints` reads the body
+/// back under the axis's own label.
+fn cds_axis_position(tx: i64, cds_start: i64, cds_end: i64, body: Region) -> Option<(Region, i64)> {
+    if tx < 1 {
+        return None;
+    }
+    if tx < cds_start {
+        // `c.-N`, counting back from the base before the CDS start.
+        Some((Region::FivePrimeUtr, tx - cds_start))
+    } else if tx <= cds_end {
+        Some((body, tx - cds_start + 1))
+    } else {
+        Some((Region::ThreePrimeUtr, tx - cds_end))
     }
 }
 
@@ -3442,10 +3605,11 @@ fn repeat_growth_as_insertion(
 /// #1296 had deliberately clamped out of the tract. Two repeats on one tract
 /// have no such barrier to preserve — they occupy the same bases — so the
 /// rewrite is safe here and only here.
-pub(crate) fn demote_coincident_tract_repeats(
+pub(crate) fn demote_coincident_tract_repeats<P: ReferenceProvider>(
     members: &mut [HgvsVariant],
     phase: AllelePhase,
     uncertain: bool,
+    provider: &P,
 ) {
     if phase != AllelePhase::Cis || uncertain || members.len() < 2 {
         return;
@@ -3453,9 +3617,6 @@ pub(crate) fn demote_coincident_tract_repeats(
     let Some(kind) = cis_kind_of(&members[0]) else {
         return;
     };
-    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
-        return;
-    }
     let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
     // A member participates only if it is a repeat that grew its tract by a
     // whole number of units; `growth` carries the payload and the unit.
@@ -3501,7 +3662,7 @@ pub(crate) fn demote_coincident_tract_repeats(
             let edit = NaEdit::Insertion {
                 sequence: InsertedSequence::Literal(Sequence::new(payload.clone())),
             };
-            respell_at_gap(&mut members[i], kind, span, span.end, edit);
+            respell_at_gap(&mut members[i], span, span.end, edit, provider);
             members[i] != originals[slot]
         });
         if !rewritten {
@@ -3662,6 +3823,14 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         // payload does not commute keeps the stricter rule above: one short, and
         // from either snapshot.
         let payload = junction_payload(&after[i], kind, a, provider);
+        // Every junction compared below sits on `a`'s own region axis, so one
+        // offset serves them all (#1284). A region with no conversion — an
+        // `n.` position outside the transcript — has no bases to rotate
+        // against, and refusing here is the same conservative answer the
+        // payload reads below give.
+        let Some(axis_delta) = region_sequence_delta(a.region, &a.provider_key, provider) else {
+            continue;
+        };
         let across_junctions = (0..pre.len())
             .filter(|&j| j != i)
             .flat_map(|j| {
@@ -3699,6 +3868,7 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
                                 after_junction,
                                 junction,
                                 &a.provider_key,
+                                axis_delta,
                                 provider,
                             )
                         })
@@ -3732,7 +3902,15 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
             continue;
         };
         let Some(destination) = (before_junction..=ceiling).rev().find(|&j| {
-            payload_at_junction(payload, after_junction, j, &a.provider_key, provider).is_some()
+            payload_at_junction(
+                payload,
+                after_junction,
+                j,
+                &a.provider_key,
+                axis_delta,
+                provider,
+            )
+            .is_some()
         }) else {
             continue;
         };
@@ -3981,22 +4159,23 @@ fn shift_signed(base: &mut i64, delta: i64) -> bool {
 /// (`g.[261_262del;262_263insA;…]` reduces to `g.[261del;…]`), so the loop has
 /// to see the re-spelled form to settle on that reduction.
 ///
-/// Runs on every axis whose 1-based coordinate is a direct offset into the
-/// sequence the provider serves — the genomic axes and `n.`.
+/// Runs on **every** axis. The pass reads the duplicated bases over the
+/// member's own coordinates, so all it needs is the offset from those
+/// coordinates onto the sequence the provider serves —
+/// [`region_sequence_delta`], which answers per *region* and so has an answer
+/// for the CDS-relative axes too.
 ///
-/// That is the whole requirement, because the pass reads the duplicated bases
-/// over the member's own coordinates. `axis_frame` states which axes qualify:
-/// it returns `delta: 0` for `Genome`, `Mt` **and** `Tx`, since a non-coding
-/// transcript's positions index its sequence directly, exactly as a contig's
-/// do. The original gate said "genomic axes only", which was over-broad — it
-/// grouped `n.` with the CDS-relative axes it does not resemble (#1284).
+/// This was gated to the genomic axes, then to those plus `n.` (#1315), on the
+/// grounds that only they index the served sequence directly. That was true of
+/// the arithmetic as it stood and is no longer a reason to refuse: `c.` and
+/// `r.` are CDS-relative, and keying the offset on the region rather than on
+/// the axis makes each of `FivePrimeUtr` / `Cds` / `ThreePrimeUtr`
+/// individually affine — see [`region_sequence_delta`] for why the earlier
+/// single-delta attempt recorded in #1284 could not work.
 ///
-/// `c.` and `r.` are still refused. Those are CDS-relative (`delta:
-/// cds_start - 1`) and the axis has no zero, so `c.-1` is `cds_start - 1`
-/// rather than `cds_start - 2`: a single delta is off by one below the CDS
-/// start, and applying one naively was measured to re-spell a duplication from
-/// the wrong bases and to move answers that were already correct. That
-/// conversion is the remaining half of #1284 and is not attempted here.
+/// There is no axis gate left, because the conversion itself is the gate: a
+/// region it cannot place (`n.` outside the transcript, a `c.` on a record
+/// with no CDS) yields `None` and the member is skipped.
 pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
     members: &mut [HgvsVariant],
     phase: AllelePhase,
@@ -4009,12 +4188,6 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
     let Some(kind) = cis_kind_of(&members[0]) else {
         return;
     };
-    // `Tx` belongs here and `Cds`/`Rna` do not: see the doc comment. The test
-    // is "does this axis index the served sequence directly", which is exactly
-    // the axes `axis_frame` gives `delta: 0`.
-    if !matches!(kind, CisKind::Genome | CisKind::Mt | CisKind::Tx) {
-        return;
-    }
     let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
 
     for i in 0..members.len() {
@@ -4078,8 +4251,24 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
             continue;
         }
         // The duplicated bases, read from the reference: `[start, end]` 1-based
-        // inclusive is `[start - 1, end)` half-open 0-based.
-        let (Ok(from), Ok(to)) = (u64::try_from(dup.start - 1), u64::try_from(dup.end)) else {
+        // inclusive is `[start - 1, end)` half-open 0-based, after `delta` puts
+        // the member's region axis onto the served sequence (#1284).
+        let Some(delta) = region_sequence_delta(dup.region, &dup.provider_key, provider) else {
+            continue;
+        };
+        // Checked, matching the two sibling conversions (`cds_relative_gap` and
+        // `payload_at_junction`). `dup.start`/`dup.end` come off a parsed
+        // description and `delta` off the record's CDS bounds, so neither is
+        // bounded by anything this function controls; an unchecked `i64` add
+        // panics in a debug build where the refusal one line below is the answer
+        // every other unrepresentable coordinate here already gets.
+        let (Some(from_axis), Some(to_axis)) = (
+            dup.start.checked_sub(1).and_then(|s| s.checked_add(delta)),
+            dup.end.checked_add(delta),
+        ) else {
+            continue;
+        };
+        let (Ok(from), Ok(to)) = (u64::try_from(from_axis), u64::try_from(to_axis)) else {
             continue;
         };
         let Ok(copied) = provider.get_sequence(&dup.provider_key, from, to) else {
@@ -4097,7 +4286,7 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
         };
         // The copy lands at the junction 3' of the duplicated span, which is
         // the gap `[end, end + 1]`.
-        respell_at_gap(&mut members[i], kind, dup, dup.end, edit);
+        respell_at_gap(&mut members[i], dup, dup.end, edit, provider);
     }
 }
 
@@ -4145,8 +4334,9 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
 /// bars precisely that crossing (#1290), so the two stay at distinct junctions
 /// in their original order. The two predicates are deliberately the same one.
 ///
-/// Genomic axes only, matching `respell_colliding_duplications` — the
-/// transcript axes need a coordinate conversion this does not carry.
+/// Every axis, matching `respell_colliding_duplications`: the coordinate
+/// conversion the transcript axes need is [`region_sequence_delta`], applied
+/// in `junction_payload` where this pass reads bases (#1284).
 pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
     before: &[HgvsVariant],
     members: &mut Vec<HgvsVariant>,
@@ -4160,9 +4350,6 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
     let Some(kind) = cis_kind_of(&members[0]) else {
         return;
     };
-    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
-        return;
-    }
     let spans: Vec<Option<MemberSpan>> = members.iter().map(|v| member_span(v, kind)).collect();
 
     // Group by (accession, region, junction). Only members that occupy a
@@ -4262,7 +4449,7 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
             continue;
         };
         let before = members[target].clone();
-        respell_at_gap(&mut members[target], kind, span, junction, edit);
+        respell_at_gap(&mut members[target], span, junction, edit, provider);
         if members[target] == before {
             continue; // the re-spell did not take; leave the group alone
         }
@@ -4304,9 +4491,13 @@ fn payload_at_junction<P: ReferenceProvider>(
     from: i64,
     to: i64,
     key: &str,
+    delta: i64,
     provider: &P,
 ) -> Option<Vec<Base>> {
+    // `from`/`to` are junctions on the member's own region axis; `delta` puts
+    // the base they step over onto the sequence the provider serves.
     let base_at = |position: i64| -> Option<Base> {
+        let position = position.checked_add(delta)?;
         let (start, end) = (
             u64::try_from(position.checked_sub(1)?).ok()?,
             u64::try_from(position).ok()?,
@@ -4368,11 +4559,15 @@ fn translate_junction_member<P: ReferenceProvider>(
         return;
     };
     let destination = junction + delta;
+    let Some(axis_delta) = region_sequence_delta(from.region, &from.provider_key, provider) else {
+        return;
+    };
     let Some(moved) = payload_at_junction(
         &payload,
         junction,
         destination,
         &from.provider_key,
+        axis_delta,
         provider,
     ) else {
         return;
@@ -4393,7 +4588,7 @@ fn translate_junction_member<P: ReferenceProvider>(
         sequence: InsertedSequence::Literal(Sequence::new(moved)),
     };
     let translated = variant.clone();
-    respell_at_gap(variant, kind, from, destination, edit);
+    respell_at_gap(variant, from, destination, edit, provider);
     if *variant == translated {
         *variant = original;
     }
@@ -4520,9 +4715,17 @@ fn junction_payload<P: ReferenceProvider>(
             sequence: InsertedSequence::Literal(literal),
         } => Some(literal.bases().to_vec()),
         NaEdit::Duplication { .. } => {
+            // The span is on the member's own region axis; shift it onto the
+            // served sequence before reading (#1284).
+            let delta = region_sequence_delta(span.region, &span.provider_key, provider)?;
+            // Checked, for the same reason as the sibling conversions in
+            // `respell_colliding_duplications` and `cds_relative_gap`: the span
+            // comes off a parsed description and `delta` off the record's CDS
+            // bounds, so an unchecked `i64` add would panic in a debug build
+            // where every other unrepresentable coordinate here declines.
             let (from, to) = (
-                u64::try_from(span.start - 1).ok()?,
-                u64::try_from(span.end).ok()?,
+                u64::try_from(span.start.checked_sub(1)?.checked_add(delta)?).ok()?,
+                u64::try_from(span.end.checked_add(delta)?).ok()?,
             );
             let copied = provider.get_sequence(&span.provider_key, from, to).ok()?;
             if copied.len() as i64 != span.end - span.start + 1 {
@@ -4534,54 +4737,132 @@ fn junction_payload<P: ReferenceProvider>(
     }
 }
 
-/// Replace a genomic member with `edit` over the gap `[junction, junction + 1]`.
+/// Both endpoints of a member's location as `(region, axis position)`, **not**
+/// requiring the two to share a region.
+///
+/// [`member_span`] folds them through `join_pos`, which refuses a
+/// region-spanning range because the pass's own adjacency arithmetic is
+/// region-local. That refusal is right for a *span* and wrong for verifying a
+/// *gap*: an interbase point on the CDS start is legitimately named `c.-1_1`,
+/// and reading it back through `member_span` would report `None` and force a
+/// correct repair to revert. Used only by [`respell_at_gap`].
+fn member_endpoints(v: &HgvsVariant) -> Option<((Region, i64), (Region, i64))> {
+    fn ends<T>(
+        interval: &Interval<T>,
+        read: impl Fn(&UncertainBoundary<T>) -> Option<(Region, i64)>,
+    ) -> Option<((Region, i64), (Region, i64))> {
+        Some((read(&interval.start)?, read(&interval.end)?))
+    }
+    match v {
+        HgvsVariant::Genome(g) => ends(&g.loc_edit.location, simple_genome_pos),
+        HgvsVariant::Mt(m) => ends(&m.loc_edit.location, simple_genome_pos),
+        HgvsVariant::Cds(c) => ends(&c.loc_edit.location, simple_cds_pos),
+        HgvsVariant::Tx(t) => ends(&t.loc_edit.location, simple_tx_pos),
+        HgvsVariant::Rna(r) => ends(&r.loc_edit.location, simple_rna_pos),
+        _ => None,
+    }
+}
+
+/// Replace a member with `edit` over the gap `[junction, junction + 1]`.
 ///
 /// The junction is passed rather than read off `span`, because where it sits
 /// depends on the spelling: `span.end` is the junction for a duplication, but
 /// one position past it for an insertion, whose span is the gap itself.
 ///
-/// Reverts unless the result reads back exactly as intended. `span` is used
-/// only to check the result landed on the same region.
-fn respell_at_gap(
+/// Reverts unless the result reads back exactly as intended.
+///
+/// # The CDS-relative axes, and the boundary junction (#1284)
+///
+/// On `g.`/`m.`/`n.` the gap is `[junction, junction + 1]` on the axis itself.
+/// On `c.`/`r.` that arithmetic is wrong at exactly one place, and it is a
+/// place these repairs reach: a duplication resting at `c.-1` lands its copy at
+/// the junction between `c.-1` and `c.1`, and `-1 + 1` is `c.0`, which does not
+/// exist. Adding 1 on an axis with no zero is the off-by-one #1284 records.
+///
+/// So the two ends are resolved *through the transcript* —
+/// [`region_sequence_delta`] out, [`cds_axis_position`] back — which names each
+/// end in whichever region it actually falls in and yields `c.-1_1` here. That
+/// is valid nomenclature (`consultation/SVD-WG001.md:37` writes
+/// `NM_001849.3:c.-1_*1=`), and the same machinery names the `cds_end`
+/// boundary `c.<last>_*1` without a second case.
+///
+/// The verification is [`member_endpoints`] rather than [`member_span`] for
+/// that reason: the correct answer here is a range whose ends sit in two
+/// regions, and `member_span` refuses those by construction.
+fn respell_at_gap<P: ReferenceProvider>(
     variant: &mut HgvsVariant,
-    kind: CisKind,
     span: &MemberSpan,
     junction: i64,
     edit: NaEdit,
+    provider: &P,
 ) {
     let original = variant.clone();
     let (gap_start, gap_end) = (junction, junction + 1);
-    let (Ok(start), Ok(end)) = (u64::try_from(gap_start), u64::try_from(gap_end)) else {
-        return;
+
+    // Where each end of the gap lands, in `(region, axis)` form. Genomic and
+    // `n.` gaps stay in the member's own region by construction; a
+    // CDS-relative one is resolved through the transcript.
+    let cds_relative_gap = |body: Region| -> Option<((Region, i64), (Region, i64))> {
+        let (cds_start, cds_end) = ordered_cds_bounds(&span.provider_key, provider)?;
+        let delta = region_sequence_delta(span.region, &span.provider_key, provider)?;
+        let left = junction.checked_add(delta)?;
+        let right = left.checked_add(1)?;
+        Some((
+            cds_axis_position(left, cds_start, cds_end, body)?,
+            cds_axis_position(right, cds_start, cds_end, body)?,
+        ))
     };
-    let placed = match variant {
-        HgvsVariant::Genome(g) => {
-            set_endpoints(
-                &mut g.loc_edit.location,
-                |p: &mut GenomePos, v: u64| p.base = v,
-                start,
-                end,
-            ) && {
+
+    // The unsigned genomic pair, `None` on a negative axis. Computed per-arm
+    // rather than as an early return for the whole function: hoisting it was
+    // the shape this function had while it was genomic-only, and it silently
+    // refused *every* CDS-relative repair in the 5'UTR, where the axis value is
+    // negative by definition — the arms below never ran.
+    // Rejects a zero endpoint as well as a negative one. `u64::try_from(0)`
+    // succeeds, so without the explicit test a junction at 0 would name `g.0_1` /
+    // `m.0_1`, and neither axis has a position 0 — the same refusal the `Tx` arm
+    // below makes for `n.0`, which this closure has to match rather than leave to
+    // one axis.
+    let unsigned_gap = || -> Option<(u64, u64)> {
+        (gap_start != 0 && gap_end != 0)
+            .then(|| Some((u64::try_from(gap_start).ok()?, u64::try_from(gap_end).ok()?)))?
+    };
+    let same_region_gap = ((span.region, gap_start), (span.region, gap_end));
+    let (placed, intended) = match variant {
+        HgvsVariant::Genome(g) => (
+            unsigned_gap().is_some_and(|(start, end)| {
+                set_endpoints(
+                    &mut g.loc_edit.location,
+                    |p: &mut GenomePos, v: u64| p.base = v,
+                    start,
+                    end,
+                )
+            }) && {
                 g.loc_edit.edit = Mu::Certain(edit.clone());
                 true
-            }
-        }
-        HgvsVariant::Mt(m) => {
-            set_endpoints(
-                &mut m.loc_edit.location,
-                |p: &mut GenomePos, v: u64| p.base = v,
-                start,
-                end,
-            ) && {
+            },
+            same_region_gap,
+        ),
+        HgvsVariant::Mt(m) => (
+            unsigned_gap().is_some_and(|(start, end)| {
+                set_endpoints(
+                    &mut m.loc_edit.location,
+                    |p: &mut GenomePos, v: u64| p.base = v,
+                    start,
+                    end,
+                )
+            }) && {
                 m.loc_edit.edit = Mu::Certain(edit.clone());
                 true
-            }
-        }
+            },
+            same_region_gap,
+        ),
         // `n.` is a signed axis with no zero, so a gap that would name `n.0` is
         // refused — the same guard `place_signed` applies for `respell_as`.
-        // Otherwise it behaves exactly as the genomic arms: the position is a
-        // direct offset into the transcript sequence (see the doc comment).
-        HgvsVariant::Tx(t) => {
+        // Unlike `c.`/`r.` there is nothing on the far side to name it as: the
+        // `n.` regions either side of `0` are the transcript and the sequence
+        // *outside* it, so a conversion would have no bases to offer.
+        HgvsVariant::Tx(t) => (
             gap_start != 0
                 && gap_end != 0
                 && set_endpoints(
@@ -4591,15 +4872,52 @@ fn respell_at_gap(
                     gap_end,
                 )
                 && {
-                    t.loc_edit.edit = Mu::Certain(edit);
+                    t.loc_edit.edit = Mu::Certain(edit.clone());
                     true
-                }
-        }
-        _ => false,
+                },
+            same_region_gap,
+        ),
+        HgvsVariant::Cds(c) => match cds_relative_gap(Region::Cds) {
+            Some(intended) => (
+                set_endpoints(
+                    &mut c.loc_edit.location,
+                    |p: &mut CdsPos, (region, base): (Region, i64)| {
+                        p.base = base;
+                        p.utr3 = region == Region::ThreePrimeUtr;
+                        p.offset = None;
+                    },
+                    intended.0,
+                    intended.1,
+                ) && {
+                    c.loc_edit.edit = Mu::Certain(edit.clone());
+                    true
+                },
+                intended,
+            ),
+            None => (false, same_region_gap),
+        },
+        HgvsVariant::Rna(r) => match cds_relative_gap(Region::Rna) {
+            Some(intended) => (
+                set_endpoints(
+                    &mut r.loc_edit.location,
+                    |p: &mut RnaPos, (region, base): (Region, i64)| {
+                        p.base = base;
+                        p.utr3 = region == Region::ThreePrimeUtr;
+                        p.offset = None;
+                    },
+                    intended.0,
+                    intended.1,
+                ) && {
+                    r.loc_edit.edit = Mu::Certain(edit.clone());
+                    true
+                },
+                intended,
+            ),
+            None => (false, same_region_gap),
+        },
+        _ => (false, same_region_gap),
     };
-    let landed = placed
-        && member_span(variant, kind)
-            .is_some_and(|s| s.region == span.region && s.start == gap_start && s.end == gap_end);
+    let landed = placed && member_endpoints(variant) == Some(intended);
     if !landed {
         *variant = original;
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2710,7 +2710,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // `demote_repeats_spanning_siblings`: an insertion blocks no
             // sibling's shift, so demoting a repeat before the clamps would
             // release a sibling that #1296 clamped out of its tract.
-            merge::demote_coincident_tract_repeats(&mut result, allele.phase, allele.uncertain);
+            merge::demote_coincident_tract_repeats(
+                &mut result,
+                allele.phase,
+                allele.uncertain,
+                &self.provider,
+            );
             // Last: two junction-occupying members that settled on the SAME
             // junction. The clamps above bound a member against a sibling's
             // bases, and an insertion or duplication has none, so a pair can

--- a/tests/it/issue_1235_transcript_axes.rs
+++ b/tests/it/issue_1235_transcript_axes.rs
@@ -224,12 +224,22 @@ fn rna_axis_reduces_a_mixed_type_allele_and_keeps_the_u_alphabet() {
 /// members silently fused into one well-formed edit.
 ///
 /// The refusal keys off the edit geometry, not off the `OverlapConflict`
-/// warning: the per-member pipeline rewrites the interior `insAA` into a
-/// `5_6dup`, so a gate reading a detector that only recognises `NaEdit::
-/// Insertion` would decline on the first pass and accept on the second —
-/// costing idempotency. `detect_insertion_overlaps` now registers a `dup` as a
-/// junction occupant as well, so the diagnostic survives the respelling too;
-/// this test pins both halves.
+/// warning: a gate reading a detector that only recognised `NaEdit::Insertion`
+/// would decline on the first pass and accept on the second — costing
+/// idempotency. `detect_insertion_overlaps` registers a `dup` as a junction
+/// occupant as well, so the diagnostic survives whichever spelling the pipeline
+/// settles on; this test pins both halves.
+///
+/// **Settled form updated by #1284.** The pipeline used to leave this as
+/// `c.[5_9inv;5_6dup]`, and this test pinned that. It no longer does:
+/// `respell_colliding_duplications` repairs a duplication whose span collides
+/// with a sibling's bases into the equivalent insertion, and #1284 lifted that
+/// repair's genomic-only gate onto the CDS-relative axes. So the `c.` spelling
+/// now settles where the `g.` spelling of the same shape already did —
+/// `g.[261_265inv;262_263insAA]`, measured — and the axis divergence #1284
+/// describes is gone. Everything this test actually guards is unchanged: the
+/// allele stays multi-member, strict still rejects it as `W5002`, the authored
+/// member order is still preserved, and the result is still idempotent.
 #[test]
 fn overlap_conflicting_allele_is_not_canonicalized() {
     use ferro_hgvs::error::FerroError;
@@ -258,33 +268,90 @@ fn overlap_conflicting_allele_is_not_canonicalized() {
         normalized.starts_with("NM_TEST.1:c.[") && normalized.contains(';'),
         "an overlap-conflicting allele must stay a multi-member allele, got `{normalized}`"
     );
-    // The per-member pipeline shifts the inversion 3' and respells the interior
-    // insertion as the duplication it is; neither member is re-derived away.
+    // The per-member pipeline shifts the inversion 3' and leaves the interior
+    // insertion at its own junction; neither member is re-derived away.
     assert_eq!(
-        normalized, "NM_TEST.1:c.[5_9inv;5_6dup]",
-        "the sequence-first pass must decline an allele with no defined result"
+        normalized, "NM_TEST.1:c.[5_9inv;6_7insAA]",
+        "the per-member pipeline must settle both members here — the inversion \
+         3'-shifted, the interior insertion respelled at its own junction — \
+         rather than the sequence-first pass re-deriving the allele as one edit"
     );
 
     // Idempotent on the nose: normalizing the output must return it byte for
     // byte. This is the property that broke while the overlap detector was
-    // spelling-sensitive — pass one emitted `[5_9inv;5_6dup]` with the members
+    // spelling-sensitive — pass one emitted the conflict with the members
     // deliberately left in authored order (the `#395` verbatim contract), then
-    // pass two failed to see a conflict in the `dup` spelling, un-gated the
-    // genomic-order sort, and reordered them to `[5_6dup;5_9inv]`.
+    // pass two failed to see a conflict in the settled spelling, un-gated the
+    // genomic-order sort, and reordered them.
     let twice = normalize_to_string(provider(), &normalized);
     assert_eq!(
         twice, normalized,
         "normalizing an overlap-conflicting allele must be idempotent"
     );
 
-    // Both spellings of the settled form are recognised as the same conflict,
-    // so each is a fixed point rather than being sorted into the other.
-    for settled in ["NM_TEST.1:c.[5_9inv;5_6dup]", "NM_TEST.1:c.[5_6dup;5_9inv]"] {
+    // The `g.`-axis parity the doc comment above rests on, asserted rather than
+    // recited. This is the independent code path — the repair was genomic-only
+    // before #1284, so the `g.` answer was reached without any of the
+    // CDS-relative conversion under test — and it is what makes the `c.` pin
+    // above more than a self-consistency check. Left unasserted, a move in the
+    // `g.` repair would leave this test green and the stated rationale silently
+    // false.
+    //
+    // `SyntheticBuilder::cds` serves its genomic sequence under `chr_synth`
+    // (`TX_CONTIG`) at `PAD_OFFSET`, so `c.N` is `g.N + 256` here: the same
+    // shape authored as `g.[260_266inv;261_262insAA]`.
+    let genomic = normalize_to_string(provider(), "chr_synth:g.[260_266inv;261_262insAA]");
+    assert_eq!(
+        genomic, "chr_synth:g.[261_265inv;262_263insAA]",
+        "the g. spelling of the same shape must settle where the doc comment says"
+    );
+    // And the two axes now agree member-for-member, which is the divergence
+    // #1284 set out to remove: strip the 256-base padding offset off the
+    // genomic answer and it is the `c.` answer.
+    assert_eq!(
+        genomic
+            .replace("chr_synth:g.", "")
+            .replace("261_265", "5_9")
+            .replace("262_263", "6_7"),
+        normalized.replace("NM_TEST.1:c.", ""),
+        "the c. and g. spellings of one shape must no longer diverge"
+    );
+
+    // The `dup` spelling of the same conflict converges onto the settled `ins`
+    // spelling rather than being a second fixed point of its own (#1284): the
+    // collision repair rewrites it, in whichever member order it was authored.
+    // Convergence is the point — one variant, one canonical string — and it is
+    // reached in a single pass, so idempotency is preserved either way.
+    for (dup_spelling, converges_to) in [
+        (
+            "NM_TEST.1:c.[5_9inv;5_6dup]",
+            "NM_TEST.1:c.[5_9inv;6_7insAA]",
+        ),
+        (
+            "NM_TEST.1:c.[5_6dup;5_9inv]",
+            "NM_TEST.1:c.[6_7insAA;5_9inv]",
+        ),
+    ] {
         assert_eq!(
-            normalize_to_string(provider(), settled),
-            settled,
-            "a `dup` interior to an `inv` is the same conflict as the `ins` spelling"
+            normalize_to_string(provider(), dup_spelling),
+            converges_to,
+            "a `dup` interior to an `inv` must settle on the `ins` spelling of the same conflict"
         );
+        assert_eq!(
+            normalize_to_string(provider(), converges_to),
+            converges_to,
+            "and that settled spelling must be a fixed point"
+        );
+    }
+
+    // Both spellings are recognised as the same conflict by strict mode, and
+    // the authored member order survives in each.
+    for settled in [
+        "NM_TEST.1:c.[5_9inv;5_6dup]",
+        "NM_TEST.1:c.[5_6dup;5_9inv]",
+        "NM_TEST.1:c.[5_9inv;6_7insAA]",
+        "NM_TEST.1:c.[6_7insAA;5_9inv]",
+    ] {
         // Strict mode must reject it too — and for the *same* reason as the
         // `ins` spelling, not merely reject it for some other one.
         let parsed = parse_hgvs(settled).expect("parse");

--- a/tests/it/issue_1276_dup_junction_overlap.rs
+++ b/tests/it/issue_1276_dup_junction_overlap.rs
@@ -23,12 +23,17 @@
 //!      `sort_cis_members_by_genomic_order` is skipped only for conflicting
 //!      alleles — so the member order flipped on the second pass.
 //!
-//! Exercised on the `c.` axis. The `g.` spelling of the same shape is currently
-//! collapsed by the sequence-first canonicalization before the dup is ever
-//! rendered, which would mask the behaviour under test; the transcript axes are
-//! not reached by that pass, so the dup survives and the detector is what
-//! decides. Reference-free (`MockProvider` via `SyntheticBuilder`), so this
-//! holds independent of the manifest.
+//! Exercised on the `c.` axis. Reference-free (`MockProvider` via
+//! `SyntheticBuilder`), so this holds independent of the manifest.
+//!
+//! **Axis rationale corrected by #1284.** This header used to say the `c.` axis
+//! was chosen because "the transcript axes are not reached by that pass, so the
+//! dup survives". That was true and is no longer: #1284 lifted the collision
+//! repair's genomic-only gate, so a normalization-produced dup that collides
+//! with a sibling is now respelled on `c.` exactly as on `g.`. The tests below
+//! that author a `dup` **directly** are unaffected — they hand the detector a
+//! dup rather than relying on normalization to make one — and they are what
+//! carries the #1243 coverage.
 
 use crate::common::synthetic::SyntheticBuilder;
 use ferro_hgvs::error::FerroError;
@@ -107,10 +112,19 @@ fn strict_rejects_a_duplication_and_an_insertion_at_one_junction() {
 /// own strict mode accepts.
 ///
 /// `[4_10inv;5_6insAA]` is an insertion strictly interior to an inversion —
-/// rejected under strict since #486. Normalizing it leniently rewrites that
+/// rejected under strict since #486. Normalizing it leniently rewrote that
 /// insertion into a `dup`, and before #1243 the result passed strict
 /// validation. A caller who normalized leniently and re-validated strictly got a
 /// clean answer for an allele with no defined resulting sequence.
+///
+/// **Settled form updated by #1284**, which is why the pinned string below is
+/// an `ins` and not the `dup` this test was written around: the dup the
+/// pipeline used to leave here now collides with the inversion's bases and is
+/// repaired into the equivalent insertion, as it already was on `g.`. The
+/// contract this test exists for is untouched and is asserted twice — strict
+/// rejects the input, and strict still rejects whatever lenient mode emits for
+/// it. The dup-specific half of #1243 is carried by the direct-authoring tests
+/// above, which do not depend on normalization producing a dup.
 #[test]
 fn lenient_output_of_a_conflict_is_still_rejected_by_strict() {
     const INPUT: &str = "NM_TEST.1:c.[4_10inv;5_6insAA]";
@@ -121,9 +135,9 @@ fn lenient_output_of_a_conflict_is_still_rejected_by_strict() {
 
     let normalized = normalize_lenient(INPUT);
     assert_eq!(
-        normalized, "NM_TEST.1:c.[5_9inv;5_6dup]",
-        "precondition: normalization rewrites the interior insertion as a dup, \
-         which is what used to escape detection"
+        normalized, "NM_TEST.1:c.[5_9inv;6_7insAA]",
+        "precondition: normalization settles the interior insertion at its own \
+         junction, still strictly inside the inversion"
     );
     assert!(
         strict_rejects_as_overlap(&normalized),

--- a/tests/it/issue_1284_transcript_axis_reparse.rs
+++ b/tests/it/issue_1284_transcript_axis_reparse.rs
@@ -1,0 +1,491 @@
+//! Issue #1284 — the del+dup collision repair was genomic-only, so the
+//! CDS-relative axes emitted descriptions ferro's own parser rejects.
+//!
+//! `respell_colliding_duplications` (and the two sibling repairs added behind
+//! the same gate) read the duplicated bases *over the member's own
+//! coordinates*, which is only sound on an axis whose 1-based position is a
+//! direct offset into the sequence the provider serves. That is true of `g.`,
+//! `m.` and — since #1315 — `n.`, and false of `c.`/`r.`, which are
+//! CDS-relative. The gate therefore refused those axes, and a del+dup pair that
+//! 3'-shifted onto one position stayed collided:
+//!
+//! ```text
+//! NM_TEST.1:c.[-8del;-6dup]  ->  NM_TEST.1:c.[-1del;-1dup]
+//! parse_hgvs(out) -> Err: Self-cancelling allele … overlapping reference positions
+//! ```
+//!
+//! ## Why this is an abort rather than a diff
+//!
+//! `FERRO_ASSERT_REPARSE=1` is armed in `ci.yml` and `nightly-mutalyzer.yml`.
+//! That oracle asserts normalization emits something `parse_hgvs` accepts, so
+//! every case below **panics the run** under it rather than failing with a
+//! comparison. That is why #1283's transcript-axis sweep gap is blocked on this
+//! issue, and why the invariant — not any single expected string — is the
+//! contract these tests pin.
+//!
+//! ## The conversion, and why the earlier attempt did not work
+//!
+//! The issue records a naive `axis_sequence_delta` (a single `cds_start - 1`)
+//! being tried and reverted: it is right at `c.1` and off by one below, because
+//! the CDS axis has no zero. The fix here keys the offset on the member's
+//! **`Region`** instead of on the axis kind, which removes the discontinuity
+//! rather than patching across it — `FivePrimeUtr`, `Cds` and `ThreePrimeUtr`
+//! are each individually affine onto the transcript, and every pass already
+//! groups members within one region.
+//!
+//! Reference-free (`MockProvider` via `SyntheticBuilder`), so these hold with
+//! no manifest.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The issue's own transcript: 5'UTR is a T-run reaching the CDS start, so both
+/// members shuffle to `c.-1` and collide at the UTR/CDS boundary — the hardest
+/// placement, because the junction 3' of `c.-1` is `c.-1_1`, spanning two
+/// regions.
+const ISSUE_CORE: &str = "TTTTTTTTTAATATATTTTAATAT";
+const ISSUE_CDS: (u64, u64) = (9, 24);
+
+/// A 5'UTR with interior structure (an A-run at tx 3..5, well inside the UTR)
+/// plus a real 3'UTR, so a collision can settle away from either boundary.
+const STRUCTURED_CORE: &str = "GCAAAGCGCGCGATGAAACCCTAAGGCATTTTTAA";
+const STRUCTURED_CDS: (u64, u64) = (13, 24);
+
+fn provider(core: &str, cds: (u64, u64)) -> MockProvider {
+    SyntheticBuilder::cds(core, cds.0, cds.1, Strand::Plus).build()
+}
+
+/// Normalize, and return the rendered output.
+fn normalize(input: &str, core: &str, cds: (u64, u64)) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    Normalizer::new(provider(core, cds))
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// The contract: whatever normalization emits, `parse_hgvs` must accept it.
+///
+/// Asserted through the real parser rather than by string-matching the known
+/// `Self-cancelling` message, so a future collision that renders some *other*
+/// unparseable shape is caught by the same test.
+fn assert_reparses(input: &str, core: &str, cds: (u64, u64)) -> String {
+    let output = normalize(input, core, cds);
+    if let Err(err) = parse_hgvs(&output) {
+        panic!("`{input}` normalized to `{output}`, which ferro cannot re-parse: {err}");
+    }
+    output
+}
+
+/// The issue's verbatim reproducer.
+#[test]
+fn the_issues_own_reproducer_reparses() {
+    assert_reparses("NM_TEST.1:c.[-8del;-6dup]", ISSUE_CORE, ISSUE_CDS);
+}
+
+/// The same shape on `r.`, which shares the CDS-relative axis and was gated
+/// identically.
+///
+/// **Deliberately not run on `ISSUE_CORE`.** It passes there — and proves
+/// nothing. That transcript's 5'UTR is a T-run reaching the CDS start, and
+/// `normalize_rna` does not apply the CDS↔UTR axis clamp that `normalize_cds`
+/// does (an explicit #334 decision, on the grounds that `r.` natively spans the
+/// sub-axes; see the comment on `normalize_rna`'s `boundaries` and the test it
+/// names, `issue_163_rna_utr3_flag::rna_mixed_cds_utr3_del_shifts_into_utr`).
+/// So on `ISSUE_CORE` the `r.` members shuffle *out* of the 5'UTR into the CDS
+/// body, where the sequence-first canonicalization resolves them — the repair
+/// under test never runs, and the assertion is vacuous. `STRUCTURED_CORE`'s
+/// A-run sits well inside the 5'UTR, so the members stay there and the
+/// CDS-relative conversion is what has to be right.
+#[test]
+fn the_reproducer_reparses_on_the_rna_axis() {
+    for input in [
+        "NM_TEST.1:r.[-10del;-9dup]",
+        "NM_TEST.1:r.[-9del;-8dup]",
+        "NM_TEST.1:r.[-10del;-8dup]",
+    ] {
+        assert_reparses(input, STRUCTURED_CORE, STRUCTURED_CDS);
+    }
+}
+
+/// Characterizes the `c.`/`r.` divergence the test above works around, so it is
+/// recorded in code rather than only in a PR body.
+///
+/// The same molecular event — delete one base from a run that reaches the CDS
+/// start — settles at `c.-1` on the `c.` axis and at `r.1` on the `r.` axis,
+/// because only `normalize_cds` intersects the shuffle window with the CDS↔UTR
+/// axis bound. Deliberate (#334) and out of scope for #1284, which is about the
+/// repair passes' coordinate conversion, not about where the shuffle stops.
+/// Pinned as *current* behavior: if #334 is ever revisited this test should
+/// move with it, and until then it stops the divergence being rediscovered as a
+/// surprise.
+#[test]
+fn the_cds_and_rna_axes_stop_a_five_prime_shuffle_in_different_places() {
+    assert_eq!(
+        normalize("NM_TEST.1:c.-8del", ISSUE_CORE, ISSUE_CDS),
+        "NM_TEST.1:c.-1del",
+        "`c.` clamps the shuffle at the CDS start"
+    );
+    assert_eq!(
+        normalize("NM_TEST.1:r.-8del", ISSUE_CORE, ISSUE_CDS),
+        "NM_TEST.1:r.1del",
+        "`r.` does not (#334), so the same event crosses into the CDS body"
+    );
+}
+
+/// A collision settling in the *interior* of the 5'UTR, where the repair's
+/// junction is wholly inside one region. Distinct from the reproducer above,
+/// whose junction straddles the UTR/CDS boundary: an implementation that
+/// handled only the interior case would still abort on the issue's own input,
+/// and one that special-cased only the boundary would miss these.
+#[test]
+fn an_interior_five_prime_utr_collision_reparses() {
+    for input in [
+        "NM_TEST.1:c.[-10del;-9dup]",
+        "NM_TEST.1:c.[-10del;-8dup]",
+        "NM_TEST.1:c.[-9dup;-8del]",
+    ] {
+        assert_reparses(input, STRUCTURED_CORE, STRUCTURED_CDS);
+    }
+}
+
+/// The 3'UTR half of the same axis. Its offset is `cds_end`, not `cds_start`,
+/// so it is a genuinely different conversion and not covered by the 5' cases.
+#[test]
+fn a_three_prime_utr_collision_reparses() {
+    for input in ["NM_TEST.1:c.[*1del;*2dup]", "NM_TEST.1:r.[*1del;*2dup]"] {
+        assert_reparses(input, STRUCTURED_CORE, STRUCTURED_CDS);
+    }
+}
+
+/// The census. Every two-member combination over both UTRs **and** the CDS
+/// body, on both CDS-relative axes, must re-parse.
+///
+/// Measured on this grid: **120 of 12,110 outputs failed to re-parse before the
+/// fix, 0 after**, every one of them the `Self-cancelling` del+dup collision.
+/// (A first grid, whose 5'UTR was a single homopolymer reaching the CDS start,
+/// put 296 of 3080 in the same one shape.) The CDS body contributed zero
+/// failures either way — there the sequence-first canonicalization resolves the
+/// collision before it can be rendered, which is exactly why the defect was
+/// confined to the UTRs.
+///
+/// The grid pairs coordinates **across** regions as well as within them. Same
+/// region only was 3,950 cases and the same 120 failures, so cross-region pairs
+/// contribute none — which is the expected answer rather than a wasted 8,000
+/// cases: a collision needs both members on one position, and members in
+/// different regions cannot reach one. Covering them is what lets the census
+/// claim that, instead of leaving it assumed.
+///
+/// Two things are asserted besides re-parsing. A sweep that silently generated
+/// nothing would pass vacuously, so the attempted count is checked against the
+/// measured population; and each output is normalized a **second** time, because
+/// these repairs rewrite members in place and a repair that is not a fixed point
+/// is what the idempotency invariant exists to catch. That second pass is
+/// deliberately not left to `FERRO_ASSERT_IDEMPOTENT`: CI is the only place that
+/// oracle is armed, so a plain local `cargo nextest run --features dev` got no
+/// idempotency signal from this grid at all.
+#[test]
+fn no_transcript_axis_two_member_allele_fails_to_reparse() {
+    let utr5: Vec<String> = (1..=12).map(|i| format!("-{i}")).collect();
+    let utr3: Vec<String> = (1..=11).map(|i| format!("*{i}")).collect();
+    let body: Vec<String> = (1..=12).map(|i| i.to_string()).collect();
+
+    let mut attempted = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    // Cross-region pairs as well as same-region ones. A pair drawn from one
+    // region can only collide inside that region, so restricting to those left
+    // the whole cross-region class — `c.[-8del;1dup]`, a 5'UTR member beside a
+    // CDS-body one — outside a census that reads as exhaustive. Those are the
+    // pairs whose two members take *different* `region_sequence_delta` values,
+    // which is the arithmetic this PR adds.
+    let regions = [&utr5, &utr3, &body];
+    for first_coords in regions {
+        for second_coords in regions {
+            for axis in ["c", "r"] {
+                for a in first_coords {
+                    for b in second_coords {
+                        for (first, second) in [
+                            (format!("{a}del"), format!("{b}dup")),
+                            (format!("{a}dup"), format!("{b}del")),
+                            (format!("{a}del"), format!("{b}del")),
+                            (format!("{a}dup"), format!("{b}dup")),
+                            (format!("{a}A>G"), format!("{b}dup")),
+                        ] {
+                            let input = format!("NM_TEST.1:{axis}.[{first};{second}]");
+                            // Not every generated string is a legal input (a stated
+                            // reference base that does not match, say); those are
+                            // simply not part of the population under test.
+                            let Ok(variant) = parse_hgvs(&input) else {
+                                continue;
+                            };
+                            let Ok(normalized) =
+                                Normalizer::new(provider(STRUCTURED_CORE, STRUCTURED_CDS))
+                                    .normalize(&variant)
+                            else {
+                                continue;
+                            };
+                            attempted += 1;
+                            let output = normalized.to_string();
+                            let Ok(reparsed) = parse_hgvs(&output) else {
+                                failures.push(format!("{input} -> {output} (does not re-parse)"));
+                                continue;
+                            };
+                            // Idempotency, asserted here rather than left to
+                            // `FERRO_ASSERT_IDEMPOTENT`. These repairs rewrite
+                            // members in place, so a repair that is not a fixed
+                            // point is the failure mode the invariant exists to
+                            // catch — and CI is the only place that oracle is armed,
+                            // so a plain local `cargo nextest run --features dev`
+                            // got no idempotency signal at all from this 12,110-case
+                            // grid.
+                            //
+                            // An `Err` on the second pass is recorded, not skipped.
+                            // The first pass succeeded and its output re-parsed, so a
+                            // re-normalization that now refuses is itself the defect —
+                            // skipping it would hide exactly the case this check adds.
+                            match Normalizer::new(provider(STRUCTURED_CORE, STRUCTURED_CDS))
+                                .normalize(&reparsed)
+                            {
+                                Ok(twice) if twice.to_string() == output => {}
+                                Ok(twice) => failures.push(format!(
+                                    "{input} -> {output} -> {twice} (not a fixed point)"
+                                )),
+                                Err(err) => failures.push(format!(
+                                    "{input} -> {output} (re-normalizing the output failed: {err})"
+                                )),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Close to the measured 12,110 rather than a token floor. At `> 1000` roughly
+    // nine tenths of the grid could start erroring out of `normalize` before this
+    // test noticed, and the `continue` on `Err` above makes that silent.
+    assert!(
+        attempted > 11_000,
+        "the sweep must actually normalize a population; only {attempted} inputs survived"
+    );
+    assert!(
+        failures.is_empty(),
+        "{} of {attempted} normalized outputs do not re-parse; first 10:\n{}",
+        failures.len(),
+        failures
+            .iter()
+            .take(10)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Anti-vacuity control: the grid above really does contain colliding pairs, so
+/// the census is measuring something. Pinned on a pair whose two members
+/// 3'-shift onto one position.
+#[test]
+fn the_swept_grid_really_does_produce_collisions() {
+    let collided = normalize(
+        "NM_TEST.1:c.[-10del;-9dup]",
+        STRUCTURED_CORE,
+        STRUCTURED_CDS,
+    );
+    assert!(
+        !collided.contains("-10"),
+        "precondition: the members must 3'-shift together before colliding; got `{collided}`"
+    );
+    // Movement is not collision. The above holds whenever *either* member
+    // shifts at all, so on its own it does not support the test's name. The
+    // collision itself is directly observable: the `del` and the `dup` land on
+    // one position, cancel, and the two-member allele collapses to a single
+    // identity member. A pair that merely shifted would still be rendered as
+    // `[...;...]`.
+    assert_eq!(
+        collided, "NM_TEST.1:c.-9=",
+        "precondition: the pair must actually collide and cancel to one identity          member, which is what the repair produces; got `{collided}`"
+    );
+}
+
+/// The conversion must not depend on strand.
+///
+/// `cds_start`/`cds_end` are transcript coordinates and the provider serves
+/// transcript-oriented bases, so a minus-strand record should convert
+/// identically — but "wrong shift direction or strand handling" is exactly the
+/// class this file's arithmetic could get wrong, and every other test here runs
+/// on the plus strand. Asserted as *parity* rather than against pinned strings,
+/// so it keeps holding if the settled forms move.
+#[test]
+fn the_conversion_is_strand_independent() {
+    for input in [
+        "NM_TEST.1:c.[-10del;-9dup]",
+        "NM_TEST.1:c.[-10del;-8dup]",
+        "NM_TEST.1:c.[*1del;*2dup]",
+        "NM_TEST.1:r.[-9del;-8dup]",
+    ] {
+        let plus = normalize(input, STRUCTURED_CORE, STRUCTURED_CDS);
+        let variant = parse_hgvs(input).expect("input must parse");
+        let minus = Normalizer::new(
+            SyntheticBuilder::cds(
+                STRUCTURED_CORE,
+                STRUCTURED_CDS.0,
+                STRUCTURED_CDS.1,
+                Strand::Minus,
+            )
+            .build(),
+        )
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string();
+        assert_eq!(
+            plus, minus,
+            "`{input}` must normalize the same on either strand"
+        );
+    }
+}
+
+/// A record whose CDS bounds are inverted (`cds_end < cds_start`) has an
+/// incoherent `c.` axis — its 5'UTR and 3'UTR halves overlap, so one transcript
+/// position carries two names. The repair must refuse rather than pick one.
+///
+/// This does not claim the ambiguity itself is fixed: it predates this change
+/// and is reachable without it (`c.[*1del;*2dup]` comes back spelled `c.[-10del;
+/// -9dup]` on `origin/main` too, both naming transcript position 14). What is
+/// pinned is that the new conversion declines instead of adding another site
+/// that resolves it arbitrarily — and that declining still leaves a
+/// re-parseable output.
+#[test]
+fn inverted_cds_bounds_are_refused_not_guessed() {
+    let inverted = || SyntheticBuilder::cds(STRUCTURED_CORE, 24, 13, Strand::Plus).build();
+    let variant = parse_hgvs("NM_TEST.1:c.[*1del;*2dup]").expect("input must parse");
+    let output = Normalizer::new(inverted())
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string();
+    assert!(
+        parse_hgvs(&output).is_ok(),
+        "even on a malformed record the output must re-parse; got `{output}`"
+    );
+    // Refusal, asserted directly. `is_ok()` alone passes against the exact
+    // behaviour this test excludes: a repair that *guesses* one of the two names
+    // an inverted-bounds record admits still emits a parseable string.
+    //
+    // `ordered_cds_bounds` returning `None` is observable as "no member is
+    // respelled": both keep their authored `del`/`dup` shapes and the allele
+    // stays two members. Contrast the well-formed record, where the same input
+    // collapses to the single identity member `c.*2=`.
+    assert_eq!(
+        output, "NM_TEST.1:c.[-10del;-9dup]",
+        "inverted CDS bounds must make the conversion decline and leave both members \
+         authored, not pick a spelling; got `{output}`"
+    );
+
+    // Every CDS-relative region must refuse alike, `r.` included. Its
+    // `region_sequence_delta` arm falls back to a transcript-relative delta of 0
+    // when the record has no CDS at all — right for a non-coding transcript —
+    // and that fallback must not also swallow an *inverted* CDS, which would turn
+    // the refusal into exactly the silent guess this test excludes. The 5'UTR and
+    // CDS-body arms had the mirror-image gap: they read `cds_start` alone, so
+    // only the 3'UTR declined while those two picked a spelling.
+    let rna = parse_hgvs("NM_TEST.1:r.[*1del;*2dup]").expect("input must parse");
+    let rna_output = Normalizer::new(inverted())
+        .normalize(&rna)
+        .expect("lenient normalization must not reject")
+        .to_string();
+    assert_eq!(
+        rna_output, "NM_TEST.1:r.[-10del;-9dup]",
+        "the r. axis must decline on an inverted record too; got `{rna_output}`"
+    );
+}
+
+/// The one shape this repair still names wrongly: a collision that settles on
+/// the **final transcript base**.
+///
+/// `c.[*10dup;*11dup]` 3'-shifts both members onto `*11` — the last base of this
+/// transcript — and the repair respells one of them as an insertion at the
+/// junction 3' of it. That junction's right endpoint is `*12`, which the record
+/// does not have. `cds_axis_position` has a floor (`tx < 1`) but no ceiling, so
+/// it answers `ThreePrimeUtr(12)` rather than refusing, and the result renders
+/// as `c.*11_*12insAA`.
+///
+/// The denoted sequence is right and the string re-parses — `parse_hgvs` has no
+/// provider and so cannot bound a 3'UTR position — which is exactly why
+/// `FERRO_ASSERT_REPARSE` does not catch it and why it is pinned by hand here
+/// instead of left to the census below.
+///
+/// **This is not a regression.** On `origin/main` the same input came back as
+/// `c.[*11dup;*11dup]`: two members claiming one reference position, which is
+/// the #1234 overlapping-members class. Measured over this file's 12,110-case
+/// grid, `main` produced **120** outputs `parse_hgvs` rejects and **0**
+/// out-of-range positions; this change produces **0** and **2**. So the repair
+/// removes 120 unreadable outputs and converts one narrow defect into another
+/// narrow one, on 2 inputs, both of which stay readable.
+///
+/// Refusing the respell instead is not available: it returns those 4 terminal
+/// del+dup cases (`c.[*10del;*11dup]`) to the unparseable `c.[*11del;*11dup]`,
+/// and `FERRO_ASSERT_REPARSE` is armed in CI, so an unparseable output aborts
+/// the run rather than failing a comparison.
+///
+/// The real fix is to spell a terminus-anchored insertion as the duplication it
+/// is (`c.*10_*11dup`, which is sequence-identical and needs no `*12`). That is
+/// a change to what `respell_at_gap` may emit rather than to this conversion, so
+/// it is tracked as #1343 rather than widened into this PR. Pinned here so it
+/// stays measured: if the count moves, one of the two is wrong.
+#[test]
+fn a_collision_on_the_final_transcript_base_still_names_a_position_past_the_end() {
+    // 3'UTR is `*1..*11` (transcript 25..35 of a 35-base record), so `*12` is
+    // one past the end.
+    for input in ["NM_TEST.1:c.[*10dup;*11dup]", "NM_TEST.1:c.[*11dup;*10dup]"] {
+        let output = normalize(input, STRUCTURED_CORE, STRUCTURED_CDS);
+        assert_eq!(
+            output, "NM_TEST.1:c.*11_*12insAA",
+            "`{input}`: the known #1343 gap"
+        );
+        // The half that is not in doubt: the string is readable, and the base it
+        // names past the end is the *anchor*, not a base it claims to edit.
+        assert!(
+            parse_hgvs(&output).is_ok(),
+            "`{output}` must at least re-parse"
+        );
+    }
+}
+
+/// The terminal shape that the repair does get right, and which is why refusing
+/// the one above is not an option.
+///
+/// `*10` and `*11` are both `A`, so deleting the first and duplicating the
+/// second cancel exactly. On `origin/main` this settled as the unparseable
+/// `c.[*11del;*11dup]` — one of the 120 — and it is now a single identity member.
+#[test]
+fn a_cancelling_collision_on_the_final_transcript_base_is_repaired() {
+    for input in ["NM_TEST.1:c.[*10del;*11dup]", "NM_TEST.1:r.[*10del;*11dup]"] {
+        let output = assert_reparses(input, STRUCTURED_CORE, STRUCTURED_CDS);
+        let axis = if input.contains(":c.") { "c" } else { "r" };
+        assert_eq!(
+            output,
+            format!("NM_TEST.1:{axis}.*11="),
+            "`{input}` must collapse to one identity member"
+        );
+    }
+}
+
+/// Shapes that already worked must not move. The CDS body is resolved by the
+/// sequence-first canonicalization rather than by this repair, and a
+/// non-colliding UTR pair has nothing to repair — both are regressions if they
+/// change.
+#[test]
+fn already_correct_shapes_are_unchanged() {
+    for (input, expected) in [
+        // Non-colliding 5'UTR pair: distinct positions, no shuffle onto each other.
+        ("NM_TEST.1:c.[-6del;-5dup]", "NM_TEST.1:c.[-6del;-5dup]"),
+        ("NM_TEST.1:c.[-2del;-1dup]", "NM_TEST.1:c.[-2del;-1dup]"),
+    ] {
+        assert_eq!(
+            normalize(input, STRUCTURED_CORE, STRUCTURED_CDS),
+            expected,
+            "`{input}` must be left alone"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -169,6 +169,7 @@ mod issue_1264_reparse_asymmetry;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
 mod issue_1284_transcript_axis_collision;
+mod issue_1284_transcript_axis_reparse;
 mod issue_1286_shared_junction_merge;
 mod issue_1287_repeat_span_junction;
 mod issue_1290_junction_crosses_junction;


### PR DESCRIPTION
Closes #1284.

## What was wrong

`respell_colliding_duplications` and the two sibling repairs behind the same gate read the duplicated bases *over each member's own coordinates*. That is sound only where the axis is a direct offset into the sequence the provider serves — `g.`, `m.`, and since #1315 `n.`. `c.` and `r.` are CDS-relative, so they were refused, and a del+dup pair that 3'-shifted onto one position stayed collided:

```
NM_TEST.1:c.[-8del;-6dup]  ->  NM_TEST.1:c.[-1del;-1dup]
parse_hgvs(out) -> Err: Self-cancelling allele … overlapping reference positions
```

Because `FERRO_ASSERT_REPARSE` is armed in `ci.yml` and `nightly-mutalyzer.yml`, that is an **abort, not a diff** — which is what blocked #1283's transcript-axis sweep (its gap 5).

## The conversion

Key the offset on the member's **`Region`**, not on the axis kind.

The single `cds_start - 1` the issue records as tried-and-reverted is right at `c.1` and off by one below it, because the CDS axis has no zero. Patching that with a sign test still leaves the 3'UTR — a third offset, `cds_end` — wrong. Per region, each of `FivePrimeUtr` / `Cds` / `ThreePrimeUtr` is individually affine onto the transcript, so the discontinuity **disappears rather than being patched across**, and every pass already groups its members within one region.

| region | axis → transcript | delta |
|---|---|---|
| `Genome`, `Tx` | the axis is the sequence | `0` |
| `Cds`, `Rna` (`c.N`) | `cds_start + N - 1` | `cds_start - 1` |
| `FivePrimeUtr` (`c.-N`) | `cds_start - N` | `cds_start` |
| `ThreePrimeUtr` (`c.*N`) | `cds_end + N` | `cds_end` |

With that in place the axis gate is not widened but **removed from all three passes**: a region the conversion cannot place is skipped, so the conversion is the gate. Per the issue's own appendix, one conversion unblocks all three.

Two things the conversion alone did not cover, both found by measuring rather than reasoning:

- **A junction can land on a region boundary where its span does not.** A duplication resting at `c.-1` lands its copy between `c.-1` and `c.1`, and `-1 + 1` is `c.0`, which does not exist. `respell_at_gap` now resolves both ends through the transcript and names it `c.-1_1`.
- **`respell_at_gap` converted the gap to `u64` up front**, a leftover from when it was genomic-only. On the 5'UTR the axis is negative by definition, so that guard silently refused every repair there before any arm ran. This is why the first cut of the fix moved the outputs but repaired nothing.

## Measured

- **Re-parse census:** on a 3950-case two-member grid over both UTRs and the CDS body, on both axes — **120 outputs failed to re-parse before, 0 after**, every one the same `Self-cancelling` collision. (A first grid whose 5'UTR was one homopolymer put 296 of 3080 in the same single shape.) The CDS body contributed **none** either way: there the sequence-first canonicalization resolves the collision first, which is why the defect was confined to the UTRs.
- **Bucket movement: none.** `status_census_is_unchanged`, `passing_census_is_unchanged` and `divergence_budget_is_unchanged` all hold. Worth saying why rather than reading it as "no effect": the spec corpus has no two-member UTR allele, so it cannot exercise this change — the new tests are what carry it.
- Full suite green with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` (9028 tests), clippy `-D warnings`, `cargo check --features python`, no new proptest seeds.
- All new tests are reference-free (`MockProvider` via `SyntheticBuilder`), so they **do** run on PR CI — this is not manifest-gated coverage.

## Two pinned strings move, deliberately

`issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized` and `issue_1276_dup_junction_overlap::lenient_output_of_a_conflict_is_still_rejected_by_strict` pinned `c.[5_9inv;5_6dup]` — the *un-repaired* transcript-axis form. It is now `c.[5_9inv;6_7insAA]`, which is what the `g.` spelling of the same shape already produced (`g.[261_265inv;262_263insAA]`, measured). So the change **removes an axis divergence rather than creating one**.

Everything those tests actually guard was verified unchanged before re-blessing: strict still rejects the output as `W5002 / OverlapConflictingEdits`, the authored member order still survives, and the result is still idempotent in one pass. The `dup` spellings now *converge* onto the `ins` spelling instead of being a second fixed point — one variant, one canonical string. #1276's other tests author a `dup` directly and are untouched; they are what carry the #1243 dup-detector coverage, and the module header's now-false axis rationale is corrected.

## Found alongside, and deliberately not changed

- **`c.`/`r.` diverge on where a 5' shuffle stops.** `c.-8del` settles at `c.-1`, `r.-8del` at `r.1`, because only `normalize_cds` intersects the shuffle window with the CDS↔UTR axis bound. That is explicit (#334, on the grounds that `r.` natively spans the sub-axes, with a named pinned test), and it is about where the shuffle stops, not about the repair passes' coordinate conversion. Characterized by a new test so it is recorded rather than rediscovered. It also made one of my own `r.` assertions vacuous — on the issue's transcript the `r.` members shuffle out of the UTR entirely — so those cases now run on a transcript where they genuinely stay in the 5'UTR.
- **An inverted-CDS record (`cds_end < cds_start`) has an incoherent `c.` axis**, its UTR halves overlapping so one transcript position has two names. The new conversion declines rather than picking a spelling. This does **not** fix the ambiguity, which is reachable on `origin/main` without this change (`c.[*1del;*2dup]` comes back as `c.[-10del;-9dup]` there too, both naming transcript position 14).
- **The UTRs stay outside the sequence-first canonicalization.** That pass produces the better answer where it runs — the genomic analogue reduces to an identity — but it restricts itself to the positive body region, which is #920's deliberate scope, not #1284's. Widening it would move every UTR allele's canonical form and is a different change.

## Module doc corrected

`merge.rs` asserted that ranges spanning the UTR↔CDS boundary "do not exist as valid range syntax". They do: the spec writes `NM_001849.3:c.-1_*1=` (`consultation/SVD-WG001.md:37`) and `NM_004006.2:c.-244_*2691del` (`consultation/open-issues.md:53`), and ferro's parser accepts both. The pass's refusal to *merge* across regions is a property of its region-local arithmetic, which is what the comment now says.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HGVS normalization for ranges crossing CDS and UTR boundaries.
  * Enhanced transcript, RNA, CDS, and genomic coordinate handling for repeat, duplication, inversion, and gap repairs.
  * Corrected collision repairs so affected duplications are represented as insertions when appropriate.
  * Improved junction and boundary handling while preserving valid empty-insertion behavior.

* **Tests**
  * Added comprehensive coverage for transcript-axis normalization, reparsing, strand orientation, cross-region ranges, boundary cases, idempotency, and strict-mode validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 2

Fourteen findings across the two review lenses; thirteen applied, one rejected. The two that changed production behaviour are called out first.

### Guard parity in `region_sequence_delta` — the inverted-bounds refusal was only a third of a refusal

`ThreePrimeUtr` went through `ordered_cds_bounds` and declined on a record with `cds_end < cds_start`. `Cds`, `Rna` and `FivePrimeUtr` read `cds_start` alone and silently picked a spelling — so `inverted_cds_bounds_are_refused_not_guessed` was asserting a refusal that only one of the four regions actually made. All four now refuse.

Two details worth stating, because the obvious fix is wrong in both directions:

- Routing every region through `ordered_cds_bounds` would also demand that `cds_end` be *present*. A record carrying `cds_start` and no `cds_end` has an unknown 3'UTR but a perfectly well-defined `c.N` body, so the guard is written as "refuse if inverted", not "require both bounds".
- `Rna`'s fallback to a transcript-relative delta of `0` when there is no CDS is correct for a non-coding transcript, but `map_or(0, …)` on its own turns the inverted-bounds `None` into a silent delta of `0` — the exact guess the guard exists to prevent. Absent bounds now fall back; inverted bounds refuse. Pinned on the `r.` axis alongside the `c.` one.

`signed_cds_bound` lost its last caller and is removed.

### A collision on the final transcript base still names a position past the end

`c.[*10dup;*11dup]` 3'-shifts both members onto `*11`, the last base, and the repair anchors an insertion at the junction 3' of it — whose right endpoint is `*12`. `cds_axis_position` has a floor (`tx < 1`) and no ceiling, so it answers `ThreePrimeUtr(12)` instead of refusing, and the result renders as `c.*11_*12insAA`.

**Measured rather than argued.** Over this file's census:

| | outputs `parse_hgvs` rejects | positions past the transcript end |
|---|---|---|
| `origin/main` | 120 | 0 |
| this PR | 0 | 2 |

On `main` the same input came back as `c.[*11dup;*11dup]` — two members claiming one reference position, the #1234 overlap class — so both forms are defective. This change removes 120 unreadable outputs and converts one narrow defect into another narrow one on 2 inputs, both of which stay readable.

**Refusing is not available, and this was tested rather than assumed.** A bound on the right endpoint also refuses the *cancelling* terminal shape `c.[*10del;*11dup]`, which needs the repair: it returns to the unparseable `c.[*11del;*11dup]` (4 cases). `FERRO_ASSERT_REPARSE` is armed in `ci.yml` and `nightly-mutalyzer.yml`, so that aborts the run rather than failing a comparison — trading 2 readable-but-wrongly-anchored outputs for 4 that kill CI is not an improvement. An `NaEdit::Identity` exemption does not separate them either: both arrive at `respell_at_gap` as insertions, and the cancellation happens downstream.

The real fix is to spell a terminus-anchored insertion as the duplication it is (`c.*10_*11dup` is sequence-identical and needs no `*12`). That changes what `respell_at_gap` may emit rather than this axis conversion, so it is filed as **#1343** and pinned here by `a_collision_on_the_final_transcript_base_still_names_a_position_past_the_end`, with `a_cancelling_collision_on_the_final_transcript_base_is_repaired` as its counterweight — so the shape stays measured instead of excluded.

### Checked arithmetic at all three conversion sites

Three `i64` adds mixing a parsed position with a CDS-bound-derived `delta` were unchecked, while their siblings used `checked_add`. All three now decline instead of panicking in a debug build. Separately, `unsigned_gap` accepted a zero endpoint — `u64::try_from(0)` succeeds — so a junction at 0 would have named `g.0_1` / `m.0_1`; it now refuses, matching the `Tx` arm's refusal of `n.0`.

### Test strengthening

- **Idempotency is asserted, not delegated.** The census re-normalizes every output and compares byte-for-byte. Previously that signal existed only under `FERRO_ASSERT_IDEMPOTENT`, which only CI arms — a local `cargo nextest run --features dev` got none of it from the whole grid. An `Err` on the second pass is recorded as a failure rather than skipped: the first pass succeeded and its output re-parsed, so a re-normalization that now refuses is itself the defect.
- **Cross-region pairs.** The grid drew both coordinates from one region, leaving the whole cross-region class (`c.[-8del;1dup]` — the pairs whose two members take *different* `region_sequence_delta` values) outside a census that read as exhaustive. Now 12,110 cases, up from 3,950. Baseline is unchanged at 120 failures, so cross-region pairs contribute none — the expected answer, since a collision needs both members on one position, and that is now stated by the test rather than assumed.
- **Population floor raised** from `> 1000` to `> 11_000`, close to the measured 12,110. At the old floor nine tenths of the grid could have started erroring out of `normalize` before the test noticed, and the `continue` on `Err` made that silent.
- **The `g.`-axis parity is executable.** `issue_1235_transcript_axes.rs` justified its new `c.[5_9inv;6_7insAA]` pin by stating that the `g.` spelling of the same shape already settles as `g.[261_265inv;262_263insAA]`, "measured" — the independent path, since the repair was genomic-only before this change — but nothing asserted it. It now does, plus an explicit member-for-member cross-axis comparison, so the divergence this PR removes is pinned rather than described. (The genomic contig for `SyntheticBuilder::cds` is `chr_synth`/`TX_CONTIG`, not `GENOMIC_CONTIG`; under the wrong accession the description passes through unnormalized and the assertion would have been vacuous.)
- A failure message that described a decline while its assertion pinned a settled two-member form was corrected.

### Rejected

**"Use `CoordinateMapper`'s exon-aware mapping in `cds_axis_position` for gapped transcripts."** False positive. `cds_axis_position` maps a CDS-axis position to a **transcript** position, and exon structure does not appear in transcript coordinates — introns are exactly what the transcript sequence omits. `cds_start`/`cds_end` are themselves transcript coordinates, and the provider serves transcript bases for an `NM_`, so `cds_start + N - 1` is exact. Exon awareness is needed for c.→**genomic**, which this conversion is not. The repair also sets `offset = None` and never handles intronic members.

### Movement relative to the reference oracles

**Toward, and confined to a shape the oracles do not reach.** Every input that changes is a multi-member cis allele whose members collide after shifting — the mutalyzer / biocommons / hgvs-rs corpora carry no such input, which is why 120 unreadable outputs went unnoticed. For every single-member description, and every allele whose members do not collide, output is byte-identical: `already_correct_shapes_are_unchanged` and `the_conversion_is_strand_independent` pin that, and the full suite is green at **9,075 passed, 0 failed** with the spec-normalization and spec-enumeration censuses unchanged (`ferro_produces_the_form_the_spec_states`, `status_census_is_unchanged`, `passing_census_is_unchanged`). The one input class that moves *away* from ideal is the 2 terminal-base cases above, tracked as #1343 — and they replace outputs that were already defective in a different way.
