### PR TITLE
docs: correct two normalizer comments that name the wrong mechanism

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -338,16 +338,34 @@ pub(crate) fn has_same_gap_insertions(variants: &[HgvsVariant], phase: AllelePha
 /// group:
 ///   * all sub-variants are same-accession genomic `NaEdit`s with simple
 ///     (certain, non-special, non-offset) positions, and one of
-///     ins/del/sub/delins (literal payloads only);
+///     ins/**dup**/del/sub/delins, and where the edit carries a payload at all
+///     that payload is literal (a `dup` carries none — it copies the range it
+///     names from the reference);
 ///   * the del/sub/delins spans form one contiguous interval with no
 ///     unchanged interior base (no holes);
-///   * every insertion attaches to that interval (its gap lies in
+///   * every insertion-like member attaches to that interval (its gap lies in
 ///     `[c_lo - 1, c_hi]`);
-///   * the group has BOTH an insertion and a del/sub/delins.
+///   * the group has BOTH an insertion-like member and a del/sub/delins.
 ///
-/// Anything else passes through untouched, so pure-insertion groups,
-/// pure-deletion groups (owned by `merge_consecutive_edits`), and
-/// non-overlapping inputs are unaffected.
+/// **`dup` is insertion-like here, not a span (#1436.)** The list above used to
+/// omit it, which read as an exhaustive precondition and told anyone tracing
+/// whether a `dup` can reach this collapse that it cannot. It can: the body
+/// treats it as one of the members that attaches to the del/sub/delins interval
+/// —
+///
+/// ```ignore
+/// let is_insertion_like = |e: &GEdit| matches!(e, GEdit::Ins { .. } | GEdit::Dup { .. });
+/// ```
+///
+/// — plus four further `GEdit::Dup` arms in the span and gap computations. That
+/// is the same read/write distinction #1411 drew: a `dup` writes at the junction
+/// 3' of the run it reads, so it attaches to an interval rather than forming
+/// one.
+///
+/// Anything else passes through untouched, so pure-insertion groups (including
+/// pure-`dup` ones, which have no del/sub/delins to attach to), pure-deletion
+/// groups (owned by `merge_consecutive_edits`), and non-overlapping inputs are
+/// unaffected.
 pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     variants: Vec<HgvsVariant>,
     phase: AllelePhase,

--- a/tests/it/strict_rejection_survives_normalization.rs
+++ b/tests/it/strict_rejection_survives_normalization.rs
@@ -32,15 +32,32 @@
 //! same bases, and strict-**acceptable**. That is #1307, and it is the shape the
 //! rows below start from.
 //!
-//! ## The control
+//! ## The companion row, and what it does *not* guard
 //!
-//! `a_non_conflicting_allele_of_the_same_shape_still_merges` is what makes the
-//! rows above mean "no laundering" rather than "multi-member alleles stay
-//! multi-member". It is the *same* `dup`-plus-substitution shape one base to the
-//! left, where the duplication has a junction to be respelled at and so never
-//! becomes a conflict — and it must still collapse to one member. A gate keyed
-//! on the shape rather than on the conflict would refuse it too, and this test
-//! is what would notice.
+//! `a_non_conflicting_allele_of_the_same_shape_still_merges` pins that the
+//! *same* `dup`-plus-substitution shape one base to the left — where the
+//! duplication has a junction to be respelled at and so never becomes a
+//! conflict — still collapses to one member. That is a real regression guard for
+//! the merge outcome and worth keeping.
+//!
+//! **It is not a control on the gate's scoping**, though this header and that
+//! test's own docstring both used to claim it was (#1435). The claim was that a
+//! gate keyed on the `dup`-plus-substitution *shape* rather than on the conflict
+//! would refuse it, and the test would notice. It would not: `sequence_first_pass`
+//! runs *after* the legacy per-member collapse, so `g.[23dup;23A>G]` has already
+//! become the single member `g.22_23insG` by the time the gate is reached, and a
+//! shape-keyed gate would have nothing left to key on.
+//!
+//! Measured rather than argued, on this file's own fixture: instrumenting the
+//! gate reports `sequence_first_pass sees 1 member` for that input, so its
+//! `members.len() > 1` precondition is false and the gate never runs — and
+//! disabling the gate outright leaves the test passing unchanged.
+//!
+//! Left corrected rather than deleted because the wrong version was load-bearing
+//! in the wrong direction: it told a reader that gate scoping was already
+//! covered, which is exactly what stops someone writing the control that would
+//! cover it. **A genuine control needs an input that reaches
+//! `sequence_first_pass` with two members still intact.**
 
 use ferro_hgvs::error_handling::ErrorMode;
 use ferro_hgvs::normalize::NormalizeConfig;
@@ -158,27 +175,36 @@ fn a_conflict_strict_rejects_survives_lenient_normalization() {
     }
 }
 
-/// The gate must key on the conflict, not on the shape it was found in.
+/// A non-conflicting `dup`-plus-substitution pair still collapses to one member.
 ///
-/// `g.[23dup;23A>G]` is the identical `dup`-plus-substitution pair one base to
-/// the left of #1307's. There it is *not* a conflict — the duplication has a
-/// junction 3' of itself to be respelled at, so the two members never end up
-/// coincident — and the derivation is expected to merge it into a single
-/// insertion exactly as it did before the gate existed.
+/// `g.[23dup;23A>G]` is the identical pair one base to the left of #1307's.
+/// There it is *not* a conflict — the duplication has a junction 3' of itself to
+/// be respelled at, so the two members never end up coincident — and the
+/// **legacy per-member collapse** merges it into a single insertion.
+///
+/// **This does not guard `sequence_first_pass`'s gate (#1435.)** It used to say
+/// it did — "a gate that refused this would be keyed on the shape rather than on
+/// the conflict" — and that is not reachable here. The collapse runs first, so
+/// the gate is handed one member, its `members.len() > 1` precondition is false,
+/// and it never runs: instrumenting it reports `sees 1 member` for this input,
+/// and disabling the gate outright leaves this test passing unchanged. A gate
+/// erroneously keyed on the shape would have nothing to key on.
+///
+/// What it does guard is the merge outcome, which is worth keeping on its own
+/// terms. See the module header for what a genuine control on the gate's
+/// scoping would need.
 #[test]
 fn a_non_conflicting_allele_of_the_same_shape_still_merges() {
     let input = "NC_TEST.1:g.[23dup;23A>G]";
     assert!(
         !strict_rejects("NC_TEST.1", input),
-        "`{input}` is the control precisely because it is *not* a conflict; if \
-         strict mode has started rejecting it, it can no longer show that the \
-         gate is scoped to conflicts rather than to the shape"
+        "`{input}` carries no conflict — the duplication writes at its own \
+         junction, clear of the substitution — so strict mode must accept it"
     );
     assert_eq!(
         normalize_lenient("NC_TEST.1", input),
         "NC_TEST.1:g.22_23insG",
-        "`{input}` carries no conflict, so the derivation must still merge it \
-         into one member — a gate that refused this would be keyed on the \
-         `dup`-plus-substitution shape rather than on the conflict"
+        "`{input}` must still collapse to one member through the legacy \
+         per-member collapse"
     );
 }


### PR DESCRIPTION
Closes #1435. Closes #1436.

Both were raised during #1411's review and deferred as out of scope. Neither changes behaviour. They are grouped because they are the same failure — a comment that names a mechanism it does not have — and both were load-bearing in the wrong direction.

## #1435 — a "control" that cannot fail for the reason it gives

`a_non_conflicting_allele_of_the_same_shape_still_merges` claimed to guard `sequence_first_pass`'s gate:

> The gate must key on the conflict, not on the shape it was found in.

and the module header called it the thing that would notice "a gate keyed on the shape rather than on the conflict".

It cannot notice. The legacy per-member collapse runs **before** `sequence_first_pass`, so `g.[23dup;23A>G]` reaches the gate as the single member `g.22_23insG`; the gate's `members.len() > 1` precondition is false and it never runs. A gate erroneously keyed on the `dup`-plus-substitution shape would have nothing left to key on, and this test would pass anyway.

**Measured rather than argued**, since the issue's claim is structural and worth checking before rewriting docs on its strength:

- Instrumenting the gate to report its member count prints `SEQFIRST sees 1 member(s)` for this input, on both the strict and lenient calls.
- Disabling the gate entirely (`detect_overlap_conflicts` check short-circuited) leaves the test passing, byte-identically. A test that guards a gate cannot be indifferent to the gate's existence.

Corrected rather than deleted: the assertions are a real regression guard for the merge outcome and worth keeping, but the wrong docstring told a reader that gate scoping was already covered — which is exactly what stops someone writing the control that would cover it. Both the docstring and the module header now say what the test does guard, and the header states what a genuine control needs: **an input that reaches `sequence_first_pass` with two members still intact.**

## #1436 — an "exhaustive" kind list missing a kind

`collapse_overlapping_cis_edits`' doc comment enumerated its accepted edit kinds as `ins/del/sub/delins` and omitted `dup`. The body treats `dup` as insertion-like throughout:

```rust
let is_insertion_like = |e: &GEdit| matches!(e, GEdit::Ins { .. } | GEdit::Dup { .. });
```

plus four further `GEdit::Dup` arms in the span and gap computations — i.e. exactly the role the list is describing: a member that attaches to the del/sub/delins interval rather than forming one. That is the same read/write distinction #1411 drew, since a `dup` writes at the junction 3' of the run it reads.

The list reads as an exhaustive precondition, so someone reasoning about whether a `dup` can reach this collapse would conclude it cannot. `dup` is now in the kind list and in the attachment bullet, the two bullets say "insertion-like" where they mean it rather than "insertion", and the closing "unaffected" paragraph is checked against the addition — pure-`dup` groups are still unaffected, because they have no del/sub/delins to attach to.

## Verification

- `cargo nextest run --features dev` with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1` and `FERRO_SWEEP_SEEDS=full`: **9366 passed, 0 failed**.
- `cargo fmt --all --check` clean.
- The instrumentation used for the #1435 measurement was temporary and is not in this diff.