### PR TITLE
test(normalize): assert at the seam that no coordinate runs off its sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,11 +587,20 @@ jobs:
         # Separate from the above because neither subsumes the other, and the
         # idempotency oracle has a blind spot this one covers — it verifies by
         # re-normalizing its own output, which it cannot do for an output that
-        # will not parse. Both sit at the same seam,
-        # `normalize_core_checked`'s single exit.
+        # will not parse.
+        #
+        # `FERRO_ASSERT_IN_BOUNDS` is the third: no coordinate an output names may
+        # be past the end of its own sequence (#1353). Neither of the other two
+        # asks that question — `parse_hgvs` holds no provider, so an out-of-range
+        # position is well-formed to it, and while a bad coordinate sometimes
+        # perturbs idempotency it need not. The class had been found by hand three
+        # times (#1274, #1343, #1307) before it was asserted here.
+        #
+        # All three sit at the same seam, `normalize_core_checked`'s single exit.
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
+          FERRO_ASSERT_IN_BOUNDS: "1"
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
@@ -733,6 +742,11 @@ jobs:
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
+          # The sweeps are where this one earns its keep: they enumerate members
+          # onto terminal positions in bulk, which is where every instance of the
+          # class so far has come from. See the note on the pair in the `test`
+          # job above.
+          FERRO_ASSERT_IN_BOUNDS: "1"
         # `--no-tests=fail` for the reason spelled out on `soak`, and it matters
         # more here: `SWEEP_FILTER` names three modules explicitly, so renaming
         # one is exactly the edit that would drop a sweep from CI silently.

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -139,6 +139,18 @@ jobs:
           # themselves re-parse are exempt; see the note beside the same pair
           # in ci.yml.
           FERRO_ASSERT_REPARSE: "1"
+          # And that no coordinate it names is past the end of its own sequence
+          # (#1353). This job is the only one with a real prepared reference, so
+          # it is the only place the check runs against true transcript and contig
+          # lengths rather than a fixture's; an authored overrun is exempt, since
+          # W4004 `PositionPastEnd` is what reports those.
+          #
+          # Non-gating here, like the two above it: `continue-on-error` on this
+          # step means a fire lands in the xfail report rather than failing the
+          # workflow (see the comment on the step). The gate for this oracle is
+          # ci.yml's `test-oracle` and `sweeps` jobs, which set the same flag and
+          # carry no `continue-on-error`.
+          FERRO_ASSERT_IN_BOUNDS: "1"
         run: |
           cargo nextest run --features dev \
             -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/) | test(/hgvs_rs_projection_tests::/)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,15 @@ into a `OnceLock`, so a disabled run pays only one atomic load. CI runs the suit
 a second time with it set; the nightly reference-aware job sets it too, which is
 where the manifest-backed conformance corpora are actually covered.
 
-The check sits at the single shared exit of `normalize_core_checked`, so it covers
-both `normalize()` and every `VariantProjector` path (the projection-driven
-genomic/coding/protein axes). Its verification pass re-enters that same method, so
-a thread-local `IN_IDEMPOTENCY_CHECK` guard breaks the recursion — the inner call
-skips its own check.
+The check runs from `Normalizer::assert_seam_oracles`, which all three oracles
+share. It is called from two places, because ferro has two normalization exits and
+only one of them is the "shared" one: `normalize_core_checked`, covering
+`normalize()` and every `VariantProjector` path (the projection-driven
+genomic/coding/protein axes), and `normalize_with_diagnostics`, which reaches
+`normalize_core_canonical` directly and so was returning results no oracle had
+inspected — for all three checks, not just the newest. Its verification pass
+re-enters normalization, so a thread-local `IN_IDEMPOTENCY_CHECK` guard breaks the
+recursion — the inner call skips its own check.
 
 #### Normalization re-parse oracle
 
@@ -121,8 +125,68 @@ FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev
 Kept separate from `FERRO_ASSERT_IDEMPOTENT` because neither subsumes the other,
 and the idempotency oracle has a blind spot this one covers: it verifies by
 *re-normalizing* its own output, which it cannot do for an output that fails to
-parse, so an unparseable result is invisible to it. Both sit at
-`normalize_core_checked`'s single exit and CI sets both together.
+parse, so an unparseable result is invisible to it. Both run from
+`assert_seam_oracles` alongside the in-bounds check, and CI sets all three together.
+
+#### Normalization in-bounds oracle
+
+`FERRO_ASSERT_IN_BOUNDS=1` is the third at the same seam: no coordinate a
+normalized description names may be past the end of its own sequence.
+
+```bash
+FERRO_ASSERT_IN_BOUNDS=1 cargo nextest run --features dev
+```
+
+It exists because the class kept being found by hand, one shape at a time —
+**#1274** (`T:g.[8_9insA;10del]` -> `g.10_11=` on a 10-base contig), **#1343**
+(`c.[*10dup;*11dup]` -> `c.*11_*12insAA`) and **#1307**
+(`g.[24dup;24C>G]` -> `g.[24C>G;24_25insC]`) — each filed, fixed and
+regression-tested separately. Three instances of one defect class is the argument
+for an invariant at the seam rather than a fourth per-shape test.
+
+Neither of the other two asks the question. `FERRO_ASSERT_REPARSE` cannot:
+`parse_hgvs` holds no provider, so `g.24_25insC` is well-formed to it.
+`FERRO_ASSERT_IDEMPOTENT` catches some instances incidentally — the #1307 output
+re-normalizes to `g.23_24insG`, so it is not a fixed point — but an out-of-range
+output that *is* a fixed point passes it, which is the #1327 shape
+(`m.16569_16570insAA`).
+
+What makes it non-trivial, and what it deliberately does not check, is documented
+on `merge::first_out_of_bounds_coordinate`. In brief:
+
+- **Positions are converted onto the served sequence's axis first.** A `c.`
+  position may legitimately exceed the CDS length (`*n` into the 3'UTR, `-n` into
+  the 5'UTR), so `region_sequence_delta` runs before any comparison.
+- **A reversed range is not an error.** SVD-WG006 admits `<high>_<low>` for a
+  circular deletion or duplication, so the two endpoints are checked
+  independently and their order is never compared.
+- **An authored overrun is exempt** — W4004 `PositionPastEnd` is what reports
+  those. Detecting it requires reading each endpoint independently, because a
+  special position (`pter`) on one end otherwise hides a past-end coordinate on
+  the other.
+- **Not covered:** protein axes, and an inserted-range payload
+  (`g.10_11ins[20_30]`).
+
+Like the two above it, compiled out in release (`#[cfg(debug_assertions)]`) and
+read once into a `OnceLock`. CI sets all three together, in the sharded
+`test-oracle` job and the `sweeps` job (those two and nowhere else — the plain
+`test` and `soak` jobs run without the flags); the nightly sets it too, where it
+is the only place the check runs against true transcript and contig lengths.
+
+**An oracle failure is visible in PR CI and silent in the nightly.** In PR CI,
+`test-oracle` and `sweeps` carry no `continue-on-error`, so a fire turns the job
+red. The nightly reference-aware job does carry it, deliberately — its purpose is
+to surface drift in the xfail report rather than to gate, and the corpus runner
+wraps normalization in `catch_panics`, so an oracle panic there lands in the
+uploaded xfail artifact as a FAILing case instead of failing the workflow. That
+applies equally to all three flags, and it is why a red oracle in the nightly must
+be read out of the xfail report rather than from the workflow conclusion.
+
+Red is not the same as blocked, though: `main`'s ruleset requires only eight
+checks — Build, Test, Clippy, Clippy (all features), Format, Python Lint, Python
+Wheel Test, abi3 floor — and neither `Test oracle` nor `Exhaustive sweeps` is
+among them. So an oracle fire shows up as a failed job that a human must not
+merge past, not as a ruleset-enforced merge block.
 
 ### Generated spec fixture (not committed)
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -5852,6 +5852,168 @@ fn cds_axis_end<P: ReferenceProvider>(
     cds_axis_position(i64::try_from(length).ok()?, cds_start, cds_end, body)
 }
 
+// ----------------------------------------------------------------------------
+// In-bounds seam oracle (#1353)
+// ----------------------------------------------------------------------------
+
+/// A coordinate an output names that its own sequence does not have.
+///
+/// Carries what the panic message needs and nothing more; every field is read
+/// by `Normalizer::assert_in_bounds`.
+///
+/// Gated like the rest of this chain: `assert_in_bounds` and its
+/// `in_bounds_self_check_enabled` flag are `#[cfg(debug_assertions)]`, and so is
+/// the `use merge::OutOfBoundsCoordinate` that imports this, so in release these
+/// items had no caller at all and only added compile time and dead code to the
+/// binary. `test` rides along so the unit tests below still build under
+/// `cargo test --release`, where `cfg(test)` holds but `debug_assertions` does not.
+#[cfg(any(debug_assertions, test))]
+#[derive(Debug)]
+pub(crate) struct OutOfBoundsCoordinate {
+    /// The provider key the length was read under, not the accession as
+    /// written — that is the thing the number was actually compared against.
+    pub(crate) accession: String,
+    /// The offending position, converted onto the served sequence's own 1-based
+    /// axis, so `c.*12` on an 11-base 3'UTR reports the transcript position
+    /// rather than `12`.
+    pub(crate) position: i64,
+    /// The sequence's length, i.e. the largest position that does exist.
+    pub(crate) length: u64,
+    /// The member as rendered, so a failure inside an allele names which member.
+    pub(crate) member: String,
+}
+
+/// The first coordinate in `variant` naming a position past the end of its own
+/// sequence, or `None` if every coordinate exists.
+///
+/// This is the predicate behind `FERRO_ASSERT_IN_BOUNDS` (#1353). Three
+/// instances of the class had been found by hand — #1274, #1343 and #1307 — each
+/// filed and fixed separately, which is the argument for asking the question
+/// once at the seam.
+///
+/// # Why it needs the axis conversion rather than a raw comparison
+///
+/// A `c.` position may legitimately exceed the CDS length: `*n` counts into the
+/// 3'UTR and `-n` into the 5'UTR, so `c.*11` on a 35-base transcript with a
+/// 12-base CDS is in range while `12` compared against `24` says nothing. Every
+/// endpoint is therefore put onto the **served sequence's** axis with
+/// [`region_sequence_delta`] before it is compared, which is the same conversion
+/// the repair passes use.
+///
+/// # What it deliberately does not check
+///
+/// - **A reversed range is not an error.** SVD-WG006 admits `<high>_<low>` for a
+///   circular deletion or duplication (`NC_012920.1:m.16563_13del`), so the two
+///   endpoints are each checked against `[1, length]` independently and their
+///   order is never compared. That also makes the check identical on `m.`/`o.`
+///   and on the linear axes, which is the honest answer: a circular sequence has
+///   a last base like any other, and #1327 established that the wrapped
+///   *insertion* spelling that would blur it is not valid HGVS anyway.
+/// - **A junction insertion naming `end + 1` is fine when that base exists.**
+///   The question is whether a position exists, not whether an edit touches the
+///   last one — `g.23_24insC` on a 24-base contig is correct and must stay
+///   silent, while `g.24_25insC` is the #1307 defect.
+/// - **Intronic offsets, unknown, uncertain and special positions** (`pter`,
+///   `qter`) yield no plain axis position, so they are skipped — see
+///   [`readable_endpoints`], which reads each end independently for a reason
+///   worth knowing.  An intronic offset is outside the transcript by
+///   construction and has no length to be compared with.
+/// - **Protein axes**, for the same reason: `member_endpoints` covers the
+///   nucleotide axes only. The three known instances of this class are all
+///   nucleotide, so widening it is a separate change with its own evidence.
+/// - **An inserted range payload** (`g.10_11ins[20_30]`), which names positions
+///   in the location of no member. Not covered; if a defect of that shape turns
+///   up, this is where to extend.
+/// - **A provider that cannot report a length** leaves the member unchecked,
+///   rather than failing a run for a reference that simply does not know. The
+///   oracle only ever fires on a *known* overrun.
+#[cfg(any(debug_assertions, test))]
+pub(crate) fn first_out_of_bounds_coordinate<P: ReferenceProvider>(
+    variant: &HgvsVariant,
+    provider: &P,
+) -> Option<OutOfBoundsCoordinate> {
+    let members: &[HgvsVariant] = match variant {
+        HgvsVariant::Allele(allele) => &allele.variants,
+        single => std::slice::from_ref(single),
+    };
+    members
+        .iter()
+        .find_map(|member| member_out_of_bounds_coordinate(member, provider))
+}
+
+/// [`first_out_of_bounds_coordinate`] for one member.
+#[cfg(any(debug_assertions, test))]
+fn member_out_of_bounds_coordinate<P: ReferenceProvider>(
+    member: &HgvsVariant,
+    provider: &P,
+) -> Option<OutOfBoundsCoordinate> {
+    let accession = member.accession()?.transcript_accession();
+    let length = provider.get_sequence_length(&accession).ok()?;
+    let ceiling = i64::try_from(length).ok()?;
+    readable_endpoints(member)
+        .into_iter()
+        .flatten()
+        .find_map(|(region, axis)| {
+            let delta = region_sequence_delta(region, &accession, provider)?;
+            let position = axis.checked_add(delta)?;
+            // The floor is part of the same invariant: a position at or below
+            // zero exists on no sequence either, and the repairs that produce
+            // `g.0_1` (#1282) are the same family as the ones that produce
+            // `g.24_25`.
+            (position < 1 || position > ceiling).then(|| OutOfBoundsCoordinate {
+                accession: accession.clone(),
+                position,
+                length,
+                member: member.to_string(),
+            })
+        })
+}
+
+/// Each end of a member's interval that has a plain `(region, axis position)`,
+/// independently of whether the other end does.
+///
+/// [`member_endpoints`] deliberately demands **both** ends, because its callers
+/// place a two-ended gap and cannot act on half of one. This oracle wants the
+/// opposite: an endpoint it can read is one it can check, and an endpoint it
+/// cannot read is simply not its business.
+///
+/// The difference is load-bearing rather than stylistic, and a measured false
+/// positive is what showed it. `NC_PASTEND.1:g.pter_5000del` on a 200-base contig
+/// normalizes to `g.1_5000del` — `pter` resolves to `1`, and `5000` is carried
+/// through from the input. Asking `member_endpoints` about that *input* yields
+/// `None`, because `pter` is a special position: the authored overrun becomes
+/// invisible, the "did normalization introduce this?" exemption never fires, and
+/// the oracle blames normalization for a coordinate the caller wrote. Reading the
+/// ends independently sees the input's `5000`, and W4004 `PositionPastEnd`
+/// remains the mechanism that reports it.
+#[cfg(any(debug_assertions, test))]
+fn readable_endpoints(v: &HgvsVariant) -> [Option<(Region, i64)>; 2] {
+    fn ends<T>(
+        interval: &Interval<T>,
+        read: impl Fn(&UncertainBoundary<T>) -> Option<(Region, i64)>,
+    ) -> [Option<(Region, i64)>; 2] {
+        [read(&interval.start), read(&interval.end)]
+    }
+    match v {
+        HgvsVariant::Genome(g) => ends(&g.loc_edit.location, simple_genome_pos),
+        HgvsVariant::Mt(m) => ends(&m.loc_edit.location, simple_genome_pos),
+        // `o.` reads exactly like `m.`: both are circular genomic axes carrying a
+        // plain `GenomePos` interval. Omitting it left every `o.` member with no
+        // readable endpoint, so the oracle could not fire on one at all — while
+        // the doc above claimed the check was "identical on `m.`/`o.`". This is
+        // the branch that makes that true. Note the sibling `member_endpoints`
+        // deliberately still omits `o.`: its callers are the repair passes, which
+        // exclude circular members by design (see `respell_colliding_duplications`
+        // and the note at the top of this module), and widening it would change
+        // what those passes rewrite rather than what this oracle inspects.
+        HgvsVariant::Circular(o) => ends(&o.loc_edit.location, simple_genome_pos),
+        HgvsVariant::Cds(c) => ends(&c.loc_edit.location, simple_cds_pos),
+        HgvsVariant::Tx(t) => ends(&t.loc_edit.location, simple_tx_pos),
+        HgvsVariant::Rna(r) => ends(&r.loc_edit.location, simple_rna_pos),
+        _ => [None, None],
+    }
+}
+
 fn member_endpoints(v: &HgvsVariant) -> Option<((Region, i64), (Region, i64))> {
     fn ends<T>(
         interval: &Interval<T>,
@@ -6158,6 +6320,234 @@ mod tests {
     use crate::hgvs::parser::parse_hgvs;
     use crate::hgvs::variant::Accession;
     use crate::reference::MockProvider;
+
+    // ------------------------------------------------------------------
+    // In-bounds seam oracle (#1353)
+    // ------------------------------------------------------------------
+
+    /// A 24-base genomic contig, matching #1307's fixture length.
+    fn bounds_genomic_provider() -> MockProvider {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_TEST.1", "TTTTTTTTTAATATATTTTAATAC");
+        provider
+    }
+
+    /// A 35-base transcript whose CDS is `13..=24`, so the 3'UTR runs `*1`..`*11`
+    /// and the 5'UTR `-1`..`-12`. The axis conversion is the whole point of the
+    /// oracle, and only a transcript with real UTRs on both sides exercises it.
+    fn bounds_transcript_provider() -> MockProvider {
+        use crate::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: Some("TEST".to_string()),
+            strand: Strand::Plus,
+            sequence: Some("GCAAAGCGCGCGATGAAACCCTAAGGCATTTTTAA".to_string()),
+            cds_start: Some(13),
+            cds_end: Some(24),
+            exons: vec![Exon::new(1, 1, 35)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::Select,
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            cds_start_incomplete: false,
+            exon_cigars: Vec::new(),
+            cached_introns: std::sync::OnceLock::new(),
+        });
+        provider
+    }
+
+    fn overrun(descriptor: &str, provider: &MockProvider) -> Option<OutOfBoundsCoordinate> {
+        let variant = parse_hgvs(descriptor).expect("fixture must parse");
+        first_out_of_bounds_coordinate(&variant, provider)
+    }
+
+    /// The three shapes the class was found in, spelled as descriptions rather
+    /// than reached through a defect, so they keep testing the predicate after
+    /// each producer is fixed.
+    #[test]
+    fn the_known_out_of_range_shapes_are_flagged() {
+        let genomic = bounds_genomic_provider();
+        // #1307 on a 24-base contig, and the same overrun inside an allele.
+        for descriptor in [
+            "NC_TEST.1:g.24_25insC",
+            "NC_TEST.1:g.[24C>G;24_25insC]",
+            // #1274's shape: a two-base identity running one past the end.
+            "NC_TEST.1:g.24_25=",
+            "NC_TEST.1:g.25del",
+            "NC_TEST.1:g.30_40del",
+        ] {
+            let found = overrun(descriptor, &genomic)
+                .unwrap_or_else(|| panic!("`{descriptor}` must be flagged as out of bounds"));
+            assert_eq!(
+                found.length, 24,
+                "`{descriptor}` compared against {found:?}"
+            );
+            assert!(
+                found.position > 24,
+                "`{descriptor}` must report the offending position, got {found:?}"
+            );
+        }
+        // #1343's shape on the transcript axis: `*12` does not exist when the
+        // 3'UTR ends at `*11`.
+        let transcript = bounds_transcript_provider();
+        let found = overrun("NM_TEST.1:c.*11_*12insAA", &transcript)
+            .expect("`c.*11_*12insAA` must be flagged");
+        assert_eq!(
+            (found.position, found.length),
+            (36, 35),
+            "the report must be on the transcript's own axis, not the `*` count: {found:?}"
+        );
+    }
+
+    /// Everything legitimate must stay silent. These are the cases that make the
+    /// check non-trivial, and each would be a false positive under a naive
+    /// comparison.
+    #[test]
+    fn legitimate_coordinates_are_not_flagged() {
+        let genomic = bounds_genomic_provider();
+        for descriptor in [
+            // A junction insertion whose right anchor IS the last base. The
+            // question is whether a position exists, not whether an edit reaches
+            // the end.
+            "NC_TEST.1:g.23_24insC",
+            "NC_TEST.1:g.24dup",
+            "NC_TEST.1:g.24C>G",
+            "NC_TEST.1:g.1_24del",
+            "NC_TEST.1:g.[24dup;24C>G]",
+            // An accession the provider does not serve: no length, no verdict.
+            "NC_ABSENT.1:g.9999del",
+        ] {
+            assert!(
+                overrun(descriptor, &genomic).is_none(),
+                "`{descriptor}` names only positions that exist and must not be flagged"
+            );
+        }
+        let transcript = bounds_transcript_provider();
+        for descriptor in [
+            // `*n` and `-n` legitimately exceed the CDS length — the reason the
+            // conversion exists. `*11` is the transcript's last base.
+            "NM_TEST.1:c.*11del",
+            "NM_TEST.1:c.*10_*11insAA",
+            "NM_TEST.1:c.-12del",
+            "NM_TEST.1:c.13del",
+            // An intronic offset has no plain axis position and is skipped.
+            "NM_TEST.1:c.13+5del",
+            // So is an uncertain boundary.
+            "NM_TEST.1:c.(13_15)del",
+        ] {
+            assert!(
+                overrun(descriptor, &transcript).is_none(),
+                "`{descriptor}` must not be flagged"
+            );
+        }
+    }
+
+    /// The 5' end of the same invariant. A position at or below zero exists on no
+    /// sequence, and the repairs that reach `g.0_1` (#1282) are the same family as
+    /// the ones that reach `g.24_25`.
+    #[test]
+    fn a_five_prime_overrun_is_flagged_too() {
+        let transcript = bounds_transcript_provider();
+        // `c.-13` is one before the transcript's first base (the 5'UTR is 12 long).
+        let found = overrun("NM_TEST.1:c.-13del", &transcript).expect("`c.-13del` must be flagged");
+        assert_eq!(
+            found.position, 0,
+            "expected the transcript-axis 0: {found:?}"
+        );
+    }
+
+    /// SVD-WG006 admits the reversed `<high>_<low>` range for a circular deletion
+    /// or duplication, so the endpoints are checked independently and their order
+    /// is never compared. Both must still exist.
+    #[test]
+    fn a_reversed_circular_range_is_judged_only_on_its_endpoints() {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_012920.1", "TTTTTTTTTAATATATTTTAATAC");
+        // In range, wrapping: legal, and the check must not read it as 24 > 3.
+        assert!(
+            overrun("NC_012920.1:m.24_3del", &provider).is_none(),
+            "a wrapped range whose ends both exist must not be flagged"
+        );
+        // Out of range on the high end, wrapping or not.
+        assert!(
+            overrun("NC_012920.1:m.25_3del", &provider).is_some(),
+            "a wrapped range naming a position past the end must still be flagged"
+        );
+    }
+
+    /// The whole diagnostic payload, not just the two numeric fields the tests
+    /// above read.
+    ///
+    /// `accession` and `member` exist so a failure inside an allele says *which*
+    /// member overran and *what length it was compared against*; they are read
+    /// only by `Normalizer::assert_in_bounds`, which is `#[cfg(debug_assertions)]`.
+    /// That left them provably dead in a release build — `cargo clippy --release
+    /// --features dev --all-targets -- -D warnings` failed with "fields
+    /// `accession` and `member` are never read" — and, more to the point, unasserted
+    /// anywhere. Reading them here fixes both.
+    #[test]
+    fn the_report_names_the_member_and_the_accession_it_compared() {
+        let genomic = bounds_genomic_provider();
+        let found = overrun("NC_TEST.1:g.[24C>G;24_25insC]", &genomic)
+            .expect("the allele's second member overruns");
+        assert_eq!(
+            found.accession, "NC_TEST.1",
+            "the report must name the provider key the length was read under"
+        );
+        assert_eq!(
+            found.member, "NC_TEST.1:g.24_25insC",
+            "the report must name the offending member, not the whole allele: {found:?}"
+        );
+        assert_eq!((found.position, found.length), (25, 24), "{found:?}");
+    }
+
+    /// The `o.` half of the case above. `o.` is a circular genomic axis like
+    /// `m.`, and the predicate's doc claims the check is "identical on `m.`/`o.`"
+    /// — but `readable_endpoints` had no `Circular` branch, so every `o.` member
+    /// yielded no readable endpoint and the oracle could not fire on one at all.
+    /// Measured before the fix: `o.25_3del` on a 24-base sequence returned
+    /// `None`, i.e. an out-of-bounds `o.` output was invisible to
+    /// `FERRO_ASSERT_IN_BOUNDS`.
+    ///
+    /// Both directions are pinned, because a branch that returned the endpoints
+    /// in the wrong order would pass a one-sided test.
+    #[test]
+    fn a_reversed_circular_o_range_is_judged_only_on_its_endpoints() {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("J01749.1", "TTTTTTTTTAATATATTTTAATAC");
+        // In range, wrapping: legal under SVD-WG006, and the check must not read
+        // it as 24 > 3.
+        assert!(
+            overrun("J01749.1:o.24_3del", &provider).is_none(),
+            "a wrapped `o.` range whose ends both exist must not be flagged"
+        );
+        // Past the end on the high side — the endpoint the wrap makes `start`.
+        let found = overrun("J01749.1:o.25_3del", &provider)
+            .expect("a wrapped `o.` range naming a position past the end must be flagged");
+        assert_eq!((found.position, found.length), (25, 24), "{found:?}");
+        // And on the *other* endpoint, so the branch is not reading only one end.
+        let found = overrun("J01749.1:o.20_25del", &provider)
+            .expect("an `o.` range whose second end is past the end must be flagged");
+        assert_eq!((found.position, found.length), (25, 24), "{found:?}");
+    }
+
+    /// An authored overrun must be reported by the same predicate on the *input*,
+    /// which is what lets the assertion exempt it instead of blaming
+    /// normalization. Reading each end independently is load-bearing here: `pter`
+    /// is unreadable, and demanding both ends made the authored `5000` invisible.
+    #[test]
+    fn an_authored_overrun_is_visible_through_a_special_position() {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_PASTEND.1", "A".repeat(200));
+        let found = overrun("NC_PASTEND.1:g.pter_5000del", &provider)
+            .expect("the readable end must be checked even though `pter` is not");
+        assert_eq!((found.position, found.length), (5000, 200), "{found:?}");
+    }
 
     /// #1135: an insertion-shaped anchor with nothing left to insert (a
     /// cancelling del+ins after 3'-shifting) must not become an `Insertion`

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -65,6 +65,8 @@ use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use boundary::Boundaries;
 pub use config::{NormalizeConfig, ShuffleDirection};
+#[cfg(debug_assertions)]
+use merge::OutOfBoundsCoordinate;
 use rules::{
     canonicalize_conversion_to_delins, canonicalize_edit, canonicalize_insertion_expand,
     is_real_substitution, is_uncertain_real_substitution, needs_normalization,
@@ -1505,6 +1507,32 @@ fn reparse_self_check_enabled() -> bool {
     })
 }
 
+/// Whether the opt-in in-bounds self-check is active.
+///
+/// Enabled when `FERRO_ASSERT_IN_BOUNDS` is set to anything other than
+/// `0`/empty. Read once and cached, like the two gates above it.
+///
+/// The third of a set, and separate from both for the same reason they are
+/// separate from each other: neither existing oracle asks this question
+/// *directly*. `parse_hgvs` has no provider and so cannot bounds-check, which
+/// makes an out-of-range output perfectly re-parseable; and while the
+/// idempotency oracle does happen to catch some instances — the #1307 output is
+/// not a fixed point — that is incidental, not the invariant. An overrun that
+/// re-normalizes to itself would pass both.
+///
+/// Cheaper than either, too: one length lookup per member, no re-normalization
+/// and no parse.
+#[cfg(debug_assertions)]
+fn in_bounds_self_check_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("FERRO_ASSERT_IN_BOUNDS")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(debug_assertions)]
 thread_local! {
     /// Re-entrancy guard for the idempotency self-check.
@@ -1696,6 +1724,58 @@ impl<P: ReferenceProvider> Normalizer<P> {
         panic!(
             "FERRO_ASSERT_REPARSE: normalization produced a description ferro cannot re-parse\n  \
              input:  {variant}\n  output: {rendered}\n  error:  {e}",
+        );
+    }
+
+    /// Assert that no coordinate in a normalized description names a position
+    /// its own sequence does not have.
+    ///
+    /// The third seam oracle (#1353), and the one that asks the question
+    /// directly. It exists because the class kept being found by hand, one shape
+    /// at a time — #1274 (`T:g.[8_9insA;10del]` → `g.10_11=` on ten bases),
+    /// #1343 (`c.[*10dup;*11dup]` → `c.*11_*12insAA`) and #1307
+    /// (`g.[24dup;24C>G]` → `g.[24C>G;24_25insC]`) — each filed, fixed and
+    /// regression-tested separately. Three instances of one defect class is the
+    /// argument for an invariant at the seam rather than a fourth per-shape test.
+    ///
+    /// Neither existing oracle covers it. `FERRO_ASSERT_REPARSE` cannot:
+    /// `parse_hgvs` holds no provider, so `g.24_25insC` is well-formed to it.
+    /// `FERRO_ASSERT_IDEMPOTENT` catches some instances incidentally — the #1307
+    /// output re-normalizes to `g.23_24insG`, so it is not a fixed point — but an
+    /// out-of-range output that *is* a fixed point passes it, which is exactly
+    /// the #1327 shape (`m.16569_16570insAA`).
+    ///
+    /// See [`merge::first_out_of_bounds_coordinate`] for what is checked, what is
+    /// deliberately not, and why a reversed circular range is not an error.
+    ///
+    /// Compiled out in release, like the two beside it.
+    #[cfg(debug_assertions)]
+    fn assert_in_bounds(&self, variant: &HgvsVariant, normalized: &HgvsVariant) {
+        if !in_bounds_self_check_enabled() {
+            return;
+        }
+        let Some(overrun) = merge::first_out_of_bounds_coordinate(normalized, &self.provider)
+        else {
+            return;
+        };
+        // Only fire when normalization *introduced* it, matching
+        // `assert_reparseable`'s discipline: an input that already names a
+        // position off the end is a caller error, and W4004 `PositionPastEnd` is
+        // the mechanism that reports it. Blaming normalization for preserving it
+        // would make the oracle's failures mean two different things.
+        if merge::first_out_of_bounds_coordinate(variant, &self.provider).is_some() {
+            return;
+        }
+        let OutOfBoundsCoordinate {
+            accession,
+            position,
+            length,
+            member,
+        } = overrun;
+        panic!(
+            "FERRO_ASSERT_IN_BOUNDS: normalization produced a coordinate the sequence does not \
+             have\n  input:  {variant}\n  output: {normalized}\n  member: {member}\n  names \
+             position {position} on {accession}, which has {length} bases",
         );
     }
 
@@ -2215,15 +2295,41 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
-        // Idempotency oracle. Placed at the single shared exit of the core so it
-        // covers `normalize()` AND every `VariantProjector` path; see
-        // `assert_idempotent` for the re-entrancy guard.
-        #[cfg(debug_assertions)]
-        self.assert_reparseable(variant, &result.result);
-        #[cfg(debug_assertions)]
-        self.assert_idempotent(variant, &result.result);
+        self.assert_seam_oracles(variant, &result.result);
 
         Ok((result.result, result.warnings))
+    }
+
+    /// The three seam oracles, run on a normalized result before it is returned.
+    ///
+    /// Ordered cheapest-and-most-specific first, so the failure a run reports is
+    /// the most precise one available: a bad coordinate is a bad coordinate
+    /// whether or not the string also re-parses or re-normalizes, and
+    /// `assert_idempotent` would otherwise report an out-of-range output as a
+    /// non-idempotency, which is the symptom rather than the fault. See
+    /// `assert_idempotent` for the re-entrancy guard.
+    ///
+    /// A method rather than an inline block because there is more than one public
+    /// exit to cover. `normalize_core_checked` is the seam for `normalize()` and
+    /// every `VariantProjector` path, but `normalize_with_diagnostics` reaches
+    /// `normalize_core_canonical` directly and so returned a normalized variant
+    /// that no oracle had ever inspected — for all three checks, not just the new
+    /// one. Calling this from both is what makes "the oracles cover every
+    /// normalized output ferro hands back" true rather than nearly true.
+    ///
+    /// Each call stays individually `#[cfg(debug_assertions)]`-gated, so the whole
+    /// body compiles away in release exactly as the inline block did.
+    fn assert_seam_oracles(&self, variant: &HgvsVariant, normalized: &HgvsVariant) {
+        #[cfg(debug_assertions)]
+        self.assert_in_bounds(variant, normalized);
+        #[cfg(debug_assertions)]
+        self.assert_reparseable(variant, normalized);
+        #[cfg(debug_assertions)]
+        self.assert_idempotent(variant, normalized);
+        // Release builds read neither parameter once the three calls above are
+        // compiled out.
+        #[cfg(not(debug_assertions))]
+        let _ = (variant, normalized);
     }
 
     /// Normalize a variant with detailed warnings
@@ -2239,6 +2345,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // must emit the same canonical variant `normalize()` does, and `infos`
         // must describe the shift from the input to *that* variant.
         let (result, warnings) = self.normalize_core_canonical(variant)?;
+        // This exit does not pass through `normalize_core_checked`, so the oracles
+        // have to be run here too — otherwise a public entry point hands back a
+        // normalized variant none of the three ever saw.
+        self.assert_seam_oracles(variant, &result);
         let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
         Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
     }
@@ -10577,6 +10687,50 @@ mod tests {
     use super::*;
     use crate::hgvs::parser::parse_hgvs;
     use crate::reference::MockProvider;
+
+    /// `Normalizer` has exactly two public normalizing methods — `normalize` and
+    /// `normalize_with_diagnostics` — and only the first went through
+    /// `normalize_core_checked`. So before `assert_seam_oracles` was factored out,
+    /// this one returned a normalized variant none of the three seam oracles had
+    /// inspected: `FERRO_ASSERT_IN_BOUNDS`, `FERRO_ASSERT_REPARSE` and
+    /// `FERRO_ASSERT_IDEMPOTENT` alike.
+    ///
+    /// The flags themselves are process-wide `OnceLock`s read from the
+    /// environment, so a unit test cannot toggle one; asserting the *invariant*
+    /// with the same predicate the oracle uses is the env-independent equivalent,
+    /// and it fails if this path ever starts emitting an out-of-range coordinate
+    /// again. In CI, where all three flags are set, this path now also gets the
+    /// live assertions for free — which is the actual fix.
+    ///
+    /// The inputs are the shapes the in-bounds class was found in (#1307's
+    /// terminal-dup collision and #1274's two-base identity), each authored at the
+    /// end of a 24-base contig where an overrun is one step away.
+    #[test]
+    fn the_diagnostics_exit_returns_in_bounds_coordinates_too() {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_TEST.1", "TTTTTTTTTAATATATTTTAATAC".to_string());
+        let normalizer = Normalizer::new(provider);
+        for descriptor in [
+            "NC_TEST.1:g.[24dup;24C>G]",
+            "NC_TEST.1:g.[24dup;24delinsGG]",
+            "NC_TEST.1:g.24dup",
+            "NC_TEST.1:g.23_24insC",
+            "NC_TEST.1:g.24C>G",
+        ] {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            let diagnosed = normalizer
+                .normalize_with_diagnostics(&variant)
+                .unwrap_or_else(|e| panic!("`{descriptor}` must normalize: {e}"));
+            let overrun =
+                merge::first_out_of_bounds_coordinate(&diagnosed.result, normalizer.provider());
+            assert!(
+                overrun.is_none(),
+                "`{descriptor}` -> `{}` through normalize_with_diagnostics names a \
+                 coordinate off the end: {overrun:?}",
+                diagnosed.result
+            );
+        }
+    }
 
     #[test]
     fn test_normalize_substitution_unchanged() {

--- a/tests/it/issue_336_position_past_end.rs
+++ b/tests/it/issue_336_position_past_end.rs
@@ -247,9 +247,17 @@ fn strict_mode_n_in_bounds_does_not_emit_warning() {
     // Non-coding transcript: no cds_start / cds_end. An in-bounds n.
     // position must pass the new check_tx_pos_past_end check silently
     // — no panic, no warning.
+    //
+    // The stated reference base has to be the real one. The fixture is
+    // `ACGTACGTACGTACGTACGT`, so `n.10` is `C`, and this read `n.10G>C` until the
+    // seam oracles started covering `normalize_with_diagnostics`: in strict mode
+    // the wrong base is a `RefSeqMismatch`, which `normalize()` promotes to a hard
+    // error but this exit does not, so `FERRO_ASSERT_IDEMPOTENT` failed
+    // re-normalizing an output `normalize()` would have rejected outright. The
+    // position, not the base, is what this test is about, so it states `C`.
     let provider = provider_with_short_noncoding_transcript();
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
-    let variant = parse_hgvs("NR_TEST.1:n.10G>C").expect("parse");
+    let variant = parse_hgvs("NR_TEST.1:n.10C>G").expect("parse");
     let result = normalizer
         .normalize_with_diagnostics(&variant)
         .expect("in-bounds n. variant must not error");


### PR DESCRIPTION
Closes #1353

Adds `FERRO_ASSERT_IN_BOUNDS`, a third oracle at `normalize_core_checked`'s single exit: no coordinate a normalized description names may be past the end of its own sequence. Being at that seam, it covers `normalize()` and every `VariantProjector` path.

## Why a seam invariant rather than a fourth test

The class kept being found by hand, one shape at a time, each filed and fixed separately:

| issue | shape | state |
| --- | --- | --- |
| #1274 | `T:g.[8_9insA;10del]` → `g.10_11=` on a 10-base contig | closed (#1341) |
| #1343 | `c.[*10dup;*11dup]` → `c.*11_*12insAA`, `*12` does not exist | closed (#1339) |
| #1307 | `g.[24dup;24C>G]` → `g.[24C>G;24_25insC]` on 24 bases | fixed by #1365 |

Neither existing oracle asks the question. `FERRO_ASSERT_REPARSE` cannot — `parse_hgvs` holds no provider, so `g.24_25insC` is well-formed to it.

`FERRO_ASSERT_IDEMPOTENT` is a more interesting case, and **#1353's premise about it is not quite right**. The issue says it "accepts it, because it is a fixed point". Measured against `origin/main`, the #1307 output is *not* a fixed point:

```text
input: NC_TEST.1:g.[24dup;24C>G]
once:  NC_TEST.1:g.[24C>G;24_25insC]
twice: NC_TEST.1:g.23_24insG
```

So that oracle does catch some instances — incidentally, not by design. An out-of-range output that *is* a fixed point passes it, which is exactly the #1327 shape (`m.16569_16570insAA`). The new oracle asks directly, and is the cheapest of the three: one length lookup per member, no parse and no re-normalization.

## What makes it more than a comparison

- **Positions are converted onto the served sequence's axis first.** A `c.` position legitimately exceeds the CDS length — `*n` counts into the 3'UTR, `-n` into the 5'UTR — so `region_sequence_delta` runs before anything is compared. `c.*11` on a 35-base transcript with a 12-base CDS is in range; comparing `11` against `24` would say nothing.
- **A reversed range is not an error.** SVD-WG006 admits `<high>_<low>` for a circular deletion or duplication (`NC_012920.1:m.16563_13del`), so the two endpoints are checked independently and their order is never compared. That makes the check identical on `m.`/`o.` and on the linear axes, which is the honest answer — a circular sequence has a last base like any other, and #1327 already established that the wrapped *insertion* spelling that would blur it is not valid HGVS. It also agrees with the existing `issue_393_mt_w4004` guard.
- **A junction insertion whose right anchor is the last base stays silent.** The question is whether a position exists, not whether an edit reaches the end: `g.23_24insC` on 24 bases is correct, `g.24_25insC` is the defect.
- **An authored overrun is exempt**, since W4004 `PositionPastEnd` is the mechanism that reports those. Blaming normalization for preserving a caller's coordinate would make the oracle's failures mean two different things.

## A correction the suite found

The first cut failed one test, and the failure was instructive rather than cosmetic:

```text
FERRO_ASSERT_IN_BOUNDS: normalization produced a coordinate the sequence does not have
  input:  NC_PASTEND.1:g.pter_5000del
  output: NC_PASTEND.1:g.1_5000del
  names position 5000 on NC_PASTEND.1, which has 200 bases
```

`5000` is the caller's. The exemption did not fire because `member_endpoints` demands **both** ends and `pter` is unreadable, so the input looked in-bounds. `readable_endpoints` reads each end independently — the difference is load-bearing, not stylistic, and is pinned by its own test.

## Not covered, and said so

Documented on `merge::first_out_of_bounds_coordinate` rather than left implicit: protein axes (`member_endpoints` is nucleotide-only, and all three known instances are nucleotide), an inserted-range payload (`g.10_11ins[20_30]`), and intronic/unknown/uncertain/special positions, which have no plain axis position to check. A provider that cannot report a length leaves the member unchecked — the oracle only fires on a *known* overrun.

## Tests

The predicate is `pub(crate)`, so its contract is unit-tested directly in `merge.rs` rather than through the env-gated assertion. Five tests: the three known out-of-range shapes (spelled as descriptions, so they keep testing the predicate after each producer is fixed); the legitimate cases that would each be a false positive under a naive comparison; the 5' half of the invariant (`c.-13` → transcript position 0); the reversed circular range; and the authored-overrun-behind-`pter` case above.

End-to-end wiring is verified by CI running the whole suite with the flag set. Separately measured by hand on this branch, where #1307 is still live:

```text
output: NC_TEST.1:g.[24C>G;24_25insC]
oracle FIRES: OutOfBoundsCoordinate { accession: "NC_TEST.1", position: 25, length: 24, member: "NC_TEST.1:g.24_25insC" }
input flagged? false
```

## Merge order

The oracle **does** fire on #1307, which **#1365** fixes. No exemption was needed here because no test in the current corpus normalizes that shape, so this branch is green either way — but #1365 should land first, so the invariant is never briefly true only by corpus accident.

## CI

Set alongside the existing pair in the sharded `test` job and the soak job, and in `nightly-mutalyzer.yml` — the nightly being the only job with a real prepared reference, so the only place the check runs against true transcript and contig lengths. `actionlint` clean. Documented in `CLAUDE.md` beside the other two oracles.

## Verification

- `FERRO_ASSERT_IN_BOUNDS=1 FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — **9191/9191 pass**, 146 skipped
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean; `actionlint` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect normalized coordinates extending beyond their referenced sequence.
  * Improved handling of transcript-relative, circular, terminal, and special-position coordinates.
  * Prevented false positives for overruns already present in the original input.
  * Extended validation to diagnostic normalization and improved regression coverage.

* **Documentation**
  * Documented the optional bounds-validation check, supported cases, exemptions, failure handling, and CI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->