### PR TITLE
fix(normalize): answer the del→repeat codon gate on the tract, not the input span

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -9162,6 +9162,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         result.start as usize,
                         result.end as usize,
                         gate.input_span_is_coding(),
+                        // #1270: as on the insertion path above, the verdict is
+                        // the INPUT span's; the bounds let the helper re-ask
+                        // about the tract the repeat would actually occupy.
+                        gate.cds_bounds(),
                     ) {
                         let bases: Option<Vec<Base>> = rep
                             .unit

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -856,11 +856,34 @@ pub(crate) struct DelToRepeatResult {
 /// The bounds check rejects 0-length deletions (`del_start == del_end`).
 /// Callers passing insertion-point-shaped zero-width ranges should use
 /// `extend_tandem_tract` directly instead.
+///
+/// # The codon gate is answered for the tract, not the input (#1270)
+///
+/// A sixth condition applies on the `c.`/`r.` axes and is deliberately not in
+/// the list above, because it is about the *emitted* description rather than the
+/// trigger: `repeated.md` requires `unit_len % 3 == 0` for repeat notation in a
+/// coding context.
+///
+/// `is_coding` is the caller's verdict for the span the *input* deletion
+/// occupied. Where `cds_span` is supplied it takes precedence, and the gate is
+/// re-answered for the tandem tract this function discovers — the span the
+/// emitted repeat actually occupies. The two differ exactly when the tract runs
+/// past `cds_end`, whose 3'UTR part the carve-out exempts. Pass `None`
+/// (genomic, `n.`, or any caller with no CDS context) to keep `is_coding`
+/// verbatim.
+///
+/// This mirrors [`insertion_to_repeat`], which took the same argument for #1185
+/// and #1210; before #1270 only that path re-asked, so a `T` run spanning
+/// `cds_end` gave `c.5_6insTT` -> `c.4_*5T[16]` while the matching `c.5_6del`
+/// gave a plain `c.*4_*5del`. The gate is therefore evaluated *after*
+/// `extend_tandem_tract` rather than before it, since the tract is what it now
+/// asks about.
 pub(crate) fn deletion_to_repeat(
     ref_seq: &[u8],
     del_start: usize,
     del_end: usize,
     is_coding: bool,
+    cds_span: Option<(u64, u64)>,
 ) -> Option<DelToRepeatResult> {
     if del_start >= del_end || del_end > ref_seq.len() {
         return None;
@@ -872,14 +895,38 @@ pub(crate) fn deletion_to_repeat(
         return None;
     }
 
-    // HGVS spec (repeated.md): in c. context, repeat notation requires
-    // unit_len % 3 == 0. Falls back to plain del when the gate blocks.
-    if is_coding && !p.is_multiple_of(3) {
+    let tract = extend_tandem_tract(ref_seq, del_start..del_end, unit_slice)?;
+    if tract.ref_count < 2 {
         return None;
     }
 
-    let tract = extend_tandem_tract(ref_seq, del_start..del_end, unit_slice)?;
-    if tract.ref_count < 2 {
+    // HGVS spec (repeated.md): in c. context, repeat notation requires
+    // unit_len % 3 == 0. Falls back to plain del when the gate blocks.
+    //
+    // Answered for the **tract**, not for the input span — the #1185/#1210
+    // argument that `insertion_to_repeat` above already applies, and the gate
+    // is therefore checked after `extend_tandem_tract` rather than before it.
+    // `is_coding` is the caller's verdict for the span the *input* deletion
+    // occupied, and a CDS-resident deletion inside a tract that runs past
+    // `cds_end` sits on a tract the carve-out exempts. Measured on a `T` run
+    // spanning `cds_end`: `c.5_6insTT` produced `c.4_*5T[16]` while the
+    // matching `c.5_6del` produced a plain `c.*4_*5del`, because only the
+    // insertion path re-asked (#1270).
+    //
+    // Frames line up as they do there: `tract.start` / `tract.end` are 0-based
+    // indices into the transcript-frame `ref_seq` with `end` exclusive, and
+    // `cds_span` is 1-based inclusive in that same frame. `None` keeps the
+    // caller's verdict verbatim, so genomic / `n.` callers and the unit tests
+    // below are unaffected.
+    let gate_is_coding = match cds_span {
+        Some((cds_start, cds_end)) => {
+            let tract_start = tract.start as u64 + 1;
+            let tract_end = tract.end as u64;
+            tract_start >= cds_start && tract_end <= cds_end
+        }
+        None => is_coding,
+    };
+    if gate_is_coding && !p.is_multiple_of(3) {
         return None;
     }
 
@@ -4614,7 +4661,7 @@ mod tests {
         // After 3' shift, del lands at [5..7). post-shift slice "AA", unit "A", k=2.
         // Tract [2..7), ref_count=5, post_count=3 → A[3] at HGVS [3..7] (1-based).
         let ref_seq = b"TTAAAAATT";
-        let r = deletion_to_repeat(ref_seq, 5, 7, false).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 5, 7, false, None).expect("should fire");
         assert_eq!(r.unit, b"A");
         assert_eq!(r.count, 3);
         assert_eq!(r.start, 3); // 1-based HGVS
@@ -4627,7 +4674,7 @@ mod tests {
         // post-shift slice "GCAGCA", unit "GCA", k=2. Tract [2..11), ref_count=3,
         // post_count=1 → GCA[1] at HGVS [3..11] (1-based).
         let ref_seq = b"TTGCAGCAGCATT";
-        let r = deletion_to_repeat(ref_seq, 5, 11, false).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 5, 11, false, None).expect("should fire");
         assert_eq!(r.unit, b"GCA");
         assert_eq!(r.count, 1);
         assert_eq!(r.start, 3);
@@ -4639,7 +4686,7 @@ mod tests {
         // k=1 → stays as del.
         // ref "TTAAAAATT", delete 1 A at [6..7).
         let ref_seq = b"TTAAAAATT";
-        assert!(deletion_to_repeat(ref_seq, 6, 7, false).is_none());
+        assert!(deletion_to_repeat(ref_seq, 6, 7, false, None).is_none());
     }
 
     #[test]
@@ -4647,7 +4694,7 @@ mod tests {
         // post_count == 0 → stays as del.
         // ref "TTAATT", delete both A's at [2..4). ref_count=2, k=2, post_count=0.
         let ref_seq = b"TTAATT";
-        assert!(deletion_to_repeat(ref_seq, 2, 4, false).is_none());
+        assert!(deletion_to_repeat(ref_seq, 2, 4, false, None).is_none());
     }
 
     #[test]
@@ -4656,7 +4703,7 @@ mod tests {
         // ref "TTGCATT", delete "GCA" at [2..5). smallest_repeat_unit("GCA")="GCA",
         // ref_count=1, returns None.
         let ref_seq = b"TTGCATT";
-        assert!(deletion_to_repeat(ref_seq, 2, 5, false).is_none());
+        assert!(deletion_to_repeat(ref_seq, 2, 5, false, None).is_none());
     }
 
     #[test]
@@ -4664,7 +4711,7 @@ mod tests {
         // ref "TTATATATATATT" (5 ATs at [2..12)). Delete "ATAT" at [8..12).
         // smallest_repeat_unit("ATAT")="AT", k=2, ref_count=5, post_count=3 → AT[3].
         let ref_seq = b"TTATATATATATT";
-        let r = deletion_to_repeat(ref_seq, 8, 12, false).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 8, 12, false, None).expect("should fire");
         assert_eq!(r.unit, b"AT");
         assert_eq!(r.count, 3);
         assert_eq!(r.start, 3); // 1-based HGVS [3..12]
@@ -4905,7 +4952,7 @@ mod tests {
         // return None via the unrelated `k < 2` early exit, so it would not
         // discriminate the gate.
         let ref_seq = b"CAAAAAC";
-        let result = deletion_to_repeat(ref_seq, 2, 4, true);
+        let result = deletion_to_repeat(ref_seq, 2, 4, true, None);
         assert!(
             result.is_none(),
             "is_coding=true + unit_len=1 must return None"
@@ -4917,7 +4964,7 @@ mod tests {
         // ref "CCAGCAGCAGT": 3-CAG tract at indices 1..10. Delete 2 CAGs at
         // [1..7) (6 bases CAGCAG). With codon-aligned unit, gate passes.
         let ref_seq = b"CCAGCAGCAGT";
-        let result = deletion_to_repeat(ref_seq, 1, 7, true);
+        let result = deletion_to_repeat(ref_seq, 1, 7, true, None);
         assert!(
             result.is_some(),
             "is_coding=true + unit_len=3 must allow rewrite"

--- a/tests/it/issue_1270_del_repeat_codon_gate.rs
+++ b/tests/it/issue_1270_del_repeat_codon_gate.rs
@@ -1,0 +1,208 @@
+//! Issue #1270 — the del→repeat path answered the codon-frame gate on the
+//! *input* span where ins→repeat answers it on the tract the repeat occupies.
+//!
+//! `repeated.md` restricts repeat notation in a coding context to units that
+//! are a multiple of three. #1185/#1210 established that the restriction is
+//! about where the repeat **lands**, not where the input edit sat, and wired
+//! `insertion_to_repeat` to re-ask for the tract. `deletion_to_repeat` was
+//! still passed `gate.input_span_is_coding()` alone, so the two paths could
+//! answer differently about one and the same tract.
+//!
+//! ## The issue filed this as unverified; it is reachable
+//!
+//! "I have not constructed a case that reaches it, so this is an asymmetry with
+//! a plausible consequence rather than a demonstrated defect." It is
+//! demonstrated. On a `T` run spanning `cds_end`, measured before the fix:
+//!
+//! ```text
+//! NM_TEST.1:c.5_6insTT  ->  NM_TEST.1:c.4_*5T[16]   tract-aware: repeat emitted
+//! NM_TEST.1:c.5_6del    ->  NM_TEST.1:c.*4_*5del    input-span:  repeat suppressed
+//! ```
+//!
+//! Same tract, same unit (`T`, length 1, not a multiple of three), opposite
+//! answers. The deletion 3'-shifts clean out of the CDS — the `c.`-axis
+//! shuffle does not clamp it at `cds_end` here — so by the time the repeat is
+//! spelled the tract is not coding, and the carve-out applies to it exactly as
+//! it does to the insertion.
+//!
+//! The fix is the one the issue suggests: give `deletion_to_repeat` the same
+//! `gate.cds_bounds()` treatment, and move its gate check to after the tract is
+//! extended so there is a tract to ask about.
+//!
+//! Reference-free (`MockProvider` via `SyntheticBuilder`), so these run on PR
+//! CI rather than only in the manifest-backed nightly.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// ```text
+/// tx      1  2  3 | 4  5  6 | 7 ................ 20 | 21 ....... 26
+///         G  C  A | A  T  G | T x 14                | G C G C G C
+/// region  5'UTR   | CDS 4..15 .....| 3'UTR 16..26 ..|
+/// ```
+///
+/// The `T` run spans tx 7..20 and so crosses `cds_end = 15`: its 5' half is
+/// coding and its 3' half is not. That is the whole point of the fixture — a
+/// tract whose own verdict differs from that of an input span inside it.
+const CORE: &str = "GCAATGTTTTTTTTTTTTTTGCGCGC";
+const CDS: (u64, u64) = (4, 15);
+
+/// A tract of the same shape with a **3-base** unit, where the gate does not
+/// block either way. Used to show the change is scoped to the disagreement.
+const CORE_UNIT3: &str = "GCAATGCAGCAGCAGCAGCAGCAGGCGC";
+
+fn normalize(core: &str, cds: (u64, u64), input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    let provider: MockProvider = SyntheticBuilder::cds(core, cds.0, cds.1, Strand::Plus).build();
+    Normalizer::new(provider)
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// The defect proper: a CDS-resident deletion inside a tract that crosses
+/// `cds_end` must reach repeat notation, because the tract it lands on is not
+/// wholly coding.
+///
+/// The reference run is 14 `T`, so deleting `n` of them leaves `14 - n`.
+#[test]
+fn a_deletion_whose_tract_leaves_the_cds_reaches_repeat_notation() {
+    for (input, expected) in [
+        ("NM_TEST.1:c.5_6del", "NM_TEST.1:c.4_*5T[12]"),
+        ("NM_TEST.1:c.4_5del", "NM_TEST.1:c.4_*5T[12]"),
+        ("NM_TEST.1:c.10_11del", "NM_TEST.1:c.4_*5T[12]"),
+        ("NM_TEST.1:c.5_7del", "NM_TEST.1:c.4_*5T[11]"),
+        ("NM_TEST.1:c.4_9del", "NM_TEST.1:c.4_*5T[8]"),
+    ] {
+        assert_eq!(
+            normalize(CORE, CDS, input),
+            expected,
+            "`{input}` must be spelled as a repeat over the tract it lands on"
+        );
+    }
+}
+
+/// The asymmetry the issue is about, asserted directly: the two paths must
+/// agree about one tract.
+///
+/// Stated as a relation between the two rather than as two independent pinned
+/// strings, so it keeps meaning if the canonical spelling ever moves — the
+/// contract is that del and ins answer the *same* question, and the counts
+/// bracket the reference's 14 copies from either side.
+#[test]
+fn the_deletion_and_insertion_paths_agree_about_one_tract() {
+    let deleted = normalize(CORE, CDS, "NM_TEST.1:c.5_6del");
+    let inserted = normalize(CORE, CDS, "NM_TEST.1:c.5_6insTT");
+
+    // Split at the *location/edit* boundary, not on the unit letter: the
+    // accession `NM_TEST.1` contains a `T`, so `split('T')` returns `"NM_"` for
+    // both sides and the comparison is vacuously true. (It was written that way
+    // first; the self-review caught it.)
+    let tract_of = |s: &str| {
+        s.rsplit_once("T[")
+            .map(|(location, _)| location.to_string())
+            .unwrap_or_else(|| panic!("expected a `T[...]` repeat spelling; got `{s}`"))
+    };
+    assert_eq!(
+        tract_of(&deleted),
+        tract_of(&inserted),
+        "both must name the same tract; got `{deleted}` and `{inserted}`"
+    );
+    assert_eq!(
+        tract_of(&deleted),
+        "NM_TEST.1:c.4_*5",
+        "and it must be the tract that crosses cds_end"
+    );
+    assert_eq!(
+        deleted, "NM_TEST.1:c.4_*5T[12]",
+        "14 reference copies less 2"
+    );
+    assert_eq!(
+        inserted, "NM_TEST.1:c.4_*5T[16]",
+        "14 reference copies plus 2"
+    );
+}
+
+/// A tract that stays wholly inside the CDS must still be gated. Without this
+/// the change would read as "the codon rule was removed" rather than "it is
+/// answered about the right span".
+///
+/// Same reference and same input as the first test — only `cds_end` moves, from
+/// 15 to 24, which brings the whole `T` run inside the CDS. That isolates the
+/// variable to the tract's own verdict: nothing about the edit or the unit
+/// changes, and the repeat must disappear.
+#[test]
+fn a_tract_wholly_inside_the_cds_is_still_gated() {
+    // CDS 4..24 puts the entire `T` run (tx 7..20) inside the CDS, so the
+    // tract's own verdict is coding and the 1-base unit must stay blocked.
+    let output = normalize(CORE, (4, 24), "NM_TEST.1:c.5_6del");
+    assert!(
+        !output.contains("T["),
+        "a coding tract with a 1-base unit must not be spelled as a repeat; got `{output}`"
+    );
+    // Pinned as well as negated: "contains no repeat" alone would also be
+    // satisfied by the normalizer erroring into some unrelated shape.
+    assert_eq!(
+        output, "NM_TEST.1:c.16_17del",
+        "it must fall back to the plain 3'-shifted deletion"
+    );
+}
+
+/// A unit that satisfies the codon rule is unaffected in either direction —
+/// the gate never blocked it, so the re-ask must not change the answer.
+#[test]
+fn a_three_base_unit_is_unchanged() {
+    for input in ["NM_TEST.1:c.4_9del", "NM_TEST.1:c.7_12del"] {
+        assert_eq!(
+            normalize(CORE_UNIT3, CDS, input),
+            "NM_TEST.1:c.4_*9CAG[4]",
+            "`{input}` must keep the repeat spelling it already had"
+        );
+    }
+}
+
+/// The tract-aware verdict must not depend on strand.
+///
+/// `cds_span` is in transcript coordinates and the provider serves
+/// transcript-oriented bases, so a minus-strand record should reach the same
+/// answer — but "wrong shift direction or strand handling" is exactly what this
+/// arithmetic could get wrong, and every other test here is plus-strand.
+/// Asserted as parity so it survives a change in the canonical spelling.
+#[test]
+fn the_tract_verdict_is_strand_independent() {
+    for input in ["NM_TEST.1:c.5_6del", "NM_TEST.1:c.4_9del"] {
+        let variant = parse_hgvs(input).expect("input must parse");
+        let minus: MockProvider = SyntheticBuilder::cds(CORE, CDS.0, CDS.1, Strand::Minus).build();
+        let on_minus = Normalizer::new(minus)
+            .normalize(&variant)
+            .expect("lenient normalization must not reject")
+            .to_string();
+        assert_eq!(
+            normalize(CORE, CDS, input),
+            on_minus,
+            "`{input}` must normalize the same on either strand"
+        );
+    }
+}
+
+/// A deletion with no tandem tract around it must stay a plain deletion.
+#[test]
+fn a_deletion_outside_any_tract_is_unchanged() {
+    assert_eq!(
+        normalize(CORE, CDS, "NM_TEST.1:c.1_2del"),
+        "NM_TEST.1:c.1_2del"
+    );
+}
+
+/// Normalizing the repeat form again must return it byte for byte.
+///
+/// This is the property #1210 was actually filed about — the input-span verdict
+/// made pass 1 and pass 2 disagree, because pass 2's input was by then
+/// UTR-resident — so it is asserted here for the deletion path too rather than
+/// left to the global oracle.
+#[test]
+fn the_repeat_spelling_is_a_fixed_point() {
+    let once = normalize(CORE, CDS, "NM_TEST.1:c.5_6del");
+    assert_eq!(normalize(CORE, CDS, &once), once, "`{once}` must settle");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -166,6 +166,7 @@ mod issue_1249_inv_one_base_residue;
 mod issue_1254_sibling_crossing_shift;
 mod issue_1261_cis_member_order;
 mod issue_1264_reparse_asymmetry;
+mod issue_1270_del_repeat_codon_gate;
 mod issue_1276_dup_junction_overlap;
 mod issue_1281_reducing_member_shift;
 mod issue_1284_transcript_axis_collision;


### PR DESCRIPTION
Closes #1270.

## The issue filed this as unverified. It is reachable.

> "I have not constructed a case that reaches it, so this is an asymmetry with a plausible consequence rather than a demonstrated defect."

It is a demonstrated defect. On a 14-base `T` run spanning `cds_end`, measured on `origin/main`:

```
NM_TEST.1:c.5_6insTT  ->  NM_TEST.1:c.4_*5T[16]    tract-aware verdict: repeat emitted
NM_TEST.1:c.5_6del    ->  NM_TEST.1:c.*4_*5del     input-span verdict:  repeat suppressed
```

Same tract, same unit (`T`, length 1, not a multiple of three), opposite answers.

What makes it reachable is that the `c.`-axis shuffle does **not** clamp a deletion at `cds_end` here — `c.5_6del` shifts clean out of the CDS to `c.*4_*5`. So by the time the repeat would be spelled, the tract is not coding and `repeated.md`'s carve-out applies to it exactly as it applies to the insertion. Only the insertion path re-asked.

## The fix

The one the issue suggests: pass `gate.cds_bounds()` to `deletion_to_repeat`, and move its gate check to **after** `extend_tandem_tract` so there is a tract to ask about. The re-ask is the same three lines `insertion_to_repeat` already uses, on the same frames — 0-based `ref_seq` indices with an exclusive end, against 1-based inclusive CDS bounds. `None` keeps the caller's verdict verbatim, so genomic / `n.` callers and the helper's own unit tests are unaffected.

```
NM_TEST.1:c.5_6del  ->  NM_TEST.1:c.4_*5T[12]
```

which is the insertion's answer with the count going the other way: 14 reference copies less 2, against 14 plus 2.

## Tests

- **The disagreement itself**, asserted as a *relation* between the two paths rather than only as two pinned strings, so it keeps meaning if the canonical spelling ever moves.
- **A tract held wholly inside the CDS**, by moving only `cds_end` (15 → 24) and changing nothing else — it must stay gated. Without this the change would read as "the codon rule was removed" rather than "it is answered about the right span".
- A 3-base unit that was never gated, and a deletion outside any tract: both unchanged.
- **Idempotency of the repeat form**, which is the property #1210 was actually filed about — the input-span verdict is what made pass 1 and pass 2 disagree there.

Reference-free (`MockProvider` via `SyntheticBuilder`), so these run on PR CI rather than only in the manifest-backed nightly.

## Verification

Full suite green with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` (9035 tests), `cargo clippy --features dev --all-targets -- -D warnings` clean, `cargo check --features python` clean, no new proptest seeds.

**Bucket movement: none.** `status_census_is_unchanged`, `passing_census_is_unchanged` and `divergence_budget_is_unchanged` all hold — the spec corpus has no coding deletion sitting in a tandem tract that crosses `cds_end`, so it cannot exercise this change and the new tests are what carry it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deletion-to-repeat normalization for coding regions by evaluating the complete repeat tract.
  - Corrected codon-frame gating across plus- and minus-strand transcripts.
  - Preserved expected behavior for three-base repeats and non-repeat deletions.
  - Ensured equivalent deletion and insertion cases normalize consistently.

- **Tests**
  - Added integration coverage for repeat gating and normalization idempotence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->