### PR TITLE
fix(parse): let a UTR-marker ins payload reach the message written for it

### DIFF
--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -355,7 +355,14 @@ fn parse_inserted_sequence(
             // Parenthesized range: (10_20)
             parse_parenthesized_count(input)
         }
-        b'0'..=b'9' => {
+        // `*` joins the digits here so the **unbracketed** form of a UTR-marker
+        // range parses too (#1376). Without it `ins[*100_*200]` parsed while its
+        // own rendering, `ins*100_*200`, did not — a parse/display asymmetry, and
+        // one the intronic sibling does not have (`ins244-8_249` round-trips
+        // because it starts with a digit). A `*` that is not the start of such a
+        // range still falls through: `parse_cds_position_range` requires digits
+        // after the marker and an `_`-joined second position.
+        b'0'..=b'9' | b'*' => {
             // Could be CDS position range (423-1933_423-1687inv) or simple count (10)
             // Try CDS position range first if it looks like one (has _ with possible +/- offsets)
             if let Ok((remaining, part)) = parse_cds_position_range(input) {
@@ -714,32 +721,74 @@ fn parse_external_ref_part(input: &str) -> IResult<&str, crate::hgvs::edit::Inse
     ))
 }
 
-/// Parse a CDS-style position range (e.g., 401_419, 244-8_249, 100+5_200-10, with optional inv suffix)
+/// Parse a CDS-style position range (e.g., 401_419, 244-8_249, 100+5_200-10,
+/// `*100_*200`, with optional inv suffix)
+///
+/// A leading `*` marks a 3'UTR position. It is admitted here so the range
+/// reaches [`InsertedPart::CdsPositionRange`], whose refusal downstream already
+/// names this shape — "CDS-offset range (intronic **or UTR-marker**) is
+/// spec-undefined". Before #1376 the grammar stopped at the `*` instead, so
+/// `c.249_250ins[*100_*200]` died with a bare `nom` `Tag` error while its
+/// intronic sibling `ins[244-8_249]` parsed and got the sentence. Accepting it
+/// here is the consistent half of that pair: parse, then refuse with a reason.
 fn parse_cds_position_range(input: &str) -> IResult<&str, crate::hgvs::edit::InsertedPart> {
     use crate::hgvs::edit::InsertedPart;
 
-    // Try to parse CDS-style position (may have offsets like -8 or +5)
-    // Format: base[+-offset]_base[+-offset][inv]
-    let mut end_pos = 0;
+    /// Consume one position: an optional 3'UTR `*` marker, then digits, then an
+    /// optional `+N`/`-N` intronic offset. Returns `None` if no digits follow,
+    /// which is what makes a bare `*` or an empty token a parse failure rather
+    /// than a zero-length match.
+    ///
+    /// An offset marker must be followed by digits too. Without that check a
+    /// bare `+`/`-` was consumed as if it were an offset and the position still
+    /// matched, so `ins[100+_200]`, `ins[100_200+]` and `ins[*100_*200-]` all
+    /// parsed — none of which is a position. That predates the `*` work, but
+    /// this helper is where the offset scan now lives, so it is fixed here.
+    fn take_position(bytes: &[u8], mut at: usize) -> Option<usize> {
+        if at < bytes.len() && bytes[at] == b'*' {
+            at += 1;
+        }
+        let digits_start = at;
+        while at < bytes.len() && bytes[at].is_ascii_digit() {
+            at += 1;
+        }
+        if at == digits_start {
+            return None;
+        }
+        if at < bytes.len() && (bytes[at] == b'+' || bytes[at] == b'-') {
+            let offset_digits_start = at + 1;
+            let mut probe = offset_digits_start;
+            while probe < bytes.len() && bytes[probe].is_ascii_digit() {
+                probe += 1;
+            }
+            if probe == offset_digits_start {
+                // A marker with no magnitude is not an offset, and a position
+                // that ends in one is not a position.
+                return None;
+            }
+            at = probe;
+        }
+        Some(at)
+    }
+
     let bytes = input.as_bytes();
 
-    // Parse first position (digits with optional +/- offset)
-    while end_pos < bytes.len() && bytes[end_pos].is_ascii_digit() {
-        end_pos += 1;
-    }
-    if end_pos == 0 {
+    // Parse first position (optional `*`, digits, optional +/- offset).
+    //
+    // `take_position` consumes the offset itself, so there is deliberately no
+    // second offset pass here. There used to be — the pre-refactor code scanned
+    // digits inline and then handled one offset — and leaving it in place after
+    // the extraction let the FIRST position take two offsets while the second
+    // (which only calls `take_position`) takes one: `ins[100+5-3_200]` parsed
+    // while `ins[100_200+5-3]` did not. A c. position carries at most one
+    // intronic offset, so that asymmetry accepted a position the spec rejects,
+    // in a fuzzed parser.
+    let Some(mut end_pos) = take_position(bytes, 0) else {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Digit,
         )));
-    }
-    // Check for offset (+N or -N)
-    if end_pos < bytes.len() && (bytes[end_pos] == b'+' || bytes[end_pos] == b'-') {
-        end_pos += 1;
-        while end_pos < bytes.len() && bytes[end_pos].is_ascii_digit() {
-            end_pos += 1;
-        }
-    }
+    };
 
     // Must have underscore separator
     if end_pos >= bytes.len() || bytes[end_pos] != b'_' {
@@ -750,28 +799,23 @@ fn parse_cds_position_range(input: &str) -> IResult<&str, crate::hgvs::edit::Ins
     }
     end_pos += 1; // skip underscore
 
-    // Parse second position
-    let second_start = end_pos;
-    while end_pos < bytes.len() && bytes[end_pos].is_ascii_digit() {
-        end_pos += 1;
-    }
-    if end_pos == second_start {
+    // Parse second position, same shape as the first.
+    let Some(second_end) = take_position(bytes, end_pos) else {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Digit,
         )));
-    }
-    // Check for offset on second position
-    if end_pos < bytes.len() && (bytes[end_pos] == b'+' || bytes[end_pos] == b'-') {
-        end_pos += 1;
-        while end_pos < bytes.len() && bytes[end_pos].is_ascii_digit() {
-            end_pos += 1;
-        }
-    }
+    };
+    end_pos = second_end;
 
     let range_str = &input[..end_pos];
     let mut remaining = &input[end_pos..];
-    let has_offset = range_str.contains('+') || range_str.contains('-');
+    // Anything that is not a pair of plain positive integers needs offset- or
+    // UTR-aware translation, which the same-reference lookup does not do — so it
+    // routes to `CdsPositionRange` and is refused with a reason. `*` joins `+`
+    // and `-` here for that purpose (#1376).
+    let needs_axis_translation =
+        range_str.contains('+') || range_str.contains('-') || range_str.contains('*');
 
     // Check for inversion suffix
     let has_inv = if remaining.starts_with("inv") {
@@ -781,8 +825,8 @@ fn parse_cds_position_range(input: &str) -> IResult<&str, crate::hgvs::edit::Ins
         false
     };
 
-    // Determine which variant to use based on whether there are offsets
-    if has_offset {
+    // Determine which variant to use based on whether the positions are plain.
+    if needs_axis_translation {
         let range_with_inv = if has_inv {
             format!("{}inv", range_str)
         } else {

--- a/tests/it/issue_1376_utr_ins_payload.rs
+++ b/tests/it/issue_1376_utr_ins_payload.rs
@@ -1,0 +1,254 @@
+//! Issue #1376 — a UTR-marker `ins[...]` payload leaked a raw `nom` error.
+//!
+//! `c.249_250ins[*100_*200]` failed with
+//!
+//! ```text
+//! Failed to parse variant: Error(Error { input: "ins[*100_*200]", code: Tag })
+//! ```
+//!
+//! a combinator's internal state reaching the user, naming neither the construct
+//! nor the reason. Its intronic sibling `ins[244-8_249]` parsed and was refused
+//! downstream with a sentence that **already names this shape**: "CDS-offset
+//! range (intronic *or UTR-marker*) is spec-undefined and not yet supported".
+//!
+//! So the message existed and the shape simply never reached it:
+//! `parse_cds_position_range` required a leading digit, and stopped at the `*`.
+//! Admitting the `*` routes the range to `InsertedPart::CdsPositionRange`, which
+//! is the arm that carries the refusal.
+//!
+//! What this does **not** change: whether such a payload is expandable. #466's
+//! candidate 2 asks SVD-WG to define the canonical expansion for these shapes,
+//! and stays open either way. This is only about the diagnostic.
+
+use ferro_hgvs::hgvs::edit::{InsertedPart, InsertedSequence, NaEdit};
+use ferro_hgvs::hgvs::uncertainty::Mu;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::parse_hgvs;
+
+/// The `InsertedPart`s a parsed `ins[...]` payload decomposed into.
+///
+/// Asserting on the parsed shape rather than on a normalization error message is
+/// deliberate: the routing to `CdsPositionRange` *is* the fix, and it is what
+/// determines which refusal a caller gets. Reaching the message itself needs a
+/// provider that resolves the transcript's CDS, so it is verified end to end
+/// against a real prepared reference (see the PR) rather than pinned against a
+/// mock whose plumbing could change the answer for unrelated reasons.
+fn inserted_parts(descriptor: &str) -> Vec<InsertedPart> {
+    let variant = parse_hgvs(descriptor)
+        .unwrap_or_else(|e| panic!("`{descriptor}` must now parse, but: {e}"));
+    let HgvsVariant::Cds(cds) = variant else {
+        panic!("`{descriptor}` must parse as a c. variant");
+    };
+    let Mu::Certain(NaEdit::Insertion { sequence }) = cds.loc_edit.edit else {
+        panic!("`{descriptor}` must parse as a certain insertion");
+    };
+    match sequence {
+        InsertedSequence::Complex(parts) => parts,
+        other => panic!("`{descriptor}` must carry a complex payload, got {other:?}"),
+    }
+}
+
+/// The UTR-marker payload parses, and routes to the arm that carries the curated
+/// refusal — instead of dying in the grammar with a `nom` error.
+#[test]
+fn a_utr_marker_range_payload_routes_to_the_curated_refusal() {
+    let parts = inserted_parts("NM_000088.3:c.249_250ins[*100_*200]");
+    assert_eq!(parts.len(), 1, "one payload part, got {parts:?}");
+    assert!(
+        matches!(&parts[0], InsertedPart::CdsPositionRange(range) if range == "*100_*200"),
+        "must route to CdsPositionRange, whose refusal already names UTR markers; \
+         got {parts:?}"
+    );
+}
+
+/// The intronic sibling is unchanged — it is the behaviour being matched, so a
+/// change here would mean the two drifted apart again rather than converged.
+#[test]
+fn the_intronic_sibling_is_unchanged() {
+    let parts = inserted_parts("NM_000088.3:c.249_250ins[244-8_249]");
+    assert!(
+        matches!(&parts[0], InsertedPart::CdsPositionRange(range) if range == "244-8_249"),
+        "got {parts:?}"
+    );
+}
+
+/// A plain positive-integer range must still be a plain same-reference range,
+/// not routed to the refusal — `*` widened the grammar, and this pins that it
+/// widened it only where intended.
+#[test]
+fn a_plain_range_payload_still_resolves() {
+    let parts = inserted_parts("NM_000088.3:c.249_250ins[401_419]");
+    assert!(
+        matches!(
+            &parts[0],
+            InsertedPart::PositionRange {
+                start: 401,
+                end: 419
+            }
+        ),
+        "a plain range must stay a plain same-reference range, got {parts:?}"
+    );
+    let variant = parse_hgvs("NM_000088.3:c.249_250ins[401_419]").expect("must parse");
+    assert_eq!(
+        variant.to_string(),
+        "NM_000088.3:c.249_250ins401_419",
+        "a plain range must keep its flat same-reference form"
+    );
+}
+
+/// The rendered form must itself parse.
+///
+/// A second regression this change had to avoid, and did not at first: admitting
+/// `ins[*100_*200]` in the *bracketed* grammar alone made it parse into something
+/// whose own rendering — `ins*100_*200`, brackets dropped for a single part — was
+/// still rejected. Parse-then-display then produced a string ferro could not read
+/// back, which is the asymmetry `FERRO_ASSERT_REPARSE` exists to catch for
+/// normalization and which nothing catches at the parse seam.
+///
+/// The intronic sibling never had it, because `ins244-8_249` starts with a digit
+/// and so was already accepted unbracketed. Admitting `*` on that path too makes
+/// the pair symmetric again.
+#[test]
+fn the_rendered_form_parses_back() {
+    for descriptor in [
+        "NM_000088.3:c.249_250ins[*100_*200]",
+        // The unbracketed form directly, which is what the one above renders as.
+        "NM_000088.3:c.249_250ins*100_*200",
+    ] {
+        let variant = parse_hgvs(descriptor).unwrap_or_else(|e| panic!("`{descriptor}`: {e}"));
+        let rendered = variant.to_string();
+        let reparsed = parse_hgvs(&rendered).unwrap_or_else(|e| {
+            panic!("`{descriptor}` rendered `{rendered}`, which will not parse: {e}")
+        });
+        assert_eq!(
+            reparsed.to_string(),
+            rendered,
+            "`{descriptor}` must reach a display fixed point"
+        );
+    }
+}
+
+/// Widening the unbracketed path must not disturb the other things that can
+/// follow `ins`: a literal sequence, a bare count, a repeat, or an intronic
+/// range. `*` was added to the dispatch arm those share.
+#[test]
+fn the_other_unbracketed_payload_shapes_are_unchanged() {
+    for descriptor in [
+        "NM_000088.3:c.249_250insATG",
+        "NM_000088.3:c.249_250ins10",
+        "NM_000088.3:c.249_250insN[15]",
+        "NM_000088.3:c.249_250ins244-8_249",
+        "NM_000088.3:c.249_250ins401_419",
+    ] {
+        let variant =
+            parse_hgvs(descriptor).unwrap_or_else(|e| panic!("`{descriptor}` must parse: {e}"));
+        assert_eq!(
+            variant.to_string(),
+            descriptor,
+            "`{descriptor}` must round-trip unchanged"
+        );
+    }
+}
+
+/// The `*` is a marker on a position, not a position. A bare one, or an empty
+/// token, must still be a parse error — otherwise admitting `*` would have made
+/// the grammar accept nonsense.
+#[test]
+fn a_marker_without_a_position_is_still_rejected() {
+    for descriptor in [
+        "NM_000088.3:c.249_250ins[*_*200]",
+        "NM_000088.3:c.249_250ins[*100_*]",
+        "NM_000088.3:c.249_250ins[*100_]",
+        "NM_000088.3:c.249_250ins[*]",
+    ] {
+        assert!(
+            parse_hgvs(descriptor).is_err(),
+            "`{descriptor}` names no second position and must not parse"
+        );
+    }
+}
+
+/// The mixed form the issue's real-world example uses — an intronic range beside
+/// `N[k]` padding — routes the same way, and so does its UTR twin.
+#[test]
+fn a_padded_multi_part_payload_routes_the_same_way() {
+    for (descriptor, expected) in [
+        ("NM_000088.3:c.249_250ins[N[2800];244-8_249]", "244-8_249"),
+        ("NM_000088.3:c.249_250ins[N[2800];*100_*200]", "*100_*200"),
+    ] {
+        let parts = inserted_parts(descriptor);
+        assert_eq!(parts.len(), 2, "`{descriptor}` -> {parts:?}");
+        assert!(
+            matches!(&parts[0], InsertedPart::Repeat { .. }),
+            "`{descriptor}`: the `N[2800]` padding must survive, got {parts:?}"
+        );
+        assert!(
+            matches!(&parts[1], InsertedPart::CdsPositionRange(range) if range == expected),
+            "`{descriptor}` -> {parts:?}"
+        );
+    }
+}
+
+/// Both positions of the range must admit exactly the same shapes.
+///
+/// A c. position carries at most ONE intronic offset, so `100+5-3` is not a
+/// position at all. The refactor that admitted `*` extracted the position scan
+/// into a helper that consumes the offset itself, and for a while the caller
+/// still ran its own offset pass afterwards — but only for the FIRST position.
+/// That made the two ends of one range disagree: `ins[100+5-3_200]` parsed while
+/// `ins[100_200+5-3]` did not, so the grammar accepted a position the spec has no
+/// reading for. Green suites do not catch this; nothing asserted the pair.
+///
+/// Asserted as a symmetry rather than as two independent cases, so a future
+/// change that loosens one end has to loosen the other deliberately.
+#[test]
+fn both_ends_of_a_range_accept_the_same_position_shapes() {
+    // Each row carries the expected verdict as well as the pair, because
+    // symmetry alone is satisfied by BOTH ends being wrong together — a change
+    // that rejected every offset would keep `lhs == rhs` and pass.
+    for (first, second, accepted) in [
+        // One offset per position is legal at either end.
+        ("100+5_200", "100_200+5", true),
+        ("100-5_200", "100_200-5", true),
+        // Two offsets on one position is not a position, at either end.
+        ("100+5-3_200", "100_200+5-3", false),
+        ("100-5+3_200", "100_200-5+3", false),
+        // An offset marker with no magnitude is not a position either.
+        ("100+_200", "100_200+", false),
+        ("100-_200", "100_200-", false),
+        // UTR markers, the shape this file exists for.
+        ("*100_*200", "*100_*200", true),
+        ("*100-_*200", "*100_*200-", false),
+    ] {
+        let lhs = ferro_hgvs::parse_hgvs(&format!("NM_000088.3:c.249_250ins[{first}]")).is_ok();
+        let rhs = ferro_hgvs::parse_hgvs(&format!("NM_000088.3:c.249_250ins[{second}]")).is_ok();
+        assert_eq!(
+            lhs,
+            accepted,
+            "`ins[{first}]` should {} parse",
+            if accepted { "" } else { "not" }
+        );
+        assert_eq!(
+            rhs,
+            accepted,
+            "`ins[{second}]` should {} parse",
+            if accepted { "" } else { "not" }
+        );
+        assert_eq!(
+            lhs, rhs,
+            "`ins[{first}]` and `ins[{second}]` disagree ({lhs} vs {rhs}) — the two \
+             positions of one range must admit the same shapes"
+        );
+    }
+
+    // And the specific regression: a doubled offset is refused at BOTH ends.
+    for descriptor in [
+        "NM_000088.3:c.249_250ins[100+5-3_200]",
+        "NM_000088.3:c.249_250ins[100_200+5-3]",
+    ] {
+        assert!(
+            ferro_hgvs::parse_hgvs(descriptor).is_err(),
+            "`{descriptor}` carries two offsets on one position and must not parse"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -195,6 +195,7 @@ mod issue_1334_liftover_position_zero;
 mod issue_1349_rotation_fallback_dup;
 mod issue_1355_rotation_gate_repeat;
 mod issue_1362_identity_span;
+mod issue_1376_utr_ins_payload;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1376

`c.249_250ins[*100_*200]` failed with a combinator's internal state reaching the user:

```
Failed to parse variant: Error(Error { input: "ins[*100_*200]", code: Tag })
```

Its intronic sibling `ins[244-8_249]` parsed and was refused downstream with a sentence that **already names this shape**:

> `ins[244-8_249]` CDS-offset range (intronic **or UTR-marker**) is spec-undefined and not yet supported by ferro

So the message existed, and the shape simply never reached it. `parse_cds_position_range` required a leading digit and stopped at the `*`, while every consumer of `InsertedPart::CdsPositionRange` was already written to cover UTR markers.

## After

Both siblings now fail identically, measured against a real prepared reference:

```
ins[*100_*200]  -> Unsupported variant type: … CDS-offset range (intronic or UTR-marker) is spec-undefined …
ins[244-8_249]  -> Unsupported variant type: … CDS-offset range (intronic or UTR-marker) is spec-undefined …
```

## The change

An optional leading `*` on each position, and `*` joins `+`/`-` in the test that decides a range needs axis-aware translation — none of the three is a plain positive integer, which is the property that arm exists for.

Both positions now go through **one** helper rather than two near-copies, which is what lets the second position accept `*` without a third copy of the logic.

## Widened only where intended

| input | before | after |
| --- | --- | --- |
| `ins[*100_*200]` | `nom` `Tag` error | curated refusal |
| `ins[244-8_249]` | curated refusal | unchanged |
| `ins[401_419]` | plain `PositionRange` | unchanged |
| `ins[*_*200]`, `ins[*100_*]`, `ins[*]` | parse error | still a parse error |

A `*` with no digits after it stays rejected — the helper returns `None` unless digits follow, so the marker is a modifier on a position, not a position.

## Diagnostic, not policy

Whether such a payload is *expandable* is **#466's candidate 2**, which asks SVD-WG to define the canonical expansion for intronic-offset and UTR-marker ranges. That stays open either way; this only decides which error a caller sees today.

## A note on how the tests are written

They assert the parsed **routing** (`InsertedPart::CdsPositionRange("*100_*200")`) rather than a normalization message. The routing is the fix, and reaching the message needs a provider that resolves the transcript's CDS — pinning it against a mock would let provider plumbing decide the outcome for reasons unrelated to this change. The end-to-end message is verified against a real prepared reference (output above) rather than asserted against a fixture.

Five tests: the UTR routing, the intronic sibling unchanged, a plain range unchanged, the marker-without-a-position rejections, and the real-world `N[k]`-padded multi-part form (`ins[N[2800];244-8_249]` and its UTR twin) where the padding must survive alongside the range.

## Provenance

Found while auditing #466 — see that issue's audit comment, which also corrects candidate 2's "ferro today" line, since it recorded `UnsupportedVariant` without noting that one of the three shapes never got there.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — **9195/9195 pass**, 146 skipped. That includes the spec-fixture census guards, so widening the grammar moved no harvested spec row.
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.


## Review fix: the two ends of a range had stopped agreeing

Extracting the position scan into `take_position` moved offset handling *into* the helper, but the caller's original offset pass was left in place — and only for the **first** position. The second position calls `take_position` alone. So one range's two ends admitted different grammars:

```
c.249_250ins[100+5-3_200]   parsed
c.249_250ins[100_200+5-3]   did not
```

A c. position carries at most one intronic offset, so `100+5-3` is not a position; the first end was accepting a form the spec has no reading for, in a parser that is fuzzed. Removing the duplicate pass makes both ends refuse it, and leaves this PR's actual subject untouched — `ins*100_*200` and `ins[*100_*200]` still parse and still route to the curated refusal.

`both_ends_of_a_range_accept_the_same_position_shapes` pins it as a **symmetry** rather than as two independent cases, so a later change that loosens one end has to loosen the other on purpose.

Verified: `fast_path_differential` (table and proptest) and `fast_path_drift_scope` pass, and the full suite with all three oracles armed (`FERRO_ASSERT_IDEMPOTENT` / `FERRO_ASSERT_REPARSE` / `FERRO_ASSERT_IN_BOUNDS`) is **9249/9249**. The spec-enumeration census is unmoved — an earlier local failure there was a stale generated fixture in the worktree, not this change.
