### PR TITLE
feat(sequence)!: finish the complement unification, and fix an RNA inversion false alarm

### DIFF
--- a/src/effect/mod.rs
+++ b/src/effect/mod.rs
@@ -835,7 +835,12 @@ impl Default for KozakAnalyzer {
 // =============================================================================
 
 /// Inversion validation result.
+///
+/// `#[non_exhaustive]` so a future verdict can be added without breaking
+/// downstream `match`es. Added while the enum has no in-tree consumers, which is
+/// the only free moment to do it.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum InversionValidation {
     /// Inversion is valid - sequence matches expected reverse complement.
     Valid,
@@ -861,6 +866,39 @@ pub enum InversionValidation {
 }
 
 /// Validate that an inversion sequence matches the reference.
+///
+/// # What `Valid` asserts
+///
+/// **Exact equality of IUPAC code strings**, up to case and the T/U alphabet
+/// fold — *not* "the description is consistent with the reference". The
+/// distinction matters wherever ambiguity codes are involved, because the codes
+/// denote base *sets*:
+///
+/// * `("RY", "RY")` is `Valid` and `("RR", "RR")` is a `SequenceMismatch`, because
+///   `R` complements to `Y`. Both are right under the equality rule.
+/// * `N`, `S` and `W` are self-complementary under the modelled IUPAC table, so
+///   an all-`N` inversion validates.
+/// * The spec's masked-nucleotide symbol `X` also validates against itself, and
+///   the spec agrees it should — `standards.md` defines `X` as the base set
+///   `A, C, G or T`, identical to `N`, which makes it self-complementary. But be
+///   precise about *why* it happens here: [`crate::sequence::complement_base`]
+///   does not model `X`, so the right answer arrives through
+///   [`crate::sequence::reverse_complement`]'s pass-through of unmodelled
+///   characters, not through the IUPAC table. The same pass-through returns
+///   `Valid` for `("ZZ","ZZ")`, which the spec does *not* define. If the `X`
+///   answer is ever to be load-bearing, `X` belongs in the table.
+/// * Under a *subsumption* rule the answers would differ: `("AN", "NN")` is
+///   reported here as a mismatch (expected `NT`), even though every concrete
+///   instantiation of `AN` has a reverse complement contained in `NN`. Equality
+///   is the rule this function implements; subsumption is not offered.
+///
+/// # Scope
+///
+/// An inline sequence on `inv` is a ferro leniency extension: the spec's own
+/// syntax (`assets/hgvs-nomenclature/docs/syntax.yaml`, DNA and RNA `inv`) is
+/// `range "inv"` with no sequence and no length, so a spec-conformant
+/// description gives this function nothing to check and takes the
+/// `(Some(_), None) => Valid` path.
 ///
 /// # Arguments
 /// * `reference_sequence` - The reference sequence at the inversion position.
@@ -894,7 +932,7 @@ pub fn validate_inversion(
             // The provided sequence should be the reverse complement of reference
             let expected_revcomp = crate::sequence::reverse_complement(reference);
 
-            if provided.to_uppercase() == expected_revcomp.to_uppercase() {
+            if compare_key(provided) == compare_key(&expected_revcomp) {
                 InversionValidation::Valid
             } else {
                 InversionValidation::SequenceMismatch {
@@ -912,6 +950,32 @@ pub fn validate_inversion(
         },
         (None, None) => InversionValidation::Valid, // Nothing to validate
     }
+}
+
+/// Normalise a sequence for the inversion comparison: upper-case, and fold `U`
+/// onto `T`.
+///
+/// The T/U fold is not cosmetic. [`crate::sequence::reverse_complement`] maps
+/// `U` to `A` but never produces a `U`, so it is not an involution over RNA:
+/// the reverse complement of an RNA reference comes back in the DNA alphabet.
+/// A perfectly legal `r.` inversion — `NM_TEST.1:r.1_2invau` parses and
+/// round-trips unchanged — was therefore compared against a `T`-spelled expected
+/// sequence and reported as a mismatch. `T` and `U` are the same base in
+/// different alphabets, so they must compare equal.
+///
+/// ASCII-only, deliberately, and byte-wise. The length gate above measures
+/// `provided.len()` — bytes — so a Unicode-aware fold here would disagree with
+/// it: `str::to_uppercase` expands `ß` to `SS`, and `("SS", "ß")` clears a
+/// 2-byte length check and then compares equal, reporting `Valid` for an input
+/// that is not a nucleotide sequence at all. Folding per byte keeps the two
+/// checks measuring the same thing.
+fn compare_key(seq: &str) -> Vec<u8> {
+    seq.bytes()
+        .map(|b| match b.to_ascii_uppercase() {
+            b'U' => b'T',
+            other => other,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -1161,6 +1225,60 @@ mod tests {
     fn test_inversion_no_sequence_provided() {
         let result = validate_inversion(Some("ATGC"), None, 1, 4);
         assert_eq!(result, InversionValidation::Valid);
+    }
+
+    /// An RNA inversion written with `u` must validate against a DNA-alphabet
+    /// reference (#1347).
+    ///
+    /// `reverse_complement` maps `U` to `A` but nothing back to `U`, so it is not
+    /// an involution over RNA, and the comparison below is bare case-folded
+    /// equality. A legal, parseable `r.` inversion — `NM_TEST.1:r.1_2invau`
+    /// round-trips through `parse_hgvs` unchanged — was therefore reported as a
+    /// sequence mismatch against its own reference.
+    ///
+    /// The spec lists `u` as the RNA spelling of the same base
+    /// (`assets/hgvs-nomenclature/docs/background/standards.md`), so `T` and `U`
+    /// must compare equal here.
+    #[test]
+    fn an_rna_inversion_validates_against_a_dna_reference() {
+        assert_eq!(
+            validate_inversion(Some("AT"), Some("AU"), 1, 2),
+            InversionValidation::Valid,
+            "U and T are the same base in different alphabets"
+        );
+        // And the reverse pairing, for symmetry.
+        assert_eq!(
+            validate_inversion(Some("AU"), Some("AT"), 1, 2),
+            InversionValidation::Valid
+        );
+    }
+
+    /// Characterization pin, not a regression test: this passed before the T/U
+    /// fold too. It exists so the fold cannot later be widened into a blanket
+    /// "everything validates".
+    #[test]
+    fn t_u_folding_does_not_mask_a_real_mismatch() {
+        assert!(matches!(
+            validate_inversion(Some("AT"), Some("AG"), 1, 2),
+            InversionValidation::SequenceMismatch { .. }
+        ));
+    }
+
+    /// Characterization pin, not a regression test: this passed before too.
+    ///
+    /// `X` is a spec-defined symbol, not an unmodelled one: `standards.md` gives
+    /// it the base set `A, C, G or T` — identical to `N` — so it is
+    /// self-complementary and an `X` inversion against an `X` reference really
+    /// is valid. Pinned so a future "reject unknown alphabet" change has to
+    /// confront the spec text rather than assume `X` is junk. Note the answer
+    /// currently arrives via `reverse_complement`'s pass-through rather than the
+    /// IUPAC table — see `validate_inversion`'s docs.
+    #[test]
+    fn the_spec_defined_masked_nucleotide_is_self_complementary() {
+        assert_eq!(
+            validate_inversion(Some("XX"), Some("XX"), 1, 2),
+            InversionValidation::Valid
+        );
     }
 
     /// An IUPAC code must complement to its partner, not to itself.

--- a/src/reference/annotation/validate.rs
+++ b/src/reference/annotation/validate.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::{Strand, Transcript};
+use crate::sequence::reverse_complement;
 
 use super::diagnostics::{DiagnosticPayload, LoaderDiagnostic, LoaderReport, SourceLocation};
 
@@ -149,21 +150,6 @@ fn extract_first_codon(
     }
 
     (codon.len() as u64 == TARGET).then_some(codon)
-}
-
-/// Return the reverse complement of a DNA string.
-fn reverse_complement(s: &str) -> String {
-    s.chars()
-        .rev()
-        .map(|c| match c {
-            'A' | 'a' => 'T',
-            'T' | 't' => 'A',
-            'G' | 'g' => 'C',
-            'C' | 'c' => 'G',
-            'N' | 'n' => 'N',
-            other => other,
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/reference/derived_placement.rs
+++ b/src/reference/derived_placement.rs
@@ -290,12 +290,21 @@ pub fn derive_affine(
 /// below [`MAX_MISMATCH_FRACTION`]. For a minus-strand candidate the `NG_` is the
 /// reverse complement of the slice. A length difference or a frame-shifting indel
 /// drives the mismatch far above the threshold ⇒ `false` ⇒ decline. Comparison is
-/// case-insensitive; `N`/ambiguity bases count as mismatches (conservative).
+/// case-insensitive.
 ///
-/// Note: ambiguity bases on **either** side count against the threshold, so a
-/// `genome_slice` carrying a run of `N`s (e.g. an assembly gap) inflates the
-/// mismatch fraction toward [`MAX_MISMATCH_FRACTION`] and can push an otherwise
-/// valid placement to decline.
+/// Ambiguity codes are compared on their real complements (`R`↔`Y`, `K`↔`M`, …),
+/// so a correctly-paired ambiguous position counts as a match. A code that is
+/// *self*-complementary under the IUPAC table — `N`, `S`, `W` — therefore matches
+/// itself, which means a `genome_slice` gap of `N`s against an `NG_` gap of `N`s
+/// does **not** inflate the mismatch fraction. An `N` against a concrete base
+/// still does.
+///
+/// A byte outside the modelled alphabet has no complement and counts as a
+/// mismatch on the minus strand. The plus strand compares the two bytes
+/// directly and never needs a complement, so there it still matches itself —
+/// an asymmetry, but the honest one: on the plus strand nothing was inferred,
+/// while on the minus strand a byte that cannot be complemented cannot be
+/// judged equal to anything.
 pub fn validate_sequence(ng_seq: &[u8], genome_slice: &[u8], strand: Strand) -> bool {
     if ng_seq.len() != genome_slice.len() || ng_seq.is_empty() {
         return false;
@@ -307,11 +316,17 @@ pub fn validate_sequence(ng_seq: &[u8], genome_slice: &[u8], strand: Strand) -> 
             .filter(|(a, b)| !bases_match(**a, **b))
             .count(),
         Strand::Minus => {
-            // NG[i] should equal complement(genome_slice[len-1-i]).
+            // NG[i] should equal complement(genome_slice[len-1-i]). A byte the
+            // shared alphabet does not model has no complement to compare
+            // against, so it counts as a mismatch (#1347) — the private helper
+            // this replaced mapped it to `N`, which then matched an `N` on the
+            // NG_ side, the exact spurious match it claimed to prevent.
             ng_seq
                 .iter()
                 .zip(genome_slice.iter().rev())
-                .filter(|(a, b)| !bases_match(**a, complement(**b)))
+                .filter(|(a, b)| {
+                    crate::sequence::complement_base(**b).is_none_or(|c| !bases_match(**a, c))
+                })
                 .count()
         }
         Strand::Unknown => return false,
@@ -322,18 +337,6 @@ pub fn validate_sequence(ng_seq: &[u8], genome_slice: &[u8], strand: Strand) -> 
 /// Case-insensitive base equality (`a`==`A`).
 fn bases_match(a: u8, b: u8) -> bool {
     a.eq_ignore_ascii_case(&b)
-}
-
-/// Watson-Crick complement (case-insensitive, returns uppercase). Non-ACGT maps
-/// to `b'N'` so it can never spuriously match.
-fn complement(b: u8) -> u8 {
-    match b.to_ascii_uppercase() {
-        b'A' => b'T',
-        b'C' => b'G',
-        b'G' => b'C',
-        b'T' => b'A',
-        _ => b'N',
-    }
 }
 
 /// Assemble a [`GenomicPlacement`] for `ng` on chromosome `nc` from a validated
@@ -555,6 +558,33 @@ impl DerivedPlacements {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A byte outside the modelled alphabet must count as a mismatch, not be
+    /// laundered into `N` where it matches an `N` on the other side (#1347).
+    ///
+    /// The private complement mapped every non-ACGT byte to `N` "so it can never
+    /// spuriously match" — but `N` is exactly what it produced, so an `N` in the
+    /// `NG_` matched *any* unmodelled genome byte. A placement validated against
+    /// bases nobody could complement.
+    #[test]
+    fn an_unmodelled_genome_byte_does_not_match_an_n_in_the_ng() {
+        assert!(
+            !validate_sequence(b"NNNN", b"XXXX", Strand::Minus),
+            "unmodelled genome bytes must not validate a placement"
+        );
+    }
+
+    /// The flip side: an IUPAC code has a real complement and must be credited
+    /// with it. `R` (A or G) complements to `Y` (C or T); collapsing it to `N`
+    /// counted a correct pairing as a mismatch.
+    #[test]
+    fn an_iupac_code_complements_to_its_partner_on_the_minus_strand() {
+        // NG "YYYY" vs genome "RRRR" read in reverse: complement(R) == Y.
+        assert!(
+            validate_sequence(b"YYYY", b"RRRR", Strand::Minus),
+            "R must complement to Y rather than collapsing to N"
+        );
+    }
 
     #[test]
     fn legacy_artifact_without_schema_version_is_accepted() {

--- a/src/reference/derived_tx_structure.rs
+++ b/src/reference/derived_tx_structure.rs
@@ -146,20 +146,15 @@ impl DerivedTxStructures {
     }
 }
 
-fn revcomp(s: &str) -> String {
-    s.bytes()
-        .rev()
-        .map(|b| match b.to_ascii_uppercase() {
-            b'A' => 'T',
-            b'C' => 'G',
-            b'G' => 'C',
-            b'T' => 'A',
-            _ => 'N',
-        })
-        .collect()
-}
-
 /// Concatenate a transcript's exon genome slices in tx order (rev-comp on minus).
+///
+/// Minus-strand exons go through the shared [`crate::sequence::reverse_complement`]
+/// (#1347). The private helper this replaced mapped every non-ACGT byte to `N`,
+/// discarding an ambiguity code's meaning and making it indistinguishable from a
+/// genuine `N`. It also upper-cased, where the plus-strand arm below passes the
+/// genome slice through verbatim; both arms now preserve case alike. That is
+/// inert against the FASTA providers, which upper-case on read
+/// (`fasta.rs`, `multi_fasta.rs`).
 pub fn reconstruct_spliced_mrna(cdot: &CdotTranscript, genome: &dyn GenomeSlice) -> Option<String> {
     // Exons are stored ascending by tx coordinate. On the minus strand the
     // forward-genome slice of each exon must be reverse-complemented; the exon
@@ -170,7 +165,7 @@ pub fn reconstruct_spliced_mrna(cdot: &CdotTranscript, genome: &dyn GenomeSlice)
         let raw = genome.slice(&cdot.contig, gs, ge)?;
         match cdot.strand {
             Strand::Plus => out.push_str(&raw),
-            Strand::Minus => out.push_str(&revcomp(&raw)),
+            Strand::Minus => out.push_str(&crate::sequence::reverse_complement(&raw)),
             Strand::Unknown => return None,
         }
     }
@@ -570,6 +565,30 @@ mod derivation_tests {
             protein: Some("NP_M.1".to_string()),
         };
         (cdot, genome)
+    }
+
+    /// Reconstructing a minus-strand mRNA must complement an IUPAC ambiguity
+    /// code, not collapse it to `N` (#1347).
+    ///
+    /// The private `revcomp` mapped every non-ACGT byte to `N`, so an `R` in the
+    /// genome became `N` in the reconstructed mRNA — silently discarding the
+    /// "A or G" information and making a genuine `N` indistinguishable from a
+    /// code that simply was not modelled.
+    #[test]
+    fn minus_strand_reconstruction_complements_iupac_codes() {
+        let (mut cdot, _) = minus_sibling_fixture();
+        // One exon, g[1,5) = "ARGT" -> reverse "TGRA" -> complement "ACYT".
+        cdot.exons = vec![[1, 5, 0, 4]];
+        cdot.exon_cigars = vec![None];
+        let genome = FakeGenome {
+            contig: "NC_TEST.1".to_string(),
+            seq: "ARGTAAAAAA".to_string(),
+        };
+        assert_eq!(
+            reconstruct_spliced_mrna(&cdot, &genome).unwrap(),
+            "ACYT",
+            "R must complement to Y rather than collapsing to N"
+        );
     }
 
     #[test]

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -24,6 +24,7 @@ use crate::hgvs::variant::{CdsVariant, GenomeVariant, HgvsVariant, RnaVariant, T
 use crate::project::edit::u_to_t_edit;
 use crate::reference::transcript::{GenomeBuild, Transcript};
 use crate::reference::ReferenceProvider;
+use crate::sequence::reverse_complement;
 
 use super::record::VcfRecord;
 
@@ -1068,24 +1069,6 @@ fn rna_pos_to_tx(pos: &RnaPos) -> TxPos {
         offset: pos.offset,
         downstream: false,
     }
-}
-
-/// Compute reverse complement of a DNA sequence
-fn reverse_complement(seq: &str) -> String {
-    seq.chars()
-        .rev()
-        .map(|c| match c {
-            'A' => 'T',
-            'T' => 'A',
-            'C' => 'G',
-            'G' => 'C',
-            'a' => 't',
-            't' => 'a',
-            'c' => 'g',
-            'g' => 'c',
-            _ => c,
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -2418,6 +2401,39 @@ mod tests {
         assert_eq!(record.reference, "AACC");
         // reverse_complement("AACC") == "GGTT".
         assert_eq!(record.alternate, vec!["GGTT"]);
+    }
+
+    /// An inversion over a span containing an IUPAC ambiguity code must complement
+    /// that code, not emit it verbatim into the ALT field (#1347).
+    ///
+    /// `R` (A or G) complements to `Y` (C or T). Passing it through unchanged
+    /// claims the ambiguity is self-complementary, which is wrong for every code
+    /// except `S`, `W` and `N` — and it writes that claim into produced VCF.
+    #[test]
+    fn inversion_alt_complements_iupac_ambiguity_codes() {
+        let transcript = create_test_transcript();
+        let mut provider = MockProvider::new();
+        // Same tiling as `test_build_vcf_record_inversion`, with the third base
+        // replaced by `R`: genomic 1049..1052 = "AARC".
+        let seq = "AARCGGTT".repeat(200);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
+
+        let variant = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::new(CdsPos::new(1), CdsPos::new(4)),
+                NaEdit::Inversion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        });
+
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.reference, "AARC");
+        // reverse_complement("AARC") == "GYTT": R -> Y, not R -> R.
+        assert_eq!(record.alternate, vec!["GYTT"]);
     }
 
     /// `c.1 CAG[5]`: a repeat expansion is an insertion anchored on the base at


### PR DESCRIPTION
Closes #1347

Finishes the #1318 complement unification. Three commits, matching the issue's suggested order — read them in sequence.

## 1. The two pass-through copies (`97235c1`)

`vcf::from_hgvs` and `reference::annotation::validate` each carried a private `reverse_complement` whose fallback returned the character unchanged. Both *produce* sequence rather than compare it, so neither showed the misclassification #1346 fixed — but an unmodelled character went verbatim into produced data.

The VCF site is the observable one. An inversion spanning an IUPAC code emitted it uncomplemented into the ALT field:

```
ALT was "GRTT", should be "GYTT"     # R (A or G) complements to Y (C or T)
```

The start-codon site is behaviour-preserving: it upper-cased where the shared helper preserves case, but `validate_start_codon` upper-cases the assembled codon before matching it against ATG/CTG/GTG/TTG, so the delta is inert. Covered by the existing minus-strand split-codon tests.

## 2. The two `N`-mapping copies (`14be296`)

Both mapped every non-ACGT byte to `N`. In the placement validator that creates the exact spurious match its own comment claimed to prevent:

`validate_sequence` compared `bases_match(ng, complement(genome))` where `complement` returned `N` for anything unmodelled — so an `N` on the `NG_` side matched **any** unmodelled genome byte. A placement could validate against bases nobody could complement. It also counted a correctly-paired ambiguity as a mismatch, since `R` collapsed to `N`, which does not equal the `Y` opposite it.

`reconstruct_spliced_mrna` had the same map on its minus-strand arm, so an `R` in the genome became `N` in the reconstructed mRNA — indistinguishable from a genuine `N`.

That arm also upper-cased where the plus-strand arm passes the slice through verbatim. Both now preserve case alike, which is inert in production because the FASTA providers upper-case on read (`fasta.rs:199`, `multi_fasta.rs:1295`).

`validate_sequence`'s doc comment claimed `N`/ambiguity bases "count as mismatches" and that an assembly-gap run of `N`s inflates the mismatch fraction. Neither was true — `N` complements to `N` and matched itself on both strands. Corrected to describe what the code does.

### Measured against the prepared reference

The issue asked for a before/after on the reference-data paths. Both were run against a real prepared reference (cdot 0.2.32, GRCh38).

**Blast radius, from the genome's actual alphabet.** `validate_sequence` complements the *genome* byte, so the genome FASTA's alphabet bounds the change exactly. Full scan of GRCh38.fna (3.1 GB):

```
T 559373567   A 558619211   G 413917617   C 413530454
t 366543471   a 364497992   g 231314379   c 229022463
N 161611379
Y 36   R 29   W 15   M 8   K 8   S 5   B 2
```

Two things follow. **Nothing lies outside the modelled alphabet**, so the new "no complement ⇒ mismatch" path never fires on this reference — it is a guard against corrupt input, not a live behaviour change. But **103 genuine ambiguity codes do exist**, so the `R → Y` correction is live wherever a minus-strand slice covers one; previously each of those collapsed to `N`.

**Artifact re-derivation.** `derive_tx_placements` re-run against the same manifest and diffed against the committed `derived_transcript_placements.json`, which the old code produced. The only differences are two schema fields added by earlier PRs (`schema_version` from #1001, `cds_start_incomplete` from #972) that the older artifact predates:

```
2d1  <   "schema_version": 1,
57d55  <       "cds_start_incomplete": false,
95d92  <       "cds_start_incomplete": false,
```

Every derived value — exons, coordinates, `mismatch_fraction` — is byte-identical. No drift from this change.

Stated honestly: that artifact covers only 2 accessions, so on its own it is weak evidence. The alphabet scan is what actually bounds the risk, and it bounds it at 103 positions in 3.1 Gb.

## 3. The `validate_inversion` residual (`dd9fa0d`) — not the bug the issue described

The issue proposed teaching `validate_inversion` a "cannot validate this alphabet" answer, because reference `XX` + provided `XX` returns `Valid`. **That premise is wrong, and the spec says so.**

`assets/hgvs-nomenclature/docs/background/standards.md:36` defines `X`:

```
|   X†   | A, C, G or T |        masked nucleotide        |
|   -†   |     none     |   gap of indeterminate length   |
† used in alignment only.
```

`X` is set-identical to `N`. The IUPAC complement map is the set-complement map, so `X` is **self-complementary** — today's `Valid` is the correct answer, reached by accident through the display helper's pass-through. Rejecting it would have replaced a right answer with a vaguer one.

It is also unreachable from parsed input:

```
NC_TEST.1:g.1_2invXX -> Err(Parse { pos: 18, msg: "Unexpected trailing characters: 'XX'" })
```

**The real defect next door.** `reverse_complement` maps `U` to `A` but never produces a `U`, so it is not an involution over RNA — the reverse complement of an RNA reference comes back spelled in the DNA alphabet. With bare case-folded equality, a legal `r.` inversion was reported as a mismatch against its own reference:

```
validate_inversion(Some("AT"), Some("AU"), 1, 2)
  -> SequenceMismatch { expected: "AT", provided: "AU" }
```

`NM_TEST.1:r.1_2invau` parses and round-trips unchanged. **But see review round 2 below**: parseability is not reachability — `validate_inversion` has no callers outside its own tests, and the live inversion check is a different function with different semantics. This is a latent defect in a public-but-unused API. Fixed by folding `U` onto `T` for the comparison only; the reported `expected` string is untouched.

Also in this commit:

- **Documents what `Valid` asserts**, which was undeclared: exact equality of IUPAC code strings up to case and the T/U fold, *not* "consistent with the reference". That is why `("RY","RY")` is valid while `("RR","RR")` is a mismatch.
- **Adds `#[non_exhaustive]`** to `InversionValidation` while it still has no in-tree consumers — the only free moment to add it. Shipped as `feat!` with a `BREAKING CHANGE:` footer; see round 2.
- Pins the `X` finding in a test, so a future "reject unknown alphabet" change has to confront the spec text first.

### Known and deliberately not changed

`("AN","NN")` reports a mismatch with expected `"NT"`, even though every concrete instantiation of `AN` reverse-complements into `NN`. That is the equality rule behaving as specified rather than a subsumption rule. Changing it would redesign what the function means, so it is documented instead.

## Tests

Seven new tests, each written first and watched fail:

| test | what it caught |
|---|---|
| `inversion_alt_complements_iupac_ambiguity_codes` | ALT `GRTT` instead of `GYTT` |
| `an_unmodelled_genome_byte_does_not_match_an_n_in_the_ng` | placement validating against unmodelled bytes |
| `an_iupac_code_complements_to_its_partner_on_the_minus_strand` | `R` collapsing to `N` and failing to match `Y` |
| `minus_strand_reconstruction_complements_iupac_codes` | reconstructed mRNA `ACNT` instead of `ACYT` |
| `an_rna_inversion_validates_against_a_dna_reference` | the T/U false mismatch |
| `t_u_folding_does_not_mask_a_real_mismatch` | guard: folding must not validate everything |
| `the_spec_defined_masked_nucleotide_is_self_complementary` | guard: pins the spec's `X` semantics |

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev --no-fail-fast` — **9191 passed, 146 skipped, 0 failed**.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean.
- Generated spec artifacts regenerated before the run.

**Oracle movement:** none. No test retired, relaxed, or re-blessed.

---

## Review round 2

Both lenses run. CodeRabbit CLI: **0 findings**. The agent lens found seven, of which five were accepted and fixed; the two `[Info]` ones are addressed in docs.

**Accepted and fixed:**

1. **A pre-existing doc comment was severed from its test.** The new tests were inserted between `an_iupac_code_is_not_its_own_complement`'s doc comment and the `#[test]` it documents, so that test lost its docs and mine absorbed a `#1249` R/Y rationale that has nothing to do with T/U. Genuinely my error; both comments are re-attached.

2. **The reachability claim in the commit message was wrong.** It said `NM_TEST.1:r.1_2invau` "parses and round-trips unchanged, so this is reachable from ordinary input". Parseability of the description is not reachability of the function — `validate_inversion` has **no callers** outside its own unit tests, which the same commit conceded two paragraphs later when justifying `#[non_exhaustive]`. The message now states the scope plainly: a latent defect in a public-but-unused API.

   The review also established that the **live** inversion check is a different function with different semantics — `normalize::validate::validate_sequence`, reached from `normalize/validate.rs`'s `NaEdit::Inversion` arm, compares stated bases against the reference span *itself* rather than its reverse complement, and has no T/U fold. That is recorded in the commit message and left for a follow-up rather than widened into this PR.

3. **`#[non_exhaustive]` would have shipped in a patch release.** `release-plz.toml` sets `features_always_increment_minor = true`, so `feat:` takes a minor bump and `fix:` a patch. Adding `#[non_exhaustive]` breaks a downstream exhaustive `match` at compile time, so shipping it under `fix(effect):` would deliver a compile-breaking change as 0.11.0 → 0.11.1. Retyped `feat(effect)!:` with a `BREAKING CHANGE:` footer.

4. **`X` was given two contradictory meanings in one PR** — spec-defined and self-complementary in `effect`, the exemplar of an unmodelled byte in `derived_placement`. Worse, the doc claimed the `X` answer was "a correct answer, not a pass-through accident" when `complement_base` does not model `X` at all, so it *is* pass-through — the same pass-through returns `Valid` for `("ZZ","ZZ")`, which the spec does not define. The doc now says exactly that, and notes `X` belongs in the table if the answer is ever to be load-bearing.

5. **`compare_key` used `str::to_uppercase`, which can expand.** `ß` uppercases to `SS`, while the length gate above measures bytes — so `("SS", "ß")` clears a 2-byte length check and then compares equal, reporting `Valid`. Pre-existing rather than introduced, but the PR claims to specify what `Valid` asserts, so it is now an ASCII byte-wise fold that measures the same thing the gate does.

**Addressed in documentation:**

6. Two of the three new `effect` tests (`t_u_folding_does_not_mask_a_real_mismatch`, `the_spec_defined_masked_nucleotide_is_self_complementary`) pass against pre-change code. They are guards, not regression tests, and are now labelled as characterization pins so they are not mistaken for the latter. The four tests that do fail pre-change are unchanged.

7. The plus/minus asymmetry in `validate_sequence` — an unmodelled byte still matches itself on the plus strand, because that arm compares bytes directly and never needs a complement — is now documented rather than left implicit.

**Not changed:** the review confirmed the case-semantics claim independently (every `GenomeSlice` implementor upper-cases, so no lowercase slice can reach the byte-exact `find_clean_offset`), confirmed the rewritten `validate_sequence` closure is equivalent to the old one for all ACGTN input and that `is_none_or` is not inverted, and confirmed `#[non_exhaustive]` breaks nothing in-crate and has no Python exposure.

Re-verified after the fixes: **9191 passed, 146 skipped, 0 failed** with both oracles; fmt and clippy clean.
