### PR TITLE
fix(normalize): apply the strict-mode ladder on both public exits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,14 +82,20 @@ a second time with it set; the nightly reference-aware job sets it too, which is
 where the manifest-backed conformance corpora are actually covered.
 
 The check runs from `Normalizer::assert_seam_oracles`, which all three oracles
-share. It is called from two places, because ferro has two normalization exits and
-only one of them is the "shared" one: `normalize_core_checked`, covering
-`normalize()` and every `VariantProjector` path (the projection-driven
-genomic/coding/protein axes), and `normalize_with_diagnostics`, which reaches
-`normalize_core_canonical` directly and so was returning results no oracle had
-inspected — for all three checks, not just the newest. Its verification pass
-re-enters normalization, so a thread-local `IN_IDEMPOTENCY_CHECK` guard breaks the
-recursion — the inner call skips its own check.
+share, at the single exit of `normalize_core_checked`. That covers every public
+normalization: `normalize()`, `normalize_with_diagnostics()`, and every
+`VariantProjector` path (the projection-driven genomic/coding/protein axes).
+
+It is one call site again as of #1382. `normalize_with_diagnostics` used to reach
+`normalize_core_canonical` directly, which bypassed both the oracles and — the
+actual defect — the strict-mode rejection ladder, so #1366 had to call
+`assert_seam_oracles` from it separately. Routing it through
+`normalize_core_checked` fixes both at once, and the extra call would now just
+re-run all three oracles on that path.
+
+The idempotency oracle's verification pass re-enters normalization, so a
+thread-local `IN_IDEMPOTENCY_CHECK` guard breaks the recursion — the inner call
+skips its own check.
 
 #### Normalization re-parse oracle
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2341,14 +2341,29 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         variant: &HgvsVariant,
     ) -> Result<NormalizeResult, FerroError> {
-        // Through `normalize_core_canonical`, not `normalize_core`: this exit
-        // must emit the same canonical variant `normalize()` does, and `infos`
-        // must describe the shift from the input to *that* variant.
-        let (result, warnings) = self.normalize_core_canonical(variant)?;
-        // This exit does not pass through `normalize_core_checked`, so the oracles
-        // have to be run here too — otherwise a public entry point hands back a
-        // normalized variant none of the three ever saw.
-        self.assert_seam_oracles(variant, &result);
+        // Through `normalize_core_checked`, not `normalize_core_canonical`: this
+        // is a *public* exit, so it owes the caller the same strict-mode contract
+        // `normalize()` does (#1382). It used to call the canonical core directly
+        // and so applied none of the `should_reject_*` ladder, which meant a
+        // strict-configured `Normalizer` rejected a variant through `normalize()`
+        // and accepted the very same one through here. The asymmetry was invisible
+        // in the default lenient config, where every rung is a no-op.
+        //
+        // `normalize_core_checked` routes through `normalize_core_canonical`
+        // itself, so the variant this returns is the same canonical one as before
+        // and `infos` still describes the shift from the input to *that* variant —
+        // which is why the ladder can be added without moving the output.
+        //
+        // The warnings it returns are the ones NOT promoted to hard errors, so a
+        // lenient caller still sees everything this entry point exists to report.
+        //
+        // This also subsumes #1366's separate `assert_seam_oracles` call here.
+        // That call existed precisely because this exit bypassed
+        // `normalize_core_checked`; now that it does not, the oracles run once at
+        // that method's own exit. Calling them here as well would re-run all three
+        // on every diagnostics normalization — including `assert_idempotent`'s full
+        // re-normalization, the most expensive of them.
+        let (result, warnings) = self.normalize_core_checked(variant)?;
         let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
         Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
     }
@@ -10702,17 +10717,20 @@ mod tests {
 
     /// `Normalizer` has exactly two public normalizing methods — `normalize` and
     /// `normalize_with_diagnostics` — and only the first went through
-    /// `normalize_core_checked`. So before `assert_seam_oracles` was factored out,
-    /// this one returned a normalized variant none of the three seam oracles had
-    /// inspected: `FERRO_ASSERT_IN_BOUNDS`, `FERRO_ASSERT_REPARSE` and
-    /// `FERRO_ASSERT_IDEMPOTENT` alike.
+    /// `normalize_core_checked`. So this one returned a normalized variant none of
+    /// the three seam oracles had inspected: `FERRO_ASSERT_IN_BOUNDS`,
+    /// `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IDEMPOTENT` alike. #1366 covered it
+    /// by calling `assert_seam_oracles` from this exit directly; #1382 then routed
+    /// the exit through `normalize_core_checked`, so the coverage now comes from the
+    /// same single call site as every other public normalization — and the strict
+    /// ladder comes with it.
     ///
     /// The flags themselves are process-wide `OnceLock`s read from the
     /// environment, so a unit test cannot toggle one; asserting the *invariant*
     /// with the same predicate the oracle uses is the env-independent equivalent,
     /// and it fails if this path ever starts emitting an out-of-range coordinate
-    /// again. In CI, where all three flags are set, this path now also gets the
-    /// live assertions for free — which is the actual fix.
+    /// again. In CI, where all three flags are set, this path also gets the
+    /// live assertions.
     ///
     /// The inputs are the shapes the in-bounds class was found in (#1307's
     /// terminal-dup collision and #1274's two-base identity), each authored at the

--- a/tests/it/issue_1382_diagnostics_strict_ladder.rs
+++ b/tests/it/issue_1382_diagnostics_strict_ladder.rs
@@ -1,0 +1,180 @@
+//! #1382 — both public normalization exits must apply the same strict-mode
+//! rejection ladder.
+//!
+//! `Normalizer` has exactly two public normalizing methods, and they routed
+//! differently:
+//!
+//! | method | route | strict ladder |
+//! | --- | --- | --- |
+//! | `normalize()` | `normalize_core_checked` | yes |
+//! | `normalize_with_diagnostics()` | `normalize_core_canonical` | **no** |
+//!
+//! `normalize_core_checked` is where the `should_reject_*` ladder lives —
+//! `RefSeqMismatch`, W5002/W5003/W5004/W4004/W4005/W4006, `EINTRONIC`, and the
+//! `ReducedCapabilityNoGenome` promotion. `normalize_core_canonical` is just
+//! `normalize_core` plus `canonicalize_from_sequence`, so the diagnostics exit
+//! returned a result no rejection had ever seen. A strict-configured
+//! `Normalizer` therefore rejected a variant through one entry point and
+//! accepted it through the other.
+//!
+//! It stayed hidden because in the default lenient config every
+//! `should_reject_*` is false and the ladder is a no-op — the two exits agree
+//! everywhere except under a strict config, and almost nothing normalizes
+//! strictly through the diagnostics exit.
+//!
+//! ## How it surfaced
+//!
+//! `issue_336_position_past_end::strict_mode_n_in_bounds_does_not_emit_warning`
+//! was passing a variant whose stated reference base is wrong — fixture
+//! `ACGTACGTACGTACGTACGT`, where `n.10` is `C`, against an authored
+//! `NR_TEST.1:n.10G>C` — under `NormalizeConfig::strict()`. The `RefSeqMismatch`
+//! was never promoted on that path. #1366 corrected that fixture (the test is
+//! about the position, not the base) and left the asymmetry for this issue.
+//!
+//! ## What these tests pin
+//!
+//! Agreement between the two exits, asserted as agreement rather than as two
+//! independent expectations: each case runs the *same* variant through both and
+//! requires the verdicts to match. A test that asserted "both reject" would go
+//! green if a future change made `normalize()` stop rejecting, which is the
+//! opposite of what this issue is about.
+
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
+
+/// A 20-base non-coding transcript, `ACGTACGT…`, so 1-based position `p` holds
+/// `"ACGT"[(p - 1) % 4]`. Position 10 is `C` and position 20 is `T`.
+///
+/// Non-coding (no `cds_start`/`cds_end`) so the `n.` axis is the transcript's
+/// own and no CDS arithmetic enters the picture.
+fn noncoding_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "ACGTACGTACGTACGTACGT".to_string();
+    let len = sequence.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NR_TEST.1".to_string(),
+        Some("NCRNA".to_string()),
+        Strand::Plus,
+        sequence,
+        None,
+        None,
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Run one descriptor through both public exits under `config` and return
+/// whether each rejected it.
+fn verdicts(descriptor: &str, config: NormalizeConfig) -> (bool, bool) {
+    let variant = parse_hgvs(descriptor).expect("fixture must parse");
+    let normalizer = Normalizer::with_config(noncoding_provider(), config);
+    (
+        normalizer.normalize(&variant).is_err(),
+        normalizer.normalize_with_diagnostics(&variant).is_err(),
+    )
+}
+
+/// The reproducer. A wrong stated reference base under a strict config is a
+/// `RefSeqMismatch`, which `normalize()` promotes to a hard error — so the
+/// diagnostics exit must promote it too.
+#[test]
+fn a_strict_config_rejects_a_reference_mismatch_through_both_exits() {
+    let (plain, diagnostics) = verdicts("NR_TEST.1:n.10G>C", NormalizeConfig::strict());
+    assert!(
+        plain,
+        "`normalize()` must reject a stated `G` where the transcript has `C` under a \
+         strict config — if this is false the premise of #1382 has changed and the \
+         assertion below is measuring nothing"
+    );
+    assert_eq!(
+        plain, diagnostics,
+        "the two public exits disagree: `normalize()` rejected `n.10G>C` and \
+         `normalize_with_diagnostics()` did not. Both must apply the same \
+         strict-mode rejection ladder (#1382)"
+    );
+}
+
+/// The same input past the transcript's end, so a second rung of the ladder is
+/// covered rather than only `RefSeqMismatch`. `n.21` does not exist on a
+/// 20-base transcript (W4004 `PositionPastEnd`).
+#[test]
+fn a_strict_config_rejects_a_past_end_position_through_both_exits() {
+    let (plain, diagnostics) = verdicts("NR_TEST.1:n.21G>C", NormalizeConfig::strict());
+    assert!(
+        plain,
+        "`normalize()` must reject `n.21` on a 20-base transcript under a strict config"
+    );
+    assert_eq!(
+        plain, diagnostics,
+        "the two public exits disagree on a past-end position: `normalize()` \
+         rejected `n.21G>C` and `normalize_with_diagnostics()` did not (#1382)"
+    );
+}
+
+/// Lenient is the default and must stay permissive on **both** exits. This is
+/// the control: the fix routes the ladder through the diagnostics exit, and if
+/// it accidentally rejected in lenient mode it would break every caller.
+#[test]
+fn the_default_lenient_config_still_accepts_on_both_exits() {
+    for descriptor in ["NR_TEST.1:n.10G>C", "NR_TEST.1:n.10C>G"] {
+        let (plain, diagnostics) = verdicts(descriptor, NormalizeConfig::default());
+        assert!(
+            !plain && !diagnostics,
+            "`{descriptor}` must be accepted by both exits in the default lenient \
+             config; got normalize()={plain:?} normalize_with_diagnostics()={diagnostics:?}"
+        );
+    }
+}
+
+/// A correct description must be accepted under a strict config through both
+/// exits, so the fix is not simply making the diagnostics exit reject more.
+#[test]
+fn a_strict_config_accepts_a_correct_description_through_both_exits() {
+    let (plain, diagnostics) = verdicts("NR_TEST.1:n.10C>G", NormalizeConfig::strict());
+    assert!(
+        !plain && !diagnostics,
+        "`n.10C>G` states the real base at position 10 and is in bounds, so a strict \
+         config must accept it on both exits; got normalize()={plain:?} \
+         normalize_with_diagnostics()={diagnostics:?}"
+    );
+}
+
+/// The warnings the diagnostics exit exists to surface must survive the change.
+///
+/// Routing through the ladder must not swallow the advisory warnings a lenient
+/// caller reads — that is the whole point of this entry point, and a fix that
+/// returned the variant with an empty warning list would pass every assertion
+/// above while destroying the method's purpose.
+#[test]
+fn the_diagnostics_exit_still_reports_its_warnings() {
+    let variant = parse_hgvs("NR_TEST.1:n.10G>C").expect("fixture must parse");
+    let normalizer = Normalizer::with_config(
+        noncoding_provider(),
+        NormalizeConfig::default().with_error_mode(ErrorMode::Lenient),
+    );
+    let diagnosed = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("lenient must not reject");
+    // The specific warning, not merely "some warning": this exit now runs the
+    // whole ladder, which can surface unrelated warnings, and any one of them
+    // would satisfy a non-empty check while the reference-mismatch report this
+    // test exists for had quietly stopped being emitted.
+    assert!(
+        diagnosed
+            .warnings
+            .iter()
+            .any(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. })),
+        "a stated `G` where the transcript has `C` must surface a RefSeqMismatch on \
+         the diagnostics exit; got {:?}",
+        diagnosed.warnings
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -196,6 +196,7 @@ mod issue_1349_rotation_fallback_dup;
 mod issue_1355_rotation_gate_repeat;
 mod issue_1362_identity_span;
 mod issue_1376_utr_ins_payload;
+mod issue_1382_diagnostics_strict_ladder;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1382

`Normalizer` has exactly two public normalizing methods and only one applied the strict-mode rejection ladder.

| method | route | strict ladder |
| --- | --- | --- |
| `normalize()` | → `normalize_core_checked` | yes |
| `normalize_with_diagnostics()` | → `normalize_core_canonical` | **no** |

`normalize_core_checked` is where the `should_reject_*` rungs live — `RefSeqMismatch`, W5002/W5003/W5004/W4004/W4005/W4006, `EINTRONIC`, `InitiatorMetCanonicalization`, and the `ReducedCapabilityNoGenome` promotion. `normalize_core_canonical` is just `normalize_core` + `canonicalize_from_sequence`, so a strict-configured `Normalizer` rejected a variant through one entry point and accepted the same variant through the other.

The asymmetry was invisible in the default lenient config, where every rung is a no-op — which is why it survived.

## The fix

`normalize_with_diagnostics` now calls `normalize_core_checked`. Because that method itself routes through `normalize_core_canonical`, the returned variant is the same canonical one as before and `infos` still describes the shift from the input to *that* variant, so the ladder is added without moving any output. The warnings it returns are those **not** promoted to hard errors, so a lenient caller still receives everything this entry point exists to report.

It also subsumes #1366's separate `assert_seam_oracles` call on this exit. That call existed precisely because the exit bypassed `normalize_core_checked`; now that it does not, the oracles run once at that method's own exit. Keeping both would re-run all three on every diagnostics normalization, including `assert_idempotent`'s full re-normalization.

## How it was found

`FERRO_ASSERT_IDEMPOTENT` failed while #1366 was wiring the oracles to this exit:

```
FERRO_ASSERT_IDEMPOTENT: normalized output failed to re-normalize
  input: NR_TEST.1:n.10G>C
  once:  NR_TEST.1:n.10G>C
  error: Reference mismatch at 10-10: expected G, found C
```

`issue_336_position_past_end::strict_mode_n_in_bounds_does_not_emit_warning` was authoring `n.10G>C` against fixture `ACGTACGTACGTACGTACGT`, whose position 10 is `C`, under `NormalizeConfig::strict()` — and passing, because the `RefSeqMismatch` was never promoted on that path. #1366 corrected that fixture (the test is about the position, not the base) and left this asymmetry for its own PR.

## Tests (written first, watched failing)

`tests/it/issue_1382_diagnostics_strict_ladder.rs` asserts the two exits **agree**, rather than asserting each rejects — a test of the latter shape would go green if a future change made `normalize()` stop rejecting, which is the opposite of the point.

Before the fix, both agreement tests failed with `left: true, right: false` (i.e. `normalize()` rejected, the diagnostics exit did not) and the three controls passed:

- `a_strict_config_rejects_a_reference_mismatch_through_both_exits` — the reproducer.
- `a_strict_config_rejects_a_past_end_position_through_both_exits` — a second rung (W4004), so this is not only about `RefSeqMismatch`.
- `the_default_lenient_config_still_accepts_on_both_exits` — control; the default must stay permissive.
- `a_strict_config_accepts_a_correct_description_through_both_exits` — control; the fix must not simply reject more.
- `the_diagnostics_exit_still_reports_its_warnings` — control; a fix that returned an empty warning list would satisfy every assertion above while destroying the method's purpose.

## Blast radius, measured

37 files under `tests/` call `normalize_with_diagnostics`, so this could have newly rejected in any of them. Before rebasing onto #1366 the full suite showed **exactly one** failure — `strict_mode_n_in_bounds_does_not_emit_warning`, the known-bad fixture #1366 fixes. After rebasing, with that fixture corrected upstream:

- `cargo clippy --features dev --all-targets -- -D warnings` → clean
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 cargo nextest run --features dev` → **9228 passed, 0 failed**

So nothing else in the suite was relying on the missing ladder.

## Docs

`CLAUDE.md`'s oracle section said `assert_seam_oracles` is called from two places because `normalize_with_diagnostics` reaches `normalize_core_canonical` directly. That is no longer true, so it now describes the single call site and records why the second one existed. #1366's test doc in `src/normalize/mod.rs` got the same correction.