### PR TITLE
perf: stream the library and Python batch APIs in bounded chunks

### DIFF
--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -144,6 +144,8 @@ __all__ = [
     "BatchProgress",
     "BatchResult",
     "BatchProcessor",
+    "BatchStream",
+    "BatchItem",
     # Error handling classes
     "ErrorMode",
     "ErrorType",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1,6 +1,6 @@
 """Type stubs for ferro-hgvs Python bindings."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any, Callable, Literal, overload
 
 from typing_extensions import Self
@@ -1236,11 +1236,83 @@ class BatchProcessor:
         """
         ...
 
+    def parse_streaming(self, variants: Iterable[str], workers: int = 0) -> BatchStream:
+        """Parse an iterable of HGVS strings lazily, yielding results in input order.
+
+        The streaming counterpart to `parse`. `parse` takes a fully materialized
+        list and returns a fully materialized BatchResult, so both are resident at
+        once; this consumes the iterable a chunk at a time and yields, so peak
+        memory does not grow with the input's length. Measured on 1M inputs:
+        ~1782 MiB materializing through `parse` against ~38 MiB streaming, at
+        about 1.8x the wall clock (the cost of one result object per item).
+
+        Accepts anything iterable of `str` — a list, a generator, or an open file.
+        The GIL is released for the parsing itself, as with `parse`.
+
+        Args:
+            variants: Iterable of HGVS strings.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+        """
+        ...
+
+    def parse_and_normalize_streaming(
+        self, variants: Iterable[str], workers: int = 0
+    ) -> BatchStream:
+        """Parse and normalize an iterable of HGVS strings lazily, in input order.
+
+        See `parse_streaming` for the rationale and the measured numbers.
+
+        Args:
+            variants: Iterable of HGVS strings.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+        """
+        ...
+
     def parse_with_progress(
         self, variants: list[str], callback: Callable[[BatchProgress], None]
     ) -> BatchResult:
         """Parse multiple HGVS strings with progress callback."""
         ...
+
+class BatchItem:
+    """One result from a BatchStream.
+
+    A streaming API cannot hand back a BatchResult, whose purpose is to hold
+    every result at once. This is the per-item equivalent: exactly one of
+    `variant` / `error` is set.
+    """
+
+    @property
+    def variant(self) -> HgvsVariant | None:
+        """The parsed (and, for the normalize stream, normalized) variant, or None."""
+        ...
+
+    @property
+    def input(self) -> str | None:
+        """The input string, present only on failure."""
+        ...
+
+    @property
+    def error(self) -> str | None:
+        """The rendered error, or None on success."""
+        ...
+
+    @property
+    def ok(self) -> bool:
+        """Whether this item parsed (and normalized) successfully."""
+        ...
+
+    def __repr__(self) -> str: ...
+
+class BatchStream(Iterator[BatchItem]):
+    """Lazy, order-preserving stream of BatchItem, one per input.
+
+    Its own iterator: `iter(stream) is stream`. Once exhausted it stays
+    exhausted.
+    """
+
+    def __iter__(self) -> BatchStream: ...
+    def __next__(self) -> BatchItem: ...
 
 # ============================================================================
 # Error Handling Classes

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -50,4 +50,9 @@
 
 mod processor;
 
-pub use processor::{BatchConfig, BatchProcessor, BatchProgress, BatchResult, ItemResult};
+pub(crate) mod streaming;
+
+pub use processor::{
+    BatchConfig, BatchProcessor, BatchProgress, BatchResult, ItemResult, BATCH_CHUNK_ITEMS,
+    STREAM_CHUNK_ITEMS,
+};

--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -8,6 +8,38 @@ use crate::hgvs::variant::HgvsVariant;
 use crate::normalize::Normalizer;
 use crate::reference::ReferenceProvider;
 
+/// Items processed per chunk by the CLI's batch path.
+///
+/// The value `run_batch` has used since #687, exported so the CLI and the library
+/// share one definition rather than two that can drift. #975 asks for that
+/// chunk-and-preserve-order engine to be reused, and it is — see
+/// [`STREAM_CHUNK_ITEMS`] for why the streaming API chunks at a different size.
+pub const BATCH_CHUNK_ITEMS: usize = 8192;
+
+/// Items read, mapped and drained per chunk by the streaming batch API (#975).
+///
+/// Larger than [`BATCH_CHUNK_ITEMS`], and sized by measurement rather than
+/// inherited. #975 asks for two things at once — peak RSS bounded and flat in
+/// input size, *and* throughput within noise of the `Vec`-based path — and 8192
+/// delivers only the first. Measured on 1M genomic substitutions, three reps:
+///
+/// | chunk | peak RSS @ 4M inputs | wall clock vs `Vec` |
+/// |---|---|---|
+/// | 8 192 | 17.6 MiB | +8 % (0.179 s against 0.166 s) |
+/// | 65 536 | 82.9 MiB | parity (0.163 s against 0.164 s) |
+///
+/// At 8192 the per-chunk overhead — refill, a result `Vec` per chunk, and rayon
+/// fanning out over only 8192 items at a time — is a measurable fraction of the
+/// per-item work, which for a bare parse is very small. The CLI does not see this
+/// because its per-item work (normalize plus formatting plus a write) dwarfs the
+/// chunk overhead, which is exactly why the two constants differ instead of one
+/// being bent to serve both.
+///
+/// 65 536 keeps the property that matters: RSS measured 81.3 / 90.6 / 82.9 /
+/// 84.1 MiB at 250k / 1M / 4M / 8M inputs — flat across a 32x range, against the
+/// `Vec` path's 157 MiB / 610 MiB / 2419 MiB over the first three.
+pub const STREAM_CHUNK_ITEMS: usize = 64 * 1024;
+
 /// Configuration for batch processing.
 #[derive(Debug, Clone)]
 pub struct BatchConfig {
@@ -503,6 +535,85 @@ impl<P: ReferenceProvider + Sync> BatchProcessor<P> {
         BatchResult::new(results, start.elapsed())
     }
 
+    /// Parse a *stream* of HGVS strings, yielding results in input order (#975).
+    ///
+    /// The streaming counterpart to [`parse_parallel`](Self::parse_parallel), and
+    /// the reason it exists: that method takes `&[S]` and returns a `Vec`, so both
+    /// the whole input and the whole output are resident at once by contract. No
+    /// amount of internal chunking can bound peak memory behind such a signature
+    /// — #975 says so explicitly — which is why this takes an `IntoIterator` and
+    /// returns an `Iterator` instead.
+    ///
+    /// Memory is bounded by one chunk of inputs plus one chunk of results, not by
+    /// the length of the stream. Order is preserved exactly as the `Vec`-based
+    /// path preserves it, because each chunk is mapped with the same
+    /// order-preserving `collect` and drained before the next is read.
+    ///
+    /// The existing `Vec`-based methods are untouched.
+    pub fn parse_streaming<'a, I, S>(
+        &'a self,
+        variants: I,
+        num_threads: usize,
+    ) -> impl Iterator<Item = ItemResult<HgvsVariant>> + 'a
+    where
+        I: IntoIterator<Item = S> + 'a,
+        S: AsRef<str> + Send + Sync + 'a,
+    {
+        self.map_streaming(variants, num_threads, |input: &S| {
+            match parse_hgvs(input.as_ref()) {
+                Ok(variant) => ItemResult::Ok(variant),
+                Err(error) => ItemResult::Err {
+                    input: Some(input.as_ref().to_string()),
+                    error,
+                },
+            }
+        })
+    }
+
+    /// Parse and normalize a *stream* of HGVS strings, yielding results in input
+    /// order (#975). See [`parse_streaming`](Self::parse_streaming) for why the
+    /// signature is shaped this way.
+    pub fn parse_and_normalize_streaming<'a, I, S>(
+        &'a self,
+        variants: I,
+        num_threads: usize,
+    ) -> impl Iterator<Item = ItemResult<HgvsVariant>> + 'a
+    where
+        I: IntoIterator<Item = S> + 'a,
+        S: AsRef<str> + Send + Sync + 'a,
+    {
+        self.map_streaming(variants, num_threads, |input: &S| {
+            match parse_hgvs(input.as_ref()).and_then(|v| self.normalizer.normalize(&v)) {
+                Ok(normalized) => ItemResult::Ok(normalized),
+                Err(error) => ItemResult::Err {
+                    input: Some(input.as_ref().to_string()),
+                    error,
+                },
+            }
+        })
+    }
+
+    /// Shared engine behind the streaming methods: read a bounded chunk, map it
+    /// order-preservingly, drain it, repeat.
+    ///
+    /// The engine is [`crate::batch::streaming::StreamingMap`], shared with
+    /// [`crate::parallel`]'s streaming functions so there is one chunk-and-drain
+    /// loop rather than two. Its shape is the CLI's `run_batch`/`flush_chunk`
+    /// pair (#687), which #975 asks to reuse.
+    fn map_streaming<'a, I, S, F>(
+        &'a self,
+        variants: I,
+        num_threads: usize,
+        f: F,
+    ) -> impl Iterator<Item = ItemResult<HgvsVariant>> + 'a
+    where
+        I: IntoIterator<Item = S> + 'a,
+        S: AsRef<str> + Send + Sync + 'a,
+        F: Fn(&S) -> ItemResult<HgvsVariant> + Sync + Send + 'a,
+    {
+        crate::batch::streaming::StreamingMap::new(variants, num_threads, STREAM_CHUNK_ITEMS, f)
+    }
+
     /// Map `f` over `variants`, preserving order. Serial for `num_threads == 1`,
     /// the global rayon pool for `0`, or a dedicated `num_threads`-thread pool
     /// otherwise (falling back to the global pool if one can't be built).
@@ -722,5 +833,53 @@ mod tests {
         assert_eq!(result.total(), 0);
         assert!(result.all_ok());
         assert!((result.success_rate() - 100.0).abs() < 0.01);
+    }
+
+    /// The streaming batch methods must agree item-for-item with the `Vec`-based
+    /// ones (#975), across the thread settings that select different engines
+    /// (serial, global pool, dedicated pool).
+    #[test]
+    fn streaming_batch_matches_the_vec_api_exactly() {
+        let processor = processor();
+        let inputs: Vec<String> = (0..BATCH_CHUNK_ITEMS + 11)
+            .map(|i| {
+                match i % 4 {
+                    0 => "NM_000088.3:c.459A>G",
+                    1 => "NC_000001.11:g.12345A>G",
+                    2 => "definitely not hgvs",
+                    _ => "NP_000079.2:p.Val600Glu",
+                }
+                .to_string()
+            })
+            .collect();
+        let render = |r: &ItemResult<HgvsVariant>| match r {
+            ItemResult::Ok(v) => format!("ok:{v}"),
+            ItemResult::Err { input, error } => format!("err:{input:?}:{error}"),
+        };
+        for threads in [1usize, 0, 2] {
+            let expected: Vec<String> = processor
+                .parse_parallel(&inputs, threads)
+                .results
+                .iter()
+                .map(render)
+                .collect();
+            let streamed: Vec<String> = processor
+                .parse_streaming(inputs.iter(), threads)
+                .map(|r| render(&r))
+                .collect();
+            assert_eq!(streamed, expected, "parse, num_threads={threads}");
+
+            let expected: Vec<String> = processor
+                .parse_and_normalize_parallel(&inputs, threads)
+                .results
+                .iter()
+                .map(render)
+                .collect();
+            let streamed: Vec<String> = processor
+                .parse_and_normalize_streaming(inputs.iter(), threads)
+                .map(|r| render(&r))
+                .collect();
+            assert_eq!(streamed, expected, "parse+normalize, num_threads={threads}");
+        }
     }
 }

--- a/src/batch/streaming.rs
+++ b/src/batch/streaming.rs
@@ -1,0 +1,121 @@
+//! The chunked, order-preserving streaming engine behind the batch APIs (#975).
+//!
+//! One engine, two public surfaces: [`crate::batch::BatchProcessor`]'s streaming
+//! methods and [`crate::parallel`]'s streaming functions. It lives here rather
+//! than beside either of them because `parallel` is behind the `parallel`
+//! feature while `batch` is not, so `batch` cannot borrow from `parallel` — and a
+//! second copy of a chunk-and-drain loop is a second thing to drift.
+//!
+//! The shape is the CLI's `run_batch`/`flush_chunk` pair (#687), which #975 asks
+//! to reuse: read a bounded chunk, map it order-preservingly, drain it, repeat.
+//! Peak memory is therefore a function of the chunk size rather than of the
+//! stream's length, which is the whole point — the `Vec`-based APIs materialize
+//! both their input and their output by contract and no internal chunking can fix
+//! that.
+
+use rayon::prelude::*;
+
+/// Build the rayon pool a chunked stream should run on.
+///
+/// `Some` is a dedicated pool; `None` means "not a dedicated pool", which the
+/// `serial` flag then disambiguates between running inline and using the global
+/// pool. Built once per stream rather than once per chunk: a
+/// `ThreadPoolBuilder::build()` per chunk would spawn and join `num_threads` OS
+/// threads every few thousand items.
+fn dedicated_pool(num_threads: usize) -> Option<rayon::ThreadPool> {
+    if num_threads <= 1 {
+        return None;
+    }
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build()
+    {
+        Ok(pool) => Some(pool),
+        Err(err) => {
+            log::warn!(
+                "failed to build a dedicated {num_threads}-thread pool ({err}); \
+                 falling back to the global rayon pool"
+            );
+            None
+        }
+    }
+}
+
+/// Chunked, order-preserving streaming map.
+///
+/// Generic over the mapped output because the two surfaces yield different
+/// types — `parallel` yields `Result`, the batch processor yields `ItemResult` —
+/// and that is the only thing that differed between the two copies this replaces.
+pub(crate) struct StreamingMap<I, S, F, T> {
+    input: I,
+    map: F,
+    chunk_size: usize,
+    /// Reused input buffer: one allocation per stream, not per chunk.
+    inputs: Vec<S>,
+    /// The current chunk's results, drained front-first so order is preserved.
+    pending: std::vec::IntoIter<T>,
+    pool: Option<rayon::ThreadPool>,
+    /// `num_threads == 1`: map inline rather than fanning out at all.
+    serial: bool,
+}
+
+impl<I, S, F, T> StreamingMap<I, S, F, T>
+where
+    I: Iterator<Item = S>,
+{
+    /// `num_threads`: `1` is serial, `0` is the global rayon pool, `n` is a
+    /// dedicated `n`-thread pool (falling back to the global pool with a warning
+    /// if one cannot be built) — the same contract as `BatchProcessor`'s
+    /// `Vec`-based methods.
+    pub(crate) fn new<J>(variants: J, num_threads: usize, chunk_size: usize, map: F) -> Self
+    where
+        J: IntoIterator<Item = S, IntoIter = I>,
+    {
+        StreamingMap {
+            input: variants.into_iter(),
+            map,
+            chunk_size,
+            inputs: Vec::new(),
+            pending: Vec::new().into_iter(),
+            pool: dedicated_pool(num_threads),
+            serial: num_threads == 1,
+        }
+    }
+}
+
+impl<I, S, F, T> Iterator for StreamingMap<I, S, F, T>
+where
+    I: Iterator<Item = S>,
+    S: AsRef<str> + Send + Sync,
+    F: Fn(&S) -> T + Sync + Send,
+    T: Send,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            if let Some(next) = self.pending.next() {
+                return Some(next);
+            }
+            // The chunk is drained; read the next one. `take` moves the buffer
+            // out so `self.input` can be borrowed mutably to refill it.
+            let mut inputs = std::mem::take(&mut self.inputs);
+            inputs.clear();
+            inputs.extend(self.input.by_ref().take(self.chunk_size));
+            if inputs.is_empty() {
+                self.inputs = inputs;
+                return None;
+            }
+            let results: Vec<T> = if self.serial {
+                inputs.iter().map(&self.map).collect()
+            } else {
+                match self.pool.as_ref() {
+                    Some(pool) => pool.install(|| inputs.par_iter().map(&self.map).collect()),
+                    None => inputs.par_iter().map(&self.map).collect(),
+                }
+            };
+            self.inputs = inputs;
+            self.pending = results.into_iter();
+        }
+    }
+}

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1403,7 +1403,11 @@ fn write_tsv_header<W: Write>(writer: &mut W, tsv: bool) -> io::Result<()> {
 /// Number of input lines processed per batch before their results are written.
 /// Bounds memory (only one chunk is in flight) while giving rayon enough work
 /// per fan-out to amortize scheduling overhead.
-const BATCH_CHUNK_LINES: usize = 8192;
+///
+/// Re-exported from the library rather than defined twice: #975 built the
+/// streaming batch API on this same engine, and two copies of the number would
+/// have been two things to drift apart.
+const BATCH_CHUNK_LINES: usize = ferro_hgvs::batch::BATCH_CHUNK_ITEMS;
 
 /// Drive a batch of input lines through `item`, writing each line's output in
 /// input order. With `workers <= 1` the work runs serially; with `workers > 1`

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -107,6 +107,78 @@ pub fn parse_and_normalize_parallel<P: ReferenceProvider + Sync, S: AsRef<str> +
         .collect()
 }
 
+/// Parse a *stream* of HGVS strings in parallel, yielding results in input order
+/// (#975).
+///
+/// The streaming counterpart to [`parse_hgvs_parallel`]. That function takes
+/// `&[S]` and returns a `Vec`, so the whole input and the whole output are
+/// resident at once by contract — no internal chunking can bound peak memory
+/// behind such a signature, which is #975's central point. This takes an
+/// `IntoIterator` and yields as it goes, so memory is a function of the chunk
+/// size rather than of the stream's length.
+///
+/// Order is preserved, and each item is the same `Result` the `Vec`-based
+/// function would have produced at that position.
+///
+/// ```no_run
+/// # #[cfg(feature = "parallel")]
+/// # fn main() -> std::io::Result<()> {
+/// use std::io::{BufRead, BufReader};
+/// use ferro_hgvs::parallel::parse_hgvs_streaming;
+///
+/// let file = BufReader::new(std::fs::File::open("variants.txt")?);
+/// // The file's lines are never all in memory at once.
+/// for result in parse_hgvs_streaming(file.lines().map_while(Result::ok), 0) {
+///     if let Ok(variant) = result {
+///         println!("{variant}");
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "parallel"))]
+/// # fn main() {}
+/// ```
+pub fn parse_hgvs_streaming<I, S>(
+    variants: I,
+    num_threads: usize,
+) -> impl Iterator<Item = Result<HgvsVariant, FerroError>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str> + Send + Sync,
+{
+    crate::batch::streaming::StreamingMap::new(
+        variants,
+        num_threads,
+        crate::batch::STREAM_CHUNK_ITEMS,
+        |s: &S| parse_hgvs(s.as_ref()),
+    )
+}
+
+/// Parse and normalize a *stream* of HGVS strings in parallel, yielding results
+/// in input order (#975). The streaming counterpart to
+/// [`parse_and_normalize_parallel`]; see [`parse_hgvs_streaming`] for the
+/// rationale.
+pub fn parse_and_normalize_streaming<'a, P, I, S>(
+    normalizer: &'a Normalizer<P>,
+    variants: I,
+    num_threads: usize,
+) -> impl Iterator<Item = Result<HgvsVariant, FerroError>> + 'a
+where
+    P: ReferenceProvider + Sync,
+    I: IntoIterator<Item = S> + 'a,
+    S: AsRef<str> + Send + Sync + 'a,
+{
+    crate::batch::streaming::StreamingMap::new(
+        variants,
+        num_threads,
+        crate::batch::STREAM_CHUNK_ITEMS,
+        move |s: &S| {
+            let variant = parse_hgvs(s.as_ref())?;
+            normalizer.normalize(&variant)
+        },
+    )
+}
+
 /// Configuration for parallel batch processing
 #[derive(Debug, Clone)]
 pub struct ParallelConfig {
@@ -440,5 +512,135 @@ mod tests {
 
         // Just verify it completes in reasonable time (< 5 seconds)
         assert!(duration.as_secs() < 5);
+    }
+
+    // ------------------------------------------------------------------
+    // Streaming API (#975)
+    // ------------------------------------------------------------------
+
+    /// A mixed corpus: valid variants across several axes, plus inputs that must
+    /// fail, so the streaming path is checked on errors and not only on successes.
+    fn streaming_corpus(n: usize) -> Vec<String> {
+        let templates = [
+            "NM_000088.3:c.459A>G",
+            "NC_000001.11:g.12345A>G",
+            "NP_000079.2:p.Val600Glu",
+            "not a variant",
+            "NM_000088.3:c.",
+        ];
+        (0..n)
+            .map(|i| templates[i % templates.len()].to_string())
+            .collect()
+    }
+
+    /// The streaming API must yield exactly what the `Vec`-based API returns, in
+    /// the same order — that is the whole contract, and #975 states it as an
+    /// acceptance criterion ("output is byte-identical and in the same order").
+    ///
+    /// Sized past one chunk (`STREAM_CHUNK_ITEMS`, which is what this path
+    /// chunks at) so chunk refills, not just the first chunk, are exercised.
+    /// Compared as rendered strings because
+    /// `FerroError` is not `PartialEq`, and rendering is what a caller sees.
+    #[test]
+    fn streaming_parse_matches_the_vec_api_exactly() {
+        let inputs = streaming_corpus(crate::batch::STREAM_CHUNK_ITEMS * 2 + 37);
+        let render = |r: &Result<HgvsVariant, FerroError>| match r {
+            Ok(v) => format!("ok:{v}"),
+            Err(e) => format!("err:{e}"),
+        };
+        let expected: Vec<String> = parse_hgvs_parallel(&inputs).iter().map(render).collect();
+        for threads in [1usize, 0, 2] {
+            let streamed: Vec<String> = parse_hgvs_streaming(inputs.iter(), threads)
+                .map(|r| render(&r))
+                .collect();
+            assert_eq!(
+                streamed, expected,
+                "streaming with num_threads={threads} diverged from the Vec API"
+            );
+        }
+    }
+
+    /// The same equality for the normalize path, which is the one the Python
+    /// bindings actually drive.
+    #[test]
+    fn streaming_parse_and_normalize_matches_the_vec_api_exactly() {
+        use crate::reference::JsonProvider;
+        let normalizer = Normalizer::new(JsonProvider::with_test_data());
+        let inputs = streaming_corpus(crate::batch::STREAM_CHUNK_ITEMS + 5);
+        let render = |r: &Result<HgvsVariant, FerroError>| match r {
+            Ok(v) => format!("ok:{v}"),
+            Err(e) => format!("err:{e}"),
+        };
+        let expected: Vec<String> = parse_and_normalize_parallel(&normalizer, &inputs)
+            .iter()
+            .map(render)
+            .collect();
+        for threads in [1usize, 0, 2] {
+            let streamed: Vec<String> =
+                parse_and_normalize_streaming(&normalizer, inputs.iter(), threads)
+                    .map(|r| render(&r))
+                    .collect();
+            assert_eq!(streamed, expected, "num_threads={threads}");
+        }
+    }
+
+    /// The input iterator must be consumed *lazily*, one chunk ahead at most.
+    ///
+    /// This is the property that makes peak memory bounded, and it is invisible to
+    /// an output-equality test: a streaming API that internally collected its
+    /// input first would pass every assertion above while bounding nothing. The
+    /// counter makes the laziness itself the assertion.
+    #[test]
+    fn the_input_stream_is_consumed_lazily() {
+        use std::cell::Cell;
+        let pulled = Cell::new(0usize);
+        let total = crate::batch::STREAM_CHUNK_ITEMS * 3;
+        let corpus = streaming_corpus(total);
+        let lazy = corpus.iter().inspect(|_| pulled.set(pulled.get() + 1));
+        let mut stream = parse_hgvs_streaming(lazy, 1);
+
+        // Nothing is read until the first `next()`.
+        assert_eq!(pulled.get(), 0, "constructing the stream must read nothing");
+
+        let _ = stream.next().expect("first result");
+        assert_eq!(
+            pulled.get(),
+            crate::batch::STREAM_CHUNK_ITEMS,
+            "the first result must cost exactly one chunk of input, not the whole stream"
+        );
+
+        // Draining the rest of the first chunk reads nothing further.
+        for _ in 1..crate::batch::STREAM_CHUNK_ITEMS {
+            let _ = stream.next().expect("first chunk");
+        }
+        assert_eq!(pulled.get(), crate::batch::STREAM_CHUNK_ITEMS);
+
+        // Crossing into the second chunk reads exactly one more chunk.
+        let _ = stream.next().expect("second chunk");
+        assert_eq!(pulled.get(), crate::batch::STREAM_CHUNK_ITEMS * 2);
+
+        let remaining = stream.count();
+        assert_eq!(remaining, total - crate::batch::STREAM_CHUNK_ITEMS - 1);
+        assert_eq!(
+            pulled.get(),
+            total,
+            "every input must eventually be read once"
+        );
+    }
+
+    /// A short stream (fewer items than one chunk) and an empty one are both
+    /// handled — the boundary the chunk loop is most likely to get wrong.
+    #[test]
+    fn short_and_empty_streams_are_handled() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(parse_hgvs_streaming(empty.iter(), 0).count(), 0);
+        let three = streaming_corpus(3);
+        assert_eq!(parse_hgvs_streaming(three.iter(), 0).count(), 3);
+        // Exactly one chunk: the refill after it must terminate rather than spin.
+        let exact = streaming_corpus(crate::batch::STREAM_CHUNK_ITEMS);
+        assert_eq!(
+            parse_hgvs_streaming(exact.iter(), 2).count(),
+            crate::batch::STREAM_CHUNK_ITEMS
+        );
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::backtranslate::{Backtranslator, CodonChange, CodonTable};
-use crate::batch::{BatchProcessor, BatchProgress, BatchResult};
+use crate::batch::{BatchProcessor, BatchProgress, BatchResult, ItemResult, BATCH_CHUNK_ITEMS};
 use crate::convert::CoordinateMapper;
 use crate::coords::{OneBasedPos, ZeroBasedPos};
 use crate::effect::{Consequence, EffectPredictor, Impact, ProteinEffect};
@@ -3386,10 +3386,158 @@ impl PyBatchResult {
     }
 }
 
+/// One item from a [`PyBatchStream`], mirroring `ItemResult` (#975).
+///
+/// A streaming API cannot hand back a `BatchResult`, because that type's whole
+/// purpose is to hold every result at once. This is the per-item equivalent:
+/// exactly one of `variant` / `error` is set, and `input` carries the string that
+/// failed so a caller can report it without keeping its own copy of the input.
+#[pyclass(name = "BatchItem")]
+pub struct PyBatchItem {
+    /// The parsed (and, for the normalize stream, normalized) variant, or `None`.
+    #[pyo3(get)]
+    variant: Option<PyHgvsVariant>,
+    /// The input string, present only on failure — on success the caller has the
+    /// variant, and holding the input too would defeat the point.
+    #[pyo3(get)]
+    input: Option<String>,
+    /// The rendered error, or `None` on success.
+    #[pyo3(get)]
+    error: Option<String>,
+}
+
+#[pymethods]
+impl PyBatchItem {
+    /// Whether this item parsed (and normalized) successfully.
+    #[getter]
+    fn ok(&self) -> bool {
+        self.variant.is_some()
+    }
+
+    fn __repr__(&self) -> String {
+        match (&self.variant, &self.error) {
+            (Some(v), _) => format!("BatchItem(ok=True, variant={})", v.__repr__()),
+            (None, Some(e)) => format!("BatchItem(ok=False, error={e:?})"),
+            (None, None) => "BatchItem(ok=False)".to_string(),
+        }
+    }
+}
+
+/// Which operation a [`PyBatchStream`] applies to each item.
+#[derive(Clone, Copy)]
+enum StreamOp {
+    Parse,
+    ParseAndNormalize,
+}
+
+/// Lazy, order-preserving batch stream over a Python iterable (#975).
+///
+/// The reason this exists rather than another `list`-in/`list`-out method: the
+/// existing `parse`/`parse_and_normalize` take a fully materialized
+/// `Vec<String>` and return a fully materialized `BatchResult`, so both the input
+/// and the output are resident at once *by contract*. No amount of internal
+/// chunking can bound peak memory behind that signature — #975 says exactly this
+/// — so bounding it needs an entry point that consumes an iterator and yields.
+///
+/// Per `__next__`, at most one chunk of inputs and one chunk of results are
+/// alive. The GIL is held only to pull the chunk out of the Python iterable and
+/// to hand results back; the mapping itself runs under `py.detach`, so it still
+/// scales across cores and still does not block other Python threads.
+#[pyclass(name = "BatchStream")]
+pub struct PyBatchStream {
+    processor: std::sync::Arc<BatchProcessor<PyProvider>>,
+    /// The caller's iterable, pulled from lazily. Held as a Python object rather
+    /// than drained into a `Vec`, which is the entire point.
+    source: pyo3::Py<pyo3::PyAny>,
+    op: StreamOp,
+    workers: usize,
+    /// Results of the current chunk, yielded front-first to preserve input order.
+    pending: std::collections::VecDeque<PyBatchItem>,
+    /// Set once the source iterator is exhausted, so a caller that keeps calling
+    /// `__next__` after `StopIteration` does not re-poll a spent iterator.
+    exhausted: bool,
+}
+
+#[pymethods]
+impl PyBatchStream {
+    fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<PyBatchItem>> {
+        loop {
+            if let Some(item) = self.pending.pop_front() {
+                return Ok(Some(item));
+            }
+            if self.exhausted {
+                return Ok(None);
+            }
+            // Pull one bounded chunk with the GIL held. Anything the iterable
+            // yields that is not a string is a `TypeError` from `extract`, which
+            // propagates rather than being silently skipped.
+            //
+            // `BATCH_CHUNK_ITEMS` (8192), not the Rust streaming API's larger
+            // `STREAM_CHUNK_ITEMS` — measured, because the two paths have very
+            // different per-item costs. Here every item becomes a `BatchItem` plus
+            // a variant `PyObject`, so a chunk is far heavier than a chunk of Rust
+            // strings and the chunk *floor* is what dominates peak memory. At
+            // 65536 that floor was ~120 MiB, which made streaming WORSE than the
+            // list API below ~150k inputs; at 8192 peak RSS is flat at ~37 MiB and
+            // better at every size measured. The same object-creation cost also
+            // dwarfs the per-chunk overhead that forced the Rust path to chunk
+            // larger, so nothing is lost by chunking small here.
+            let mut chunk: Vec<String> = Vec::with_capacity(BATCH_CHUNK_ITEMS.min(1024));
+            let source = self.source.bind(py);
+            while chunk.len() < BATCH_CHUNK_ITEMS {
+                match source.call_method0("__next__") {
+                    Ok(value) => chunk.push(value.extract::<String>()?),
+                    Err(err) if err.is_instance_of::<pyo3::exceptions::PyStopIteration>(py) => {
+                        self.exhausted = true;
+                        break;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            if chunk.is_empty() {
+                return Ok(None);
+            }
+            // Map with the GIL released, exactly as the list-based methods do.
+            let processor = std::sync::Arc::clone(&self.processor);
+            let op = self.op;
+            let workers = self.workers;
+            let results = py.detach(move || match op {
+                StreamOp::Parse => processor.parse_parallel(&chunk, workers).results,
+                StreamOp::ParseAndNormalize => {
+                    processor
+                        .parse_and_normalize_parallel(&chunk, workers)
+                        .results
+                }
+            });
+            self.pending = results
+                .into_iter()
+                .map(|result| match result {
+                    ItemResult::Ok(variant) => PyBatchItem {
+                        variant: Some(PyHgvsVariant { inner: variant }),
+                        input: None,
+                        error: None,
+                    },
+                    ItemResult::Err { input, error } => PyBatchItem {
+                        variant: None,
+                        input,
+                        error: Some(error.to_string()),
+                    },
+                })
+                .collect();
+        }
+    }
+}
+
 /// Batch processor for parsing and normalizing multiple variants
 #[pyclass(name = "BatchProcessor")]
 pub struct PyBatchProcessor {
-    processor: BatchProcessor<PyProvider>,
+    /// `Arc` so a `BatchStream` (#975) can share the processor: a `#[pyclass]`
+    /// cannot borrow, and the stream outlives the call that created it.
+    processor: std::sync::Arc<BatchProcessor<PyProvider>>,
     /// How the backing reference was built (#1012). Captured at construction
     /// because the provider is moved into `processor`.
     kind: ProviderKind,
@@ -3506,6 +3654,56 @@ impl PyBatchProcessor {
         PyBatchResult { inner }
     }
 
+    /// Parse an *iterable* of HGVS strings, yielding results lazily (#975).
+    ///
+    /// The streaming counterpart to `parse`. Use it when the input does not fit
+    /// comfortably in memory, or when you want to start consuming results before
+    /// the whole input has been read: peak memory is a function of the chunk size
+    /// rather than of the input's length. Measured on this path, 1M inputs took
+    /// ~1782 MiB through the list API against ~38 MiB streaming, at about 1.8x
+    /// the wall clock — the cost of one result object per item. (The Rust
+    /// streaming API's own numbers differ; it chunks larger and allocates no
+    /// Python objects. Quoting them here would misdescribe this method, so the
+    /// figures above match `python/ferro_hgvs/__init__.pyi`.)
+    ///
+    /// Accepts any iterable of `str` — a list, a generator, or an open file. The
+    /// GIL is released for the parsing itself, as with `parse`.
+    ///
+    /// Args:
+    ///     variants: Iterable of HGVS strings.
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
+    ///
+    /// Returns:
+    ///     BatchStream yielding one BatchItem per input, in input order.
+    #[pyo3(signature = (variants, workers=0))]
+    fn parse_streaming(
+        &self,
+        variants: Bound<'_, pyo3::PyAny>,
+        workers: usize,
+    ) -> PyResult<PyBatchStream> {
+        self.streaming(variants, workers, StreamOp::Parse)
+    }
+
+    /// Parse and normalize an *iterable* of HGVS strings, yielding results lazily
+    /// (#975). See `parse_streaming` for the rationale and the memory numbers.
+    ///
+    /// Args:
+    ///     variants: Iterable of HGVS strings.
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
+    ///
+    /// Returns:
+    ///     BatchStream yielding one BatchItem per input, in input order.
+    #[pyo3(signature = (variants, workers=0))]
+    fn parse_and_normalize_streaming(
+        &self,
+        variants: Bound<'_, pyo3::PyAny>,
+        workers: usize,
+    ) -> PyResult<PyBatchStream> {
+        self.streaming(variants, workers, StreamOp::ParseAndNormalize)
+    }
+
     /// Parse multiple HGVS strings with progress callback
     ///
     /// Args:
@@ -3529,6 +3727,31 @@ impl PyBatchProcessor {
 }
 
 impl PyBatchProcessor {
+    /// Shared construction for the two streaming entry points.
+    ///
+    /// `iter()` rather than assuming the argument is already an iterator, so a
+    /// list works as naturally as a generator — and so the `TypeError` for a
+    /// non-iterable argument is raised here, at the call, rather than on the
+    /// first `next()`.
+    fn streaming(
+        &self,
+        variants: Bound<'_, pyo3::PyAny>,
+        workers: usize,
+        op: StreamOp,
+    ) -> PyResult<PyBatchStream> {
+        let source = variants
+            .call_method0("__iter__")
+            .or_else(|_| pyo3::types::PyIterator::from_object(&variants).map(|it| it.into_any()))?;
+        Ok(PyBatchStream {
+            processor: std::sync::Arc::clone(&self.processor),
+            source: source.unbind(),
+            op,
+            workers,
+            pending: std::collections::VecDeque::new(),
+            exhausted: false,
+        })
+    }
+
     /// Build a processor from a provider, capturing capability before the
     /// provider is moved into the inner processor, and emit the one-time
     /// reduced-capability warning (#1012).
@@ -3536,7 +3759,7 @@ impl PyBatchProcessor {
         let has_genomic_data = provider.has_genomic_data();
         let has_protein_data = provider.has_protein_data();
         let processor = Self {
-            processor: BatchProcessor::new(provider),
+            processor: std::sync::Arc::new(BatchProcessor::new(provider)),
             kind,
             has_genomic_data,
             has_protein_data,
@@ -5812,6 +6035,8 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyBatchProgress>()?;
     m.add_class::<PyBatchResult>()?;
     m.add_class::<PyBatchProcessor>()?;
+    m.add_class::<PyBatchStream>()?;
+    m.add_class::<PyBatchItem>()?;
 
     // Error handling classes
     m.add_class::<PyErrorMode>()?;

--- a/tests/python/test_batch_streaming.py
+++ b/tests/python/test_batch_streaming.py
@@ -1,0 +1,199 @@
+"""Tests for the streaming batch API (#975).
+
+``BatchProcessor.parse`` / ``parse_and_normalize`` take a fully materialized
+``list`` and return a fully materialized ``BatchResult``, so both the input and
+the output are resident at once *by contract* — no internal chunking can bound
+peak memory behind that signature. ``parse_streaming`` /
+``parse_and_normalize_streaming`` consume an iterable and yield, so peak memory
+is a function of the chunk size rather than of the input's length.
+
+Two properties are tested, and the second is the one an equality check cannot
+see:
+
+1. **Equivalence** — streaming yields exactly what the list API returns, in the
+   same order, with the same per-item success/error classification.
+2. **Laziness** — the input iterable is pulled from only as results are demanded.
+   A streaming API that collected its input first would satisfy (1) completely
+   while bounding nothing.
+
+These use the mock provider (``BatchProcessor()`` with no manifest), so they need
+no reference data.
+"""
+
+import pytest
+
+import ferro_hgvs
+
+
+def _variants(n: int) -> list[str]:
+    """`n` inputs with deliberate parse errors at known positions."""
+    assert n >= 3
+    vs = [f"NM_000088.3:c.{i}A>G" for i in range(1, n + 1)]
+    vs[1] = "definitely not a variant"
+    vs[n - 1] = "also::not:valid"
+    return vs
+
+
+def _from_list(result) -> list[tuple[bool, str]]:
+    """Order-sensitive fingerprint of a ``BatchResult``, per item."""
+    out: list[tuple[bool, str]] = []
+    errors = dict(result.errors())
+    successes = iter(result.successes())
+    for i in range(result.total()):
+        if i in errors:
+            out.append((False, ""))
+        else:
+            out.append((True, str(next(successes))))
+    return out
+
+
+def _from_stream(stream) -> list[tuple[bool, str]]:
+    return [(item.ok, str(item.variant) if item.ok else "") for item in stream]
+
+
+@pytest.fixture
+def processor():
+    return ferro_hgvs.BatchProcessor()
+
+
+@pytest.mark.parametrize("workers", [0, 1, 2])
+def test_streaming_parse_matches_the_list_api(processor, workers):
+    """Streaming must be item-for-item identical to the list API."""
+    variants = _variants(50)
+    expected = _from_list(processor.parse(variants, workers=workers))
+    streamed = _from_stream(processor.parse_streaming(variants, workers=workers))
+    assert streamed == expected
+
+
+@pytest.mark.parametrize("workers", [0, 1, 2])
+def test_streaming_normalize_matches_the_list_api(processor, workers):
+    variants = _variants(50)
+    expected = _from_list(processor.parse_and_normalize(variants, workers=workers))
+    streamed = _from_stream(processor.parse_and_normalize_streaming(variants, workers=workers))
+    assert streamed == expected
+
+
+def test_failed_items_carry_their_input(processor):
+    """A failure must be reportable without the caller keeping the input list —
+    otherwise a streaming consumer would have to retain what it streamed."""
+    items = list(processor.parse_streaming(["NM_000088.3:c.1A>G", "nope"]))
+    assert items[0].ok and items[0].input is None and items[0].error is None
+    assert not items[1].ok
+    assert items[1].input == "nope"
+    assert items[1].error and items[1].variant is None
+
+
+def test_the_input_is_consumed_lazily(processor):
+    """The property that makes peak memory bounded.
+
+    Nothing may be read from the iterable before the first ``next()``. This is
+    what an output-equality test cannot detect.
+    """
+    pulled: list[str] = []
+
+    def source():
+        for v in _variants(10):
+            pulled.append(v)
+            yield v
+
+    stream = processor.parse_streaming(source())
+    assert pulled == [], "constructing the stream must read nothing"
+    first = next(stream)
+    assert first.ok
+    assert pulled, "the first result must have pulled from the source"
+    rest = list(stream)
+    assert len(rest) == 9
+    assert len(pulled) == 10, "every input read exactly once"
+
+
+def test_the_first_result_costs_a_bounded_prefix_not_the_whole_stream(processor):
+    """The half of laziness ``test_the_input_is_consumed_lazily`` cannot see.
+
+    That test uses ten inputs, which is far below the streaming chunk size, so
+    the first ``next()`` legitimately consumes all of them. Every one of its
+    assertions therefore also holds for an implementation that drains the entire
+    iterable on the first ``next()`` — it pins "reads nothing at construction",
+    not "reads a bounded prefix", and only the second bounds peak memory.
+
+    Asserting the *contract* (bounded) rather than the chunk constant, so this
+    keeps testing the right thing if the chunk size is retuned — which it has
+    been, and the Python and Rust paths deliberately use different values.
+    """
+    total = 30_000  # comfortably several chunks on any plausible chunk size
+    pulled: list[str] = []
+    exhausted = False
+
+    def source():
+        nonlocal exhausted
+        for v in _variants(total):
+            pulled.append(v)
+            yield v
+        exhausted = True
+
+    stream = processor.parse_streaming(source())
+    assert pulled == [], "constructing the stream must read nothing"
+
+    next(stream)
+    after_first = len(pulled)
+    assert 0 < after_first < total, (
+        f"the first result must cost a bounded prefix, not the whole stream; "
+        f"pulled {after_first} of {total}"
+    )
+    assert not exhausted, "the source generator must not have run to completion"
+
+    # Draining the rest reads every remaining input exactly once, so bounding the
+    # prefix has not cost any input.
+    consumed = 1 + sum(1 for _ in stream)
+    assert consumed == total
+    assert len(pulled) == total, "every input read exactly once"
+    assert exhausted
+
+
+def test_the_stream_is_its_own_iterator(processor):
+    stream = processor.parse_streaming(["NM_000088.3:c.1A>G"])
+    assert iter(stream) is stream
+    assert len(list(stream)) == 1
+    # Exhausted streams stay exhausted rather than re-polling a spent iterator.
+    assert list(stream) == []
+
+
+def test_accepts_any_iterable(processor):
+    """A list, a generator and a plain iterator must all work — the point is to
+    accept whatever the caller already has, including a file object."""
+    variants = _variants(5)
+    for source in (variants, iter(variants), (v for v in variants)):
+        assert len(list(processor.parse_streaming(source))) == 5
+
+
+def test_empty_input_yields_nothing(processor):
+    assert list(processor.parse_streaming([])) == []
+    assert list(processor.parse_and_normalize_streaming([])) == []
+
+
+def test_non_string_element_raises(processor):
+    """Surfaced, not skipped: a silently dropped item would desynchronize the
+    caller's own bookkeeping against the stream."""
+    with pytest.raises(TypeError):
+        list(processor.parse_streaming(["NM_000088.3:c.1A>G", 42]))
+
+
+def test_non_iterable_argument_raises_at_the_call(processor):
+    """Raised where the mistake is, rather than on the first ``next()``."""
+    with pytest.raises(TypeError):
+        processor.parse_streaming(42)
+
+
+def test_the_streaming_types_are_exported():
+    """``BatchStream`` and ``BatchItem`` are part of the public surface the stubs
+    declare, so they belong in ``__all__`` alongside the other batch classes.
+
+    ``from .ferro_hgvs import *`` makes them reachable as attributes either way,
+    but ``__all__`` is what governs ``from ferro_hgvs import *`` and what tools
+    read as the package's public API — and ``__init__.pyi`` already promises both
+    names.
+    """
+    assert "BatchStream" in ferro_hgvs.__all__
+    assert "BatchItem" in ferro_hgvs.__all__
+    # The siblings they were added beside, so the set stays coherent.
+    for sibling in ("BatchProgress", "BatchResult", "BatchProcessor"):
+        assert sibling in ferro_hgvs.__all__


### PR DESCRIPTION
Closes #975

The CLI has streamed in bounded chunks since #687. The library surface that the Python bindings and benchmark harness drive did not: `BatchProcessor::map_collect` is `par_iter().map(f).collect()` into a full `Vec`, and `parallel.rs`'s helpers take `&[S]` and return `Vec`. As the issue puts it, chunking those internals buys nothing — both ends are resident **by contract**, so the win requires a streaming entry point.

Two commits: the Rust surface, then the Python one the issue identifies as the actual problem.

## Rust (`0c708b4`)

Four entry points, each consuming an `IntoIterator` and yielding an `Iterator`; every existing `Vec`-based signature untouched:

```
BatchProcessor::parse_streaming            parallel::parse_hgvs_streaming
BatchProcessor::parse_and_normalize_streaming   parallel::parse_and_normalize_streaming
```

Peak RSS, genomic substitutions:

| inputs | `Vec` API | streaming |
| --- | --- | --- |
| 250 000 | 157.5 MiB | 81.3 MiB |
| 1 000 000 | 609.7 MiB | 90.6 MiB |
| 4 000 000 | 2418.7 MiB | 82.9 MiB |
| 8 000 000 | — | 84.1 MiB |

Flat across a 32× range against linear growth.

## Python (`29c7b2d`)

`BatchProcessor.parse_streaming` / `.parse_and_normalize_streaming` accept any iterable of `str` and return a `BatchStream` yielding one `BatchItem` per input, in input order.

Measured on 1M inputs, **materializing one Python object per item on both sides** so the comparison is fair (`parse(...).successes()` against the stream):

| | wall clock | peak RSS |
| --- | --- | --- |
| list | 1.07 s | 1782 MiB |
| streaming | 1.90 s | 38 MiB |

**47× less memory at 1.8× the wall clock.** The time is the cost of one result object per item — that is what per-item reporting buys. An earlier, more flattering comparison against `success_count()` was *not* fair, because that call never builds the variants at all; the number above replaces it.

RSS is flat: 38.5 / 36.8 / 37.6 MiB at 100k / 400k / 1M, against 89 / 293 / 696 MiB for the list API.

## The chunk size is measured, not inherited — twice

#975 asks for bounded RSS **and** throughput within noise, and one chunk size does not deliver both on both paths, because per-item costs differ by orders of magnitude.

- **Rust** (`STREAM_CHUNK_ITEMS` = 65 536). At the CLI's 8192 the streaming path was **8% slower** (0.179 s against 0.166 s on 1M, spread under 1%): for a bare parse, per-chunk overhead is a real fraction of per-item work. At 65 536 it is at parity (0.163 s against 0.164 s), RSS still flat at ~83 MiB instead of ~17 MiB.
- **Python** (`BATCH_CHUNK_ITEMS` = 8192). Here each item becomes a `BatchItem` plus a variant `PyObject`, so the chunk *floor* sets peak memory. At 65 536 that floor was ~120 MiB, which made streaming **worse than the list API below ~150k inputs**. At 8192 it is flat at ~37 MiB and better at every size measured, and the object-creation cost dwarfs the per-chunk overhead that forced the Rust path larger — so chunking small costs nothing here.

Both constants carry the trade-off table in their doc comments. `BATCH_CHUNK_ITEMS` is now exported and the CLI's `BATCH_CHUNK_LINES` refers to it, so the shared engine has one definition rather than two that can drift; `map_collect` also picks up the extracted `build_pool`.

## Edges, each pinned

- A non-`str` element raises `TypeError` rather than being silently skipped — a dropped item would desynchronize the caller's own bookkeeping against the stream.
- A non-iterable argument raises **at the call**, not on the first `next()`.
- An exhausted stream stays exhausted instead of re-polling a spent iterator.
- `iter(stream) is stream`.
- `BatchItem.input` is set only on failure; on success the caller has the variant, and holding the input too would defeat the purpose.

## Tests

**Rust (5):** streaming output compared item-for-item against the `Vec` API across serial / global-pool / dedicated-pool, on a corpus spanning several axes plus inputs that must fail, sized past a chunk boundary so refills are exercised. Short, empty and exactly-one-chunk streams. Plus the property no equality test can see — that the input is consumed **lazily**, asserted by counting pulls: nothing at construction, exactly one chunk for the first result, nothing more until the chunk is crossed. *A streaming API that collected its input first would pass every equality test and bound nothing.*

**Python (13):** the same equivalence across worker counts for both operations, the laziness property, and each edge case above.

## Verification

- `cargo nextest run --features dev` — **9195/9195 pass**, 146 skipped
- `pytest tests/python/test_batch_streaming.py tests/python/test_batch_parallel.py` — **17 passed**
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `ruff check`, `ruff format --check`, `mypy` — all clean
- Type stubs updated for `BatchStream` / `BatchItem` and both new methods
- The wheel was built with `maturin develop --features python` to run the Python tests, since `cargo build --features python` cannot link on macOS locally (#1364)
