### PR TITLE
fix(normalize): shift derived pieces in the direction that was requested

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2052,6 +2052,7 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     variants: &[HgvsVariant],
     phase: AllelePhase,
     provider: &P,
+    direction: ShuffleDirection,
 ) -> Option<Vec<HgvsVariant>> {
     if variants.is_empty() || (variants.len() > 1 && phase != AllelePhase::Cis) {
         return None;
@@ -2223,7 +2224,7 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         piece.ref_start += lo;
         piece.ref_end += lo;
     }
-    shift_pieces_three_prime(&mut pieces, &ref_bytes);
+    shift_pieces(&mut pieces, &ref_bytes, direction);
     coalesce_adjacent_pieces(&mut pieces);
     // Partitioning decides where the members are; this decides how wide each
     // one is spelled, and the two are not the same question — see
@@ -4278,7 +4279,8 @@ fn pieces_from_columns(columns: &[Column], reference: &[u8], result: &[u8]) -> V
     pieces
 }
 
-/// 3'-shift each length-changing piece, clamped so it cannot reach a sibling.
+/// Shift each length-changing piece in `direction`, clamped so it cannot reach
+/// a sibling.
 ///
 /// The clamp is the #1234 fix. The 3' rule (`general.md:41`) is stated per
 /// description with no allele-awareness, and the only text that ever addressed
@@ -4286,7 +4288,21 @@ fn pieces_from_columns(columns: &[Column], reference: &[u8], result: &[u8]) -> V
 /// deletion shifts over a downstream substitution and the two members overlap —
 /// malformed, and denoting a different sequence. Substitutions are anchored and
 /// never shift.
-fn shift_pieces_three_prime(pieces: &mut [Piece], ref_bytes: &[u8]) {
+///
+/// **`direction` is a parameter, not a constant (#1429).** This was hardcoded to
+/// `ThreePrime`, and `canonicalize_from_sequence` never received the caller's
+/// direction at all — so under a 5' shuffle the derivation handed back a
+/// *3'-shifted* allele, which the per-member pipeline then moved on the next
+/// pass:
+///
+/// ```text
+/// c.[16dup;18_19insC]  ->  c.*1_*2insCT  ->  c.18_*1insTC
+/// ```
+///
+/// Two passes, two directions. The 5' answer was also simply wrong on the first
+/// pass, independently of the idempotency: a caller asking for a 5' shuffle got
+/// a 3'-shifted merged allele.
+fn shift_pieces(pieces: &mut [Piece], ref_bytes: &[u8], direction: ShuffleDirection) {
     for i in 0..pieces.len() {
         if !pieces[i].is_pure_indel() {
             continue;
@@ -4302,7 +4318,7 @@ fn shift_pieces_three_prime(pieces: &mut [Piece], ref_bytes: &[u8]) {
             pieces[i].ref_start as u64,
             pieces[i].ref_end as u64,
             &bounds,
-            ShuffleDirection::ThreePrime,
+            direction,
         );
         let old_start = pieces[i].ref_start;
         let new_start = shuffled.start as usize;
@@ -4326,19 +4342,32 @@ fn shift_pieces_three_prime(pieces: &mut [Piece], ref_bytes: &[u8]) {
         // This is the hazard the per-member pipeline documents inside
         // `Normalizer::normalize_na_edit` (the #1157 follow-up).
         if !pieces[i].alt.is_empty() {
-            // A 3'-shuffle only ever advances: it initialises its cursor to
-            // `start` and mutates it solely via `new_start += 1`. Unlike the
-            // `mod.rs` precedent, which serves both directions and once
-            // regressed 5' insertions by clamping leftward moves with
-            // `saturating_sub`, this call site is `ThreePrime`-only, so a
-            // leftward move would be a bug in `shuffle`, not a case to handle.
-            debug_assert!(
-                new_start >= old_start,
-                "a 3'-shuffle cannot move a piece 5' (old={old_start}, new={new_start})",
-            );
-            let rotation = new_start.saturating_sub(old_start) % pieces[i].alt.len();
+            // Each direction moves the point only its own way — `shuffle`
+            // initialises its cursor to `start` and mutates it solely via
+            // `+= 1` or `-= 1` — so the two are asserted separately rather
+            // than with one `abs`, which would mask a `shuffle` that moved a
+            // piece the wrong way.
+            match direction {
+                ShuffleDirection::ThreePrime => debug_assert!(
+                    new_start >= old_start,
+                    "a 3'-shuffle cannot move a piece 5' (old={old_start}, new={new_start})",
+                ),
+                ShuffleDirection::FivePrime => debug_assert!(
+                    new_start <= old_start,
+                    "a 5'-shuffle cannot move a piece 3' (old={old_start}, new={new_start})",
+                ),
+            }
+            let distance = new_start.abs_diff(old_start);
+            let rotation = distance % pieces[i].alt.len();
             if rotation > 0 {
-                pieces[i].alt.rotate_left(rotation);
+                // Mirror images. Moving the point 3' by `k` rotates the payload
+                // left by `k`; moving it 5' by `k` rotates it right by the same
+                // `k`, because the payload's phase against the reference is what
+                // the rotation tracks and the point moved the other way.
+                match direction {
+                    ShuffleDirection::ThreePrime => pieces[i].alt.rotate_left(rotation),
+                    ShuffleDirection::FivePrime => pieces[i].alt.rotate_right(rotation),
+                }
             }
         }
     }
@@ -4600,7 +4629,7 @@ fn rebuild_members(
     // Window offset one past the last reference base the *previous* piece
     // claimed, for `duplication_anchor`'s disjointness check. `0` before the
     // first piece. Correct because `pieces` is in ascending offset order —
-    // `partition_block` builds it that way and neither `shift_pieces_three_prime`
+    // `partition_block` builds it that way and neither `shift_pieces`
     // nor `coalesce_adjacent_pieces` reorders — which the assertion below pins
     // rather than assumes, since a silent reordering would turn the check into a
     // no-op instead of a failure.
@@ -9222,13 +9251,13 @@ mod tests {
                     };
 
                     let mut shift_first = pieces.clone();
-                    shift_pieces_three_prime(&mut shift_first, block);
+                    shift_pieces(&mut shift_first, block, ShuffleDirection::ThreePrime);
                     coalesce_adjacent_pieces(&mut shift_first);
                     shrink_pieces_to_differences(&mut shift_first, block);
 
                     let mut shrink_first = pieces.clone();
                     shrink_pieces_to_differences(&mut shrink_first, block);
-                    shift_pieces_three_prime(&mut shrink_first, block);
+                    shift_pieces(&mut shrink_first, block, ShuffleDirection::ThreePrime);
                     coalesce_adjacent_pieces(&mut shrink_first);
 
                     assert_eq!(

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2034,7 +2034,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `phase` is `Cis` on both arms — the allele arm refuses anything else
         // above — and `uncertain` is likewise always false, which is exactly what
         // `AlleleVariant::new` builds.
-        let rebuilt = merge::canonicalize_from_sequence(members, AllelePhase::Cis, &self.provider)?;
+        let rebuilt = merge::canonicalize_from_sequence(
+            members,
+            AllelePhase::Cis,
+            &self.provider,
+            self.config.shuffle_direction,
+        )?;
         match rebuilt.len() {
             0 => None,
             1 => rebuilt.into_iter().next(),

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -874,30 +874,47 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
 /// boundary behaviour has its own dedicated tests and would only add noise to a
 /// smoke slice.
 ///
-/// # `#[ignore]`d pending #1398, which this sweep found
+/// # No longer `#[ignore]`d — it took five fixes to get here
 ///
-/// It passes at the default 4-seed prefix and **fails at the full corpus**, on a
-/// real defect rather than on anything about the sweep: `c.[11_12dup;16_17insC]`
-/// over `TAAATAATAAATATATATTA` normalizes to `c.18_*1insCAT`, an insertion across
-/// the CDS/3'UTR boundary, and re-normalizing that does not return it
-/// (`c.18delinsTCAT` under 3', `c.16_17insATC` under 5'). That trips
-/// `FERRO_ASSERT_IDEMPOTENT` as a panic, so the sweep cannot merely count it the
-/// way `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` counts its class.
+/// It was committed `#[ignore]`d rather than narrowed, deliberately: trimming the
+/// position range until the boundary shape was unreachable would have been the
+/// exact move #1283 exists to complain about — a generator that reads wider than
+/// it is — and the gap it closes was worth the wait. What it found, in the order
+/// each was unmasked by the one before it:
 ///
-/// Committed `#[ignore]`d rather than narrowed, deliberately. Trimming the
-/// position range until the boundary shape is unreachable would be the exact
-/// move #1283 exists to complain about — a generator that reads wider than it is
-/// — and the gap it closes is worth more than the few days it spends ignored.
-/// Un-ignore it when #1398 lands; it is already green on everything else.
+/// 1. **#1398** (#1417) — the original fire. `c.[11_12dup;16_17insC]` over
+///    `TAAATAATAAATATATATTA` normalized to `c.18_*1insCAT`, an insertion across
+///    the CDS/3'UTR boundary, and re-normalizing that did not return it
+///    (`c.18delinsTCAT` under 3', `c.16_17insATC` under 5').
+/// 2. **#1418** (#1425) — a sibling-crossing shift unbounded across a region
+///    boundary.
+/// 3. **#1426, 3' half** (#1427) — a junction insertion needing two passes to
+///    finish its shift.
+/// 4. **#1426, 5' half** (#1428) — the same defect arriving from the other side,
+///    via the axis clamp rather than the #918 relaxation.
+/// 5. **#1429** (this PR) — the sequence-first derivation shifting 3' whatever
+///    direction was asked for.
 ///
-/// Run it with:
+/// Each was a genuine defect, and each was invisible until its predecessor was
+/// fixed. That is the argument for committing a sweep `#[ignore]`d instead of
+/// narrowing it: a narrowed generator would have found none of the five.
+///
+/// It runs in the `sweeps` job only — `cis_junction_crossing_shift` is inside
+/// `SWEEP_FILTER`, which `test` and `test-oracle` negate — so it is exercised at
+/// the full corpus with the oracles set, which is the configuration that found
+/// all five. Measured at 280s for 829,440 cases.
+///
+/// Run it locally in the configuration `sweeps` uses — the oracles are not
+/// optional here, since four of the five defects above were *reported* by
+/// `FERRO_ASSERT_IDEMPOTENT` rather than by this sweep's own sequence comparison:
 ///
 /// ```text
-/// FERRO_SWEEP_SEEDS=full cargo nextest run --features dev \
-///   -E 'test(no_two_member_transcript_axis_allele)' --run-ignored all
+/// FERRO_SWEEP_SEEDS=full \
+///   FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
+///   cargo nextest run --features dev \
+///   -E 'test(no_two_member_transcript_axis_allele)'
 /// ```
 #[test]
-#[ignore = "finds #1398 at the full corpus; un-ignore when that lands"]
 fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
     use crate::common::cis_apply_oracle::apply_with;
     use crate::common::synthetic::SyntheticBuilder;

--- a/tests/it/issue_1429_derivation_honours_shuffle_direction.rs
+++ b/tests/it/issue_1429_derivation_honours_shuffle_direction.rs
@@ -1,0 +1,82 @@
+//! The sequence-first derivation must shift its pieces in the **configured**
+//! direction (#1429).
+//!
+//! `canonicalize_from_sequence` never received the caller's shuffle direction,
+//! and its piece shift was hardcoded to `ThreePrime`. A caller asking for a 5'
+//! shuffle therefore got a *3'-shifted* merged allele, which the per-member
+//! pipeline then moved on the next pass:
+//!
+//! ```text
+//! c.[16dup;18_19insC]  ->  c.*1_*2insCT  ->  c.18_*1insTC
+//! ```
+//!
+//! Two things were wrong there and the idempotency failure is the lesser one:
+//! the first-pass answer was simply not the 5' answer. So these tests assert the
+//! *value*, not merely that it is a fixed point — a derivation that stably
+//! returned the 3' form would satisfy idempotency while still ignoring the
+//! direction it was asked for.
+//!
+//! Found by the transcript-axis sweep (#1400), the fifth distinct defect behind
+//! its single `#[ignore]`.
+//!
+//! The case below is deliberately **not** the one from the sweep. That input
+//! lands on the CDS/3'UTR junction, so its idempotency also depends on #1427 and
+//! #1428 (the two halves of #1426) and a guard here would be red for reasons
+//! that are not this change. This one sits nine bases inside the CDS, where the
+//! only thing deciding the answer is which way the derivation shifts. Verified
+//! end-to-end separately: with all five fixes applied the full 829,440-case
+//! transcript sweep passes under all three oracles.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// 20 bases, CDS `1..=18`. The nine-`T` run at the 5' end is the tract the
+/// merged duplication travels, and it is long enough that the two directions
+/// land seven bases apart — far too much to read as a rounding difference.
+const CORE: &str = "TTTTTTTTTAATATATTTTA";
+
+fn normalize_once(input: &str, dir: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        SyntheticBuilder::cds(CORE, 1, 18, Strand::Plus).build(),
+        NormalizeConfig::default()
+            .with_direction(dir)
+            .allow_crossing_boundaries(),
+    );
+    normalizer
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// A 5' request produces the 5'-most merged form.
+///
+/// Before the fix this returned `c.8_9dup` — the 3' answer — because the
+/// derivation shifted its pieces 3' whatever it was asked for.
+#[test]
+fn a_five_prime_request_gets_the_five_prime_merged_form() {
+    let once = normalize_once("NM_TEST.1:c.[1dup;2dup]", ShuffleDirection::FivePrime);
+    assert_eq!(once, "NM_TEST.1:c.1_2dup");
+    assert_eq!(
+        normalize_once(&once, ShuffleDirection::FivePrime),
+        once,
+        "and is stable there"
+    );
+}
+
+/// The 3' direction is unchanged: it passed `ThreePrime` before and still does.
+///
+/// Pinned so the new parameter cannot be threaded through backwards — an
+/// inversion would swap these two answers and nothing else in the suite would
+/// notice.
+#[test]
+fn a_three_prime_request_is_unaffected() {
+    let once = normalize_once("NM_TEST.1:c.[1dup;2dup]", ShuffleDirection::ThreePrime);
+    assert_eq!(once, "NM_TEST.1:c.8_9dup");
+    assert_eq!(
+        normalize_once(&once, ShuffleDirection::ThreePrime),
+        once,
+        "and is stable there"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -204,6 +204,7 @@ mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_1416_cancelled_identity_beside_repeat;
 mod issue_1426_five_prime_junction_insertion;
 mod issue_1426_junction_insertion_settles_in_one_pass;
+mod issue_1429_derivation_honours_shuffle_direction;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1429. **This is the last of the five defects behind #1400's `#[ignore]`** — see the ladder at the bottom.

## Root cause

`canonicalize_from_sequence` never received the caller's shuffle direction, and its piece shift hardcoded it:

```rust
fn shift_pieces_three_prime(pieces: &mut [Piece], ref_bytes: &[u8]) { …
    shuffle(…, ShuffleDirection::ThreePrime);
```

So the sequence-first derivation shifted 3' whatever was asked for, and a 5' request got a 3'-shifted merged allele:

```
c.[1dup;2dup]  [5']  ->  c.8_9dup      <- the 3' answer, seven bases away
```

The per-member pipeline then moved it on the next pass, which is how it surfaced — as the sweep's non-idempotency `c.[16dup;18_19insC] -> c.*1_*2insCT -> c.18_*1insTC`.

**The idempotency failure is the lesser half.** The first-pass answer was simply not the answer the caller asked for; a derivation that *stably* returned the 3' form under a 5' request would be equally wrong and pass every idempotency check. That is why the tests assert the value, not just the fixed point.

The fix threads the direction through and renames the function. The payload rotation mirrors — moving an insertion point 3' by `k` rotates the payload left by `k`, moving it 5' by `k` rotates it right by the same `k`, since the rotation tracks phase against the reference and the point moved the other way. Debug assertions stay per-direction rather than collapsing to one `abs`, so a `shuffle` that moved a piece the wrong way is still caught.

## Verification

Full suite green under all three oracles on this branch alone: **9338 passed**. `fmt`/`clippy` clean.

The regression test deliberately uses `c.[1dup;2dup]`, nine bases inside the CDS, **not** the sweep's input. The sweep case lands on the CDS/3'UTR junction, so its idempotency also depends on #1427 and #1428, and a guard here would go red for reasons that are not this change. The chosen case is decided purely by which way the derivation shifts, and the two directions land seven bases apart.

## Representation stability

Dumped normalized output over 24,208 corpus rows on `main` and on this branch:

| | rows |
|---|---|
| total | 24,208 |
| **moved** | **99 (0.41%)** |
| moved under the default 3' direction | **0** |

All 99 are 5'-direction only — the default 3' shuffle is byte-identical, because it passed `ThreePrime` before and still does. Movement is of the form:

```
[5'] c.[1dup;16dup] :  c.[1dup;*1dup]  ->  c.[1dup;16dup]
```

The member moves *out of the 3'UTR back into the CDS* — i.e. it is now genuinely 5'-shifted rather than 3'-shifted. Every one of the 99 is a case that was previously answering a 5' request with a 3' answer, so this is the bugfix direction rather than churn: nobody asking for a 5' shuffle was getting a form worth preserving.

Same standing caveats: `main`-to-branch, not release-to-release (the harness postdates v0.12.0); 24,208 rows over these shape families is an order of magnitude, not a bound.

## The ladder — #1400's sweep now passes

Measured at `FERRO_SWEEP_SEEDS=full` with all three oracles, adding one fix at a time:

| state | no oracles | with oracles |
|---|---|---|
| `main` | FAIL — 32 sequence-changing | FAIL — #1398 |
| + #1425 | **PASS** | FAIL — #1398 |
| + #1417 | PASS | FAIL — #1426 3' |
| + #1427 | PASS | FAIL — #1426 5' |
| + #1428 | PASS | FAIL — #1429 |
| **+ this** | **PASS** | **PASS** |

829,440 cases, 338s. So once #1417, #1425, #1427, #1428 and this are all in, the `#[ignore]` on `no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence` can come off — its comment still names only #1398 and should be deleted with it.

**One cost to flag before that happens:** at the full corpus this sweep takes **338s**, and CI's `sweeps` job is already the slowest in the matrix. Un-ignoring adds that. Worth deciding whether it belongs in `sweeps` as-is or wants its own seed profile.


## This PR now removes the `#[ignore]` — the ladder is complete

Rebased onto `main` at `bf4b983a`, so #1417, #1425, #1427 and #1428 are all in the base. With this fix on top, #1400's sweep **passes at the full corpus with all three oracles**:

```
FERRO_SWEEP_SEEDS=full FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  cargo nextest run --features dev -E 'test(no_two_member_transcript_axis_allele)'

PASS [ 279.850s] no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence
```

**So the `#[ignore]` comes off here.** That was worth catching: five PRs each said "the ignore stays until the next fix lands," and this one — the fifth and last — did not remove it either. Left as it was, an **829,440-case guard** would have stayed dark after every defect behind it was fixed, which is the failure mode where lost coverage looks exactly like a pass.

The stale rationale is rewritten to record the ladder rather than name #1398 as a pending blocker: #1398 (#1417) → #1418 (#1425) → #1426 3' (#1427) → #1426 5' (#1428) → #1429 (this). Each was invisible until its predecessor was fixed, which is the case for having committed the sweep `#[ignore]`d instead of narrowing its position range.

### Where it runs, and what that costs

`cis_junction_crossing_shift` is inside `SWEEP_FILTER`, which `test` and `test-oracle` **negate** and `sweeps` selects **on**. So un-ignoring adds it to the `sweeps` job at the full corpus (~280s) and to a local `cargo nextest run` at the 4-seed prefix; it does not widen the sharded test jobs.

Checked the partition invariant `ci.yml` asks for — "the absolute counts drift as tests are added, the sum must not":

| selection | count |
|---|---|
| `not test(proptest)` | 5350 |
| `and not (SWEEP_FILTER)` | 5310 |
| `SWEEP_FILTER` alone | 40 |

5310 + 40 == 5350, so nothing falls between the jobs and nothing runs twice. (The absolutes differ from the comment's 8908/8878/30 — drift, exactly as it anticipates. Removing `#[ignore]` does not move them at all, since an ignored test is still listed.)

### Verification

Suite **9352 passed** under all three oracles on the rebased base — with `skipped` down 147 → 146, which is the un-ignored test now running. `fmt`/`clippy` clean.
