### PR TITLE
chore(review): stop implying three suites cover both normalization exits

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -135,11 +135,20 @@ reviews:
         (`boundary.rs`), repeat shuffling, edit merging (`merge.rs`), overlap
         resolution (`overlap.rs`), and rule application (`rules.rs`). The core
         invariant is IDEMPOTENCY — normalize(normalize(x)) == normalize(x) —
-        enforced in debug builds by `FERRO_ASSERT_IDEMPOTENT=1` at the shared
-        exit of `normalize_core_checked`, which covers both `normalize()` and
-        every `VariantProjector` path. Confirm changes are covered by
-        `tests/it/idempotency_tests.rs`, `tests/it/normalize_property_tests.rs`,
-        and `tests/it/normalize_idempotency_proptest.rs`. Flag: off-by-one in
+        enforced in debug builds by `FERRO_ASSERT_IDEMPOTENT=1`, which runs from
+        `Normalizer::assert_seam_oracles` and covers every public normalization:
+        `normalize()`, `normalize_with_diagnostics()` and every
+        `VariantProjector` path.
+        `Normalizer` has exactly TWO public normalizing methods — `normalize()`
+        and `normalize_with_diagnostics()` — and a change can affect one without
+        the other, so establish which of them the change reaches before judging
+        its coverage. `tests/it/idempotency_tests.rs`,
+        `tests/it/normalize_property_tests.rs` and
+        `tests/it/normalize_idempotency_proptest.rs` are the idempotency-corpus
+        entry points and go through `normalize()` ONLY — none of the three calls
+        `normalize_with_diagnostics`, so they are a starting point rather than
+        sufficient coverage, and for a change on that exit they are no coverage at
+        all (roughly three dozen other `tests/it/` files do call it). Flag: off-by-one in
         shuffle or boundary windows; wrong shift direction or strand handling;
         mishandled circular/mitochondrial wraparound; overlap merges that
         silently drop or reorder edits; any path that can make a second


### PR DESCRIPTION
Closes #1384

The `src/normalize/**/*.rs` review instruction told a reviewer to *"confirm changes are covered by `tests/it/idempotency_tests.rs`, `tests/it/normalize_property_tests.rs`, and `tests/it/normalize_idempotency_proptest.rs`"*. None of those three exercises `normalize_with_diagnostics`, one of `Normalizer`'s two public normalizing methods.

Measured on `origin/main`:

```
$ for f in tests/it/idempotency_tests.rs tests/it/normalize_property_tests.rs \
           tests/it/normalize_idempotency_proptest.rs; do
    echo "$f: $(grep -c normalize_with_diagnostics $f)"
  done
tests/it/idempotency_tests.rs: 0
tests/it/normalize_property_tests.rs: 0
tests/it/normalize_idempotency_proptest.rs: 0

$ grep -rl normalize_with_diagnostics tests/ | wc -l
37
```

So a change confined to that exit could satisfy the prescribed coverage list while being wholly unexercised by it. That is close to what happened while reviewing the in-bounds oracle (#1366): the coverage that mattered came from the other 37 files, not from the three the instruction names. It also matters more than it looks, because that exit is the one #1382 found was skipping the strict-mode rejection ladder.

## What changed

- The three suites are now described as the **idempotency-corpus entry points**, explicitly `normalize()`-only — a starting point rather than sufficient coverage, and *no* coverage for a change on the other exit.
- The two-public-exit fact is stated, with the instruction to establish which exit a change reaches before judging its coverage. That is the fact the old wording obscured.
- The `FERRO_ASSERT_IDEMPOTENT` sentence now attributes the check to `Normalizer::assert_seam_oracles` and names all three covered paths. Worded mechanism-neutrally on purpose: it is accurate both on `main` today and after #1382 moves the diagnostics exit behind `normalize_core_checked`.
- Every `Flag:` clause is unchanged.

Review configuration only — no behavioural change, no source touched.

Verified the file still parses and the instruction survived intact:

```
$ python3 -c "
import yaml
d=yaml.safe_load(open(\".coderabbit.yaml\"))
t=[p for p in d[\"reviews\"][\"path_instructions\"] if p[\"path\"]==\"src/normalize/**/*.rs\"][0][\"instructions\"]
assert \"Flag: off-by-one\" in t and \"bypasses the shared checked exit\" in t
print(\"OK\")
"
OK
```