### PR TITLE
ci: drop two 3 GiB nightly caches that never once hit

### DIFF
--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -31,16 +31,16 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Bump this tag whenever the manifest layout or `ferro prepare`
-  # invocation changes meaningfully, so stale caches are invalidated
-  # without manual purging. (v2: added --derive-ng-placements so the
-  # prepared reference carries derived NG_ placements + ng_hosted_transcripts,
-  # matching the blessed reference; #875. v3: added --ensembl so the reference
-  # provisions Ensembl cdot + cDNA, matching the Ensembl-inclusive blessed
-  # reference the corpus identity is recorded against; #933.) nightly-perf.yml
-  # keeps its OWN RefSeq-only cache (its `-refseq-` key) and does NOT provision
-  # Ensembl, so the two caches deliberately diverge — do not re-sync them (#933).
-  MANIFEST_CACHE_VERSION: v3
+  # NOTE: `MANIFEST_CACHE_VERSION` is gone along with the manifest cache it
+  # keyed — see the block above the `ferro prepare` step for the measurement
+  # that removed it (#1218). Its history is worth keeping for whoever restores
+  # the cache: v2 added `--derive-ng-placements` so the prepared reference
+  # carries derived NG_ placements + `ng_hosted_transcripts`, matching the
+  # blessed reference (#875); v3 added `--ensembl` so the reference provisions
+  # Ensembl cdot + cDNA, matching the Ensembl-inclusive blessed reference the
+  # corpus identity is recorded against (#933). This workflow provisions
+  # Ensembl and nightly-perf.yml deliberately does not — if both caches ever
+  # come back, they must stay separate (#933).
 
 jobs:
   reference-aware-tests:
@@ -73,35 +73,37 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-
 
-      - name: Cache prepared reference manifest
-        # This job's Ensembl-inclusive manifest cache. nightly-perf.yml no longer
-        # reuses it — it keeps a separate RefSeq-only cache (its `-refseq-` key)
-        # so its startup-budget gate is not perturbed by the eager Ensembl merge
-        # (#933). The two keys are intentionally distinct; do not re-merge them.
-        id: cache-manifest
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          # `benchmark-output/manifest.json` is one of the well-known
-          # paths the test harness probes (see `manifest_path()` in
-          # `tests/mutalyzer_normalize_tests.rs`); the surrounding
-          # `benchmark-output/` directory holds the FASTAs / cdot
-          # transcripts the manifest references.
-          path: benchmark-output/
-          # Invalidation surface: lock file (downstream-dep changes),
-          # the `prepare` crate (manifest-output shape), the CLI
-          # wiring at `src/bin/ferro.rs` (the `prepare` subcommand
-          # binding), and the NG accession fixture
-          # (`--derive-ng-placements` input — changing it changes the
-          # derived NG placements). If a future PR adds a
-          # `src/reference/**` dep that changes `ferro prepare`
-          # behavior, bump MANIFEST_CACHE_VERSION manually.
-          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs', 'tests/fixtures/mutalyzer-normalize/ng_accessions.txt') }}
-
+      # The prepared reference is NOT cached. It used to be
+      # (`Linux-ferro-manifest-v3-<hash>`, `path: benchmark-output/`), and that
+      # cache was measured at **3.25 GiB with a 0 % hit rate** — see #1218.
+      #
+      # The repository's Actions cache budget is 10 GiB and PR CI alone mints
+      # ~3 GiB per cargo entry across eight entries, so a 3.25 GiB nightly entry
+      # was evicted by LRU long before the next night could use it. Measured on
+      # five consecutive nights (runs 30606298814, 30685312545, 30733613038,
+      # 30786830075, 30879794391): every one logged `Cache not found for input
+      # keys: Linux-ferro-manifest-v3-…`, and four of the five asked for the
+      # *identical* key, so this was eviction rather than key churn. The
+      # 2026-08-04 run saved its entry at 05:43 and the entry was already gone
+      # from `actions/caches` by 05:57.
+      #
+      # So the cache cost a third of the whole repository budget, evicted PR CI's
+      # cargo caches as collateral (the failure mode #1218 records from the
+      # reverted `bf70635`), and never once saved this job a `ferro prepare`. The
+      # step below therefore always runs, which is what was already happening —
+      # dropping the cache does not slow this workflow down, it only stops it
+      # taking budget from workflows that can use it.
+      #
+      # If the cache budget is ever raised or PR CI's footprint shrinks enough to
+      # leave 3.25 GiB spare, restore the cache from git history and re-add the
+      # `if: steps.cache-manifest.outputs.cache-hit != 'true'` guard below. A
+      # better answer may be to keep the reference out of the cache budget
+      # entirely — Actions *artifacts* are billed and quota'd separately — but
+      # that has storage-cost implications and belongs in its own change.
       - name: Build ferro (for prepare)
         run: cargo build --release --bin ferro
 
-      - name: Run `ferro prepare` (cache miss only)
-        if: steps.cache-manifest.outputs.cache-hit != 'true'
+      - name: Run `ferro prepare`
         run: |
           ./target/release/ferro prepare \
             --output-dir benchmark-output \

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -39,14 +39,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Perf keeps a SEPARATE, RefSeq-only manifest cache (its own `-refseq-` key
-  # below) — deliberately NOT shared with nightly-mutalyzer.yml's Ensembl-inclusive
-  # cache. The startup-budget gate must measure the RefSeq `ferro normalize`
-  # startup it was tuned for (#585); provisioning Ensembl would make a RefSeq
-  # startup eagerly merge ~198k Ensembl transcripts into the primary build and
-  # inflate the baseline (#933). Bump on any `ferro prepare` change that alters
-  # the RefSeq manifest shape. (v2: --derive-ng-placements added; #875.)
-  MANIFEST_CACHE_VERSION: v3
+  # NOTE: `MANIFEST_CACHE_VERSION` is gone along with the RefSeq-only manifest
+  # cache it keyed — see the block above this workflow's `ferro prepare` step
+  # (#1218). The reason the two nightlies kept SEPARATE caches still stands and
+  # must be honoured if either comes back: this workflow's startup-budget gate
+  # measures the RefSeq `ferro normalize` startup it was tuned for (#585), and
+  # provisioning Ensembl would make a RefSeq startup eagerly merge ~198k Ensembl
+  # transcripts into the primary build and inflate the baseline (#933).
   # Budget knobs (seconds). Today's startup floor is ~1.0s; the #585 bug was
   # ~4.8s. 2.5s sits ~2.5x above healthy and ~2x below the bug — outside runner
   # noise in both directions.
@@ -83,23 +82,22 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-
 
-      - name: Cache prepared reference manifest
-        # SEPARATE, RefSeq-only cache (own `-refseq-` namespace) — deliberately
-        # NOT shared with nightly-mutalyzer.yml's Ensembl-inclusive cache, so the
-        # startup-budget gate measures RefSeq `ferro normalize` startup without the
-        # eager Ensembl-merge cost (#585/#933). Repopulated by this workflow's own
-        # RefSeq-only `ferro prepare` below on a cache miss.
-        id: cache-manifest
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: benchmark-output/
-          key: ${{ runner.os }}-ferro-manifest-refseq-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs', 'tests/fixtures/mutalyzer-normalize/ng_accessions.txt') }}
-
+      # The prepared reference is NOT cached, for the reason recorded in
+      # nightly-mutalyzer.yml and measured in #1218: a 3+ GiB entry cannot
+      # survive LRU eviction inside a 10 GiB repository budget that PR CI already
+      # fills, so it was re-saved nightly and never once restored. Run
+      # 30686892059 logged `Cache not found for input keys:
+      # Linux-ferro-manifest-refseq-…` like every other. Removing it does not
+      # slow this workflow — the `ferro prepare` below was already running every
+      # time — it stops the workflow taking budget from workflows that can use it.
+      #
+      # If it is ever restored, it must stay a SEPARATE RefSeq-only entry: the
+      # startup-budget gate below measures RefSeq startup (#585), and an
+      # Ensembl-inclusive reference inflates that baseline (#933).
       - name: Build ferro (release)
         run: cargo build --release --bin ferro
 
-      - name: Run `ferro prepare` (cache miss only)
-        if: steps.cache-manifest.outputs.cache-hit != 'true'
+      - name: Run `ferro prepare`
         run: |
           ./target/release/ferro prepare \
             --output-dir benchmark-output \


### PR DESCRIPTION
Refs #1218 — **step 1 of 3.** Does not close the issue; the key rotation it asks for lands in step 3, once the footprint fits two generations.

#1218's blocker is budget, and it names reclaiming the nightly's 3.25 GiB reference cache as the highest-value item. Measured: that cache has **never once hit**.

## The measurement

`nightly-mutalyzer.yml` cached `benchmark-output/` (the prepared reference — genome FASTAs + cdot, ~3.25 GiB) under `Linux-ferro-manifest-v3-<hash>`.

| run | date | manifest cache | key |
| --- | --- | --- | --- |
| 30879794391 | 2026-08-04 | `Cache not found` | `…-cad991a1c119` |
| 30786830075 | 2026-08-03 | `Cache not found` | `…-78073890138b` |
| 30733613038 | 2026-08-02 | `Cache not found` | `…-78073890138b` |
| 30685312545 | 2026-08-01 | `Cache not found` | `…-78073890138b` |
| 30606298814 | 2026-07-31 | `Cache not found` | `…-78073890138b` |

Four of five asked for the **identical key** and still missed, so this is LRU eviction, not key churn. Watched directly on the most recent run: it saved its entry at `05:43:04` and the entry was already gone from `actions/caches` by `05:57` — the same fifteen-minute disappearance the layout notes recorded for PR #1300.

Current state, for scale:

```
active_caches_size_in_bytes: 12630256757   # 11.76 GiB against a 10 GiB cap
```

So the entry consumed a third of the repository budget, evicted PR CI's cargo caches as collateral — exactly the failure mode #1218 records from the reverted `bf70635`, including the nightly-cache-destroyed-by-PR-CI direction — and never saved this workflow a single `ferro prepare`.

## Why removing it is free

The `ferro prepare` step was guarded by `if: steps.cache-manifest.outputs.cache-hit != 'true'`. Since the cache never hit, that step **already ran every night** (measured: 05:13:23 → 05:43:04, ~30 min). Dropping the cache does not slow the workflow by a second; it only stops the workflow taking budget from workflows that can use it.

`nightly-perf.yml` carries the same pattern in its deliberately separate RefSeq-only entry (`Linux-ferro-manifest-refseq-…`); run 30686892059 logged the same miss, and it gets the same treatment. Together that frees up to **~6.5 GiB**.

## What is preserved

Both `MANIFEST_CACHE_VERSION` variables go with the keys they fed, but their rationale is kept in comments — deliberately, because it matters to whoever restores the cache:

- the `v2`/`v3` history (`--derive-ng-placements` for #875, `--ensembl` for #933);
- and above all **why the two nightlies kept separate caches**: the perf workflow's startup-budget gate measures RefSeq `ferro normalize` startup (#585), and an Ensembl-inclusive reference makes a RefSeq startup eagerly merge ~198k Ensembl transcripts and inflates that baseline (#933). If either cache comes back, they must stay separate.

The comments also name the alternative worth weighing: Actions **artifacts** are quota'd and billed separately from caches, so they may be the right home for a 3 GiB reference. That has storage-cost implications, so it is flagged rather than done here.

## A finding: the issue's third item is already done

#1218 lists "drop `target/` from the cache for jobs that no longer build — the sharded test jobs consume a `nextest archive` and do not compile." Verified against every job in `ci.yml`:

```
no-cache  test          no-cache  soak           no-cache  test-required
no-cache  test-oracle   no-cache  sweeps
CACHE     clippy        CACHE     clippy-all-features   CACHE  spec-fixtures
CACHE     test-build    CACHE     test-build-soak       CACHE  generated-docs
CACHE     python-wheel-test        CACHE  build
```

Every job that caches also compiles, so there is nothing left to drop there. The eight compiling jobs each cache the same five paths including a full `target/` — that is 5b's subject.

## Also observed, feeding step 2

The nightly's own cargo cache restored **`Linux-cargo-…-coverage`** via its bare `${{ runner.os }}-cargo-` restore-key — a coverage-instrumented `target/` tree served to a plain release build. That is the cross-profile mismatch the layout notes warn about, and four jobs still carry that bare restore-key. Left alone here to keep this change to budget reclamation; it belongs with the key restructuring in step 3.

## Verification

- `actionlint` clean on both workflows; both parse as YAML.
- No Rust or test changes, so no suite run applies. The behavioural claim — that `ferro prepare` already ran unconditionally — is from the run logs quoted above rather than from reasoning about the `if:`.
