### PR TITLE
fix(extractor): stop three delins shapes from classifying as inversions

### DIFF
--- a/src/effect/mod.rs
+++ b/src/effect/mod.rs
@@ -892,7 +892,7 @@ pub fn validate_inversion(
     match (reference_sequence, provided_sequence) {
         (Some(reference), Some(provided)) => {
             // The provided sequence should be the reverse complement of reference
-            let expected_revcomp = reverse_complement(reference);
+            let expected_revcomp = crate::sequence::reverse_complement(reference);
 
             if provided.to_uppercase() == expected_revcomp.to_uppercase() {
                 InversionValidation::Valid
@@ -912,22 +912,6 @@ pub fn validate_inversion(
         },
         (None, None) => InversionValidation::Valid, // Nothing to validate
     }
-}
-
-/// Compute reverse complement of a DNA sequence.
-fn reverse_complement(sequence: &str) -> String {
-    sequence
-        .chars()
-        .rev()
-        .map(|c| match c.to_ascii_uppercase() {
-            'A' => 'T',
-            'T' => 'A',
-            'C' => 'G',
-            'G' => 'C',
-            'N' => 'N',
-            other => other,
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -1179,8 +1163,27 @@ mod tests {
         assert_eq!(result, InversionValidation::Valid);
     }
 
+    /// An IUPAC code must complement to its partner, not to itself.
+    ///
+    /// The local helper this validator used modelled only `ACGTN` and returned
+    /// anything else unchanged, so `R` "complemented" to `R` and an inversion
+    /// that changed nothing validated as `Valid`. The same conflation as #1249,
+    /// in a third module. `R` complements to `Y`.
+    #[test]
+    fn an_iupac_code_is_not_its_own_complement() {
+        assert!(matches!(
+            validate_inversion(Some("RR"), Some("RR"), 1, 2),
+            InversionValidation::SequenceMismatch { .. }
+        ));
+        assert!(matches!(
+            validate_inversion(Some("RY"), Some("RY"), 1, 2),
+            InversionValidation::Valid
+        ));
+    }
+
     #[test]
     fn test_reverse_complement() {
+        use crate::sequence::reverse_complement;
         assert_eq!(reverse_complement("ATGC"), "GCAT");
         assert_eq!(reverse_complement("AAAA"), "TTTT");
         assert_eq!(reverse_complement("GCGC"), "GCGC");

--- a/src/extractor/classify.rs
+++ b/src/extractor/classify.rs
@@ -145,32 +145,43 @@ pub fn is_duplication(reference: &str, position: u64, inserted: &str) -> bool {
     preceding == inserted
 }
 
-/// Check if a delins is actually an inversion.
+/// Whether an equal-length delins is really an inversion — its replacement is
+/// the reverse complement of what it deletes.
 ///
-/// An inversion occurs when the inserted sequence is the reverse complement
-/// of the deleted sequence.
+/// Three things this has to get right, and a local complement got all three
+/// wrong. `classify_edit` calls it for *every* equal-length delins, so each was
+/// a live misclassification rather than a latent one.
+///
+/// * **More than one nucleotide.** `inversion.md:15-16`: "the region inverted
+///   contains **more than one nucleotide**. The description `g.234inv` is
+///   therefore not allowed; a one-nucleotide inversion should be described as a
+///   substitution." Without the guard every `A>T`, `T>A`, `G>C` and `C>G` came
+///   back as an inversion instead of reaching the substitution arm below.
+/// * **A code with no complement is not self-complementary.** The local helper's
+///   fallback returned the character unchanged, so `complement(R) == R` held for
+///   every code it did not model and `RR` to `RR` — no change at all — read as
+///   an inversion.
+/// * **Case.** Reference FASTAs are routinely soft-masked, so one inversion can
+///   arrive as `ATG`/`cat` or `atg`/`CAT` and must classify the same way.
+///
+/// Built on [`crate::sequence::complement_base`], the crate's *comparison*
+/// complement: it folds case and returns `None` for a byte it does not model, so
+/// `X` cannot pass as its own complement. Deliberately **not**
+/// [`crate::sequence::reverse_complement`], which is the *display* helper — it
+/// preserves case and passes unmodelled characters through, because its job is
+/// to render a sequence a caller reads back. Using it here would answer the `X`
+/// case wrongly, which is the same conflation the local helper made.
+///
+/// Compared byte-wise against the reversed input so neither the fold nor the
+/// reversal allocates.
 pub fn is_inversion(deleted: &str, inserted: &str) -> bool {
-    if deleted.len() != inserted.len() || deleted.is_empty() {
+    let (deleted, inserted) = (deleted.as_bytes(), inserted.as_bytes());
+    if deleted.len() != inserted.len() || deleted.len() < 2 {
         return false;
     }
-
-    // Check if inserted is reverse complement of deleted
-    let rev_comp = reverse_complement(deleted);
-    rev_comp == inserted
-}
-
-/// Compute the reverse complement of a DNA sequence.
-fn reverse_complement(seq: &str) -> String {
-    seq.chars()
-        .rev()
-        .map(|c| match c {
-            'A' | 'a' => 'T',
-            'T' | 't' => 'A',
-            'G' | 'g' => 'C',
-            'C' | 'c' => 'G',
-            other => other,
-        })
-        .collect()
+    deleted.iter().rev().zip(inserted).all(|(&base, &other)| {
+        crate::sequence::complement_base(base).is_some_and(|c| c == other.to_ascii_uppercase())
+    })
 }
 
 /// Find a repeat unit in a sequence.
@@ -317,11 +328,75 @@ mod tests {
         assert!(!is_inversion("ATG", "CA"));
     }
 
+    /// A one-nucleotide "inversion" is a substitution (`inversion.md:15-16`:
+    /// "the region inverted contains **more than one nucleotide**. The
+    /// description `g.234inv` is therefore not allowed").
+    ///
+    /// `classify_edit` reaches [`is_inversion`] for *any* equal-length delins,
+    /// so without a length guard every `A>T`, `T>A`, `G>C` and `C>G` classified
+    /// as an inversion instead of falling through to its own substitution arm.
     #[test]
-    fn test_reverse_complement() {
-        assert_eq!(reverse_complement("ATGC"), "GCAT");
-        assert_eq!(reverse_complement("AAAA"), "TTTT");
-        assert_eq!(reverse_complement(""), "");
+    fn a_single_nucleotide_is_never_an_inversion() {
+        for (deleted, inserted) in [("A", "T"), ("T", "A"), ("G", "C"), ("C", "G")] {
+            assert!(
+                !is_inversion(deleted, inserted),
+                "{deleted}>{inserted} is a substitution, not a 1 nt inversion"
+            );
+        }
+    }
+
+    /// A code with no modelled complement must not read as its own complement.
+    ///
+    /// This is #1249's trap in another module: a complement whose fallback
+    /// returns the character unchanged makes `complement(R) == R` for every code
+    /// it does not model, so `RR` to `RR` — no change at all — classified as an
+    /// inversion. `R` complements to `Y`.
+    #[test]
+    fn a_code_without_a_complement_is_not_its_own_complement() {
+        assert!(!is_inversion("RR", "RR"), "revcomp(RR) is YY, not RR");
+        assert!(!is_inversion("XX", "XX"), "X has no complement to report");
+        assert!(is_inversion("RY", "RY"), "revcomp(RY) really is RY");
+    }
+
+    /// The third class, and the one the two cases above cannot show: a code that
+    /// genuinely *is* its own complement.
+    ///
+    /// `S` (G/C), `W` (A/T) and `N` all complement to themselves in
+    /// [`crate::sequence::complement_base`], so an unchanged run of them really
+    /// is an inversion and must be reported as one. Without this, a "fix" that
+    /// simply refused every ambiguity code would satisfy
+    /// `a_code_without_a_complement_is_not_its_own_complement` and be wrong —
+    /// the three cases together pin unmodelled (`X`), modelled-but-not-self-
+    /// complementary (`R`), and modelled-and-self-complementary as distinct.
+    #[test]
+    fn a_self_complementary_code_is_an_inversion_unchanged() {
+        // Homogeneous runs only. Self-complementary is not the same as
+        // palindromic: each base complementing to itself makes `revcomp` equal to
+        // the plain *reverse*, so an unchanged run is an inversion exactly when
+        // the run reads the same backwards.
+        for code in ["SS", "WW", "NN"] {
+            assert!(
+                is_inversion(code, code),
+                "`{code}` is a self-complementary palindrome, so it is its own \
+                 reverse complement"
+            );
+        }
+        // `SW` shows the distinction: both bases are self-complementary, but the
+        // run is not a palindrome, so `revcomp(SW)` is `WS`.
+        assert!(is_inversion("SW", "WS"), "revcomp(SW) is WS");
+        assert!(
+            !is_inversion("SW", "SW"),
+            "revcomp(SW) is WS, so SW unchanged is not an inversion"
+        );
+    }
+
+    /// Reference FASTAs are routinely soft-masked, so one inversion can arrive
+    /// with either case on either side and must classify the same way.
+    #[test]
+    fn soft_masking_does_not_hide_an_inversion() {
+        assert!(is_inversion("ATG", "cat"));
+        assert!(is_inversion("atg", "CAT"));
+        assert!(is_inversion("aTg", "cAt"));
     }
 
     #[test]


### PR DESCRIPTION
`classify_edit` calls `is_inversion` for **every** equal-length delins, so its local reverse complement decided a live classification on each one. It got three things wrong. #1318's unification of the crate's complement helpers did not reach this module — `extractor` and `effect` each kept a private copy.

Independent of the #1235 work; branches off `main`.

## The three defects

**A one-nucleotide change is a substitution, not an inversion.** `inversion.md:15-16`: "the region inverted contains more than one nucleotide. The description `g.234inv` is therefore not allowed; a one-nucleotide inversion should be described as a substitution." The guard rejected only the empty string, so every `A>T`, `T>A`, `G>C` and `C>G` classified as an inversion instead of falling through to the substitution arm immediately below it.

**A code with no complement is not self-complementary.** The helper's fallback returned the character unchanged, so `complement(R) == R` held for every code it did not model, and `RR` → `RR` — no change at all — read as an inversion. #1249's trap in a third module: a pass-through fallback makes "no answer" indistinguishable from "its own complement".

**Soft-masking hid inversions.** The comparison was case-sensitive while the complement upper-cased its output, so `ATG`/`cat` did not classify even though `atg`/`CAT` describes the same inversion. Reference FASTAs are routinely soft-masked.

## The fix

All three resolve to using `sequence::complement_base`, the crate's **comparison** complement — folds case, returns `None` for an unmodelled byte.

Deliberately *not* `sequence::reverse_complement`, the **display** helper, which preserves case and passes unmodelled characters through because its job is rendering a sequence a caller reads back. Reaching for the display helper answers the `X` case wrongly — that was tried first here and the `X` test caught it, which is the same display/comparison conflation the local copy made. #1318 drew that line and gave each side a contract; these two modules never moved onto either.

`effect::validate_inversion` carried a second copy of the same defect (`ACGTN` only, pass-through fallback), so an inversion of `RR` → `RR` validated as `Valid`. It now uses the shared helper. Its `expected:` field wants display semantics for the message and the comparison already folds case on both sides, so `reverse_complement` is correct there.

**Swept for other copies:** `sequence::complement_char`'s pass-through is the documented display contract, and `spdi::convert::apply_alphabet`'s is an alphabet mapping rather than a complement. Neither is a defect.

## Verification

| gate | result |
| --- | --- |
| `cargo nextest run --features dev` | **9085 passed, 0 failed** |
| clippy `-D warnings`, `cargo fmt --check` | clean |
| `tests/proptest-regressions/` | unchanged |

Four tests, written failing-first — one per defect plus the IUPAC case in `effect`. Log grepped for `SIGABRT` and `stack overflow`, not only `FAIL`: none.

One thing worth knowing if you regenerate locally: the three `spec_enumeration_tests` census guards failed in my worktree until I re-ran `generate_spec_enumeration`. That artifact is gitignored and the tests regenerate it only when *absent*, not when *stale*, so a worktree created before #1330–#1338 landed compares fresh code against an old artifact. Not caused by this change — verified by running those guards on clean `main`, where they pass, and again here after regenerating, where they also pass. This change moves no census row.

## Out of scope, noted

`validate_inversion` still reports `Valid` for `XX` → `XX`, because the display helper passes `X` through and the comparison then matches. Refusing it means giving the validator a "cannot validate this alphabet" answer, which changes the public `InversionValidation` surface — a separate decision, not a drive-by.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inversion detection for mixed-case sequences.
  * Correctly handles IUPAC ambiguity codes and their complements.
  * Rejects unsupported bases instead of incorrectly treating them as self-complementary.
  * Prevents single-base sequences from being classified as inversions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 2

Two findings, one from each lens. No unresolved review threads on the PR itself.

### The complement sweep was under-inclusive — filed as #1347

The PR states: *"Swept for other copies: `sequence::complement_char`'s pass-through is the documented display contract, and `spdi::convert::apply_alphabet`'s is an alphabet mapping rather than a complement. Neither is a defect."* Both of those calls are right, but the sweep missed four more private implementations:

| site | fallback | how it is used | same defect? |
|---|---|---|---|
| `src/vcf/from_hgvs.rs:1074` | `_ => c` | builds the ALT for `NaEdit::Inversion` (`:659`) | pass-through, but **produces** rather than compares |
| `src/reference/annotation/validate.rs:155` | `other => other` | assembles a minus-strand codon (`:143`) | pass-through, but produces rather than compares |
| `src/reference/derived_placement.rs:329` | `_ => b'N'` | placement validation | **no** — maps to `N`, so `complement(R) != R` |
| `src/reference/derived_tx_structure.rs:148` | `_ => 'N'` | minus-strand exon assembly | **no** — same |

(`src/project/edit.rs:100`'s `complement_base` takes a `Base` enum, so its alphabet is closed and it cannot have this failure mode.)

**None is the live misclassification this PR fixes**, which is why the suite is green either way: all four *produce* sequence rather than decide a classification. The two fixed sites answered a question — `is_inversion` on every equal-length delins, and `validate_inversion`'s verdict — so a self-complementary `R` was an immediately wrong answer there. Here the consequences are narrower: the two pass-through copies emit an unmodelled character verbatim into produced data, and the two `N` copies silently lose the code rather than complement it.

Not folded in, for the same reason this PR scopes out its own `XX` residual: moving the `N`-mapping pair onto the shared helper is a **behaviour change** needing its own before/after over the reference-data and VCF paths. Tracked in **#1347** with the full inventory and a suggested order.

### A third test class: self-complementary is not the same as palindromic

`a_code_without_a_complement_is_not_its_own_complement` pinned two classes — unmodelled (`X`) and modelled-but-not-self-complementary (`R`) — but not the third: a code that genuinely *is* its own complement. Without it, a "fix" that simply refused every ambiguity code would satisfy the existing test and be wrong.

Added `a_self_complementary_code_is_an_inversion_unchanged`. `S` (G/C), `W` (A/T) and `N` all complement to themselves in `sequence::complement_base`, so an unchanged run of them really is an inversion.

The case is more interesting than it first looks, and getting it wrong on the first attempt is what surfaced why: **self-complementary is not palindromic**. When every base complements to itself, `revcomp` degenerates to the plain *reverse*, so an unchanged run is an inversion exactly when the run reads the same backwards. `SS`/`WW`/`NN` qualify; `SW` does not — `revcomp(SW)` is `WS`, so `SW`→`WS` is the inversion and `SW`→`SW` is not. Both directions are now asserted, which pins the distinction rather than leaving it to be re-derived.

### Movement relative to the reference oracles

**Toward, on a shape no oracle covers.** Three input classes change classification, and each moves onto the spec's stated answer: a 1 nt equal-length delins is now a substitution (`inversion.md:15-16` — "the region inverted contains **more than one nucleotide**"), an unchanged run of a non-self-complementary ambiguity code is no longer an inversion, and a soft-masked pair now classifies the same as its uppercase twin. The biocommons / Mutalyzer / hgvs-rs corpora are uppercase `ACGT` and carry no ambiguity codes, so none of the three is an input they exercise — which is why the defects went unnoticed rather than showing up as oracle divergence. For every uppercase `ACGT` delins of two or more nucleotides, output is unchanged.

Full suite: **9,177 passed, 0 failed**; `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean; `tests/proptest-regressions/` unchanged.
