### PR TITLE
fix(normalize): bound a cis junction's 5' shift at its siblings

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4458,6 +4458,18 @@ pub(crate) fn demote_coincident_tract_repeats<P: ReferenceProvider>(
 /// its insertion lands at `306|307` against a substitution at `307`, which is
 /// the last position the rule permits — so the collapse still fires.
 ///
+/// A sibling's own junction bounds it as well, not only a sibling's bases
+/// (#1290): two junction-occupying members add their payloads at two interbase
+/// points, and their relative order is the only thing fixing the order of those
+/// payloads, so sweeping past one reorders them. That bound stops one position
+/// short of the sibling's junction unless the two payloads commute.
+///
+/// Both shift directions are governed. The 5' half was missing until #1267 —
+/// which is the shape where the sibling is *upstream* and the junction travels
+/// toward it — and the two bounds needed it independently: base-claiming
+/// siblings accounted for half the measured defect, junction-occupying siblings
+/// the other half.
+///
 /// A junction sits immediately 3' of one position: `end` for a duplication
 /// (the copy follows the duplicated bases), `start` for an insertion (whose
 /// span is the gap `start_end`).
@@ -4506,29 +4518,43 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
             .filter(|s| s.claims_bases && s.region == a.region && s.accession == a.accession)
             .collect();
 
-        // 3' only, and the 5' case is genuinely unsolved rather than merely
-        // unwritten. A duplication's span and its junction move together under a
-        // 5' shift, so bounding the junction there mis-places the copy: a mirror
-        // of the rule below was measured to turn 80 previously-correct outputs
-        // into silently wrong ones, and was removed as defective rather than
-        // deferred.
+        // Both directions, and the rule is the same in each: a junction may
+        // reach a sibling's edge but not pass it (#1267).
         //
-        // A 5' junction *does* cross, in a shape this rule would not have caught
-        // anyway — when the sibling is **upstream** and the junction travels
-        // toward it. The duplication half of that (`g.[4A>G;9dup]`, which used
-        // to emit `g.4_5insG`) is closed by `blocks_sibling_shift`, which bounds
-        // the duplication's *span* rather than its junction. The insertion half
-        // remains open, narrowed and characterised in
-        // `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`.
-        if after_junction < before_junction {
-            continue;
-        }
+        // The 5' half was absent, and its absence read as deliberate — #1259
+        // measured a 5' mirror turning 80 previously-correct outputs silently
+        // wrong, on the reasoning that a duplication's span and junction move
+        // together so bounding the junction mis-places the copy. But that mirror
+        // bounded the junction against a sibling the member was moving *away*
+        // from, not one it was moving *toward*; it was a different rule, and its
+        // failure does not bear on this one.
+        //
+        // Restricting the 5' half by input spelling — admitting only a member the
+        // input wrote as an insertion — was tried and refuted by measurement.
+        // Over 73,376 duplication-mover cases with an upstream sibling, bounding
+        // every junction mover leaves **zero** sequence changes while the
+        // restricted form leaves **12**, all of them a `dup` whose junction swept
+        // past an upstream sibling's junction. Deciding this from the input's
+        // encoding was both more complex and less correct, so the direction is
+        // simply mirrored.
+        let five_prime = after_junction < before_junction;
         // The junction crossed a base-claiming sibling if it started 5' of the
-        // sibling's first base and ended at or past it.
-        let onto_bases = siblings
-            .iter()
-            .filter(|s| s.start > before_junction && s.start <= after_junction)
-            .map(|s| s.start - 1);
+        // sibling's first base and ended at or past it. Mirrored under a 5'
+        // shift: the junction started 3' of the sibling's *last* base and ended
+        // at or before it, and must stay at or above that base.
+        let onto_bases: Vec<i64> = if five_prime {
+            siblings
+                .iter()
+                .filter(|s| s.end > after_junction && s.end <= before_junction)
+                .map(|s| s.end)
+                .collect()
+        } else {
+            siblings
+                .iter()
+                .filter(|s| s.start > before_junction && s.start <= after_junction)
+                .map(|s| s.start - 1)
+                .collect()
+        };
         // It can equally cross another *junction* (#1290). Two junction-
         // occupying members add their payloads at two interbase points, and
         // their relative order is the only thing fixing the order of those
@@ -4604,7 +4630,15 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
             })
             .filter_map(|(settled, variant, s)| {
                 let junction = s.junction?;
-                if junction <= before_junction || junction > after_junction {
+                // Was it swept over? Under a 3' shift the sibling's junction
+                // must lie above where this one started and at or below where it
+                // ended; under a 5' shift, mirrored.
+                let swept = if five_prime {
+                    junction >= after_junction && junction < before_junction
+                } else {
+                    junction > before_junction && junction <= after_junction
+                };
+                if !swept {
                     return None;
                 }
                 // Commuting is tested against the payload this member would
@@ -4645,22 +4679,31 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
                     // approached. Its pre-normalization position is exactly the
                     // order commuting makes unobservable, so it is not a bound.
                     true => settled.then_some(junction),
+                    // One short of it, on the side this member came from.
+                    false if five_prime => Some(junction + 1),
                     false => Some(junction - 1),
                 }
             });
-        let limit = onto_bases.chain(across_junctions).min();
+        // The most restrictive bound: the lowest ceiling under a 3' shift, the
+        // highest floor under a 5' one.
+        let bounds = onto_bases.into_iter().chain(across_junctions);
+        let limit = if five_prime {
+            bounds.max()
+        } else {
+            bounds.min()
+        };
         let Some(limit) = limit else {
+            continue;
+        };
+        let Some(payload) = payload.as_ref() else {
             continue;
         };
         // Never move past where the junction started, and never onto a junction
         // this member's payload is out of phase with: the walk back finds the
-        // most 3' position it can legally occupy. `before_junction` always can,
-        // since that is where the shift began.
-        let ceiling = limit.max(before_junction).min(after_junction);
-        let Some(payload) = payload.as_ref() else {
-            continue;
-        };
-        let Some(destination) = (before_junction..=ceiling).rev().find(|&j| {
+        // most extreme position it can legally occupy in the direction it was
+        // travelling. `before_junction` always can, since that is where the
+        // shift began.
+        let legal = |j: i64| {
             payload_at_junction(
                 payload,
                 after_junction,
@@ -4670,7 +4713,15 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
                 provider,
             )
             .is_some()
-        }) else {
+        };
+        let destination = if five_prime {
+            let floor = limit.min(before_junction).max(after_junction);
+            (floor..=before_junction).find(|&j| legal(j))
+        } else {
+            let ceiling = limit.max(before_junction).min(after_junction);
+            (before_junction..=ceiling).rev().find(|&j| legal(j))
+        };
+        let Some(destination) = destination else {
             continue;
         };
         let delta = destination - after_junction;

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -36,8 +36,6 @@
 //! repeats too, and the junction is then bounded at the sibling's 5' edge —
 //! still flush against it, so the #999 collapse keeps firing.
 
-use std::collections::BTreeMap;
-
 use crate::common::cis_apply_oracle::{
     apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize, normalize_in,
     sweep_sequences,
@@ -61,46 +59,20 @@ const RUN: &str = "ACAAAAAAAACGTACGTACG";
 /// in that shape specifically.
 const FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES: usize = 0;
 
-/// Sequence-changing cases the tandem-tract sweep finds in the 5'-shuffle
-/// insertion-junction shape — the insertion half of #1267, which
-/// `blocks_sibling_shift` deliberately does not reach.
-///
-/// **Not zero.** This is a live, tracked defect, pinned here as an exact count
-/// so the shape stays inside the sweep rather than being excluded from it: a
-/// *new* defect landing in the same shape would raise the number and fail.
-/// `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`
-/// characterises one case by hand on a homopolymer; this counts the whole shape
-/// over a non-homopolymer `(CAG)` tract.
-///
-/// The count breaks down by the sibling's **position**, not its edit type,
-/// which is what a junction-crossing defect predicts: the junction travels past
-/// a *position*, so the sibling's shape does not change how many cases it
-/// corrupts. The two sibling *positions* outside the tract (9 and 42, four
-/// shapes each) contribute **zero**, because the junction cannot travel out of
-/// the tract to reach them — which is why neither appears as a key.
-///
-/// Pinned **per position** rather than as a total, and the map is compared
-/// whole. That buys two things a scalar cannot:
-///
-/// * a defect that adds cases at `inside_5p` while removing the same number at
-///   `inside_3p` no longer passes with the total unchanged — the very asymmetry
-///   the paragraph above tells the reader to treat as a new defect, now
-///   executable rather than merely documented; and
-/// * a sequence change at an *unlisted* position fails on the extra key. That
-///   matters since the sweep reaches the boundary junctions: at junction 10 the
-///   outside-5' sibling at 9 satisfies `sibling_pos < junction`, so it is inside
-///   the `known_1267_shape` predicate and a scalar would have absorbed it as
-///   part of the known gap instead of surfacing it.
-///
-/// The numbers are fully accounted for, which is what makes a move readable:
-/// each is `<junctions 3' of the sibling> x <2 siblings at that position> x
-/// <2 member orders>`. Position 15 is reached from junctions 16..=40, so
-/// `25 x 2 x 2 = 100`; position 36 from junctions 37..=40, so `4 x 2 x 2 = 16`.
-/// Exactly one of the nine `(rotation, copies)` payload combinations corrupts
-/// per junction — the out-of-phase one — which is why rotation and copy count
-/// do not appear as factors.
-const TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION: [(usize, usize); 2] =
-    [(15, 100), (36, 16)];
+// The 5'-shuffle insertion-junction shape — the insertion half of #1267 — used
+// to be excluded from this file's sequence-preservation assertion and counted
+// instead, as `TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION =
+// [(15, 100), (36, 16)]`: 116 cases pinned per sibling position so the shape
+// stayed measured while it was broken.
+//
+// It is fixed, so the exclusion is gone and those cases are asserted like every
+// other — a regression there now reports the offending descriptions rather than
+// a bare count. The two halves of that 116 needed separate bounds, and measuring
+// per-position is what showed the second half existed: bounding the junction
+// against base-claiming siblings alone took the map to `{15: 50, 36: 8}`,
+// exactly half, because the other half's sibling was a `dup` or an `ins` —
+// junction-occupying, so invisible to `claims_bases`. Mirroring the
+// junction-vs-junction bound (#1290) closed the rest.
 
 #[test]
 fn an_insertion_does_not_shift_past_a_substituted_base() {
@@ -375,28 +347,122 @@ fn a_five_prime_duplication_does_not_cross_an_upstream_sibling() {
 }
 
 #[test]
-fn a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap() {
-    // The rest of #1267, which `blocks_sibling_shift` deliberately does not
-    // reach. That predicate makes a member a barrier because the bases under
-    // its span are what it copies — true of a `Duplication`, false of a pure
-    // `Insertion`, whose payload is a literal and whose span is zero-width.
-    // There is nothing for a sibling to land *on*.
+fn an_insertion_junction_does_not_cross_an_upstream_sibling() {
+    // The rest of #1267: the member written as an insertion. Under 5' shuffle
+    // its payload travelled 5' past an upstream sibling, so the allele denoted
+    // different bases while staying well-formed, disjoint and warning-free:
     //
-    // Bounding the insertion's **junction** in the 5' direction is the fix this
-    // shape needs, and #1259 measured a 5' mirror of the junction clamp turning
-    // 80 previously-correct outputs into silently wrong ones. So this stays
-    // open, narrowed to the insertion case.
+    //   reference             ACAAAAAAAACGTACGTACG        A-run at 3-10
+    //   g.[4A>G;9_10insA]     applies to  ACAGAAAAAAACGTACGTACG
+    //   emitted  g.4_5insG                ACAAGAAAAAACGTACGTACG   <- moved base
     //
-    // Pinned as *currently wrong*: fixing it fails this test loudly.
+    // `blocks_sibling_shift` does not reach it, and neither does the span clamp:
+    // the member is an `Insertion` on the way in but canonicalises to a
+    // `Duplication` (`g.9_10insA` alone -> `g.3dup`), so it *grew*, and a member
+    // that grew is refused there for reasons #1266/#1279 measured. What bounds
+    // it is the junction clamp's 5' half, which governs **every** junction mover
+    // regardless of how the input spelled it — restricting it to inputs written
+    // as insertions was tried and refuted by measurement (see
+    // `clamp_sibling_crossing_junctions`: over 73,376 duplication-mover cases the
+    // unrestricted bound leaves zero sequence changes against the restricted
+    // form's twelve).
+    //
+    // Member order is an input the normalizer must be indifferent to, so both
+    // orders are asserted.
     let seq = "ACAAAAAAAACGTACGTACG";
-    let input = "TEMPLATE:g.[4A>G;9_10insA]";
-    let actual = normalize_in(seq, input, ShuffleDirection::FivePrime);
-    assert_eq!(actual, "TEMPLATE:g.4_5insG", "known-gap shape changed");
-    assert_ne!(
-        apply(seq, &actual).expect("output applies"),
-        apply(seq, input).expect("input applies"),
-        "{input} is fixed — update this test and close the insertion half of #1267"
-    );
+    for input in ["TEMPLATE:g.[4A>G;9_10insA]", "TEMPLATE:g.[9_10insA;4A>G]"] {
+        let actual = normalize_in(seq, input, ShuffleDirection::FivePrime);
+        // Pinned, not merely sequence-preserving. The `apply` comparison below
+        // is satisfied by an output identical to the input — which is exactly
+        // what a clamp that failed to fire would produce — so on its own it
+        // cannot tell "bounded correctly" from "nothing happened". The junction
+        // must land at `3|4`, one short of the substituted base at 4, where it
+        // coalesces with the sibling.
+        assert_eq!(
+            actual, "TEMPLATE:g.3_4insG",
+            "{input} must bound its junction at the sibling's 5' edge"
+        );
+        assert_ne!(actual, input, "the clamp must actually move the junction");
+        assert_eq!(
+            apply(seq, &actual).expect("output applies"),
+            apply(seq, input).expect("input applies"),
+            "{input} -> {actual} changed the denoted sequence"
+        );
+    }
+}
+
+/// `(CAG)x10` at 1-based 11..=40, flanked by `T`. The tract the tandem sweep
+/// uses; a junction can travel it without the payload being in phase everywhere,
+/// which is what makes it the corpus for the 5' insertion-junction shape.
+fn cag_tract() -> String {
+    format!("{}{}{}", "T".repeat(10), "CAG".repeat(10), "T".repeat(20))
+}
+
+#[test]
+fn an_insertion_junction_does_not_cross_an_upstream_junction_sibling() {
+    // The other half of #1267's 5' shape. Here the upstream sibling adds
+    // sequence at a junction instead of claiming bases, so `claims_bases` — the
+    // bound that stops the substitution case above — does not see it at all:
+    //
+    //   g.[16_17insCAG;15dup]  ->  g.[11_13dup;15dup]
+    //
+    // The two members stay disjoint (11-13 against 15), so nothing flags it, but
+    // the payload has moved from 3' of the sibling to 5' of it. Two junctions'
+    // relative order is the only thing fixing the order of their payloads, which
+    // is the same reasoning the 3' half already applies (#1290) — mirrored.
+    let seq = cag_tract();
+    for input in [
+        "TEMPLATE:g.[16_17insCAG;15dup]",
+        "TEMPLATE:g.[15dup;16_17insCAG]",
+        "TEMPLATE:g.[37_38insCAG;36_37insTT]",
+        "TEMPLATE:g.[36_37insTT;37_38insCAG]",
+    ] {
+        let actual = normalize_in(&seq, input, ShuffleDirection::FivePrime);
+        assert_eq!(
+            apply(&seq, &actual).expect("output applies"),
+            apply(&seq, input).expect("input applies"),
+            "{input} -> {actual} changed the denoted sequence"
+        );
+    }
+}
+
+#[test]
+fn a_duplication_junction_does_not_cross_an_upstream_junction_sibling() {
+    // The 5' junction bound applies to a **duplication** mover too, not only one
+    // the input spelled as an insertion.
+    //
+    // Restricting it to input insertions looks like the conservative reading of
+    // #1259 — a duplication's span and junction move together under a 5' shift,
+    // and a blanket mirror of the 3' rule was measured there to turn 80
+    // previously-correct outputs silently wrong. But that mirror bounded the
+    // junction against a sibling the member was moving *away* from, which is a
+    // different rule from this one. Restricting by input spelling instead leaves
+    // the shape below broken: a `dup` whose junction sweeps past an upstream
+    // sibling's junction, reordering the two payloads.
+    //
+    //   reference   GGGGGGGG + (A x 24) + GGGGGGGG
+    //   g.[3dup;2_3insTT]   applies to  GGTTGGGGGGGAAA…
+    //   unbounded           g.[1dup;2_3insTT]   GGGTTGGGGGG AAA…   <- payloads swapped
+    //
+    // Measured over 73,376 duplication-mover cases with an upstream sibling:
+    // bounding every junction mover leaves **zero** sequence changes, while
+    // restricting the bound to input insertions leaves **12** — all of this
+    // shape. So the unrestricted rule is both simpler and strictly more correct,
+    // and it does not decide the output from the input's encoding.
+    let seq = format!("{}{}{}", "G".repeat(8), "A".repeat(24), "G".repeat(8));
+    for input in [
+        "TEMPLATE:g.[3dup;2_3insTT]",
+        "TEMPLATE:g.[2_3insTT;3dup]",
+        "TEMPLATE:g.[4dup;2_3insTT]",
+        "TEMPLATE:g.[2_3insTT;4dup]",
+    ] {
+        let actual = normalize_in(&seq, input, ShuffleDirection::FivePrime);
+        assert_eq!(
+            apply(&seq, &actual).expect("output applies"),
+            apply(&seq, input).expect("input applies"),
+            "{input} -> {actual} changed the denoted sequence"
+        );
+    }
 }
 
 #[test]
@@ -473,9 +539,6 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
 
     let mut checked = 0usize;
     let mut skipped = 0usize;
-    // Bucketed by the sibling's position, not summed: see
-    // `TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION`.
-    let mut residual: BTreeMap<usize, usize> = BTreeMap::new();
     let mut overlapping: Vec<String> = Vec::new();
     let mut changed: Vec<String> = Vec::new();
 
@@ -514,36 +577,28 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
                 let inside_5p = tract_start + 4;
                 let inside_3p = tract_end - 4;
                 let base_at = |pos: usize| seq.as_bytes()[pos - 1] as char;
+                // Each sibling names its own position, so the shapes are grouped
+                // by comment rather than carried alongside a redundant index.
                 let siblings = [
-                    (tract_start - 2, format!("{}T>A", tract_start - 2)), // 5' of tract
-                    (tract_start - 2, format!("{}del", tract_start - 2)),
-                    (tract_start - 2, format!("{}dup", tract_start - 2)),
-                    (
-                        tract_start - 2,
-                        format!("{}_{}insA", tract_start - 2, tract_start - 1),
-                    ),
-                    (tract_end + 2, format!("{}T>A", tract_end + 2)), // 3' of tract
-                    (tract_end + 2, format!("{}del", tract_end + 2)),
-                    (tract_end + 2, format!("{}dup", tract_end + 2)),
-                    (
-                        tract_end + 2,
-                        format!("{}_{}insA", tract_end + 2, tract_end + 3),
-                    ),
-                    (inside_5p, format!("{inside_5p}{}>T", base_at(inside_5p))), // inside
-                    (inside_5p, format!("{inside_5p}dup")),
-                    (inside_3p, format!("{inside_3p}del")),
-                    (
-                        inside_3p,
-                        // `T` is absent from a `(CAG)` tract, so this stays an
-                        // `Insertion`. Inserting `base_at(inside_3p)` here —
-                        // the reference base immediately 5' of the junction —
-                        // denotes the same edit as `{inside_3p}dup`, so the
-                        // array would have claimed four sibling shapes while
-                        // carrying three.
-                        format!("{inside_3p}_{}insTT", inside_3p + 1),
-                    ),
+                    format!("{}T>A", tract_start - 2), // 5' of tract
+                    format!("{}del", tract_start - 2),
+                    format!("{}dup", tract_start - 2),
+                    format!("{}_{}insA", tract_start - 2, tract_start - 1),
+                    format!("{}T>A", tract_end + 2), // 3' of tract
+                    format!("{}del", tract_end + 2),
+                    format!("{}dup", tract_end + 2),
+                    format!("{}_{}insA", tract_end + 2, tract_end + 3),
+                    format!("{inside_5p}{}>T", base_at(inside_5p)), // inside
+                    format!("{inside_5p}dup"),
+                    format!("{inside_3p}del"),
+                    // `T` is absent from a `(CAG)` tract, so this stays an
+                    // `Insertion`. Inserting `base_at(inside_3p)` here — the
+                    // reference base immediately 5' of the junction — denotes the
+                    // same edit as `{inside_3p}dup`, so the array would have
+                    // claimed four sibling shapes while carrying three.
+                    format!("{inside_3p}_{}insTT", inside_3p + 1),
                 ];
-                for (sibling_pos, sibling) in siblings {
+                for sibling in siblings {
                     for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
                         // Author the sibling first or second: member order is
                         // an input the normalizer must be indifferent to.
@@ -557,35 +612,18 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
                                 skipped += 1;
                                 continue;
                             };
-                            // The insertion half of #1267, counted rather than
-                            // skipped — the same treatment the two-member sweep
-                            // gives its `dup` + `del` + 5' residual, and for the
-                            // same reason: excluding a shape drops it out of the
-                            // check entirely, so a *new* defect landing in it
-                            // would pass silently. Counting keeps it measured
-                            // and names the shape if the number moves.
-                            //
-                            // Under 5' shuffle an insertion's junction travels
-                            // toward the tract's 5' end and crosses an upstream
-                            // sibling. `blocks_sibling_shift` deliberately does
-                            // not reach a pure `Insertion` (zero-width span,
-                            // nothing to land on), and #1259 measured a 5'
-                            // mirror of the junction clamp turning 80
-                            // previously-correct outputs silently wrong — so
-                            // this is not a local fix. Pinned by
-                            // `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`
-                            // on a homopolymer; this is the same shape on a
-                            // non-homopolymer tract.
-                            let known_1267_shape =
-                                direction == ShuffleDirection::FivePrime && sibling_pos < junction;
+                            // Every shape is asserted, including the 5'
+                            // insertion-junction one that used to be excluded and
+                            // counted (see the note above the sweep). A sibling
+                            // upstream of the junction is the #1267 shape; it is
+                            // bounded now, so a sequence change there is a
+                            // regression like any other and reports the
+                            // description rather than incrementing a count.
                             match apply(&seq, &output) {
                                 None if overlapping.len() < 10 => {
                                     overlapping.push(format!("{input} -> {output}"));
                                 }
                                 None => {}
-                                Some(got) if got != want && known_1267_shape => {
-                                    *residual.entry(sibling_pos).or_default() += 1;
-                                }
                                 Some(got) if got != want && changed.len() < 10 => {
                                     changed.push(format!(
                                         "{input} [{direction:?}] -> {output} \
@@ -621,18 +659,10 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
         overlapping.is_empty(),
         "overlapping or unconvertible output in {checked} tract cases: {overlapping:#?}"
     );
+    // No excluded shape: this covers the 5' insertion-junction cases too, which
+    // is where the 116 pinned residuals used to live.
     assert!(
         changed.is_empty(),
         "sequence-changing normalizations in {checked} tract cases: {changed:#?}"
-    );
-    // Pinned exactly, so the known gap stays measured rather than excluded. A
-    // *rise* is a new defect in the #1267 shape; a *fall* means the insertion
-    // half of #1267 is being fixed — in which case update this number and the
-    // sibling test `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`
-    // together.
-    assert_eq!(
-        residual,
-        BTreeMap::from(TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION),
-        "the 5' insertion-junction shape over a tandem tract changed"
     );
 }

--- a/tests/it/rewrite_target_corpus.rs
+++ b/tests/it/rewrite_target_corpus.rs
@@ -26,11 +26,13 @@
 //!   independent of the normalizer under test) and it keeps passing after the rewrite
 //!   lands; a malformed pin here would prove nothing about the normalizer, which is why the
 //!   guard exists at all.
-//! - *Denotation* (#1267, #1325): normalizing must not change what the description
-//!   denotes. It does, today. `assert_denotation_currently_broken` asserts the normalized
-//!   output either denotes a different sequence than the input (#1267), or denotes no
-//!   sequence at all (#1325) because its members now overlap and the independent applier
-//!   declines to splice them.
+//! - *Denotation* (#1325): normalizing must not change what the description denotes. It
+//!   does, today. `assert_denotation_currently_broken` asserts the normalized output
+//!   denotes no sequence at all, because #1325's members overlap and the independent
+//!   applier declines to splice them. **#1267 was the other half of this row and is
+//!   fixed** — the 5' half of `clamp_sibling_crossing_junctions` bounds the junction, so
+//!   the case left the PARTITION list rather than being re-pinned; see the note where its
+//!   test used to be.
 //! - *Boundary-validity* (#1274): normalizing must not name a position past the contig's
 //!   end. **Fixed** — by #1327's terminal re-spelling, which lands the repair's junction
 //!   inside the sequence instead of one past it. Flipped from a pinned failure to a
@@ -192,15 +194,15 @@
 //!
 //! ## An unexpected pass, found while building this corpus
 //!
-//! #1267's issue body gives three lines over reference `ACAAAAAAAACGTACGTACG`. Only the
-//! insertion form asserted below (`g.[4A>G;9_10insA]` -> `g.4_5insG`) still reproduces on
-//! this branch. The two duplication-form lines the issue also lists —
-//! `g.[4A>G;9dup]` -> `g.[4A>G;5dup]` and `g.[5A>G;10dup]` -> `g.[5A>G;6dup]` — were
-//! independently checked here (via this module's own applier) and already normalize
-//! correctly, preserving the denoted sequence; `blocks_sibling_shift` fixed them, and
-//! `cis_junction_crossing_shift.rs`'s `a_five_prime_duplication_does_not_cross_an_upstream_sibling`
-//! already pins them as passing. They are not asserted here as failures — reported here so
-//! the unexpected pass isn't silently dropped, per the corpus's own rules.
+//! #1267's issue body gives three lines over reference `ACAAAAAAAACGTACGTACG`. When this
+//! corpus was built, only the insertion form (`g.[4A>G;9_10insA]`) still reproduced; the
+//! two duplication-form lines — `g.[4A>G;9dup]` -> `g.[4A>G;5dup]` and
+//! `g.[5A>G;10dup]` -> `g.[5A>G;6dup]` — were independently checked here (via this
+//! module's own applier) and already normalized correctly, `blocks_sibling_shift` having
+//! fixed them. They were reported rather than asserted, per the corpus's own rules.
+//!
+//! All three now pass, the insertion form included, so nothing from #1267 is asserted
+//! here any more.
 
 use crate::common::cis_apply_oracle::{apply, normalize, normalize_in};
 use crate::common::synthetic::padded;
@@ -289,18 +291,15 @@ fn assert_denotation_currently_broken(
     );
 }
 
-/// #1267: a 5'-shifting insertion's junction crosses an upstream sibling substitution,
-/// moving the base the sibling edited — well-formed, disjoint, warning-free, and wrong.
-#[test]
-fn a_five_prime_insertion_junction_still_crosses_an_upstream_sibling() {
-    let seq = "ACAAAAAAAACGTACGTACG";
-    assert_denotation_currently_broken(
-        seq,
-        "TEMPLATE:g.[4A>G;9_10insA]",
-        ShuffleDirection::FivePrime,
-        "#1267",
-    );
-}
+// #1267 was pinned here as a denotation target and is **fixed** — the 5' half of
+// `clamp_sibling_crossing_junctions` bounds the junction, so `g.[4A>G;9_10insA]`
+// now reaches `g.3_4insG`, which denotes the input's bases. Per this file's
+// contract the case moves out of the PARTITION list rather than being re-pinned;
+// the positive assertions live with the rest of their shape in
+// `cis_junction_crossing_shift.rs`
+// (`an_insertion_junction_does_not_cross_an_upstream_sibling`,
+// `an_insertion_junction_does_not_cross_an_upstream_junction_sibling` and
+// `a_duplication_junction_does_not_cross_an_upstream_junction_sibling`).
 
 /// #1325: two insertions collapse into a repeat correctly, but adding a third pushes a
 /// junction inside the tract; the tract grew by more bases than it can express as a


### PR DESCRIPTION
Closes #1267.

## What was wrong

Under 5' shuffle, a junction-occupying cis member swept past an upstream sibling, moving its payload from one side of the sibling to the other. The result stays well-formed, its members disjoint, and no warning fires — it simply denotes different bases.

```
reference          ACAAAAAAAACGTACGTACG      A-run at 3-10
g.[4A>G;9_10insA]  applies to  ACAGAAAAAAACGTACGTACG
emitted g.4_5insG              ACAAGAAAAAACGTACGTACG   <- the substituted base moved
```

`clamp_sibling_crossing_junctions` already documented the rule for **both** directions — "a junction may reach a sibling's 5' edge but not pass it: for a sibling claiming `[s, e]`, a 3'-shifted junction must stay at or below `s - 1`, and a 5'-shifted one at or above `e`" — and implemented only the 3' half. This mirrors it. Output is now `g.3_4insG`, which denotes the input's bases.

This is user-reachable, not a test-only mode: `ferro normalize --direction 5prime` and `direction="5prime"` in the Python bindings.

## The issue and two code comments described the mover wrongly

Both said the shape needed no bound because a pure `Insertion` has a zero-width span with "nothing for a sibling to land on." That is true only of the *input* form. The member canonicalises to a duplication before it settles:

```
alone, 5' shuffle:   g.9_10insA  ->  g.3dup        g.16_17insCAG  ->  g.11_13dup
```

Which is also why the span clamp cannot take it: the member *grew*, and a member that grew is refused there for the reasons #1266/#1279 measured. Three separate gates declined this shape, not one.

## Two bounds were needed, not one

Bounding against base-claiming siblings fixed exactly half the measured cases — the tract census went `{15: 100, 36: 16}` to `{15: 50, 36: 8}`. The other half's sibling was a `dup` or an `ins`: junction-occupying, so invisible to `claims_bases`. Mirroring the junction-vs-junction bound (#1290) closed the rest.

Worth noting for its own sake: pinning that census **per sibling position** rather than as a total is what made the second half visible. A scalar would have read as "half fixed, keep going" with no indication of where the remainder lived.

## An admission test was implemented, then refuted by measurement

The first version restricted the 5' half to members the input spelled as an `Insertion`, on the reading that a duplication's span and junction move together so bounding the junction mis-places the copy. Measured against a purpose-built sweep of duplication movers with an upstream sibling:

| | cases | sequence-changing |
|---|---|---|
| restricted to input insertions | 73,376 | **12** |
| unrestricted | 73,376 | **0** |

The gate was not protecting duplication movers from a bad bound — it was excluding them from a good one and leaving twelve broken (`g.[3dup;2_3insTT]` -> `g.[1dup;2_3insTT]`, payloads reordered). So there is no gate, and neither direction consults the input's encoding to decide the output. One of the twelve is pinned by `a_duplication_junction_does_not_cross_an_upstream_junction_sibling`, which fails if the gate is reintroduced.

A first attempt at a guard for that gate passed with the gate both on and off — a restatement, not a guard. Noticing that is what prompted the sweep.

**#1259's 80 regressions do not bear on this rule.** That mirror bounded the junction against a sibling the member was moving *away* from, not one it was moving *toward* — a different rule. #1267's body says so; the code comment did not, and read as a general warning against any 5' bound.

## Test changes

- `a_five_prime_insertion_junction_with_an_upstream_sibling_is_a_known_gap`, which pinned the wrong output, is replaced by `an_insertion_junction_does_not_cross_an_upstream_sibling` asserting sequence preservation in both member orders.
- Two new positive pins for the junction-sibling half and the duplication-mover half.
- The tandem sweep no longer **excludes** the 5' insertion-junction shape and count it: with the residual at zero the exclusion is gone, so a regression there reports the offending descriptions instead of incrementing a bucket. `TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION` is removed, its history kept in a comment.
- #1267 leaves `rewrite_target_corpus.rs`'s PARTITION target list, per that file's own assert-then-flip contract — its guard fired with exactly the instruction it was written to give.

## Verification

| gate | result |
|---|---|
| tract census (116 cases at positions 15 and 36) | **0** |
| `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` | still `0` |
| two-member sweep, 276k cases | green |
| dup-mover upstream-sibling sweep, 73,376 cases (throwaway probe) | 0 sequence-changing, 0 non-applying |
| full suite, `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` | **9174 passed** |
| conformance axis, manifest-backed | **260 passed** |
| `cargo fmt --check`, `clippy --features dev --all-targets -D warnings`, `cargo check --features python` | clean |
| `tests/proptest-regressions/` | unchanged — no strategy touched |

## Relationship to #1235

The rule is spelling-independent, so unlike the gate that was refuted there is nothing here the sequence-first rewrite needs to delete on principle. It remains a repair pass, and the rewrite should still dissolve the need for it: partitioning derives the payload's position instead of moving it. Note the rewrite does not make the problem vanish — #1235's step 3 still shifts derived pieces, so "a shifting piece must not cross its neighbour" survives as one uniform rule over derived pieces rather than a kind-by-kind test.


---

## Review round 2

No unresolved review threads. Two findings from the CodeRabbit CLI lens, one applied, one rejected — plus one the lens did not name.

### Applied: the new #1267 test could not fail

`an_insertion_junction_does_not_cross_an_upstream_sibling` asserted only that the output denotes the same sequence as the input, via `apply()`. An output *identical to the input* satisfies that trivially — and that is exactly what a clamp which failed to fire would produce. So the test could not distinguish "bounded correctly" from "nothing happened", which is a poor guard for the defect this PR exists to close.

Now pins the canonical output — `TEMPLATE:g.3_4insG` for both member orders, the junction landing at `3|4`, one short of the substituted base at 4, where it coalesces with the sibling — plus an explicit `assert_ne!(actual, input)`. The `apply()` comparison is kept as the supplementary check.

### Also fixed: that test's comment contradicted this PR's own implementation

Not flagged by either lens. The comment said the 5' half is *"admitted only for a member the input spelled as an insertion"* — but `clamp_sibling_crossing_junctions`'s own comment in this same diff records that exact restriction being **tried and refuted by measurement** (over 73,376 duplication-mover cases the unrestricted bound leaves zero sequence changes, the restricted form twelve) and concludes "the direction is simply mirrored". The test comment described the approach that was abandoned. Corrected to match, and it now cites the measurement.

### Rejected: replace the `five_prime` branches with a direction abstraction

The suggestion is to introduce a `ThreePrime`/`FivePrime` enum with helpers for the crossing check, the one-short bound, the restrictive-bound selection and the search order, replacing the five `if five_prime` sites.

Declined, with reasons rather than by omission. It is a pure structural refactor of code this PR has just made correct and covered: no behaviour would change, each branch is individually documented, and the mirrors were verified by reading them against each other (`onto_bases` maps to `s.end` under 5' against `s.start - 1` under 3'; `swept` is `[after, before)` against `(before, after]`; the one-short bound is `junction + 1` against `junction - 1`; the selection is `max` against `min`; the search walks up from the floor against down from the ceiling). Folding a refactor of the normalize core into a behaviour fix also cuts against keeping functional and structural changes in separate PRs. Worth doing on its own if the parallel branching grows further; not worth the risk attached to this change.

### Interaction with #1337, which is already on `main`

Recorded because no single PR's CI can see it. #1337 pinned this exact shape as a known gap:

```rust
const TRACT_FIVE_PRIME_INSERTION_SEQUENCE_CHANGES_BY_POSITION: [(usize, usize); 2] =
    [(15, 100), (36, 16)];
```

with the instruction that *"a **fall** means the insertion half of #1267 is being fixed — in which case update this number"*. This PR is that fall: the exclusion is removed entirely and those 116 cases are now asserted like every other case in the sweep rather than counted. The pin did its job — it is being consumed as designed, not deleted to make a test pass.

### Movement relative to the reference oracles

**Toward, on a shape the oracles do not contain.** Every input whose output changes is a multi-member cis allele whose junction previously swept past an upstream sibling — well-formed, disjoint and warning-free, but denoting different bases. The biocommons / Mutalyzer / hgvs-rs corpora carry no such input, which is why the defect survived: it was invisible to them and to `FERRO_ASSERT_REPARSE`, and only the sequence-preservation sweep in `cis_junction_crossing_shift.rs` could see it. Single-member descriptions and non-crossing alleles are byte-identical.

Full suite: **9,178 passed, 0 failed**; `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean.
