### PR TITLE
fix(normalize): waive the weight bound for a policy collapse

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2146,7 +2146,8 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         return None; // no net change; leave it to the existing pipeline.
     }
 
-    let mut pieces = partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+    let (mut pieces, collapse) =
+        partition_block_detailed(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
     // Shadow the sequence-first splitter on the very same trimmed block, before
     // any 3'-shift or coalescing, so a reported disagreement is a disagreement
     // about the *split* and not about a downstream pass. Never affects `pieces`.
@@ -2261,7 +2262,21 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // Strict on purpose: #1229, #1231, #1233 and #1234 all sit exactly at
     // equality, and equality is where prioritisation (`general.md:56`) may
     // legitimately prefer the re-derived shape.
-    if changed_columns_of_pieces(&pieces) > changed_columns_of_edits(&edits) {
+    //
+    // One exemption, and only one: a block `partition_block` collapsed *by
+    // policy* (`BlockCollapse::ByPolicy`). There the aligner did find a
+    // multi-piece partition and `split_buys_no_higher_priority_type` merged it
+    // deliberately, because the split bought nothing but more `delins` members
+    // across a single unchanged base. That collapse is necessarily heavier than
+    // the split it replaced — merging across an unchanged base always is — so
+    // the bound refused ferro's own preferred spelling whenever the input
+    // happened to arrive already split, and `g.[257_258delinsGGG;260_261delinsGG]`
+    // and `g.257_261delinsGGGTGG` were both stable: one variant, two normal
+    // forms. The bound is a guard against derivations that are *accidentally*
+    // worse, and a policy that widens on purpose is not that.
+    if collapse != BlockCollapse::ByPolicy
+        && changed_columns_of_pieces(&pieces) > changed_columns_of_edits(&edits)
+    {
         return None;
     }
 
@@ -3464,6 +3479,26 @@ fn trim_common_flanks(reference: &[u8], result: &[u8]) -> (usize, usize, usize) 
     (lo, hi_ref, hi_alt)
 }
 
+/// Why [`partition_block_detailed`] returned a single whole-block piece.
+///
+/// The distinction matters to the weight bound in `canonicalize_from_sequence`,
+/// which refuses a derivation heavier than the input. That refusal is right for
+/// [`BlockCollapse::Fallback`] — no usable partition was found, so the lone piece
+/// is a worse description that the per-member pipeline should answer instead. It
+/// is wrong for [`BlockCollapse::ByPolicy`], where the aligner *did* find a
+/// multi-piece partition and a deliberate rule merged it: refusing there makes
+/// ferro's own preferred spelling unreachable from an input that is already
+/// split, which is how one variant ended up with two stable normal forms.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BlockCollapse {
+    /// Not collapsed — the pieces are the alignment's own partition.
+    No,
+    /// Collapsed deliberately by [`split_buys_no_higher_priority_type`].
+    ByPolicy,
+    /// Collapsed because no usable partition was available.
+    Fallback,
+}
+
 /// Partition a changed block into maximal runs of change separated by at least
 /// one unchanged base.
 ///
@@ -3475,7 +3510,21 @@ fn trim_common_flanks(reference: &[u8], result: &[u8]) -> (usize, usize, usize) 
 /// pieces — and break ties by placing the indel 5'-most. The tie-break is an
 /// implementer's choice; the spec does not reach it. Each piece is 3'-shifted
 /// afterwards, so the 3' rule is still honoured per member.
+///
+/// Test-only since the weight bound began reading the collapse origin: every
+/// production caller needs [`partition_block_detailed`]'s second element, and
+/// the tests here care only about the pieces.
+#[cfg(test)]
 fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
+    partition_block_detailed(reference, result).0
+}
+
+/// Why a block came back as one whole-block piece — see [`BlockCollapse`].
+///
+/// Split out from [`partition_block`] because the caller cannot otherwise tell a
+/// *deliberate* collapse from a fallback, and the weight bound needs to
+/// (`BlockCollapse::ByPolicy`).
+fn partition_block_detailed(reference: &[u8], result: &[u8]) -> (Vec<Piece>, BlockCollapse) {
     let whole = || {
         vec![Piece {
             ref_start: 0,
@@ -3486,14 +3535,14 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
     // One bound for every regime now that every length-changing regime has a
     // real guard — see `separations_are_meaningful` (#1271).
     if reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK {
-        return whole();
+        return (whole(), BlockCollapse::Fallback);
     }
     let Some(columns) = best_alignment(reference, result) else {
-        return whole();
+        return (whole(), BlockCollapse::Fallback);
     };
     let pieces = pieces_from_columns(&columns, reference, result);
     if pieces.is_empty() {
-        return whole();
+        return (whole(), BlockCollapse::Fallback);
     }
     // Every length-changing block, not just net insertions (#1271). Equal-length
     // blocks are exempt because `best_alignment` compares position-wise there —
@@ -3501,7 +3550,7 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
     if reference.len() != result.len()
         && !separations_are_meaningful(&pieces, result.len().abs_diff(reference.len()))
     {
-        return whole();
+        return (whole(), BlockCollapse::Fallback);
     }
     // Scoped to length-changing blocks: an equal-length block has no gap to
     // place, so every matched base is a genuine coordinate-wise identity rather
@@ -3512,9 +3561,9 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
         && every_separation_is_a_single_base(&pieces)
         && split_buys_no_higher_priority_type(&pieces, reference)
     {
-        return whole();
+        return (whole(), BlockCollapse::ByPolicy);
     }
-    pieces
+    (pieces, BlockCollapse::No)
 }
 
 /// Merge a run of pieces that together span one inversion back into that single

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -439,28 +439,35 @@ fn cross_reference_inv_suffix_expands_inside_a_complex_bracket() {
         "the spanning delins must be a normalization fixed point",
     );
 
-    // KNOWN LIMITATION, pinned deliberately so it is visible rather than merely
-    // absent: the hand-written two-member spelling of this same variant does
-    // *not* converge on the spanning delins. Two stable strings, one variant.
+    // This was a pinned KNOWN LIMITATION — the hand-written two-member spelling
+    // of this same variant did not converge on the spanning delins, so one
+    // variant had two stable strings. **It now converges**, and the condition
+    // the old pin set for changing it is met.
     //
-    // It cannot be closed from here. The two-member input trips the
-    // `input_separator_positions` veto (`general.md:34` — do not merge across a
-    // base the input left unchanged), which returns it verbatim. Letting a
-    // coincidence-driven collapse override that veto does close this case, but it
-    // also merges `g.[306dup;308C>A]` into `g.307_308delinsCGA`, breaking #999 —
-    // and the collapse cannot tell the two apart, because both are two-member
-    // inputs whose derived pieces collapse to one. The veto is what protects
-    // #999, so it stays and this case stays split.
+    // That pin said the case "cannot be closed from here", because closing it
+    // seemed to require letting a coincidence-driven collapse override the
+    // `general.md:34` veto — which would also merge `g.[306dup;308C>A]` into
+    // `g.307_308delinsCGA` and break #999, "and the collapse cannot tell the two
+    // apart, because both are two-member inputs whose derived pieces collapse to
+    // one."
     //
-    // Change this assertion only alongside a fix that keeps #999 green.
+    // It can tell them apart, once it is asked to record *why* it collapsed.
+    // `partition_block` now reports a `BlockCollapse`, and the weight bound is
+    // waived only for `ByPolicy` — a block where the aligner found a multi-piece
+    // partition and `split_buys_no_higher_priority_type` deliberately merged it
+    // because the split bought nothing but more `delins` members across one
+    // unchanged base. #999's split buys a `dup`, which is a higher-priority type,
+    // so that predicate is false, no policy collapse is recorded, the bound still
+    // applies, and `g.[306dup;308C>A]` stays split. All four #999 tests are green
+    // — verified directly, not inferred from the suite.
     assert_eq!(
         normalize(
             "NC_000022.10:g.[10_11delinsAA;13_15delinsCCCC]",
             inv_payload_provider()
         )
         .expect("normalize"),
-        "NC_000022.10:g.[10_11delinsAA;13_15delinsCCCC]",
-        "the two-member spelling is left alone by the separator veto (known non-confluence)",
+        "NC_000022.10:g.10_15delinsAAACCCC",
+        "the two-member spelling now converges on the spanning delins",
     );
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -18,6 +18,7 @@ mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
+mod residual_split_buys_normal_forms;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/residual_split_buys_normal_forms.rs
+++ b/tests/it/residual_split_buys_normal_forms.rs
@@ -1,0 +1,53 @@
+//! A block the partitioner collapses *by policy* must be reachable from the
+//! split spelling too, or one variant has two normal forms.
+//!
+//! `partition_block` deliberately returns the whole block when every gap
+//! between pieces is a single unchanged base and the split buys no
+//! higher-priority type — `every_separation_is_a_single_base` plus
+//! `split_buys_no_higher_priority_type`. The reasoning is that a lone matched
+//! base inside a length-changing block is more likely coincidence than
+//! structure, so the spanning `delins` is the better description
+//! (`delins.md:44-47`).
+//!
+//! That is a policy, and it was unreachable from half its own inputs:
+//!
+//! ```text
+//! reference  ("ACGT" x 64) + "ACTAC" + ("ACGT" x 64)
+//!
+//! g.257_261delinsGGGTGG              stable — the policy's own preferred form
+//! g.[257_258delinsGGG;260_261delinsGG]  stable — and denotes the same GGGTGG
+//! ```
+//!
+//! Both were fixed points, so one variant had two stable normal forms. The
+//! spanning form is necessarily *heavier* than the split it replaces — merging
+//! across an unchanged base always is — and `canonicalize_from_sequence`'s
+//! weight bound refuses any derivation heavier than the input. So the policy
+//! could never be applied to an input that had already arrived split.
+//!
+//! The bound guards against derivations that are *accidentally* worse: the
+//! single-gap aligner parking its lone gap at one end and reading the offset as
+//! a run of substitutions. A rule that widens on purpose is not that, so
+//! `partition_block` now reports whether its collapse was `ByPolicy`, and only
+//! that case is exempt.
+//!
+//! The narrowness is the point. #999's `g.[306dup;308C>A]` is also a two-member
+//! input whose derived pieces collapse to one, and it must stay split — its
+//! split buys a `dup`, a higher-priority type, so `split_buys_no_higher_priority_type`
+//! is false, nothing is recorded as `ByPolicy`, and the bound still refuses.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// Five bases with a single `T` at 259, which is the coincidental match.
+const CORE: &str = "ACTAC";
+
+#[test]
+fn the_split_spelling_reaches_the_policys_own_spanning_form() {
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[257_258delinsGGG;260_261delinsGG]");
+    assert_eq!(output, "NC_TEST.1:g.257_261delinsGGGTGG");
+}
+
+#[test]
+fn the_spanning_spelling_is_still_a_fixed_point() {
+    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.257_261delinsGGGTGG");
+    assert_eq!(output, "NC_TEST.1:g.257_261delinsGGGTGG");
+}


### PR DESCRIPTION
Refs #1235 — the first of the two confluence residuals recorded on that issue ([comment](https://github.com/fulcrumgenomics/ferro-hgvs/issues/1235#issuecomment-5185660755)).

**Stacked on #1399** (criterion 2). Review that one first; this PR's diff against it is a single commit.

## The defect

`partition_block` deliberately returns the whole block when every gap between pieces is a single unchanged base and the split buys no higher-priority type (`every_separation_is_a_single_base` + `split_buys_no_higher_priority_type`). The reasoning is `delins.md:44-47`: a lone matched base inside a length-changing block is more likely coincidence than structure, so the spanning `delins` is the better description.

That policy was unreachable from half its own inputs:

```
reference  ("ACGT" x 64) + "ACTAC" + ("ACGT" x 64)

g.257_261delinsGGGTGG                 stable
g.[257_258delinsGGG;260_261delinsGG]  stable, and denotes the same GGGTGG
```

Both fixed points. One variant, two stable normal forms.

## Why it could not be reached

A spanning form is necessarily **heavier** than the split it replaces — merging across an unchanged base always is — and `canonicalize_from_sequence` refuses any derivation heavier than the input (`changed_columns_of_pieces > changed_columns_of_edits`). So whenever the input arrived already split, ferro's own preferred spelling was refused.

This is a direct instance of the characterisation recorded on #1235: *the derivation is confluent exactly on haplotypes whose derived partition is weight-minimal, because the bound compares derived weight against the input's weight.*

## The fix, and why it is narrow

The bound guards against derivations that are *accidentally* worse — the single-gap aligner parking its lone gap at one end so the offset between two changes reads as a run of substitutions. A rule that widens **on purpose** is not that.

`partition_block_detailed` now reports a `BlockCollapse` (`No` / `ByPolicy` / `Fallback`), and the weight bound is waived only for `ByPolicy`. Every other collapse — oversized block, no alignment, empty pieces, `separations_are_meaningful` declining — stays `Fallback` and keeps the bound.

## This closes a limitation #422 pinned as unclosable

`issue_422_cross_reference_ins` carried this same shape as a deliberate known non-confluence, and its comment said it could not be closed from there:

> Letting a coincidence-driven collapse override that veto does close this case, but it also merges `g.[306dup;308C>A]` into `g.307_308delinsCGA`, breaking #999 — and the collapse cannot tell the two apart, because both are two-member inputs whose derived pieces collapse to one.

Recording *why* the block collapsed is what tells them apart. **#999's split buys a `dup`** — a higher-priority type — so `split_buys_no_higher_priority_type` is false, nothing is recorded as `ByPolicy`, and the bound still refuses. `g.[306dup;308C>A]` stays split.

That pin set an explicit condition for changing it — "change this assertion only alongside a fix that keeps #999 green" — and it is met. All four #999 tests were run directly and confirmed green, not inferred from a green suite.

## Verification

- Suite **9253/9253**; all three oracles **9253/9253**
- Conformance axis **201/201** against the prepared reference (not run by PR CI)
- CI's eight soak shards (1,000,000 cases per property) clean, no seed appended
- clippy `-D warnings` and `cargo fmt --check` clean

The only test whose expectation moved is #422's pinned limitation, and it moved from "two stable strings" to convergence.

## Remaining for #1235

One residual left — non-confluence above `MAX_SPLIT_BLOCK` (L>=1026), where `partition_block` short-circuits to `whole()` on length alone. A PR for it will stack on this branch, and that tip is what should carry `Closes #1235` — noting #1392 also has to land for criterion 1.


## Representation stability — measured, and this one is a migration

Rebased onto `main` at `1ee1f9a2` (#1399 squash-merged, so its two commits are dropped rather than replayed; this PR is now a single commit). Re-verified there: suite **9358 passed** under all three oracles, `fmt`/`clippy` clean, and the 20 `issue_999` + `issue_422` tests pass directly.

**The PR body had no stability section, and it needed one.** Measured by dumping normalized output on `1ee1f9a2` and on this branch over a corpus built for the shape this PR changes — 48 sequences (24 seeds x 2 alphabets), each enumerated over every two-member position, in three spellings: the split form, the spanning form of the same variant, and #999's `dup`+`sub` control.

| | rows |
|---|---|
| total | 2,160 |
| **moved** | **498 (23.1%)** |
| of which: split spelling (the intended target) | 498 |
| of which: spanning spelling | **0** |
| of which: #999 `dup`+`sub` control | **0** |

**Read the 23% correctly: this corpus is deliberately enriched for the affected shape, so that is the rate *within the shape family*, not a repo-wide rate.** The other PRs in this family quoted 0.2–0.8% because they measured over broader corpora. What is comparable across them is the direction and the class, below.

**Class: expensive.** Of the 498 moved rows, **457 were fixed points on `main`** — previously-accepted, stable output. A consumer storing `g.[257_258delinsGGG;260_261delinsGG]` today gets `g.257_261delinsGGGTGG` after this lands. The remaining 41 were already unstable on `main` (their first-pass answer was not a fixed point), so those are free.

**Direction: toward the spec's stated form, away from the shipped one.** `delins.md:44-47` is what the collapse policy cites, and this PR makes that policy reachable from the split spelling. So it is the case `CLAUDE.md` describes as "where the spec mandates the other form, change it, and flag it loudly as a migration" — hence this section rather than a footnote.

**What it buys:** confluence on this shape goes from **28.9% to 98.1%** of split/spanning pairs (208/720 → 706/720). That is the point of the PR, and it is a large gain — but it is bought with a real migration, not for free, and the two should be weighed together rather than the second being assumed.

**Scoping confirmed by measurement, not by argument.** Zero of the #999 `dup`+`sub` controls moved, across all 720 of them — which is the empirical version of the `split_buys_no_higher_priority_type` claim in the description above.

Caveats: `main`-to-branch rather than release-to-release (the harness postdates v0.12.0), and this is a synthetic 20-mer corpus over one shape family — an order of magnitude for that family, not a bound on the library.
