### PR TITLE
fix(spdi): read a single-position repeat anchor as the whole tract

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -93,6 +93,21 @@ use crate::sequence::reverse_complement;
 /// we'd plausibly emit as a single SPDI.
 const MAX_REPEAT_EXPANSION_BASES: usize = 100_000;
 
+/// Widest reference window [`resolve_repeat_tract_span`] will read while looking
+/// for the physical extent of a start-only repeat anchor.
+///
+/// Named separately from [`MAX_REPEAT_EXPANSION_BASES`] because it bounds a
+/// different thing: that one caps the `ins` string a repeat *count* can
+/// generate, this one caps how much reference is *read* to find the tract the
+/// anchor names. Reusing the expansion bound for both read as if one number
+/// governed both, and the growth loop compared it against a half-width, so the
+/// window it declined at was twice the figure its own error message quoted.
+///
+/// 200 KB is far above any biological tandem repeat — the largest known
+/// pathogenic expansions run to a few tens of kilobases — so a tract still
+/// growing at this width is a degenerate reference, not a variant.
+const MAX_REPEAT_SEARCH_BASES: u64 = 200_000;
+
 /// Error type for conversion failures.
 ///
 /// Marked `#[non_exhaustive]` so a new conversion-failure case is additive
@@ -1533,8 +1548,42 @@ where
                     ),
                 });
             }
+            // A single-position anchor names the tract's *start*, not a
+            // one-base span, so widen it to the physical run before fetching
+            // (#1431).
+            //
+            // The spec presents the two spellings as two formats of one
+            // variant — "a Community Consultation proposal is being prepared
+            // which will suggest to allow only the format where the **entire
+            // range** of the repeated sequence is indicated; so
+            // `g.123_191CAG[23]`, **not** `g.123CAG[23]`"
+            // (`DNA/repeated.md`) — and `123_191` is 69 bases, the whole
+            // 23-copy tract. Reading the anchor as a one-base span instead
+            // made the two disagree: on a 3-base `A` tract at 263,
+            // `g.263A[7]` came out as `262:A:AAAAAAA`, which denotes **nine**
+            // `A`s once the two untouched tract bases are counted, while
+            // `g.263_265A[7]` correctly denotes seven.
+            //
+            // The one-base reading also does not survive a multi-base unit at
+            // all: `g.263CAG[5]` fetched a single base and died on the
+            // divisibility check below ("length 1 is not a multiple of unit
+            // length 3"), so the spec's own start-only format was unusable for
+            // every unit the spec actually illustrates it with.
+            //
+            // This is the reading `merge::lowered_repeat` already documents —
+            // "a single-position anchor (`e == s`) names only the tract's
+            // start and means 'the whole run becomes N', so it absorbs
+            // nothing" — so widening here makes the two sites agree rather
+            // than introducing a third answer.
+            let (del_start, del_end) = match provider {
+                Some(p) if start_one_based == end_one_based => {
+                    resolve_repeat_tract_span(p, &sequence, start_one_based, unit_str.as_bytes())?
+                }
+                _ => (start_one_based, end_one_based),
+            };
+            let spdi_pos = del_start - 1;
             let del_raw = match provider {
-                Some(p) => fetch_reference_bases(p, &sequence, start_one_based, end_one_based)?,
+                Some(p) => fetch_reference_bases(p, &sequence, del_start, del_end)?,
                 None => {
                     return Err(unspelled_bases_error(
                         UnspelledBases::RepeatTract,
@@ -1552,8 +1601,8 @@ where
                     description: format!(
                         "repeat span {}:{}-{} length {} is not a multiple of unit length {}",
                         sequence,
-                        start_one_based,
-                        end_one_based,
+                        del_start,
+                        del_end,
                         del_str.len(),
                         unit_str.len()
                     ),
@@ -1567,7 +1616,7 @@ where
                 return Err(ConversionError::InvalidPosition {
                     description: format!(
                         "repeat span {}:{}-{} does not match repeat unit {}",
-                        sequence, start_one_based, end_one_based, unit_str
+                        sequence, del_start, del_end, unit_str
                     ),
                 });
             }
@@ -1686,6 +1735,128 @@ fn unspelled_bases_error(
 /// Returns [`ConversionError::MissingReferenceData`] when neither call
 /// returns data, or when the returned string length does not match the
 /// requested interval length (insufficient ref data near a boundary).
+/// The physical repeat run a single-position repeat anchor names, as a 1-based
+/// inclusive span (#1431).
+///
+/// A start-only repeat (`g.263A[7]`, `g.123CAG[23]`) addresses the whole tandem
+/// run it points into, not the one base or one unit at the anchor — see the
+/// call site for the spec text and the two ways the one-base reading went
+/// wrong. This finds that run with the same routine the normalizer uses
+/// ([`crate::normalize::rules::count_tandem_repeats`]) so the two cannot drift
+/// apart.
+///
+/// **Window growth, and why the cap is not a silent truncation.** The tract's
+/// extent is not known before it is read, so the reference is fetched in a
+/// window around the anchor and the window is doubled while the run still
+/// reaches either edge. A tract that is still growing at
+/// [`MAX_REPEAT_SEARCH_BASES`] is *declined* rather than reported at the
+/// window's width: returning the clamped span would silently under-count the
+/// run and emit a triple denoting the wrong bases, which is the exact defect
+/// this function exists to remove.
+///
+/// Falls back to the unit-wide span at the anchor when no run is found — the
+/// unit does not match the reference there — so the caller's existing
+/// "does not match repeat unit" diagnostic is what reports it, rather than a
+/// second error for one condition.
+fn resolve_repeat_tract_span<P>(
+    provider: &P,
+    accession: &str,
+    anchor_one_based: u64,
+    unit: &[u8],
+) -> Result<(u64, u64), ConversionError>
+where
+    P: ReferenceProvider + ?Sized,
+{
+    /// Half-width of the first window. Comfortably covers the tract lengths the
+    /// spec illustrates (its `CAG[23]` example is 69 bases) so the common case
+    /// costs one fetch.
+    const INITIAL_HALF_WIDTH: u64 = 128;
+
+    if unit.is_empty() {
+        return Ok((anchor_one_based, anchor_one_based));
+    }
+    let unit_len = unit.len() as u64;
+    let fallback = (
+        anchor_one_based,
+        anchor_one_based.saturating_add(unit_len - 1),
+    );
+
+    // A failed length lookup must not fail the conversion. `get_sequence_length`
+    // carries a trait default that always errors (`provider.rs:424`), so a
+    // provider that serves bases perfectly well but does not implement it would
+    // otherwise go from converting `g.263A[7]` to refusing it outright — a
+    // regression for every out-of-tree `ReferenceProvider`, and one no in-repo
+    // test can see because all of ferro's own providers override it.
+    //
+    // Without a length the window cannot be clamped or its edges judged, so the
+    // tract search is not attempted; the unit-wide span is what this returns
+    // instead. That leaves such a provider with the pre-#1431 answer rather than
+    // the corrected one, which is a known and stated limit, not a silent wrong
+    // span — the caller's divisibility and unit-match checks still judge it.
+    let Ok(sequence_length) = provider.get_sequence_length(accession) else {
+        return Ok(fallback);
+    };
+    if sequence_length == 0 || anchor_one_based > sequence_length {
+        return Ok(fallback);
+    }
+    // Now that the length is known, keep the fallback inside the contig: a
+    // multi-base unit anchored within `unit_len` of the 3' end would otherwise
+    // hand `fetch_reference_bases` a range past the end, replacing the
+    // documented "does not match repeat unit" diagnostic with a fetch failure.
+    let fallback = (fallback.0, fallback.1.min(sequence_length));
+
+    let mut half_width = INITIAL_HALF_WIDTH;
+    loop {
+        let window_start = anchor_one_based.saturating_sub(half_width).max(1);
+        let window_end = anchor_one_based
+            .saturating_add(half_width)
+            .min(sequence_length);
+        let window = fetch_reference_bases(provider, accession, window_start, window_end)?;
+        let bytes = window.as_bytes();
+        let anchor_offset = (anchor_one_based - window_start) as usize;
+
+        let Some((_, tract_start, tract_end)) =
+            crate::normalize::rules::count_tandem_repeats(bytes, anchor_offset, unit)
+        else {
+            return Ok(fallback);
+        };
+
+        // Only grow while the run is still touching an edge the contig has not
+        // itself ended at — otherwise the window is not what is bounding it.
+        //
+        // Both tests are stated in units, not bytes, because
+        // `count_tandem_repeats` steps by `unit_len`: a run clipped by the
+        // window stops up to `unit_len - 1` bytes short of the edge rather than
+        // on it. Testing `tract_end == bytes.len()` therefore only fires when
+        // the remaining byte count happens to be a multiple of the unit — true
+        // for a 1- or 3-base unit at the initial half-width, false for a 4- or
+        // 5-base one — and the clipped span was returned as if it were the whole
+        // run. Same on the 5' side: the backward scan stops at
+        // `anchor_offset % unit_len`, which need not be 0.
+        let open_at_start = tract_start < unit.len() && window_start > 1;
+        let open_at_end = tract_end + unit.len() > bytes.len() && window_end < sequence_length;
+        if !open_at_start && !open_at_end {
+            return Ok((
+                window_start + tract_start as u64,
+                window_start + tract_end as u64 - 1,
+            ));
+        }
+        // Judged on the whole window, not the half-width, so the figure the
+        // message quotes is the window that was actually read.
+        if half_width.saturating_mul(2).saturating_add(1) >= MAX_REPEAT_SEARCH_BASES {
+            return Err(ConversionError::UnsupportedEditType {
+                description: format!(
+                    "repeat tract at {accession}:{anchor_one_based} still extends past a \
+                     {MAX_REPEAT_SEARCH_BASES}-base search window; spell the whole range \
+                     explicitly (`g.<start>_<end>{}[n]`) rather than the start alone",
+                    String::from_utf8_lossy(unit)
+                ),
+            });
+        }
+        half_width = half_width.saturating_mul(2);
+    }
+}
+
 fn fetch_reference_bases<P>(
     provider: &P,
     accession: &str,

--- a/tests/it/issue_1431_single_position_repeat_anchor.rs
+++ b/tests/it/issue_1431_single_position_repeat_anchor.rs
@@ -1,0 +1,296 @@
+//! #1431 — a single-position repeat anchor was read two ways, and the two
+//! readings denoted different sequences.
+//!
+//! `hgvs_to_spdi` read `g.263A[7]` as *"the one base named at 263 becomes 7
+//! copies"* — a deletion span of one — so on a 3-base `A` tract the two
+//! untouched tract bases survived and the description denoted **nine** `A`s.
+//! `merge::lowered_repeat` documents the opposite reading, explicitly:
+//!
+//! > A single-position anchor (`e == s`) names only the tract's start and means
+//! > "the whole run becomes N", so it absorbs nothing.
+//!
+//! Under that reading the answer is seven, matching the range spelling
+//! `g.263_265A[7]`. Two sites, two answers, one variant.
+//!
+//! **The spec settles it.** `DNA/repeated.md` presents the two spellings as two
+//! *formats of one variant*:
+//!
+//! > a Community Consultation proposal is being prepared which will suggest to
+//! > allow only the format where the **entire range** of the repeated sequence
+//! > is indicated; so `g.123_191CAG[23]`, **not** `g.123CAG[23]`.
+//!
+//! `123_191` is 69 bases — the whole 23-copy tract — so the start-only form
+//! addresses the run, not one base of it.
+//!
+//! Two things were wrong, not one. Besides the arithmetic above, the one-base
+//! reading did not survive a multi-base unit **at all**: `g.263CAG[5]` fetched a
+//! single base and died on the divisibility check ("repeat span length 1 is not
+//! a multiple of unit length 3"), so the spec's own start-only format was
+//! unusable for every unit the spec illustrates it with.
+//!
+//! Why it matters beyond the arithmetic: it made the apply oracle unreliable for
+//! single-position repeats, and that oracle is the independent check several
+//! sweeps and regression tests grade the normalizer against. It produced a
+//! well-formed output denoting different bases, caught by none of
+//! `FERRO_ASSERT_REPARSE` (both parse), `FERRO_ASSERT_IN_BOUNDS` (both in range)
+//! or `FERRO_ASSERT_IDEMPOTENT` (the output is a fixed point).
+
+use crate::common::cis_apply_oracle::apply;
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+/// 256 `N`s, so core position 1 is `g.257` and the `N` flanks can never look
+/// like part of a tract — `N` matches no repeat unit used here.
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{PAD}{core}{PAD}")
+}
+
+fn provider(sequence: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", sequence.to_string());
+    provider
+}
+
+/// The SPDI triple, rendered.
+fn spdi(sequence: &str, input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    hgvs_to_spdi(&variant, &provider(sequence))
+        .unwrap_or_else(|e| panic!("`{input}` must convert to SPDI: {e}"))
+        .to_string()
+}
+
+/// The core bases a description denotes, with the `N` padding trimmed off.
+fn denotes(sequence: &str, input: &str) -> String {
+    apply(sequence, input)
+        .unwrap_or_else(|| panic!("`{input}` must apply"))
+        .trim_matches('N')
+        .to_string()
+}
+
+/// The headline: the two spellings of one repeat denote the same sequence.
+///
+/// A 3-base `A` tract at 263-265. Both descriptions say "this `A` tract has
+/// seven copies", and both must mean it.
+#[test]
+fn the_two_spellings_of_one_repeat_denote_one_sequence() {
+    let sequence = padded("GATCATAAATTCAGC");
+    let anchored = denotes(&sequence, "TEMPLATE:g.263A[7]");
+    let ranged = denotes(&sequence, "TEMPLATE:g.263_265A[7]");
+    assert_eq!(
+        anchored, ranged,
+        "the start-only and full-range spellings of one repeat must denote one sequence"
+    );
+    // Pinned, not merely equal: equality alone would be satisfied if both
+    // regressed to nine `A`s together.
+    assert_eq!(
+        anchored, "GATCATAAAAAAATTCAGC",
+        "seven `A`s, not the nine the one-base reading produced"
+    );
+    // The *tract*, not every `A` in the core — `GATCAT…TTCAGC` has three more.
+    assert_eq!(
+        longest_run(&anchored, 'A'),
+        7,
+        "the tract must hold exactly the seven copies the description states"
+    );
+}
+
+/// …and the triples themselves are identical, not merely equivalent.
+///
+/// The width of the SPDI deletion is what decides overlap
+/// (`triples_are_disjoint`), so two triples that denote the same bases at
+/// different widths still disagree about whether an allele is well-formed. That
+/// is the failure in `an_anchored_repeat_and_its_range_agree_on_overlap` below,
+/// and this pins the property that removes it.
+#[test]
+fn the_two_spellings_produce_the_same_triple() {
+    let sequence = padded("GATCATAAATTCAGC");
+    assert_eq!(
+        spdi(&sequence, "TEMPLATE:g.263A[7]"),
+        spdi(&sequence, "TEMPLATE:g.263_265A[7]"),
+    );
+    assert_eq!(
+        spdi(&sequence, "TEMPLATE:g.263A[7]"),
+        "TEMPLATE:262:AAA:AAAAAAA",
+        "the deletion must span the whole 3-base tract, not the anchor base alone"
+    );
+}
+
+/// A multi-base unit — the shape the spec actually illustrates the start-only
+/// format with (`g.123CAG[23]`).
+///
+/// This did not merely give a wrong answer before; it was a hard error, because
+/// a one-base deletion span is not divisible by a 3-base unit. So the format the
+/// spec documents was unusable for the unit the spec documents it with.
+#[test]
+fn a_multi_base_unit_works_from_the_anchor_alone() {
+    // A 3-copy `CAG` tract at 263-271.
+    let sequence = padded("GATCATCAGCAGCAGTTC");
+    let anchored = denotes(&sequence, "TEMPLATE:g.263CAG[5]");
+    let ranged = denotes(&sequence, "TEMPLATE:g.263_271CAG[5]");
+    assert_eq!(
+        anchored, ranged,
+        "the start-only spelling of a multi-base repeat must reach the range spelling's answer"
+    );
+    assert_eq!(anchored, "GATCATCAGCAGCAGCAGCAGTTC");
+    assert_eq!(
+        anchored.matches("CAG").count(),
+        5,
+        "five copies, as the description states"
+    );
+}
+
+/// A range that names only *part* of a tract is unchanged: it still states which
+/// copies the count applies to, and the copies outside it survive.
+///
+/// This is the discriminating half. Widening every repeat to its physical tract
+/// would break this case, and it would pass every assertion above.
+#[test]
+fn a_partial_range_still_absorbs_only_its_own_copies() {
+    let sequence = padded("GATCATCAGCAGCAGTTC");
+    // `263_265` names the first of three `CAG` copies. Five copies there plus
+    // the two the range does not name is seven, not five.
+    assert_eq!(
+        denotes(&sequence, "TEMPLATE:g.263_265CAG[5]"),
+        "GATCATCAGCAGCAGCAGCAGCAGCAGTTC"
+    );
+    assert_eq!(
+        spdi(&sequence, "TEMPLATE:g.263_265CAG[5]"),
+        "TEMPLATE:262:CAG:CAGCAGCAGCAGCAG",
+        "an explicit range must keep its own width"
+    );
+}
+
+/// The overlap verdict now agrees between the two spellings.
+///
+/// The deletion width decides `triples_are_disjoint`, so before this fix
+/// `g.[263A[7];264dup]` was *admitted* — its repeat triple was one base wide and
+/// so missed the duplication at 264 — while `g.[263_265A[7];264dup]`, the same
+/// variant, was declined as overlapping. One variant, two spellings, opposite
+/// answers to "is this even well-formed".
+///
+/// Both decline now, which is the right verdict: the repeat spans 263-265 and
+/// the duplication claims 264, so they genuinely collide.
+#[test]
+fn an_anchored_repeat_and_its_range_agree_on_overlap() {
+    let sequence = padded("GATCATAAATTCAGC");
+    assert_eq!(
+        apply(&sequence, "TEMPLATE:g.[263A[7];264dup]"),
+        None,
+        "a repeat whose tract contains its sibling must be declined as overlapping"
+    );
+    assert_eq!(
+        apply(&sequence, "TEMPLATE:g.[263_265A[7];264dup]"),
+        None,
+        "and the range spelling of that same allele must get the same verdict"
+    );
+}
+
+/// An anchor with no tract under it is untouched: the unit does not match the
+/// reference there, and the existing "does not match repeat unit" diagnostic is
+/// what must report it — not a second error introduced by the tract search.
+#[test]
+fn an_anchor_with_no_matching_tract_still_reports_the_mismatch() {
+    let sequence = padded("GATCATAAATTCAGC");
+    // Position 257 is `G`; a `C` unit does not match it.
+    let variant = parse_hgvs("TEMPLATE:g.257C[4]").expect("parse");
+    let error = hgvs_to_spdi(&variant, &provider(&sequence))
+        .expect_err("a unit that does not match the reference must be refused");
+    let message = error.to_string();
+    assert!(
+        message.contains("does not match repeat unit"),
+        "the mismatch must be reported by the existing diagnostic; got: {message}"
+    );
+}
+
+/// A single isolated copy is a one-unit tract, so the anchored spelling keeps
+/// the width it always had. Guards the boundary between "no tract" and "a tract
+/// of one".
+#[test]
+fn a_lone_copy_is_a_one_unit_tract() {
+    // Core `GATCATAAATTCAGC` starts at `g.257`, so its 14th base — the lone `G`
+    // between `A` and `C` — is `g.270`.
+    let sequence = padded("GATCATAAATTCAGC");
+    assert_eq!(
+        spdi(&sequence, "TEMPLATE:g.270G[3]"),
+        "TEMPLATE:269:G:GGG",
+        "a lone copy must keep its one-unit width"
+    );
+}
+
+/// A tract longer than the initial search window is found whole, for a unit
+/// length that does not divide the window evenly.
+///
+/// The window doubles while the run still reaches an edge, and both edge tests
+/// have to be stated in **units** rather than bytes: `count_tandem_repeats`
+/// steps by `unit_len`, so a clipped run stops up to `unit_len - 1` bytes short
+/// of the edge instead of on it. A byte-equality test therefore only fires when
+/// the bytes remaining happen to be a multiple of the unit — which at the
+/// initial half-width is true for a 1- and 3-base unit and false for a 4- and
+/// 5-base one.
+///
+/// That asymmetry is why this guard uses `CAGT`: with a byte-equality test the
+/// 3-base units the spec illustrates (`g.123_191CAG[23]`) pass while a 4-base
+/// unit silently returns the clipped span — 128 bases of a 240-base tract,
+/// which is itself a multiple of 4 and so clears both the divisibility and
+/// unit-match checks downstream. A well-formed triple denoting the wrong bases,
+/// which is the very defect this whole change removes.
+#[test]
+fn a_tract_longer_than_the_search_window_is_found_whole() {
+    const COPIES: usize = 60;
+    let core = "CAGT".repeat(COPIES);
+    let sequence = padded(&core);
+    let tract_end = 257 + core.len() - 1;
+
+    // The anchored spelling and the explicit-range spelling must agree, and
+    // both must denote five copies rather than five copies plus the tail of an
+    // under-counted tract.
+    let anchored = denotes(&sequence, "TEMPLATE:g.257CAGT[5]");
+    let ranged = denotes(&sequence, &format!("TEMPLATE:g.257_{tract_end}CAGT[5]"));
+    assert_eq!(
+        anchored, ranged,
+        "the two spellings of one repeat must denote one sequence at any tract length"
+    );
+    assert_eq!(
+        anchored,
+        "CAGT".repeat(5),
+        "the whole {}-base tract must be replaced, not the window-clipped prefix",
+        core.len()
+    );
+}
+
+/// The 5' mirror: an anchor *inside* a tract that extends past the window's
+/// left edge must still find the run's true start.
+///
+/// The backward scan stops at `anchor_offset % unit_len`, which is 0 only by
+/// coincidence, so a `tract_start == 0` test misses the same way the 3' one did.
+#[test]
+fn a_tract_extending_past_the_left_edge_is_found_whole() {
+    const COPIES: usize = 60;
+    let core = "CAGT".repeat(COPIES);
+    let sequence = padded(&core);
+    let tract_end = 257 + core.len() - 1;
+    // Anchor on the last copy, so the run extends 236 bases 5' of it — well
+    // past the 128-base initial half-window.
+    let anchor = tract_end - 3;
+
+    let anchored = denotes(&sequence, &format!("TEMPLATE:g.{anchor}CAGT[5]"));
+    let ranged = denotes(&sequence, &format!("TEMPLATE:g.257_{tract_end}CAGT[5]"));
+    assert_eq!(
+        anchored, ranged,
+        "an anchor anywhere in the run must address the whole run"
+    );
+}
+
+/// The length of the longest run of `base`.
+fn longest_run(sequence: &str, base: char) -> usize {
+    sequence
+        .split(|c| c != base)
+        .map(str::len)
+        .max()
+        .unwrap_or(0)
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -207,6 +207,7 @@ mod issue_1416_cancelled_identity_beside_repeat;
 mod issue_1426_five_prime_junction_insertion;
 mod issue_1426_junction_insertion_settles_in_one_pass;
 mod issue_1429_derivation_honours_shuffle_direction;
+mod issue_1431_single_position_repeat_anchor;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1431.

## The disagreement

Two sites read a start-only repeat anchor two ways, and the two readings denote different sequences. Measured on `padded("GATCATAAATTCAGC")`, a 3-base `A` tract at 263-265:

| description | `hgvs_to_spdi` (before) | denotes |
|---|---|---|
| `g.263A[7]` | `262:A:AAAAAAA` | `GATCAT` **AAAAAAAAA** `TTCAGC` — nine `A`s |
| `g.263_265A[7]` | `262:AAA:AAAAAAA` | `GATCAT` **AAAAAAA** `TTCAGC` — seven `A`s |

Both descriptions say "this `A` tract has seven copies". `merge::lowered_repeat` already documents the reading that makes them agree, explicitly:

> A single-position anchor (`e == s`) names only the tract's start and means "the whole run becomes N", so it absorbs nothing.

## The spec settles which reading is right

`assets/hgvs-nomenclature/docs/recommendations/DNA/repeated.md` presents the two spellings as two **formats of one variant**:

> **NOTE**: a Community Consultation proposal is being prepared which will suggest to allow only the format where the **entire range** of the repeated sequence is indicated; so `g.123_191CAG[23]`, **not** `g.123CAG[23]`.

`123_191` is 69 bases — the whole 23-copy tract. So the start-only form addresses the run, not one base of it. `lowered_repeat` was right; `hgvs_to_spdi` was wrong.

## A second defect the issue does not record: the start-only form was unusable for every unit the spec illustrates it with

The one-base reading does not merely give a wrong answer for a 1-base unit — for a multi-base unit it is a hard error, because a one-base deletion span is not divisible by the unit length:

```
g.263CAG[5]  ->  <ERR: repeat span TEMPLATE:263-263 length 1 is not a multiple of unit length 3>
```

`g.123CAG[23]` is the spec's own example of this format. It could not be converted at all.

## The fix

Widen a start-only repeat to its physical run before fetching the deletion bases, using the **same** `count_tandem_repeats` the normalizer uses, so the two sites cannot drift apart again.

The tract's extent is not known before it is read, so the reference is fetched in a window around the anchor that **doubles while the run still reaches an edge**. A run still growing at `MAX_REPEAT_EXPANSION_BASES` is **declined**, not reported at the window's width — returning a clamped span would silently under-count the run and emit a triple denoting the wrong bases, which is the exact defect being removed. The initial half-width is 128 bases, comfortably covering the spec's 69-base example, so the ordinary case costs one fetch.

After:

| description | triple | denotes |
|---|---|---|
| `g.263A[7]` | `262:AAA:AAAAAAA` | seven `A`s |
| `g.263_265A[7]` | `262:AAA:AAAAAAA` | seven `A`s |
| `g.263CAG[5]` | `262:CAGCAGCAG:CAGCAGCAGCAGCAG` | five copies |
| `g.263_271CAG[5]` | `262:CAGCAGCAG:CAGCAGCAGCAGCAG` | five copies |

Identical triples, not merely equivalent ones — which matters, because the deletion **width** is what decides overlap.

## The overlap verdict now agrees too

`triples_are_disjoint` reads the SPDI deletion width, so a one-base-wide repeat triple missed a sibling inside its own tract:

```
g.[263A[7];264dup]        admitted    (repeat triple one base wide, misses the dup at 264)
g.[263_265A[7];264dup]    declined    (overlapping)
```

One variant, two spellings, opposite answers to "is this even well-formed". Both decline now, which is the correct verdict — the repeat spans 263-265 and the duplication claims 264.

## Unchanged on purpose

An explicit range keeps its own width, **including a range that names only part of a tract**. `g.263_265CAG[5]` still stays 3 bases wide and still absorbs only its own copies (five stated plus the two the range does not name = seven), because a range states which reference copies the count applies to. Widening every repeat to its physical tract would break this and would pass every other assertion in the new module — so it has a dedicated test.

An anchor whose unit does not match the reference is also unchanged: the tract search finds nothing, falls back to the unit-wide span, and the existing `does not match repeat unit` diagnostic reports it rather than a second error for one condition.

## Representation stability

**No normalized HGVS string moves.** The change is confined to `hgvs_to_spdi`'s `Repeat` arm, and `Normalizer` does not route through it — repeats reach `merge::lowered_repeat` instead, which already held the correct reading. The full suite (9346 tests, all three oracles, `FERRO_SWEEP_SEEDS=full`) passes with **no existing test moved**.

What does change is SPDI output for start-only repeats, and with it `EquivalenceChecker`: it compares members via `hgvs_to_spdi`, so it previously judged `g.263A[7]` and `g.263_265A[7]` to denote *different* sequences. They now compare equal, which is the correct answer. Both changes are from wrong-or-erroring to right.

## Why this was worth fixing beyond the arithmetic

It made the apply oracle unreliable for single-position repeats, and that oracle is the independent check several sweeps and regression tests grade the normalizer against — including #1400's transcript-axis sweep. A mismatch it reported could be the oracle's rather than the normalizer's, or it could agree for the wrong reason. None of `FERRO_ASSERT_REPARSE` (both parse), `FERRO_ASSERT_IN_BOUNDS` (both in range) or `FERRO_ASSERT_IDEMPOTENT` (the output is a fixed point) can see this class.

## Verification

- `cargo nextest run --features dev` with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1` and `FERRO_SWEEP_SEEDS=full`: **9346 passed, 0 failed**, no existing expectation changed.
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- New `tests/it/issue_1431_single_position_repeat_anchor.rs`: seven tests — the two spellings denoting one sequence, producing one triple, the multi-base unit working at all, the partial range still absorbing only its own copies (the discriminating half), the overlap verdict agreeing, the no-matching-tract diagnostic preserved, and a lone copy keeping its one-unit width.