### PR TITLE
fix(normalize): stop an out-of-phase rotation from killing a valid dup

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -531,9 +531,16 @@ pub(crate) struct InsToDupResult {
 /// 2. For each rotation `r in 0..unit.len()`, build the rotated unit and
 ///    call `find_tandem_extent` to locate the maximal tandem run abutting
 ///    the insertion point.
-/// 3. Pick the rotation yielding the largest tandem run (ties broken by
-///    iteration order — same convention as `insertion_to_repeat`).
-/// 4. Return the unit-aligned duplication slot inside that tract whose
+/// 3. Resolve each rotation all the way to the duplication it would emit
+///    (step 5), and hold it to the `tandem_edit_preserves_insertion` phase
+///    gate (#882) — a rotation that would decode to a different sequence than
+///    the input is not a candidate at all.
+/// 4. Among the rotations that clear that gate, pick the one yielding the
+///    largest tandem run (ties broken by direction, below). The gate is
+///    evaluated only for a rotation that would otherwise take the lead, which
+///    selects the same winner while skipping the gate's `ref_seq`-sized
+///    reconstructions for rotations that have already lost.
+/// 5. Return the unit-aligned duplication slot inside that tract whose
 ///    position matches the requested shuffle direction:
 ///    - `ThreePrime`: `dup_start_idx = tract.end - unit.len()` — the
 ///      most-3' unit (current default; pre-#340 behavior).
@@ -546,11 +553,21 @@ pub(crate) struct InsToDupResult {
 ///    HGVS positions.
 ///
 /// Returns `None` when no rotation matches an adjacent tract (true
-/// non-tandem insertion), **and also** when the best-matching rotation's
-/// emitted duplication is out of phase — i.e. it would decode to a different
-/// sequence than the input insertion, so it is not a tandem duplication per
+/// non-tandem insertion), **and also** when every matching rotation's emitted
+/// duplication is out of phase — i.e. it would decode to a different sequence
+/// than the input insertion, so it is not a tandem duplication per
 /// `duplication.md` (the `tandem_edit_preserves_insertion` gate, #882). In
 /// both cases the caller leaves it as a plain `ins`.
+///
+/// The phase gate is applied per rotation *during* selection, not once to the
+/// winner (#1349). Scoring first and gating afterwards let a high-scoring but
+/// out-of-phase rotation shadow a lower-scoring in-phase one and take the whole
+/// result down with it: for `insTCC` at `GTACGT|CCCCTCCTCCTCCTCCC`, the alt's
+/// own phase abuts a one-copy `TCC` tract (the correct dup) while the `CCT`
+/// rotation abuts a two-copy tract further 3' that is out of phase with the
+/// insertion. `CCT` won on count, failed the gate, and the correct candidate was
+/// never reconsidered — costing the 5' path its `ins → dup` promotion and
+/// leaving a non-idempotent boundary `delins` behind.
 pub(crate) fn insertion_to_duplication(
     ref_seq: &[u8],
     pos: u64,
@@ -570,8 +587,23 @@ pub(crate) fn insertion_to_duplication(
         return None;
     }
 
+    /// One rotation resolved all the way to the duplication it would emit, and
+    /// already past the phase gate — i.e. a candidate the caller could receive.
+    struct DupCandidate {
+        /// Emitted unit, post-alignment (the aligner may re-rotate it).
+        unit: Vec<u8>,
+        /// 0-based start of the emitted duplication slot.
+        dup_start_idx: usize,
+        /// 0-based end of the emitted duplication slot (inclusive).
+        dup_end_idx: usize,
+        /// Start of the matched reference tract, used only for the tie-break.
+        ref_start: usize,
+        /// Copies of `unit` in the matched tract — the primary score.
+        ref_count: u64,
+    }
+
     let u_len = base_unit.len();
-    let mut best: Option<(Vec<u8>, usize, u64)> = None;
+    let mut best: Option<DupCandidate> = None;
     for r in 0..u_len {
         let mut rotated = Vec::with_capacity(u_len);
         rotated.extend_from_slice(&base_unit[r..]);
@@ -583,6 +615,13 @@ pub(crate) fn insertion_to_duplication(
         if ref_count == 0 {
             continue;
         }
+
+        // Resolve this rotation to the duplication it would emit, so the phase
+        // gate below judges the same values the caller would receive.
+        let (unit, dup_start_idx) =
+            align_dup_slot(ref_seq, ref_start, ref_count, rotated, direction);
+        let dup_end_idx = dup_start_idx + unit.len() - 1;
+
         // Selection rules:
         // - Higher `ref_count` wins outright (preserves the multi-copy
         //   tract phase per #132 / #180).
@@ -597,21 +636,73 @@ pub(crate) fn insertion_to_duplication(
         //   #403.
         let is_better = match best.as_ref() {
             None => true,
-            Some((_, best_ref_start, best_ref_count)) => match ref_count.cmp(best_ref_count) {
+            Some(current) => match ref_count.cmp(&current.ref_count) {
                 std::cmp::Ordering::Greater => true,
                 std::cmp::Ordering::Less => false,
                 std::cmp::Ordering::Equal => match direction {
-                    ShuffleDirection::FivePrime => ref_start < *best_ref_start,
-                    ShuffleDirection::ThreePrime => ref_start > *best_ref_start,
+                    ShuffleDirection::FivePrime => ref_start < current.ref_start,
+                    ShuffleDirection::ThreePrime => ref_start > current.ref_start,
                 },
             },
         };
-        if is_better {
-            best = Some((rotated, ref_start, ref_count));
+        if !is_better {
+            // Cannot become `best` whatever the gate says, and the gate rebuilds
+            // two `ref_seq`-sized buffers per call — so don't pay for it.
+            continue;
         }
+
+        // #882 phase gate, applied per candidate (#1349): only emit a dup when it
+        // decodes to the same sequence as the input insertion. A rotation that
+        // fails here is not a duplication of this insertion at all, so it must
+        // not compete — and must not shadow a lower-scoring rotation that is.
+        // Gating a rotation that already lost the comparison above would change
+        // nothing, since a failing rotation never becomes `best` either way.
+        if !tandem_edit_preserves_insertion(
+            ref_seq,
+            pos as usize,
+            inserted_seq,
+            dup_start_idx,
+            dup_end_idx + 1,
+            &unit,
+            2,
+        ) {
+            continue;
+        }
+
+        best = Some(DupCandidate {
+            unit,
+            dup_start_idx,
+            dup_end_idx,
+            ref_start,
+            ref_count,
+        });
     }
 
-    let (mut unit, ref_start, ref_count) = best?;
+    let best = best?;
+
+    Some(InsToDupResult {
+        unit: best.unit,
+        start: index_to_hgvs_pos(best.dup_start_idx),
+        end: index_to_hgvs_pos(best.dup_end_idx),
+        ref_count: best.ref_count,
+    })
+}
+
+/// Resolve a matched tandem tract to the duplication slot to emit for `direction`,
+/// returning the (possibly re-rotated) unit and the 0-based start of the slot.
+///
+/// Split out of `insertion_to_duplication` so each rotation can be resolved —
+/// and phase-checked — independently during selection (#1349).
+fn align_dup_slot(
+    ref_seq: &[u8],
+    ref_start: usize,
+    ref_count: u64,
+    rotated: Vec<u8>,
+    direction: crate::normalize::config::ShuffleDirection,
+) -> (Vec<u8>, usize) {
+    use crate::normalize::config::ShuffleDirection;
+
+    let mut unit = rotated;
     let tract_end_idx = ref_start + (ref_count as usize) * unit.len();
     // `find_tandem_extent` returns `ref_start` aligned on a `unit`-length
     // anchor probe, so picking `ref_start` for the 5' end never lands the
@@ -653,29 +744,7 @@ pub(crate) fn insertion_to_duplication(
             aligned_start
         }
     };
-    let dup_end_idx = dup_start_idx + unit.len() - 1;
-
-    // #882: only emit the dup when it decodes to the same sequence as the input
-    // insertion. `dup_start_idx`/`dup_end_idx`/`unit` are the post-alignment
-    // emitted values; a dup expands the emitted single unit to two copies.
-    if !tandem_edit_preserves_insertion(
-        ref_seq,
-        pos as usize,
-        inserted_seq,
-        dup_start_idx,
-        dup_end_idx + 1,
-        &unit,
-        2,
-    ) {
-        return None;
-    }
-
-    Some(InsToDupResult {
-        unit,
-        start: index_to_hgvs_pos(dup_start_idx),
-        end: index_to_hgvs_pos(dup_end_idx),
-        ref_count,
-    })
+    (unit, dup_start_idx)
 }
 
 /// Smallest unit `U` such that `seq = U * k` for some integer k ≥ 1.
@@ -5959,6 +6028,67 @@ mod tests {
             String::from_utf8_lossy(&inserted),
             String::from_utf8_lossy(&duplicated),
             "dup and insertion spellings must reconstruct byte-identical sequences"
+        );
+    }
+
+    /// Regression for #1349: a higher-scoring rotation that fails the #882
+    /// equivalence check must not shadow a lower-scoring rotation that passes it.
+    ///
+    /// In `GTACGTCCCCTCCTC` the insertion point is between indices 7 and 8
+    /// (`pos = 7`) and the alt `TCC` equals the immediately preceding tract at
+    /// indices 5..8 — a textbook single-copy duplication. But a *different*
+    /// rotation of the same unit, `CCT`, has a two-copy tract at indices 8..14,
+    /// so it wins the `ref_count` comparison outright. That tract is out of phase
+    /// with the insertion, so it fails `tandem_edit_preserves_insertion` — and
+    /// before this fix the whole function returned `None`, discarding the correct
+    /// `TCC` candidate that was never reconsidered.
+    ///
+    /// Downstream that `None` cost the 5' path its `ins → dup` promotion, and the
+    /// CDS-start clamp turned the surviving insertion into a boundary `delins`
+    /// that was not a fixed point (`c.2_3insTCC` → `c.1delinsCCTC` → `c.-1_2dup`).
+    #[test]
+    fn insertion_to_duplication_falls_back_past_a_non_preserving_rotation() {
+        let r = b"GTACGTCCCCTCCTC";
+        let got = insertion_to_duplication(r, 7, b"TCC", ShuffleDirection::FivePrime)
+            .expect("the in-phase TCC rotation is a valid dup and must not be discarded");
+        assert_eq!(got.unit, b"TCC");
+        assert_eq!(
+            (got.start, got.end),
+            (6, 8),
+            "the dup covers the preceding TCC tract at 0-based 5..8"
+        );
+
+        // The emitted dup must describe the SAME haplotype as the input insertion.
+        let inserted = {
+            let mut s = r.to_vec();
+            s.splice(8..8, b"TCC".iter().copied());
+            s
+        };
+        let duplicated = {
+            let (s, e) = (got.start as usize - 1, got.end as usize); // 1-based incl → 0-based excl
+            let mut v = r.to_vec();
+            let copy = r[s..e].to_vec();
+            v.splice(e..e, copy);
+            v
+        };
+        assert_eq!(
+            String::from_utf8_lossy(&inserted),
+            String::from_utf8_lossy(&duplicated),
+            "dup and insertion spellings must reconstruct byte-identical sequences"
+        );
+    }
+
+    /// The 3' direction reaches the same fallback: the winning rotation is chosen
+    /// by `ref_count` before any equivalence check, so the out-of-phase `CCT`
+    /// tract shadows the correct `TCC` one in both directions.
+    #[test]
+    fn insertion_to_duplication_falls_back_past_a_non_preserving_rotation_three_prime() {
+        let r = b"GTACGTCCCCTCCTC";
+        let got = insertion_to_duplication(r, 7, b"TCC", ShuffleDirection::ThreePrime)
+            .expect("the in-phase TCC rotation is a valid dup and must not be discarded");
+        assert_eq!(
+            (got.unit.as_slice(), got.start, got.end),
+            (&b"TCC"[..], 6, 8)
         );
     }
 

--- a/tests/it/issue_1349_rotation_fallback_dup.rs
+++ b/tests/it/issue_1349_rotation_fallback_dup.rs
@@ -1,0 +1,118 @@
+//! Regression for #1349: a 5' normalization that was not a fixed point.
+//!
+//! `NM_TEST1349.1:c.2_3insTCC` normalized (5') to `c.1delinsCCTC`, and
+//! re-normalizing *that* gave `c.-1_2dup` — a stable answer only on the third
+//! pass. The 3' direction reached `c.-1_2dup` immediately, so the two directions
+//! also disagreed on the first pass about an edit that is direction-independent.
+//!
+//! Root cause is in `rules::insertion_to_duplication`, not in the CDS-start
+//! clamp. That function tries every cyclic rotation of the inserted unit, scores
+//! each by the size of the reference tandem tract it abuts, and keeps the single
+//! highest-scoring one — applying the #882 equivalence check
+//! (`tandem_edit_preserves_insertion`) only afterwards. Here the alt `TCC`
+//! abuts a one-copy tract (the `TCC` at c.-1_2, which is the correct answer),
+//! while its rotation `CCT` abuts a *two-copy* tract further 3'. `CCT` wins on
+//! count, fails the equivalence check because that tract is out of phase with
+//! the insertion, and the function returns `None` — discarding the correct
+//! `TCC` candidate, which was never reconsidered.
+//!
+//! With no `ins → dup` promotion the 5' path emitted a plain insertion resting
+//! at the CDS boundary, which #383's clamp then rewrote as `c.1delinsCCTC`. The
+//! clamp was doing its job on the input it was handed; the promotion upstream is
+//! what was missing. Once the dup is recognised, #401's `spanning_dup_exception`
+//! already lets it through the clamp unchanged.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// 5'UTR `…GTACGT` followed by a CDS opening `CCCCTCCTCCTCCTCCCGGGG`.
+///
+///   axis: c.-6 … c.-2 c.-1 | c.1 c.2 c.3 c.4 c.5 c.6 c.7 c.8 …
+///   base:  G   A  C   G    T  | C   C   C   C   T   C   C   T  …
+///
+/// The two tracts that compete for `c.2_3insTCC`:
+///   - `TCC` at c.-1_2 (one copy) — abuts the insertion point, in phase.
+///   - `CCT` at c.3_5 and c.6_8 (two copies) — out of phase with the insertion.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let mut seq = String::from("GTACGT"); // 5'UTR: c.-6 … c.-1
+    seq.push_str("CCCCTCCTCCTCCTCCCGGGG"); // c.1 … c.21
+    while seq.len() < 6 + 30 {
+        seq.push('A'); // pad the CDS out to 30 bases (10 codons)
+    }
+    let cds_end = seq.len() as u64;
+    seq.push_str("AAAAAAAAAA"); // 3'UTR
+    let len = seq.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST1349.1".to_string(),
+        Some("TEST1349".to_string()),
+        Strand::Plus,
+        seq,
+        Some(7), // c.1 is the 7th base (1-based)
+        Some(cds_end),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{normalized}")
+}
+
+/// The inserted `TCC` duplicates the `TCC` at c.-1_2, so the canonical form is
+/// that spanning dup — `dup` outranks both `ins` and `delins` in the spec's
+/// prioritisation, and the dup-source genuinely equals the alt.
+#[test]
+fn five_prime_insertion_promotes_to_the_in_phase_dup() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST1349.1:c.2_3insTCC"),
+        "NM_TEST1349.1:c.-1_2dup",
+    );
+}
+
+/// The 3' direction already reached this answer (via the post-shuffle simple-dup
+/// path rather than the rotation search), and must keep reaching it.
+#[test]
+fn three_prime_insertion_promotes_to_the_in_phase_dup() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST1349.1:c.2_3insTCC"),
+        "NM_TEST1349.1:c.-1_2dup",
+    );
+}
+
+/// The defect's actual signature: `norm(norm(x)) != norm(x)`. Pinned separately
+/// from the value assertions above so a future change that moves the canonical
+/// answer still has to keep it a fixed point.
+#[test]
+fn five_prime_normalization_is_a_fixed_point() {
+    let once = normalize_with(ShuffleDirection::FivePrime, "NM_TEST1349.1:c.2_3insTCC");
+    let twice = normalize_with(ShuffleDirection::FivePrime, &once);
+    assert_eq!(once, twice, "normalization must be idempotent");
+}
+
+/// The boundary `delins` that the clamp used to emit is still reachable by
+/// writing it directly, and still normalizes to the dup — so the fix did not
+/// simply disable the clamp.
+#[test]
+fn the_equivalent_boundary_delins_still_normalizes_to_the_same_dup() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST1349.1:c.1delinsCCTC"),
+        "NM_TEST1349.1:c.-1_2dup",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -191,6 +191,7 @@ mod issue_1323_shared_junction_order;
 mod issue_1327_mt_respell_past_contig_end;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_1334_liftover_position_zero;
+mod issue_1349_rotation_fallback_dup;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;

--- a/tests/proptest-regressions/normalize_idempotency_proptest.txt
+++ b/tests/proptest-regressions/normalize_idempotency_proptest.txt
@@ -12,3 +12,4 @@ cc 963ed918c565168dda03912561f65f99d0a3a5398c144fdd1dd0157e4c5563ae # shrinks to
 cc 8d1ceaa8eae1c6162271d431b2cb4395e0359a560661739dc5402acd0d9bdf33 # shrinks to case = Case { core: "CCCCAACACACGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15delinsgaa" }
 cc 24fe771b144622c1c4e142a45e3fc249cb5854ebf628a862b56e84b448fe9937 # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: Genomic, hgvs: "NC_TEST.1:g.264_266delinsG" }
 cc eefd532b0deeee1b5d2768acd582bf9bfeb81cbfe4a46cb6b5a5d537561f5db7 # shrinks to case = Case { core: "CCCCAAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15con4_5" }
+cc 9e5c683cf90cbeea9efbabaad533f4288eecda1d6e7844f3f79118a7f7f6f81d # shrinks to case = Case { core: "CCCCTCCTCCTCCTCCCGGGG", sys: CdsUtr3Plus, hgvs: "NM_TEST.1:c.2_3insTCC" }


### PR DESCRIPTION
Closes #1349

## What was wrong

`rules::insertion_to_duplication` tries every cyclic rotation of the inserted unit, scores each by the size of the reference tandem tract it abuts, keeps the single highest-scoring one, and only *then* applies the #882 phase gate (`tandem_edit_preserves_insertion`) — returning `None` when that winner fails.

So a high-scoring but out-of-phase rotation shadows a lower-scoring in-phase one and takes the whole result down with it. Measured on the fixture the idempotency proptest found (`GTACGT|CCCCTCCTCCTCCTCCC`, `c.2_3insTCC`):

```
find_tandem_extent(pos=7, "TCC") = Some((5, 1))   <- in phase; the correct dup at c.-1_2
find_tandem_extent(pos=7, "CCT") = Some((8, 2))   <- two copies, wins on count, out of phase
```

`CCT` wins, fails the gate, and `insertion_to_duplication` returns `None`. The correct `TCC` candidate is never reconsidered.

## Why that showed up as a normalization defect

With no `ins -> dup` promotion the 5' path emitted a plain insertion resting at the CDS boundary, and #383's CDS-start clamp rewrote it as a boundary `delins`. That was not a fixed point:

| pass | 5' output |
|---|---|
| input | `NM_TEST.1:c.2_3insTCC` |
| once | `NM_TEST.1:c.1delinsCCTC` |
| twice | `NM_TEST.1:c.-1_2dup` |
| thrice | `NM_TEST.1:c.-1_2dup` |

The description only settled on the third pass, and the two shuffle directions disagreed on the first about an edit that is direction-independent — 3' reached `c.-1_2dup` immediately, via the post-shuffle simple-dup path rather than the rotation search.

Traced with instrumentation at the clamp rather than inferred:

```
5' pass 1:  cds_start=257  new_tx=(256,257)  new_edit=Insertion(CCT)   spanning_dup=false
3' pass 1:  cds_start=257  new_tx=(256,258)  new_edit=Duplication      spanning_dup=true
```

## The fix

Resolve each rotation all the way to the duplication it would emit, and apply the phase gate **per candidate, during selection**. Only rotations that survive it compete.

The clamp is untouched. Once the dup is recognised, #401's `spanning_dup_exception` already lets it through — this was a missing promotion upstream, not a boundary policy question.

The alignment step is extracted to `align_dup_slot` so each rotation can be resolved independently; the selection rules (`ref_count` first, direction tie-break on ties) are unchanged.

**This can only widen the function's domain.** If the old winner passed the gate it is still the argmax of the filtered set, so every existing `Some` is unchanged and only `None` results can become a dup. The pre-existing #882 rejection tests still return `None`, because there *every* rotation fails the gate.

## Tests

Written first and watched fail, each with the exact defect signature:

- `insertion_to_duplication_falls_back_past_a_non_preserving_rotation` (+ a 3' twin) — unit-level, pins the fallback and asserts the emitted dup and the input insertion reconstruct byte-identical sequences.
- `tests/it/issue_1349_rotation_fallback_dup.rs` — end to end. Pins the value in both directions, pins idempotency *separately* so a future change that moves the canonical answer still has to keep it a fixed point, and pins that the equivalent boundary `delins` still normalizes to the same dup (so the fix cannot be mistaken for disabling the clamp).
- The proptest seed that found it is now pinned in `tests/proptest-regressions/normalize_idempotency_proptest.txt`.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev --no-fail-fast` — **9184 passed, 146 skipped, 0 failed**.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean.
- Generated spec artifacts regenerated before the run, so the census guards are judging current code.

**Oracle movement:** none. No test was retired, relaxed, or re-blessed; the six new tests are additions, and the pre-existing `insertion_to_duplication` and #882 suites pass unmodified.
