### PR TITLE
fix(normalize): bound a sibling-crossing shift across a region boundary

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -5081,6 +5081,22 @@ fn blocks_sibling_shift(edit: &NaEdit) -> bool {
 /// live list keeps the pass independent of member order.
 ///
 /// [`ShuffleDirection::FivePrime`]: crate::normalize::ShuffleDirection
+/// One sibling's bounds, on the **sequence** axis rather than its own region's.
+///
+/// [`clamp_sibling_crossing_shifts`] compares a moving member against every
+/// sibling, and the two need not share a region — a member shifting out of the
+/// CDS is bounded by siblings still inside it (#1418). Region axes are not
+/// comparable position-by-position (`c.12` and `c.*1` are adjacent bases with
+/// unrelated numbers), so each span is converted once, here, via
+/// [`region_sequence_delta`], and the pass then does ordinary arithmetic.
+struct SiblingBound {
+    claims_bases: bool,
+    blocks_shift: bool,
+    start: i64,
+    end: i64,
+    junction: Option<i64>,
+}
+
 pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
     before: &[HgvsVariant],
     after: &mut [HgvsVariant],
@@ -5104,11 +5120,34 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
         let (Some(b), Some(a)) = (pre[i].as_ref(), post[i].as_ref()) else {
             continue;
         };
-        if !b.blocks_shift || !a.blocks_shift || b.region != a.region {
+        if !b.blocks_shift || !a.blocks_shift {
             continue;
         }
+        // A shift that changes region is still a shift, and still has to respect
+        // siblings (#1418). It used to be skipped here, which let a member cross
+        // the CDS/3'UTR boundary — and every sibling on the way — unchecked:
+        // `c.[11_12del;14del]` emitted `c.[14del;*1_*2del]`, straight past the
+        // `14del`, denoting different bases.
+        //
+        // Regions cannot be compared position-by-position: `c.12` and `c.*1` are
+        // adjacent bases with unrelated numbers. So the whole pass runs on the
+        // **sequence** axis, via the same `region_sequence_delta` conversion the
+        // in-bounds oracle and the payload reads use. Within one region that is a
+        // constant offset and changes nothing, which is why the arithmetic below
+        // is untouched; across regions it is what makes the comparison mean
+        // anything at all.
+        //
+        // A region with no conversion — an `n.` position outside the transcript —
+        // is skipped, the same conservative answer its sibling reads give.
+        let seq = |s: &MemberSpan| -> Option<(i64, i64)> {
+            let delta = region_sequence_delta(s.region, &s.provider_key, provider)?;
+            Some((s.start.checked_add(delta)?, s.end.checked_add(delta)?))
+        };
+        let (Some((b_start, b_end)), Some((a_start, a_end))) = (seq(b), seq(a)) else {
+            continue;
+        };
         // A member that did not move cannot have crossed anything.
-        let delta = a.start - b.start;
+        let delta = a_start - b_start;
         if delta == 0 {
             continue;
         }
@@ -5128,8 +5167,8 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
         // a duplication moves its span and its junction together, so bounding
         // the span mis-places the copy — measured on the 5' sweep, that turns
         // correct outputs into silently wrong ones (#1266, #1279).
-        let translated = a.end - b.end == delta;
-        let shrank = a.end - a.start < b.end - b.start;
+        let translated = a_end - b_end == delta;
+        let shrank = a_end - a_start < b_end - b_start;
         if !translated && !shrank {
             continue;
         }
@@ -5140,11 +5179,28 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
         // sliding a deletion past the point where a sibling adds sequence
         // reorders the two edits and changes what the allele denotes (`g.
         // [258del;259_260insC]` emitted `g.[259_260insC;263del]`).
-        let siblings: Vec<&MemberSpan> = (0..pre.len())
+        //
+        // Matched on accession alone, not on region: a sibling in the 3'UTR is
+        // on this member's coordinate line just as much as one in the CDS, and
+        // filtering by region was the other half of #1418 — it hid exactly the
+        // siblings a boundary-crossing member sweeps over. `seq` puts both on
+        // the sequence axis, which is what makes them comparable; a sibling
+        // whose region has no conversion is dropped rather than mis-placed.
+        let siblings: Vec<SiblingBound> = (0..pre.len())
             .filter(|&j| j != i)
             .flat_map(|j| [pre[j].as_ref(), post[j].as_ref()])
             .flatten()
-            .filter(|s| s.region == a.region && s.accession == a.accession)
+            .filter(|s| s.accession == a.accession)
+            .filter_map(|s| {
+                let delta = region_sequence_delta(s.region, &s.provider_key, provider)?;
+                Some(SiblingBound {
+                    claims_bases: s.claims_bases,
+                    blocks_shift: s.blocks_shift,
+                    start: s.start.checked_add(delta)?,
+                    end: s.end.checked_add(delta)?,
+                    junction: s.junction.and_then(|j| j.checked_add(delta)),
+                })
+            })
             .collect();
 
         let pull = if delta > 0 {
@@ -5164,7 +5220,7 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
                 .iter()
                 .filter(|s| s.claims_bases)
                 .map(|s| s.start)
-                .filter(|&start| start > b.end && start <= a.end)
+                .filter(|&start| start > b_end && start <= a_end)
                 .map(|start| start - 1);
             // A junction between `j` and `j+1` is crossed once this member's
             // end reaches `j + 1`; stopping at `j` leaves it flush against the
@@ -5172,18 +5228,18 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
             let across_junctions = siblings
                 .iter()
                 .filter_map(|s| s.junction)
-                .filter(|&j| j >= b.end && j < a.end);
+                .filter(|&j| j >= b_end && j < a_end);
             onto_bases
                 .chain(across_junctions)
                 .min()
-                .map(|limit| a.end - limit)
+                .map(|limit| a_end - limit)
         } else {
             // 5'-shift: mirror image, window `[a.start, b.end]`.
             let onto_bases = siblings
                 .iter()
                 .filter(|s| s.blocks_shift)
                 .map(|s| s.end)
-                .filter(|&end| end < b.start && end >= a.start)
+                .filter(|&end| end < b_start && end >= a_start)
                 .map(|end| end + 1);
             // Mirror of the 3' junction barrier. A junction between `j` and
             // `j + 1` is crossed once this member's start reaches `j`; stopping
@@ -5209,12 +5265,12 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
                 .iter()
                 .filter(|_| a.junction.is_none())
                 .filter_map(|s| s.junction)
-                .filter(|&j| j < b.start && j >= a.start)
+                .filter(|&j| j < b_start && j >= a_start)
                 .map(|j| j + 1);
             onto_bases
                 .chain(across_junctions)
                 .max()
-                .map(|limit| a.start - limit)
+                .map(|limit| a_start - limit)
         };
         // Never move past where the member started: those positions were not
         // reachable by this shift and are not equivalent to it.
@@ -5228,12 +5284,36 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
             continue;
         };
         if pull != 0 {
-            // A duplication blocks a sibling's shift without claiming bases, so
-            // it reaches this pass too — and its payload is read from under its
-            // own span, so it cannot simply be slid (#1280, #1292).
-            match a.junction {
-                Some(_) => translate_junction_member(&mut after[i], -pull, kind, a, provider),
-                None => translate_member(&mut after[i], -pull, kind, a),
+            if a.region == b.region {
+                // A duplication blocks a sibling's shift without claiming bases,
+                // so it reaches this pass too — and its payload is read from
+                // under its own span, so it cannot simply be slid (#1280, #1292).
+                match a.junction {
+                    Some(_) => translate_junction_member(&mut after[i], -pull, kind, a, provider),
+                    None => translate_member(&mut after[i], -pull, kind, a),
+                }
+            } else {
+                // The member crossed a region boundary, and the pull would carry
+                // it back across (#1418). Neither translate can express that:
+                // both add `-pull` to the axis number and then verify the result
+                // landed in `from.region`, so a `c.*1` pulled seven bases 5'
+                // would be written as `c.*-6` and reverted — silently leaving the
+                // uncorrected output in place.
+                //
+                // Restore the pre-shift member instead. That is a *stronger* pull
+                // than the bound requires, so it is always inside the swept
+                // window and cannot cross anything itself; and the input spelling
+                // is sequence-correct by construction, since it is what the
+                // allele denoted before this pass moved it. The cost is
+                // canonicalisation, not correctness: the member may sit 5' of the
+                // most-3' position a boundary-aware translate would reach.
+                //
+                // Re-spelling it properly means a translate that converts between
+                // region axes rather than adding to one. That is worth doing, and
+                // is deliberately not done here — it is a change to shared
+                // machinery every clamp uses, and this pass's job is to stop the
+                // allele denoting the wrong bases.
+                after[i] = before[i].clone();
             }
         }
     }

--- a/tests/it/issue_1398_cds_utr3_insertion_idempotency.rs
+++ b/tests/it/issue_1398_cds_utr3_insertion_idempotency.rs
@@ -77,10 +77,16 @@ const PINNED: &[(&str, ShuffleDirection, &str)] = &[
         ShuffleDirection::ThreePrime,
         "NM_TEST.1:c.18delinsTCAT",
     ),
+    // Re-blessed by #1418. This was `c.[16_17insC;*1_*2dup]` — the `dup` had
+    // shifted across the CDS/3'UTR boundary and past its own sibling, which is
+    // the defect #1418 fixes by bounding a sibling-crossing shift on the
+    // sequence axis. With that bound in place the sibling case converges on the
+    // same answer as `CORE`, and both members stay in the CDS. A deliberate
+    // representation change, declared in that PR.
     (
         CORE_SIBLING,
         ShuffleDirection::ThreePrime,
-        "NM_TEST.1:c.[16_17insC;*1_*2dup]",
+        "NM_TEST.1:c.18delinsTCAT",
     ),
     (CORE, ShuffleDirection::FivePrime, "NM_TEST.1:c.16_17insATC"),
     (


### PR DESCRIPTION
Closes #1418.

A `c.`-axis cis member could 3'-shift out of the CDS, past a sibling, into the 3'UTR — changing what the allele denotes:

```
c.[11_12del;14del]  ->  c.[14del;*1_*2del]
  input denotes  TAATTTATTAAATATAT
  output denotes TAATTTATTAATAATAT
```

## Root cause

`clamp_sibling_crossing_shifts` is the pass that stops a member leapfrogging a sibling, and it skipped this case outright:

```rust
if !b.blocks_shift || !a.blocks_shift || b.region != a.region { continue; }
```

`11_12del` starts in `Region::Cds` and lands in `Region::ThreePrimeUtr`, so **a shift that changed region was exempted from the sibling-crossing invariant entirely** — and crossed the `14del` unchecked. (Confirmed by instrumenting the guard: `before=(Cds, 11, 12)`, `after=(ThreePrimeUtr, 1, 2)`.)

The guard was avoiding a real problem: region axes cannot be compared position-by-position, since `c.12` and `c.*1` are adjacent bases with unrelated numbers. So the pass now runs on the **sequence** axis, converting each span once through `region_sequence_delta` — the same conversion the in-bounds oracle and the payload reads already use. Within one region that is a constant offset and changes nothing, which is why the arithmetic is otherwise untouched. Sibling matching drops its region filter for the same reason: filtering siblings by region hid exactly the ones a boundary-crossing member sweeps over.

Applying the pull is where the boundary still bites. Both `translate_member` and `translate_junction_member` add to the axis number and then verify the result landed in the original region — so a `c.*1` pulled 5' would be written `c.*-6` and reverted, silently leaving the uncorrected output. A cross-region pull therefore **restores the pre-shift member**: a stronger pull than the bound requires, so always inside the swept window, and sequence-correct by construction. The cost is canonicalisation, not correctness — a boundary-aware translate would reach a more-3' position, and that is deliberately left out of scope as a change to shared machinery every clamp uses.

## Verification

Full 829,440-case transcript-axis sweep (#1400), at `FERRO_SWEEP_SEEDS=full`: **32 sequence-changing normalizations before, 0 after.**

Full suite green under all three oracles: **9328 passed**. `fmt`/`clippy` clean.

## Representation stability — this PR moves shipped forms

Per `CLAUDE.md` and the 2026-08-05 relay, stating this explicitly rather than as "fixes non-confluence".

Measured by dumping normalized output over a 14,080-row slice of the transcript-axis corpus (two directions × dup/del first members × del/dup/ins second members) on `main` and on this branch:

| | rows |
|---|---|
| total | 14,080 |
| **moved** | **9 (0.064%)** |

And the part that matters — I checked each moved row against the apply oracle:

**All 9 moved rows were already correct on `main`.** So within this slice the change is **pure churn, not bugfix**: 9 outputs that denoted the right bases now denote them with a different string. The 32 genuinely-wrong outputs live in the wider sweep corpus, outside this slice's shape set.

Direction of movement — away from a two-member form with a 3'UTR member, toward a single CDS-side member:

```
c.[11_12dup;16del]  :  c.[15_16dup;*1del]  ->  c.16_17insA
c.[11_12dup;16dup]  :  c.[15_16dup;*1dup]  ->  c.16_17insATT
c.[16_17dup;18dup]  :  c.[17_18dup;*2dup]  ->  c.18_*1insATT
```

Both spellings denote identical bases in every case. The clamp pulls the member back inside the CDS, and the collapse pass then merges the now-adjacent pair.

**Two caveats I do not want to paper over:**

- **This is `main`-to-branch, not release-to-release.** The relay asks for the latter. I could not run it: the harness (`sweep_sequences` / `sweep_seeds`) postdates v0.12.0, so the corpus does not exist on that tag. Someone comparing against the shipped release should expect this movement *plus* whatever #1392, #1380 and #1393 already moved this cycle.
- **The slice is not the corpus.** 14,080 rows over one shape family, chosen to be cheap to dump on both sides — not the 829,440-case sweep, and not a clinical corpus. Treat 0.064% as an order of magnitude, not a bound.

Given the relay's "break spec-permitted ties toward the already-shipped form", these 9 are a cost, not a benefit. They are collateral to bounding the 32 wrong ones and I do not see how to fix the latter without the former — but they should be batched into the same release as the other normalizer changes, not dribbled out separately.

## #1400's sweep stays `#[ignore]`d — it needs a third fix

I checked whether this unblocks the un-ignore. It does not, and the reason is worth recording since the ignore comment currently names only #1398:

| state | full sweep, no oracles | full sweep, with oracles (as CI runs it) |
|---|---|---|
| `main` | FAIL — 32 sequence-changing | FAIL — #1398 idempotency panic |
| + this PR | **PASS** | FAIL — #1398 idempotency panic |
| + this PR + #1417 | **PASS** | **FAIL — a third defect** |

With both fixes applied the sweep still fires `FERRO_ASSERT_IDEMPOTENT`, on a shape neither addresses:

```
c.18_*1insACT  <->  c.*1_*2insCTA
```

Filed as #1426. So the `#[ignore]` needs to survive until all three land, and its comment should then name whichever is last.


---

## ⚠️ Representation change

Per the repository's representation-stability rule, this PR moves a normalized output and the movement is named here rather than left to be found downstream.

| input | was (shipped) | now |
|---|---|---|
| `NM_TEST.1:c.[11_12dup;16_17insC]` on `CORE_SIBLING`, 3' direction | `c.[16_17insC;*1_*2dup]` | `c.18delinsTCAT` |

The old form is the defect: the `dup` had shifted across the CDS/3'UTR boundary **and past its own sibling**, denoting different bases. The new form keeps both members inside the CDS and converges on the same answer the no-sibling core already gave, so this narrows two spellings onto one rather than splitting them.

Caught by `issue_1398_cds_utr3_insertion_idempotency::the_clamped_answers_are_unchanged`, a value pin added in #1417 for exactly this purpose — that test asserted the property "does not span the junction", which the old output satisfied while still being wrong. It is re-blessed here with the reason recorded inline.

No other pinned output moves: 9339/9339 with all three oracles.
