### PR TITLE
fix(normalize): take the overlap verdict from the input, not the repair

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2700,6 +2700,80 @@ impl<P: ReferenceProvider> Normalizer<P> {
             allele.phase,
         ));
 
+        // Coincident *bounds* among the raw members, for exactly the reason the
+        // insertion detector above runs pre-merge — and the half that was
+        // missing (#1406).
+        //
+        // `detect_overlap_conflicts` also runs post-shift, on the normalized
+        // members, which meant W5002 reported whether the repair had *succeeded*
+        // rather than whether the input conflicted. Two inputs of the same shape
+        // got opposite verdicts:
+        //
+        // ```text
+        // reference  TTTTTTTTTAATATATTTTAATAC     24 bases
+        // g.[23dup;23A>G]  -> g.22_23insG          no warning, strict ACCEPTS
+        // g.[24dup;24C>G]  -> unchanged            W5002, strict REJECTS
+        // ```
+        //
+        // Both are a `dup` of one base beside a substitution of that same base.
+        // The only difference is that at 23 the repair collapses the pair into a
+        // single member, so by the time the post-shift detector looks there is
+        // nothing left to conflict; at 24 the terminal decline (#1307) leaves
+        // the pair intact and it is reported. Proximity to the end of the contig
+        // decided whether a conflicting description was rejected.
+        //
+        // The same mechanism let lenient mode launder a conflict outright:
+        // `g.[11_12inv;11_12insAA]` is strict-rejected, and its own lenient
+        // output `g.[11_12=;10_11A[4]]` is strict-*accepted*.
+        //
+        // So the verdict is taken from the input, where the conflict lives, and
+        // a conflicting allele is preserved as authored — the same answer
+        // `has_same_gap_insertions` gives just below, and ferro's standing one
+        // since #395/#486/#1004: report the conflict and leave the description
+        // alone rather than pick a winner among orderings the spec does not
+        // rank.
+        // Scoped to *coincident bounds*, and deliberately not widened to the
+        // insertion-interior-to-a-span conflicts `detect_insertion_overlaps`
+        // reports. Those alleles are still expected to have each member
+        // normalized on its own — `[4_10inv;5_6insAA]` settles as
+        // `[5_9inv;6_7insAA]`, the inversion 3'-shifted and the insertion
+        // respelled at its own junction — and preserving them verbatim would
+        // drop the per-member 3' rule that #1276 and #1235's transcript axes
+        // pin. What those alleles do not get is whole-allele re-derivation,
+        // which they already did not.
+        let raw_conflicts =
+            crate::normalize::overlap::detect_overlap_conflicts(&allele.variants, allele.phase);
+        if !raw_conflicts.is_empty() {
+            // Harvest the per-member diagnostics before preserving. Returning
+            // here skips the per-member loop below, which is where every
+            // *member-local* finding is raised — so without this a conflicting
+            // allele that ALSO misstates a reference base reports only the
+            // conflict. Measured on `g.[13G>A;13A>C]` (base 13 is `A`): the
+            // warning set went from `[RefSeqMismatch, OverlapConflict]` to
+            // `[OverlapConflict]`, and strict mode's error changed from
+            // "Reference mismatch at 13-13: expected G" to the coincidence
+            // message. A reference mismatch is a data-integrity signal about the
+            // caller's input, independent of whether the members also collide;
+            // losing it to a sibling's conflict is a strictly worse report.
+            //
+            // Each member is normalized in isolation purely to collect what it
+            // says — the results are discarded, because preserving the authored
+            // members is the whole point of this branch. A member that fails to
+            // normalize contributes nothing rather than aborting: the allele is
+            // being refused anyway, and the conflict below is the finding that
+            // matters.
+            for member in &allele.variants {
+                if let Ok((_, member_warnings)) = self.normalize_core(member) {
+                    all_warnings.extend(member_warnings);
+                }
+            }
+            all_warnings.extend(raw_conflicts);
+            let mut preserved =
+                crate::hgvs::variant::AlleleVariant::new(allele.variants.clone(), allele.phase);
+            preserved.uncertain = allele.uncertain;
+            return Ok((HgvsVariant::Allele(preserved), all_warnings));
+        }
+
         // Two separate insertions at the *same* junction (`g.[4_5insT;4_5insA]`)
         // are an order-ambiguous overlap conflict, not a normalizable form:
         // there is no canonical order for the two inserted sequences, so the

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2758,14 +2758,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
             //
             // Each member is normalized in isolation purely to collect what it
             // says — the results are discarded, because preserving the authored
-            // members is the whole point of this branch. A member that fails to
-            // normalize contributes nothing rather than aborting: the allele is
-            // being refused anyway, and the conflict below is the finding that
-            // matters.
+            // members is the whole point of this branch.
+            //
+            // Errors propagate rather than being swallowed. An earlier cut used
+            // `if let Ok(..)`, which quietly made this branch *more* permissive
+            // than the ordinary per-member path: a member that fails hard —
+            // `TranscriptVersionNotExact`, say — surfaces to the caller there
+            // and would have been discarded here, so an allele would go from
+            // erroring to returning a preserved value merely because a sibling
+            // conflicted with it. Whether the members collide is unrelated to
+            // whether one of them is resolvable at all.
             for member in &allele.variants {
-                if let Ok((_, member_warnings)) = self.normalize_core(member) {
-                    all_warnings.extend(member_warnings);
-                }
+                let (_, member_warnings) = self.normalize_core(member)?;
+                all_warnings.extend(member_warnings);
             }
             all_warnings.extend(raw_conflicts);
             let mut preserved =

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -366,7 +366,51 @@ fn na_range<L>(
     if !is_overlap_edit(edit) {
         return None;
     }
+    if writes_only_at_a_junction(edit) {
+        return None;
+    }
     range_fn(&loc_edit.location)
+}
+
+/// Whether this edit's *write* lands at a junction rather than over the span it
+/// names — in which case coincident bounds are not a conflict.
+///
+/// Coincident-bounds detection asks whether two members claim the same bases.
+/// That is a question about what they **write**, and for most edit kinds the
+/// two coincide: a substitution, deletion, delins or inversion replaces the span
+/// it names. A `dup` does not. `duplication.md:5` places the copy "directly 3'
+/// of the original copy", so `g.23dup` *reads* base 23 and *writes* at the
+/// junction 23|24. Against `g.23A>G`, which writes base 23, the two write
+/// footprints are disjoint and the composition is unique — `g.22_23insG` — with
+/// no ordering to choose. Grouping them by the read span reported a conflict
+/// that is not one, and made the verdict depend on the spelling: the same
+/// variant written `g.[23A>G;23_24insA]` was accepted.
+///
+/// The spec says merge rather than reject for this shape. `delins.md:86-89`
+/// marks `NM_007294.3:c.[2077G>A;2077_2078insTA]` invalid and gives
+/// `c.2077delinsATA` as the correct description, and `general.md:56`
+/// prioritisation then requires that form be spelled as a `dup` where it is one.
+///
+/// **`Repeat` is deliberately not here**, though it also writes at a junction
+/// when it grows. Whether it *only* does so depends on whether its unit tiles
+/// the reference tract — `A[8]`, `G[6]` and `TA[3]` are indistinguishable at
+/// this layer, and `g.[4_9G[6];4_9inv]` rewrites all six bases while satisfying
+/// any purely syntactic "does not shorten" test. This function has no reference
+/// provider and cannot tell them apart, so a repeat keeps its span. That is the
+/// principled line: a `dup`'s write footprint is reference-*independent*, a
+/// repeat's is not, which is also why a repeat is registered in *both* detectors
+/// and a `dup` in only one.
+///
+/// An uncertain-extent `dup` keeps its span too — its footprint is not known to
+/// be that junction. Same condition `merge::has_same_gap_insertions` uses.
+fn writes_only_at_a_junction(edit: &NaEdit) -> bool {
+    matches!(
+        edit,
+        NaEdit::Duplication {
+            uncertain_extent: None,
+            ..
+        }
+    )
 }
 
 /// The certain inner [`NaEdit`] of an NaEdit-bearing variant, or `None` for

--- a/tests/it/issue_1307_terminal_dup_respell.rs
+++ b/tests/it/issue_1307_terminal_dup_respell.rs
@@ -70,31 +70,53 @@
 //! `issue_1327_mt_respell_past_contig_end`. The circular axis therefore gets the
 //! same answer as the linear one.
 //!
-//! **And not the single member the trace above ends on**, tempting as it looks:
-//! `g.23_24insG` is in range, is one member, and denotes the same sequence. It is
-//! unreachable *by policy*. `normalize_allele` disables its pre-merge reorder
-//! when the input carries an overlap conflict, and both shapes here are such an
-//! input — a `dup` and a substitution on one base is exactly what strict mode
-//! rejects as `OverlapConflictingEdits / W5002`. Dropping that guard does reach
-//! `g.23_24insG` (measured), and it breaks four committed guards that exist to
-//! forbid precisely this: `issue_395_overlap_conflict_strict_rejection::
+//! ## The single member the trace ends on — reached, as of #1406
+//!
+//! This section previously argued that `g.23_24insG` — in range, one member,
+//! denoting the same sequence — was **unreachable by policy**, because
+//! `normalize_allele` disables its pre-merge reorder when the input carries an
+//! overlap conflict, and "a `dup` and a substitution on one base is exactly what
+//! strict mode rejects as `OverlapConflictingEdits / W5002`."
+//!
+//! **That premise was wrong, and #1406 corrected it.** A `dup` is not an
+//! in-place edit: `duplication.md:5` places the copy "directly 3' of the
+//! original copy", so `g.24dup` *reads* base 24 and *writes* at the junction
+//! 24|25, while `g.24C>G` writes base 24. The two write footprints are disjoint,
+//! there is no ordering to choose, and the composition is unique. Coincident
+//! *read* spans were being reported as a conflict that never existed —
+//! `detect_overlap_conflicts` keyed on the span a member names rather than on
+//! the bases it claims.
+//!
+//! The spec asks for the merge, not the refusal. `delins.md:86-89` marks
+//! `NM_007294.3:c.[2077G>A;2077_2078insTA]` invalid and gives `c.2077delinsATA`
+//! as *the correct description*; `general.md:56` prioritisation then requires
+//! that form be spelled as a `dup` where it is one. And the old reading made the
+//! verdict depend on the spelling: the same variant written
+//! `g.[24C>G;24_25insC]` was accepted while `g.[24dup;24C>G]` was rejected.
+//!
+//! **So the issue's own bug is fixed more cleanly than by declining.** The
+//! reported defect is a coordinate one base past the contig — `g.24_25insC`.
+//! Reaching `g.23_24insG` never constructs an out-of-range coordinate at all,
+//! rather than constructing one and then refusing to repair around it.
+//! `assert_within_contig` below still guards every output, and now passes on a
+//! merged form instead of on an un-repaired pair.
+//!
+//! The four guards this section used to cite as blocking still **pass**,
+//! measured: `issue_395_overlap_conflict_strict_rejection::
 //! lenient_mode_preserves_authored_order_of_conflicting_members`,
 //! `issue_1276_dup_junction_overlap::
 //! lenient_output_of_a_conflict_is_still_rejected_by_strict`,
 //! `issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized`
 //! and `idempotency_tests::
-//! test_overlap_conflicting_allele_is_idempotent_across_respellings`.
+//! test_overlap_conflicting_allele_is_idempotent_across_respellings`. They are
+//! unaffected because nothing was dropped wholesale — the change is to *which
+//! shapes are conflicts*, and every allele those four use is one still.
 //!
-//! A conflicting allele must stay recognisable as one so strict mode can reject
-//! it, rather than being canonicalised into something that looks valid. Which
-//! makes the pre-fix behaviour worse than the issue reports: it did not merely
-//! name a position past the end, it laundered a conflict into an output strict
-//! mode **accepts** (`g.[24C>G;24_25insC]` normalizes strictly to
-//! `g.23_24insG`). Declining restores both properties at once — in range, and
-//! still a conflict.
+//! A genuinely conflicting allele must still stay recognisable as one so strict
+//! mode can reject it rather than being canonicalised into something that looks
+//! valid. That property is intact; this shape simply was never a member of it.
 
-use ferro_hgvs::error_handling::ErrorMode;
-use ferro_hgvs::normalize::NormalizeConfig;
+use crate::common::cis_apply_oracle::apply_with;
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
 
 /// The issue's reference: 24 bases ending in a unique `C`, so a duplication
@@ -156,14 +178,14 @@ fn assert_within_contig(input: &str, output: &str) {
 fn a_substitution_sibling_leaves_the_terminal_duplication_alone() {
     assert_eq!(SEQUENCE.len(), LENGTH, "fixture must be 24 bases");
     for (input, expected) in [
-        ("NC_TEST.1:g.[24dup;24C>G]", "NC_TEST.1:g.[24dup;24C>G]"),
-        ("NC_TEST.1:g.[24C>G;24dup]", "NC_TEST.1:g.[24C>G;24dup]"),
+        ("NC_TEST.1:g.[24dup;24C>G]", "NC_TEST.1:g.23_24insG"),
+        ("NC_TEST.1:g.[24C>G;24dup]", "NC_TEST.1:g.23_24insG"),
     ] {
         let output = normalize("NC_TEST.1", SEQUENCE, input);
         assert_within_contig(input, &output);
         assert_eq!(
             output, expected,
-            "`{input}` must keep both members in range"
+            "`{input}` must reach the merged form, in range"
         );
     }
 }
@@ -179,7 +201,10 @@ fn a_delins_sibling_leaves_the_terminal_duplication_alone() {
     let input = "NC_TEST.1:g.[24dup;24delinsGG]";
     let output = normalize("NC_TEST.1", SEQUENCE, input);
     assert_within_contig(input, &output);
-    assert_eq!(output, "NC_TEST.1:g.[24dup;24delinsGG]");
+    // Two members still, unlike the substitution case — the pair does not
+    // collapse to one edit. What changed is that they are now ordered rather
+    // than refused, and the out-of-range junction is never constructed.
+    assert_eq!(output, "NC_TEST.1:g.[24delinsGG;24dup]");
 }
 
 /// The same overrun on the circular axis. Not a special case: `m.` has a last
@@ -187,15 +212,20 @@ fn a_delins_sibling_leaves_the_terminal_duplication_alone() {
 /// it one is not valid HGVS (see the module docs).
 #[test]
 fn the_circular_axis_gets_the_same_answer() {
-    for input in [
-        "NC_012920.1:m.[24dup;24C>G]",
-        "NC_012920.1:m.[24dup;24delinsGG]",
+    // The genomic answers, verbatim, on `m.` — that identity is the whole
+    // claim, so they are written out rather than derived from the input.
+    for (input, expected) in [
+        ("NC_012920.1:m.[24dup;24C>G]", "NC_012920.1:m.23_24insG"),
+        (
+            "NC_012920.1:m.[24dup;24delinsGG]",
+            "NC_012920.1:m.[24delinsGG;24dup]",
+        ),
     ] {
         let output = normalize("NC_012920.1", SEQUENCE, input);
         assert_within_contig(input, &output);
         assert_eq!(
-            output, input,
-            "`{input}` must keep both members in range on the circular axis"
+            output, expected,
+            "`{input}` must get the same answer as the linear axis, in range"
         );
     }
 }
@@ -328,36 +358,46 @@ fn the_declined_output_is_idempotent() {
     }
 }
 
-/// The conflict must survive into strict mode.
+/// The merged form must denote the bases the input denotes.
 ///
-/// The point of declining rather than repairing: an overlap-conflicting input
-/// stays recognisable as one, so strict mode still rejects it. The out-of-range
-/// spelling failed this — `g.[24C>G;24_25insC]` is strict-*acceptable*, so the
-/// old behaviour laundered a conflict into a valid-looking description while also
-/// naming a position the contig does not have.
+/// This replaces `the_declined_output_is_still_rejected_by_strict`, whose
+/// premise #1406 removed: these shapes are not overlap conflicts, so there is no
+/// conflict left for strict mode to reject and asserting one would pin the
+/// misclassification rather than the behaviour.
 ///
-/// The sibling of `issue_1276_dup_junction_overlap::
-/// lenient_output_of_a_conflict_is_still_rejected_by_strict`, at the terminus.
+/// What matters now is stronger and specific to having *started* merging a shape
+/// that was previously refused. A refusal is safe by construction — the output
+/// is the input. A merge is not: it asserts that two members compose into one
+/// edit, and if the composition is wrong the result is a well-formed description
+/// of the wrong bases, which no oracle in this suite would notice. So the check
+/// is a sequence identity, made with an applier that is **not** the normalizer:
+/// convert each member to its SPDI triple and splice the reference.
+///
+/// `g.[24dup;24delinsGG]` is included even though it does not collapse to one
+/// member, because reordering must be sequence-preserving too.
 #[test]
-fn the_declined_output_is_still_rejected_by_strict() {
-    for input in [
-        "NC_TEST.1:g.[24dup;24C>G]",
-        "NC_TEST.1:g.[24C>G;24dup]",
-        "NC_TEST.1:g.[24dup;24delinsGG]",
+fn the_merged_output_denotes_the_inputs_bases() {
+    // The circular inputs are here too, not only on the linear axis. `m.` is
+    // where the wrapped spelling would have been tempting, so it is the axis
+    // where a wrong composition is most plausible — checking only `g.` would
+    // leave the riskier half to a string comparison.
+    for (accession, input) in [
+        ("NC_TEST.1", "NC_TEST.1:g.[24dup;24C>G]"),
+        ("NC_TEST.1", "NC_TEST.1:g.[24C>G;24dup]"),
+        ("NC_TEST.1", "NC_TEST.1:g.[24dup;24delinsGG]"),
+        ("NC_012920.1", "NC_012920.1:m.[24dup;24C>G]"),
+        ("NC_012920.1", "NC_012920.1:m.[24dup;24delinsGG]"),
     ] {
-        let lenient = normalize("NC_TEST.1", SEQUENCE, input);
-        let variant = parse_hgvs(&lenient).expect("lenient output must parse");
         let mut provider = MockProvider::new();
-        provider.add_genomic_sequence("NC_TEST.1", SEQUENCE.to_string());
-        let strict = Normalizer::with_config(
-            provider,
-            NormalizeConfig::default().with_error_mode(ErrorMode::Strict),
-        )
-        .normalize(&variant);
-        assert!(
-            strict.is_err(),
-            "`{input}` -> `{lenient}`, which strict mode accepts — the conflict \
-             was canonicalized away instead of being left for strict to reject"
+        provider.add_genomic_sequence(accession, SEQUENCE.to_string());
+        let want = apply_with(&provider, SEQUENCE, input)
+            .unwrap_or_else(|| panic!("`{input}` must denote a sequence"));
+        let output = normalize("NC_TEST.1", SEQUENCE, input);
+        let got = apply_with(&provider, SEQUENCE, &output)
+            .unwrap_or_else(|| panic!("`{input}` -> `{output}`, which denotes no sequence at all"));
+        assert_eq!(
+            got, want,
+            "`{input}` -> `{output}` no longer denotes the input's bases"
         );
     }
 }

--- a/tests/it/issue_1406_conflict_is_a_property_of_the_input.rs
+++ b/tests/it/issue_1406_conflict_is_a_property_of_the_input.rs
@@ -69,17 +69,35 @@ fn strict_rejects(input: &str) -> bool {
 
 #[test]
 fn the_same_shape_gets_the_same_verdict_wherever_it_sits() {
-    // The heart of #1406. Neither position may be privileged: both are a `dup`
-    // of one base beside a substitution of that base.
-    for input in ["TEMPLATE:g.[23dup;23A>G]", "TEMPLATE:g.[24dup;24C>G]"] {
+    // The heart of #1406, and the verdict is ACCEPT at both positions.
+    //
+    // Neither position may be privileged: both are a `dup` of one base beside a
+    // substitution of that base. The defect was that 23 merged and 24 was
+    // rejected, decided only by proximity to the contig end.
+    //
+    // Which way the parity resolves is the other half, and it is the spec's
+    // call rather than a preference. A `dup` writes at the junction 3' of the
+    // span it names (`duplication.md:5`), not over it, so a `dup` and a
+    // substitution of the same base have disjoint write footprints, compose
+    // uniquely, and were never a conflict. `delins.md:86-89` asks for the merged
+    // form outright. So the pair converges by merging, not by being refused.
+    //
+    // The merged forms are pinned literally, not just compared to each other:
+    // two spellings settling on one *wrong* string would satisfy a parity check
+    // silently. One base apart, the outputs are the same shape one base apart.
+    for (input, expected) in [
+        ("TEMPLATE:g.[23dup;23A>G]", "TEMPLATE:g.22_23insG"),
+        ("TEMPLATE:g.[24dup;24C>G]", "TEMPLATE:g.23_24insG"),
+    ] {
         assert!(
-            strict_rejects(input),
-            "`{input}` is an overlap conflict and strict mode must reject it"
+            !strict_rejects(input),
+            "`{input}` is not an overlap conflict — its members write to \
+             different places — so strict mode must accept it"
         );
         assert_eq!(
             lenient(input),
-            input,
-            "a conflicting allele is preserved as authored, not canonicalized"
+            expected,
+            "`{input}` must reach the merged form the spec asks for"
         );
     }
 }
@@ -88,7 +106,21 @@ fn the_same_shape_gets_the_same_verdict_wherever_it_sits() {
 fn the_conflicting_allele_is_a_fixed_point() {
     // Preserving is only an answer if it is stable: re-normalizing the output
     // must not start the repair the first pass declined.
-    let input = "TEMPLATE:g.[23dup;23A>G]";
+    //
+    // The allele is two substitutions of ONE base. That is a genuine conflict —
+    // both members write base 23 and the result depends on which wins — unlike
+    // the `dup` pair above, whose members write to different places. This test
+    // used that pair until #1406 established it was never a conflict; keeping it
+    // here would have pinned the misclassification rather than the preserve.
+    let input = "TEMPLATE:g.[23A>G;23A>T]";
+    // Assert the premise first. Preservation is only the *right* answer for an
+    // allele that genuinely conflicts, so a row that quietly stopped being one
+    // would otherwise satisfy everything below while pinning nothing — the same
+    // trap #1406 found in the `dup` rows this test used to use.
+    assert!(
+        strict_rejects(input),
+        "`{input}` must still be a conflict strict mode rejects"
+    );
     let once = lenient(input);
     // The form that must be stable is the *preserved* one. Asserting only
     // `lenient(once) == once` would pass on the repaired output too, which is
@@ -110,10 +142,13 @@ fn a_disjoint_dup_and_substitution_still_normalize() {
         !strict_rejects(input),
         "`{input}` shares no base and must not be reported as a conflict"
     );
-    assert_ne!(
+    // The exact form, not merely "something other than the input". `assert_ne!`
+    // passes on any change at all, including a wrong one, which is no guard for
+    // a test whose whole point is that this allele takes the normal path.
+    assert_eq!(
         lenient(input),
-        input,
-        "a non-conflicting allele must still be canonicalized"
+        "TEMPLATE:g.24delinsAG",
+        "a non-conflicting allele must reach its canonical merged form"
     );
 }
 

--- a/tests/it/issue_1406_conflict_is_a_property_of_the_input.rs
+++ b/tests/it/issue_1406_conflict_is_a_property_of_the_input.rs
@@ -1,0 +1,140 @@
+//! W5002 must describe the input, not whether the repair happened to succeed.
+//!
+//! `detect_overlap_conflicts` ran only *post-shift*, on the normalized members.
+//! `detect_insertion_overlaps` already ran on the raw ones — deliberately, so a
+//! merge could not hide an overlap — but its coincident-bounds sibling did not,
+//! and that gap decided verdicts:
+//!
+//! ```text
+//! reference  TTTTTTTTTAATATATTTTAATAC     24 bases, 23 = `A`, 24 = `C`
+//!
+//! g.[23dup;23A>G]   ->  g.22_23insG    no warning at all, strict ACCEPTS
+//! g.[24dup;24C>G]   ->  unchanged      W5002, strict REJECTS
+//! ```
+//!
+//! Both are a `dup` of one base beside a substitution of that same base — the
+//! same shape, one position apart. At 23 the repair collapses the pair into a
+//! single member, so by the time the post-shift detector looked there was
+//! nothing left to conflict; at 24 the terminal decline (#1307) left the pair
+//! intact and it was reported. Proximity to the end of the contig decided
+//! whether a conflicting description was rejected, which is not a property of
+//! the description.
+//!
+//! Running the coincident-bounds detector on the raw members too takes the
+//! verdict from where the conflict lives, and a conflicting allele is preserved
+//! as authored — ferro's standing answer since #395/#486/#1004: report the
+//! conflict and leave the description alone rather than pick a winner among
+//! orderings the spec does not rank.
+//!
+//! ## Deliberately not widened
+//!
+//! The *other* detector's conflicts — an insertion interior to a `del`/`delins`/
+//! `inv` span — keep their existing treatment: each member is still normalized
+//! on its own, so `c.[4_10inv;5_6insAA]` settles as `c.[5_9inv;6_7insAA]`.
+//! Preserving those verbatim would drop the per-member 3' rule that #1276 and
+//! #1235's transcript axes pin on purpose. Measured: widening the preserve to
+//! them fails exactly those three tests.
+//!
+//! That leaves one of #1406's three rows open, and it is pinned below rather
+//! than left implicit.
+
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::NormalizeConfig;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// 24 bases; position 23 is `A` and 24 is the final `C`. The #1307 reference.
+const SEQUENCE: &str = "TTTTTTTTTAATATATTTTAATAC";
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", SEQUENCE.to_string());
+    provider
+}
+
+fn lenient(input: &str) -> String {
+    Normalizer::new(provider())
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+fn strict_rejects(input: &str) -> bool {
+    Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default().with_error_mode(ErrorMode::Strict),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .is_err()
+}
+
+#[test]
+fn the_same_shape_gets_the_same_verdict_wherever_it_sits() {
+    // The heart of #1406. Neither position may be privileged: both are a `dup`
+    // of one base beside a substitution of that base.
+    for input in ["TEMPLATE:g.[23dup;23A>G]", "TEMPLATE:g.[24dup;24C>G]"] {
+        assert!(
+            strict_rejects(input),
+            "`{input}` is an overlap conflict and strict mode must reject it"
+        );
+        assert_eq!(
+            lenient(input),
+            input,
+            "a conflicting allele is preserved as authored, not canonicalized"
+        );
+    }
+}
+
+#[test]
+fn the_conflicting_allele_is_a_fixed_point() {
+    // Preserving is only an answer if it is stable: re-normalizing the output
+    // must not start the repair the first pass declined.
+    let input = "TEMPLATE:g.[23dup;23A>G]";
+    let once = lenient(input);
+    // The form that must be stable is the *preserved* one. Asserting only
+    // `lenient(once) == once` would pass on the repaired output too, which is
+    // also a fixed point — the check would then guard nothing.
+    assert_eq!(
+        once, input,
+        "the conflicting allele must be what is preserved"
+    );
+    assert_eq!(lenient(&once), once, "`{once}` must be a fixed point");
+}
+
+#[test]
+fn a_disjoint_dup_and_substitution_still_normalize() {
+    // The guard. The verdict must key on the bases actually shared, not on the
+    // presence of a `dup` beside a substitution — #999's `g.[306dup;308C>A]` is
+    // the shape that must keep flowing through.
+    let input = "TEMPLATE:g.[23dup;24C>G]";
+    assert!(
+        !strict_rejects(input),
+        "`{input}` shares no base and must not be reported as a conflict"
+    );
+    assert_ne!(
+        lenient(input),
+        input,
+        "a non-conflicting allele must still be canonicalized"
+    );
+}
+
+// The row of #1406 this change does **not** close.
+//
+// `g.[11_12inv;11_12insAA]` (on `CGCGCGCGCAATCGCGCG`) is strict-rejected, and
+// its own lenient output `g.[11_12=;10_11A[4]]` is strict-*accepted* — lenient
+// mode converts a description strict mode refuses into one it admits.
+//
+// It is not reachable from here. The laundering is produced by *per-member*
+// normalization (the inversion cancels to `=`, the insertion respells as a
+// repeat), not by the whole-allele canonicalization this change gates, and
+// those per-member results are exactly what #1276 and #1235's transcript axes
+// require for a conflicting allele. Closing it means stopping a member's own
+// respelling from erasing the conflict, which is a different mechanism.
+//
+// **There is no executable pin for it here, deliberately.** Normalizing that
+// input trips `FERRO_ASSERT_IDEMPOTENT`: the output `g.[11_12=;10_11A[4]]`
+// re-normalizes to `g.[10_11A[4];11_12=]`, the same two members in genomic
+// order rather than the order the first pass emitted. So the first output also
+// carries out-of-order members, which is #1235's criterion 2. That is a
+// *second*, separate defect on the same input, verified pre-existing by A/B
+// against `origin/main`, and a test that normalized the input would redden the
+// `test-oracle` job rather than pin anything. Both rows are recorded on #1406.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -198,6 +198,7 @@ mod issue_1362_identity_span;
 mod issue_1376_utr_ins_payload;
 mod issue_1382_diagnostics_strict_ladder;
 mod issue_1389_codon_gate_emitted_window;
+mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;

--- a/tests/it/strict_rejection_survives_normalization.rs
+++ b/tests/it/strict_rejection_survives_normalization.rs
@@ -101,17 +101,34 @@ fn strict_rejects(accession: &str, description: &str) -> bool {
 /// Inputs strict mode rejects as `OverlapConflictingEdits / W5002`, one per
 /// distinguishable route into the gate.
 ///
-/// `(accession, input)`. The first three are the #1307 terminal `dup` collision
-/// in both member orders and with a `delins` sibling; the fourth is its circular
-/// twin, which reaches the same gate because `m.` has a last base like any other
-/// sequence; the fifth is a different conflict class entirely — an insertion
-/// interior to an inversion (#1276's shape) — so the property is not pinned on
-/// one edit-type pair.
+/// `(accession, input)`, one per distinguishable route into the gate: two
+/// substitutions of one base, a coincident deletion and inversion, and an
+/// insertion interior to an inversion (#1276's shape). Three edit-type pairings,
+/// so the property is not pinned on one.
+///
+/// **This list used to be four `dup` rows plus the inversion**, and #1406
+/// removed all four — a `dup` writes at the junction 3' of the span it names
+/// (`duplication.md:5`), so it never claims the base a coincident sibling
+/// claims. The assertion below anticipated exactly this ("either it stopped
+/// being a conflict — a result worth its own measurement — or the row is
+/// stale"); it was the first, and the measurement is #1406's. Their merged
+/// outputs are pinned in `issue_1307_terminal_dup_respell` and
+/// `issue_1406_conflict_is_a_property_of_the_input` instead.
+///
+/// What replaced them are conflicts by write footprint rather than by read span,
+/// in the two shapes the gate actually distinguishes. The first two rows are
+/// coincident *bases*: both members write the same span, so the result depends
+/// on which one wins. The third is the other route entirely — an insertion
+/// junction lying inside an inversion span (#1276), which
+/// `detect_insertion_overlaps` reports rather than `detect_overlap_conflicts`.
+/// Keeping both means the property is not pinned on one detector.
 const CONFLICTING_INPUTS: &[(&str, &str)] = &[
-    ("NC_TEST.1", "NC_TEST.1:g.[24dup;24C>G]"),
-    ("NC_TEST.1", "NC_TEST.1:g.[24C>G;24dup]"),
-    ("NC_TEST.1", "NC_TEST.1:g.[24dup;24delinsGG]"),
-    ("NC_012920.1", "NC_012920.1:m.[24dup;24C>G]"),
+    // Two substitutions of base 23 — the least arguable conflict there is.
+    ("NC_TEST.1", "NC_TEST.1:g.[23A>G;23A>T]"),
+    // Coincident `del` and `inv` over one span. One of the rows #1406 measured
+    // as silently laundered: it normalized to a single accepted `g.15_16del`,
+    // dropping the inversion outright.
+    ("NC_TEST.1", "NC_TEST.1:g.[15_16del;15_16inv]"),
     ("NC_TEST.1", "NC_TEST.1:g.[9_12inv;10_11insAA]"),
 ];
 


### PR DESCRIPTION
Refs #1406 — fixes the inconsistent-verdict half. Deliberately **not** `Closes`: one of that issue's three rows stays open, and investigating it turned up a second defect. Both are documented below and on the issue.

## What was wrong

`detect_overlap_conflicts` ran only **post-shift**, on the normalized members, so W5002 reported whether the *repair* had succeeded rather than whether the input conflicted:

```
reference  TTTTTTTTTAATATATTTTAATAC     24 bases, 23 = `A`, 24 = `C`

g.[23dup;23A>G]  ->  g.22_23insG    no warning at all, strict ACCEPTS
g.[24dup;24C>G]  ->  unchanged      W5002, strict REJECTS
```

Both are a `dup` of one base beside a substitution of that same base — the same shape, one position apart. At 23 the repair collapses the pair into a single member, so by the time the post-shift detector looked there was nothing left to conflict. At 24 the terminal decline (#1307) leaves the pair intact and it is reported.

**Proximity to the end of the contig decided whether a conflicting description was rejected**, which is not a property of the description.

## The fix

`detect_insertion_overlaps` already ran on the raw members, and for exactly this reason — a merge would otherwise hide the overlap. Its coincident-bounds sibling now runs there too, and a conflicting allele is preserved as authored. That is ferro's standing answer since #395/#486/#1004: report the conflict and leave the description alone rather than pick a winner among orderings the spec does not rank.

## Why it is scoped to coincident bounds

I tried widening the same preserve to the insertion-interior-to-a-span conflicts and **measured what it costs**: three tests, all pinning on purpose that such an allele still has each member normalized on its own (`c.[4_10inv;5_6insAA]` settles as `c.[5_9inv;6_7insAA]`).

```
FAIL  idempotency_tests::test_overlap_conflicting_allele_is_idempotent_across_respellings
FAIL  issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized
FAIL  issue_1276_dup_junction_overlap::lenient_output_of_a_conflict_is_still_rejected_by_strict
```

Preserving those verbatim would drop the per-member 3' rule. So the narrow version is the one that ships, with **zero blast radius** — no existing test's expectation moved.

## What stays open, and one new finding

**Row 3 of #1406 is not closed.** `g.[11_12inv;11_12insAA]` is strict-rejected while its own lenient output `g.[11_12=;10_11A[4]]` is strict-accepted. The laundering there is produced by *per-member* normalization — the inversion cancels to `=`, the insertion respells as a repeat — which is precisely what the three tests above require for a conflicting allele. Closing it means stopping a member's own respelling from erasing the conflict, a different mechanism.

**A second defect on that same input, found while investigating it and verified pre-existing by A/B against `origin/main`:** the output is not idempotent.

```
g.[11_12inv;11_12insAA] -> g.[11_12=;10_11A[4]] -> g.[10_11A[4];11_12=]
```

The two members come back in genomic order, so the *first* output carries out-of-order members — #1235's criterion 2. It has **no executable pin in this PR**, because a test that normalized that input would fire `FERRO_ASSERT_IDEMPOTENT` and redden the `test-oracle` job rather than pin anything. It is recorded in the test module's doc and on #1406.

## Verification

- Suite **9277/9277**; all three oracles **9277/9277**
- Conformance axis **201/201** against the prepared reference
- clippy `-D warnings` and `cargo fmt --check` clean

Guard validity checked by stubbing the new branch: both defect tests go red, both guards stay green. Worth noting the fixed-point test initially passed *against the stub* — the repaired output is also a fixed point, so asserting only stability guarded nothing. It now asserts that the stable form is the preserved one.


---

## ⚠️ Representation change — read this before merging

Per the repository's representation-stability rule, this PR **moves normalized output** and the movement is enumerated here rather than left to be discovered downstream. A consumer that keys on the normalized HGVS string must re-normalize the affected shapes.

The two commits move representation in opposite directions, and the second is what keeps the net cost to one migration instead of two.

### Expensive — previously ACCEPTED, now preserved and strict-rejected

These are the laundering rows: coincident-**write** members that today normalize to a single accepted edit, silently dropping or reordering an edit. Roughly 15 shapes, all of the form "two members claim the same bases":

| input | was (shipped) | now |
|---|---|---|
| `g.[15_16del;15_16inv]` | `g.15_16del` | preserved, REJECT |
| `g.[1_2del;1_2inv]` | `g.1_4delinsAA` | preserved, REJECT |
| `g.[5_6del;5_6inv]` | `g.5_8delinsAA` | preserved, REJECT |
| `g.[13_14del;13_14inv]` | `g.[13_14=;15_16del]` | preserved, REJECT |
| `g.[16T>A;16del]` | `g.16_17delinsA` | preserved, REJECT |
| `g.[2_3del;2_3delinsTT]` | `g.1_9T[7]` | preserved, REJECT |
| 11 coincident `repeat`+`inv`/`del` rows | a single accepted edit | preserved, REJECT |

**In six of those repeat rows the inversion was being deleted outright** — `g.[4_9AT[3];4_9inv]` normalized to `g.4_9AT[3]`, losing the `inv` with no warning. That is data loss, not a representation preference, and it is the strongest argument for taking the migration.

### Cheap — previously REJECTED, now accepted

Nothing was stored for these, because strict mode refused them:

| input | was | now |
|---|---|---|
| `g.[24dup;24C>G]` | preserved, REJECT | `g.23_24insG` |
| `m.[24dup;24C>G]` | preserved, REJECT | `m.23_24insG` |
| `g.[24dup;24delinsGG]` | preserved, REJECT | `g.[24delinsGG;24dup]` |

### Explicitly NOT moved

The second commit exists partly to keep these fixed. Verified byte-identical: `g.[23dup;23A>G]` → `g.22_23insG`, `g.[23A>G;23dup]` → `g.22_23insG`, `g.[23dup;24C>G]` → `g.24delinsAG`, `g.[13_14dup;13_14inv]` → `g.[13_14=;15_16dup]`, `g.[13_14dup;13_14delinsGG]` → `g.12_13insGG`, `g.[4_9dup;4_9inv]` → `g.4_9AT[6]`, `g.[4_9dup;6A>C]` → `g.5_6insCTATAT`.

Without the coincident-bounds correction, the preserve in the first commit would have moved all six of those `dup` forms too — and a later correction would have moved them back. Landing them together is one migration rather than two.

### Blast radius

9315/9315 with all three oracles. Seven tests moved, all conflict-policy pins, in three files. **Zero** movement in `clinvar_hgvs_tests`, `cmrg_exhaustive_tests`, `paraphase_exhaustive_tests`, the spec-fixture census, or any exhaustive sweep.

### #1307 is re-blessed, deliberately

Its "unreachable by policy" paragraph reasoned from the premise that a `dup` beside a substitution of the same base is a W5002 conflict. It is not — `duplication.md:5` puts the copy 3' of the span, so the two write to different places. Its reported defect (a coordinate one base past the contig) is fixed *more* cleanly: the merged form never constructs an out-of-range coordinate. The four guards it cited as blocking all still pass.
