### PR TITLE
fix(normalize): validate the reference base an identity member states

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2224,8 +2224,8 @@ fn collect_canonical_edits(
 /// Whether every member's *stated* reference base agrees with the window.
 ///
 /// `NaEdit` optionally carries the reference bases the submitter asserted
-/// (`c.5A>T`, `c.5_7delACG`). Where present they must match, otherwise the
-/// variant is a reference mismatch and belongs to the per-member pipeline's
+/// (`c.5A>T`, `c.5_7delACG`, `c.263A=`). Where present they must match, otherwise
+/// the variant is a reference mismatch and belongs to the per-member pipeline's
 /// strict-reject / warn path rather than to canonicalization.
 fn stated_reference_bases_match(
     variants: &[HgvsVariant],
@@ -2245,7 +2245,27 @@ fn stated_reference_bases_match(
         // canonicalized out from under strict mode.
         let stated = match edit {
             NaEdit::Substitution { reference, .. } => Some(vec![*reference]),
-            NaEdit::Deletion {
+            // `c.263A=` asserts that position 263 is `A`, so an identity that
+            // spells its sequence is a stated-reference channel like any other
+            // (#1352). It was missing while the doc comment above claimed the
+            // list was complete, and the safety therefore rested on a refusal in
+            // a *different* function — `collect_canonical_edits` declines
+            // `Identity` at its catch-all — which is exactly the coupling that
+            // comment warns against. Inert until something upstream stops
+            // refusing identity members, which is the point: the validator
+            // should be correct before the refusal is relaxed, not as part of
+            // relaxing it.
+            //
+            // `..` rather than `whole_entity: false`: a whole-entity identity
+            // (`c.=`) carries no sequence in anything the parser produces, but if
+            // one ever arrives with bases, comparing them is the fail-safe
+            // answer — a mismatch refuses canonicalization, whereas skipping the
+            // arm is the very hole being closed.
+            NaEdit::Identity {
+                sequence: Some(seq),
+                ..
+            }
+            | NaEdit::Deletion {
                 sequence: Some(seq),
                 ..
             }
@@ -6447,6 +6467,79 @@ mod tests {
         }
     }
 
+    // Stated-reference validator (#1352)
+    // ------------------------------------------------------------------
+
+    /// `stated_reference_bases_match` against a window that starts at position 1,
+    /// so a member's stated bases are compared with `reference[s - 1..]`.
+    fn stated_bases_agree(descriptor: &str, reference: &str) -> bool {
+        let variant = parse_hgvs(descriptor).expect("fixture must parse");
+        let members: Vec<HgvsVariant> = match variant {
+            HgvsVariant::Allele(allele) => allele.variants.clone(),
+            single => vec![single],
+        };
+        stated_reference_bases_match(&members, CisKind::Genome, reference.as_bytes(), 1)
+    }
+
+    /// An identity spelling its base asserts that base, so a wrong assertion must
+    /// be caught (#1352).
+    ///
+    /// The channel was missing from the alternation while the function's own doc
+    /// comment claimed the list was complete, so a wrongly-stated `g.3T=` on a
+    /// reference `A` fell through to `_ => None` and was accepted. The validator's
+    /// correctness rested instead on `collect_canonical_edits` refusing identity
+    /// members — a guard in a different function, which is the coupling the doc
+    /// comment warns about.
+    #[test]
+    fn a_wrongly_stated_identity_base_is_rejected() {
+        //                     1234567
+        let reference = "GGATTAC";
+        // Position 3 is `A`.
+        assert!(
+            stated_bases_agree("NC_TEST.1:g.3A=", reference),
+            "a correctly stated identity base must be accepted"
+        );
+        assert!(
+            !stated_bases_agree("NC_TEST.1:g.3T=", reference),
+            "a wrongly stated identity base must be rejected — before #1352 this \
+             channel fell through to the catch-all and was accepted"
+        );
+    }
+
+    /// An identity that states no base asserts nothing, so it must stay neutral.
+    /// The arm keys off `sequence: Some(..)`, and a bare `g.3=` has `None`.
+    #[test]
+    fn a_bare_identity_asserts_nothing() {
+        assert!(
+            stated_bases_agree("NC_TEST.1:g.3=", "GGATTAC"),
+            "a bare identity carries no assertion and must not be judged"
+        );
+    }
+
+    /// The channels that were already covered must keep working — the new arm
+    /// shares its binding with four of them, so a mis-edit there would be silent.
+    #[test]
+    fn the_pre_existing_stated_reference_channels_still_match() {
+        //                     1234567
+        let reference = "GGATTAC";
+        for (descriptor, expected) in [
+            ("NC_TEST.1:g.3A>G", true),
+            ("NC_TEST.1:g.3T>G", false),
+            ("NC_TEST.1:g.3_5delATT", true),
+            ("NC_TEST.1:g.3_5delAAA", false),
+            ("NC_TEST.1:g.3_5dupATT", true),
+            ("NC_TEST.1:g.3_5dupAAA", false),
+            ("NC_TEST.1:g.3_5delATTinsGG", true),
+            ("NC_TEST.1:g.3_5delAAAinsGG", false),
+        ] {
+            assert_eq!(
+                stated_bases_agree(descriptor, reference),
+                expected,
+                "`{descriptor}` against `{reference}`"
+            );
+        }
+    }
+
     /// The 5' end of the same invariant. A position at or below zero exists on no
     /// sequence, and the repairs that reach `g.0_1` (#1282) are the same family as
     /// the ones that reach `g.24_25`.
@@ -6547,6 +6640,16 @@ mod tests {
         let found = overrun("NC_PASTEND.1:g.pter_5000del", &provider)
             .expect("the readable end must be checked even though `pter` is not");
         assert_eq!((found.position, found.length), (5000, 200), "{found:?}");
+    }
+
+    /// A stated base running past the window is a refusal, not a panic. Shared
+    /// with every channel, but the new arm is a fresh way to reach it.
+    #[test]
+    fn a_stated_identity_past_the_window_is_refused() {
+        assert!(
+            !stated_bases_agree("NC_TEST.1:g.99A=", "GGATTAC"),
+            "an assertion outside the window must be refused rather than indexed"
+        );
     }
 
     /// #1135: an insertion-shaped anchor with nothing left to insert (a


### PR DESCRIPTION
Closes #1352

`stated_reference_bases_match` guards the sequence-first cis canonicalization against a member whose submitter-asserted reference base disagrees with the reference: that is a reference mismatch, and it belongs to the per-member pipeline's strict-reject / warn path rather than to canonicalization. Its doc comment claims the channel list is complete, and says why that matters:

> a validator that silently ignores half the channels it claims to cover is one pipeline reordering away from letting a reference mismatch be canonicalized out from under strict mode.

`NaEdit::Identity { sequence: Some(..) }` does carry an assertion — `c.263A=` states that position 263 is `A` — and was not in the list, so it fell through to `_ => None` and nothing was checked.

## Why this is worth fixing while it changes nothing

Verified inert, and the mechanism is the point. `collect_canonical_edits` runs first (line 1896 against the validator's 1930) and refuses `Identity` at its catch-all, so no identity member reaches the validator today. The validator's correctness therefore rests on a refusal in a **different function** rather than on its own coverage — exactly the coupling its doc comment warns about. Relaxing that refusal (as #1351's work on identity members may want to) would make the gap live in the same commit that introduces it.

Full suite is unchanged at 9194/9194, which is the claim rather than a caveat.

## Matched with `..`, not `whole_entity: false`

Nothing the parser produces gives a whole-entity identity (`c.=`) a sequence. If one ever arrives with bases, comparing them is the fail-safe answer — a mismatch refuses canonicalization — whereas restricting the arm to `whole_entity: false` would silently skip it, which is the shape of the hole being closed.

## Tests

The validator is private and the arm is unreachable end to end, so four unit tests in `merge.rs` cover it directly:

- a correctly-stated identity base is accepted, a wrongly-stated one rejected (`g.3A=` vs `g.3T=` on `GGATTAC`)
- a bare `g.3=` asserts nothing and stays neutral — the arm keys off `Some(..)`
- the four pre-existing channels that share the new arm's binding still match, both ways (sub / del / dup / delins)
- an assertion running past the window is a refusal, not a panic

**Verified the tests fail without the fix**: removing the arm again turns `a_wrongly_stated_identity_base_is_rejected` and `a_stated_identity_past_the_window_is_refused` red, so they test the change rather than merely accompany it.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — **9194/9194 pass**, 146 skipped
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of asserted reference bases in sequence-bearing identity edits.
  * Correctly handles descriptions such as `c.263A=`.
  * Preserves support for bare identities without sequence data.
  * Added safeguards for out-of-window references and existing reference validation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->