### PR TITLE
docs(normalize): repoint the circular-normalizer deferral at its live tracker

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -725,7 +725,7 @@ impl SequenceEnds {
 ///
 /// `o.` stays out: `normalize_core` returns circular `o.` variants unchanged, so
 /// no shuffle runs and nothing can saturate. A genuine circular normalizer is
-/// #951.
+/// #466's circular candidate.
 ///
 /// The genomic caller passes a **window** rather than the whole contig, so it
 /// must say which of its ends are real — see [`SequenceEnds`].
@@ -2527,8 +2527,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // 3'-shift runs and no warning is emitted. A genuine circular
             // normalizer would 3'-shift with origin-wraparound semantics (cf.
             // the mitochondrial wraparound handling in `normalize_mt`), which is
-            // not yet implemented. Tracked by #951. (The earlier "normalize like
-            // genomic variants" note overstated this pass-through clone.)
+            // not yet implemented.
+            //
+            // Tracked by #466's circular candidate, which asks SVD-WG to state
+            // the origin-wraparound shift semantics first — "the most 3'
+            // position possible" is ill-defined on a ring, so there is nothing
+            // to implement against yet.
+            //
+            // NOT #951, and not #129 before it: both are closed. This pointer
+            // has now gone stale twice (#129 -> #951 -> here), and #951's own
+            // body was filed *because* the comment then cited the closed #129.
+            // If #466's candidate is ever closed too, repoint this rather than
+            // leaving the third generation of the same dangling reference.
+            // (The earlier "normalize like genomic variants" note overstated
+            // this pass-through clone.)
             HV::Circular(v) => (
                 HV::Circular(crate::hgvs::variant::CircularVariant {
                     accession: v.accession.clone(),
@@ -9798,10 +9810,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
 ///
 /// `Circular` (o.) is included even though its current normalizer is a
 /// pass-through clone (positions cannot change); the surface is
-/// forward-safe for when circular shuffling is implemented (tracked by
-/// #951 — the prior reference to the now-closed #129 was to its MT-scoped
-/// deferral) and costs nothing today (the post-hoc equality check trivially
-/// returns no info).
+/// forward-safe for when circular shuffling is implemented (tracked by #466's
+/// circular candidate; the earlier pointers at #951 and, before it, the
+/// MT-scoped #129 are both closed) and costs nothing today (the post-hoc
+/// equality check trivially returns no info).
 fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
     match variant {
         HV::Genome(v) => Some(format!("{}", v.loc_edit.location)),

--- a/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
+++ b/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
@@ -231,7 +231,8 @@ fn non_shuffling_insertion_at_the_mito_start_is_untouched() {
 
 /// `o.` is returned unchanged by `normalize_core` — no shuffle runs, so no
 /// saturation and nothing for the clamp to fix. Pins that this fix does not
-/// extend there by reflex; a real circular normalizer is #951.
+/// extend there by reflex; a real circular normalizer is #466's circular
+/// candidate (the closed #951 was the previous tracker).
 #[test]
 fn circular_o_axis_is_untouched() {
     let mut provider = MockProvider::new();

--- a/tests/it/issue_1282_position_zero.rs
+++ b/tests/it/issue_1282_position_zero.rs
@@ -193,7 +193,8 @@ fn a_substitution_off_the_first_base_is_out_of_scope() {
 /// single-position `delins`, which needs no reversed range at all.
 ///
 /// So the clamp firing on `m.` is the established behaviour, not an oversight —
-/// this pins it so a future circular normalizer (#951) has to decide
+/// this pins it so a future circular normalizer (#466's circular candidate,
+/// which supersedes the closed #951) has to decide
 /// deliberately rather than change it by accident.
 #[test]
 fn the_mitochondrial_axis_takes_the_same_boundary_delins() {

--- a/tests/it/issue_951_circular_normalize_passthrough.rs
+++ b/tests/it/issue_951_circular_normalize_passthrough.rs
@@ -1,8 +1,17 @@
 //! Issue #951 — `o.` (circular, SVD-WG006) normalization is a deliberate
 //! pass-through: the variant is returned unchanged, with no 3'-shift and no
 //! warning. A genuine circular normalizer would 3'-shift with origin-wraparound
-//! semantics, which is not yet implemented (tracked by the open #951; the prior
-//! in-code reference to the now-closed, MT-scoped #129 was misleading).
+//! semantics, which is not yet implemented.
+//!
+//! **The live tracker is #466's circular candidate, not #951.** #951 was closed
+//! `NOT_PLANNED` on 2026-07-08, superseded by that candidate, which asks SVD-WG
+//! to define the origin-wraparound shift semantics before anything is built
+//! against them. The file keeps its name as the historical anchor for the
+//! behaviour it pins.
+//!
+//! Note the shape of the mistake this corrects, since it has now happened
+//! twice: #951 was itself filed because the code then pointed at the closed,
+//! MT-scoped #129.
 //!
 //! These tests pin the current documented behavior so a future implementer of
 //! circular shuffling knows exactly what contract they are changing.
@@ -22,7 +31,8 @@ fn circular_deletion_is_returned_unchanged_without_warnings() {
     assert_eq!(
         format!("{}", outcome.result),
         input,
-        "circular o. normalization must be a pass-through (no 3'-shift) — #951",
+        "circular o. normalization must be a pass-through (no 3'-shift) — see \
+         #466's circular candidate",
     );
     assert!(
         outcome.warnings.is_empty(),


### PR DESCRIPTION
Refs #466 — a follow-up from auditing that tracker. Comments only; no behaviour change.

Seven comments across `normalize/mod.rs` and three test modules cite **#951** as the tracker for implementing circular (`o.`) 3'-shifting, and two of them say "the **open** #951".

It is not open. #951 was closed `NOT_PLANNED` on 2026-07-08, superseded by **#466's circular candidate**, which asks SVD-WG to state the origin-wraparound shift semantics before anything is built against them — "the most 3' position possible" is ill-defined on a ring, so there is currently nothing to implement.

#466's candidate 4 already records that it supersedes #951. Only the code had not been told.

## Why this is more than a search-and-replace

This is the **second** time the same pointer has gone stale in the same place. #951's own body was filed precisely because the comment then cited the closed, MT-scoped **#129**:

> The deferral this points at, **#129, is CLOSED**, so the gap has no open tracker.

So the chain is `#129 → #951 → #466's candidate`. The comment at the pass-through arm now records that chain and asks the next person to repoint rather than leave a third dangling generation — which is the part likely to save someone the same investigation.

## Scope

- `src/normalize/mod.rs` — three sites, including the `HV::Circular` pass-through arm.
- `tests/it/issue_951_circular_normalize_passthrough.rs` — module docs and one assertion message. **Keeps its filename** as the historical anchor for the behaviour it pins; only the claim about what is open changes.
- `tests/it/issue_1282_position_zero.rs`, `tests/it/issue_1217_mito_terminus_insertion_clamp.rs` — one site each.

## Verification

- `cargo nextest run --features dev` — **9190/9190 pass**, 146 skipped
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean

The audit that found this is on #466, along with re-verification of all four of its candidates and both markup defects against submodule `21.1.4`.
