### PR TITLE
feat(normalize): sequence-first cis-allele splitter, and the measurements that bound it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,22 @@ cargo nextest run --features dev          # All tests (preferred)
 cargo test --features dev                 # Alternative
 cargo nextest run -E 'test(test_name)'    # Specific test
 cargo test -- --nocapture                 # With output
-cargo bench                              # Benchmarks
+cargo bench --features dev               # Benchmarks (`dev` is required by seqfirst_align)
+```
+
+### Conformance axis (manifest-backed)
+
+`cargo nextest run --features dev -E 'test(axis_)'` selects the manifest-backed
+conformance tests, but each of those silently returns early (reported as
+PASSED, not skipped) when `FERRO_MANIFEST` is unset or points at a missing
+file — so running that filter bare can look like a clean pass while testing
+nothing. Use `scripts/run_conformance_axis.sh` instead: it validates the
+manifest *before* invoking nextest, so a missing one is a hard failure rather
+than a silent green. See `scripts/README.md` for details, including why the
+test count the script prints is a weaker signal than the manifest check.
+
+```bash
+FERRO_MANIFEST=/path/to/manifest.json scripts/run_conformance_axis.sh
 ```
 
 ## Code Style

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,11 @@ harness = false
 name = "baseline_head"
 harness = false
 
+[[bench]]
+name = "seqfirst_align"
+harness = false
+required-features = ["dev"]
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/seqfirst_align.rs
+++ b/benches/seqfirst_align.rs
@@ -1,8 +1,11 @@
 //! Sizing the sequence-first DP.
 //!
-//! `AlignmentDag::build` is `O(n*m)` in time and space. This measures where
-//! that stops being acceptable, so the block-size cap in the migration is
-//! chosen on evidence rather than picked.
+//! `AlignmentDag::build` is `O(n*m)` in time **and space**, but Criterion has
+//! no memory axis — this measures wall-clock time only. It shows where that
+//! grows too slow to be acceptable, so the block-size cap in the migration is
+//! chosen on time evidence; the memory dimension is not measured here.
+
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
@@ -32,9 +35,11 @@ fn bench_build(c: &mut Criterion) {
         group.throughput(Throughput::Elements((len * len) as u64));
         group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, _| {
             b.iter(|| {
-                let dag =
-                    ferro_hgvs::normalize::seqfirst::align::AlignmentDag::build(&reference, &alt);
-                criterion::black_box(dag.edit_distance())
+                let dag = ferro_hgvs::normalize::seqfirst::align::AlignmentDag::build(
+                    black_box(&reference),
+                    black_box(&alt),
+                );
+                black_box(dag.edit_distance())
             })
         });
     }

--- a/benches/seqfirst_align.rs
+++ b/benches/seqfirst_align.rs
@@ -1,0 +1,45 @@
+//! Sizing the sequence-first DP.
+//!
+//! `AlignmentDag::build` is `O(n*m)` in time and space. This measures where
+//! that stops being acceptable, so the block-size cap in the migration is
+//! chosen on evidence rather than picked.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+/// Deterministic pseudo-random bases; no RNG dependency, and reproducible
+/// across runs so successive measurements are comparable.
+fn bases(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            b"ACGT"[(state >> 33) as usize % 4]
+        })
+        .collect()
+}
+
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seqfirst_align_build");
+    for &len in &[16usize, 64, 256, 1024, 4096] {
+        let reference = bases(len, 1);
+        let mut alt = reference.clone();
+        // Perturb ~5% of positions so the DAG is non-trivial.
+        for k in (0..len).step_by(20) {
+            alt[k] = if alt[k] == b'A' { b'C' } else { b'A' };
+        }
+        group.throughput(Throughput::Elements((len * len) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, _| {
+            b.iter(|| {
+                let dag =
+                    ferro_hgvs::normalize::seqfirst::align::AlignmentDag::build(&reference, &alt);
+                criterion::black_box(dag.edit_distance())
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_build);
+criterion_main!(benches);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ Utility scripts for generating and updating test fixtures used by ferro-hgvs.
 | `fetch_ncbi_variation.py` | Ad-hoc live fetch of HGVS/SPDI conversions from the [NCBI Variation Services API](https://api.ncbi.nlm.nih.gov/variation/v0/). **Does not regenerate the committed fixture** (see note below). | `tests/fixtures/validation/ncbi_variation.live.json` (live; not committed) |
 | `fetch_variantvalidator.py` | Fetches validated HGVS variants from the [VariantValidator API](https://rest.variantvalidator.org) | `tests/fixtures/validation/variantvalidator_api.json` |
 | `benchmark_python.py` | Benchmarks ferro-hgvs Python bindings against biocommons/hgvs | N/A (prints results) |
+| `run_conformance_axis.sh` | Runs the manifest-backed conformance axis (`axis_*` tests) with a validated `FERRO_MANIFEST` | N/A (runs tests) |
 
 ## Requirements
 
@@ -52,4 +53,39 @@ python scripts/fetch_variantvalidator.py
 
 # Run Python binding benchmarks
 python scripts/benchmark_python.py --iterations 10000
+
+# Run the manifest-backed conformance axis (axis_ tests). Fails loudly
+# instead of silently passing if FERRO_MANIFEST is unset or missing --
+# see the script's header comment for why that matters.
+FERRO_MANIFEST=/path/to/manifest.json scripts/run_conformance_axis.sh
+# or:
+scripts/run_conformance_axis.sh /path/to/manifest.json
 ```
+
+### Conformance axis (`axis_*` tests)
+
+The conformance corpora (`tests/it/mutalyzer_normalize_tests.rs`,
+`tests/it/biocommons_normalize_tests.rs`,
+`tests/it/hgvs_rs_projection_tests.rs`) assert against a real prepared
+reference and are gated on the `FERRO_MANIFEST` environment variable: when it
+is unset, or points at a path that does not exist, each test's manifest-lookup
+helper returns early *without asserting anything*, and `cargo nextest` reports
+that as **PASSED**, not skipped. Running
+`cargo nextest run --features dev -E 'test(axis_)'` directly, without
+`FERRO_MANIFEST` set, is therefore a vacuous all-green run for exactly those
+tests, and looks identical to a real conformance pass.
+
+`scripts/run_conformance_axis.sh` closes that hole by validating the manifest
+path *before* invoking nextest, hard-failing if it is unset or missing. Build
+a manifest with `ferro prepare` (see `ferro prepare --help`); the manifest
+itself is never committed and this script never hardcodes a machine-local
+path.
+
+**What the printed test count does and does not prove.** `test(axis_)` is a
+substring match, so it selects ~179 tests — but only ~26 of them, the three
+corpora above, are manifest-gated. The rest (`cli::project::tests`,
+`hgvs::variant::tests`, `issue_337_cds_start_clamp`, `issue_1086_*`, …) merely
+contain `axis_` in their names and run identically with or without a manifest.
+They are harmless to run, but a non-zero count on its own is **not** evidence
+that conformance ran; it only shows the filter matched something. The
+pre-flight manifest check is the load-bearing guard.

--- a/scripts/run_conformance_axis.sh
+++ b/scripts/run_conformance_axis.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Runs the manifest-backed HGVS conformance axis (the `axis_*` test family
+# in tests/it/{mutalyzer_normalize,biocommons_normalize,hgvs_rs_projection,...}
+# _tests.rs) against a real ferro-prepared reference.
+#
+# Why this script exists: the manifest-backed conformance tests are gated at
+# runtime on `FERRO_MANIFEST` -- when it's unset, or points at a path that
+# doesn't exist, the test's own manifest-lookup helper returns `None` and the
+# test body returns early without asserting anything. `cargo nextest` reports
+# that early return as PASSED, not skipped. So `cargo nextest run --features
+# dev -E 'test(axis_)'` run bare is a vacuous, all-green no-op for exactly the
+# tests you wanted -- it can look identical to a real conformance pass.
+# Confirmed directly: with FERRO_MANIFEST unset the filter reports
+# "179 tests run: 179 passed".
+#
+# This script closes that hole by validating the manifest *before* invoking
+# nextest at all, so a missing/unset manifest is a hard failure here -- never
+# a silent pass buried inside the test suite. That pre-flight check is what
+# does the real work; the test count reported at the end is a weaker guard
+# that only proves the filter matched something (see the note below).
+#
+# Note on the filter: `test(axis_)` is a substring match, so it selects far
+# more than the conformance corpora -- ~179 tests, of which only the ~26 in
+# mutalyzer_normalize_tests / biocommons_normalize_tests /
+# hgvs_rs_projection_tests are manifest-gated. The rest (cli::project::tests,
+# hgvs::variant::tests, issue_337_cds_start_clamp, issue_1086_*, ...) merely
+# have "axis_" in their names and run identically with or without a manifest.
+# They are harmless to run, but they mean a non-zero test count on its own is
+# NOT evidence that conformance ran. Do not weaken the pre-flight check on the
+# strength of the count.
+#
+# Usage:
+#   FERRO_MANIFEST=/path/to/manifest.json scripts/run_conformance_axis.sh
+#   scripts/run_conformance_axis.sh /path/to/manifest.json
+#
+# The manifest is always operator-supplied -- this script never hardcodes a
+# machine-local path. Build one with `ferro prepare` (see `ferro prepare
+# --help`, or README.md's Reference Data section).
+set -euo pipefail
+
+MANIFEST="${1:-${FERRO_MANIFEST:-}}"
+
+if [[ -z "$MANIFEST" ]]; then
+    echo "error: no conformance manifest supplied." >&2
+    echo "  Set FERRO_MANIFEST=/path/to/manifest.json, or pass the path as \$1 to this script." >&2
+    echo "  Build one with 'ferro prepare' (see 'ferro prepare --help')." >&2
+    exit 1
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "error: manifest not found at '$MANIFEST'" >&2
+    echo "  FERRO_MANIFEST (or \$1) must point at an existing manifest.json produced by 'ferro prepare'." >&2
+    exit 1
+fi
+
+export FERRO_MANIFEST="$MANIFEST"
+echo "Running conformance axis (axis_ tests) with FERRO_MANIFEST=${FERRO_MANIFEST}"
+
+OUTPUT="$(mktemp)"
+trap 'rm -f "$OUTPUT"' EXIT
+
+# Tee so the operator sees live nextest output, then re-derive the summary
+# from the captured copy to confirm a non-zero number of tests actually ran
+# -- the whole point of this script is to make a vacuous run impossible to
+# miss.
+set +e
+cargo nextest run --features dev -E 'test(axis_)' 2>&1 | tee "$OUTPUT"
+STATUS="${PIPESTATUS[0]}"
+set -e
+
+# nextest writes "1 test run" (singular) and "N tests run" (plural), so the
+# optional `s` is load-bearing: without it a legitimate single-test run parses
+# as no run at all and is misreported below as vacuous.
+RAN="$(grep -Eo '[0-9]+ tests? run' "$OUTPUT" | tail -1 | grep -Eo '^[0-9]+' || true)"
+
+# A non-zero nextest status is reported as itself. Only claim "vacuous" when
+# the run actually succeeded and still matched nothing -- otherwise a build
+# break (no summary line at all, so RAN is empty) gets misattributed.
+if [[ "$STATUS" -ne 0 ]]; then
+    echo "error: conformance axis FAILED (nextest exit ${STATUS}) against ${FERRO_MANIFEST}." >&2
+    exit "$STATUS"
+fi
+
+if [[ -z "$RAN" || "$RAN" -eq 0 ]]; then
+    echo "error: no axis_ tests ran -- this would be a vacuous conformance run." >&2
+    exit 1
+fi
+
+echo "Conformance axis: ${RAN} axis_ test(s) ran against ${FERRO_MANIFEST}."

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -5536,6 +5536,9 @@ fn respell_at_gap<P: ReferenceProvider>(
 }
 
 #[cfg(test)]
+mod splitter_reproducer_corpus;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::hgvs::parser::parse_hgvs;

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1643,6 +1643,44 @@ impl Piece {
     }
 }
 
+/// Whether to run both block splitters and report their disagreements.
+///
+/// Enabled by `FERRO_SEQFIRST_SHADOW=1`. Read once and cached, like the
+/// idempotency gate in [`crate::normalize`], so a disabled run pays one relaxed
+/// atomic load per canonicalization. When on, the sequence-first splitter runs
+/// *in addition to* the live one and any disagreement goes to stderr; it never
+/// changes what is returned.
+fn seqfirst_shadow_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("FERRO_SEQFIRST_SHADOW").as_deref() == Ok("1"))
+}
+
+/// A piece list rendered on one line with `alt` as text rather than bytes.
+///
+/// Only used by the `FERRO_SEQFIRST_SHADOW` report, whose whole value is being
+/// greppable: `Piece`'s derived `Debug` prints `alt` as `[65, 67, …]`, which
+/// makes a report of a 40-base block unreadable and long.
+struct DebugPieces<'a>(&'a [Piece]);
+
+impl std::fmt::Debug for DebugPieces<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[")?;
+        for (i, piece) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(",")?;
+            }
+            write!(
+                f,
+                "{}..{}>{}",
+                piece.ref_start,
+                piece.ref_end,
+                String::from_utf8_lossy(&piece.alt)
+            )?;
+        }
+        f.write_str("]")
+    }
+}
+
 /// One column of an alignment between the reference and result blocks.
 ///
 /// `None` on either side is a gap. Both-`Some` columns are matches when the
@@ -1749,6 +1787,31 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     }
 
     let mut pieces = partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+    // Shadow the sequence-first splitter on the very same trimmed block, before
+    // any 3'-shift or coalescing, so a reported disagreement is a disagreement
+    // about the *split* and not about a downstream pass. Never affects `pieces`.
+    if seqfirst_shadow_enabled() {
+        let shadow = partition_block_sequence_first(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+        if shadow.as_ref() == Some(&pieces) {
+            // The denominator. Without it, `grep -c SEQFIRST_SHADOW` returning 0
+            // cannot be told apart from a shadow that never ran — the failure
+            // mode that would make an audit of the disagreements vacuous.
+            eprintln!("SEQFIRST_AGREE");
+        } else {
+            eprintln!(
+                // Space-separated, and no space inside a piece list, on purpose:
+                // `cargo nextest` strips tab characters when it re-emits captured
+                // test output (`--success-output immediate`), so a tab-delimited
+                // report is unparseable in the one run mode that covers the whole
+                // suite. Verified by `od -c` on both run modes.
+                "SEQFIRST_SHADOW ref={} alt={} live={:?} shadow={:?}",
+                String::from_utf8_lossy(&ref_bytes[lo..hi_ref]),
+                String::from_utf8_lossy(&result[lo..hi_alt]),
+                DebugPieces(&pieces),
+                shadow.as_deref().map(DebugPieces),
+            );
+        }
+    }
     for piece in &mut pieces {
         piece.ref_start += lo;
         piece.ref_end += lo;
@@ -2591,11 +2654,9 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
 ///
 /// Returns `None` when the block cannot be partitioned this way, which today
 /// means only that [`member_alt_spans`] declined. The caller falls back.
-// Not yet called from `normalize_allele` or anywhere else — wiring it in is a
-// later task in this migration. Allowed here for the same reason
-// `seqfirst::mod` allows it at the module level: deliberately unused until
-// that wiring lands, not a code-quality issue to restructure around.
-#[allow(dead_code)]
+///
+/// Called only from the `FERRO_SEQFIRST_SHADOW` comparison in
+/// [`canonicalize_from_sequence`]; it does not yet decide any result.
 fn partition_block_sequence_first(reference: &[u8], result: &[u8]) -> Option<Vec<Piece>> {
     use crate::normalize::seqfirst::align::AlignmentDag;
     use crate::normalize::seqfirst::partition::{member_alt_spans, partition_members_with};
@@ -5671,6 +5732,333 @@ mod tests {
                 pair[0].ref_end <= pair[1].ref_start,
                 "pieces overlap or are out of order: {pieces:?}"
             );
+        }
+    }
+
+    /// The enumerated classes of disagreement between the two block splitters.
+    ///
+    /// Harvested with `FERRO_SEQFIRST_SHADOW=1` over the whole suite plus the
+    /// exhaustive two-member sweeps: **30 261 distinct `(reference, alternate)`
+    /// blocks** disagree. Every one of the 60 522 piece lists — both sides, every
+    /// block — reproduces the alternate block when its payloads are substituted
+    /// into the reference. So **neither splitter is ever wrong** in the only sense
+    /// that admits a definitive answer; each disagreement is a difference in how
+    /// the change is *divided*, and the tie-breaker below is minimality: the
+    /// changed-column count `changed_columns_of_pieces` measures, which is the
+    /// quantity HGVS asks a description to minimise.
+    ///
+    /// Counts are distinct blocks, and sum to 30 261.
+    ///
+    /// | class | mechanism | n | more minimal |
+    /// |-------|-----------|---|--------------|
+    /// | `A1` | shadow splits a block live kept whole | 7 035 | shadow |
+    /// | `A2` | shadow replaces live's coincidental substitution run with one indel pair | 6 915 | shadow |
+    /// | `A3` | shadow narrows a piece live over-widened | 4 567 | shadow |
+    /// | `A4` | shadow widens one piece but lowers the total | 379 | shadow |
+    /// | `B1` | shadow widens a member over an indel it will not localise | 8 044 | live |
+    /// | `B2` | shadow merges pieces live kept separate | 3 088 | live |
+    /// | `B3` | shadow narrows one piece and pays for it in the next | 1 | live |
+    /// | `C1` | equal weight, different division | 232 | neither |
+    ///
+    /// `A1`–`A4` (18 896, 62.4%) are the migration's payoff. The mechanism, in the
+    /// blocks pinned below, is `partition_block`'s single-gap restriction: two
+    /// independent length changes have no one-gap explanation, so the lone gap
+    /// parks at one end and the offset columns pair up as coincidental
+    /// substitutions or as one whole-block `delins`.
+    ///
+    /// `B1`–`B3` (11 133, 36.8%) are the risk, and they have two distinct causes.
+    /// `B1` is inherent to deriving the split from the alignment steps common to
+    /// every minimal alignment: when the inserted bases can sit at more than one
+    /// offset inside a run, no single alignment node is common to all of them, so
+    /// the member absorbs the whole ambiguous span instead of committing to a
+    /// tie-broken offset.
+    ///
+    /// `B2` splits in two by the narrowest unchanged run between live's pieces:
+    /// 1 453 blocks are separated by exactly one unchanged base (1 106 of those
+    /// equal-length, where `partition_block` compares position-wise and there is
+    /// no alignment choice to make), and 1 635 by two or more. The one-base half
+    /// is a threshold mismatch rather than an ambiguity —
+    /// `seqfirst::MIN_SEPARATION` is 2 on every axis, whereas this module's own
+    /// `MIN_PIECE_SEPARATION` of 2 gates only net insertions.
+    ///
+    /// `B2` is the class that bears on flipping the default, because it is what
+    /// the curated issue corpora overwhelmingly reach: of the 49 distinct blocks
+    /// the non-sweep, non-proptest tests produce, 38 are a `B2` merge. See
+    /// `shadow_merges_across_one_unchanged_base_where_live_splits`, which pins two
+    /// blocks taken straight from the #1232 and #1235 transcript-axis tests.
+    mod seqfirst_shadow_audit {
+        use super::*;
+
+        /// Substitute each piece's payload into `reference`.
+        ///
+        /// Returns `None` if the pieces are not disjoint and ascending, so a
+        /// caller cannot mistake an ill-formed piece list for a denotation.
+        fn denotes(reference: &[u8], pieces: &[Piece]) -> Option<Vec<u8>> {
+            let mut cursor = 0;
+            let mut out = Vec::new();
+            for piece in pieces {
+                if piece.ref_start < cursor
+                    || piece.ref_end < piece.ref_start
+                    || piece.ref_end > reference.len()
+                {
+                    return None;
+                }
+                out.extend_from_slice(&reference[cursor..piece.ref_start]);
+                out.extend_from_slice(&piece.alt);
+                cursor = piece.ref_end;
+            }
+            out.extend_from_slice(&reference[cursor..]);
+            Some(out)
+        }
+
+        /// `(ref_start, ref_end, alt)` triples, for terse expectations.
+        fn shape(pieces: &[Piece]) -> Vec<(usize, usize, &[u8])> {
+            pieces
+                .iter()
+                .map(|p| (p.ref_start, p.ref_end, p.alt.as_slice()))
+                .collect()
+        }
+
+        /// Run both splitters on one block and check the two invariants that hold
+        /// for every disagreement found: both sides denote the alternate block,
+        /// and the sequence-first side never declines.
+        ///
+        /// Returns `(live, shadow)` for the caller to pin exactly.
+        fn both(reference: &[u8], result: &[u8]) -> (Vec<Piece>, Vec<Piece>) {
+            let live = partition_block(reference, result);
+            let shadow = partition_block_sequence_first(reference, result)
+                .expect("no harvested disagreement had the sequence-first side decline");
+            assert_eq!(
+                denotes(reference, &live).as_deref(),
+                Some(result),
+                "live pieces must denote the alternate block: {live:?}"
+            );
+            assert_eq!(
+                denotes(reference, &shadow).as_deref(),
+                Some(result),
+                "shadow pieces must denote the alternate block: {shadow:?}"
+            );
+            assert_ne!(shape(&live), shape(&shadow), "this block must disagree");
+            (live, shadow)
+        }
+
+        /// `A1` (7 035 blocks). `partition_block` has no single-gap explanation
+        /// for two separate deletions, so it emits the whole block as one
+        /// `delins`; the sequence-first split finds both deletions.
+        #[test]
+        fn shadow_splits_a_block_live_kept_whole() {
+            let (live, shadow) = both(b"ACAC", b"CA");
+            assert_eq!(shape(&live), [(0, 4, b"CA".as_slice())]);
+            assert_eq!(
+                shape(&shadow),
+                [(0, 1, b"".as_slice()), (3, 4, b"".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 4);
+            assert_eq!(changed_columns_of_pieces(&shadow), 2);
+        }
+
+        /// `A2` (6 915 blocks). The block is a 5' insertion plus a 3' deletion.
+        /// `partition_block`'s lone gap parks at one end, so the offset columns
+        /// pair up position-wise and read as a run of substitutions — three
+        /// pieces claiming three changed columns for what is one base in and one
+        /// base out.
+        #[test]
+        fn shadow_replaces_a_coincidental_substitution_run_with_one_indel_pair() {
+            let (live, shadow) = both(b"AACCA", b"TAACC");
+            assert_eq!(
+                shape(&live),
+                [
+                    (0, 1, b"T".as_slice()),
+                    (2, 3, b"A".as_slice()),
+                    (4, 5, b"C".as_slice()),
+                ]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 0, b"T".as_slice()), (4, 5, b"".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 3);
+            assert_eq!(changed_columns_of_pieces(&shadow), 2);
+        }
+
+        /// `A3` (4 567 blocks). Same piece count; the live first piece spans one
+        /// base more than it needs to, and pays for it with a substitution the
+        /// sequence-first split renders as a deletion.
+        #[test]
+        fn shadow_narrows_a_piece_live_over_widened() {
+            let (live, shadow) = both(b"ACCA", b"CC");
+            assert_eq!(
+                shape(&live),
+                [(0, 2, b"".as_slice()), (3, 4, b"C".as_slice())]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 1, b"".as_slice()), (3, 4, b"".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 3);
+            assert_eq!(changed_columns_of_pieces(&shadow), 2);
+        }
+
+        /// `A4` (379 blocks). The rarest of the four: the sequence-first first
+        /// piece is *wider* than live's, and the total is still lower.
+        #[test]
+        fn shadow_widens_one_piece_and_still_lowers_the_total() {
+            let (live, shadow) = both(b"AACAC", b"CA");
+            assert_eq!(
+                shape(&live),
+                [(0, 1, b"C".as_slice()), (2, 5, b"".as_slice())]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 2, b"".as_slice()), (4, 5, b"".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 4);
+            assert_eq!(changed_columns_of_pieces(&shadow), 3);
+        }
+
+        /// `B1` (8 044 blocks) — **the sequence-first answer is less minimal.**
+        ///
+        /// `CA` is inserted into a run where it can sit at more than one offset,
+        /// so no alignment node is common to every minimal alignment there and
+        /// the member absorbs `reference[0..1]` rather than committing to the
+        /// 5'-most tie-break live picks. Both denote `CAACAG`; live spends 3
+        /// changed columns, the sequence-first split 4.
+        #[test]
+        fn shadow_widens_a_member_over_an_indel_it_will_not_localise() {
+            let (live, shadow) = both(b"ACAA", b"CAACAG");
+            assert_eq!(
+                shape(&live),
+                [(0, 0, b"CA".as_slice()), (3, 4, b"G".as_slice())]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 1, b"CAA".as_slice()), (3, 4, b"G".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 3);
+            assert_eq!(changed_columns_of_pieces(&shadow), 4);
+        }
+
+        /// `B2` (3 088 blocks, 1 265 of them equal-length) — **the sequence-first
+        /// answer is less minimal, and this is the class that reaches the curated
+        /// corpora.**
+        ///
+        /// `seqfirst::MIN_SEPARATION` is 2, so one unchanged reference base
+        /// between two runs of change merges them. `partition_block` splits
+        /// there: it compares equal-length blocks position-wise, and its own
+        /// `MIN_PIECE_SEPARATION` of 2 gates only net insertions.
+        ///
+        /// The three blocks below are, in order, the smallest instance, the block
+        /// `issue_1235_transcript_axes::noncoding_axis_converges_on_separated_changes`
+        /// produces, and the block
+        /// `issue_1235_cis_allele_confluence::issue_1232_spanning_delins_splits_at_unchanged_base`
+        /// produces. Both of those tests are named for the split the
+        /// sequence-first splitter declines to make.
+        #[test]
+        fn shadow_merges_across_one_unchanged_base_where_live_splits() {
+            let (live, shadow) = both(b"ACA", b"CC");
+            assert_eq!(
+                shape(&live),
+                [(0, 1, b"".as_slice()), (2, 3, b"C".as_slice())]
+            );
+            assert_eq!(shape(&shadow), [(0, 3, b"CC".as_slice())]);
+            assert_eq!(changed_columns_of_pieces(&live), 2);
+            assert_eq!(changed_columns_of_pieces(&shadow), 3);
+
+            // #1235's `noncoding_axis_converges_on_separated_changes`: an
+            // equal-length block, two substitutions one unchanged base apart.
+            let (live, shadow) = both(b"CAA", b"TAG");
+            assert_eq!(
+                shape(&live),
+                [(0, 1, b"T".as_slice()), (2, 3, b"G".as_slice())]
+            );
+            assert_eq!(shape(&shadow), [(0, 3, b"TAG".as_slice())]);
+            assert_eq!(changed_columns_of_pieces(&live), 2);
+            assert_eq!(changed_columns_of_pieces(&shadow), 3);
+
+            // #1232's `spanning_delins_splits_at_unchanged_base`: the split the
+            // issue is named for is the one that goes away.
+            let (live, shadow) = both(b"CAATT", b"TA");
+            assert_eq!(
+                shape(&live),
+                [(0, 3, b"".as_slice()), (4, 5, b"A".as_slice())]
+            );
+            assert_eq!(shape(&shadow), [(0, 5, b"TA".as_slice())]);
+            assert_eq!(changed_columns_of_pieces(&live), 4);
+            assert_eq!(changed_columns_of_pieces(&shadow), 5);
+        }
+
+        /// `B3` (1 block) — **the sequence-first answer is less minimal.** The
+        /// only harvested block where the two splits have the same piece count,
+        /// the sequence-first first piece is narrower, and the total is still
+        /// higher because the second piece grows by more than the first shrank.
+        #[test]
+        fn shadow_narrows_one_piece_and_pays_for_it_in_the_next() {
+            let (live, shadow) = both(b"GCCATA", b"CATAAC");
+            assert_eq!(
+                shape(&live),
+                [(0, 3, b"CAT".as_slice()), (4, 6, b"AC".as_slice())]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 3, b"C".as_slice()), (5, 6, b"AAC".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 5);
+            assert_eq!(changed_columns_of_pieces(&shadow), 6);
+        }
+
+        /// `C1` (232 blocks). Both denote the alternate block and both spend the
+        /// same number of changed columns; they only divide the change
+        /// differently. Which is preferable is not decided here — the spec's
+        /// prioritisation rule (`general.md:56`) is what reaches these, and the
+        /// two blocks below fall to it in opposite directions.
+        #[test]
+        fn equal_weight_different_division() {
+            let (live, shadow) = both(b"ACAGCG", b"CGCTGT");
+            assert_eq!(shape(&live), [(0, 6, b"CGCTGT".as_slice())]);
+            assert_eq!(
+                shape(&shadow),
+                [(0, 3, b"C".as_slice()), (5, 6, b"TGT".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 6);
+            assert_eq!(changed_columns_of_pieces(&shadow), 6);
+
+            let (live, shadow) = both(b"AGAGT", b"GAAGAG");
+            assert_eq!(
+                shape(&live),
+                [(0, 2, b"GA".as_slice()), (4, 5, b"AG".as_slice())]
+            );
+            assert_eq!(
+                shape(&shadow),
+                [(0, 1, b"GAA".as_slice()), (4, 5, b"".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&live), 4);
+            assert_eq!(changed_columns_of_pieces(&shadow), 4);
+        }
+
+        /// The one property that held over all 30 261 harvested disagreements:
+        /// both piece lists are disjoint, ascending, and denote the alternate
+        /// block. `denotes` returns `None` on a piece list that is not, so this
+        /// is what makes "neither splitter is ever wrong" a checked claim rather
+        /// than a reading of the log.
+        #[test]
+        fn every_pinned_class_denotes_the_alternate_block_on_both_sides() {
+            for (reference, result) in [
+                (b"ACAC".as_slice(), b"CA".as_slice()),
+                (b"AACCA", b"TAACC"),
+                (b"ACCA", b"CC"),
+                (b"AACAC", b"CA"),
+                (b"ACAA", b"CAACAG"),
+                (b"ACA", b"CC"),
+                (b"CAA", b"TAG"),
+                (b"CAATT", b"TA"),
+                (b"GCCATA", b"CATAAC"),
+                (b"ACAGCG", b"CGCTGT"),
+                (b"AGAGT", b"GAAGAG"),
+            ] {
+                // `both` asserts the denotation on each side and that the block
+                // does in fact disagree.
+                both(reference, result);
+            }
         }
     }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1820,7 +1820,21 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
             MIN_SEPARATION_NO_FRAME
         };
         let block = &ref_bytes[lo..hi_ref];
-        let shadow = partition_block_sequence_first(block, &result[lo..hi_alt], min_separation);
+        let mut shadow = partition_block_sequence_first(block, &result[lo..hi_alt], min_separation);
+        // `min_separation` alone captures only the distance half of
+        // `general.md:35`'s exception; this captures the codon half, splitting
+        // back apart any merge the exception does not actually license. `lo`
+        // is added because `block`'s offsets (unlike `pieces`' at this point)
+        // have not yet been shifted into the untrimmed window `w_lo` is
+        // relative to.
+        if let Some(shadow_pieces) = shadow.as_mut() {
+            split_codon_incompatible_triplets(
+                shadow_pieces,
+                frame.reading_frame,
+                w_lo + lo as i64,
+                block,
+            );
+        }
         // Both sides are also compared after `shrink_pieces_to_differences`,
         // because a split that only differs in how wide its members are is a
         // difference the rendering stage removes. Reported as a third outcome
@@ -3145,6 +3159,84 @@ fn apply_coding_codon_exception(
             previous.ref_end = previous.ref_start + 3;
         }
         index += 1;
+    }
+}
+
+/// Split a sequence-first merge back apart when it crosses a codon boundary.
+///
+/// `min_separation` (`seqfirst::MIN_SEPARATION`, `2`, on a reading-frame axis)
+/// captures only the *distance* half of `general.md:35`'s exception — merging
+/// any two runs separated by fewer than 2 unchanged bases, whichever codons
+/// they fall in. The exception itself is narrower: "two variants separated by
+/// one nucleotide, **together affecting one amino acid**" — both conditions,
+/// not one. A pair in different codons affects *two* amino acids and
+/// `general.md:34`'s plain rule governs it instead: described individually.
+///
+/// Scoped to the exact shape the exception describes — two single-nucleotide
+/// substitutions with their shared unchanged base carried in the middle
+/// (`ref_end - ref_start == 3`, `alt.len() == 3`, the middle alt base equal to
+/// the middle reference base, both flanking bases actually changed) — using
+/// the same [`same_codon`] arithmetic [`apply_coding_codon_exception`] already
+/// uses for the live splitter's own triplet, on the same axis distinction
+/// (`reading_frame`, from [`AxisFrame`]). A wider merged piece is not "two
+/// variants" in `general.md:35`'s sense at all — `LRG_199t1:c.850_901`
+/// (`delins.md:44`) merges a 52-base member for an unrelated reason (its
+/// `partition_block` sibling never reaches `best_alignment` in the first place;
+/// see [`MAX_UNGUARDED_SPLIT_BLOCK`]), not this exception, so it must not be
+/// touched here and is not: 52 ≠ 3.
+///
+/// Pinned by `sequence_first_split_declines_the_codon_exception_across_a_boundary`
+/// (`GCA -> TCC`, `general.md:34`'s split rule wins) and
+/// `sequence_first_split_keeps_the_codon_exception_within_one_codon`
+/// (`CCC -> GCA`, `general.md:35`'s exception wins) — the same two blocks
+/// `merge_consecutive_edits_tests::test_no_codon_frame_pair_straddles_codon_boundary`
+/// and `test_codon_frame_two_subs_one_codon` pin for the live splitter, so
+/// both sides are checked against the identical spec-derived expectation.
+fn split_codon_incompatible_triplets(
+    pieces: &mut Vec<Piece>,
+    reading_frame: bool,
+    w_lo: i64,
+    ref_bytes: &[u8],
+) {
+    if !reading_frame {
+        return;
+    }
+    let mut index = 0;
+    while index < pieces.len() {
+        let piece = &pieces[index];
+        let is_merged_triplet = piece.ref_end == piece.ref_start + 3
+            && piece.alt.len() == 3
+            && piece.alt[1] == ref_bytes[piece.ref_start + 1]
+            && piece.alt[0] != ref_bytes[piece.ref_start]
+            && piece.alt[2] != ref_bytes[piece.ref_start + 2];
+        if !is_merged_triplet {
+            index += 1;
+            continue;
+        }
+        let triplet_start = w_lo + piece.ref_start as i64;
+        if same_codon(triplet_start, triplet_start + 2) {
+            index += 1;
+            continue;
+        }
+        let ref_start = piece.ref_start;
+        let first_alt = piece.alt[0];
+        let third_alt = piece.alt[2];
+        pieces.splice(
+            index..=index,
+            [
+                Piece {
+                    ref_start,
+                    ref_end: ref_start + 1,
+                    alt: vec![first_alt],
+                },
+                Piece {
+                    ref_start: ref_start + 2,
+                    ref_end: ref_start + 3,
+                    alt: vec![third_alt],
+                },
+            ],
+        );
+        index += 2;
     }
 }
 
@@ -5841,6 +5933,125 @@ mod tests {
             (coding[0].ref_start, coding[0].ref_end),
             (0, reference.len())
         );
+    }
+
+    /// Codon-precision follow-up to Task 3: the coding-axis merge must also
+    /// check the codon, not just the distance. `ref=GCA alt=TCC` is the block
+    /// `issue_275_codon_frame_extensions::no_codon_frame_rna_pair_straddles_codon_boundary`
+    /// produces, from the `FERRO_SEQFIRST_SHADOW` audit's residual `B2` list —
+    /// and it is the exact block
+    /// `merge_consecutive_edits_tests::test_no_codon_frame_pair_straddles_codon_boundary`
+    /// already pins for the live splitter, at the same real position (`c.3G>T`,
+    /// `c.5A>C`: `(3-1)/3 = 0`, `(5-1)/3 = 1`, different codons).
+    /// `min_separation = 2` alone merges it into one triplet;
+    /// `split_codon_incompatible_triplets` must split it straight back apart.
+    #[test]
+    fn sequence_first_split_declines_the_codon_exception_across_a_boundary() {
+        let reference = b"GCA";
+        let result = b"TCC";
+        let mut merged = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("must partition");
+        assert_eq!(
+            merged.len(),
+            1,
+            "the distance rule alone merges this into one triplet: {merged:?}"
+        );
+
+        split_codon_incompatible_triplets(&mut merged, true, 3, reference);
+        assert_eq!(
+            merged.len(),
+            2,
+            "different codons must not merge, even one nucleotide apart: {merged:?}"
+        );
+        assert_eq!(
+            (
+                merged[0].ref_start,
+                merged[0].ref_end,
+                merged[0].alt.as_slice()
+            ),
+            (0, 1, b"T".as_slice())
+        );
+        assert_eq!(
+            (
+                merged[1].ref_start,
+                merged[1].ref_end,
+                merged[1].alt.as_slice()
+            ),
+            (2, 3, b"C".as_slice())
+        );
+
+        // No reading frame: never touched, regardless of codon arithmetic.
+        let mut no_frame = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("must partition");
+        split_codon_incompatible_triplets(&mut no_frame, false, 3, reference);
+        assert_eq!(
+            no_frame.len(),
+            1,
+            "no reading frame means no split: {no_frame:?}"
+        );
+    }
+
+    /// The other side of the same pin: two substitutions genuinely within one
+    /// codon must still merge. `ref=CCC alt=GCA` at `w_lo=10` is
+    /// `merge_consecutive_edits_tests::test_codon_frame_two_subs_one_codon`'s
+    /// exact block (`c.10C>G`, `c.12C>A`: `(10-1)/3 = 3`, `(12-1)/3 = 3`, same
+    /// codon) — the spec's `c.[145C>T;147C>G]` → `c.145_147delinsTGG` example,
+    /// re-based. `split_codon_incompatible_triplets` must leave it merged.
+    #[test]
+    fn sequence_first_split_keeps_the_codon_exception_within_one_codon() {
+        let reference = b"CCC";
+        let result = b"GCA";
+        let mut merged = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("must partition");
+        assert_eq!(merged.len(), 1, "must merge into one triplet: {merged:?}");
+
+        split_codon_incompatible_triplets(&mut merged, true, 10, reference);
+        assert_eq!(merged.len(), 1, "same codon must stay merged: {merged:?}");
+        assert_eq!((merged[0].ref_start, merged[0].ref_end), (0, 3));
+        assert_eq!(merged[0].alt, b"GCA");
+    }
+
+    /// The calibration this task must not break: `LRG_199t1:c.850_901`
+    /// (`delins.md:44`) merges a 52-base member for a reason unrelated to the
+    /// codon exception (its `partition_block` sibling never reaches
+    /// `best_alignment` at all — see `MAX_UNGUARDED_SPLIT_BLOCK`), so
+    /// `split_codon_incompatible_triplets` must not touch it: the piece is 52
+    /// nt wide, not the 3 nt the codon exception's shape requires.
+    #[test]
+    fn split_codon_incompatible_triplets_leaves_the_spec_delins_example_whole() {
+        let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+        let result = b"TTCCTCGATGCCTG";
+        let mut pieces = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("the spec example must partition");
+        assert_eq!(pieces.len(), 1);
+
+        // The real accession's CDS offset (`c.850` = this block's reference
+        // offset 0; `cds_start = 245`, `LRG_199t1` transcript offset 1094,
+        // `spec_enumeration_transcripts.fna`), so this is the exact codon
+        // arithmetic production would run, not a stand-in value.
+        split_codon_incompatible_triplets(&mut pieces, true, 850, reference);
+        assert_eq!(
+            pieces.len(),
+            1,
+            "spec still requires one delins, got {pieces:?}"
+        );
+        assert_eq!((pieces[0].ref_start, pieces[0].ref_end), (0, 52));
     }
 
     /// Every piece the new splitter emits must reconstruct the result block

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1819,16 +1819,35 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         } else {
             MIN_SEPARATION_NO_FRAME
         };
-        let shadow = partition_block_sequence_first(
-            &ref_bytes[lo..hi_ref],
-            &result[lo..hi_alt],
-            min_separation,
-        );
+        let block = &ref_bytes[lo..hi_ref];
+        let shadow = partition_block_sequence_first(block, &result[lo..hi_alt], min_separation);
+        // Both sides are also compared after `shrink_pieces_to_differences`,
+        // because a split that only differs in how wide its members are is a
+        // difference the rendering stage removes. Reported as a third outcome
+        // rather than folded into either of the other two, so one run yields
+        // both the raw disagreement count and the count that survives
+        // minimisation. The shrink runs here before the 3'-shift, whereas the
+        // returned `pieces` are shrunk after it — see
+        // `shrinking_before_and_after_the_three_prime_shift_agree`.
+        let mut min_live = pieces.clone();
+        shrink_pieces_to_differences(&mut min_live, block);
+        let mut min_shadow = shadow.clone();
+        if let Some(min_shadow) = min_shadow.as_mut() {
+            shrink_pieces_to_differences(min_shadow, block);
+        }
         if shadow.as_ref() == Some(&pieces) {
             // The denominator. Without it, `grep -c SEQFIRST_SHADOW` returning 0
             // cannot be told apart from a shadow that never ran — the failure
             // mode that would make an audit of the disagreements vacuous.
             eprintln!("SEQFIRST_AGREE");
+        } else if min_shadow.as_ref() == Some(&min_live) {
+            eprintln!(
+                "SEQFIRST_MINAGREE ref={} alt={} live={:?} shadow={:?}",
+                String::from_utf8_lossy(block),
+                String::from_utf8_lossy(&result[lo..hi_alt]),
+                DebugPieces(&pieces),
+                shadow.as_deref().map(DebugPieces),
+            );
         } else {
             eprintln!(
                 // Space-separated, and no space inside a piece list, on purpose:
@@ -1836,11 +1855,13 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
                 // test output (`--success-output immediate`), so a tab-delimited
                 // report is unparseable in the one run mode that covers the whole
                 // suite. Verified by `od -c` on both run modes.
-                "SEQFIRST_SHADOW ref={} alt={} live={:?} shadow={:?}",
-                String::from_utf8_lossy(&ref_bytes[lo..hi_ref]),
+                "SEQFIRST_SHADOW ref={} alt={} live={:?} shadow={:?} min_live={:?} min_shadow={:?}",
+                String::from_utf8_lossy(block),
                 String::from_utf8_lossy(&result[lo..hi_alt]),
                 DebugPieces(&pieces),
                 shadow.as_deref().map(DebugPieces),
+                DebugPieces(&min_live),
+                min_shadow.as_deref().map(DebugPieces),
             );
         }
     }
@@ -1850,6 +1871,11 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     }
     shift_pieces_three_prime(&mut pieces, &ref_bytes);
     coalesce_adjacent_pieces(&mut pieces);
+    // Partitioning decides where the members are; this decides how wide each
+    // one is spelled, and the two are not the same question — see
+    // `shrink_pieces_to_differences`. Placed before the weight bound below so
+    // that the bound judges the pieces that will actually be rendered.
+    shrink_pieces_to_differences(&mut pieces, &ref_bytes);
 
     // A canonicalization may re-partition and re-type the change. It may not
     // describe *more* change than the input already did.
@@ -3138,6 +3164,43 @@ fn coalesce_adjacent_pieces(pieces: &mut Vec<Piece>) {
         } else {
             i += 1;
         }
+    }
+}
+
+/// Shrink each piece to the hull of its own differences.
+///
+/// A piece is a *region*, and a region is not obliged to be the narrowest span
+/// that spells the change it holds. Where an edit sits inside an ambiguous run
+/// the two come apart: on `ACAA -> CAACAG` the inserted `CA` can sit at more
+/// than one offset, so a partition derived from the alignment steps common to
+/// every minimal alignment confines it to `reference[0..1]` — which spells a
+/// `delins` of `CAA` over one base for what those same bases denote as an
+/// insertion of `CA`.
+///
+/// This is [`trim_common_flanks`] applied *within* a piece rather than to the
+/// whole block, and like that call it reads only the reference span and the
+/// payload — never the input spelling — so it cannot reintroduce a dependence
+/// on how the variant was written.
+///
+/// Only a `delins` can move. A deletion has no payload to share a flank with,
+/// an insertion spans no reference base, and a substitution's single base
+/// differs by construction, so each is returned untouched; the widened forms
+/// this exists to narrow are the only ones narrowed. Growing a run back to a
+/// `dup` or a repeat spelling is a rendering decision made downstream, on the
+/// narrowed member.
+fn shrink_pieces_to_differences(pieces: &mut [Piece], ref_bytes: &[u8]) {
+    for piece in pieces.iter_mut() {
+        let (lo, hi_ref, hi_alt) =
+            trim_common_flanks(&ref_bytes[piece.ref_start..piece.ref_end], &piece.alt);
+        // A piece that trims away entirely spells no change; leaving it whole
+        // keeps `anchor_for_piece` from building a member with no extent.
+        if lo == hi_ref && lo == hi_alt {
+            continue;
+        }
+        piece.alt.truncate(hi_alt);
+        piece.alt.drain(..lo);
+        piece.ref_end = piece.ref_start + hi_ref;
+        piece.ref_start += lo;
     }
 }
 
@@ -6182,6 +6245,279 @@ mod tests {
                 // `both` asserts the denotation on each side and that the block
                 // does in fact disagree.
                 both(reference, result);
+            }
+        }
+    }
+
+    /// Minimal member rendering — [`shrink_pieces_to_differences`].
+    ///
+    /// The decision this pins: keep the sequence-derived partition, and spell
+    /// each member as the hull of its own differences. A whole ambiguous run is
+    /// described as one unit only where that unit has an edit type of its own
+    /// (`dup`, `NNN[k]`), never as a `delins` spanning the run.
+    mod minimal_member_rendering {
+        use super::*;
+
+        /// `(ref_start, ref_end, alt)` triples, for terse expectations.
+        fn shape(pieces: &[Piece]) -> Vec<(usize, usize, &[u8])> {
+            pieces
+                .iter()
+                .map(|p| (p.ref_start, p.ref_end, p.alt.as_slice()))
+                .collect()
+        }
+
+        /// The sequence-first split of `reference -> result`, shrunk.
+        ///
+        /// At [`MIN_SEPARATION_NO_FRAME`], the threshold
+        /// `canonicalize_from_sequence` chooses on an axis with no reading
+        /// frame — which is the axis every block below was harvested from.
+        fn shrunk_sequence_first(reference: &[u8], result: &[u8]) -> Vec<Piece> {
+            let mut pieces =
+                partition_block_sequence_first(reference, result, MIN_SEPARATION_NO_FRAME)
+                    .expect("the sequence-first split must not decline on these blocks");
+            shrink_pieces_to_differences(&mut pieces, reference);
+            pieces
+        }
+
+        /// Every trimmed `(block, alternate)` pair drawn from `{A,C,G}` with
+        /// both sides of length 1..=4, excluding the pairs that trim away to no
+        /// change at all (which `canonicalize_from_sequence` returns early on).
+        ///
+        /// Small on purpose: the blocks the shrink acts on are already trimmed
+        /// and rarely long, and an exhaustive sweep of short blocks covers the
+        /// shapes — homopolymer, tandem 2-mer, net insertion, net deletion,
+        /// equal length — more evenly than a longer random sample would.
+        fn enumerated_blocks() -> Vec<(Vec<u8>, Vec<u8>)> {
+            fn words(alphabet: &[u8], max_len: usize) -> Vec<Vec<u8>> {
+                let mut out: Vec<Vec<u8>> = Vec::new();
+                let mut level = vec![Vec::new()];
+                for _ in 0..max_len {
+                    let mut next = Vec::new();
+                    for word in &level {
+                        for base in alphabet {
+                            let mut grown = word.clone();
+                            grown.push(*base);
+                            next.push(grown);
+                        }
+                    }
+                    out.extend(next.iter().cloned());
+                    level = next;
+                }
+                out
+            }
+
+            let words = words(b"ACG", 4);
+            let mut out = Vec::new();
+            for reference in &words {
+                for result in &words {
+                    let (lo, hi_ref, hi_alt) = trim_common_flanks(reference, result);
+                    if lo == hi_ref && lo == hi_alt {
+                        continue;
+                    }
+                    out.push((reference[lo..hi_ref].to_vec(), result[lo..hi_alt].to_vec()));
+                }
+            }
+            out
+        }
+
+        /// Substitute each piece's payload into `reference` (see the audit
+        /// module's `denotes`, duplicated here so this module stands alone).
+        fn denotes(reference: &[u8], pieces: &[Piece]) -> Vec<u8> {
+            let mut cursor = 0;
+            let mut out = Vec::new();
+            for piece in pieces {
+                assert!(piece.ref_start >= cursor, "pieces overlap: {pieces:?}");
+                out.extend_from_slice(&reference[cursor..piece.ref_start]);
+                out.extend_from_slice(&piece.alt);
+                cursor = piece.ref_end;
+            }
+            out.extend_from_slice(&reference[cursor..]);
+            out
+        }
+
+        /// Class `B1`: the sequence-first split widens a member over an indel it
+        /// will not localise. Shrinking each member to its own differences
+        /// recovers the minimal spelling — on all three blocks, the very piece
+        /// list `partition_block` produces.
+        ///
+        /// The blocks are the audit's pinned `B1` example plus two more taken
+        /// from the same harvest, chosen to cover both directions and the widest
+        /// widening seen: a net insertion widened by one base, a net deletion
+        /// widened by one base, and an 8-base homopolymer where the derived
+        /// member is 8 columns wider than the change it holds.
+        #[test]
+        fn shrinking_collapses_the_b1_blocks_onto_the_minimal_split() {
+            for (reference, result) in [
+                (b"ACAA".as_slice(), b"CAACAG".as_slice()),
+                (b"ACCAA", b"CAG"),
+                (b"AAAAAAAATA", b"TAAAAAAAAATG"),
+            ] {
+                let live = partition_block(reference, result);
+                let shrunk = shrunk_sequence_first(reference, result);
+                assert_eq!(
+                    shape(&shrunk),
+                    shape(&live),
+                    "block {} -> {}",
+                    String::from_utf8_lossy(reference),
+                    String::from_utf8_lossy(result)
+                );
+                assert_eq!(denotes(reference, &shrunk), result);
+                assert_eq!(
+                    changed_columns_of_pieces(&shrunk),
+                    changed_columns_of_pieces(&live)
+                );
+            }
+        }
+
+        /// The audit's `B1` block in full, with the weights it recorded: the
+        /// sequence-first split spends 4 changed columns, shrinking brings it
+        /// back to live's 3, and the widened `delins` of `CAA` over one base
+        /// becomes the insertion of `CA` those bases denote.
+        #[test]
+        fn the_pinned_b1_block_loses_its_spanning_delins() {
+            let reference = b"ACAA";
+            let raw = partition_block_sequence_first(reference, b"CAACAG", MIN_SEPARATION_NO_FRAME)
+                .expect("must partition");
+            assert_eq!(
+                shape(&raw),
+                [(0, 1, b"CAA".as_slice()), (3, 4, b"G".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&raw), 4);
+
+            let shrunk = shrunk_sequence_first(reference, b"CAACAG");
+            assert_eq!(
+                shape(&shrunk),
+                [(0, 0, b"CA".as_slice()), (3, 4, b"G".as_slice())]
+            );
+            assert_eq!(changed_columns_of_pieces(&shrunk), 3);
+        }
+
+        /// The guard against over-shrinking, at the piece level: a deletion, an
+        /// insertion, a duplicating insertion and a substitution are returned
+        /// exactly as they arrived. None of them can share a flank between span
+        /// and payload, so the shrink reaches only `delins`-shaped pieces.
+        #[test]
+        fn a_deletion_insertion_dup_and_substitution_are_left_alone() {
+            let ref_bytes = b"AAAAAG";
+            for piece in [
+                // A 2-base deletion inside the A-run: no payload.
+                Piece {
+                    ref_start: 1,
+                    ref_end: 3,
+                    alt: Vec::new(),
+                },
+                // An insertion of two A into the same run: no reference span.
+                Piece {
+                    ref_start: 4,
+                    ref_end: 4,
+                    alt: b"AA".to_vec(),
+                },
+                // A duplicating insertion — `is_tandem_duplication` holds.
+                Piece {
+                    ref_start: 3,
+                    ref_end: 3,
+                    alt: b"A".to_vec(),
+                },
+                // A substitution: one base, and it differs.
+                Piece {
+                    ref_start: 5,
+                    ref_end: 6,
+                    alt: b"T".to_vec(),
+                },
+            ] {
+                let mut pieces = [piece.clone()];
+                shrink_pieces_to_differences(&mut pieces, ref_bytes);
+                assert_eq!(pieces[0], piece);
+            }
+        }
+
+        /// A piece whose span and payload are identical would trim to nothing.
+        /// It is left whole instead, so `anchor_for_piece` never sees a member
+        /// with no extent.
+        #[test]
+        fn a_piece_that_trims_away_entirely_is_left_alone() {
+            let piece = Piece {
+                ref_start: 0,
+                ref_end: 1,
+                alt: b"A".to_vec(),
+            };
+            let mut pieces = [piece.clone()];
+            shrink_pieces_to_differences(&mut pieces, b"A");
+            assert_eq!(pieces[0], piece);
+        }
+
+        /// The live splitter's own pieces are already minimal, so adding the
+        /// shrink to `canonicalize_from_sequence` cannot move them.
+        ///
+        /// `best_alignment` maximises matched columns, and a piece that shared a
+        /// flank between its span and its payload would mean a better placement
+        /// of the single gap was available — so the property is a consequence of
+        /// the search, not a coincidence. Enumerated over the same 14 280 blocks
+        /// as the ordering test: `partition_block`'s answer is a fixed point of
+        /// the shrink on every one.
+        #[test]
+        fn shrinking_never_moves_a_piece_the_live_splitter_produced() {
+            let mut compared = 0usize;
+            for (block, alt) in enumerated_blocks() {
+                let pieces = partition_block(&block, &alt);
+                let mut shrunk = pieces.clone();
+                shrink_pieces_to_differences(&mut shrunk, &block);
+                assert_eq!(
+                    shape(&shrunk),
+                    shape(&pieces),
+                    "the shrink moved a live piece on {} -> {}",
+                    String::from_utf8_lossy(&block),
+                    String::from_utf8_lossy(&alt)
+                );
+                compared += 1;
+            }
+            assert_eq!(compared, 14_280);
+        }
+
+        /// Shrinking commutes with the 3'-shift.
+        ///
+        /// `canonicalize_from_sequence` shifts, coalesces, then shrinks; the
+        /// opposite order — shrink, then shift and coalesce — is not obviously
+        /// the same pipeline, because shrinking can turn a `delins` into a pure
+        /// indel and only pure indels shift. Enumerated over every block pair
+        /// drawn from `{A,C,G}` of length 1..=4 on each side, at both separation
+        /// thresholds (14 280 partitioned blocks per threshold), the two orders
+        /// agree on every block.
+        #[test]
+        fn shrinking_before_and_after_the_three_prime_shift_agree() {
+            let blocks = enumerated_blocks();
+            for min_separation in [
+                MIN_SEPARATION_NO_FRAME,
+                crate::normalize::seqfirst::MIN_SEPARATION,
+            ] {
+                let mut compared = 0usize;
+                for (block, alt) in &blocks {
+                    let Some(pieces) = partition_block_sequence_first(block, alt, min_separation)
+                    else {
+                        continue;
+                    };
+
+                    let mut shift_first = pieces.clone();
+                    shift_pieces_three_prime(&mut shift_first, block);
+                    coalesce_adjacent_pieces(&mut shift_first);
+                    shrink_pieces_to_differences(&mut shift_first, block);
+
+                    let mut shrink_first = pieces.clone();
+                    shrink_pieces_to_differences(&mut shrink_first, block);
+                    shift_pieces_three_prime(&mut shrink_first, block);
+                    coalesce_adjacent_pieces(&mut shrink_first);
+
+                    assert_eq!(
+                        shape(&shift_first),
+                        shape(&shrink_first),
+                        "orders disagree at min_separation {min_separation} on {} -> {}",
+                        String::from_utf8_lossy(block),
+                        String::from_utf8_lossy(alt)
+                    );
+                    compared += 1;
+                }
+                // Every enumerated block partitions; none declines.
+                assert_eq!(compared, blocks.len());
             }
         }
     }

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1622,29 +1622,39 @@ const MAX_UNGUARDED_SPLIT_BLOCK: usize = 32;
 /// net insertion, one coincidentally matched interior base — and the type of
 /// the resulting members is the only thing that separates them.
 ///
-/// It applies only to blocks no larger than
-/// [`MAX_SINGLE_BASE_SEPARATION_BLOCK`]; above that a single unchanged base is
+/// It applies only where the block's net length change is at most
+/// [`MAX_SINGLE_BASE_SEPARATION_CHANGE`]; beyond that a single unchanged base is
 /// not believable and the threshold stays at 2.
 const MIN_PIECE_SEPARATION: usize = 1;
 
-/// Largest block, in bases, for which one unchanged base counts as separation.
+/// Largest **net length change**, in bases, for which one unchanged base counts
+/// as separation.
 ///
-/// A single matched base is evidence of structure in a short block and evidence
-/// of nothing in a long one, where a two- or three-base run recurs by chance.
-/// The Mutalyzer conformance corpus is what forces this: a 6 nt block replaced
-/// by a 21 nt payload (`NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC` and
-/// nine siblings) has interior bases that happen to match, and the oracle keeps
-/// it as one `delins`. Without a bound, a threshold of 1 shreds it into
+/// A single matched base is evidence of structure when the surrounding change is
+/// small and evidence of nothing when it is large, where a one- or two-base run
+/// recurs by chance. The Mutalyzer conformance corpus is what forces this: a 6 nt
+/// block replaced by a 21 nt payload
+/// (`NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC` and nine siblings) has
+/// interior bases that happen to match, and the oracle keeps it as one `delins`.
+/// Without a bound, a threshold of 1 shreds it into
 /// `g.[5207_5209delinsGTC;5211C>T;5213_5214insGCTCATTATCTGGCT]` — mixed member
 /// types, so [`split_buys_no_higher_priority_type`] does not reach it either.
 ///
+/// # Why the change and not the block length
+///
+/// Keying on block length looks equivalent and is not, because the block is
+/// about to be handed the *supremal* extent rather than the trimmed one. A
+/// variant rolled out over a homopolymer has a long block and a tiny change —
+/// #1260's window is 7 nt of reference for 2 inserted bases — while the
+/// Mutalyzer block is long *and* changes a lot. Length cannot tell those apart;
+/// the net change can, and it is the quantity the belief is actually about.
+///
 /// **The value is under-determined and the bounds are what is measured.** The
-/// corpus constrains it only to `(4, 21]`: `#1260b`'s block is 4 nt and must
-/// split at one base, the Mutalyzer block is 21 nt and must not. Every value in
-/// between scores identically, so `8` is a choice inside a measured window, not
-/// a calibrated constant. Narrowing it needs a case in that gap, not a
-/// re-derivation.
-const MAX_SINGLE_BASE_SEPARATION_BLOCK: usize = 8;
+/// corpus constrains it only to `[2, 15)`: #1260's window changes 2 bases and
+/// must split at one unchanged base, the Mutalyzer block changes 15 and must
+/// not. Every value in between scores identically, so `4` is a choice inside a
+/// measured window, not a calibrated constant.
+const MAX_SINGLE_BASE_SEPARATION_CHANGE: usize = 4;
 
 /// [`partition_block_sequence_first`]'s separation threshold on an axis with no
 /// reading frame (`g.`, `m.`, `n.`, and `r.` on a non-coding transcript).
@@ -2746,7 +2756,7 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
         return whole();
     }
     if result.len() > reference.len()
-        && !separations_are_meaningful(&pieces, reference.len().max(result.len()))
+        && !separations_are_meaningful(&pieces, result.len().abs_diff(reference.len()))
     {
         return whole();
     }
@@ -2915,13 +2925,13 @@ fn changed_columns_of_pieces(pieces: &[Piece]) -> usize {
 /// that fails when the bound is raised across the board. Extending this rule to
 /// cover them, and retiring that constant, is the principled fix and needs its
 /// own measurement pass.
-fn separations_are_meaningful(pieces: &[Piece], block_len: usize) -> bool {
+fn separations_are_meaningful(pieces: &[Piece], net_change: usize) -> bool {
     // `ref_end` is exclusive and a pure insertion has `ref_start == ref_end`, so
     // this already counts unchanged *bases* rather than event indices: a
     // junction contributes no width because it occupies none. The sequence-first
     // splitter had to be corrected for exactly this, because it works in event
     // space where a junction and a changed position are both one offset.
-    let required = if block_len > MAX_SINGLE_BASE_SEPARATION_BLOCK {
+    let required = if net_change > MAX_SINGLE_BASE_SEPARATION_CHANGE {
         2
     } else {
         MIN_PIECE_SEPARATION

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1605,6 +1605,25 @@ const MAX_UNGUARDED_SPLIT_BLOCK: usize = 32;
 /// before the split between them is believed. See `separations_are_meaningful`.
 const MIN_PIECE_SEPARATION: usize = 2;
 
+/// [`partition_block_sequence_first`]'s separation threshold on an axis with no
+/// reading frame (`g.`, `m.`, `n.`, and `r.` on a non-coding transcript).
+///
+/// `1`, not `seqfirst::MIN_SEPARATION`'s `2`. `general.md:34`'s general rule is
+/// "two variants separated by one or more nucleotides should be described
+/// individually" — one or more unchanged bases between two runs of change means
+/// they split, so runs merge only when separated by *fewer than one*, i.e. zero,
+/// unchanged bases. `general.md:35`'s exception — "separated by one nucleotide,
+/// together affecting one amino acid" — is what licenses merging across exactly
+/// one unchanged base, and it is scoped to "one amino acid": a reading frame,
+/// which `AxisFrame::reading_frame` already isolates for
+/// `apply_coding_codon_exception`. Applying `seqfirst::MIN_SEPARATION` (`2`)
+/// unconditionally therefore grants every axis the coding exception, which is
+/// what the `FERRO_SEQFIRST_SHADOW` audit's class `B2` measured: 3 088 blocks
+/// where the sequence-first splitter merged across an unchanged base the live
+/// splitter, correctly, kept split. Pinned by
+/// `sequence_first_split_axis_separation_matches_general_rule`.
+const MIN_SEPARATION_NO_FRAME: u32 = 1;
+
 /// One derived edit: a maximal run of change over the reference window, as
 /// 0-based half-open offsets into that window plus its replacement bases.
 ///
@@ -1791,7 +1810,20 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // any 3'-shift or coalescing, so a reported disagreement is a disagreement
     // about the *split* and not about a downstream pass. Never affects `pieces`.
     if seqfirst_shadow_enabled() {
-        let shadow = partition_block_sequence_first(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+        // Reading-frame axes get the coding one-amino-acid exception
+        // (`seqfirst::MIN_SEPARATION`, 2); every other axis gets the general
+        // rule (`MIN_SEPARATION_NO_FRAME`, 1). Same distinction
+        // `apply_coding_codon_exception` uses below, via the same `AxisFrame`.
+        let min_separation = if frame.reading_frame {
+            crate::normalize::seqfirst::MIN_SEPARATION
+        } else {
+            MIN_SEPARATION_NO_FRAME
+        };
+        let shadow = partition_block_sequence_first(
+            &ref_bytes[lo..hi_ref],
+            &result[lo..hi_alt],
+            min_separation,
+        );
         if shadow.as_ref() == Some(&pieces) {
             // The denominator. Without it, `grep -c SEQFIRST_SHADOW` returning 0
             // cannot be told apart from a shadow that never ran — the failure
@@ -2655,16 +2687,25 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
 /// Returns `None` when the block cannot be partitioned this way, which today
 /// means only that [`member_alt_spans`] declined. The caller falls back.
 ///
+/// `min_separation` is the unchanged-base threshold `partition_members_with`
+/// merges below (see that function's doc). It is **not** hardcoded to
+/// `seqfirst::MIN_SEPARATION` — the caller must choose it per axis. See
+/// `MIN_SEPARATION_NO_FRAME` for why: the value that is correct on a
+/// reading-frame axis is wrong on a genomic one.
+///
 /// Called only from the `FERRO_SEQFIRST_SHADOW` comparison in
 /// [`canonicalize_from_sequence`]; it does not yet decide any result.
-fn partition_block_sequence_first(reference: &[u8], result: &[u8]) -> Option<Vec<Piece>> {
+fn partition_block_sequence_first(
+    reference: &[u8],
+    result: &[u8],
+    min_separation: u32,
+) -> Option<Vec<Piece>> {
     use crate::normalize::seqfirst::align::AlignmentDag;
     use crate::normalize::seqfirst::partition::{member_alt_spans, partition_members_with};
-    use crate::normalize::seqfirst::MIN_SEPARATION;
 
     let dag = AlignmentDag::build(reference, result);
     let dominators = dag.dominators();
-    let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
+    let members = partition_members_with(&dag, &dominators, min_separation);
     let spans = member_alt_spans(&dag, &dominators, &members)?;
 
     Some(
@@ -5654,8 +5695,12 @@ mod tests {
         let reference = b"GACTGACTGA";
         let result = b"GACTAACTGA";
         let old = partition_block(reference, result);
-        let new = partition_block_sequence_first(reference, result)
-            .expect("an unambiguous single substitution must partition");
+        let new = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("an unambiguous single substitution must partition");
         assert_eq!(new.len(), 1, "expected one member, got {new:?}");
         assert_eq!(
             (new[0].ref_start, new[0].ref_end, new[0].alt.clone()),
@@ -5670,10 +5715,69 @@ mod tests {
     fn sequence_first_split_keeps_the_spec_delins_example_whole() {
         let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
         let result = b"TTCCTCGATGCCTG";
-        let pieces = partition_block_sequence_first(reference, result)
-            .expect("the spec example must partition");
+        let pieces = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("the spec example must partition");
         assert_eq!(pieces.len(), 1, "spec requires one delins, got {pieces:?}");
         assert_eq!((pieces[0].ref_start, pieces[0].ref_end), (0, 52));
+    }
+
+    /// Task 3, class `B2`: the separation threshold is axis-dependent, not a
+    /// uniform constant. `general.md:34`'s general rule — two variants
+    /// separated by one or more nucleotides are described individually — governs
+    /// a genomic axis, so `MIN_SEPARATION_NO_FRAME` (`1`) must keep two runs one
+    /// unchanged base apart split. `general.md:35`'s exception — separated by one
+    /// nucleotide, together affecting one amino acid — governs a reading-frame
+    /// axis, so `seqfirst::MIN_SEPARATION` (`2`) must merge the very same block.
+    ///
+    /// `CAA -> TAG` is the block `issue_1235_transcript_axes::` `n.`
+    /// (non-coding, hence `AxisFrame::reading_frame == false`)
+    /// `noncoding_axis_converges_on_separated_changes` produces, taken from the
+    /// `FERRO_SEQFIRST_SHADOW` audit's class `B2` — a test named for exactly the
+    /// genomic-axis split this threshold must preserve. Its equal-length blocks
+    /// have a single dominator match at the middle base (only one minimal
+    /// alignment achieves the edit distance), so the split is a pure threshold
+    /// question with no alignment ambiguity involved.
+    ///
+    /// Not chosen: `AAT -> CAA` and `CAATT -> TA`, two of `B2`'s other curated
+    /// blocks. Both stay one member even at `MIN_SEPARATION_NO_FRAME` — their
+    /// apparent single unchanged base is not a dominator match at all (a second,
+    /// equally minimal alignment matches the same reference position to a
+    /// *different* alternate offset, so `Dominators::matched` is empty; see
+    /// `align.rs`'s `AT -> AAT` example). That is `B1`'s mechanism, not `B2`'s,
+    /// even though the audit's live-gap-width heuristic filed them under `B2`.
+    /// So this fix does not close every `B2` block — only the ones where a
+    /// dominator genuinely exists and the threshold alone was suppressing it.
+    #[test]
+    fn sequence_first_split_axis_separation_matches_general_rule() {
+        let reference = b"CAA";
+        let result = b"TAG";
+        let genomic = partition_block_sequence_first(reference, result, MIN_SEPARATION_NO_FRAME)
+            .expect("must partition");
+        assert_eq!(
+            genomic.len(),
+            2,
+            "a genomic axis must split at the one unchanged base: {genomic:?}"
+        );
+
+        let coding = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("must partition");
+        assert_eq!(
+            coding.len(),
+            1,
+            "a reading-frame axis must merge across the one unchanged base: {coding:?}"
+        );
+        assert_eq!(
+            (coding[0].ref_start, coding[0].ref_end),
+            (0, reference.len())
+        );
     }
 
     /// Every piece the new splitter emits must reconstruct the result block
@@ -5697,7 +5801,11 @@ mod tests {
         let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
         for reference in &all {
             for result in &all {
-                let Some(pieces) = partition_block_sequence_first(reference, result) else {
+                let Some(pieces) = partition_block_sequence_first(
+                    reference,
+                    result,
+                    crate::normalize::seqfirst::MIN_SEPARATION,
+                ) else {
                     continue;
                 };
                 let mut rebuilt = Vec::new();
@@ -5726,7 +5834,12 @@ mod tests {
     fn sequence_first_split_emits_disjoint_ascending_pieces() {
         let reference = b"ACGTACGTACGTACGT";
         let result = b"ATGTACGTACGTACTT";
-        let pieces = partition_block_sequence_first(reference, result).expect("must partition");
+        let pieces = partition_block_sequence_first(
+            reference,
+            result,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        )
+        .expect("must partition");
         for pair in pieces.windows(2) {
             assert!(
                 pair[0].ref_end <= pair[1].ref_start,
@@ -5786,6 +5899,13 @@ mod tests {
     /// the non-sweep, non-proptest tests produce, 38 are a `B2` merge. See
     /// `shadow_merges_across_one_unchanged_base_where_live_splits`, which pins two
     /// blocks taken straight from the #1232 and #1235 transcript-axis tests.
+    ///
+    /// This module's tests call `partition_block_sequence_first` directly at the
+    /// uniform `seqfirst::MIN_SEPARATION` (`2`), on purpose: they document the
+    /// raw algorithm-level disagreement this audit found, unchanged. The fix —
+    /// choosing the separation per axis at the `canonicalize_from_sequence` call
+    /// site rather than changing this default — is pinned separately, by
+    /// `sequence_first_split_axis_separation_matches_general_rule`.
     mod seqfirst_shadow_audit {
         use super::*;
 
@@ -5826,8 +5946,12 @@ mod tests {
         /// Returns `(live, shadow)` for the caller to pin exactly.
         fn both(reference: &[u8], result: &[u8]) -> (Vec<Piece>, Vec<Piece>) {
             let live = partition_block(reference, result);
-            let shadow = partition_block_sequence_first(reference, result)
-                .expect("no harvested disagreement had the sequence-first side decline");
+            let shadow = partition_block_sequence_first(
+                reference,
+                result,
+                crate::normalize::seqfirst::MIN_SEPARATION,
+            )
+            .expect("no harvested disagreement had the sequence-first side decline");
             assert_eq!(
                 denotes(reference, &live).as_deref(),
                 Some(result),

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1603,7 +1603,48 @@ const MAX_UNGUARDED_SPLIT_BLOCK: usize = 32;
 
 /// Unchanged reference bases two pieces of a net insertion must be separated by
 /// before the split between them is believed. See `separations_are_meaningful`.
-const MIN_PIECE_SEPARATION: usize = 2;
+///
+/// `1`, per `general.md:34`: "two variants separated by one or more nucleotides
+/// should be described individually and **not** as a 'delins'". One base is one
+/// or more, so a split across one unchanged base is what the spec asks for, not
+/// something to disbelieve.
+///
+/// It was `2`, which granted every axis `general.md:35`'s exception — "separated
+/// by one nucleotide, **together affecting one amino acid**" — although that
+/// exception is doubly conditioned and cannot reach a genomic axis at all. The
+/// codon half is applied where it belongs, triplet-precisely, by
+/// `apply_coding_codon_exception` *after* partitioning; see
+/// [`MIN_SEPARATION_NO_FRAME`], which reached the same value from the same
+/// reading for the sequence-first splitter.
+///
+/// Lowering it is only safe alongside [`split_buys_no_higher_priority_type`]:
+/// #422 and #999's negative control are the *same shape* at this threshold —
+/// net insertion, one coincidentally matched interior base — and the type of
+/// the resulting members is the only thing that separates them.
+///
+/// It applies only to blocks no larger than
+/// [`MAX_SINGLE_BASE_SEPARATION_BLOCK`]; above that a single unchanged base is
+/// not believable and the threshold stays at 2.
+const MIN_PIECE_SEPARATION: usize = 1;
+
+/// Largest block, in bases, for which one unchanged base counts as separation.
+///
+/// A single matched base is evidence of structure in a short block and evidence
+/// of nothing in a long one, where a two- or three-base run recurs by chance.
+/// The Mutalyzer conformance corpus is what forces this: a 6 nt block replaced
+/// by a 21 nt payload (`NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC` and
+/// nine siblings) has interior bases that happen to match, and the oracle keeps
+/// it as one `delins`. Without a bound, a threshold of 1 shreds it into
+/// `g.[5207_5209delinsGTC;5211C>T;5213_5214insGCTCATTATCTGGCT]` — mixed member
+/// types, so [`split_buys_no_higher_priority_type`] does not reach it either.
+///
+/// **The value is under-determined and the bounds are what is measured.** The
+/// corpus constrains it only to `(4, 21]`: `#1260b`'s block is 4 nt and must
+/// split at one base, the Mutalyzer block is 21 nt and must not. Every value in
+/// between scores identically, so `8` is a choice inside a measured window, not
+/// a calibrated constant. Narrowing it needs a case in that gap, not a
+/// re-derivation.
+const MAX_SINGLE_BASE_SEPARATION_BLOCK: usize = 8;
 
 /// [`partition_block_sequence_first`]'s separation threshold on an axis with no
 /// reading frame (`g.`, `m.`, `n.`, and `r.` on a non-coding transcript).
@@ -2704,10 +2745,46 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
     if pieces.is_empty() {
         return whole();
     }
-    if result.len() > reference.len() && !separations_are_meaningful(&pieces) {
+    if result.len() > reference.len()
+        && !separations_are_meaningful(&pieces, reference.len().max(result.len()))
+    {
+        return whole();
+    }
+    // Scoped to length-changing blocks: an equal-length block has no gap to
+    // place, so every matched base is a genuine coordinate-wise identity rather
+    // than an artefact of where the gap landed, and a split across one is real.
+    // `MAX_UNGUARDED_SPLIT_BLOCK`'s own doc draws the same line.
+    if reference.len() != result.len()
+        && pieces.len() > 1
+        && every_separation_is_a_single_base(&pieces)
+        && split_buys_no_higher_priority_type(&pieces, reference)
+    {
         return whole();
     }
     pieces
+}
+
+/// Whether every gap between consecutive pieces is a single unchanged base —
+/// the regime where a match is most likely to be coincidence rather than
+/// structure.
+///
+/// This is what keeps [`split_buys_no_higher_priority_type`] from overriding
+/// `general.md:34` outright. That rule — "two variants separated by one or more
+/// nucleotides should be described individually and **not** as a 'delins'" — is
+/// unambiguous once there is real distance between the members, and an
+/// all-`delins` split at, say, two unchanged bases is one the rule plainly
+/// wants: `AGAGT -> GAAGAG` divides into `AG>GA` and `T>AG` for 4 changed
+/// columns against the spanning form's 6, so collapsing it would be both less
+/// minimal and against the rule.
+///
+/// At exactly one base the two readings genuinely compete, which is why #422 is
+/// a *deliberately pinned* non-confluence rather than a plain bug, and why
+/// `delins.md:44-47` prefers the spanning form where a payload merely *aligns*.
+/// Restricting the collapse to that regime is what lets both rules stand.
+fn every_separation_is_a_single_base(pieces: &[Piece]) -> bool {
+    pieces
+        .windows(2)
+        .all(|pair| pair[1].ref_start.saturating_sub(pair[0].ref_end) <= 1)
 }
 
 /// Partition a changed block by deriving member boundaries from the **denoted
@@ -2838,10 +2915,94 @@ fn changed_columns_of_pieces(pieces: &[Piece]) -> usize {
 /// that fails when the bound is raised across the board. Extending this rule to
 /// cover them, and retiring that constant, is the principled fix and needs its
 /// own measurement pass.
-fn separations_are_meaningful(pieces: &[Piece]) -> bool {
+fn separations_are_meaningful(pieces: &[Piece], block_len: usize) -> bool {
+    // `ref_end` is exclusive and a pure insertion has `ref_start == ref_end`, so
+    // this already counts unchanged *bases* rather than event indices: a
+    // junction contributes no width because it occupies none. The sequence-first
+    // splitter had to be corrected for exactly this, because it works in event
+    // space where a junction and a changed position are both one offset.
+    let required = if block_len > MAX_SINGLE_BASE_SEPARATION_BLOCK {
+        2
+    } else {
+        MIN_PIECE_SEPARATION
+    };
     pieces
         .windows(2)
-        .all(|pair| pair[1].ref_start.saturating_sub(pair[0].ref_end) >= MIN_PIECE_SEPARATION)
+        .all(|pair| pair[1].ref_start.saturating_sub(pair[0].ref_end) >= required)
+}
+
+/// Whether a proposed split buys nothing over the spanning `delins` it came
+/// from — that is, whether **every** member would render as a `delins` too.
+///
+/// # This is ferro policy, not a spec rule
+///
+/// It is tempting to cite `general.md:56`'s prioritisation here, and an earlier
+/// revision of this comment did — claiming `delins` was "last" in it. That
+/// citation does not reach. The list is "(1) substitution, (2) deletion, (3)
+/// inversion, (4) duplication, (5) insertion", and `delins` is not in it at
+/// all. What it ranks is the type of *one description of one change*, which is
+/// how msto's #1231/#1233 use it — comparing two two-member descriptions
+/// member-wise. It never ranks a multi-member allele against a single spanning
+/// description.
+///
+/// What licenses the collapse is an analogy plus the corpus. `delins.md:44-47`
+/// keeps the spanning form where the payload merely *"aligns"* against a
+/// coincidentally matched interior base, and that is the shape of every corpus
+/// row required to stay whole. A split whose members are all `delins` buys no
+/// descriptive gain over the spanning `delins` it came from, so in the one
+/// regime where the matched base is least believable — a single unchanged base,
+/// see [`every_separation_is_a_single_base`] — this prefers the form the
+/// analogous spec case prefers. Stated as a policy choice inside a spec gap so
+/// it is not mistaken for a mandate.
+///
+/// This is what separates #422 from #999's negative control. The two are the
+/// same shape at [`MIN_PIECE_SEPARATION`] — a net insertion with one
+/// coincidentally matched interior base — and their split *member types* are the
+/// only difference: `delins` + `delins` for #422, `ins` + `sub` for #999.
+/// `issue_422_cross_reference_ins.rs` calls that conjunction impossible; it is
+/// not, and #1235's own comment asks for precisely this fix.
+///
+/// # Typing is block-local
+///
+/// `ins`, `del` and `sub` are structural. So are `dup` and repeat notations —
+/// they add or remove copies, so they arrive as insertions or deletions and are
+/// already excluded. `inv` is the one renderer type that hides inside a
+/// structural `delins`, and it is detectable from the member's own span:
+/// [`is_inversion`] does it, on [`reverse_complement_bytes`], which refuses a
+/// byte it cannot complement rather than passing it through. Nothing here needs
+/// the renderer, so the test runs on the trimmed block before rendering.
+///
+/// Measured over an exhaustive reverse-complement-closed sweep, omitting the
+/// `inv` and self-repeat cases would collapse 694 of 1 094 firings (`AT`, ≤7 nt)
+/// and 2 592 of 26 244 (`ACGT`, ≤5 nt) — so both are load-bearing, not defensive.
+fn split_buys_no_higher_priority_type(pieces: &[Piece], reference: &[u8]) -> bool {
+    pieces.iter().all(|piece| {
+        let span = piece.ref_end - piece.ref_start;
+        span > 0
+            && !piece.alt.is_empty()
+            && !(span == 1 && piece.alt.len() == 1)
+            && !is_inversion(piece, reference)
+            && !is_tandem_duplication(piece, reference)
+            && !alt_repeats_its_own_span(piece, reference)
+    })
+}
+
+/// A member whose payload is its own reference span repeated, which renders as
+/// a `dup` (two copies) or a repeat notation rather than a `delins`.
+///
+/// [`is_tandem_duplication`] covers the *insertion* spelling of a duplication,
+/// where the copy sits outside the member's span; this covers the `delins`
+/// spelling, where the member's span carries the copies itself. Both are
+/// block-local. Case-folded, because reference FASTAs arrive soft-masked.
+fn alt_repeats_its_own_span(piece: &Piece, reference: &[u8]) -> bool {
+    let span = &reference[piece.ref_start..piece.ref_end];
+    !span.is_empty()
+        && piece.alt.len() > span.len()
+        && piece.alt.len().is_multiple_of(span.len())
+        && piece
+            .alt
+            .chunks(span.len())
+            .all(|chunk| chunk.eq_ignore_ascii_case(span))
 }
 
 /// The alignment maximizing matched bases, ties broken by the 5'-most gap.
@@ -6913,6 +7074,64 @@ mod tests {
                     (None, Some(1)),
                     (Some(1), Some(2))
                 ])
+            );
+        }
+
+        #[test]
+        fn a_split_at_one_unchanged_base_is_admitted() {
+            // `general.md:34`: "two variants separated by one or more
+            // nucleotides should be described individually and not as a
+            // delins". One base is one or more. #1260's trimmed block reaches
+            // this only because the two-gap alignment can express it.
+            assert_eq!(
+                partition_block(b"A", b"CAC").len(),
+                2,
+                "#1260a: two insertions either side of the retained A"
+            );
+            assert_eq!(
+                partition_block(b"GC", b"CGA").len(),
+                2,
+                "#999-neg: the two-member count the corpus records as required"
+            );
+        }
+
+        #[test]
+        fn a_split_that_buys_no_higher_priority_type_collapses() {
+            // #422. The same shape as #999-neg — net insertion, one
+            // coincidentally matched interior base — but its split is two
+            // `delins` members, so it buys nothing `general.md:56` ranks above
+            // the spanning `delins` it came from. #1235's own comment asks for
+            // exactly this: a fix that resolves #422 and keeps #999 green.
+            assert_eq!(partition_block(b"CTATAG", b"AAACCCC").len(), 1);
+        }
+
+        #[test]
+        fn the_collapse_spares_an_equal_length_block() {
+            // `long-delins-40nt`: both members are `delins`, but the block is
+            // equal-length, so there is no gap to place and every matched base
+            // is a genuine coordinate-wise identity rather than a placement
+            // artefact. Collapsing here would lose a real two-member answer.
+            assert_eq!(
+                partition_block(
+                    b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
+                    b"CATGCATGCATGCATGCATTCATGCATGCATGCATGCATG"
+                )
+                .len(),
+                2
+            );
+        }
+
+        #[test]
+        fn the_collapse_spares_a_member_that_renders_as_inv_or_dup() {
+            // A structural `delins` can still render as an `inv` — the one
+            // renderer type that hides inside one — and `inv` outranks `delins`,
+            // so such a split is worth keeping. Measured: a naive all-`delins`
+            // test collapses 694 of 1094 firings over an exhaustive `AT` sweep.
+            let pieces = partition_block(b"AAAAA", b"TATT");
+            assert!(
+                pieces.len() > 1,
+                "a member that is the reverse complement of its own span must \
+                 not be collapsed away: {pieces:?}"
             );
         }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1627,6 +1627,22 @@ const MAX_UNGUARDED_SPLIT_BLOCK: usize = 32;
 /// not believable and the threshold stays at 2.
 const MIN_PIECE_SEPARATION: usize = 1;
 
+/// Largest block, in aligned positions, over which a tied gap placement is
+/// broken by what it separates rather than by being 5'-most.
+///
+/// The score for one placement is O(1) — that is what makes `best_alignment`'s
+/// search linear — but ranking a *tie* needs the placement's member count, which
+/// costs a pass over the block. In a repeat tract every placement ties, so the
+/// tie-break is O(n²) there, which at [`MAX_SPLIT_BLOCK`] would be ~1e6 column
+/// operations for one call.
+///
+/// **This is a bound on coverage, not a silent cap.** Above it the 5'-most
+/// placement wins as before, so a tied block longer than this keeps whatever
+/// description the old rule gave. Nothing in the corpus is near it — #1262's
+/// block is 3 aligned positions — and the bound exists so a pathological
+/// homopolymer cannot make one call quadratic in the window size.
+const MAX_TIE_BREAK_SWEEP: usize = 256;
+
 /// Largest **net length change**, in bases, for which one unchanged base counts
 /// as separation.
 ///
@@ -3077,16 +3093,56 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
     let mut leading = 0usize;
     let mut trailing = (0..anchored).filter(|&i| ungapped(i)).count();
 
-    let mut best: Option<(usize, usize)> = None;
+    // How many members a placement separates the change into. Computed only to
+    // break a tie, because it costs a pass over the block where the score costs
+    // O(1) — see the tie-break note below.
+    let members_at = |k: usize| -> usize {
+        let columns =
+            single_gap_alignment(k, gap_len, shorter_is_ref, reference.len(), result.len());
+        pieces_from_columns(&columns, reference, result).len()
+    };
+
+    // `(matched columns, members separated, k)`.
+    let mut best: Option<(usize, usize, usize)> = None;
     for k in 0..=anchored {
         if k > 0 {
             leading += usize::from(reference[k - 1] == result[k - 1]);
             trailing -= usize::from(ungapped(k - 1));
         }
         let matches = leading + trailing;
-        // Strictly greater keeps the first (5'-most) alignment on a tie.
-        if best.as_ref().is_none_or(|(score, _)| matches > *score) {
-            best = Some((matches, k));
+        match best {
+            Some((score, _, _)) if matches < score => continue,
+            // A TIE, and the score cannot choose. In a repeat tract every
+            // placement matches the same number of columns, so this is the
+            // common case there rather than a corner: `AAA -> CA` ties three
+            // ways. `delins.md:17` decides it — "two variants separated by one
+            // or more nucleotides should be described individually and not as a
+            // 'delins'" — so prefer the placement that leaves a matched base
+            // *between* the changes, which is the one separating them into more
+            // members. `general.md:56` says the same from the other side, since
+            // `delins` is last in the priority order.
+            //
+            // This is not the 5'-most/3'-most flip that was tried and rejected:
+            // it does not rank placements by position at all. `AAA -> CA`'s
+            // winner happens to be 3'-most, but the criterion is what the
+            // placement separates, and `split_buys_no_higher_priority_type`
+            // still collapses a split that buys nothing.
+            Some((score, separated, _)) if matches == score => {
+                if anchored <= MAX_TIE_BREAK_SWEEP {
+                    let candidate = members_at(k);
+                    if candidate > separated {
+                        best = Some((matches, candidate, k));
+                    }
+                }
+            }
+            _ => {
+                let separated = if anchored <= MAX_TIE_BREAK_SWEEP {
+                    members_at(k)
+                } else {
+                    0
+                };
+                best = Some((matches, separated, k));
+            }
         }
     }
     // A single gap cannot express *insertion, retained reference, insertion*,
@@ -3094,14 +3150,14 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
     // base unmatched. Scoped to net insertions by `shorter_is_ref`, which is
     // what keeps it clear of the corpus the single-gap restriction protects —
     // see [`two_gap_insertion_alignment`].
-    if shorter_is_ref && best.is_some_and(|(matches, _)| matches < reference.len()) {
+    if shorter_is_ref && best.is_some_and(|(matches, _, _)| matches < reference.len()) {
         if let Some(columns) = two_gap_insertion_alignment(reference, result) {
             return Some(columns);
         }
     }
 
     // Only the winner is materialized.
-    best.map(|(_, k)| {
+    best.map(|(_, _, k)| {
         single_gap_alignment(k, gap_len, shorter_is_ref, reference.len(), result.len())
     })
 }
@@ -7023,6 +7079,63 @@ mod tests {
         // The same inversion clear of the bad byte still applies.
         let clean = [GEdit::Inv { s: 6, e: 9 }];
         assert!(apply_edits_to_window(&clean, reference, 1).is_some());
+    }
+
+    /// Ties between gap placements, broken by what they separate (#1262).
+    ///
+    /// In a repeat tract every placement of the gap matches the same number of
+    /// columns, so the score cannot choose and the tie-break decides the
+    /// description. msto's `high` corpus states the rule the spec gives for
+    /// that: two variants separated by one or more unchanged nucleotides are
+    /// described individually and **not** as a `delins` (`delins.md:17`, cited
+    /// by #1232), and `general.md:56` ranks `delins` last (#1231, #1233).
+    mod tie_break_by_separation {
+        use super::*;
+
+        #[test]
+        fn a_tied_placement_that_separates_the_change_wins() {
+            // #1262's authored block. Deleting `ref[0]`, `ref[1]` or `ref[2]`
+            // each leaves exactly one matched column, so all three placements
+            // tie. Only the third leaves the match *between* the two changes,
+            // which is what makes them separate members.
+            assert_eq!(
+                partition_block(b"AAA", b"CA"),
+                vec![
+                    Piece {
+                        ref_start: 0,
+                        ref_end: 1,
+                        alt: b"C".to_vec()
+                    },
+                    Piece {
+                        ref_start: 2,
+                        ref_end: 3,
+                        alt: Vec::new()
+                    },
+                ],
+                "a substitution and a deletion, separated by the unchanged base"
+            );
+        }
+
+        #[test]
+        fn an_untied_placement_is_still_chosen_by_score() {
+            // #1232's block: the placements do not tie — one matches strictly
+            // more columns — so the score decides and the tie-break never runs.
+            // Already correct before this rule, and it must stay that way.
+            assert_eq!(partition_block(b"TTTTT", b"TA").len(), 2);
+        }
+
+        #[test]
+        fn the_tie_break_leaves_the_contiguous_corpus_alone() {
+            // Cluster A stays whole: these have no tie to break, because their
+            // best placement is unique.
+            assert_eq!(
+                partition_block(b"CAGTGACTAG", b"TGTCACGACT").len(),
+                1,
+                "#1040"
+            );
+            assert_eq!(partition_block(b"GCT", b"AGC").len(), 1, "#1034");
+            assert_eq!(partition_block(b"CTATAG", b"AAACCCC").len(), 1, "#422");
+        }
     }
 
     /// The two-gap insertion form (#1260).

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2575,6 +2575,50 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
     pieces
 }
 
+/// Partition a changed block by deriving member boundaries from the **denoted
+/// sequence**, via [`crate::normalize::seqfirst`].
+///
+/// Same contract as [`partition_block`] — pieces are disjoint, ascending, and
+/// reconstruct `result` when substituted into `reference` — but derived from
+/// the alignment steps common to *every* minimal alignment rather than from a
+/// single-gap search. Two spellings of one variant produce the same
+/// `(reference, result)` pair and therefore the same pieces.
+///
+/// `reference` and `result` must already have their common flanks trimmed;
+/// `canonicalize_from_sequence` does that with [`trim_common_flanks`] before
+/// calling in. An untrimmed flank changes the partition, so this is a
+/// precondition and not a convenience.
+///
+/// Returns `None` when the block cannot be partitioned this way, which today
+/// means only that [`member_alt_spans`] declined. The caller falls back.
+// Not yet called from `normalize_allele` or anywhere else — wiring it in is a
+// later task in this migration. Allowed here for the same reason
+// `seqfirst::mod` allows it at the module level: deliberately unused until
+// that wiring lands, not a code-quality issue to restructure around.
+#[allow(dead_code)]
+fn partition_block_sequence_first(reference: &[u8], result: &[u8]) -> Option<Vec<Piece>> {
+    use crate::normalize::seqfirst::align::AlignmentDag;
+    use crate::normalize::seqfirst::partition::{member_alt_spans, partition_members_with};
+    use crate::normalize::seqfirst::MIN_SEPARATION;
+
+    let dag = AlignmentDag::build(reference, result);
+    let dominators = dag.dominators();
+    let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
+    let spans = member_alt_spans(&dag, &dominators, &members)?;
+
+    Some(
+        members
+            .iter()
+            .zip(spans)
+            .map(|(member, (alt_start, alt_end))| Piece {
+                ref_start: member.ref_start as usize,
+                ref_end: member.ref_end as usize,
+                alt: result[alt_start as usize..alt_end as usize].to_vec(),
+            })
+            .collect(),
+    )
+}
+
 /// Alignment columns a description marks as changed.
 ///
 /// One member occupies `max(|span|, |replacement|)` columns: a substitution costs
@@ -5539,6 +5583,95 @@ mod tests {
             pieces[0].ref_start, 2,
             "the first piece must be the lone 5' substitution; got {pieces:?}"
         );
+    }
+
+    /// The two splitters must agree wherever the old one is already right.
+    /// A single changed base has one unambiguous answer, so any disagreement
+    /// here is a bug in the new path rather than a behavioural change.
+    #[test]
+    fn sequence_first_split_agrees_on_an_unambiguous_single_change() {
+        let reference = b"GACTGACTGA";
+        let result = b"GACTAACTGA";
+        let old = partition_block(reference, result);
+        let new = partition_block_sequence_first(reference, result)
+            .expect("an unambiguous single substitution must partition");
+        assert_eq!(new.len(), 1, "expected one member, got {new:?}");
+        assert_eq!(
+            (new[0].ref_start, new[0].ref_end, new[0].alt.clone()),
+            (old[0].ref_start, old[0].ref_end, old[0].alt.clone())
+        );
+    }
+
+    /// The spec's own worked example (`delins.md:44`, `LRG_199t1:c.850_901`)
+    /// must stay one member. This is the case that discriminates counting
+    /// unchanged bases from comparing event offsets.
+    #[test]
+    fn sequence_first_split_keeps_the_spec_delins_example_whole() {
+        let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+        let result = b"TTCCTCGATGCCTG";
+        let pieces = partition_block_sequence_first(reference, result)
+            .expect("the spec example must partition");
+        assert_eq!(pieces.len(), 1, "spec requires one delins, got {pieces:?}");
+        assert_eq!((pieces[0].ref_start, pieces[0].ref_end), (0, 52));
+    }
+
+    /// Every piece the new splitter emits must reconstruct the result block
+    /// exactly. A split that does not round-trip denotes a different variant.
+    #[test]
+    fn sequence_first_split_round_trips_every_block_it_accepts() {
+        fn words(len: u32) -> Vec<Vec<u8>> {
+            if len == 0 {
+                return vec![Vec::new()];
+            }
+            let mut out = Vec::new();
+            for shorter in words(len - 1) {
+                for base in *b"AC" {
+                    let mut w = shorter.clone();
+                    w.push(base);
+                    out.push(w);
+                }
+            }
+            out
+        }
+        let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        for reference in &all {
+            for result in &all {
+                let Some(pieces) = partition_block_sequence_first(reference, result) else {
+                    continue;
+                };
+                let mut rebuilt = Vec::new();
+                let mut cursor = 0usize;
+                for piece in &pieces {
+                    rebuilt.extend_from_slice(&reference[cursor..piece.ref_start]);
+                    rebuilt.extend_from_slice(&piece.alt);
+                    cursor = piece.ref_end;
+                }
+                rebuilt.extend_from_slice(&reference[cursor..]);
+                assert_eq!(
+                    rebuilt,
+                    *result,
+                    "{} -> {} rebuilt as {}",
+                    String::from_utf8_lossy(reference),
+                    String::from_utf8_lossy(result),
+                    String::from_utf8_lossy(&rebuilt)
+                );
+            }
+        }
+    }
+
+    /// Pieces must be disjoint and ascending — the property that makes the
+    /// overlap and ordering repair passes unnecessary.
+    #[test]
+    fn sequence_first_split_emits_disjoint_ascending_pieces() {
+        let reference = b"ACGTACGTACGTACGT";
+        let result = b"ATGTACGTACGTACTT";
+        let pieces = partition_block_sequence_first(reference, result).expect("must partition");
+        for pair in pieces.windows(2) {
+            assert!(
+                pair[0].ref_end <= pair[1].ref_start,
+                "pieces overlap or are out of order: {pieces:?}"
+            );
+        }
     }
 
     fn flip_base(base: u8) -> u8 {

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1643,6 +1643,43 @@ const MIN_PIECE_SEPARATION: usize = 1;
 /// homopolymer cannot make one call quadratic in the window size.
 const MAX_TIE_BREAK_SWEEP: usize = 256;
 
+/// Placements [`two_gap_insertion_alignment`] will examine before giving up.
+///
+/// The search sweeps `a` over the two blocks' common prefix and `b` over their
+/// common suffix. Both are **zero on a trimmed block**, which is what every
+/// caller passes today, so the sweep costs a handful of placements — but the
+/// point of generalising that search was to stop depending on the caller's trim,
+/// and leaving the *cost* dependent on it would reintroduce the same coupling.
+///
+/// Each placement costs an `O(block)` slice comparison. Measured worst case (no
+/// solution exists, so the sweep runs to exhaustion) at [`MAX_SPLIT_BLOCK`] with
+/// a 6-base insertion:
+///
+/// ```text
+/// common affixes 0, 0        5 placements     (trimmed — today)
+/// common affixes 1, 1       20 placements     (one flank base restored per side)
+/// common affixes 512, 512    1 315 840        (~1.3e9 byte comparisons)
+/// ```
+///
+/// # Why this declines rather than narrowing the sweep
+///
+/// An earlier revision clamped the affix *lengths* to a small constant instead.
+/// That is not a cost bound, it is a **silent change of answer**, and it was
+/// measured doing exactly that: `AAAAAAA -> AACACAAAA` (#1260's untrimmed
+/// window) decomposes only at `a = 2, b = 3`, which needs a common suffix of 4.
+/// Clamping to 2 excluded the sole solution, the function returned `None`, and
+/// the block fell back to a spanning `delins`. It went unnoticed because on that
+/// row the single-gap search happens to reach the same member count by another
+/// route — so the clamp was wrong in a way no test could see until something
+/// else moved.
+///
+/// Exceeding this budget therefore abandons the whole two-gap search and lets
+/// [`best_alignment`] keep its single-gap winner — the answer it gave before this
+/// function existed — rather than returning a decomposition found under a
+/// narrower search than the one documented. The budget is sized far above the
+/// worked cases above; nothing in the corpus approaches it.
+const MAX_TWO_GAP_PLACEMENTS: usize = 65_536;
+
 /// Largest **net length change**, in bases, for which one unchanged base counts
 /// as separation.
 ///
@@ -3162,7 +3199,7 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
     })
 }
 
-/// The alignment that keeps the **whole** reference intact between two
+/// The alignment that keeps the **whole** reference intact across two
 /// insertions, or `None` when the pair does not have that shape (#1260).
 ///
 /// PR #1285 named the gap this fills: for #1260 the answer is "a two-gap
@@ -3171,16 +3208,58 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
 /// swallow the retained base into a spanning `delins` or leave one insertion
 /// unaccounted for.
 ///
-/// # Why one shape is the whole search
+/// # The shape, and why it is not just `I1 + reference + I2`
 ///
-/// The caller trims common flanks before partitioning
-/// (`canonicalize_from_sequence` via [`trim_common_flanks`]), and on a trimmed
-/// block the general three-chunk form collapses to this one. Writing an
-/// all-matched two-gap alignment as `result = ref[..a] + I1 + ref[a..b] + I2 +
-/// ref[b..]`: if `a > 0` the two blocks share a first base, and if `b <
-/// ref.len()` they share a last one — both contradict trimming. So `a == 0` and
-/// `b == ref.len()`, leaving `result = I1 + reference + I2`. That is a substring
-/// search, not a quadratic sweep over gap placements.
+/// The general all-matched two-gap alignment is
+///
+/// ```text
+/// result = ref[..a] + I1 + ref[a..b] + I2 + ref[b..]
+/// ```
+///
+/// with `0 <= a < b <= ref.len()` and both insertions non-empty. An earlier
+/// revision searched only `a == 0, b == ref.len()`, deriving that from the
+/// caller having trimmed common flanks: on a trimmed block `a > 0` would mean
+/// the two blocks share a first base and `b < ref.len()` a last one, both
+/// contradicting the trim.
+///
+/// That derivation is sound *only while the precondition holds*, and it makes
+/// the function silently wrong the moment a caller widens a block — which is
+/// exactly what any attempt to give back an ambiguously-trimmed flank base
+/// must do. #1260 is the worked example: trimmed its block is `A -> CAC` with
+/// `a = 0`, and with one flank base restored per side it is `AAA -> ACACA`,
+/// whose only decomposition is `a = 1, b = 2`. A search fixed at `a == 0`
+/// finds nothing there, `best_alignment` falls through to the single-gap
+/// winner, and #1260 reverts to a spanning `delins`.
+///
+/// No caller widens a block today, so this generalisation changes no current
+/// result — it removes a hidden coupling between this function and the
+/// caller's trim, and it is verified against blocks that exercise `a > 0` and
+/// `b < ref.len()` directly rather than through a caller.
+///
+/// `b > a` is required rather than incidental: with `b == a` the two insertions
+/// are adjacent in `result`, which is a single gap the existing search already
+/// places.
+///
+/// # Cost
+///
+/// Every reference base survives verbatim in this form, so `a` cannot exceed the
+/// two blocks' common prefix and `ref.len() - b` cannot exceed their common
+/// suffix. Both are 0 on a trimmed block — collapsing the search to the single
+/// case the earlier revision hardcoded — and at most one after a restored flank.
+/// The sweep is therefore bounded by the *residual* affix lengths, not by the
+/// block length. A block whose affixes would make that sweep large is declined
+/// outright — see [`MAX_TWO_GAP_PLACEMENTS`] — rather than searched under a
+/// narrower bound than this doc describes.
+///
+/// # The tie-break is an implementer's choice
+///
+/// The decomposition is **not unique**: `AA -> AAAA` admits `(a, b)` of `(0, 1)`,
+/// `(0, 2)` and `(1, 2)`, all with `I1 = I2 = "A"`, all matching every reference
+/// base and all yielding two members. Nothing in the spec reaches this. The
+/// smallest `a`, then the smallest `|I1|`, is taken — the 5'-most placement,
+/// preserving the earlier revision's behaviour. Deliberately *not* the 3'-most
+/// rule [`best_alignment`] applies to a member-count tie: adopting it here would
+/// move every such tie in a homopolymer.
 ///
 /// # Why this does not reopen the corpus the single-gap rule protects
 ///
@@ -3189,12 +3268,11 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
 /// of coincidence and shredding a contiguous replacement (#1034/#1040/#182).
 /// Both gaps here are insertions in a net-insertion block, so no deletion is
 /// introduced and no match is manufactured: every matched column is a reference
-/// base surviving verbatim. Cluster A is structurally out of reach — #1040 and
-/// the `inv` cases are equal-length, #1157A is a net deletion, and an
-/// equal-length or net-deletion block never reaches this function.
-///
-/// Both insertions must be non-empty; otherwise this is a single gap and the
-/// existing search already places it, 5'-most.
+/// base surviving verbatim. That argument never depended on `a` being 0 — all
+/// three chunks are verbatim reference either way. Cluster A is structurally out
+/// of reach — #1040 and the `inv` cases are equal-length, #1157A is a net
+/// deletion, and an equal-length or net-deletion block never reaches this
+/// function.
 ///
 /// Comparison is byte-exact, matching [`best_alignment`]'s own `==` throughout.
 /// Making only this path case-insensitive would let the two-gap form win on a
@@ -3205,16 +3283,63 @@ fn two_gap_insertion_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Co
     if reference.is_empty() || result.len() < reference.len() + 2 {
         return None;
     }
-    // 5'-most placement, matching `best_alignment`'s tie-break. The bounds put
-    // at least one base on each side of the retained reference.
-    let last_start = result.len() - reference.len() - 1;
-    let start = (1..=last_start).find(|&p| result[p..p + reference.len()] == *reference)?;
+    let ref_len = reference.len();
+    let inserted = result.len() - ref_len;
 
-    let mut columns = Vec::with_capacity(result.len());
-    columns.extend((0..start).map(|a| (None, Some(a))));
-    columns.extend((0..reference.len()).map(|i| (Some(i), Some(start + i))));
-    columns.extend((start + reference.len()..result.len()).map(|a| (None, Some(a))));
-    Some(columns)
+    // Bounds, not shortcuts: a matched `ref[..a]` is a common prefix of the two
+    // blocks, and a matched `ref[b..]` a common suffix. Not clamped — narrowing
+    // them changes the answer rather than bounding the cost, which is what
+    // [`MAX_TWO_GAP_PLACEMENTS`] is for.
+    let common_prefix = reference
+        .iter()
+        .zip(result)
+        .take_while(|(r, a)| r == a)
+        .count();
+    let common_suffix = reference
+        .iter()
+        .rev()
+        .zip(result.iter().rev())
+        .take_while(|(r, a)| r == a)
+        .count();
+
+    // Refuse the whole search rather than truncate it, so a block over budget
+    // gets `best_alignment`'s single-gap answer instead of one found under a
+    // narrower sweep than this function documents.
+    let lowest_b = (ref_len - common_suffix.min(ref_len)).max(1);
+    let placements = (common_prefix + 1)
+        .saturating_mul(inserted.saturating_sub(1))
+        .saturating_mul(ref_len + 1 - lowest_b.min(ref_len + 1));
+    if placements > MAX_TWO_GAP_PLACEMENTS {
+        return None;
+    }
+
+    // 5'-most: smallest `a`, then smallest `|I1|`, then smallest `b`.
+    for a in 0..=common_prefix {
+        for first_insert in 1..inserted {
+            for b in (a + 1).max(lowest_b)..=ref_len {
+                let retained_start = a + first_insert;
+                let retained_end = retained_start + (b - a);
+                if result[retained_start..retained_end] != reference[a..b] {
+                    continue;
+                }
+                // `result[..a] == reference[..a]` already holds by `a <=
+                // common_prefix`; the suffix is checked rather than inferred so
+                // the three chunk equalities read together.
+                let tail_start = retained_end + (inserted - first_insert);
+                if result[tail_start..] != reference[b..] {
+                    continue;
+                }
+                let mut columns = Vec::with_capacity(result.len());
+                columns.extend((0..a).map(|i| (Some(i), Some(i))));
+                columns.extend((a..retained_start).map(|j| (None, Some(j))));
+                columns.extend((a..b).map(|i| (Some(i), Some(retained_start + i - a))));
+                columns.extend((retained_end..tail_start).map(|j| (None, Some(j))));
+                columns.extend((b..ref_len).map(|i| (Some(i), Some(tail_start + i - b))));
+                return Some(columns);
+            }
+        }
+    }
+    None
 }
 
 /// Columns for an alignment with a single gap of `gap_len` after `k` aligned
@@ -7117,10 +7242,14 @@ mod tests {
         }
 
         #[test]
-        fn an_untied_placement_is_still_chosen_by_score() {
-            // #1232's block: the placements do not tie — one matches strictly
-            // more columns — so the score decides and the tie-break never runs.
-            // Already correct before this rule, and it must stay that way.
+        fn a_three_way_tie_still_yields_the_separating_placement() {
+            // #1232's block at an untrimmed extent. All three placements match
+            // exactly one column, so they DO tie and the tie-break runs; only
+            // the placement that leaves the match between the two changes gives
+            // two members. An earlier revision of this comment claimed the
+            // placements did not tie and that the score decided — measured,
+            // that is false, and the test's name is the part that is wrong
+            // rather than its assertion.
             assert_eq!(partition_block(b"TTTTT", b"TA").len(), 2);
         }
 
@@ -7182,6 +7311,107 @@ mod tests {
                         alt: b"C".to_vec()
                     },
                 ]
+            );
+        }
+
+        #[test]
+        fn a_retained_chunk_need_not_be_the_whole_reference() {
+            // #1260's block with one flank base restored per side — the shape
+            // any widening of a trimmed block produces inside a poly-A run.
+            // The only all-matched decomposition is `a = 1, b = 2`:
+            // `A` + `C` + `A` + `C` + `A`. A search fixed at `a == 0` finds
+            // nothing here, and #1260 reverts to a spanning `delins`.
+            assert_eq!(
+                best_alignment(b"AAA", b"ACACA"),
+                Some(vec![
+                    (Some(0), Some(0)),
+                    (None, Some(1)),
+                    (Some(1), Some(2)),
+                    (None, Some(3)),
+                    (Some(2), Some(4)),
+                ]),
+                "every reference base must survive, with `a = 1`"
+            );
+            assert_eq!(
+                partition_block(b"AAA", b"ACACA").len(),
+                2,
+                "and it must still partition into the two insertions"
+            );
+        }
+
+        #[test]
+        fn an_untrimmed_flank_on_one_side_only_is_also_expressible() {
+            // The asymmetric case: a restored base on the 5' side alone, so
+            // `a = 1` and `b == ref.len()`.
+            assert_eq!(
+                partition_block(b"AA", b"ACAC").len(),
+                2,
+                "a > 0 with the retained chunk running to the block's end"
+            );
+            // ...and on the 3' side alone, so `a == 0` and `b < ref.len()`.
+            assert_eq!(
+                partition_block(b"AA", b"CACA").len(),
+                2,
+                "b < ref.len() with the retained chunk starting at the block's start"
+            );
+        }
+
+        #[test]
+        fn two_adjacent_insertions_are_left_to_the_single_gap_search() {
+            // `b == a` would put the two insertions next to each other in the
+            // result, which is one contiguous gap. The single-gap search already
+            // places it, so this must decline rather than re-express it as two
+            // members that a coalesce would immediately merge back.
+            assert_eq!(
+                partition_block(b"AA", b"AACC").len(),
+                1,
+                "an insertion at one junction is one member, not two"
+            );
+        }
+
+        #[test]
+        fn the_decomposition_tie_is_broken_five_prime() {
+            // `AA -> AAAA` admits (a,b) of (0,1), (0,2) and (1,2), all matching
+            // both reference bases. Nothing in the spec reaches this, so the
+            // smallest `a` wins — the 5'-most placement, as before.
+            assert_eq!(
+                two_gap_insertion_alignment(b"AA", b"AAAA"),
+                Some(vec![
+                    (None, Some(0)),
+                    (Some(0), Some(1)),
+                    (None, Some(2)),
+                    (Some(1), Some(3)),
+                ]),
+                "a = 0, b = 1, |I1| = 1"
+            );
+        }
+
+        #[test]
+        fn a_long_shared_affix_does_not_hide_the_decomposition() {
+            // #1260's UNTRIMMED window. Its only all-matched decomposition is
+            // `a = 2, b = 3` — `AA` + `C` + `A` + `C` + `AAAA` — which needs a
+            // common prefix of 2 and a common suffix of 4. An earlier revision
+            // bounded cost by clamping those affix lengths to 2, which excluded
+            // the sole solution and silently returned `None`.
+            //
+            // It was invisible: on this block the single-gap search reaches the
+            // same member count by another route, so no corpus row moved. Only
+            // a change elsewhere in the tie-break exposed it. Hence this asserts
+            // the exact columns rather than a piece count.
+            assert_eq!(
+                two_gap_insertion_alignment(b"AAAAAAA", b"AACACAAAA"),
+                Some(vec![
+                    (Some(0), Some(0)),
+                    (Some(1), Some(1)),
+                    (None, Some(2)),
+                    (Some(2), Some(3)),
+                    (None, Some(4)),
+                    (Some(3), Some(5)),
+                    (Some(4), Some(6)),
+                    (Some(5), Some(7)),
+                    (Some(6), Some(8)),
+                ]),
+                "every reference base must survive, with a = 2 and b = 3"
             );
         }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1623,9 +1623,21 @@ const MAX_UNGUARDED_SPLIT_BLOCK: usize = 32;
 /// the resulting members is the only thing that separates them.
 ///
 /// It applies only where the block's net length change is at most
-/// [`MAX_SINGLE_BASE_SEPARATION_CHANGE`]; beyond that a single unchanged base is
-/// not believable and the threshold stays at 2.
+/// [`MAX_SINGLE_BASE_SEPARATION_CHANGE`]; beyond that the threshold rises to
+/// [`RAISED_PIECE_SEPARATION`].
 const MIN_PIECE_SEPARATION: usize = 1;
+
+/// The separation [`separations_are_meaningful`] requires once the block's net
+/// length change exceeds [`MAX_SINGLE_BASE_SEPARATION_CHANGE`].
+///
+/// Named rather than written inline because it is a policy choice doing
+/// semantic work, not an arithmetic constant: beyond that much change a single
+/// matched base is not believable as structure, so two are required before a
+/// split is believed. `2` is the value the threshold had for every block before
+/// [`MIN_PIECE_SEPARATION`] was lowered to 1, so this is the old behaviour
+/// retained where the evidence for the new one runs out — not a second
+/// calibration.
+const RAISED_PIECE_SEPARATION: usize = 2;
 
 /// Largest block, in aligned positions, over which a tied gap placement is
 /// broken by what it separates rather than by being 5'-most.
@@ -1679,6 +1691,31 @@ const MAX_TIE_BREAK_SWEEP: usize = 256;
 /// narrower search than the one documented. The budget is sized far above the
 /// worked cases above; nothing in the corpus approaches it.
 const MAX_TWO_GAP_PLACEMENTS: usize = 65_536;
+
+/// Largest alignment grid the sequence-first splitter will build, in cells.
+///
+/// `AlignmentDag::build` is `Θ(n·m)` in **space** as well as time, and it
+/// allocates four grids of that size: two `u32` edit grids, the on-path flags,
+/// and the adjacency mask. Only the reference side is bounded upstream
+/// ([`MAX_CANONICAL_WINDOW`]); the alternate side is whatever the members
+/// produce, and a duplication over the whole window doubles it. A 4096 x 8192
+/// grid is 33.5 M cells, or roughly 340 MB across the four — enough to matter,
+/// and reachable from a single description rather than from a pathological
+/// corpus.
+///
+/// Derived from [`MAX_CANONICAL_WINDOW`] rather than picked: the budget is a
+/// *square* grid at that bound, so it admits any block whose alternate side is
+/// within the same limit already imposed on the reference side, and refuses one
+/// where the alternate side runs past it. The 4096 x 8192 duplication above is
+/// 33.5 M cells against this 16.8 M, so it is declined.
+///
+/// The honest cost of stating it this way: at the very top of the reference range
+/// an alternate side even slightly longer than the reference is declined too.
+/// That is a cost bound, not a policy — above it
+/// [`partition_block_sequence_first`] returns `None` and the caller keeps the
+/// per-member result, the same fallback every other bound here takes.
+const MAX_SEQFIRST_GRID_CELLS: usize =
+    (MAX_CANONICAL_WINDOW as usize + 1) * (MAX_CANONICAL_WINDOW as usize + 1);
 
 /// Largest **net length change**, in bases, for which one unchanged base counts
 /// as separation.
@@ -1768,11 +1805,17 @@ impl Piece {
 
 /// Whether to run both block splitters and report their disagreements.
 ///
-/// Enabled by `FERRO_SEQFIRST_SHADOW=1`. Read once and cached, like the
-/// idempotency gate in [`crate::normalize`], so a disabled run pays one relaxed
-/// atomic load per canonicalization. When on, the sequence-first splitter runs
-/// *in addition to* the live one and any disagreement goes to stderr; it never
-/// changes what is returned.
+/// A **development-only audit switch**, enabled by `FERRO_SEQFIRST_SHADOW=1`.
+/// Read once and cached, like the idempotency gate in [`crate::normalize`], so a
+/// disabled run pays one relaxed atomic load per canonicalization. When on, the
+/// sequence-first splitter runs *in addition to* the live one and every
+/// comparison is reported; it never changes what is returned.
+///
+/// Reports go through `log::debug!` rather than `eprintln!`, so ordinary log
+/// filtering applies — the switch fires once per canonicalized block, which over
+/// a whole suite run is tens of thousands of lines that no level or target filter
+/// could reach when they were written straight to stderr. Capture them with
+/// `RUST_LOG=ferro_hgvs::normalize::merge=debug`.
 fn seqfirst_shadow_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var("FERRO_SEQFIRST_SHADOW").as_deref() == Ok("1"))
@@ -1957,9 +2000,9 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
             // The denominator. Without it, `grep -c SEQFIRST_SHADOW` returning 0
             // cannot be told apart from a shadow that never ran — the failure
             // mode that would make an audit of the disagreements vacuous.
-            eprintln!("SEQFIRST_AGREE");
+            log::debug!("SEQFIRST_AGREE");
         } else if min_shadow.as_ref() == Some(&min_live) {
-            eprintln!(
+            log::debug!(
                 "SEQFIRST_MINAGREE ref={} alt={} live={:?} shadow={:?}",
                 String::from_utf8_lossy(block),
                 String::from_utf8_lossy(&result[lo..hi_alt]),
@@ -1967,7 +2010,7 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
                 shadow.as_deref().map(DebugPieces),
             );
         } else {
-            eprintln!(
+            log::debug!(
                 // Space-separated, and no space inside a piece list, on purpose:
                 // `cargo nextest` strips tab characters when it re-emits captured
                 // test output (`--success-output immediate`), so a tab-delimited
@@ -2883,6 +2926,17 @@ fn partition_block_sequence_first(
     use crate::normalize::seqfirst::align::AlignmentDag;
     use crate::normalize::seqfirst::partition::{member_alt_spans, partition_members_with};
 
+    // Refuse an oversized grid before building it, not after: the allocation is
+    // the cost. Checked, because `(n + 1) * (m + 1)` on two `usize` lengths is
+    // itself an overflow site.
+    let cells = reference
+        .len()
+        .checked_add(1)?
+        .checked_mul(result.len().checked_add(1)?)?;
+    if cells > MAX_SEQFIRST_GRID_CELLS {
+        return None;
+    }
+
     let dag = AlignmentDag::build(reference, result);
     let dominators = dag.dominators();
     let members = partition_members_with(&dag, &dominators, min_separation);
@@ -2985,7 +3039,7 @@ fn separations_are_meaningful(pieces: &[Piece], net_change: usize) -> bool {
     // splitter had to be corrected for exactly this, because it works in event
     // space where a junction and a changed position are both one offset.
     let required = if net_change > MAX_SINGLE_BASE_SEPARATION_CHANGE {
-        2
+        RAISED_PIECE_SEPARATION
     } else {
         MIN_PIECE_SEPARATION
     };
@@ -3622,7 +3676,13 @@ fn split_codon_incompatible_triplets(
     let mut index = 0;
     while index < pieces.len() {
         let piece = &pieces[index];
+        // `ref_end <= ref_bytes.len()` is tested before any indexing. Every
+        // caller today passes pieces carved from this same window, so the span is
+        // in range — but this reads three bytes by raw index off a piece it does
+        // not own, and a piece whose span outran the window would panic rather
+        // than decline. An out-of-range span is simply not a merged triplet.
         let is_merged_triplet = piece.ref_end == piece.ref_start + 3
+            && piece.ref_end <= ref_bytes.len()
             && piece.alt.len() == 3
             && piece.alt[1] == ref_bytes[piece.ref_start + 1]
             && piece.alt[0] != ref_bytes[piece.ref_start]
@@ -6494,6 +6554,12 @@ mod tests {
             out
         }
         let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        // Counted, because the `continue` below is silent: if a regression made
+        // `member_alt_spans` decline every pair, the round-trip assertion would
+        // never run and this test would still pass. The sibling sweep
+        // `shrinking_before_and_after_the_three_prime_shift_agree` guards itself
+        // the same way.
+        let mut accepted = 0usize;
         for reference in &all {
             for result in &all {
                 let Some(pieces) = partition_block_sequence_first(
@@ -6503,6 +6569,7 @@ mod tests {
                 ) else {
                     continue;
                 };
+                accepted += 1;
                 let mut rebuilt = Vec::new();
                 let mut cursor = 0usize;
                 for piece in &pieces {
@@ -6521,6 +6588,56 @@ mod tests {
                 );
             }
         }
+        assert!(
+            accepted > 3_000,
+            "the sweep accepted only {accepted} blocks; a mass decline would make \
+             this round-trip assertion vacuous"
+        );
+    }
+
+    /// An oversized grid is declined rather than allocated.
+    ///
+    /// The reference side is bounded upstream by `MAX_CANONICAL_WINDOW` (4096),
+    /// but the alternate side is not: a duplication over the window doubles it,
+    /// and `AlignmentDag::build` allocates four `Θ(n·m)` grids. The shape
+    /// `4096 -> 8192` is 33.5 M cells, past the bound, and must come back `None`
+    /// so the caller keeps the per-member result.
+    ///
+    /// Asserted on the boundary from both sides, so the test fails if the bound
+    /// is removed *or* set low enough to refuse ordinary blocks.
+    #[test]
+    fn sequence_first_split_declines_an_oversized_grid() {
+        // The budget is a square grid at the reference bound, so the largest
+        // equal-length block is exactly admissible.
+        assert_eq!(MAX_SEQFIRST_GRID_CELLS, 4097 * 4097);
+
+        // Just inside: a 4096 x 4096 grid is the boundary square.
+        let reference = b"ACGT".repeat(1024);
+        let result = b"ACGA".repeat(1024);
+        assert_eq!(reference.len(), 4096);
+        assert!(
+            partition_block_sequence_first(
+                &reference,
+                &result,
+                crate::normalize::seqfirst::MIN_SEPARATION
+            )
+            .is_some(),
+            "a 4096 x 4096 grid is within budget and must still be partitioned"
+        );
+
+        // Past it: the same reference against a duplicated alternate, the shape a
+        // whole-window `dup` produces.
+        let doubled = b"ACGT".repeat(2048);
+        assert_eq!(doubled.len(), 8192);
+        assert_eq!(
+            partition_block_sequence_first(
+                &reference,
+                &doubled,
+                crate::normalize::seqfirst::MIN_SEPARATION
+            ),
+            None,
+            "a 4096 x 8192 grid is 33.5 M cells and must be declined, not allocated"
+        );
     }
 
     /// Pieces must be disjoint and ascending — the property that makes the

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2918,10 +2918,76 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
             best = Some((matches, k));
         }
     }
+    // A single gap cannot express *insertion, retained reference, insertion*,
+    // so consider the two-gap form when the best single gap leaves a reference
+    // base unmatched. Scoped to net insertions by `shorter_is_ref`, which is
+    // what keeps it clear of the corpus the single-gap restriction protects —
+    // see [`two_gap_insertion_alignment`].
+    if shorter_is_ref && best.is_some_and(|(matches, _)| matches < reference.len()) {
+        if let Some(columns) = two_gap_insertion_alignment(reference, result) {
+            return Some(columns);
+        }
+    }
+
     // Only the winner is materialized.
     best.map(|(_, k)| {
         single_gap_alignment(k, gap_len, shorter_is_ref, reference.len(), result.len())
     })
+}
+
+/// The alignment that keeps the **whole** reference intact between two
+/// insertions, or `None` when the pair does not have that shape (#1260).
+///
+/// PR #1285 named the gap this fills: for #1260 the answer is "a two-gap
+/// alignment — insertion, retained base, insertion — which `best_alignment`'s
+/// single-gap restriction cannot express". One contiguous indel must either
+/// swallow the retained base into a spanning `delins` or leave one insertion
+/// unaccounted for.
+///
+/// # Why one shape is the whole search
+///
+/// The caller trims common flanks before partitioning
+/// (`canonicalize_from_sequence` via [`trim_common_flanks`]), and on a trimmed
+/// block the general three-chunk form collapses to this one. Writing an
+/// all-matched two-gap alignment as `result = ref[..a] + I1 + ref[a..b] + I2 +
+/// ref[b..]`: if `a > 0` the two blocks share a first base, and if `b <
+/// ref.len()` they share a last one — both contradict trimming. So `a == 0` and
+/// `b == ref.len()`, leaving `result = I1 + reference + I2`. That is a substring
+/// search, not a quadratic sweep over gap placements.
+///
+/// # Why this does not reopen the corpus the single-gap rule protects
+///
+/// `merge.rs`'s single-gap restriction exists to stop *compensating* gaps — a
+/// deletion **and** an insertion in one block — from manufacturing matches out
+/// of coincidence and shredding a contiguous replacement (#1034/#1040/#182).
+/// Both gaps here are insertions in a net-insertion block, so no deletion is
+/// introduced and no match is manufactured: every matched column is a reference
+/// base surviving verbatim. Cluster A is structurally out of reach — #1040 and
+/// the `inv` cases are equal-length, #1157A is a net deletion, and an
+/// equal-length or net-deletion block never reaches this function.
+///
+/// Both insertions must be non-empty; otherwise this is a single gap and the
+/// existing search already places it, 5'-most.
+///
+/// Comparison is byte-exact, matching [`best_alignment`]'s own `==` throughout.
+/// Making only this path case-insensitive would let the two-gap form win on a
+/// soft-masked block where the single-gap search sees a mismatch.
+fn two_gap_insertion_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
+    // `reference.len() + 2` is the shortest result that leaves room for two
+    // insertions of one base each; an empty reference has nothing to retain.
+    if reference.is_empty() || result.len() < reference.len() + 2 {
+        return None;
+    }
+    // 5'-most placement, matching `best_alignment`'s tie-break. The bounds put
+    // at least one base on each side of the retained reference.
+    let last_start = result.len() - reference.len() - 1;
+    let start = (1..=last_start).find(|&p| result[p..p + reference.len()] == *reference)?;
+
+    let mut columns = Vec::with_capacity(result.len());
+    columns.extend((0..start).map(|a| (None, Some(a))));
+    columns.extend((0..reference.len()).map(|i| (Some(i), Some(start + i))));
+    columns.extend((start + reference.len()..result.len()).map(|a| (None, Some(a))));
+    Some(columns)
 }
 
 /// Columns for an alignment with a single gap of `gap_len` after `k` aligned
@@ -6786,5 +6852,91 @@ mod tests {
         // The same inversion clear of the bad byte still applies.
         let clean = [GEdit::Inv { s: 6, e: 9 }];
         assert!(apply_edits_to_window(&clean, reference, 1).is_some());
+    }
+
+    /// The two-gap insertion form (#1260).
+    ///
+    /// A single gap cannot express *insertion, retained reference, insertion*:
+    /// it has one contiguous indel to place, so it must either swallow the
+    /// retained base into a spanning `delins` or leave one of the insertions
+    /// unaccounted for. PR #1285 named this directly — for #1260 the answer is
+    /// "a two-gap alignment — insertion, retained base, insertion — which
+    /// `best_alignment`'s single-gap restriction cannot express".
+    mod two_gap_insertion_alignment {
+        use super::*;
+
+        #[test]
+        fn a_retained_reference_between_two_insertions_is_expressible() {
+            // #1260's trimmed block. The single-gap search scores 0 matched
+            // columns either way it places the 2 nt gap; keeping the reference
+            // `A` intact between two 1 nt insertions matches it, which is the
+            // most any alignment of this pair can match.
+            assert_eq!(
+                best_alignment(b"A", b"CAC"),
+                Some(vec![(None, Some(0)), (Some(0), Some(1)), (None, Some(2))]),
+                "the whole reference should survive between the two insertions"
+            );
+        }
+
+        #[test]
+        fn the_two_gap_form_partitions_into_two_pure_insertions() {
+            // The point of expressing it: two members, each a pure insertion,
+            // separated by the retained base. `general.md:56` prefers those to
+            // one spanning `delins`.
+            let columns = best_alignment(b"A", b"CAC").expect("aligned");
+            assert_eq!(
+                pieces_from_columns(&columns, b"A", b"CAC"),
+                vec![
+                    Piece {
+                        ref_start: 0,
+                        ref_end: 0,
+                        alt: b"C".to_vec()
+                    },
+                    Piece {
+                        ref_start: 1,
+                        ref_end: 1,
+                        alt: b"C".to_vec()
+                    },
+                ]
+            );
+        }
+
+        #[test]
+        fn a_single_gap_that_already_keeps_the_whole_reference_is_left_alone() {
+            // `AT -> ACT`: the 1 nt gap placed after `A` keeps both reference
+            // bases, so there is nothing for a second gap to buy. One gap, and
+            // the 5'-most placement, per `best_alignment`'s existing tie-break.
+            assert_eq!(
+                best_alignment(b"AT", b"ACT"),
+                Some(vec![
+                    (Some(0), Some(0)),
+                    (None, Some(1)),
+                    (Some(1), Some(2))
+                ])
+            );
+        }
+
+        #[test]
+        fn the_second_gap_is_scoped_out_of_cluster_a() {
+            // Equal-length and net-deletion blocks never reach the two-gap
+            // search, which is what keeps it clear of the "stays delins" corpus
+            // (#1034/#1040/#182) that `merge.rs`'s single-gap restriction
+            // exists to protect. Pinned as behaviour, not as a code path.
+            assert_eq!(
+                partition_block(b"CAGTGACTAG", b"TGTCACGACT").len(),
+                1,
+                "#1040"
+            );
+            assert_eq!(
+                partition_block(b"GCT", b"AGC").len(),
+                1,
+                "#1034 whole-run revcomp"
+            );
+            assert_eq!(
+                partition_block(b"AGTCAGT", b"GATTA").len(),
+                3,
+                "#1157A, net deletion"
+            );
+        }
     }
 }

--- a/src/normalize/merge/splitter_reproducer_corpus.rs
+++ b/src/normalize/merge/splitter_reproducer_corpus.rs
@@ -7,6 +7,24 @@
 //! against — it says what today's splitter does on every block the corpus
 //! reaches, not what any candidate design ought to do.
 //!
+//! # These blocks are the harvest's, not necessarily the pipeline's
+//!
+//! The rows were harvested when `canonicalize_from_sequence` handed the splitter
+//! a maximally trimmed block. It no longer always does: `restore_unforced_flank`
+//! gives back one base per side where the trim boundary sat inside a run, so a
+//! case whose harvested block is `AA -> C` now reaches the splitter as
+//! `AAAA -> ACA`. Both are legitimate splitter inputs and both are worth
+//! pinning, but a row's block is what the *harvest* recorded — do not read it as
+//! what the live pipeline passes today.
+//!
+//! `#1262a` is where the two come apart most visibly. Its harvested block is
+//! still a collision the splitter cannot resolve (`AA -> C` is
+//! placement-invariant: every alignment of it yields the same single piece), so
+//! the row stays a `KnownDefect` below. End to end, though, **#1262 converges** —
+//! the widened block is what its answer needed. A defect at the block level and
+//! a fix at the pipeline level are not in contradiction; they are two different
+//! questions about two different inputs.
+//!
 //! # Why this lives here and not in `tests/it/`
 //!
 //! [`partition_block`] and [`Piece`](super::Piece) are private to `merge.rs`.
@@ -19,38 +37,48 @@
 //!
 //! `recorded_members` is the member count recorded for the case's *normalized
 //! output*. For most rows the block alone determines it and the assertion is
-//! direct. Nine rows carry a `splitter_returns` override: on those, the block
-//! does **not** determine the recorded count. They fall in three groups, and the
-//! third is a finding rather than a known design seam:
+//! direct. **Eleven** rows carry a `splitter_returns` override: on those, the
+//! block does **not** determine the recorded count. The exact set is pinned by
+//! `recorded_and_splitter_counts_diverge_on_exactly_these_rows` — trust that
+//! list over this prose. They fall in three groups, and the third is a finding
+//! rather than a known design seam:
 //!
-//! 1. **Two-member spellings** (`#422-two-member`, `#999-neg-split`,
-//!    `#1260a-split`, `#1262a-split`, `#1262b-split`). Each shares its block
-//!    with a spanning sibling row in this table that the splitter answers
-//!    identically. Their recorded two-member outputs therefore cannot come from
-//!    the splitter; see the collision census below.
+//! 1. **Two-member spellings.** Each shares its block with a sibling row in this
+//!    table that the splitter answers identically, so its recorded two-member
+//!    output cannot come from the splitter; see the collision census below.
 //!
-//!    `#1260b` is the exception, and it is the override *inverted*: the two-gap
-//!    alignment (#1260, PR #1285) made the splitter answer the **split** count,
-//!    so `#1260b-spanning` is the row that now carries the override.
+//!    Which side of a pair carries the override is not uniform, and that is the
+//!    record of what has been fixed. `#422-two-member` and `#1262a-split` carry
+//!    it, the shape this group was named for. `#999-neg-spanning`,
+//!    `#1260a-spanning`, `#1260b-spanning` and `#1262b-spanning` carry it
+//!    *inverted*: the two-gap alignment (#1260, PR #1285) and a separation
+//!    threshold of one unchanged base made the splitter answer the **split**
+//!    count on those, so it is the spanning row that the splitter no longer
+//!    reproduces. `#1000` carries one for the same reason.
 //! 2. **Coding-axis codon merges** (`#1235-c-codon-exception`, `#1235-r-coding`).
 //!    The block splits into two; the one-member coding answer is produced after
 //!    partitioning, so it is not a block-level fact.
-//! 3. **`#1262-window`** — `("AAAAAAA", "ACAAAA")`, the untrimmed poly-A window
-//!    pinned at one member for the sequence-first partitioner
-//!    (`seqfirst::partition`'s `calibration_corpus_partitions_as_measured`).
-//!    `partition_block` returns **two** pieces for the same input. The two
-//!    splitters disagree on this window. Its `#1260` sibling
-//!    (`("AAAAAAA", "AACACAAAA")`) agrees at one member, so the disagreement is
-//!    specific to this pair, not to untrimmed windows in general.
+//! 3. **The untrimmed poly-A windows**, `#1260-window`
+//!    (`("AAAAAAA", "AACACAAAA")`) and `#1262-window` (`("AAAAAAA", "ACAAAA")`).
+//!    Both are pinned at one member for the sequence-first partitioner
+//!    (`seqfirst::partition`'s `calibration_corpus_partitions_as_measured`) and
+//!    both get **two** pieces from `partition_block`, so the two splitters
+//!    disagree on each of them — identically. An earlier revision of this comment
+//!    named only `#1262-window` and said its `#1260` sibling agreed, concluding
+//!    the disagreement was specific to that pair; the corpus rows say otherwise
+//!    (`diverging(… 1, (2, …))` for both), and both appear in this group's
+//!    membership assertion below.
 //!
 //! # Collision census
 //!
 //! Six block pairs each carry two different recorded member counts. Since a
 //! pure function of the pair returns one answer, at most one of each pair's two
 //! recorded counts can be a splitter decision. [`COLLISIONS`] pins all six:
-//! two are recorded with **both** answers asserted correct in the repo, three
-//! remain **known defects**, and one — `#1260b` — is **resolved at the
-//! splitter**, which now answers its split count rather than its spanning one.
+//! **one** is recorded with both answers asserted correct in the repo (`#422`,
+//! the deliberate pin), **one** remains a known defect (`#1262a`), and **four**
+//! are **resolved at the splitter**, which now answers their split count rather
+//! than their spanning one. `the_census_is_one_correct_pin_one_known_defect_and_four_resolved`
+//! is the executable statement of that; this sentence is a gloss on it.
 //!
 //! # Recorded but deliberately not asserted here
 //!
@@ -152,7 +180,10 @@ const fn diverging(
     }
 }
 
-/// Reason string shared by the six two-member-spelling rows.
+/// Reason string shared by the two-member-spelling rows that still carry the
+/// override in its original direction — `#422-two-member` and `#1262a-split`.
+/// The other pairs' overrides moved to their spanning siblings as the splitter
+/// learned to derive the split count, and carry their own reasons.
 const SPELLING: &str = "recorded count is the two-member spelling's output; the block \
                         is shared with this row's spanning sibling";
 
@@ -316,8 +347,9 @@ struct Collision {
     pinning: Pinning,
 }
 
-/// The collision census: six pairs, two recorded correct, four recorded as
-/// known defects.
+/// The collision census: six pairs — one with both answers recorded correct
+/// (`#422`), one still a known defect (`#1262a`), and four resolved at the
+/// splitter.
 const COLLISIONS: &[Collision] = &[
     Collision {
         spanning: "#422-spanning",

--- a/src/normalize/merge/splitter_reproducer_corpus.rs
+++ b/src/normalize/merge/splitter_reproducer_corpus.rs
@@ -233,11 +233,16 @@ const CORPUS: &[BlockRow] = &[
         "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
         "CATGCATGCATGCATGCATTCATGCATGCATGCATGCATG", 2,
         "equal length, so every column is compared in place; only offset 19 matches"),
-    row("#1260a-spanning", "A", "CAC", 1, "net +2 with no preserved reference base"),
-    diverging("#1260a-split", "A", "CAC", 2, (1, SPELLING),
-        "same block as #1260a-spanning: collision, recorded as a known defect"),
+    diverging("#1260a-spanning", "A", "CAC", 1,
+        (2, "the two-gap alignment keeps the reference A between the two insertions"),
+        "net +2; the splitter now answers the SPLIT count"),
+    row("#1260a-split", "A", "CAC", 2,
+        "same block as #1260a-spanning: the collision the two-gap alignment resolved"),
     row("#1260-window", "AAAAAAA", "AACACAAAA", 1,
-        "the untrimmed 7 nt poly-A window; both splitters return one member"),
+        "the UNTRIMMED 7 nt poly-A window, 9 nt on the alt side, so above \
+         MAX_SINGLE_BASE_SEPARATION_BLOCK and held whole. The pipeline never \
+         sees this: trim_common_flanks reduces it to #1260a's (A, CAC), which \
+         is 3 nt and does split -- which is how #1260 converges"),
     diverging("#1260b-spanning", "AA", "CAAC", 1,
         (2, "the two-gap alignment keeps the whole reference between the two insertions"),
         "the separation-2 instance of #1260; the splitter now answers the SPLIT count"),
@@ -249,16 +254,23 @@ const CORPUS: &[BlockRow] = &[
     diverging("#1262-window", "AAAAAAA", "ACAAAA", 1,
         (2, "the sequence-first partitioner pins one member for this same input"),
         "the untrimmed poly-A window where the two splitters disagree"),
-    row("#1262b-spanning", "AA", "CAC", 1, "the sub-plus-insertion instance of #1262"),
-    diverging("#1262b-split", "AA", "CAC", 2, (1, SPELLING),
-        "same block as #1262b-spanning: collision, recorded as a known defect"),
+    diverging("#1262b-spanning", "AA", "CAC", 1,
+        (2, "ins + sub outranks a spanning delins, so the split stands"),
+        "the sub-plus-insertion instance of #1262; the splitter now answers the SPLIT count"),
+    row("#1262b-split", "AA", "CAC", 2,
+        "same block as #1262b-spanning: the collision the separation threshold resolved"),
     row("#999-positive", "G", "CT", 1,
         "an insertion shifted flush against a substitution leaves no gap"),
-    row("#999-neg-spanning", "GC", "CGA", 1,
+    diverging("#999-neg-spanning", "GC", "CGA", 1,
+        (2, "ins + sub outranks a spanning delins, so the required split stands"),
         "net +1 with exactly one preserved interior base, like #422-spanning"),
-    diverging("#999-neg-split", "GC", "CGA", 2, (1, SPELLING),
-        "same block as #999-neg-spanning: collision, the two-member count is required"),
-    row("#1000", "C", "GCA", 1, "a 2 nt insertion shifted flush against a substitution"),
+    row("#999-neg-split", "GC", "CGA", 2,
+        "same block as #999-neg-spanning: the splitter now derives the REQUIRED \
+         two-member count from sequence alone, with no help from the spelling"),
+    diverging("#1000", "C", "GCA", 1,
+        (2, "base for base #1260's `A -> CAC`: two insertions either side of the \
+             retained C, re-blessed with it"),
+        "a 2 nt insertion shifted flush against a substitution"),
 
     // --- spelling-confluence gap: trimmed blocks are pure insertions --------
     row("#1287", "", "GAAA", 1, "pure insertion: an empty ref block cannot be partitioned"),
@@ -314,12 +326,12 @@ const COLLISIONS: &[Collision] = &[
     Collision {
         spanning: "#999-neg-spanning",
         split: "#999-neg-split",
-        pinning: Pinning::BothCorrect,
+        pinning: Pinning::ResolvedToSplit,
     },
     Collision {
         spanning: "#1260a-spanning",
         split: "#1260a-split",
-        pinning: Pinning::KnownDefect,
+        pinning: Pinning::ResolvedToSplit,
     },
     Collision {
         spanning: "#1260b-spanning",
@@ -334,7 +346,7 @@ const COLLISIONS: &[Collision] = &[
     Collision {
         spanning: "#1262b-spanning",
         split: "#1262b-split",
-        pinning: Pinning::KnownDefect,
+        pinning: Pinning::ResolvedToSplit,
     },
 ];
 
@@ -428,12 +440,13 @@ fn recorded_and_splitter_counts_diverge_on_exactly_these_rows() {
             "#422-two-member",
             "#1235-c-codon-exception",
             "#1235-r-coding",
-            "#1260a-split",
+            "#1260a-spanning",
             "#1260b-spanning",
             "#1262a-split",
             "#1262-window",
-            "#1262b-split",
-            "#999-neg-split",
+            "#1262b-spanning",
+            "#999-neg-spanning",
+            "#1000",
         ]
     );
     for row in CORPUS.iter().filter(|r| r.splitter_returns.is_some()) {
@@ -493,35 +506,41 @@ fn colliding_block_pairs_are_one_splitter_input_with_two_recorded_answers() {
     }
 }
 
-/// Two collisions are recorded with both answers correct, three remain known
-/// defects, and one — `#1260b` — is now resolved at the splitter by the two-gap
-/// alignment (#1260, PR #1285). That split is the census's whole point, so it
-/// is pinned.
+/// One collision is recorded with both answers correct (`#422`, the deliberate
+/// pin), one remains a known defect (`#1262a`), and **four are now resolved at
+/// the splitter** — the two-gap alignment plus a separation threshold of one
+/// unchanged base made the splitter derive the split count from sequence alone.
+/// That split is the census's whole point, so it is pinned.
 #[test]
-fn the_census_is_two_correct_pins_three_known_defects_and_one_resolved() {
+fn the_census_is_one_correct_pin_one_known_defect_and_four_resolved() {
     let correct: Vec<&str> = COLLISIONS
         .iter()
         .filter(|c| c.pinning == Pinning::BothCorrect)
         .map(|c| c.split)
         .collect();
-    assert_eq!(correct, vec!["#422-two-member", "#999-neg-split"]);
+    assert_eq!(correct, vec!["#422-two-member"]);
 
     let defects: Vec<&str> = COLLISIONS
         .iter()
         .filter(|c| c.pinning == Pinning::KnownDefect)
         .map(|c| c.split)
         .collect();
-    assert_eq!(
-        defects,
-        vec!["#1260a-split", "#1262a-split", "#1262b-split"]
-    );
+    assert_eq!(defects, vec!["#1262a-split"]);
 
     let resolved: Vec<&str> = COLLISIONS
         .iter()
         .filter(|c| c.pinning == Pinning::ResolvedToSplit)
         .map(|c| c.split)
         .collect();
-    assert_eq!(resolved, vec!["#1260b-split"]);
+    assert_eq!(
+        resolved,
+        vec![
+            "#999-neg-split",
+            "#1260a-split",
+            "#1260b-split",
+            "#1262b-split"
+        ]
+    );
 }
 
 /// The corpus is a table, so a duplicated or renamed id would silently shadow a

--- a/src/normalize/merge/splitter_reproducer_corpus.rs
+++ b/src/normalize/merge/splitter_reproducer_corpus.rs
@@ -1,0 +1,513 @@
+//! The harvested reproducer corpus, as executable rows.
+//!
+//! Each row is one reproducer reduced to the only thing [`partition_block`]
+//! can see: the maximally affix-trimmed `(ref_block, alt_block)` pair, plus the
+//! member count recorded for that case. The splitter is a pure function of that
+//! pair, so this table is the measurement a future splitter change is scored
+//! against — it says what today's splitter does on every block the corpus
+//! reaches, not what any candidate design ought to do.
+//!
+//! # Why this lives here and not in `tests/it/`
+//!
+//! [`partition_block`] and [`Piece`](super::Piece) are private to `merge.rs`.
+//! Reaching them from an integration test would mean widening their visibility
+//! for test convenience, so the corpus is a `#[cfg(test)]` child module of
+//! `merge` instead — child modules see their ancestors' private items, and
+//! nothing in the shipping API surface moves.
+//!
+//! # `recorded_members` vs. what the splitter returns
+//!
+//! `recorded_members` is the member count recorded for the case's *normalized
+//! output*. For most rows the block alone determines it and the assertion is
+//! direct. Nine rows carry a `splitter_returns` override: on those, the block
+//! does **not** determine the recorded count. They fall in three groups, and the
+//! third is a finding rather than a known design seam:
+//!
+//! 1. **Two-member spellings** (`#422-two-member`, `#999-neg-split`,
+//!    `#1260a-split`, `#1260b-split`, `#1262a-split`, `#1262b-split`). Each
+//!    shares its block with a spanning sibling row in this table that the
+//!    splitter answers identically. Their recorded two-member outputs therefore
+//!    cannot come from the splitter; see the collision census below.
+//! 2. **Coding-axis codon merges** (`#1235-c-codon-exception`, `#1235-r-coding`).
+//!    The block splits into two; the one-member coding answer is produced after
+//!    partitioning, so it is not a block-level fact.
+//! 3. **`#1262-window`** — `("AAAAAAA", "ACAAAA")`, the untrimmed poly-A window
+//!    pinned at one member for the sequence-first partitioner
+//!    (`seqfirst::partition`'s `calibration_corpus_partitions_as_measured`).
+//!    `partition_block` returns **two** pieces for the same input. The two
+//!    splitters disagree on this window. Its `#1260` sibling
+//!    (`("AAAAAAA", "AACACAAAA")`) agrees at one member, so the disagreement is
+//!    specific to this pair, not to untrimmed windows in general.
+//!
+//! # Collision census
+//!
+//! Six block pairs each carry two different recorded member counts. Since a
+//! pure function of the pair returns one answer, at most one of each pair's two
+//! recorded counts can be a splitter decision. [`COLLISIONS`] pins all six:
+//! two are recorded with **both** answers asserted correct in the repo, four are
+//! recorded as **known defects**.
+//!
+//! # Recorded but deliberately not asserted here
+//!
+//! - **`#1157` case B, template instance** (`TEMPLATE:g.10_20delinsTC` /
+//!   `g.12_20del`, and the `g.19_29delinsTG` second instance) — STALE. The
+//!   idempotence violation the issue records no longer reproduces. Its two
+//!   VERIFIED siblings, `#1157-B-del` and `#1157-B-dup`, are rows below.
+//! - **`#1158`** — STALE. The reported `NotEquivalent` no longer reproduces, and
+//!   the committed test deliberately asserts only `level.is_equivalent()` rather
+//!   than a rung. It is an equivalence-level case and derives no block pair of
+//!   its own; its blocks are `#1157`'s.
+//! - **`LRG_199t1:c.850_901` end to end** — UNVERIFIABLE in the harvest: the
+//!   ferro-prepared reference volumes were offline, so the accession could not
+//!   be resolved. Only its block-level form is asserted (`LRG_199` below), from
+//!   the literal already committed in `seqfirst::partition` and
+//!   `seqfirst::align`. No bases were reconstructed from memory.
+//! - **`#1234`'s distant-sibling negative control** (`g.[4_6del;60T>C]`) — its
+//!   two members are 54 nt apart, so the splitter never receives that span as
+//!   one block.
+//! - **`#1235`'s mixed-type and overlap-refusal cases** — the harvest derives no
+//!   block pair for them; they are member-typing and refusal behaviour.
+//!
+//! The five `#1286`/`#1297`/`#1316`/`#1321`/`#1323` rows are recorded as
+//! producing no `partition_block` call at all on either spelling — they converge
+//! through the repeat/`dup` path. They are kept as rows because their trimmed
+//! blocks pin what the splitter *would* have no choice about, not because the
+//! splitter decides them.
+
+use super::{partition_block, Piece};
+
+/// The `LRG_199t1:c.850_901` reference block, 52 nt of real sequence, copied
+/// from the literal already committed in `seqfirst::partition` (`LRG199_REF`)
+/// and `seqfirst::align`'s `lrg199_has_exactly_one_dominator_match`.
+const LRG199_REF: &str = "CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+
+/// The `LRG_199` payload, 14 nt, from the same committed literal.
+const LRG199_ALT: &str = "TTCCTCGATGCCTG";
+
+/// One harvested reproducer, reduced to the pair the splitter sees.
+struct BlockRow {
+    /// Issue or case identifier, as the harvest names it.
+    id: &'static str,
+    /// The maximally affix-trimmed reference block.
+    ref_block: &'static str,
+    /// The trimmed replacement block.
+    alt_block: &'static str,
+    /// Member count recorded for this case's normalized output.
+    recorded_members: usize,
+    /// Set only where `partition_block` does not return `recorded_members`:
+    /// the count it does return, and where the difference comes from. The row
+    /// is asserted at this value; `recorded_members` stays as recorded.
+    splitter_returns: Option<(usize, &'static str)>,
+    /// One line about the block itself.
+    note: &'static str,
+}
+
+impl BlockRow {
+    /// The member count this row asserts against the live splitter.
+    fn expected(&self) -> usize {
+        self.splitter_returns
+            .map_or(self.recorded_members, |(n, _)| n)
+    }
+}
+
+/// Shorthand for a row whose block determines the recorded member count.
+const fn row(
+    id: &'static str,
+    ref_block: &'static str,
+    alt_block: &'static str,
+    recorded_members: usize,
+    note: &'static str,
+) -> BlockRow {
+    BlockRow {
+        id,
+        ref_block,
+        alt_block,
+        recorded_members,
+        splitter_returns: None,
+        note,
+    }
+}
+
+/// Shorthand for a row where the block does not determine the recorded count.
+const fn diverging(
+    id: &'static str,
+    ref_block: &'static str,
+    alt_block: &'static str,
+    recorded_members: usize,
+    splitter_returns: (usize, &'static str),
+    note: &'static str,
+) -> BlockRow {
+    BlockRow {
+        id,
+        ref_block,
+        alt_block,
+        recorded_members,
+        splitter_returns: Some(splitter_returns),
+        note,
+    }
+}
+
+/// Reason string shared by the six two-member-spelling rows.
+const SPELLING: &str = "recorded count is the two-member spelling's output; the block \
+                        is shared with this row's spanning sibling";
+
+/// The corpus.
+///
+/// Ordered as the harvest orders it: cluster A (contiguous replacements that
+/// must stay one member), cluster B (blocks that must split), cluster C, then
+/// the calibration set.
+#[rustfmt::skip]
+const CORPUS: &[BlockRow] = &[
+    // --- cluster A: contiguous replacements that must stay ONE member -------
+    row("#1034", "CTG", "ACA", 1,
+        "revcomp(CTG) = CAG != ACA, so the 2 nt sub-run TG->CA is not carved out"),
+    row("#1034b", "TCC", "GAG", 1,
+        "the 2 nt prefix TC->GA is a revcomp; the run still stays whole"),
+    row("#1034-guard-3nt", "GCT", "AGC", 1,
+        "whole-run revcomp: one piece, which is what lets it render as inv"),
+    row("#1034-guard-2nt", "GG", "CC", 1, "whole-run revcomp, 2 nt"),
+    row("#1040", "CAGTGACTAG", "TGTCACGACT", 1,
+        "10 nt run whose interior GTGA->TCAC is a revcomp; not carved"),
+    row("#1040-affix-trim", "GA", "TC", 1,
+        "the shared AC.. / ..GT affixes are already trimmed off here"),
+    row("#1040-length-changing", "GCT", "AG", 1,
+        "a length-changing block can never be an inv"),
+    row("#1040-two-invs", "TGACA", "CAATG", 2,
+        "the unchanged A at offset 2 separates two revcomp pairs"),
+    row("#1041", "GCA", "TGC", 1, "whole-run revcomp: revcomp(GCA) = TGC"),
+    row("#160-1092", "GG", "CC", 1, "the only part of #160 that survived #1034"),
+    row("#160-1150", "TCC", "GAG", 1, "same block as #1034b, reached from #160"),
+    row("#160-1099", "TGCTC", "AAGCT", 1,
+        "interior 3 nt GCT->AGC is a revcomp; the whole run is not"),
+    row("#182-a", "GATCC", "TCTAA", 2, "unchanged base at offset 2"),
+    row("#182-b", "CCTGA", "AATTC", 2, "unchanged base at offset 2"),
+    row("#182-c", "CCTGATCC", "AATTCTAA", 3, "unchanged bases at offsets 2 and 5"),
+    row("#182-d", "CTGA", "ATTC", 2, "a single-base run stays its own piece"),
+    row("#182-e", "GATCTC", "TCTATA", 3, "unchanged bases at offsets 2 and 4"),
+    row("#422-spanning", "CTATAG", "AAACCCC", 1,
+        "6 nt replaced by 7 nt with one coincidentally preserved interior base"),
+    diverging("#422-two-member", "CTATAG", "AAACCCC", 2, (1, SPELLING),
+        "same block as #422-spanning: collision, both counts pinned correct"),
+
+    // --- cluster B: blocks that must SPLIT ----------------------------------
+    row("#1232", "CAATT", "TA", 2, "5 nt -> 2 nt; the minimal edit set is not unique"),
+    row("#1231", "AAT", "CAA", 2, "offsets 0 and 2 change, offset 1 does not"),
+    row("#1233", "AAT", "TAA", 2, "offsets 0 and 2 change, offset 1 does not"),
+    row("#1157-A-padded", "AGTCAGT", "GATTA", 3,
+        "7 nt -> 5 nt splitting at two unchanged bases: the cluster-B calibration"),
+    row("#1157-A-template", "AGTCACC", "GATTA", 3,
+        "the issue body's own instance of the same shape, one base different"),
+    row("#1157-B-del", "AA", "", 1, "pure 2 nt deletion inside an A-tract"),
+    row("#1157-B-dup", "", "G", 1, "pure 1 nt insertion inside a G-tract"),
+    row("#1229", "CAC", "AGT", 1,
+        "three consecutive changed nt are one piece; revcomp(CAC) = GTG != AGT"),
+    row("#1230", "GATG", "CATC", 2,
+        "only offsets 0 and 3 change; the interior AT is untouched"),
+    row("#1235-n", "CAA", "TAG", 2, "no reading frame, so the separation stands"),
+    diverging("#1235-c-codon-exception", "CAA", "TAG", 1,
+        (2, "the coding-axis one-amino-acid merge runs after partitioning"),
+        "the same block as #1235-n and #1241, on a coding axis"),
+    row("#1235-c-codon-boundary", "ATT", "GTA", 2,
+        "separation 1 on a coding axis still splits when the codon differs"),
+    diverging("#1235-r-coding", "CAA", "TAG", 1,
+        (2, "the coding-axis one-amino-acid merge runs after partitioning"),
+        "the r. sibling of #1235-c-codon-exception, same block"),
+    row("#1241", "CAA", "TAG", 2,
+        "the non-coding r. half: no CDS, so no codon frame, same block"),
+
+    // --- cluster C ----------------------------------------------------------
+    row("#1234", "ACCA", "T", 1, "4 nt -> 1 nt with no preserved interior base"),
+    row("#1234-lone-del", "CCA", "", 1, "the lone-deletion negative control"),
+
+    // --- calibration --------------------------------------------------------
+    row("LRG_199", LRG199_REF, LRG199_ALT, 1,
+        "the spec's own worked example: 52 nt -> 14 nt must stay one member"),
+    row("LRG_199-standin", "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT", LRG199_ALT, 1,
+        "the periodic synthetic stand-in for the row above, same net-deletion regime"),
+    row("long-delins-40nt",
+        "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
+        "CATGCATGCATGCATGCATTCATGCATGCATGCATGCATG", 2,
+        "equal length, so every column is compared in place; only offset 19 matches"),
+    row("#1260a-spanning", "A", "CAC", 1, "net +2 with no preserved reference base"),
+    diverging("#1260a-split", "A", "CAC", 2, (1, SPELLING),
+        "same block as #1260a-spanning: collision, recorded as a known defect"),
+    row("#1260-window", "AAAAAAA", "AACACAAAA", 1,
+        "the untrimmed 7 nt poly-A window; both splitters return one member"),
+    row("#1260b-spanning", "AA", "CAAC", 1, "the separation-2 instance of #1260"),
+    diverging("#1260b-split", "AA", "CAAC", 2, (1, SPELLING),
+        "same block as #1260b-spanning: collision, recorded as a known defect"),
+    row("#1262a-spanning", "AA", "C", 1, "net -1 with no preserved reference base"),
+    diverging("#1262a-split", "AA", "C", 2, (1, SPELLING),
+        "same block as #1262a-spanning: collision, recorded as a known defect"),
+    diverging("#1262-window", "AAAAAAA", "ACAAAA", 1,
+        (2, "the sequence-first partitioner pins one member for this same input"),
+        "the untrimmed poly-A window where the two splitters disagree"),
+    row("#1262b-spanning", "AA", "CAC", 1, "the sub-plus-insertion instance of #1262"),
+    diverging("#1262b-split", "AA", "CAC", 2, (1, SPELLING),
+        "same block as #1262b-spanning: collision, recorded as a known defect"),
+    row("#999-positive", "G", "CT", 1,
+        "an insertion shifted flush against a substitution leaves no gap"),
+    row("#999-neg-spanning", "GC", "CGA", 1,
+        "net +1 with exactly one preserved interior base, like #422-spanning"),
+    diverging("#999-neg-split", "GC", "CGA", 2, (1, SPELLING),
+        "same block as #999-neg-spanning: collision, the two-member count is required"),
+    row("#1000", "C", "GCA", 1, "a 2 nt insertion shifted flush against a substitution"),
+
+    // --- spelling-confluence gap: trimmed blocks are pure insertions --------
+    row("#1287", "", "GAAA", 1, "pure insertion: an empty ref block cannot be partitioned"),
+    row("#1290", "", "CA", 1, "pure insertion"),
+    row("#1296", "C", "A", 1,
+        "the only one of the thirteen whose trimmed block is a 1 nt substitution"),
+    row("#1301", "", "CAAA", 1, "pure insertion"),
+    row("#1304", "", "GA", 1, "pure insertion"),
+    row("#1308", "", "TTGG", 1, "pure insertion"),
+    row("#1312", "", "AACC", 1, "pure insertion"),
+    row("#1320", "", "CAAAAA", 1, "pure insertion"),
+    row("#1286", "", "AA", 1, "pure insertion; recorded as reaching no partition_block call"),
+    row("#1297", "", "AA", 1, "pure insertion; recorded as reaching no partition_block call"),
+    row("#1316", "", "AAAA", 1, "pure insertion; recorded as reaching no partition_block call"),
+    row("#1321", "", "GA", 1, "pure insertion; recorded as reaching no partition_block call"),
+    row("#1323", "", "AGA", 1, "pure insertion; recorded as reaching no partition_block call"),
+];
+
+/// How the repo records the two answers a colliding block pair carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Pinning {
+    /// Both recorded answers are asserted correct somewhere in the repo.
+    BothCorrect,
+    /// The divergence is recorded as a defect that must stay visible.
+    KnownDefect,
+}
+
+/// One collision: two corpus rows that share a block pair but carry different
+/// recorded member counts.
+struct Collision {
+    /// The row whose recorded count the splitter reproduces.
+    spanning: &'static str,
+    /// The row whose recorded count the splitter does not reproduce.
+    split: &'static str,
+    pinning: Pinning,
+}
+
+/// The collision census: six pairs, two recorded correct, four recorded as
+/// known defects.
+const COLLISIONS: &[Collision] = &[
+    Collision {
+        spanning: "#422-spanning",
+        split: "#422-two-member",
+        pinning: Pinning::BothCorrect,
+    },
+    Collision {
+        spanning: "#999-neg-spanning",
+        split: "#999-neg-split",
+        pinning: Pinning::BothCorrect,
+    },
+    Collision {
+        spanning: "#1260a-spanning",
+        split: "#1260a-split",
+        pinning: Pinning::KnownDefect,
+    },
+    Collision {
+        spanning: "#1260b-spanning",
+        split: "#1260b-split",
+        pinning: Pinning::KnownDefect,
+    },
+    Collision {
+        spanning: "#1262a-spanning",
+        split: "#1262a-split",
+        pinning: Pinning::KnownDefect,
+    },
+    Collision {
+        spanning: "#1262b-spanning",
+        split: "#1262b-split",
+        pinning: Pinning::KnownDefect,
+    },
+];
+
+/// Look up a row by id, panicking with the id when it is missing so a renamed
+/// row fails loudly rather than silently dropping a collision.
+fn find(id: &str) -> &'static BlockRow {
+    CORPUS
+        .iter()
+        .find(|r| r.id == id)
+        .unwrap_or_else(|| panic!("no corpus row with id {id}"))
+}
+
+/// Substitute `pieces` into `reference` and return the sequence they denote.
+///
+/// This is the splitter's own contract stated independently: the pieces must be
+/// disjoint, ascending, and reconstruct the alt block exactly.
+fn apply(reference: &[u8], pieces: &[Piece]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    for piece in pieces {
+        assert!(
+            piece.ref_start >= cursor,
+            "pieces must be disjoint and ascending; got {pieces:?}"
+        );
+        assert!(
+            piece.ref_end <= reference.len(),
+            "piece runs past the reference; got {pieces:?}"
+        );
+        out.extend_from_slice(&reference[cursor..piece.ref_start]);
+        out.extend_from_slice(&piece.alt);
+        cursor = piece.ref_end;
+    }
+    out.extend_from_slice(&reference[cursor..]);
+    out
+}
+
+/// Every block in the corpus, against the live splitter.
+#[test]
+fn corpus_blocks_partition_as_the_live_splitter_does() {
+    let mut wrong = Vec::new();
+    for row in CORPUS {
+        let pieces = partition_block(row.ref_block.as_bytes(), row.alt_block.as_bytes());
+        if pieces.len() != row.expected() {
+            wrong.push(format!(
+                "  {}: ({}, {}) expected {} pieces, got {} {:?}\n    recorded as: {}",
+                row.id,
+                row.ref_block,
+                row.alt_block,
+                row.expected(),
+                pieces.len(),
+                pieces,
+                row.note
+            ));
+        }
+    }
+    assert!(wrong.is_empty(), "corpus rows moved:\n{}", wrong.join("\n"));
+}
+
+/// The pieces of every corpus block reconstruct that block's alt exactly.
+///
+/// A member count alone would be satisfied by a partition that denotes the
+/// wrong sequence, so the count assertions above are only worth as much as this.
+#[test]
+fn corpus_pieces_reconstruct_every_alt_block() {
+    for row in CORPUS {
+        let reference = row.ref_block.as_bytes();
+        let pieces = partition_block(reference, row.alt_block.as_bytes());
+        assert_eq!(
+            String::from_utf8_lossy(&apply(reference, &pieces)),
+            row.alt_block,
+            "{} pieces do not denote the alt block: {pieces:?}",
+            row.id
+        );
+    }
+}
+
+/// The rows where the block does not determine the recorded member count.
+///
+/// Pinned as an exact set: a change that closes one of these — or opens a new
+/// one — must say so here rather than move a count quietly.
+#[test]
+fn recorded_and_splitter_counts_diverge_on_exactly_these_rows() {
+    let diverging: Vec<&str> = CORPUS
+        .iter()
+        .filter(|r| r.splitter_returns.is_some())
+        .map(|r| r.id)
+        .collect();
+    assert_eq!(
+        diverging,
+        vec![
+            "#422-two-member",
+            "#1235-c-codon-exception",
+            "#1235-r-coding",
+            "#1260a-split",
+            "#1260b-split",
+            "#1262a-split",
+            "#1262-window",
+            "#1262b-split",
+            "#999-neg-split",
+        ]
+    );
+    for row in CORPUS.iter().filter(|r| r.splitter_returns.is_some()) {
+        assert_ne!(
+            row.recorded_members,
+            row.expected(),
+            "{} carries an override that matches the recorded count",
+            row.id
+        );
+    }
+}
+
+/// The collision census, executable.
+///
+/// For each pair: the two rows really are the same splitter input, they carry
+/// different recorded member counts, and the splitter returns one answer for
+/// both. That is what makes the pair unsatisfiable for a splitter that sees
+/// only the block — at most one of the two recorded counts can be its decision.
+#[test]
+fn colliding_block_pairs_are_one_splitter_input_with_two_recorded_answers() {
+    for collision in COLLISIONS {
+        let spanning = find(collision.spanning);
+        let split = find(collision.split);
+
+        assert_eq!(
+            (spanning.ref_block, spanning.alt_block),
+            (split.ref_block, split.alt_block),
+            "{} and {} are recorded as a collision but are different blocks",
+            spanning.id,
+            split.id
+        );
+        assert_ne!(
+            spanning.recorded_members, split.recorded_members,
+            "{} and {} record the same member count, so they do not collide",
+            spanning.id, split.id
+        );
+
+        let pieces = partition_block(spanning.ref_block.as_bytes(), spanning.alt_block.as_bytes());
+        assert_eq!(
+            pieces.len(),
+            spanning.recorded_members,
+            "{} is the recorded count the splitter reproduces",
+            spanning.id
+        );
+        assert_ne!(
+            pieces.len(),
+            split.recorded_members,
+            "{} is the recorded count the splitter does not reproduce",
+            split.id
+        );
+    }
+}
+
+/// Two collisions are recorded with both answers correct; four are recorded as
+/// known defects. That split is the census's whole point, so it is pinned.
+#[test]
+fn the_census_is_two_correct_pins_and_four_known_defects() {
+    let correct: Vec<&str> = COLLISIONS
+        .iter()
+        .filter(|c| c.pinning == Pinning::BothCorrect)
+        .map(|c| c.split)
+        .collect();
+    assert_eq!(correct, vec!["#422-two-member", "#999-neg-split"]);
+
+    let defects: Vec<&str> = COLLISIONS
+        .iter()
+        .filter(|c| c.pinning == Pinning::KnownDefect)
+        .map(|c| c.split)
+        .collect();
+    assert_eq!(
+        defects,
+        vec![
+            "#1260a-split",
+            "#1260b-split",
+            "#1262a-split",
+            "#1262b-split"
+        ]
+    );
+}
+
+/// The corpus is a table, so a duplicated or renamed id would silently shadow a
+/// case. Ids are unique; shared *blocks* are expected and are not deduplicated.
+#[test]
+fn corpus_ids_are_unique() {
+    let mut ids: Vec<&str> = CORPUS.iter().map(|r| r.id).collect();
+    let total = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), total, "duplicate corpus id");
+    assert_eq!(total, 65, "corpus size changed; update the module doc");
+}

--- a/src/normalize/merge/splitter_reproducer_corpus.rs
+++ b/src/normalize/merge/splitter_reproducer_corpus.rs
@@ -24,10 +24,14 @@
 //! third is a finding rather than a known design seam:
 //!
 //! 1. **Two-member spellings** (`#422-two-member`, `#999-neg-split`,
-//!    `#1260a-split`, `#1260b-split`, `#1262a-split`, `#1262b-split`). Each
-//!    shares its block with a spanning sibling row in this table that the
-//!    splitter answers identically. Their recorded two-member outputs therefore
-//!    cannot come from the splitter; see the collision census below.
+//!    `#1260a-split`, `#1262a-split`, `#1262b-split`). Each shares its block
+//!    with a spanning sibling row in this table that the splitter answers
+//!    identically. Their recorded two-member outputs therefore cannot come from
+//!    the splitter; see the collision census below.
+//!
+//!    `#1260b` is the exception, and it is the override *inverted*: the two-gap
+//!    alignment (#1260, PR #1285) made the splitter answer the **split** count,
+//!    so `#1260b-spanning` is the row that now carries the override.
 //! 2. **Coding-axis codon merges** (`#1235-c-codon-exception`, `#1235-r-coding`).
 //!    The block splits into two; the one-member coding answer is produced after
 //!    partitioning, so it is not a block-level fact.
@@ -44,8 +48,9 @@
 //! Six block pairs each carry two different recorded member counts. Since a
 //! pure function of the pair returns one answer, at most one of each pair's two
 //! recorded counts can be a splitter decision. [`COLLISIONS`] pins all six:
-//! two are recorded with **both** answers asserted correct in the repo, four are
-//! recorded as **known defects**.
+//! two are recorded with **both** answers asserted correct in the repo, three
+//! remain **known defects**, and one — `#1260b` — is **resolved at the
+//! splitter**, which now answers its split count rather than its spanning one.
 //!
 //! # Recorded but deliberately not asserted here
 //!
@@ -233,9 +238,11 @@ const CORPUS: &[BlockRow] = &[
         "same block as #1260a-spanning: collision, recorded as a known defect"),
     row("#1260-window", "AAAAAAA", "AACACAAAA", 1,
         "the untrimmed 7 nt poly-A window; both splitters return one member"),
-    row("#1260b-spanning", "AA", "CAAC", 1, "the separation-2 instance of #1260"),
-    diverging("#1260b-split", "AA", "CAAC", 2, (1, SPELLING),
-        "same block as #1260b-spanning: collision, recorded as a known defect"),
+    diverging("#1260b-spanning", "AA", "CAAC", 1,
+        (2, "the two-gap alignment keeps the whole reference between the two insertions"),
+        "the separation-2 instance of #1260; the splitter now answers the SPLIT count"),
+    row("#1260b-split", "AA", "CAAC", 2,
+        "same block as #1260b-spanning: the collision the two-gap alignment resolved"),
     row("#1262a-spanning", "AA", "C", 1, "net -1 with no preserved reference base"),
     diverging("#1262a-split", "AA", "C", 2, (1, SPELLING),
         "same block as #1262a-spanning: collision, recorded as a known defect"),
@@ -277,6 +284,13 @@ enum Pinning {
     BothCorrect,
     /// The divergence is recorded as a defect that must stay visible.
     KnownDefect,
+    /// The defect is **fixed at the splitter**: the splitter now answers the
+    /// *split* row's count rather than the spanning one, so the two spellings
+    /// no longer disagree about how to divide the block. Kept as a row rather
+    /// than deleted, because the pair is what makes the resolution legible —
+    /// and because the two recorded counts still differ until the rest of the
+    /// pipeline follows the splitter.
+    ResolvedToSplit,
 }
 
 /// One collision: two corpus rows that share a block pair but carry different
@@ -310,7 +324,7 @@ const COLLISIONS: &[Collision] = &[
     Collision {
         spanning: "#1260b-spanning",
         split: "#1260b-split",
-        pinning: Pinning::KnownDefect,
+        pinning: Pinning::ResolvedToSplit,
     },
     Collision {
         spanning: "#1262a-spanning",
@@ -415,7 +429,7 @@ fn recorded_and_splitter_counts_diverge_on_exactly_these_rows() {
             "#1235-c-codon-exception",
             "#1235-r-coding",
             "#1260a-split",
-            "#1260b-split",
+            "#1260b-spanning",
             "#1262a-split",
             "#1262-window",
             "#1262b-split",
@@ -457,26 +471,34 @@ fn colliding_block_pairs_are_one_splitter_input_with_two_recorded_answers() {
             spanning.id, split.id
         );
 
+        // Which side the splitter reproduces is the census's whole content, so
+        // it is asserted per-pinning rather than assumed to be the spanning one.
         let pieces = partition_block(spanning.ref_block.as_bytes(), spanning.alt_block.as_bytes());
+        let (reproduced, not_reproduced) = match collision.pinning {
+            Pinning::ResolvedToSplit => (split, spanning),
+            Pinning::BothCorrect | Pinning::KnownDefect => (spanning, split),
+        };
         assert_eq!(
             pieces.len(),
-            spanning.recorded_members,
+            reproduced.recorded_members,
             "{} is the recorded count the splitter reproduces",
-            spanning.id
+            reproduced.id
         );
         assert_ne!(
             pieces.len(),
-            split.recorded_members,
+            not_reproduced.recorded_members,
             "{} is the recorded count the splitter does not reproduce",
-            split.id
+            not_reproduced.id
         );
     }
 }
 
-/// Two collisions are recorded with both answers correct; four are recorded as
-/// known defects. That split is the census's whole point, so it is pinned.
+/// Two collisions are recorded with both answers correct, three remain known
+/// defects, and one — `#1260b` — is now resolved at the splitter by the two-gap
+/// alignment (#1260, PR #1285). That split is the census's whole point, so it
+/// is pinned.
 #[test]
-fn the_census_is_two_correct_pins_and_four_known_defects() {
+fn the_census_is_two_correct_pins_three_known_defects_and_one_resolved() {
     let correct: Vec<&str> = COLLISIONS
         .iter()
         .filter(|c| c.pinning == Pinning::BothCorrect)
@@ -491,13 +513,15 @@ fn the_census_is_two_correct_pins_and_four_known_defects() {
         .collect();
     assert_eq!(
         defects,
-        vec![
-            "#1260a-split",
-            "#1260b-split",
-            "#1262a-split",
-            "#1262b-split"
-        ]
+        vec!["#1260a-split", "#1262a-split", "#1262b-split"]
     );
+
+    let resolved: Vec<&str> = COLLISIONS
+        .iter()
+        .filter(|c| c.pinning == Pinning::ResolvedToSplit)
+        .map(|c| c.split)
+        .collect();
+    assert_eq!(resolved, vec!["#1260b-split"]);
 }
 
 /// The corpus is a table, so a duplicated or renamed id would silently shadow a

--- a/src/normalize/merge/splitter_reproducer_corpus.rs
+++ b/src/normalize/merge/splitter_reproducer_corpus.rs
@@ -238,11 +238,12 @@ const CORPUS: &[BlockRow] = &[
         "net +2; the splitter now answers the SPLIT count"),
     row("#1260a-split", "A", "CAC", 2,
         "same block as #1260a-spanning: the collision the two-gap alignment resolved"),
-    row("#1260-window", "AAAAAAA", "AACACAAAA", 1,
-        "the UNTRIMMED 7 nt poly-A window, 9 nt on the alt side, so above \
-         MAX_SINGLE_BASE_SEPARATION_BLOCK and held whole. The pipeline never \
-         sees this: trim_common_flanks reduces it to #1260a's (A, CAC), which \
-         is 3 nt and does split -- which is how #1260 converges"),
+    diverging("#1260-window", "AAAAAAA", "AACACAAAA", 1,
+        (2, "the untrimmed window changes only 2 bases, so one unchanged base is \
+             still believable separation and the two insertions stay apart"),
+        "the UNTRIMMED 7 nt poly-A window. The pipeline reaches the same answer \
+         through #1260a's trimmed (A, CAC); that both extents agree is what makes \
+         the supremal extent safe to adopt"),
     diverging("#1260b-spanning", "AA", "CAAC", 1,
         (2, "the two-gap alignment keeps the whole reference between the two insertions"),
         "the separation-2 instance of #1260; the splitter now answers the SPLIT count"),
@@ -441,6 +442,7 @@ fn recorded_and_splitter_counts_diverge_on_exactly_these_rows() {
             "#1235-c-codon-exception",
             "#1235-r-coding",
             "#1260a-spanning",
+            "#1260-window",
             "#1260b-spanning",
             "#1262a-split",
             "#1262-window",

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -28,6 +28,7 @@ pub mod config;
 pub(crate) mod merge;
 mod overlap;
 pub mod rules;
+pub(crate) mod seqfirst;
 pub mod shuffle;
 pub mod validate;
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -28,6 +28,19 @@ pub mod config;
 pub(crate) mod merge;
 mod overlap;
 pub mod rules;
+// `pub` only under the `dev` feature (test/bench builds), so the
+// `seqfirst_align` criterion benchmark — an external crate — can reach
+// `AlignmentDag::build`/`edit_distance`; `pub(crate)` otherwise, since there is
+// no public API here yet.
+//
+// Not "unwired into `normalize_allele`": it IS compiled in and run there, as a
+// shadow comparison behind `FERRO_SEQFIRST_SHADOW=1` that never affects output.
+// What remains is promoting it from shadow to authoritative. (Same correction as
+// the module's own header — this comment is its sibling and said the same wrong
+// thing.)
+#[cfg(feature = "dev")]
+pub mod seqfirst;
+#[cfg(not(feature = "dev"))]
 pub(crate) mod seqfirst;
 pub mod shuffle;
 pub mod validate;

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -38,7 +38,12 @@ pub(crate) enum Step {
 /// Nodes are grid cells `(i, j)`, meaning "`i` reference bases and `j`
 /// alternate bases consumed". A cell is present only if some minimal alignment
 /// passes through it. Edges are the steps a minimal alignment may take.
-pub(crate) struct AlignmentDag {
+///
+/// `pub` (rather than `pub(crate)`) so the `seqfirst_align` criterion
+/// benchmark can name the type; actually reachable from outside the crate
+/// only when the enclosing `seqfirst`/`align` modules are also `pub`, which
+/// they are only under the `dev` feature — see `seqfirst/mod.rs`.
+pub struct AlignmentDag {
     ref_len: u32,
     alt_len: u32,
     total: u32,
@@ -54,7 +59,7 @@ impl AlignmentDag {
     ///
     /// Both slices are raw bases with common flanks already trimmed. Either may
     /// be empty. Cost is `O(ref_len * alt_len)` in time and space.
-    pub(crate) fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
+    pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
         let n = ref_block.len();
         let m = alt_block.len();
         let prefix = edit_grid(ref_block, alt_block);
@@ -120,7 +125,7 @@ impl AlignmentDag {
     }
 
     /// Minimal edit distance between the two blocks.
-    pub(crate) fn edit_distance(&self) -> u32 {
+    pub fn edit_distance(&self) -> u32 {
         self.total
     }
 

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -161,6 +161,101 @@ impl AlignmentDag {
     }
 }
 
+/// Steps that every minimal alignment takes.
+///
+/// `matched` holds `(reference offset, alternate offset)` for each match edge
+/// present in every minimal alignment — the positions that are genuinely
+/// unchanged, together with where they sit in the alternate block. Sorted by
+/// reference offset. `forced_ins_junctions` holds junctions (reference offsets,
+/// with junction `k` sitting between reference bases `k - 1` and `k`) where
+/// every minimal alignment inserts.
+///
+/// The alternate offset is not decoration: it is the only reliable way to
+/// recover a member's alternate span. See `partition::member_alt_spans`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct Dominators {
+    pub(crate) matched: Vec<(u32, u32)>,
+    pub(crate) forced_ins_junctions: Vec<u32>,
+}
+
+impl Dominators {
+    /// Reference offsets that every minimal alignment matches.
+    pub(crate) fn matched_ref(&self) -> Vec<u32> {
+        self.matched.iter().map(|&(r, _)| r).collect()
+    }
+
+    /// The alternate offset pinned by the dominator match at `ref_pos`, if that
+    /// reference position is a dominator match.
+    pub(crate) fn alt_at(&self, ref_pos: u32) -> Option<u32> {
+        self.matched
+            .binary_search_by_key(&ref_pos, |&(r, _)| r)
+            .ok()
+            .map(|idx| self.matched[idx].1)
+    }
+}
+
+impl AlignmentDag {
+    /// Edges present in **every** minimal alignment.
+    ///
+    /// An edge lies on every source-to-sink path exactly when removing it
+    /// disconnects them. In a DAG this is found with one topological sweep:
+    /// track how many edges cross from the processed set to the unprocessed
+    /// set, and whenever that count falls to one, that single edge is on every
+    /// path.
+    ///
+    /// `O(V + E)`. Deliberately not the per-edge reachability probe the
+    /// calibration prototype used — that is `O(E)` per edge, which is fine for
+    /// a 52 nt block and not for production. The probe survives as the test
+    /// oracle.
+    pub(crate) fn dominators(&self) -> Dominators {
+        let mut result = Dominators::default();
+        let sink = (self.ref_len, self.alt_len);
+        let order: Vec<(u32, u32)> = self.cells().collect();
+
+        // In-degree within the DAG, needed to know when a node's incoming edges
+        // stop crossing the frontier.
+        let mut in_degree = vec![0u32; (self.ref_len as usize + 1) * (self.alt_len as usize + 1)];
+        for &(i, j) in &order {
+            for (ni, nj, _) in self.out_edges(i, j) {
+                in_degree[self.index(ni, nj)] += 1;
+            }
+        }
+
+        let mut crossing: i64 = 0;
+        for &(i, j) in &order {
+            crossing -= i64::from(in_degree[self.index(i, j)]);
+            let outs: Vec<(u32, u32, Step)> = self.out_edges(i, j).collect();
+            crossing += outs.len() as i64;
+
+            // If exactly one edge crosses the frontier now, it is on every
+            // path. Any node with two or more out-edges contributes two or more
+            // crossings itself, so a count of one means this node has exactly
+            // one out-edge and nothing older is still crossing.
+            if crossing == 1 && (i, j) != sink {
+                debug_assert_eq!(
+                    outs.len(),
+                    1,
+                    "a single crossing must be this cell's only out-edge"
+                );
+                let (_, _, step) = outs[0];
+                match step {
+                    // `(i, j)` is the cell the edge leaves, so it pins the
+                    // alternate coordinate as well as the reference one.
+                    Step::Match => result.matched.push((i, j)),
+                    Step::Ins => result.forced_ins_junctions.push(i),
+                    Step::Sub | Step::Del => {}
+                }
+            }
+        }
+
+        result.matched.sort_unstable();
+        result.matched.dedup();
+        result.forced_ins_junctions.sort_unstable();
+        result.forced_ins_junctions.dedup();
+        result
+    }
+}
+
 /// Full Levenshtein distance grid, row-major with `alt.len() + 1` columns.
 fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u32> {
     let n = reference.len();
@@ -241,5 +336,131 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Brute-force oracle: an edge is a dominator iff deleting it disconnects
+    /// the source from the sink. `O(E)` per edge — correct but far too slow for
+    /// production, which is exactly why it belongs in the tests.
+    fn dominators_by_brute_force(dag: &AlignmentDag) -> (Vec<(u32, u32)>, Vec<u32>) {
+        let sink = (dag.ref_len(), dag.alt_len());
+        let mut matched = Vec::new();
+        let mut forced_ins = Vec::new();
+        for (i, j) in dag.cells().collect::<Vec<_>>() {
+            for (ni, nj, step) in dag.out_edges(i, j).collect::<Vec<_>>() {
+                if matches!(step, Step::Sub | Step::Del) {
+                    continue;
+                }
+                let banned = (i, j, ni, nj);
+                let mut seen = vec![(0u32, 0u32)];
+                let mut stack = vec![(0u32, 0u32)];
+                let mut reached = false;
+                while let Some(v) = stack.pop() {
+                    if v == sink {
+                        reached = true;
+                        break;
+                    }
+                    for (wi, wj, _) in dag.out_edges(v.0, v.1).collect::<Vec<_>>() {
+                        if (v.0, v.1, wi, wj) == banned || seen.contains(&(wi, wj)) {
+                            continue;
+                        }
+                        seen.push((wi, wj));
+                        stack.push((wi, wj));
+                    }
+                }
+                if !reached {
+                    match step {
+                        Step::Match => matched.push((i, j)),
+                        Step::Ins => forced_ins.push(i),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+        }
+        matched.sort_unstable();
+        matched.dedup();
+        forced_ins.sort_unstable();
+        forced_ins.dedup();
+        (matched, forced_ins)
+    }
+
+    #[test]
+    fn lrg199_has_exactly_one_dominator_match() {
+        // The spec's own worked example, `delins.md:44` / LRG_199t1:c.850_901.
+        // Real sequence, pulled from LRG_199.fasta; CDS offset verified against
+        // the spec's own `c.145_147 = CGC = Arg49`.
+        let dag = AlignmentDag::build(
+            b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT",
+            b"TTCCTCGATGCCTG",
+        );
+        let dom = dag.dominators();
+        assert_eq!(
+            dom.matched_ref(),
+            vec![48],
+            "LRG_199 must have exactly one dominator match, at reference offset 48"
+        );
+        assert!(
+            dom.alt_at(48).is_some(),
+            "the dominator must pin an alternate coordinate too"
+        );
+    }
+
+    #[test]
+    fn a_pure_insertion_is_seen_as_a_forced_junction() {
+        // #1260: two `insC` at adjacent gaps in a poly-A run. A node model
+        // reports this as zero members because no reference position changes;
+        // the junctions are the whole signal.
+        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let dom = dag.dominators();
+        assert_eq!(
+            dom.matched_ref().len(),
+            7,
+            "every reference position is matched in every minimal alignment"
+        );
+        assert!(
+            !dom.forced_ins_junctions.is_empty(),
+            "the insertions must show up as forced junctions, or they vanish"
+        );
+    }
+
+    #[test]
+    fn dominators_agree_with_brute_force_on_exhaustive_small_inputs() {
+        // Exhaustive over a 2-letter alphabet, lengths 0..=5 both sides. Small
+        // alphabet and short blocks maximise alternative minimal alignments,
+        // which is where a wrong dominator rule shows up.
+        fn words(len: u32) -> Vec<Vec<u8>> {
+            if len == 0 {
+                return vec![Vec::new()];
+            }
+            let mut out = Vec::new();
+            for shorter in words(len - 1) {
+                for base in *b"AC" {
+                    let mut w = shorter.clone();
+                    w.push(base);
+                    out.push(w);
+                }
+            }
+            out
+        }
+        let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        let mut checked = 0usize;
+        for r in &all {
+            for a in &all {
+                let dag = AlignmentDag::build(r, a);
+                let got = dag.dominators();
+                let (want_matched, want_ins) = dominators_by_brute_force(&dag);
+                assert_eq!(
+                    (got.matched, got.forced_ins_junctions),
+                    (want_matched, want_ins),
+                    "disagreement on {} -> {}",
+                    String::from_utf8_lossy(r),
+                    String::from_utf8_lossy(a)
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 3000,
+            "expected a large exhaustive sweep, ran {checked}"
+        );
     }
 }

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -3,12 +3,9 @@
 //! Global alignment (both ends anchored) under **unit-cost Levenshtein**. Both
 //! choices are deliberate:
 //!
-//! - *Global*, because the eventual caller in the migration will trim common
-//!   flanks before calling in, making them identical by construction and
-//!   removing any "where do these correspond" question. Nothing here requires
-//!   that: an untrimmed flank only adds harmless leading/trailing dominator
-//!   matches, since a flank match is itself a dominator (every minimal
-//!   alignment matches it) and so cannot change the partition.
+//! - *Global*, because the caller trims common flanks before calling in, so
+//!   both ends correspond by construction. That trimming is a precondition,
+//!   not a convenience — see [`AlignmentDag::build`].
 //! - *Unit cost, not affine*. The criterion is not "which alignment is best"
 //!   but "which steps appear in **all** minimal alignments" — the cost model's
 //!   job is to define that set, not to pick a winner. Affine penalties are
@@ -49,24 +46,52 @@ pub(crate) enum Step {
 pub struct AlignmentDag {
     ref_len: u32,
     alt_len: u32,
+    /// Read only through [`AlignmentDag::edit_distance`], whose sole non-test
+    /// caller is the `dev`-gated `seqfirst_align` benchmark — so without that
+    /// feature the field is genuinely unread. Scoped on the feature rather than
+    /// allowed unconditionally, so it starts warning again if the benchmark is
+    /// ever the only thing keeping it alive under `dev` too.
+    #[cfg_attr(not(feature = "dev"), allow(dead_code))]
     total: u32,
     /// Row-major `(ref_len + 1) x (alt_len + 1)`; `true` when the cell lies on
     /// at least one minimal alignment.
     on_optimal_path: Vec<bool>,
-    /// Row-major, parallel to `on_optimal_path`. Out-edges of each cell.
-    out: Vec<Vec<(u32, u32, Step)>>,
+    /// Row-major, parallel to `on_optimal_path`. One bit per possible out-edge:
+    /// [`OUT_MATCH`], [`OUT_SUB`], [`OUT_DEL`], [`OUT_INS`].
+    ///
+    /// A flat bitmask rather than a `Vec<Vec<_>>`. A cell has at most three
+    /// out-edges (diagonal, down, right) and the diagonal's kind is fixed by
+    /// whether the two bases are equal, so four bits describe a cell exactly.
+    /// The nested form cost 24 bytes of `Vec` header per grid cell whether or
+    /// not the cell was on-path — about 400 MB before a single edge was stored
+    /// for the 4096 x 4096 block `benches/seqfirst_align.rs` measures — plus one
+    /// allocator call per on-path cell. This keeps the same `Θ(n·m)` space with
+    /// one allocation and an order-of-magnitude smaller constant.
+    out: Vec<u8>,
 }
+
+/// Diagonal out-edge whose two bases are equal (`Step::Match`).
+const OUT_MATCH: u8 = 1 << 0;
+/// Diagonal out-edge whose two bases differ (`Step::Sub`).
+const OUT_SUB: u8 = 1 << 1;
+/// Down out-edge: a reference base is deleted (`Step::Del`).
+const OUT_DEL: u8 = 1 << 2;
+/// Right out-edge: an alternate base is inserted (`Step::Ins`).
+const OUT_INS: u8 = 1 << 3;
 
 impl AlignmentDag {
     /// Build the DAG for `ref_block` -> `alt_block`.
     ///
-    /// Both slices are raw bases. Either may be empty. There is no requirement
-    /// that common flanks be pre-trimmed: an untrimmed flank only contributes
-    /// extra leading/trailing dominator matches (a flank match is matched by
-    /// every minimal alignment), which leaves the partition unchanged. The
-    /// eventual caller in the migration will trim flanks anyway, but that is a
-    /// caller convenience, not a precondition of this function. Cost is
-    /// `O(ref_len * alt_len)` in time and space.
+    /// Both slices are raw bases; either may be empty.
+    ///
+    /// **The caller must trim common flanks first.** The partition is a
+    /// function of this exact pair, and an untrimmed flank base can be absorbed
+    /// into a neighbouring member rather than sitting outside it: `AT -> AAT`
+    /// yields one member at ref `0..1`, while the flank-trimmed `T -> AT`
+    /// yields a pure insertion at ref `1`. Trimming is therefore a
+    /// precondition, not a convenience.
+    ///
+    /// Cost is `O(ref_len * alt_len)` in time and space.
     pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
         let n = ref_block.len();
         let m = alt_block.len();
@@ -90,7 +115,7 @@ impl AlignmentDag {
             }
         }
 
-        let mut out: Vec<Vec<(u32, u32, Step)>> = vec![Vec::new(); (n + 1) * width];
+        let mut out = vec![0u8; (n + 1) * width];
         for i in 0..=n {
             for j in 0..=m {
                 if !on_optimal_path[i * width + j] {
@@ -102,22 +127,21 @@ impl AlignmentDag {
                     let cost = u32::from(ref_block[i] != alt_block[j]);
                     let next = (i + 1) * width + (j + 1);
                     if here + cost == prefix[next] && on_optimal_path[next] {
-                        let step = if cost == 0 { Step::Match } else { Step::Sub };
-                        out[i * width + j].push((i as u32 + 1, j as u32 + 1, step));
+                        out[i * width + j] |= if cost == 0 { OUT_MATCH } else { OUT_SUB };
                     }
                 }
                 // Down: deletion of a reference base.
                 if i < n {
                     let next = (i + 1) * width + j;
                     if here + 1 == prefix[next] && on_optimal_path[next] {
-                        out[i * width + j].push((i as u32 + 1, j as u32, Step::Del));
+                        out[i * width + j] |= OUT_DEL;
                     }
                 }
                 // Right: insertion of an alternate base.
                 if j < m {
                     let next = i * width + (j + 1);
                     if here + 1 == prefix[next] && on_optimal_path[next] {
-                        out[i * width + j].push((i as u32, j as u32 + 1, Step::Ins));
+                        out[i * width + j] |= OUT_INS;
                     }
                 }
             }
@@ -133,6 +157,11 @@ impl AlignmentDag {
     }
 
     /// Minimal edit distance between the two blocks.
+    ///
+    /// Called by the `dev`-gated `seqfirst_align` benchmark and by this module's
+    /// tests; the shadow comparison in `normalize_allele` does not need it, hence
+    /// the feature-scoped allowance.
+    #[cfg_attr(not(feature = "dev"), allow(dead_code))]
     pub fn edit_distance(&self) -> u32 {
         self.total
     }
@@ -175,11 +204,12 @@ impl AlignmentDag {
 
     /// Out-edges of a cell, as `(next_i, next_j, step)`.
     ///
-    /// `(i, j)` must be within the grid (`i <= ref_len`, `j <= alt_len`); this
-    /// does not panic off-grid, it silently aliases another cell's edges (the
-    /// backing storage is a flat row-major array, so an out-of-range `j`
-    /// wraps into the next row). Checked by the `debug_assert` below in debug
-    /// builds.
+    /// `(i, j)` must be within the grid (`i <= ref_len`, `j <= alt_len`).
+    /// Off-grid is not uniformly caught in release: with `i < ref_len` an
+    /// out-of-range `j` wraps into a later row and silently returns another
+    /// cell's edges; in the last row (`i == ref_len`), or for any
+    /// `i > ref_len`, the flat index runs past the backing `Vec` and panics.
+    /// The `debug_assert` below catches both in debug builds.
     pub(crate) fn out_edges(&self, i: u32, j: u32) -> impl Iterator<Item = (u32, u32, Step)> + '_ {
         debug_assert!(
             i <= self.ref_len && j <= self.alt_len,
@@ -187,7 +217,18 @@ impl AlignmentDag {
             self.ref_len,
             self.alt_len
         );
-        self.out[self.index(i, j)].iter().copied()
+        // Reconstructed from the mask and `(i, j)`. The order matches what the
+        // nested-`Vec` form pushed — diagonal, then down, then right — so any
+        // caller that depended on edge order is unaffected.
+        let mask = self.out[self.index(i, j)];
+        [
+            (mask & OUT_MATCH != 0).then_some((i + 1, j + 1, Step::Match)),
+            (mask & OUT_SUB != 0).then_some((i + 1, j + 1, Step::Sub)),
+            (mask & OUT_DEL != 0).then_some((i + 1, j, Step::Del)),
+            (mask & OUT_INS != 0).then_some((i, j + 1, Step::Ins)),
+        ]
+        .into_iter()
+        .flatten()
     }
 }
 
@@ -275,8 +316,12 @@ impl AlignmentDag {
         let mut crossing: i64 = 0;
         for &(i, j) in &order {
             crossing -= i64::from(in_degree[self.index(i, j)]);
-            let outs: Vec<(u32, u32, Step)> = self.out_edges(i, j).collect();
-            crossing += outs.len() as i64;
+            // Counted, not collected. The edge itself is only needed on the
+            // `crossing == 1` branch below, and that is rare; collecting on every
+            // cell put a heap allocation back on the `Θ(n·m)` sweep that the flat
+            // adjacency exists to keep off it.
+            let out_degree = self.out_edges(i, j).count();
+            crossing += out_degree as i64;
 
             // If exactly one edge crosses the frontier now, it is on every
             // path. Any node with two or more out-edges contributes two or more
@@ -284,11 +329,12 @@ impl AlignmentDag {
             // one out-edge and nothing older is still crossing.
             if crossing == 1 && (i, j) != sink {
                 debug_assert_eq!(
-                    outs.len(),
-                    1,
+                    out_degree, 1,
                     "a single crossing must be this cell's only out-edge"
                 );
-                let (_, _, step) = outs[0];
+                let Some((_, _, step)) = self.out_edges(i, j).next() else {
+                    continue;
+                };
                 match step {
                     // `(i, j)` is the cell the edge leaves, so it pins the
                     // alternate coordinate as well as the reference one.

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -1,0 +1,245 @@
+//! Unit 2: build the DAG of every minimal-cost alignment.
+//!
+//! Global alignment (both ends anchored) under **unit-cost Levenshtein**. Both
+//! choices are deliberate:
+//!
+//! - *Global*, because the flanks were trimmed by the caller and are identical
+//!   by construction, so there is no "where do these correspond" question and
+//!   every base must be accounted for.
+//! - *Unit cost, not affine*. The criterion is not "which alignment is best"
+//!   but "which steps appear in **all** minimal alignments" — the cost model's
+//!   job is to define that set, not to pick a winner. Affine penalties are
+//!   tuned parameters, and tuning is where the previous principled attempts at
+//!   this died. Unit cost has no knob to tune.
+//!
+//! There is **no shifting here**. The DAG holds all minimal alignments at once,
+//! so it has no 5'/3' bias to choose; that is exactly why it is confluent.
+//! Shifting is the renderer's job.
+//!
+//! There is also **no seeding from the input's own alignment** — that would
+//! reintroduce input-relativity by a new route.
+
+/// One step of an alignment, as an edge in the DAG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Step {
+    /// Reference and alternate bases agree; consumes one of each.
+    Match,
+    /// Reference and alternate bases differ; consumes one of each.
+    Sub,
+    /// Consumes a reference base with no alternate base.
+    Del,
+    /// Consumes an alternate base with no reference base.
+    Ins,
+}
+
+/// The DAG of every minimal-cost alignment of a reference block to an alternate
+/// block.
+///
+/// Nodes are grid cells `(i, j)`, meaning "`i` reference bases and `j`
+/// alternate bases consumed". A cell is present only if some minimal alignment
+/// passes through it. Edges are the steps a minimal alignment may take.
+pub(crate) struct AlignmentDag {
+    ref_len: u32,
+    alt_len: u32,
+    total: u32,
+    /// Row-major `(ref_len + 1) x (alt_len + 1)`; `true` when the cell lies on
+    /// at least one minimal alignment.
+    on_optimal_path: Vec<bool>,
+    /// Row-major, parallel to `on_optimal_path`. Out-edges of each cell.
+    out: Vec<Vec<(u32, u32, Step)>>,
+}
+
+impl AlignmentDag {
+    /// Build the DAG for `ref_block` -> `alt_block`.
+    ///
+    /// Both slices are raw bases with common flanks already trimmed. Either may
+    /// be empty. Cost is `O(ref_len * alt_len)` in time and space.
+    pub(crate) fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
+        let n = ref_block.len();
+        let m = alt_block.len();
+        let prefix = edit_grid(ref_block, alt_block);
+
+        // Suffix distances, computed as prefix distances of the reversed
+        // blocks: `suffix(i, j)` is the cost of aligning `ref[i..]` to
+        // `alt[j..]`.
+        let ref_rev: Vec<u8> = ref_block.iter().rev().copied().collect();
+        let alt_rev: Vec<u8> = alt_block.iter().rev().copied().collect();
+        let suffix_grid = edit_grid(&ref_rev, &alt_rev);
+        let suffix = |i: usize, j: usize| suffix_grid[(n - i) * (m + 1) + (m - j)];
+
+        let total = prefix[n * (m + 1) + m];
+        let width = m + 1;
+
+        let mut on_optimal_path = vec![false; (n + 1) * width];
+        for i in 0..=n {
+            for j in 0..=m {
+                on_optimal_path[i * width + j] = prefix[i * width + j] + suffix(i, j) == total;
+            }
+        }
+
+        let mut out: Vec<Vec<(u32, u32, Step)>> = vec![Vec::new(); (n + 1) * width];
+        for i in 0..=n {
+            for j in 0..=m {
+                if !on_optimal_path[i * width + j] {
+                    continue;
+                }
+                let here = prefix[i * width + j];
+                // Diagonal: match or substitution.
+                if i < n && j < m {
+                    let cost = u32::from(ref_block[i] != alt_block[j]);
+                    let next = (i + 1) * width + (j + 1);
+                    if here + cost == prefix[next] && on_optimal_path[next] {
+                        let step = if cost == 0 { Step::Match } else { Step::Sub };
+                        out[i * width + j].push((i as u32 + 1, j as u32 + 1, step));
+                    }
+                }
+                // Down: deletion of a reference base.
+                if i < n {
+                    let next = (i + 1) * width + j;
+                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                        out[i * width + j].push((i as u32 + 1, j as u32, Step::Del));
+                    }
+                }
+                // Right: insertion of an alternate base.
+                if j < m {
+                    let next = i * width + (j + 1);
+                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                        out[i * width + j].push((i as u32, j as u32 + 1, Step::Ins));
+                    }
+                }
+            }
+        }
+
+        Self {
+            ref_len: n as u32,
+            alt_len: m as u32,
+            total,
+            on_optimal_path,
+            out,
+        }
+    }
+
+    /// Minimal edit distance between the two blocks.
+    pub(crate) fn edit_distance(&self) -> u32 {
+        self.total
+    }
+
+    /// Length of the reference block.
+    pub(crate) fn ref_len(&self) -> u32 {
+        self.ref_len
+    }
+
+    /// Length of the alternate block.
+    pub(crate) fn alt_len(&self) -> u32 {
+        self.alt_len
+    }
+
+    fn index(&self, i: u32, j: u32) -> usize {
+        i as usize * (self.alt_len as usize + 1) + j as usize
+    }
+
+    /// Whether the cell lies on at least one minimal alignment.
+    pub(crate) fn contains_cell(&self, i: u32, j: u32) -> bool {
+        i <= self.ref_len && j <= self.alt_len && self.on_optimal_path[self.index(i, j)]
+    }
+
+    /// Every cell on a minimal alignment, in topological order (`i + j`
+    /// ascending). Every edge strictly increases `i + j`, so this ordering is a
+    /// valid topological sort.
+    pub(crate) fn cells(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        let mut cells: Vec<(u32, u32)> = (0..=self.ref_len)
+            .flat_map(move |i| (0..=self.alt_len).map(move |j| (i, j)))
+            .filter(|&(i, j)| self.contains_cell(i, j))
+            .collect();
+        cells.sort_by_key(|&(i, j)| (i + j, i));
+        cells.into_iter()
+    }
+
+    /// Out-edges of a cell, as `(next_i, next_j, step)`.
+    pub(crate) fn out_edges(&self, i: u32, j: u32) -> impl Iterator<Item = (u32, u32, Step)> + '_ {
+        self.out[self.index(i, j)].iter().copied()
+    }
+}
+
+/// Full Levenshtein distance grid, row-major with `alt.len() + 1` columns.
+fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u32> {
+    let n = reference.len();
+    let m = alt.len();
+    let width = m + 1;
+    let mut d = vec![0u32; (n + 1) * width];
+    for (i, x) in d.iter_mut().step_by(width).enumerate() {
+        *x = i as u32;
+    }
+    for (j, x) in d.iter_mut().take(width).enumerate() {
+        *x = j as u32;
+    }
+    for i in 1..=n {
+        for j in 1..=m {
+            let cost = u32::from(reference[i - 1] != alt[j - 1]);
+            d[i * width + j] = (d[(i - 1) * width + j] + 1)
+                .min(d[i * width + j - 1] + 1)
+                .min(d[(i - 1) * width + j - 1] + cost);
+        }
+    }
+    d
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edit_distance_matches_known_values() {
+        for (r, a, expected) in [
+            (&b""[..], &b""[..], 0),
+            (&b"ACGT"[..], &b"ACGT"[..], 0),
+            (&b"ACGT"[..], &b"AGGT"[..], 1),
+            (&b"ACGT"[..], &b"ACT"[..], 1),
+            (&b"ACGT"[..], &b"ACGGT"[..], 1),
+            (&b"AAAAAAA"[..], &b"AACACAAAA"[..], 2),
+            (&b"AAAAAAA"[..], &b"ACAAAA"[..], 2),
+        ] {
+            let dag = AlignmentDag::build(r, a);
+            assert_eq!(
+                dag.edit_distance(),
+                expected,
+                "d({}, {})",
+                String::from_utf8_lossy(r),
+                String::from_utf8_lossy(a)
+            );
+        }
+    }
+
+    #[test]
+    fn every_cell_lies_on_a_minimal_path() {
+        // A cell is in the DAG only if some minimal alignment passes through
+        // it: prefix(i,j) + suffix(i,j) == total.
+        let dag = AlignmentDag::build(b"ACGTACGT", b"ATGTTCGT");
+        assert!(dag.contains_cell(0, 0), "source must be present");
+        assert!(
+            dag.contains_cell(dag.ref_len(), dag.alt_len()),
+            "sink must be present"
+        );
+        for (i, j) in dag.cells() {
+            assert!(
+                dag.out_edges(i, j).next().is_some() || (i, j) == (dag.ref_len(), dag.alt_len()),
+                "cell ({i},{j}) is a dead end but is not the sink"
+            );
+        }
+    }
+
+    #[test]
+    fn every_edge_advances_the_topological_key() {
+        // i + j strictly increases along every edge, which is what makes
+        // sorting cells by i + j a valid topological order.
+        let dag = AlignmentDag::build(b"ACGTACGTAC", b"ACGTTACGTGAC");
+        for (i, j) in dag.cells() {
+            for (ni, nj, _step) in dag.out_edges(i, j) {
+                assert!(
+                    ni + nj > i + j,
+                    "edge ({i},{j}) -> ({ni},{nj}) does not advance i+j"
+                );
+            }
+        }
+    }
+}

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -3,9 +3,12 @@
 //! Global alignment (both ends anchored) under **unit-cost Levenshtein**. Both
 //! choices are deliberate:
 //!
-//! - *Global*, because the flanks were trimmed by the caller and are identical
-//!   by construction, so there is no "where do these correspond" question and
-//!   every base must be accounted for.
+//! - *Global*, because the eventual caller in the migration will trim common
+//!   flanks before calling in, making them identical by construction and
+//!   removing any "where do these correspond" question. Nothing here requires
+//!   that: an untrimmed flank only adds harmless leading/trailing dominator
+//!   matches, since a flank match is itself a dominator (every minimal
+//!   alignment matches it) and so cannot change the partition.
 //! - *Unit cost, not affine*. The criterion is not "which alignment is best"
 //!   but "which steps appear in **all** minimal alignments" — the cost model's
 //!   job is to define that set, not to pick a winner. Affine penalties are
@@ -57,8 +60,13 @@ pub struct AlignmentDag {
 impl AlignmentDag {
     /// Build the DAG for `ref_block` -> `alt_block`.
     ///
-    /// Both slices are raw bases with common flanks already trimmed. Either may
-    /// be empty. Cost is `O(ref_len * alt_len)` in time and space.
+    /// Both slices are raw bases. Either may be empty. There is no requirement
+    /// that common flanks be pre-trimmed: an untrimmed flank only contributes
+    /// extra leading/trailing dominator matches (a flank match is matched by
+    /// every minimal alignment), which leaves the partition unchanged. The
+    /// eventual caller in the migration will trim flanks anyway, but that is a
+    /// caller convenience, not a precondition of this function. Cost is
+    /// `O(ref_len * alt_len)` in time and space.
     pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
         let n = ref_block.len();
         let m = alt_block.len();
@@ -149,19 +157,36 @@ impl AlignmentDag {
     }
 
     /// Every cell on a minimal alignment, in topological order (`i + j`
-    /// ascending). Every edge strictly increases `i + j`, so this ordering is a
-    /// valid topological sort.
+    /// ascending, then `i` ascending). Every edge strictly increases `i + j`,
+    /// so this ordering is a valid topological sort.
+    ///
+    /// Emitted by walking anti-diagonals (`d = i + j`) directly, rather than
+    /// collecting every on-path cell and sorting it — diagonal order is
+    /// already topological, so no sort is needed.
     pub(crate) fn cells(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
-        let mut cells: Vec<(u32, u32)> = (0..=self.ref_len)
-            .flat_map(move |i| (0..=self.alt_len).map(move |j| (i, j)))
-            .filter(|&(i, j)| self.contains_cell(i, j))
-            .collect();
-        cells.sort_by_key(|&(i, j)| (i + j, i));
-        cells.into_iter()
+        (0..=self.ref_len + self.alt_len)
+            .flat_map(move |d| {
+                let i_min = d.saturating_sub(self.alt_len);
+                let i_max = d.min(self.ref_len);
+                (i_min..=i_max).map(move |i| (i, d - i))
+            })
+            .filter(move |&(i, j)| self.contains_cell(i, j))
     }
 
     /// Out-edges of a cell, as `(next_i, next_j, step)`.
+    ///
+    /// `(i, j)` must be within the grid (`i <= ref_len`, `j <= alt_len`); this
+    /// does not panic off-grid, it silently aliases another cell's edges (the
+    /// backing storage is a flat row-major array, so an out-of-range `j`
+    /// wraps into the next row). Checked by the `debug_assert` below in debug
+    /// builds.
     pub(crate) fn out_edges(&self, i: u32, j: u32) -> impl Iterator<Item = (u32, u32, Step)> + '_ {
+        debug_assert!(
+            i <= self.ref_len && j <= self.alt_len,
+            "out_edges({i}, {j}) is off-grid ({} x {}) and would alias another cell",
+            self.ref_len,
+            self.alt_len
+        );
         self.out[self.index(i, j)].iter().copied()
     }
 }
@@ -177,6 +202,23 @@ impl AlignmentDag {
 ///
 /// The alternate offset is not decoration: it is the only reliable way to
 /// recover a member's alternate span. See `partition::member_alt_spans`.
+///
+/// # Why node agreement is not enough
+///
+/// A reference position can lie on every minimal alignment's path (node
+/// agreement) without any single match *edge* into it being common to all of
+/// them — and only a common edge pins a single alternate coordinate.
+///
+/// Worked example: `AT -> AAT`. Reference offset 0 (`A`) is `Match`-stepped on
+/// both minimal alignments, but at different alternate offsets: one path
+/// matches it to alternate offset 0, the other to alternate offset 1 (the
+/// inserted `A` sits before it on one path and after it on the other). No
+/// single match edge is common to both, so reference offset 0 is *not* a
+/// dominator match — it counts as changed. `matched = [(1, 2)]`, `changed =
+/// [0]`.
+///
+/// (`AAAAAAA -> AACACAAAA` is not a usable example here: all seven of its
+/// reference positions are dominator-matched, so its `changed` set is empty.)
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct Dominators {
     pub(crate) matched: Vec<(u32, u32)>,
@@ -208,10 +250,14 @@ impl AlignmentDag {
     /// set, and whenever that count falls to one, that single edge is on every
     /// path.
     ///
-    /// `O(V + E)`. Deliberately not the per-edge reachability probe the
-    /// calibration prototype used — that is `O(E)` per edge, which is fine for
-    /// a 52 nt block and not for production. The probe survives as the test
-    /// oracle.
+    /// `Θ(n·m)` — no worse than `build()`'s own cost. `cells()` walks the full
+    /// `(ref_len + 1) x (alt_len + 1)` grid once to filter the on-path cells
+    /// (`V` of them) in topological order, and the in-degree table below is
+    /// sized to that same grid, so this pass cannot beat `Θ(n·m)` regardless of
+    /// how few cells are actually on-path; on top of that it is `O(V + E)` to
+    /// sweep. Deliberately not the per-edge reachability probe the calibration
+    /// prototype used — that is `O(E)` per edge, which is fine for a 52 nt
+    /// block and not for production. The probe survives as the test oracle.
     pub(crate) fn dominators(&self) -> Dominators {
         let mut result = Dominators::default();
         let sink = (self.ref_len, self.alt_len);
@@ -403,9 +449,10 @@ mod tests {
             vec![48],
             "LRG_199 must have exactly one dominator match, at reference offset 48"
         );
-        assert!(
-            dom.alt_at(48).is_some(),
-            "the dominator must pin an alternate coordinate too"
+        assert_eq!(
+            dom.alt_at(48),
+            Some(13),
+            "the dominator must pin alternate offset 13, not merely some coordinate"
         );
     }
 
@@ -421,9 +468,10 @@ mod tests {
             7,
             "every reference position is matched in every minimal alignment"
         );
-        assert!(
-            !dom.forced_ins_junctions.is_empty(),
-            "the insertions must show up as forced junctions, or they vanish"
+        assert_eq!(
+            dom.forced_ins_junctions,
+            vec![2, 3],
+            "the insertions must show up as forced junctions at exactly 2 and 3, or they vanish"
         );
     }
 

--- a/src/normalize/seqfirst/mod.rs
+++ b/src/normalize/seqfirst/mod.rs
@@ -1,0 +1,45 @@
+//! Sequence-first cis-allele canonicalization: alignment and partitioning.
+//!
+//! This module derives member boundaries from the **denoted sequence** rather
+//! than from how the input allele was spelled. Given a reference block and the
+//! alternate block it becomes, it builds the DAG of every minimal-cost
+//! alignment and cuts the reference at the edges common to all of them.
+//!
+//! Two spellings of one variant produce the same `(ref_block, alt_block)` pair,
+//! so they produce the same partition. Confluence is structural here, not a
+//! property that has to be tested for and repaired.
+//!
+//! # The two rules
+//!
+//! 1. **Dominance.** A reference position counts as unchanged only if *every*
+//!    minimal alignment matches it; a junction has a forced insertion only if
+//!    *every* minimal alignment inserts there. A coincidental match is not in
+//!    every minimal alignment, so coincidental splits are refused structurally
+//!    — without gap penalties, a block-size cap, or a net-insertion
+//!    restriction.
+//! 2. **Separation.** Two runs of change merge when separated by fewer than
+//!    [`MIN_SEPARATION`] *unchanged reference bases*.
+//!
+//! Both are load-bearing and neither suffices alone. See
+//! `partition::partition_members` for the measured evidence.
+//!
+//! # Coordinates
+//!
+//! 0-based half-open throughout, matching [`crate::normalize::shuffle`].
+//! Reference offsets are relative to the start of `ref_block`.
+
+// This module is complete and tested but not yet wired into `normalize_allele`;
+// that is the migration step. Remove this allow when the wiring lands.
+#![allow(dead_code)]
+
+pub(crate) mod align;
+
+/// Unchanged reference bases two runs of change must be separated by before the
+/// split between them is believed.
+///
+/// `2`, not `1`. The HGVS spec contradicts itself here: `general.md:34` says
+/// variants "separated by one or more nucleotides" are described individually,
+/// while its own NOTE says the rule is moving to "separated by less than two →
+/// delins". The spec's worked example (`delins.md:44`, `LRG_199t1:c.850_901`)
+/// is only reproducible under the second reading, so that is the one used.
+pub(crate) const MIN_SEPARATION: u32 = 2;

--- a/src/normalize/seqfirst/mod.rs
+++ b/src/normalize/seqfirst/mod.rs
@@ -30,8 +30,16 @@
 
 // This module is complete and tested but not yet wired into `normalize_allele`;
 // that is the migration step. Remove this allow when the wiring lands.
+//
+// The module (and `align`'s `AlignmentDag::build`/`edit_distance`, needed by
+// the `seqfirst_align` criterion benchmark) is `pub` only under the `dev`
+// feature so an external benchmark crate can reach it; it stays `pub(crate)`
+// otherwise, since there is no public API here yet.
 #![allow(dead_code)]
 
+#[cfg(feature = "dev")]
+pub mod align;
+#[cfg(not(feature = "dev"))]
 pub(crate) mod align;
 pub(crate) mod partition;
 

--- a/src/normalize/seqfirst/mod.rs
+++ b/src/normalize/seqfirst/mod.rs
@@ -28,14 +28,21 @@
 //! 0-based half-open throughout, matching [`crate::normalize::shuffle`].
 //! Reference offsets are relative to the start of `ref_block`.
 
-// This module is complete and tested but not yet wired into `normalize_allele`;
-// that is the migration step. Remove this allow when the wiring lands.
+// The sequence-first path IS compiled into production: `normalize_allele` runs
+// it as a shadow comparison. It is gated behind `FERRO_SEQFIRST_SHADOW=1` and
+// never affects output, so the migration step that remains is promoting it from
+// shadow to authoritative — not wiring it up at all, which the earlier version
+// of this comment claimed.
+//
+// The allowance is therefore scoped to the items that genuinely have no
+// non-test, non-benchmark caller yet, rather than blanketed over the module: a
+// module-wide `allow` would also hide a helper that becomes unreachable when the
+// shadow is promoted, which is exactly when the warning is worth having.
 //
 // The module (and `align`'s `AlignmentDag::build`/`edit_distance`, needed by
 // the `seqfirst_align` criterion benchmark) is `pub` only under the `dev`
 // feature so an external benchmark crate can reach it; it stays `pub(crate)`
 // otherwise, since there is no public API here yet.
-#![allow(dead_code)]
 
 #[cfg(feature = "dev")]
 pub mod align;
@@ -46,9 +53,15 @@ pub(crate) mod partition;
 /// Unchanged reference bases two runs of change must be separated by before the
 /// split between them is believed.
 ///
-/// `2`, not `1`. The HGVS spec contradicts itself here: `general.md:34` says
-/// variants "separated by one or more nucleotides" are described individually,
-/// while its own NOTE says the rule is moving to "separated by less than two →
-/// delins". The spec's worked example (`delins.md:44`, `LRG_199t1:c.850_901`)
-/// is only reproducible under the second reading, so that is the one used.
+/// `2`, not `1`. The HGVS spec's general rule (`general.md:34`) says variants
+/// "separated by one or more nucleotides" are described individually, but its
+/// own exception (`general.md:35`) already carves out "separated by one
+/// nucleotide, together affecting one amino acid" as a delins — i.e. a single
+/// unchanged base between two runs merges them. `DNA/delins.md:42` applies
+/// exactly that exception, rejecting the individually-described
+/// `c.[145C>T;147C>G]` in favor of `LRG_199t1:c.145_147delinsTGG`. The spec's
+/// worked example at `delins.md:44` (`LRG_199t1:c.850_901`) has that same
+/// one-unchanged-base gap and is only reproducible when it merges, so
+/// `MIN_SEPARATION` is `2` — merge when fewer than 2 unchanged bases separate
+/// two runs — not `1`.
 pub(crate) const MIN_SEPARATION: u32 = 2;

--- a/src/normalize/seqfirst/mod.rs
+++ b/src/normalize/seqfirst/mod.rs
@@ -33,6 +33,7 @@
 #![allow(dead_code)]
 
 pub(crate) mod align;
+pub(crate) mod partition;
 
 /// Unchanged reference bases two runs of change must be separated by before the
 /// split between them is believed.

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -1,9 +1,11 @@
 //! Unit 3: cut the reference block into disjoint member blocks.
 //!
 //! Members are runs of *change*, where a reference position counts as unchanged
-//! only when every minimal alignment matches it, and a junction counts as
-//! changed when every minimal alignment inserts there. Consecutive runs merge
-//! when separated by fewer than [`MIN_SEPARATION`] unchanged bases.
+//! only when the same match **edge** is present in every minimal alignment
+//! (node agreement is not enough — see `align.rs`'s `Dominators` doc), and a
+//! junction counts as changed when every minimal alignment inserts there.
+//! Consecutive runs merge when separated by fewer than [`MIN_SEPARATION`]
+//! unchanged bases.
 //!
 //! Members come out disjoint **by construction** — they are a partition — so
 //! the overlap and ordering defects the repair passes exist to fix become
@@ -76,10 +78,11 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
             // occupies no reference base at all and so ends at `end`.
             //
             // Widening an insertion-only end to `end + 1` would claim a
-            // reference base that every alignment matches, and the member would
-            // then denote the wrong sequence. Measured: #1260
-            // (`AAAAAAA -> AACACAAAA`) fails the Task 4 round-trip under the
-            // wider reading and passes under this one.
+            // reference base that every minimal alignment matches, giving the
+            // member a non-minimal extent. Both readings denote the same
+            // sequence and round-trip, so the round-trip invariant does not
+            // catch this — only the exact-span assertion in
+            // `insertion_junctions_do_not_claim_a_matched_base` does.
             //
             // When a position is both changed and a forced-insertion junction,
             // the changed reading wins — it is the wider of the two and the

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -81,8 +81,9 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
             // reference base that every minimal alignment matches, giving the
             // member a non-minimal extent. Both readings denote the same
             // sequence and round-trip, so the round-trip invariant does not
-            // catch this — only the exact-span assertion in
-            // `insertion_junctions_do_not_claim_a_matched_base` does.
+            // catch this. The exact-span assertions in
+            // `insertion_junctions_do_not_claim_a_matched_base` and
+            // `an_insertion_only_member_has_an_empty_reference_span` do.
             //
             // When a position is both changed and a forced-insertion junction,
             // the changed reading wins — it is the wider of the two and the
@@ -214,8 +215,9 @@ mod tests {
         // The failure this pins is widening the end to 4 because the run's last
         // event is at offset 3. Offset 3 is an insertion *junction*, not a
         // changed base, so it occupies no reference base. Getting this wrong
-        // still yields one member — the count looks right — and only the Task 4
-        // round-trip catches it.
+        // still yields one member — the count looks right, and both the wider
+        // and narrower spans denote the same sequence, so the round-trip
+        // invariant does not catch it either. This exact-span assertion does.
         let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
         let members = partition_members(&dag);
         assert_eq!(

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -11,7 +11,7 @@
 //! the overlap and ordering defects the repair passes exist to fix become
 //! unrepresentable rather than repaired.
 
-use super::align::AlignmentDag;
+use super::align::{AlignmentDag, Dominators};
 use super::MIN_SEPARATION;
 
 /// One member of the canonicalized allele, as a half-open reference span
@@ -25,12 +25,23 @@ pub(crate) struct MemberBlock {
 }
 
 /// Partition the reference block at [`MIN_SEPARATION`].
+///
+/// Computes [`AlignmentDag::dominators`] itself, so it is the convenient
+/// entry point for a one-off partition. A caller that also needs
+/// [`member_alt_spans`] on the same DAG should instead compute the
+/// `Dominators` once and call [`partition_members_with`] and
+/// [`member_alt_spans`] directly, to avoid sweeping the DAG twice.
 pub(crate) fn partition_members(dag: &AlignmentDag) -> Vec<MemberBlock> {
-    partition_members_with(dag, MIN_SEPARATION)
+    let dominators = dag.dominators();
+    partition_members_with(dag, &dominators, MIN_SEPARATION)
 }
 
 /// Partition the reference block, merging runs separated by fewer than
 /// `min_separation` **unchanged reference bases**.
+///
+/// Takes `dominators` rather than computing it, so a caller that also needs
+/// [`member_alt_spans`] can sweep the DAG once and pass the same `Dominators`
+/// to both.
 ///
 /// The unit of separation is unchanged bases, not event indices. Two events at
 /// reference offsets `p` and `q` are separated by `q - p - 1` bases. Comparing
@@ -38,8 +49,11 @@ pub(crate) fn partition_members(dag: &AlignmentDag) -> Vec<MemberBlock> {
 /// into two members where the spec describes one; the other calibration cases
 /// score identically under both readings, so that error is invisible without
 /// that case.
-pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) -> Vec<MemberBlock> {
-    let dominators = dag.dominators();
+pub(crate) fn partition_members_with(
+    dag: &AlignmentDag,
+    dominators: &Dominators,
+    min_separation: u32,
+) -> Vec<MemberBlock> {
     let ref_len = dag.ref_len();
 
     // An event is a reference position no minimal alignment agrees is matched,
@@ -89,7 +103,12 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
             // the changed reading wins — it is the wider of the two and the
             // base really does change.
             ref_end: if changed.binary_search(&end).is_ok() {
-                (end + 1).min(ref_len)
+                // `end` is itself a changed position, so `end < ref_len`
+                // always (a changed position is by definition within the
+                // block); the `+ 1` can never reach past `ref_len`, so no
+                // clamp is needed.
+                debug_assert!(end < ref_len, "a changed position must be within the block");
+                end + 1
             } else {
                 end
             },
@@ -99,13 +118,25 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
 
 /// The alternate-block span each member consumes, parallel to `members`.
 ///
+/// Takes `dominators` rather than computing it, so a caller that also calls
+/// [`partition_members_with`] on the same DAG can sweep it once and pass the
+/// same `Dominators` to both — `dominators` must be `dag.dominators()` (or
+/// equal to it), since the two are read together below.
+///
 /// Each member's *start* is reached across a run of reference bases that every
 /// minimal alignment matches, so the alternate cursor advances one-for-one
 /// there. Each member's *end* is read from the dominator that terminates it.
 ///
-/// Returns `None` if a member's end is neither the end of the block nor a
-/// dominator match, or if the members are not an ascending partition — both
-/// mean a bug upstream rather than an unusual input.
+/// Returns `None` in any of three cases, each meaning a bug upstream rather
+/// than an unusual input:
+///
+/// 1. a member's end is neither the end of the block nor a dominator match;
+/// 2. the members are not an ascending, non-overlapping partition (a member's
+///    `ref_start` precedes the previous member's `ref_end`, or a member's own
+///    `ref_end` precedes its `ref_start`);
+/// 3. the computed span would be inverted (`alt_end < alt_start`) — this can
+///    only arise alongside a malformed `members` input, since a well-formed
+///    partition's alternate cursor never runs backward.
 ///
 /// # Why the end must come from a dominator
 ///
@@ -113,9 +144,9 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
 /// coordinate at each reference boundary. That is wrong: away from dominators,
 /// different minimal alignments assign different alternate coordinates to the
 /// same reference boundary, so a walked path yields spans that rebuild the
-/// wrong alternate block. Measured while writing this plan — `AAAAAAA ->
-/// AACACAAAA` and `ACGTACGTAC -> ACGTTACGTGAC` both fail the round-trip that
-/// way, and both pass when the end is taken from the dominator's own cell.
+/// wrong alternate block. `AAAAAAA -> AACACAAAA` and `ACGTACGTAC ->
+/// ACGTTACGTGAC` both fail the round-trip that way, and both pass when the end
+/// is taken from the dominator's own cell.
 ///
 /// A member's `ref_end` is always either `ref_len` or a dominator-matched
 /// position: a run ending at a changed position `p` has `ref_end = p + 1`, and
@@ -124,9 +155,9 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
 /// it would have been a changed position.
 pub(crate) fn member_alt_spans(
     dag: &AlignmentDag,
+    dominators: &Dominators,
     members: &[MemberBlock],
 ) -> Option<Vec<(u32, u32)>> {
-    let dominators = dag.dominators();
     let alt_at_boundary = |r: u32| -> Option<u32> {
         if r == dag.ref_len() {
             Some(dag.alt_len())
@@ -160,7 +191,7 @@ pub(crate) fn member_alt_spans(
 mod tests {
     use super::*;
 
-    /// The calibration corpus. Seven cases; 7/7 is the bar this design cleared
+    /// The calibration corpus. Six cases; 6/6 is the bar this design cleared
     /// and no other candidate did (score-margin and match-density both failed
     /// here — see `separations_are_meaningful` in `merge.rs` for their
     /// remains).
@@ -309,13 +340,103 @@ mod tests {
         );
     }
 
+    #[test]
+    fn lrg199_partitions_to_the_exact_whole_block_span() {
+        // The design's headline case (`delins.md:44`, `LRG_199t1:c.850_901`) is
+        // otherwise pinned only by member *count* (the corpus row above). Only
+        // reference offset 48 is a dominator match, so the two runs either
+        // side of it merge across the single unchanged base between them
+        // (fewer than `MIN_SEPARATION`), giving one member spanning the whole
+        // 52 nt block.
+        let dag = AlignmentDag::build(LRG199_REF, b"TTCCTCGATGCCTG");
+        let members = partition_members(&dag);
+        assert_eq!(
+            members,
+            vec![MemberBlock {
+                ref_start: 0,
+                ref_end: 52
+            }]
+        );
+    }
+
+    #[test]
+    fn min_separation_changes_whether_runs_merge() {
+        // "control two subs exactly 2 apart": at the default MIN_SEPARATION
+        // (2), the gap of exactly 2 unchanged bases does not merge, giving two
+        // members. Raising `min_separation` to 3 must merge them into one,
+        // pinning that the parameter is actually load-bearing rather than
+        // dead flexibility.
+        let dag = AlignmentDag::build(b"ACGTACGT", b"ATGTTCGT");
+        let dominators = dag.dominators();
+        assert_eq!(
+            partition_members_with(&dag, &dominators, 2).len(),
+            2,
+            "gap of exactly 2 must not merge at min_separation 2"
+        );
+        assert_eq!(
+            partition_members_with(&dag, &dominators, 3).len(),
+            1,
+            "gap of exactly 2 must merge at min_separation 3"
+        );
+    }
+
+    #[test]
+    fn member_alt_spans_matches_measured_values() {
+        // Verified exact spans, not just member boundaries: #1260's single
+        // member and both members of the "two insertions 5 apart" case.
+        for (name, r, a, expected_spans) in [
+            (
+                "#1260 two insC at adjacent gaps",
+                &b"AAAAAAA"[..],
+                &b"AACACAAAA"[..],
+                vec![(2u32, 5u32)],
+            ),
+            (
+                "two insertions 5 apart",
+                &b"ACGTACGTAC"[..],
+                &b"ACGTTACGTGAC"[..],
+                vec![(3u32, 5u32), (9u32, 10u32)],
+            ),
+        ] {
+            let dag = AlignmentDag::build(r, a);
+            let dominators = dag.dominators();
+            let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
+            let spans = member_alt_spans(&dag, &dominators, &members)
+                .unwrap_or_else(|| panic!("{name}: member_alt_spans returned None"));
+            assert_eq!(spans, expected_spans, "{name}: alt spans");
+        }
+    }
+
+    #[test]
+    fn member_alt_spans_rejects_overlapping_members() {
+        // `member_alt_spans` takes an arbitrary `&[MemberBlock]`, not only ones
+        // `partition_members` could have produced, and its contract promises
+        // `None` for a members list that is not an ascending, non-overlapping
+        // partition. Exercise that directly rather than trying to coax an
+        // impossible members list out of `partition_members` itself.
+        let dag = AlignmentDag::build(b"ACGT", b"ACGT");
+        let dominators = dag.dominators();
+        let overlapping = [
+            MemberBlock {
+                ref_start: 0,
+                ref_end: 2,
+            },
+            MemberBlock {
+                ref_start: 1,
+                ref_end: 3,
+            },
+        ];
+        assert_eq!(member_alt_spans(&dag, &dominators, &overlapping), None);
+    }
+
     /// Rebuild the alternate block from the reference block plus the members'
     /// payloads. This is the invariant that makes the partition meaningful: if
     /// it does not hold, the members denote a different sequence.
     fn round_trips(reference: &[u8], alt: &[u8]) -> bool {
         let dag = AlignmentDag::build(reference, alt);
-        let members = partition_members(&dag);
-        let Some(alt_spans) = member_alt_spans(&dag, &members) else {
+        let dominators = dag.dominators();
+        let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
+        let Some(alt_spans) = member_alt_spans(&dag, &dominators, &members) else {
             return false;
         };
         let mut rebuilt = Vec::new();

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -1,0 +1,247 @@
+//! Unit 3: cut the reference block into disjoint member blocks.
+//!
+//! Members are runs of *change*, where a reference position counts as unchanged
+//! only when every minimal alignment matches it, and a junction counts as
+//! changed when every minimal alignment inserts there. Consecutive runs merge
+//! when separated by fewer than [`MIN_SEPARATION`] unchanged bases.
+//!
+//! Members come out disjoint **by construction** — they are a partition — so
+//! the overlap and ordering defects the repair passes exist to fix become
+//! unrepresentable rather than repaired.
+
+use super::align::AlignmentDag;
+use super::MIN_SEPARATION;
+
+/// One member of the canonicalized allele, as a half-open reference span
+/// relative to the start of the reference block.
+///
+/// A pure insertion has `ref_start == ref_end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemberBlock {
+    pub(crate) ref_start: u32,
+    pub(crate) ref_end: u32,
+}
+
+/// Partition the reference block at [`MIN_SEPARATION`].
+pub(crate) fn partition_members(dag: &AlignmentDag) -> Vec<MemberBlock> {
+    partition_members_with(dag, MIN_SEPARATION)
+}
+
+/// Partition the reference block, merging runs separated by fewer than
+/// `min_separation` **unchanged reference bases**.
+///
+/// The unit of separation is unchanged bases, not event indices. Two events at
+/// reference offsets `p` and `q` are separated by `q - p - 1` bases. Comparing
+/// `q - p` instead splits the spec's own worked example (`LRG_199t1:c.850_901`)
+/// into two members where the spec describes one; the other calibration cases
+/// score identically under both readings, so that error is invisible without
+/// that case.
+pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) -> Vec<MemberBlock> {
+    let dominators = dag.dominators();
+    let ref_len = dag.ref_len();
+
+    // An event is a reference position no minimal alignment agrees is matched,
+    // or a junction every minimal alignment inserts at. Both live in reference
+    // offset space: junction `k` sits between reference bases `k - 1` and `k`.
+    let matched_ref = dominators.matched_ref();
+    let changed: Vec<u32> = (0..ref_len)
+        .filter(|p| matched_ref.binary_search(p).is_err())
+        .collect();
+
+    let mut events: Vec<u32> = changed.clone();
+    events.extend(dominators.forced_ins_junctions.iter().copied());
+    events.sort_unstable();
+    events.dedup();
+
+    // Group consecutive events into runs, merging across short gaps.
+    let mut runs: Vec<(u32, u32)> = Vec::new();
+    for event in events {
+        match runs.last_mut() {
+            // `event - last_end - 1` is the count of unchanged bases between
+            // the previous event and this one.
+            Some((_, last_end))
+                if event.saturating_sub(*last_end).saturating_sub(1) < min_separation =>
+            {
+                *last_end = event;
+            }
+            _ => runs.push((event, event)),
+        }
+    }
+
+    runs.into_iter()
+        .map(|(start, end)| MemberBlock {
+            ref_start: start,
+            // A run's last event is either a changed reference position, which
+            // occupies `end..end + 1`, or a forced-insertion junction, which
+            // occupies no reference base at all and so ends at `end`.
+            //
+            // Widening an insertion-only end to `end + 1` would claim a
+            // reference base that every alignment matches, and the member would
+            // then denote the wrong sequence. Measured: #1260
+            // (`AAAAAAA -> AACACAAAA`) fails the Task 4 round-trip under the
+            // wider reading and passes under this one.
+            //
+            // When a position is both changed and a forced-insertion junction,
+            // the changed reading wins — it is the wider of the two and the
+            // base really does change.
+            ref_end: if changed.binary_search(&end).is_ok() {
+                (end + 1).min(ref_len)
+            } else {
+                end
+            },
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The calibration corpus. Seven cases; 7/7 is the bar this design cleared
+    /// and no other candidate did (score-margin and match-density both failed
+    /// here — see `separations_are_meaningful` in `merge.rs` for their
+    /// remains).
+    const LRG199_REF: &[u8] = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+
+    #[test]
+    fn calibration_corpus_partitions_as_measured() {
+        for (name, r, a, expected) in [
+            // Dominance alone is not enough here: every reference position is
+            // matched, and it is the separation rule that merges the two
+            // forced insertion junctions.
+            (
+                "#1260 two insC at adjacent gaps",
+                &b"AAAAAAA"[..],
+                &b"AACACAAAA"[..],
+                1,
+            ),
+            // Separation is not enough here: there are no dominators at all,
+            // so nothing can legitimately be split.
+            (
+                "#1262 sub + del vs spanning delins",
+                &b"AAAAAAA"[..],
+                &b"ACAAAA"[..],
+                1,
+            ),
+            // The spec's own worked example. One dominator, which would split
+            // the block if the separation rule did not merge across it.
+            (
+                "delins.md:44 LRG_199t1 c.850_901",
+                LRG199_REF,
+                &b"TTCCTCGATGCCTG"[..],
+                1,
+            ),
+            // Genuine splits must survive.
+            (
+                "control two subs 12 apart",
+                &b"ACGTACGTACGTACGT"[..],
+                &b"ATGTACGTACGTACTT"[..],
+                2,
+            ),
+            (
+                "control two subs exactly 2 apart",
+                &b"ACGTACGT"[..],
+                &b"ATGTTCGT"[..],
+                2,
+            ),
+            (
+                "control two insertions 5 apart",
+                &b"ACGTACGTAC"[..],
+                &b"ACGTTACGTGAC"[..],
+                2,
+            ),
+        ] {
+            let dag = AlignmentDag::build(r, a);
+            let members = partition_members(&dag);
+            assert_eq!(members.len(), expected, "{name}: got {members:?}");
+        }
+    }
+
+    /// The one cheap case that distinguishes counting unchanged bases from
+    /// comparing event indices.
+    ///
+    /// Two substitutions with exactly **one** unchanged base between them must
+    /// merge, because one is fewer than `MIN_SEPARATION`. Comparing event
+    /// indices instead gives `4 - 2 = 2`, which is not less than 2, so the
+    /// wrong rule splits this into two members.
+    ///
+    /// Without this test and the `LRG_199` row above, that off-by-one is
+    /// invisible — the other five calibration cases score the same either way.
+    #[test]
+    fn one_unchanged_base_between_runs_merges() {
+        let dag = AlignmentDag::build(b"GACTGACTGA", b"GAATAACTGA");
+        assert_eq!(
+            partition_members(&dag).len(),
+            1,
+            "one unchanged base is fewer than MIN_SEPARATION, so these merge"
+        );
+    }
+
+    #[test]
+    fn two_unchanged_bases_between_runs_split() {
+        // The boundary from the other side: exactly MIN_SEPARATION unchanged
+        // bases must NOT merge.
+        let dag = AlignmentDag::build(b"GACTGACTGA", b"GAATGTCTGA");
+        assert_eq!(partition_members(&dag).len(), 2);
+    }
+
+    #[test]
+    fn an_unchanged_block_has_no_members() {
+        let dag = AlignmentDag::build(b"ACGTACGT", b"ACGTACGT");
+        assert!(partition_members(&dag).is_empty());
+    }
+
+    #[test]
+    fn members_are_disjoint_and_ascending() {
+        let dag = AlignmentDag::build(b"ACGTACGTACGTACGT", b"ATGTACGTACGTACTT");
+        let members = partition_members(&dag);
+        for pair in members.windows(2) {
+            assert!(
+                pair[0].ref_end <= pair[1].ref_start,
+                "members overlap or are out of order: {members:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn insertion_junctions_do_not_claim_a_matched_base() {
+        // #1260 collapses to one member spanning the two forced junctions and
+        // the single matched base between them: reference 2..3, exactly.
+        //
+        // The failure this pins is widening the end to 4 because the run's last
+        // event is at offset 3. Offset 3 is an insertion *junction*, not a
+        // changed base, so it occupies no reference base. Getting this wrong
+        // still yields one member — the count looks right — and only the Task 4
+        // round-trip catches it.
+        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let members = partition_members(&dag);
+        assert_eq!(
+            members,
+            vec![MemberBlock {
+                ref_start: 2,
+                ref_end: 3
+            }]
+        );
+    }
+
+    #[test]
+    fn an_insertion_only_member_has_an_empty_reference_span() {
+        // Two insertions 5 apart: the second is a pure insertion at junction 8
+        // with an empty reference span, which must be reported and not dropped.
+        let dag = AlignmentDag::build(b"ACGTACGTAC", b"ACGTTACGTGAC");
+        let members = partition_members(&dag);
+        assert_eq!(
+            members,
+            vec![
+                MemberBlock {
+                    ref_start: 3,
+                    ref_end: 4
+                },
+                MemberBlock {
+                    ref_start: 8,
+                    ref_end: 8
+                },
+            ]
+        );
+    }
+}

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -97,6 +97,65 @@ pub(crate) fn partition_members_with(dag: &AlignmentDag, min_separation: u32) ->
         .collect()
 }
 
+/// The alternate-block span each member consumes, parallel to `members`.
+///
+/// Each member's *start* is reached across a run of reference bases that every
+/// minimal alignment matches, so the alternate cursor advances one-for-one
+/// there. Each member's *end* is read from the dominator that terminates it.
+///
+/// Returns `None` if a member's end is neither the end of the block nor a
+/// dominator match, or if the members are not an ascending partition — both
+/// mean a bug upstream rather than an unusual input.
+///
+/// # Why the end must come from a dominator
+///
+/// It is tempting to walk one minimal alignment and record the alternate
+/// coordinate at each reference boundary. That is wrong: away from dominators,
+/// different minimal alignments assign different alternate coordinates to the
+/// same reference boundary, so a walked path yields spans that rebuild the
+/// wrong alternate block. Measured while writing this plan — `AAAAAAA ->
+/// AACACAAAA` and `ACGTACGTAC -> ACGTTACGTGAC` both fail the round-trip that
+/// way, and both pass when the end is taken from the dominator's own cell.
+///
+/// A member's `ref_end` is always either `ref_len` or a dominator-matched
+/// position: a run ending at a changed position `p` has `ref_end = p + 1`, and
+/// `p + 1` cannot itself be changed or it would be in the same run; a run
+/// ending at an insertion junction `k` has `ref_end = k`, and `k` is matched or
+/// it would have been a changed position.
+pub(crate) fn member_alt_spans(
+    dag: &AlignmentDag,
+    members: &[MemberBlock],
+) -> Option<Vec<(u32, u32)>> {
+    let dominators = dag.dominators();
+    let alt_at_boundary = |r: u32| -> Option<u32> {
+        if r == dag.ref_len() {
+            Some(dag.alt_len())
+        } else {
+            dominators.alt_at(r)
+        }
+    };
+
+    let mut spans = Vec::with_capacity(members.len());
+    let mut prev_ref_end = 0u32;
+    let mut prev_alt_end = 0u32;
+    for member in members {
+        if member.ref_start < prev_ref_end || member.ref_end < member.ref_start {
+            return None;
+        }
+        // The matched run between the previous member and this one advances
+        // both cursors equally.
+        let alt_start = prev_alt_end + (member.ref_start - prev_ref_end);
+        let alt_end = alt_at_boundary(member.ref_end)?;
+        if alt_end < alt_start {
+            return None;
+        }
+        spans.push((alt_start, alt_end));
+        prev_ref_end = member.ref_end;
+        prev_alt_end = alt_end;
+    }
+    Some(spans)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +307,90 @@ mod tests {
                 },
             ]
         );
+    }
+
+    /// Rebuild the alternate block from the reference block plus the members'
+    /// payloads. This is the invariant that makes the partition meaningful: if
+    /// it does not hold, the members denote a different sequence.
+    fn round_trips(reference: &[u8], alt: &[u8]) -> bool {
+        let dag = AlignmentDag::build(reference, alt);
+        let members = partition_members(&dag);
+        let Some(alt_spans) = member_alt_spans(&dag, &members) else {
+            return false;
+        };
+        let mut rebuilt = Vec::new();
+        let mut ref_cursor = 0usize;
+        for (member, (alt_start, alt_end)) in members.iter().zip(&alt_spans) {
+            rebuilt.extend_from_slice(&reference[ref_cursor..member.ref_start as usize]);
+            rebuilt.extend_from_slice(&alt[*alt_start as usize..*alt_end as usize]);
+            ref_cursor = member.ref_end as usize;
+        }
+        rebuilt.extend_from_slice(&reference[ref_cursor..]);
+        rebuilt == alt
+    }
+
+    #[test]
+    fn calibration_corpus_round_trips() {
+        for (r, a) in [
+            (&b"AAAAAAA"[..], &b"AACACAAAA"[..]),
+            (&b"AAAAAAA"[..], &b"ACAAAA"[..]),
+            (LRG199_REF, &b"TTCCTCGATGCCTG"[..]),
+            (&b"ACGTACGTACGTACGT"[..], &b"ATGTACGTACGTACTT"[..]),
+            (&b"ACGTACGT"[..], &b"ATGTTCGT"[..]),
+            (&b"ACGTACGTAC"[..], &b"ACGTTACGTGAC"[..]),
+            (&b"GACTGACTGA"[..], &b"GAATAACTGA"[..]),
+            (&b"ACGT"[..], &b"ACGT"[..]),
+            (&b""[..], &b"ACGT"[..]),
+            (&b"ACGT"[..], &b""[..]),
+        ] {
+            assert!(
+                round_trips(r, a),
+                "{} -> {} does not round-trip",
+                String::from_utf8_lossy(r),
+                String::from_utf8_lossy(a)
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_exhaustively_over_a_small_alphabet() {
+        fn words(len: u32) -> Vec<Vec<u8>> {
+            if len == 0 {
+                return vec![Vec::new()];
+            }
+            let mut out = Vec::new();
+            for shorter in words(len - 1) {
+                for base in *b"AC" {
+                    let mut w = shorter.clone();
+                    w.push(base);
+                    out.push(w);
+                }
+            }
+            out
+        }
+        let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        for r in &all {
+            for a in &all {
+                assert!(
+                    round_trips(r, a),
+                    "{} -> {} does not round-trip",
+                    String::from_utf8_lossy(r),
+                    String::from_utf8_lossy(a)
+                );
+            }
+        }
+    }
+
+    proptest::proptest! {
+        /// The same invariant on random four-letter sequences.
+        #[test]
+        fn round_trips_on_random_blocks(
+            reference in proptest::collection::vec(
+                proptest::sample::select(vec![b'A', b'C', b'G', b'T']), 0..40usize),
+            alt in proptest::collection::vec(
+                proptest::sample::select(vec![b'A', b'C', b'G', b'T']), 0..40usize),
+        ) {
+            proptest::prop_assert!(round_trips(&reference, &alt));
+        }
     }
 }

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -31,6 +31,13 @@ pub(crate) struct MemberBlock {
 /// [`member_alt_spans`] on the same DAG should instead compute the
 /// `Dominators` once and call [`partition_members_with`] and
 /// [`member_alt_spans`] directly, to avoid sweeping the DAG twice.
+// The only item in this module with no production caller: `normalize_allele`'s
+// shadow comparison needs `member_alt_spans` on the same DAG, so it takes the
+// `partition_members_with` route that shares one `Dominators` sweep. This
+// convenience wrapper is used by tests and is kept as the documented one-off
+// entry point. Scoped rather than allowed module-wide, so a helper that becomes
+// unreachable when the shadow is promoted still warns.
+#[allow(dead_code)]
 pub(crate) fn partition_members(dag: &AlignmentDag) -> Vec<MemberBlock> {
     let dominators = dag.dominators();
     partition_members_with(dag, &dominators, MIN_SEPARATION)
@@ -43,12 +50,19 @@ pub(crate) fn partition_members(dag: &AlignmentDag) -> Vec<MemberBlock> {
 /// [`member_alt_spans`] can sweep the DAG once and pass the same `Dominators`
 /// to both.
 ///
-/// The unit of separation is unchanged bases, not event indices. Two events at
-/// reference offsets `p` and `q` are separated by `q - p - 1` bases. Comparing
-/// `q - p` instead splits the spec's own worked example (`LRG_199t1:c.850_901`)
-/// into two members where the spec describes one; the other calibration cases
-/// score identically under both readings, so that error is invisible without
-/// that case.
+/// The unit of separation is unchanged bases, not event indices: two events are
+/// separated by the count of reference bases lying strictly between the extents
+/// they occupy. Comparing event indices instead splits the spec's own worked
+/// example (`LRG_199t1:c.850_901`) into two members where the spec describes
+/// one; the other calibration cases score identically under both readings, so
+/// that error is invisible without that case.
+///
+/// The left extent is therefore *exclusive* and depends on what the event is: a
+/// changed position `p` occupies `p..p + 1`, so an event at `q` is `q - p - 1`
+/// bases away, but an insertion junction at `k` occupies no reference base at
+/// all, so an event at `q` is `q - k` bases away. Subtracting one
+/// unconditionally undercounts after a junction and merges runs that a
+/// separation of one unchanged base should keep apart.
 pub(crate) fn partition_members_with(
     dag: &AlignmentDag,
     dominators: &Dominators,
@@ -69,14 +83,40 @@ pub(crate) fn partition_members_with(
     events.sort_unstable();
     events.dedup();
 
+    // Where an event's extent ends, exclusive: a changed reference position
+    // occupies `end..end + 1`, while a forced-insertion junction occupies no
+    // reference base at all and so ends at `end`.
+    //
+    // Widening an insertion-only end to `end + 1` would claim a reference base
+    // that every minimal alignment matches, giving the member a non-minimal
+    // extent. Both readings denote the same sequence and round-trip, so the
+    // round-trip invariant does not catch this. The exact-span assertions in
+    // `insertion_junctions_do_not_claim_a_matched_base` and
+    // `an_insertion_only_member_has_an_empty_reference_span` do.
+    //
+    // When a position is both changed and a forced-insertion junction, the
+    // changed reading wins — it is the wider of the two and the base really
+    // does change.
+    let exclusive_end = |end: u32| -> u32 {
+        if changed.binary_search(&end).is_ok() {
+            // `end` is itself a changed position, so `end < ref_len` always (a
+            // changed position is by definition within the block); the `+ 1`
+            // can never reach past `ref_len`, so no clamp is needed.
+            debug_assert!(end < ref_len, "a changed position must be within the block");
+            end + 1
+        } else {
+            end
+        }
+    };
+
     // Group consecutive events into runs, merging across short gaps.
     let mut runs: Vec<(u32, u32)> = Vec::new();
     for event in events {
         match runs.last_mut() {
-            // `event - last_end - 1` is the count of unchanged bases between
-            // the previous event and this one.
+            // The unchanged bases between the run so far and this event are the
+            // ones from where the run's extent ends up to this event's start.
             Some((_, last_end))
-                if event.saturating_sub(*last_end).saturating_sub(1) < min_separation =>
+                if event.saturating_sub(exclusive_end(*last_end)) < min_separation =>
             {
                 *last_end = event;
             }
@@ -87,31 +127,7 @@ pub(crate) fn partition_members_with(
     runs.into_iter()
         .map(|(start, end)| MemberBlock {
             ref_start: start,
-            // A run's last event is either a changed reference position, which
-            // occupies `end..end + 1`, or a forced-insertion junction, which
-            // occupies no reference base at all and so ends at `end`.
-            //
-            // Widening an insertion-only end to `end + 1` would claim a
-            // reference base that every minimal alignment matches, giving the
-            // member a non-minimal extent. Both readings denote the same
-            // sequence and round-trip, so the round-trip invariant does not
-            // catch this. The exact-span assertions in
-            // `insertion_junctions_do_not_claim_a_matched_base` and
-            // `an_insertion_only_member_has_an_empty_reference_span` do.
-            //
-            // When a position is both changed and a forced-insertion junction,
-            // the changed reading wins — it is the wider of the two and the
-            // base really does change.
-            ref_end: if changed.binary_search(&end).is_ok() {
-                // `end` is itself a changed position, so `end < ref_len`
-                // always (a changed position is by definition within the
-                // block); the `+ 1` can never reach past `ref_len`, so no
-                // clamp is needed.
-                debug_assert!(end < ref_len, "a changed position must be within the block");
-                end + 1
-            } else {
-                end
-            },
+            ref_end: exclusive_end(end),
         })
         .collect()
 }
@@ -268,6 +284,30 @@ mod tests {
             partition_members(&dag).len(),
             1,
             "one unchanged base is fewer than MIN_SEPARATION, so these merge"
+        );
+    }
+
+    /// An insertion junction occupies no reference base, so the run it ends
+    /// stops *at* that offset rather than after it, and the base at that offset
+    /// is still unchanged and still separates it from whatever follows.
+    ///
+    /// #1260's block has forced insertion junctions at reference offsets 2 and
+    /// 3, with the base at offset 2 unchanged between them: the separation is
+    /// `3 - 2 = 1` unchanged base, not `3 - 2 - 1 = 0`.
+    ///
+    /// At `MIN_SEPARATION` (2) both readings merge, which is why neither the
+    /// exhaustive round-trip sweep nor the proptest catches the difference —
+    /// the members denote the same sequence either way. Only a threshold of 1
+    /// separates them, and there the undercount is the difference between
+    /// merging and splitting.
+    #[test]
+    fn separation_after_an_insertion_junction_counts_the_base_it_does_not_occupy() {
+        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let dominators = dag.dominators();
+        assert_eq!(
+            partition_members_with(&dag, &dominators, 1).len(),
+            2,
+            "one unchanged base is not fewer than a separation threshold of 1"
         );
     }
 

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -51,8 +51,10 @@
 //!   spellings, and only the input-relative gates in `canonicalize_from_sequence`
 //!   (the `changed_columns_of_edits` bound and the `input_separator_gaps` veto)
 //!   decide differently, because both are measured against how the input
-//!   happened to be written. Tracked by #1260 and #1262 and pinned by
-//!   `adjacent_gap_insertions_are_a_known_gap`.
+//!   happened to be written. #1260 is now **fixed** — the two-gap alignment can
+//!   express *insertion, retained base, insertion* and the separation threshold
+//!   admits the split across the retained base — so what remains is #1262,
+//!   pinned by `adjacent_gap_insertions_converge_but_the_delins_gap_remains`.
 //!
 //!   This is the **only** restriction those two issues justify. The generator
 //!   used to carry a second one citing them — a filter excluding two insertions
@@ -782,7 +784,7 @@ impl IndelHaplotype {
     /// Whether two insertions sit at **adjacent gaps**.
     ///
     /// The strategy no longer filters this shape out (#1294). It is kept because
-    /// `adjacent_gap_insertions_are_a_known_gap` uses it to assert that the
+    /// `adjacent_gap_insertions_converge_but_the_delins_gap_remains` uses it to assert that the
     /// haplotype it pins really is one, so that test cannot drift onto a
     /// different shape than the one it claims to pin.
     fn has_adjacent_gap_insertions(&self) -> bool {
@@ -987,12 +989,12 @@ proptest! {
     }
 }
 
-/// Pins the shapes the indel model holds back, so neither the filter nor the
-/// missing spanning-delins comparison becomes permanent by inattention.
+/// Pins the shapes the indel model holds back, so the missing spanning-delins
+/// comparison does not become permanent by inattention.
 ///
-/// Both are **currently broken**, and this test asserts they still are. Fixing
-/// #1260 or #1262 fails it, which is the prompt to drop
-/// `has_adjacent_gap_insertions` and to restore the delins encoding to
+/// **#1260 is now fixed** and this test pins the form it converged on. #1262 is
+/// still open, and the test asserts it still diverges; fixing it fails here,
+/// which is the prompt to restore the delins encoding to
 /// `an_indel_haplotype_normalizes_to_its_own_sequence`'s comparison set.
 ///
 /// The two rows are not two edge cases. They are the general behaviour of
@@ -1002,7 +1004,7 @@ proptest! {
 /// the `input_separator_gaps` veto — decide differently, because both are
 /// measured against how the input happened to be written.
 #[test]
-fn adjacent_gap_insertions_are_a_known_gap() {
+fn adjacent_gap_insertions_converge_but_the_delins_gap_remains() {
     let provider = SyntheticBuilder::genomic("AAAAAA").build();
     let normalizer = Normalizer::new(provider);
     let normalize_str = |input: &str| normalize(&normalizer, input).to_string();
@@ -1034,11 +1036,17 @@ fn adjacent_gap_insertions_are_a_known_gap() {
         "the pinned haplotype must have two distinct encodings, got {encodings:?}"
     );
     let normalized: Vec<String> = encodings.iter().map(|e| normalize_str(e)).collect();
-    assert_ne!(
+    // #1260 is FIXED. Both spellings converge, on the split form PR #1285 named:
+    // the two-gap alignment `best_alignment` gained can express *insertion,
+    // retained base, insertion*, and the separation threshold admits the split
+    // across the one retained base.
+    assert_eq!(
         normalized[0], normalized[1],
-        "#1260 appears fixed — drop `has_adjacent_gap_insertions` from \
-         `indel_haplotype_strategy` and restore the delins comparison to \
-         `an_indel_haplotype_normalizes_to_its_own_sequence`"
+        "#1260's two spellings must converge"
+    );
+    assert_eq!(
+        normalized[0], "NC_TEST.1:g.[258_259insC;259_260insC]",
+        "and they converge on the split form, not the spanning delins"
     );
 
     // #1262: a substitution and a deletion against the spanning delins. Spelled
@@ -1117,7 +1125,8 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// The property's doc comment records the reproduction, but a doc comment does
 /// not run: the live defect could be fixed and the property would simply stay
 /// ignored, which is the coverage-that-reads-wider-than-it-is complaint in
-/// #1268/#1283. This is the same guard `adjacent_gap_insertions_are_a_known_gap`
+/// #1268/#1283. This is the same guard
+/// `adjacent_gap_insertions_converge_but_the_delins_gap_remains`
 /// gives the two shapes the model holds back.
 ///
 /// One row, not a list: the property stops at its first failure, so only the

--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -1,0 +1,158 @@
+//! Two spellings of one variant that normalize to two different strings.
+//!
+//! #1235's criterion 1 requires every encoding of a variant to reach one
+//! normalized string. These eight pairs do not, and each pair's *split*
+//! spelling is an expectation this repository blessed and shipped.
+//!
+//! The pairs were found by deriving each variant's minimal-alignment partition
+//! from the resulting sequence, rendering the derived single-block form, and
+//! normalizing both spellings. Every pair below was verified to denote the same
+//! sequence by an applier independent of the normalizer.
+//!
+//! Each row asserts the two spellings still DIVERGE. This test failing means a
+//! pair converged, and that pair's blessed expectation should be re-blessed to
+//! the converged form.
+
+use crate::common::cis_apply_oracle::{apply, normalize};
+use crate::common::synthetic::padded;
+
+/// `(issue, core, split spelling, merged spelling)`.
+const DIVERGENT: &[(&str, &str, &str, &str)] = &[
+    (
+        "#1287",
+        "ATACAGAAAATCAGGGCATA",
+        "TEMPLATE:g.[261_262insGA;263_264insAA]",
+        "TEMPLATE:g.263_264insGAAA",
+    ),
+    (
+        "#1290",
+        "ATACAGAAAATCAGGGCATA",
+        "TEMPLATE:g.[263_264insA;265_266insC]",
+        "TEMPLATE:g.266_267insCA",
+    ),
+    (
+        "#1296",
+        "AAAAAAATAATCGCAACAGAAG",
+        "TEMPLATE:g.[272_273del;274_275insAA]",
+        "TEMPLATE:g.273delinsA",
+    ),
+    (
+        "#1301",
+        "GCATGAAAAT",
+        "TEMPLATE:g.[263_264insAC;264_265insAA]",
+        "TEMPLATE:g.264_265insCAAA",
+    ),
+    (
+        "#1304",
+        "GCATGAAAAT",
+        "TEMPLATE:g.[260_261insGA;261_262insA;264del]",
+        "TEMPLATE:g.262_263insGA",
+    ),
+    (
+        "#1308",
+        "CAGAAGATGAATAA",
+        "TEMPLATE:g.[263_264insTG;264_265insTG]",
+        "TEMPLATE:g.265_266insTTGG",
+    ),
+    (
+        "#1312",
+        "TAAAACCA",
+        "TEMPLATE:g.[260_261insAC;261_262insAC]",
+        "TEMPLATE:g.262_263insAACC",
+    ),
+    (
+        "#1320",
+        "AACAGTAAAATAT",
+        "TEMPLATE:g.[263_264insAC;265_266insAA;266_267insAA]",
+        "TEMPLATE:g.264_265insCAAAAA",
+    ),
+];
+
+/// `(issue, core, split spelling, merged spelling)` for pairs that agree today.
+const CONVERGED: &[(&str, &str, &str, &str)] = &[
+    (
+        "#1286",
+        "AAAAAA",
+        "TEMPLATE:g.[258_259insA;259_260insA]",
+        "TEMPLATE:g.263_264insAA",
+    ),
+    (
+        "#1297",
+        "GCATGAAAAT",
+        "TEMPLATE:g.[261_262insAA;263del;264_265insA]",
+        "TEMPLATE:g.265_266insAA",
+    ),
+    (
+        "#1316",
+        "CAGCCAGTCAGCGCATCAG",
+        "TEMPLATE:g.[261_262insAA;262_263insAA]",
+        "TEMPLATE:g.262_263insAAAA",
+    ),
+    (
+        "#1321",
+        "TCCCAGAAAAT",
+        "TEMPLATE:g.[261_262insGA;262_263insA;263del]",
+        "TEMPLATE:g.263_264insGA",
+    ),
+    (
+        "#1323",
+        "CAGGGATCAT",
+        "TEMPLATE:g.[260del;261_262insGA;262_263insGA]",
+        "TEMPLATE:g.262_263insAGA",
+    ),
+];
+
+/// Both spellings in every row must denote the same sequence, or the row is a
+/// broken pin rather than evidence about the normalizer.
+#[test]
+fn every_pinned_pair_denotes_one_variant() {
+    for (issue, core, split, merged) in DIVERGENT.iter().chain(CONVERGED) {
+        let seq = padded(core);
+        let a = apply(&seq, split)
+            .unwrap_or_else(|| panic!("{issue}: split spelling `{split}` does not apply"));
+        let b = apply(&seq, merged)
+            .unwrap_or_else(|| panic!("{issue}: merged spelling `{merged}` does not apply"));
+        assert_eq!(
+            a, b,
+            "{issue}: `{split}` and `{merged}` are not the same variant"
+        );
+    }
+}
+
+#[test]
+fn the_eight_spelling_pairs_still_diverge() {
+    // The count "eight" is asserted in three places' prose — this test's name,
+    // the module doc above, and `tests/it/rewrite_target_corpus.rs` — and in none
+    // of them executably. Adding or removing a row would leave all three wrong
+    // and silent. `splitter_reproducer_corpus.rs` guards its own table the same
+    // way.
+    assert_eq!(
+        DIVERGENT.len(),
+        8,
+        "row count changed; update this test's name, the module doc, and \
+         tests/it/rewrite_target_corpus.rs's reference to these eight pairs"
+    );
+    for (issue, core, split, merged) in DIVERGENT {
+        let seq = padded(core);
+        let (a, b) = (normalize(&seq, split), normalize(&seq, merged));
+        assert_ne!(
+            a, b,
+            "{issue} appears fixed — `{split}` and `{merged}` now both normalize to \
+             `{a}`. Re-bless {issue}'s expectation to the converged form and delete \
+             this row."
+        );
+    }
+}
+
+#[test]
+fn converged_pairs_stay_converged() {
+    for (issue, core, split, merged) in CONVERGED {
+        let seq = padded(core);
+        let (a, b) = (normalize(&seq, split), normalize(&seq, merged));
+        assert_eq!(
+            a, b,
+            "{issue} regressed — `{split}` -> `{a}` but `{merged}` -> `{b}`; these \
+             two spellings of one variant must agree."
+        );
+    }
+}

--- a/tests/it/issue_999_shift_created_adjacency_collapse.rs
+++ b/tests/it/issue_999_shift_created_adjacency_collapse.rs
@@ -62,14 +62,26 @@ fn cis_insertion_shifted_adjacent_to_substitution_coalesces_to_delins() {
 fn cis_shift_created_adjacency_reaches_fixed_point_in_one_pass() {
     // #1000. `insCG` at 611_612 legitimately 3'-shifts to `insGC` at
     // 612_613 (ref[612]=C lets the dinucleotide roll one position; 613
-    // blocks a second roll), landing adjacent to `613C>A`. The collapse
-    // must fire on the *same* pass: inserted `GC` then substituted `A` at
-    // 613 -> `613delinsGCA`.
+    // blocks a second roll), landing adjacent to `613C>A`.
+    //
+    // Re-blessed with the two-gap alignment (#1260, PR #1285). The trimmed
+    // block is `C -> GCA`, which reads two ways: as *ins `GC`* plus *sub
+    // `C>A`* — adjacent, one member, 3 changed columns — or as *ins `G`*,
+    // retained `C`, *ins `A`* — separated by one unchanged base, two members,
+    // 2 changed columns. The second is more minimal and is what
+    // `general.md:34` licenses; the first is the reading that mirrors how the
+    // *input* happened to be spelled, which is the asymmetry this campaign is
+    // removing. It is also, base for base, #1260's `A -> CAC`.
+    //
+    // What #1000 asks for is a **fixed point in one pass**, not a particular
+    // form — and that still holds, which is why this is a re-bless and not a
+    // regression. `cis_shift_created_adjacency_is_idempotent` below asserts the
+    // invariant directly and is unchanged.
     let out = normalize(
         provider_with(600, "TGACTTCAGTCACCTGACTGACTG"),
         "NC_000001.11:g.[611_612insCG;613C>A]",
     );
-    assert_eq!(out, "NC_000001.11:g.613delinsGCA");
+    assert_eq!(out, "NC_000001.11:g.[612_613insG;613_614insA]");
 }
 
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -365,6 +365,7 @@ mod reject_coord_system_mismatch;
 mod reject_dupins;
 mod reject_single_position_insertion;
 mod reject_u_in_dna;
+mod render_calibration;
 mod repeat_count_trans;
 mod repeat_deln_uncertain_range;
 mod repeat_span_sibling_overlap;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -370,6 +370,7 @@ mod repeat_count_trans;
 mod repeat_deln_uncertain_range;
 mod repeat_span_sibling_overlap;
 mod repeat_tract_maximization;
+mod rewrite_target_corpus;
 mod rna_coding_consistency;
 mod rna_spl_marker;
 mod service_tools_tests;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -37,6 +37,7 @@ mod bulk_fixture_tests;
 mod cds_utr3_crossing_shift_idempotency;
 mod cis_allele_confluence_proptest;
 mod cis_junction_crossing_shift;
+mod cis_spelling_confluence_gap;
 mod civic_validation;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -332,6 +332,7 @@ mod mito_circular_audit;
 mod mito_heteroplasmy_audit;
 mod mosaic_chimeric_compact;
 mod mosaic_predicted_eqslash;
+mod msto_regression_corpus;
 mod mutalyzer_grammar_tests;
 mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;

--- a/tests/it/msto_regression_corpus.rs
+++ b/tests/it/msto_regression_corpus.rs
@@ -1,0 +1,342 @@
+//! Regression corpus for the tests that guard `msto`'s ferro-hgvs issues.
+//!
+//! The cis-allele normalizer is being rewritten to derive member boundaries
+//! from the denoted sequence (`FERRO_SEQFIRST_SHADOW=1` reports where the new
+//! splitter would differ from the live one). A prior review found that
+//! driving live output from the new splitter changes the rendered string for
+//! several tests tied to issues `msto` filed, without changing which
+//! sequence is denoted. That review is not committed to this repository (it
+//! is a working artifact); this module is the durable, checked artifact that
+//! survives it.
+//!
+//! [`MSTO_ISSUES`] enumerates every issue `msto` has filed against
+//! `fulcrumgenomics/ferro-hgvs` (`gh issue list --author msto --state all`)
+//! and, for each, the test functions that reference it by number
+//! (`issue_<N>`, `#<N>`, or `issue #<N>`, either in the function's own name
+//! or in a comment immediately above it). Where no such test exists, the
+//! `tests` slice is empty — that is itself the finding for a `high`-labeled
+//! issue, per [`no_high_priority_issue_is_unguarded_without_being_named`].
+//!
+//! ## What this module does NOT claim
+//!
+//! It does not re-run the shadow/live comparison, so it makes no claim about
+//! which tests currently pass or fail under the rewrite. The `note` field on
+//! the eleven pinned at-risk issues below summarizes the prior review's own
+//! grouping (three mechanism clusters) as a risk flag for what to re-check
+//! before the rewrite's default is flipped — it is not something a test in
+//! this module executes or verifies.
+//!
+//! ## Self-checks
+//!
+//! A mapping nobody validates rots silently (a test gets renamed or deleted
+//! and the table quietly stops guarding anything). So this module checks
+//! itself:
+//!
+//! - [`every_cataloged_test_exists_in_its_source_file`] greps each
+//!   `(file, fn)` pair's source file for a matching `fn` definition.
+//! - [`issue_and_test_totals_match_their_pinned_counts`] pins the issue
+//!   count, the `high`-label count, and the total number of distinct
+//!   cataloged tests, so any addition/removal of an issue or a test
+//!   reference is visible in a diff instead of buried in a 9,000-test
+//!   summary.
+//! - [`pinned_at_risk_issues_carry_a_mechanism_note`] checks that exactly
+//!   the eleven issues named in the migration review carry a `note`, and
+//!   that no other issue does.
+
+use regex::Regex;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Issue state as of the last `gh issue list` enumeration.
+///
+/// An enum rather than a `&'static str`, so a typo such as `"Closed"` is a
+/// compile error instead of something a runtime assertion has to catch. The same
+/// pattern is used for `Pinning` in
+/// `src/normalize/merge/splitter_reproducer_corpus.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    Open,
+    Closed,
+}
+
+/// One `msto`-filed issue and the tests (if any) that reference it by number.
+struct MstoIssue {
+    /// GitHub issue number in `fulcrumgenomics/ferro-hgvs`.
+    number: u32,
+    /// Whether the issue carries the `high` label.
+    high: bool,
+    /// Issue state as of the last `gh issue list` enumeration.
+    state: State,
+    /// `(repo-relative file path, test function name)` pairs that reference
+    /// this issue number in the function's own name or in a comment
+    /// immediately above it. Empty means no such test was found.
+    tests: &'static [(&'static str, &'static str)],
+    /// One-line mechanism note for the eleven issues the sequence-first
+    /// migration review flagged as at risk. `None` for every other issue.
+    note: Option<&'static str>,
+}
+
+/// Every issue `msto` has filed against `fulcrumgenomics/ferro-hgvs`
+/// (`gh issue list -R fulcrumgenomics/ferro-hgvs --state all --author msto`),
+/// mapped to the tests that reference it by number.
+///
+/// Assembled by searching `tests/` and `src/` for `issue_<N>`, `#<N>`, and
+/// `issue #<N>` occurring in a test function's own name or in a comment
+/// directly above it. This is a name-based search: a test that exercises an
+/// issue's behavior without ever citing the issue number is not in this
+/// table.
+#[rustfmt::skip]
+static MSTO_ISSUES: &[MstoIssue] = &[
+    MstoIssue { number: 30, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 31, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 33, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 35, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 36, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 40, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 45, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 46, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 47, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 51, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 54, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 59, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 60, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 61, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 62, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 67, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 69, high: false, state: State::Closed, tests: &[("src/hgvs/parser/accession.rs", "test_parse_simple_accession_with_gene_selector")], note: None },
+    MstoIssue { number: 72, high: false, state: State::Closed, tests: &[("tests/it/allele_trans_phase.rs", "test_trans_does_not_trigger_consecutive_edit_merge")], note: None },
+    MstoIssue { number: 73, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 74, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 75, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 79, high: false, state: State::Closed, tests: &[("tests/it/issue_165_delins_sub_only_decompose.rs", "cds_codon_frame_pair_preserved_as_delins"), ("tests/it/merge_consecutive_edits_tests.rs", "test_codon_frame_then_strict_chain"), ("tests/it/merge_consecutive_edits_tests.rs", "test_codon_frame_two_subs_one_codon")], note: None },
+    MstoIssue { number: 82, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 83, high: false, state: State::Closed, tests: &[("tests/it/hgvs_spec_normalization_tests.rs", "harvester_yields_only_real_variants"), ("tests/it/hgvs_spec_normalization_tests.rs", "pinned_v21_normalization_behavior"), ("tests/it/protein_unknown_roundtrip.rs", "protein_unknown_trans_compound_with_position_unknown_arm_round_trips"), ("tests/it/protein_unknown_roundtrip.rs", "protein_unknown_trans_compound_with_predicted_arm_round_trips")], note: None },
+    MstoIssue { number: 84, high: false, state: State::Closed, tests: &[("tests/it/hgvs_spec_normalization_tests.rs", "harvester_yields_only_real_variants"), ("tests/it/hgvs_spec_normalization_tests.rs", "pinned_v21_normalization_behavior")], note: None },
+    MstoIssue { number: 87, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 160, high: false, state: State::Closed, tests: &[("tests/it/normalize_tests.rs", "cds_full_span_revcomp_in_cis_merges_to_inv"), ("tests/it/normalize_tests.rs", "cds_sub_span_revcomp_stays_single_delins"), ("tests/it/normalize_tests.rs", "cds_user_typed_delins_with_revcomp_subspan_stays_delins_symmetric"), ("tests/it/normalize_tests.rs", "full_span_revcomp_in_cis_merges_to_inv"), ("tests/it/normalize_tests.rs", "mt_user_typed_full_span_revcomp_delins_becomes_inv"), ("tests/it/normalize_tests.rs", "near_miss_complement_only_stays_delins"), ("tests/it/normalize_tests.rs", "near_miss_reverse_only_stays_delins"), ("tests/it/normalize_tests.rs", "rna_full_span_revcomp_in_cis_merges_to_inv"), ("tests/it/normalize_tests.rs", "rna_sub_span_revcomp_stays_single_delins"), ("tests/it/normalize_tests.rs", "single_nt_complement_remains_substitution"), ("tests/it/normalize_tests.rs", "split_drops_identity_subedit_no_eq_emitted"), ("tests/it/normalize_tests.rs", "sub_span_revcomp_stays_single_delins"), ("tests/it/normalize_tests.rs", "three_nt_revcomp_subrun_in_contiguous_change_stays_delins"), ("tests/it/normalize_tests.rs", "tx_user_typed_delins_with_full_span_revcomp"), ("tests/it/normalize_tests.rs", "user_typed_delins_with_revcomp_subspan_stays_delins_symmetric")], note: Some("Cluster A: the new splitter allows compensating gaps and shreds a contiguous replacement into pieces.") },
+    MstoIssue { number: 161, high: false, state: State::Closed, tests: &[("tests/it/del_shift_matrix.rs", "issue_161_bracket_cis_allele_2bp_del_shifts_one_rotation"), ("tests/it/del_shift_matrix.rs", "issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation"), ("tests/it/del_shift_matrix.rs", "issue_161_canonical_form_4bp_del_matches_bracket_form")], note: None },
+    MstoIssue { number: 179, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 180, high: false, state: State::Closed, tests: &[("tests/it/issue_180_allele_3prime_shift.rs", "allele_ins_canonicalized_to_dup_then_shifted_3prime"), ("tests/it/issue_180_allele_3prime_shift.rs", "allele_norm_3prime_shift_is_idempotent"), ("tests/it/issue_180_allele_3prime_shift.rs", "allele_seven_single_dels_spanning_run_boundary_shift_3prime"), ("tests/it/issue_180_allele_3prime_shift.rs", "allele_single_del_in_bracket_shifts_to_3prime_end_of_run"), ("tests/it/issue_180_allele_3prime_shift.rs", "allele_two_single_dels_shift_to_3prime_end_of_homopolymer"), ("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_1_adjacent_dels_no_duplicate_position"), ("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_2_eight_adjacent_dels_no_overlap"), ("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_3_mixed_dels_and_ins_no_duplicate_position")], note: None },
+    MstoIssue { number: 181, high: false, state: State::Closed, tests: &[("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_1_adjacent_dels_no_duplicate_position"), ("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_2_eight_adjacent_dels_no_overlap"), ("tests/it/issue_180_allele_3prime_shift.rs", "issue_181_example_3_mixed_dels_and_ins_no_duplicate_position")], note: None },
+    MstoIssue { number: 182, high: false, state: State::Closed, tests: &[("tests/it/issue_165_delins_sub_only_decompose.rs", "cds_adjacent_sub_pair_stays_as_delins"), ("tests/it/issue_182_postcanon_adjacency.rs", "identity_at_between_subs_prevents_grouping"), ("tests/it/issue_182_postcanon_adjacency.rs", "inv_flanked_by_two_sub_runs_each_side_groups_both_flanks"), ("tests/it/issue_182_postcanon_adjacency.rs", "single_sub_flank_stays_as_substitution"), ("tests/it/issue_182_postcanon_adjacency.rs", "two_subs_leading_an_inv_merge_to_delins"), ("tests/it/issue_182_postcanon_adjacency.rs", "two_subs_trailing_an_inv_merge_to_delins")], note: None },
+    MstoIssue { number: 183, high: true, state: State::Closed, tests: &[("src/reference/annotation/builder.rs", "ladder_step3_cds_as_exon_for_issue_183"), ("src/reference/annotation/builder.rs", "ladder_step3_preserves_utr_when_cds_is_subset_of_mrna"), ("src/reference/annotation/mod.rs", "load_gff3_issue_183_single_exon_no_exon_line")], note: None },
+    MstoIssue { number: 184, high: false, state: State::Closed, tests: &[("tests/it/cli_build_transcript.rs", "build_transcript_emit_genomic_sequences_makes_reference_genome_capable"), ("tests/it/cli_build_transcript.rs", "build_transcript_emit_genomic_sequences_stores_forward_bytes_on_minus_strand"), ("tests/it/cli_build_transcript.rs", "build_transcript_emits_valid_json_for_single_exon"), ("tests/it/cli_build_transcript.rs", "build_transcript_rejects_cds_beyond_contig"), ("tests/it/cli_build_transcript.rs", "build_transcript_supports_minus_strand_and_custom_id"), ("tests/it/cli_build_transcript.rs", "build_transcript_without_flag_omits_genomic_sequences")], note: None },
+    MstoIssue { number: 185, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 200, high: true, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 310, high: true, state: State::Closed, tests: &[("src/project/protein/identity.rs", "whole_molecule_identity_anchors_on_the_reference_initiator"), ("src/reference/transcript.rs", "test_transcript_default_is_minimal_and_non_coding"), ("tests/it/gene_selector_roundtrip.rs", "display_drops_gene_selector_refseq_nm"), ("tests/it/issue_1099_all_silent_protein.rs", "gene_symbol_rendering_matches_the_changed_residue_sibling"), ("tests/it/issue_310_projector_non_refseq.rs", "non_refseq_id_with_explicit_protein_id_uses_protein_id"), ("tests/it/issue_310_projector_non_refseq.rs", "non_refseq_id_without_protein_id_falls_back_to_transcript_id"), ("tests/it/issue_310_projector_non_refseq.rs", "parser_still_accepts_legacy_np_with_selector"), ("tests/it/issue_310_projector_non_refseq.rs", "refseq_nm_prefix_without_protein_falls_back_to_transcript_id"), ("tests/it/issue_310_projector_non_refseq.rs", "refseq_xm_prefix_without_protein_falls_back_to_transcript_id")], note: None },
+    MstoIssue { number: 311, high: true, state: State::Closed, tests: &[("tests/it/issue_311_transcript_prefix_chromosome.rs", "allele_normalizes_when_tx_id_differs_only_in_case"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "allele_normalizes_when_tx_id_does_not_collide"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "allele_normalizes_when_tx_id_equals_chromosome"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "allele_normalizes_when_tx_id_starts_with_chromosome"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "delins_roundtrips_when_tx_id_starts_with_chromosome"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_protein_sequence_versioning_contract"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_transcript_does_not_collide_with_chromosome_prefix"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_transcript_rejects_non_version_boundary_prefix"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_transcript_rejects_versioned_query_against_other_version"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_transcript_resolves_exact_id"), ("tests/it/issue_311_transcript_prefix_chromosome.rs", "get_transcript_resolves_unversioned_query_to_versioned_key")], note: None },
+    MstoIssue { number: 1026, high: false, state: State::Closed, tests: &[("src/reference/mock.rs", "from_json_accepts_consistent_genomic_reference"), ("src/reference/mock.rs", "from_json_skips_backing_check_without_genomic_sequences"), ("tests/it/issue_1026_genome_capable_json.rs", "genome_capable_reference_normalizes_intronic"), ("tests/it/issue_1026_genome_capable_json.rs", "transcripts_only_reference_cannot_normalize_intronic")], note: None },
+    MstoIssue { number: 1027, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 1028, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 1034, high: true, state: State::Closed, tests: &[("tests/it/issue_1034_inv_subspan_delins.rs", "contiguous_delins_with_internal_revcomp_subrun_stays_delins"), ("tests/it/issue_1034_inv_subspan_delins.rs", "contiguous_delins_with_leading_revcomp_subrun_stays_delins"), ("tests/it/issue_1034_inv_subspan_delins.rs", "full_run_reverse_complement_still_emits_inv"), ("tests/it/issue_1034_inv_subspan_delins.rs", "two_base_full_run_reverse_complement_still_emits_inv"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1034_minimal_contiguous_run_stays_delins"), ("tests/it/issue_291_rna_axis_convention.rs", "rna_canonical_split_fetch_is_cds_relative"), ("tests/it/normalize_tests.rs", "cds_full_span_revcomp_in_cis_merges_to_inv")], note: Some("Cluster A: the new splitter allows compensating gaps and shreds a contiguous replacement into pieces.") },
+    MstoIssue { number: 1035, high: false, state: State::Closed, tests: &[("tests/it/build_transcript_library_parity.rs", "library_matches_cli_minus_strand_custom_id_gene"), ("tests/it/build_transcript_library_parity.rs", "library_matches_cli_plus_strand"), ("tests/it/build_transcript_library_parity.rs", "library_matches_cli_with_emit_genomic_sequences"), ("tests/it/convert_gff_library_parity.rs", "library_matches_cli_transcript_only"), ("tests/it/convert_gff_library_parity.rs", "library_matches_cli_with_emit_genomic_sequences"), ("tests/it/convert_gff_library_parity.rs", "library_matches_cli_with_gene_filter")], note: None },
+    MstoIssue { number: 1040, high: true, state: State::Closed, tests: &[("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1034_minimal_contiguous_run_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1040_compound_allele_near_3prime_end_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1040_contiguous_run_near_3prime_end_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1040_literal_ten_nt_contiguous_run_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "issue_1040_same_run_as_delins_input_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "length_changing_revcomp_delins_stays_delins"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "revcomp_runs_in_distinct_codons_are_individual_on_cds_axis"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "revcomp_runs_separated_by_identity_are_individual_on_genomic_axis"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "shared_affix_trimming_reveals_inner_inv"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "two_nt_reverse_complement_emits_inv"), ("tests/it/issue_1040_inv_overrecognition_probes.rs", "whole_run_reverse_complement_emits_inv")], note: Some("Cluster A: the new splitter allows compensating gaps and shreds a contiguous replacement into pieces.") },
+    MstoIssue { number: 1041, high: true, state: State::Closed, tests: &[("tests/it/issue_1041_repro.rs", "issue_1041_compound_subs_near_3prime_end_merge_to_inv"), ("tests/it/issue_1041_repro.rs", "issue_1041_root_cause_also_restores_3prime_shift"), ("tests/it/issue_1041_repro.rs", "issue_1041_span_past_contig_end_passes_through_unchanged"), ("tests/it/issue_1041_repro.rs", "issue_1041_whole_run_revcomp_is_inv_regardless_of_3prime_proximity")], note: Some("Cluster A: the new splitter allows compensating gaps and shreds a contiguous replacement into pieces.") },
+    MstoIssue { number: 1050, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 1051, high: false, state: State::Closed, tests: &[("tests/it/gene_selector_display_preserve.rs", "display_drops_redundant_gene_selector_with_compound_ref"), ("tests/it/gene_selector_roundtrip.rs", "display_drops_gene_selector_in_compact_cis_allele"), ("tests/it/gene_selector_roundtrip.rs", "display_drops_gene_selector_refseq_nm"), ("tests/it/gene_selector_roundtrip.rs", "display_drops_redundant_gene_selector_with_compound_ref"), ("tests/it/gene_selector_roundtrip.rs", "parse_captures_gene_symbol_refseq_nm"), ("tests/it/gene_selector_roundtrip.rs", "reparse_preserves_gene_symbol_on_nontranscript_reference")], note: None },
+    MstoIssue { number: 1052, high: true, state: State::Closed, tests: &[("tests/it/issue_1052_substitution_refseq.rs", "correct_ref_cds_sub_no_warning"), ("tests/it/issue_1052_substitution_refseq.rs", "correct_ref_exonic_sub_at_transcript_boundary_no_capability_warning"), ("tests/it/issue_1052_substitution_refseq.rs", "correct_ref_exonic_sub_at_transcript_boundary_passes_strict"), ("tests/it/issue_1052_substitution_refseq.rs", "correct_ref_genomic_sub_no_warning"), ("tests/it/issue_1052_substitution_refseq.rs", "correct_ref_mito_sub_no_warning"), ("tests/it/issue_1052_substitution_refseq.rs", "genomic_sub_without_reference_passes_through"), ("tests/it/issue_1052_substitution_refseq.rs", "intronic_sub_bare_nm_stays_on_pre_existing_eintronic_warning_only"), ("tests/it/issue_1052_substitution_refseq.rs", "intronic_sub_without_genomic_sequence_is_silent_passthrough"), ("tests/it/issue_1052_substitution_refseq.rs", "uncertain_correct_ref_genomic_sub_preserves_wrapper"), ("tests/it/issue_1052_substitution_refseq.rs", "uncertain_wrong_ref_cds_sub_stays_silent_in_lenient"), ("tests/it/issue_1052_substitution_refseq.rs", "uncertain_wrong_ref_cds_sub_stays_silent_in_strict"), ("tests/it/issue_1052_substitution_refseq.rs", "uncertain_wrong_ref_genomic_sub_stays_silent_in_lenient_and_strict"), ("tests/it/issue_1052_substitution_refseq.rs", "uncertain_wrong_ref_mito_sub_stays_silent"), ("tests/it/issue_1052_substitution_refseq.rs", "wrong_ref_cds_sub_warns"), ("tests/it/issue_1052_substitution_refseq.rs", "wrong_ref_genomic_sub_rejects_in_strict"), ("tests/it/issue_1052_substitution_refseq.rs", "wrong_ref_genomic_sub_warns_in_lenient"), ("tests/it/issue_1052_substitution_refseq.rs", "wrong_ref_mito_sub_rejects_in_strict"), ("tests/it/issue_1052_substitution_refseq.rs", "wrong_ref_mito_sub_warns_in_lenient")], note: None },
+    MstoIssue { number: 1059, high: true, state: State::Closed, tests: &[("src/hgvs/variant.rs", "test_coordinate_axis_allele_shares_member_axis"), ("src/hgvs/variant.rs", "test_coordinate_axis_enum_groupings"), ("src/hgvs/variant.rs", "test_coordinate_axis_genome_ring_is_genomic"), ("src/hgvs/variant.rs", "test_coordinate_axis_leaf_kinds"), ("src/hgvs/variant.rs", "test_coordinate_axis_markers_contribute_no_axis"), ("src/hgvs/variant.rs", "test_coordinate_axis_mixed_allele_is_none"), ("src/hgvs/variant.rs", "test_coordinate_axis_nested_allele")], note: None },
+    MstoIssue { number: 1070, high: true, state: State::Closed, tests: &[("src/project/projector.rs", "classify_cis_member_intronic_span"), ("src/project/projector.rs", "project_cis_exon_boundary_member_forces_fallback"), ("src/project/projector.rs", "project_cis_inframe_with_pure_intron_member"), ("src/project/projector.rs", "project_cis_init_member_wins_over_combined"), ("src/project/projector.rs", "project_cis_insertion_member_nets_in_frame"), ("src/project/projector.rs", "project_cis_net_in_frame_allele_is_not_frameshift"), ("src/project/projector.rs", "project_cis_net_in_frame_but_mid_shift_stop_is_frameshift"), ("src/project/projector.rs", "project_cis_overlapping_frameshift_members_fall_back"), ("src/project/projector.rs", "project_cis_separated_inframe_deletions_stay_individual"), ("src/project/projector.rs", "project_trans_net_shifting_allele_is_frameshift"), ("src/project/protein/indel.rs", "cis_combined_rejects_out_of_bounds_span_without_panic")], note: None },
+    MstoIssue { number: 1076, high: true, state: State::Closed, tests: &[("src/project/projector.rs", "combine_by_codon_adjacent_codons_form_delins"), ("src/project/projector.rs", "combine_by_codon_same_codon_missense"), ("src/project/projector.rs", "combine_by_codon_same_codon_nonsense"), ("src/project/projector.rs", "combine_by_codon_same_codon_synonymous"), ("src/project/projector.rs", "combine_by_codon_same_position_overlap_returns_none"), ("src/project/projector.rs", "combine_by_codon_separated_codons_stay_bracketed"), ("src/project/projector.rs", "combine_by_codon_single_member_returns_none"), ("src/project/projector.rs", "combine_by_codon_synonymous_group_drops_leaving_single"), ("src/project/projector.rs", "project_cis_intron_split_codon_combines_to_single_missense"), ("src/project/projector.rs", "project_cis_same_codon_all_three_bases_combine_to_single_missense"), ("src/project/projector.rs", "project_cis_same_codon_bases_1_and_2_combine_to_single_missense"), ("src/project/projector.rs", "project_cis_same_codon_bases_1_and_3_combine_to_single_missense"), ("src/project/projector.rs", "project_cis_same_codon_combines_to_nonsense"), ("src/project/projector.rs", "project_cis_same_codon_minus_strand_combines_to_single_missense"), ("src/project/projector.rs", "project_cis_same_position_overlap_stays_bracketed"), ("src/project/projector.rs", "project_cis_terminal_stop_member_keeps_extension_form")], note: None },
+    MstoIssue { number: 1097, high: true, state: State::Closed, tests: &[("tests/it/issue_1097_range_sub_refseq_reject.rs", "correct_ref_range_sub_normalizes_cleanly"), ("tests/it/issue_1097_range_sub_refseq_reject.rs", "per_base_allele_subs_wrong_ref_rejects"), ("tests/it/issue_1097_range_sub_refseq_reject.rs", "single_base_sub_wrong_ref_rejects"), ("tests/it/issue_1097_range_sub_refseq_reject.rs", "three_base_range_sub_wrong_ref_rejects"), ("tests/it/issue_1097_range_sub_refseq_reject.rs", "two_base_range_sub_wrong_ref_rejects")], note: None },
+    MstoIssue { number: 1098, high: true, state: State::Closed, tests: &[("tests/it/allele_grammar_corners.rs", "protein_descending_order_members_coalesce_to_the_same_delins"), ("tests/it/allele_grammar_corners.rs", "protein_same_residue_changes_are_not_coalesced"), ("tests/it/cis_allele_confluence_proptest.rs", "an_indel_haplotype_is_authored_order_independent"), ("tests/it/issue_1116_protein_coalesce_order_independence.rs", "a_gapped_run_stays_a_bracket_in_both_orders"), ("tests/it/issue_221_cis_three_plus_no_merge.rs", "all_permutations_normalize_to_same_canonical_string"), ("tests/it/issue_221_cis_three_plus_no_merge.rs", "descending_position_order_sorts_to_ascending")], note: None },
+    MstoIssue { number: 1099, high: false, state: State::Closed, tests: &[("src/project/projector.rs", "combine_by_codon_consecutive_silent_codons_form_a_range"), ("src/project/projector.rs", "combine_by_codon_ignores_a_member_that_rewrites_nothing"), ("src/project/projector.rs", "combine_by_codon_separated_silent_codons_are_bracketed"), ("src/project/projector.rs", "combine_by_residue_all_silent_names_every_rewritten_codon"), ("src/project/projector.rs", "combine_by_residue_ignores_a_member_that_rewrites_nothing"), ("tests/it/issue_1099_all_silent_protein.rs", "all_silent_cis_allele_names_every_rewritten_codon"), ("tests/it/issue_1099_all_silent_protein.rs", "all_silent_members_in_one_codon_stay_a_single_residue"), ("tests/it/issue_1099_all_silent_protein.rs", "an_unchanged_interior_codon_is_not_named"), ("tests/it/issue_1099_all_silent_protein.rs", "emitted_identities_reparse"), ("tests/it/issue_1099_all_silent_protein.rs", "emitted_identities_survive_normalization_unchanged"), ("tests/it/issue_1099_all_silent_protein.rs", "gene_symbol_rendering_matches_the_changed_residue_sibling"), ("tests/it/issue_1099_all_silent_protein.rs", "output_is_independent_of_member_order"), ("tests/it/issue_1099_all_silent_protein.rs", "separated_silent_codons_render_as_a_bracket"), ("tests/it/issue_1099_all_silent_protein.rs", "silent_delins_names_its_codons_instead_of_whole_protein_identity"), ("tests/it/issue_1099_all_silent_protein.rs", "single_silent_substitution_is_unchanged"), ("tests/it/issue_1099_all_silent_protein.rs", "the_codon_level_combiner_also_brackets_separated_codons"), ("tests/it/issue_1099_all_silent_protein.rs", "three_consecutive_silent_codons_render_as_one_range"), ("tests/it/protein_render_policy.rs", "a_silent_protein_allele_honours_the_render_style")], note: None },
+    MstoIssue { number: 1102, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 1139, high: false, state: State::Closed, tests: &[("tests/it/gene_selector_roundtrip.rs", "assembly_ref_keeps_its_gene_selector"), ("tests/it/issue_1139_gene_symbol_specification.rs", "a_reference_without_a_gene_symbol_is_unchanged"), ("tests/it/issue_1139_gene_symbol_specification.rs", "gene_symbol_is_not_stacked_as_a_second_specification_on_the_coding_axis"), ("tests/it/issue_1139_gene_symbol_specification.rs", "gene_symbol_is_not_stacked_as_a_second_specification_on_the_noncoding_axis"), ("tests/it/issue_1139_gene_symbol_specification.rs", "projected_coding_name_round_trips_through_the_parser"), ("tests/it/issue_1139_gene_symbol_specification.rs", "projected_noncoding_name_round_trips_through_the_parser"), ("tests/it/issue_1139_gene_symbol_specification.rs", "the_protein_axis_stays_gene_symbol_free")], note: None },
+    MstoIssue { number: 1157, high: true, state: State::Closed, tests: &[("tests/it/issue_1157_delins_reduction_shift.rs", "decomposed_cis_allele_is_idempotent"), ("tests/it/issue_1157_delins_reduction_shift.rs", "decomposed_cis_allele_is_not_collapsed_into_a_spanning_delins"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_deletion_is_idempotent"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_deletion_is_three_prime_shifted"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_deletion_matches_direct_deletion"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_duplication_is_idempotent"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_duplication_is_three_prime_shifted"), ("tests/it/issue_1157_delins_reduction_shift.rs", "delins_reducing_to_duplication_matches_direct_duplication"), ("tests/it/issue_1157_delins_reduction_shift.rs", "sequence_identical_delins_and_allele_normalize_equal"), ("tests/it/issue_1157_delins_reduction_shift.rs", "single_delins_is_decomposed_at_its_unchanged_bases"), ("tests/it/issue_1157_five_prime_insertion_rotation.rs", "five_prime_multibase_insertion_rotates_and_is_idempotent"), ("tests/it/issue_1157_five_prime_insertion_rotation.rs", "five_prime_rotated_insertion_is_a_fixed_point"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "delins_reducing_to_deletion_matches_direct_deletion")], note: Some("Cluster B: a non-unique minimal alignment leaves no dominator, so the block stays one spanning member.") },
+    MstoIssue { number: 1158, high: true, state: State::Closed, tests: &[("tests/it/issue_1158_equivalence_resulting_sequence.rs", "decomposed_allele_with_different_sequence_stays_not_equivalent"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "delins_and_decomposed_allele_with_same_sequence_are_equivalent"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "delins_reducing_to_deletion_matches_direct_deletion"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "delins_with_different_resulting_sequence_stays_not_equivalent"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "identical_variants_still_identical"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "sequence_match_is_equivalent"), ("tests/it/issue_1158_equivalence_resulting_sequence.rs", "substitution_written_two_ways_still_normalized_match")], note: Some("Cluster B: confluence diverges rather than relocates (NormalizedMatch degrades to SequenceMatch).") },
+    MstoIssue { number: 1159, high: false, state: State::Open, tests: &[], note: None },
+    MstoIssue { number: 1229, high: true, state: State::Closed, tests: &[("tests/it/cis_allele_confluence_proptest.rs", "members_are_disjoint_and_ascending"), ("tests/it/issue_1235_cis_allele_confluence.rs", "both_public_exits_emit_the_same_canonical_variant"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1229_adjacent_inv_member_coalesces"), ("tests/it/issue_1249_inv_one_base_residue.rs", "every_spelling_of_the_variant_normalizes_alike")], note: None },
+    MstoIssue { number: 1230, high: true, state: State::Closed, tests: &[("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1230_inv_with_unchanged_interior_becomes_substitutions")], note: None },
+    MstoIssue { number: 1231, high: true, state: State::Closed, tests: &[("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1231_dup_del_reduces_to_substitutions")], note: Some("Cluster B: a non-unique minimal alignment leaves no dominator, so the block stays one spanning member.") },
+    MstoIssue { number: 1232, high: true, state: State::Closed, tests: &[("src/normalize/merge.rs", "shadow_merges_across_one_unchanged_base_where_live_splits"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1232_spanning_delins_splits_at_unchanged_base"), ("tests/it/issue_1235_cis_allele_confluence.rs", "soft_masked_reference_yields_the_same_canonical_form")], note: Some("Cluster B: a non-unique minimal alignment leaves no dominator, so the block stays one spanning member.") },
+    MstoIssue { number: 1233, high: true, state: State::Closed, tests: &[("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1233_ins_del_reduces_to_substitutions")], note: Some("Cluster B: a non-unique minimal alignment leaves no dominator, so the block stays one spanning member.") },
+    MstoIssue { number: 1234, high: true, state: State::Closed, tests: &[("tests/it/cis_allele_confluence_proptest.rs", "members_are_disjoint_and_ascending"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "a_distant_sibling_does_not_clamp_the_shift"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "a_lone_deletion_still_shifts_to_its_three_prime_most_position"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "an_uncertain_allele_keeps_its_predicted_marker"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "deletion_shift_stops_before_a_sibling_substitution"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "normalization_preserves_the_resulting_sequence"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "normalized_cis_members_never_overlap"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "the_certain_spelling_of_that_allele_still_clamps"), ("tests/it/issue_1234_sibling_clamped_shift.rs", "the_clamped_spelling_reaches_the_same_string"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1234_lone_deletion_still_shifts_fully"), ("tests/it/issue_1235_cis_allele_confluence.rs", "normalization_preserves_the_resulting_sequence")], note: Some("Cluster C: the fix lives in a repair pass (clamp_sibling_crossing_shifts) the rewrite's splitter never reaches.") },
+    MstoIssue { number: 1235, high: true, state: State::Open, tests: &[("src/normalize/merge.rs", "shadow_merges_across_one_unchanged_base_where_live_splits"), ("tests/it/cis_allele_confluence_proptest.rs", "members_are_disjoint_and_ascending"), ("tests/it/idempotency_tests.rs", "test_overlap_conflicting_allele_is_idempotent_across_respellings"), ("tests/it/issue_1235_cis_allele_confluence.rs", "both_public_exits_emit_the_same_canonical_variant"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1229_adjacent_inv_member_coalesces"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1230_inv_with_unchanged_interior_becomes_substitutions"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1231_dup_del_reduces_to_substitutions"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1232_spanning_delins_splits_at_unchanged_base"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1233_ins_del_reduces_to_substitutions"), ("tests/it/issue_1235_cis_allele_confluence.rs", "issue_1234_lone_deletion_still_shifts_fully"), ("tests/it/issue_1235_cis_allele_confluence.rs", "normalization_is_idempotent"), ("tests/it/issue_1235_cis_allele_confluence.rs", "normalization_preserves_the_resulting_sequence"), ("tests/it/issue_1235_cis_allele_confluence.rs", "normalized_cis_members_are_disjoint_and_ordered"), ("tests/it/issue_1235_cis_allele_confluence.rs", "shifted_insertion_piece_rotates_its_payload"), ("tests/it/issue_1235_cis_allele_confluence.rs", "soft_masked_reference_yields_the_same_canonical_form"), ("tests/it/issue_1235_transcript_axes.rs", "cds_axis_converges_on_separated_changes"), ("tests/it/issue_1235_transcript_axes.rs", "cds_axis_reduces_a_mixed_type_allele_to_substitutions"), ("tests/it/issue_1235_transcript_axes.rs", "cds_axis_splits_across_a_codon_boundary"), ("tests/it/issue_1235_transcript_axes.rs", "coding_rna_axis_keeps_its_reading_frame"), ("tests/it/issue_1235_transcript_axes.rs", "noncoding_axis_converges_on_separated_changes"), ("tests/it/issue_1235_transcript_axes.rs", "noncoding_rna_axis_converges_without_a_reading_frame"), ("tests/it/issue_1235_transcript_axes.rs", "overlap_conflicting_allele_is_not_canonicalized"), ("tests/it/issue_1235_transcript_axes.rs", "rna_axis_converges_and_keeps_the_u_alphabet"), ("tests/it/issue_1235_transcript_axes.rs", "rna_axis_reduces_a_mixed_type_allele_and_keeps_the_u_alphabet"), ("tests/it/issue_1249_inv_one_base_residue.rs", "every_spelling_of_the_variant_normalizes_alike"), ("tests/it/rewrite_target_corpus.rs", "a_repeat_growth_exceeding_its_tract_still_swallows_a_sibling_junction")], note: Some("Cluster B (c./r. axes): a non-unique minimal alignment leaves no dominator, so the block stays spanning.") },
+    MstoIssue { number: 1244, high: true, state: State::Closed, tests: &[("tests/it/issue_1244_equivalence_overlap_panic.rs", "a_disjoint_cis_allele_is_not_declined"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "an_overlapping_allele_compared_with_itself_is_still_decided"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "an_overlapping_cis_allele_returns_a_verdict_instead_of_panicking"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "members_that_merely_abut_are_not_treated_as_overlapping"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "normalizing_the_same_overlapping_allele_does_not_panic"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "pure_insertions_at_one_position_are_not_treated_as_overlapping"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "the_crash_is_symmetric_in_argument_order"), ("tests/it/issue_1244_equivalence_overlap_panic.rs", "three_insertions_at_one_position_are_still_not_overlapping")], note: None },
+    MstoIssue { number: 1245, high: false, state: State::Closed, tests: &[], note: None },
+    MstoIssue { number: 1246, high: false, state: State::Closed, tests: &[], note: None },
+];
+
+/// The eleven issues the sequence-first migration review flagged as at risk,
+/// pinned so drift in [`MSTO_ISSUES`] is caught by
+/// [`pinned_at_risk_issues_carry_a_mechanism_note`].
+const PINNED_AT_RISK_ISSUES: &[u32] = &[
+    160, 1034, 1040, 1041, 1157, 1158, 1231, 1232, 1233, 1234, 1235,
+];
+
+/// Pinned totals, checked by [`issue_and_test_totals_match_their_pinned_counts`].
+/// A change to any of these numbers means [`MSTO_ISSUES`] changed — update the
+/// constant only after confirming the new count is intentional (a `gh issue
+/// list` re-enumeration, a newly-tagged test, or a rename/deletion this table
+/// should reflect), not to silence a failing assertion.
+const PINNED_ISSUE_COUNT: usize = 69;
+const PINNED_HIGH_ISSUE_COUNT: usize = 23;
+const PINNED_UNIQUE_TEST_COUNT: usize = 253;
+
+/// Reads `relative_path` (relative to the crate root) and returns whether it
+/// contains a function definition named `fn_name` — i.e. a line containing
+/// `fn <fn_name>` immediately followed by `(` or `<` (accounting for
+/// generics), possibly preceded by `pub`/`async`/whitespace.
+fn source_defines_fn(relative_path: &str, fn_name: &str) -> bool {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {relative_path}: {e}"));
+    let pattern = format!(r"fn\s+{}\s*[(<]", regex::escape(fn_name));
+    Regex::new(&pattern)
+        .expect("pattern built from an escaped literal is always valid")
+        .is_match(&content)
+}
+
+/// Every `(file, fn)` pair cataloged in [`MSTO_ISSUES`] must still name a real
+/// function in its source file. A pair that fails here means the guarding
+/// test was renamed or deleted without updating this table — the exact
+/// silent-rot failure mode this module exists to catch.
+#[test]
+fn every_cataloged_test_exists_in_its_source_file() {
+    let mut missing = Vec::new();
+    for issue in MSTO_ISSUES {
+        for &(file, fn_name) in issue.tests {
+            if !source_defines_fn(file, fn_name) {
+                missing.push(format!("#{}: {file}::{fn_name}", issue.number));
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "cataloged tests no longer found in their source files (renamed, moved, or deleted; \
+         update MSTO_ISSUES in tests/it/msto_regression_corpus.rs):\n{}",
+        missing.join("\n")
+    );
+}
+
+/// Pins the issue count, the `high`-label count, and the number of distinct
+/// tests cataloged across every issue, so an edit to [`MSTO_ISSUES`] that
+/// silently changes one of these totals shows up as a failing assertion
+/// instead of only as a diff someone has to notice.
+#[test]
+fn issue_and_test_totals_match_their_pinned_counts() {
+    assert_eq!(
+        MSTO_ISSUES.len(),
+        PINNED_ISSUE_COUNT,
+        "msto issue count changed \u{2014} re-run `gh issue list -R fulcrumgenomics/ferro-hgvs \
+         --state all --author msto` and update MSTO_ISSUES and PINNED_ISSUE_COUNT"
+    );
+
+    let high_count = MSTO_ISSUES.iter().filter(|i| i.high).count();
+    assert_eq!(
+        high_count, PINNED_HIGH_ISSUE_COUNT,
+        "count of `high`-labeled msto issues changed \u{2014} update PINNED_HIGH_ISSUE_COUNT \
+         after confirming the new count against GitHub"
+    );
+
+    let unique_tests: HashSet<(&str, &str)> = MSTO_ISSUES
+        .iter()
+        .flat_map(|issue| issue.tests.iter().copied())
+        .collect();
+    assert_eq!(
+        unique_tests.len(),
+        PINNED_UNIQUE_TEST_COUNT,
+        "total distinct cataloged tests changed \u{2014} update PINNED_UNIQUE_TEST_COUNT after \
+         confirming the new count is an intentional addition/removal, not corpus rot"
+    );
+
+    // No duplicate issue numbers, and no test pair claimed by an issue twice.
+    let mut seen_numbers = HashSet::new();
+    for issue in MSTO_ISSUES {
+        assert!(
+            seen_numbers.insert(issue.number),
+            "issue #{} appears more than once in MSTO_ISSUES",
+            issue.number
+        );
+        let mut seen_pairs = HashSet::new();
+        for &pair in issue.tests {
+            assert!(
+                seen_pairs.insert(pair),
+                "issue #{} lists {}::{} more than once",
+                issue.number,
+                pair.0,
+                pair.1
+            );
+        }
+    }
+}
+
+/// Exactly the eleven issues the sequence-first migration review named as at
+/// risk carry a `note`; no other issue does. Catches both directions of
+/// drift: an at-risk issue silently losing its note, and an unrelated issue
+/// picking one up by copy-paste.
+#[test]
+fn pinned_at_risk_issues_carry_a_mechanism_note() {
+    assert_eq!(PINNED_AT_RISK_ISSUES.len(), 11);
+
+    let noted: HashSet<u32> = MSTO_ISSUES
+        .iter()
+        .filter(|i| i.note.is_some())
+        .map(|i| i.number)
+        .collect();
+    let pinned: HashSet<u32> = PINNED_AT_RISK_ISSUES.iter().copied().collect();
+    assert_eq!(
+        noted, pinned,
+        "the set of issues carrying a mechanism `note` no longer matches PINNED_AT_RISK_ISSUES"
+    );
+
+    // Ten of the eleven pinned issues are `high`; #160 is the review's sole
+    // non-`high` exception (it surfaced from a full-suite run, not the
+    // `high`-labeled backlog).
+    let high_count = PINNED_AT_RISK_ISSUES
+        .iter()
+        .filter(|&&number| {
+            MSTO_ISSUES
+                .iter()
+                .find(|i| i.number == number)
+                .unwrap_or_else(|| panic!("pinned at-risk issue #{number} is not in MSTO_ISSUES"))
+                .high
+        })
+        .count();
+    assert_eq!(
+        high_count, 10,
+        "expected exactly ten of the eleven pinned at-risk issues to be labeled `high` \
+         (#160 is the sole non-high exception)"
+    );
+}
+
+/// Exactly the two issues known to be open (#1159, the SPDI feature request,
+/// and #1235, the rewrite's own tracking issue) are marked as such.
+///
+/// The "is the state one of the two legal values" half of this check is gone,
+/// because `State` makes an illegal value unrepresentable — the compiler owns it
+/// now.
+#[test]
+fn issue_state_matches_the_known_open_set() {
+    let open: HashSet<u32> = MSTO_ISSUES
+        .iter()
+        .filter(|i| i.state == State::Open)
+        .map(|i| i.number)
+        .collect();
+    assert_eq!(
+        open,
+        HashSet::from([1159, 1235]),
+        "the set of open msto issues changed \u{2014} re-check against GitHub and update \
+         MSTO_ISSUES"
+    );
+}
+
+/// A `high`-labeled issue with no cataloged test is a finding, not an error
+/// in this table: it means no test in the corpus can be traced to that issue
+/// by number. Pinned to the set actually found so that closing the gap (or
+/// opening a new one) is visible rather than silently absorbed.
+#[test]
+fn no_high_priority_issue_is_unguarded_without_being_named() {
+    let unguarded: Vec<u32> = MSTO_ISSUES
+        .iter()
+        .filter(|i| i.high && i.tests.is_empty())
+        .map(|i| i.number)
+        .collect();
+    assert_eq!(
+        unguarded,
+        vec![200],
+        "the set of unguarded high-priority msto issues changed; if this is a newly-found gap, \
+         leave it here as a finding rather than silently dropping it"
+    );
+}

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -5603,18 +5603,53 @@ mod ins_bracketed_expansion {
     }
 
     // -------------------------------------------------------------------
-    // 10. The same canonicalization applies to a `delins` payload. The
-    //     literal prefix starts with `G` so the surrounding A-padded
-    //     context cannot 3'-shift / contract the delins span.
+    // 10. The same canonicalization applies to a `delins` payload.
+    //
+    //     Re-blessed with the two-gap insertion alignment (#1260, PR #1285).
+    //     This test is about the *payload expansion* — `[GCG;100_110]` becoming
+    //     `GCGTTTGGGAAACC` — which is unchanged, and is asserted below against
+    //     the normalizer's own output rather than against the fixture literal.
+    //     What moved is how the expanded payload is then divided.
+    //
+    //     The reference here is A-padded, so the two replaced bases `AA` occur
+    //     inside the expanded payload; keeping them means the whole reference
+    //     survives between two insertions. That is more minimal (9 + 3 = 12
+    //     changed columns against the spanning `delins`'s 14) and two `ins`
+    //     members outrank one `delins` (`general.md:56`).
+    //
+    //     Worth knowing: a short reference block inside a long payload is
+    //     exactly where "the whole reference survives" is most likely to be
+    //     coincidence. The separation here is 2 reference bases, so the existing
+    //     `MIN_PIECE_SEPARATION` gate admits it. Whether that gate should scale
+    //     with payload length is a live question, not settled by this test.
     // -------------------------------------------------------------------
     #[test]
     fn delins_bracketed_payload_expands() {
         let bases = "TTTGGGAAACC";
         let provider = provider_with_genomic("NC_000001.11", 100, bases);
         let result = normalize_ok(provider, "NC_000001.11:g.5207_5208delins[GCG;100_110]");
+        // The payload expanded: `GCG` + the 100..=110 span, split across the two
+        // retained reference bases and 3'-shifted.
         assert_eq!(
             result,
-            format!("NC_000001.11:g.5207_5208delinsGCG{}", bases)
+            "NC_000001.11:g.[5206_5207insGCGTTTGGG;5209_5210insCCA]"
+        );
+        // Checked against the normalizer's output, not against itself. `expanded`
+        // is built from the same `bases` literal three lines up, so comparing the
+        // two was a tautology that could not fail if the expansion regressed —
+        // and the comment above claimed this assertion covered exactly that.
+        //
+        // The expanded payload survives in the output split across the two
+        // retained `AA` and rotated by the 3'-shift, so it is recoverable as its
+        // leading 9 bases plus the rotated tail rather than as one contiguous run.
+        let expanded = format!("GCG{bases}");
+        assert_eq!(
+            expanded, "GCGTTTGGGAAACC",
+            "fixture drift, not a behaviour claim"
+        );
+        assert!(
+            result.contains(&expanded[..9]) && result.contains("CCA"),
+            "the expanded payload `{expanded}` is no longer recoverable from `{result}`"
         );
     }
 

--- a/tests/it/render_calibration.rs
+++ b/tests/it/render_calibration.rs
@@ -17,15 +17,20 @@
 //! covered is the full pairwise ladder — each row shows one outcome winning,
 //! not that it beats every lower-ranked alternative in turn.
 //!
-//! **Repeat/STR notation is not exercised, because on this axis ferro does not
-//! emit it.** Measured against these same synthetic references: over core
-//! `CAGCAGCAGG`, a fourth `CAG` copy (whether spelled `g.265_266insCAG` or
-//! `g.263_265dup`) renders as `g.263_265dup`, and dropping a copy
-//! (`g.263_265del`) renders as `g.263_265del` — never `CAG[4]`/`CAG[2]`. That
-//! is consistent with prioritisation (duplication outranks insertion) and is
-//! not asserted here to be right or wrong; it is recorded so that a future
-//! change which starts emitting repeat notation is understood as a deliberate
-//! behavioural change and not a silent regression against untested ground.
+//! **Repeat/STR notation is exercised, on both sides of the boundary where
+//! ferro starts emitting it.** One unit added or removed stays a `dup`/`del`:
+//! over core `CAGCAGCAGG`, a fourth `CAG` copy (whether spelled
+//! `g.265_266insCAG` or `g.263_265dup`) renders as `g.263_265dup`, and dropping
+//! a copy (`g.263_265del`) renders as `g.263_265del` — never `CAG[4]`/`CAG[2]`,
+//! which is consistent with prioritisation (duplication outranks insertion).
+//! Two units is where the whole run is described as one repeat instead, and
+//! `repeat_notation_describes_the_whole_run` pins that.
+//!
+//! Which side of that boundary a change falls on is a rendering decision, and
+//! it is the one place this axis describes a whole ambiguous run as a single
+//! member. It does so only as `dup` or `NNN[k]` — never as a `delins` spanning
+//! the run — so those rows are the guard against a minimisation pass that
+//! narrows more than it should.
 
 use crate::common::cis_apply_oracle::normalize;
 use crate::common::synthetic::padded;
@@ -119,13 +124,60 @@ fn rendering_rules_are_pinned() {
     }
 }
 
+/// Where a change inside a homopolymer is described as the whole run, and where
+/// it is not.
+///
+/// One unit is localised (`g.263del`, `g.261dup` — the same answers rows 1 and 2
+/// of `CASES` pin); two units is spelled as the whole tract in repeat notation,
+/// which is *wider* than the change itself. Both directions grow: a 2-base
+/// deletion out of a 7-A run and a 2-base insertion into a 5-A run.
+///
+/// The grown forms are the ones to watch. They are the only members on this axis
+/// that describe more reference than they change, and they are legitimate
+/// because `NNN[k]` is an edit type of its own — a `delins` over the same span
+/// would not be. Any pass that narrows members to their differences must leave
+/// these four rows exactly as they are.
+#[test]
+fn repeat_notation_describes_the_whole_run() {
+    for (core, input, expected) in [
+        // Core `AAAAAA` at 257..262, and the pad's trailing `A` at 263 extends
+        // it, so the run is 257..263 — seven A.
+        ("AAAAAA", "TEMPLATE:g.260del", "TEMPLATE:g.263del"),
+        ("AAAAAA", "TEMPLATE:g.260_261del", "TEMPLATE:g.257_263A[5]"),
+        // Core `CAAAAG`: a four-A run at 258..261.
+        ("CAAAAG", "TEMPLATE:g.260_261insA", "TEMPLATE:g.261dup"),
+        (
+            "CAAAAG",
+            "TEMPLATE:g.260_261insAA",
+            "TEMPLATE:g.258_261A[6]",
+        ),
+    ] {
+        let seq = padded(core);
+        let got = normalize(&seq, input);
+        assert_eq!(
+            &got, expected,
+            "`{input}` over core `{core}` rendered as `{got}`, expected `{expected}`"
+        );
+    }
+}
+
 /// Rendering must not depend on which equivalent spelling was supplied: two
 /// spellings of one single-member variant must render identically.
 #[test]
 fn rendering_does_not_depend_on_the_input_spelling() {
-    for (core, a, b) in [
-        ("CTAGG", "TEMPLATE:g.258_259insT", "TEMPLATE:g.258dup"),
-        ("CAAAAG", "TEMPLATE:g.258del", "TEMPLATE:g.261del"),
+    for (core, a, b, expected) in [
+        (
+            "CTAGG",
+            "TEMPLATE:g.258_259insT",
+            "TEMPLATE:g.258dup",
+            "TEMPLATE:g.258dup",
+        ),
+        (
+            "CAAAAG",
+            "TEMPLATE:g.258del",
+            "TEMPLATE:g.261del",
+            "TEMPLATE:g.261del",
+        ),
         // A tandem-repeat expansion, reached from both spellings: inserting a
         // fourth `CAG` after the tract, versus duplicating the third copy.
         // Both denote `CAGCAGCAGCAGG` and must render alike.
@@ -133,10 +185,20 @@ fn rendering_does_not_depend_on_the_input_spelling() {
             "CAGCAGCAGG",
             "TEMPLATE:g.265_266insCAG",
             "TEMPLATE:g.263_265dup",
+            "TEMPLATE:g.263_265dup",
         ),
     ] {
         let seq = padded(core);
         let (na, nb) = (normalize(&seq, a), normalize(&seq, b));
         assert_eq!(na, nb, "`{a}` -> `{na}` but `{b}` -> `{nb}`");
+        // Agreement alone is not enough: two spellings converging on the same
+        // *wrong* form satisfies it. Rows 1 and 2 are anchored elsewhere (in
+        // `CASES` and in `repeat_notation_describes_the_whole_run`); the third was
+        // anchored nowhere, so its expected answer — stated in this module's own
+        // doc — is pinned here.
+        assert_eq!(
+            na, expected,
+            "both spellings agree, but on `{na}` rather than the pinned `{expected}`"
+        );
     }
 }

--- a/tests/it/render_calibration.rs
+++ b/tests/it/render_calibration.rs
@@ -1,0 +1,142 @@
+//! Rendering rules pinned on single-member inputs.
+//!
+//! Partitioning decides *where* members are; rendering decides how each is
+//! spelled — the 3' rule (`general.md:41`) and prioritisation (`general.md:56`:
+//! substitution > deletion > inversion > duplication > insertion). A change can
+//! partition correctly and still spell wrongly, and nothing else in the suite
+//! tests that axis systematically.
+//!
+//! Single-member only, deliberately: with one member there is no sibling
+//! interaction, so a failure here is unambiguously a rendering fault.
+//!
+//! # What these rows do *not* cover
+//!
+//! Stated explicitly so the file is not read as wider than it is. All five
+//! prioritisation outcomes now have a row: substitution, deletion, inversion,
+//! duplication and insertion each appear as the winning spelling. What is *not*
+//! covered is the full pairwise ladder — each row shows one outcome winning,
+//! not that it beats every lower-ranked alternative in turn.
+//!
+//! **Repeat/STR notation is not exercised, because on this axis ferro does not
+//! emit it.** Measured against these same synthetic references: over core
+//! `CAGCAGCAGG`, a fourth `CAG` copy (whether spelled `g.265_266insCAG` or
+//! `g.263_265dup`) renders as `g.263_265dup`, and dropping a copy
+//! (`g.263_265del`) renders as `g.263_265del` — never `CAG[4]`/`CAG[2]`. That
+//! is consistent with prioritisation (duplication outranks insertion) and is
+//! not asserted here to be right or wrong; it is recorded so that a future
+//! change which starts emitting repeat notation is understood as a deliberate
+//! behavioural change and not a silent regression against untested ground.
+
+use crate::common::cis_apply_oracle::normalize;
+use crate::common::synthetic::padded;
+
+/// `(rule, core, input, expected)`.
+const CASES: &[(&str, &str, &str, &str)] = &[
+    // 3' rule: a deletion inside a homopolymer takes the most 3' position.
+    (
+        "3' rule, deletion in a run",
+        "CAAAAG",
+        "TEMPLATE:g.258del",
+        "TEMPLATE:g.261del",
+    ),
+    // 3' rule: an insertion's junction travels to the tract's 3' end.
+    (
+        "3' rule, insertion in a run",
+        "CAAAAG",
+        "TEMPLATE:g.257_258insA",
+        "TEMPLATE:g.261dup",
+    ),
+    // Prioritisation: an insertion duplicating the preceding base is a dup.
+    (
+        "ins -> dup",
+        "CTAGG",
+        "TEMPLATE:g.258_259insT",
+        "TEMPLATE:g.258dup",
+    ),
+    // Prioritisation: a one-base delins restating a different base is a sub.
+    (
+        "delins -> sub",
+        "CTAGG",
+        "TEMPLATE:g.258delinsG",
+        "TEMPLATE:g.258T>G",
+    ),
+    // A delins whose replacement is the reverse complement is an inversion
+    // (`DNA/inversion.md:5`: "more than one nucleotide replacing the original
+    // sequence is the reverse complement of the original sequence").
+    //
+    // The task brief's original row here used core `CTAGCTAG` with
+    // `g.258_261delinsCTAG`, expecting `g.258_261inv`. That expectation was
+    // wrong on the arithmetic, not on the spec: over this file's padding
+    // (`padded`, `PAD_OFFSET` = 256), position 258 is the core's *second*
+    // base, so `g.258_261` deletes core bases `TAGC`, not `CTAG`.
+    // revcomp(`TAGC`) = `GCTA`, which is not the stated replacement `CTAG` —
+    // so that delins never described an inversion in the first place, and
+    // ferro leaving it spelled as `delins` was the correct call. (`CTAG`
+    // itself is a palindrome — revcomp(`CTAG`) = `CTAG` — so no shift of the
+    // same span could have produced a genuine inversion either; the row
+    // needed a non-self-complementary 4-mer.) Replaced with `CATCGG` /
+    // `delinsCGAT`, where the deleted span `ATCG` and the replacement `CGAT`
+    // really are reverse complements of one another, to exercise the same
+    // rule with a case that is actually an inversion.
+    (
+        "delins -> inv",
+        "CATCGG",
+        "TEMPLATE:g.258_261delinsCGAT",
+        "TEMPLATE:g.258_261inv",
+    ),
+    // Prioritisation: deletion's own slot. Over core `CTAGG` (257..261 =
+    // C,T,A,G,G), `g.258_259` is `TA` and the replacement is `A`, so the net
+    // edit removes one base and must render as a deletion — not as a delins
+    // restating what it kept. Deleting 258 (`T`) yields `CAGG`, which is the
+    // sequence `delinsA` denotes.
+    (
+        "delins -> del",
+        "CTAGG",
+        "TEMPLATE:g.258_259delinsA",
+        "TEMPLATE:g.258del",
+    ),
+    // Prioritisation: insertion's own slot — the lowest rank, so it is what
+    // survives when nothing higher applies. `CC` neither duplicates the
+    // flanking bases nor inverts them, so it must stay spelled as an
+    // insertion rather than being re-spelled as a dup.
+    (
+        "ins stays ins",
+        "CTAGG",
+        "TEMPLATE:g.258_259insCC",
+        "TEMPLATE:g.258_259insCC",
+    ),
+];
+
+#[test]
+fn rendering_rules_are_pinned() {
+    for (rule, core, input, expected) in CASES {
+        let seq = padded(core);
+        let got = normalize(&seq, input);
+        assert_eq!(
+            &got, expected,
+            "{rule}: `{input}` over core `{core}` rendered as `{got}`, expected `{expected}`"
+        );
+    }
+}
+
+/// Rendering must not depend on which equivalent spelling was supplied: two
+/// spellings of one single-member variant must render identically.
+#[test]
+fn rendering_does_not_depend_on_the_input_spelling() {
+    for (core, a, b) in [
+        ("CTAGG", "TEMPLATE:g.258_259insT", "TEMPLATE:g.258dup"),
+        ("CAAAAG", "TEMPLATE:g.258del", "TEMPLATE:g.261del"),
+        // A tandem-repeat expansion, reached from both spellings: inserting a
+        // fourth `CAG` after the tract, versus duplicating the third copy.
+        // Both denote `CAGCAGCAGCAGG` and must render alike.
+        (
+            "CAGCAGCAGG",
+            "TEMPLATE:g.265_266insCAG",
+            "TEMPLATE:g.263_265dup",
+        ),
+    ] {
+        let seq = padded(core);
+        let (na, nb) = (normalize(&seq, a), normalize(&seq, b));
+        assert_eq!(na, nb, "`{a}` -> `{na}` but `{b}` -> `{nb}`");
+    }
+}

--- a/tests/it/rewrite_target_corpus.rs
+++ b/tests/it/rewrite_target_corpus.rs
@@ -18,8 +18,9 @@
 //! Three forms:
 //!
 //! - *Confluence* (#1260, #1262): two spellings of one variant must reach the same
-//!   normalized string. They don't, today. `the_two_confluence_targets_still_diverge`
-//!   asserts they still don't. `every_confluence_target_denotes_one_variant` is **not**
+//!   normalized string. #1260 now does; #1262 does not.
+//!   `the_confluence_targets_converge_only_for_1260` pins both facts.
+//!   `every_confluence_target_denotes_one_variant` is **not**
 //!   itself a pinned failure — it is a sanity guard on this file's own rows (both
 //!   spellings really are the same variant, checked by `cis_apply_oracle::apply`,
 //!   independent of the normalizer under test) and it keeps passing after the rewrite
@@ -31,8 +32,11 @@
 //!   sequence at all (#1325) because its members now overlap and the independent applier
 //!   declines to splice them.
 //! - *Boundary-validity* (#1274): normalizing must not name a position past the contig's
-//!   end. It does, today. `a_cancelling_edit_at_the_contig_end_still_emits_an_out_of_bounds_span`
-//!   asserts the normalized output's highest position number exceeds the contig length.
+//!   end. **Fixed** — by #1327's terminal re-spelling, which lands the repair's junction
+//!   inside the sequence instead of one past it. Flipped from a pinned failure to a
+//!   positive pin, `a_cancelling_edit_at_the_contig_end_stays_inside_the_contig`, per this
+//!   file's own contract: when the assertion goes red, the case moves out of the target
+//!   list rather than being silenced.
 //!
 //! Apart from the guard noted above, every test here is a **pinned failure**, not a
 //! `#[ignore]`d one: it currently passes *because* it asserts the defect reproduces. The
@@ -237,16 +241,29 @@ fn every_confluence_target_denotes_one_variant() {
     }
 }
 
-/// #1260 and #1262: pinned as *currently diverging*. Fixing either fails this test loudly.
+/// #1260 has **converged**; #1262 has not.
+///
+/// #1260's row is now a positive pin: both spellings reach the split form named by
+/// PR #1285, which the two-gap alignment made expressible. #1262's row stays pinned as
+/// diverging, and fixing it fails this test loudly — that is still the point of the
+/// corpus.
 #[test]
-fn the_two_confluence_targets_still_diverge() {
+fn the_confluence_targets_converge_only_for_1260() {
     for (issue, core, a, b) in CONFLUENCE_TARGETS {
         let seq = padded(core);
         let (norm_a, norm_b) = (normalize(&seq, a), normalize(&seq, b));
+        if *issue == "#1260" {
+            assert_eq!(norm_a, norm_b, "{issue}: `{a}` and `{b}` must converge");
+            assert_eq!(
+                norm_a, "TEMPLATE:g.[258_259insC;259_260insC]",
+                "{issue}: and they converge on the split form, not the spanning delins"
+            );
+            continue;
+        }
         assert_ne!(
             norm_a, norm_b,
             "{issue} appears fixed — `{a}` and `{b}` now both normalize to `{norm_a}`. \
-             Move this case out of the PARTITION target list and delete this test."
+             Move this case out of the PARTITION target list and give it a positive pin."
         );
     }
 }
@@ -318,27 +335,40 @@ fn max_hgvs_position(output: &str) -> u64 {
         .unwrap_or(0)
 }
 
-/// #1274: an insertion and a deletion that cancel exactly at a contig's last base still
-/// normalize to a coordinate one past the end of the contig (`g.10_11=` on a 10-base
-/// contig), because a repair pass derives a span for the (correctly empty) residue
-/// independently of the contig's actual length. Sequence-first cancellation would apply
-/// the allele, get back the reference unchanged, align with zero changed columns, and have
-/// no block left to render a span for at all — so this is read as PARTITION,
-/// likely-fixed-incidentally, not a coordinate-layer bug the rewrite has no reason to touch.
+/// #1274, **fixed**: an insertion and a deletion that cancel exactly at a contig's last
+/// base used to normalize to a coordinate one past the end (`g.10_11=` on a 10-base
+/// contig), because a repair pass derived a span for the (correctly empty) residue
+/// independently of the contig's actual length.
 ///
-/// The independent applier does not catch this one the way it catches #1325: an `=` edit's
-/// SPDI triple does not exercise the same out-of-bounds check a deletion's does, so
-/// `apply()` happily returns the (correct) reference back. The defect is purely that the
-/// stated span names a position the contig does not have, so that is what's asserted.
+/// #1327's terminal re-spelling closed it — the repair's landing junction is now expressed
+/// through the boundary identity at the last base rather than at the junction past it — and
+/// this file's contract says a case that goes green moves out of the target list. So the
+/// assertion is inverted rather than deleted: the boundary-validity property is worth a
+/// standing guard, and inverting keeps the reproducer that found the defect attached to it.
+///
+/// Two things are asserted, because the position bound alone is weak. The independent
+/// applier never caught this one the way it catches #1325 — an `=` edit's SPDI triple does
+/// not exercise the out-of-bounds check a deletion's does, so `apply()` happily returned the
+/// (correct) reference — which is exactly why "stays in range" needs pairing with "still
+/// denotes the reference", or a fix that clamped the span while corrupting the sequence
+/// would pass.
 #[test]
-fn a_cancelling_edit_at_the_contig_end_still_emits_an_out_of_bounds_span() {
+fn a_cancelling_edit_at_the_contig_end_stays_inside_the_contig() {
     let seq = "ACGTACGTAA";
-    let actual = normalize(seq, "TEMPLATE:g.[8_9insA;10del]");
+    let input = "TEMPLATE:g.[8_9insA;10del]";
+    let actual = normalize(seq, input);
     let max_pos = max_hgvs_position(&actual);
     assert!(
-        max_pos > seq.len() as u64,
-        "#1274 appears fixed — `{actual}` no longer names a position past the {}-base \
-         contig. Move this case out of the PARTITION target list and delete this test.",
+        max_pos <= seq.len() as u64,
+        "`{input}` -> `{actual}` names position {max_pos}, past the {}-base contig (#1274)",
         seq.len()
+    );
+    // The pair cancels exactly, so the allele denotes the reference unchanged. Asserted
+    // through the independent applier, not by re-normalizing.
+    let want = apply(&padded(seq), input).expect("input applies");
+    let got = apply(&padded(seq), &actual).expect("output applies");
+    assert_eq!(
+        got, want,
+        "`{input}` -> `{actual}` changed the denoted sequence"
     );
 }

--- a/tests/it/rewrite_target_corpus.rs
+++ b/tests/it/rewrite_target_corpus.rs
@@ -1,0 +1,193 @@
+//! Acceptance corpus for the cis-allele normalizer's sequence-first rewrite (v1, genomic
+//! axis).
+//!
+//! The rewrite (#1235) replaces "normalize each member independently, then repair the
+//! damage with seven passes" with "apply the allele, align the result to the reference,
+//! partition at the alignment's dominators, render." This module pins the open defects
+//! that rewrite is meant to fix, and states in one place which open defects it is **not**
+//! meant to fix.
+//!
+//! ## PARTITION targets asserted here
+//!
+//! Every assertion below is sequence-level — never a hardcoded "correct" output string,
+//! since these are open defects and nobody has stated what the fixed rendering should be.
+//! Two forms:
+//!
+//! - *Confluence* (#1260, #1262): two spellings of one variant must reach the same
+//!   normalized string. They don't, today. `the_two_confluence_targets_still_diverge`
+//!   asserts they still don't; `every_confluence_target_denotes_one_variant` guards that
+//!   both spellings really are the same variant, checked by `cis_apply_oracle::apply`,
+//!   independent of the normalizer under test.
+//! - *Denotation* (#1267, #1325): normalizing must not change what the description
+//!   denotes. It does, today. `assert_denotation_currently_broken` asserts the normalized
+//!   output either denotes a different sequence than the input (#1267), or denotes no
+//!   sequence at all (#1325) because its members now overlap and the independent applier
+//!   declines to splice them.
+//!
+//! Every test here is a **pinned failure**, not a `#[ignore]`d one: it currently passes
+//! *because* it asserts the defect reproduces. The moment the rewrite fixes a case, the
+//! assertion flips and the test goes red — that's the signal to delete it (or move it to
+//! a "fixed" note), never something to silence.
+//!
+//! ## PARTITION issues not asserted
+//!
+//! - **#1235** — the tracking/design issue for the whole rewrite. It supplies no
+//!   reproducer of its own (a table of one-line sketches, not full HGVS strings); its
+//!   acceptance criteria (confluence, no overlapping/out-of-order members, idempotence)
+//!   are exactly what `cis_allele_confluence_proptest.rs` and
+//!   `issue_1235_cis_allele_confluence.rs` already exercise. Nothing new to assert here.
+//! - **#1271** — the issue's own worked example (the HGVS spec's `LRG_199` delins) is
+//!   **not a live defect** on this branch: the regression that used to split it four ways
+//!   was already fixed (a regime-aware `MAX_UNGUARDED_SPLIT_BLOCK`, per the issue's own
+//!   account). What #1271 tracks is a *principled* follow-up (extending
+//!   `separations_are_meaningful` to net deletions) with no constructed failing case yet.
+//!   Its illustrative example is also stated as a coding-axis (`c.`) description, and the
+//!   split spelling's coordinates are relative/illustrative rather than full genomic
+//!   positions — there is no sequence content to build a synthetic genomic reproducer from
+//!   without inventing it. Excluded rather than forced into a frame it doesn't fit.
+//!
+//! ## BOUNDARY — explicitly not this rewrite's targets
+//!
+//! These four are contig-bounds, arithmetic-underflow, or circular-wraparound bugs, not
+//! member-partitioning bugs; the rewrite's apply/align/partition/render pipeline has no
+//! reason to touch any of them. Documented here so the exclusion is a decision, not an
+//! oversight. None of the four are asserted below.
+//!
+//! - **#1274** — a cis insertion+deletion that cancels at a contig's last base emits a
+//!   coordinate one past the end (`g.10_11=` on a 10-base contig). The sequence itself is
+//!   right; only the stated span is out of bounds. A clamp/validation fix, not a
+//!   partition fix.
+//! - **#1282** — 5'-shifting a member to position 1 underflows `hgvs_pos_to_index`'s
+//!   `(pos - 1)` and panics in debug builds (silently wraps to a garbage index in
+//!   release). An input-validation/guard fix at the coordinate layer, not a partition fix.
+//! - **#1307** — respelling a duplication that ends at a contig's last base as an
+//!   insertion places it at a gap that does not exist (`24_25insC` on a 24-base contig). A
+//!   bounds check on `respell_at_gap`, not a partition fix.
+//! - **#1327** — the same `respell_at_gap` gap-placement defect as #1307, but on the
+//!   mitochondrial/circular (`m.`) axis: a junction at the contig's last base should wrap
+//!   to `16569_1` instead of running off the end. No concrete reproducer exists (a
+//!   code-level report only); circular wraparound is also out of a genomic-only v1's scope
+//!   regardless of reproducibility.
+//!
+//! ## OTHER
+//!
+//! - **#1270** — an unconfirmed coding-axis (`c.`) codon-frame-gate asymmetry between the
+//!   deletion-to-repeat and insertion-to-repeat paths. The issue's own author states no
+//!   case has been constructed that reaches it ("an asymmetry with a plausible consequence
+//!   rather than a demonstrated defect"). Not genomic, not reproduced, nothing to assert.
+//!
+//! ## An unexpected pass, found while building this corpus
+//!
+//! #1267's issue body gives three lines over reference `ACAAAAAAAACGTACGTACG`. Only the
+//! insertion form asserted below (`g.[4A>G;9_10insA]` -> `g.4_5insG`) still reproduces on
+//! this branch. The two duplication-form lines the issue also lists —
+//! `g.[4A>G;9dup]` -> `g.[4A>G;5dup]` and `g.[5A>G;10dup]` -> `g.[5A>G;6dup]` — were
+//! independently checked here (via this module's own applier) and already normalize
+//! correctly, preserving the denoted sequence; `blocks_sibling_shift` fixed them, and
+//! `cis_junction_crossing_shift.rs`'s `a_five_prime_duplication_does_not_cross_an_upstream_sibling`
+//! already pins them as passing. They are not asserted here as failures — reported here so
+//! the unexpected pass isn't silently dropped, per the corpus's own rules.
+
+use crate::common::cis_apply_oracle::{apply, normalize, normalize_in};
+use crate::common::synthetic::padded;
+use ferro_hgvs::ShuffleDirection;
+
+/// `(issue, core, split spelling, spanning/merged spelling)` — the two spellings that
+/// currently reach two different fixed points instead of one.
+const CONFLUENCE_TARGETS: &[(&str, &str, &str, &str)] = &[
+    (
+        "#1260",
+        "AAAAAA",
+        "TEMPLATE:g.[258_259insC;259_260insC]",
+        "TEMPLATE:g.258_260delinsACACA",
+    ),
+    (
+        "#1262",
+        "AAAAAA",
+        "TEMPLATE:g.[258A>C;260del]",
+        "TEMPLATE:g.258_260delinsCA",
+    ),
+];
+
+/// Both spellings in every row must denote the same sequence, or the row is a broken pin
+/// rather than evidence about the normalizer (this has happened before in this campaign).
+#[test]
+fn every_confluence_target_denotes_one_variant() {
+    for (issue, core, a, b) in CONFLUENCE_TARGETS {
+        let seq = padded(core);
+        let from_a = apply(&seq, a).unwrap_or_else(|| panic!("{issue}: `{a}` does not apply"));
+        let from_b = apply(&seq, b).unwrap_or_else(|| panic!("{issue}: `{b}` does not apply"));
+        assert_eq!(
+            from_a, from_b,
+            "{issue}: `{a}` and `{b}` are not the same variant"
+        );
+    }
+}
+
+/// #1260 and #1262: pinned as *currently diverging*. Fixing either fails this test loudly.
+#[test]
+fn the_two_confluence_targets_still_diverge() {
+    for (issue, core, a, b) in CONFLUENCE_TARGETS {
+        let seq = padded(core);
+        let (norm_a, norm_b) = (normalize(&seq, a), normalize(&seq, b));
+        assert_ne!(
+            norm_a, norm_b,
+            "{issue} appears fixed — `{a}` and `{b}` now both normalize to `{norm_a}`. \
+             Move this case out of the PARTITION target list and delete this test."
+        );
+    }
+}
+
+/// Assert that normalizing `input` in `direction` currently changes what it denotes: the
+/// output either splices to a different sequence than the input, or (when its members now
+/// overlap) does not splice to a well-defined sequence at all. Flips to a failing
+/// assertion, on purpose, the moment the rewrite fixes the case — that is the point of
+/// this corpus.
+fn assert_denotation_currently_broken(
+    seq: &str,
+    input: &str,
+    direction: ShuffleDirection,
+    issue: &str,
+) {
+    let actual = normalize_in(seq, input, direction);
+    let from_input = apply(seq, input)
+        .unwrap_or_else(|| panic!("{issue}: `{input}` has no well-defined resulting sequence"));
+    let from_output = apply(seq, &actual);
+    assert_ne!(
+        from_output,
+        Some(from_input),
+        "{issue} appears fixed — `{input}` now normalizes to `{actual}` (under {direction:?} \
+         shuffle), which denotes the same sequence as the input. Move this case out of the \
+         PARTITION target list and delete this test."
+    );
+}
+
+/// #1267: a 5'-shifting insertion's junction crosses an upstream sibling substitution,
+/// moving the base the sibling edited — well-formed, disjoint, warning-free, and wrong.
+#[test]
+fn a_five_prime_insertion_junction_still_crosses_an_upstream_sibling() {
+    let seq = "ACAAAAAAAACGTACGTACG";
+    assert_denotation_currently_broken(
+        seq,
+        "TEMPLATE:g.[4A>G;9_10insA]",
+        ShuffleDirection::FivePrime,
+        "#1267",
+    );
+}
+
+/// #1325: two insertions collapse into a repeat correctly, but adding a third pushes a
+/// junction inside the tract; the tract grew by more bases than it can express as a
+/// duplication, so the demotion pass declines and the repeat is left spanning (swallowing)
+/// the sibling's junction. The independent applier refuses to splice the resulting
+/// members at all, since they overlap — there is no single well-defined resulting sequence
+/// for them, which is itself the defect this pins (#1235's criterion 2).
+#[test]
+fn a_repeat_growth_exceeding_its_tract_still_swallows_a_sibling_junction() {
+    let seq = padded("GATCATAAATTCAGC");
+    assert_denotation_currently_broken(
+        &seq,
+        "TEMPLATE:g.[262_263insAA;263_264insAA;264_265insC]",
+        ShuffleDirection::ThreePrime,
+        "#1325",
+    );
+}

--- a/tests/it/rewrite_target_corpus.rs
+++ b/tests/it/rewrite_target_corpus.rs
@@ -4,38 +4,80 @@
 //! The rewrite (#1235) replaces "normalize each member independently, then repair the
 //! damage with seven passes" with "apply the allele, align the result to the reference,
 //! partition at the alignment's dominators, render." This module pins the open defects
-//! that rewrite is meant to fix, and states in one place which open defects it is **not**
-//! meant to fix.
+//! that rewrite is meant to fix, and tries to say honestly what it does and does not cover.
+//! An earlier draft of this file claimed to be the one place every open defect the rewrite
+//! is not meant to fix was recorded; an independent audit found six in-class defects it had
+//! simply omitted, one BOUNDARY exclusion it had misclassified, and two more BOUNDARY
+//! exclusions whose stated *reason* was wrong even though the exclusion itself was right.
+//! Corrected below; this paragraph is left in as the record of that.
 //!
 //! ## PARTITION targets asserted here
 //!
 //! Every assertion below is sequence-level — never a hardcoded "correct" output string,
 //! since these are open defects and nobody has stated what the fixed rendering should be.
-//! Two forms:
+//! Three forms:
 //!
 //! - *Confluence* (#1260, #1262): two spellings of one variant must reach the same
 //!   normalized string. They don't, today. `the_two_confluence_targets_still_diverge`
-//!   asserts they still don't; `every_confluence_target_denotes_one_variant` guards that
-//!   both spellings really are the same variant, checked by `cis_apply_oracle::apply`,
-//!   independent of the normalizer under test.
+//!   asserts they still don't. `every_confluence_target_denotes_one_variant` is **not**
+//!   itself a pinned failure — it is a sanity guard on this file's own rows (both
+//!   spellings really are the same variant, checked by `cis_apply_oracle::apply`,
+//!   independent of the normalizer under test) and it keeps passing after the rewrite
+//!   lands; a malformed pin here would prove nothing about the normalizer, which is why the
+//!   guard exists at all.
 //! - *Denotation* (#1267, #1325): normalizing must not change what the description
 //!   denotes. It does, today. `assert_denotation_currently_broken` asserts the normalized
 //!   output either denotes a different sequence than the input (#1267), or denotes no
 //!   sequence at all (#1325) because its members now overlap and the independent applier
 //!   declines to splice them.
+//! - *Boundary-validity* (#1274): normalizing must not name a position past the contig's
+//!   end. It does, today. `a_cancelling_edit_at_the_contig_end_still_emits_an_out_of_bounds_span`
+//!   asserts the normalized output's highest position number exceeds the contig length.
 //!
-//! Every test here is a **pinned failure**, not a `#[ignore]`d one: it currently passes
-//! *because* it asserts the defect reproduces. The moment the rewrite fixes a case, the
-//! assertion flips and the test goes red — that's the signal to delete it (or move it to
-//! a "fixed" note), never something to silence.
+//! Apart from the guard noted above, every test here is a **pinned failure**, not a
+//! `#[ignore]`d one: it currently passes *because* it asserts the defect reproduces. The
+//! moment the rewrite fixes a case, the assertion flips and the test goes red — that's the
+//! signal to delete it (or move it to a "fixed" note), never something to silence.
+//!
+//! ## The other half of the acceptance evidence
+//!
+//! `tests/it/cis_spelling_confluence_gap.rs` pins eight *other* currently-diverging spelling
+//! pairs (#1287, #1290, #1296, #1301, #1304, #1308, #1312, #1320) on the same
+//! `cis_apply_oracle` + `padded()` machinery and the same assert-then-flip-red contract as
+//! this file, plus five pairs that have already converged. Those eight are also things the
+//! sequence-first rewrite must converge, and will also go red when it lands. Read the two
+//! files together — this one is not the sole record of confluence targets, only of the
+//! ones harvested separately from #1235's descendant chain.
+//!
+//! ## #1235 itself: what's actually running
+//!
+//! #1235 is the tracking/design issue for the whole rewrite and supplies no reproducer of
+//! its own (a table of one-line sketches, not full HGVS strings). Its three acceptance
+//! criteria are confluence, no overlapping/out-of-order members, and idempotence. An
+//! earlier draft of this doc said these are "exactly what `cis_allele_confluence_proptest.rs`
+//! ... already exercise" — true only for half of it:
+//!
+//! - The **substitution model** (`Haplotype`/`haplotype_strategy`) backs three properties
+//!   that run on every test invocation: `all_encodings_of_one_haplotype_converge`,
+//!   `the_converged_form_is_a_fixed_point`, and `members_are_disjoint_and_ascending`. These
+//!   genuinely exercise confluence, idempotence, and ordering — for substitution-only,
+//!   length-preserving haplotypes.
+//! - The **indel model** (`IndelHaplotype`/`indel_haplotype_strategy`) is what reaches
+//!   insertions, deletions, and the shifting machinery — and its confluence/no-overlap
+//!   property, `an_indel_haplotype_normalizes_to_its_own_sequence`, is `#[ignore]`d and its
+//!   own doc comment says plainly: "this currently fails, and the failure is real." It is
+//!   the property that found the entire #1286 -> #1287 -> #1290 -> #1292 -> #1296 -> #1301
+//!   -> #1304 -> #1297 -> #1308 -> #1312 -> #1316 -> #1320 -> #1321 -> #1323 -> #1325 chain
+//!   (sixteen defects). It does not run by default; enabling it is `cargo test --features
+//!   dev -- --ignored an_indel_haplotype`.
+//!
+//! So criterion 2 (no overlapping/out-of-order members) for indel haplotypes is currently
+//! enforced by no test that runs in CI. #1325 below is the live failure that property last
+//! found; there is nothing further to assert for #1235 itself beyond that, but "already
+//! exercised" overstated what's actually wired in.
 //!
 //! ## PARTITION issues not asserted
 //!
-//! - **#1235** — the tracking/design issue for the whole rewrite. It supplies no
-//!   reproducer of its own (a table of one-line sketches, not full HGVS strings); its
-//!   acceptance criteria (confluence, no overlapping/out-of-order members, idempotence)
-//!   are exactly what `cis_allele_confluence_proptest.rs` and
-//!   `issue_1235_cis_allele_confluence.rs` already exercise. Nothing new to assert here.
 //! - **#1271** — the issue's own worked example (the HGVS spec's `LRG_199` delins) is
 //!   **not a live defect** on this branch: the regression that used to split it four ways
 //!   was already fixed (a regime-aware `MAX_UNGUARDED_SPLIT_BLOCK`, per the issue's own
@@ -45,29 +87,97 @@
 //!   split spelling's coordinates are relative/illustrative rather than full genomic
 //!   positions — there is no sequence content to build a synthetic genomic reproducer from
 //!   without inventing it. Excluded rather than forced into a frame it doesn't fit.
+//! - **#1284** — three cis repair passes (`respell_colliding_duplications`,
+//!   `coalesce_members_at_one_junction`, and the junction arm of
+//!   `demote_repeats_spanning_siblings`) are gated `CisKind::Genome | Mt`, so a `c.`/`n.`/
+//!   `r.` cis allele that needs one of them emits a description ferro's own parser rejects
+//!   — and with `FERRO_ASSERT_REPARSE` armed, that panics and aborts the run instead of
+//!   failing with a diff. Out of a genomic-only v1's *axis* scope, so not asserted here —
+//!   recorded, not silently dropped, because a v1 rewrite that only wires up `g.` leaves
+//!   this exact hole open on the other axes.
+//! - **#1328** — `junction_rank` (`src/hgvs/variant.rs`) has no `HgvsVariant::Protein` arm
+//!   (falls through its `match` to `_ => None`), so protein cis members sharing a span tie
+//!   and fall back to an alphabetical tie-break that renders `dup` before `ins` — reversing
+//!   apply order. Same shape as the closed #1301, on the protein axis. Out of a
+//!   genomic-only v1's scope, recorded rather than omitted.
 //!
-//! ## BOUNDARY — explicitly not this rewrite's targets
+//! ## Coverage gaps in the acceptance evidence itself (not defects in the normalizer)
 //!
-//! These four are contig-bounds, arithmetic-underflow, or circular-wraparound bugs, not
-//! member-partitioning bugs; the rewrite's apply/align/partition/render pipeline has no
-//! reason to touch any of them. Documented here so the exclusion is a decision, not an
-//! oversight. None of the four are asserted below.
+//! - **#1268** — no committed sweep generates a **three**-member cis allele; both committed
+//!   sweeps (`cis_junction_crossing_shift.rs`'s
+//!   `no_two_member_allele_normalizes_to_a_different_sequence` and
+//!   `repeat_span_sibling_overlap.rs`'s
+//!   `no_two_member_allele_normalizes_to_overlapping_members`) are explicitly two-member.
+//!   Every recent defect in the #1286 chain, #1325 included, is three-member. This is a gap
+//!   in the corpus's own evidence, flagged prominently rather than quietly worked around:
+//!   nothing here asserts three-member coverage either, so the gap remains open after this
+//!   file lands.
+//! - **#1283** — the ~276k-case sibling-crossing sweep is read as covering sibling-crossing
+//!   shifts broadly, but cannot reach five named shapes it does not generate (a second
+//!   member that is `dup`/`ins` rather than a plain edit, more than two members, siblings
+//!   in *trans* rather than in phase, seeds shorter than 20bp, and non-`g.` axes). Same
+//!   status as #1268: a gap in the acceptance evidence, not asserted or closed here.
 //!
-//! - **#1274** — a cis insertion+deletion that cancels at a contig's last base emits a
-//!   coordinate one past the end (`g.10_11=` on a 10-base contig). The sequence itself is
-//!   right; only the stated span is out of bounds. A clamp/validation fix, not a
-//!   partition fix.
+//! `cis_allele_confluence_proptest.rs`'s own module doc already names both gaps ("#1268/
+//! #1283's complaint about coverage that reads wider than it is") — this section is not the
+//! first place they're written down, but they were missing from this corpus specifically.
+//!
+//! ## Marginal / render-path — recorded, not asserted
+//!
+//! - **#1318** — `canonicalize_delins` (`src/normalize/rules.rs`) does case-sensitive byte
+//!   comparisons on the delins-to-inversion typing path. A soft-masked (lowercase)
+//!   reference can therefore stop a genuine reverse complement from being typed `inv`, so
+//!   two spellings of what should be one variant diverge by case alone. Single-member, so
+//!   not a cis-allele partitioning defect strictly, but it is confluence-shaped and lives in
+//!   the *render* step v1's rewrite inherits unchanged rather than replaces — worth carrying
+//!   here rather than dropping for being adjacent to the class instead of squarely in it.
+//! - **#1264** — the parser accepts an `ins` whose two anchors are not adjacent positions,
+//!   but normalizing or re-rendering the same variant is rejected outbound — an inbound/
+//!   outbound asymmetry. Currently recorded only as an oracle-exemption comment in
+//!   `normalize_reparse_invariant.rs` (why that file's re-parse oracle passes over it), with
+//!   no assertion anywhere that the asymmetry itself holds or has closed. Noted here so it
+//!   isn't invisible to a reader of this corpus; not asserted, since fixing it is a parser
+//!   grammar question orthogonal to member-partitioning.
+//!
+//! ## BOUNDARY — excluded on axis/coordinate-layer grounds, not because the rewrite can't
+//! ## incidentally affect them
+//!
+//! None of the three below are asserted here. But two of the three reproducers currently
+//! reach the pipeline **through a repair pass the rewrite deletes** — so "the rewrite has no
+//! reason to touch this" is the wrong justification for excluding them, even though excluding
+//! them from this corpus's *asserted* set is still the right call (no genuine partition
+//! defect is being deferred; see each entry).
+//!
 //! - **#1282** — 5'-shifting a member to position 1 underflows `hgvs_pos_to_index`'s
-//!   `(pos - 1)` and panics in debug builds (silently wraps to a garbage index in
-//!   release). An input-validation/guard fix at the coordinate layer, not a partition fix.
-//! - **#1307** — respelling a duplication that ends at a contig's last base as an
-//!   insertion places it at a gap that does not exist (`24_25insC` on a 24-base contig). A
-//!   bounds check on `respell_at_gap`, not a partition fix.
-//! - **#1327** — the same `respell_at_gap` gap-placement defect as #1307, but on the
-//!   mitochondrial/circular (`m.`) axis: a junction at the contig's last base should wrap
-//!   to `16569_1` instead of running off the end. No concrete reproducer exists (a
-//!   code-level report only); circular wraparound is also out of a genomic-only v1's scope
-//!   regardless of reproducibility.
+//!   `(pos - 1) as usize` at the coordinate layer and panics in debug builds (silently wraps
+//!   to a garbage index in release). This is a real coordinate-layer bug independent of any
+//!   repair pass, and excluding it from the partition-defect set is correct. **Caveat:** its
+//!   reproducer (`g.[3_4insT;1T>A]`) is two members the rewrite will very plausibly merge
+//!   into one block before the 5'-shift ever reaches position 1 alone — so the panic may
+//!   simply stop reproducing once the rewrite lands, with the underflow itself untouched.
+//!   That would be **masking**, not fixing: a third outcome distinct from "fixed" and
+//!   "still broken" that this corpus does not have machinery to tell apart from a real fix,
+//!   because nothing here re-tests `hgvs_pos_to_index` directly. The underflow needs its own
+//!   test against the coordinate function, independent of this reproducer, so a masked
+//!   #1282 cannot be mistaken for a closed one.
+//! - **#1307** — respelling a duplication that ends at a contig's last base as an insertion
+//!   places it at a gap that does not exist (`24_25insC` on a 24-base contig). The out-of-
+//!   bounds gap is produced by `respell_colliding_duplications` -> `respell_at_gap` — a
+//!   repair pass that exists only to fix a collision independent per-member normalization
+//!   manufactures. Under sequence-first, `24dup` and `24C>G` both touch position 24 and land
+//!   in one changed block, so no collision is manufactured and `respell_at_gap` is never
+//!   called: the rewrite plausibly retires this reproducer **incidentally**, not because
+//!   anyone decided it was in scope. Not asserted here regardless, since there is no
+//!   partition defect being deferred — the repair-pass bug and the rewrite's likely
+//!   side-effect on it are both worth knowing, which is why they're written down instead of
+//!   just "BOUNDARY, out of scope."
+//! - **#1327** — the same `respell_at_gap` gap-placement defect as #1307, reached through
+//!   the same two repair-pass callers (`respell_colliding_duplications` and
+//!   `coalesce_members_at_one_junction`), but on the mitochondrial/circular (`m.`) axis: a
+//!   junction at the contig's last base should wrap to `16569_1` instead of running off the
+//!   end. Excluded on **axis scope alone** — circular wraparound is out of a genomic-only
+//!   v1's scope regardless of which pass produces the bug or whether the rewrite happens to
+//!   retire it too. No concrete reproducer exists in the issue (a code-level report only).
 //!
 //! ## OTHER
 //!
@@ -111,6 +221,9 @@ const CONFLUENCE_TARGETS: &[(&str, &str, &str, &str)] = &[
 
 /// Both spellings in every row must denote the same sequence, or the row is a broken pin
 /// rather than evidence about the normalizer (this has happened before in this campaign).
+///
+/// This is a sanity guard on this file's own rows, not a pinned failure: it passes because
+/// the rows are well-formed, and it keeps passing after the rewrite lands.
 #[test]
 fn every_confluence_target_denotes_one_variant() {
     for (issue, core, a, b) in CONFLUENCE_TARGETS {
@@ -189,5 +302,43 @@ fn a_repeat_growth_exceeding_its_tract_still_swallows_a_sibling_junction() {
         "TEMPLATE:g.[262_263insAA;263_264insAA;264_265insC]",
         ShuffleDirection::ThreePrime,
         "#1325",
+    );
+}
+
+/// The highest 1-based HGVS position named anywhere in `output`'s coordinate part (the
+/// substring after the accession's `:`). Used only to check a position against a contig
+/// length, not to parse HGVS in general — `TEMPLATE` (this module's only accession) has no
+/// digits, so every digit run found belongs to a position, not to the accession.
+fn max_hgvs_position(output: &str) -> u64 {
+    let coord_part = output.rsplit(':').next().unwrap_or(output);
+    coord_part
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|token| token.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+}
+
+/// #1274: an insertion and a deletion that cancel exactly at a contig's last base still
+/// normalize to a coordinate one past the end of the contig (`g.10_11=` on a 10-base
+/// contig), because a repair pass derives a span for the (correctly empty) residue
+/// independently of the contig's actual length. Sequence-first cancellation would apply
+/// the allele, get back the reference unchanged, align with zero changed columns, and have
+/// no block left to render a span for at all — so this is read as PARTITION,
+/// likely-fixed-incidentally, not a coordinate-layer bug the rewrite has no reason to touch.
+///
+/// The independent applier does not catch this one the way it catches #1325: an `=` edit's
+/// SPDI triple does not exercise the same out-of-bounds check a deletion's does, so
+/// `apply()` happily returns the (correct) reference back. The defect is purely that the
+/// stated span names a position the contig does not have, so that is what's asserted.
+#[test]
+fn a_cancelling_edit_at_the_contig_end_still_emits_an_out_of_bounds_span() {
+    let seq = "ACGTACGTAA";
+    let actual = normalize(seq, "TEMPLATE:g.[8_9insA;10del]");
+    let max_pos = max_hgvs_position(&actual);
+    assert!(
+        max_pos > seq.len() as u64,
+        "#1274 appears fixed — `{actual}` no longer names a position past the {}-base \
+         contig. Move this case out of the PARTITION target list and delete this test.",
+        seq.len()
     );
 }


### PR DESCRIPTION
Groundwork for #1235's cis-allele canonical form: a sequence-first block splitter, the reproducer corpus that scores it, and the alignment work that #1260 needed. Everything here is measured; what was tried and did not survive measurement is recorded below rather than dropped, because several of them look clean enough to be re-proposed.

**This does not close #1262, and it does not enable the confluence property.** Both were attempted, both worked on the local suite, and both were reverted after the manifest-backed conformance axis caught a regression against Mutalyzer. What the axis then showed about *why* is the most important thing here — see *What was reverted* below.

## What lands

- **`AlignmentDag` and the dominator partition** (`src/normalize/seqfirst/`) — the DAG of every minimal alignment, the edges common to all of them, and a partition derived from those. Members come out disjoint by construction rather than being repaired afterwards. Verified against a brute-force oracle over an exhaustive sweep.
- **The two-gap insertion alignment** — a single gap structurally cannot express *insertion, retained reference, insertion*, which is #1260's shape. This adds it, and then generalises the search off the caller's trim so the retained chunk need not be the whole reference.
- **`partition_block`'s separation threshold and type guard** — a length-changing block splits at one unchanged base (`delins.md:17`), unless every resulting member would render at `delins` rank, in which case the spanning form stands. **#1260 is fixed**: both spellings converge on `g.[258_259insC;259_260insC]`.
- **The reproducer corpus** (`src/normalize/merge/splitter_reproducer_corpus.rs`) — 65 harvested blocks as executable rows, plus a collision census. This is the instrument every splitter change in this area should be scored against; four collisions that were open when it was written are now resolved at the splitter.
- **The `FERRO_SEQFIRST_SHADOW` audit** — runs both splitters and reports disagreements, so the migration can be measured before it decides anything.

## What was reverted, and why it matters

The full six-step build was implemented and green on the local suite (9094/9094). It then failed the conformance axis, which the local suite does not run:

```
NG_012337.1:g.[7109T>A;7110del]
  mutalyzer expects  NG_012337.1:g.7109_7110delinsA
  produced           NG_012337.1:g.[7109T>A;7111del]
```

Baseline is 183/183 green — re-verified by re-running the axis with `src/` and `tests/` checked out at the pre-change commit — so this was a regression introduced by the work, not a stale ledger. Bisected per commit, the cause is **giving back a flank base the trim had no grounds to take**, which is what #1262's block needs before any tie-break can reach it.

**#1262's premise is not in doubt — an earlier revision of this description said it was, and that was wrong.** Two corrections.

`delins.md:86-89`, in the Q&A rather than the Notes, is a worked example of the disputed shape: ref `..CAT`**G**`ACA..`, patient `..CAT`**A**`TA``ACA..`, asked as `c.[2077G>A;2077_2078insTA]`. The answer is `c.2077delinsATA`, and the NOTE records that the permission to spell it as two members *was removed*. A substitution plus an **adjacent** indel is one `delins`. That settles #7109 against us.

Mutalyzer was also under-sampled — one row generalised into "the oracle prefers merging". Across the 55 multi-member cis inputs in the corpus it does both, discriminated by adjacency:

```
NG_017013.2:g.[16985A>T;17011_17012del] -> [16985A>T;17013_17014del]   split, and 3'-shifted
NG_012337.1:g.[7109T>A;7110del]         -> g.7109_7110delinsA          merged
```

#1262's members are separated by an unchanged base, so `delins.md:17` applies and the split is right. #7109 is a **different** defect: reference bases at 7109..7113 are `T C C T T`, so the deleted `C` is ambiguous across 7110/7111; ferro 3'-shifted it out of adjacency and then applied `:17` to a separation it had manufactured.

Preferring the contiguous placement fixes that — re-measured with the flank restore, the axis is 183/183 and one corpus row moves. But it **still does not make #1262 converge**, which is the only reason to want the restore, so it costs three pinned expectations and buys nothing. Not adopted here.

**What the next attempt has to solve** is therefore not #1262's target form, but keeping a member's 3'-shift from breaking an adjacency that `delins.md:16` and `delins.md:86-89` require be described as one `delins`.


## Hypotheses refuted by measurement

Recorded so they are not re-proposed. Three of these looked clean before being run.

| hypothesis | verdict |
| --- | --- |
| **Dominance** — a match is real when present in every minimal alignment | **anti-correlated**: 6 of 8 rows backwards. #422 and #1040 must merge and have dominators; #1262, #1157A, #275 and #1232 must split and have none |
| **Supremal extent** — hand the partitioner the rolled-out window | regresses #1260 and does not fix #1262 |
| **Contiguity** (`delins.md:16` decides the tie) | provably a no-op on a trimmed block, so it fires only on untrimmed ones. Re-measured with the flank restore it is axis-green and moves one corpus row — but it does not make #1262 converge, so it buys nothing |
| **Prioritisation prefers a split** (`general.md:56`) | `delins` is not in that list at all, and the list ranks one description's type, never a multi-member allele against a spanning one |
| **Removing the input-separator veto** | costs #180 (`g.[1006_1008del;1009_1010insCCC]` collapses across the untouched 1009) and buys nothing measurable — #422's two-member spelling does not converge either way |

The contiguity rule's motivating worked example turned out to be fiction at the block level: the `repeat_span` rows it was said to fix reach `partition_block` as `TTT -> A`, for which every placement yields the identical single piece.

## Corrections to earlier work on this branch

- `general.md:56` was cited for the typed collapse in a commit message and in `split_buys_no_higher_priority_type`'s doc, claiming `delins` was "last in the priority order". It is not in the list. Both now state the rule as ferro policy inside a spec gap, licensed by `delins.md:44-47`'s analogy and the corpus.
- The corpus module doc had drifted from its own executable pins in four places, all understating how much is resolved. Each is now written as a gloss naming the pin, so the next drift is a test failure rather than a paragraph.
- `separations_are_meaningful`'s raised threshold was a bare `2` inline — a policy choice doing semantic work with no name and no doc. It is now `RAISED_PIECE_SEPARATION`.
- A unit test's comment claimed its placements did not tie. All three tie; the tie-break runs. The assertion was right and the name was wrong, so the name changed.
- A cost bound added during self-review was itself a defect: it clamped the two-gap search's *affix lengths*, which narrows the search rather than bounding work, and it excluded the sole decomposition of `AAAAAAA -> AACACAAAA` (`a = 2, b = 3`, needing a common suffix of 4). Invisible on this branch, because the single-gap search reaches the same member count there by another route. Replaced with a budget that declines the whole search instead of truncating it, pinned by a test asserting the exact columns.

## Two upstream spec defects found

Neither blocks this work.

- **`general.md:36-39` advertises a rejected proposal as forthcoming.** It says the SVD-WG "is preparing" a change and "the new recommendation **will be**: two variants separated by less than two nucleotides should be described as a 'delins'". That is SVD-WG010, and `consultation/SVD-WG010.md:5` reads `Status: rejected` (opened 2021-05-15, closed 2021-07-31). Ferro does not implement the advertised rule.
- **`delins.md:42`'s NOTE is attached to the wrong example.** It sits under `c.9002_9009delinsTTT` but discusses `c.[145C>T;147C>G]`, which belongs to the `c.145_147delinsTGG` example at `:37`.

## Verification

- `cargo nextest run --features dev` — **9093 passed, 0 failed**, 146 skipped. Log grepped for `SIGABRT` and `stack overflow`, not only `FAIL`: none.
- Manifest-backed with both oracles (`FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`) — 9093 passed.
- `scripts/run_conformance_axis.sh` — **183/183**.
- `cargo fmt --all --check`, `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- `tests/proptest-regressions/` unchanged — no seeds appended by any probe run.
- Anti-loss guard against the pre-branch test-name baseline: no tests lost, 7 gained.

## Reading order

`src/normalize/seqfirst/align.rs` and `partition.rs` first — they are self-contained and carry the design rationale. Then `partition_block` and `best_alignment` in `merge.rs`, then the corpus. The shadow audit in `canonicalize_from_sequence` is measurement scaffolding and decides nothing.

Relates to #1235. #1260 is fixed; #1262 remains open, with the finding above as the next thing to measure.


---

## Review round 2

Sixteen findings across the two lenses (nine from the GitHub review, seven from the CLI), all applied and squashed into their introducing commits. Grouped by what they change.

### Memory: the alignment DAG's adjacency

`AlignmentDag.out` was `Vec<Vec<(u32, u32, Step)>>`, allocated at `(n + 1) * (m + 1)`. That is 24 bytes of `Vec` header per grid cell whether the cell is on-path or not — about **400 MB before a single edge is stored** for the 4096 x 4096 block `benches/seqfirst_align.rs` measures — plus one allocator call per on-path cell.

A cell has at most three out-edges and the diagonal's kind is fixed by whether the two bases are equal, so four bits describe it exactly. `out` is now a flat `Vec<u8>` bitmask and `out_edges` reconstructs the tuples from `(i, j)` and the mask, in the same order the nested form pushed them. Same `Θ(n·m)` space, one allocation, order-of-magnitude smaller constant. `dominators` also stopped collecting `out_edges` into a `Vec` per cell — it counts, and only materialises the edge on the rare `crossing == 1` branch, which was putting the allocation straight back onto the sweep.

The exhaustive brute-force oracle (`dominators_agree_with_brute_force_on_exhaustive_small_inputs`) still passes, which is what makes this safe to do mechanically.

### Memory: an unbounded grid

Only the *reference* side of the sequence-first splitter is bounded upstream (`MAX_CANONICAL_WINDOW`, 4096). The alternate side is whatever the members produce, and a duplication over the window doubles it — 4096 x 8192 is 33.5 M cells across four grids. `partition_block_sequence_first` now refuses an oversized grid **before building it**, with a checked multiply (that product is itself an overflow site), returning `None` so the caller keeps the per-member result like every other cost bound here.

The budget is *derived* from `MAX_CANONICAL_WINDOW` rather than picked: a square grid at that bound. Pinned by `sequence_first_split_declines_an_oversized_grid`, which asserts the boundary from both sides so the test fails if the bound is removed **or** tightened enough to refuse ordinary blocks. (First attempt used `2^24` and refused the boundary square by 8,193 cells — the test caught it.)

### A panic path and a logging path

- `split_codon_incompatible_triplets` read `ref_bytes[piece.ref_start + 1]` and `+ 2` by raw index off a piece it does not own; `ref_end <= ref_bytes.len()` is now tested first, so an out-of-range span declines instead of panicking.
- The `FERRO_SEQFIRST_SHADOW` reports went to `eprintln!`, which fires once per canonicalized block — tens of thousands of lines over a suite run that no level or target filter could reach. Now `log::debug!` (the crate's unconditional facade; `tracing` is `web-service`-only), and the switch is documented as development-only with the `RUST_LOG` target to capture it.

### `dead_code`: the blanket was hiding exactly three items

`#![allow(dead_code)]` on `seqfirst/mod.rs` is gone. Removing it surfaced three items, each now scoped with a reason: `partition_members` (no production caller — the shadow takes the `partition_members_with` route that shares one `Dominators` sweep), and `AlignmentDag::edit_distance` + the `total` field it reads (benchmark-only, so `#[cfg_attr(not(feature = "dev"), allow(dead_code))]` — they warn again if `dev` stops keeping them alive). Verified clean with and without `--all-features`.

The module header also claimed the path was "unwired into `normalize_allele`". It is not — it is compiled in and run there as a shadow comparison behind `FERRO_SEQFIRST_SHADOW=1`; what remains is promoting it from shadow to authoritative. **The same wrong claim appeared in `src/normalize/mod.rs`**, which the CLI lens caught as the sibling site; both are corrected.

### Tests that could pass vacuously or tautologically

- `sequence_first_split_round_trips_every_block_it_accepts` counted nothing. Its `else { continue }` is silent, so a regression making `member_alt_spans` decline all 3,969 pairs would leave the round-trip assertion unexecuted and the test green. Now floors the accepted count, matching how the sibling sweep guards itself.
- `delins_bracketed_payload_expands` asserted `expanded == "GCGTTTGGGAAACC"` where `expanded` was built from the same literal three lines up — two literals compared to each other, unable to fail if the expansion regressed, while the comment above claimed it covered exactly that. Now checked against the normalizer's own output.
- `rendering_does_not_depend_on_the_input_spelling` asserted only `na == nb`. Two spellings converging on the same *wrong* form satisfies that. Rows 1 and 2 were anchored elsewhere; the third was anchored nowhere, so its expected answer — already stated in the module doc — is now pinned.
- `the_eight_spelling_pairs_still_diverge` had the count "eight" in three places' prose (its own name, the module doc, and `rewrite_target_corpus.rs`) and executable in none. `DIVERGENT.len()` is now asserted.
- `msto_regression_corpus`'s `state: &'static str` admitted any string, so a runtime check existed to catch `"Closed"`. A two-variant `State` enum moves that to compile time and the assertion is deleted rather than kept.

### Corpus and doc corrections

- The `COLLISIONS` census said "two recorded correct, four recorded as known defects"; the actual census is one `BothCorrect`, one `KnownDefect`, four `ResolvedToSplit` — which the module doc and the executable census test both already said.
- The untrimmed poly-A window note claimed the splitter disagreement was specific to `#1262-window` because its `#1260` sibling agreed. Both rows are `diverging(… 1, (2, …))` and both are in that group's membership assertion, so they diverge identically; corrected.
- `CONTRIBUTING.md`'s `cargo bench` silently skips `seqfirst_align`, which is `required-features = ["dev"]`.
- `benches/seqfirst_align.rs` used the deprecated `criterion::black_box`; now `std::hint::black_box`.

### #1274 is fixed, so its pin is inverted rather than deleted

Rebasing onto `main` after #1339 landed turned `a_cancelling_edit_at_the_contig_end_still_emits_an_out_of_bounds_span` red — which is this file's contract working as designed. #1327's terminal re-spelling closed #1274: `g.[8_9insA;10del]` on a 10-base contig now gives `g.[9dup;10del]` rather than naming position 11.

The assertion is inverted into `a_cancelling_edit_at_the_contig_end_stays_inside_the_contig` rather than deleted, so the reproducer that found the defect stays attached to a standing boundary-validity guard. It asserts **two** things, because the position bound alone is weak: the independent applier never caught this defect (an `=` edit's SPDI triple does not exercise the out-of-bounds check a deletion's does), so "stays in range" is paired with "still denotes the reference" — otherwise a fix that clamped the span while corrupting the sequence would pass.

### Movement relative to the reference oracles

**None — no output changes.** The sequence-first splitter remains shadow-only behind `FERRO_SEQFIRST_SHADOW=1` and does not affect what ferro emits; this round's production edits are a bounds check that only fires on a span no caller produces, a cost bound whose fallback is the existing per-member result, a data-structure change to a DAG whose exhaustive oracle is unchanged, and a logging facade swap. The one behavioural line that moved (`#1274`) moved in `main` via #1339, not here — this PR only re-points its guard at the fixed answer.

Full suite: **9,172 passed, 0 failed**. `cargo fmt --check` clean and `clippy --all-features --all-targets -D warnings` clean, plus a second clippy pass without `dev` to confirm the narrowed `dead_code` scoping holds in both feature sets.
