### PR TITLE
fix(normalize): order a conflicting cis allele whose members were rewritten

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3114,9 +3114,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // accession-string sort is not it — so those are left in authored order.
         //
         // Skip when the overlap passes above (`detect_insertion_overlaps`,
-        // `detect_overlap_conflicts`) flagged an `OverlapConflict`. Reordering is
-        // only meaning-preserving for *disjoint* members; a conflict means two
-        // members collide on one molecule, so they are NOT independent.
+        // `detect_overlap_conflicts`) flagged an `OverlapConflict` **and** the
+        // allele really was handed back untouched. Reordering is only
+        // meaning-preserving for *disjoint* members; a conflict means two members
+        // collide on one molecule, so they are NOT independent.
         // `merge_consecutive_edits` collapses strictly-adjacent members but does
         // not resolve a genuine overlap — that is exactly what those passes warn
         // about — so overlapping members can reach here. Leaving them in authored
@@ -3127,10 +3128,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // (`[(a;b)]`) are left untouched to preserve their authored form.
         // `sort_by` (not `sort_unstable_by`) is a belt-and-suspenders choice — the
         // key is already total, so stability is not relied upon.
+        //
+        // **The conflict alone does not earn the skip (#1414).** The reasoning
+        // above is a contract about output the pipeline did not touch, so it
+        // applies only when the output *is* untouched. A conflicting allele whose
+        // members were all rewritten has no verbatim form left to preserve, and
+        // skipping the sort for it produced two defects at once:
+        // out-of-genomic-order members — a direct violation of #1235's criterion
+        // 2 — and non-idempotence, since the rewritten output no longer conflicts
+        // and so takes the *other* branch of this gate on the second pass.
+        // Measured on `origin/main` at `94817bf6`, 41 inputs in four shape
+        // families reach it (`[inv;insAA]` 16, `[inv;insA]` 16, `[dup;inv]` 7,
+        // `[insA;inv]` 2); #1423 had
+        // repaired only the single example the issue cited, because it drops an
+        // identity a sibling *overlaps* and a zero-width junction insertion
+        // overlaps nothing.
+        //
+        // So the predicate is the conjunction, not the conflict alone: an
+        // allele emitted verbatim keeps its authored order, and everything else
+        // is sorted exactly as before.
         let has_overlap_conflict = all_warnings
             .iter()
             .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
-        if is_cis && !allele.uncertain && !has_overlap_conflict && normalized.len() > 1 {
+        let emitted_verbatim = normalized == allele.variants;
+        if is_cis
+            && !allele.uncertain
+            && !(has_overlap_conflict && emitted_verbatim)
+            && normalized.len() > 1
+        {
             sort_cis_members_by_genomic_order(&mut normalized);
         }
 

--- a/tests/it/issue_1235_transcript_axes.rs
+++ b/tests/it/issue_1235_transcript_axes.rs
@@ -322,27 +322,39 @@ fn overlap_conflicting_allele_is_not_canonicalized() {
     // collision repair rewrites it, in whichever member order it was authored.
     // Convergence is the point — one variant, one canonical string — and it is
     // reached in a single pass, so idempotency is preserved either way.
-    for (dup_spelling, converges_to) in [
-        (
-            "NM_TEST.1:c.[5_9inv;5_6dup]",
-            "NM_TEST.1:c.[5_9inv;6_7insAA]",
-        ),
-        (
-            "NM_TEST.1:c.[5_6dup;5_9inv]",
-            "NM_TEST.1:c.[6_7insAA;5_9inv]",
-        ),
-    ] {
+    //
+    // **Both authored orders now reach the same string (#1414).** They used to
+    // reach two, differing only in member order, because the genomic-order sort
+    // was skipped for any allele that reported an overlap conflict. That skip
+    // exists to honour #395's "preserve the input verbatim" contract, and the
+    // contract does not apply here: the collision repair rewrote the `dup` into
+    // an `ins`, so there is no authored form left to preserve. The sort is now
+    // skipped only when the allele really was handed back untouched, which is
+    // why this loop pins one target rather than two.
+    const CONVERGES_TO: &str = "NM_TEST.1:c.[5_9inv;6_7insAA]";
+    for dup_spelling in ["NM_TEST.1:c.[5_9inv;5_6dup]", "NM_TEST.1:c.[5_6dup;5_9inv]"] {
         assert_eq!(
             normalize_to_string(provider(), dup_spelling),
-            converges_to,
-            "a `dup` interior to an `inv` must settle on the `ins` spelling of the same conflict"
-        );
-        assert_eq!(
-            normalize_to_string(provider(), converges_to),
-            converges_to,
-            "and that settled spelling must be a fixed point"
+            CONVERGES_TO,
+            "a `dup` interior to an `inv` must settle on the `ins` spelling of the same \
+             conflict, in genomic order whichever order it was authored in"
         );
     }
+    assert_eq!(
+        normalize_to_string(provider(), CONVERGES_TO),
+        CONVERGES_TO,
+        "and that settled spelling must be a fixed point"
+    );
+    // The reversed-order `ins` spelling remains a fixed point of its own: it is
+    // authored exactly as its members settle, so it *is* returned verbatim and
+    // #395's contract genuinely applies. Whether a conflicting allele should be
+    // preserved that faithfully is #1406's question, not this one — recorded
+    // here so the residual is visible rather than mistaken for convergence.
+    assert_eq!(
+        normalize_to_string(provider(), "NM_TEST.1:c.[6_7insAA;5_9inv]"),
+        "NM_TEST.1:c.[6_7insAA;5_9inv]",
+        "an allele authored exactly as it settles is still returned verbatim"
+    );
 
     // Both spellings are recognised as the same conflict by strict mode, and
     // the authored member order survives in each.

--- a/tests/it/issue_1414_conflicting_allele_member_order.rs
+++ b/tests/it/issue_1414_conflicting_allele_member_order.rs
@@ -1,0 +1,223 @@
+//! #1414 — a conflicting cis allele skipped the genomic-order sort even when
+//! every one of its members had been rewritten.
+//!
+//! `normalize_allele` gated the sort on whether an `OverlapConflict` was
+//! reported. The skip itself is right and long-standing: an overlap-conflicting
+//! allele is emitted **verbatim** (#395), and reordering an allele you are
+//! handing back untouched would contradict that.
+//!
+//! The premise is what failed. *Conflict was reported* and *allele was emitted
+//! verbatim* are different predicates, and they come apart exactly when the
+//! repair passes succeed: `11_12inv` cancels to `11_12=` because the span is its
+//! own reverse complement, `11_12insAA` respells as `10_11A[4]`, and the
+//! pipeline then declines to order the two on the strength of a contract about
+//! *not* rewriting them.
+//!
+//! Two defects followed, and the first is the more serious:
+//!
+//! 1. **Out-of-genomic-order members** — a direct violation of #1235's
+//!    criterion 2 ("no normalized cis allele contains overlapping or
+//!    out-of-order members"), on a shape its confluence proptest cannot
+//!    generate (its indel model draws no inversion beside a co-located
+//!    insertion).
+//! 2. **Non-idempotence**, for the subset whose reordered output no longer
+//!    conflicts: pass 2 then takes the *other* branch of the same gate and
+//!    sorts. `FERRO_ASSERT_IDEMPOTENT` fires on those.
+//!
+//! **#1423 is not this fix, and did not make this unreachable.** It repaired the
+//! single input the issue cited (`g.[11_12inv;11_12insAA]`, now the single
+//! member `g.10_11A[4]`) by dropping an identity a sibling *overlaps* — and a
+//! zero-width junction insertion overlaps nothing, so the whole `[inv;ins]`
+//! family survived it. Measured on `origin/main` at `94817bf6` over four
+//! sequences and eleven member shapes: **41** inputs in four families still
+//! reached the divergence.
+//!
+//! The gate now asks the question the contract is actually about — was this
+//! allele handed back untouched? — so an allele whose members were rewritten is
+//! ordered like any other, and one authored exactly as it settles is not.
+
+use crate::common::cis_apply_oracle::{normalize, normalize_in};
+use ferro_hgvs::ShuffleDirection;
+
+/// The `A`/`T` corpus sequence the sweep draws, where the `[inv;ins]` and
+/// `[dup;inv]` families both settle out of order on `main`.
+const AT_SEQUENCE: &str = "TTTTTTTTTAATATATTTTA";
+
+/// The issue's own reference: 18 bases, `10` and `11` are `A`, `12` is `T`.
+const CG_SEQUENCE: &str = "CGCGCGCGCAATCGCGCG";
+
+/// The headline: a rewritten conflicting allele comes back in genomic order.
+///
+/// **Rewritten, not necessarily wholly rewritten.** In both rows below the
+/// inversion survives *as an inversion* and only its sibling moves — the
+/// duplication respells as an insertion at its own junction, the insertion
+/// 3'-shifts within the inverted span. That is enough: the trigger is that the
+/// allele was not emitted verbatim, so there is no authored form left for #395
+/// to preserve, and one moved member is as disqualifying as all of them.
+///
+/// (An earlier revision of this comment said "every member here is rewritten —
+/// the inversion cancels to an identity". That described the rows this test
+/// carried before #1445, which are now preserved rather than repaired and have
+/// moved to `issue_1406_lenient_output_keeps_the_conflict`.)
+///
+/// Pinned as exact strings rather than checked for orderedness. A "members are
+/// sorted" predicate is satisfied by a refusal, by a dropped member, and by any
+/// other ordered spelling; what must come back is these members, in this order.
+///
+/// **Re-blessed against #1406/#1445.** Two of the rows this test originally
+/// carried — `g.[9_10insA;9_10inv]` and `g.[11_12dup;12_13inv]` — are no longer
+/// rewritten at all. #1445 hands a laundered conflict back as authored, because
+/// the independent applier declines such an input (`ApplyFailure::Overlapping`)
+/// and so there is no denoted sequence for a repair to preserve. They are
+/// therefore not examples of "a rewritten conflicting allele" any more, and
+/// `issue_1406_lenient_output_keeps_the_conflict` is where they are now pinned.
+///
+/// What still reaches this gate is an allele whose members are rewritten and
+/// which **still conflicts afterwards**, so #1445's restore does not fire. Both
+/// rows below are that shape, and the gate is load-bearing for them: measured by
+/// reverting it to `!has_overlap_conflict` on top of #1445, this test and
+/// `issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized`
+/// both fail.
+#[test]
+fn a_rewritten_conflicting_allele_is_returned_in_genomic_order() {
+    for (input, expected) in [
+        // `[inv;dup]` — the duplication respells as an insertion at its own
+        // junction; the inversion survives as an inversion.
+        (
+            "TEMPLATE:g.[11_13inv;11dup]",
+            "TEMPLATE:g.[11_12insA;11_13inv]",
+        ),
+        // `[ins;inv]` where the insertion 3'-shifts inside the inversion's span
+        // rather than out of it, so the pair still conflicts and is still
+        // ordered by this gate.
+        (
+            "TEMPLATE:g.[12_13insA;12_14inv]",
+            "TEMPLATE:g.[12_14inv;13_14insA]",
+        ),
+    ] {
+        assert_eq!(
+            normalize(AT_SEQUENCE, input),
+            expected,
+            "`{input}` rewrote every member, so the genomic-order sort must run"
+        );
+    }
+}
+
+/// …and the same on the 5' axis, which carries the larger share of the moved
+/// rows (1178 of 2037 measured). The gate is direction-agnostic, so a fix that
+/// only reached the default direction would be half a fix.
+#[test]
+fn the_five_prime_axis_gets_the_same_answer() {
+    let input = "TEMPLATE:g.[10_11inv;10dup]";
+    let five = normalize_in(AT_SEQUENCE, input, ShuffleDirection::FivePrime);
+    assert_eq!(
+        five, "TEMPLATE:g.[10_11insA;10_11inv]",
+        "the 5' axis must order a rewritten conflicting allele too"
+    );
+    assert_eq!(
+        five,
+        normalize_in(AT_SEQUENCE, &five, ShuffleDirection::FivePrime),
+        "the 5' answer must be a fixed point too"
+    );
+}
+
+/// The idempotency half, on the subset where the reordered output no longer
+/// conflicts — the shape that fires `FERRO_ASSERT_IDEMPOTENT`.
+///
+/// 209 of the 2037 moved rows were non-idempotent on `main` this way; the rest
+/// were stable but out of order. Both are criterion-2 violations, and this pins
+/// the one that is also a live oracle failure.
+#[test]
+fn the_rewritten_output_is_a_fixed_point_in_one_pass() {
+    // The same two rows the headline test uses, and for the same reason: since
+    // #1445 the inputs this test originally named are handed back as authored,
+    // so they are fixed points trivially and would no longer exercise the
+    // second-pass branch this test exists to reach.
+    for input in [
+        "TEMPLATE:g.[11_13inv;11dup]",
+        "TEMPLATE:g.[12_13insA;12_14inv]",
+    ] {
+        let once = normalize(AT_SEQUENCE, input);
+        let twice = normalize(AT_SEQUENCE, &once);
+        assert_eq!(
+            once, twice,
+            "`{input}` must settle in one pass; got `{once}` then `{twice}`"
+        );
+    }
+}
+
+/// The contract the gate exists to honour is unchanged: an allele authored
+/// exactly as its members settle is still handed back verbatim, in its authored
+/// order, however un-genomic that order is.
+///
+/// This is the discriminating half of the fix. Replacing the conflict test with
+/// an unconditional sort would pass every assertion above and break #395 here.
+#[test]
+fn an_allele_emitted_verbatim_keeps_its_authored_order() {
+    // `main`'s own out-of-order output for `g.[12_13insA;12_14inv]`. Both
+    // members are already settled — the insertion sits at its 3'-most junction,
+    // the inversion at its own span — so nothing is rewritten and the verbatim
+    // contract genuinely applies, un-genomic order and all.
+    let verbatim = "TEMPLATE:g.[13_14insA;12_14inv]";
+    assert_eq!(
+        normalize(AT_SEQUENCE, verbatim),
+        verbatim,
+        "an allele whose members are already settled must be returned untouched"
+    );
+    // Deliberately the reverse of genomic order, and it must survive.
+    assert_ne!(
+        members_of(verbatim),
+        sorted_members_of(verbatim),
+        "the fixture must actually be out of genomic order, or it guards nothing"
+    );
+}
+
+/// #1423's own input stays fixed: the fix must not disturb a single-member
+/// output, which has no ordering question at all.
+#[test]
+fn the_single_member_output_of_1423_is_untouched() {
+    assert_eq!(
+        normalize(CG_SEQUENCE, "TEMPLATE:g.[11_12inv;11_12insAA]"),
+        "TEMPLATE:g.10_11A[4]",
+        "#1423's collapse to one member must survive this change"
+    );
+}
+
+/// A disjoint, non-conflicting allele is still sorted, as it was before. The
+/// gate's new term only ever *adds* sorting, and this pins that the ordinary
+/// path did not move.
+#[test]
+fn a_disjoint_allele_is_still_sorted() {
+    let out = normalize(CG_SEQUENCE, "TEMPLATE:g.[12T>G;10A>G]");
+    assert_eq!(
+        out, "TEMPLATE:g.[10A>G;12T>G]",
+        "a disjoint allele must still be rendered in genomic order"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// The member list of a bracketed allele, in the order it is rendered.
+fn members_of(description: &str) -> Vec<String> {
+    description
+        .rsplit_once('[')
+        .and_then(|(_, rest)| rest.strip_suffix(']'))
+        .map(|inner| inner.split(';').map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
+/// The same members in genomic order, by leading coordinate then by text.
+///
+/// A presentational sort for the assertions above, not a re-implementation of
+/// `cis_member_order_key` — the exact-string pins are what judge the order; this
+/// only has to be right enough to tell "ordered" from "reversed".
+fn sorted_members_of(description: &str) -> Vec<String> {
+    let mut members = members_of(description);
+    members.sort_by_key(|member| {
+        let digits: String = member.chars().take_while(|c| c.is_ascii_digit()).collect();
+        (digits.parse::<u32>().unwrap_or(u32::MAX), member.clone())
+    });
+    members
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -205,6 +205,7 @@ mod issue_1394_repeat_growth_swallows_deletion;
 mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
 mod issue_1406_lenient_output_keeps_the_conflict;
+mod issue_1414_conflicting_allele_member_order;
 mod issue_1416_cancelled_identity_beside_repeat;
 mod issue_1426_five_prime_junction_insertion;
 mod issue_1426_junction_insertion_settles_in_one_pass;


### PR DESCRIPTION
Closes #1414.

## The defect

`normalize_allele` skipped the genomic-order sort whenever an `OverlapConflict` was reported:

```rust
let has_overlap_conflict = all_warnings.iter()
    .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
if is_cis && !allele.uncertain && !has_overlap_conflict && normalized.len() > 1 {
```

The skip itself is right and long-standing: an overlap-conflicting allele is emitted **verbatim** (#395), and reordering an allele you are handing back untouched would contradict that. What fails is the premise. *Conflict was reported* and *allele was emitted verbatim* are different predicates, and they come apart exactly when the repair passes succeed — `11_12inv` cancels to `11_12=` because the span is its own reverse complement, `11_12insAA` respells as `10_11A[4]`, and the pipeline then declines to order the two on the strength of a contract about *not* rewriting them.

Two consequences, and the first is the more serious:

1. **Out-of-genomic-order members** — a direct violation of #1235's criterion 2, on a shape its confluence proptest cannot generate (the indel model draws no inversion beside a co-located insertion).
2. **Non-idempotence**, for the subset whose reordered output no longer conflicts: pass 2 takes the *other* branch of the same gate and sorts, so `FERRO_ASSERT_IDEMPOTENT` fires.

The gate now asks the question the contract is actually about:

```rust
let emitted_verbatim = normalized == allele.variants;
if is_cis && !allele.uncertain && !(has_overlap_conflict && emitted_verbatim) && normalized.len() > 1 {
```

## #1423 did not make this unreachable

#1423 repaired the single input the issue cited — `g.[11_12inv;11_12insAA]` is now the single member `g.10_11A[4]` — by dropping an identity a sibling *overlaps*. A zero-width junction insertion overlaps nothing, so the whole `[inv;ins]` family survived it untouched. Measured on `origin/main` at `94817bf6` over four sequences and eleven member shapes, **41 inputs in four families** still reached the divergence:

| count | family | example |
|---|---|---|
| 16 | `[inv;insAA]` | `g.[2_3inv;2_3insAA]` -> `g.[2_3=;2_3insAA]` -> `g.[2_3insAA;2_3=]` |
| 16 | `[inv;insA]` | `g.[2_3inv;2_3insA]` -> `g.[2_3=;2_3insA]` -> `g.[2_3insA;2_3=]` |
| 7 | `[dup;inv]` | `g.[2_3dup;3_4inv]` -> `g.[8_9dup;3_4=]` -> `g.[3_4=;8_9dup]` |
| 2 | `[insA;inv]` | `g.[9_10insA;9_10inv]` -> `g.[11dup;9_10=]` -> `g.[9_10=;11dup]` |

With this change that census is **0**.

## Representation change — measured and disclosed

Per the representation-stability guidance, this PR **moves normalized output**, and here is the blast radius. Corpus: every two-member cis allele over `sweep_sequences(16)` (32 sequences x 11 member shapes x co-located and near-co-located spans), both shuffle directions — **313,984 rows**, diffed row-for-row against `origin/main`.

| measure | value |
|---|---|
| rows compared | 313,984 |
| rows moved | **2,037 (0.65%)** |
| moved rows that are a pure **reordering** (identical member multiset) | **2,037 / 2,037** |
| moved rows where any **member changed** | **0** |
| moved rows already non-idempotent on `main` | 209 |
| moved rows stable on `main` | 1,828 |
| split by direction | 859 3', 1,178 5' |

Reading that honestly, in the terms the guidance asks for:

- **No allele changes the sequence it denotes.** Every moved row emits the same members; only their order changes. That is the strongest form of "safe" available here, and it is measured rather than argued.
- **All 2,037 were out of genomic order on `main`**, i.e. criterion-2 violations. The direction of the change is toward the spec's stated form, not away from it.
- **The affected inputs were previously *accepted***, so for a consumer keying on the normalized string this is a **migration**, not a free fix. 209 of them were already unstable on `main` (its second pass produced this PR's first-pass answer, so anyone normalizing to a fixed point already holds the new string). The other **1,828 were stable on `main` and genuinely move** — that is the cost, and it is the larger share.
- Not release-to-release: the harness (`sweep_sequences`/`sweep_seeds`) postdates v0.12.0, so this corpus does not exist at that tag. The comparison is `main`-to-branch.

## One existing test changed

`issue_1235_transcript_axes::overlap_conflicting_allele_is_not_canonicalized` pinned **two** outputs for the two authored orders of one variant:

```
c.[5_9inv;5_6dup] -> c.[5_9inv;6_7insAA]
c.[5_6dup;5_9inv] -> c.[6_7insAA;5_9inv]
```

Two strings for one variant, differing only in member order — while the comment immediately above them reads *"Convergence is the point — one variant, one canonical string"*. Both now reach `c.[5_9inv;6_7insAA]`, so the test pins what it says it wants. Its other guards are untouched: the allele stays multi-member, strict still rejects it as W5002, and the settled form is still a fixed point.

The reversed-order `ins` spelling remains a fixed point of its own, because it *is* authored exactly as its members settle and so is genuinely returned verbatim. Whether a conflicting allele should be preserved that faithfully is #1406's open question, not this one; it is now asserted explicitly so the residual is visible rather than mistaken for convergence.

## Verification

- `cargo nextest run --features dev` with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1` and `FERRO_SWEEP_SEEDS=full`: **9348 passed, 0 failed**.
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- New `tests/it/issue_1414_conflicting_allele_member_order.rs`: six tests covering the rewritten case on both shuffle directions, the one-pass fixed point, the verbatim contract still holding for an out-of-order allele that was *not* rewritten (the discriminating half — an unconditional sort passes everything else and fails this), #1423's single-member output, and the ordinary disjoint path.