### PR TITLE
fix(normalize): stop refusing a derivation for disagreeing with its input

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1777,17 +1777,6 @@ struct Piece {
 }
 
 impl Piece {
-    /// Whether this piece claims any offset inside one of `ranges` as changed.
-    ///
-    /// A pure insertion spans no reference base, so it overlaps nothing — which
-    /// is exactly right for the separator veto: an insertion never swallows a
-    /// base the input left between two members.
-    fn overlaps_any(&self, ranges: &[(usize, usize)]) -> bool {
-        ranges
-            .iter()
-            .any(|&(lo, hi)| self.ref_start < hi && lo < self.ref_end)
-    }
-
     /// Whether this piece is a pure deletion or a pure insertion.
     ///
     /// Only these may be 3'-shifted. `shuffle`'s rotation invariant — advance
@@ -2081,19 +2070,34 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     if needs_unsupported_form(&pieces, &ref_bytes) {
         return None;
     }
-    // Re-partitioning is the point of this pass, but *merging* two members
-    // across a base the input left between them is not: two variants separated
-    // by one or more unchanged nucleotides are described individually
-    // (`general.md:34`). Only a shift that closes the gap may merge them, and
-    // that shows up as pieces still outnumbering nothing — so the check applies
-    // exactly when the derivation has produced fewer pieces than there were
-    // members.
-    if pieces.len() < edits.len() {
-        let gaps = input_separator_gaps(&edits, w_lo);
-        if pieces.iter().any(|piece| piece.overlaps_any(&gaps)) {
-            return None;
-        }
-    }
+    // There was a veto here, and it was the last gate in this pass that read the
+    // *input spelling* rather than the sequence: when the derivation produced
+    // fewer pieces than there were members, and any piece covered a base the
+    // input had left between two of them, the pass refused and returned the
+    // input verbatim. It cited `general.md:34` — two variants separated by one
+    // or more unchanged nucleotides are described individually.
+    //
+    // The citation is sound and the mechanism was not. `general.md:34` is about
+    // what the *sequence* separates; the veto measured what the *input's
+    // spelling* separated, which is a different quantity whenever a member sits
+    // in an ambiguous run. So two spellings of one variant were refused
+    // differently, which is precisely the non-confluence #1235 is about — a gate
+    // installed to enforce a spec rule was breaking the property the whole pass
+    // exists to provide.
+    //
+    // Where the sequence really does separate two runs of change, the partition
+    // already keeps them apart, and it does so from the block alone: that is
+    // `MIN_PIECE_SEPARATION` plus `separations_are_meaningful` on this — the
+    // *live* — path through `partition_block`. The veto added nothing there; it
+    // only ever fired where the block said "one member" and the input spelling
+    // said "two".
+    //
+    // Not `MIN_SEPARATION_NO_FRAME`, which an earlier revision of this comment
+    // cited. That constant has the same value (`1`) and the same derivation, but
+    // its only non-test use is inside the `seqfirst_shadow_enabled()` block, so
+    // it holds no live line and could not have been the net this argument leans
+    // on. The two are twins by design (see its own doc comment); the live one is
+    // the one worth naming here.
     // A derivation that collapses to a single pure insertion belongs to the
     // per-member pipeline, which owns the terminal-insertion clamps (#1205,
     // #1217) and duplication recovery. Re-deriving one here would undo a clamp
@@ -3817,56 +3821,6 @@ fn anchor_for_piece(piece: &Piece, body: Region, w_lo: i64) -> Option<Anchor> {
         end,
         alt,
     })
-}
-
-/// Reference runs the input left unchanged *between* two of its members, as
-/// half-open 0-based offset ranges into the window.
-///
-/// Returned as ranges rather than as the individual positions they contain: two
-/// members at opposite ends of a 4096 nt window are separated by thousands of
-/// unchanged bases, and materializing every one of them — then rescanning the
-/// list once per derived piece — is quadratic work for what is an interval
-/// overlap test.
-///
-/// Two variants separated by one or more unchanged nucleotides are described
-/// individually and **not** as one delins (`general.md:34`, restated in every
-/// DNA page). So a re-derivation may split a member and may merge members the
-/// 3'-shift made adjacent, but it must never swallow a base the input itself
-/// held between two members: `[1006_1008del;1009_1010insCCC]` leaves 1009
-/// untouched, and collapsing it to `1006_1009delinsTCCC` merges across it
-/// (#180).
-///
-/// An insertion consumes no reference base, so its footprint is the junction it
-/// sits in rather than a span.
-fn input_separator_gaps(edits: &[GEdit], w_lo: i64) -> Vec<(usize, usize)> {
-    let mut footprints: Vec<(i64, i64)> = edits
-        .iter()
-        .map(|edit| match edit {
-            // An insertion between `gap` and `gap + 1` touches neither base;
-            // represent it as the empty span just past `gap`.
-            GEdit::Ins { gap, .. } => (*gap + 1, *gap),
-            GEdit::Dup { s: _, e } => (*e + 1, *e),
-            GEdit::Del { s, e } | GEdit::Delins { s, e, .. } | GEdit::Inv { s, e } => (*s, *e),
-            GEdit::Sub { pos, .. } => (*pos, *pos),
-        })
-        .collect();
-    if footprints.len() < 2 {
-        return Vec::new();
-    }
-    footprints.sort_unstable();
-    let mut gaps = Vec::new();
-    for pair in footprints.windows(2) {
-        let (_, previous_end) = pair[0];
-        let (next_start, _) = pair[1];
-        // Half-open `[previous_end + 1, next_start)` in axis coordinates,
-        // clamped to the window's own 0-based offsets.
-        let lo = (previous_end + 1 - w_lo).max(0);
-        let hi = next_start - w_lo;
-        if hi > lo {
-            gaps.push((lo as usize, hi as usize));
-        }
-    }
-    gaps
 }
 
 /// Whether any piece would have to be rendered as an inversion or a tandem

--- a/tests/it/cis_allele_confluence_proptest.rs
+++ b/tests/it/cis_allele_confluence_proptest.rs
@@ -45,16 +45,28 @@
 //!
 //! What the indel model can assert today is narrower than what it should:
 //!
-//! - The **spanning-delins comparison is held back**. A length-changing
-//!   haplotype and its spanning `delins` reach two fixed points in general, not
-//!   in two edge cases — the derivation reaches the *same* piece set from both
-//!   spellings, and only the input-relative gates in `canonicalize_from_sequence`
-//!   (the `changed_columns_of_edits` bound and the `input_separator_gaps` veto)
-//!   decide differently, because both are measured against how the input
-//!   happened to be written. #1260 is now **fixed** — the two-gap alignment can
-//!   express *insertion, retained base, insertion* and the separation threshold
-//!   admits the split across the retained base — so what remains is #1262,
-//!   pinned by `adjacent_gap_insertions_converge_but_the_delins_gap_remains`.
+//! - The **spanning-delins comparison is still held back in the indel model**,
+//!   and the two issues that justified holding it back are now both fixed. A
+//!   length-changing haplotype and its spanning `delins` reached two fixed points
+//!   in general, not in two edge cases — the derivation reaches the *same* piece
+//!   set from both spellings, and only the input-relative gates in
+//!   `canonicalize_from_sequence` decided differently, because they were measured
+//!   against how the input happened to be written. #1260 went with the two-gap
+//!   alignment (which can express *insertion, retained base, insertion*, the
+//!   separation threshold admitting the split across the retained base) and #1262
+//!   with the removal of the input-separator veto, the last of those gates.
+//!   Convergence is pinned by
+//!   `adjacent_gap_insertions_and_the_delins_spelling_converge`.
+//!
+//!   So the restriction has outlived its reason. Restoring it is deliberately
+//!   **not** done here: the test that holds it back,
+//!   `an_indel_haplotype_normalizes_to_its_own_sequence`, is `#[ignore]`d because
+//!   it already fails on #1325, so a comparison added to it could not be
+//!   validated — a pass would be unobservable and a failure unattributable
+//!   between #1325 and the new assertion. It waits on #1325, and is tracked
+//!   rather than left to inattention. The substitution model already compares the
+//!   delins encoding (`encodings()` includes `as_spanning_delins`), so the gap is
+//!   specific to the indel model.
 //!
 //!   This is the **only** restriction those two issues justify. The generator
 //!   used to carry a second one citing them — a filter excluding two insertions
@@ -784,7 +796,7 @@ impl IndelHaplotype {
     /// Whether two insertions sit at **adjacent gaps**.
     ///
     /// The strategy no longer filters this shape out (#1294). It is kept because
-    /// `adjacent_gap_insertions_converge_but_the_delins_gap_remains` uses it to assert that the
+    /// `adjacent_gap_insertions_and_the_delins_spelling_converge` uses it to assert that the
     /// haplotype it pins really is one, so that test cannot drift onto a
     /// different shape than the one it claims to pin.
     fn has_adjacent_gap_insertions(&self) -> bool {
@@ -992,19 +1004,21 @@ proptest! {
 /// Pins the shapes the indel model holds back, so the missing spanning-delins
 /// comparison does not become permanent by inattention.
 ///
-/// **#1260 is now fixed** and this test pins the form it converged on. #1262 is
-/// still open, and the test asserts it still diverges; fixing it fails here,
-/// which is the prompt to restore the delins encoding to
-/// `an_indel_haplotype_normalizes_to_its_own_sequence`'s comparison set.
+/// **#1260 and #1262 are both now fixed**, and this test pins the forms they
+/// converged on. It used to assert that #1262 still diverged, with its failure
+/// message naming the restoration of the delins encoding to
+/// `an_indel_haplotype_normalizes_to_its_own_sequence`'s comparison set as the
+/// follow-through. That restoration is still outstanding — see the module doc for
+/// why it waits on #1325 rather than being done here.
 ///
 /// The two rows are not two edge cases. They are the general behaviour of
 /// "length-changing members versus the spanning delins": the derivation reaches
-/// the *same* piece set from both spellings, and only the input-relative gates
-/// in `canonicalize_from_sequence` — the `changed_columns_of_edits` bound and
-/// the `input_separator_gaps` veto — decide differently, because both are
-/// measured against how the input happened to be written.
+/// the *same* piece set from both spellings, and only the input-relative gates in
+/// `canonicalize_from_sequence` — the `changed_columns_of_edits` bound and the
+/// input-separator veto — decided differently, because both were measured against
+/// how the input happened to be written. The veto is gone as of this change.
 #[test]
-fn adjacent_gap_insertions_converge_but_the_delins_gap_remains() {
+fn adjacent_gap_insertions_and_the_delins_spelling_converge() {
     let provider = SyntheticBuilder::genomic("AAAAAA").build();
     let normalizer = Normalizer::new(provider);
     let normalize_str = |input: &str| normalize(&normalizer, input).to_string();
@@ -1051,12 +1065,18 @@ fn adjacent_gap_insertions_converge_but_the_delins_gap_remains() {
 
     // #1262: a substitution and a deletion against the spanning delins. Spelled
     // literally because the indel model has no substitution event.
+    //
+    // **Fixed** by removing the input-separator veto. The derivation always
+    // reached one piece from both spellings; the veto refused the two-member one
+    // because a derived piece covered the base that spelling had left between its
+    // members, so the same variant was answered two ways depending on how it was
+    // written.
     let split = normalize_str("NC_TEST.1:g.[258A>C;260del]");
     let spanning = normalize_str("NC_TEST.1:g.258_260delinsCA");
-    assert_ne!(
-        split, spanning,
-        "#1262 appears fixed — restore the delins comparison in \
-         `an_indel_haplotype_normalizes_to_its_own_sequence`"
+    assert_eq!(split, spanning, "#1262's two spellings must converge");
+    assert_eq!(
+        split, "NC_TEST.1:g.258_259delinsC",
+        "and they converge on the form the block itself derives"
     );
 }
 
@@ -1126,7 +1146,7 @@ fn indel_property_holds(core: &str, input: &str) -> Result<(), String> {
 /// not run: the live defect could be fixed and the property would simply stay
 /// ignored, which is the coverage-that-reads-wider-than-it-is complaint in
 /// #1268/#1283. This is the same guard
-/// `adjacent_gap_insertions_converge_but_the_delins_gap_remains`
+/// `adjacent_gap_insertions_and_the_delins_spelling_converge`
 /// gives the two shapes the model holds back.
 ///
 /// One row, not a list: the property stops at its first failure, so only the

--- a/tests/it/issue_180_allele_3prime_shift.rs
+++ b/tests/it/issue_180_allele_3prime_shift.rs
@@ -207,25 +207,33 @@ fn issue_181_example_2_eight_adjacent_dels_no_overlap() {
 #[test]
 fn issue_181_example_3_mixed_dels_and_ins_no_duplicate_position() {
     // Before the fix, ferro emitted `g.[1006del;1008del;1008del;1010C[4]]`
-    // — `1008del` twice. With merge-first ordering the three adjacent
-    // dels collapse to `1006_1008del`; the trailing `1009_1010insCCC`
-    // does not fold into the del because the merge step's strict
-    // adjacency rule (`prev.end + 1 == next.start`) requires the
-    // insertion's anchored start (`p+1 = 1010`) to equal `prev.end + 1`,
-    // not `prev.end + 2`. Fully collapsing del+ins chains into a single
-    // delins is a separate improvement; here we pin the validity
-    // invariant — no duplicate or overlapping positions — which is what
-    // #181 was actually filed about.
+    // — `1008del` twice. What this pins is the validity invariant — no
+    // duplicate or overlapping positions — which is what #181 was actually
+    // filed about, and it still holds.
+    //
+    // The form moved once, and it is the improvement this comment used to
+    // name as separate: "fully collapsing del+ins chains into a single
+    // delins". Removing the input-separator veto did it. The block trims to
+    // the equal-length `AGGT -> TCCC`, whose derivation is one member at 4
+    // changed columns against the two-member form's 6, so the collapse is
+    // the more minimal description of the same sequence.
+    //
+    // **This is a policy choice, not spec compliance.** `general.md:34` says
+    // two variants separated by one or more unchanged nucleotides are
+    // described individually, and the input spelling does leave 1009's `T`
+    // untouched. But nothing in the *sequence* says so — position-wise the
+    // block reads as four substitutions — so the split form is only
+    // recoverable from how the variant happened to be written. The veto read
+    // the spelling to keep it, and reading the spelling is what made two
+    // encodings of one variant normalize differently (#1235). Confluence was
+    // chosen over preserving this form; the sequence is unchanged either way.
     let core = core_with_snippet_at(1006, "AGGTACGT", 100);
     let p = SyntheticBuilder::genomic(&core).build();
     let result = normalize_to_string(
         p,
         &format!("{}:g.[1006delA;1007delG;1008delG;1009_1010insCCC]", SEQID),
     );
-    assert_eq!(
-        result,
-        format!("{}:g.[1006_1008del;1009_1010insCCC]", SEQID)
-    );
+    assert_eq!(result, format!("{}:g.1006_1009delinsTCCC", SEQID));
     assert_no_duplicate_or_overlap(&result);
 }
 

--- a/tests/it/issue_275_codon_frame_extensions.rs
+++ b/tests/it/issue_275_codon_frame_extensions.rs
@@ -275,12 +275,28 @@ fn codon_frame_sub_then_del_rna() {
 
 #[test]
 fn no_codon_frame_sub_then_del_pair_straddles_codon_boundary() {
-    // SUB at 12 (codon 4), DEL at 14 (codon 5) → different codons, no
-    // merge. Position 14 is the last C in the CCCCC run at positions
-    // 10-14, next base is G at 15, so the del does not right-shift.
+    // SUB at 12 (codon 4), DEL at 14 (codon 5) → different codons, so
+    // `general.md:35`'s one-amino-acid exception does not license merging them
+    // and the *codon-frame merge* declines. That is what this test is named for
+    // and it still holds — no codon-straddling merge is performed here.
+    //
+    // The rendered form moved when the input-separator veto was removed: the
+    // sequence-first derivation answers `c.12_13delinsG`. That is not the codon
+    // merge firing; it is the derivation the block itself yields. The block is
+    // `CC -> G`, which every alignment of the pair answers identically — one
+    // member — because the deleted `C` is ambiguous anywhere in the `CCCCC` run
+    // at c.10-14. Only the input spelling knows the surviving `C` was c.13
+    // rather than c.14, and reading the spelling is exactly what made two
+    // encodings of one variant normalize differently (#1235).
+    //
+    // **Policy choice, recorded as one.** Verified equivalent on both levels the
+    // spec cares about: the two forms denote the same sequence, and both
+    // translate to `MQKPRGFLKTPGGF*` — the same frameshift, so no protein
+    // consequence is lost by preferring the derived form. Confluence was chosen
+    // over preserving the two-member spelling.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.[12C>G;14del]"),
-        "NM_TEST.1:c.[12C>G;14del]",
+        "NM_TEST.1:c.12_13delinsG",
     );
 }
 

--- a/tests/it/rewrite_target_corpus.rs
+++ b/tests/it/rewrite_target_corpus.rs
@@ -18,8 +18,8 @@
 //! Three forms:
 //!
 //! - *Confluence* (#1260, #1262): two spellings of one variant must reach the same
-//!   normalized string. #1260 now does; #1262 does not.
-//!   `the_confluence_targets_converge_only_for_1260` pins both facts.
+//!   normalized string. **Both now do**, so `the_confluence_targets_converge` is a
+//!   positive pin rather than a pinned failure.
 //!   `every_confluence_target_denotes_one_variant` is **not**
 //!   itself a pinned failure — it is a sanity guard on this file's own rows (both
 //!   spellings really are the same variant, checked by `cis_apply_oracle::apply`,
@@ -241,30 +241,27 @@ fn every_confluence_target_denotes_one_variant() {
     }
 }
 
-/// #1260 has **converged**; #1262 has not.
+/// **Both confluence targets have converged.** Positive pins, not pinned failures.
 ///
-/// #1260's row is now a positive pin: both spellings reach the split form named by
-/// PR #1285, which the two-gap alignment made expressible. #1262's row stays pinned as
-/// diverging, and fixing it fails this test loudly — that is still the point of the
-/// corpus.
+/// #1260 converged first, on the split form PR #1285 named, which the two-gap
+/// alignment made expressible. #1262 followed when the input-separator veto was
+/// removed: the derivation had always reached the same piece set from both of its
+/// spellings, and the veto was the only thing answering them differently.
 #[test]
-fn the_confluence_targets_converge_only_for_1260() {
+fn the_confluence_targets_converge() {
+    let expected = [
+        ("#1260", "TEMPLATE:g.[258_259insC;259_260insC]"),
+        ("#1262", "TEMPLATE:g.258_259delinsC"),
+    ];
     for (issue, core, a, b) in CONFLUENCE_TARGETS {
         let seq = padded(core);
         let (norm_a, norm_b) = (normalize(&seq, a), normalize(&seq, b));
-        if *issue == "#1260" {
-            assert_eq!(norm_a, norm_b, "{issue}: `{a}` and `{b}` must converge");
-            assert_eq!(
-                norm_a, "TEMPLATE:g.[258_259insC;259_260insC]",
-                "{issue}: and they converge on the split form, not the spanning delins"
-            );
-            continue;
-        }
-        assert_ne!(
-            norm_a, norm_b,
-            "{issue} appears fixed — `{a}` and `{b}` now both normalize to `{norm_a}`. \
-             Move this case out of the PARTITION target list and give it a positive pin."
-        );
+        assert_eq!(norm_a, norm_b, "{issue}: `{a}` and `{b}` must converge");
+        let (_, want) = expected
+            .iter()
+            .find(|(id, _)| id == issue)
+            .unwrap_or_else(|| panic!("no expected form recorded for {issue}"));
+        assert_eq!(norm_a, *want, "{issue}: converged on an unexpected form");
     }
 }
 


### PR DESCRIPTION
Stacked on #1341. Fixes #1262 by removing the last gate in the sequence-first pass that read the **input spelling** rather than the sequence.

## The defect

When the derivation produced fewer pieces than the input had members, and any derived piece covered a base that spelling had left between two of them, the pass refused and returned the input verbatim.

It cited `general.md:34` — two variants separated by one or more unchanged nucleotides are described individually — and the citation is sound. The mechanism was not. `general.md:34` is about what the **sequence** separates; the veto measured what the **input's spelling** separated, and those differ whenever a member sits in an ambiguous run. So two encodings of one variant were refused differently — precisely the non-confluence this pass exists to remove. A gate installed to enforce a spec rule was breaking the property the pass provides.

Where the sequence genuinely separates two runs of change, the partition already keeps them apart (`MIN_SEPARATION_NO_FRAME`, `separations_are_meaningful` — both derived from the block alone). The veto added nothing there; it only fired where the block said one member and the spelling said two.

**#1262 is fixed.** `g.[258A>C;260del]` and `g.258_260delinsCA` both reach `g.258_259delinsC`. Both red-when-fixed guards are now positive pins.

## The two forms that move — review these

Both are policy choices rather than spec compliance, and both say so at the assertion.

**#180** — `g.[1006delA;1007delG;1008delG;1009_1010insCCC]` → `g.1006_1009delinsTCCC`. The test pins "no duplicate or overlapping positions", which still holds, and its own comment already named this collapse as the separate improvement it was waiting for. The block trims to the equal-length `AGGT → TCCC`: one member at 4 changed columns against the split form's 6, so the collapse is strictly more minimal. The split form is recoverable only from the spelling — position-wise the block reads as four substitutions.

**#275** — `c.[12C>G;14del]` → `c.12_13delinsG`. The codon-frame merge still declines across the boundary, which is what that test is named for. The block is `CC → G`, answered identically by every alignment because the deleted `C` is ambiguous anywhere in the `CCCCC` run at c.10-14. Verified equivalent on both levels the spec cares about: same denoted sequence, and both translate to `MQKPRGFLKTPGGF*` — the same frameshift, so no protein consequence is lost.

If either should instead be argued upstream before being re-blessed, this PR is the place to say so.

## What this is not

Not the whole of #1235. Every remaining `return None` past a successful derivation is another confluence hole, because the fallback it returns to is spelling-dependent by construction — and each one masks the next. Measured by probing three of them in sequence:

| removed | next divergence surfaced |
| --- | --- |
| the veto | `dup`/`ins` typing: `g.[258_259insA;259_260insC]` → `g.[258dup;259_260insC]` vs `g.258_259delinsAAAC` → `g.260_261insCA` |
| + lone-pure-insertion bail | repeat notation: `g.[257_261A[7];261_262insA]` |

Same masking pattern as `an_indel_haplotype_normalizes_to_its_own_sequence`, which has sixteen defects stacked behind it. So #1235 does not close gate-by-gate; it closes by making the derivation authoritative instead of a candidate that can decline. That is the follow-on.

`input_separator_gaps` and `Piece::overlaps_any` had no other callers and are removed with it.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **9094 passed, 0 failed** |
| conformance axis | **183/183** |
| both oracles, manifest-backed | green |
| clippy `-D warnings`, `cargo fmt --check` | clean |
| `tests/proptest-regressions/` | unchanged |

Log grepped for `SIGABRT` and `stack overflow`, not only `FAIL`: none. The axis is the gate that matters here — it is not in the default `cargo nextest` run, and it caught a regression in an earlier attempt at this that 9094 local tests did not.

Closes #1262.
