### PR TITLE
test(sweep): exercise the non-coding `r.` axis in the transcript cis sweep

### DIFF
--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -902,7 +902,15 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
 /// It runs in the `sweeps` job only — `cis_junction_crossing_shift` is inside
 /// `SWEEP_FILTER`, which `test` and `test-oracle` negate — so it is exercised at
 /// the full corpus with the oracles set, which is the configuration that found
-/// all five. Measured at 280s for 829,440 cases.
+/// all five. Measured at 280s for 829,440 cases over two axes (`c.`, `n.`).
+///
+/// #1471 added a third (non-coding `r.`), taking it to **1,244,160 cases**. That
+/// count is exact and deterministic — three axes over the same corpus, shapes and
+/// positions — so it is quoted where a wall-clock is not: the machine this was
+/// developed on was running three concurrent copies of this sweep at a load
+/// average of 81, which makes any timing taken there contention noise rather than
+/// a measurement. Expect roughly 1.5x the 280s above on a quiet machine, and
+/// treat the `sweeps` job's own duration as the figure of record.
 ///
 /// Run it locally in the configuration `sweeps` uses — the oracles are not
 /// optional here, since four of the five defects above were *reported* by
@@ -928,13 +936,67 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
     let mut skipped = 0usize;
     let mut overlapping: Vec<String> = Vec::new();
     let mut changed: Vec<String> = Vec::new();
+    // Per axis, not just in aggregate. `checked` sums all three, and the floor
+    // below is a *per-seed* constant, so dropping an entire axis would remove a
+    // third of the corpus and still clear it — the aggregate cannot detect its
+    // own coverage being deleted. That matters most for `r.`, which is the axis
+    // this sweep gained last and the cheapest one to remove if the runtime is
+    // ever trimmed.
+    let mut per_axis: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
 
     let seeds = sweep_seeds(48);
     for seq in sweep_sequences(seeds) {
-        // `c.` and `n.` share the generator; `r.` is excluded because its
-        // `U`/`T` alphabet makes the payload construction below a different
-        // problem, and `issue_1235_transcript_axes.rs` pins that axis by hand.
-        for (accession, axis) in [("NM_TEST.1", "c"), ("NR_TEST.1", "n")] {
+        // All three transcript axes share the generator.
+        //
+        // `r.` was excluded until #1471 on two grounds, both of which were
+        // measured and neither of which held:
+        //
+        // * *"its `U`/`T` alphabet makes the payload construction below a
+        //   different problem"* — it does not. The parser accepts the
+        //   DNA-alphabet payloads this generator already builds and renders
+        //   them in the RNA alphabet on output, so not one line below changes:
+        //   `NR_TEST.1:r.5_6insAA` parses as `r.5_6insaa` and `r.5T>A` as
+        //   `r.5u>a`. The oracle needs no adjustment either — `apply_with`
+        //   applies an `r.` description to the same bases as its `n.` twin
+        //   (verified byte-identical), because `hgvs_to_spdi` folds the
+        //   alphabet.
+        // * *"`issue_1235_transcript_axes.rs` pins that axis by hand"* — it
+        //   does, with 13 `r.` cases including a non-coding one, but they are
+        //   substitutions and `delins`. Those reach `canonicalize_from_sequence`
+        //   and never the *repair* passes, so none of them produces two
+        //   junction-occupying members shifting onto one junction.
+        //
+        // That second gap is what #1453 fell through: on a non-coding `r.`
+        // record every repair routed through `respell_at_gap` was a silent
+        // no-op, so `r.[9dup;10dup;11dup]` normalized to `r.[9dup;11dup;11dup]`
+        // — one interbase point claimed twice, denoting no sequence. It was
+        // invisible to this suite and to two of the three seam oracles: the
+        // output is well-formed, so `FERRO_ASSERT_REPARSE` accepts it, and every
+        // coordinate is in range, so `FERRO_ASSERT_IN_BOUNDS` does too. Only the
+        // apply oracle distinguishes it, as `CoincidentInsertions`.
+        //
+        // Verified against the defect rather than assumed: with #1465's fix
+        // reverted, this arm fails at **four** seeds on the earliest shapes it
+        // emits — `r.[2dup;4dup] -> r.[9dup;9dup]` and nine more, the collector's
+        // cap. (The 849-output figure quoted in #1453 and #1471 comes from a
+        // purpose-built 63 nt census in #1465, not from this sweep's 20-mers;
+        // the two corpora are not comparable and only the *direction* carries
+        // over.)
+        //
+        // **Non-coding `r.` only, and coding `r.` is a deliberate remaining
+        // gap** — not a covered one. It would be convenient to say `c.` already
+        // sweeps it, since `axis_frame` gives both `reading_frame: true`, but
+        // that is only true of the frame: the two still take different code
+        // paths (`build_rna_merged` vs `build_cds_merged`, and
+        // `cds_relative_gap(Region::Rna)` vs `(Region::Cds)`), so a coding `r.`
+        // defect could hide exactly the way the non-coding one did.
+        //
+        // The reason to stop here is cost, stated plainly: each axis is +50% on
+        // what is already the slowest test in the suite. Non-coding `r.` buys a
+        // *measured* gap — 849 corrupt outputs — and coding `r.` buys an
+        // unmeasured one. Worth adding if a defect ever turns up there, or if
+        // this sweep is made cheaper.
+        for (accession, axis) in [("NM_TEST.1", "c"), ("NR_TEST.1", "n"), ("NR_TEST.1", "r")] {
             // Built once per (sequence, axis) and cloned per case. `SyntheticBuilder`
             // pads, maps to a genomic contig and reverse-complements on demand, so
             // constructing one inside the innermost loop dominated the test:
@@ -945,6 +1007,7 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
             } else {
                 SyntheticBuilder::noncoding(&seq, Strand::Plus).build()
             };
+            let checked_before_axis = checked;
             for first_start in 2..=11usize {
                 for first_len in 1..=2usize {
                     let first_end = first_start + first_len - 1;
@@ -1041,6 +1104,7 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
                     }
                 }
             }
+            *per_axis.entry(axis).or_insert(0) += checked - checked_before_axis;
         }
     }
 
@@ -1051,6 +1115,22 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
         checked > floor,
         "transcript-axis sweep covered too little: {checked} over {seeds} seeds (floor {floor})"
     );
+    // Each axis clears the floor on its own. Pinning the axis *set* as well as
+    // the counts, so that deleting an arm fails here with the axis named rather
+    // than silently shrinking a total that stays above the bar.
+    assert_eq!(
+        per_axis.keys().copied().collect::<Vec<_>>(),
+        vec!["c", "n", "r"],
+        "the transcript-axis sweep must run all three axes; got {per_axis:?}"
+    );
+    for (axis, axis_checked) in &per_axis {
+        assert!(
+            *axis_checked > floor,
+            "transcript-axis sweep covered too little on the `{axis}.` axis: \
+             {axis_checked} over {seeds} seeds (floor {floor}); the aggregate \
+             {checked} can hide this because the other axes make up the total"
+        );
+    }
     assert!(
         skipped * 2 < checked,
         "too many transcript-axis cases skipped: {skipped} of {checked}"


### PR DESCRIPTION
Closes #1471.

> **Stacked on #1465.** The base of this PR is `fix/issue-1453-rna-repeated-member`, not `main`, because the new sweep arm is **red without that fix** — that is the point of it. Merge #1465 first, then this retargets to `main` cleanly.

## The defect this closes

`no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence` swept `c.` and `n.` and excluded `r.`, on two stated grounds. Both were measured and neither holds.

**1. "its `U`/`T` alphabet makes the payload construction below a different problem."** It does not. The parser accepts the DNA-alphabet payloads this generator already builds, and renders them in the RNA alphabet on output — so not one line of the generator changes:

```
NR_TEST.1:r.5_6insAA  parses as  NR_TEST.1:r.5_6insaa
NR_TEST.1:r.5T>A      parses as  NR_TEST.1:r.5u>a
```

The oracle needs no adjustment either: an `r.` description applies to bases byte-identical to its `n.` twin, because `hgvs_to_spdi` folds the alphabet.

**2. "`issue_1235_transcript_axes.rs` pins that axis by hand."** It does — 13 `r.` cases, including a non-coding one. But they are substitutions and `delins`, which reach `canonicalize_from_sequence` and never the *repair* passes. None of them produces two junction-occupying members shifting onto one junction.

That second gap is what #1453 fell through: on a non-coding `r.` record every repair routed through `respell_at_gap` was a silent no-op, so `r.[9dup;10dup;11dup]` normalized to `r.[9dup;11dup;11dup]` — one interbase point claimed twice, denoting no sequence. It was invisible to two of the three seam oracles, since the output is well-formed (`FERRO_ASSERT_REPARSE` accepts it) and every coordinate is in range (`FERRO_ASSERT_IN_BOUNDS` accepts it). Only the apply oracle distinguishes it, as `CoincidentInsertions` — and nothing was calling it on `r.`.

## The change

One tuple, plus the comment that justified the exclusion:

```diff
-for (accession, axis) in [("NM_TEST.1", "c"), ("NR_TEST.1", "n")] {
+for (accession, axis) in [("NM_TEST.1", "c"), ("NR_TEST.1", "n"), ("NR_TEST.1", "r")] {
```

The sweep body was already axis-generic (`format!("{accession}:{axis}.[{first};{second}]")`) and the provider selector (`if axis == "c" { cds } else { noncoding }`) already does the right thing for `"r"`.

## Verification — the red/green pair is the evidence

Adding cases proves nothing on its own; what matters is that the arm *fails on the defect*.

| configuration | result |
|---|---|
| 4 seeds, #1465's `merge.rs` reverted to `ee6a19cc` | **FAIL** |
| 4 seeds, with #1465's fix | PASS |
| **full corpus + all three oracles**, with #1465's fix | **PASS** (9,409/9,409 in the full gate) |

The failure, at only four seeds, on the earliest shapes the generator emits:

```
overlapping or unconvertible output in 103680 transcript-axis cases: [
    "NR_TEST.1:r.[2dup;4dup] [ThreePrime] -> NR_TEST.1:r.[9dup;9dup]",
    "NR_TEST.1:r.[2dup;5dup] [ThreePrime] -> NR_TEST.1:r.[9dup;9dup]",
    ... 8 more, the collector's cap
]
```

## Cost

**829,440 → 1,244,160 cases, +50%**, on what is already the suite's slowest test.

**No wall-clock figure is quoted, deliberately.** The machine this was developed on was running three concurrent copies of this sweep at load average 81; the full-corpus run took 1,117s there against a ~460s expectation, so any timing taken on it is contention noise rather than a measurement. The doc comment says this rather than recording a number nobody can reproduce, and points at the `sweeps` job's own duration as the figure of record.

Two things that limit the blast radius of that cost:

- The default local run is a 4-seed prefix, so it lands mostly on CI's `Exhaustive sweeps` job — which is not among the eight checks `main`'s ruleset requires.
- No new test is added, only cases inside an existing one, so `ci.yml`'s `SWEEP_FILTER` partition invariant (`8878 + 30 == 8908`) is untouched.

## Unchanged on purpose

- **No pinned count breaks.** The sweep's only count assertion is a floor (`checked > 1000 * seeds`), which more cases satisfy. `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` belongs to the genomic sweep, not this one.
- **Coding `r.` is a deliberate remaining gap, and is documented as one rather than quietly skipped.** It would be convenient to claim `c.` covers it since `axis_frame` gives both `reading_frame: true`, but that is only true of the frame — the two still take different paths (`build_rna_merged` vs `build_cds_merged`, `cds_relative_gap(Region::Rna)` vs `(Region::Cds)`), so a coding `r.` defect could hide the way the non-coding one did. It is deferred because it buys an *unmeasured* gap for another +50%, where non-coding `r.` buys a measured one.
- **No production code changes.** Tests only.

## Verification commands

```
cargo fmt --all --check                                       # clean
cargo clippy --all-features --all-targets -- -D warnings      # clean, exit 0
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev
# 9409 tests run: 9409 passed (3 slow), 145 skipped
```