### PR TITLE
fix(normalize): report span edits whose spans intersect without coinciding

### DIFF
--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -88,7 +88,117 @@ pub(crate) fn detect_overlap_conflicts(
             edit_kinds,
         });
     }
+
+    // Spans that *intersect* without coinciding (#1448).
+    //
+    // The grouping above keys on exact `(accession, coord_system, region, start,
+    // end)` equality, so two members that overlap only partially — or that nest —
+    // land in different groups and were reported by nothing. Strict mode
+    // therefore accepted them, and they denote no sequence at all: the
+    // independent applier declines them in either member order.
+    //
+    //     g.[10_14del;12_16del]        ACCEPTED, applies to nothing
+    //     g.[10_14inv;12_16inv]        ACCEPTED, applies to nothing
+    //     g.[10_14del;10_16del]        ACCEPTED, applies to nothing (nested)
+    //
+    // Measured over two-member span-edit alleles on four sequences: 10,499 of
+    // the 25,848 strict mode accepted — 41% — denoted nothing.
+    //
+    // **Restricted to edits whose write footprint *is* their span**, which is
+    // the #1411 principle and what makes the `dup` behaviour fall out rather
+    // than need a special case: a `dup`/`repeat` reads its span and writes at
+    // the junction 3' of it, so two overlapping `dup` spans genuinely do
+    // compose, and none appeared in the measured families.
+    // `detect_insertion_overlaps` owns the junction geometry.
+    //
+    // Pairwise rather than grouped, and skipping pairs whose keys are equal, so
+    // an exactly-coincident pair is reported once — by the loop above, which
+    // names every member of its group — rather than twice.
+    for (i, first) in variants.iter().enumerate() {
+        let Some((coord_system, region, first_start, first_end)) = span_writer_footprint(first)
+        else {
+            continue;
+        };
+        let Some(first_accession) = first.accession().map(|a| a.to_string()) else {
+            continue;
+        };
+        for (j, second) in variants.iter().enumerate().skip(i + 1) {
+            let Some((second_system, second_region, second_start, second_end)) =
+                span_writer_footprint(second)
+            else {
+                continue;
+            };
+            let Some(second_accession) = second.accession().map(|a| a.to_string()) else {
+                continue;
+            };
+            if first_accession != second_accession
+                || coord_system != second_system
+                || region != second_region
+            {
+                continue;
+            }
+            // Coincident pairs belong to the grouped loop above.
+            if first_start == second_start && first_end == second_end {
+                continue;
+            }
+            // A reversed span is not an interval, so do not test it as one.
+            // SVD-WG006 admits `<high>_<low>` for a circular deletion or
+            // duplication, and `genome_range` passes those through with
+            // `start > end` — nothing upstream reorders them. Read as an
+            // ordinary interval, `m.16569_5del` claims to end before it begins,
+            // so the test below would decide the pair by accident rather than
+            // by geometry. Declining to judge it is the conservative answer and
+            // the same one #1423 reached for the containment test next door: a
+            // missed report is a verdict this pass simply does not make, while a
+            // wrong one is a rejection the caller cannot explain.
+            let reversed = first_start > first_end || second_start > second_end;
+            // Closed intervals: they intersect when neither ends before the
+            // other begins.
+            if reversed || first_end < second_start || second_end < first_start {
+                continue;
+            }
+            let kinds: Vec<String> = [i, j]
+                .iter()
+                .filter_map(|&idx| edit_kind(&variants[idx]).map(|s| s.to_string()))
+                .collect();
+            warnings.push(NormalizationWarning::OverlapConflict {
+                accession: first_accession.clone(),
+                coordinate_system: coord_system.to_string(),
+                location: location_for_variant(first)
+                    .expect("span_writer_footprint established a renderable location"),
+                edit_kinds: kinds,
+            });
+        }
+    }
     warnings
+}
+
+/// The reference span an edit **writes over**, for the edits whose write
+/// footprint is their own span.
+///
+/// `None` for anything else, which is what keeps the intersection test above
+/// narrow:
+///
+/// - an **insertion** writes at a zero-width junction, not over a span;
+/// - a **`dup`/`repeat`** reads its span and writes at the junction 3' of it
+///   (`duplication.md:5`), so two overlapping `dup` spans compose uniquely —
+///   the #1411 principle, and the reason no `dup` family appears in #1448's
+///   measured census.
+///
+/// Both of those geometries belong to [`detect_insertion_overlaps`].
+fn span_writer_footprint(variant: &HgvsVariant) -> Option<(&'static str, Region, i64, i64)> {
+    let edit = inner_edit(variant)?;
+    if !matches!(
+        edit,
+        NaEdit::Substitution { .. }
+            | NaEdit::SubstitutionNoRef { .. }
+            | NaEdit::Deletion { .. }
+            | NaEdit::Delins { .. }
+            | NaEdit::Inversion { .. }
+    ) {
+        return None;
+    }
+    simple_span(variant)
 }
 
 /// Detect overlaps that involve at least one junction-anchored edit within a
@@ -907,6 +1017,34 @@ mod tests {
             panic!("expected OverlapConflict, got {:?}", warnings[0]);
         };
         assert_eq!(location, "*1_*2");
+    }
+
+    /// Two **overlapping `dup` spans** are not a coincident-bounds conflict (#1448).
+    ///
+    /// The intersection test added for #1448 is restricted to edits whose write
+    /// footprint *is* their span. A `dup` reads its span and writes at the
+    /// junction 3' of it (`duplication.md:5`), so overlapping read spans do not
+    /// mean colliding writes — and keying the test on the read span instead,
+    /// the reading #1411 corrected, would report these.
+    ///
+    /// Asserted here rather than end to end because
+    /// `detect_insertion_overlaps` reports an overlapping `dup` pair for its own
+    /// separate reasons (#1437); this pins only what *this* detector decides.
+    #[test]
+    fn overlapping_duplication_spans_are_not_a_coincident_conflict() {
+        for input in [
+            "NG_012337.1:g.[10_14dup;12_16dup]",
+            "NG_012337.1:g.[10_14dup;10_16dup]",
+        ] {
+            let (variants, phase) = parse_allele(input);
+            let warnings = detect_overlap_conflicts(&variants, phase);
+            assert!(
+                warnings.is_empty(),
+                "`{input}`: two duplications write at different junctions, so \
+                 their overlapping read spans are not a coincident-bounds \
+                 conflict; got {warnings:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/it/issue_1448_partial_span_overlap.rs
+++ b/tests/it/issue_1448_partial_span_overlap.rs
@@ -1,0 +1,200 @@
+//! #1448 — strict mode accepted span edits whose spans *intersect* without
+//! coinciding, and those descriptions denote no sequence at all.
+//!
+//! `detect_overlap_conflicts` grouped sub-variants by **exact**
+//! `(accession, coord_system, region, start, end)` equality. Two members that
+//! overlap only partially — or that nest — land in different groups, so nothing
+//! reported them and strict mode accepted them. The independent applier declines
+//! them, in either member order:
+//!
+//! ```text
+//! g.[10_14del;12_16del]        ACCEPTED, denotes nothing
+//! g.[10_14inv;12_16inv]        ACCEPTED, denotes nothing
+//! g.[10_14del;10_16del]        ACCEPTED, denotes nothing  (nested)
+//! ```
+//!
+//! Measured over two-member span-edit alleles on four sequences at widths 1-3
+//! and separations 0-4: **10,499 of the 25,848 strict mode accepted — 41% —
+//! denoted nothing.** With the intersection test, zero.
+//!
+//! None of the three seam oracles could see this. `FERRO_ASSERT_REPARSE` passes
+//! (both spellings parse), `FERRO_ASSERT_IN_BOUNDS` passes (every coordinate is
+//! in range), and `FERRO_ASSERT_IDEMPOTENT` passes whenever the output is a
+//! fixed point — which most of these are. The applier is not wired in as an
+//! oracle, so "denotes no sequence" was invisible.
+//!
+//! The test restricted to edits whose write footprint **is** their span. That is
+//! #1411's principle, and it is what makes the `dup` behaviour fall out instead
+//! of needing a special case: a `dup`/`repeat` reads its span and writes at the
+//! junction 3' of it, so two overlapping `dup` spans genuinely compose — and no
+//! `dup` family appeared anywhere in the measured census.
+//!
+//! The `dup` exemption is asserted where it can be isolated — as a unit test
+//! on `detect_overlap_conflicts` in `src/normalize/overlap.rs`. End to end it
+//! cannot be: `detect_insertion_overlaps` reports an overlapping `dup` pair
+//! for its own reasons on `main` (#1437), so an integration assertion here
+//! would be measuring that detector rather than this one.
+
+use crate::common::cis_apply_oracle::apply;
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
+
+/// 29 bases, with a `TTT` run at 9-11 so a member has somewhere to shift.
+const SEQUENCE: &str = "ACGTACGTTTTACGTACGTGGGCCCACGT";
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", SEQUENCE.to_string());
+    provider
+}
+
+fn strict_accepts(input: &str) -> bool {
+    let variant = parse_hgvs(input).expect("input must parse");
+    Normalizer::with_config(provider(), NormalizeConfig::strict())
+        .normalize(&variant)
+        .is_ok()
+}
+
+fn lenient(input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    Normalizer::new(provider())
+        .normalize(&variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// The headline, stated as the invariant rather than as four verdicts: strict
+/// mode must not accept a description that denotes no sequence.
+///
+/// Written this way on purpose. Pinning "these four are rejected" would be
+/// satisfied by a change that rejected them for an unrelated reason while
+/// letting a fifth shape through; tying the verdict to the applier's answer is
+/// what makes it a property.
+#[test]
+fn strict_never_accepts_a_description_that_denotes_no_sequence() {
+    for input in [
+        // Partial overlap, every combination of the span-writing kinds.
+        "TEMPLATE:g.[10_14del;12_16del]",
+        "TEMPLATE:g.[10_14delinsAA;12_16del]",
+        // Both members `delins`, which the row above does not reach: a `delins`
+        // is the only span-writing kind that carries a payload, so a pair of
+        // them is the case where two *different* payloads compete for the same
+        // bases rather than one payload competing with a removal.
+        "TEMPLATE:g.[10_14delinsAA;12_16delinsCC]",
+        "TEMPLATE:g.[10_14inv;12_16inv]",
+        "TEMPLATE:g.[10_14del;12_16inv]",
+        "TEMPLATE:g.[10_14inv;12_16delinsAA]",
+        // Nested, which shares no bound at all with its sibling.
+        "TEMPLATE:g.[10_14del;10_16del]",
+        // A single-base member interior to a span — caught before this fix, and
+        // it must stay caught.
+        "TEMPLATE:g.[10_14del;12C>G]",
+        "TEMPLATE:g.[10_14inv;12C>G]",
+    ] {
+        assert!(
+            apply(SEQUENCE, input).is_none(),
+            "fixture error: `{input}` was chosen because it denotes no sequence, \
+             but the applier accepted it"
+        );
+        assert!(
+            !strict_accepts(input),
+            "`{input}` denotes no sequence, so strict mode must reject it"
+        );
+    }
+}
+
+/// A conflicting allele is returned as authored, not shifted.
+///
+/// Before the fix, two of these were *shifted* while left overlapping —
+/// `g.[10_14del;12_16del]` came back as `g.[11_15del;12_16del]` — which is the
+/// pipeline repairing a member of an allele it should have been preserving
+/// (#395). Reporting the conflict routes them to the verbatim path.
+#[test]
+fn a_conflicting_allele_is_returned_as_authored() {
+    for input in [
+        "TEMPLATE:g.[10_14del;12_16del]",
+        "TEMPLATE:g.[10_14del;10_16del]",
+    ] {
+        assert_eq!(
+            lenient(input),
+            input,
+            "`{input}` conflicts, so it must be preserved rather than shifted"
+        );
+    }
+}
+
+/// Disjoint members are untouched. The intersection test must not widen into
+/// members that merely sit near each other.
+#[test]
+fn disjoint_span_members_are_still_accepted() {
+    for input in [
+        // Adjacent, sharing no base.
+        "TEMPLATE:g.[10_14del;15_16del]",
+        // Separated.
+        "TEMPLATE:g.[10_14del;20_22del]",
+        "TEMPLATE:g.[10_14inv;20_22inv]",
+    ] {
+        assert!(
+            strict_accepts(input),
+            "`{input}`'s members share no base, so it must still be accepted"
+        );
+        assert!(
+            apply(SEQUENCE, input).is_some(),
+            "`{input}` must denote a sequence"
+        );
+    }
+}
+
+/// Exactly-coincident members are reported once, not twice.
+///
+/// The pre-existing grouped loop names every member of a coincident group; the
+/// intersection pass skips equal-bound pairs so it does not re-report them.
+#[test]
+fn a_coincident_pair_is_reported_once() {
+    use ferro_hgvs::normalize::NormalizationWarning;
+    let variant = parse_hgvs("TEMPLATE:g.[10_14del;10_14inv]").expect("parse");
+    let outcome = Normalizer::new(provider())
+        .normalize_with_diagnostics(&variant)
+        .expect("lenient normalization must not reject");
+    let warnings = outcome.warnings;
+    let conflicts = warnings
+        .iter()
+        .filter(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }))
+        .count();
+    assert_eq!(
+        conflicts, 1,
+        "one coincident pair must yield one conflict warning, got {conflicts}: {warnings:?}"
+    );
+}
+
+/// …and so is an intersecting pair, which the coincident test cannot show.
+///
+/// The pass walks unordered pairs (`for i`, then `for j` skipping `i + 1`), so
+/// each pair is visited once — but nothing pinned that, and a loop that visited
+/// both orderings would report every partial overlap twice while still passing
+/// every other test in this file. The count is the only thing that notices.
+///
+/// Both a partial overlap and a nested pair, because they reach the test
+/// through different branches of the interval comparison.
+#[test]
+fn an_intersecting_pair_is_reported_once_too() {
+    use ferro_hgvs::normalize::NormalizationWarning;
+    for input in [
+        "TEMPLATE:g.[10_14del;12_16del]",
+        "TEMPLATE:g.[10_14del;10_16del]",
+    ] {
+        let variant = parse_hgvs(input).expect("parse");
+        let outcome = Normalizer::new(provider())
+            .normalize_with_diagnostics(&variant)
+            .expect("lenient normalization must not reject");
+        let warnings = outcome.warnings;
+        let conflicts = warnings
+            .iter()
+            .filter(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }))
+            .count();
+        assert_eq!(
+            conflicts, 1,
+            "`{input}` is one intersecting pair and must yield one conflict warning, \
+             got {conflicts}: {warnings:?}"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -212,6 +212,7 @@ mod issue_1426_junction_insertion_settles_in_one_pass;
 mod issue_1429_derivation_honours_shuffle_direction;
 mod issue_1431_single_position_repeat_anchor;
 mod issue_1437_dup_read_span_interior_sibling;
+mod issue_1448_partial_span_overlap;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1448.

## The defect

`detect_overlap_conflicts` grouped sub-variants by **exact** `(accession, coord_system, region, start, end)` equality. Two span edits that overlap only *partially* — or that *nest* — share no key, so nothing reported them and strict mode accepted them. They denote no sequence at all; the independent applier declines them in either member order.

Measured on `origin/main` at `699fb592`, reference `ACGTACGTTTTACGTACGTGGGCCCACGT`:

```
g.[10_14del;12_16del]        strict: ACCEPT   applies: NO   -> g.[11_15del;12_16del]
g.[10_14delinsAA;12_16del]   strict: ACCEPT   applies: NO   -> unchanged
g.[10_14inv;12_16inv]        strict: ACCEPT   applies: NO   -> unchanged
g.[10_14del;10_16del]        strict: ACCEPT   applies: NO   -> g.[10_16del;11_15del]   (nested)
```

Note the first and last: the normalizer *shifted* a member while leaving the pair overlapping — repairing a member of an allele it should have been preserving verbatim (#395).

## Scale

Enumerating two-member cis alleles over four sequences, member widths 1-3, separations 0-4, restricted to span edits:

| measure | `main` | this PR |
|---|---|---|
| enumerated | 31,110 | 31,110 |
| strict-accepted | 25,848 | 15,349 |
| **accepted but denoting no sequence** | **10,499** | **0** |
| families | 9 | 0 |

**41% of everything strict mode accepted in this shape class denoted nothing.**

## Why nothing caught it

- `detect_overlap_conflicts` keys on exact coincidence, so `10_14` and `12_16` are different groups.
- `detect_insertion_overlaps` needs a junction-anchored member; neither of these is one.
- **None of the three seam oracles can see it.** `FERRO_ASSERT_REPARSE` passes (both spellings parse), `FERRO_ASSERT_IN_BOUNDS` passes (every coordinate is in range), and `FERRO_ASSERT_IDEMPOTENT` passes whenever the output is a fixed point — which most of these are. The applier is not wired in as an oracle, so "denotes no sequence" was invisible to CI.

## The fix

Report a conflict when two members' spans **intersect**, not only when they coincide.

**Restricted to edits whose write footprint *is* their span** — `sub`, `del`, `delins`, `inv`. That is #1411's principle, and it is what makes the `dup` behaviour fall out instead of needing a special case: a `dup`/`repeat` reads its span and writes at the junction 3' of it, so two overlapping `dup` spans genuinely compose. That prediction is borne out by the census — no `dup` family appears in any of the nine. `detect_insertion_overlaps` owns the junction geometry.

Pairwise rather than grouped, and skipping equal-bound pairs, so an exactly-coincident pair is still reported **once** by the existing grouped loop (which names every member of its group) rather than twice. Pinned by a test.

## Representation stability

This **widens W5002**: 10,499 inputs move from accepted to rejected. Stated plainly, since that is a shipped-behaviour change.

What makes it the cheap direction is that every affected input's accepted output denoted no sequence, so no consumer can be holding a meaningful normalized string for one. And the lenient output for two of the four measured shapes was *worse* than meaningless — it was a shifted member of an allele the pipeline should have been preserving. Those now take the verbatim path, which is what #395 specifies.

### The committed harness reports zero, and that result is uninformative here

Run per #1441/#1442, base `699fb592` against this branch:

| | rows |
|---|---|
| total | 18,432 |
| **moved** | **0 (0.0%)** |
| previously accepted (a migration) | 0 |
| previously not a fixed point (free) | 0 |

**Do not read that as "no blast radius".** `examples/dump_normalized_corpus.rs` emits five
families — `adjacent_junction_ins`, `del_plus_sub`, `dup_plus_ins`, `dup_plus_sub`,
`split_vs_spanning_delins` — and **every one of them places its members disjointly**:
`split_vs_spanning_delins` is `[s_s+1delinsGGG; s+3_s+4delinsGG]` with an unchanged base at
`s+2`, `del_plus_sub` puts its substitution three positions past the deletion, and so on. Two
span edits whose spans *intersect* — this PR's entire subject — do not occur anywhere in that
corpus. The zero is real, and it measures a population this change cannot touch.

So the load-bearing measurement for this PR remains the one in the table above (10,499 → 0 over
31,110 enumerated two-member span alleles), plus a green suite with no existing expectation
moved. The harness result is included because it was run and should be on the record, not
because it is evidence.

That gap is worth closing separately: overlapping and nested span members are the shape class
#1406, #1437 and #1448 all live in, and the harness cannot currently see any of them.

## Verification

- `cargo nextest run --features dev` with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1` and `FERRO_SWEEP_SEEDS=full`: **9371 passed, 0 failed**, with **no existing expectation changed**.
- `cargo fmt --all --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- New `tests/it/issue_1448_partial_span_overlap.rs`: the headline stated as an invariant (strict must never accept a description the applier declines, checked per input rather than pinned as four verdicts), the verbatim-not-shifted property, disjoint members still accepted, and single-reporting of coincident pairs.
- New unit test in `src/normalize/overlap.rs`: overlapping `dup` spans are not a coincident-bounds conflict. Asserted there rather than end to end because `detect_insertion_overlaps` reports an overlapping `dup` pair for its own separate reasons on `main` (#1437, fixed by #1446), so an integration assertion would be measuring the other detector.


---

## Representation movement — it is not only a strict-mode change

**This section was added after #1445 merged, which this PR predates.** #1445 hands an overlap-conflicting allele back as authored when the pipeline would otherwise launder the conflict away. So every conflict this PR newly *detects* is now also an allele that is newly *preserved* — and the lenient output moves, not just the strict verdict.

Measured on this PR's own fixture sequence, against `main` at `a52fef26`:

| input | `main` | this PR |
|---|---|---|
| `g.[10_14del;12_16del]` | `g.[11_15del;13_17del]` | preserved as authored |
| `g.[10_14del;10_16del]` | `g.[10_16del;11_15del]` | preserved as authored |
| `g.[10_14inv;12_16inv]` | `g.[11_13inv;12_16inv]` | preserved as authored |

Three of three. The bound on how many rows this reaches is the census already reported above — the newly-detected conflicts, 10,499 of the 25,848 two-member span alleles enumerated — since detection is what triggers preservation.

**Every one of those rows is cheap in the stability sense**, which is the reason to land it rather than defer it: the outputs that move are the ones the applier declines outright. `main` shifts them into a well-formed description of a sequence *neither member denotes*, so no consumer holds a correct key for them today. Moving from a wrong answer to a preserved input costs nothing that was right.

**The committed corpus reports 0 of 18,432 moved, and that is not evidence here.** `dump_normalized_corpus` builds no overlap-conflicting alleles at all, so it cannot see this class — filed as #1456. The zero means no *collateral* movement outside the conflict families, which is worth having but is not the measurement this section is about.
