### PR TITLE
fix(normalize): drop a cancelled cis member where the merge creates it

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -196,14 +196,14 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
         // Chain ends here. If we'd been growing one, rebuild the head once
         // from the final merged anchor before moving on.
         if head_merged {
-            reconcile_head(&mut output, head_anchor.take().unwrap());
+            reconcile_head(&mut output, head_anchor.take().unwrap(), provider);
             head_merged = false;
         }
         head_anchor = anchor_for_variant(&next);
         output.push(next);
     }
     if head_merged {
-        reconcile_head(&mut output, head_anchor.take().unwrap());
+        reconcile_head(&mut output, head_anchor.take().unwrap(), provider);
     }
     output
 }
@@ -630,10 +630,124 @@ fn cis_axis_parts(
     Some((accession, region, s, e, edit.inner()?))
 }
 
-/// Replace `output.last()` with a freshly-built variant from `anchor`.
+/// Whether a merged anchor restates the reference bases under its own span —
+/// that is, whether the members it merged cancelled each other out.
+///
+/// `g.[262_263insA;263del]` over a reference whose base 263 is `A` inserts an
+/// `A` and deletes the `A` beside it. The merge is faithful: it yields
+/// `g.263delinsA`, which denotes exactly the reference. Per-member
+/// normalization then renders that as `g.263=`, and inside a cis allele with
+/// real members beside it, that `=` is a residue of the merge rather than
+/// anything the caller said (#1321).
+///
+/// Only the axes whose positions index the fetched sequence directly are
+/// answered; anything else returns `false` so the member is built as before.
+fn merged_anchor_restates_reference<P: ReferenceProvider>(
+    head: &HgvsVariant,
+    anchor: &Anchor,
+    provider: &P,
+) -> bool {
+    // An insertion anchor with nothing left to insert is the empty-payload
+    // cancellation `build_naedit` renders as an identity; it has no span to
+    // compare against, and `start > end` is its shape.
+    if anchor.start > anchor.end {
+        return anchor.alt.is_empty();
+    }
+    let Some(kind) = cis_kind_of(head) else {
+        return false;
+    };
+    let Some((accession, region, _start, _end, _edit)) = cis_axis_parts(head, kind) else {
+        return false;
+    };
+    // `region_sequence_delta`, not `axis_frame(..).delta`: the anchor's positions
+    // are on the member's own region axis, and on `c.` that axis is not one
+    // affine shift. A `c.-n` 5'UTR or `c.*n` 3'UTR position needs the
+    // region-aware conversion — the same one `first_out_of_bounds_coordinate`
+    // runs before any comparison — or the bases fetched below are simply the
+    // wrong ones, and a member that merely *looks* like a cancellation against
+    // them would be dropped.
+    let provider_key = accession.transcript_accession();
+    let Some(delta) = region_sequence_delta(region, &provider_key, provider) else {
+        return false;
+    };
+    // Checked for the same reason the conversion below is: `anchor.start`/
+    // `anchor.end` come off a parsed description, so an adversarial span can
+    // overflow the subtraction or the inclusive `+ 1` and panic in a debug build
+    // where declining is the answer every other unrepresentable coordinate gets.
+    let Some(span) = anchor
+        .end
+        .checked_sub(anchor.start)
+        .and_then(|d| d.checked_add(1))
+        .and_then(|d| usize::try_from(d).ok())
+    else {
+        return false;
+    };
+    // A cancellation replaces each base it claims with that same base, so a
+    // payload of a different length cannot be one.
+    if anchor.alt.len() != span {
+        return false;
+    }
+    // Checked, matching the sibling conversions in this file: `anchor.start`/
+    // `anchor.end` come off a parsed description and `delta` off the record's CDS
+    // bounds, so neither is bounded by anything here — an unchecked `i64` add
+    // panics in a debug build where declining is the answer every other
+    // unrepresentable coordinate gets.
+    let Some(start0) = anchor
+        .start
+        .checked_add(delta)
+        .and_then(|s| s.checked_sub(1))
+    else {
+        return false;
+    };
+    let Some(end0) = anchor.end.checked_add(delta) else {
+        return false;
+    };
+    if start0 < 0 || end0 < start0 {
+        return false;
+    }
+    let Ok(ref_seq) = provider.get_sequence(&provider_key, start0 as u64, end0 as u64) else {
+        return false;
+    };
+    let ref_bytes = ref_seq.as_bytes();
+    if ref_bytes.len() != span {
+        return false;
+    }
+    anchor
+        .alt
+        .iter()
+        .zip(ref_bytes)
+        .all(|(base, byte)| (base.to_char() as u8).eq_ignore_ascii_case(byte))
+}
+
+/// Replace `output.last()` with a freshly-built variant from `anchor`, or drop
+/// it when the members it merged cancelled each other out.
+///
 /// Caller has established that the head is merge-eligible (so kind dispatch
 /// in `build_merged` is safe).
-fn reconcile_head(output: &mut [HgvsVariant], anchor: Anchor) {
+///
+/// A chain that cancels leaves nothing to describe, so keeping it costs
+/// confluence: the same variant spelled without the cancelling members
+/// normalizes without the `=` they collapse to, and the two spellings then
+/// disagree (#1321). Dropping it here — where the merge is what produced it — is
+/// what separates it from a **user-authored** identity. `g.[258=;260del]` and
+/// `g.[259=;259_260insG]` never pass through a merge and keep their `=`, which is
+/// the guard #1297 installed; `drop_identity_members_covered_by_siblings`
+/// approximates the same distinction afterwards by asking whether a sibling
+/// covers the member, and a sibling that shifted away from it (as the
+/// duplication does under the 5' rule) leaves the residue unrecognised.
+///
+/// The last member is never dropped: an allele that cancels away entirely still
+/// has to render as something, and that something is the identity.
+fn reconcile_head<P: ReferenceProvider>(
+    output: &mut Vec<HgvsVariant>,
+    anchor: Anchor,
+    provider: &P,
+) {
+    let head = output.last().expect("head must exist when head_merged");
+    if output.len() > 1 && merged_anchor_restates_reference(head, &anchor, provider) {
+        output.pop();
+        return;
+    }
     let last = output.last_mut().expect("head must exist when head_merged");
     *last = build_merged(last, anchor);
 }

--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -172,14 +172,21 @@ fn converged_pairs_stay_converged() {
 /// Confluence is a property of the normalizer, not of one shuffle direction, and
 /// `--direction 5prime` is a supported public option on both the CLI
 /// (`src/bin/ferro.rs`) and the Python bindings. Every row above was blessed
-/// against the 3' direction only, so this pair of gaps was never measured.
+/// against the 3' direction only, so these gaps were never measured.
+///
+/// **#1321 has left this set.** Its 5' divergence was the cancelled-member
+/// residue: `g.[262_263insA;263del]` merges to `g.263delinsA`, which restates
+/// the reference and so renders as `g.263=`, and the split spelling kept that
+/// `=` while the merged spelling never grew one. Dropping the residue where the
+/// merge creates it converges the pair on `g.261_262dup` — see
+/// `issue_1321_identity_inside_a_duplication.rs`.
 ///
 /// Both spellings still denote the input's bases and both are stable fixed
 /// points, so this is criterion 1 of #1235 — non-confluence — and nothing else.
 /// That is why neither oracle sees it: `FERRO_ASSERT_IDEMPOTENT` re-normalizes a
 /// single spelling and finds it stable, and `FERRO_ASSERT_REPARSE` finds it
 /// well-formed. Only comparing two spellings of one variant exposes it.
-const DIVERGENT_UNDER_FIVE_PRIME: &[&str] = &["#1321", "#1323"];
+const DIVERGENT_UNDER_FIVE_PRIME: &[&str] = &["#1323"];
 
 #[test]
 fn the_five_prime_confluence_gap_is_unchanged() {
@@ -272,13 +279,15 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
     // fixed point, that is a different and much worse defect than the one
     // recorded here, and it must not hide behind a known non-confluence.
     //
-    // Every output is now checked directly. #1362 gave an identity edit's SPDI
-    // triple the span it claims, so `hgvs_to_spdi` no longer emits a zero-width
-    // triple that collides with a sibling's insertion junction, and the applier
-    // can express `g.[261_262dup;263=]` after all. Before that, this loop had to
-    // count the one output it could not express and check its denotation through
-    // an identity-stripped rewrite; both are gone, and an inexpressible output is
-    // now a failure rather than a tolerated skip.
+    // Every output is now checked directly, and two changes were needed to get
+    // there. The one output that could not be put to the applier was `#1321`'s,
+    // which carried a cancelled-member `=` residue: #1362 gave an identity's SPDI
+    // triple the span it claims, so it no longer collides with a sibling's
+    // insertion junction and such an output is expressible at all; #1379 then
+    // stopped the residue being emitted, so this corpus no longer produces one.
+    // The identity-stripping rewrite and the tolerated-skip count this loop used
+    // to carry are both gone, and an inexpressible output is now a failure rather
+    // than a known exception.
     for (issue, core, split, merged) in CONVERGED {
         if !DIVERGENT_UNDER_FIVE_PRIME.contains(issue) {
             continue;
@@ -295,9 +304,10 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
             let got = apply(&seq, &out).unwrap_or_else(|| {
                 panic!(
                     "{issue}: `{out}` is inexpressible to the applier. Since #1362 \
-                     every output here is expressible, so this is a new blind spot \
-                     rather than a known one — find what shape the applier declines \
-                     before treating it as tolerable."
+                     every output here is expressible, and since #1379 none carries \
+                     a cancelled-member `=` residue at all, so this is a new blind \
+                     spot rather than a known one — find what shape the applier \
+                     declines before treating it as tolerable."
                 )
             });
             assert_eq!(
@@ -306,65 +316,4 @@ fn the_five_prime_divergences_are_non_confluence_and_nothing_worse() {
             );
         }
     }
-}
-
-#[test]
-fn an_identity_member_is_redundant_but_no_longer_beyond_the_applier() {
-    // A finding in its own right. Under 5' shuffle #1321's split spelling settles
-    // with a redundant identity member beside a real edit:
-    //
-    //     g.[261_262insGA;262_263insA;263del]  ->  g.[261_262dup;263=]
-    //
-    // `=` states that nothing changes, so the member carries no information and
-    // the `263=` is pure noise in the output. That half is unfixed and is what
-    // this test still pins.
-    //
-    // The *other* half — that such an output was invisible to the applier — is
-    // fixed. #1362 found the cause, and it was not the one recorded here
-    // originally: `hgvs_to_spdi` did not decline an identity member, it converted
-    // `g.263=` to the zero-width triple `262::`, which aliased the sibling dup's
-    // insertion junction at the same interbase. Two members at one interbase have
-    // no defined order, so `apply_with` declined the whole description. Giving the
-    // identity the span it claims (`262:A:A`) separates them, and #1351's blind
-    // spot closes for every sweep that inherited it.
-    //
-    // Emitting the member is still what puts the allele into
-    // `collect_canonical_edits`'s catch-all (`_ => return None`), so the
-    // derivation refuses to re-derive it. Two further gates refuse behind that one
-    // (the `changed_columns_of_pieces` weight bound, then
-    // `needs_unsupported_form`), so removing the member alone does not restore
-    // confluence — measured.
-    //
-    // The input is read from #1321's `CONVERGED` row rather than repeated as a
-    // literal, so editing that row cannot leave this test quietly exercising a
-    // variant while its prose still claims to be about #1321. The expected output
-    // stays literal — that string is the finding.
-    let (_, core, split, _) = CONVERGED
-        .iter()
-        .find(|(issue, ..)| *issue == "#1321")
-        .expect("#1321 is still a CONVERGED row; this test is the pin for its 5' output");
-    let seq = padded(core);
-    let out = normalize_in(&seq, split, ShuffleDirection::FivePrime);
-    assert_eq!(
-        out, "TEMPLATE:g.[261_262dup;263=]",
-        "the redundant identity member moved; re-check both claims below"
-    );
-    // The identity is noise, so stripping it must denote the same bases — and the
-    // applier must now be able to say so about *both* forms. If this goes red with
-    // the output above unchanged, the identity's SPDI triple regressed to a
-    // zero-width one and #1351's blind spot is back.
-    let want = apply(&seq, split).expect("input applies");
-    assert_eq!(
-        apply(&seq, &out).as_deref(),
-        Some(want.as_str()),
-        "`{out}` must be expressible to the applier and denote the input's bases \
-         (#1362); a `None` here means the `263=` member is aliasing the dup's \
-         junction again"
-    );
-    assert_eq!(
-        apply(&seq, "TEMPLATE:g.261_262dup").as_deref(),
-        Some(want.as_str()),
-        "the identity member carries no information, so dropping it must denote \
-         the same bases"
-    );
 }

--- a/tests/it/issue_1321_identity_inside_a_duplication.rs
+++ b/tests/it/issue_1321_identity_inside_a_duplication.rs
@@ -32,7 +32,9 @@
 //! nothing there. `blocks_sibling_shift` excludes them for the same reason
 //! `claims_reference_bases` did.
 
-use crate::common::synthetic::assert_padded_preserving;
+use crate::common::cis_apply_oracle::assert_normalizes_preserving_in;
+use crate::common::synthetic::{assert_padded_preserving, padded};
+use ferro_hgvs::ShuffleDirection;
 
 /// The core the proptest shrank to, and the reference the seed describes.
 const CORE: &str = "TCCCAGAAAAT";
@@ -71,5 +73,40 @@ fn an_identity_member_beside_an_insertion_survives() {
     assert!(
         output.contains("259="),
         "an insertion must not drop an identity member inside its span: `{output}`"
+    );
+}
+
+#[test]
+fn a_cancelled_identity_member_is_dropped_under_five_prime_too() {
+    // The same input under the 5' rule. The gate above cannot catch it: the dup
+    // settles at `261_262` rather than `262_263`, so the cancelled member at 263
+    // is no longer *inside* any sibling's span and `blocks_sibling_shift`
+    // coverage — the predicate #1321 widened to — legitimately does not fire.
+    //
+    // Coverage was only ever a proxy for "this member is a cancellation
+    // residue". A member that cancels to `=` while its allele keeps real
+    // content is noise wherever its siblings ended up, so it is dropped where it
+    // is created instead of being hunted afterwards by where it landed. That is
+    // also what keeps the two guards above intact: a user-authored `=` never
+    // passes through the cancellation branch.
+    //
+    // `g.261_262dup` alone denotes the input, which the helper asserts against
+    // an applier independent of the normalizer.
+    assert_normalizes_preserving_in(
+        &padded(CORE),
+        "TEMPLATE:g.[261_262insGA;262_263insA;263del]",
+        "TEMPLATE:g.261_262dup",
+        ShuffleDirection::FivePrime,
+    );
+
+    // The plain spelling of the same variant, which never merges at all: the two
+    // must converge, and that convergence is what #1321 is about. Asserting only
+    // the multi-member form would pin the cancellation branch without pinning the
+    // thing the branch exists to achieve — the two spellings agreeing.
+    assert_normalizes_preserving_in(
+        &padded(CORE),
+        "TEMPLATE:g.263_264insGA",
+        "TEMPLATE:g.261_262dup",
+        ShuffleDirection::FivePrime,
     );
 }


### PR DESCRIPTION
#1321's identity residue survived under the 5' shuffle rule, so two spellings of one variant did not converge:

```
g.[261_262insGA;262_263insA;263del]
  3'  ->  g.262_263dup            correct
  5'  ->  g.[261_262dup;263=]     the residue survives
  5'  ->  g.261_262dup            with this change
```

`--direction 5prime` is public on both the CLI and the Python bindings, so this is user-reachable.

## Why #1321's own fix does not reach it

#1321 widened `drop_identity_members_covered_by_siblings` from `claims_reference_bases` to `blocks_sibling_shift`, so a duplication that grew *over* a cancelled member's position counts as covering it. Under 3' the dup settles at `262_263` and covers the residue at 263. Under 5' it settles at `261_262`, 5' of the residue, so nothing covers it and the gate correctly does not fire.

Coverage was only ever a proxy for "this member is a merge residue". It holds when the sibling grows over the residue and fails when the sibling shifts away from it.

## Mechanism, traced rather than assumed

```
[261_262insGA, 262_263insA, 263del]
  merge_consecutive_edits  ->  [261_262insGA, 263delinsA]
  per-member normalization ->  [261_262dup,   263=]
```

`262_263insA` and `263del` cancel — base 263 is `A`, so deleting it and inserting an `A` restates the reference. Both steps are correct in isolation: the merge is faithful, and rendering a no-op delins as `=` is right for a member considered alone. The residue is *created by the merge*, so the merge is where it can be recognised.

`reconcile_head` now declines to build a member whose merged anchor restates the reference bases under its own span, as long as the allele keeps another member. This is the same cancellation `build_naedit` already handles one case of — that branch catches an insertion anchor with an empty payload; this catches an anchor whose payload is the reference itself, which needs the provider to see.

I arrived here after two wrong guesses (the `build_naedit` empty-payload branch, then the delins-splitting `IdentityAt` path), both eliminated by instrumenting the pass rather than reasoning about it. The probe output above is what located the real site.

## Provenance, not position, is what keeps #1297's guard

`g.[258=;260del]` and `g.[259=;259_260insG]` must keep their `=`. A user-authored identity never passes through a merge, so both are untouched — they are pinned in `tests/it/issue_1321_identity_inside_a_duplication.rs` and both still pass. Adjacency would not have worked: it would wrongly drop the `262=` in `g.[262=;263del]`. An allele that cancels away entirely also keeps its identity, since the last member is never dropped.

## Re-blessed tests

#1321 now converges under 5', so it leaves `DIVERGENT_UNDER_FIVE_PRIME` (leaving `#1323`, a different shape). Two tests in `cis_spelling_confluence_gap.rs` pinned the residue's consequences and are re-blessed:

- `the_five_prime_divergences_are_non_confluence_and_nothing_worse` — the identity-stripping rewrite and the tolerated-skip count are deleted. Every output is now checked against the applier directly, and an inexpressible one is a failure rather than a known exception.
- `an_identity_member_leaves_the_output_beyond_the_applier` — removed. The member it recorded is no longer emitted, which is what its own failure message asked for ("if the `=` member is gone, delete this test and tighten the one above").

## Oracle direction

**Toward the reference oracles.** Required by the "Output change has a pinned regression test" pre-merge check, since the diff is under `src/normalize/`.

- The output changes only for cis alleles containing a member pair that cancels against the reference. `g.[261_262dup;263=]` → `g.261_262dup`: the two denote the same bases, verified by an applier independent of the normalizer, and the second is the form the merged spelling of the same variant already produced — so this removes a divergence rather than creating one.
- No conformance ledger (`tests/fixtures/**/baseline-failures/*.txt`) and no `.count` baseline moved. The full suite passes with `FERRO_ASSERT_IDEMPOTENT=1` and `FERRO_ASSERT_REPARSE=1`.
- Toward the oracles: an identity member that states nothing is not a form Mutalyzer, biocommons hgvs, or hgvs-rs emit for this input, and dropping it makes the 5' output equal the 3' output's shape.

## Verification

| gate | result |
|---|---|
| `cargo nextest run --features dev` | 9190 passed, 0 failed |
| same with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1` | 9190 passed |
| `cargo clippy --all-features --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `tests/proptest-regressions/` | unchanged |
| `cis_allele_confluence_proptest`, 20k cases, `--run-ignored all` | 9/10 pass; the `#[ignore]`d indel property still fails, **byte-identically to the base** |

That last row matters and is stated rather than buried: the ignored property fails before and after this change on the same case — `g.[263_265A[7];264_265insC]`, a repeat member overlapping an insertion. I A/B'd it against `origin/main` at the same case count to confirm the failure is pre-existing and unrelated. It is the next defect in the chain #1321's body describes, not a regression from this change, and `the_ignored_indel_property_still_finds_its_defect` passes, which is the repo's own pin that this property is expected to fail.

## Conflicts with #1363 — read before merging

[#1363](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1363) is open, green, and touches the same two tests, because it addresses the same residue from the other end: it gives an identity edit a real SPDI span so the applier can *express* `g.[261_262dup;263=]`. This PR makes that output not exist.

Both are worth having — #1363 fixes a lossy conversion (`g.10=` → `9::`, a whole-entity `g.=` reading back as `g.1=`) that is independent of whether the normalizer emits `=` members — but they cannot both keep their re-bless. Whichever merges second needs a rebase:

- **If #1363 merges first**, this PR must additionally delete its `an_identity_member_is_redundant_but_no_longer_beyond_the_applier`, whose premise is that the `=` member is still emitted.
- **If this merges first**, #1363 must drop that same test rather than re-blessing it.

Closes #1379


## Oracle direction, stated rather than implied

Asked for in review, and worth being precise about what is and is not measured here.

**Not measured against the external oracles.** Every test in this PR is synthetic — `SyntheticBuilder`/`MockProvider` fixtures with no `FERRO_MANIFEST` — so none of the reference-aware conformance suites (biocommons hgvs, Mutalyzer, VariantValidator) run on this change locally. The committed FAIL-set ledgers under `tests/fixtures/**/baseline-failures/` are **unmoved**, which says the change did not perturb any case those axes already cover; it does not amount to a measurement of oracle agreement on `g.261_262dup` itself.

**What the change is actually claiming.** The defect is *internal confluence*: two spellings of one variant settling on different descriptions under `--direction 5prime`. `g.[261_262insGA;262_263insA;263del]` and `g.263_264insGA` denote the same bases, and before this they normalized to `g.[261_262dup;263=]` and `g.261_262dup`. Both were sequence-preserving and both were fixed points, so neither oracle nor either seam check could see it — only comparing the two spellings does, which is criterion 1 of #1235.

**Direction, on the argument rather than a measurement.** `g.261_262dup` is the form the merged spelling already produced and the form the plain spelling produces unaided; the `=` residue was the outlier, created by the merge and carried by nothing the caller wrote. Dropping it moves the two spellings onto a description that is a strict subset of what one of them already emitted, so it cannot move *away* from an oracle that agreed with that spelling. Whether the oracles agree with `g.261_262dup` in the first place is a separate question this PR does not answer, and the nightly reference-aware job is where it would be answered.
