### PR TITLE
fix(normalize): clamp a derived insertion at the CDS/3'UTR junction

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2379,7 +2379,34 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         SequenceEnds::INTERIOR
     };
 
-    let rebuilt = rebuild_members(&pieces, &variants[0], body, w_lo, &ref_bytes, ends)?;
+    // The CDS end on the member axis, for `cds_end_delins_anchor`. `None`
+    // wherever there is no CDS to change axis at — every genomic kind, and a
+    // non-coding transcript — which makes that clamp inert there.
+    //
+    // `CisKind::Cds` only: `r.` reaches the same junction, but `normalize_cds`'s
+    // #387 clamp is gated on `AxisRegion::Cds`, so claiming the `r.` case here
+    // would make the derivation *disagree* with the per-member pipeline in the
+    // opposite direction — the very fault this fixes. Left for its own evidence.
+    let cds_end_axis = if matches!(kind, CisKind::Cds) {
+        provider
+            .get_transcript(&accession)
+            .ok()
+            .and_then(|tx| tx.cds_end)
+            .and_then(|end| i64::try_from(end).ok())
+            .map(|end| end - frame.delta)
+    } else {
+        None
+    };
+
+    let rebuilt = rebuild_members(
+        &pieces,
+        &variants[0],
+        body,
+        w_lo,
+        &ref_bytes,
+        ends,
+        cds_end_axis,
+    )?;
     if rebuilt == variants {
         return None;
     }
@@ -4567,6 +4594,7 @@ fn rebuild_members(
     w_lo: i64,
     ref_bytes: &[u8],
     ends: SequenceEnds,
+    cds_end_axis: Option<i64>,
 ) -> Option<Vec<HgvsVariant>> {
     let mut members = Vec::with_capacity(pieces.len());
     // Window offset one past the last reference base the *previous* piece
@@ -4582,7 +4610,15 @@ fn rebuild_members(
             piece.ref_start >= previous_ref_end,
             "pieces must be in ascending offset order for the dup disjointness check"
         );
-        let anchor = anchor_for_piece(piece, body, w_lo, ref_bytes, ends, previous_ref_end)?;
+        let anchor = anchor_for_piece(
+            piece,
+            body,
+            w_lo,
+            ref_bytes,
+            ends,
+            previous_ref_end,
+            cds_end_axis,
+        )?;
         previous_ref_end = piece.ref_end;
         members.push(build_merged(template, anchor));
     }
@@ -4619,6 +4655,7 @@ fn anchor_for_piece(
     ref_bytes: &[u8],
     ends: SequenceEnds,
     previous_ref_end: usize,
+    cds_end_axis: Option<i64>,
 ) -> Option<Anchor> {
     let alt: Vec<Base> = piece
         .alt
@@ -4633,6 +4670,11 @@ fn anchor_for_piece(
             return Some(anchor);
         }
         if let Some(anchor) = boundary_delins_anchor(piece, &alt, body, w_lo, ref_bytes, ends) {
+            return Some(anchor);
+        }
+        if let Some(anchor) =
+            cds_end_delins_anchor(piece, &alt, body, w_lo, ref_bytes, cds_end_axis)
+        {
             return Some(anchor);
         }
     }
@@ -4771,6 +4813,66 @@ fn boundary_delins_anchor(
         region: body,
         start: position,
         end: position,
+        alt: bases,
+        form: AnchorForm::Replacement,
+    })
+}
+
+/// The **axis-change** counterpart to [`boundary_delins_anchor`]: a derived pure
+/// insertion resting exactly on the CDS/3'UTR junction is re-spelled as
+/// `c.<cds_end>delins<ref[cds_end] ++ payload>` (#387, #1398).
+///
+/// [`boundary_delins_anchor`] deliberately covers only the *representability*
+/// bounds, on the grounds that `normalize_cds` keeps the axis-change policy. For
+/// a lone member that reasoning holds — the per-member pipeline re-clamps it. It
+/// does **not** hold for a derivation, which is authoritative for the group and
+/// whose output nothing re-clamps: `c.[11_12dup;16_17insC]` came back as
+/// `c.18_*1insCAT`, and normalizing *that* produced `c.18delinsTCAT`, so the
+/// first answer was not a fixed point and the two shuffle directions disagreed
+/// about the second (#1398). The clamp therefore has to exist on both paths.
+///
+/// The identity is the same one `normalize_cds` applies and is shared, not
+/// copied: inserting `A'` between `cds_end` and `cds_end + 1` is exactly
+/// "delete `ref[cds_end]`, insert `ref[cds_end] ++ A'`", true for any `A'`.
+///
+/// **Spanning duplications are not clamped.** Per the spec a `dup` is the
+/// priority form even when its span bridges the boundary (`c.9171_*1dup`), which
+/// #401 pins. That carve-out needs no gate here: [`anchor_for_piece`] tries
+/// [`duplication_anchor`] first, so a piece that a `dup` describes never reaches
+/// this function — the same positive-list-`Insertion` effect `normalize_cds`
+/// spells out explicitly, obtained from the call order instead.
+///
+/// `cds_end_axis` is the CDS end expressed on the member axis (`cds_end - delta`,
+/// the `AxisFrame` identity), and is `None` for every axis without a CDS, which
+/// makes this inert there. Positions run continuously past it — `c.<n>` beyond
+/// the CDS length denotes the base `c.*(n - cds_len)` does — so the junction is
+/// simply `cds_end_axis` and `cds_end_axis + 1`, with no discontinuity to correct
+/// for. That is only true at the **3'** end; the 5' end has one (`c.-1` is
+/// `cds_start - 1`, the reason `region_sequence_delta` exists), which is why this
+/// has no `cds_start` mirror here.
+fn cds_end_delins_anchor(
+    piece: &Piece,
+    alt: &[Base],
+    body: Region,
+    w_lo: i64,
+    ref_bytes: &[u8],
+    cds_end_axis: Option<i64>,
+) -> Option<Anchor> {
+    let cds_end_axis = cds_end_axis?;
+    // A pure insertion's anchor spans `(start - 1, start)`, so it rests on the
+    // junction exactly when its insertion point is the first 3'UTR base.
+    let insertion_point = w_lo + i64::try_from(piece.ref_start).ok()?;
+    if insertion_point != cds_end_axis + 1 {
+        return None;
+    }
+    // Same 1-based-into-the-slice convention `boundary_delins_anchor` uses; the
+    // anchor base is `ref[cds_end]`, one before the insertion point.
+    let anchor_1b = u64::try_from(piece.ref_start).ok()?;
+    let bases = boundary_delins_bases(ref_bytes, alt, anchor_1b, BoundarySide::ThreePrime)?;
+    Some(Anchor {
+        region: body,
+        start: cds_end_axis,
+        end: cds_end_axis,
         alt: bases,
         form: AnchorForm::Replacement,
     })
@@ -7703,6 +7805,7 @@ mod tests {
             ref_bytes,
             SequenceEnds::INTERIOR,
             4,
+            None,
         )
         .expect("the piece is still built");
         assert_eq!(anchor.form, AnchorForm::Replacement);

--- a/tests/it/issue_1398_cds_utr3_insertion_idempotency.rs
+++ b/tests/it/issue_1398_cds_utr3_insertion_idempotency.rs
@@ -1,0 +1,144 @@
+//! A `c.`-axis cis allele must not normalize to an insertion spanning the
+//! CDS/3'UTR junction (#1398).
+//!
+//! ferro's design forbids re-axing a CDS-interior edit onto the `c.*N` axis: the
+//! CDS-end clamp turns a saturating insertion into `c.<cds_end>delins…` rather
+//! than the spanning `c.<cds_end>_*1ins…`. That rule is stated and locked for
+//! single variants in `five_prime_boundary_delins_unification.rs`.
+//!
+//! The merge path reached the same junction without it. `c.[11_12dup;16_17insC]`
+//! normalized to `c.18_*1insCAT`, and re-normalizing *that* applied the clamp
+//! after all — so the first answer was not a fixed point, and the two shuffle
+//! directions did not even agree on the second pass:
+//!
+//! ```text
+//! once   c.18_*1insCAT
+//! twice  c.18delinsTCAT   (3')
+//! twice  c.16_17insATC    (5')
+//! ```
+//!
+//! Found by the transcript-axis sweep added for #1283, and only at the full
+//! corpus — the two triggering sequences are corpus indices 26 and 36, outside
+//! the 4-seed default prefix (#1295).
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// The transcript from the issue: 20 bases, CDS `1..=18`, so `c.18` is the last
+/// coding base and `c.*1` the first 3'UTR base.
+const CORE: &str = "TAAATAATAAATATATATTA";
+const CDS_START: u64 = 1;
+const CDS_END: u64 = 18;
+
+/// The second sequence in the same corpus that reaches the same first pass.
+const CORE_SIBLING: &str = "TAATTTATTAATATATATAT";
+
+/// A range starting on a CDS coordinate and ending on a `*` one, e.g. `18_*1`.
+///
+/// The leading `[.\[;]` is load-bearing. A bare `\d+_\*\d+` also matches the
+/// `1_*2` *inside* `*1_*2` — a range wholly within the 3'UTR, which is a
+/// legitimate answer and not what this rule forbids — so the left endpoint is
+/// pinned to a position that actually starts one: after the `c.`, after the
+/// allele's `[`, or after a member separator.
+static SPANS_JUNCTION: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"[.\[;]\d+_\*\d+").expect("valid regex"));
+
+fn normalize_once(core: &str, input: &str, dir: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        SyntheticBuilder::cds(core, CDS_START, CDS_END, Strand::Plus).build(),
+        NormalizeConfig::default()
+            .with_direction(dir)
+            .allow_crossing_boundaries(),
+    );
+    normalizer
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// Normalizing twice must reproduce the first answer.
+///
+/// This is what `FERRO_ASSERT_IDEMPOTENT` asserts globally; pinning it here
+/// keeps the case named and reproducible without depending on that flag being
+/// set, and covers both shuffle directions, which disagreed.
+/// The answer each `(core, direction)` settles on, pinned literally.
+///
+/// The two tests below were property-only — "it is stable" and "it does not
+/// span the junction" — and a regression producing a *stable, non-spanning,
+/// wrong* string satisfies both. These are what make them value guards. The
+/// four differ from one another, which is itself the point: the clamp's answer
+/// depends on both the sibling and the direction, so a fix that collapsed them
+/// to one form would be caught here rather than passing quietly.
+const PINNED: &[(&str, ShuffleDirection, &str)] = &[
+    (
+        CORE,
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.18delinsTCAT",
+    ),
+    (
+        CORE_SIBLING,
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.[16_17insC;*1_*2dup]",
+    ),
+    (CORE, ShuffleDirection::FivePrime, "NM_TEST.1:c.16_17insATC"),
+    (
+        CORE_SIBLING,
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.16_17insATC",
+    ),
+];
+
+/// Every pinned answer must be the one the normalizer actually produces.
+#[test]
+fn the_clamped_answers_are_unchanged() {
+    for (core, dir, expected) in PINNED {
+        let once = normalize_once(core, "NM_TEST.1:c.[11_12dup;16_17insC]", *dir);
+        assert_eq!(
+            &once, expected,
+            "the clamped answer moved for {core} under {dir:?}"
+        );
+    }
+}
+
+#[test]
+fn a_cis_allele_across_the_cds_utr3_junction_is_a_fixed_point() {
+    for dir in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        for core in [CORE, CORE_SIBLING] {
+            let once = normalize_once(core, "NM_TEST.1:c.[11_12dup;16_17insC]", dir);
+            let twice = normalize_once(
+                core,
+                &format!("NM_TEST.1:{}", once.split(':').nth(1).unwrap()),
+                dir,
+            );
+            assert_eq!(
+                once, twice,
+                "normalizing twice changed the answer for {core} under {dir:?}: \
+                 {once} -> {twice}"
+            );
+        }
+    }
+}
+
+/// The output must not span the CDS/3'UTR junction.
+///
+/// Stated separately from idempotency because it is the *design* rule, and a
+/// fix that merely made the spanning form stable would satisfy the test above
+/// while still contradicting the CDS-end clamp every other path applies.
+#[test]
+fn a_cis_allele_does_not_re_axis_onto_the_utr3() {
+    for dir in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        for core in [CORE, CORE_SIBLING] {
+            let once = normalize_once(core, "NM_TEST.1:c.[11_12dup;16_17insC]", dir);
+            // A range is only *spanning* when it starts on a CDS coordinate and
+            // ends on a `*` one. A range wholly inside the 3'UTR (`*1_*2`) is a
+            // legitimate answer, so match the junction shape rather than any
+            // `_*`, which would flag it too.
+            assert!(
+                !SPANS_JUNCTION.is_match(&once),
+                "output spans the CDS/3'UTR junction for {core} under {dir:?}: {once}"
+            );
+        }
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -199,6 +199,7 @@ mod issue_1362_identity_span;
 mod issue_1376_utr_ins_payload;
 mod issue_1382_diagnostics_strict_ladder;
 mod issue_1389_codon_gate_emitted_window;
+mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1398.

A `c.`-axis cis allele normalized to an insertion spanning the CDS/3'UTR junction, and re-normalizing that output did not return it:

```
in     c.[11_12dup;16_17insC]
once   c.18_*1insCAT
twice  c.18delinsTCAT   (3')
twice  c.16_17insATC    (5')
```

## Root cause

`boundary_delins_anchor` in the piece builder clamps a derived pure insertion only at the **representability** bounds — contig ends, transcript ends. Its doc says so explicitly, and gives the reason: the axis-change boundaries at `cds_start`/`cds_end` have a representable far side (`c.-1`, `c.*1`), so clamping there is a policy with carve-outs, and `normalize_cds` keeps it.

**That reasoning holds for a lone member and not for a derivation.** A single variant gets re-clamped by the per-member pipeline. The sequence-first derivation (#1392) is authoritative for the group, and nothing re-clamps its output — so the insertion kept the `c.<cds_end>_*1` spelling that every other path rewrites, and only the *second* normalize applied the policy. Hence the non-idempotency, and hence the two directions disagreeing about the second pass.

merge.rs already anticipates this exact situation:

> Do not restore it. If a terminal or tandem case regresses, **the fix belongs in the builder**; refusing here also refuses every merge the derivation gets right.

So the 3' half of the policy now lives in the builder, as `cds_end_delins_anchor`. The identity is `normalize_cds`'s and is shared rather than copied — inserting `A'` between `cds_end` and `cds_end + 1` is exactly "delete `ref[cds_end]`, insert `ref[cds_end] ++ A'`", true for any `A'`.

Two things deliberately **not** done, each with its reason in the code:

- **No `cds_start` mirror.** The axis identity is discontinuous at the 5' end (`c.-1` is `cds_start - 1`, the reason `region_sequence_delta` exists), so that side needs its own arithmetic and its own evidence.
- **`r.` is not claimed.** `normalize_cds`'s #387 clamp is gated on `AxisRegion::Cds`, so claiming `r.` in the derivation would recreate the same disagreement in the opposite direction.

Spanning duplications stay unclamped, per #401, and need no gate: `anchor_for_piece` tries `duplication_anchor` first, so a piece a `dup` describes never reaches the new function. That is the call order supplying the same positive-list-`Insertion` effect `normalize_cds` states explicitly.

## Verification

`tests/it/issue_1398_cds_utr3_insertion_idempotency.rs` pins both directions and both corpus sequences, and asserts two separate things: that the result is a fixed point, and that it does not re-axis onto the 3'UTR. The second is stated separately on purpose — a fix that merely made the spanning form *stable* would satisfy idempotency while still contradicting the clamp every other path applies.

Full suite green under all three oracles (`FERRO_ASSERT_IDEMPOTENT` / `REPARSE` / `IN_BOUNDS`): **9314 passed**. `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean.

## What this does NOT fix — #1400's sweep stays `#[ignore]`d

I ran #1400's full-corpus transcript sweep against this change, which is the reason that sweep is ignored. **It still fails**, and it is worth being precise about why:

| | cases |
|---|---|
| baseline (no fix), full corpus | 32 sequence-changing |
| with this fix, full corpus | 32 sequence-changing — **identical set** |

So this fix neither regresses nor resolves them. They are a **separate, pre-existing defect class** that the idempotency panic was previously masking: with the panic gone the sweep runs to completion and reports them. They are *more* severe than #1398 — normalization changing what the variant means:

```
c.[11_12del;14del] -> c.[14del;*1_*2del]
   want TAATTTATTAAATATAT
   got  TAATTTATTAATAATAT
```

`11_12del` 3'-shifts through the `(AT)₅` tract into the 3'UTR, which is valid *in isolation* — but the sibling `14del` disrupts the tract, so the shift is not. Filed separately as #1418.

**#1400's `#[ignore]` therefore stays until that one lands**, and its comment should be re-pointed from #1398 to the new issue. I did not touch #1400 here to avoid editing another open PR's branch from this one.
