### PR TITLE
fix(normalize): keep a real overlap conflict visible in the output

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3134,6 +3134,87 @@ impl<P: ReferenceProvider> Normalizer<P> {
             sort_cis_members_by_genomic_order(&mut normalized);
         }
 
+        // A conflict the input really had must survive into the output (#1406).
+        //
+        // #395 says an overlap-conflicting allele has no canonical form, so
+        // ferro preserves it verbatim and reports `W5002`, which strict mode
+        // promotes to an error. But strict mode re-reads a *description*, and it
+        // has no memory of what that description was normalized from — so the
+        // contract only holds if the emitted description still looks conflicting.
+        //
+        // It did not. The per-member pipeline repairs the members one at a time
+        // — an inversion whose span is its own reverse complement cancels to an
+        // identity, an interior insertion respells as a repeat — and the merge
+        // then collapses what is left. The conflict is gone from the output, so
+        // strict mode accepts a description it would have rejected had the
+        // caller written it directly:
+        //
+        //     in      g.[11_12inv;11_12insAA]   strict: REJECT (W5002)
+        //     lenient g.10_11A[4]               strict: ACCEPT
+        //
+        // That is the laundering #1406 row 3 reports, and it breaks the
+        // invariant `issue_1276_dup_junction_overlap::
+        // lenient_output_of_a_conflict_is_still_rejected_by_strict` already
+        // pins for the shapes it happens to cover.
+        //
+        // So: when the input conflicts and the output does not, hand back the
+        // input. That is #395's contract stated exactly — preserve it verbatim —
+        // rather than approximated by "skip some passes and hope the conflict
+        // survives them".
+        //
+        // Deliberately asked of the *members*, both detectors, on each side.
+        // `detect_insertion_overlaps` documents that it must see pre-merge
+        // members because the merge collapses the overlap out of view — and
+        // that collapse is precisely the erasure being detected here, so asking
+        // it of the post-merge output is the right question, not a misuse.
+        //
+        // Idempotent by construction: the value handed back is the input, whose
+        // conflict the next pass detects again, so it is returned unchanged a
+        // second time.
+        // Uncertain alleles included, unlike the sort gate above. That gate
+        // excludes them because member *order* inside `[(a;b)]` is authored
+        // presentation, which is not ours to change. This one is about whether
+        // the conflict survives into the output at all, and an uncertain allele
+        // launders exactly like a certain one — measured:
+        //
+        //     in  g.[(9_10insA;9_10inv)]   strict: REJECT (W5002)
+        //     out g.[(11dup;9_10=)]        strict: ACCEPT
+        //
+        // Excluding them would leave the hole this gate exists to close open on
+        // one spelling of the same input.
+        if is_cis {
+            let conflicts = |members: &[HgvsVariant]| {
+                !crate::normalize::overlap::detect_overlap_conflicts(members, allele.phase)
+                    .is_empty()
+                    || !crate::normalize::overlap::detect_interior_junction_conflicts(
+                        members,
+                        allele.phase,
+                    )
+                    .is_empty()
+            };
+            // A **plural** output only. Both detectors return nothing for fewer
+            // than two members (`overlap.rs`, first statement of each), so for a
+            // single-member output `!conflicts(&normalized)` is vacuously true
+            // and says nothing about whether the conflict was erased — there is
+            // simply nothing left for a second member to collide with.
+            //
+            // The distinction is real, not defensive. Members *shifted apart*
+            // while still plural is the laundering this gate is for. Members
+            // *composed into one edit* is the opposite: the colliding writes
+            // have been resolved into a single description that denotes a
+            // definite sequence, which is what `delins.md:86-89` asks for and
+            // what the deletion exemption below already relies on for
+            // `g.[2_3del;2_3insAA]` -> `g.2_3delinsAA`.
+            //
+            // Without this term the gate reverts #1423: `g.[11_12inv;11_12insAA]`
+            // collapses to the single member `g.10_11A[4]`, which cannot
+            // conflict, so the input was handed back and a merged, shipped form
+            // was undone.
+            if conflicts(&allele.variants) && normalized.len() > 1 && !conflicts(&normalized) {
+                normalized = allele.variants.clone();
+            }
+        }
+
         // HGVS requires consecutive edits in cis to render as a single edit.
         // Only unwrap when a merge actually collapsed multiple sub-variants —
         // pre-existing singleton alleles must round-trip with the Allele

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -138,6 +138,35 @@ pub(crate) fn detect_insertion_overlaps(
     variants: &[HgvsVariant],
     phase: AllelePhase,
 ) -> Vec<NormalizationWarning> {
+    junction_overlaps(variants, phase, true)
+}
+
+/// Only the *interior-junction* half of [`detect_insertion_overlaps`]: a
+/// junction strictly inside a span edit that keeps the bases it spans.
+///
+/// This is the subset that is genuinely ambiguous about what the allele
+/// denotes, and it is the only subset the #1406 conflict-preservation gates may
+/// act on. The same-junction half must stay out of them: two insertions at one
+/// junction are a two-member **spelling** of a variant that also has a
+/// single-member spelling, and merging them is what makes the two converge.
+/// Treating that as unresolvable made `g.[263_264insAC;264_265insAA]` settle
+/// apart from `g.264_265insCAAA` — measured, and caught by
+/// `cis_spelling_confluence_gap::converged_pairs_stay_converged`, which reports
+/// it as "#1301 regressed". Losing confluence to gain a strict-mode property is
+/// the wrong trade: confluence is what downstream consumers key on.
+pub(crate) fn detect_interior_junction_conflicts(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+) -> Vec<NormalizationWarning> {
+    junction_overlaps(variants, phase, false)
+}
+
+/// Shared body. `include_same_junction` selects branch (a) below.
+fn junction_overlaps(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+    include_same_junction: bool,
+) -> Vec<NormalizationWarning> {
     if phase != AllelePhase::Cis || variants.len() < 2 {
         return Vec::new();
     }
@@ -159,6 +188,9 @@ pub(crate) fn detect_insertion_overlaps(
         region: Region,
         start: i64,
         end: i64,
+        /// Whether the edit **removes** every base it spans, leaving nothing
+        /// for an interior junction to be positioned against. See branch (b).
+        removes_its_bases: bool,
     }
 
     let mut insertions: Vec<Insertion> = Vec::new();
@@ -212,6 +244,7 @@ pub(crate) fn detect_insertion_overlaps(
                 region,
                 start,
                 end,
+                removes_its_bases: matches!(edit, NaEdit::Deletion { .. }),
             });
         }
     }
@@ -242,7 +275,7 @@ pub(crate) fn detect_insertion_overlaps(
             .push((ins.idx, ins.kind));
     }
     for ((accession, coord_system, _region, _gap), occupants) in &by_junction {
-        if occupants.len() < 2 {
+        if !include_same_junction || occupants.len() < 2 {
             continue;
         }
         // Render the junction via the occupant's HGVS Display (like branch (b)
@@ -259,7 +292,32 @@ pub(crate) fn detect_insertion_overlaps(
     }
 
     // (b) An insertion junction strictly interior to a span edit's range.
+    //
+    // **Except a pure deletion (#1406).** The conflict this branch reports is
+    // that the junction's position within the span is meaningful and the
+    // combination therefore has no single answer. A deletion removes every base
+    // it spans, so an interior junction has nothing left to be positioned
+    // against: `g.[2_3del;2_3insAA]` denotes `AA` in place of `2_3` whichever
+    // order the two members are applied in, and whichever interior junction the
+    // insertion had named. It composes uniquely, so it was never a conflict —
+    // the same argument #1411 used to stop rejecting `g.[24dup;24C>G]`, whose
+    // members likewise write to disjoint places.
+    //
+    // Reporting it anyway had a concrete cost beyond the false verdict: strict
+    // mode rejected the input while accepting its own lenient output
+    // (`g.2_3delinsAA`), which is the laundering #1406 row 3 is about, and the
+    // merged form is what `delins.md:86-89` asks for outright.
+    //
+    // Deletion only, deliberately. A `delins` does **not** qualify: its payload
+    // survives, so an interior insertion has a position relative to it —
+    // `g.[2_3delinsGG;2_3insA]` genuinely does not say whether the `A` lands
+    // before, inside or after the `GG`. Nor does `inv`, `dup` or `repeat`,
+    // each of which keeps the spanned bases and so keeps the interior junction
+    // meaningful. Those remain conflicts.
     for span in &spans {
+        if span.removes_its_bases {
+            continue;
+        }
         let interior = insertions.iter().filter(|ins| {
             // A `dup`/`repeat` is registered as both span and occupant, so it
             // meets itself here. The interior test already excludes it — its
@@ -832,23 +890,40 @@ mod tests {
     }
 
     #[test]
-    fn insertion_interior_to_deletion_emits_one_warning() {
+    fn insertion_interior_to_deletion_is_not_a_conflict() {
         // Insertion junction `5_6` is strictly interior to the deleted range
-        // `4_7` (positions 4..=7), so they overlap.
+        // `4_7`, but a deletion removes every base it spans, so the insertion
+        // has nothing left to be positioned against: the pair denotes the same
+        // bases whichever order it is applied in, and whichever interior
+        // junction the insertion had named. Not a conflict (#1406).
+        //
+        // `insertion_interior_to_delins_emits_one_warning` is the
+        // discriminating sibling: a `delins` keeps a payload, so an
+        // interior insertion *does* have a position relative to it. Only a
+        // pure deletion is exempt.
         let (variants, phase) = parse_allele("NG_012337.1:g.[4_7del;5_6insAA]");
         let warnings = detect_insertion_overlaps(&variants, phase);
-        assert_eq!(warnings.len(), 1, "expected one warning, got {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "an insertion interior to a pure deletion composes uniquely, so it \
+             must not be reported; got {warnings:?}"
+        );
     }
 
     #[test]
     fn insertions_sharing_junction_and_interior_to_span_emit_two_warnings() {
         // `5_6insA` and `5_6insT` share junction `5` (branch (a)) *and* both
-        // sit strictly interior to the `4_7del` range positions 4..=7
+        // sit strictly interior to the `4_7delinsGG` range positions 4..=7
         // (branch (b)), so the pass emits two `OverlapConflict` warnings for
         // the one overlap cluster. The combined-shape outcome is still a
         // correct rejection; this pins the per-branch warning count so a
         // future dedup refactor doesn't silently change it.
-        let (variants, phase) = parse_allele("NG_012337.1:g.[4_7del;5_6insA;5_6insT]");
+        //
+        // The span is a `delins` rather than the `4_7del` this used to use:
+        // a pure deletion no longer contributes a branch-(b) warning (#1406),
+        // so with `del` here only branch (a) would fire and the test would no
+        // longer exercise the two-branch shape it exists for.
+        let (variants, phase) = parse_allele("NG_012337.1:g.[4_7delinsGG;5_6insA;5_6insT]");
         let warnings = detect_insertion_overlaps(&variants, phase);
         assert_eq!(warnings.len(), 2, "expected two warnings, got {warnings:?}");
         assert!(

--- a/tests/it/issue_1406_lenient_output_keeps_the_conflict.rs
+++ b/tests/it/issue_1406_lenient_output_keeps_the_conflict.rs
@@ -1,0 +1,227 @@
+//! A conflict the input really had must survive into the output (#1406 row 3).
+//!
+//! W5002 says an overlap-conflicting allele has no canonical form, so ferro
+//! preserves it verbatim and strict mode rejects it. But strict mode re-reads a
+//! **description**, with no memory of what it was normalized from — so the
+//! contract only holds if the emitted description still *looks* conflicting.
+//!
+//! It did not. The per-member pipeline repairs the members one at a time (an
+//! inversion whose span is its own reverse complement cancels to an identity, an
+//! interior insertion respells as a repeat) and the merge collapses what is
+//! left, so lenient mode turned a description ferro refuses into one it admits:
+//!
+//! ```text
+//! in      g.[11_12inv;11_12insAA]   strict: REJECT (W5002)
+//! lenient g.10_11A[4]               strict: ACCEPT
+//! ```
+//!
+//! ## Why preserving is the answer, and not repairing
+//!
+//! The independent applier declines an overlap-conflicting allele outright —
+//! `ApplyFailure::Overlapping`, because "an overlapping description has no
+//! single well-defined resulting sequence, and silently double-splicing one
+//! would invent a sequence neither side denotes". So there are no "input's
+//! bases" for a repair to preserve: any answer the repair produces comes from
+//! *choosing* an apply order, which is precisely what W5002 refuses to do.
+//!
+//! The spec does not decide this either way — searched `alleles.md`,
+//! `general.md` and every DNA/RNA recommendation, and no rule addresses two
+//! members writing to the same reference bases. So the applier's refusal is the
+//! strongest evidence available, and it points at preservation.
+//!
+//! ## The gate is on a PLURAL output, and that term is load-bearing
+//!
+//! Both detectors return nothing below two members, so for a single-member
+//! output "the output does not conflict" is vacuously true — there is nothing
+//! left for a second member to collide with. Two very different things reach
+//! that state:
+//!
+//! * members **shifted apart** while still plural — the conflict was erased and
+//!   the description launders; this is what the gate is for;
+//! * members **composed into one edit** — the colliding writes were resolved
+//!   into a single description denoting a definite sequence, which is what
+//!   `delins.md:86-89` asks for and what the pure-deletion exemption in
+//!   `overlap.rs` already relies on.
+//!
+//! Without the plural term the gate reverts #1423, whose whole point is that
+//! `g.[11_12inv;11_12insAA]` collapses to the single member `g.10_11A[4]`.
+
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::NormalizeConfig;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// 20 bases of `A`/`T`, the corpus sequence the `[inv;ins]` families settle on.
+const AT_SEQUENCE: &str = "TTTTTTTTTAATATATTTTA";
+
+/// 18 bases; `10` and `11` are `A`, `12` is `T`. #1416/#1423's reference.
+const CG_SEQUENCE: &str = "CGCGCGCGCAATCGCGCG";
+
+fn provider(sequence: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", sequence.to_string());
+    provider
+}
+
+fn lenient(sequence: &str, input: &str) -> String {
+    Normalizer::new(provider(sequence))
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// Strict mode rejects `input` **as an overlap conflict**.
+///
+/// Keyed on the diagnostic, not on `is_err()`. A bare error check would count
+/// any unrelated failure — a stated-reference mismatch, an out-of-bounds
+/// coordinate — as a successful rejection, so the laundering assertion below
+/// could pass while the conflict really had been laundered and the output was
+/// refused for some other reason entirely.
+fn strict_rejects_as_conflict(sequence: &str, input: &str) -> bool {
+    match Normalizer::with_config(
+        provider(sequence),
+        NormalizeConfig::default().with_error_mode(ErrorMode::Strict),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    {
+        Ok(_) => false,
+        Err(error) => {
+            let message = error.to_string();
+            assert!(
+                message.contains("W5002") || message.contains("OverlapConflictingEdits"),
+                "`{input}` was rejected, but not as an overlap conflict; got: {message}"
+            );
+            true
+        }
+    }
+}
+
+/// The headline: lenient mode must not turn a rejected description into an
+/// accepted one.
+///
+/// Asserted as the property rather than as a pinned string, because that is the
+/// contract — whatever the output is, strict mode must judge it the same way it
+/// judged the input.
+#[test]
+fn the_lenient_output_of_a_conflict_is_still_rejected_by_strict() {
+    for input in [
+        "TEMPLATE:g.[9_10insA;9_10inv]",
+        "TEMPLATE:g.[11_12dup;12_13inv]",
+        "TEMPLATE:g.[10_11inv;10dup]",
+    ] {
+        assert!(
+            strict_rejects_as_conflict(AT_SEQUENCE, input),
+            "`{input}` must be an overlap conflict for this test to mean anything"
+        );
+        let out = lenient(AT_SEQUENCE, input);
+        assert!(
+            strict_rejects_as_conflict(AT_SEQUENCE, &out),
+            "lenient mode turned `{input}` into `{out}`, which strict mode accepts — \
+             the conflict was laundered out of the description"
+        );
+    }
+}
+
+/// The preserved output is the input, so it is a fixed point in one pass.
+#[test]
+fn a_preserved_conflict_is_a_fixed_point() {
+    for input in [
+        "TEMPLATE:g.[9_10insA;9_10inv]",
+        "TEMPLATE:g.[11_12dup;12_13inv]",
+    ] {
+        let once = lenient(AT_SEQUENCE, input);
+        assert_eq!(
+            once, input,
+            "a conflicting allele must come back as authored"
+        );
+        assert_eq!(
+            lenient(AT_SEQUENCE, &once),
+            once,
+            "and must settle in one pass"
+        );
+    }
+}
+
+/// An **uncertain** cis allele launders the same way, so the gate must reach it
+/// too.
+///
+/// This is the one place the preserve gate deliberately differs from the sort
+/// gate above it. That gate excludes `[(a;b)]` because member order inside an
+/// uncertain group is authored presentation and not ours to reorder. Whether the
+/// conflict survives into the output is a different question, and the answer
+/// does not depend on the wrapper — measured before the gate was widened:
+///
+/// ```text
+/// in  g.[(9_10insA;9_10inv)]   strict: REJECT (W5002)
+/// out g.[(11dup;9_10=)]        strict: ACCEPT
+/// ```
+#[test]
+fn an_uncertain_conflict_is_preserved_too() {
+    for input in [
+        "TEMPLATE:g.[(9_10insA;9_10inv)]",
+        "TEMPLATE:g.[(11_12dup;12_13inv)]",
+    ] {
+        assert!(
+            strict_rejects_as_conflict(AT_SEQUENCE, input),
+            "`{input}` must be an overlap conflict for this test to mean anything"
+        );
+        let out = lenient(AT_SEQUENCE, input);
+        assert!(
+            strict_rejects_as_conflict(AT_SEQUENCE, &out),
+            "the uncertain spelling laundered: `{input}` became `{out}`, which strict accepts"
+        );
+        assert!(
+            out.contains("[("),
+            "the uncertainty wrapper must survive preservation; got `{out}`"
+        );
+    }
+}
+
+/// The discriminating half: a conflict resolved by **composition into a single
+/// member** is not preserved, because there is no laundering — the colliding
+/// writes were merged into one description that denotes a definite sequence.
+///
+/// This is #1423's case, and it is the guard that stops the gate being written
+/// as "the output no longer conflicts" alone. That predicate is vacuously true
+/// for any single-member output, so without the plural term this input would be
+/// handed back unchanged and #1423 would be undone.
+#[test]
+fn a_conflict_resolved_into_one_member_is_not_preserved() {
+    let input = "TEMPLATE:g.[11_12inv;11_12insAA]";
+    assert!(
+        strict_rejects_as_conflict(CG_SEQUENCE, input),
+        "the input must be a conflict for this test to discriminate"
+    );
+    assert_eq!(
+        lenient(CG_SEQUENCE, input),
+        "TEMPLATE:g.10_11A[4]",
+        "a conflict composed into a single member must keep #1423's collapse, \
+         not be handed back as authored"
+    );
+}
+
+/// A junction interior to a **pure deletion** was never a conflict, so nothing
+/// here is preserved and the merged form the spec asks for survives.
+///
+/// A deletion removes every base it spans, so an interior junction has nothing
+/// left to be positioned against: the pair denotes the same bases in either
+/// order and whichever interior junction the insertion named.
+///
+/// Deliberately on `CG_SEQUENCE`, where `2_3` is `GC`. On the `A`/`T` reference
+/// the same input settles as `g.2_3inv` instead — `AA` is the reverse
+/// complement of `TT`, so the merged form is a textbook inversion
+/// (`inversion.md:5`) and the assertion would be testing the type dispatcher
+/// rather than the exemption. `revcomp("GC")` is `GC`, so no payload spelled
+/// `AA` can be read as an inversion there.
+#[test]
+fn a_junction_interior_to_a_deletion_still_merges() {
+    let input = "TEMPLATE:g.[2_3del;2_3insAA]";
+    assert!(
+        !strict_rejects_as_conflict(CG_SEQUENCE, input),
+        "a junction interior to a pure deletion composes uniquely, so it is not a conflict"
+    );
+    assert_eq!(
+        lenient(CG_SEQUENCE, input),
+        "TEMPLATE:g.2_3delinsAA",
+        "`delins.md:86-89` asks for the merged form"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -204,6 +204,7 @@ mod issue_1389_codon_gate_emitted_window;
 mod issue_1394_repeat_growth_swallows_deletion;
 mod issue_1398_cds_utr3_insertion_idempotency;
 mod issue_1406_conflict_is_a_property_of_the_input;
+mod issue_1406_lenient_output_keeps_the_conflict;
 mod issue_1416_cancelled_identity_beside_repeat;
 mod issue_1426_five_prime_junction_insertion;
 mod issue_1426_junction_insertion_settles_in_one_pass;


### PR DESCRIPTION
Addresses #1406 row 3. Leaves the issue open — see "What this deliberately does not do".

## The defect

W5002 says an overlap-conflicting allele has no canonical form, so ferro preserves it verbatim and strict mode rejects it. But strict mode re-reads a **description**, and has no memory of what that description was normalized from — so the contract only holds if the emitted description still *looks* conflicting.

It did not. The per-member pipeline repairs the members one at a time (an inversion whose span is its own reverse complement cancels to an identity; an interior insertion respells as a repeat), and the merge collapses what is left:

```
in      TEMPLATE:g.[11_12inv;11_12insAA]   strict: REJECT (W5002)
lenient TEMPLATE:g.10_11A[4]               strict: ACCEPT
```

Lenient mode converts a description ferro refuses into one it admits, with no warning surviving the trip. That also breaks the invariant `issue_1276_dup_junction_overlap::lenient_output_of_a_conflict_is_still_rejected_by_strict` already pins for the shapes it happens to cover.

## Measured, not assumed

The issue reports one input. Enumerating 23,134 two-member cis alleles over four sequences and eleven member shapes shows it is systemic:

| | `main` | this PR |
|---|---|---|
| inputs enumerated | 23,134 | 23,134 |
| strict-rejected | 8,457 | 8,177 |
| **laundered** (reject -> accept) | **1,888** | **486** |
| shape families laundered | 26 | 7 |

## Two changes

**1. When the input conflicts and the output does not, hand back the input.** That is #395's verbatim contract stated exactly, rather than approximated by "skip some passes and hope the conflict survives them". Idempotent by construction: the value handed back is the input, whose conflict the next pass detects again.

**2. A junction interior to a *pure deletion* is no longer a conflict.** A deletion removes every base it spans, so an interior junction has nothing left to be positioned against — `g.[2_3del;2_3insAA]` denotes `AA` in place of `2_3` whichever order the members are applied in and whichever interior junction the insertion named. It composes uniquely, so it was never a conflict. This is the same argument #1411 used to stop rejecting `g.[24dup;24C>G]`, and the merged form `g.2_3delinsAA` is what `delins.md:86-89` asks for.

Deletion **only**. A `delins` does not qualify — its payload survives, so an interior insertion has a position relative to it, and `g.[2_3delinsGG;2_3insA]` genuinely does not say whether the `A` lands before, inside or after the `GG`. Nor does `inv`, `dup` or `repeat`. `insertion_interior_to_delins_emits_one_warning` is the discriminating guard.

## What this deliberately does not do, and why

The remaining 486 rows are erased by the **sequence-first derivation**, which runs after the back-off and re-derives the allele. Closing them means gating that pass on the junction detectors too. That was implemented and measured, and it is the wrong trade:

```
#1301 regressed — TEMPLATE:g.[263_264insAC;264_265insAA] -> TEMPLATE:g.[264_265insCA;264_265dup]
                  but TEMPLATE:g.264_265insCAAA          -> TEMPLATE:g.264_265insCAAA
                  these two spellings of one variant must agree.
```

Those are two spellings of one variant. Gating the derivation stops them merging, so they settle apart — new non-confluence, caught by `cis_spelling_confluence_gap::converged_pairs_stay_converged` and again under 5' shuffle by `the_five_prime_confluence_gap_is_unchanged` ("#1320 has started diverging"). With the gate, 11 tests fail; without it, 4 (all addressed here).

That is precisely the class #1229-#1235 and #1419-#1421 track, and the failure mode behind the read-count dropouts they report. **Confluence is what downstream consumers key on; a strict-mode hygiene property is not worth buying with it.**

The underlying point: two writers at one junction are not an unresolvable conflict — `g.[263_264insAC;264_265insAA]` is simply a two-member *spelling* of `g.264_265insCAAA`, and merging them is what makes the two converge. So #1406's residual is narrower than the census first suggests, and the right frame for it is whether W5002 is over-firing rather than whether the repair is over-eager. The census by family is on the issue.

## Representation stability

**No normalized output moves except for alleles ferro already declares to have no canonical form.** The back-off fires only when the input carries an overlap conflict — i.e. strict mode rejects it, so ferro is on record that it has no canonical form and a consumer has no sanctioned normalized string for it. The full suite is green with no confluence or merge expectation changed, which is the measurement that matters: the shapes that *do* have a canonical form are untouched.

## The one place two issues disagreed

#1416's two oracle tests reached their shape by normalizing `g.[11_12inv;11_12insAA]`. That input is #1406 row 3's own witness, so #1416 wants it repaired and #1406 wants it preserved. They cannot both hold.

The evidence favours preserving it: that input denotes **no sequence at all** — the independent applier declines it in either member order — so there are no "input's bases" to preserve, and the answer the repair produced came from *choosing* an apply order, which is exactly what W5002 exists to refuse.

#1416's **fix** is untouched and still guarded. Its tests now enter at `g.[11_12=;10_11A[4]]` — the allele the fix actually operates on, which is not a conflict (strict mode accepts it) and is what #1416 reported. Only the entry point changed; both assertions, and the wraparound-sibling guard, are unchanged.

## Verification

- `cargo nextest run --features dev` with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1` and `FERRO_SWEEP_SEEDS=full`: **9349 passed, 0 failed**.
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- `insertion_interior_to_deletion_emits_one_warning` becomes `insertion_interior_to_deletion_is_not_a_conflict` (the behaviour this PR changes), and `insertions_sharing_junction_and_interior_to_span_emit_two_warnings` moves its span from `4_7del` to `4_7delinsGG` so it still exercises both branches rather than silently dropping to one.

---

## Revised after review

### The restore requires a plural output

Both detectors return nothing below two members, so for a **single-member** output `!conflicts(&normalized)` is *vacuously* true — there is nothing left for a second member to collide with. Two different things reach that state and only one of them is laundering:

- members **shifted apart** while still plural — the conflict was erased, the description launders. This is the target.
- members **composed into one edit** — the colliding writes were resolved into a single description denoting a definite sequence, which is what `delins.md:86-89` asks for and what the pure-deletion exemption here already relies on.

Without the plural term this gate **reverted #1423**: `g.[11_12inv;11_12insAA]` collapses to the single member `g.10_11A[4]`, which cannot conflict, so the input was handed back and a merged, shipped form was undone.

Consequence: the earlier revision had to re-point `issue_1416_cancelled_identity_beside_repeat.rs` at the downstream shape, on the premise that "the upstream spelling no longer reaches this fix". That premise is now false, so **the file is back to `main` unchanged** and this PR touches no existing test's expectations.

### Uncertain alleles are inside the gate

This is the one place the preserve gate deliberately differs from the genomic-order sort gate above it. That gate excludes `[(a;b)]` because member order inside an uncertain group is authored presentation. Whether the conflict survives is a different question, and the answer does not depend on the wrapper:

```
in  g.[(9_10insA;9_10inv)]   strict: REJECT (W5002)
out g.[(11dup;9_10=)]        strict: ACCEPT
```

Excluding them left the hole open on one spelling of the same input.

### Representation movement

`dump_normalized_corpus` (the #1442 harness), 18,432 rows across both axes and both shuffle directions, against `origin/main`: **0 moved (0.0%)**, zero in all five shape families.

That is a statement about *collateral* movement only. The corpus builds `dup_plus_sub`, `del_plus_sub`, `adjacent_junction_ins`, `dup_plus_ins` and `split_vs_spanning_delins` — none of which construct an overlap-conflicting allele, the only class this PR touches. The movement inside that class is the enumeration already reported above (laundered rows 1,888 -> 486).

### Coverage

`tests/it/issue_1406_lenient_output_keeps_the_conflict.rs`, five guards, each A/B'd:

| A/B | result |
|---|---|
| against `origin/main` | 3 of 4 original guards fail — the restore and the deletion exemption are real |
| plural term removed | the composition guard fails **and two of #1416's own tests fail** — the #1423 revert, demonstrated |
| `!allele.uncertain` restored | the uncertain guard fails |

`strict_rejects_as_conflict` keys on the W5002 diagnostic rather than `is_err()`, so an unrelated failure cannot masquerade as a successful rejection.
