### PR TITLE
ci: stop caching cargo binaries in the two archive-building jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,13 +352,23 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: test-archive
-      # `install-action` stays AFTER the cache step, deliberately. `rust-cache`
-      # leaves `cache-bin` at its default of `true`, so `${CARGO_HOME}/bin` is
-      # still cached and a restore running second would extract a
-      # previously-saved `cargo-nextest` over the one just installed, pinning
-      # this job to whichever version first populated the key. The job that
-      # writes an archive and the jobs that read it have to agree on the nextest
-      # version, so let the install win.
+          # `rust-cache` caches `${CARGO_HOME}/bin` unless told not to, so a
+          # restore could extract a previously-saved `cargo-nextest` over the one
+          # `install-action` puts there and pin this job to whichever version
+          # first populated the key. This job writes an archive that other jobs
+          # read, and producer and consumer must agree on the nextest version.
+          #
+          # This used to be handled by ORDERING — the install step below sat
+          # after the cache step, with a comment saying that was deliberate. Not
+          # caching the binaries removes the hazard at the source instead (#1396),
+          # which matters because reordering two `uses:` steps looks harmless and
+          # would silently reintroduce it. `nightly-soak.yml` and `fuzz.yml`
+          # already do it this way.
+          #
+          # The cost is nil: `install-action` downloads a prebuilt binary rather
+          # than compiling one. Measured on this PR's own runs rather than
+          # assumed — see the PR body.
+          cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - name: Build test archive
         # Compiles every test binary and packs them with their run metadata.
@@ -410,9 +420,11 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: test-archive-soak
-      # AFTER the cache step — see the same note on `test-build`. `rust-cache`
-      # still caches `${CARGO_HOME}/bin`, and this job writes the archive that
-      # `soak` and `sweeps` read.
+          # Same reason as `test-build` above, and it applies at least as
+          # strongly here: this job writes the archive that `soak` and `sweeps`
+          # read, so a stale cached `cargo-nextest` would desynchronise three
+          # jobs rather than one (#1396).
+          cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - name: Build soak archive
         # No `--features dev`. That feature pulls in `web-service` (axum, tokio,

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,6 +53,15 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: coverage
+          # This job needs it too, and needs it more than `ci.yml`'s two do
+          # (#1396). `install-action` puts `cargo-llvm-cov` into
+          # `${CARGO_HOME}/bin` at the step ABOVE this one, so with `cache-bin`
+          # left at its default the restore runs *after* the install and can
+          # extract a previously-saved `cargo-llvm-cov` over it — pinning this
+          # job to whichever version first populated the key. In `test-build` the
+          # cache step at least runs first; here the hazardous order is the one
+          # already written.
+          cache-bin: "false"
       - name: Run coverage
         run: |
           cargo llvm-cov --features dev --codecov --output-path codecov.json


### PR DESCRIPTION
Closes #1396. Base `main` — #1370 has merged, so this applies directly.

## What changes

`test-build` and `test-build-soak` both install `cargo-nextest` via `install-action` and write a nextest archive other jobs read, so producer and consumer must agree on the nextest version. `rust-cache` caches `${CARGO_HOME}/bin` unless told not to, so a restore can extract a previously-saved binary over the one just installed.

Both jobs handled that by **ordering** — install placed after the cache step, with a comment saying the order was deliberate. That works, but it is a constraint a future edit silently breaks: reordering two `uses:` steps looks harmless. `cache-bin: "false"` removes the hazard at the source, which is how `nightly-soak.yml` and `fuzz.yml` (from #1391) already do it.

## Scope — audited, not assumed

The issue asks to check whether any other job needs the same. Every `rust-cache` step against whether its job installs into `${CARGO_HOME}/bin`:

| job | rust-cache key | `cache-bin` | installs into cargo bin |
|---|---|---|---|
| `test-build` | `test-archive` | **false** | yes |
| `test-build-soak` | `test-archive-soak` | **false** | yes |
| `test`, `test-oracle` | *(none)* | — | yes |
| `soak`, `sweeps` | *(none)* | — | yes |
| `clippy` | `clippy` | default | no |
| `clippy-all-features` | `clippy-all-features` | default | no |
| `spec-fixtures` | `spec-fixtures` | default | no |
| `generated-docs` | `generated-docs` | default | no |
| `python-wheel-test` | `python-wheel` | default | no |
| `build` | `build-release` | default | no |

**No other job needs it.** The four other jobs that install a binary keep no cargo cache at all, and the six that keep one install nothing into `${CARGO_HOME}/bin`. `python-wheel-test` installs maturin through `pip`, into the Python venv rather than the cargo bin directory.

## Cost — measured, as the issue asks

#1396 asks that the near-zero cost be confirmed rather than assumed, since `install-action` downloads a prebuilt binary rather than compiling one.

Baseline from the three most recent successful `main` runs:

| job | run 30973321571 | 30970642225 | 30969775774 |
|---|---:|---:|---:|
| `Build test archive` | 83s | 83s | 84s |
| `Build soak archive (optimized)` | 124s | 143s | 140s |

I will post this PR's own numbers as a comment once CI completes, so the comparison is against the same jobs on the same runner class rather than against an assumption. Note the first run after a cache-key change is a miss by construction, so the *second* run is the one to read — the `cache-bin` change alters what is saved, not the key.

## Verification

- `actionlint .github/workflows/ci.yml` clean
- the workflow still parses as YAML
- no change outside the two `with:` blocks
