### PR TITLE
docs: describe batch workloads generically in binding and test comments

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -2012,7 +2012,7 @@ impl PyVariantProjector {
     /// Equivalent to `[self.project_all(s) for s in hgvs_strings]`, but takes a
     /// single Python→Rust call, releases the GIL for the entire batch, and
     /// reuses the projector's internal transcript / ref-protein caches across
-    /// all inputs. Fast path for SatMut-style fan-out workloads.
+    /// all inputs. Fast path for high-throughput fan-out workloads.
     ///
     /// Args:
     ///     hgvs_strings: List of g. HGVS variant strings.

--- a/tests/it/issue_1235_cis_allele_confluence.rs
+++ b/tests/it/issue_1235_cis_allele_confluence.rs
@@ -200,7 +200,7 @@ fn soft_masked_reference_yields_the_same_canonical_form() {
 }
 
 /// #1233 — `[ins;del]` reduces to substitutions. Highest-frequency shape in the
-/// reporter's saturation-mutagenesis counting run.
+/// reporter's variant-counting run.
 #[test]
 fn issue_1233_ins_del_reduces_to_substitutions() {
     converges_to(

--- a/tests/python/test_issue_1035_convert_gff_binding.py
+++ b/tests/python/test_issue_1035_convert_gff_binding.py
@@ -4,7 +4,7 @@
 
 A synthetic/local reference (own GFF3 + FASTA) can be built and normalized
 entirely in-process via the PyPI wheel — no shelling out to the `ferro` CLI.
-This exercises the exact Python surface a saturation-mutagenesis pipeline uses.
+This exercises the exact Python surface a high-throughput variant pipeline uses.
 """
 
 import json


### PR DESCRIPTION
Three comments described a specific external workload by name. Describe the workload shape instead — what the code does is unchanged.

- `src/python.rs` — `project_all_many` docstring (this one ships as a runtime Python `__doc__` string in the wheel)
- `tests/it/issue_1235_cis_allele_confluence.rs` — `#1233` test comment
- `tests/python/test_issue_1035_convert_gff_binding.py` — module docstring

Comment text only; no behavior, API or test changes.