### PR TITLE
fix(normalize): let a junction insertion finish its shift in one pass

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4269,9 +4269,40 @@ impl<P: ReferenceProvider> Normalizer<P> {
         //     stops the shuffle at the exon edge (the #670 machinery then
         //     governs any genomic-space continuation).
         // `tx_to_cds_pos` re-expresses any resulting `tx > cds_end` as `c.*<M>`.
+        //     The `end_axis` test asks whether the variant's *reference span*
+        //     straddles the boundary. An insertion has no reference span: its
+        //     two endpoints are the flanks of a gap, so an insertion resting on
+        //     the CDS/3'UTR junction necessarily reads `end_axis == ThreeUtr`
+        //     while covering no 3'UTR base at all. Requiring both flanks
+        //     therefore excluded every junction insertion from the relaxation
+        //     above — including the ones this relaxation was extended to
+        //     `Insertion` for — and reproduced #1209's own alternation one shape
+        //     over (#1426):
+        //
+        //         c.18_*1insACT -> c.18delinsTACT -> c.*1_*2insCTA
+        //
+        //     The first pass is barred here, stops on the boundary and is
+        //     rewritten by the #387 clamp; the resulting `Delins` has both
+        //     flanks on `c.18`, so the second pass is admitted and shifts. Two
+        //     passes, two branches — the exact defect #1209 records.
+        //
+        //     So for an insertion the question is asked of the 5' flank alone.
+        //     A del/dup/delins still needs both, because for those the span is
+        //     real and #350's bail is what keeps a genuinely straddling variant
+        //     from being reinterpreted.
+        //
+        //     `is_zero_width_insertion`, not `matches!(edit, Insertion { .. })`.
+        //     The argument above rests on an insertion covering no reference
+        //     base, and that is what `tx_end == tx_start + 1` establishes. A
+        //     malformed insertion with non-adjacent flanks (`c.10_20insA`) does
+        //     name a span, and it is exactly the straddling shape #350's bail
+        //     exists to refuse — so it must not be waved through on the strength
+        //     of its edit kind. This is the same predicate the 5' mirror below
+        //     uses, and the two arms should not disagree about what counts as an
+        //     insertion for this purpose.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && matches!(start_axis, boundary::AxisRegion::Cds)
-            && matches!(end_axis, boundary::AxisRegion::Cds)
+            && (matches!(end_axis, boundary::AxisRegion::Cds) || is_zero_width_insertion)
             && matches!(
                 edit,
                 NaEdit::Deletion { .. }

--- a/tests/it/issue_1426_junction_insertion_settles_in_one_pass.rs
+++ b/tests/it/issue_1426_junction_insertion_settles_in_one_pass.rs
@@ -1,0 +1,108 @@
+//! An insertion resting on the CDS/3'UTR junction must complete its 3'-shift on
+//! the **first** pass (#1426).
+//!
+//! This is #1209's defect one shape over, and its file records the identical
+//! three-step alternation:
+//!
+//! ```text
+//! #1209:  c.25_26insGAT  ->  c.26delinsGATG  ->  c.*1_*2insTGA
+//! #1426:  c.18_*1insACT  ->  c.18delinsTACT  ->  c.*1_*2insCTA
+//! ```
+//!
+//! #1209 fixed it by admitting `Insertion` to the #918 bound relaxation. That
+//! relaxation also asks both endpoints to be CDS-resident, which an insertion
+//! *on* the junction can never satisfy: its endpoints are the two flanks of a
+//! gap, so `end_axis` reads `ThreeUtr` while it covers no 3'UTR base at all. So
+//! the first pass was barred, stopped on the boundary and was rewritten by the
+//! #387 clamp; the resulting `Delins` has both flanks on `c.18`, so the second
+//! pass was admitted and shifted. Two passes, two branches.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// 20 bases, CDS `1..=18`, so `c.18` is the last coding base and `c.*1` the
+/// first 3'UTR base. Drawn from the transcript-axis sweep corpus, which is where
+/// this was found.
+const CORE: &str = "TAATTTATTAATATATATAT";
+
+fn normalize_twice(input: &str) -> (String, String) {
+    let once = normalize_once(input);
+    (once.clone(), normalize_once(&once))
+}
+
+fn normalizer() -> Normalizer<impl ferro_hgvs::reference::ReferenceProvider> {
+    Normalizer::with_config(
+        SyntheticBuilder::cds(CORE, 1, 18, Strand::Plus).build(),
+        NormalizeConfig::default()
+            .with_direction(ShuffleDirection::ThreePrime)
+            .allow_crossing_boundaries(),
+    )
+}
+
+fn normalize_once(input: &str) -> String {
+    normalizer()
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// The same input through `normalize_with_diagnostics`.
+///
+/// ferro has **two** public normalization exits, and they are not the same code
+/// path: `normalize()` reaches `normalize_core_checked`, while
+/// `normalize_with_diagnostics` historically reached `normalize_core_canonical`
+/// directly and so returned results no oracle had inspected (#1382). A bound
+/// relaxation like this one has to hold on both, or the fix is real for one
+/// caller and absent for the other.
+fn normalize_once_with_diagnostics(input: &str) -> String {
+    normalizer()
+        .normalize_with_diagnostics(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .result
+        .to_string()
+}
+
+/// Both exits must agree, on the pinned answer and with each other.
+#[test]
+fn both_public_exits_settle_on_the_same_form() {
+    for input in ["NM_TEST.1:c.18_*1insACT", "NM_TEST.1:c.*1_*2insCTA"] {
+        let plain = normalize_once(input);
+        let with_diagnostics = normalize_once_with_diagnostics(input);
+        assert_eq!(
+            plain, with_diagnostics,
+            "`{input}` settles differently through the two public exits"
+        );
+    }
+}
+
+/// The junction insertion shifts the whole way immediately.
+#[test]
+fn a_junction_insertion_settles_in_one_pass() {
+    let (once, twice) = normalize_twice("NM_TEST.1:c.18_*1insACT");
+    assert_eq!(once, "NM_TEST.1:c.*1_*2insCTA");
+    assert_eq!(twice, once, "and is stable from there");
+}
+
+/// The clamped form is no longer produced, and converges on the shifted one.
+///
+/// The mirror of `issue_1209_cds_end_insertion_shift::
+/// the_old_clamped_output_converges_on_the_shifted_form`, and stated separately
+/// because it is the assertion that would fail if someone "fixed" this by
+/// widening the #387 clamp instead — that makes `c.18delins…` a fixed point,
+/// which is the behaviour #1209 deliberately removed.
+#[test]
+fn the_clamped_form_converges_on_the_shifted_form() {
+    let (once, twice) = normalize_twice("NM_TEST.1:c.18delinsTACT");
+    assert_eq!(once, "NM_TEST.1:c.*1_*2insCTA");
+    assert_eq!(twice, once, "and is stable from there");
+}
+
+/// A 3'UTR-resident insertion is untouched — it was already stable.
+#[test]
+fn a_three_prime_utr_insertion_is_unchanged() {
+    let (once, twice) = normalize_twice("NM_TEST.1:c.*1_*2insCTA");
+    assert_eq!(once, "NM_TEST.1:c.*1_*2insCTA");
+    assert_eq!(twice, once);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -202,6 +202,7 @@ mod issue_1389_codon_gate_emitted_window;
 mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_1416_cancelled_identity_beside_repeat;
+mod issue_1426_junction_insertion_settles_in_one_pass;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Partial fix for #1426 — the 3'-direction half. Deliberately not claiming to close it; see **Scope** below.

An insertion resting on the CDS/3'UTR junction alternated between naming the junction from each side:

```
c.18_*1insACT  ->  c.18delinsTACT  ->  c.*1_*2insCTA
```

## Root cause

This is **#1209's defect one shape over**. That file's header records the identical alternation — `c.25_26insGAT -> c.26delinsGATG -> c.*1_*2insTGA` — and fixed it by admitting `Insertion` to the #918 bound relaxation.

But that relaxation also requires **both** endpoints CDS-resident, so it never reinterprets a variant whose *reference span* straddles the axis boundary:

```rust
&& matches!(start_axis, AxisRegion::Cds)
&& matches!(end_axis, AxisRegion::Cds)
```

An insertion has no reference span. Its two endpoints are the flanks of a gap, so an insertion sitting *on* the junction necessarily reads `end_axis == ThreeUtr` while covering no 3'UTR base at all. **Every junction insertion was excluded — including the ones #1209 extended the relaxation to `Insertion` for.** Confirmed by instrumenting the gate: `start_axis=Cds end_axis=ThreeUtr`.

So the first pass is barred, stops on the boundary, and the #387 clamp rewrites it to a `Delins`; that `Delins` has both flanks on `c.18`, so the second pass is admitted and shifts. Two passes, two branches of one `match`.

The fix asks the question of the **5' flank alone** for an insertion. A `del`/`dup`/`delins` still needs both, because for those the span is real and #350's bail is what keeps a genuinely straddling variant from being reinterpreted.

## The tempting wrong fix, measured

The obvious reading is that #387's CDS-end clamp is missing the disjunct its CDS-start mirror has (`insertion_rests_at_cds_start || new_tx_start < cds_start`, #383). It is missing it, and adding it is wrong:

| attempt | full suite |
|---|---|
| `\|\| new_tx_start > cds_end_tx` | **7 failures** — #1185's `delins_reducing_to_deletion_shifts_across_cds_end_in_one_pass`, the `cds_utr3_crossing_shift_idempotency` trio |
| narrowed to `Insertion` only | **5 failures** — all four of `issue_1209_cds_end_insertion_shift`, plus `issue_1235_transcript_axes::cds_axis_clamps_a_derived_insertion_at_the_transcript_end` |

`the_old_clamped_output_converges_on_the_shifted_form` is the one that settles it: it pins that `c.<cds_end>delins…` **must** converge on the shifted form. Widening the clamp makes the clamped form a fixed point — the behaviour #1209 deliberately removed. `the_clamped_form_converges_on_the_shifted_form` in the new test file guards that direction from this side too.

## Verification

Full suite green under all three oracles: **9331 passed**, 0 failed. `fmt`/`clippy` clean.

## Representation stability — this PR moves shipped forms

Measured by dumping normalized output over 7,296 corpus rows (48 seeds x both directions x junction-spanning, 3'UTR and CDS-interior shapes) on `main` and on this branch:

| | rows |
|---|---|
| total | 7,296 |
| **moved** | **57 (0.78%)** |

All 57 are the junction-spanning `c.<cds_end>_*1ins…` shape, all in one direction — clamped CDS-side form to shifted 3'UTR form:

```
c.18_*1insACT :  c.18delinsTACT  ->  c.*1_*2insCTA
c.18_*1insACT :  c.18delinsAACT  ->  c.*1_*2insCTA
c.18_*1insACT :  c.16_18dup      ->  c.18_*2dup
```

**The important property: these are not new forms.** Each is exactly what `main` already produces on the *second* normalize — the old first-pass answer was an unstable intermediate. So a consumer who normalizes to a fixed point, or whose stored input was already normalized, sees no change at all. What moves is only the answer for a single-pass normalization of a junction insertion, and it moves onto the form `main` itself converges to.

That makes this the cheap direction of the tie-break the relay asks for: it removes an intermediate rather than picking a new winner.

Caveats, same as #1425: this is `main`-to-branch, not release-to-release — the harness postdates v0.12.0 — and 7,296 rows over these shape families is an order of magnitude, not a bound.

## Scope — #1426 stays open for the 5' mirror

The 5'-direction case is **not** fixed:

```
[5'] c.*1_*2insCTA  ->  c.18_*1insACT  ->  c.17_18insTAC
```

That is not the same omission. #918's relaxation is explicitly 3'-direction-only and relaxes the *right* bound; there is no 5' counterpart to extend. Admitting one is a policy decision about whether the 5' shuffle may cross `cds_end` at all — a representation change in its own right, and not something to fold into a bug fix.

**Consequence for #1400's sweep:** still `#[ignore]`d. I ran it at `FERRO_SWEEP_SEEDS=full` with all three fixes applied (#1417 + #1425 + this) and the oracles set as CI runs them; it still fires `FERRO_ASSERT_IDEMPOTENT`, now on the 5' case above. Three of the four defects behind that ignore are fixed; the 5' mirror is the last.
