### PR TITLE
fix(normalize): cap the split only where there is a gap to place

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1730,12 +1730,26 @@ const MAX_CANONICAL_WINDOW: i64 = 4096;
 /// Padding either side of the changed interval, giving the 3'-shift room.
 const CANONICAL_PAD: i64 = 128;
 
-/// Longest changed block the canonicalizer will attempt to partition.
+/// Longest **length-changing** block the canonicalizer will attempt to
+/// partition.
 ///
-/// This is a cost bound, not a policy: the alignment is quadratic in the block
-/// length, and a block this long is a structural event rather than a few
-/// nucleotide changes. It is deliberately far above the size at which the
-/// separation rule (`delins.md:17`) is the interesting question.
+/// Equal-length blocks are exempt: [`best_alignment`] returns their
+/// position-wise pairing immediately, so there is no gap placement to search for
+/// and nothing here to protect. They are bounded instead by
+/// [`MAX_CANONICAL_WINDOW`], the widest window the canonicalizer will fetch at
+/// all.
+///
+/// This is a cost bound, not a policy, and a block this long is a structural
+/// event rather than a few nucleotide changes. It is deliberately far above the
+/// size at which the separation rule (`delins.md:17`) is the interesting
+/// question.
+///
+/// It does **not** bound a quadratic cost, despite what an earlier revision of
+/// this comment claimed. A placement scores in O(1) because the score is
+/// separable, so [`best_alignment`]'s search is linear; the one quadratic step —
+/// ranking a tie by what it separates — carries its own and tighter bound in
+/// [`MAX_TIE_BREAK_SWEEP`], which binds first at every length this constant
+/// reaches.
 ///
 /// It is *not* the `delins.md:44-47` "coincidental alignment" guard. That
 /// concern — a large replacement whose interior only accidentally aligns, which
@@ -3483,9 +3497,26 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
             alt: result.to_vec(),
         }]
     };
-    // One bound for every regime now that every length-changing regime has a
-    // real guard — see `separations_are_meaningful` (#1271).
-    if reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK {
+    // Scoped to length-changing blocks, because that is the only regime the cap
+    // reaches at all. An equal-length block has no gap to place, so
+    // `best_alignment` returns the position-wise pairing on its first statement
+    // and the whole partition is linear — there is no search here to bound.
+    //
+    // Note what the cap does *not* do, even where it applies: it does not bound
+    // a quadratic cost. Scoring one placement is O(1) because the score is
+    // separable, which makes `best_alignment`'s search linear, and the one
+    // quadratic step — ranking a tie by what it separates — carries its own and
+    // tighter bound in `MAX_TIE_BREAK_SWEEP` (256), which binds first.
+    //
+    // Capping it anyway cost confluence rather than time: the un-partitioned
+    // whole block is refused by the weight bound whenever the input was spelled
+    // as its individual changes, so a 1100 nt near-palindrome left
+    // `g.257_1356inv` and `g.[257C>A;267A>C;1346G>T;1356T>G]` both stable — one
+    // variant, two normal forms, with an exact boundary at the cap (1024
+    // confluent, 1026 not) that gave the length short-circuit away.
+    if reference.len() != result.len()
+        && (reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK)
+    {
         return whole();
     }
     let Some(columns) = best_alignment(reference, result) else {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -18,6 +18,7 @@ mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
+mod residual_above_cap_confluence;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/residual_above_cap_confluence.rs
+++ b/tests/it/residual_above_cap_confluence.rs
@@ -1,0 +1,160 @@
+//! A block larger than `MAX_SPLIT_BLOCK` is still partitionable when its two
+//! sides are the same length.
+//!
+//! `partition_block` short-circuits to the whole block on length alone:
+//!
+//! ```text
+//! if reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK { whole() }
+//! ```
+//!
+//! The cap is there to bound `best_alignment`'s gap-placement sweep, which is
+//! O(n²) in the block length — at 1024 that is already ~1e6 column comparisons.
+//! But that sweep only runs when the two sides differ in length. For an
+//! **equal-length** block `best_alignment` returns immediately:
+//!
+//! ```text
+//! if reference.len() == result.len() {
+//!     return Some((0..reference.len()).map(|i| (Some(i), Some(i))).collect());
+//! }
+//! ```
+//!
+//! There is no gap to place, so there is nothing to search and nothing for the
+//! cap to protect — the partition is position-wise and linear. Capping it anyway
+//! cost confluence, because the un-partitioned whole block is then refused by the
+//! weight bound whenever the input was spelled as its individual changes:
+//!
+//! ```text
+//! a 1100 nt near-palindrome at 257_1356, differing from its own reverse
+//! complement at exactly two mirror pairs (257/1356 and 267/1346)
+//!
+//! g.257_1356inv                                 stable
+//! g.[257C>A;267A>C;1346G>T;1356T>G]             stable, and denotes the same bases
+//! ```
+//!
+//! One variant, two stable normal forms. The cap boundary was exact — 1024
+//! confluent, 1026 not — which is the signature of a length short-circuit rather
+//! than anything about the sequence.
+//!
+//! The four substitutions are the canonical form here, and not merely the
+//! lighter one: an inversion whose interior is unchanged is the #1230 shape from
+//! #1235's own table ("inv over-recognized (unchanged interior) -> separate
+//! subs"). A 1100 nt inversion that alters four bases is not an inversion.
+//!
+//! ## What still bounds the cost
+//!
+//! Lifting the cap here does not open an unbounded path, because
+//! `MAX_CANONICAL_WINDOW` (4096) already refuses a wider group before any block
+//! is partitioned — it bounds the reference window the canonicalizer will fetch
+//! at all. Measured on whole-span inversions: 2,000 nt and 3,000 nt partition
+//! (1.6 ms and 0.3 ms), 4,000 nt and beyond are refused at the window and stay
+//! `inv`. So this change moves the equal-length confluence ceiling from 1024 up
+//! to that window bound, and leaves the guard that actually caps cost in place.
+
+use crate::common::synthetic::assert_padded_preserving;
+
+/// Length of the near-palindromic span, chosen to sit above `MAX_SPLIT_BLOCK`
+/// (1024) so the short-circuit is what the test exercises.
+const SPAN: usize = 1100;
+
+/// Offsets into the span whose bases are perturbed away from palindromy. Each
+/// one breaks its own column *and* its mirror, so two perturbations yield four
+/// changed positions.
+const PERTURBED: [usize; 2] = [0, 10];
+
+fn complement(base: u8) -> u8 {
+    match base {
+        b'A' => b'T',
+        b'C' => b'G',
+        b'G' => b'C',
+        b'T' => b'A',
+        other => other,
+    }
+}
+
+/// A span that is its own reverse complement except at [`PERTURBED`] and their
+/// mirrors, built deterministically rather than committed as a fixture.
+fn near_palindrome() -> String {
+    const UNIT: &[u8] = b"ACGTTGCAAGCT";
+    let mut bases = vec![0u8; SPAN];
+    // Fill the 5' half, then mirror it as the reverse complement so the span
+    // inverts to itself.
+    for i in 0..SPAN / 2 {
+        let base = UNIT[i % UNIT.len()];
+        bases[i] = base;
+        bases[SPAN - 1 - i] = complement(base);
+    }
+    // Break palindromy at two positions. `inv` then differs from the reference
+    // at those two columns and at their two mirrors: four changed bases.
+    for &offset in &PERTURBED {
+        bases[offset] = match bases[offset] {
+            b'A' => b'C',
+            b'C' => b'A',
+            b'G' => b'T',
+            _ => b'G',
+        };
+    }
+    String::from_utf8(bases).expect("ASCII bases")
+}
+
+/// The four positions at which the span differs from its own reverse
+/// complement, as 1-based coordinates in the padded reference (the core starts
+/// at 257).
+fn changed_positions() -> Vec<usize> {
+    let mut positions: Vec<usize> = PERTURBED
+        .iter()
+        .flat_map(|&offset| [257 + offset, 257 + SPAN - 1 - offset])
+        .collect();
+    positions.sort_unstable();
+    positions
+}
+
+#[test]
+fn the_inversion_spelling_reduces_to_its_four_substitutions() {
+    let core = near_palindrome();
+    let output = assert_padded_preserving(&core, "NC_TEST.1:g.257_1356inv");
+    assert!(
+        !output.contains("inv"),
+        "a 1100 nt inversion that alters four bases must not stay an inversion: {output}"
+    );
+    // Not pinned as a literal string — the bases come from `near_palindrome`, so
+    // pinning one would restate the generator rather than check it. Pinned
+    // against the member list that generator implies instead, which checks the
+    // substituted bases and not only the positions. Containment on the bare
+    // positions was the weaker earlier form: `257` also matches inside `1257`,
+    // and nothing there read the payload at all.
+    assert_eq!(
+        output,
+        substitution_spelling(&core),
+        "the inversion must reduce to exactly the four substitutions it performs"
+    );
+}
+
+/// The same variant spelled as its individual substitutions, built from the
+/// generated span so the two spellings cannot drift apart.
+///
+/// `inv` replaces the span with its reverse complement, so the base the
+/// inversion puts at offset `i` is `complement(span[SPAN - 1 - i])`.
+fn substitution_spelling(core: &str) -> String {
+    let bases = core.as_bytes();
+    let members: Vec<String> = changed_positions()
+        .into_iter()
+        .map(|position| {
+            let offset = position - 257;
+            let from = bases[offset] as char;
+            let to = complement(bases[SPAN - 1 - offset]) as char;
+            format!("{position}{from}>{to}")
+        })
+        .collect();
+    format!("NC_TEST.1:g.[{}]", members.join(";"))
+}
+
+#[test]
+fn both_spellings_reach_the_same_normal_form() {
+    let core = near_palindrome();
+    let from_inversion = assert_padded_preserving(&core, "NC_TEST.1:g.257_1356inv");
+    let from_substitutions = assert_padded_preserving(&core, &substitution_spelling(&core));
+    assert_eq!(
+        from_inversion, from_substitutions,
+        "the two spellings of one variant must converge on one string"
+    );
+}


### PR DESCRIPTION
**Refs #1235.** One of the two confluence residuals recorded on that issue ([comment](https://github.com/fulcrumgenomics/ferro-hgvs/issues/1235#issuecomment-5185660755)).

> **No longer stacked.** This was the tip of a three-PR stack (#1399 <- #1401 <- this). #1399 has merged, and **#1401 was closed without merging** — its waiver is not spec-supported at any scope (`delins.md:18`'s exception reaches only two single-base substitutions inside one codon, which is closed-and-implemented #79). So this PR now sits directly on `main`, and nothing here depends on #1401's `BlockCollapse`.
>
> **The closing keyword for the root cause stays demoted to `Refs`.** This fixes **0 of the 9** rows reported in #1419/#1420/#1421: those need a *split* heavier than the input's own spelling, which is the opposite direction. Auto-closing the root cause while that class is open is the pattern that produced #1419-#1421 out of #1231-#1233.

## The defect

`partition_block` short-circuited to the whole block on length alone, in every regime:

```rust
if reference.len() > MAX_SPLIT_BLOCK || result.len() > MAX_SPLIT_BLOCK { whole() }
```

An **equal-length** block has no gap to place, so `best_alignment` returns the position-wise pairing on its first statement:

```rust
if reference.len() == result.len() {
    return Some((0..reference.len()).map(|i| (Some(i), Some(i))).collect());
}
```

There is no placement search there for the cap to bound. Capping it anyway cost confluence: the un-partitioned whole block is refused by the weight bound whenever the input was spelled as its individual changes, so on a 1100 nt near-palindrome both spellings were stable fixed points:

```
g.257_1356inv                       and   g.[257C>A;267A>C;1346G>T;1356T>G]
```

One variant, two normal forms — with an **exact** boundary at the cap (1024 confluent, 1026 not), which is the signature of a length short-circuit rather than anything about the sequence.

## What the cap actually bounds — corrected

An earlier revision of this PR (and of `MAX_SPLIT_BLOCK`'s own doc comment, which this PR now fixes) justified the cap as bounding "`best_alignment`'s gap-placement sweep, which is O(n²)". **That is not true, and has not been since the scoring was made separable.** `best_alignment`'s own doc says so: a placement scores in O(1), so the search is linear — "at `MAX_SPLIT_BLOCK` that is ~1024 comparisons against ~1e6". The one quadratic step is ranking a *tie* by what it separates, and it carries its own and tighter bound in `MAX_TIE_BREAK_SWEEP` (256), which binds first at every length `MAX_SPLIT_BLOCK` reaches.

So the scoping stands on the simpler ground — an equal-length block has no search at all — and `MAX_SPLIT_BLOCK`'s doc is updated to say what it really is: a bound on **length-changing** blocks that is not a quadratic guard.

## Which form is canonical

The four substitutions, and not merely because they are lighter: an inversion whose interior is unchanged is the #1230 shape from #1235's own table ("inv over-recognized (unchanged interior) -> separate subs"). A 1100 nt inversion that alters four bases is not an inversion.

## Representation movement — measured

Per the representation-stability guidance, here is the blast radius rather than an assurance.

**Committed representation corpus** (`dump_normalized_corpus`, the #1442 harness), 18,432 rows across both axes and both shuffle directions, diffed row-for-row against `origin/main`:

| measure | value |
|---|---|
| rows | 18,432 |
| **moved** | **0 (0.0%)** |
| of which previously accepted (a migration) | 0 |
| of which previously not a fixed point (free) | 0 |

Zero in all five shape families (`adjacent_junction_ins`, `del_plus_sub`, `dup_plus_ins`, `dup_plus_sub`, `split_vs_spanning_delins`).

That corpus draws 20-mers, so it cannot reach a changed block above `MAX_SPLIT_BLOCK` at all — the result above is a statement that nothing *else* moved, not evidence about the regime this PR changes. Movement is confined by construction to **equal-length changed blocks longer than 1024 bases**, which requires a description spanning >1 kb. Those are structural events, not the few-nucleotide descriptions the corpus and the consumer's library are made of.

**Directly measured in the regime that does change**, one normalize call per row, branch against `origin/main`:

| span | members (main) | members (branch) | elapsed (main) | elapsed (branch) |
|---|---|---|---|---|
| 1,100 | 550 | 550 | 28 ms | 44 ms |
| 2,000 | 1,000 | 1,000 | 80 ms | 109 ms |
| 3,000 | 1,500 | 1,500 | 169 ms | 210 ms |
| 3,800 | 1,900 | 1,900 | 262 ms | 352 ms |

(An equal-length spanning `delins` whose payload differs at every other base.) Member counts are **identical** — that shape reaches its members through the `delins`-to-substitution decomposition, not through the capped path — so it is not a representation change. What it does cost is roughly 30% more wall time on a >1 kb equal-length block, because `partition_block` now runs where it previously short-circuited and arrives at the same answer. Single rep, so read it as a magnitude rather than a figure.

## This does not open an unbounded path

`MAX_CANONICAL_WINDOW` (4096) already refuses a wider group *before* any block is partitioned — it bounds the reference window the canonicalizer will fetch at all. Measured on whole-span inversions:

| span | result |
|---|---|
| 2,000 nt | partitions, 1.6 ms |
| 3,000 nt | partitions, 0.3 ms |
| 4,000 nt and up | refused at the window, stays `inv` |

So this moves the equal-length confluence ceiling from 1024 up to that window bound, and leaves the guard that actually caps cost untouched. The reach is stated in the test module rather than left for someone to rediscover.

## Verification

- Suite **9368/9368**; all three oracles (`FERRO_ASSERT_IDEMPOTENT` / `_REPARSE` / `_IN_BOUNDS`)
- clippy `--all-features --all-targets -D warnings` and `cargo fmt --check` clean
- No proptest seed appended
- **The new guard is falsifiable**: against `main`'s `merge.rs` both tests in `residual_above_cap_confluence` fail, `g.257_1356inv` staying an inversion

The reproduction builds its near-palindrome programmatically rather than committing a 1100-base fixture, and pins the reduced form against the member list that same generator implies — so the assertion checks the substituted bases, not only that the digits appear somewhere in the output.
