### PR TITLE
ci: delegate the last six workflows' cargo caches to rust-cache

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -56,16 +56,27 @@ jobs:
           export PATH="$HOME/.pixi/bin:$PATH"
           pixi install
 
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching via `rust-cache`; rationale recorded above the equivalent
+      # step in `ci.yml` (#1218).
+      #
+      # This job builds `--release --features "web-service hgvs-rs"`, a feature
+      # set no other job builds, so its dependency tree is its own. That is an
+      # argument for caching it and for keying it separately — which the key this
+      # replaces did get right (`-web-hgvs-rs-`, suffix before hash, scoped
+      # restore-key). What it could not fix is that `actions/cache` skips the save
+      # on a primary-key hit, so the tree froze at the first run per lockfile.
+      #
+      # `cache-bin: false` because this job runs on a PERSISTENT self-hosted
+      # runner (`runs-on: [self-hosted, …, ferro-deploy]`) with its own rustup
+      # install — the step below sources `$HOME/.cargo/env`. `rust-cache` caches
+      # `${CARGO_HOME}/bin` unless told not to, so on a hosted runner that is a
+      # throwaway directory, but here it would restore a snapshot of the
+      # operator's toolchain over the live one. Dependency artifacts are what is
+      # worth caching; the binaries on this box are not ours to replace.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-web-hgvs-rs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-web-hgvs-rs-
+          key: deploy-local-web-hgvs-rs
+          cache-bin: "false"
 
       - name: Build release binary (with hgvs-rs)
         run: |

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -114,14 +114,20 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching via `rust-cache`; rationale recorded above the equivalent
+      # step in `ci.yml` (#1218).
+      #
+      # Note what the key it replaces did NOT have: a job suffix. Both jobs in
+      # this workflow used the identical `${{ runner.os }}-cargo-<lock-hash>`,
+      # so they shared one entry despite installing different toolchain
+      # components and building different targets — whichever ran first decided
+      # what the other restored, and `actions/cache` then skipped the save on the
+      # key hit so neither could correct it. `rust-cache` keys per job by
+      # default; the `key` below only adds a legible name so
+      # `gh api .../actions/caches` stays diagnosable.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: external-validation-api
 
       - name: Run API comparison tests
         run: |
@@ -194,14 +200,12 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # The second half of the shared-key problem described in the job above:
+      # this job installs `clippy` and builds the spec generators, and used the
+      # same key. Distinct name, so the two no longer overwrite each other (#1218).
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: external-validation-spec
 
       # The spec-normalization fixture is a generated artifact (gitignored);
       # regenerate it before the suite so the reader tests find it.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,16 +42,29 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching via `rust-cache`; rationale recorded above the equivalent
+      # step in `ci.yml` (#1218).
+      #
+      # `workspaces` is required here and is not boilerplate: `fuzz/Cargo.toml`
+      # declares its own empty `[workspace]` to stay out of the root package, so
+      # the tree cargo-fuzz builds into is `fuzz/target/` and `rust-cache` would
+      # otherwise cache the root workspace's `target/`, which this job never
+      # populates. The old key cached `fuzz/target/` explicitly; this preserves
+      # that.
+      #
+      # `cache-bin: false` fixes a pre-existing hazard rather than introducing
+      # one. `cargo install cargo-fuzz` runs in the step ABOVE this one, and the
+      # old key cached `~/.cargo/bin/` — so the restore landed on top of the
+      # just-installed binary and could overwrite it with whatever version first
+      # populated the key. Not caching binaries removes the possibility. It also
+      # means `cargo install cargo-fuzz` compiles every run, which it already did
+      # (the install ran before the restore, so it never read the cache anyway);
+      # making that install cheap is a separate change and is not attempted here.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            fuzz/target/
-          key: ${{ runner.os }}-fuzz-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          key: fuzz-${{ matrix.target }}
+          workspaces: fuzz
+          cache-bin: "false"
 
       - name: Download corpus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -60,18 +60,21 @@ jobs:
 
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching is delegated to `Swatinem/rust-cache` rather than
+      # hand-rolled `actions/cache` keys. The full measurement is recorded once,
+      # above the equivalent step in `ci.yml`; in short, a hand-rolled entry
+      # cached a whole `target/` and grew to ~3 GiB, and `actions/cache` skips
+      # the save on a primary-key hit so a lockfile-only key froze that tree
+      # permanently (#1218).
+      #
+      # The bare `${{ runner.os }}-cargo-` last-resort restore-key that used to
+      # sit here was its own hazard: it is a prefix of every cargo cache in the
+      # repository, so this job could restore a tree built by any other job
+      # under a different profile. `rust-cache` keys per job, so there is no
+      # cross-job fallback to get wrong.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
+          key: nightly-mutalyzer
 
       # The prepared reference is NOT cached. It used to be
       # (`Linux-ferro-manifest-v3-<hash>`, `path: benchmark-output/`), and that

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -69,18 +69,19 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching via `rust-cache`; rationale recorded above the equivalent
+      # step in `ci.yml` (#1218).
+      #
+      # This job gates on a startup-time budget, so what it restores matters more
+      # here than elsewhere. That argues *for* the change rather than against it:
+      # the hand-rolled key it replaces ended in a bare
+      # `${{ runner.os }}-cargo-` restore-key, which is a prefix of every cargo
+      # cache in the repository and could hand this job a `target/` built under a
+      # different profile — exactly the kind of variance a timing gate must not
+      # inherit. `rust-cache` keys per job and stores dependency artifacts only.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
+          key: nightly-perf
 
       # The prepared reference is NOT cached, for the reason recorded in
       # nightly-mutalyzer.yml and measured in #1218: a 3+ GiB entry cannot

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -65,40 +65,33 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Cargo caching via `rust-cache`; rationale recorded above the equivalent
+      # step in `ci.yml` (#1218).
+      #
+      # The hand-rolled key this replaces was already correct about staleness —
+      # it hashed this workflow file as well as the lockfile, suffix-before-hash
+      # so its restore-key was a real prefix, after the measurement that a
+      # lockfile-only key had frozen dev-feature artifacts into an
+      # `opt-level = 3` tree and was re-compiling reqwest/hyper/criterion every
+      # run. That reasoning is preserved in `ci.yml`; what it could not fix is
+      # size, and this job's `soak` profile tree is the largest in the repo.
+      # `rust-cache` stores dependency artifacts only, and its key already
+      # covers the dependency set, rustc version and job.
+      #
+      # `cache-bin: false` is the load-bearing option here, not a default worth
+      # skipping past. `rust-cache` caches `~/.cargo/bin` unless told not to, so
+      # a restored `cargo-nextest` would overwrite the one `install-action` puts
+      # there and pin this job to whichever version first populated the key.
+      # This job writes the archive the eight shards below read, and producer and
+      # consumer must agree on the nextest version. The old step documented that
+      # hazard and dodged it by *ordering* — install after restore. Not caching
+      # the binaries removes it at the source instead, so the ordering below is
+      # no longer what protects correctness (it is kept only because it costs
+      # nothing).
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Keyed on the workflow file as well as the lockfile. `actions/cache`
-          # SKIPS the save on an exact key hit ("Cache hit occurred on the
-          # primary key ..., not saving cache"), so a key derived from
-          # `Cargo.lock` alone freezes `target/` at whatever the first run for
-          # that lockfile produced. Measured directly: after this job dropped
-          # `--features dev`, the restored cache still held the dev-feature
-          # artifacts, so every run re-compiled reqwest, hyper, criterion and
-          # the rest at opt-level 3 — about 60s, repeated forever rather than
-          # paid once. The build flags live in this file, so hashing it makes
-          # the cache follow them.
-          #
-          # Suffix before the hash so `restore-keys` is a real PREFIX of `key`.
-          # The two `hashFiles(...)` calls digest different file sets and so
-          # produce different values, which means a `...-<lock-hash>-soak`
-          # restore-key is not a prefix of a `...-<lock+workflow-hash>-soak`
-          # primary key and can never match it. See the longer note on
-          # `test-build` in ci.yml.
-          key: ${{ runner.os }}-cargo-nightly-soak-${{ hashFiles('**/Cargo.lock', '.github/workflows/nightly-soak.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-nightly-soak-
-      # AFTER the cache restore, deliberately. `~/.cargo/bin/` is one of the
-      # cached paths, so a restore running second would extract a
-      # previously-saved `cargo-nextest` over the one just installed and pin
-      # this job to whichever version first populated the key. This job writes
-      # the archive the eight shards below read, and producer and consumer have
-      # to agree on the nextest version, so let the install win.
+          key: nightly-soak
+          cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - name: Build soak archive
         # No `--features dev` — see the same step in ci.yml. The feature drags


### PR DESCRIPTION
Refs #1218. **Stacked on #1369** — base is `ci/issue-1218-reclaim-cache-budget`, not `main`. Deliberately does not close #1218; see [Why the verification is not here](#why-the-verification-is-not-here).

Completes what #1370 started in `ci.yml`/`coverage.yml`: the last seven hand-rolled `actions/cache` steps, across six workflows, now use `Swatinem/rust-cache`. The measurement behind it is recorded once, above the equivalent step in `ci.yml` (#1370) — each entry cached a whole `target/` and had grown to ~3 GiB, and `actions/cache` skips the save on a primary-key hit, so a lockfile-only key froze that tree permanently.

| workflow | steps | `rust-cache` key |
| --- | ---: | --- |
| `nightly-mutalyzer.yml` | 1 | `nightly-mutalyzer` |
| `nightly-perf.yml` | 1 | `nightly-perf` |
| `nightly-soak.yml` | 1 | `nightly-soak` |
| `external-validation.yml` | 2 | `external-validation-api`, `external-validation-spec` |
| `fuzz.yml` | 1 | `fuzz-${{ matrix.target }}` |
| `deploy-local.yml` | 1 | `deploy-local-web-hgvs-rs` |

It stacks on #1369 because converting these was deferred out of that PR to avoid an adjacent-hunk conflict with its removal of the manifest caches. `git merge-tree` is clean against `origin/main` and against #1370 (their files are disjoint), so merge order between #1369→this and #1370 does not matter.

## Three defects found in the steps being replaced

Each came out of reading the step, not from assuming the conversion was mechanical.

**`external-validation`'s two jobs shared one cache entry.** Both used the identical `${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}` — no job suffix — despite installing different toolchain components (the second adds `clippy`) and building different targets. Whichever job ran first decided what the other restored, and the primary-key hit then skipped the save, so neither could ever correct it.

**`nightly-mutalyzer` and `nightly-perf` ended in a bare `${{ runner.os }}-cargo-` restore-key.** That is a prefix of every cargo cache in the repository, so either job could restore a `target/` built by any other job under a different profile. It matters most for `nightly-perf`, which gates on a startup-time budget — a timing gate must not inherit that variance.

**`fuzz.yml` restored on top of its own freshly-installed binary.** `cargo install cargo-fuzz` runs in the step *above* the cache, and the old key cached `~/.cargo/bin/`, so the restore could replace the new binary with whatever version first populated the key.

## Two options that are load-bearing, not defaults

`workspaces: fuzz` — `fuzz/Cargo.toml` declares its own empty `[workspace]` to stay out of the root package, so cargo-fuzz builds into `fuzz/target/`. Without this, `rust-cache` would cache the root workspace's `target/`, which that job never populates. The old key cached `fuzz/target/` explicitly; this preserves it.

`cache-bin: "false"` on `nightly-soak` and `fuzz` — `rust-cache` caches `~/.cargo/bin` unless told otherwise, so both hazards above would have survived the conversion. On `nightly-soak` this replaces an ordering constraint with a structural one: the old step documented that `install-action` had to run *after* the restore or a stale `cargo-nextest` would overwrite it, and since that job writes the archive eight shards consume, producer and consumer must agree on the version. Not caching binaries removes the hazard rather than dodging it.

## Deliberately unchanged

**`fuzz.yml`'s corpus cache.** Not a cargo cache — it accumulates a fuzzing corpus across runs and is keyed on `github.run_id` with a prefix restore-key precisely so that every run saves. That is the correct shape for what it stores, and converting it would destroy the accumulation.

**`ci.yml` and `coverage.yml`** — #1370's scope.

**`fuzz.yml`'s `cargo install cargo-fuzz` still compiles every run.** It already did: the install ran *before* the restore, so it never read the cache. Making it cheap needs a step reorder or a prebuilt binary and is a separate change; flagging it rather than bundling a guess.

## Why the verification is not here

#1218's definition of done is a measurement, and it cannot be taken from a PR. Two reasons, both measured today rather than assumed:

```
$ gh api /repos/fulcrumgenomics/ferro-hgvs/actions/cache/usage
12972353164 bytes = 12.08 GiB in 17 entries      (cap: 10 GiB — already over)

$ gh api ".../actions/caches?ref=refs/pull/1381/merge" --jq .total_count
0
$ gh api ".../actions/caches?ref=refs/pull/1377/merge" --jq .total_count
0
```

PR refs hold **zero** entries under current eviction pressure, so nothing a PR writes survives for a second run to restore — a warm-cache measurement here would measure nothing. And the DoD requires *consecutive runs* with the nightly's caches intact, which is a `main` property. #1369 landing is what frees the headroom that makes any of it measurable.

Note also that **#1360 (the release PR) currently owns ~5 GiB of the 12.08 GiB** across six entries on `refs/pull/1360/merge`, which is a large part of why nothing else stays warm.

So: this PR is the code half. The measurement, and `Closes #1218`, belong to a follow-up once #1369 and #1370 are on `main` — expect the first post-merge run to be a miss by construction and read the second.

## Verification

- `actionlint .github/workflows/*.yml` — clean
- every workflow file still parses as YAML
- the `Swatinem/rust-cache` pin is checked, not copied on faith: annotated tag `v2.9.1` → `c19371144df3bb44fab255c43d04cbc2ab54d1c4`, matching both the comment and the pin #1370 uses
- no hand-rolled `actions/cache` step remains in any file this PR touches; the only one left in the six is the fuzz corpus, above
