### PR TITLE
feat(normalize): add the member-count-minimal partitioner behind a flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,10 @@ required-features = ["dev"]
 [[example]]
 name = "report_conformance_reference_gaps"
 required-features = ["dev"]
+
+[[example]]
+name = "dump_partitions"
+required-features = ["dev"]
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/examples/dump_partitions.rs
+++ b/examples/dump_partitions.rs
@@ -1,0 +1,239 @@
+//! Dump all three block partitions side by side, one row per block.
+//!
+//! The bake-off harness for ferro's three partitioners. Each input row is a
+//! `(reference_block, alternate_block)` pair; each output row is what `live`,
+//! `shadow` and `canonical` each make of it, together with the block's
+//! Levenshtein distance and each arm's changed-column count so distance-minimality
+//! is checkable per arm straight from the dump.
+//!
+//! The three rules are not variations on one another:
+//!
+//! * **live** — `partition_block`: a single-gap alignment search plus two narrow
+//!   escapes. The shipped rule.
+//! * **shadow** — `partition_block_sequence_first`: cut at the alignment steps
+//!   common to *every* minimal alignment, then merge runs separated by fewer than
+//!   `--min-separation` unchanged bases. `mutalyzer-algebra`'s `local_supremal`.
+//! * **canonical** — `partition_block_canonical`: the minimal alignment with the
+//!   fewest members, 3'-most among ties. `mutalyzer-algebra`'s `canonical`.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --features dev --example dump_partitions -- [--min-separation N] [PATH]
+//! ```
+//!
+//! `PATH` defaults to `-` (standard input). Input is tab-separated
+//! `reference<TAB>alternate`, one block pair per line; empty lines and lines
+//! beginning with `#` are skipped, and either block may be empty. Bases are
+//! compared byte-exactly and are **not** case-folded — pass the blocks in the
+//! same case the normalizer would, which is upper case.
+//!
+//! `--min-separation` applies to the `shadow` arm only; the other two take no
+//! such parameter. It defaults to the coding one-amino-acid exception (2). Pass
+//! `1` to measure the arm as a genomic axis would run it.
+//!
+//! # Output
+//!
+//! One header row, then one tab-separated row per input block:
+//!
+//! ```text
+//! ref  alt  distance  live  live_cols  shadow  shadow_cols  canonical  canonical_cols
+//! ```
+//!
+//! A partition renders as its members joined by `|`, each as
+//! `ref_start:ref_end/alt` over 0-based half-open reference offsets into the
+//! block — so `0:1/|3:4/` is two deletions and `2:2/CAC` is one insertion. An
+//! empty partition (an unchanged block) renders as `-`.
+//!
+//! Two sentinels replace a partition rather than a member list. `DECLINED` is an
+//! arm that legitimately returned nothing — the `shadow` arm does on some blocks
+//! — and `PANIC` is an arm that panicked, which is caught per arm so one bad
+//! block cannot abandon the dump. Their column counts render as `-`.
+
+use ferro_hgvs::normalize::dev_partitioners::{self, DevPiece, DEFAULT_MIN_SEPARATION};
+use std::io::{BufRead, BufWriter, Write};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// What one partitioner made of one block.
+enum Outcome {
+    Partitioned(Vec<DevPiece>),
+    /// The arm returned `None`.
+    Declined,
+    /// The arm panicked. Recorded rather than propagated, so a dump over a large
+    /// corpus reports the bad block instead of stopping at it.
+    Panicked,
+}
+
+impl Outcome {
+    /// Run one arm, converting a panic into [`Outcome::Panicked`].
+    fn of<F: FnOnce() -> Option<Vec<DevPiece>>>(arm: F) -> Self {
+        match catch_unwind(AssertUnwindSafe(arm)) {
+            Ok(Some(pieces)) => Outcome::Partitioned(pieces),
+            Ok(None) => Outcome::Declined,
+            Err(_) => Outcome::Panicked,
+        }
+    }
+
+    /// The partition as one deterministic field.
+    fn render(&self) -> String {
+        match self {
+            Outcome::Partitioned(pieces) if pieces.is_empty() => "-".to_string(),
+            Outcome::Partitioned(pieces) => pieces
+                .iter()
+                .map(|piece| {
+                    format!(
+                        "{}:{}/{}",
+                        piece.ref_start,
+                        piece.ref_end,
+                        String::from_utf8_lossy(&piece.alt)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("|"),
+            Outcome::Declined => "DECLINED".to_string(),
+            Outcome::Panicked => "PANIC".to_string(),
+        }
+    }
+
+    /// Changed columns the partition claims, or `-` when there is no partition.
+    fn columns(&self) -> String {
+        match self {
+            Outcome::Partitioned(pieces) => dev_partitioners::changed_columns(pieces).to_string(),
+            Outcome::Declined | Outcome::Panicked => "-".to_string(),
+        }
+    }
+}
+
+/// Command-line arguments: an optional input path and the shadow arm's
+/// separation threshold.
+struct Args {
+    path: String,
+    min_separation: u32,
+}
+
+fn parse_args() -> Result<Args, String> {
+    // Tracked separately from `path`'s default so a second positional argument
+    // is an error rather than a silent overwrite: `dump_partitions a.tsv b.tsv`
+    // would otherwise read `b.tsv` and never mention `a.tsv`, which on a corpus
+    // run looks like the first file simply contained nothing of interest.
+    let mut path: Option<String> = None;
+    let mut min_separation = DEFAULT_MIN_SEPARATION;
+    let mut argv = std::env::args().skip(1);
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--min-separation" => {
+                let value = argv
+                    .next()
+                    .ok_or_else(|| "--min-separation needs a value".to_string())?;
+                min_separation = value
+                    .parse()
+                    .map_err(|_| format!("--min-separation: {value} is not a number"))?;
+            }
+            "-h" | "--help" => {
+                return Err("usage: dump_partitions [--min-separation N] [PATH]".to_string())
+            }
+            other if other.starts_with("--") => return Err(format!("unknown flag {other}")),
+            other if path.is_some() => {
+                return Err(format!(
+                    "unexpected second PATH {other}; dump_partitions reads one file (or `-`)"
+                ))
+            }
+            other => path = Some(other.to_string()),
+        }
+    }
+    Ok(Args {
+        path: path.unwrap_or_else(|| "-".to_string()),
+        min_separation,
+    })
+}
+
+fn main() {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(2);
+        }
+    };
+
+    // One terse line per panicking block instead of the default hook's payload
+    // and backtrace: a dump over a large corpus is a table, and a hook that
+    // writes paragraphs to stderr for every bad row buries the rows that matter.
+    // The block itself is already identified by the `PANIC` cell in the table.
+    std::panic::set_hook(Box::new(|info| {
+        eprintln!(
+            "panic: {}",
+            info.location().map_or(String::new(), |l| l.to_string())
+        );
+    }));
+
+    let input: Box<dyn BufRead> = if args.path == "-" {
+        Box::new(std::io::stdin().lock())
+    } else {
+        match std::fs::File::open(&args.path) {
+            Ok(file) => Box::new(std::io::BufReader::new(file)),
+            Err(error) => {
+                eprintln!("cannot read {}: {error}", args.path);
+                std::process::exit(2);
+            }
+        }
+    };
+
+    let stdout = std::io::stdout();
+    let mut out = BufWriter::new(stdout.lock());
+    writeln!(
+        out,
+        "ref\talt\tdistance\tlive\tlive_cols\tshadow\tshadow_cols\tcanonical\tcanonical_cols"
+    )
+    .expect("write header");
+
+    for line in input.lines() {
+        // Exit rather than panic: a read or UTF-8 error part-way through a corpus
+        // leaves a truncated TSV, and a panic's backtrace buries that fact under
+        // noise. Status 2 distinguishes it from the usage errors above (1).
+        let line = match line {
+            Ok(line) => line,
+            Err(error) => {
+                eprintln!("cannot read input: {error}");
+                std::process::exit(2);
+            }
+        };
+        // `is_empty`, not `trim().is_empty()`: a lone tab is the legitimate
+        // empty-to-empty block pair, and trimming would silently drop it.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((reference, alt)) = line.split_once('\t') else {
+            eprintln!("skipping line without a tab: {line}");
+            continue;
+        };
+        let (reference, alt) = (reference.as_bytes(), alt.as_bytes());
+
+        // `live` cannot decline, but it can panic, so it goes through the same
+        // wrapper with a `Some` of its own.
+        let live = Outcome::of(|| Some(dev_partitioners::live(reference, alt)));
+        let shadow = Outcome::of(|| dev_partitioners::shadow(reference, alt, args.min_separation));
+        let canonical = Outcome::of(|| dev_partitioners::canonical(reference, alt));
+        let distance = match catch_unwind(AssertUnwindSafe(|| {
+            dev_partitioners::edit_distance(reference, alt)
+        })) {
+            Ok(distance) => distance.to_string(),
+            Err(_) => "-".to_string(),
+        };
+
+        writeln!(
+            out,
+            "{}\t{}\t{distance}\t{}\t{}\t{}\t{}\t{}\t{}",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alt),
+            live.render(),
+            live.columns(),
+            shadow.render(),
+            shadow.columns(),
+            canonical.render(),
+            canonical.columns(),
+        )
+        .expect("write row");
+    }
+    out.flush().expect("flush output");
+}

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2012,6 +2012,73 @@ fn seqfirst_shadow_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("FERRO_SEQFIRST_SHADOW").as_deref() == Ok("1"))
 }
 
+/// Which block partitioner [`canonicalize_from_sequence`] cuts with.
+///
+/// Three rules exist and they are not variations on one — see
+/// [`crate::normalize::seqfirst::partition::CanonicalAlignment`] for what
+/// separates the latter two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartitionRule {
+    /// [`partition_block`]: a single-gap alignment search plus its two narrow
+    /// escapes. The shipped rule, and the default.
+    Live,
+    /// [`partition_block_sequence_first`]: cut at the steps common to every
+    /// minimal alignment (`mutalyzer-algebra`'s `local_supremal`).
+    Shadow,
+    /// [`partition_block_canonical`]: the member-count-minimal minimal alignment
+    /// (`mutalyzer-algebra`'s `canonical`).
+    Canonical,
+}
+
+/// Read a [`PartitionRule`] from what `FERRO_PARTITION` was set to.
+///
+/// Unset, empty, or unrecognised all yield [`PartitionRule::Live`], so no
+/// environment can make ferro emit something other than its shipped
+/// representation by accident. An unrecognised value is warned about rather than
+/// rejected: this is a measurement knob, and a typo that silently selected a
+/// different partitioner would poison a bake-off far more quietly than one that
+/// silently ran the default and said so.
+///
+/// Split out from [`partition_rule`] so the mapping is testable without an
+/// environment variable — the cached read below can only ever be exercised once
+/// per process.
+fn partition_rule_from_env(value: Option<&str>) -> PartitionRule {
+    match value {
+        None | Some("") | Some("live") => PartitionRule::Live,
+        Some("shadow") => PartitionRule::Shadow,
+        Some("canonical") => PartitionRule::Canonical,
+        Some(other) => {
+            log::warn!("FERRO_PARTITION={other} is not one of live|shadow|canonical; using live");
+            PartitionRule::Live
+        }
+    }
+}
+
+/// Which partitioner this process cuts blocks with, from `FERRO_PARTITION`.
+///
+/// A **development-only bake-off switch**. Read once and cached, like
+/// [`seqfirst_shadow_enabled`], so the default path pays one relaxed atomic load
+/// per canonicalized block and nothing else; with the variable unset the result
+/// is byte-identical to having no switch at all.
+fn partition_rule() -> PartitionRule {
+    static RULE: std::sync::OnceLock<PartitionRule> = std::sync::OnceLock::new();
+    *RULE.get_or_init(|| partition_rule_from_env(std::env::var("FERRO_PARTITION").ok().as_deref()))
+}
+
+/// The unchanged-base separation threshold an axis merges runs below.
+///
+/// A reading-frame axis gets `general.md:35`'s coding one-amino-acid exception
+/// ([`crate::normalize::seqfirst::MIN_SEPARATION`], 2); every other axis gets the
+/// general rule ([`MIN_SEPARATION_NO_FRAME`], 1). See the latter for why applying
+/// the exception everywhere is wrong.
+fn axis_min_separation(reading_frame: bool) -> u32 {
+    if reading_frame {
+        crate::normalize::seqfirst::MIN_SEPARATION
+    } else {
+        MIN_SEPARATION_NO_FRAME
+    }
+}
+
 /// A piece list rendered on one line with `alt` as text rather than bytes.
 ///
 /// Only used by the `FERRO_SEQFIRST_SHADOW` report, whose whole value is being
@@ -2178,20 +2245,47 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         return None; // no net change; leave it to the existing pipeline.
     }
 
-    let mut pieces = partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+    // Which rule cuts the block. `FERRO_PARTITION` unset — the only configuration
+    // that ships — takes the `Live` arm, so this is `partition_block` and nothing
+    // else. The other two arms fall back to it when their splitter declines,
+    // rather than abandoning the canonicalization, so a bake-off run measures the
+    // partitioners and not their decline rates.
+    let mut pieces = match partition_rule() {
+        PartitionRule::Live => partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]),
+        PartitionRule::Shadow => partition_block_sequence_first(
+            &ref_bytes[lo..hi_ref],
+            &result[lo..hi_alt],
+            axis_min_separation(frame.reading_frame),
+        )
+        .unwrap_or_else(|| partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt])),
+        PartitionRule::Canonical => {
+            partition_block_canonical(&ref_bytes[lo..hi_ref], &result[lo..hi_alt])
+                .unwrap_or_else(|| partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]))
+        }
+    };
     // Shadow the sequence-first splitter on the very same trimmed block, before
     // any 3'-shift or coalescing, so a reported disagreement is a disagreement
     // about the *split* and not about a downstream pass. Never affects `pieces`.
     if seqfirst_shadow_enabled() {
-        // Reading-frame axes get the coding one-amino-acid exception
-        // (`seqfirst::MIN_SEPARATION`, 2); every other axis gets the general
-        // rule (`MIN_SEPARATION_NO_FRAME`, 1). Same distinction
-        // `apply_coding_codon_exception` uses below, via the same `AxisFrame`.
-        let min_separation = if frame.reading_frame {
-            crate::normalize::seqfirst::MIN_SEPARATION
-        } else {
-            MIN_SEPARATION_NO_FRAME
-        };
+        // The audit's live baseline, computed independently of `partition_rule()`.
+        //
+        // It cannot be `pieces`: since `FERRO_PARTITION` was added, `pieces` is
+        // whatever rule the environment selected, so
+        // `FERRO_SEQFIRST_SHADOW=1 FERRO_PARTITION=shadow` would compare the
+        // sequence-first splitter with *itself* and report `SEQFIRST_AGREE` on
+        // every block — a full denominator and zero disagreements, which reads
+        // as the strongest possible result and is produced by comparing a thing
+        // with itself. That is the precise failure the denominator below exists
+        // to rule out. `canonical` would not be vacuous but would label its
+        // output `live=`, which is worse than useless in a bake-off log.
+        //
+        // The extra `partition_block` call is paid only when the shadow audit is
+        // on, which is already a measurement-only path.
+        let live = partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]);
+        // Per-axis separation threshold (see `axis_min_separation`) — the same
+        // distinction `apply_coding_codon_exception` uses below, via the same
+        // `AxisFrame`.
+        let min_separation = axis_min_separation(frame.reading_frame);
         let block = &ref_bytes[lo..hi_ref];
         let mut shadow = partition_block_sequence_first(block, &result[lo..hi_alt], min_separation);
         // `min_separation` alone captures only the distance half of
@@ -2216,13 +2310,13 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         // minimisation. The shrink runs here before the 3'-shift, whereas the
         // returned `pieces` are shrunk after it — see
         // `shrinking_before_and_after_the_three_prime_shift_agree`.
-        let mut min_live = pieces.clone();
+        let mut min_live = live.clone();
         shrink_pieces_to_differences(&mut min_live, block);
         let mut min_shadow = shadow.clone();
         if let Some(min_shadow) = min_shadow.as_mut() {
             shrink_pieces_to_differences(min_shadow, block);
         }
-        if shadow.as_ref() == Some(&pieces) {
+        if shadow.as_ref() == Some(&live) {
             // The denominator. Without it, `grep -c SEQFIRST_SHADOW` returning 0
             // cannot be told apart from a shadow that never ran — the failure
             // mode that would make an audit of the disagreements vacuous.
@@ -2232,7 +2326,7 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
                 "SEQFIRST_MINAGREE ref={} alt={} live={:?} shadow={:?}",
                 String::from_utf8_lossy(block),
                 String::from_utf8_lossy(&result[lo..hi_alt]),
-                DebugPieces(&pieces),
+                DebugPieces(&live),
                 shadow.as_deref().map(DebugPieces),
             );
         } else {
@@ -2245,7 +2339,7 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
                 "SEQFIRST_SHADOW ref={} alt={} live={:?} shadow={:?} min_live={:?} min_shadow={:?}",
                 String::from_utf8_lossy(block),
                 String::from_utf8_lossy(&result[lo..hi_alt]),
-                DebugPieces(&pieces),
+                DebugPieces(&live),
                 shadow.as_deref().map(DebugPieces),
                 DebugPieces(&min_live),
                 min_shadow.as_deref().map(DebugPieces),
@@ -3780,6 +3874,152 @@ fn partition_block_sequence_first(
             })
             .collect(),
     )
+}
+
+/// Partition a changed block by the **canonical** rule: the member-count-minimal
+/// minimal alignment, via
+/// [`crate::normalize::seqfirst::partition::CanonicalAlignment`].
+///
+/// Same contract as [`partition_block`] — pieces are disjoint, ascending, and
+/// reconstruct `result` when substituted into `reference` — and the same
+/// precondition as [`partition_block_sequence_first`]: `reference` and `result`
+/// must already have their common flanks trimmed.
+///
+/// Takes no `min_separation`. The canonical rule describes exactly what one
+/// alignment changes, so merging runs across a short unchanged gap would make it
+/// claim more changed columns than the block's edit distance —
+/// `partition_members_canonical`'s doc works the case through.
+///
+/// Returns `None` only when the alignment grid would exceed
+/// [`MAX_SEQFIRST_GRID_CELLS`]; the caller falls back to [`partition_block`].
+///
+/// Reached only under `FERRO_PARTITION=canonical` and from the `dump_partitions`
+/// example; it does not decide any shipped result.
+fn partition_block_canonical(reference: &[u8], result: &[u8]) -> Option<Vec<Piece>> {
+    use crate::normalize::seqfirst::align::AlignmentDag;
+    use crate::normalize::seqfirst::partition::CanonicalAlignment;
+
+    // Refuse an oversized grid before building it, for the same reason
+    // `partition_block_sequence_first` does: the allocation is the cost, and
+    // `(n + 1) * (m + 1)` is itself an overflow site.
+    let cells = reference
+        .len()
+        .checked_add(1)?
+        .checked_mul(result.len().checked_add(1)?)?;
+    if cells > MAX_SEQFIRST_GRID_CELLS {
+        return None;
+    }
+
+    let dag = AlignmentDag::build(reference, result);
+    let canonical = CanonicalAlignment::of(&dag);
+    Some(
+        canonical
+            .members()
+            .iter()
+            .zip(canonical.alt_spans())
+            .map(|(member, (alt_start, alt_end))| Piece {
+                ref_start: member.ref_start as usize,
+                ref_end: member.ref_end as usize,
+                alt: result[alt_start as usize..alt_end as usize].to_vec(),
+            })
+            .collect(),
+    )
+}
+
+/// The three block partitioners, callable by name for measurement.
+///
+/// **Dev-only measurement surface, not API.** It exists so the `dump_partitions`
+/// example can run all three rules over the same blocks and print them side by
+/// side; nothing here is part of ferro's supported interface, none of it is
+/// covered by semantic versioning, and it may change or vanish with the
+/// bake-off it serves. Production code must go through
+/// `canonicalize_from_sequence`, which is where the axis, the window and the
+/// downstream passes are applied.
+///
+/// Gated on the `dev` feature, and re-exported as
+/// `ferro_hgvs::normalize::dev_partitioners` only there, because the underlying
+/// functions are private to this module and should stay that way.
+#[cfg(feature = "dev")]
+pub mod dev_partitioners {
+    use super::Piece;
+
+    /// The default unchanged-base separation threshold for the `shadow` rule:
+    /// the coding one-amino-acid exception (`general.md:35`).
+    ///
+    /// A raw block carries no axis, so a caller measuring blocks in isolation has
+    /// to choose. See `MIN_SEPARATION_NO_FRAME` for why the other value is the
+    /// right one on an axis with no reading frame.
+    pub const DEFAULT_MIN_SEPARATION: u32 = crate::normalize::seqfirst::MIN_SEPARATION;
+
+    /// One derived member of a partitioned block, as 0-based half-open offsets
+    /// into the reference block plus its replacement bases.
+    ///
+    /// A pure insertion has `ref_start == ref_end`; a pure deletion has an empty
+    /// `alt`.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DevPiece {
+        pub ref_start: usize,
+        pub ref_end: usize,
+        pub alt: Vec<u8>,
+    }
+
+    /// Re-shape the module-private `Piece` into the public one.
+    ///
+    /// A free function rather than a `From` impl on purpose: an
+    /// `impl From<&Piece> for DevPiece` would put a module-private type into a
+    /// public trait implementation, which is exactly the leak this whole module
+    /// exists to avoid.
+    fn convert(pieces: &[Piece]) -> Vec<DevPiece> {
+        pieces
+            .iter()
+            .map(|piece| DevPiece {
+                ref_start: piece.ref_start,
+                ref_end: piece.ref_end,
+                alt: piece.alt.clone(),
+            })
+            .collect()
+    }
+
+    /// The shipped rule: `partition_block`'s single-gap alignment search.
+    ///
+    /// Never declines — an unsplittable block comes back as one spanning member.
+    pub fn live(reference: &[u8], result: &[u8]) -> Vec<DevPiece> {
+        convert(&super::partition_block(reference, result))
+    }
+
+    /// The dominator rule: cut at the steps common to every minimal alignment.
+    ///
+    /// `None` when the sequence-first splitter declines — an oversized alignment
+    /// grid, or an alternate-span derivation that refused.
+    pub fn shadow(reference: &[u8], result: &[u8], min_separation: u32) -> Option<Vec<DevPiece>> {
+        super::partition_block_sequence_first(reference, result, min_separation)
+            .as_deref()
+            .map(convert)
+    }
+
+    /// The canonical rule: the member-count-minimal minimal alignment.
+    ///
+    /// `None` only when the alignment grid would be oversized.
+    pub fn canonical(reference: &[u8], result: &[u8]) -> Option<Vec<DevPiece>> {
+        super::partition_block_canonical(reference, result)
+            .as_deref()
+            .map(convert)
+    }
+
+    /// The block's unit-cost Levenshtein distance — the floor every arm's
+    /// changed-column count is measured against.
+    pub fn edit_distance(reference: &[u8], result: &[u8]) -> u32 {
+        crate::normalize::seqfirst::align::AlignmentDag::build(reference, result).edit_distance()
+    }
+
+    /// Changed columns a member set claims, `sum(max(ref_span, alt_len))` — the
+    /// same measure `changed_columns_of_pieces` applies inside the normalizer.
+    pub fn changed_columns(pieces: &[DevPiece]) -> usize {
+        pieces
+            .iter()
+            .map(|piece| (piece.ref_end - piece.ref_start).max(piece.alt.len()))
+            .sum()
+    }
 }
 
 /// Alignment columns a description marks as changed.
@@ -8842,6 +9082,136 @@ mod tests {
     /// choosing the separation per axis at the `canonicalize_from_sequence` call
     /// site rather than changing this default — is pinned separately, by
     /// `sequence_first_split_axis_separation_matches_general_rule`.
+    /// The `FERRO_PARTITION` bake-off knob.
+    ///
+    /// The knob exists to make three partitioners measurable side by side. Its
+    /// most important property is therefore the one nobody looks at: that leaving
+    /// it alone changes nothing at all.
+    mod partition_rule_knob {
+        use super::*;
+
+        /// The shadow audit's baseline is the **live** rule, not whatever
+        /// `FERRO_PARTITION` selected.
+        ///
+        /// Regression guard for a defect introduced with the knob itself: the
+        /// audit read its baseline off `pieces`, which stopped being live's
+        /// output the moment the knob could change it. Under
+        /// `FERRO_SEQFIRST_SHADOW=1 FERRO_PARTITION=shadow` it therefore compared
+        /// the sequence-first splitter with itself and logged `SEQFIRST_AGREE`
+        /// for every block — a full denominator with zero disagreements, which
+        /// is the most convincing possible result and is worth nothing. Under
+        /// `canonical` it labelled canonical's pieces `live=`.
+        ///
+        /// What this test can and cannot do: `partition_rule()` caches in a
+        /// `OnceLock`, so one process cannot exercise two rules and the audit
+        /// itself is unreachable from here. What it *can* pin is the premise the
+        /// fix rests on — that live and canonical genuinely disagree on some
+        /// block, so which one the audit names is observable rather than moot.
+        /// `A -> ACA` is the smallest such block: both spellings denote `ACA`,
+        /// but live anchors the inserted `AC` at reference 0 while canonical
+        /// takes the 3'-most optimal step and anchors `CA` at reference 1.
+        /// The end-to-end guard needs an isolated process per rule (#1444
+        /// follow-up).
+        #[test]
+        fn live_and_canonical_disagree_so_the_audit_baseline_is_observable() {
+            let live = partition_block(b"A", b"ACA");
+            let canonical =
+                partition_block_canonical(b"A", b"ACA").expect("grid is far below the bound");
+            assert_ne!(
+                live, canonical,
+                "if these ever agree, pick another block — this test is vacuous otherwise"
+            );
+        }
+
+        /// Unset means `live`, and so does anything the knob does not recognise.
+        ///
+        /// This is the property the default path depends on. A knob that fell
+        /// through to a different rule on an empty string, or that treated a
+        /// typo (`FERRO_PARTITION=cannonical`) as an instruction rather than as
+        /// noise, would silently re-partition every block for whoever set it —
+        /// which for this repo is a representation change, not a configuration.
+        #[test]
+        fn unset_and_unrecognised_values_select_the_live_rule() {
+            for value in [None, Some(""), Some("live")] {
+                assert_eq!(
+                    partition_rule_from_env(value),
+                    PartitionRule::Live,
+                    "{value:?}"
+                );
+            }
+            for typo in ["cannonical", "LIVE", "shadow ", "1", "true"] {
+                assert_eq!(
+                    partition_rule_from_env(Some(typo)),
+                    PartitionRule::Live,
+                    "{typo} must not select a rule"
+                );
+            }
+        }
+
+        /// The two non-default rules are reachable, and only by their own names.
+        #[test]
+        fn the_two_alternative_rules_are_selected_by_name() {
+            assert_eq!(
+                partition_rule_from_env(Some("shadow")),
+                PartitionRule::Shadow
+            );
+            assert_eq!(
+                partition_rule_from_env(Some("canonical")),
+                PartitionRule::Canonical
+            );
+        }
+
+        /// This suite's expectations are the live rule's, and the cached read
+        /// agrees with the pure mapping above.
+        ///
+        /// Every other test in this file asserts a *shipped* representation, and
+        /// switching the rule moves dozens of them at once (measured: 36 under
+        /// `shadow`, 33 under `canonical`). This is the one that names the cause.
+        /// It therefore **fails by design** during a deliberate
+        /// `FERRO_PARTITION=…` bake-off run — that failure is the message
+        /// "you are not measuring the shipped rule", not a defect.
+        #[test]
+        fn the_suite_runs_on_the_live_rule() {
+            assert!(
+                std::env::var_os("FERRO_PARTITION").is_none(),
+                "this suite's expectations are the live rule's; FERRO_PARTITION must be unset"
+            );
+            assert_eq!(partition_rule(), PartitionRule::Live);
+        }
+
+        /// The canonical arm produces pieces that denote the block, so the arm is
+        /// wired to something that works rather than merely something that
+        /// compiles.
+        ///
+        /// Uses the spec's own worked example (`delins.md:44`,
+        /// `LRG_199t1:c.850_901`) because it is the block with the most
+        /// alternative minimal alignments in the calibration corpus — the regime
+        /// where a mis-selected path would still round-trip but claim more
+        /// columns than the block's distance.
+        #[test]
+        fn the_canonical_arm_denotes_the_block_it_partitions() {
+            let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+            let result = b"TTCCTCGATGCCTG";
+            let pieces =
+                partition_block_canonical(reference, result).expect("grid is far below the bound");
+            let mut rebuilt = Vec::new();
+            let mut cursor = 0usize;
+            for piece in &pieces {
+                rebuilt.extend_from_slice(&reference[cursor..piece.ref_start]);
+                rebuilt.extend_from_slice(&piece.alt);
+                cursor = piece.ref_end;
+            }
+            rebuilt.extend_from_slice(&reference[cursor..]);
+            assert_eq!(rebuilt, result.to_vec(), "canonical pieces: {pieces:?}");
+            assert_eq!(
+                changed_columns_of_pieces(&pieces),
+                crate::normalize::seqfirst::align::AlignmentDag::build(reference, result)
+                    .edit_distance() as usize,
+                "the canonical arm must claim exactly the block's edit distance"
+            );
+        }
+    }
+
     mod seqfirst_shadow_audit {
         use super::*;
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -45,6 +45,11 @@ pub(crate) mod seqfirst;
 pub mod shuffle;
 pub mod validate;
 
+// The three block partitioners, re-exported for the `dump_partitions` example.
+// Dev-only measurement surface, not API — see the module's own doc.
+#[cfg(feature = "dev")]
+pub use merge::dev_partitioners;
+
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::hgvs::edit::{

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -11,7 +11,7 @@
 //! the overlap and ordering defects the repair passes exist to fix become
 //! unrepresentable rather than repaired.
 
-use super::align::{AlignmentDag, Dominators};
+use super::align::{AlignmentDag, Dominators, Step};
 use super::MIN_SEPARATION;
 
 /// One member of the canonicalized allele, as a half-open reference span
@@ -201,6 +201,244 @@ pub(crate) fn member_alt_spans(
         prev_alt_end = alt_end;
     }
     Some(spans)
+}
+
+/// One maximal run of change along a single alignment: the reference and
+/// alternate spans it consumes, both half-open and both relative to the start of
+/// their block.
+///
+/// A pure insertion has `ref_start == ref_end`; a pure deletion has
+/// `alt_start == alt_end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CanonicalRun {
+    ref_start: u32,
+    ref_end: u32,
+    alt_start: u32,
+    alt_end: u32,
+}
+
+/// Whether a run is open at this point of the walk.
+///
+/// The cost of a change step depends on it — the first change after a match
+/// opens a new run and costs one member, every change after that is free — so it
+/// is part of the shortest-path state rather than something recoverable from the
+/// cell alone.
+const RUN_CLOSED: usize = 0;
+/// A run is open: the next change step extends it rather than opening another.
+const RUN_OPEN: usize = 1;
+
+/// The **canonical** alignment: among the minimal alignments the DAG encodes,
+/// one that splits the block into the fewest members.
+///
+/// This is the second of the two rules `mutalyzer-algebra` distinguishes, and
+/// the one ferro did not have. [`partition_members_with`] implements the
+/// *dominator* rule — cut at the steps common to **every** minimal alignment,
+/// which is algebra's `local_supremal`. This implements algebra's `canonical`:
+///
+/// > Traverse (BFS) the LCS graph to extract the canonical variant, i.e.
+/// > minimize the number of separate variants within an allele.
+///
+/// The two answer different questions and neither subsumes the other. The
+/// dominator rule describes the *union* of what every minimal alignment changes,
+/// so it is independent of which alignment you pick; this rule picks one
+/// alignment and describes exactly what it changes.
+///
+/// # Why minimising members is a second key and not a competing one
+///
+/// Every path through [`AlignmentDag`] is distance-minimal by construction —
+/// that is what the DAG encodes — so ranking its paths by member count cannot
+/// trade edit distance away. Minimal distance stays the primary key; member
+/// count is applied strictly within it.
+///
+/// # Cost
+///
+/// One reverse topological sweep plus one forward walk, both `Θ(n·m)` — the same
+/// order as [`AlignmentDag::build`] and [`AlignmentDag::dominators`]. The cost of
+/// a *path* is the number of maximal change runs on it, not its edge count, so
+/// the sweep carries the two-valued run state described above rather than a
+/// plain per-cell distance.
+///
+/// # The tie-break is an implementer's choice
+///
+/// Member-count-minimal alignments are **not** unique. `AAC -> AC` deletes
+/// either of the two `A`s for one member either way, and nothing in the HGVS
+/// spec reaches the choice. The **3'-most** alignment is taken, matching
+/// `general.md:41` ("the most 3' position possible of the reference sequence is
+/// arbitrarily assigned to have been changed") and the tie-break
+/// [`AlignmentDag`]'s live counterpart already applies.
+///
+/// It is realised as a preference order on the forward walk: at every cell, among
+/// the out-edges that preserve the minimum, take `Match` first. Preferring the
+/// match defers change for as long as the alignment allows, which *is* the 3'
+/// placement — on `AAC -> AC` it matches reference offset 0 and deletes offset 1.
+///
+/// Ties that survive that — a cell whose only optimal steps are two different
+/// *kinds* of change — are broken by [`AlignmentDag::out_edges`]'s own order
+/// (`Match`, `Sub`, `Del`, `Ins`). That residual order is arbitrary and is
+/// deliberately not dressed up as a rule: a run's ref and alt spans are fixed by
+/// where it starts and ends, and the order of steps *within* it does not move
+/// either. It is stated only so the function is deterministic by construction
+/// rather than by accident.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CanonicalAlignment {
+    runs: Vec<CanonicalRun>,
+}
+
+impl CanonicalAlignment {
+    /// Select the canonical alignment of `dag`.
+    ///
+    /// `dag`'s blocks must have had their common flanks trimmed, for the same
+    /// reason [`AlignmentDag::build`] states: an untrimmed flank base is
+    /// absorbed into a neighbouring member and changes the answer.
+    pub(crate) fn of(dag: &AlignmentDag) -> Self {
+        let ref_len = dag.ref_len();
+        let alt_len = dag.alt_len();
+        let width = alt_len as usize + 1;
+        let size = (ref_len as usize + 1) * width;
+        let index = |i: u32, j: u32| i as usize * width + j as usize;
+        let sink = (ref_len, alt_len);
+
+        // `to_go[state * size + cell]` is the fewest additional members any
+        // minimal alignment can reach the sink with, from that cell and that run
+        // state. `u32::MAX` marks "not yet computed"; every cell in the DAG
+        // reaches the sink, so no cell keeps it.
+        let mut to_go = vec![u32::MAX; 2 * size];
+        to_go[RUN_CLOSED * size + index(sink.0, sink.1)] = 0;
+        to_go[RUN_OPEN * size + index(sink.0, sink.1)] = 0;
+
+        // `cells()` is topological (ascending `i + j`), and every edge strictly
+        // increases `i + j`, so walking it backwards visits every successor
+        // before its predecessor.
+        let cells: Vec<(u32, u32)> = dag.cells().collect();
+        for &(i, j) in cells.iter().rev() {
+            if (i, j) == sink {
+                continue;
+            }
+            for state in [RUN_CLOSED, RUN_OPEN] {
+                let mut best = u32::MAX;
+                for (next_i, next_j, step) in dag.out_edges(i, j) {
+                    let (cost, next_state) = step_cost(step, state);
+                    let onward = to_go[next_state * size + index(next_i, next_j)];
+                    if onward != u32::MAX {
+                        best = best.min(onward + cost);
+                    }
+                }
+                to_go[state * size + index(i, j)] = best;
+            }
+        }
+
+        // Walk forward, taking at each cell the first out-edge that preserves
+        // the minimum. `out_edges` yields `Match` before any change step, so
+        // "first" is the 3'-most preference documented above.
+        let mut runs: Vec<CanonicalRun> = Vec::new();
+        let (mut i, mut j) = (0u32, 0u32);
+        let mut state = RUN_CLOSED;
+        while (i, j) != sink {
+            let target = to_go[state * size + index(i, j)];
+            let chosen = dag.out_edges(i, j).find(|&(next_i, next_j, step)| {
+                let (cost, next_state) = step_cost(step, state);
+                let onward = to_go[next_state * size + index(next_i, next_j)];
+                onward != u32::MAX && onward + cost == target
+            });
+            // Unreachable: `to_go` was computed from these same edges, so some
+            // edge attains it. Declining beats panicking inside a library, and a
+            // truncated answer cannot escape: `canonicalize_from_sequence`
+            // re-applies the rebuilt edits and compares them against `result`
+            // (`merge.rs`, the `if reapplied != result { return None; }` just
+            // before it returns `Some(rebuilt)`). That is a *runtime* refusal
+            // carried into release builds, not the `debug_assert_eq!` beside it,
+            // so a partial partition declines rather than being emitted.
+            let Some((next_i, next_j, step)) = chosen else {
+                debug_assert!(false, "no out-edge of ({i},{j}) attains its own optimum");
+                break;
+            };
+            if step == Step::Match {
+                state = RUN_CLOSED;
+            } else {
+                if state == RUN_CLOSED {
+                    runs.push(CanonicalRun {
+                        ref_start: i,
+                        ref_end: i,
+                        alt_start: j,
+                        alt_end: j,
+                    });
+                }
+                if let Some(run) = runs.last_mut() {
+                    run.ref_end = next_i;
+                    run.alt_end = next_j;
+                }
+                state = RUN_OPEN;
+            }
+            (i, j) = (next_i, next_j);
+        }
+
+        Self { runs }
+    }
+
+    /// The member blocks of the canonical alignment, ascending and disjoint.
+    pub(crate) fn members(&self) -> Vec<MemberBlock> {
+        self.runs
+            .iter()
+            .map(|run| MemberBlock {
+                ref_start: run.ref_start,
+                ref_end: run.ref_end,
+            })
+            .collect()
+    }
+
+    /// The alternate-block span each member consumes, parallel to
+    /// [`CanonicalAlignment::members`].
+    ///
+    /// Unlike [`member_alt_spans`] this needs no dominator lookup and cannot
+    /// decline: the spans are read straight off the chosen path, which pins one
+    /// alternate coordinate per boundary by construction.
+    pub(crate) fn alt_spans(&self) -> Vec<(u32, u32)> {
+        self.runs
+            .iter()
+            .map(|run| (run.alt_start, run.alt_end))
+            .collect()
+    }
+}
+
+/// The member cost of taking `step` with a run in `state`, and the state it
+/// leaves behind.
+///
+/// A match closes any open run and costs nothing. A change step costs one member
+/// when it opens a run and nothing when it extends one — which is what makes the
+/// path cost the number of maximal change runs rather than the number of edges.
+fn step_cost(step: Step, state: usize) -> (u32, usize) {
+    match step {
+        Step::Match => (0, RUN_CLOSED),
+        Step::Sub | Step::Del | Step::Ins => (u32::from(state == RUN_CLOSED), RUN_OPEN),
+    }
+}
+
+/// Partition the reference block by the **canonical** rule: the member blocks of
+/// a member-count-minimal minimal alignment.
+///
+/// The counterpart of [`partition_members_with`] for the other of the two rules
+/// — see [`CanonicalAlignment`] for what distinguishes them, and for the
+/// tie-break this makes among equally-few-member alignments.
+///
+/// It takes no `min_separation`, and that absence is deliberate. Merging runs
+/// across a short unchanged gap **widens** a member past what the alignment
+/// changes, so a merged partition claims more changed columns than the block's
+/// edit distance: #1260's `AAAAAAA -> AACACAAAA` is distance 2, and merging its
+/// two insertion runs across the single matched base between them yields one
+/// member spanning `2..3` with a 3-base payload — 3 changed columns for a
+/// distance-2 block. Distance-minimality is the property this rule exists to
+/// have, so the separation rule stays where it belongs, on the dominator side.
+// No caller outside this module's own tests. `partition_block_canonical` does
+// not route through here — it calls `CanonicalAlignment::of` and then
+// `members()`/`alt_spans()` directly, because it needs both halves and this
+// returns only the first — and `dump_partitions` reaches the canonical rule
+// through `dev_partitioners`, which wraps `partition_block_canonical`. So the
+// sole call site is `round_trips_exhaustively_over_a_small_alphabet` below.
+// Scoped rather than allowed module-wide, so a helper that becomes unreachable
+// still warns.
+#[allow(dead_code)]
+pub(crate) fn partition_members_canonical(dag: &AlignmentDag) -> Vec<MemberBlock> {
+    CanonicalAlignment::of(dag).members()
 }
 
 #[cfg(test)]
@@ -515,6 +753,26 @@ mod tests {
 
     #[test]
     fn round_trips_exhaustively_over_a_small_alphabet() {
+        let all = small_alphabet_words(5);
+        for r in &all {
+            for a in &all {
+                assert!(
+                    round_trips(r, a),
+                    "{} -> {} does not round-trip",
+                    String::from_utf8_lossy(r),
+                    String::from_utf8_lossy(a)
+                );
+            }
+        }
+    }
+
+    /// Every word over `{A, C}` up to `max_len`, shortest first.
+    ///
+    /// A two-letter alphabet and short blocks maximise the number of *distinct*
+    /// minimal alignments per block, which is the regime the canonical rule is
+    /// about — over four letters most blocks have one minimal alignment and the
+    /// selection has nothing to select.
+    fn small_alphabet_words(max_len: u32) -> Vec<Vec<u8>> {
         fn words(len: u32) -> Vec<Vec<u8>> {
             if len == 0 {
                 return vec![Vec::new()];
@@ -529,17 +787,166 @@ mod tests {
             }
             out
         }
-        let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        (0..=max_len).flat_map(words).collect()
+    }
+
+    /// Changed columns a member set claims: `max(ref_span, alt_len)` summed,
+    /// mirroring `merge::changed_columns_of_pieces`.
+    fn changed_columns(members: &[MemberBlock], alt_spans: &[(u32, u32)]) -> u32 {
+        members
+            .iter()
+            .zip(alt_spans)
+            .map(|(member, (alt_start, alt_end))| {
+                (member.ref_end - member.ref_start).max(alt_end - alt_start)
+            })
+            .sum()
+    }
+
+    /// The canonical rule may not describe more change than the block contains.
+    ///
+    /// This is the property that separates it from the dominator rule and the
+    /// reason it takes no `min_separation`: its members come from **one**
+    /// alignment, so their changed columns must total exactly the block's
+    /// Levenshtein distance. Anything that merges or widens a member breaks this
+    /// — see `partition_members_canonical`'s doc for the worked #1260 case that
+    /// a separation threshold would push to 3 columns on a distance-2 block.
+    ///
+    /// Exhaustive over `{A, C}` up to length 6 both sides (16 129 pairs): a
+    /// two-letter alphabet is where alternative minimal alignments are dense, so
+    /// a selection rule that silently picks a non-minimal path shows up here and
+    /// nowhere cheaper.
+    #[test]
+    fn canonical_members_claim_exactly_the_blocks_edit_distance() {
+        let all = small_alphabet_words(6);
+        let mut checked = 0usize;
         for r in &all {
             for a in &all {
-                assert!(
-                    round_trips(r, a),
+                let dag = AlignmentDag::build(r, a);
+                let canonical = CanonicalAlignment::of(&dag);
+                assert_eq!(
+                    changed_columns(&canonical.members(), &canonical.alt_spans()),
+                    dag.edit_distance(),
+                    "{} -> {} claims a non-minimal number of changed columns",
+                    String::from_utf8_lossy(r),
+                    String::from_utf8_lossy(a)
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 127 * 127, "expected the full sweep, ran {checked}");
+    }
+
+    /// The members must denote the block they were derived from.
+    ///
+    /// Distance-minimality above says the members are *small enough*; this says
+    /// they are *right*. Without it a rule that dropped a run entirely would
+    /// score better on changed columns, not worse.
+    #[test]
+    fn canonical_members_rebuild_the_alternate_block() {
+        let all = small_alphabet_words(6);
+        for r in &all {
+            for a in &all {
+                let dag = AlignmentDag::build(r, a);
+                let canonical = CanonicalAlignment::of(&dag);
+                let members = canonical.members();
+                let spans = canonical.alt_spans();
+                let mut rebuilt = Vec::new();
+                let mut ref_cursor = 0usize;
+                for (member, (alt_start, alt_end)) in members.iter().zip(&spans) {
+                    assert!(
+                        member.ref_start as usize >= ref_cursor,
+                        "members overlap or are out of order: {members:?}"
+                    );
+                    rebuilt.extend_from_slice(&r[ref_cursor..member.ref_start as usize]);
+                    rebuilt.extend_from_slice(&a[*alt_start as usize..*alt_end as usize]);
+                    ref_cursor = member.ref_end as usize;
+                }
+                rebuilt.extend_from_slice(&r[ref_cursor..]);
+                assert_eq!(
+                    rebuilt,
+                    *a,
                     "{} -> {} does not round-trip",
                     String::from_utf8_lossy(r),
                     String::from_utf8_lossy(a)
                 );
             }
         }
+    }
+
+    /// The tie-break, pinned on the smallest block that has one.
+    ///
+    /// `AAC -> AC` deletes either `A` for one member either way, so member count
+    /// cannot choose and `general.md:41`'s 3' rule does: the deleted base is
+    /// reference offset **1**, not 0. Pinned because the tie-break is an
+    /// implementer's choice — nothing in the spec forces it — so a change to it
+    /// is a change of representation and must be a deliberate edit rather than a
+    /// side effect of touching the walk order.
+    #[test]
+    fn canonical_breaks_a_member_count_tie_three_prime_most() {
+        let dag = AlignmentDag::build(b"AAC", b"AC");
+        assert_eq!(
+            partition_members_canonical(&dag),
+            vec![MemberBlock {
+                ref_start: 1,
+                ref_end: 2
+            }]
+        );
+    }
+
+    /// The canonical rule can report **more** members than the dominator rule,
+    /// and this pins the smallest block where it does.
+    ///
+    /// It is tempting to assume that minimising members bounds it below the
+    /// dominator partition. It does not, and the two rules are not comparable at
+    /// all: the dominator rule merges runs separated by fewer than
+    /// [`MIN_SEPARATION`] unchanged bases, which the canonical rule has no
+    /// counterpart for and deliberately does not want — merging is what would
+    /// cost it distance-minimality.
+    ///
+    /// `A -> CAC` is #1260's own block, trimmed, and it is the shortest block in
+    /// the `{A, C}` sweep where they diverge. It is distance 2 (one `C` inserted
+    /// either side of the `A`) and admits exactly one minimal alignment, so this
+    /// is not a tie-break disagreement: the dominator rule merges the two forced
+    /// insertion junctions across the single matched base between them into one
+    /// member claiming **3** changed columns, while the canonical rule reports
+    /// them as two pure insertions claiming **2**.
+    ///
+    /// Recorded rather than asserted away because it is the whole reason both
+    /// rules are worth measuring. Neither is a better approximation of the other:
+    /// one is minimal in members-after-merging and the other in changed columns,
+    /// and the spec does not settle which a description should be.
+    #[test]
+    fn canonical_can_report_more_members_than_the_dominator_rule() {
+        let dag = AlignmentDag::build(b"A", b"CAC");
+        let dominators = dag.dominators();
+        assert_eq!(
+            partition_members_with(&dag, &dominators, MIN_SEPARATION),
+            vec![MemberBlock {
+                ref_start: 0,
+                ref_end: 1
+            }],
+            "the dominator rule merges both insertions into one spanning member"
+        );
+        let canonical = CanonicalAlignment::of(&dag);
+        assert_eq!(
+            canonical.members(),
+            vec![
+                MemberBlock {
+                    ref_start: 0,
+                    ref_end: 0
+                },
+                MemberBlock {
+                    ref_start: 1,
+                    ref_end: 1
+                },
+            ],
+            "the canonical rule keeps them as two pure insertions"
+        );
+        assert_eq!(
+            changed_columns(&canonical.members(), &canonical.alt_spans()),
+            dag.edit_distance(),
+            "and only the canonical partition claims exactly the block's distance"
+        );
     }
 
     proptest::proptest! {


### PR DESCRIPTION
Closes #1444

## The default path does not move a single normalized output

Stating this first, because it is the thing a reviewer needs to know: **this PR changes no shipped representation.** The new partitioner is behind `FERRO_PARTITION` and is off by default.

Measured with the committed `#1441` harness at this branch's exact parent (`ee0e37ac`), default environment, no flag set:

| | rows |
|---|---|
| total | 18,432 |
| **moved** | **0 (0.0%)** |
| of which previously accepted (a migration) | 0 |

Byte-identical, `md5 436379ddba88a98cd7150909cec4af27` on both sides.

A zero can also mean the corpus never reaches the new code, so the same corpus was run through the new arm to prove the measurement is sensitive: `FERRO_PARTITION=canonical` moves **5,188 rows (28.1%)**. The instrument works; the default genuinely does not move.

## What it adds

`CanonicalAlignment` — a member-count-minimal partitioner — plus a three-way selector and a dump harness:

- `FERRO_PARTITION=live` (default) — the shipped `partition_block`, unchanged
- `FERRO_PARTITION=shadow` — the seqfirst DAG splitter
- `FERRO_PARTITION=canonical` — the new one
- `examples/dump_partitions.rs` — dumps and diffs partitions across the three arms

The objective is fewest members subject to minimal edit distance. Where the live splitter's decisions are driven by the *input spelling*, this one is a function of `(reference, observed)` alone, which is what makes it a candidate for the confluence work in #1235.

## What the canonical arm would cost, if it were ever turned on

Not proposed here, but measured, because the numbers should be on the record next to the code:

| corpus | rows | moved |
|---|---|---|
| synthetic (enriched for churning shapes) | 18,432 | 5,188 (28.1%) |
| designed multi-member cis alleles | 650 | 16 (2.66%) |
| ClinVar | 500,004 | 164 (0.033%) |
| CMRG (stride 24) | 201,086 | 106 (0.053%) |
| Paraphase (stride 3) | 145,079 | 94 (0.065%) |

The 28.1% is a rate **within the enriched shape families**, never a library-wide figure — the harness's own docs flag that trap and it is repeated here so the number is not quoted loose. Across 846,819 real rows there were **zero** regressions: no row errored or declined where the baseline succeeded.

Two properties of that churn matter more than its size, and both argue for keeping the flag off until #1235 resolves them:

1. **153 of the 164 ClinVar moves are single-member `g.` delins becoming multi-member alleles** — a change of *arity*, not spelling. A consumer's schema and joins see a shape change, not just a different string.
2. A hand adjudication of 5 moved rows against the spec came back **4 for the stored form, 1 for the new one**. The losing pattern is consistent: the new form splits a block only because the delins payload spuriously aligns with the reference, which is what `DNA/delins.md:44-47` explicitly recommends against. That adjudication is being scaled to all 180 moved rows before any proposal to flip the default.

## Review notes

- No behavioural change reaches any default path; the diff is additive plus the env-var selector.
- Full gate green at `ee0e37ac`: `9418 tests run: 9418 passed, 145 skipped`, with `FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and `FERRO_SWEEP_SEEDS=full`.
- Merging this does not commit the project to the canonical form. It commits it to being able to *measure* it, which is currently only possible by rebuilding the harness by hand.
