### PR TITLE
fix(normalize): let a 5'-shifting junction insertion finish in one pass

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4314,6 +4314,48 @@ impl<P: ReferenceProvider> Normalizer<P> {
             boundaries = Boundaries::new(boundaries.left, exon_only.right);
         }
 
+        // The 5' mirror, for zero-width insertions only (#1426).
+        //
+        // The relaxation above is 3'-direction-only, deliberately: the 3' rule
+        // is what HGVS mandates. But the *bound* it relaxes is not a rule, it is
+        // an axis clamp derived from the region the variant currently sits in —
+        // and for a zero-width insertion that region flips as the insertion
+        // moves, so the bound that stops it is one the next pass no longer
+        // applies:
+        //
+        //     c.*1_*2insCTA  tx=(19,20) start_axis=ThreeUtr clamped.left=18
+        //         -> stops at c.18_*1
+        //     c.18_*1insACT  tx=(18,19) start_axis=Cds      clamped.left=0
+        //         -> continues to c.17_18insTAC
+        //
+        // Two passes, two bounds, because the first pass's answer changed which
+        // clamp the second pass reads. That is the same defect the 3' half of
+        // #1426 was, arriving from the other side, and it is not a question of
+        // whether the 5' shuffle *should* cross `cds_end` — it already does,
+        // just one base per pass.
+        //
+        // Scoped to a zero-width insertion for the same reason the 3' arm asks
+        // only its 5' flank: an insertion covers no reference base, so the axis
+        // clamp's purpose — never reinterpret a variant whose span straddles the
+        // boundary — has nothing to bite on. A `del`/`dup`/`delins` keeps both
+        // bounds; for those the span is real.
+        //
+        // This reuses `is_zero_width_insertion` rather than re-deriving the same
+        // predicate locally. The 3' arm's note above asks that the two arms not
+        // disagree about what counts as an insertion here, and two bindings that
+        // are equal today are exactly how that promise is broken later — a
+        // narrowing applied to one would leave the other admitting a malformed
+        // `c.10_20insA` on the strength of its edit kind alone.
+        if self.config.shuffle_direction == ShuffleDirection::FivePrime
+            && is_zero_width_insertion
+            && matches!(
+                start_axis,
+                boundary::AxisRegion::Cds | boundary::AxisRegion::ThreeUtr
+            )
+        {
+            boundaries = Boundaries::new(exon_only.left, boundaries.right);
+        }
+
         // #918: a whole-CDS-spanning del/dup (5'UTR→3'UTR, carved out of the
         // #350 bail above) shuffles over the full contiguous spliced transcript
         // — its deleted block already crosses every internal CDS exon/intron

--- a/tests/it/issue_1426_five_prime_junction_insertion.rs
+++ b/tests/it/issue_1426_five_prime_junction_insertion.rs
@@ -1,0 +1,109 @@
+//! The 5' mirror of #1426: a 3'UTR insertion shifting toward the CDS must
+//! finish in one pass.
+//!
+//! ```text
+//! c.*1_*2insCTA  ->  c.18_*1insACT  ->  c.17_18insTAC
+//! ```
+//!
+//! The cause is not the 3' half's — that was the #918 relaxation asking an
+//! insertion for both its flanks. Here it is the axis clamp itself: its left
+//! bound is derived from the region the variant currently sits in, and for a
+//! zero-width insertion that region flips as the insertion moves, so the bound
+//! that stops one pass is one the next no longer reads.
+//!
+//! ```text
+//! c.*1_*2insCTA  tx=(19,20)  start_axis=ThreeUtr  clamped.left=18  -> stops at c.18_*1
+//! c.18_*1insACT  tx=(18,19)  start_axis=Cds       clamped.left=0   -> reaches c.17_18
+//! ```
+//!
+//! So the 5' shuffle already crossed `cds_end` before this fix — one base per
+//! pass. The fix makes it do so in one, which is why this is a defect rather
+//! than a policy change about whether it may cross at all.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// 20 bases, CDS `1..=18`; `c.18` is the last coding base, `c.*1` the first
+/// 3'UTR base. From the transcript-axis sweep corpus, where this was found.
+const CORE: &str = "TAATTTATTAATATATATAT";
+
+fn normalizer() -> Normalizer<impl ferro_hgvs::reference::ReferenceProvider> {
+    Normalizer::with_config(
+        SyntheticBuilder::cds(CORE, 1, 18, Strand::Plus).build(),
+        NormalizeConfig::default()
+            .with_direction(ShuffleDirection::FivePrime)
+            .allow_crossing_boundaries(),
+    )
+}
+
+fn normalize_twice(input: &str) -> (String, String) {
+    let once = normalize_once(input);
+    (once.clone(), normalize_once(&once))
+}
+
+fn normalize_once(input: &str) -> String {
+    normalizer()
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// The same input through `normalize_with_diagnostics`.
+///
+/// ferro has **two** public normalization exits and they are not the same code
+/// path: `normalize()` reaches `normalize_core_checked`, while
+/// `normalize_with_diagnostics` historically reached `normalize_core_canonical`
+/// directly and so returned results no oracle had inspected (#1382). A bound
+/// relaxation like this one has to hold on both, or the fix is real for one
+/// caller and absent for the other.
+///
+/// Mirrors `normalize_once_with_diagnostics` in
+/// `issue_1426_junction_insertion_settles_in_one_pass` — the 3' half of this
+/// same fix covers both exits, and the two arms should not differ in what they
+/// pin any more than they should differ in their predicate.
+fn normalize_once_with_diagnostics(input: &str) -> String {
+    normalizer()
+        .normalize_with_diagnostics(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .result
+        .to_string()
+}
+
+/// Both exits must agree, on the pinned answer and with each other.
+#[test]
+fn both_public_exits_settle_on_the_same_form() {
+    for input in ["NM_TEST.1:c.*1_*2insCTA", "NM_TEST.1:c.18_*1insACT"] {
+        let plain = normalize_once(input);
+        let with_diagnostics = normalize_once_with_diagnostics(input);
+        assert_eq!(
+            plain, with_diagnostics,
+            "`{input}` settles differently through the two public exits"
+        );
+        assert_eq!(
+            with_diagnostics, "NM_TEST.1:c.17_18insTAC",
+            "`{input}` must reach the 5'-most form through the diagnostics exit too"
+        );
+    }
+}
+
+/// The 3'UTR-resident insertion reaches its 5'-most position immediately.
+#[test]
+fn a_three_prime_utr_insertion_settles_in_one_pass() {
+    let (once, twice) = normalize_twice("NM_TEST.1:c.*1_*2insCTA");
+    assert_eq!(once, "NM_TEST.1:c.17_18insTAC");
+    assert_eq!(twice, once, "and is stable from there");
+}
+
+/// The intermediate the old code stopped on now settles to the same place.
+///
+/// Stated separately: a fix that merely made `c.18_*1insACT` stable would
+/// satisfy idempotency for that input while leaving the two entry points
+/// disagreeing about where the same edit belongs.
+#[test]
+fn the_junction_intermediate_reaches_the_same_answer() {
+    let (once, twice) = normalize_twice("NM_TEST.1:c.18_*1insACT");
+    assert_eq!(once, "NM_TEST.1:c.17_18insTAC");
+    assert_eq!(twice, once);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -202,6 +202,7 @@ mod issue_1389_codon_gate_emitted_window;
 mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_1416_cancelled_identity_beside_repeat;
+mod issue_1426_five_prime_junction_insertion;
 mod issue_1426_junction_insertion_settles_in_one_pass;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
The 5' mirror of #1426, and the other half of PR #1427. Closes #1426 together with that one.

```
c.*1_*2insCTA  ->  c.18_*1insACT  ->  c.17_18insTAC
```

## Root cause — different from the 3' half

#1427's half was the #918 relaxation asking an insertion for both its flanks. This one is the **axis clamp itself**. Its left bound comes from the region the variant currently sits in, and for a zero-width insertion that region flips as the insertion moves — so the bound that stops one pass is one the next never reads. Measured by instrumenting the bound:

```
c.*1_*2insCTA   tx=(19,20)  start_axis=ThreeUtr  clamped=(18,20)  -> stops at c.18_*1
c.18_*1insACT   tx=(18,19)  start_axis=Cds       clamped=(0,18)   -> reaches c.17_18
```

**This matters for how the change should be read.** I flagged on #1427 that a 5' fix might be a policy decision about whether the 5' shuffle may cross `cds_end` at all. Having measured it: it already crosses — *one base per pass*, taking as many passes as the distance. So this is a defect in how far a single pass goes, not a new permission.

The fix relaxes the left bound to the exon bound for a zero-width insertion, mirroring the 3' arm, and is scoped the same way for the same reason: an insertion covers no reference base, so the axis clamp's purpose — never reinterpret a variant whose span straddles the boundary — has nothing to bite on. A `del`/`dup`/`delins` keeps both bounds; for those the span is real and #350's bail is what protects it.

## Verification

Full suite green under all three oracles: **9330 passed**. `fmt`/`clippy` clean.

## Representation stability

Dumped normalized output over 7,296 corpus rows on `main` and on this branch:

| | rows |
|---|---|
| total | 7,296 |
| **moved** | **19 (0.26%)** |

All 19 are one shape in one direction:

```
[5'] c.*1_*2insCT :  c.*1_*2dup  ->  c.18_*1dup
```

An insertion input that canonicalises to a duplication, now 5'-shifted one base further, onto the junction. Spanning duplications are the spec-canonical form (#401) and stay duplications; what moves is only how far 5' the 5' direction takes them, which is the thing this PR fixes.

Note this is the **5' direction only** — ferro's optional direction, not the HGVS-mandated 3' rule — so a consumer on the default 3' shuffle sees none of it. Same caveats as before: `main`-to-branch rather than release-to-release (the harness postdates v0.12.0), and 7,296 rows over these shape families is an order of magnitude, not a bound.

## It still does not un-ignore #1400's sweep — a fifth defect

I ran the full-corpus transcript sweep with **all four** fixes applied (#1417, #1425, #1427, this) and the oracles set as CI sets them. It still fires:

```
left:  c.*1_*2insCTA
right: c.17_18insTAC
```

With this PR, normalizing `c.*1_*2insCTA` gives `c.17_18insTAC` in one pass — so the *first* normalize is producing `c.*1_*2insCTA` from somewhere that never runs this shuffle. That points at the sequence-first derivation emitting a member the per-member pipeline would have shifted, which is the same family as #1398: derivation and per-member pipeline disagreeing, with nothing re-running the latter over the former's output.

Filed as #1429. That makes five distinct defects behind #1400's one `#[ignore]`, each of which was masking the next.


## Rebased onto #1425 + #1427, and the two arms now share one predicate

Rebased onto `main` at `b57f31cf` (so #1417, #1425 and #1427 are all in the base now). Re-verified on that base: **9348 passed** under all three oracles, `fmt`/`clippy` clean.

**One change from review.** This PR originally introduced its own binding:

```rust
let is_zero_width_insertion_5p =
    matches!(edit, NaEdit::Insertion { .. }) && tx_end == tx_start + 1;
```

which is character-for-character the same condition as `is_zero_width_insertion`, already in scope ~170 lines up and now used by the 3' arm that #1427 merged. #1427's own comment asks for exactly this not to happen:

> This is the same predicate the 5' mirror below uses, and the two arms should not disagree about what counts as an insertion for this purpose.

Two equal bindings are how that promise gets broken later — a narrowing applied to one arm would leave the other admitting a malformed `c.10_20insA` on the strength of its edit kind alone. Now reuses the shared binding, with a comment saying why.

## Caveat on the stability numbers above

The 7,296-row measurement was taken before this rebase, against a `main` that did not yet contain #1425 or #1427. The 19 moved rows are **5'-direction only**, on the `c.*1_*2insCT -> dup` shape; #1427's 57 moved rows are **3'-direction only**; #1425's movement was the `CORE_SIBLING` re-bless. So the sets are expected to stay disjoint and the number to hold — but that is reasoning, not a re-measurement, and it should be read as such.

The dump-diff harness these measurements come from is not committed anywhere, which is why re-running it is not a one-liner. It is the same harness the retrospective v0.13.0 representation summary needs, so it is worth building once as a checked-in tool rather than re-deriving ad hoc per PR.


## CLI-lens findings

Two, both asking for the same thing, and it was right.

**Applied — the 5' arm only covered one of ferro's two public normalization exits.** The 3' half of this fix (#1427) pins both, with a helper whose docstring explains why: `normalize_with_diagnostics` historically reached `normalize_core_canonical` directly and returned results no oracle had inspected (#1382). This file tested `normalize()` only. Added `normalize_once_with_diagnostics` and `both_public_exits_settle_on_the_same_form`, mirroring the sibling file — the same "the two arms should not differ" argument as the predicate fix above, applied to what they pin rather than to what they compute.

**Confirmed the new guard can fail.** With the 5' relaxation disabled (`if false && …`), it goes red:

```
FAIL both_public_exits_settle_on_the_same_form
FAIL a_three_prime_utr_insertion_settles_in_one_pass
PASS the_junction_intermediate_reaches_the_same_answer
```

That third one passing without the fix is expected and is what the table above predicts: `c.18_*1insACT` already reads `start_axis=Cds` with `clamped.left=0`, so it never needed the relaxation. It is a stability guard, not a fix guard, and the file says so.

**Declined — extending to the `VariantProjector` paths.** All three oracles run from `assert_seam_oracles` at the single exit of `normalize_core_checked`, which every projector path reaches; since #1382 that is one call site, so a projector assertion here would re-run the same check rather than cover new ground. The diagnostics exit is different in kind — it is the one with a documented history of bypassing that seam, which is why it earns a pin and the projector paths do not.

**Also noted:** the finding described the regression test as untracked. It is tracked (`git ls-files` matches it) — the CLI cache is computed against a wider base, the usual base-sensitivity.

Re-verified after both changes: **9349 passed** under all three oracles, `fmt`/`clippy` clean.
