### PR TITLE
fix(normalize): stop an out-of-phase rotation from killing a valid repeat

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -362,23 +362,135 @@ pub fn insertion_to_repeat(
     // inside `normalize_repeat` below, not here — see the delegation note.
 
     // The inserted sequence may be written as any cyclic rotation of the
-    // reference repeat unit (e.g. `insCAGCAG` against a `GCA` tract). Try
-    // every rotation of `base_unit` and pick the one that yields the
-    // largest contiguous tandem run anchored at the insertion point.
+    // reference repeat unit (e.g. `insCAGCAG` against a `GCA` tract). Try every
+    // rotation of `base_unit` and pick the one that yields the largest
+    // contiguous tandem run anchored at the insertion point.
+    //
+    // Each rotation is resolved to the repeat it would actually emit — and
+    // gated — before it can win (#1355). Scoring first and gating only the
+    // winner let a rotation that abuts a longer but out-of-phase tract discard a
+    // valid in-phase one and take the whole result down with it, which is
+    // byte-for-byte the defect #1349 corrected in `insertion_to_duplication`.
+    // The two functions are a deliberate symmetric pair, so they now share the
+    // shape as well: resolve per candidate, `continue` on rejection.
     let u_len = base_unit.len();
-    let mut best: Option<(Vec<u8>, usize, u64)> = None;
+    let mut best: Option<RepeatCandidate> = None;
     for r in 0..u_len {
         let mut rotated = Vec::with_capacity(u_len);
         rotated.extend_from_slice(&base_unit[r..]);
         rotated.extend_from_slice(&base_unit[..r]);
-        if let Some((ref_start, ref_count)) = find_tandem_extent(ref_seq, pos as usize, &rotated) {
-            if ref_count > 0 && best.as_ref().is_none_or(|(_, _, bc)| ref_count > *bc) {
-                best = Some((rotated, ref_start, ref_count));
-            }
+        let Some((ref_start, ref_count)) = find_tandem_extent(ref_seq, pos as usize, &rotated)
+        else {
+            continue;
+        };
+        if ref_count == 0 {
+            continue;
         }
+        // Ties still fall to iteration order, as before: strictly-greater keeps
+        // the first rotation found. Adding a direction-aware tie-break here
+        // would be a separate behaviour change from the ordering fix
+        // (`insertion_to_duplication` grew one for #403; this function has never
+        // had one).
+        if best
+            .as_ref()
+            .is_some_and(|current| ref_count <= current.ref_count)
+        {
+            // Cannot become `best` whatever the gates say, and resolving it
+            // costs a `normalize_repeat` call plus two `ref_seq`-sized buffers.
+            continue;
+        }
+        let Some(candidate) = resolve_repeat_rotation(
+            ref_seq,
+            pos,
+            inserted_seq,
+            ref_start,
+            ref_count,
+            rotated,
+            added_copies,
+            is_coding,
+            cds_span,
+            direction,
+        ) else {
+            continue;
+        };
+        best = Some(candidate);
     }
 
-    let (unit, ref_start, ref_count) = best?;
+    let best = best?;
+    Some((
+        best.rotated_unit[0],
+        best.total_count,
+        index_to_hgvs_pos(best.start_idx),
+        best.emitted_end_hgvs,
+        best.rotated_unit,
+    ))
+}
+
+/// One rotation's resolved repeat emission, after both gates have accepted it.
+struct RepeatCandidate {
+    /// Copies of the rotated unit in the matched reference tract — the score.
+    ref_count: u64,
+    /// 0-based start of the emitted repeat window.
+    start_idx: usize,
+    /// 1-based inclusive HGVS end of the emitted repeat window.
+    emitted_end_hgvs: u64,
+    /// The phase-aligned unit `normalize_repeat` settled on, which may differ
+    /// from the rotation fed in.
+    rotated_unit: Vec<u8>,
+    /// Total copies the emitted repeat asserts.
+    total_count: u64,
+}
+
+/// Resolve one cyclic rotation to the repeat it would emit, or `None` if either
+/// gate rejects it.
+///
+/// Split out of [`insertion_to_repeat`] so every rotation is judged on the values
+/// the caller would actually receive (#1355), mirroring [`align_dup_slot`]'s role
+/// in `insertion_to_duplication` (#1349). The difference between the two is why
+/// this one is bigger: a duplication slot is pure arithmetic, whereas a repeat
+/// has to go through `normalize_repeat`, which owns the window, the count and the
+/// codon decision.
+///
+/// # Both rejections are a `continue` at the call site, and both mean `None`
+///
+/// - The **#882 phase gate** (`tandem_edit_preserves_insertion`): a rotation that
+///   fails it is not a repeat of *this* insertion at all, so it must not compete,
+///   and must not shadow a lower-scoring rotation that is. This is the #1355 fix.
+/// - The **#1210 codon gate**, reached as `RepeatNormResult::Insertion`: in a `c.`
+///   context a non-codon-length unit may not be written as repeat notation, so
+///   the caller emits the literal `ins` instead.
+///
+/// The codon gate previously aborted the whole function (`return None`) because
+/// it was only ever reached by the winner. Inside a selection loop that would be
+/// wrong in a new way — a losing rotation could abort a search that had a valid
+/// answer — so it became a `continue` too. **This is observably different only
+/// when the highest-scoring rotation is codon-gated while a lower-scoring one is
+/// not**, and the two answers there are "literal `ins`" versus "a repeat over the
+/// other tract". `continue` is the right one, for the same reason the phase gate
+/// is: all rotations of a unit share its length, so the codon gate can differ
+/// between them only through `gate_is_coding` — that is, through which *tract*
+/// each rotation found. The gate is a statement about a tract, not about the
+/// insertion, and a tract that clears both gates describes the same edit
+/// correctly.
+///
+/// The FAIL-set ledgers this could have moved are the manifest-gated conformance
+/// axes — `axis_normalized`, `axis_genomic`, `axis_errors` and both idempotency
+/// axes. They were re-run against a real prepared reference when this landed; the
+/// measurement lives in the commit message rather than here, since a doc comment
+/// asserting "the suite is green" rots the moment anything else changes.
+#[allow(clippy::too_many_arguments)]
+fn resolve_repeat_rotation(
+    ref_seq: &[u8],
+    pos: u64,
+    inserted_seq: &[u8],
+    ref_start: usize,
+    ref_count: u64,
+    unit: Vec<u8>,
+    added_copies: u64,
+    is_coding: bool,
+    cds_span: Option<(u64, u64)>,
+    direction: crate::normalize::config::ShuffleDirection,
+) -> Option<RepeatCandidate> {
     let ref_end_excl = ref_start + ref_count as usize * unit.len();
 
     // #1210: answer the codon gate for the span the REPEAT will occupy, not for
@@ -402,7 +514,9 @@ pub fn insertion_to_repeat(
     // Frames line up: `ref_start` / `ref_end_excl` are 0-based indices into the
     // transcript-frame `ref_seq`, and `cds_span` is 1-based inclusive in that
     // same frame, so the 1-based inclusive tract is
-    // `(ref_start + 1) ..= ref_end_excl`.
+    // `(ref_start + 1) ..= ref_end_excl`. Per rotation since #1355, which is also
+    // more correct than it was: each rotation finds its own tract, so each gets
+    // its own residency answer instead of the winner's.
     let gate_is_coding = match cds_span {
         Some((cds_start, cds_end)) => {
             let tract_start = ref_start as u64 + 1;
@@ -422,8 +536,8 @@ pub fn insertion_to_repeat(
     // direction-aware phase alignment + codon gate — so the emitted
     // window/unit/count agree with `normalize_repeat` on the same reference tract
     // in the same direction. `added_copies >= 2` ⇒ the target is
-    // `>= ref_count + 2`, so only `Repeat` (or the codon-gated `Insertion` → None)
-    // is reachable; `Deletion`/`Duplication`/`Unchanged` cannot occur.
+    // `>= ref_count + 2`, so only `Repeat` (or the codon-gated `Insertion` →
+    // `None`) is reachable; `Deletion`/`Duplication`/`Unchanged` cannot occur.
     let target = ref_count + added_copies;
     let end_pos_incl = ref_end_excl - 1;
     let (start_idx, emitted_end_hgvs, rotated_unit, total_count) = match normalize_repeat(
@@ -474,13 +588,13 @@ pub fn insertion_to_repeat(
         return None;
     }
 
-    Some((
-        rotated_unit[0],
-        total_count,
-        index_to_hgvs_pos(start_idx),
+    Some(RepeatCandidate {
+        ref_count,
+        start_idx,
         emitted_end_hgvs,
         rotated_unit,
-    ))
+        total_count,
+    })
 }
 
 /// Description of how a single-copy insertion can be re-expressed as a
@@ -5917,6 +6031,62 @@ mod tests {
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 10);
         assert_eq!(r.end, 11);
+    }
+
+    /// #1355: an out-of-phase rotation with a longer tract must not discard a
+    /// valid in-phase repeat.
+    ///
+    /// The same defect #1349 fixed in `insertion_to_duplication`, one function
+    /// over. `insertion_to_repeat` scored every cyclic rotation, kept the single
+    /// highest-`ref_count` winner, and only then applied the #882 phase gate — so
+    /// a rotation that abuts a longer but out-of-phase tract took the whole result
+    /// down with it.
+    ///
+    /// On `GTACGTCCCCTCCTCCTCCTCCCGGGG` with a 2-copy `TCCTCC` inserted at 7:
+    ///   - rotation `TCC` abuts a one-copy in-phase tract at `[5, 8)` — valid;
+    ///   - rotation `CCT` abuts a four-copy tract at index 8 — out of phase, and
+    ///     it wins on `ref_count`.
+    #[test]
+    fn an_out_of_phase_rotation_does_not_discard_a_valid_repeat() {
+        let r = b"GTACGTCCCCTCCTCCTCCTCCCGGGG";
+        // The candidate that was being thrown away is genuinely valid.
+        assert!(
+            tandem_edit_preserves_insertion(r, 7, b"TCCTCC", 5, 8, b"TCC", 3),
+            "the discarded `TCC` candidate must pass the #882 gate"
+        );
+        // Both directions must find it. `find_tandem_extent` scores the rotations
+        // identically either way, so the loser-takes-all bug was direction-blind.
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let emitted = insertion_to_repeat(r, 7, b"TCCTCC", false, None, direction)
+                .unwrap_or_else(|| panic!("{direction:?}: a valid in-phase repeat must be found"));
+            let (_, count, start, end, unit) = emitted;
+            assert_eq!(
+                (unit.as_slice(), count, start, end),
+                (b"TCC".as_slice(), 3, 6, 8),
+                "{direction:?}: expected the in-phase `TCC[3]` over the 1-based tract 6_8"
+            );
+        }
+    }
+
+    /// The emitted repeat must decode back to the input insertion, whichever
+    /// rotation won. This is the property the phase gate exists to guarantee, and
+    /// asserting it separately means a future selection change cannot satisfy the
+    /// pinned values above while breaking the contract underneath them.
+    #[test]
+    fn every_emitted_repeat_decodes_to_its_input_insertion() {
+        let r = b"GTACGTCCCCTCCTCCTCCTCCCGGGG";
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let (_, count, start, end, unit) =
+                insertion_to_repeat(r, 7, b"TCCTCC", false, None, direction).expect("fires");
+            let start_idx = hgvs_pos_to_index(start);
+            let end_excl = hgvs_pos_to_index(end) + 1;
+            assert!(
+                tandem_edit_preserves_insertion(r, 7, b"TCCTCC", start_idx, end_excl, &unit, count),
+                "{direction:?}: emitted `{}[{count}]` over [{start_idx}, {end_excl}) does not \
+                 decode to the input insertion",
+                String::from_utf8_lossy(&unit)
+            );
+        }
     }
 
     #[test]

--- a/tests/it/issue_1355_rotation_gate_repeat.rs
+++ b/tests/it/issue_1355_rotation_gate_repeat.rs
@@ -1,0 +1,267 @@
+//! Regression for #1355, at the `Normalizer` level.
+//!
+//! `insertion_to_repeat` scored every cyclic rotation of the inserted unit by the
+//! size of the reference tandem tract it abuts, kept the single
+//! highest-`ref_count` winner, and only then applied the #882 preservation gate.
+//! So a rotation abutting a longer but *out-of-phase* tract discarded a valid
+//! in-phase repeat and took the whole result down with it — the rotation that
+//! lost on score was never reconsidered.
+//!
+//! `NM_TEST1355.1:c.2_3insTCCTCC` is the repro. Rotation `TCC` abuts a one-copy
+//! in-phase tract at c.-1_2 (the correct answer); rotation `CCT` abuts a
+//! four-copy tract further 3' that is out of phase with the insertion, and wins
+//! on count. Before the fix the 3' direction emitted the un-promoted
+//! `c.2_3insTCCTCC` while the 5' direction emitted `c.1delinsCCTCCTC`, so the two
+//! directions also *disagreed* about an edit that is direction-independent. Both
+//! now reach `c.-1_2TCC[3]`.
+//!
+//! This is byte-for-byte the defect #1349 corrected in `insertion_to_duplication`
+//! one function over, so this file is deliberately the sibling of
+//! `issue_1349_rotation_fallback_dup.rs` and shares its synthetic reference.
+//!
+//! The unit tests in `rules.rs` call `insertion_to_repeat` directly. These go
+//! through `Normalizer::normalize` — and therefore `normalize_core_checked`,
+//! where the `FERRO_ASSERT_IDEMPOTENT=1` / `FERRO_ASSERT_REPARSE=1` oracles sit —
+//! so the emitted repeat is judged as a whole-variant answer rather than as a
+//! tuple of five fields.
+
+use ferro_hgvs::normalize::rules::insertion_to_repeat;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// 5'UTR `GTACGT`, then a CDS opening `CCCCTCCTCCTCCTCCCGGGG` (the #1349
+/// sequence, so the sibling defects share a reference), then a CDS-internal `TA`
+/// tract for the codon-gate case below.
+///
+/// ```text
+/// axis: c.-6 … c.-1 | c.1 c.2 c.3 … c.21 c.22 c.23 … c.30
+/// base:  G  …   T   |  C   C   C  …   G    G    T  …   A
+/// ```
+///
+/// The two tracts that compete for `c.2_3insTCCTCC`:
+///   - `TCC` at c.-1_2 (one copy) — abuts the insertion point, in phase;
+///   - `CCT` over c.3_14 (four copies, 0-based `[8, 20)`) — out of phase with the
+///     insertion, and it outscores `TCC` four to one.
+const UTR5: &str = "GTACGT";
+const CDS_OPEN: &str = "CCCCTCCTCCTCCTCCCGGGG";
+const CDS_TA_TRACT: &str = "GTATATATA";
+const UTR3: &str = "AAAAAAAAAA";
+
+/// 1-based position of `c.1`: `UTR5` is six bases, so `c.1` is the seventh.
+const CDS_START: u64 = 7;
+
+fn transcript_sequence() -> String {
+    format!("{UTR5}{CDS_OPEN}{CDS_TA_TRACT}{UTR3}")
+}
+
+/// 1-based inclusive CDS end — everything but the 3'UTR. The CDS is 30 bases
+/// (ten codons), so the codon gate is not tripped by a ragged CDS length.
+fn cds_end() -> u64 {
+    (UTR5.len() + CDS_OPEN.len() + CDS_TA_TRACT.len()) as u64
+}
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = transcript_sequence();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST1355.1".to_string(),
+        Some("TEST1355".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(CDS_START),
+        Some(cds_end()),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{normalized}")
+}
+
+const REPRO: &str = "NM_TEST1355.1:c.2_3insTCCTCC";
+const EXPECTED: &str = "NM_TEST1355.1:c.-1_2TCC[3]";
+
+/// The in-phase `TCC` tract must be found even though the out-of-phase `CCT`
+/// rotation outscores it. Before the fix this direction emitted the input back
+/// unchanged, having discarded the only valid candidate.
+#[test]
+fn three_prime_insertion_promotes_to_the_in_phase_repeat() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, REPRO),
+        EXPECTED
+    );
+}
+
+/// Same answer in the other direction. `find_tandem_extent` scores the rotations
+/// identically either way, so the loser-takes-all bug was direction-blind — but
+/// its *symptoms* were not: 5' fell through to the CDS-start clamp and emitted
+/// `c.1delinsCCTCCTC`, so the two directions disagreed about an edit whose
+/// canonical form is direction-independent.
+#[test]
+fn five_prime_insertion_promotes_to_the_in_phase_repeat() {
+    assert_eq!(normalize_with(ShuffleDirection::FivePrime, REPRO), EXPECTED);
+}
+
+/// The directions agree, pinned as its own assertion so a future change that
+/// moves the canonical answer still has to move it in both directions together.
+#[test]
+fn both_directions_agree() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, REPRO),
+        normalize_with(ShuffleDirection::FivePrime, REPRO),
+    );
+}
+
+/// `norm(norm(x)) == norm(x)` in both directions, which is what the
+/// `FERRO_ASSERT_IDEMPOTENT=1` oracle asserts for every normalize call in the
+/// suite; pinned here too so the guard holds without the env var set.
+#[test]
+fn normalization_is_a_fixed_point_in_both_directions() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let once = normalize_with(direction, REPRO);
+        let twice = normalize_with(direction, &once);
+        assert_eq!(
+            once, twice,
+            "{direction:?}: normalization must be idempotent"
+        );
+    }
+}
+
+/// The emitted repeat must describe the *same haplotype* as the input insertion.
+///
+/// Checked by splicing both edits into the reference by hand and comparing bytes,
+/// deliberately **not** through `tandem_edit_preserves_insertion` — that is the
+/// production predicate the fix relies on, so using it here would only assert
+/// that the code agrees with itself.
+///
+/// Coordinates, both derived from the pinned strings above:
+///   - input `c.2_3ins`: `c.2` is 1-based position 8, so the insertion splices in
+///     at 0-based index 8;
+///   - emitted `c.-1_2TCC[3]`: `c.-1` is 1-based position 6 and `c.2` is 8, so
+///     the repeat replaces 0-based `[5, 8)` with three copies of `TCC`.
+#[test]
+fn the_emitted_repeat_reconstructs_the_inserted_haplotype() {
+    // Tie the hardcoded coordinates below to what normalization actually emits.
+    // Without this the test would assert only a property of the reference and
+    // would stay green if the emission ever moved.
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize_with(direction, REPRO),
+            EXPECTED,
+            "{direction:?}: the coordinates below are derived from this emission"
+        );
+    }
+
+    let reference = transcript_sequence();
+
+    let mut from_input = String::new();
+    from_input.push_str(&reference[..8]);
+    from_input.push_str("TCCTCC");
+    from_input.push_str(&reference[8..]);
+
+    let mut from_repeat = String::new();
+    from_repeat.push_str(&reference[..5]);
+    from_repeat.push_str(&"TCC".repeat(3));
+    from_repeat.push_str(&reference[8..]);
+
+    assert_eq!(
+        from_input, from_repeat,
+        "`{EXPECTED}` must spell the same haplotype as `{REPRO}`"
+    );
+}
+
+/// A codon-gated tract declines the repeat and the pipeline still lands a valid
+/// answer.
+///
+/// In a `c.` context a CDS-resident tract with a non-codon-length unit may not be
+/// written as repeat notation (#1210), which inside the rotation loop arrives as
+/// `RepeatNormResult::Insertion`. `c.24_25insTATA` sits in the `TA` tract at
+/// c.23_30, wholly inside the CDS, so `insertion_to_repeat` declines — proven to be
+/// the *gate*, not a failed tract search, by the sibling test below. The pipeline
+/// keeps going and promotes the edit to a duplication; `dup` carries no codon
+/// restriction, since the spec's exception forbids only `[N]`. Which copy is named
+/// is the direction rule's call, so the two directions differ here by design.
+///
+/// **What this does not pin.** #1355 turned that gate's `return None` into a
+/// `continue`, and this case cannot tell the two apart: *every* rotation here
+/// shares the one CDS-resident tract, so both spellings decline the function and
+/// this test passes against `main` as well. The two are observably different only
+/// when the highest-scoring rotation is codon-gated while a lower-scoring one is
+/// not — which needs two tracts straddling `cds_end` so they get different
+/// residency answers, and is not constructed here. The value below is still worth
+/// pinning: it is the fixed point the codon-gated path has to keep reaching.
+#[test]
+fn a_codon_gated_tract_still_reaches_a_fixed_point() {
+    for (direction, expected) in [
+        (ShuffleDirection::ThreePrime, "NM_TEST1355.1:c.27_30dup"),
+        (ShuffleDirection::FivePrime, "NM_TEST1355.1:c.23_26dup"),
+    ] {
+        let once = normalize_with(direction, "NM_TEST1355.1:c.24_25insTATA");
+        assert_eq!(
+            once, expected,
+            "{direction:?}: a codon-gated repeat must fall through to the dup"
+        );
+        let twice = normalize_with(direction, &once);
+        assert_eq!(once, twice, "{direction:?}: and must be a fixed point");
+    }
+}
+
+/// It is the *codon gate* that declines the tract above, not a failure to find it.
+///
+/// Called directly because that is the only way to hold the tract search fixed
+/// while flipping the gate: with CDS context every rotation is rejected and the
+/// function declines, and with the gate lifted the very same tract is emitted as
+/// `TA[6]` over c.23_30 (1-based 29_36).
+#[test]
+fn the_codon_gate_is_what_declines_the_tract() {
+    let reference = transcript_sequence();
+    let reference = reference.as_bytes();
+    // `c.24` is 1-based position 30 (`c.n` is position `n + 6`), and
+    // `insertion_to_repeat` takes the 0-based index of the base to the *left* of
+    // the insertion point, so `c.24_25ins` is index 29.
+    let insertion_point = CDS_START + 24 - 1 - 1;
+
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert!(
+            insertion_to_repeat(
+                reference,
+                insertion_point,
+                b"TATA",
+                true,
+                Some((CDS_START, cds_end())),
+                direction,
+            )
+            .is_none(),
+            "{direction:?}: a CDS-resident `TA` unit must be codon-gated"
+        );
+
+        let (_, count, start, end, unit) =
+            insertion_to_repeat(reference, insertion_point, b"TATA", false, None, direction)
+                .unwrap_or_else(|| {
+                    panic!("{direction:?}: the same tract must be found once the gate is lifted")
+                });
+        assert_eq!(
+            (unit.as_slice(), count, start, end),
+            (b"TA".as_slice(), 6, 29, 36),
+            "{direction:?}: expected `TA[6]` over the 1-based tract 29_36"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -193,6 +193,7 @@ mod issue_1327_mt_respell_past_contig_end;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_1334_liftover_position_zero;
 mod issue_1349_rotation_fallback_dup;
+mod issue_1355_rotation_gate_repeat;
 mod issue_1362_identity_span;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1355

`insertion_to_repeat` iterated every cyclic rotation of the inserted unit, kept the single highest-`ref_count` winner, and applied the #882 phase gate only afterwards. A rotation abutting a longer but out-of-phase tract therefore discarded a valid in-phase repeat and took the whole result down with it — the rotation that lost on score was never reconsidered.

This is byte-for-byte the defect **#1349** corrected in `insertion_to_duplication`, one function over. The two are documented as a deliberate symmetric pair, so they now share the shape as well: resolve each rotation to the emission it would actually produce, gate it there, `continue` on rejection.

## The repro

On `GTACGTCCCCTCCTCCTCCTCCCGGGG` with a 2-copy `TCCTCC` inserted at 7:

| rotation | tract | copies | phase |
| --- | --- | --- | --- |
| `TCC` | `[5, 8)` | 1 | in phase — the correct answer |
| `CCT` | index 8 | 4 | out of phase — wins on `ref_count` |

Both shuffle directions returned `None`. Both now emit `TCC[3]` over the 1-based tract `6_8`.

## The decision the issue asks for

The issue's point 3: whether a codon-gate `Insertion` result should `continue` or still abort. It used to abort the whole function (`return None`), which was fine while only the winner ever reached it — but inside a selection loop that is wrong in a *new* way, because a losing rotation could abort a search that had a valid answer. It is now a `continue`.

The two behaviours differ only when the highest-scoring rotation is codon-gated and a lower-scoring one is not, i.e. "emit a literal `ins`" against "emit a repeat over the other tract". `continue` is right for the same reason the phase gate is: **every rotation of a unit shares its length**, so the #1210 codon gate can differ between rotations only through `gate_is_coding` — that is, through which *tract* each rotation found. The gate states something about a tract, not about the insertion, and a tract clearing both gates describes the same edit correctly.

A side effect worth naming: `gate_is_coding` is now computed per rotation, from that rotation's own tract, rather than once from the winner's. That is strictly more correct — #1210's whole point was to ask the CDS-residency question about the span the repeat will occupy.

## Measured, not argued

The issue flags conformance-ledger exposure for this decision, so:

- Full suite with **all three** seam oracles (`FERRO_ASSERT_IDEMPOTENT=1`, `FERRO_ASSERT_REPARSE=1`, `FERRO_ASSERT_IN_BOUNDS=1`): **9236/9236 pass**, run with `FERRO_MANIFEST` pointed at a real prepared reference so the manifest-gated tests executed rather than skipping.
- That covers the FAIL-set ledgers this could have moved — `axis_normalized`, `axis_genomic`, `axis_errors`, `axis_normalized_idempotent` and `axis_genomic_idempotent`, in both the mutalyzer and biocommons suites. **No ledger moved and nothing needed re-blessing.**
- Those axes resolve their reference from `FERRO_MANIFEST`, which **PR CI does not provision** — they skip silently there and only the nightly job runs them. So the run above is local evidence, not pre-merge coverage. The regressions below are all `MockProvider`-backed and do run on PR CI.

## Not changed

Ties still fall to iteration order — strictly-greater keeps the first rotation found. `insertion_to_duplication` grew a direction-aware tie-break for #403; this function never had one, and adding it would be a separate behaviour change from the ordering fix.

## Tests

Two units in `rules.rs`:

- `an_out_of_phase_rotation_does_not_discard_a_valid_repeat` — the issue's repro in both directions, with the emission pinned rather than merely asserted non-`None`, plus a direct check that the discarded candidate really did pass the #882 gate.
- `every_emitted_repeat_decodes_to_its_input_insertion` — the property the phase gate exists to guarantee, asserted so a future selection change cannot satisfy the pinned values while breaking the contract underneath them.

And a normalizer-level file, `tests/it/issue_1355_rotation_gate_repeat.rs` — deliberately the sibling of #1349's, sharing its synthetic reference. It goes through `Normalizer::normalize`, and so through `normalize_core_checked` where all three oracles sit, rather than calling `insertion_to_repeat` directly:

- `c.2_3insTCCTCC` → `c.-1_2TCC[3]` in both directions, as separate tests, plus a third asserting the directions agree.
- `norm(norm(x)) == norm(x)` in both directions, pinned without needing the env var set.
- **Byte identity, independently.** The emitted repeat must spell the same haplotype as the input insertion — checked by splicing both edits into the reference by hand and comparing strings, deliberately **not** through `tandem_edit_preserves_insertion`, which is the production predicate the fix relies on. It asserts the emission equals the pinned value first, so the coordinates cannot drift away from what is actually emitted.
- **The codon-gated path.** A CDS-resident `TA` tract declines the repeat and the pipeline still lands a fixed-point `dup`, with a direct-call test that holds the tract search fixed while flipping the gate — proving the gate is what declined it, not a failed search.

Three of the normalizer-level guards fail on `origin/main`: 3' emits the un-promoted `c.2_3insTCCTCC` and 5' emits `c.1delinsCCTCCTC`, so the two directions disagreed about an edit whose canonical form is direction-independent. The two unit tests fail there too.

One limit, written into the file rather than left looking like coverage it is not: it does **not** pin `continue` versus the old `return None`. Every rotation in that case shares the one CDS-resident tract, so both spellings decline and the test passes against `main` too; telling them apart needs two tracts straddling `cds_end`.

## Verification

- `FERRO_MANIFEST=<prepared> FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 cargo nextest run --features dev` — **9236/9236**, zero failures
- `cargo fmt --all -- --check` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean
- Rebased onto `origin/main` (`dfea7d3`) and re-verified there, since CI tests the merge rather than the head

## Follow-up

CodeRabbit also flagged that the #1210 codon gate is answered for the tract `find_tandem_extent` discovered rather than for the window `normalize_repeat` actually emits, so a repeat whose emitted window is wholly CDS-resident can be written with a non-codon-length unit. That reproduces **byte-identically on `origin/main`** — it predates this PR, which moved the gate per-rotation but did not change which window it asks about — so it is filed separately as **#1389** rather than folded in here. It is a change to the #1210 seam and can move the manifest-gated ledgers, so it needs its own oracle statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeat detection for cyclic sequences by rejecting invalid rotations.
  * Added fallback handling so valid lower-scoring rotations can be selected when the top candidate is unsuitable.
  * Ensured emitted repeats accurately reconstruct the original insertion.
  * Improved handling of codon-gated repeat conversion by falling back to duplication when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
