### PR TITLE
fix(normalize): keep a junction re-spelling inside the sequence

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -520,6 +520,23 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     } else {
         (del_start, w_lo + hi_ref as i64 - 1)
     };
+    // The collapse has its own way of naming a position past the end (#1327):
+    // when the group nets to a pure insertion at the window's 3' edge,
+    // `del_start` is one past the last base, and the insertion-shaped anchor
+    // `(del_start, del_start - 1)` renders as `m.16569_16570=` on rCRS.
+    //
+    // Distinct from the `respell_at_gap` overrun this issue names — a different
+    // pass, reached without it — but the same defect, so it is fixed here too
+    // rather than left for the symptom to survive the fix. Refusing the
+    // collapse is the right answer *here* (unlike in `respell_at_gap`, where it
+    // reintroduced #1286): the members are left as they are, which is in range,
+    // and refusing is this module's convention for a group it cannot place.
+    if let Ok(length) = provider.get_sequence_length(&accession) {
+        let past_end = |p: i64| u64::try_from(p + delta).is_ok_and(|v| v > length);
+        if past_end(a_start) || past_end(a_end) {
+            return variants;
+        }
+    }
     let anchor = Anchor {
         region: body,
         start: a_start,
@@ -3662,7 +3679,14 @@ pub(crate) fn demote_coincident_tract_repeats<P: ReferenceProvider>(
             let edit = NaEdit::Insertion {
                 sequence: InsertedSequence::Literal(Sequence::new(payload.clone())),
             };
-            respell_at_gap(&mut members[i], span, span.end, edit, provider);
+            respell_at_gap(
+                &mut members[i],
+                span,
+                span.end,
+                edit,
+                provider,
+                TerminalRespell::Allowed,
+            );
             members[i] != originals[slot]
         });
         if !rewritten {
@@ -4286,7 +4310,26 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
         };
         // The copy lands at the junction 3' of the duplicated span, which is
         // the gap `[end, end + 1]`.
-        respell_at_gap(&mut members[i], dup, dup.end, edit, provider);
+        //
+        // The terminal boundary re-spelling (#1327) is refused when a
+        // base-claiming sibling already occupies the base that gap runs past
+        // (#1344). Re-spelling turns this member into a `delins` on that base,
+        // so the pair goes from an adjacency the collapse pass merges to an
+        // overlap it cannot; the zero-width junction form is what lets the
+        // cancellation happen. The out-of-range coordinate is transient there —
+        // the merge consumes it before anything is rendered.
+        // `dup.end`, not `dup.end + 1`: the boundary identity deletes the *last*
+        // base and re-inserts it carrying the payload, so the base the re-spelt
+        // member claims is the one at the 5' side of the gap.
+        let sibling_claims_the_landing_base = siblings()
+            .filter(|s| s.claims_bases)
+            .any(|s| s.start <= dup.end && s.end >= dup.end);
+        let terminal = if sibling_claims_the_landing_base {
+            TerminalRespell::Refused
+        } else {
+            TerminalRespell::Allowed
+        };
+        respell_at_gap(&mut members[i], dup, dup.end, edit, provider, terminal);
     }
 }
 
@@ -4449,7 +4492,14 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
             continue;
         };
         let before = members[target].clone();
-        respell_at_gap(&mut members[target], span, junction, edit, provider);
+        respell_at_gap(
+            &mut members[target],
+            span,
+            junction,
+            edit,
+            provider,
+            TerminalRespell::Allowed,
+        );
         if members[target] == before {
             continue; // the re-spell did not take; leave the group alone
         }
@@ -4588,7 +4638,14 @@ fn translate_junction_member<P: ReferenceProvider>(
         sequence: InsertedSequence::Literal(Sequence::new(moved)),
     };
     let translated = variant.clone();
-    respell_at_gap(variant, from, destination, edit, provider);
+    respell_at_gap(
+        variant,
+        from,
+        destination,
+        edit,
+        provider,
+        TerminalRespell::Allowed,
+    );
     if *variant == translated {
         *variant = original;
     }
@@ -4746,6 +4803,181 @@ fn junction_payload<P: ReferenceProvider>(
 /// *gap*: an interbase point on the CDS start is legitimately named `c.-1_1`,
 /// and reading it back through `member_span` would report `None` and force a
 /// correct repair to revert. Used only by [`respell_at_gap`].
+/// Re-spell a member whose landing junction is one past the sequence end as the
+/// equivalent boundary `delins` on the last base (#1327).
+///
+/// `edit` must be the literal `Insertion` the repair passes build; anything else
+/// has no payload to fold into the `delins` and is left alone. Reverts unless
+/// the rewritten member reads back as a single position at the last base — the
+/// same all-or-nothing discipline [`respell_at_gap`] applies to its own writes.
+fn respell_at_sequence_end<P: ReferenceProvider>(
+    variant: &mut HgvsVariant,
+    span: &MemberSpan,
+    edit: &NaEdit,
+    delta: i64,
+    length: u64,
+    provider: &P,
+) {
+    let NaEdit::Insertion {
+        sequence: InsertedSequence::Literal(payload),
+    } = edit
+    else {
+        return;
+    };
+    // The last base, read as the one-byte slice `insertion_to_boundary_delins`
+    // anchors at position 1.
+    let Ok(last) = provider.get_sequence(&span.provider_key, length.saturating_sub(1), length)
+    else {
+        return;
+    };
+    let Some(delins) = crate::normalize::insertion_to_boundary_delins(
+        last.as_bytes(),
+        payload,
+        1,
+        crate::normalize::BoundarySide::ThreePrime,
+    ) else {
+        return;
+    };
+    // Back onto the member's own axis: the last base is `length - delta` there.
+    // `raw_length` keeps the unsigned form for the CDS-relative conversion below.
+    let raw_length = length;
+    let Ok(length) = i64::try_from(length) else {
+        return;
+    };
+    let axis = length - delta;
+    let original = variant.clone();
+    let placed = match variant {
+        HgvsVariant::Genome(g) => {
+            u64::try_from(axis).is_ok_and(|v| {
+                set_endpoints(
+                    &mut g.loc_edit.location,
+                    |p: &mut GenomePos, v: u64| p.base = v,
+                    v,
+                    v,
+                )
+            }) && {
+                g.loc_edit.edit = Mu::Certain(delins.clone());
+                true
+            }
+        }
+        HgvsVariant::Mt(m) => {
+            u64::try_from(axis).is_ok_and(|v| {
+                set_endpoints(
+                    &mut m.loc_edit.location,
+                    |p: &mut GenomePos, v: u64| p.base = v,
+                    v,
+                    v,
+                )
+            }) && {
+                m.loc_edit.edit = Mu::Certain(delins.clone());
+                true
+            }
+        }
+        // The transcript axes reach this too, and must be handled rather than
+        // refused. `c.*11` on a 35-base transcript *is* the last base, so a
+        // duplication resting there lands its copy past the end exactly as the
+        // mitochondrial case does — and refusing left #1284's collision
+        // unrepaired and the output unparseable, which the re-parse oracle
+        // caught immediately. (An earlier draft of this arm asserted no such
+        // case had been measured; the suite falsified that.)
+        HgvsVariant::Tx(t) => {
+            axis != 0
+                && set_endpoints(
+                    &mut t.loc_edit.location,
+                    |p: &mut TxPos, v: i64| p.base = v,
+                    axis,
+                    axis,
+                )
+                && {
+                    t.loc_edit.edit = Mu::Certain(delins.clone());
+                    true
+                }
+        }
+        HgvsVariant::Cds(c) => {
+            let Some((region, axis)) = cds_axis_end(span, provider, raw_length, Region::Cds) else {
+                return;
+            };
+            let utr3 = region == Region::ThreePrimeUtr;
+            axis != 0
+                && set_endpoints(
+                    &mut c.loc_edit.location,
+                    |p: &mut CdsPos, v: i64| {
+                        p.base = v;
+                        p.utr3 = utr3;
+                        p.offset = None;
+                    },
+                    axis,
+                    axis,
+                )
+                && {
+                    c.loc_edit.edit = Mu::Certain(delins.clone());
+                    true
+                }
+        }
+        HgvsVariant::Rna(r) => {
+            let Some((region, axis)) = cds_axis_end(span, provider, raw_length, Region::Rna) else {
+                return;
+            };
+            let utr3 = region == Region::ThreePrimeUtr;
+            axis != 0
+                && set_endpoints(
+                    &mut r.loc_edit.location,
+                    |p: &mut RnaPos, v: i64| {
+                        p.base = v;
+                        p.utr3 = utr3;
+                        p.offset = None;
+                    },
+                    axis,
+                    axis,
+                )
+                && {
+                    r.loc_edit.edit = Mu::Certain(delins.clone());
+                    true
+                }
+        }
+        _ => false,
+    };
+    // Compare against the region the arm actually wrote, not against
+    // `span.region`. For `c.`/`r.` those differ exactly when the last base lies
+    // outside the member's own region — which is the case this guard exists for,
+    // so keying the check on `span.region` would make it vacuously true for the
+    // one input it has to judge.
+    let written = match variant {
+        HgvsVariant::Cds(_) => cds_axis_end(span, provider, raw_length, Region::Cds),
+        HgvsVariant::Rna(_) => cds_axis_end(span, provider, raw_length, Region::Rna),
+        _ => Some((span.region, axis)),
+    };
+    let landed = placed && written.is_some_and(|w| member_endpoints(variant) == Some((w, w)));
+    if !landed {
+        *variant = original;
+    }
+}
+
+/// Which `(region, axis position)` names the sequence's **last base** on a
+/// CDS-relative axis.
+///
+/// `respell_at_sequence_end` otherwise reaches the last base as
+/// `length - delta`, using the *member's own* region delta. That is right only
+/// while the last base lies in the member's region. It does not have to: a
+/// positive coordinate outside the CDS is classified as a body region, so on a
+/// 35-base record with `cds_start = 13`, `cds_end = 24` the last base came out
+/// as `c.23` — which converts back the same way, so `member_endpoints` accepted
+/// it — where the record's own axis calls it `c.*11`. `c.23` names a coding
+/// position in a CDS that has only 12 bases.
+///
+/// Resolving through the transcript instead is what `respell_at_gap`'s
+/// `cds_relative_gap` already does for the junction case; this is the same
+/// conversion for the terminal case.
+fn cds_axis_end<P: ReferenceProvider>(
+    span: &MemberSpan,
+    provider: &P,
+    length: u64,
+    body: Region,
+) -> Option<(Region, i64)> {
+    let (cds_start, cds_end) = ordered_cds_bounds(&span.provider_key, provider)?;
+    cds_axis_position(i64::try_from(length).ok()?, cds_start, cds_end, body)
+}
+
 fn member_endpoints(v: &HgvsVariant) -> Option<((Region, i64), (Region, i64))> {
     fn ends<T>(
         interval: &Interval<T>,
@@ -4789,12 +5021,24 @@ fn member_endpoints(v: &HgvsVariant) -> Option<((Region, i64), (Region, i64))> {
 /// The verification is [`member_endpoints`] rather than [`member_span`] for
 /// that reason: the correct answer here is a range whose ends sit in two
 /// regions, and `member_span` refuses those by construction.
+/// Whether [`respell_at_gap`] may apply the terminal boundary re-spelling
+/// (#1327) when the gap runs one past the last base.
+///
+/// `Refused` when a sibling already claims that base: see the comment at the
+/// gate for why the two spellings are not interchangeable there (#1344).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TerminalRespell {
+    Allowed,
+    Refused,
+}
+
 fn respell_at_gap<P: ReferenceProvider>(
     variant: &mut HgvsVariant,
     span: &MemberSpan,
     junction: i64,
     edit: NaEdit,
     provider: &P,
+    terminal_respell: TerminalRespell,
 ) {
     let original = variant.clone();
     let (gap_start, gap_end) = (junction, junction + 1);
@@ -4812,6 +5056,73 @@ fn respell_at_gap<P: ReferenceProvider>(
             cds_axis_position(right, cds_start, cds_end, body)?,
         ))
     };
+
+    // The gap's 3' end must name a base the sequence actually has (#1327).
+    //
+    // Nothing else checks it. `landed` below only confirms the member reads
+    // back at the gap it was *told* to use, which an out-of-range gap does; and
+    // `parse_hgvs` does not know the sequence's length, so `m.16569_16570insAA`
+    // re-parses cleanly and the `FERRO_ASSERT_REPARSE` oracle stays silent. A
+    // member that 3'-shifts onto the final base is exactly how the repair
+    // reaches this: its landing junction is one past the end.
+    //
+    // The wrapped spelling is not available. SVD-WG006 authorises the reversed
+    // `<high>_<low>` range for **deletions and duplications only** (line 33,
+    // examples `NC_012920.1:m.16563_13del` and `J01749.1:o.4344_197dup`);
+    // `insertion.md` is silent, so the general 5'→3' rule stands and ferro's
+    // parser rejects `m.16569_1insA` (#129). Every re-spelling here produces an
+    // insertion, so there is no legal wrapped form to emit.
+    //
+    // **Declining is not good enough either**, which measurement is what
+    // showed: refusing here left `coalesce_members_at_one_junction`'s two
+    // members unmerged, and they had each already been canonicalised to
+    // `m.16569dup` — an allele claiming one position twice, which is the very
+    // #1286 defect that pass exists to remove, and which re-parses so no oracle
+    // sees it. Refusing traded an out-of-range spelling for an overlapping one.
+    //
+    // So re-spell at the boundary instead, via the identity every other clamp
+    // in this crate already uses: inserting `A'` immediately 3' of the last
+    // base *is* deleting that base and inserting `ref[last] ++ A'`
+    // (`insertion_to_boundary_delins`, shared with #1170 / #387 / #1202 /
+    // #1205 / #1217). That is in range, valid on a circular or linear
+    // reference alike, and denotes exactly what the out-of-range insertion did.
+    //
+    // Only acts when the overrun is *known*: a provider that cannot report a
+    // length leaves the check unevaluated rather than rewriting a repair it
+    // cannot judge.
+    //
+    // The trigger is the last base *exactly* (`junction + delta == length`), not
+    // "at or past it". A junction genuinely beyond the end is a different case:
+    // re-spelling it at the last base would silently relocate an edit the author
+    // placed elsewhere, which is a worse answer than declining. Only the
+    // one-past-the-end overrun has a boundary identity that denotes the same
+    // bases.
+    //
+    // Skipped entirely when a sibling already claims the last base (#1344). The
+    // boundary identity trades a zero-width junction insertion for a `delins`
+    // that *claims* that base, and those two are not interchangeable when
+    // something else is already there: an insertion flush against a sibling's
+    // deleted base is the #999 adjacency the collapse pass merges, while two
+    // members claiming one base is an overlap it cannot. Re-spelling therefore
+    // converted a mergeable pair into an unmergeable one, and the out-of-range
+    // coordinate it was avoiding never reached the output in that case anyway —
+    // the merge consumed it. Measured: `c.[*10del;*11dup]` gave
+    // `c.[*11del;*11delinsAA]`, which ferro's own strict mode rejects as
+    // `OverlapConflictingEdits / W5002`, where the junction form settles on the
+    // correct `c.*11=`.
+    if terminal_respell == TerminalRespell::Allowed {
+        if let Some(delta) = region_sequence_delta(span.region, &span.provider_key, provider) {
+            let Some(last) = junction.checked_add(delta) else {
+                return;
+            };
+            if let Ok(length) = provider.get_sequence_length(&span.provider_key) {
+                if u64::try_from(last) == Ok(length) {
+                    respell_at_sequence_end(variant, span, &edit, delta, length, provider);
+                    return;
+                }
+            }
+        }
+    }
 
     // The unsigned genomic pair, `None` on a negative axis. Computed per-arm
     // rather than as an early return for the whole function: hoisting it was
@@ -4972,6 +5283,55 @@ mod tests {
             NaEdit::Insertion { .. } => {}
             other => panic!("expected NaEdit::Insertion, got {other:?}"),
         }
+    }
+
+    /// The terminal base of a CDS-relative record is named by the record's own
+    /// axis, not by the member's region delta.
+    ///
+    /// `respell_at_sequence_end` used to reach the last base as
+    /// `length - delta`, taking `delta` from the *member's* region. On a 35-base
+    /// record with `cds_start = 13`, `cds_end = 24` a member classified as CDS
+    /// body has `delta = cds_start - 1 = 12`, so the last base came out as
+    /// `c.23` — and `member_endpoints` converts `c.23` back the same way, so the
+    /// self-consistency check accepted it. `c.23` names a coding position in a
+    /// CDS that has only 12 bases; the record's own axis calls transcript 35
+    /// `c.*11`.
+    ///
+    /// Asserted on the conversion rather than end-to-end, deliberately: no
+    /// *reachable* input distinguishes the two today, because positive
+    /// out-of-CDS coordinates are re-spelled to `*N` upstream (`c.23dup`
+    /// normalizes to `c.*11dup`), so `span.region` is already `ThreePrimeUtr`
+    /// by the time the helper runs. Every candidate input was measured
+    /// byte-identical with and without the fix. The guard is kept as hardening —
+    /// it matches what `respell_at_gap`'s `cds_relative_gap` already does for
+    /// the junction case — and pinned here rather than dressed up as an
+    /// end-to-end regression it is not.
+    #[test]
+    fn the_terminal_base_is_named_by_the_records_own_axis() {
+        // Transcript 35 on a record whose CDS is transcript 13..24.
+        assert_eq!(
+            cds_axis_position(35, 13, 24, Region::Cds),
+            Some((Region::ThreePrimeUtr, 11)),
+            "transcript 35 is `c.*11`, not the `c.23` that `length - delta` gave"
+        );
+        // The `r.` axis names the body differently and the UTRs identically.
+        assert_eq!(
+            cds_axis_position(35, 13, 24, Region::Rna),
+            Some((Region::ThreePrimeUtr, 11))
+        );
+        // Inside the CDS the two agree, which is why the defect only showed at
+        // the ends: transcript 20 is `c.8`, and `20 - 12` is also 8.
+        assert_eq!(
+            cds_axis_position(20, 13, 24, Region::Cds),
+            Some((Region::Cds, 8))
+        );
+        // And the 5' side, where the axis has no zero.
+        assert_eq!(
+            cds_axis_position(12, 13, 24, Region::Cds),
+            Some((Region::FivePrimeUtr, -1))
+        );
+        // No transcript position 0 or below.
+        assert_eq!(cds_axis_position(0, 13, 24, Region::Cds), None);
     }
 
     #[test]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -545,7 +545,7 @@ impl CodonGate {
 
 /// Which side of `anchor` a shuffled insertion payload came to rest on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BoundarySide {
+pub(crate) enum BoundarySide {
     /// Payload rests immediately 5' of `anchor` (`…ins` before `ref[anchor]`).
     FivePrime,
     /// Payload rests immediately 3' of `anchor` (`…ins` after `ref[anchor]`).
@@ -576,7 +576,7 @@ enum BoundarySide {
 ///
 /// Returns `None` — leaving the caller's values untouched — when `anchor` lies
 /// outside `seq` or the reference byte there is not a base we can spell.
-fn insertion_to_boundary_delins(
+pub(crate) fn insertion_to_boundary_delins(
     seq: &[u8],
     a_prime: &Sequence,
     anchor: u64,

--- a/tests/it/issue_1284_transcript_axis_reparse.rs
+++ b/tests/it/issue_1284_transcript_axis_reparse.rs
@@ -400,64 +400,66 @@ fn inverted_cds_bounds_are_refused_not_guessed() {
     );
 }
 
-/// The one shape this repair still names wrongly: a collision that settles on
-/// the **final transcript base**.
+/// A collision that settles on the **final transcript base** is spelled in
+/// range — the #1343 gap, closed by #1327's terminal re-spelling.
 ///
-/// `c.[*10dup;*11dup]` 3'-shifts both members onto `*11` — the last base of this
-/// transcript — and the repair respells one of them as an insertion at the
-/// junction 3' of it. That junction's right endpoint is `*12`, which the record
-/// does not have. `cds_axis_position` has a floor (`tx < 1`) but no ceiling, so
-/// it answers `ThreePrimeUtr(12)` rather than refusing, and the result renders
-/// as `c.*11_*12insAA`.
+/// `c.[*10dup;*11dup]` 3'-shifts both members onto `*11`, the last base of this
+/// transcript. Anchoring the repair's insertion at the junction 3' of it would
+/// need `*12`, which the record does not have: `cds_axis_position` has a floor
+/// (`tx < 1`) and no ceiling, so it answered `ThreePrimeUtr(12)` rather than
+/// refusing, and the result rendered as `c.*11_*12insAA` — readable, so
+/// `FERRO_ASSERT_REPARSE` could not see it, and wrong.
 ///
-/// The denoted sequence is right and the string re-parses — `parse_hgvs` has no
-/// provider and so cannot bound a 3'UTR position — which is exactly why
-/// `FERRO_ASSERT_REPARSE` does not catch it and why it is pinned by hand here
-/// instead of left to the census below.
+/// `respell_at_sequence_end` now spells the terminal case as the duplication it
+/// is, which needs no position past the end. Three answers for one input, in
+/// order:
 ///
-/// **This is not a regression.** On `origin/main` the same input came back as
-/// `c.[*11dup;*11dup]`: two members claiming one reference position, which is
-/// the #1234 overlapping-members class. Measured over this file's 12,110-case
-/// grid, `main` produced **120** outputs `parse_hgvs` rejects and **0**
-/// out-of-range positions; this change produces **0** and **2**. So the repair
-/// removes 120 unreadable outputs and converts one narrow defect into another
-/// narrow one, on 2 inputs, both of which stay readable.
-///
-/// Refusing the respell instead is not available: it returns those 4 terminal
-/// del+dup cases (`c.[*10del;*11dup]`) to the unparseable `c.[*11del;*11dup]`,
-/// and `FERRO_ASSERT_REPARSE` is armed in CI, so an unparseable output aborts
-/// the run rather than failing a comparison.
-///
-/// The real fix is to spell a terminus-anchored insertion as the duplication it
-/// is (`c.*10_*11dup`, which is sequence-identical and needs no `*12`). That is
-/// a change to what `respell_at_gap` may emit rather than to this conversion, so
-/// it is tracked as #1343 rather than widened into this PR. Pinned here so it
-/// stays measured: if the count moves, one of the two is wrong.
+/// ```text
+/// origin/main   c.[*11dup;*11dup]   two members on one position (#1234 class)
+/// #1284 alone   c.*11_*12insAA      names a base the transcript does not have
+/// with #1327    c.*10_*11A[4]       in range, one member, same bases
+/// ```
 #[test]
-fn a_collision_on_the_final_transcript_base_still_names_a_position_past_the_end() {
+fn a_collision_on_the_final_transcript_base_is_spelled_in_range() {
     // 3'UTR is `*1..*11` (transcript 25..35 of a 35-base record), so `*12` is
-    // one past the end.
+    // one past the end and must not appear.
     for input in ["NM_TEST.1:c.[*10dup;*11dup]", "NM_TEST.1:c.[*11dup;*10dup]"] {
         let output = normalize(input, STRUCTURED_CORE, STRUCTURED_CDS);
         assert_eq!(
-            output, "NM_TEST.1:c.*11_*12insAA",
-            "`{input}`: the known #1343 gap"
+            output, "NM_TEST.1:c.*10_*11A[4]",
+            "`{input}` must be spelled without a position past the transcript end"
         );
-        // The half that is not in doubt: the string is readable, and the base it
-        // names past the end is the *anchor*, not a base it claims to edit.
         assert!(
-            parse_hgvs(&output).is_ok(),
-            "`{output}` must at least re-parse"
+            !output.contains("*12"),
+            "`{input}` -> `{output}` names a position past the transcript end"
         );
+        assert!(parse_hgvs(&output).is_ok(), "`{output}` must re-parse");
     }
 }
 
-/// The terminal shape that the repair does get right, and which is why refusing
-/// the one above is not an option.
+/// The other terminal shape: a collision at the last base whose two members
+/// **cancel**.
 ///
-/// `*10` and `*11` are both `A`, so deleting the first and duplicating the
-/// second cancel exactly. On `origin/main` this settled as the unparseable
-/// `c.[*11del;*11dup]` — one of the 120 — and it is now a single identity member.
+/// `*10` and `*11` are both `A`, so deleting the first and duplicating the second
+/// cancel exactly and the allele denotes the reference. On `origin/main` this
+/// settled as the unparseable `c.[*11del;*11dup]` — one of the 120 — and #1284
+/// resolves it to the single identity member asserted here.
+///
+/// **This is the guard that caught #1344.** The terminal re-spelling #1327 adds
+/// is right for the `dup`+`dup` case above, but applied here it turned the
+/// cancellation into `c.[*11del;*11delinsAA]` — two coincident edits on one
+/// position, which ferro's own strict mode rejects (`OverlapConflictingEdits /
+/// W5002`) and which was a stable fixed point, so a permanent answer rather than
+/// a transient one.
+///
+/// The cause was that the boundary identity trades a zero-width junction
+/// insertion for a `delins` that *claims* the last base, and those are not
+/// interchangeable when a sibling already claims it: an insertion flush against
+/// a deleted base is the #999 adjacency the collapse pass merges, two members on
+/// one base is an overlap it cannot. `respell_colliding_duplications` now refuses
+/// the re-spelling in that case, which leaves the junction form for the merge to
+/// consume — so the out-of-range coordinate #1327 was avoiding still never
+/// reaches the output.
 #[test]
 fn a_cancelling_collision_on_the_final_transcript_base_is_repaired() {
     for input in ["NM_TEST.1:c.[*10del;*11dup]", "NM_TEST.1:r.[*10del;*11dup]"] {

--- a/tests/it/issue_1327_mt_respell_past_contig_end.rs
+++ b/tests/it/issue_1327_mt_respell_past_contig_end.rs
@@ -1,0 +1,264 @@
+//! Issue #1327 — a junction re-spelling could place an edit one base past the
+//! end of a circular mitochondrial contig.
+//!
+//! `respell_at_gap` writes its member over the gap `[junction, junction + 1]`.
+//! When a member 3'-shifts to rest on the contig's final base that gap is
+//! `[16569, 16570]` on rCRS, and 16570 does not exist. Both callers admit
+//! `CisKind::Mt`, and both were reachable:
+//!
+//! ```text
+//! NC_012920.1:m.[16566del;16567dup]            -> m.16569_16570=
+//! NC_012920.1:m.[16566_16567insA;16567_16568insA] -> m.16569_16570insAA
+//! ```
+//!
+//! ## Why the existing guards do not catch it
+//!
+//! `respell_at_gap`'s `landed` check only confirms the member reads back at the
+//! gap it was *told* to use, which an out-of-range gap does. And
+//! `FERRO_ASSERT_REPARSE` is blind here: `parse_hgvs` does not know the
+//! contig's length, so `m.16569_16570insAA` re-parses cleanly. The defect is
+//! therefore silent in both oracles, which is why it needs its own assertions.
+//!
+//! ## What the repair emits instead, and why not the other two options
+//!
+//! **Not the wrapped form.** The obvious circular answer — spell the gap
+//! `m.16569_1` — is not available for an insertion. SVD-WG006 authorises the
+//! reversed `<high>_<low>` range only for deletions and duplications
+//! ("deletions/duplications", line 33, with the `NC_012920.1:m.16563_13del` and
+//! `J01749.1:o.4344_197dup` examples); `insertion.md` is silent, so the general
+//! 5'→3' rule applies and ferro's parser rejects `m.16569_1insA` (#129). Every
+//! re-spelling here produces an insertion, so there is no legal wrapped form.
+//!
+//! **Not a refusal either**, though the issue offers it. Measured: refusing
+//! left `coalesce_members_at_one_junction`'s two members unmerged, and each had
+//! already been canonicalised to `m.16569dup` — an allele claiming one position
+//! twice, which is the #1286 defect that pass exists to remove, and which
+//! re-parses so no oracle sees it. That trades an out-of-range spelling for an
+//! overlapping one.
+//!
+//! **A boundary `delins`.** Inserting `A'` immediately 3' of the last base *is*
+//! deleting that base and inserting `ref[last] ++ A'` — the identity every
+//! other clamp in the crate already uses (`insertion_to_boundary_delins`,
+//! shared with #1170 / #387 / #1202 / #1205 / #1217). In range, valid on a
+//! circular or linear reference alike, and denoting exactly what the
+//! out-of-range insertion denoted.
+//!
+//! A second producer of the same overrun — `collapse_overlapping_cis_edits`
+//! naming `del_start` one past the end when a group nets to a boundary
+//! insertion — is fixed alongside it. There refusing *is* right, because it
+//! leaves the members in the in-range spelling they already had.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+const MT: &str = "NC_012920.1";
+const MT_LENGTH: usize = 16569;
+
+/// An rCRS-length circular contig ending in a 4-base run, so a junction member
+/// can 3'-shift onto the final base.
+fn mt_provider(tail: &str) -> MockProvider {
+    let mut sequence = "ACGT".repeat(4000);
+    sequence.push_str(&"C".repeat(MT_LENGTH - sequence.len() - tail.len()));
+    sequence.push_str(tail);
+    assert_eq!(sequence.len(), MT_LENGTH, "contig must be rCRS length");
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(MT, sequence);
+    provider
+}
+
+fn normalize(input: &str, tail: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    Normalizer::new(mt_provider(tail))
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// Every endpoint the output names must exist on the contig.
+///
+/// Checked by parsing the rendered output and reading its coordinates back,
+/// rather than by string-matching `"16570"`, so an overrun by any amount at any
+/// endpoint is caught.
+///
+/// Deliberately over-approximate: it scans *every* integer after the `:`, so a
+/// repeat count (`A[6]`) or an inserted length is checked as though it were a
+/// position. That is sound for these fixtures — the counts are single digits
+/// against a 16569-base contig — and it fails safe, since the risk is a
+/// spurious failure rather than a missed overrun. If a future case here emits a
+/// count above the contig length, narrow this to the location field rather than
+/// loosening the bound.
+fn assert_within_contig(input: &str, output: &str) {
+    let reparsed = parse_hgvs(output).unwrap_or_else(|e| {
+        panic!("`{input}` normalized to `{output}`, which will not re-parse: {e}")
+    });
+    // `parse_hgvs` does not length-check, so the coordinates have to be read
+    // out of the rendered string; every integer in the position field must be
+    // a real 1-based position on the contig.
+    let positions = output
+        .rsplit_once(':')
+        .map(|(_, rest)| rest)
+        .unwrap_or(output);
+    for run in positions.split(|c: char| !c.is_ascii_digit()) {
+        if run.is_empty() {
+            continue;
+        }
+        let Ok(position) = run.parse::<usize>() else {
+            continue;
+        };
+        assert!(
+            (1..=MT_LENGTH).contains(&position),
+            "`{input}` normalized to `{output}` ({reparsed}), which names position \
+             {position} on a {MT_LENGTH}-base contig"
+        );
+    }
+}
+
+/// The `respell_colliding_duplications` caller: a deletion and a duplication
+/// that both 3'-shift through the terminal run and collide on the last base.
+#[test]
+fn a_collision_repaired_at_the_last_base_stays_on_the_contig() {
+    for input in [
+        "NC_012920.1:m.[16566del;16567dup]",
+        "NC_012920.1:m.[16566del;16568dup]",
+        "NC_012920.1:m.[16567dup;16566del]",
+    ] {
+        let output = normalize(input, "AAAA");
+        assert_within_contig(input, &output);
+        // The pair nets to no change at all, so an identity is the right
+        // answer; what matters is that it is spelled in range. Pinned as well
+        // as bounded, because "stays on the contig" alone would also be
+        // satisfied by silently dropping a member.
+        assert_eq!(
+            output, "NC_012920.1:m.16568=",
+            "`{input}` must settle on an in-range identity"
+        );
+    }
+}
+
+/// The `coalesce_members_at_one_junction` caller (#1289), which places its
+/// merged insertion through the same helper.
+#[test]
+fn a_junction_merge_at_the_last_base_stays_on_the_contig() {
+    for input in [
+        "NC_012920.1:m.[16566_16567insA;16567_16568insA]",
+        "NC_012920.1:m.[16565_16566insA;16566_16567insA]",
+    ] {
+        let output = normalize(input, "AAAA");
+        assert_within_contig(input, &output);
+        // Two `A`s added to the terminal 4-`A` tract. The boundary `delins`
+        // this repair emits is re-canonicalised to the repeat form by the next
+        // pass, which is the spelling the same edit gets anywhere else in the
+        // contig — the terminus is no longer a special case in the output.
+        //
+        // Pinning this specifically guards the regression that declining
+        // caused: refusing left the two members unmerged as
+        // `m.[16569dup;16569dup]`, one position claimed twice (#1286).
+        assert_eq!(
+            output, "NC_012920.1:m.16566_16569A[6]",
+            "`{input}` must merge into one in-range member"
+        );
+        assert!(
+            !output.contains(';'),
+            "`{input}` must not come back as a multi-member allele; got `{output}`"
+        );
+    }
+}
+
+/// The wrapped insertion spelling is not an option, so this pins the reason the
+/// repair declines rather than producing it.
+///
+/// If `m.16569_1insA` ever becomes parseable, this test fails and the decision
+/// above should be revisited — the wrapped form would then be strictly better
+/// than declining.
+#[test]
+fn the_wrapped_insertion_spelling_is_not_valid_hgvs() {
+    assert!(
+        parse_hgvs("NC_012920.1:m.16569_1insA").is_err(),
+        "SVD-WG006 authorises the reversed range for del/dup only; a wrapped \
+         `ins` must stay rejected (#129)"
+    );
+    // The del/dup forms it *does* authorise are still accepted, so the
+    // assertion above is about the edit type and not about wraparound at large.
+    assert!(parse_hgvs("NC_012920.1:m.16569_1del").is_ok());
+    assert!(parse_hgvs("NC_012920.1:m.16569_1dup").is_ok());
+}
+
+/// Declining must not cost the in-range repairs. A collision one base earlier
+/// resolves exactly as it did before.
+#[test]
+fn an_in_range_collision_is_still_repaired() {
+    // Terminal run of `T`s with the members in a `C` run further 5', so the
+    // shuffle settles well inside the contig.
+    let input = "NC_012920.1:m.[16000del;16001dup]";
+    let output = normalize(input, "TTTT");
+    assert_within_contig(input, &output);
+    // Pinned, not merely "parseable". A refusal, a dropped member, or some other
+    // in-range spelling all satisfy a parse check, and every one of those would
+    // be the regression this control exists to catch — the point is that
+    // declining at the contig end costs the in-range repair nothing, which only
+    // a pinned output can state.
+    assert_eq!(
+        output, "NC_012920.1:m.16000T>C",
+        "`{input}` must still collapse to the single substitution it did before"
+    );
+    assert!(
+        parse_hgvs(&output).is_ok(),
+        "an in-range repair must still produce a parseable result"
+    );
+}
+
+/// The same overrun on a **transcript** axis, where the last base is `c.*N`.
+///
+/// Not a mitochondrial special case: any sequence has a last base, and a
+/// duplication resting on it lands its copy past the end whatever the axis is
+/// called. This is here because the first cut of the fix refused instead of
+/// re-spelling, and refusing on this axis left #1284's collision unrepaired and
+/// the output unparseable — the re-parse oracle caught it. Pinned so the
+/// transcript half cannot silently regress to a refusal again.
+#[test]
+fn the_same_overrun_on_a_transcript_axis_is_repaired() {
+    use crate::common::synthetic::SyntheticBuilder;
+    use ferro_hgvs::reference::transcript::Strand;
+
+    // 35 bases, CDS 13..24, so the 3'UTR is `c.*1`..`c.*11` and `c.*11` is the
+    // transcript's final base. The terminal `TTTTAA` gives the members a run to
+    // shuffle through.
+    const CORE: &str = "GCAAAGCGCGCGATGAAACCCTAAGGCATTTTTAA";
+    let input = "NM_TEST.1:c.[*10del;*11dup]";
+    let variant = parse_hgvs(input).expect("input must parse");
+    let output = Normalizer::new(SyntheticBuilder::cds(CORE, 13, 24, Strand::Plus).build())
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string();
+    parse_hgvs(&output).unwrap_or_else(|e| {
+        panic!("`{input}` normalized to `{output}`, which will not re-parse: {e}")
+    });
+    assert!(
+        !output.contains("*12"),
+        "`{input}` normalized to `{output}`, which names a position past the transcript end"
+    );
+    // Pinned, not merely bounded. `*10` and `*11` are both `A`, so deleting the
+    // first and duplicating the second cancel exactly and the allele denotes the
+    // reference — the single identity member #1284 settles on.
+    //
+    // A bounds-and-parseability check is satisfied by a refusal, a dropped
+    // member, or any other in-range spelling, and that is how #1344 hid here: an
+    // earlier cut of this fix re-spelled the member as `c.*11delinsAA`, giving
+    // two coincident edits on `c.*11` — rejected by ferro's own strict mode as
+    // `OverlapConflictingEdits / W5002`, and a stable fixed point, so a permanent
+    // wrong answer that passed both of the weaker checks.
+    assert_eq!(
+        output, "NM_TEST.1:c.*11=",
+        "`{input}` must settle on the identity, not an overlapping pair"
+    );
+}
+
+/// A lone duplication at the final base has no sibling to collide with and must
+/// pass through untouched — the control that shows the guard is scoped to the
+/// repair and is not clamping ordinary terminal edits.
+#[test]
+fn a_lone_terminal_duplication_is_unchanged() {
+    assert_eq!(
+        normalize("NC_012920.1:m.16566dup", "AAAA"),
+        "NC_012920.1:m.16569dup"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -186,6 +186,7 @@ mod issue_1318_soft_masked_delins;
 mod issue_1320_dup_spans_sibling_junction;
 mod issue_1321_identity_inside_a_duplication;
 mod issue_1323_shared_junction_order;
+mod issue_1327_mt_respell_past_contig_end;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_1334_liftover_position_zero;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Closes #1327.

> **Stacked on #1338** (issue #1284), which rewrote `respell_at_gap`. The guard added here sits inside that rewrite, so this PR's base should be #1338's branch — review or merge that first. The diff below is this commit only.

## What was wrong

`respell_at_gap` writes its member over the gap `[junction, junction + 1]`. A member that 3'-shifts onto the sequence's final base therefore lands one past the end — on rCRS that is `m.16569_16570`, and 16570 does not exist.

Neither existing guard sees it:

- `landed` only confirms the member reads back at the gap it was *told* to use, which an out-of-range gap does;
- `parse_hgvs` does not know the sequence's length, so `m.16569_16570insAA` re-parses cleanly and `FERRO_ASSERT_REPARSE` stays silent.

Both callers that admit `CisKind::Mt` were reachable. Measured:

```
m.[16566del;16567dup]               -> m.16569_16570=
m.[16566_16567insA;16567_16568insA] -> m.16569_16570insAA
```

## The fix: a boundary `delins`

Inserting `A'` immediately 3' of the last base **is** deleting that base and inserting `ref[last] ++ A'`. That identity is already the crate's answer to "an insertion saturated at a sequence bound" — `insertion_to_boundary_delins`, shared by #1170, #387, #1202, #1205 and #1217 — so this reuses it (raised to `pub(crate)`) rather than adding a second implementation. It is in range, valid on a circular or linear reference alike, and denotes exactly what the out-of-range insertion denoted.

```
m.[16566del;16567dup]               -> m.16568=
m.[16566_16567insA;16567_16568insA] -> m.16566_16569A[6]
```

The second is the nicest evidence the fix is right: two `A`s added to the terminal 4-`A` tract come back as the ordinary repeat spelling, i.e. the terminus stops being a special case in the output at all.

## Both alternatives were tried and refuted by measurement

- **The wrapped form** `m.16569_1ins` is not valid HGVS. SVD-WG006 authorises the reversed `<high>_<low>` range for deletions and duplications only (line 33; `NC_012920.1:m.16563_13del`, `J01749.1:o.4344_197dup`), and `insertion.md` is silent, so ferro's parser rejects it (#129). Every re-spelling here produces an insertion, so there is no wrapped form available. A test pins this, and will fail if `m.16569_1insA` ever becomes parseable — at which point the decision is worth revisiting.
- **Declining** — which the issue explicitly offers as an option — turned out to be *worse than the bug* for `coalesce_members_at_one_junction`. Refusing left its two members unmerged, and each had already been canonicalised to `m.16569dup`, giving `m.[16569dup;16569dup]`: an allele claiming one position twice. That is the #1286 defect that pass exists to remove, and it re-parses, so no oracle catches it. Refusing traded an out-of-range spelling for an overlapping one.

## Two things beyond the issue's scope, both found by measuring

- **A second producer.** `collapse_overlapping_cis_edits` reaches the same overrun by a different route: when a group nets to a pure insertion at the window's 3' edge, `del_start` is one past the last base and the insertion-shaped anchor renders `m.16569_16570=`. It does not go through `respell_at_gap` at all, so fixing only the function the issue names would have left the issue's own symptom in place. Refusing **is** the right answer there — it leaves the members in the in-range spelling they already had.
- **The transcript axes are not exempt.** `c.*11` on a 35-base transcript *is* the final base, so the same overrun happens there. An earlier draft of this fix refused on those axes, with a comment asserting no such case had been measured. The suite falsified that immediately: refusing left #1284's collision unrepaired and its output unparseable. They are handled now, and pinned by their own test so the transcript half cannot quietly regress to a refusal.

## Verification

Full suite green with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` (9045 tests), `cargo clippy --features dev --all-targets -- -D warnings` clean, `cargo check --features python` clean, no new proptest seeds, and the enumeration / normalization censuses unmoved.

New tests are reference-free (`MockProvider`), so they run on PR CI rather than only in the nightly. Note the two oracles cannot catch this defect class on their own — an out-of-range coordinate re-parses and re-normalizes fine — which is why the assertions read the coordinates back and check them against the sequence length directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved normalization of edits that extend beyond the end of a reference sequence.
  - Prevented generated coordinates from exceeding valid sequence boundaries.
  - Added support for terminal insertion repairs across genomic, mitochondrial, transcript, CDS, and RNA representations.
  - Preserved valid in-range repairs while rejecting unsupported wrapped insertion syntax.

- **Tests**
  - Added coverage for sequence-end handling, including mitochondrial and transcript cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->