### PR TITLE
docs(normalize): stop citing prioritisation for a rule it does not state

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3210,8 +3210,10 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
             // or more nucleotides should be described individually and not as a
             // 'delins'" — so prefer the placement that leaves a matched base
             // *between* the changes, which is the one separating them into more
-            // members. `general.md:56` says the same from the other side, since
-            // `delins` is last in the priority order.
+            // members. `general.md:56` is *not* a second authority for this:
+            // `delins` does not appear in its list at all, and what it ranks is
+            // the type of one description of one change — see
+            // `split_buys_no_higher_priority_type`'s doc.
             //
             // This is not the 5'-most/3'-most flip that was tried and rejected:
             // it does not rank placements by position at all. `AAA -> CA`'s
@@ -6944,9 +6946,10 @@ mod tests {
 
         /// `C1` (232 blocks). Both denote the alternate block and both spend the
         /// same number of changed columns; they only divide the change
-        /// differently. Which is preferable is not decided here — the spec's
-        /// prioritisation rule (`general.md:56`) is what reaches these, and the
-        /// two blocks below fall to it in opposite directions.
+        /// differently. Which is preferable is not decided here — `delins.md:17`
+        /// and ferro's own `split_buys_no_higher_priority_type` policy are what
+        /// reach these, and the two blocks below fall to them in opposite
+        /// directions.
         #[test]
         fn equal_weight_different_division() {
             let (live, shadow) = both(b"ACAGCG", b"CGCTGT");
@@ -7330,7 +7333,9 @@ mod tests {
     /// description. msto's `high` corpus states the rule the spec gives for
     /// that: two variants separated by one or more unchanged nucleotides are
     /// described individually and **not** as a `delins` (`delins.md:17`, cited
-    /// by #1232), and `general.md:56` ranks `delins` last (#1231, #1233).
+    /// by #1232). `general.md:56` does not rank `delins` last — `delins` is
+    /// absent from that list, which ranks the type of one description of one
+    /// change, the way #1231/#1233 apply it member-wise.
     mod tie_break_by_separation {
         use super::*;
 
@@ -7411,8 +7416,9 @@ mod tests {
         #[test]
         fn the_two_gap_form_partitions_into_two_pure_insertions() {
             // The point of expressing it: two members, each a pure insertion,
-            // separated by the retained base. `general.md:56` prefers those to
-            // one spanning `delins`.
+            // separated by the retained base. That preference is `delins.md:17`
+            // plus ferro policy, not `general.md:56`, whose list does not
+            // contain `delins`.
             let columns = best_alignment(b"A", b"CAC").expect("aligned");
             assert_eq!(
                 pieces_from_columns(&columns, b"A", b"CAC"),
@@ -7569,8 +7575,10 @@ mod tests {
         fn a_split_that_buys_no_higher_priority_type_collapses() {
             // #422. The same shape as #999-neg — net insertion, one
             // coincidentally matched interior base — but its split is two
-            // `delins` members, so it buys nothing `general.md:56` ranks above
-            // the spanning `delins` it came from. #1235's own comment asks for
+            // `delins` members, so it buys no higher-priority type than the
+            // spanning `delins` it came from — ferro policy, per
+            // `split_buys_no_higher_priority_type`'s doc, not `general.md:56`.
+            // #1235's own comment asks for
             // exactly this: a fix that resolves #422 and keeps #999 green.
             assert_eq!(partition_block(b"CTATAG", b"AAACCCC").len(), 1);
         }

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1152,7 +1152,7 @@ pub enum DelinsSubedit {
 /// - Issue #160 (item A2 + A10 inv-branch of tracking issue #81), as
 ///   corrected by issue #1034: an `Inversion` is emitted only when a whole
 ///   maximal contiguous mismatch run is a reverse complement, per the HGVS
-///   edit-priority rule (`general.md:56`: `inv > delins`) applied to the
+///   edit-priority rule applied to the
 ///   *maximal contiguous run* (`DNA/inversion.md`). A reverse-complement
 ///   sub-run of a longer contiguous change is NOT carved out — that change
 ///   stays a single `delins`.

--- a/tests/it/issue_92_protein_delins_to_dup.rs
+++ b/tests/it/issue_92_protein_delins_to_dup.rs
@@ -6,7 +6,12 @@
 //! prefix or suffix with the deleted residues must be re-described
 //! with the trimmed range and trimmed insert (`delins.md:53-56`). After
 //! affix-trim, the residual is canonicalized per Prioritization
-//! (`general.md:56-57`): `sub > del > dup > ins > delins`.
+//! (`general.md:56-57`), whose list is `sub > del > inv > dup > ins` — on the
+//! protein axis, `sub > del > dup > ins`, since there is no protein
+//! `inversion.md`. `delins` is **not** a rung on it: `protein/delins.md:5`
+//! defines a delins as a change "which is **not** a substitution or
+//! frameshift", so it is the residual left when no ranked type applies, which
+//! is why reaching a `dup` here is an improvement rather than a re-ranking.
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::{parse_hgvs, Normalizer};

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -4737,8 +4737,10 @@ mod cigar_cds_mapping {
 // compound variants
 // =============================================================================
 // HGVS spec: an inversion describes a *maximal contiguous run* whose alt is
-// the reverse complement of the reference (`DNA/inversion.md`,
-// `general.md:56`). A delins whose WHOLE contiguous run is a revcomp becomes
+// the reverse complement of the reference (`DNA/inversion.md`;
+// `general.md:56` ranks `inversion` third of the five types it lists, and
+// `delins` is not on that list — it is the residual). A delins whose WHOLE
+// contiguous run is a revcomp becomes
 // an `inv`; a revcomp SUB-run of a longer contiguous change is NOT carved out
 // — that change stays a single `delins` (issue #1034 regression fix). A run
 // that is a full inversion but separated from other edits by an unchanged
@@ -5615,7 +5617,9 @@ mod ins_bracketed_expansion {
     //     inside the expanded payload; keeping them means the whole reference
     //     survives between two insertions. That is more minimal (9 + 3 = 12
     //     changed columns against the spanning `delins`'s 14) and two `ins`
-    //     members outrank one `delins` (`general.md:56`).
+    //     members are preferred to one spanning `delins` — `delins.md:17` plus
+    //     ferro policy, not `general.md:56`, whose prioritisation list is
+    //     `sub > del > inv > dup > ins` and does not contain `delins` at all.
     //
     //     Worth knowing: a short reference block inside a long payload is
     //     exactly where "the whole reference survives" is most likely to be

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -217,8 +217,17 @@ class TestNormalizeDelinsSubOnlyDecompose:
     """Issue #81 item A10 (sub-only branch, tracked in #165): a delins whose
     span contains two or more independent single-base mismatches separated
     by at least one unchanged nucleotide decomposes to the individual
-    `[X>A; B>Y]` form per `general.md:56` (sub > delins). The codon-frame
-    exception (`general.md:35-38`) preserves an embedded
+    `[X>A; B>Y]` form.
+
+    The rule that splits it is `delins.md:17` — two variants separated by one or
+    more nucleotides are described individually and **not** as a "delins". It is
+    not prioritisation: `general.md:56` lists five types
+    (`sub > del > inv > dup > ins`) and `delins` is not one of them, so there is
+    no "sub > delins" rung to appeal to. Prioritisation only settles what each
+    resulting member is once the split has happened — a single-base change is a
+    substitution.
+
+    The codon-frame exception (`general.md:35-38`) preserves an embedded
     `[Sub; Identity; Sub]` triplet whose endpoints share a codon.
 
     Reference: NM_000088.3 has CDS sequence


### PR DESCRIPTION
`general.md:56`'s prioritisation list is "(1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion". **`delins` is not in it.** What the rule ranks is the type of *one description of one change* — which is how #1231/#1233 apply it, comparing two two-member descriptions member-wise. It never ranks a multi-member allele against a single spanning description.

`split_buys_no_higher_priority_type`'s doc comment already states this, and explicitly records that an earlier revision of itself made the mistake:

> It is tempting to cite `general.md:56`'s prioritisation here, and an earlier revision of this comment did — claiming `delins` was "last" in it. That citation does not reach.

Four other sites in the same file still made that claim, and a fifth attributed an undecided tie to the rule. Notably one of the four is the test for `split_buys_no_higher_priority_type` itself, so the function's doc and its test disagreed.

| site | was | now |
|---|---|---|
| `best_alignment` tie-break | "`general.md:56` says the same from the other side, since `delins` is last in the priority order" | says the rule is *not* a second authority here, and points at `split_buys_no_higher_priority_type` |
| `equal_weight_different_division` | "the spec's prioritisation rule is what reaches these" | `delins.md:17` plus ferro's split policy |
| `tie_break_by_separation` | "`general.md:56` ranks `delins` last" | notes `delins` is absent from the list |
| `the_two_gap_form_partitions_into_two_pure_insertions` | "`general.md:56` prefers those to one spanning `delins`" | `delins.md:17` plus ferro policy |
| `a_split_that_buys_no_higher_priority_type_collapses` | "buys nothing `general.md:56` ranks above" | ferro policy, per the function's own doc |

Two sites are left untouched because they use the rule correctly — the weight-bound comment (equality, where member-wise prioritisation legitimately applies) and the `split_buys_no_higher_priority_type` doc itself.

**Comment-only; no behaviour change.** The behaviour these comments describe is unchanged and remains correct — it is ferro policy resting on `delins.md:17`, which is what the comments now say.

## Verification

- `cargo nextest run --features dev` — 9173 passed, 146 skipped
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

---

## Review round 2

**The claim is verified against the submodule, not taken on trust.** `assets/hgvs-nomenclature` at `21.0.4-82-g6f85311`, `docs/recommendations/general.md:56`:

> **prioritisation**: when a description is possible according to several types, the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion.

Five types, and `delins` is genuinely not among them. `DNA/delins.md:17` is also quoted accurately ("two variants separated by one or more nucleotides should be described individually and **not** as a 'delins'"). So the premise holds.

**The fix was incomplete, which is the same drift the PR exists to remove.** It corrected six citations in `src/normalize/merge.rs` and left the identical wrong claim in four other files. Swept and corrected:

| site | was | now |
|---|---|---|
| `src/normalize/rules.rs:1155` | "`general.md:56`: `inv > delins`" | the rung is dropped; `inv` is ranked, `delins` is not |
| `tests/it/normalize_tests.rs:5618` | "two `ins` members outrank one `delins` (`general.md:56`)" | `delins.md:17` plus ferro policy — the same wording this PR put in `merge.rs` |
| `tests/it/normalize_tests.rs:4741` | `DNA/inversion.md`, `general.md:56` read as ranking `inv` over `delins` | states that `inversion` is third of the five and `delins` is the residual |
| `tests/python/test_core.py:220` | "`general.md:56` (sub > delins)" | `delins.md:17` is the rule that *splits*; prioritisation only settles what each member is afterwards |
| `tests/it/issue_92_protein_delins_to_dup.rs:9` | "`sub > del > dup > ins > delins`" | the real list, noting the protein axis has no `inversion.md`, and citing `protein/delins.md:5` — a delins is defined as a change "which is **not** a substitution or frameshift", i.e. residual by definition |

Left alone because they were already right: `issue_165_delins_sub_only_decompose.rs:6` (lists the five and calls `delins` "the residual when no higher-priority form applies" — the model the others now follow), `render_calibration.rs:4`, `mod.rs:2534/3362/5267/9383/9970`, `issue_182_postcanon_adjacency.rs:18`, `issue_1235_cis_allele_confluence.rs:120/139`, and `test_core.py:112` (inversion *is* a ranked type).

`grep -rn 'general.md:56' src/ tests/ | grep -i delins` now returns only statements that `delins` is absent from the list.

### Movement relative to the reference oracles

**None. Zero non-comment lines changed** — verified mechanically, not asserted: `git diff origin/main...HEAD -U0` filtered to non-comment `+`/`-` lines returns 0. Every edit is a doc comment, a code comment, or a Python docstring.

Suite green (`9,173` passed at the time of the sweep), `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean, `ruff check` and `ruff format --check` clean on the touched Python file.

### Unrelated defect surfaced while validating, filed not folded in

The full-suite run drew a fresh proptest seed and hit a 5'-shuffle non-idempotency: `NM_TEST.1:c.2_3insTCC` on `CCCCTCCTCCTCCTCCCGGGG` (`CdsUtr3Plus`) gives `c.1delinsCCTC` once and `c.-1_2dup` twice. Filed as **#1349**.

It is **not** caused by this change — bisected to `8aff336`, the tip of `main` before #1335–#1341 merged, where the failure is byte-identical. The seed proptest auto-appended to `tests/proptest-regressions/normalize_idempotency_proptest.txt` was reverted rather than committed: attaching an unrelated live defect's seed to a documentation-only branch would misattribute it. The seed line is recorded in #1349 for whoever fixes it.
