### PR TITLE
test(spec): accept either spec-legal stop spelling as conformant

### DIFF
--- a/examples/common/spec_harvest.rs
+++ b/examples/common/spec_harvest.rs
@@ -663,23 +663,36 @@ pub mod prefix {
 
 pub mod classify {
     /// Status taxonomy is a function of (parse_ok, normalize_ok, spec_expected,
-    /// current == spec_expected). `spec_expected: None` is the spec-rejects-this
-    /// sentinel (set by override or by `<code class="invalid">` extraction).
+    /// whether ferro renders the spec's form). `spec_expected: None` is the
+    /// spec-rejects-this sentinel (set by override or by `<code class="invalid">`
+    /// extraction).
     ///
-    /// | spec_expected | parse | normalize | current == spec_expected | status              |
-    /// |---------------|-------|-----------|--------------------------|---------------------|
-    /// | `None`        | err   | —         | —                        | `correctly-rejected`|
-    /// | `None`        | ok    | —         | —                        | `false-acceptance`  |
-    /// | `Some`        | err   | —         | —                        | `parse-error`       |
-    /// | `Some`        | ok    | err       | —                        | `needs-reference`   |
-    /// | `Some`        | ok    | ok        | true                     | `preserved`         |
-    /// | `Some`        | ok    | ok        | false                    | `diverges`          |
+    /// | spec_expected | parse | normalize | renders spec's form | status              |
+    /// |---------------|-------|-----------|---------------------|---------------------|
+    /// | `None`        | err   | —         | —                   | `correctly-rejected`|
+    /// | `None`        | ok    | —         | —                   | `false-acceptance`  |
+    /// | `Some`        | err   | —         | —                   | `parse-error`       |
+    /// | `Some`        | ok    | err       | —                   | `needs-reference`   |
+    /// | `Some`        | ok    | ok        | yes                 | `preserved`         |
+    /// | `Some`        | ok    | ok        | no                  | `diverges`          |
+    ///
+    /// "Renders the spec's form" is a match against `current` **or** any of
+    /// `equivalent_renderings`. Where the spec presents two spellings as equals,
+    /// a description that uses either one conforms, so pinning the comparison to
+    /// ferro's default rendering alone would manufacture divergences out of a
+    /// display-convention choice. The caller decides which alternates are
+    /// spec-legal; this function only takes them as given. `current` remains the
+    /// canonical rendering and is what the row records.
     pub fn classify(
         parse_ok: bool,
         normalize_ok: bool,
         current: &str,
+        equivalent_renderings: &[String],
         spec_expected: Option<&str>,
     ) -> &'static str {
+        let renders_spec_form = |expected: &str| {
+            current == expected || equivalent_renderings.iter().any(|r| r == expected)
+        };
         match (parse_ok, normalize_ok, spec_expected) {
             (false, _, None) => "correctly-rejected",
             (false, _, Some(_)) => "parse-error",
@@ -687,8 +700,70 @@ pub mod classify {
             // regardless of whether ferro's normalize() then errored.
             (true, _, None) => "false-acceptance",
             (true, false, Some(_)) => "needs-reference",
-            (true, true, Some(expected)) if current == expected => "preserved",
+            (true, true, Some(expected)) if renders_spec_form(expected) => "preserved",
             (true, true, Some(_)) => "diverges",
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::classify;
+
+        /// The taxonomy's shape must not depend on the alternates list: with none
+        /// supplied, every arm is exactly what it was before alternates existed.
+        #[test]
+        fn taxonomy_without_alternates_is_unchanged() {
+            assert_eq!(classify(false, false, "x", &[], None), "correctly-rejected");
+            assert_eq!(classify(true, false, "x", &[], None), "false-acceptance");
+            assert_eq!(classify(true, true, "x", &[], None), "false-acceptance");
+            assert_eq!(classify(false, false, "x", &[], Some("y")), "parse-error");
+            assert_eq!(
+                classify(true, false, "x", &[], Some("y")),
+                "needs-reference"
+            );
+            assert_eq!(classify(true, true, "y", &[], Some("y")), "preserved");
+            assert_eq!(classify(true, true, "x", &[], Some("y")), "diverges");
+        }
+
+        #[test]
+        fn an_alternate_rendering_of_the_spec_form_is_preserved() {
+            let alts = vec!["p.Trp24*".to_string()];
+            assert_eq!(
+                classify(true, true, "p.Trp24Ter", &alts, Some("p.Trp24*")),
+                "preserved",
+                "the spec spells this stop `*`; ferro renders `Ter`. Both are \
+                 spec-legal (checklist.md:63), so this conforms."
+            );
+        }
+
+        /// The canonical rendering must still be accepted when *it* is the form
+        /// the spec states — the alternates widen the match, they don't replace it.
+        #[test]
+        fn the_canonical_rendering_still_matches() {
+            let alts = vec!["p.Trp24*".to_string()];
+            assert_eq!(
+                classify(true, true, "p.Trp24Ter", &alts, Some("p.Trp24Ter")),
+                "preserved"
+            );
+        }
+
+        /// Alternates must not launder a genuine divergence: a row differing by
+        /// more than the stop glyph stays divergent even though an alternate exists.
+        #[test]
+        fn an_alternate_does_not_excuse_an_unrelated_difference() {
+            let alts = vec!["p.[Lys79*;Lys79Asn]".to_string()];
+            assert_eq!(
+                classify(
+                    true,
+                    true,
+                    "p.[Lys79Ter;Lys79Asn]",
+                    &alts,
+                    // Spec states a *parenthesised* predicted form — a bracket
+                    // difference no stop spelling can account for.
+                    Some("p.[(Lys79*;Lys79Asn)]")
+                ),
+                "diverges"
+            );
         }
     }
 }

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -161,6 +161,22 @@ mod runner {
     use ferro_hgvs::reference::mock::MockProvider;
     use ferro_hgvs::{parse_hgvs, Normalizer};
 
+    /// What ferro did with one harvested input.
+    ///
+    /// `current` is the canonical rendering — ferro's default `Display`, and the
+    /// string recorded on the row. `equivalent_renderings` holds the *other*
+    /// spellings the spec admits for that same normalized variant; conformance
+    /// means the spec's stated form matches any of them. The rule lives in
+    /// `HgvsVariant::spec_equivalent_renderings` so this generator and the
+    /// `ferro_produces_the_form_the_spec_states` oracle cannot drift apart.
+    struct FerroOutcome {
+        current: String,
+        equivalent_renderings: Vec<String>,
+        parse_ok: bool,
+        normalize_ok: bool,
+        expected_warnings: Vec<String>,
+    }
+
     #[derive(Debug, Serialize)]
     pub struct Row {
         pub input: String,
@@ -353,8 +369,13 @@ mod runner {
             // spec_expected default (the spec wrote the bare form as
             // shorthand for the prefixed form).
             let target = input_prefixed.as_deref().unwrap_or(&input);
-            let (current, parse_ok, normalize_ok, expected_warnings) =
-                run_ferro(&normalizer, target);
+            let FerroOutcome {
+                current,
+                equivalent_renderings,
+                parse_ok,
+                normalize_ok,
+                expected_warnings,
+            } = run_ferro(&normalizer, target);
 
             // Drop position references harvested from spec prose (e.g.
             // "position `c.5690`"): they are not describable variants, just
@@ -387,8 +408,13 @@ mod runner {
             // Status is derived from the taxonomy table in `classify::classify`.
             // Overrides may pin a non-default status (e.g. for rows the
             // auditor has hand-classified into a sub-bucket).
-            let auto_status =
-                classify::classify(parse_ok, normalize_ok, &current, spec_expected.as_deref());
+            let auto_status = classify::classify(
+                parse_ok,
+                normalize_ok,
+                &current,
+                &equivalent_renderings,
+                spec_expected.as_deref(),
+            );
             let status = ov
                 .and_then(|o| o.status.clone())
                 .unwrap_or_else(|| auto_status.to_string());
@@ -433,20 +459,30 @@ mod runner {
         Ok(rows)
     }
 
-    fn run_ferro(
-        normalizer: &Normalizer<MockProvider>,
-        input: &str,
-    ) -> (String, bool, bool, Vec<String>) {
+    fn run_ferro(normalizer: &Normalizer<MockProvider>, input: &str) -> FerroOutcome {
+        let failed = |current: String, parse_ok: bool| FerroOutcome {
+            current,
+            equivalent_renderings: Vec::new(),
+            parse_ok,
+            normalize_ok: false,
+            expected_warnings: Vec::new(),
+        };
         match parse_hgvs(input) {
-            Err(e) => (format!("parse error: {e}"), false, false, Vec::new()),
+            Err(e) => failed(format!("parse error: {e}"), false),
             Ok(v) => match normalizer.normalize_with_diagnostics(&v) {
-                Err(e) => (format!("normalize error: {e}"), true, false, Vec::new()),
+                Err(e) => failed(format!("normalize error: {e}"), true),
                 Ok(n) => {
                     let mut codes: Vec<String> =
                         n.warnings.iter().map(|w| w.code().to_string()).collect();
                     codes.sort();
                     codes.dedup();
-                    (format!("{}", n.result), true, true, codes)
+                    FerroOutcome {
+                        equivalent_renderings: n.result.spec_equivalent_renderings(),
+                        current: format!("{}", n.result),
+                        parse_ok: true,
+                        normalize_ok: true,
+                        expected_warnings: codes,
+                    }
                 }
             },
         }

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -2496,6 +2496,41 @@ impl HgvsVariant {
         format!("{}", Styled(self, style))
     }
 
+    /// Renderings of this variant, **other than** its canonical [`Display`](Self)
+    /// form, that the HGVS spec admits as equally correct.
+    ///
+    /// Only the stop-codon glyph qualifies. The spec's checklist
+    /// (`docs/recommendations/checklist.md`) states *"`Ter` or `*` should be used
+    /// to indicate a translation stop codon; the `X` should not be used"* — so
+    /// `Ter` and `*` are co-equal spellings and `X` alone is deprecated. The spec
+    /// then uses both across its own examples. ferro renders `Ter` by policy
+    /// (#1114 made the `*` form parse; #1050 added [`TerStyle`] to render it), so a
+    /// description spelling the stop `*` names the same variant in a spelling the
+    /// spec sanctions.
+    ///
+    /// The one-letter amino-acid code is deliberately **excluded**, even though
+    /// [`ProteinRenderStyle`] can emit it: it is a separate axis, and a caller
+    /// asking "does this string name my variant?" should not be told yes for a
+    /// three-letter/one-letter difference it never asked to ignore.
+    ///
+    /// Empty for every non-protein variant, whose rendering the stop style cannot
+    /// affect.
+    ///
+    /// [`TerStyle`]: crate::hgvs::location::TerStyle
+    /// [`ProteinRenderStyle`]: crate::hgvs::location::ProteinRenderStyle
+    pub fn spec_equivalent_renderings(&self) -> Vec<String> {
+        use crate::hgvs::location::{ProteinRenderStyle, TerStyle};
+        let starred = self.to_styled_string(ProteinRenderStyle {
+            stop: TerStyle::Star,
+            ..Default::default()
+        });
+        if starred == self.to_string() {
+            Vec::new()
+        } else {
+            vec![starred]
+        }
+    }
+
     /// Format just the position+edit portion (without accession and coordinate prefix).
     ///
     /// For `NM_000088.3:c.459A>G`, this writes `459A>G`. Used by `AlleleVariant::Display`
@@ -5007,6 +5042,65 @@ mod tests {
         };
         let v = parse_hgvs("NM_000088.3:c.459A>G").expect("parse");
         assert_eq!(v.to_styled_string(one), v.to_string());
+    }
+
+    /// `spec_equivalent_renderings` offers the `*` spelling for exactly those
+    /// descriptions whose rendering contains a stop token, and nothing else.
+    #[test]
+    fn spec_equivalent_renderings_offers_the_star_stop_spelling() {
+        use crate::parse_hgvs;
+        for (input, want) in [
+            // A stop token anywhere in the rendering — plain, frameshift and
+            // extension shapes, plus a stop inside a cis allele.
+            ("NP_000079.2:p.Trp24Ter", Some("NP_000079.2:p.Trp24*")),
+            (
+                "NP_000079.2:p.Gln151ThrfsTer9",
+                Some("NP_000079.2:p.Gln151Thrfs*9"),
+            ),
+            (
+                "NP_000079.2:p.Ter110GlnextTer17",
+                Some("NP_000079.2:p.*110Glnext*17"),
+            ),
+            (
+                "NP_000079.2:p.[Lys79Ter;Lys79Asn]",
+                Some("NP_000079.2:p.[Lys79*;Lys79Asn]"),
+            ),
+            // Protein, but no stop token: nothing to respell.
+            ("NP_000079.2:p.(Ser4Thr)", None),
+            // Off the protein axis the stop style has no meaning at all.
+            ("NM_000088.3:c.459A>G", None),
+            ("NC_000023.11:g.32867861_32867862del", None),
+        ] {
+            let v = parse_hgvs(input).expect("parse");
+            let got = v.spec_equivalent_renderings();
+            match want {
+                Some(starred) => assert_eq!(got, vec![starred.to_string()], "for {input}"),
+                None => assert!(
+                    got.is_empty(),
+                    "expected no alternate rendering for {input}, got {got:?}"
+                ),
+            }
+        }
+    }
+
+    /// The alternates are *additional* spellings, never a replacement: the
+    /// canonical `Display` form must not appear among them, or a caller checking
+    /// "does this name my variant?" would count the same spelling twice.
+    #[test]
+    fn spec_equivalent_renderings_excludes_the_canonical_form() {
+        use crate::parse_hgvs;
+        for input in [
+            "NP_000079.2:p.Trp24Ter",
+            "NP_000079.2:p.(Ser4Thr)",
+            "NM_000088.3:c.459A>G",
+        ] {
+            let v = parse_hgvs(input).expect("parse");
+            let canonical = v.to_string();
+            assert!(
+                !v.spec_equivalent_renderings().contains(&canonical),
+                "{input}: alternates must exclude the canonical rendering"
+            );
+        }
     }
 
     #[test]

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -83,6 +83,22 @@ fn observe(normalizer: &Normalizer<MockProvider>, input: &str) -> (String, Vec<S
     }
 }
 
+/// The spellings *other than* its default rendering that the spec admits for
+/// whatever `input` normalizes to — empty when it does not normalize at all.
+///
+/// Deliberately a sibling of [`observe`] rather than an extra return value from
+/// it: only the spec-conformance oracle needs these, and the other callers of
+/// `observe` compare ferro against ferro, where a second spelling has no meaning.
+fn observe_equivalents(normalizer: &Normalizer<MockProvider>, input: &str) -> Vec<String> {
+    match parse_hgvs(input) {
+        Err(_) => Vec::new(),
+        Ok(v) => match normalizer.normalize_with_diagnostics(&v) {
+            Err(_) => Vec::new(),
+            Ok(n) => n.result.spec_equivalent_renderings(),
+        },
+    }
+}
+
 /// True when `s` is a bare coordinate reference (coord prefix + only position
 /// characters, no edit) — mirrors the harvester's drop predicate so this test
 /// pins the *outcome* (a clean fixture) independent of the generator internals.
@@ -262,10 +278,15 @@ fn pinned_v21_normalization_behavior() {
 /// fixture after `cargo run --features dev --bin generate_spec_fixture`.
 const STATUS_CENSUS: &[(&str, usize)] = &[
     ("correctly-rejected", 99),
-    ("diverges", 36),
+    // 36 -> 19 in #1079: the generator now accepts either stop-codon spelling the
+    // spec sanctions (`Ter` or `*`, per `checklist.md:63`) instead of only ferro's
+    // default rendering, so 17 rows that differed by that glyph alone are
+    // `preserved`. They moved to `preserved` below (697 -> 714); the 934-row total
+    // is unchanged, and no ferro behaviour changed — the comparison did.
+    ("diverges", 19),
     ("false-acceptance", 52),
     ("needs-reference", 50),
-    ("preserved", 697),
+    ("preserved", 714),
 ];
 
 /// The committed census must match the generated fixture exactly.
@@ -319,30 +340,32 @@ fn status_census_is_unchanged() {
 /// a regression until shown otherwise.
 ///
 /// Every entry is one of six understood classes, grouped below. They are the
-/// fixture's 36 `diverges` rows, which the status census counts but — before
+/// fixture's 19 `diverges` rows, which the status census counts but — before
 /// #1272 — nothing checked the *values* of.
+///
+/// Class 1 used to hold 19 stop-glyph rows on its own. #1079 removed them by
+/// fixing the *comparison* rather than the list: a row is no longer divergent for
+/// picking one of two spellings the spec presents as equals. Prefer that shape of
+/// fix — an entry here should record a difference someone could act on, not one
+/// the comment next to it has to argue is fine.
 const KNOWN_DIVERGENT_INPUTS: &[&str] = &[
-    // 1. `*` is canonicalised to `Ter` in protein descriptions. Deliberate
-    //    render policy: both spellings are legal on input (#1114 made the `*`
-    //    form parse), and ferro emits one of them.
+    // 1. A stop-codon glyph difference **alone** is no longer listed here. `Ter`
+    //    and `*` are co-equal in the spec (`checklist.md:63`), so #1079 taught the
+    //    generator to accept either rather than pinning 17 rows as divergences
+    //    that the comment here had to excuse as "deliberate render policy". Two
+    //    rows survive, and neither is about the stop glyph:
+    //
+    //    the spec states a **one-letter** amino-acid code (`W24`), which ferro
+    //    renders three-letter. `ProteinRenderStyle` can emit one-letter codes, but
+    //    the generator deliberately does not offer that spelling: no other
+    //    spec-stated form in the corpus uses one-letter codes, so admitting it
+    //    would let rows pass on a form the spec never states here;
     "NP_003997.1:p.W24*",
-    "NP_003997.2:p.(Asn444Lysfs*15)",
-    "NP_003997.2:p.(His321Leufs*3)",
-    "p.(*110Glnext*17)",
-    "p.(Tyr4*)",
-    "p.*110Glnext*17",
-    "p.*327Argext*?",
-    "p.Arg1459*",
-    "p.Arg456Glyfs*17",
-    "p.Arg97Profs*23",
-    "p.Gln151Thrfs*9",
-    "p.Ile327Argfs*?",
-    "p.Trp24*",
-    "p.Trp26*",
-    "p.Trp41*",
-    "p.Tyr4*",
-    "p.[(Lys79*;Lys79Asn)]",
-    "p.[(Ser868Argfs*2,Ser868=)]",
+    //    and a cis allele whose **members are reordered** into coordinate order
+    //    (`p.[Lys79Asn;Lys79Ter]` for the spec's `p.[Lys79*;Lys79Asn]`) — the same
+    //    render choice as class 6 below, which no stop spelling can account for.
+    //    Its parenthesised sibling `p.[(Lys79*;Lys79Asn)]` *does* now pass, since
+    //    there the glyph was the only difference.
     "p.[Lys79*;Lys79Asn]",
     // 2. Trans (`];[`) alleles: ferro renders the accession outside the first
     //    bracket, the spec writes it inside.
@@ -418,11 +441,15 @@ fn ferro_produces_the_form_the_spec_states() {
         }
         let target = row.input_prefixed.as_deref().unwrap_or(&row.input);
         let (observed, _) = observe(&normalizer, target);
+        let equivalents = observe_equivalents(&normalizer, target);
         let known_divergent = KNOWN_DIVERGENT_INPUTS.contains(&row.input.as_str());
 
         let conformant = match row.spec_expected.as_deref() {
-            // The spec states a form: ferro must render it.
-            Some(expected) => observed == expected,
+            // The spec states a form: ferro must render it — in any spelling the
+            // spec presents as equal to it (#1079). Pinning this to ferro's
+            // default rendering alone reported a display-convention choice as
+            // non-conformance; see `HgvsVariant::spec_equivalent_renderings`.
+            Some(expected) => observed == expected || equivalents.iter().any(|r| r == expected),
             // The spec forbids the input: ferro must refuse it.
             None => observed.starts_with("parse error") || observed.starts_with("normalize error"),
         };


### PR DESCRIPTION
Refs #1079. **Deliberately does not close it** — #1079 is the umbrella spec-divergence tracker, not something one PR resolves.

## What was wrong

`checklist.md:63` states *"`Ter` or `*` should be used to indicate a translation stop codon; the `X` should not be used"*, and the spec then uses both spellings across its own examples (`p.Trp41*` in `general.md:54`, `Ter` forms elsewhere). So the two are co-equal and only `X` is deprecated. ferro renders `Ter` by policy — #1114 made the `*` form *parse*, #1050 added `TerStyle` to *render* it.

Both spec-conformance checks compared ferro's default rendering against the spec's string with `==`:

```rust
// examples/common/spec_harvest.rs
(true, true, Some(expected)) if current == expected => "preserved",
(true, true, Some(_)) => "diverges",

// tests/it/hgvs_spec_normalization_tests.rs
Some(expected) => observed == expected,
```

That reported 17 rows as divergent for a spelling choice the spec itself presents as free. `KNOWN_DIVERGENT_INPUTS` then had to carry all of them under a comment arguing they were fine:

```rust
// 1. `*` is canonicalised to `Ter` in protein descriptions. Deliberate
//    render policy: both spellings are legal on input (#1114 made the `*`
//    form parse), and ferro emits one of them.
```

A ledger entry whose own comment explains why it is not a problem is a sign the comparison is wrong, not that the row needs pinning.

## What this changes

`HgvsVariant::spec_equivalent_renderings` returns the spellings — other than the canonical `Display` form — that the spec admits for the same variant. `classify` and `ferro_produces_the_form_the_spec_states` both consult it, so a row is conformant when ferro renders the spec's form in *any* spelling the spec sanctions.

**Why the rule is in the library rather than in `examples/`.** It is a fact about HGVS, not about either harness; and `tests/` cannot import from `examples/`, so leaving it in the generator would have meant two copies of the `checklist.md:63` reasoning that could drift apart. The first draft of this change *did* only touch the generator — it moved the `status` bookkeeping while the real oracle still called the rows divergences, and `ferro_produces_the_form_the_spec_states` failed with all 17. That failure is the reason for the current shape.

The one-letter amino-acid code is deliberately **excluded** even though `ProteinRenderStyle` can emit it: it is a separate axis, no other spec-stated form in this corpus uses one-letter codes, and admitting it would let rows pass on a form the spec never states here.

## Measurement

| status | before | after |
| --- | ---: | ---: |
| `diverges` | 36 | **19** |
| `preserved` | 697 | **714** |
| `correctly-rejected` | 99 | 99 |
| `false-acceptance` | 52 | 52 |
| `needs-reference` | 50 | 50 |
| **total** | **934** | **934** |

No ferro behaviour changed and no default output moved. `Display` still renders `Ter`, guaranteed by construction — every protein `Display::fmt` delegates to `fmt_styled(f, ProteinRenderStyle::default())`, and the default is `TerStyle::Ter`.

## Two of the 19 stay divergent, and that is the point

If the widening were too broad it would have cleared all 19. It cleared 17:

- **`NP_003997.1:p.W24*`** — the spec states a **one-letter** code (`W24`); ferro renders `Trp24Ter`. Excluded axis, per above.
- **`p.[Lys79*;Lys79Asn]`** — ferro reorders the cis members into coordinate order (`p.[Lys79Asn;Lys79Ter]`). A structural difference no stop spelling accounts for. Its parenthesised sibling `p.[(Lys79*;Lys79Asn)]` *does* now pass, since there the glyph was the only difference.

That split — spelling differences cleared, structural ones left standing — is the evidence the change does not launder real divergences. `an_alternate_does_not_excuse_an_unrelated_difference` pins it as a unit test.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev` — **9204/9204 pass**, 146 skipped
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean (exit 0; the only warning is the pre-existing `proc-macro-error2` future-incompat notice from a dependency)
- Both generated artifacts regenerated (`generate_spec_fixture`, `generate_spec_enumeration`); `spec_enumeration_tests`' `DIVERGENCE_BUDGET` / `PASSING_CENSUS` are **unmoved** — this touches the normalization fixture's statuses only.
- New tests: `spec_equivalent_renderings_offers_the_star_stop_spelling` and `..._excludes_the_canonical_form` (library); four `classify` cases including the taxonomy-unchanged-without-alternates control and the no-laundering guard.

## Interaction with the open queue

`git merge-tree --write-tree` (not `mergeStateStatus`, which lags) reports **clean against `origin/main` and against all 13 open campaign branches**. In particular it does not collide with #1373: that PR edits `spec_enumeration_tests.rs`'s projection statuses, whereas this one edits `hgvs_spec_normalization_tests.rs`, which #1373 never touches. No stacking required.
