### PR TITLE
fix(normalize): stop a terminal duplication respelling past the contig end

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3899,6 +3899,9 @@ struct MemberSpan {
     end: i64,
     /// Whether the edit consumes the reference bases under its span.
     claims_bases: bool,
+    /// Whether an insertion landing flush against this edit is the adjacency the
+    /// collapse pass merges — see [`merges_with_a_flush_insertion`].
+    absorbs_a_flush_insertion: bool,
     /// Whether the edit must stop a sibling's shift at its boundary. Superset of
     /// `claims_bases` — see `blocks_sibling_shift`.
     blocks_shift: bool,
@@ -3918,6 +3921,7 @@ fn member_span(v: &HgvsVariant, kind: CisKind) -> Option<MemberSpan> {
         start,
         end,
         claims_bases: claims_reference_bases(edit),
+        absorbs_a_flush_insertion: merges_with_a_flush_insertion(edit),
         blocks_shift: blocks_sibling_shift(edit),
         junction: junction_of(edit, start, end),
     })
@@ -3955,6 +3959,40 @@ fn claims_reference_bases(edit: &NaEdit) -> bool {
             | NaEdit::Repeat { .. }
             | NaEdit::MultiRepeat { .. }
     )
+}
+
+/// Whether an insertion placed flush against `edit` is the #999 adjacency the
+/// collapse pass merges.
+///
+/// Strictly narrower than [`claims_reference_bases`], and narrower again than
+/// "removes bases": only a **plain deletion** qualifies. `respell_at_gap`'s
+/// terminal-overrun gate is the only caller, and the question it is really
+/// asking is not what the sibling does to the reference but whether something
+/// downstream is guaranteed to consume an out-of-range junction coordinate
+/// before it renders (#1344 vs #1307). Nothing here may answer "yes" on a guess:
+/// a wrong "yes" emits a position the sequence does not have, and that output
+/// re-parses, so `FERRO_ASSERT_REPARSE` does not see it either. (The idempotency
+/// oracle does, as it happens — see `tests/it/issue_1307_terminal_dup_respell.rs`
+/// — but only for an input some test actually normalizes.)
+///
+/// Deliberately excluded, each measured on a 24-base contig with the member at
+/// the last base:
+///
+/// - **`Delins`** — removes its bases, yet nothing merged the pair:
+///   `g.[24dup;24delinsGG]` gave `g.[24delinsGG;24_25insA]`, the #1307 defect
+///   with a different sibling. Removing bases is therefore not sufficient; the
+///   collapse pass wants a deletion to absorb the payload into.
+/// - **`NPaddedDeletion`** (`delN[15]`) — a deletion that states its length as a
+///   count. Plausibly mergeable, but untested here, and the conservative branch
+///   costs nothing.
+/// - **`Repeat`/`MultiRepeat`** — whether they remove bases depends on the copy
+///   count, so it is not a property of the edit kind at all.
+///
+/// Answering "no" for any of these yields `LeaveMemberUnchanged`, which is
+/// always in range; the cost is only that a repairable collision goes
+/// unrepaired.
+fn merges_with_a_flush_insertion(edit: &NaEdit) -> bool {
+    matches!(edit, NaEdit::Deletion { .. })
 }
 
 /// Whether `edit` must stop a *sibling's* shift at its boundary, even though it
@@ -4444,7 +4482,7 @@ pub(crate) fn demote_coincident_tract_repeats<P: ReferenceProvider>(
                 span.end,
                 edit,
                 provider,
-                TerminalRespell::Allowed,
+                TerminalOverrun::RespellAtBoundary,
             );
             members[i] != originals[slot]
         });
@@ -5131,15 +5169,41 @@ pub(crate) fn respell_colliding_duplications<P: ReferenceProvider>(
         // `dup.end`, not `dup.end + 1`: the boundary identity deletes the *last*
         // base and re-inserts it carrying the payload, so the base the re-spelt
         // member claims is the one at the 5' side of the gap.
-        let sibling_claims_the_landing_base = siblings()
+        //
+        // Whether that sibling would *absorb* the junction form decides between
+        // the remaining two answers (#1307) — a stricter test than "removes the
+        // base", since a `delins` removes it and still does not absorb. Only an
+        // absorbing sibling makes the out-of-range coordinate transient; against
+        // one that does not — a substitution, a `delins`, an
+        // inversion — the repair has to be abandoned instead.
+        //
+        // Quantified over **every** claimant, not the first one found: it takes
+        // only one non-absorbing claimant to leave the junction form unconsumed,
+        // so a single absorbing sibling is not licence to write it. Taking the
+        // first match instead made the answer depend on member order, which is
+        // authoring order and carries no meaning.
+        //
+        // No input reaches a two-claimant set today — two claimants on one base
+        // is the overlap the parser rejects up front (`SelfCancellingAllele` for
+        // a `dup`/`del` pair), and where the pair arrives by *shifting* instead
+        // the cancellation runs before this pass. Measured by instrumenting this
+        // site and running the suite: 1068 hits, 832 with one claimant and 236
+        // with none, never more. So this is order-independence for its own sake
+        // rather than a fix for an observable defect, and it is the safe
+        // direction — it can only turn `WriteTransientJunction` into
+        // `LeaveMemberUnchanged`, which is always in range.
+        let mut landing_claimants = siblings()
             .filter(|s| s.claims_bases)
-            .any(|s| s.start <= dup.end && s.end >= dup.end);
-        let terminal = if sibling_claims_the_landing_base {
-            TerminalRespell::Refused
+            .filter(|s| s.start <= dup.end && s.end >= dup.end)
+            .peekable();
+        let on_overrun = if landing_claimants.peek().is_none() {
+            TerminalOverrun::RespellAtBoundary
+        } else if landing_claimants.all(|s| s.absorbs_a_flush_insertion) {
+            TerminalOverrun::WriteTransientJunction
         } else {
-            TerminalRespell::Allowed
+            TerminalOverrun::LeaveMemberUnchanged
         };
-        respell_at_gap(&mut members[i], dup, dup.end, edit, provider, terminal);
+        respell_at_gap(&mut members[i], dup, dup.end, edit, provider, on_overrun);
     }
 }
 
@@ -5308,7 +5372,7 @@ pub(crate) fn coalesce_members_at_one_junction<P: ReferenceProvider>(
             junction,
             edit,
             provider,
-            TerminalRespell::Allowed,
+            TerminalOverrun::RespellAtBoundary,
         );
         if members[target] == before {
             continue; // the re-spell did not take; leave the group alone
@@ -5454,7 +5518,7 @@ fn translate_junction_member<P: ReferenceProvider>(
         destination,
         edit,
         provider,
-        TerminalRespell::Allowed,
+        TerminalOverrun::RespellAtBoundary,
     );
     if *variant == translated {
         *variant = original;
@@ -5831,15 +5895,32 @@ fn member_endpoints(v: &HgvsVariant) -> Option<((Region, i64), (Region, i64))> {
 /// The verification is [`member_endpoints`] rather than [`member_span`] for
 /// that reason: the correct answer here is a range whose ends sit in two
 /// regions, and `member_span` refuses those by construction.
-/// Whether [`respell_at_gap`] may apply the terminal boundary re-spelling
-/// (#1327) when the gap runs one past the last base.
+/// What [`respell_at_gap`] does when the gap it is told to write runs one base
+/// past the end of the sequence.
 ///
-/// `Refused` when a sibling already claims that base: see the comment at the
-/// gate for why the two spellings are not interchangeable there (#1344).
+/// Three outcomes, not two, because the right answer depends on what else the
+/// allele has on that last base — and each of the three was arrived at by a
+/// separate measurement. The gate in `respell_at_gap` documents each in full;
+/// in brief:
+///
+/// | variant | when | why |
+/// | --- | --- | --- |
+/// | `RespellAtBoundary` | nothing else claims the last base | the boundary `delins` denotes the same bases and is in range (#1327) |
+/// | `WriteTransientJunction` | **every** sibling claiming the last base *absorbs a flush insertion* | the pair is the #999 adjacency the collapse pass merges, so the out-of-range coordinate is consumed before anything renders (#1344) |
+/// | `LeaveMemberUnchanged` | **any** sibling claiming the last base does not absorb one | nothing merges that pair, so both other outcomes are wrong: the boundary `delins` would overlap the sibling and the junction form would reach the output (#1307) |
+///
+/// "Absorbs a flush insertion" ([`merges_with_a_flush_insertion`]) rather than
+/// "removes the last base": a `delins` removes its bases and still does not
+/// absorb, so it takes the `LeaveMemberUnchanged` branch. The looser wording
+/// named a superset and was what the earlier cut of #1307 got wrong.
+///
+/// Only the overrun is affected. An in-range gap is placed identically under
+/// all three.
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum TerminalRespell {
-    Allowed,
-    Refused,
+enum TerminalOverrun {
+    RespellAtBoundary,
+    WriteTransientJunction,
+    LeaveMemberUnchanged,
 }
 
 fn respell_at_gap<P: ReferenceProvider>(
@@ -5848,7 +5929,7 @@ fn respell_at_gap<P: ReferenceProvider>(
     junction: i64,
     edit: NaEdit,
     provider: &P,
-    terminal_respell: TerminalRespell,
+    on_overrun: TerminalOverrun,
 ) {
     let original = variant.clone();
     let (gap_start, gap_end) = (junction, junction + 1);
@@ -5908,27 +5989,51 @@ fn respell_at_gap<P: ReferenceProvider>(
     // one-past-the-end overrun has a boundary identity that denotes the same
     // bases.
     //
-    // Skipped entirely when a sibling already claims the last base (#1344). The
-    // boundary identity trades a zero-width junction insertion for a `delins`
-    // that *claims* that base, and those two are not interchangeable when
-    // something else is already there: an insertion flush against a sibling's
-    // deleted base is the #999 adjacency the collapse pass merges, while two
-    // members claiming one base is an overlap it cannot. Re-spelling therefore
-    // converted a mergeable pair into an unmergeable one, and the out-of-range
-    // coordinate it was avoiding never reached the output in that case anyway —
-    // the merge consumed it. Measured: `c.[*10del;*11dup]` gave
+    // Skipped when a sibling that **removes** the last base already claims it
+    // (#1344). The boundary identity trades a zero-width junction insertion for
+    // a `delins` that *claims* that base, and those two are not interchangeable
+    // when something else is already there: an insertion flush against a
+    // sibling's deleted base is the #999 adjacency the collapse pass merges,
+    // while two members claiming one base is an overlap it cannot. Re-spelling
+    // therefore converted a mergeable pair into an unmergeable one, and the
+    // out-of-range coordinate it was avoiding never reached the output in that
+    // case anyway — the merge consumed it. Measured: `c.[*10del;*11dup]` gave
     // `c.[*11del;*11delinsAA]`, which ferro's own strict mode rejects as
     // `OverlapConflictingEdits / W5002`, where the junction form settles on the
     // correct `c.*11=`.
-    if terminal_respell == TerminalRespell::Allowed {
-        if let Some(delta) = region_sequence_delta(span.region, &span.provider_key, provider) {
-            let Some(last) = junction.checked_add(delta) else {
-                return;
-            };
-            if let Ok(length) = provider.get_sequence_length(&span.provider_key) {
-                if u64::try_from(last) == Ok(length) {
-                    respell_at_sequence_end(variant, span, &edit, delta, length, provider);
-                    return;
+    //
+    // **A sibling that claims the last base without absorbing a flush insertion
+    // is a third case** (#1307), and both of the other two answers are wrong for
+    // it. "Without absorbing" rather than "without removing": a `delins` removes
+    // its bases and still does not absorb, so it lands here too — that shape is
+    // what showed "removes the base" to be the wrong predicate, and
+    // `merges_with_a_flush_insertion` is the one that holds. There
+    // is no deletion for the junction form to abut, so nothing merges the pair
+    // and the out-of-range coordinate is not transient — it reaches the output,
+    // where it re-parses and is a fixed point, so neither existing oracle sees
+    // it. Measured on a 24-base contig: `g.[24dup;24C>G]` gave
+    // `g.[24C>G;24_25insC]`, naming a position the contig does not have. The
+    // boundary `delins` is no better, for the #1344 reason one paragraph up —
+    // the substitution already claims that base, so it would overlap. What is
+    // left is to leave the member as the duplication it was: the collision the
+    // caller wanted repaired stays unrepaired, which is the pre-existing
+    // spelling of the input rather than a new defect, and every coordinate it
+    // names exists.
+    if let Some(delta) = region_sequence_delta(span.region, &span.provider_key, provider) {
+        let Some(last) = junction.checked_add(delta) else {
+            return;
+        };
+        if let Ok(length) = provider.get_sequence_length(&span.provider_key) {
+            if u64::try_from(last) == Ok(length) {
+                match on_overrun {
+                    TerminalOverrun::RespellAtBoundary => {
+                        respell_at_sequence_end(variant, span, &edit, delta, length, provider);
+                        return;
+                    }
+                    TerminalOverrun::LeaveMemberUnchanged => return,
+                    // Falls through to the placement below, which writes the
+                    // out-of-range junction form deliberately.
+                    TerminalOverrun::WriteTransientJunction => {}
                 }
             }
         }

--- a/tests/it/issue_1307_terminal_dup_respell.rs
+++ b/tests/it/issue_1307_terminal_dup_respell.rs
@@ -1,0 +1,363 @@
+//! Issue #1307 — a terminal duplication re-spelled to an insertion one base
+//! past the end of the contig.
+//!
+//! `respell_colliding_duplications` repairs a duplication that collides with a
+//! sibling by re-spelling it as an insertion at the junction 3' of the
+//! duplicated span — the gap `[end, end + 1]`. When the duplication rests on
+//! the contig's **last** base there is no such gap:
+//!
+//! ```text
+//! reference  TTTTTTTTTAATATATTTTAATAC     24 bases
+//! in   g.[24dup;24C>G]
+//! out  g.[24C>G;24_25insC]                position 25 does not exist
+//! ```
+//!
+//! ## Which guards catch it, and which do not
+//!
+//! `respell_at_gap`'s `landed` check does not: it only confirms the member reads
+//! back at the gap it was *told* to use, which an out-of-range gap does.
+//! `FERRO_ASSERT_REPARSE` does not either — `parse_hgvs` does not know the
+//! contig's length, so `g.24_25insC` re-parses cleanly. That is #1327's blind
+//! spot exactly, and #1353 tracks the seam-level bound that would catch the
+//! class rather than the instance.
+//!
+//! **`FERRO_ASSERT_IDEMPOTENT` does catch it**, though, which #1307 and #1353
+//! both assume it cannot. The out-of-range output is not a fixed point; measured
+//! against `origin/main`:
+//!
+//! ```text
+//! input: NC_TEST.1:g.[24dup;24C>G]
+//! once:  NC_TEST.1:g.[24C>G;24_25insC]
+//! twice: NC_TEST.1:g.23_24insG
+//! ```
+//!
+//! So the oracle was never blind here — no test normalized this shape, and an
+//! oracle only covers the corpus that reaches it. Worth knowing when reading
+//! #1353's table, and worth remembering as the cheaper of the two ways to catch
+//! this class.
+//!
+//! ## Why #1327's fix did not already cover it
+//!
+//! #1327 added the terminal bound, and #1344 then *disabled* it whenever a
+//! base-claiming sibling occupies the base the gap runs past — correctly, for
+//! the case it measured: a sibling **deletion** there makes the pair the #999
+//! adjacency the collapse pass merges, and the merge consumes the out-of-range
+//! coordinate before anything renders. Re-spelling instead produced
+//! `c.[*11del;*11delinsAA]`, two members claiming one base, which ferro's own
+//! strict mode rejects.
+//!
+//! That reasoning does not carry to a sibling that claims the last base without
+//! being a deletion. There is nothing for the junction form to be absorbed into,
+//! so no merge happens and the out-of-range coordinate is not transient — it
+//! reaches the output. Two shapes reach it, both pinned below: a substitution
+//! sibling (the issue's reproducer) and a `delins` sibling (found while
+//! measuring the fix — `delins` removes its bases, yet the collapse pass still
+//! does not merge the pair).
+//!
+//! ## What it does instead, and why not the other three options
+//!
+//! **Leave the member as the duplication it was.** The collision goes
+//! unrepaired, which is the spelling the input already had, and every coordinate
+//! named exists.
+//!
+//! **Not the boundary `delins`** that #1327 emits — for #1344's reason: the
+//! sibling already claims that base, so the re-spelt member would overlap it.
+//!
+//! **Not the wrapped form** on `m.`, either. SVD-WG006 authorises the reversed
+//! `<high>_<low>` range for deletions and duplications only, so `m.24_1insC` is
+//! not valid HGVS and ferro's parser rejects it (#129) — pinned by
+//! `the_wrapped_insertion_spelling_is_not_valid_hgvs` in
+//! `issue_1327_mt_respell_past_contig_end`. The circular axis therefore gets the
+//! same answer as the linear one.
+//!
+//! **And not the single member the trace above ends on**, tempting as it looks:
+//! `g.23_24insG` is in range, is one member, and denotes the same sequence. It is
+//! unreachable *by policy*. `normalize_allele` disables its pre-merge reorder
+//! when the input carries an overlap conflict, and both shapes here are such an
+//! input — a `dup` and a substitution on one base is exactly what strict mode
+//! rejects as `OverlapConflictingEdits / W5002`. Dropping that guard does reach
+//! `g.23_24insG` (measured), and it breaks four committed guards that exist to
+//! forbid precisely this: `issue_395_overlap_conflict_strict_rejection::
+//! lenient_mode_preserves_authored_order_of_conflicting_members`,
+//! `issue_1276_dup_junction_overlap::
+//! lenient_output_of_a_conflict_is_still_rejected_by_strict`,
+//! `issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized`
+//! and `idempotency_tests::
+//! test_overlap_conflicting_allele_is_idempotent_across_respellings`.
+//!
+//! A conflicting allele must stay recognisable as one so strict mode can reject
+//! it, rather than being canonicalised into something that looks valid. Which
+//! makes the pre-fix behaviour worse than the issue reports: it did not merely
+//! name a position past the end, it laundered a conflict into an output strict
+//! mode **accepts** (`g.[24C>G;24_25insC]` normalizes strictly to
+//! `g.23_24insG`). Declining restores both properties at once — in range, and
+//! still a conflict.
+
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::NormalizeConfig;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The issue's reference: 24 bases ending in a unique `C`, so a duplication
+/// authored at position 24 stays there.
+const SEQUENCE: &str = "TTTTTTTTTAATATATTTTAATAC";
+const LENGTH: usize = 24;
+
+/// A 24-base contig ending in a 4-`A` run, so a member authored inside the run
+/// 3'-shifts onto the final base instead of being written there.
+fn run_terminated_sequence() -> String {
+    format!("{}{}", "CG".repeat(10), "A".repeat(4))
+}
+
+fn normalize(accession: &str, sequence: &str, input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(accession, sequence.to_string());
+    Normalizer::new(provider)
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// Every position the output names must exist on the contig.
+///
+/// Read out of the rendered string rather than string-matching `"25"`, so an
+/// overrun by any amount at any endpoint is caught. Deliberately
+/// over-approximate — it scans every integer after the `:`, so a repeat count or
+/// an inserted length is checked as though it were a position. Sound for these
+/// fixtures (single-digit counts against a 24-base contig) and it fails safe.
+/// Mirrors `assert_within_contig` in `issue_1327_mt_respell_past_contig_end`.
+fn assert_within_contig(input: &str, output: &str) {
+    let reparsed = parse_hgvs(output).unwrap_or_else(|e| {
+        panic!("`{input}` normalized to `{output}`, which will not re-parse: {e}")
+    });
+    let positions = output
+        .rsplit_once(':')
+        .map(|(_, rest)| rest)
+        .unwrap_or(output);
+    for run in positions.split(|c: char| !c.is_ascii_digit()) {
+        let Ok(position) = run.parse::<usize>() else {
+            continue;
+        };
+        assert!(
+            (1..=LENGTH).contains(&position),
+            "`{input}` normalized to `{output}` ({reparsed}), which names position \
+             {position} on a {LENGTH}-base contig"
+        );
+    }
+}
+
+/// The issue's reproducer, on both member orders.
+///
+/// Pinned, not merely bounded. A bounds check alone is satisfied by a refusal,
+/// by a dropped member, or by any other in-range spelling — and pinning is
+/// exactly what caught #1344 hiding behind the weaker check. What must come back
+/// is the input's own two members, unrepaired.
+#[test]
+fn a_substitution_sibling_leaves_the_terminal_duplication_alone() {
+    assert_eq!(SEQUENCE.len(), LENGTH, "fixture must be 24 bases");
+    for (input, expected) in [
+        ("NC_TEST.1:g.[24dup;24C>G]", "NC_TEST.1:g.[24dup;24C>G]"),
+        ("NC_TEST.1:g.[24C>G;24dup]", "NC_TEST.1:g.[24C>G;24dup]"),
+    ] {
+        let output = normalize("NC_TEST.1", SEQUENCE, input);
+        assert_within_contig(input, &output);
+        assert_eq!(
+            output, expected,
+            "`{input}` must keep both members in range"
+        );
+    }
+}
+
+/// A `delins` sibling reaches the same gate and must get the same answer.
+///
+/// This is the shape that showed "removes its bases" is the wrong predicate for
+/// admitting the transient out-of-range junction: a `delins` does remove them,
+/// and the collapse pass still does not merge the pair, so the earlier cut of
+/// this fix emitted `g.[24delinsGG;24_25insA]` here.
+#[test]
+fn a_delins_sibling_leaves_the_terminal_duplication_alone() {
+    let input = "NC_TEST.1:g.[24dup;24delinsGG]";
+    let output = normalize("NC_TEST.1", SEQUENCE, input);
+    assert_within_contig(input, &output);
+    assert_eq!(output, "NC_TEST.1:g.[24dup;24delinsGG]");
+}
+
+/// The same overrun on the circular axis. Not a special case: `m.` has a last
+/// base like any other sequence, and the wrapped `ins` spelling that would make
+/// it one is not valid HGVS (see the module docs).
+#[test]
+fn the_circular_axis_gets_the_same_answer() {
+    for input in [
+        "NC_012920.1:m.[24dup;24C>G]",
+        "NC_012920.1:m.[24dup;24delinsGG]",
+    ] {
+        let output = normalize("NC_012920.1", SEQUENCE, input);
+        assert_within_contig(input, &output);
+        assert_eq!(
+            output, input,
+            "`{input}` must keep both members in range on the circular axis"
+        );
+    }
+}
+
+/// The #1344 path must survive: a sibling **deletion** at the last base still
+/// gets the transient out-of-range junction form, because the collapse pass
+/// consumes it. The genomic half of what
+/// `issue_1327_mt_respell_past_contig_end` pins on `m.` and `c.`.
+///
+/// Both member orders, since the repair is order-independent and a regression
+/// that only reordered would otherwise pass.
+#[test]
+fn a_deletion_sibling_at_the_last_base_still_merges() {
+    for input in ["NC_TEST.1:g.[21del;22dup]", "NC_TEST.1:g.[22dup;21del]"] {
+        let output = normalize("NC_TEST.1", &run_terminated_sequence(), input);
+        assert_within_contig(input, &output);
+        // The pair cancels — one `A` removed from the terminal run and one added
+        // back — so an identity is the right answer, and the merge that produces
+        // it is only reachable through the junction spelling this fix must not
+        // have taken away.
+        assert_eq!(
+            output, "NC_TEST.1:g.23=",
+            "`{input}` must still collapse to an identity"
+        );
+    }
+}
+
+/// Three members, with an absorbing sibling *and* a non-absorbing one both on
+/// the terminal run: the allele must stay in range whichever order it is
+/// authored in.
+///
+/// These are the permutations that motivated quantifying the landing-claimant
+/// test over **every** claimant rather than the first one found — with a `find`,
+/// one absorbing sibling could decide the policy while a non-absorbing sibling
+/// sat behind it in member order.
+///
+/// **They do not reach a two-claimant set, and are not the guard for one.**
+/// Measured by instrumenting the selection site and running the whole suite:
+/// 1068 hits, 832 with a single claimant and 236 with none, never two. Two
+/// claimants on one base is the overlap the parser refuses outright
+/// (`SelfCancellingAllele` for the `dup`/`del` pair here), and when the pair
+/// arrives by *shifting* instead — as it does below, `21del` and `22dup` both
+/// travelling to the last `A` — the cancellation runs before this pass, so only
+/// the third member is still claiming anything by the time the policy is
+/// chosen. What these pin is therefore the outcome and its order-independence,
+/// not the `all`-vs-`find` branch; that branch is unreachable today and the
+/// quantifier is there so it cannot become order-dependent if it stops being.
+#[test]
+fn a_three_member_allele_stays_in_range_in_any_order() {
+    let sequence = run_terminated_sequence();
+    for (input, expected) in [
+        // Absorbing (`21del`) plus non-absorbing substitution.
+        ("NC_TEST.1:g.[21del;22dup;24A>G]", "NC_TEST.1:g.24A>G"),
+        ("NC_TEST.1:g.[22dup;21del;24A>G]", "NC_TEST.1:g.24A>G"),
+        ("NC_TEST.1:g.[24A>G;21del;22dup]", "NC_TEST.1:g.24A>G"),
+        // Absorbing plus non-absorbing `delins` — `delins` removes its bases and
+        // still does not absorb, the distinction the policy turns on.
+        (
+            "NC_TEST.1:g.[21del;22dup;24delinsGG]",
+            "NC_TEST.1:g.24delinsGG",
+        ),
+        (
+            "NC_TEST.1:g.[22dup;21del;24delinsGG]",
+            "NC_TEST.1:g.24delinsGG",
+        ),
+        // A non-absorbing claimant spanning two bases, so the claim reaches the
+        // last base from a span rather than a point.
+        (
+            "NC_TEST.1:g.[21del;22dup;23_24delinsGG]",
+            "NC_TEST.1:g.23_24delinsGG",
+        ),
+    ] {
+        let output = normalize("NC_TEST.1", &sequence, input);
+        assert_within_contig(input, &output);
+        assert_eq!(
+            output, expected,
+            "`{input}` must stay in range and not depend on member order"
+        );
+    }
+}
+
+/// An in-range collision is repaired exactly as before: declining at the last
+/// base must not cost the repair everywhere else.
+#[test]
+fn an_in_range_collision_is_still_repaired() {
+    let sequence = run_terminated_sequence();
+    let input = "NC_TEST.1:g.[20dup;21A>G]";
+    let output = normalize("NC_TEST.1", &sequence, input);
+    assert_within_contig(input, &output);
+    assert_eq!(
+        output, "NC_TEST.1:g.21delinsGG",
+        "`{input}` must still collapse as it did before"
+    );
+}
+
+/// A lone terminal duplication has no sibling to collide with and must pass
+/// through untouched — the control showing the gate is scoped to the repair and
+/// is not clamping ordinary terminal edits.
+#[test]
+fn a_lone_terminal_duplication_is_unchanged() {
+    assert_eq!(
+        normalize("NC_TEST.1", SEQUENCE, "NC_TEST.1:g.24dup"),
+        "NC_TEST.1:g.24dup"
+    );
+    // Authored inside the terminal run, it still shifts to the last base.
+    assert_eq!(
+        normalize("NC_TEST.1", &run_terminated_sequence(), "NC_TEST.1:g.21dup"),
+        "NC_TEST.1:g.24dup"
+    );
+}
+
+/// Declining must leave the output **idempotent**, which the out-of-range
+/// spelling was not (see the trace in the module docs).
+///
+/// This is the assertion that would have failed on `origin/main`, so it is the
+/// cheapest guard against the class and belongs beside the pinned strings rather
+/// than only in a suite-wide env-gated oracle.
+#[test]
+fn the_declined_output_is_idempotent() {
+    for input in [
+        "NC_TEST.1:g.[24dup;24C>G]",
+        "NC_TEST.1:g.[24dup;24delinsGG]",
+    ] {
+        let once = normalize("NC_TEST.1", SEQUENCE, input);
+        let twice = normalize("NC_TEST.1", SEQUENCE, &once);
+        assert_eq!(
+            once, twice,
+            "`{input}` -> `{once}` -> `{twice}` is not a fixed point"
+        );
+    }
+}
+
+/// The conflict must survive into strict mode.
+///
+/// The point of declining rather than repairing: an overlap-conflicting input
+/// stays recognisable as one, so strict mode still rejects it. The out-of-range
+/// spelling failed this — `g.[24C>G;24_25insC]` is strict-*acceptable*, so the
+/// old behaviour laundered a conflict into a valid-looking description while also
+/// naming a position the contig does not have.
+///
+/// The sibling of `issue_1276_dup_junction_overlap::
+/// lenient_output_of_a_conflict_is_still_rejected_by_strict`, at the terminus.
+#[test]
+fn the_declined_output_is_still_rejected_by_strict() {
+    for input in [
+        "NC_TEST.1:g.[24dup;24C>G]",
+        "NC_TEST.1:g.[24C>G;24dup]",
+        "NC_TEST.1:g.[24dup;24delinsGG]",
+    ] {
+        let lenient = normalize("NC_TEST.1", SEQUENCE, input);
+        let variant = parse_hgvs(&lenient).expect("lenient output must parse");
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_TEST.1", SEQUENCE.to_string());
+        let strict = Normalizer::with_config(
+            provider,
+            NormalizeConfig::default().with_error_mode(ErrorMode::Strict),
+        )
+        .normalize(&variant);
+        assert!(
+            strict.is_err(),
+            "`{input}` -> `{lenient}`, which strict mode accepts — the conflict \
+             was canonicalized away instead of being left for strict to reject"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -181,6 +181,7 @@ mod issue_1297_cancelled_identity_member;
 mod issue_129_mt_circular_wraparound;
 mod issue_1301_adjacent_gap_member_order;
 mod issue_1304_junction_barrier_snapshot;
+mod issue_1307_terminal_dup_respell;
 mod issue_1308_commuting_payload_phase;
 mod issue_1312_landed_payload_commutes;
 mod issue_1316_coincident_tract_repeats;


### PR DESCRIPTION
Closes #1307

`respell_colliding_duplications` repairs a duplication that collides with a sibling by re-spelling it as an insertion at the junction 3' of the duplicated span. A duplication resting on the contig's **last** base has no such junction, and the member was placed one past the end anyway:

```text
reference  TTTTTTTTTAATATATTTTAATAC     24 bases
in   g.[24dup;24C>G]
out  g.[24C>G;24_25insC]                position 25 does not exist
```

## Why #1327's bound did not already cover it

#1327 added the terminal bound; #1344 then disabled it whenever a base-claiming sibling occupies the base the gap runs past. That is right for the case #1344 measured, where the sibling is a **deletion**: the pair is then the #999 adjacency the collapse pass merges, so the out-of-range coordinate is consumed before anything renders, and re-spelling instead produced the overlapping `c.[*11del;*11delinsAA]`.

Nothing absorbs the junction form when the sibling is *not* a deletion. The coordinate is no longer transient — it reaches the output.

So the overrun needs three answers rather than two, which the renamed `TerminalOverrun` now names explicitly:

| variant | when | why |
| --- | --- | --- |
| `RespellAtBoundary` | nothing else claims the last base | the boundary `delins` denotes the same bases, in range (#1327) |
| `WriteTransientJunction` | a sibling absorbs a flush insertion | the collapse merge consumes the coordinate (#1344) |
| `LeaveMemberUnchanged` | a sibling claims the last base but does not absorb | both other answers are wrong (#1307) |

## Why declining, and not the single-member form

`g.23_24insG` is in range, is one member and denotes the same sequence — and it is unreachable **by policy**. It requires dropping `normalize_allele`'s pre-merge reorder guard for inputs that already carry an overlap conflict, and both shapes here are such an input (`24dup` + `24C>G` is what strict mode rejects as `OverlapConflictingEdits / W5002`). Measured: dropping that guard does produce `g.23_24insG`, and breaks four committed guards that exist to keep a conflicting allele recognizable as one rather than canonicalizing it into something that looks valid:

- `issue_395_overlap_conflict_strict_rejection::lenient_mode_preserves_authored_order_of_conflicting_members`
- `issue_1276_dup_junction_overlap::lenient_output_of_a_conflict_is_still_rejected_by_strict`
- `issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized`
- `idempotency_tests::test_overlap_conflicting_allele_is_idempotent_across_respellings`

That makes the old behaviour worse than the issue reports: `g.[24C>G;24_25insC]` is strict-**acceptable**, so a conflict was laundered into a valid-looking description that also named a position off the end. Declining restores both properties — in range, and still a conflict for strict mode to reject.

## A second live instance

Found while measuring the fix, and covered here rather than filed separately since it is the same gate and the same defect: a `delins` sibling. `g.[24dup;24delinsGG]` gave `g.[24delinsGG;24_25insA]`. It *removes* its bases and still does not absorb the payload, so the predicate is `merges_with_a_flush_insertion` — a plain deletion only — and not "removes bases". `NPaddedDeletion` and `Repeat`/`MultiRepeat` are excluded for reasons documented on the predicate; each exclusion costs at most an unrepaired collision, never an out-of-range coordinate.

## Corrects an assumption in #1307 and #1353

Both say this class is invisible to the existing oracles. `FERRO_ASSERT_REPARSE` is indeed blind — the output re-parses. `FERRO_ASSERT_IDEMPOTENT` is **not**; the out-of-range output is not a fixed point. Measured against `origin/main`:

```text
input: NC_TEST.1:g.[24dup;24C>G]
once:  NC_TEST.1:g.[24C>G;24_25insC]
twice: NC_TEST.1:g.23_24insG
```

No test normalized this shape, so it is a corpus gap rather than an oracle gap — worth knowing when #1353 is picked up, since the cheap guard already existed.

## Tests

`tests/it/issue_1307_terminal_dup_respell.rs`, eight tests. Outputs are pinned, not merely bounded — a bounds check alone is satisfied by a refusal or a dropped member, which is how #1344 hid:

- the issue's reproducer, both member orders
- the `delins` sibling instance
- the same overrun on the circular `m.` axis (the wrapped `ins` spelling is not valid HGVS, per #1327's pinned reason, so `m.` gets the same answer as `g.`)
- **controls:** a deletion sibling at the last base still merges to `g.23=` (the #1344 path, on the genomic axis this time); an in-range collision still collapses; a lone terminal duplication is untouched
- the two properties that justify the choice: the output is idempotent, and strict mode still rejects it

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — 9194/9194 pass, 146 skipped
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of terminal duplication collisions during variant normalization.
  - Preserved valid substitution and combined insertion/deletion variants at sequence boundaries.
  - Continued collapsing eligible deletion-based collisions while rejecting invalid overlap conflicts.
  - Improved behavior for both linear and circular sequences.

- **Tests**
  - Added comprehensive coverage for terminal collisions, unchanged variants, idempotency, and coordinate validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->