### PR TITLE
fix(normalize): bound a 5'-shifting member at a sibling's insertion junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4111,12 +4111,36 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
                 .map(|s| s.end)
                 .filter(|&end| end < b.start && end >= a.start)
                 .map(|end| end + 1);
-            // No junction barrier in this direction: measured, it introduced
-            // fresh 5'-shuffle failures rather than removing them (an
-            // insertion-like sibling and a 5'-shifting span interact through
-            // the merge's cancellation path, not through the crossing this
-            // rule models). 3'-only, deliberately — see the module tests.
-            onto_bases.max().map(|limit| a.start - limit)
+            // Mirror of the 3' junction barrier. A junction between `j` and
+            // `j + 1` is crossed once this member's start reaches `j`; stopping
+            // at `j + 1` leaves it flush against the junction on the 3' side,
+            // which is the adjacency the collapse pass wants.
+            //
+            // Base-claiming members only. The two branches bound opposite edges
+            // — 3' limits `a.end`, 5' limits `a.start` — and for a member that
+            // carries its own junction those are not interchangeable. A `dup`'s
+            // junction is its *end* (`junction_of`), so bounding its start
+            // holds it back by `len - 1` more than the invariant needs: on
+            // `TTAATATATAATAATATTAT`, `g.[4_5insC;5_6dup]` stops at its input
+            // position instead of reaching the 5'-most legal `4_5dup`.
+            // Sequence-preserving, so the exhaustive sweeps cannot see it —
+            // measured at 905 de-canonicalised outputs across a 64,512-case
+            // dup corpus, every one with `dup_len > 1`.
+            //
+            // Junction-carrying members are already bounded correctly, on the
+            // right edge, by `clamp_sibling_crossing_junctions` — which runs
+            // immediately after this pass against the same snapshot and carries
+            // a `commutes` escape hatch this bound would otherwise override.
+            let across_junctions = siblings
+                .iter()
+                .filter(|_| a.junction.is_none())
+                .filter_map(|s| s.junction)
+                .filter(|&j| j < b.start && j >= a.start)
+                .map(|j| j + 1);
+            onto_bases
+                .chain(across_junctions)
+                .max()
+                .map(|limit| a.start - limit)
         };
         // Never move past where the member started: those positions were not
         // reachable by this shift and are not equivalent to it.

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -135,6 +135,88 @@ fn an_insertion_reaching_the_end_of_its_run_still_collapses() {
     assert_normalizes_preserving(RUN, "TEMPLATE:g.[2_3insA;11C>G]", "TEMPLATE:g.11delinsAG");
 }
 
+/// A 5'-shuffled insertion merging with a deletion sibling must not move the
+/// base it contributes (#1342).
+///
+/// Surfaced by giving the sweep's first-member `ins` a payload that is not the
+/// span's own reference base. In the `T`-run at 1-9, inserting an `A` at the
+/// `2|3` junction and deleting a `T` at 4 is net "one `T` becomes an `A`" — and
+/// the `A` lands at position 3. It cannot shuffle 5': an `A` in a `T`-run is
+/// unique, so moving it is a different sequence, not a different spelling of
+/// the same one. The 3' direction already answered `g.3T>A`.
+#[test]
+fn an_insertion_merging_with_a_deletion_keeps_its_base_in_place() {
+    assert_normalizes_preserving_in(
+        TRACT,
+        "TEMPLATE:g.[2_3insA;4del]",
+        "TEMPLATE:g.3T>A",
+        ShuffleDirection::FivePrime,
+    );
+}
+
+/// Negative controls for the 5' junction barrier: it must bound only the shifts
+/// that actually reorder the two edits, never a member that may legitimately
+/// travel to the 5' end of its tract.
+///
+/// This is the failure mode the barrier's own assertion cannot see. A member
+/// held back too far still *preserves sequence*, so the exhaustive sweep below
+/// would pass while every answer quietly under-shifted. These pin the shifts
+/// that must still complete.
+#[test]
+fn the_five_prime_junction_barrier_does_not_over_clamp() {
+    // Payload equals the run base, so the insertion and the deletion cancel:
+    // the pair must still reduce all the way to an identity rather than being
+    // stranded as two members either side of the junction.
+    assert_normalizes_preserving_in(
+        TRACT,
+        "TEMPLATE:g.[2_3insT;4del]",
+        "TEMPLATE:g.2_3=",
+        ShuffleDirection::FivePrime,
+    );
+    // Net +1 `T` in the run. The 5'-most spelling is a duplication at 1, which
+    // is 5' of the `2|3` junction — reachable because the merged member no
+    // longer straddles it.
+    assert_normalizes_preserving_in(
+        TRACT,
+        "TEMPLATE:g.[2_3insTT;5del]",
+        "TEMPLATE:g.1dup",
+        ShuffleDirection::FivePrime,
+    );
+    // The deletion is outside the tract entirely, so there is no sweep and
+    // nothing for the barrier to bound — both members stay put.
+    assert_normalizes_preserving_in(
+        TRACT,
+        "TEMPLATE:g.[2_3insA;12del]",
+        "TEMPLATE:g.[2_3insA;12del]",
+        ShuffleDirection::FivePrime,
+    );
+}
+
+/// The barrier bounds a member by its **span start**, which is the right edge
+/// to bound only for a member that claims bases. A `dup` carries its own
+/// junction at its *end*, so bounding its start holds it back by `len - 1`
+/// more than the invariant requires.
+///
+/// `3_4dup` really is illegal here — it would share interbase 4 with the
+/// insertion — so `4_5dup` is the 5'-most legal spelling, and the member must
+/// still reach it. Bounding the start would strand it at `5_6dup`, its input
+/// position: sequence-preserving, so the exhaustive sweep cannot see it, and
+/// silently non-canonical.
+///
+/// The sweep is blind to this class twice over: its only oracle is `apply`, and
+/// its second member is always a single-base `dup` — exactly the length at
+/// which `len - 1` is zero and the over-clamp disappears.
+#[test]
+fn a_multi_base_duplication_still_reaches_its_five_prime_most_position() {
+    const DUP_RUN: &str = "TTAATATATAATAATATTAT";
+    assert_normalizes_preserving_in(
+        DUP_RUN,
+        "TEMPLATE:g.[4_5insC;5_6dup]",
+        "TEMPLATE:g.[4_5insC;4_5dup]",
+        ShuffleDirection::FivePrime,
+    );
+}
+
 #[test]
 fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // The widened class. The sweep in `repeat_span_sibling_overlap.rs` uses a
@@ -183,7 +265,27 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                 } else {
                     format!("{first_start}_{first_end}")
                 };
-                let inserted = &seq[first_start - 1..first_end];
+                // #1342: the payload must not equal either reference base
+                // flanking the insertion point, for the same reason the second
+                // member's payload excludes both of its neighbours below.
+                // This entry used to insert `seq[first_start - 1..first_end]`,
+                // the span's own reference bases — so for `first_len == 1` it
+                // denoted exactly `{first_start}dup`, the entry directly above
+                // it. Half the `first_len` values contributed two distinct
+                // first-member shapes while the array read as three, and the
+                // single-base span is the case where a junction has the least
+                // context to disambiguate it.
+                //
+                // `first_start <= 13` and `sweep_sequences` yields 20-base
+                // sequences, so index `first_start` — the 3' neighbour — is
+                // always in bounds.
+                let first_base = seq.as_bytes()[first_start - 1] as char;
+                let first_next_base = seq.as_bytes()[first_start] as char;
+                let first_ins_payload = ['A', 'C', 'G', 'T']
+                    .into_iter()
+                    .find(|b| *b != first_base && *b != first_next_base)
+                    .expect("four bases, at most two excluded");
+                let inserted: String = std::iter::repeat_n(first_ins_payload, first_len).collect();
                 let firsts = [
                     format!("{span}del"),
                     format!("{span}dup"),


### PR DESCRIPTION
Closes #1342

#1342 asked for a test-hygiene change and said what to do if it surfaced anything: *"If the change does surface sequence-changing cases, that is the finding — the shape was unreachable, not clean."* It did. This PR is the finding and its fix.

## The unreachable shape

`no_two_member_allele_normalizes_to_a_different_sequence` built its first member as three shapes, with the `ins` payload taken from the span's own reference bases:

```rust
let inserted = &seq[first_start - 1..first_end];
format!("{first_start}_{}ins{inserted}", first_start + 1)
```

For `first_len == 1` that is `{first_start}_{first_start+1}ins{ref[first_start]}` — exactly the `{first_start}dup` entry directly above it. Half the `first_len` values contributed **two** distinct first-member shapes while the array read as three, and the single-base span is where a junction has the least context to disambiguate it.

Giving the payload a base that differs from *both* flanking reference bases — the same remedy #1337 applied to the second member, and for the same reason — exposed **246 sequence-changing cases out of 276,480**, every one in a single shape:

```
MEASURE checked=276480 skipped=0 residual=0 changed_total=246 overlapping=0
SHAPE first=ins second=del dir=FivePrime first_len=1  166
SHAPE first=ins second=del dir=FivePrime first_len=2   80
```

`checked` is unchanged at 276,480, so this is a clean control: same case count, only the payload differs.

## The defect

```
reference    TTTTTTTTTAATATATTTTA        T-run at 1-9
g.[2_3insA;4del]  ->  g.2T>A             (5' direction)
input applied     TTATTTTTTAATATATTTTA
output applied    TATTTTTTTAATATATTTTA    <- the inserted base moved
```

Well-formed, disjoint, warning-free, and wrong — the silent shape this file's header describes.

**The merge is innocent.** `g.[1del;2_3insA]` really does denote `g.2T>A`; applying both gives `TATTTTTTT…`. The error is the shift that produced `1del` in the first place. `4del` and `1del` are equivalent *alone* — both remove one `T` from the run — but not beside the insertion, because the insertion splits the run at `2|3` and the deletion lands on the other side of it.

Isolation, which is what pinned this down:

| input | 5' | 3' |
|---|---|---|
| `g.2_3insA` alone | preserved | preserved |
| `g.[2_3insA;4del]` | **broken** | preserved |
| `g.[2_3insA;10del]` (deletion far away) | preserved | preserved |
| `g.[2_3insA;4dup]`, `g.[2_3insA;4T>A]` | preserved | preserved |

So: insertion + a deletion that 5'-shifts across its junction, 5' direction only. Member order is irrelevant (`g.[1del;2_3insA]` gives the same).

## The fix, and a stale measurement corrected

`clamp_sibling_crossing_shifts` had a junction barrier in the **3' direction only**. The 5' branch carried this comment:

> No junction barrier in this direction: measured, it introduced fresh 5'-shuffle failures rather than removing them (an insertion-like sibling and a 5'-shifting span interact through the merge's cancellation path, not through the crossing this rule models). 3'-only, deliberately.

That measurement is **stale**. It predates the junction-vs-junction bound (#1290) and the junction's own 5' clamp (#1350) — the very paths it was colliding with. Re-measured on this tree, the mirrored barrier introduces no fresh failures at all: the full suite passes with both oracles, and the widened sweep goes to **zero** rather than needing a pinned residual.

The mirror itself is the 3' rule read backwards: a junction between `j` and `j+1` is crossed once the member's start reaches `j`, so stop at `j+1` — flush against it on the 3' side, which is the adjacency the collapse pass wants. `g.[2_3insA;4del]` now yields `g.3T>A`, which is what the 3' direction already answered.

The comment is replaced with the new reasoning rather than left standing as a claim this PR disproves.

## Tests

- `an_insertion_merging_with_a_deletion_keeps_its_base_in_place` — the minimal reproducer, pinned in the 5' direction, asserting both the exact output and sequence preservation. Fails on `main` with `left: "TEMPLATE:g.2T>A", right: "TEMPLATE:g.3T>A"`.
- The widened sweep itself, which now asserts all 276,480 cases including the 246 that were previously unreachable. **No residual is pinned** — `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` stays at 0 and no new constant is introduced.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev --no-fail-fast` — **9185 passed, 146 skipped, 0 failed**.
- All 17 tests in `cis_junction_crossing_shift.rs` pass, including both exhaustive sweeps.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean.

**Oracle movement:** none in the pinning sense — no test retired, relaxed, or re-blessed, and no residual constant added or raised. The sweep's *coverage* grew: 246 previously-unreachable cases are now asserted.

---

## Review round 2

Both lenses run. Two findings, both about the same risk — that the new barrier bounds *too much* — and the second one proved it with a measurement I could reproduce.

### Accepted: the barrier over-clamped junction-carrying members (905 outputs)

The two branches bound **opposite edges**: 3' limits `a.end`, 5' limits `a.start`. For a member that claims bases that is exactly right. For a member carrying its own junction it is not — a `dup`'s junction is its *end*, so bounding its start holds it back by `len - 1` more than the invariant requires.

```
reference   TTAATATATAATAATATTAT          FivePrime
g.[4_5insC;5_6dup]
  before this PR  ->  g.[4_5insC;4_5dup]   junction at 5, the 5'-most legal spelling
  as first pushed ->  g.[4_5insC;5_6dup]   stranded at its input position
```

`3_4dup` genuinely is illegal (it would share interbase 4 with the insertion), so `4_5dup` is correct and the member must still reach it. Both spellings apply to the identical sequence — which is exactly why this was invisible: **sequence-preserving, so neither exhaustive sweep can detect it**, and the sweep's second member is always a single-base `dup`, the one length at which `len - 1` is zero and the class vanishes.

Measured over a 64,512-case corpus of `[ins; dup]` shapes: **905 outputs de-canonicalised**, every one with `dup_len > 1`, zero with `dup_len == 1` — precisely the predicted signature.

Fixed by restricting the new barrier to base-claiming members (`a.junction.is_none()`). Junction-carrying members are already bounded on the correct edge by `clamp_sibling_crossing_junctions`, which runs immediately after this pass against the same snapshot and carries a `commutes` escape hatch that the span bound would have overridden. With the guard: the 276,480-case sweep is byte-identical to the un-guarded version (all 246 fixes retained) and the dup corpus returns to byte-identical with `main` (0 over-clamps).

### Accepted: the replaced comment was not *entirely* stale

The deleted comment claimed a 5' junction barrier had been measured as introducing fresh 5'-shuffle failures. That is stale as to *sequence* failures — it predates #1290 and #1350, which fixed the paths it collided with. But the over-clamp above is what survived of it. The replacement comment now says that explicitly instead of presenting the mirror as unqualified, and the commit message does the same.

### Added: the negative controls this needed

`a_multi_base_duplication_still_reaches_its_five_prime_most_position` pins the case above, and fails against the un-guarded barrier with `left: g.[4_5insC;5_6dup], right: g.[4_5insC;4_5dup]`. `the_five_prime_junction_barrier_does_not_over_clamp` pins three cancellation shapes that must still complete — including the fully-commuting `g.[2_3insT;4del]`, which must still reduce all the way to `g.2_3=`.

Every other rule in this file is paired with a negative control; the barrier now is too. The review was right that a positive control alone could not have caught this.

### Confirmed, no change needed

The reviewer independently re-derived the filter boundaries from first principles and found no off-by-one in either direction; confirmed `.max()` is the correct reducer and that `i64` coordinates make underflow impossible; confirmed a duplication *sibling* is only redundantly bounded, not over-bounded; and confirmed the sweep payload cannot panic and loses no coverage. It also verified independently that the pinned test fails against pre-change code and that no existing expected value in the tree changes.

Re-verified after the guard: **9187 passed, 146 skipped, 0 failed** with both oracles; all 19 tests in this file pass; fmt and clippy clean.
