### PR TITLE
fix(spdi)!: give an unspelled identity the span it claims

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1394,12 +1394,44 @@ where
             ))
         }
         NaEdit::Identity {
-            sequence: id_seq, ..
+            sequence: id_seq,
+            whole_entity,
         } => {
-            let ref_base = id_seq
-                .as_ref()
-                .map(|s| apply_alphabet(&sequence_to_string(s), alphabet))
-                .unwrap_or_default();
+            // An identity claims the bases under its span — `g.10_12=` asserts
+            // that three bases are unchanged — so its triple must name them, the
+            // same way `Deletion`, `Delins` and `Inversion` fetch a sequence the
+            // input omitted (#1362). This arm used to default to the empty
+            // string, which lost the span and, worse, made the triple
+            // zero-width: a zero-width triple at an interbase is
+            // indistinguishable from an *insertion* at that interbase.
+            //
+            // That is what made the project's own SPDI applier decline any
+            // description containing an unspelled identity. `g.[261_262dup;263=]`
+            // — a real 5'-shuffle output — converted to `262::AG` and `262::`,
+            // two members apparently competing for one interbase, so the applier
+            // refused the whole thing. The identity actually claims base 263 and
+            // the two are disjoint; only the lossy conversion collided them.
+            //
+            // A **whole-entity** identity (`g.=`) is the exception and keeps its
+            // zero-width triple: it asserts the entire reference is unchanged and
+            // names no span, so there is nothing to fetch. Narrowing it to base 1
+            // would invent a claim, and fetching a whole chromosome to prove it
+            // unchanged would be absurd.
+            let ref_raw = match id_seq {
+                Some(seq) => sequence_to_string(seq),
+                None if *whole_entity => String::new(),
+                None => match provider {
+                    Some(p) => fetch_reference_bases(p, &sequence, start_one_based, end_one_based)?,
+                    None => {
+                        return Err(ConversionError::MissingReferenceData {
+                            description: format!(
+                                "Cannot convert identity to SPDI: the unchanged bases at                                  {start_one_based}..={end_one_based} are unknown (no reference                                  data). Spell them (e.g. `g.10A=`) or convert with a provider."
+                            ),
+                        });
+                    }
+                },
+            };
+            let ref_base = apply_alphabet(&ref_raw, alphabet);
             Ok(SpdiVariant::new(
                 sequence,
                 spdi_pos,
@@ -2077,6 +2109,90 @@ mod tests {
         assert_eq!(spdi.position, 99);
         assert_eq!(spdi.deletion, "A");
         assert_eq!(spdi.insertion, "A");
+    }
+
+    #[test]
+    fn identity_spdi_claims_the_bases_it_asserts_unchanged() {
+        // #1362: an unspelled identity used to convert to a zero-width triple,
+        // losing its span. It now fetches the bases, like the `Deletion`,
+        // `Delins` and `Inversion` arms already did.
+        //
+        // GGATTACAGGCATTAGCCT — 1-based base 10 is `G`, and 10..=12 is `GCA`.
+        let mut provider = crate::reference::mock::MockProvider::new();
+        provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCT");
+        let convert = |descriptor: &str| {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            hgvs_to_spdi(&variant, &provider)
+        };
+
+        // One base, and a three-base span whose width used to vanish.
+        let one = convert("NC_KEY.1:g.10=").expect("must convert with a provider");
+        assert_eq!(
+            (one.position, one.deletion.as_str(), one.insertion.as_str()),
+            (9, "G", "G")
+        );
+        let three = convert("NC_KEY.1:g.10_12=").expect("must convert with a provider");
+        assert_eq!(
+            (
+                three.position,
+                three.deletion.as_str(),
+                three.insertion.as_str()
+            ),
+            (9, "GCA", "GCA"),
+            "a three-base identity must claim three bases, not zero"
+        );
+
+        // A spelled identity is unchanged — it never needed the provider.
+        let spelled = convert("NC_KEY.1:g.10G=").expect("must convert");
+        assert_eq!(
+            (spelled.deletion.as_str(), spelled.insertion.as_str()),
+            ("G", "G")
+        );
+    }
+
+    /// A **whole-entity** identity keeps its zero-width triple, deliberately.
+    ///
+    /// `g.=` asserts that the entire reference is unchanged and names no span, so
+    /// there is nothing to fetch. Narrowing it to base 1 would invent a claim, and
+    /// fetching a whole chromosome to prove it unchanged would be absurd. This is
+    /// the one arm of #1362 that must *not* consult the provider.
+    #[test]
+    fn a_whole_entity_identity_stays_zero_width() {
+        let mut provider = crate::reference::mock::MockProvider::new();
+        provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCT");
+        let variant = parse_hgvs("NC_KEY.1:g.=").expect("fixture must parse");
+        let spdi = hgvs_to_spdi(&variant, &provider).expect("must convert");
+        assert_eq!(
+            (spdi.deletion.as_str(), spdi.insertion.as_str()),
+            ("", ""),
+            "a whole-entity identity names no span: {spdi:?}"
+        );
+    }
+
+    /// Without a provider, an unspelled identity now reports the same
+    /// missing-reference error its sibling arms do, rather than silently
+    /// returning a wrong-width triple (#1362).
+    ///
+    /// This is the breaking half of that change: `hgvs_to_spdi_simple`, and the
+    /// Python `hgvs_to_spdi` that wraps it, used to answer `9::` here.
+    #[test]
+    fn an_unspelled_identity_without_a_provider_is_an_error() {
+        let variant = parse_hgvs("NC_KEY.1:g.10=").expect("fixture must parse");
+        let err = hgvs_to_spdi_simple(&variant)
+            .expect_err("an unspelled identity has no bases without a reference");
+        assert!(
+            matches!(err, ConversionError::MissingReferenceData { .. }),
+            "expected MissingReferenceData, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("identity") && msg.contains("g.10A="),
+            "the message should name the construct and how to avoid the error: {msg}"
+        );
+        // A spelled identity still works without a provider — the error is about
+        // the absent bases, not about identities.
+        let spelled = parse_hgvs("NC_KEY.1:g.10A=").expect("fixture must parse");
+        assert!(hgvs_to_spdi_simple(&spelled).is_ok());
     }
 
     #[test]

--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -343,43 +343,50 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
         }
     }
     assert_eq!(
-        beyond_the_applier, 1,
-        "exactly one of these outputs should be inexpressible to the applier. If \
-         `an_identity_member_leaves_the_output_beyond_the_applier` is also red, the \
-         redundant `=` member stopped being emitted — good, re-check that row. If \
-         it is green, a second output became inexpressible — bad, find which."
+        beyond_the_applier, 0,
+        "every one of these outputs should now be expressible to the applier. This \
+         was 1 until #1362 taught `hgvs_to_spdi` to fetch an unspelled identity's \
+         bases instead of emitting a zero-width triple: the `263=` member below used \
+         to collide with its `261_262dup` sibling at one interbase, so the applier \
+         refused the whole description. If this is red again, either a new output \
+         became inexpressible — find which — or that conversion regressed."
     );
 }
 
 #[test]
-fn an_identity_member_leaves_the_output_beyond_the_applier() {
-    // A finding in its own right, recorded because it silently weakens the test
-    // above. Under 5' shuffle #1321's split spelling settles with a redundant
-    // identity member beside a real edit:
+fn an_identity_member_is_now_expressible_to_the_applier() {
+    // Under 5' shuffle #1321's split spelling settles with a redundant identity
+    // member beside a real edit:
     //
     //     g.[261_262insGA;262_263insA;263del]  ->  g.[261_262dup;263=]
     //
     // `=` states that nothing changes, so the member carries no information and
-    // the `263=` is pure noise in the output. It also has no SPDI triple, so
-    // `hgvs_to_spdi` declines and this project's own independent applier cannot
-    // evaluate the description — the one oracle that judges denotation is blind
-    // to any output containing one.
+    // the `263=` is pure noise in the output. That part is unchanged and is still
+    // worth removing on its own merits.
     //
-    // Emitting it is what puts the allele into `collect_canonical_edits`'s
-    // catch-all (`_ => return None`) too, so the derivation refuses to re-derive
-    // it. Two further gates refuse behind that one (the
-    // `changed_columns_of_pieces` weight bound, then `needs_unsupported_form`),
-    // so removing the member alone does not restore confluence — measured.
+    // What *has* changed is the second half of the old finding. This test used to
+    // assert that the output was **beyond the applier** — the one oracle that
+    // judges denotation rather than form — because `hgvs_to_spdi` mapped an
+    // unspelled identity to a zero-width triple, which at an interbase is
+    // indistinguishable from an insertion there. `261_262dup` gave `262::AG` and
+    // `263=` gave `262::`, apparently two members competing for one interbase, so
+    // the applier declined the whole description. #1362 makes the identity fetch
+    // its base, so it now claims `262..263` and the two are disjoint — as they
+    // always were in fact.
     //
-    // Filed as #1351: the blindness is a defect in the oracle rather than in this
-    // row, and every sequence-preservation sweep in the cis suite inherits it,
-    // routing such outputs into a `skipped` counter that bounds their *share* but
-    // never their *shape*. This test is the pinned instance that issue names.
+    // So the assertion inverts: the output is expressible, and the thing worth
+    // pinning is that it **denotes the input's bases**, which is what the
+    // blindness prevented anyone from checking. That also removes the exemption
+    // from the sweep above, whose `beyond_the_applier` count is now 0.
+    //
+    // The oracle-level half of #1351 is what this closes. Its other half stands:
+    // the sweeps should still distinguish "skipped because the input was
+    // unconvertible" from "skipped because the output was inexpressible".
     //
     // The input is read from #1321's `CONVERGED` row rather than repeated as a
     // literal, so editing that row cannot leave this test quietly exercising a
-    // variant while its prose still claims to be about #1321. The expected output
-    // stays literal — that string is the finding.
+    // different variant while its prose still claims to be about #1321. The
+    // expected output stays literal — that string is the finding.
     let (_, core, split, _) = CONVERGED
         .iter()
         .find(|(issue, ..)| *issue == "#1321")
@@ -390,9 +397,12 @@ fn an_identity_member_leaves_the_output_beyond_the_applier() {
         out, "TEMPLATE:g.[261_262dup;263=]",
         "the redundant identity member moved; re-check both claims below"
     );
-    assert!(
-        apply(&seq, &out).is_none(),
-        "`{out}` is now expressible to the applier — if the `=` member is gone, \
-         delete this test and tighten the one above"
+    let denoted = apply(&seq, &out)
+        .unwrap_or_else(|| panic!("`{out}` must be expressible to the applier since #1362"));
+    let expected = apply(&seq, split).expect("the input spelling has always been expressible");
+    assert_eq!(
+        denoted, expected,
+        "`{split}` -> `{out}` must denote the same bases as its input; this is the \
+         check the zero-width-identity blindness made impossible"
     );
 }


### PR DESCRIPTION
Closes #1362

`NaEdit::Identity` was the only arm of `hgvs_to_spdi` that did not consult the provider for a sequence the input omitted. It defaulted to the empty string:

| input | before | after |
| --- | --- | --- |
| `g.10A=` (spelled) | `9:A:A` | unchanged |
| `g.10=` | `9::` | `9:G:G` |
| `g.10_12=` | `9::` — span lost | `9:GCA:GCA` |
| `g.=` (whole-entity) | `0::` | unchanged, deliberately |

`Deletion`, `Delins` and `Inversion` all fetch via `fetch_reference_bases` or report `MissingReferenceData`. This arm now does too.

## The zero width was not merely lossy

A zero-width triple at an interbase is indistinguishable from an **insertion** at that interbase, and that aliasing blinded this project's own SPDI applier — the one oracle that judges denotation rather than form. On the real 5'-shuffle output `g.[261_262dup;263=]`:

```
261_262dup  ->  262::AG     insertion after 262
263=        ->  262::       zero-width at the same interbase
```

Two members apparently competing for one interbase, which has no single well-defined resulting sequence, so the applier declined the whole description. The identity in fact claims base 263 and the two are disjoint; only the conversion collided them.

## Whole-entity `g.=` stays zero-width

Deliberately, and it is the one arm that must not consult the provider: `g.=` asserts the entire reference is unchanged and names no span. Narrowing it to base 1 would invent a claim, and fetching a chromosome to prove it unchanged would be absurd. Pinned by its own test.

## Breaking change

`hgvs_to_spdi_simple` — and the Python `hgvs_to_spdi` that wraps it — now report `MissingReferenceData` for `g.10=` where they used to return a triple whose span was wrong. Hence the `!`. The message names the construct and both ways out (spell the base, or convert with a provider).

## This closes the oracle half of #1351

Two tests in `cis_spelling_confluence_gap` existed to pin the blindness, and are **inverted rather than deleted**:

- `an_identity_member_leaves_the_output_beyond_the_applier` → `an_identity_member_is_now_expressible_to_the_applier`, which asserts what the blindness made impossible: that the output **denotes the input's bases**. That check is the actual gain here — a real 5'-shuffle output whose denotation nothing could previously verify.
- the sweep's `beyond_the_applier` count goes **1 → 0**, with the reason recorded at the assertion so a future regression is legible.

**#1351's other half stands** and I have not touched it: the sweeps should still distinguish "skipped because the *input* was unconvertible" from "skipped because the *output* was inexpressible". Only the second was an oracle gap, and only that one is now closed.

## Interaction with #1374

#1374 (reference-aware SPDI / apply-to-reference, `#1159`) builds its `variant_edit_triples` on `hgvs_to_spdi`, so it inherits this fix: `apply_to_reference` and `canonical_spdi` can now handle a description containing an unspelled identity member, which they would previously have declined. The two are independent changes and merge in either order.

## A note on triage

This issue was open when this campaign's triage ran and I missed it — my query returned 19 issues ending at #1355 and #1362 was filed about an hour earlier. Recorded in the campaign log so the gap is not silent.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — **9193/9193 pass**, 146 skipped
- **168/168** manifest-gated conformance tests against a real prepared reference, FAIL-set ledgers unmoved
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings` clean

