### PR TITLE
test(normalize): record the 5' shuffle confluence gap

### DIFF
--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -12,9 +12,19 @@
 //! Each row asserts the two spellings still DIVERGE. This test failing means a
 //! pair converged, and that pair's blessed expectation should be re-blessed to
 //! the converged form.
+//!
+//! Both tables are measured in both directions. Every row above was blessed
+//! against the 3' rule, but confluence is a property of the normalizer rather
+//! than of one shuffle direction, and `--direction 5prime` is a supported public
+//! option — so [`DIVERGENT_UNDER_FIVE_PRIME`] records the [`CONVERGED`] rows that
+//! converge under 3' and diverge under 5', and
+//! [`the_eight_spelling_pairs_still_diverge_under_five_prime`] pins that the
+//! [`DIVERGENT`] eight diverge under 5' too. Both use the same assert-then-flip
+//! idiom: a red assertion is a result, not a maintenance chore.
 
-use crate::common::cis_apply_oracle::{apply, normalize};
+use crate::common::cis_apply_oracle::{apply, normalize, normalize_in};
 use crate::common::synthetic::padded;
+use ferro_hgvs::ShuffleDirection;
 
 /// `(issue, core, split spelling, merged spelling)`.
 const DIVERGENT: &[(&str, &str, &str, &str)] = &[
@@ -155,4 +165,234 @@ fn converged_pairs_stay_converged() {
              two spellings of one variant must agree."
         );
     }
+}
+
+/// Rows from [`CONVERGED`] that converge under the 3' rule but **not** under 5'.
+///
+/// Confluence is a property of the normalizer, not of one shuffle direction, and
+/// `--direction 5prime` is a supported public option on both the CLI
+/// (`src/bin/ferro.rs`) and the Python bindings. Every row above was blessed
+/// against the 3' direction only, so this pair of gaps was never measured.
+///
+/// Both spellings still denote the input's bases and both are stable fixed
+/// points, so this is criterion 1 of #1235 — non-confluence — and nothing else.
+/// That is why neither oracle sees it: `FERRO_ASSERT_IDEMPOTENT` re-normalizes a
+/// single spelling and finds it stable, and `FERRO_ASSERT_REPARSE` finds it
+/// well-formed. Only comparing two spellings of one variant exposes it.
+const DIVERGENT_UNDER_FIVE_PRIME: &[&str] = &["#1321", "#1323"];
+
+#[test]
+fn the_five_prime_confluence_gap_is_unchanged() {
+    // Assert-then-flip, the same contract the rows above carry: each listed row
+    // is asserted to still DIVERGE, and each unlisted row to still CONVERGE. A
+    // red assertion here is a *result*, not a maintenance chore — move the row
+    // between the two sets rather than widening the list.
+    //
+    // The cause is not the shuffle direction reaching the derivation, which was
+    // measured and refuted: threading `ShuffleDirection` into
+    // `canonicalize_from_sequence` changes 298 of 39,600 swept outputs and all of
+    // them are sequence-preserving both before and after, so it is a lateral
+    // re-spelling with no correctness content. For these two rows the derivation
+    // instead *refuses*: `canonicalize_from_sequence` returns `None`, behind
+    // three stacked gates — the `collect_canonical_edits` catch-all (reached via
+    // a redundant `=` member the 5' pipeline emits), then the
+    // `changed_columns_of_pieces` weight bound, then `needs_unsupported_form`.
+    // Each masks the next, which is the pattern #1235 and #1345 both describe.
+    //
+    // Every listed id must still name a `CONVERGED` row. The loop below reaches
+    // an entry only through that table, so an id naming no row is inert: it
+    // asserts nothing, and the set goes on claiming to pin a divergence that is
+    // no longer measured. Deleting a row and leaving its id here is exactly how
+    // that happens, and it is silent — verified by adding a bogus id, which left
+    // all six tests in this file green. Same class of drift as the row count
+    // pinned in `the_eight_spelling_pairs_still_diverge`.
+    for issue in DIVERGENT_UNDER_FIVE_PRIME {
+        assert!(
+            CONVERGED.iter().any(|(row, ..)| row == issue),
+            "{issue} is listed in DIVERGENT_UNDER_FIVE_PRIME but names no CONVERGED \
+             row, so it pins nothing. Delete the entry, or restore the row it names."
+        );
+    }
+    for (issue, core, split, merged) in CONVERGED {
+        let seq = padded(core);
+        let (a, b) = (
+            normalize_in(&seq, split, ShuffleDirection::FivePrime),
+            normalize_in(&seq, merged, ShuffleDirection::FivePrime),
+        );
+        if DIVERGENT_UNDER_FIVE_PRIME.contains(issue) {
+            assert_ne!(
+                a, b,
+                "{issue} now CONVERGES under 5' shuffle — both spellings reach \
+                 `{a}`. Remove it from DIVERGENT_UNDER_FIVE_PRIME; the gap is \
+                 closing."
+            );
+        } else {
+            assert_eq!(
+                a, b,
+                "{issue} has started diverging under 5' shuffle — `{split}` -> \
+                 `{a}` but `{merged}` -> `{b}`. Two spellings of one variant must \
+                 agree in both directions; add it to DIVERGENT_UNDER_FIVE_PRIME \
+                 only with a measured reason."
+            );
+        }
+    }
+}
+
+#[test]
+fn the_eight_spelling_pairs_still_diverge_under_five_prime() {
+    // The 5' half of `the_eight_spelling_pairs_still_diverge`. Those eight rows
+    // were blessed against the 3' rule only, so without this the DIVERGENT table
+    // had no 5' coverage at all and the module doc's "both directions" claim
+    // covered only CONVERGED.
+    //
+    // All eight diverge under 5' as well, but they reach *different* spellings
+    // than under 3' (#1296's merged form settles at `g.273C>A` here against
+    // `g.273delinsA` there), so this is measuring the 5' pipeline rather than
+    // restating the 3' result. Assert-then-flip: a row that starts converging is
+    // the gap closing, and belongs in the message below rather than deleted.
+    for (issue, core, split, merged) in DIVERGENT {
+        let seq = padded(core);
+        let (a, b) = (
+            normalize_in(&seq, split, ShuffleDirection::FivePrime),
+            normalize_in(&seq, merged, ShuffleDirection::FivePrime),
+        );
+        assert_ne!(
+            a, b,
+            "{issue} now CONVERGES under 5' shuffle — `{split}` and `{merged}` both \
+             reach `{a}`. The gap is closing; re-bless {issue} and move it to \
+             CONVERGED if it converges under 3' too."
+        );
+    }
+}
+
+/// Drop identity (`=`) members from a cis-allele description.
+///
+/// An identity member states that nothing changes, so removing it leaves a
+/// description denoting the same bases — but one the applier *can* express.
+/// `hgvs_to_spdi` declines an identity member and takes the whole description
+/// with it (#1351), so this is how the denotation of such an output is checked
+/// at all. Returns the input unchanged when there is no allele to rewrite; the
+/// caller asserts on the result, so a no-op surfaces as a failure rather than a
+/// silent pass.
+fn strip_identity_members(description: &str) -> String {
+    let Some((prefix, rest)) = description.split_once('[') else {
+        return description.to_string();
+    };
+    let Some(members) = rest.strip_suffix(']') else {
+        return description.to_string();
+    };
+    let kept: Vec<&str> = members.split(';').filter(|m| !m.ends_with('=')).collect();
+    match kept.as_slice() {
+        // A lone survivor renders as a bare edit, not a one-member allele.
+        [only] => format!("{prefix}{only}"),
+        rest => format!("{prefix}[{}]", rest.join(";")),
+    }
+}
+
+#[test]
+fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
+    // The severity claim in DIVERGENT_UNDER_FIVE_PRIME's doc, made executable. If
+    // one of these ever starts changing the denoted sequence or ceases to be a
+    // fixed point, that is a different and much worse defect than the one
+    // recorded here, and it must not hide behind a known non-confluence.
+    //
+    // One output cannot be put to the applier at all — see
+    // `an_identity_member_leaves_the_output_beyond_the_applier` below. That output
+    // is still checked rather than merely counted: an `=` member states that
+    // nothing changes, so dropping it yields an equivalent description the applier
+    // *can* express, and its denotation is asserted against the same `want`.
+    // Counting alone would leave the "and nothing worse" half of this test's name
+    // unverified for the one output it most needs to defend, so the skip is
+    // counted AND its denotation checked by the stripped form.
+    let mut beyond_the_applier = 0usize;
+    for (issue, core, split, merged) in CONVERGED {
+        if !DIVERGENT_UNDER_FIVE_PRIME.contains(issue) {
+            continue;
+        }
+        let seq = padded(core);
+        let want = apply(&seq, split).expect("input applies");
+        for input in [split, merged] {
+            let out = normalize_in(&seq, input, ShuffleDirection::FivePrime);
+            assert_eq!(
+                normalize_in(&seq, &out, ShuffleDirection::FivePrime),
+                out,
+                "{issue}: `{out}` is no longer a fixed point"
+            );
+            match apply(&seq, &out) {
+                Some(got) => assert_eq!(
+                    got, want,
+                    "{issue}: `{input}` -> `{out}` no longer denotes the input's bases"
+                ),
+                None => {
+                    beyond_the_applier += 1;
+                    let stripped = strip_identity_members(&out);
+                    let got = apply(&seq, &stripped).unwrap_or_else(|| {
+                        panic!(
+                            "{issue}: `{out}` is beyond the applier and its \
+                             identity-stripped form `{stripped}` is too, so its \
+                             denotation cannot be checked at all"
+                        )
+                    });
+                    assert_eq!(
+                        got, want,
+                        "{issue}: `{input}` -> `{out}` no longer denotes the input's \
+                         bases (checked via its identity-stripped form `{stripped}`)"
+                    );
+                }
+            }
+        }
+    }
+    assert_eq!(
+        beyond_the_applier, 1,
+        "exactly one of these outputs should be inexpressible to the applier. If \
+         `an_identity_member_leaves_the_output_beyond_the_applier` is also red, the \
+         redundant `=` member stopped being emitted — good, re-check that row. If \
+         it is green, a second output became inexpressible — bad, find which."
+    );
+}
+
+#[test]
+fn an_identity_member_leaves_the_output_beyond_the_applier() {
+    // A finding in its own right, recorded because it silently weakens the test
+    // above. Under 5' shuffle #1321's split spelling settles with a redundant
+    // identity member beside a real edit:
+    //
+    //     g.[261_262insGA;262_263insA;263del]  ->  g.[261_262dup;263=]
+    //
+    // `=` states that nothing changes, so the member carries no information and
+    // the `263=` is pure noise in the output. It also has no SPDI triple, so
+    // `hgvs_to_spdi` declines and this project's own independent applier cannot
+    // evaluate the description — the one oracle that judges denotation is blind
+    // to any output containing one.
+    //
+    // Emitting it is what puts the allele into `collect_canonical_edits`'s
+    // catch-all (`_ => return None`) too, so the derivation refuses to re-derive
+    // it. Two further gates refuse behind that one (the
+    // `changed_columns_of_pieces` weight bound, then `needs_unsupported_form`),
+    // so removing the member alone does not restore confluence — measured.
+    //
+    // Filed as #1351: the blindness is a defect in the oracle rather than in this
+    // row, and every sequence-preservation sweep in the cis suite inherits it,
+    // routing such outputs into a `skipped` counter that bounds their *share* but
+    // never their *shape*. This test is the pinned instance that issue names.
+    //
+    // The input is read from #1321's `CONVERGED` row rather than repeated as a
+    // literal, so editing that row cannot leave this test quietly exercising a
+    // variant while its prose still claims to be about #1321. The expected output
+    // stays literal — that string is the finding.
+    let (_, core, split, _) = CONVERGED
+        .iter()
+        .find(|(issue, ..)| *issue == "#1321")
+        .expect("#1321 is still a CONVERGED row; this test is the pin for its 5' output");
+    let seq = padded(core);
+    let out = normalize_in(&seq, split, ShuffleDirection::FivePrime);
+    assert_eq!(
+        out, "TEMPLATE:g.[261_262dup;263=]",
+        "the redundant identity member moved; re-check both claims below"
+    );
+    assert!(
+        apply(&seq, &out).is_none(),
+        "`{out}` is now expressible to the applier — if the `=` member is gone, \
+         delete this test and tighten the one above"
+    );
 }


### PR DESCRIPTION
Every row in `cis_spelling_confluence_gap.rs` was blessed against the 3' rule, but confluence is a property of the normalizer rather than of one shuffle direction, and `--direction 5prime` is a supported public option on both the CLI and the Python bindings. Two rows that converge under 3' diverge under 5', and nothing measured that.

This records the gap in the file's existing assert-then-flip idiom — the two rows are asserted to still diverge, the other three to still converge — so a change in either direction is a result rather than a maintenance chore. **No production change.**

## Severity is pinned, not assumed

Both spellings still denote the input's bases and both are stable fixed points, so this is criterion 1 of #1235 and nothing else. That is also why neither oracle sees it: `FERRO_ASSERT_IDEMPOTENT` re-normalizes one spelling and finds it stable, and `FERRO_ASSERT_REPARSE` finds it well-formed. Only comparing two spellings of one variant exposes it.

## Both tables are measured in both directions

The eight `DIVERGENT` rows were blessed against the 3' rule alone, so `the_eight_spelling_pairs_still_diverge_under_five_prime` pins that they diverge under 5' too. They reach different spellings than under 3' — #1296's merged form settles at `g.273C>A` here against `g.273delinsA` there — so it measures the 5' pipeline rather than restating the 3' result.

## The output the applier cannot express is checked, not just counted

Under 5' shuffle one spelling settles with a redundant `263=` beside a real edit:

```
g.[261_262insGA;262_263insA;263del]  ->  g.[261_262dup;263=]
```

An identity member has no SPDI triple, so `hgvs_to_spdi` declines and the one oracle that judges denotation cannot evaluate the description at all. Counting the skip would leave the "and nothing worse" half of that test's name unverified for exactly the output it most needs to defend. So `strip_identity_members` drops the `=` member — which by definition changes nothing — to build an equivalent description the applier *can* express, and its denotation is asserted against the same expected bases. The skip is still counted and pinned at one. Confirmed non-vacuous: making the strip a no-op turns the test red on its own diagnostic.

That oracle blindness is a defect in the oracle rather than in this row and is filed separately as #1351 — this test is the pinned instance that issue names. It is referenced, not closed: this records the blindness, it does not fix it.

## Two candidate fixes were implemented and refuted by measurement

Recorded in the comments so the next attempt does not repeat them. Threading `ShuffleDirection` into `canonicalize_from_sequence` moves 298 of 39,600 swept outputs and every one is sequence-preserving before and after, so it is a lateral re-spelling with no correctness content. Accepting an identity member in `collect_canonical_edits` changes no output, because two further gates refuse behind that one.

## The pins are guarded against going stale

`DIVERGENT_UNDER_FIVE_PRIME` is keyed by issue id and matched against `CONVERGED`, so an id naming no row is inert: it asserts nothing while the set goes on claiming to pin a divergence. Deleting a row and leaving its id behind is exactly how that happens, and it is silent — verified by adding a bogus id, which left every test in the file green. There is now a guard for it, in the same spirit as the row count already pinned by `the_eight_spelling_pairs_still_diverge`.

The identity-member test reads its input from #1321's row rather than repeating it as a literal, so editing that row cannot leave the test exercising a different variant while its prose still names #1321. The expected output stays literal — that string is the finding.

Both guards were confirmed to fail when violated, not merely added.

## Verification

Run on this branch against `main` at `12bba7c`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --features dev` — 9190 passed, 0 failed
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — 9175 passed, 0 failed (proptests excluded, as CI does)
