### PR TITLE
fix(normalize): ask the codon gate about the window the repeat is emitted over

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -511,17 +511,60 @@ fn resolve_repeat_rotation(
     // with no CDS context (genomic / `n.`) and the unit tests below are
     // unaffected.
     //
-    // Frames line up: `ref_start` / `ref_end_excl` are 0-based indices into the
-    // transcript-frame `ref_seq`, and `cds_span` is 1-based inclusive in that
-    // same frame, so the 1-based inclusive tract is
-    // `(ref_start + 1) ..= ref_end_excl`. Per rotation since #1355, which is also
-    // more correct than it was: each rotation finds its own tract, so each gets
-    // its own residency answer instead of the winner's.
+    // Per rotation since #1355, which is also more correct than it was: each
+    // rotation finds its own tract, so each gets its own residency answer instead
+    // of the winner's.
+    //
+    // #1389: the window to ask about is the one the repeat is **emitted** over,
+    // which is not the tract `find_tandem_extent` discovered. `normalize_repeat`
+    // owns a direction-aware phase alignment and can return a shifted window, and
+    // the two disagree exactly at a CDS boundary: for `CTGTGTT` with
+    // `cds_span = (3, 6)`, the raw `TG` tract is 1-based `2..=5` and so reads as
+    // non-resident (`2 < 3`), switching the gate off — while the emitted window is
+    // `3..=6`, wholly CDS-resident, and got written as `GT[5]` with a two-base
+    // unit that `repeated.md`'s codon rule forbids. The 5' direction of the same
+    // fixture emits `TG` over `2..=5`, which genuinely is not resident, so before
+    // this the two directions disagreed about whether the repeat was admissible.
+    //
+    // So probe for the emitted window with the gate lifted, then delegate with the
+    // gate derived from it. Two calls rather than re-implementing the codon test
+    // here, which keeps `normalize_repeat` the single source of truth for the
+    // codon decision (#866) — the probe is only ever used to learn *which window*
+    // to ask about. This is sound because `is_coding` enters `normalize_repeat` at
+    // exactly one point, `codon_blocks_repeat`, which routes the result variant
+    // only: the window, unit and counts are all computed before it and do not
+    // depend on it. `insertion_to_repeat`'s `ref_count <= best.ref_count` skip
+    // means only score-improving rotations pay for the second call.
+    //
+    // Frames line up: `normalize_repeat` returns 1-based inclusive HGVS positions
+    // and `cds_span` is 1-based inclusive in the same transcript frame, so the
+    // comparison is direct. With no `cds_span` there is no window question to ask
+    // — the caller's precomputed verdict stands and no probe is issued, so callers
+    // with no CDS context (genomic / `n.`) and the unit tests below are
+    // unaffected.
+    let target = ref_count + added_copies;
+    let end_pos_incl = ref_end_excl - 1;
     let gate_is_coding = match cds_span {
         Some((cds_start, cds_end)) => {
-            let tract_start = ref_start as u64 + 1;
-            let tract_end = ref_end_excl as u64;
-            tract_start >= cds_start && tract_end <= cds_end
+            let probe = normalize_repeat(
+                ref_seq,
+                ref_start,
+                end_pos_incl,
+                &unit,
+                target,
+                // Gate lifted: this call answers "which window?", not "may it be
+                // repeat notation?". Passing the real flag would let a gated
+                // result hide the window the gate has to be asked about.
+                false,
+                direction,
+            );
+            match probe {
+                RepeatNormResult::Repeat { start, end, .. } => start >= cds_start && end <= cds_end,
+                // Unreachable for the same reason the delegation below asserts:
+                // `added_copies >= 2`. Fall back to the caller's verdict rather
+                // than panicking here, so the assertion stays in one place.
+                _ => is_coding,
+            }
         }
         None => is_coding,
     };
@@ -538,8 +581,9 @@ fn resolve_repeat_rotation(
     // in the same direction. `added_copies >= 2` ⇒ the target is
     // `>= ref_count + 2`, so only `Repeat` (or the codon-gated `Insertion` →
     // `None`) is reachable; `Deletion`/`Duplication`/`Unchanged` cannot occur.
-    let target = ref_count + added_copies;
-    let end_pos_incl = ref_end_excl - 1;
+    //
+    // `target` and `end_pos_incl` are bound above, where the #1389 probe needs
+    // them; this call is the authoritative one.
     let (start_idx, emitted_end_hgvs, rotated_unit, total_count) = match normalize_repeat(
         ref_seq,
         ref_start,
@@ -3435,6 +3479,53 @@ mod tests {
         assert_eq!(count, 5);
         assert_eq!((start, end), (3, 6));
         assert_eq!(unit, b"GT".to_vec());
+    }
+
+    /// #1389: the codon gate must be answered about the window the repeat is
+    /// **emitted** over, not the raw tract `find_tandem_extent` discovered.
+    ///
+    /// Same fixture as the test above, with the CDS pinned to exactly the emitted
+    /// window. The raw `TG` tract is 1-based `2..=5`, which is not CDS-resident
+    /// (`2 < 3`), so gating on it switches the codon rule off — but the emitted
+    /// window is `3..=6`, wholly inside the CDS, with a two-base unit that
+    /// `repeated.md`'s codon rule forbids. The literal `ins` must win.
+    #[test]
+    fn insertion_to_repeat_gates_on_the_emitted_window_not_the_raw_tract() {
+        let r = b"CTGTGTT";
+        assert_eq!(
+            insertion_to_repeat(
+                r,
+                4,
+                b"TGTGTG",
+                true,
+                Some((3, 6)),
+                ShuffleDirection::ThreePrime
+            ),
+            None,
+            "the emitted window 3..=6 is wholly CDS-resident with a 2-base unit, \
+             so the codon gate must block repeat notation"
+        );
+    }
+
+    /// The 5' direction of the same fixture, which must NOT change: it emits `TG`
+    /// over `2..=5`, genuinely outside the CDS, so gating the codon rule off there
+    /// is correct. Pinned so the #1389 fix cannot over-reach into a window whose
+    /// residency answer was already right.
+    #[test]
+    fn insertion_to_repeat_five_prime_window_outside_the_cds_still_repeats() {
+        let r = b"CTGTGTT";
+        let (_, count, start, end, unit) = insertion_to_repeat(
+            r,
+            4,
+            b"TGTGTG",
+            true,
+            Some((3, 6)),
+            ShuffleDirection::FivePrime,
+        )
+        .expect("the 5' window lies outside the CDS, so the codon gate stays off");
+        assert_eq!((start, end), (2, 5));
+        assert_eq!(unit, b"TG".to_vec());
+        assert_eq!(count, 5);
     }
 
     #[test]

--- a/tests/it/issue_1389_codon_gate_emitted_window.rs
+++ b/tests/it/issue_1389_codon_gate_emitted_window.rs
@@ -1,0 +1,171 @@
+//! Regression for #1389, at the `Normalizer` level.
+//!
+//! `insertion_to_repeat` answered the #1210 codon gate about the tract
+//! `find_tandem_extent` *discovered*, but `normalize_repeat` then phase-aligns
+//! that tract before emitting, and the two windows can differ. A repeat whose
+//! **emitted** window is wholly CDS-resident could therefore be written with a
+//! non-codon-length unit, which `repeated.md`'s codon rule forbids.
+//!
+//! The reference below puts a `TG` tract across the CDS start, so the 3'-aligned
+//! window lands inside the CDS while the raw tract does not:
+//!
+//! ```text
+//! axis:  c.-5 c.-4 c.-3 c.-2 c.-1 | c.1 c.2 c.3 c.4 c.5 c.6 …
+//! base:   A    A    A    A    T   |  G   T   G   T   G   T  …
+//!                            └────── raw TG tract starts here, in the 5'UTR
+//!                                     └──── 3'-aligned GT window starts here
+//! ```
+//!
+//! On `NM_T1389.1:c.3_4insTGTG` under 3', the discovered tract starts at `c.-1`
+//! and so reads as non-resident, switching the gate off — but the emitted window
+//! is `c.1_6`, wholly inside the CDS, and it was written `c.1_6GT[5]` with a
+//! two-base unit. Measured against this file's own fixture:
+//!
+//! | direction | before | after |
+//! |---|---|---|
+//! | 3' | `c.1_6GT[5]` (invalid: 2-base unit, wholly CDS-resident) | `c.3_6dup` |
+//! | 5' | `c.-1_5TG[5]` | `c.-1_5TG[5]` (unchanged) |
+//!
+//! The 5' answer must not move: its window genuinely includes `c.-1`, so gating
+//! the codon rule off there is correct. That the two directions still emit
+//! different forms is not a defect — they align to different windows, and the
+//! residency answer legitimately differs between them. What was wrong was
+//! computing the verdict from a window neither of them emitted.
+//!
+//! Pre-existing rather than introduced by #1355: the same 3' output appears on
+//! `main` and on #1368's head. #1368 moved the gate to run per rotation but did
+//! not change *which window* it asks about.
+//!
+//! The unit tests in `rules.rs` call `insertion_to_repeat` directly. These go
+//! through `Normalizer::normalize`, and therefore `normalize_core_checked` where
+//! the `FERRO_ASSERT_IDEMPOTENT` / `REPARSE` / `IN_BOUNDS` oracles sit, so the
+//! emitted repeat is judged as a whole-variant answer rather than as a tuple.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// 5'UTR ending in `T`, so the `TG` tract begins one base before `c.1`. That
+/// single-base straddle is the whole point of the fixture: it is what makes the
+/// raw tract non-resident while the 3'-aligned window is resident.
+const UTR5: &str = "AAAAT";
+/// CDS opening on `GTGTGT` — the rest of the straddling tract — then filler, a
+/// four-copy `CAG` tract for the codon-length control at the bottom of this file,
+/// and enough tail that the control's expanded six-copy tract still ends inside
+/// the CDS. Thirty-six bases, a whole number of codons, so a ragged CDS length
+/// cannot be mistaken for the cause of a codon-gate decision.
+const CDS: &str = "GTGTGTCCCGGGCAGCAGCAGCAGTTTTTTTTTTTT";
+const UTR3: &str = "AAAAAAAAAA";
+
+/// 1-based position of `c.1`: `UTR5` is five bases, so `c.1` is the sixth.
+const CDS_START: u64 = 6;
+
+fn cds_end() -> u64 {
+    (UTR5.len() + CDS.len()) as u64
+}
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = format!("{UTR5}{CDS}{UTR3}");
+    let len = sequence.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NM_T1389.1".to_string(),
+        Some("T1389".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(CDS_START),
+        Some(cds_end()),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{normalized}")
+}
+
+const REPRO: &str = "NM_T1389.1:c.3_4insTGTG";
+
+/// The defect. The 3'-aligned window `c.1_6` is wholly CDS-resident, so a
+/// two-base unit may not be spelled as repeat notation there; the edit falls
+/// through to the duplication, which carries no codon constraint.
+///
+/// Asserted as an inequality against the old output as well as an equality on the
+/// new one, because the equality alone would pass for the wrong reason if some
+/// later change moved the canonical answer to a third form.
+#[test]
+fn three_prime_gates_a_repeat_whose_emitted_window_is_cds_resident() {
+    let got = normalize_with(ShuffleDirection::ThreePrime, REPRO);
+    assert_ne!(
+        got, "NM_T1389.1:c.1_6GT[5]",
+        "c.1_6 is wholly inside the CDS, so a two-base repeat unit is forbidden \
+         there (repeated.md); the codon gate was answered about the raw tract"
+    );
+    assert_eq!(got, "NM_T1389.1:c.3_6dup");
+}
+
+/// The 5' direction must not move. Its window starts at `c.-1`, in the 5'UTR, so
+/// the tract is genuinely not CDS-resident and the codon rule correctly does not
+/// apply — a fix that gated this too would be over-reaching.
+#[test]
+fn five_prime_window_outside_the_cds_still_emits_the_repeat() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, REPRO),
+        "NM_T1389.1:c.-1_5TG[5]"
+    );
+}
+
+/// Whatever each direction emits must be a fixed point, which is what
+/// `FERRO_ASSERT_IDEMPOTENT=1` asserts for every normalize call in the suite —
+/// pinned here too so the guard holds without the env var set.
+///
+/// This is the assertion that would have caught the defect independently of the
+/// expected strings above: `c.1_6GT[5]` is a description whose own re-derivation
+/// has to agree with it.
+#[test]
+fn both_directions_reach_a_fixed_point() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let once = normalize_with(direction, REPRO);
+        let twice = normalize_with(direction, &once);
+        assert_eq!(
+            once, twice,
+            "{direction:?}: normalization is not idempotent"
+        );
+    }
+}
+
+/// A repeat whose emitted window is wholly CDS-resident *and* whose unit is a
+/// whole codon must still be spelled as a repeat. The gate keys on unit length,
+/// not on residency alone, so this pins that the fix did not turn CDS-residency
+/// itself into a refusal.
+#[test]
+fn a_codon_length_unit_inside_the_cds_is_still_a_repeat() {
+    // The four-copy `CAG` tract sits at c.13_24; adding two copies expands it to
+    // c.13_24CAG[6], which ends at c.24 — still inside the 36-base CDS. So this
+    // window is wholly CDS-resident, exactly like the gated case above, and
+    // differs from it only in that the unit is a whole codon.
+    //
+    // The unit has to be genuinely three-periodic. `smallest_repeat_unit` reduces
+    // `CCCCCC` to the one-base `C`, so a homopolymer would be gated on its unit
+    // length and would assert the opposite of what this test claims — a mistake
+    // this test was written with before being corrected.
+    let got = normalize_with(ShuffleDirection::ThreePrime, "NM_T1389.1:c.15_16insCAGCAG");
+    assert_eq!(
+        got, "NM_T1389.1:c.13_24CAG[6]",
+        "a codon-length unit inside the CDS must still reach repeat notation"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -197,6 +197,7 @@ mod issue_1355_rotation_gate_repeat;
 mod issue_1362_identity_span;
 mod issue_1376_utr_ins_payload;
 mod issue_1382_diagnostics_strict_ladder;
+mod issue_1389_codon_gate_emitted_window;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1389. Base is `main`.

This was authored stacked on #1368 (both change `insertion_to_repeat`), but #1368 merged as `9d09582` while it was in flight, so it is rebased onto `main` and stands alone. `git rebase` correctly recognised #1368's commit as already applied.

## The defect

`insertion_to_repeat` answered the #1210 codon gate for the tract `find_tandem_extent` discovered, then handed that verdict to `normalize_repeat` — which owns the direction-aware phase alignment and can return a **shifted** window. Nothing re-asked the residency question about the window that actually gets emitted.

Measured at the `Normalizer` level on this PR's own fixture, a `TG` tract laid across the CDS start:

| `NM_T1389.1:c.3_4insTGTG` | before | after |
|---|---|---|
| 3′ | `c.1_6GT[5]` | **`c.3_6dup`** |
| 5′ | `c.-1_5TG[5]` | unchanged |

`c.1_6` is wholly inside the CDS and `GT` is two bases, so the before-form is not a description HGVS admits (`repeated.md`'s codon rule). The raw tract starts at `c.-1`, in the 5′UTR, so gating on *it* switched the rule off.

The 5′ answer must not move, and does not: its window genuinely includes `c.-1`, so the codon rule correctly does not apply. The two directions still emit different forms, and that is **not** a defect — they align to different windows and residency legitimately differs between them. What was wrong was computing the verdict from a window neither of them emitted.

## The fix

Probe `normalize_repeat` with the gate lifted to learn the emitted window, derive CDS residency from *its* boundaries, then delegate with the correct gate — the two-call shape the issue suggests.

Two calls rather than re-implementing `!unit.len().is_multiple_of(3)` at the call site, which keeps `normalize_repeat` the single source of truth for the codon decision (#866); the probe only ever learns *which window* to ask about. This is sound because `is_coding` enters `normalize_repeat` at exactly **one** point — `codon_blocks_repeat` — which routes the result variant only, while the window, unit and counts are computed before it and do not depend on it. I verified that rather than taking it from the issue: it is the sole `is_coding` reference in the function.

No probe is issued when `cds_span` is `None`, since there is then no window question to ask, so genomic / `n.` callers and the direct unit tests are untouched. `insertion_to_repeat`'s `ref_count <= best.ref_count` skip means only score-improving rotations pay for the second call.

## Pre-existing, not introduced by #1355

A/B'd against the pre-fix code by restoring the unmodified `rules.rs` (then #1368's head `6b3308a`, now `main`) and re-running the same fixture: the identical `c.1_6GT[5]` comes out. #1368 moved the gate to run per rotation rather than once for the winner, but did not change *which window* it asks about. Raised by CodeRabbit on #1368 and deliberately scoped out of it, since that PR is an ordering fix and this is a change to the #1210 seam.

## Tests

Four at the `Normalizer` level (`tests/it/issue_1389_codon_gate_emitted_window.rs`), plus two direct-call unit tests in `rules.rs`:

- **the defect** — asserts the new form *and* `assert_ne!` against the old one, so the equality cannot pass for the wrong reason if a later change moves the canonical answer to a third form;
- **the 5′ control** — pins that the fix does not over-reach into a window whose residency answer was already right;
- **fixed point in both directions** — the assertion that would have caught this independently of any expected string;
- **a codon-length unit inside the CDS is still a repeat** (`c.13_24CAG[6]`) — pins that the fix did not turn CDS-residency itself into a refusal.

That last one was initially written with a homopolymer (`insCCCCCC`) and **failed**, correctly: `smallest_repeat_unit` reduces it to the one-base `C`, so it was gated on unit length and asserted the opposite of what it claimed. The fixture now carries a genuinely three-periodic `CAG` tract, and the note is in the test so the next person does not repeat it.

## Reference-oracle movement: none

The manifest-gated conformance axes were re-run against the real prepared reference with all three oracles set: **168/168 pass**, so no FAIL-set ledger moved and nothing needs re-blessing.

That the manifest was genuinely exercised rather than silently skipped is itself checked — those suites skip green when it is absent, so a bare "168/168" would prove nothing. The same filter emits **46** skip messages without `FERRO_MANIFEST` and **0** with it.

## Verification

- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 cargo nextest run --features dev` — **9242/9242 pass**, 146 skipped
- manifest-gated conformance axes — **168/168**
- `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean
- `tests/proptest-regressions/` unchanged — no seed appended
- `git merge-tree --write-tree` clean against `origin/main`, #1368, #1373, #1380 and #1392
