### PR TITLE
test(cis): draw a corpus prefix by default, the full sweep in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,6 +691,17 @@ jobs:
           name: nextest-archive-soak
       - name: Run the exhaustive sweeps with the normalization self-checks
         env:
+          # The full corpus, not the prefix a local run takes (#1295). The
+          # sweeps were 92% of a local `cargo nextest run` — 79.6s of an 86.6s
+          # suite for `cis_junction_crossing_shift` alone — so `sweep_seeds`
+          # defaults to a 4-seed prefix and this job is what asks for all of it.
+          #
+          # This job is the ONLY place that sets it, which is why the exhaustive
+          # coverage still runs on every PR: `test` and `test-oracle` negate
+          # `SWEEP_FILTER` and so never reach these modules at all. If a sweep is
+          # ever moved out of `SWEEP_FILTER`, it silently drops to the prefix
+          # here — check both when editing that filter.
+          FERRO_SWEEP_SEEDS: full
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
           # The sweeps are where this one earns its keep: they enumerate members

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,47 @@ Wheel Test, abi3 floor — and neither `Test oracle` nor `Exhaustive sweeps` is
 among them. So an oracle fire shows up as a failed job that a human must not
 merge past, not as a ruleset-enforced merge block.
 
+#### Exhaustive cis sweeps: `FERRO_SWEEP_SEEDS`
+
+The three exhaustive cis sweeps — `cis_junction_crossing_shift`,
+`repeat_span_sibling_overlap` and `issue_1254_sibling_crossing_shift` — draw a
+deterministic corpus of 20-mers from `sweep_sequences`. They dominated a local
+run: measured at 79.6s of an 86.6s suite for `cis_junction_crossing_shift`
+alone, so any `cargo nextest run` cost ~90s regardless of what changed (#1295).
+
+They now take a **4-seed prefix of that corpus by default**, and CI's
+`Exhaustive sweeps` job asks for all of it:
+
+```bash
+cargo nextest run --features dev                        # 4-seed prefix (fast)
+FERRO_SWEEP_SEEDS=full cargo nextest run --features dev # the full corpus, as CI runs it
+FERRO_SWEEP_SEEDS=12   cargo nextest run --features dev # an explicit count, for bisecting
+```
+
+Local suite: **86.6s → 27.5s**, with no test left over nextest's 60s SLOW
+threshold.
+
+**Only the sequence diversity is reduced — never the shapes.** The loop bounds
+over member spellings, positions and directions are untouched, which is the
+axis worth keeping: each sweep's notes record that every blocking defect found
+so far lived in a shape the generator could not emit, not in a sequence it did
+not draw.
+
+**Why the pinned counts did not become profile-dependent**, which is the hazard
+#1295 flags against exactly this change. `sweep_sequences` is prefix-stable
+(`sweep_sequences_is_prefix_stable`), so a reduced run enumerates a strict
+*subset* of the full run's cases. An `is_empty()` assertion therefore cannot
+pass at the prefix while failing at the full corpus, and
+`FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` is pinned at **zero**, which is
+subset-stable for the same reason — had that residual still been 74, this knob
+would have had to make it profile-dependent. The one genuinely seed-dependent
+assertion in each sweep is its case-count floor, which is why those are written
+per-seed rather than as absolutes.
+
+The one thing to watch: `sweeps` is the only job that sets the variable, and it
+selects on `SWEEP_FILTER`. Moving a sweep out of that filter silently drops it
+to the prefix in CI, so edit the two together.
+
 ### Generated spec fixture (not committed)
 
 `tests/fixtures/grammar/hgvs_spec_normalization.json` is a **generated build artifact** — it is `.gitignore`d, not committed. It is produced by the `generate_spec_fixture` binary from the HGVS spec submodule, the parser's behavior, and the curated `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`. (Committing it made every parser PR a merge-conflict magnet, since each PR regenerated the whole file.)

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -38,7 +38,7 @@
 
 use crate::common::cis_apply_oracle::{
     apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize, normalize_in,
-    sweep_sequences,
+    sweep_seeds, sweep_sequences,
 };
 use ferro_hgvs::ShuffleDirection;
 
@@ -302,8 +302,7 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // covering twice the shapes, which is the trade the issue asks for: its
     // five gaps are all shape gaps, not sequence-diversity gaps, and every
     // blocking defect found so far lived in a shape the generator could not
-    // emit rather than in a sequence it did not draw. The `checked > 100_000`
-    // floor below still holds with room to spare.
+    // emit rather than in a sequence it did not draw.
     //
     // One cost to keep on the record: `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES`
     // below is an exact count over *this* corpus, so halving the seeds halves
@@ -311,7 +310,15 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // a defect would have to live only in a dropped sequence *and* in the
     // dup+del+5' shape to escape — but the guard is weaker than it was, and
     // #1295's seed knob is what restores it without paying the runtime.
-    for seq in sweep_sequences(24) {
+    //
+    // #1295 delivered that knob, so the full count goes back to 48 and the
+    // diversity behind the pinned zero is restored. `sweep_seeds` returns the
+    // full 48 when CI asks (`FERRO_SWEEP_SEEDS=full`) and a 4-seed prefix
+    // otherwise, so a local run no longer pays for it: this test was 79.6s of an
+    // 86.6s local suite at 24 seeds, and the prefix is a strict subset of the
+    // corpus, not a different one.
+    let seeds = sweep_seeds(48);
+    for seq in sweep_sequences(seeds) {
         for first_start in 2..=13usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -434,7 +441,18 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
         }
     }
 
-    assert!(checked > 100_000, "sweep covered too little: {checked}");
+    // Per seed, not absolute (#1295): the seed count is now a knob, so a fixed
+    // floor would either fail at the default prefix or be vacuous at the full
+    // corpus. Measured at 11,520 cases per seed — the loop bounds below are what
+    // fix that, and they do not depend on the sequences drawn — so this floor
+    // sits deliberately loose, at roughly a third, and guards against the sweep
+    // being hollowed out by a lost loop rather than against exact drift.
+    const CASES_PER_SEED_FLOOR: usize = 4_000;
+    let floor = CASES_PER_SEED_FLOOR * seeds as usize;
+    assert!(
+        checked > floor,
+        "sweep covered too little: {checked} cases over {seeds} seeds (floor {floor})"
+    );
     // `checked` counts enumerated cases, but a case whose *input* will not
     // apply contributes nothing to either property below. Bound that share, so
     // the sweep cannot go quietly hollow while still clearing the floor.

--- a/tests/it/common/cis_apply_oracle.rs
+++ b/tests/it/common/cis_apply_oracle.rs
@@ -30,6 +30,103 @@ use ferro_hgvs::{
     parse_hgvs, HgvsVariant, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection,
 };
 
+/// Seeds a sweep should draw, given the count it wants when run in full (#1295).
+///
+/// The exhaustive sweeps are 92% of a local `cargo nextest run`: measured on this
+/// commit's parent, `cis_junction_crossing_shift` alone is 79.6s of an 86.6s
+/// suite, and `repeat_span_sibling_overlap` adds 33.1s. That is a poor edit-test
+/// loop for work that touches none of it, and it is the only cost — CI shards the
+/// `Test` job, so it does not gate CI wall-clock.
+///
+/// So the default is a small prefix of the corpus and CI asks for all of it:
+///
+/// | `FERRO_SWEEP_SEEDS` | seeds drawn |
+/// |---|---|
+/// | unset | [`DEFAULT_SWEEP_SEEDS`], or `full` if that is smaller |
+/// | `full` | `full` |
+/// | a number | that number |
+///
+/// **Why a prefix, and why this does not weaken the pinned counts.**
+/// [`sweep_sequences`] is prefix-stable — `sweep_sequences(8)` is exactly the
+/// first sixteen entries of `sweep_sequences(16)`, asserted by
+/// `sweep_sequences_is_prefix_stable` below. So a reduced run enumerates a strict
+/// *subset* of the full run's cases, which is what makes the assertions survive
+/// unchanged rather than becoming profile-dependent:
+///
+/// - `overlapping.is_empty()` / `changed.is_empty()` — a property that holds over
+///   a set holds over any subset, so a reduced run cannot pass one the full run
+///   would fail. It can only find *fewer* failures, never different ones.
+/// - `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` — pinned at **zero**, and zero is
+///   subset-stable for the same reason. Had it been a non-zero count, this knob
+///   would have had to make it profile-dependent, which #1295 flags as its own
+///   hazard; it is only safe because the residual was driven to zero first.
+///
+/// Two assertions are **not** covered by that subset argument, and it is worth
+/// being exact about which:
+///
+/// - each sweep's case-count floor is genuinely seed-dependent, which is why
+///   those are expressed per-seed rather than as absolutes;
+/// - the `skipped * 10 < checked` share is an **aggregate ratio**, and a ratio
+///   is not subset-stable. Adding seeds changes which cases are skipped, so a
+///   prefix run clearing the bound does not prove the full run will: later seeds
+///   could be skip-heavier and push the aggregate over. It is not profile-*noisy*
+///   — both runs assert the same bound — but a green local prefix is not a
+///   guarantee here the way it is for the three above. CI's `full` run is what
+///   actually settles it.
+///
+/// The escape hatch is the numeric form: `FERRO_SWEEP_SEEDS=12` when bisecting a
+/// failure that a reduced run reproduces but a full one takes too long to iterate
+/// on.
+pub fn sweep_seeds(full: u32) -> u32 {
+    let setting = match std::env::var("FERRO_SWEEP_SEEDS") {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        // Set, but not valid UTF-8. Folding this into "unset" would silently run
+        // the 4-seed prefix for someone who asked for the full corpus and typoed
+        // it — the same "ran less than you think" failure the panic below exists
+        // to prevent, so it gets the same treatment rather than a quiet default.
+        Err(std::env::VarError::NotUnicode(raw)) => panic!(
+            "FERRO_SWEEP_SEEDS is set to a non-UTF-8 value ({raw:?}); it must be \
+             `full` or a seed count. Unset it for the default \
+             {DEFAULT_SWEEP_SEEDS}-seed prefix."
+        ),
+    };
+    sweep_seeds_from(setting.as_deref(), full)
+}
+
+/// The selection rule of [`sweep_seeds`], as a pure function of the setting.
+///
+/// Split out so the rule can be tested **without touching the environment**.
+/// The tests used to `set_var`/`remove_var` around their assertions, guarded by
+/// a SAFETY note arguing that nextest gives each test its own process. That
+/// argument is sound under nextest and *false* under `cargo test`, which
+/// `CLAUDE.md` lists as a supported alternative and which runs tests as threads
+/// in one process: there, setting `FERRO_SWEEP_SEEDS=12` mid-run races every
+/// concurrently-executing sweep reading the same variable, silently shrinking
+/// its corpus. A test that can quietly hollow out the sweeps it shares a process
+/// with is not worth the coverage, and none is lost by parsing a string instead.
+fn sweep_seeds_from(setting: Option<&str>, full: u32) -> u32 {
+    match setting {
+        Some(value) if value.eq_ignore_ascii_case("full") => full,
+        Some(value) => value.trim().parse().unwrap_or_else(|_| {
+            panic!(
+                "FERRO_SWEEP_SEEDS must be `full` or a seed count, got {value:?}. \
+                 Unset it for the default {DEFAULT_SWEEP_SEEDS}-seed prefix."
+            )
+        }),
+        None => DEFAULT_SWEEP_SEEDS.min(full),
+    }
+}
+
+/// Seeds drawn when `FERRO_SWEEP_SEEDS` is unset.
+///
+/// Four keeps every *shape* the sweeps enumerate — the loop bounds over member
+/// spellings, positions and directions are untouched — and reduces only sequence
+/// diversity. That is the right axis to cut: each sweep's own notes record that
+/// every blocking defect found so far lived in a shape the generator could not
+/// emit rather than in a sequence it did not draw.
+pub const DEFAULT_SWEEP_SEEDS: u32 = 4;
+
 /// The deterministic 20-mers every cis-allele sweep enumerates over.
 ///
 /// `2 * seeds` sequences: for each seed, one over `{A,T}` — the alphabet that
@@ -278,8 +375,59 @@ mod tests {
     #[test]
     fn sweep_sequences_is_deterministic() {
         assert_eq!(sweep_sequences(8), sweep_sequences(8));
-        // A larger seed count extends the corpus rather than re-rolling it,
-        // which is what lets one sweep use 48 seeds and another 64.
+    }
+
+    /// A larger seed count **extends** the corpus rather than re-rolling it.
+    ///
+    /// This is what lets one sweep use 48 seeds and another 64, and since #1295
+    /// it is load-bearing for [`sweep_seeds`]: a reduced run must enumerate a
+    /// strict subset of the full run's cases, or the sweeps' `is_empty()` and
+    /// pinned-zero assertions could pass at the default seed count while failing
+    /// at the full one. Split out of the determinism test and named, because a
+    /// property the seed knob's soundness rests on should fail under its own name.
+    #[test]
+    fn sweep_sequences_is_prefix_stable() {
         assert_eq!(sweep_sequences(8)[..], sweep_sequences(16)[..16]);
+        // The default prefix specifically, since that is the one every local run
+        // takes.
+        let full = sweep_sequences(64);
+        let default = sweep_sequences(DEFAULT_SWEEP_SEEDS);
+        assert_eq!(default[..], full[..default.len()]);
+    }
+
+    /// The selection rule, exercised through [`sweep_seeds_from`] so nothing
+    /// here mutates a process-wide variable the sweeps are concurrently reading.
+    #[test]
+    fn sweep_seeds_defaults_to_the_prefix_and_honours_full() {
+        assert_eq!(sweep_seeds_from(None, 64), DEFAULT_SWEEP_SEEDS);
+        // A sweep asking for fewer than the default gets its own count, never more.
+        assert_eq!(sweep_seeds_from(None, 2), 2);
+
+        assert_eq!(sweep_seeds_from(Some("full"), 64), 64);
+        assert_eq!(
+            sweep_seeds_from(Some("FULL"), 48),
+            48,
+            "the sentinel is case-insensitive"
+        );
+
+        assert_eq!(
+            sweep_seeds_from(Some("12"), 64),
+            12,
+            "an explicit count overrides both"
+        );
+        assert_eq!(
+            sweep_seeds_from(Some("  12  "), 64),
+            12,
+            "surrounding whitespace is tolerated, as a shell can easily add it"
+        );
+    }
+
+    /// A value that is neither `full` nor a count must be loud, not defaulted —
+    /// silently running 4 seeds for someone who asked for 48 is the failure this
+    /// whole knob has to avoid.
+    #[test]
+    #[should_panic(expected = "FERRO_SWEEP_SEEDS must be `full` or a seed count")]
+    fn an_unparseable_sweep_seed_setting_panics() {
+        let _ = sweep_seeds_from(Some("most"), 64);
     }
 }

--- a/tests/it/issue_1254_sibling_crossing_shift.rs
+++ b/tests/it/issue_1254_sibling_crossing_shift.rs
@@ -25,7 +25,7 @@
 //! normalizes both sides, so it passed on the broken behavior.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize,
+    apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize, sweep_seeds,
     sweep_sequences,
 };
 use ferro_hgvs::ShuffleDirection;
@@ -138,7 +138,10 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
     let mut overlapping: Vec<String> = Vec::new();
     let mut mismatched: Vec<String> = Vec::new();
 
-    for seq in sweep_sequences(64) {
+    // #1295: full 64 when CI asks (`FERRO_SWEEP_SEEDS=full`), a 4-seed prefix
+    // otherwise.
+    let seeds = sweep_seeds(64);
+    for seq in sweep_sequences(seeds) {
         for first_start in 1..=14usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -189,9 +192,13 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
     // convertible fraction. The skip count is asserted separately: it is the
     // number this sweep cannot speak for, and letting it grow silently would
     // hollow the property out without moving `enumerated` at all.
+    // Per seed since #1295, for the reason recorded on the equivalent floor in
+    // `cis_junction_crossing_shift.rs`.
+    const CASES_PER_SEED_FLOOR: usize = 1_000;
+    let floor = CASES_PER_SEED_FLOOR * seeds as usize;
     assert!(
-        enumerated > 70_000,
-        "sweep covered too little: {enumerated} enumerated"
+        enumerated > floor,
+        "sweep covered too little: {enumerated} enumerated over {seeds} seeds (floor {floor})"
     );
     assert!(
         skipped * 10 < enumerated,

--- a/tests/it/repeat_span_sibling_overlap.rs
+++ b/tests/it/repeat_span_sibling_overlap.rs
@@ -25,7 +25,7 @@
 //! pre-existing on `main` and independent of both.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, normalize_in, sweep_sequences,
+    apply, assert_normalizes_preserving, normalize_in, sweep_seeds, sweep_sequences,
 };
 use ferro_hgvs::ShuffleDirection;
 
@@ -167,7 +167,10 @@ fn no_two_member_allele_normalizes_to_overlapping_members() {
     let mut overlapping: Vec<String> = Vec::new();
     let mut changed: Vec<String> = Vec::new();
 
-    for seq in sweep_sequences(64) {
+    // #1295: full 64 when CI asks (`FERRO_SWEEP_SEEDS=full`), a 4-seed prefix
+    // otherwise. This sweep was 33.1s of an 86.6s local suite.
+    let seeds = sweep_seeds(64);
+    for seq in sweep_sequences(seeds) {
         for first_start in 1..=14usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -213,7 +216,16 @@ fn no_two_member_allele_normalizes_to_overlapping_members() {
         }
     }
 
-    assert!(checked > 100_000, "sweep covered too little: {checked}");
+    // Per seed since #1295, for the reason recorded on the equivalent floor in
+    // `cis_junction_crossing_shift.rs`: the seed count is a knob, so an absolute
+    // floor would either fail at the default prefix or go vacuous at the full
+    // corpus.
+    const CASES_PER_SEED_FLOOR: usize = 1_500;
+    let floor = CASES_PER_SEED_FLOOR * seeds as usize;
+    assert!(
+        checked > floor,
+        "sweep covered too little: {checked} cases over {seeds} seeds (floor {floor})"
+    );
     // `checked` counts enumerated cases, but a case whose *input* will not
     // apply contributes nothing to either property below. Bound that share, so
     // the sweep cannot go quietly hollow while still clearing the floor.


### PR DESCRIPTION
Closes #1295. **Stacked on #1392** — base is `fix/issue-1235-confluence-ladder`, not `main`, because it edits the sweep files that PR rewrites.

## The measurement

The three exhaustive cis sweeps were 92% of a local `cargo nextest run`, measured on this PR's parent:

| | before | after (default) |
|---|---:|---:|
| local suite (`not test(proptest)`) | **86.6s** | **27.5s** |
| `cis_junction_crossing_shift` | 79.6s | 18.3s |
| `repeat_span_sibling_overlap` | 33.1s | 2.8s |
| `issue_1254_sibling_crossing_shift` | ~23s | 1.5s |

No test is left over nextest's 60s `SLOW` threshold. With all three oracles set, the full suite goes 9260/9260 in 56.7s.

## How

`sweep_seeds(full)` decides how much of the shared corpus to draw:

| `FERRO_SWEEP_SEEDS` | seeds |
|---|---|
| unset | 4-seed prefix |
| `full` | the sweep's full count |
| a number | that count (for bisecting) |

CI's `Exhaustive sweeps` job sets `full`. It is the **only** job that reaches these modules — `test` and `test-oracle` negate `SWEEP_FILTER` — so the exhaustive coverage still runs on every PR, and the comment at that env block says so, since moving a sweep out of `SWEEP_FILTER` would silently drop it to the prefix.

Only sequence diversity is reduced, never shapes: the loop bounds over member spellings, positions and directions are untouched. That is the axis worth keeping — each sweep's own notes record that every blocking defect found so far lived in a shape the generator could not emit rather than in a sequence it did not draw.

## The full count goes back to 48, and what that costs

`cis_junction_crossing_shift` had been halved to 24 seeds to pay for a shape widening, and its comment recorded the debt precisely: `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` is an exact count over that corpus, so halving the seeds halved the diversity behind its pinned zero — and it named *this issue's knob* as what would restore it. So the full count is 48 again.

The pinned zero holds at 48, which is the measurement saying that restoring the diversity revealed no hidden defect.

**That is not free.** Running the `sweeps` job's exact selection with its three oracles:

```
24 seeds (what CI runs today)    87.5s
48 seeds (this PR)              183.2s
```

It is one of ~35 checks and runs in parallel, so this is +96s on one job rather than on the critical path. If the trade is unwanted, the single-token change is `sweep_seeds(48)` → `sweep_seeds(24)` in `cis_junction_crossing_shift.rs`, which keeps the entire local speedup and simply declines to restore the diversity. Flagging it rather than deciding it quietly.

## Why the pinned counts did NOT become profile-dependent

#1295 raises this as the hazard against exactly this change — *"the pinned numbers would need to become profile-dependent, which is its own maintenance hazard"* — so it deserves an answer rather than an assumption.

`sweep_sequences` is **prefix-stable**: `sweep_sequences(8)` is exactly the first sixteen entries of `sweep_sequences(16)`. A reduced run therefore enumerates a strict *subset* of the full run's cases, and:

- `overlapping.is_empty()` / `changed.is_empty()` hold over any subset if they hold over the set, so the prefix cannot pass what the full corpus would fail — it can only find fewer failures, never different ones;
- `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` is pinned at **zero**, subset-stable for the same reason. Had that residual still been the 74 it once was, this knob *would* have forced a profile-dependent pin — it is only safe because the residual was driven to zero first;
- `skipped * 10 < checked` is a ratio and does not move with corpus size at all.

The one genuinely seed-dependent assertion is each sweep's case-count floor, so those become per-seed. That is strictly better than the absolutes they replace: `checked > 100_000` over 24 seeds sat ~64% under the measured 11,520 cases per seed, and a per-seed floor scales with the knob rather than going vacuous at one end and failing at the other.

## Tests

- `sweep_sequences_is_prefix_stable` — split out of `sweep_sequences_is_deterministic` and named, because a property the knob's soundness rests on should fail under its own name rather than inside a test about determinism. It now also checks the default prefix specifically.
- `sweep_seeds_defaults_to_the_prefix_and_honours_full` — all three input forms, including the case-insensitive sentinel and the "a sweep asking for fewer than the default gets its own count" edge.

**No proptest strategy is touched and no seed file moved.** `sweep_sequences` is a plain deterministic generator, not a proptest strategy, so the seed-invalidation hazard that applies to `cis_allele_confluence_proptest.rs` does not apply here — `git status tests/proptest-regressions/` is clean.

## Verification

- default profile, all three oracles — **9260/9260 pass**, 146 skipped, 56.7s
- `FERRO_SWEEP_SEEDS=full`, all three oracles — **9260/9260 pass**, 146 skipped
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `actionlint` all clean
- `git merge-tree --write-tree` clean against `origin/main`, #1392, #1370, #1391 and #1393

One inherited conflict to note: against **#1380** there is a clash in `tests/it/cis_spelling_confluence_gap.rs`, a file this PR does not touch. It is the pre-existing #1380 ↔ #1392 disagreement (flagged on both of those PRs), inherited by stacking, not introduced here.
