### PR TITLE
ci: let external-validation's test steps fail the job

### DIFF
--- a/.github/scripts/run_validation.sh
+++ b/.github/scripts/run_validation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run one external-validation suite so that every way it can go wrong is loud.
+#
+# Sourced by `.github/workflows/external-validation.yml`. Three failure modes
+# are in scope, and the workflow had been silently surviving all three (#1404):
+#
+#   1. the tests fail            — propagated, because `pipefail` is set and the
+#                                  step no longer carries `continue-on-error`
+#   2. the target does not exist — `cargo test` exits non-zero, which #725's
+#                                  binary consolidation made the live case
+#   3. the filter selects zero   — exits 0 with `running 0 tests`, so it is
+#      tests                       checked explicitly here
+#
+# The third is the one worth the script. A suite that runs nothing looks exactly
+# like a suite that passes, and it is *faster*, so it reads as an improvement.
+#
+# Usage: run_validation <module> <output-file> [extra cargo-test args...]
+run_validation() {
+    local module="$1"
+    local output="$2"
+    shift 2
+
+    set -euo pipefail
+
+    # `--test it`: every integration test lives in the single `it` binary since
+    # #725. `$module` is a filter on the test *name*, which is
+    # `<module>::<test>`, so it selects that module's tests and nothing else.
+    cargo test --test it "$module" -- --nocapture "$@" 2>&1 | tee "$output"
+
+    # `cargo test` prints one `running N tests` line per binary. Sum them, so a
+    # filter that matched nothing is an error rather than a fast pass.
+    local ran
+    ran=$(awk '/^running [0-9]+ test/ { total += $2 } END { print total + 0 }' "$output")
+
+    if [[ "$ran" -eq 0 ]]; then
+        echo "::error::${module}: the filter selected no tests, so this suite validated nothing." >&2
+        echo "Check that the module still exists under tests/it/ and that any" >&2
+        echo "--ignored flag still matches how its tests are marked." >&2
+        return 1
+    fi
+
+    echo "${module}: ran ${ran} test(s)."
+}

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -129,22 +129,58 @@ jobs:
         with:
           key: external-validation-api
 
+      # These three steps are the point of the workflow, so they gate it.
+      #
+      # They previously could not fail it, in two independent ways (#1404):
+      # `continue-on-error` kept the step's failure out of the job conclusion,
+      # and `cargo test … | tee` reports *tee's* status without `pipefail`, so
+      # the exit code was ~always 0 regardless. Both are gone; the report and
+      # its upload carry `if: always()` instead, so a red run still publishes
+      # what it found rather than being masked to keep the artifact.
+      #
+      # `run_validation` also fails when the filter selects **no** tests, which
+      # neither of the above would catch. Two silent-zero cases had already
+      # happened here: #725 collapsed the per-file test binaries into the single
+      # `it` target, so `--test api_comparison_tests` became
+      # `error: no test target named …` — masked, and seven consecutive weekly
+      # runs reported success while running nothing — and `spdi_tests` kept a
+      # `--ignored` flag after its last `#[ignore]` was removed, which selects
+      # an empty set and exits 0.
       - name: Run API comparison tests
+        shell: bash
         run: |
-          cargo test --test api_comparison_tests -- --ignored --nocapture 2>&1 | tee api_comparison_results.txt
-        continue-on-error: true
+          source .github/scripts/run_validation.sh
+          # All three api_comparison_tests are #[ignore]d: they are the
+          # network-fixture suite, run here and not in the standard job.
+          run_validation api_comparison_tests api_comparison_results.txt --ignored
 
+      # `!cancelled()` on the second and third suites, because dropping
+      # `continue-on-error` alone would trade one silent failure for another:
+      # by default a failed step skips every later step, so a red API-comparison
+      # run would leave SPDI and dbSNP unexecuted while the report said only
+      # "No results" for them. That is the same shape this PR exists to fix — a
+      # suite that validated nothing, reported as though it had. Each suite now
+      # runs and fails independently, and the job is red if any of them is.
+      #
+      # `!cancelled()` rather than `always()`: a cancelled run should stop, not
+      # push on through two more cargo builds.
       - name: Run SPDI tests
+        if: ${{ !cancelled() }}
+        shell: bash
         run: |
-          cargo test --test spdi_tests -- --ignored --nocapture 2>&1 | tee spdi_results.txt
-        continue-on-error: true
+          source .github/scripts/run_validation.sh
+          # No `--ignored`: spdi_tests carries no #[ignore] any more.
+          run_validation spdi_tests spdi_results.txt
 
       - name: Run dbSNP tests
+        if: ${{ !cancelled() }}
+        shell: bash
         run: |
-          cargo test --test dbsnp_tests -- --nocapture 2>&1 | tee dbsnp_results.txt
-        continue-on-error: true
+          source .github/scripts/run_validation.sh
+          run_validation dbsnp_tests dbsnp_results.txt
 
       - name: Generate validation report
+        if: always()
         run: |
           {
             echo "# External Validation Report"
@@ -171,6 +207,7 @@ jobs:
           } > validation_report.md
 
       - name: Upload validation report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: validation-report


### PR DESCRIPTION
Closes #1404.

The issue asked whether these steps are currently failing, and warned that fixing the gate would turn the workflow red if they were. The answer turned out to be worse and simpler: **they have not been running at all.**

## What the logs say

#725 collapsed ~230 per-file integration-test binaries into the single `it` target. The three steps still name the old binaries, so each one has been dying immediately:

```
error: no test target named `api_comparison_tests` in default-run packages
error: no test target named `spdi_tests` in default-run packages
error: no test target named `dbsnp_tests` in default-run packages
```

Masked by exactly the two mechanisms the issue describes, so the workflow has reported **success** every week since. The changeover is visible across a single week:

| scheduled run | `no test target` errors | `test result:` lines | conclusion |
|---|---|---|---|
| 2026-06-14 (`27483424504`) — before #725 | 0 | **3** (3 + 2 + 13 passed) | success |
| 2026-06-21 (`27888384383`) — after #725 | **3** | 0 | success |

#725 merged 2026-06-16, between them. Seven consecutive green runs (06-21 → 08-02) validated nothing.

## The fix

- **Point the steps at `--test it` with a name filter.** Restores **3 + 8 + 13 = 24** tests, all passing locally.
- **Drop `--ignored` from the SPDI step.** It had two `#[ignore]`d tests when the flag was written (the 06-14 log shows `2 passed; 6 filtered out`) and has none now, so the flag selects an empty set. This was a *second*, older silent-zero that predates #725 and would have survived a naive fix.
- **Remove `continue-on-error`** from the three test steps and run them under `set -euo pipefail`, so both the step status and the `tee` pipeline propagate. Neither change works without the other, which is why the issue is right to name them as independent.
- **`if: always()` on the report generation and upload**, so a red run still publishes what it found. Masking the tests to keep the artifact was the tradeoff the old shape made implicitly.
- **A new `.github/scripts/run_validation.sh`** that fails when the filter selects **no** tests.

That last one is the part neither of the issue's two proposals covers. An empty selection exits 0, so `pipefail` and the removed `continue-on-error` both let it through — and a suite that runs nothing looks exactly like a suite that passes, except faster, which reads as an improvement. Two instances of that had already happened here, which is the argument for a check rather than a third careful reading.

## Verification

Return codes, measured (`0` only where a real suite ran):

| invocation | tests run | exit |
|---|---|---|
| `api_comparison_tests --ignored` | 3 | 0 |
| `spdi_tests` | 8 | 0 |
| `dbsnp_tests` | 13 | 0 |
| `no_such_module_xyz` (filter matches nothing) | 0 | **1** |
| `spdi_tests --ignored` (the stale-flag case) | 0 | **1** |

And `pipefail` propagates a failing `cargo test` through `tee` — a command exiting 101 into `tee` yields 101, where the old shape yielded 0.

`actionlint` and `shellcheck` are clean, and the YAML parses.

## Scope note

The remaining `continue-on-error`s in this workflow are on the third-party fetch/download steps (LOVD, MaveDB, CIViC, the API fetches, the artifact downloads). Those are deliberate — a flaky external API should not redden the workflow — so they are left alone.

One thing I did **not** fix, because it is a separate question: if a fixture download fails, these tests skip rather than fail, which is a third way to be quietly vacuous. The new zero-selection guard does not catch it, since the tests are selected and *do* run. Worth its own issue if you want it closed.
