### PR TITLE
fix(normalize): drop a cancelled identity member a sibling partly covers

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -6579,9 +6579,27 @@ fn translate_junction_member<P: ReferenceProvider>(
 ///   the repeat alone denotes the input; the `265=` residue overlaps it
 /// ```
 ///
-/// Only the identity member is dropped, and only when a sibling's span *covers*
+/// Only the identity member is dropped, and only when a sibling's span *overlaps*
 /// it under [`blocks_sibling_shift`] — a sibling that merely adds sequence at a
 /// junction inside it contradicts nothing.
+///
+/// **Overlap, not containment** (#1416). The rule this enforces is "two members
+/// must not claim one base", and a partial overlap breaks it exactly as a
+/// containment does — the applier declines both alike:
+///
+/// ```text
+/// g.[11_12inv;11_12insAA]  ->  g.[11_12=;10_11A[4]]  over `CGCGCGCGCAATCGCGCG`
+///   the inversion of `AT` cancels to `=`; the repeat grows the `A` tract at
+///   10_11 to four copies and so claims base 11, which the identity also names.
+///   The repeat's span (10_11) does not *contain* the identity's (11_12), so a
+///   containment test left the pair overlapping and the allele denoted nothing.
+/// ```
+///
+/// Dropping is sequence-preserving even where the identity reaches past the
+/// sibling: an identity asserts only that its bases are unchanged, so removing
+/// it can never change what the allele denotes — the bases outside the sibling
+/// are unchanged whether or not anything says so. What is lost is an assertion,
+/// and keeping it costs a description no consumer can splice.
 ///
 /// `blocks_sibling_shift` rather than `claims_reference_bases`, because a
 /// duplication covers the positions it copies without consuming them (#1321):
@@ -6630,8 +6648,22 @@ pub(crate) fn drop_identity_members_covered_by_siblings(
                     s.blocks_shift
                         && s.region == span.region
                         && s.accession == span.accession
-                        && s.start <= span.start
-                        && s.end >= span.end
+                        // Both spans forward. A reversed `<high>_<low>` range is
+                        // SVD-WG006's circular deletion/duplication form, and
+                        // `cis_axis_parts` hands the endpoints over raw, so one
+                        // can reach here with `start > end`. This pass has no
+                        // wraparound semantics: the interval test below reads
+                        // such a span as an ordinary one, and widening
+                        // containment to overlap made that newly *matter* — a
+                        // reversed sibling against a forward identity now
+                        // satisfies the test where containment refused it.
+                        // Declining is the honest answer, and it is also the
+                        // conservative one: the identity is kept, which is the
+                        // behaviour that predates this rule.
+                        && s.start <= s.end
+                        && span.start <= span.end
+                        && s.start <= span.end
+                        && s.end >= span.start
                 })
             })
         })

--- a/tests/it/issue_1416_cancelled_identity_beside_repeat.rs
+++ b/tests/it/issue_1416_cancelled_identity_beside_repeat.rs
@@ -1,0 +1,107 @@
+//! A cancelled identity member must not survive beside a sibling that claims
+//! its bases (#1416).
+//!
+//! `g.[11_12inv;11_12insAA]` normalized to `g.[11_12=;10_11A[4]]`, whose two
+//! members both claim base 11 — so the allele denotes **no sequence at all**,
+//! and the independent applier declines it in either member order. The whole
+//! variant is the repeat: `11_12inv` over `AT` is its own reverse complement and
+//! cancels to `=`, while `11_12insAA` grows the `A` tract at `10_11` from two
+//! copies to four. `g.10_11A[4]` alone denotes exactly the input's bases.
+//!
+//! This is #1235's criterion 2 — "no normalized cis allele contains overlapping
+//! or out-of-order members" — on a shape its confluence proptest cannot
+//! generate, since that model never puts an inversion beside a co-located
+//! insertion.
+//!
+//! Pinned with the apply oracle rather than by re-normalizing, deliberately: the
+//! bad output also fires `FERRO_ASSERT_IDEMPOTENT` (#1414), so a
+//! re-normalization test would report the ordering symptom instead of the
+//! defect. What matters is that the output denotes something.
+
+use crate::common::cis_apply_oracle::apply;
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// 18 bases; `10` and `11` are `A`, `12` is `T`, so `11_12` is `AT` — its own
+/// reverse complement — and the `A` tract at `10_11` has two copies.
+const REFERENCE: &str = "CGCGCGCGCAATCGCGCG";
+
+fn normalize(input: &str) -> String {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", REFERENCE.to_string());
+    Normalizer::new(provider)
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// The output must denote a sequence.
+///
+/// The primary assertion: a description the applier declines is malformed in the
+/// strongest sense available, whatever else is true of it.
+#[test]
+fn the_normalized_allele_denotes_a_sequence() {
+    let out = normalize("TEMPLATE:g.[11_12inv;11_12insAA]");
+    // The whole accession-qualified string: `apply` re-parses it with
+    // `parse_hgvs`, which needs the accession. Passing the bare `g.…` makes it
+    // return `None` for *every* input, which looks exactly like the defect.
+    assert!(
+        apply(REFERENCE, &out).is_some(),
+        "normalized to a description the applier declines — its members overlap, \
+         so it denotes no sequence: {out}"
+    );
+}
+
+/// …and it must denote the *right* one.
+///
+/// Stated separately because `is_some()` alone would accept any appliable
+/// answer, including one that quietly changed the variant's meaning while
+/// fixing the overlap.
+#[test]
+fn the_normalized_allele_denotes_the_inputs_bases() {
+    let out = normalize("TEMPLATE:g.[11_12inv;11_12insAA]");
+    // The whole accession-qualified string: `apply` re-parses it with
+    // `parse_hgvs`, which needs the accession. Passing the bare `g.…` makes it
+    // return `None` for *every* input, which looks exactly like the defect.
+    // `11_12insAA` grows the two-copy `A` tract at `10_11` to four copies; the
+    // inversion cancels. Spliced by hand so the expectation does not depend on
+    // the normalizer that produced the description.
+    assert_eq!(
+        apply(REFERENCE, &out).as_deref(),
+        Some("CGCGCGCGCAAAATCGCGCG"),
+        "normalized description denotes different bases than the input: {out}"
+    );
+}
+
+/// A reversed `<high>_<low>` span must not be read as an ordinary interval.
+///
+/// SVD-WG006 admits the reversed range for a circular deletion or duplication,
+/// and `cis_axis_parts` passes the endpoints through raw, so a member with
+/// `start > end` reaches the coverage test above. Widening containment to
+/// overlap is what made that matter: `s.start <= span.end && s.end >= span.start`
+/// is satisfied by a reversed sibling against a forward identity, where the
+/// containment form refused it — so without the forward-span guard this rule
+/// would start dropping identity members on the circular axis on the strength of
+/// an interval comparison that means nothing there.
+///
+/// The assertion is deliberately weak on the output *form* and strong on the
+/// invariant: whatever `m.` normalization does with this allele, it must not
+/// silently lose a member to a wraparound comparison.
+#[test]
+fn a_wraparound_sibling_does_not_drop_an_identity_member() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_012920.1", "CGCGCGCGCAATCGCGCG".to_string());
+    let input = "NC_012920.1:m.[16569_1del;5_6=]";
+    let Ok(variant) = parse_hgvs(input) else {
+        return; // the parser is entitled to refuse this spelling; nothing to pin
+    };
+    let output = Normalizer::new(provider)
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string();
+    assert!(
+        output.contains("5_6=") || output.contains("5="),
+        "`{input}` -> `{output}`: the identity member was dropped by a \
+         wraparound span comparison"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -201,6 +201,7 @@ mod issue_1382_diagnostics_strict_ladder;
 mod issue_1389_codon_gate_emitted_window;
 mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
+mod issue_1416_cancelled_identity_beside_repeat;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1416.

`g.[11_12inv;11_12insAA]` over `CGCGCGCGCAATCGCGCG` normalized to `g.[11_12=;10_11A[4]]`, whose two members both claim base 11. The independent applier declines it in **either** member order, so the allele denoted no sequence at all.

## Root cause

`drop_identity_members_covered_by_siblings` (#1297) exists for exactly this shape — a member that cancelled to `=` while a sibling grew over the bases it names. It required the sibling's span to **contain** the identity's:

```rust
s.start <= span.start && s.end >= span.end
```

Here the repeat's tract is `10_11` and the identity claims `11_12`. They overlap on base 11, but neither contains the other, so nothing was dropped.

The rule the pass enforces is "two members must not claim one base" — its own doc says so, and cites the apply oracle as the arbiter. A **partial** overlap breaks that rule exactly as a containment does. So the test is now for overlap.

**Dropping stays sequence-preserving even where the identity reaches past the sibling.** An identity asserts only that its bases are unchanged, so removing it cannot change what the allele denotes: the bases outside the sibling are unchanged whether or not anything says so. What is lost is an assertion. What keeping it costs is a description no consumer can splice.

Output is now the single member `g.10_11A[4]`, which denotes exactly the input's bases (`11_12inv` over `AT` is its own reverse complement and cancels; `11_12insAA` grows the two-copy `A` tract to four).

## Verification

Pinned with the **apply oracle**, not by re-normalizing — the old output also fires `FERRO_ASSERT_IDEMPOTENT` (#1414), so a re-normalization test would report that ordering symptom instead of this defect. Two assertions, deliberately separate: that the output denotes *a* sequence, and that it denotes the *right* one — `is_some()` alone would accept any appliable answer, including one that fixed the overlap by changing the meaning.

Both were watched to fail against unfixed `main` before being trusted.

**A test-harness bug worth flagging**, since the same trap is available to anyone writing one of these: `cis_apply_oracle::apply` re-parses its argument with `parse_hgvs`, so it needs the **accession-qualified** string. My first version passed the bare `g.…` descriptor, which makes `apply` return `None` for *every* input — indistinguishable from the defect. It "reproduced" perfectly and would have gone on passing after the fix.

Full suite green under all three oracles (`FERRO_ASSERT_IDEMPOTENT` / `REPARSE` / `IN_BOUNDS`): **9328 passed**. `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean.

## Relationship to #1414 — read before closing it

#1414 is the same input, filed for the ordering/idempotency symptom. With this fix that symptom is gone — the output is a single member, so there is no ordering question, and it is a fixed point:

```
once  = TEMPLATE:g.10_11A[4]
twice = TEMPLATE:g.10_11A[4]
```

**I did not mark #1414 closed, on purpose.** Its stated mechanism is untouched: `normalize_allele` still gates the genomic-order sort on `has_overlap_conflict` rather than on whether the allele was actually emitted verbatim, and #1414's own analysis is that the gate asks the wrong question. This PR removes the only known input that exposes it, not the gate. Whether that is worth keeping open is a judgement call I would rather leave to you than quietly resolve by deleting the reproducer.

## Not addressed

**#1406 row 3**, the same input again, filed for the laundering symptom (input strict-rejected, output strict-accepted). #1416 already notes it needs its own answer regardless: the fixed output `g.10_11A[4]` is *still* strict-accepted.
