### PR TITLE
docs(spdi): count the UnspelledBases arms as six, not five

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1589,8 +1589,8 @@ where
 /// The edit shapes whose SPDI form needs reference bases the description did
 /// not spell out. Each names what is unknown and how the caller could spell it.
 ///
-/// Exists so the five arms of [`hgvs_to_spdi`] that hit this wall decline in one
-/// voice. They previously carried five hand-written strings, none of which named
+/// Exists so the six arms of [`hgvs_to_spdi`] that hit this wall decline in one
+/// voice. They previously carried six hand-written strings, none of which named
 /// the interval that could not be resolved or either way out, and one of which
 /// (`Delins`) had drifted into a different sentence shape than its siblings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2248,7 +2248,7 @@ mod tests {
         );
     }
 
-    /// The five shapes must be distinguishable from their messages alone — a
+    /// The six shapes must be distinguishable from their messages alone — a
     /// caller reading a log has nothing else to go on.
     #[test]
     fn each_shape_declines_distinguishably() {


### PR DESCRIPTION
Closes #1409.

`UnspelledBases` has six variants, and #1390 collapsed six hand-written error strings into the shared helper. Two comments still said five.

I counted from the source rather than taking the issue's number, and that moved the answer in both directions:

| site | says | actual | verdict |
|---|---|---|---|
| `UnspelledBases` doc — "the five arms of `hgvs_to_spdi`" | five | **six** call sites (`convert.rs:1321, 1349, 1388, 1436, 1462, 1539`) | fixed |
| same doc — "previously carried five hand-written strings" | five | **six** removed by #1390 (`git show f420bffe`) | fixed |
| `each_shape_declines_distinguishably` — "The five shapes" | five | its own array lists **six** | fixed |
| `spelled_example` — "The other five arms" | five | six minus `RepeatTract`, which that comment names as the odd one out | **correct, left alone** |

So this is three fixes rather than the two the issue describes: the test's prose at `convert.rs:2251` had drifted the same way and is not mentioned in the issue. And the fourth "five" is genuinely right — changing it would have introduced the error the issue is about.

No behaviour change; `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and the 278 SPDI tests are green.

**One follow-up I deliberately did not fold in**, since the issue scopes this to wording: three tests hand-write the full six-variant array (`convert.rs:2167, 2218, 2256`). `adjective()`'s `match` is exhaustive so the compiler forces *it* to keep up with a new variant, but those arrays would silently keep testing six of seven. A shared `const ALL: [UnspelledBases; N]` would close that, and it is a behavioural change to test coverage rather than a doc fix. Happy to file it if wanted.
