### PR TITLE
ci: lint the release profile so the oracles' debug-only gating is enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,9 +822,42 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
+          # For the release-profile lint below. The two `clippy` jobs request the
+          # component the same way; without it `cargo clippy` is not installed.
+          components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: build-release
+      # The release-profile lint (#1383). It lives in THIS job on purpose: the two
+      # `clippy` jobs both lint the debug profile, so nothing checked the release
+      # profile, and the normalization oracles are required by convention to
+      # compile out of release entirely (`#[cfg(debug_assertions)]` on
+      # `assert_in_bounds`, `assert_reparseable`, `assert_idempotent` and their
+      # `*_self_check_enabled` flags). An oracle helper left ungated becomes dead
+      # code in release, and `dead_code` is warn-by-default, so nothing went red:
+      # #1366's pre-review head failed this command with three such errors while
+      # all three CI clippy jobs were green on the same commit.
+      #
+      # Here rather than in a job of its own because the repository sits near the
+      # 10 GiB Actions cache cap and #1218 records two cache generations reaching
+      # 13.61 GiB, evicting by LRU and destroying the nightly's 3.25 GiB
+      # `ferro-manifest-v3` as collateral damage. This job already builds the
+      # release profile and already owns a `rust-cache` entry (`build-release`),
+      # so the lint adds no new cache KEY — only clippy's own fingerprints to an
+      # entry that already exists. (The +30 MB / +1.6% this was measured at
+      # originally was against the hand-rolled whole-`target/` entries that #1370
+      # retired; `rust-cache` stores dependency artifacts only, so the marginal
+      # cost is smaller still.) `Build` is also already a required check, so a
+      # failure blocks a merge rather than only turning a non-required job red.
+      #
+      # Deliberately NOT `--all-targets`: the dead code lands in the `lib` target,
+      # which the plain invocation covers. Measured by removing the four
+      # `#[cfg(any(debug_assertions, test))]` gates from
+      # `src/normalize/merge.rs` — this command then fails with all four items
+      # reported against `(lib)`, and passes with them restored. `--all-targets`
+      # would additionally compile every test and bench binary with optimisation
+      # for no gain here.
+      - run: cargo clippy --release -- -D warnings
       - run: cargo build --release
       - name: Check binary size
         run: |

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -50,6 +50,14 @@
 
 mod processor;
 
+// Gated to match its only consumers, both of which are `parallel`-only: the
+// `#[cfg(feature = "parallel")]` impl block in `processor.rs` and the streaming
+// functions in `crate::parallel`. `default = []`, so without this the module
+// compiles in a featureless build with nothing constructing `StreamingMap` —
+// dead code that `dead_code`'s warn-by-default level let through every existing
+// clippy job (they all pass `--features dev` or `--all-features`). The
+// release-profile lint added in this PR is what surfaced it.
+#[cfg(feature = "parallel")]
 pub(crate) mod streaming;
 
 pub use processor::{


### PR DESCRIPTION
Closes #1383

The three normalization oracles are required by convention to compile out of release builds — `assert_in_bounds`, `assert_reparseable`, `assert_idempotent` and their `*_self_check_enabled` flags are all `#[cfg(debug_assertions)]`. Nothing checked that an oracle helper was likewise gated.

Both existing clippy gates lint the debug profile:

- `clippy` → `cargo clippy --features dev --all-targets -- -D warnings`
- `clippy-all-features` → `cargo clippy --all-features --all-targets -- -D warnings`

and `grep -rn "clippy.*--release" .github/workflows/` returned nothing.

## The gap was live

#1366's pre-review head failed this command with three errors:

```
$ cargo clippy --release -- -D warnings
error: struct `OutOfBoundsCoordinate` is never constructed
error: function `first_out_of_bounds_coordinate` is never used
error: function `member_out_of_bounds_coordinate` is never used
```

All three CI clippy jobs were green on that same commit. `dead_code` is warn-by-default, so even the release soak build did not fail — the class is structurally invisible to CI today.

## Why it goes in the `Build` job

Not in a job of its own, on purpose. The repository sits near the **10 GiB** Actions cache cap, and #1218 records an attempt where two cache generations reached 13.61 GiB, GitHub evicted by LRU, and the nightly's 3.25 GiB `ferro-manifest-v3` was destroyed as collateral damage to an unrelated workflow. A new job with its own cache is the option to avoid until #1218 is resolved.

`Build` already caches `target/` under the `-release` key and already runs `cargo build --release`, so the lint adds **no cache entry**. It is also already one of `main`'s eight required checks, so a failure blocks a merge rather than only reddening a job nothing gates on.

## Why not `--all-targets`

The dead code lands in the `lib` target, which the plain invocation covers. `--all-targets` would additionally compile every test and bench binary with optimisation, for no gain here.

## Verified both directions

Removing the four `#[cfg(any(debug_assertions, test))]` gates from `src/normalize/merge.rs` — i.e. reproducing the pre-#1366 defect:

```
$ cargo clippy --release -- -D warnings
error: struct `OutOfBoundsCoordinate` is never constructed
error: function `first_out_of_bounds_coordinate` is never used
error: function `member_out_of_bounds_coordinate` is never used
error: function `readable_endpoints` is never used
exit 101
```

Gates restored:

```
$ cargo clippy --release -- -D warnings
exit 0
```

So the check catches the class it exists for, and does not false-positive on the current tree. `actionlint .github/workflows/ci.yml` is clean, and `components: clippy` is added to the job's toolchain step — without it `cargo clippy` is not installed, which is how the two existing clippy jobs request it.

## Note on cache measurement

Per #1218's guidance that a save must be confirmed rather than assumed, the cache-usage check is worth running on this PR before and after:

```sh
gh api /repos/fulcrumgenomics/ferro-hgvs/actions/cache/usage
```

The expectation is no new entry, since the step reuses the `Build` job's existing `-release` key.

## The gate found a live violation on `main` immediately

Rebasing onto current `main` and running the new command failed:

```
error: function `dedicated_pool` is never used      --> src/batch/streaming.rs:25:4
error: struct `StreamingMap` is never constructed   --> src/batch/streaming.rs:49:19
error: associated function `new` is never used      --> src/batch/streaming.rs:70:19
```

`src/batch/streaming.rs` arrived with #1372. Its only two consumers are both
`#[cfg(feature = "parallel")]` — the parallel `impl` block in `batch/processor.rs` and the
streaming functions in `crate::parallel` — but `batch/mod.rs` declared the module
unconditionally. With `default = []` a featureless build therefore compiles it with nothing
constructing it.

No existing job could see this: `dead_code` is warn-by-default, and all three clippy jobs pass
`--features dev` or `--all-features`, which turn `parallel` on. That is precisely the blind spot
this PR exists to close, so the one-line gate lands here with it rather than as a separate change
the gate would otherwise have to be merged red to wait for:

```rust
#[cfg(feature = "parallel")]
pub(crate) mod streaming;
```

Verified in both directions: `cargo clippy --release -- -D warnings` fails without the gate and
passes with it, and `--features dev --all-targets`, `--all-features --all-targets`, the plain
featureless debug lint, `cargo build --release` and the `batch` unit tests are all green.

Rebasing onto #1370 also required reconciling the cache step: this job's hand-rolled
`actions/cache` block is now a `Swatinem/rust-cache` step, so the `components: clippy` addition
and the lint were re-applied on top of it, and the paragraph costing the lint against the old
whole-`target/` entry was corrected to describe `rust-cache`'s dependency-only entry.
