### PR TITLE
fix(spdi)!: give an identity edit the span it claims

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1705,14 +1705,36 @@ pub fn spdi_to_hgvs(spdi: &SpdiVariant) -> Result<HgvsVariant, ConversionError> 
 
     // Determine the edit type based on deletion and insertion
     let (interval, edit) = if spdi.is_identity() {
-        // Identity
-        let seq = if spdi.deletion.is_empty() {
-            None
+        // A zero-width triple (`NC_000001.11:99::`) names no bases at all, so
+        // there is no interval it could be an identity over. Emitting one
+        // anyway rendered `g.100=`, an identity asserting a base the triple
+        // never claimed — the reverse-direction twin of the invent-a-base
+        // error #1362 fixed on the way out. `is_identity()` is `deletion ==
+        // insertion`, so a both-empty triple reaches this arm and not the
+        // deletion/insertion ones below; refusing here covers it.
+        if spdi.deletion.is_empty() {
+            return Err(ConversionError::UnsupportedEditType {
+                description: "a zero-width SPDI triple names no bases, so it cannot be \
+                              converted to an identity over an interval"
+                    .to_string(),
+            });
+        }
+        let seq = Some(string_to_sequence(&spdi.deletion)?);
+        // An identity claims every base in its triple, so a multi-base one
+        // needs a span interval — a point interval would render `g.27GT=`,
+        // whose location says one base while its sequence says two. Mirrors
+        // the `is_deletion()` arm below.
+        let del_len = spdi.deletion.len();
+        let interval = if del_len > 1 {
+            Interval::new(
+                GenomePos::new(hgvs_pos),
+                GenomePos::new(hgvs_pos + del_len as u64 - 1),
+            )
         } else {
-            Some(string_to_sequence(&spdi.deletion)?)
+            Interval::point(GenomePos::new(hgvs_pos))
         };
         (
-            Interval::point(GenomePos::new(hgvs_pos)),
+            interval,
             NaEdit::Identity {
                 sequence: seq,
                 whole_entity: false,
@@ -3038,6 +3060,44 @@ mod tests {
         let provider = provider_with_genomic(&"N".repeat(2000));
         let spdi = SpdiVariant::new("NC_000001.11", 99, "A", "A");
         let hgvs = spdi_to_hgvs_with_ref(&spdi, &provider).unwrap();
+        assert_eq!(hgvs.to_string(), "NC_000001.11:g.100A=");
+    }
+
+    /// A zero-width triple is an identity by the predicate (`deletion ==
+    /// insertion`) but names no bases, so the conversion arm must refuse it
+    /// rather than emit `g.100=` over a base the triple never claimed.
+    ///
+    /// Asserted on **both** public entry points: `spdi_to_hgvs_with_ref`
+    /// delegates to `spdi_to_hgvs` for its base conversion, so the refusal
+    /// reaches it too — and a future cut that stopped delegating would silently
+    /// lose the guard on the reference-aware path.
+    #[test]
+    fn zero_width_identity_is_refused_on_both_entry_points() {
+        let spdi = SpdiVariant::new("NC_000001.11", 99, "", "");
+        assert!(spdi.is_identity(), "both sides empty is an identity");
+        assert!(
+            matches!(
+                spdi_to_hgvs(&spdi),
+                Err(ConversionError::UnsupportedEditType { .. })
+            ),
+            "a triple naming zero bases must not convert to an identity"
+        );
+        let provider = provider_with_genomic(&"N".repeat(2000));
+        assert!(
+            matches!(
+                spdi_to_hgvs_with_ref(&spdi, &provider),
+                Err(ConversionError::UnsupportedEditType { .. })
+            ),
+            "the reference-aware path must inherit the refusal"
+        );
+    }
+
+    /// A one-base identity still converts — the guard must be scoped to the
+    /// zero-width case and not have cost the arm its ordinary behaviour.
+    #[test]
+    fn a_one_base_identity_still_converts() {
+        let spdi = SpdiVariant::new("NC_000001.11", 99, "A", "A");
+        let hgvs = spdi_to_hgvs(&spdi).expect("a one-base identity converts");
         assert_eq!(hgvs.to_string(), "NC_000001.11:g.100A=");
     }
 

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -298,13 +298,19 @@ pub fn hgvs_to_spdi_simple(variant: &HgvsVariant) -> Result<SpdiVariant, Convers
 /// This is the provider-aware companion to [`hgvs_to_spdi_simple`]. It
 /// handles `c.` (CDS) variants, `n.`/`r.` variants with UTR-style positions
 /// (`*N` downstream), and populates SPDI's mandatory `del` field for
-/// short-form deletions / delins (and the symmetric `ins` field for
-/// short-form duplications) by fetching the reference bases for the
+/// short-form deletions / delins / identities (and the symmetric `ins` field
+/// for short-form duplications) by fetching the reference bases for the
 /// variant's interval. Explicit-form input (`g.100_102delATG`,
-/// `g.100_102dupATG`, etc.) emits the user-supplied bases as-is and does
-/// not consult the provider. Intronic `n.`/`r.` positions remain
+/// `g.100_102dupATG`, `g.100A=`, etc.) emits the user-supplied bases as-is
+/// and does not consult the provider. Intronic `n.`/`r.` positions remain
 /// unsupported (SPDI has no offset notation) and return
 /// [`ConversionError::MissingReferenceData`].
+///
+/// An **unspelled identity** (`g.100=`, `g.100_102=`) therefore needs a
+/// provider: on [`hgvs_to_spdi_simple`] it returns
+/// [`ConversionError::MissingReferenceData`] rather than a zero-width triple
+/// that would claim no bases. A **whole-entity** identity (`g.=`) names no
+/// interval at all and returns [`ConversionError::UnsupportedEditType`].
 ///
 /// The resulting SPDI uses the **same accession** as the HGVS variant — for
 /// `NM_000088.3:c.1A>G` the SPDI sequence is `NM_000088.3`, not the
@@ -1248,10 +1254,15 @@ fn ensure_tx_in_bounds<P: std::fmt::Display + Copy>(
 /// # Provider behavior
 ///
 /// When `provider` is `Some` and the edit is a short-form deletion,
-/// duplication, or delins (i.e. lacks an explicit deleted sequence), the
-/// reference bases for `[start_one_based, end_one_based]` are fetched via
-/// the provider so SPDI's mandatory `del` field can be populated. When
-/// `provider` is `None`, those cases return [`ConversionError::MissingReferenceData`].
+/// duplication, delins, or identity (i.e. lacks an explicit deleted
+/// sequence), the reference bases for `[start_one_based, end_one_based]` are
+/// fetched via the provider so SPDI's mandatory `del` field can be populated.
+/// When `provider` is `None`, those cases return
+/// [`ConversionError::MissingReferenceData`].
+///
+/// A **whole-entity** identity (`g.=`) is the one exception: it names no
+/// interval, so it returns [`ConversionError::UnsupportedEditType`] rather
+/// than a triple at an arbitrary position.
 fn emit_spdi_for_edit<P>(
     sequence: String,
     start_one_based: u64,
@@ -1394,12 +1405,48 @@ where
             ))
         }
         NaEdit::Identity {
-            sequence: id_seq, ..
+            sequence: id_seq,
+            whole_entity,
         } => {
-            let ref_base = id_seq
-                .as_ref()
-                .map(|s| apply_alphabet(&sequence_to_string(s), alphabet))
-                .unwrap_or_default();
+            // An identity claims the bases it names, so its triple must span
+            // them: `g.263=` is `262:A:A`, not the zero-width `262::`. A
+            // zero-width triple is not merely less informative, it *aliases an
+            // insertion junction* — put `g.[261_262dup;263=]` through it and
+            // both members land on interbase 262, which is indistinguishable
+            // from two insertions competing for one interbase.
+            //
+            // When the input does not spell the base, fetch it, exactly as the
+            // Deletion / Delins / Inversion arms do for their own omitted
+            // sequences.
+            let ref_base = match id_seq {
+                Some(seq) => sequence_to_string(seq),
+                // `g.=` asserts the whole reference is unchanged and names no
+                // interval, so there is no position SPDI could honestly carry.
+                // Emitting `0::` looks harmless but round-trips through
+                // `spdi_to_hgvs` as `g.1=`, narrowing a statement about the
+                // whole sequence to one about base 1. Decline instead, as this
+                // module does for every other shape SPDI cannot encode.
+                None if *whole_entity => {
+                    return Err(ConversionError::UnsupportedEditType {
+                        description: "a whole-entity identity (`=`) asserts the entire \
+                                      reference is unchanged and names no interval; SPDI \
+                                      has no representation for it"
+                            .to_string(),
+                    });
+                }
+                None => match provider {
+                    Some(p) => fetch_reference_bases(p, &sequence, start_one_based, end_one_based)?,
+                    None => {
+                        return Err(ConversionError::MissingReferenceData {
+                            description:
+                                "unchanged sequence not provided; reference data needed to \
+                                 determine the bases an identity claims"
+                                    .to_string(),
+                        });
+                    }
+                },
+            };
+            let ref_base = apply_alphabet(&ref_base, alphabet);
             Ok(SpdiVariant::new(
                 sequence,
                 spdi_pos,
@@ -2077,6 +2124,142 @@ mod tests {
         assert_eq!(spdi.position, 99);
         assert_eq!(spdi.deletion, "A");
         assert_eq!(spdi.insertion, "A");
+    }
+
+    /// A 28-base `ACGT…` contig, so a 1-based position `p` holds
+    /// `"ACGT"[(p - 1) % 4]` — base 10 is `C`, and 10..12 is `CGT`.
+    fn identity_provider() -> MockProvider {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_000001.11", "ACGTACGTACGTACGTACGTACGTACGT".to_string());
+        provider
+    }
+
+    #[test]
+    fn an_unspelled_identity_takes_its_base_from_the_reference() {
+        // `g.10=` states that base 10 is unchanged without naming it. Every
+        // other arm that can omit its sequence (deletion, delins, inversion)
+        // fetches it from the provider; this one used to default to the empty
+        // string, yielding a zero-width `99::` that claims no base at all.
+        let hgvs = parse_hgvs("NC_000001.11:g.10=").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &identity_provider()).unwrap();
+        assert_eq!(spdi.position, 9);
+        assert_eq!(spdi.deletion, "C");
+        assert_eq!(spdi.insertion, "C");
+    }
+
+    #[test]
+    fn an_unspelled_identity_takes_its_whole_span_from_the_reference() {
+        let hgvs = parse_hgvs("NC_000001.11:g.10_12=").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &identity_provider()).unwrap();
+        assert_eq!(spdi.position, 9);
+        assert_eq!(spdi.deletion, "CGT");
+        assert_eq!(spdi.insertion, "CGT");
+    }
+
+    #[test]
+    fn an_unspelled_identity_fetches_on_the_non_genomic_axes_too() {
+        // The arm is shared by g./m./n./r./c., and the r. path additionally
+        // runs the fetched bases through `apply_alphabet(_, Rna)`. Each axis is
+        // asserted against its own `del` sibling on the same position, since
+        // that sibling is the fetch behavior this arm was made to match.
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NR_TEST.1", "ACGTACGTACGTACGTACGTACGTACGT".to_string());
+        for (identity, deletion) in [
+            ("NR_TEST.1:n.10=", "NR_TEST.1:n.10del"),
+            ("NR_TEST.1:r.10=", "NR_TEST.1:r.10del"),
+        ] {
+            let id_spdi = hgvs_to_spdi(&parse_hgvs(identity).unwrap(), &provider).unwrap();
+            let del_spdi = hgvs_to_spdi(&parse_hgvs(deletion).unwrap(), &provider).unwrap();
+            assert_eq!(
+                (id_spdi.position, id_spdi.deletion.as_str()),
+                (del_spdi.position, del_spdi.deletion.as_str()),
+                "{identity} must claim the same span `{deletion}` deletes"
+            );
+            // An identity keeps what it claims; the deletion drops it.
+            assert_eq!(
+                id_spdi.insertion, id_spdi.deletion,
+                "{identity} is an identity"
+            );
+            assert_eq!(del_spdi.insertion, "", "{deletion} deletes");
+        }
+    }
+
+    #[test]
+    fn an_unspelled_identity_needs_reference_data() {
+        // The provider-less path cannot know which bases the span holds, so it
+        // reports that rather than emitting a triple whose span is wrong. This
+        // matches `g.10del` on the same path.
+        let hgvs = parse_hgvs("NC_000001.11:g.10=").unwrap();
+        let result = hgvs_to_spdi_simple(&hgvs);
+        assert!(
+            matches!(result, Err(ConversionError::MissingReferenceData { .. })),
+            "expected MissingReferenceData, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn an_out_of_range_unspelled_identity_reports_the_fetch_failure() {
+        // The error path of the fetch above. An identity past the end of the
+        // contig has no bases to claim, so the fetch fails and that failure is
+        // propagated — the same answer `g.9999del` already gives, rather than a
+        // panic or a triple invented from an empty span. Before this arm
+        // consulted the provider it returned `Ok(9998::)` here, so this also
+        // pins that an out-of-range identity is no longer silently accepted.
+        let hgvs = parse_hgvs("NC_000001.11:g.9999=").unwrap();
+        let result = hgvs_to_spdi(&hgvs, &identity_provider());
+        assert!(
+            matches!(result, Err(ConversionError::MissingReferenceData { .. })),
+            "expected MissingReferenceData, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn a_whole_entity_identity_has_no_spdi() {
+        // `g.=` asserts the *entire* reference is unchanged and names no
+        // interval, so there is no position SPDI could honestly carry. It used
+        // to emit `0::`, which `spdi_to_hgvs` reads back as `g.1=` — turning a
+        // statement about the whole sequence into one about base 1. Declining
+        // is the same answer this module gives every other edit whose shape
+        // SPDI cannot encode.
+        let hgvs = parse_hgvs("NC_000001.11:g.=").unwrap();
+        let result = hgvs_to_spdi(&hgvs, &identity_provider());
+        assert!(
+            matches!(result, Err(ConversionError::UnsupportedEditType { .. })),
+            "expected UnsupportedEditType, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn an_identity_member_does_not_alias_a_sibling_insertion_junction() {
+        // The defect this fix exists for. `g.[261_262dup;263=]` is a real
+        // normalizer output (5' shuffle, #1321's split spelling). With the
+        // identity converting to a zero-width triple, both members landed at
+        // interbase 262 — the dup's junction and the identity's empty span —
+        // and an applier walking the members cannot tell that apart from two
+        // insertions competing for one interbase, so it has to decline the
+        // whole description. Giving the identity its real span separates them.
+        let provider = identity_provider();
+        let variant = parse_hgvs("NC_000001.11:g.[10_11dup;12=]").unwrap();
+        let members = match variant {
+            HgvsVariant::Allele(allele) => allele.variants,
+            other => panic!("expected an allele, got {other}"),
+        };
+        let triples: Vec<SpdiVariant> = members
+            .iter()
+            .map(|m| hgvs_to_spdi(m, &provider).expect("member converts"))
+            .collect();
+        // The dup copies bases 10-11 in at the junction after 11 (interbase 11).
+        assert_eq!(triples[0].position, 11);
+        assert_eq!(triples[0].deletion, "");
+        assert_eq!(triples[0].insertion, "CG");
+        // The identity claims base 12 itself: interbase 11..12, not 11..11.
+        assert_eq!(triples[1].position, 11);
+        assert_eq!(
+            triples[1].deletion, "T",
+            "the identity must claim its base; a zero-width deletion here is \
+             indistinguishable from a second insertion at interbase {}",
+            triples[0].position
+        );
     }
 
     #[test]

--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -265,30 +265,6 @@ fn the_eight_spelling_pairs_still_diverge_under_five_prime() {
     }
 }
 
-/// Drop identity (`=`) members from a cis-allele description.
-///
-/// An identity member states that nothing changes, so removing it leaves a
-/// description denoting the same bases — but one the applier *can* express.
-/// `hgvs_to_spdi` declines an identity member and takes the whole description
-/// with it (#1351), so this is how the denotation of such an output is checked
-/// at all. Returns the input unchanged when there is no allele to rewrite; the
-/// caller asserts on the result, so a no-op surfaces as a failure rather than a
-/// silent pass.
-fn strip_identity_members(description: &str) -> String {
-    let Some((prefix, rest)) = description.split_once('[') else {
-        return description.to_string();
-    };
-    let Some(members) = rest.strip_suffix(']') else {
-        return description.to_string();
-    };
-    let kept: Vec<&str> = members.split(';').filter(|m| !m.ends_with('=')).collect();
-    match kept.as_slice() {
-        // A lone survivor renders as a bare edit, not a one-member allele.
-        [only] => format!("{prefix}{only}"),
-        rest => format!("{prefix}[{}]", rest.join(";")),
-    }
-}
-
 #[test]
 fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
     // The severity claim in DIVERGENT_UNDER_FIVE_PRIME's doc, made executable. If
@@ -296,15 +272,13 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
     // fixed point, that is a different and much worse defect than the one
     // recorded here, and it must not hide behind a known non-confluence.
     //
-    // One output cannot be put to the applier at all — see
-    // `an_identity_member_leaves_the_output_beyond_the_applier` below. That output
-    // is still checked rather than merely counted: an `=` member states that
-    // nothing changes, so dropping it yields an equivalent description the applier
-    // *can* express, and its denotation is asserted against the same `want`.
-    // Counting alone would leave the "and nothing worse" half of this test's name
-    // unverified for the one output it most needs to defend, so the skip is
-    // counted AND its denotation checked by the stripped form.
-    let mut beyond_the_applier = 0usize;
+    // Every output is now checked directly. #1362 gave an identity edit's SPDI
+    // triple the span it claims, so `hgvs_to_spdi` no longer emits a zero-width
+    // triple that collides with a sibling's insertion junction, and the applier
+    // can express `g.[261_262dup;263=]` after all. Before that, this loop had to
+    // count the one output it could not express and check its denotation through
+    // an identity-stripped rewrite; both are gone, and an inexpressible output is
+    // now a failure rather than a tolerated skip.
     for (issue, core, split, merged) in CONVERGED {
         if !DIVERGENT_UNDER_FIVE_PRIME.contains(issue) {
             continue;
@@ -318,63 +292,48 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
                 out,
                 "{issue}: `{out}` is no longer a fixed point"
             );
-            match apply(&seq, &out) {
-                Some(got) => assert_eq!(
-                    got, want,
-                    "{issue}: `{input}` -> `{out}` no longer denotes the input's bases"
-                ),
-                None => {
-                    beyond_the_applier += 1;
-                    let stripped = strip_identity_members(&out);
-                    let got = apply(&seq, &stripped).unwrap_or_else(|| {
-                        panic!(
-                            "{issue}: `{out}` is beyond the applier and its \
-                             identity-stripped form `{stripped}` is too, so its \
-                             denotation cannot be checked at all"
-                        )
-                    });
-                    assert_eq!(
-                        got, want,
-                        "{issue}: `{input}` -> `{out}` no longer denotes the input's \
-                         bases (checked via its identity-stripped form `{stripped}`)"
-                    );
-                }
-            }
+            let got = apply(&seq, &out).unwrap_or_else(|| {
+                panic!(
+                    "{issue}: `{out}` is inexpressible to the applier. Since #1362 \
+                     every output here is expressible, so this is a new blind spot \
+                     rather than a known one — find what shape the applier declines \
+                     before treating it as tolerable."
+                )
+            });
+            assert_eq!(
+                got, want,
+                "{issue}: `{input}` -> `{out}` no longer denotes the input's bases"
+            );
         }
     }
-    assert_eq!(
-        beyond_the_applier, 1,
-        "exactly one of these outputs should be inexpressible to the applier. If \
-         `an_identity_member_leaves_the_output_beyond_the_applier` is also red, the \
-         redundant `=` member stopped being emitted — good, re-check that row. If \
-         it is green, a second output became inexpressible — bad, find which."
-    );
 }
 
 #[test]
-fn an_identity_member_leaves_the_output_beyond_the_applier() {
-    // A finding in its own right, recorded because it silently weakens the test
-    // above. Under 5' shuffle #1321's split spelling settles with a redundant
-    // identity member beside a real edit:
+fn an_identity_member_is_redundant_but_no_longer_beyond_the_applier() {
+    // A finding in its own right. Under 5' shuffle #1321's split spelling settles
+    // with a redundant identity member beside a real edit:
     //
     //     g.[261_262insGA;262_263insA;263del]  ->  g.[261_262dup;263=]
     //
     // `=` states that nothing changes, so the member carries no information and
-    // the `263=` is pure noise in the output. It also has no SPDI triple, so
-    // `hgvs_to_spdi` declines and this project's own independent applier cannot
-    // evaluate the description — the one oracle that judges denotation is blind
-    // to any output containing one.
+    // the `263=` is pure noise in the output. That half is unfixed and is what
+    // this test still pins.
     //
-    // Emitting it is what puts the allele into `collect_canonical_edits`'s
-    // catch-all (`_ => return None`) too, so the derivation refuses to re-derive
-    // it. Two further gates refuse behind that one (the
-    // `changed_columns_of_pieces` weight bound, then `needs_unsupported_form`),
-    // so removing the member alone does not restore confluence — measured.
+    // The *other* half — that such an output was invisible to the applier — is
+    // fixed. #1362 found the cause, and it was not the one recorded here
+    // originally: `hgvs_to_spdi` did not decline an identity member, it converted
+    // `g.263=` to the zero-width triple `262::`, which aliased the sibling dup's
+    // insertion junction at the same interbase. Two members at one interbase have
+    // no defined order, so `apply_with` declined the whole description. Giving the
+    // identity the span it claims (`262:A:A`) separates them, and #1351's blind
+    // spot closes for every sweep that inherited it.
     //
-    // Filed as #1351: the blindness is a defect in the oracle rather than in this
-    // row, and every sequence-preservation sweep in the cis suite inherits it,
-    // routing such outputs into a `skipped` counter that bounds their *share* but
-    // never their *shape*. This test is the pinned instance that issue names.
+    // Emitting the member is still what puts the allele into
+    // `collect_canonical_edits`'s catch-all (`_ => return None`), so the
+    // derivation refuses to re-derive it. Two further gates refuse behind that one
+    // (the `changed_columns_of_pieces` weight bound, then
+    // `needs_unsupported_form`), so removing the member alone does not restore
+    // confluence — measured.
     //
     // The input is read from #1321's `CONVERGED` row rather than repeated as a
     // literal, so editing that row cannot leave this test quietly exercising a
@@ -390,9 +349,22 @@ fn an_identity_member_leaves_the_output_beyond_the_applier() {
         out, "TEMPLATE:g.[261_262dup;263=]",
         "the redundant identity member moved; re-check both claims below"
     );
-    assert!(
-        apply(&seq, &out).is_none(),
-        "`{out}` is now expressible to the applier — if the `=` member is gone, \
-         delete this test and tighten the one above"
+    // The identity is noise, so stripping it must denote the same bases — and the
+    // applier must now be able to say so about *both* forms. If this goes red with
+    // the output above unchanged, the identity's SPDI triple regressed to a
+    // zero-width one and #1351's blind spot is back.
+    let want = apply(&seq, split).expect("input applies");
+    assert_eq!(
+        apply(&seq, &out).as_deref(),
+        Some(want.as_str()),
+        "`{out}` must be expressible to the applier and denote the input's bases \
+         (#1362); a `None` here means the `263=` member is aliasing the dup's \
+         junction again"
+    );
+    assert_eq!(
+        apply(&seq, "TEMPLATE:g.261_262dup").as_deref(),
+        Some(want.as_str()),
+        "the identity member carries no information, so dropping it must denote \
+         the same bases"
     );
 }

--- a/tests/it/issue_1362_identity_span.rs
+++ b/tests/it/issue_1362_identity_span.rs
@@ -1,0 +1,87 @@
+//! #1362 — an identity edit's SPDI triple must span the bases it claims.
+//!
+//! `hgvs_to_spdi` used to convert an identity whose bases the input did not
+//! spell (`g.100=`) into a zero-width triple that claimed nothing. That is not
+//! merely lossy: a zero-width triple at an interbase is indistinguishable from
+//! an *insertion* at that interbase, so an applier walking an allele's members
+//! cannot tell `g.[261_262dup;263=]` apart from two insertions competing for
+//! one position and has to decline the whole description.
+//!
+//! The unit tests in `src/spdi/convert.rs` cover the conversion arm directly.
+//! This file covers it through the public API at the two places an
+//! inclusive-vs-exclusive coordinate error would surface — the **last base of
+//! the contig** and one past it — because the fetch converts HGVS's 1-based
+//! inclusive end into the provider's own end convention, and an off-by-one
+//! there is invisible on an interior span.
+
+use ferro_hgvs::spdi::convert::{hgvs_to_spdi, hgvs_to_spdi_simple};
+use ferro_hgvs::{parse_hgvs, ConversionError, MockProvider};
+
+/// A 28-base `ACGT…` contig: 1-based position `p` holds `"ACGT"[(p - 1) % 4]`,
+/// so the final base (28) is `T` and 27..28 is `GT`.
+const CONTIG: &str = "ACGTACGTACGTACGTACGTACGTACGT";
+const CONTIG_LEN: u64 = 28;
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_000001.11", CONTIG.to_string());
+    provider
+}
+
+/// The identity that ends exactly on the contig's last base must fetch that
+/// base, not one past it and not one short of it.
+#[test]
+fn a_terminal_identity_claims_the_last_base() {
+    assert_eq!(CONTIG.len() as u64, CONTIG_LEN, "contig length assumption");
+    let spdi = hgvs_to_spdi(&parse_hgvs("NC_000001.11:g.28=").unwrap(), &provider()).unwrap();
+    assert_eq!(spdi.position, 27, "0-based interbase of 1-based base 28");
+    assert_eq!(spdi.deletion, "T", "base 28 of an ACGT tandem");
+    assert_eq!(spdi.insertion, "T", "an identity changes nothing");
+}
+
+/// A multi-base identity ending on the last base pins the inclusive end
+/// against the provider's exclusive one: an off-by-one yields `"G"` (end
+/// treated as exclusive) or an out-of-range error (end over-extended).
+#[test]
+fn a_terminal_identity_span_claims_both_of_its_bases() {
+    let spdi = hgvs_to_spdi(&parse_hgvs("NC_000001.11:g.27_28=").unwrap(), &provider()).unwrap();
+    assert_eq!(spdi.position, 26);
+    assert_eq!(
+        spdi.deletion, "GT",
+        "HGVS 27_28 is inclusive of both ends, so the span is two bases"
+    );
+    assert_eq!(spdi.insertion, "GT");
+}
+
+/// One past the end must be reported, not clamped to the last base.
+#[test]
+fn an_identity_past_the_contig_end_is_reported() {
+    let result = hgvs_to_spdi(&parse_hgvs("NC_000001.11:g.29=").unwrap(), &provider());
+    assert!(
+        matches!(result, Err(ConversionError::MissingReferenceData { .. })),
+        "expected MissingReferenceData for position 29 on a 28-base contig, got {result:?}"
+    );
+}
+
+/// The same span through the provider-less entry point reports rather than
+/// inventing an empty span. This is the breaking half of #1362.
+#[test]
+fn the_provider_less_path_reports_instead_of_claiming_nothing() {
+    let result = hgvs_to_spdi_simple(&parse_hgvs("NC_000001.11:g.28=").unwrap());
+    assert!(
+        matches!(result, Err(ConversionError::MissingReferenceData { .. })),
+        "expected MissingReferenceData without a provider, got {result:?}"
+    );
+}
+
+/// A whole-entity `=` names no interval, so it has no triple at all — rather
+/// than one at position 0, which read back as `g.1=` and narrowed a statement
+/// about the whole sequence to one about its first base.
+#[test]
+fn a_whole_entity_identity_has_no_triple() {
+    let result = hgvs_to_spdi(&parse_hgvs("NC_000001.11:g.=").unwrap(), &provider());
+    assert!(
+        matches!(result, Err(ConversionError::UnsupportedEditType { .. })),
+        "expected UnsupportedEditType for a whole-entity identity, got {result:?}"
+    );
+}

--- a/tests/it/issue_1362_identity_span.rs
+++ b/tests/it/issue_1362_identity_span.rs
@@ -14,8 +14,8 @@
 //! inclusive end into the provider's own end convention, and an off-by-one
 //! there is invisible on an interior span.
 
-use ferro_hgvs::spdi::convert::{hgvs_to_spdi, hgvs_to_spdi_simple};
-use ferro_hgvs::{parse_hgvs, ConversionError, MockProvider};
+use ferro_hgvs::spdi::convert::{hgvs_to_spdi, hgvs_to_spdi_simple, spdi_to_hgvs};
+use ferro_hgvs::{parse_hgvs, ConversionError, MockProvider, SpdiVariant};
 
 /// A 28-base `ACGT…` contig: 1-based position `p` holds `"ACGT"[(p - 1) % 4]`,
 /// so the final base (28) is `T` and 27..28 is `GT`.
@@ -83,5 +83,42 @@ fn a_whole_entity_identity_has_no_triple() {
     assert!(
         matches!(result, Err(ConversionError::UnsupportedEditType { .. })),
         "expected UnsupportedEditType for a whole-entity identity, got {result:?}"
+    );
+}
+
+/// A zero-width triple names no bases, so it cannot come back as an identity
+/// over one. `spdi_to_hgvs` used to read `NC_000001.11:99::` as `g.100=`, an
+/// identity asserting a base the triple never claimed — the same
+/// invent-a-base error as #1362's forward direction, in the reverse direction.
+///
+/// The triple is built directly rather than parsed so the case survives a
+/// parser that later rejects the spelling: the public constructors and
+/// `SpdiVariant`'s own fields admit it regardless, and this arm is what must
+/// refuse it.
+#[test]
+fn a_zero_width_triple_is_not_an_identity() {
+    let spdi = SpdiVariant::new("NC_000001.11", 99, "", "");
+    assert!(
+        spdi.is_identity(),
+        "deletion == insertion, so it takes the identity arm"
+    );
+    let result = spdi_to_hgvs(&spdi);
+    assert!(
+        matches!(result, Err(ConversionError::UnsupportedEditType { .. })),
+        "a triple naming zero bases must be refused, not read as `g.100=`, got {result:?}"
+    );
+}
+
+/// Round-tripping a multi-base identity keeps its span. Before #1362 the
+/// triple was zero-width, so the reverse direction never saw a multi-base
+/// identity from this input at all.
+#[test]
+fn a_multi_base_identity_keeps_its_span_through_spdi() {
+    let spdi = hgvs_to_spdi(&parse_hgvs("NC_000001.11:g.27_28=").unwrap(), &provider()).unwrap();
+    let back = spdi_to_hgvs(&spdi).expect("round trip");
+    assert_eq!(
+        back.to_string(),
+        "NC_000001.11:g.27_28GT=",
+        "a two-base identity must come back as a two-base interval, not a point"
     );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -193,6 +193,7 @@ mod issue_1327_mt_respell_past_contig_end;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_1334_liftover_position_zero;
 mod issue_1349_rotation_fallback_dup;
+mod issue_1362_identity_span;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
`NaEdit::Identity` was the only arm of `hgvs_to_spdi` that did not consult the provider for a sequence the input left unspelled. It defaulted to the empty string, producing a triple that claims no bases:

| input | before | after |
|---|---|---|
| `g.10A=` (base spelled) | `9:A:A` | unchanged |
| `g.10=` | `9::` | `9:C:C` |
| `g.10_12=` | `9::` (three-base span lost) | `9:CGT:CGT` |
| `g.10=`, no provider | `Ok("9::")` | `Err(MissingReferenceData)` |
| `g.=` (whole-entity) | `Ok("0::")` | `Err(UnsupportedEditType)` |

The sibling arms — Deletion, Delins, Inversion — already fetch their omitted sequence via `fetch_reference_bases` and return `MissingReferenceData` when there is no provider. This makes Identity behave the same way, so the change is a missing case rather than a new rule.

## Why a zero-width identity is a defect and not just a loss of detail

It aliases an insertion junction. `g.[261_262dup;263=]` is a real normalizer output — the 5'-shuffle form of `g.[261_262insGA;262_263insA;263del]` — and its members used to convert to:

```
g.261_262dup  ->  262::AG     insertion at the junction after 262
g.263=        ->  262::       zero-width, same interbase
```

Both land on interbase 262, which an applier walking the members cannot distinguish from two insertions competing for one interbase. Since that has no single well-defined resulting sequence, the applier has to decline the whole description. The identity actually claims base 263, so the two members are disjoint (`262..262` and `262..263`); only the lossy conversion made them collide.

**This is the root cause of #1351** — "the cis apply oracle cannot express an identity member, so every sequence-preservation sweep is blind to those outputs". That issue attributes the blindness to `hgvs_to_spdi` *declining* an identity member. It does not decline: it accepted the member and returned `262::`. The decline happened downstream, in the applier's disjointness guard, which is why the fix belongs in the conversion.

## Whole-entity `g.=` is now declined

`g.=` asserts the entire reference is unchanged and names no interval, so there is no position a triple can honestly carry. The `0::` it used to emit read back through `spdi_to_hgvs` as `g.1=` — narrowing a statement about the whole sequence to one about its first base. It now returns `UnsupportedEditType`, matching how this module handles every other shape SPDI cannot encode.

## Second commit: the reverse direction

`spdi_to_hgvs`'s identity arm built `Interval::point` regardless of how many bases the triple claimed, so `26:GT:GT` rendered as `g.27GT=` — a location naming one base beside a sequence naming two. It now widens the interval like the sibling `is_deletion()` arm. Reachable before this branch via the spelled form `g.27_28GT=`; giving an unspelled identity its real span is what surfaced it.

## A zero-width triple is now declined too

The same arm accepted a triple naming *no* bases. `is_identity()` is `deletion == insertion`, so a both-empty triple such as `NC_000001.11:99::` reaches the identity arm rather than the deletion or insertion ones, and with an empty `deletion` it fell through to `Interval::point` and rendered `g.100=` — an identity asserting a base the triple never claimed. That is the same invent-a-base error the first commit fixes on the way out, in the reverse direction.

It now returns `UnsupportedEditType` before computing `del_len` or constructing the interval, matching the whole-entity `g.=` case above. One- and multi-base identities are unaffected, and the refusal reaches `spdi_to_hgvs_with_ref` as well, which delegates here for its base conversion.

## Re-blessed tests from #1361

#1361 merged while this was open and pinned the blind spot this PR closes. Two of its tests are re-blessed in commit 1:

- `the_five_prime_divergences_are_non_confluence_and_nothing_worse` — the tolerated-skip counter (`beyond_the_applier == 1`) and the identity-stripping workaround are deleted. Every output is now checked directly, and an inexpressible one is a failure rather than a known skip.
- `an_identity_member_leaves_the_output_beyond_the_applier` → `an_identity_member_is_redundant_but_no_longer_beyond_the_applier`. The redundant `=` member is still emitted and still noise, so that half stays pinned; the blindness half is asserted closed.

The 5' confluence divergence for #1321 itself is **not** fixed here — that is the #1235 campaign. This closes the oracle blind spot around it.

## Oracle direction

**This change moves ferro-hgvs toward the reference oracles, and cannot move conformance output.** Required by the "Output change has a pinned regression test" pre-merge check, since the diff is under `src/spdi/`.

- No normalization, parsing, or projection output changes: the diff touches only HGVS↔SPDI conversion. The full suite passes with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1`, and no conformance ledger or `.count` baseline moved.
- Toward the oracles on two counts. An unspelled identity's triple now carries the bases it claims, which is what SPDI requires of `del` — the previous `9::` was not a triple NCBI's own service would produce. And `spdi_to_hgvs` now renders a multi-base identity as `g.27_28GT=`, a form the HGVS spec states, rather than the self-contradictory `g.27GT=`.
- The independent applier that judges denotation in the cis suite gains coverage it previously skipped, so this strictly increases what the oracles can check rather than moving a boundary.

## Tests

Written first, each watched failing before the fix:

- `an_unspelled_identity_takes_its_base_from_the_reference`
- `an_unspelled_identity_takes_its_whole_span_from_the_reference`
- `an_unspelled_identity_fetches_on_the_non_genomic_axes_too` — `n.`/`r.` share this arm, and `r.` additionally runs the fetched bases through `apply_alphabet(_, Rna)`. Each axis is asserted against its own `del` sibling.
- `an_unspelled_identity_needs_reference_data`
- `an_out_of_range_unspelled_identity_reports_the_fetch_failure`
- `a_whole_entity_identity_has_no_spdi`
- `an_identity_member_does_not_alias_a_sibling_insertion_junction` — the defect itself, on `g.[10_11dup;12=]`, asserting the two members' spans directly with no normalizer involved.

Plus `tests/it/issue_1362_identity_span.rs`, which covers the boundary through the public API: the contig's **last** base (`g.28=`, `g.27_28=`) where an inclusive-vs-exclusive end error would surface, one past it (`g.29=`), the provider-less path, the whole-entity decline, and the multi-base round trip.

## Verification

| gate | result |
|---|---|
| `cargo nextest run --features dev` | 9203 passed, 0 failed |
| same with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` | 9203 passed |
| commit 1 alone (bisect check) | 9202 passed |
| `cargo clippy --all-features --all-targets -- -D warnings` | clean |
| `cargo check --features python` | clean |
| `cargo fmt --all --check` | clean |

Rebased onto `main` @ `feb1b5c` (after #1361 merged) and re-verified there, rather than relying on a clean `merge-tree` against an older base.

## Note for reviewers

The breaking change is narrow but real: `hgvs_to_spdi_simple`, and the Python `hgvs_to_spdi` that wraps it, now return an error for an unspelled or whole-entity identity. They previously returned a triple whose span was wrong, so the alternative was to keep emitting a value known to be incorrect. Callers that need those shapes should pass a provider to `hgvs_to_spdi`. The spelled form `g.10A=` is unaffected, and no existing test covered the unspelled form through either entry point.

Suggested reading order: the `NaEdit::Identity` arm in commit 1, then `tests/it/issue_1362_identity_span.rs`, then the #1361 re-bless, then commit 2.

Closes #1362
Closes #1351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Identity conversions now preserve the correct referenced base span, including multi-base intervals.
  - Conversions provide clearer results for missing or invalid reference data and reject unsupported whole-entity identities.
  - Normalized outputs can now be applied directly while preserving the input sequence.

- **Tests**
  - Added coverage for provider-backed, provider-less, out-of-range, terminal, and multi-base identity conversions.
  - Added regression tests for round-trip conversion and identity variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
