### PR TITLE
fix(normalize): repair non-coding `r.` members instead of reverting them

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7327,7 +7327,7 @@ fn respell_at_sequence_end<P: ReferenceProvider>(
                 }
         }
         HgvsVariant::Rna(r) => {
-            let Some((region, axis)) = cds_axis_end(span, provider, raw_length, Region::Rna) else {
+            let Some((region, axis)) = rna_axis_end(span, provider, raw_length) else {
                 return;
             };
             let utr3 = region == Region::ThreePrimeUtr;
@@ -7354,9 +7354,15 @@ fn respell_at_sequence_end<P: ReferenceProvider>(
     // outside the member's own region — which is the case this guard exists for,
     // so keying the check on `span.region` would make it vacuously true for the
     // one input it has to judge.
+    //
+    // `rna_axis_end` rather than `cds_axis_end` for the same reason the arm
+    // above uses it: on a non-coding record `cds_axis_end` declines, which made
+    // this verification reject a write the arm had just made correctly (#1453).
+    // The two must be the same resolution or the guard judges the arm against a
+    // convention the arm does not use.
     let written = match variant {
         HgvsVariant::Cds(_) => cds_axis_end(span, provider, raw_length, Region::Cds),
-        HgvsVariant::Rna(_) => cds_axis_end(span, provider, raw_length, Region::Rna),
+        HgvsVariant::Rna(_) => rna_axis_end(span, provider, raw_length),
         _ => Some((span.region, axis)),
     };
     let landed = placed && written.is_some_and(|w| member_endpoints(variant) == Some((w, w)));
@@ -7388,6 +7394,87 @@ fn cds_axis_end<P: ReferenceProvider>(
 ) -> Option<(Region, i64)> {
     let (cds_start, cds_end) = ordered_cds_bounds(&span.provider_key, provider)?;
     cds_axis_position(i64::try_from(length).ok()?, cds_start, cds_end, body)
+}
+
+/// [`cds_axis_end`] for the `r.` axis, with the non-coding fallback (#1453).
+///
+/// A record with no CDS has nothing to resolve through, and needs none: its
+/// `r.` axis is the transcript's own, so the last base is `length` in the
+/// member's own region — the same answer [`respell_at_sequence_end`]'s `Tx` arm
+/// reaches directly. `cds_axis_end` declines that record, and it is called
+/// twice in that function — once to place the write and once to verify it — so
+/// the fallback has to be in one shared place or the two disagree.
+fn rna_axis_end<P: ReferenceProvider>(
+    span: &MemberSpan,
+    provider: &P,
+    length: u64,
+) -> Option<(Region, i64)> {
+    if rna_axis_is_transcript_relative(span, provider) {
+        return Some((span.region, i64::try_from(length).ok()?));
+    }
+    cds_axis_end(span, provider, length, Region::Rna)
+}
+
+/// Whether `span` sits on an `r.` axis that numbers its **transcript** rather
+/// than its CDS — i.e. a `Region::Rna` member on a record with no CDS at all
+/// (#1453).
+///
+/// The two `r.` repair arms — [`respell_at_gap`] and [`respell_at_sequence_end`]
+/// — resolve their coordinates through the CDS, via [`cds_relative_gap`] and
+/// [`cds_axis_end`] respectively. That is right on a coding record and is what
+/// names a junction on the CDS start `r.-1_1` rather than the non-existent
+/// `r.0` (#1284). Both route through [`ordered_cds_bounds`], which requires
+/// **both** bounds, so on a non-coding record they returned `None`, the write
+/// was reverted, and *every* repair became a silent no-op on a non-coding `r.`
+/// member.
+///
+/// What that cost, measured on `coalesce_members_at_one_junction`: it grouped
+/// the two colliding members and read both payloads before the revert threw its
+/// write away, so `NR_TEST.1:r.[9dup;10dup;11dup]` normalized to
+/// `r.[9dup;11dup;11dup]`. Two members claiming one interbase point denote no
+/// sequence, and no seam oracle sees it — the output is well-formed, so the
+/// re-parse oracle accepts it, and every coordinate is in range, so the
+/// in-bounds oracle does too. Over a 3,200-row corpus of nearby junction-
+/// occupying cis members on a non-coding transcript, 849 outputs repeated a
+/// member and 1,046 disagreed with the `n.` axis of the same record; both go to
+/// 0 with this fallback in place.
+///
+/// # Why this predicate and not "`ordered_cds_bounds` declined"
+///
+/// It is deliberately the same fallback [`region_sequence_delta`] and
+/// [`axis_frame`] already make, and deliberately no wider — the three have to
+/// agree about which records and regions are transcript-relative, or a repair
+/// reads its bases through one convention and names them under another. So:
+///
+/// * **`Region::Rna` only.** `region_sequence_delta` falls back for that region
+///   alone; `FivePrimeUtr` (`r.-N`) and `ThreePrimeUtr` (`r.*N`) still require
+///   CDS bounds, because without a CDS those regions do not exist and there is
+///   no position for a fallback to name.
+/// * **`cds_start` alone**, rather than any `ordered_cds_bounds` failure — and
+///   rather than "both bounds absent", which is the narrower test this
+///   predicate first carried. `region_sequence_delta` and `axis_frame` both key
+///   on `cds_start` only, so requiring `cds_end` to be absent too made the
+///   three *disagree* on a record annotated with a stop codon but no start
+///   codon. `CdotTranscript::from_*` reaches that shape from real data: its CDS
+///   guard is an **or** (`start_codon.is_some() || stop_codon.is_some()`) and
+///   then assigns both fields straight through, so a 5'-incomplete record
+///   (`cds_start_NF`, #972) arrives as `(None, Some(end))`. On those records the
+///   repair declined and #1453's repeated member survived — verbatim
+///   `r.[9dup;11dup;11dup]`, against `n.9_10insTAA` on the same transcript.
+///   The other two failures must keep refusing, and still do, because both
+///   carry a `cds_start` for [`ordered_cds_bounds`] to reject: **inverted**
+///   bounds are a malformed record whose CDS-relative axis is incoherent (see
+///   [`ordered_cds_bounds`]), and a record carrying `cds_start` without
+///   `cds_end` has a genuinely CDS-relative axis whose 3'UTR simply cannot be
+///   named.
+/// * **The provider must resolve the record.** `is_ok_and` is false for one it
+///   cannot, which keeps refusing: an unresolvable transcript gives no grounds
+///   to claim its axis is transcript-relative.
+fn rna_axis_is_transcript_relative<P: ReferenceProvider>(span: &MemberSpan, provider: &P) -> bool {
+    span.region == Region::Rna
+        && provider
+            .get_transcript(&span.provider_key)
+            .is_ok_and(|tx| tx.cds_start.is_none())
 }
 
 // ----------------------------------------------------------------------------
@@ -7754,6 +7841,31 @@ fn respell_at_gap<P: ReferenceProvider>(
             .then(|| Some((u64::try_from(gap_start).ok()?, u64::try_from(gap_end).ok()?)))?
     };
     let same_region_gap = ((span.region, gap_start), (span.region, gap_end));
+
+    // Where an `r.` gap lands, which depends on whether the record has a CDS
+    // (#1453).
+    //
+    // On a **coding** transcript the `r.` axis is CDS-relative, so the gap is
+    // resolved through the transcript exactly as `c.`'s is — that is what names
+    // the junction on the CDS start `r.-1_1` rather than the non-existent `r.0`
+    // (#1284). A **non-coding** record has no CDS to resolve through and its
+    // `r.` axis numbers the transcript directly, so the gap is
+    // `[junction, junction + 1]` on the axis itself: the `n.` arm's arithmetic
+    // below, including its refusal of a gap that would name position 0, since
+    // this axis has no zero either.
+    //
+    // `cds_relative_gap` alone *refused* that second case, which reverted the
+    // write and made every repair routed through here a silent no-op on a
+    // non-coding `r.` member. See [`rna_axis_is_transcript_relative`] for what
+    // that cost, and for why the fallback is keyed on that predicate rather
+    // than on `cds_relative_gap` returning `None`.
+    let rna_gap = || -> Option<((Region, i64), (Region, i64))> {
+        if rna_axis_is_transcript_relative(span, provider) {
+            return (gap_start != 0 && gap_end != 0).then_some(same_region_gap);
+        }
+        cds_relative_gap(Region::Rna)
+    };
+
     let (placed, intended) = match variant {
         HgvsVariant::Genome(g) => (
             unsigned_gap().is_some_and(|(start, end)| {
@@ -7822,7 +7934,7 @@ fn respell_at_gap<P: ReferenceProvider>(
             ),
             None => (false, same_region_gap),
         },
-        HgvsVariant::Rna(r) => match cds_relative_gap(Region::Rna) {
+        HgvsVariant::Rna(r) => match rna_gap() {
             Some(intended) => (
                 set_endpoints(
                     &mut r.loc_edit.location,

--- a/tests/it/issue_1453_noncoding_rna_repeated_member.rs
+++ b/tests/it/issue_1453_noncoding_rna_repeated_member.rs
@@ -1,0 +1,391 @@
+//! #1453 — a cis allele on the `r.` axis of a **non-coding** transcript emitted
+//! the same member twice.
+//!
+//! ```text
+//! NR_TEST.1:r.[9dup;10dup;11dup]  ->  NR_TEST.1:r.[9dup;11dup;11dup]
+//! NR_TEST.1:n.[9dup;10dup;11dup]  ->  NR_TEST.1:n.9_10insTAA
+//! ```
+//!
+//! Two members claiming one interbase point denote no sequence at all, so this
+//! is a well-formedness defect rather than a representation preference — and it
+//! is invisible to two of the three seam oracles. `FERRO_ASSERT_REPARSE` accepts
+//! `r.[9dup;11dup;11dup]` because it is syntactically well-formed, and
+//! `FERRO_ASSERT_IN_BOUNDS` accepts it because every coordinate is in range.
+//!
+//! ## The mechanism, which is narrower than "the `r.` axis"
+//!
+//! The issue framed this as `r.` versus `n.`. It is not: `r.` on a **coding**
+//! transcript collapses the same three members correctly
+//! (`NM_TEST.1:r.[9dup;10dup;11dup]` -> `NM_TEST.1:r.9_10insuaa`). The
+//! discriminator is whether the transcript has a CDS.
+//!
+//! `coalesce_members_at_one_junction` (#1286) is the pass that merges two
+//! members which shifted onto one junction, and it does reach this input — it
+//! groups the two `11dup`s and reads both payloads. It then calls
+//! `respell_at_gap`, whose `r.` arm resolves the gap *through the transcript*
+//! via `ordered_cds_bounds` (#1284), because on a coding transcript the `r.`
+//! axis is CDS-relative and `+1` across the CDS start would name the
+//! non-existent `r.0`. `ordered_cds_bounds` requires **both** `cds_start` and
+//! `cds_end`, so on a non-coding record it returns `None`, `respell_at_gap`
+//! reverts the member, and the pass abandons the group — leaving exactly the
+//! repeated member it exists to remove.
+//!
+//! The fallback is the one `axis_frame` and `region_sequence_delta` already
+//! make for `Region::Rna`: with no CDS the `r.` axis numbers the transcript
+//! directly, exactly as `n.` does, so the gap is `[junction, junction + 1]` on
+//! the axis itself.
+//!
+//! ## Two exits, not one
+//!
+//! `respell_at_gap` resolves through the CDS in two places, and both had to be
+//! fixed. The second is the **terminal** path: when the landing junction is one
+//! past the last base, the repair is re-spelled as the equivalent boundary
+//! `delins` (#1327), and `respell_at_sequence_end` resolves the last base
+//! through `cds_axis_end` — `ordered_cds_bounds` again. It calls it *twice*,
+//! once to place the write and once to verify it landed, so a fallback applied
+//! to only one of the two leaves the guard rejecting a correct write. The first
+//! cut of this fix did exactly that, and the census below still showed one
+//! surviving row until `rna_axis_end` was shared between them.
+//!
+//! ## Census
+//!
+//! Over 3,200 rows — 6 deterministic homopolymer-enriched 63 nt cores plus the
+//! issue's, × two- and three-member cis alleles of nearby junction-occupying
+//! edits, × both shuffle directions, on the non-coding `r.` axis:
+//!
+//! | | on `main` | with the fix |
+//! |---|---|---|
+//! | outputs repeating a member | 849 (2 families) | **0** |
+//! | outputs disagreeing with the `n.` axis of the same record | 1,046 (3 families) | **0** |
+//!
+//! ## What these tests pin
+//!
+//! The `n.`/`r.` pair is asserted as **agreement**, not as two independent
+//! expected strings. A test that pinned only the `r.` string would go green if
+//! a future change moved the `n.` axis onto the same defect, which is the
+//! opposite of what this issue is about.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The issue's 63 nt core. Positions 1-9 are `T`, 10 and 11 are `A`, 12 is `T`,
+/// so `9dup`, `10dup` and `11dup` each land inside a homopolymer run and shift
+/// independently — `10dup` and `11dup` both to the junction 3' of position 11.
+const CORE: &str = "TTTTTTTTTAATATATTTTAATATAATTAAAAAAATAATTTTTATAAATATATTATTTTAAAAA";
+
+/// A core whose 3'-most homopolymer runs to the **last** base (positions 58-63
+/// are `G` on this 63 nt sequence), so a member shifting into that run lands its
+/// copy at the junction one past the end.
+///
+/// That is the terminal path: `respell_at_gap` hands off to
+/// `respell_at_sequence_end`, which resolves the last base through
+/// `cds_axis_end` rather than through `cds_relative_gap`. Drawn from the census
+/// rather than authored — it is the one row that survived the first cut of the
+/// fix.
+const TERMINAL_CORE: &str = "CGGGTGGGGTTTTCCCCCCGAAAAAAAAAAAAAAAGAGGGGGTTTTTAAAATTTAAAGGGGGG";
+
+/// One transcript carrying [`CORE`], coding or not.
+///
+/// The coding arm sets the CDS to the whole transcript (`1..=63`) so that `c.N`,
+/// `n.N` and `r.N` all name transcript position `N`. That is what makes the
+/// coding/non-coding pair below a controlled comparison: the two records differ
+/// only in whether a CDS is annotated, never in which bases a position names.
+fn provider(accession: &str, coding: bool) -> MockProvider {
+    provider_for(accession, coding, CORE)
+}
+
+fn provider_for(accession: &str, coding: bool, core: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = core.to_string();
+    let length = sequence.len() as u64;
+    let (cds_start, cds_end) = if coding {
+        (Some(1), Some(length))
+    } else {
+        (None, None)
+    };
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        sequence,
+        cds_start,
+        cds_end,
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(provider: &MockProvider, descriptor: &str) -> String {
+    let variant = parse_hgvs(descriptor).expect("fixture must parse");
+    Normalizer::new(provider.clone())
+        .normalize(&variant)
+        .expect("fixture must normalize")
+        .to_string()
+}
+
+/// The `n.` rendering of a description, re-spelled in the `r.` alphabet: `r.`
+/// lower-cases its sequences and writes `u` for `T`.
+///
+/// Only the axis letter and the inserted bases differ between the two axes on a
+/// non-coding transcript, which is the whole point of the parity assertion —
+/// the coordinates must be identical because the two axes number the same
+/// transcript.
+fn as_rna_spelling(tx_rendering: &str) -> String {
+    let (accession, description) = tx_rendering
+        .split_once(":n.")
+        .expect("an `n.` rendering to convert");
+    let description: String = description
+        .chars()
+        .map(|c| match c {
+            'T' => 'u',
+            other if other.is_ascii_uppercase() => other.to_ascii_lowercase(),
+            other => other,
+        })
+        .collect();
+    format!("{accession}:r.{description}")
+}
+
+/// The reproducer: three duplications inside two homopolymer runs must not
+/// produce a member twice, on the `r.` axis of a non-coding transcript.
+///
+/// Pinned as an exact string rather than as "no repeated member": a predicate
+/// over the member set is satisfied by a refusal or by a dropped member just as
+/// well as by the correct collapse.
+#[test]
+fn a_noncoding_rna_allele_collapses_instead_of_repeating_a_member() {
+    let provider = provider("NR_TEST.1", false);
+    assert_eq!(
+        normalize(&provider, "NR_TEST.1:r.[9dup;10dup;11dup]"),
+        "NR_TEST.1:r.9_10insuaa",
+        "two members shifted onto the junction 3' of `r.11` must be coalesced \
+         into one insertion; emitting `r.[9dup;11dup;11dup]` claims one \
+         interbase point twice and so denotes no sequence (#1453)"
+    );
+}
+
+/// The same three members on the `n.` axis of the *same* transcript, asserted as
+/// agreement with the `r.` axis rather than as an independent expectation.
+#[test]
+fn the_noncoding_rna_and_tx_axes_agree_on_one_transcript() {
+    let provider = provider("NR_TEST.1", false);
+    let tx = normalize(&provider, "NR_TEST.1:n.[9dup;10dup;11dup]");
+    let rna = normalize(&provider, "NR_TEST.1:r.[9dup;10dup;11dup]");
+    assert_eq!(
+        rna,
+        as_rna_spelling(&tx),
+        "`n.` and `r.` number the same non-coding transcript, so the same three \
+         members must reach the same coordinates on both — only the rendering \
+         alphabet may differ (`n.` gave `{tx}`)"
+    );
+}
+
+/// The discriminating case, and the one that says the fix is scoped to the
+/// missing non-coding fallback rather than to the `r.` axis as a whole: a
+/// **coding** transcript's `r.` axis already collapsed this correctly, and must
+/// keep doing so.
+///
+/// Its `r.` gap is still resolved through the CDS (`respell_at_gap`'s
+/// `cds_relative_gap`), which is what names a junction on the CDS start
+/// `r.-1_1` instead of the non-existent `r.0` (#1284).
+///
+/// **This fixture cannot detect an over-broad fix on its own.** Its CDS spans
+/// the whole transcript, so `cds_start = 1`, the CDS delta is 0, and the
+/// CDS-relative and transcript-relative resolutions coincide — measured:
+/// replacing the predicate with a bare `span.region == Region::Rna`, applying
+/// the non-coding fallback to *every* `r.` record, leaves this test and the
+/// terminal one below passing. That is the price of the controlled comparison
+/// (`c.N`, `n.N` and `r.N` naming one base) and it is worth paying here, but
+/// the scoping claim has to be pinned somewhere the two conventions differ:
+/// [`a_coding_transcripts_terminal_rna_repair_resolves_through_the_cds`].
+#[test]
+fn a_coding_transcripts_rna_axis_is_unchanged() {
+    let provider = provider("NM_TEST.1", true);
+    assert_eq!(
+        normalize(&provider, "NM_TEST.1:r.[9dup;10dup;11dup]"),
+        "NM_TEST.1:r.9_10insuaa",
+        "the coding `r.` axis already coalesced these members and must be \
+         unaffected — it is the CDS-relative gap resolution that #1453 leaves \
+         in place"
+    );
+    assert_eq!(
+        normalize(&provider, "NM_TEST.1:c.[9dup;10dup;11dup]"),
+        "NM_TEST.1:c.9_10insTAA",
+        "and so must the `c.` axis of the same record"
+    );
+}
+
+/// The terminal path (`respell_at_sequence_end`), where the landing junction is
+/// one past the last base and the repair becomes the boundary `delins` of
+/// #1327.
+///
+/// This is a *second* exit from `respell_at_gap`, not the one the reproducer
+/// above takes, and it declines through `cds_axis_end` rather than
+/// `cds_relative_gap`. It is pinned separately because a fix applied to only
+/// the junction path leaves it broken — which is how the first cut of this fix
+/// measured, with 1 of the census's 849 rows surviving.
+#[test]
+fn a_noncoding_rna_repair_at_the_sequence_end_also_takes() {
+    let provider = provider_for("NR_TEST.1", false, TERMINAL_CORE);
+    let tx = normalize(&provider, "NR_TEST.1:n.[57dup;58dup;59dup]");
+    let rna = normalize(&provider, "NR_TEST.1:r.[57dup;58dup;59dup]");
+    assert_eq!(
+        rna, "NR_TEST.1:r.[57dup;58_63g[8]]",
+        "the two members that shifted into the terminal `G` run must be \
+         coalesced and re-spelled at the boundary; `r.[57dup;63dup;63dup]` \
+         claims one interbase point twice (#1453)"
+    );
+    assert_eq!(
+        rna,
+        as_rna_spelling(&tx),
+        "and must still agree with the `n.` axis of the same record (`n.` gave \
+         `{tx}`)"
+    );
+}
+
+/// The discriminating case for the terminal path, mirroring
+/// [`a_coding_transcripts_rna_axis_is_unchanged`]: on a **coding** record the
+/// last base is still resolved through the CDS, which is what lets
+/// `respell_at_sequence_end` name it `r.*N` when it falls outside the CDS
+/// (#1284). Measured on `origin/main` before the fix and unchanged by it.
+#[test]
+fn a_coding_transcripts_terminal_rna_repair_is_unchanged() {
+    let provider = provider_for("NM_TERM.1", true, TERMINAL_CORE);
+    assert_eq!(
+        normalize(&provider, "NM_TERM.1:r.[57dup;58dup;59dup]"),
+        "NM_TERM.1:r.57_58insagg"
+    );
+    assert_eq!(
+        normalize(&provider, "NM_TERM.1:c.[57dup;58dup;59dup]"),
+        "NM_TERM.1:c.57_58insAGG"
+    );
+}
+
+/// One transcript carrying `core`, coding, with an untranslated 5' region — so
+/// `cds_start != 1` and the CDS-relative axis is *numerically distinct* from
+/// the transcript-relative one.
+///
+/// [`provider`]'s coding arm deliberately sets the CDS to the whole transcript
+/// so that `c.N`, `n.N` and `r.N` name the same base, which is what makes its
+/// coding/non-coding pair a controlled comparison. The cost is that its CDS
+/// delta is **0**, so on those records the two conventions this fix chooses
+/// between produce identical output — see
+/// [`a_coding_transcripts_terminal_rna_repair_resolves_through_the_cds`].
+fn provider_with_five_prime_utr(accession: &str, core: &str, cds_start: u64) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = core.to_string();
+    let length = sequence.len() as u64;
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(cds_start),
+        Some(length),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// A **coding** record whose CDS does not start at transcript position 1 still
+/// resolves its terminal `r.` repair through the CDS.
+///
+/// This is the guard that actually discriminates. The two
+/// `..._is_unchanged` tests above use a CDS spanning the whole transcript, so
+/// their CDS delta is 0 and the CDS-relative and transcript-relative
+/// resolutions coincide — replacing the predicate with a bare
+/// `span.region == Region::Rna`, i.e. applying the non-coding fallback to
+/// *every* `r.` record, leaves all of them passing. On this fixture it does
+/// not: the fallback yields `r.[53dup;*4delinsggg]`, which both fails to
+/// coalesce the two members and names the last base under the wrong
+/// convention.
+///
+/// The terminal path is the discriminating one because that is where the two
+/// conventions disagree about *which position is the last base*
+/// (`cds_axis_end` vs the transcript length). The junction path agrees on this
+/// shape, which is why it is not also pinned here.
+#[test]
+fn a_coding_transcripts_terminal_rna_repair_resolves_through_the_cds() {
+    let provider = provider_with_five_prime_utr("NM_UTRT.1", TERMINAL_CORE, 5);
+    assert_eq!(
+        normalize(&provider, "NM_UTRT.1:r.[53dup;54dup;55dup]"),
+        "NM_UTRT.1:r.53_54insagg",
+        "a coding record with a 5' UTR must still resolve its terminal repair \
+         through the CDS; the non-coding fallback firing here gives \
+         `r.[53dup;*4delinsggg]` (#1453)"
+    );
+}
+
+/// One transcript carrying [`CORE`] annotated with a **stop codon but no start
+/// codon** — `cds_end` present, `cds_start` absent.
+fn provider_five_prime_incomplete(accession: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = CORE.to_string();
+    let length = sequence.len() as u64;
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        sequence,
+        None,
+        Some(length),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// The fallback keys on `cds_start` alone, so a record with `cds_end` but no
+/// `cds_start` is transcript-relative too.
+///
+/// This is the slice where a predicate requiring *both* bounds absent still
+/// reproduced the issue verbatim, emitting `r.[9dup;11dup;11dup]`. It is
+/// reachable from real data rather than only by direct construction:
+/// `CdotTranscript`'s CDS guard is an **or**
+/// (`start_codon.is_some() || stop_codon.is_some()`) and then assigns
+/// `(self.start_codon, self.stop_codon)` straight through, so a 5'-incomplete
+/// transcript (`cds_start_NF`, #972) arrives with exactly this shape.
+///
+/// Pinned as agreement with the `n.` axis for the same reason the non-coding
+/// pair above is: `region_sequence_delta` and `axis_frame` already treat this
+/// record's `r.` axis as transcript-relative, so a repair that resolved it
+/// through the CDS would read its bases under one convention and name them
+/// under another.
+#[test]
+fn a_five_prime_incomplete_records_rna_axis_is_transcript_relative() {
+    let provider = provider_five_prime_incomplete("NR_NOSTART.1");
+    let tx = normalize(&provider, "NR_NOSTART.1:n.[9dup;10dup;11dup]");
+    let rna = normalize(&provider, "NR_NOSTART.1:r.[9dup;10dup;11dup]");
+    assert_eq!(
+        rna, "NR_NOSTART.1:r.9_10insuaa",
+        "a record with `cds_end` but no `cds_start` has no CDS to resolve \
+         through, so its `r.` axis numbers the transcript — resolving it \
+         through the CDS instead reverts the write and leaves \
+         `r.[9dup;11dup;11dup]`, one interbase point claimed twice (#1453)"
+    );
+    assert_eq!(
+        rna,
+        as_rna_spelling(&tx),
+        "and it must agree with the `n.` axis of the same record (`n.` gave \
+         `{tx}`)"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -16,6 +16,7 @@ mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
 mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
+mod issue_1453_noncoding_rna_repeated_member;
 mod issue_1472_zero_length_read;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;


### PR DESCRIPTION
Closes #1453.

## The defect

`NR_TEST.1:r.[9dup;10dup;11dup]` normalizes to `NR_TEST.1:r.[9dup;11dup;11dup]` — the same member twice. Two members claiming one interbase point denote no sequence, so this is a well-formedness defect rather than a representation preference, and it is invisible to two of the three seam oracles: `FERRO_ASSERT_REPARSE` accepts the output because it is syntactically well-formed, and `FERRO_ASSERT_IN_BOUNDS` accepts it because every coordinate is in range.

**The discriminator is the CDS, not the axis.** The issue frames this as `r.` versus `n.`; it is not. `r.` on a *coding* transcript collapses the same three members correctly:

| input | on `main` |
|---|---|
| `NR_TEST.1:r.[9dup;10dup;11dup]` | `NR_TEST.1:r.[9dup;11dup;11dup]` ← repeated member |
| `NR_TEST.1:n.[9dup;10dup;11dup]` | `NR_TEST.1:n.9_10insTAA` |
| `NM_TEST.1:r.[9dup;10dup;11dup]` | `NM_TEST.1:r.9_10insuaa` |
| `NM_TEST.1:c.[9dup;10dup;11dup]` | `NM_TEST.1:c.9_10insTAA` |

### Mechanism

Found by instrumenting the per-member pipeline rather than by reading code. `coalesce_members_at_one_junction` (#1286) — the pass that exists to merge two members which shifted onto one junction — *does* reach this input: it groups the two `11dup`s and reads both payloads. It then calls `respell_at_gap`, whose `r.` arm resolves the gap through the transcript via `ordered_cds_bounds` (#1284), because on a coding transcript the `r.` axis is CDS-relative and `+1` across the CDS start would name the non-existent `r.0`.

`ordered_cds_bounds` requires **both** `cds_start` and `cds_end`. On a non-coding record it returns `None`, `respell_at_gap` reverts the member, and the pass abandons the group — leaving exactly the repeated member it exists to remove. Every repair routed through `respell_at_gap` was therefore a silent no-op on a non-coding `r.` member; the coalesce is just where it is observable.

### Census

3,200 rows: 6 deterministic homopolymer-enriched 63 nt cores plus the issue's, × two- and three-member cis alleles of nearby junction-occupying edits, × both shuffle directions, on the non-coding `r.` axis.

| | on `main` | with the fix |
|---|---|---|
| outputs repeating a member | 849 (2 families) | **0** |
| outputs disagreeing with the `n.` axis of the same record | 1,046 (3 families) | **0** |

## The fix

Fall back to the transcript-relative axis exactly where `axis_frame` and `region_sequence_delta` already do — a `Region::Rna` member on a record with no CDS bounds at all. The three have to agree about which records and regions are transcript-relative, or a repair reads its bases through one convention and names them under another.

Deliberately keyed on that predicate rather than on "`ordered_cds_bounds` declined", which is wider in three ways that all must keep refusing:

- **`Region::Rna` only.** `FivePrimeUtr` (`r.-N`) and `ThreePrimeUtr` (`r.*N`) still require CDS bounds — without a CDS those regions do not exist, so there is no position for a fallback to name.
- **Inverted bounds** are a malformed record whose CDS-relative axis is incoherent (`ordered_cds_bounds` documents why), and a record carrying `cds_start` without `cds_end` has a genuinely CDS-relative axis whose 3'UTR simply cannot be named.
- **An unresolvable transcript** gives no grounds to claim its axis is transcript-relative.

### Three call sites, not one

`respell_at_gap` is the junction path. The **terminal** path is separate: when the landing junction is one past the last base, the repair becomes the boundary `delins` of #1327 and `respell_at_sequence_end` resolves the last base through `cds_axis_end` — `ordered_cds_bounds` again. It calls it *twice*, once to place the write and once to verify it landed, so `rna_axis_end` is shared between them. The first cut of this fix covered only the junction path, and the census still showed 1 surviving row; that row is now a pinned regression test.

## Unchanged on purpose

- **Coding transcripts keep the CDS-relative resolution.** `a_coding_transcripts_rna_axis_is_unchanged` and `a_coding_transcripts_terminal_rna_repair_is_unchanged` pin values measured on `origin/main` before the fix. A fix that replaced `cds_relative_gap` / `cds_axis_end` with plain `junction + 1` arithmetic would pass the reproducer and break these — that resolution is what names a junction on the CDS start `r.-1_1` rather than `r.0`.
- **The `n.` axis.** The `n.`/`r.` pair is asserted as *agreement*, not as two independent expected strings, so a future change that moved `n.` onto the same defect would fail rather than silently agree.

## Representation stability

`dump_normalized_corpus` (#1441) reports **0 of 18,432 rows moved**, 0 previously accepted, 0 previously not a fixed point — across all five shape families. That is a weak confirmation rather than strong evidence: the committed corpus covers the `g.` and `c.` axes only, and neither can satisfy the new predicate (a `g.` member is never `Region::Rna`, and the corpus's transcript is coding). The change is provably unreachable from it.

The substantive disclosure is the census above. On the non-coding `r.` axis this **does** move output, on ~849 rows of the affected shape family. But every moved row previously emitted a description that denotes no sequence at all — a repeated member — so there is no well-formed shipped string for a consumer to have stored. This is a correctness fix with no migration attached, not a canonical-form change.

Note this is `main`-to-branch, not release-to-release; the harness postdates the last tag.

## Verification

```
cargo fmt --all --check                                       # clean
cargo clippy --all-features --all-targets -- -D warnings      # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev
# 9409 tests run: 9409 passed (3 slow), 145 skipped
```

All three oracles plus the full sweep corpus. No proptest strategy touched, so no pinned seeds are affected (`git status --porcelain tests/proptest-regressions/` is empty). No Python surface touched.

The five new tests were written before the fix and confirmed RED against `origin/main` (`left: "NR_TEST.1:r.[9dup;11dup;11dup]"`), with the two coding-transcript guards passing at that point — they discriminate the fix rather than restate it.