### PR TITLE
fix(normalize): keep the sequence-first derivation inside one exon

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2203,6 +2203,31 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
 
     let frame = axis_frame(kind, &template_accession, provider)?;
     let accession = template_accession.transcript_accession();
+
+    // `general.md:44` exempts deletions and duplications around an exon/exon
+    // junction from the 3' rule on the transcript axes, and the per-member
+    // pipeline honours it — so the members reaching this function are *already*
+    // clamped. Re-deriving across a junction throws that away: `c.[10del;13del]`
+    // on a transcript whose G-run spans c.9-c.33 arrives here as the correctly
+    // clamped `[c.11del;c.26del]` and comes back as `c.32_33del`, both members
+    // carried past their junctions and merged into one (#1450).
+    //
+    // The constraint belongs on the **input span**, here, and nowhere later. By
+    // the time `trim_common_flanks` has run, the two deletions have collapsed
+    // into a single run and which exon each came from is no longer recoverable
+    // from the resulting sequence; the merged piece then sits wholly inside one
+    // exon, so no check on the block, the partition or the shift can see that a
+    // junction was crossed. (`shift_pieces` in particular moves nothing for this
+    // shape, so a clamp there is unreachable — measured on #1450.)
+    //
+    // Declining rather than deriving per exon: the per-member result that
+    // survives a refusal *is* the expected answer, so refusing costs this shape
+    // nothing. Segmenting the block at exon edges would additionally buy
+    // confluence for cross-junction alleles; that is materially larger and is
+    // left open.
+    if crosses_exon_junction(kind, &accession, provider, &frame, c_lo, c_hi) {
+        return None;
+    }
     let start0 = w_lo + frame.delta - 1;
     let end0 = w_hi + frame.delta;
     if start0 < 0 {
@@ -3050,6 +3075,50 @@ struct AxisFrame {
     /// exception off the axis alone stamps a reading frame onto a transcript
     /// that has none (#1241).
     reading_frame: bool,
+}
+
+/// Whether `[lo, hi]` — a member-span union in axis coordinates — crosses an
+/// exon/exon junction of its own transcript (#1450).
+///
+/// The genomic axes have no exons and so never cross one. A transcript the
+/// provider cannot serve is reported as not crossing: the derivation is then no
+/// worse off than it was before this check existed, which is the same fallback
+/// `axis_frame` takes for a missing transcript.
+fn crosses_exon_junction<P: ReferenceProvider>(
+    kind: CisKind,
+    accession: &str,
+    provider: &P,
+    frame: &AxisFrame,
+    lo: i64,
+    hi: i64,
+) -> bool {
+    if matches!(kind, CisKind::Genome | CisKind::Mt) {
+        return false;
+    }
+    let Ok(transcript) = provider.get_transcript(accession) else {
+        return false;
+    };
+    // `axis + delta` is the 1-based transcript coordinate — the same conversion
+    // the window fetch performs immediately below the call site.
+    //
+    // Checked, and `try_from` rather than `as`, so neither an extreme authored
+    // coordinate nor an `exon.end` past `i64::MAX` can wrap this predicate into
+    // a wrong answer — a wrapped `junction` compares as negative and silently
+    // reports "no junction crossed", which is the direction that reinstates
+    // #1450. Both failures take the same conservative exit as an unservable
+    // transcript above.
+    //
+    // Note this hardens the predicate, not the whole path: an extreme
+    // coordinate still panics upstream at `w_hi = c_hi + CANONICAL_PAD`, which
+    // runs before this is reached and is untouched by this change. Tracked
+    // separately.
+    let (Some(tx_lo), Some(tx_hi)) = (lo.checked_add(frame.delta), hi.checked_add(frame.delta))
+    else {
+        return false;
+    };
+    transcript.exons.iter().any(|exon| {
+        i64::try_from(exon.end).is_ok_and(|junction| tx_lo <= junction && junction < tx_hi)
+    })
 }
 
 /// Resolve the group's [`AxisFrame`], or refuse the group.
@@ -7970,6 +8039,72 @@ mod tests {
     use crate::hgvs::parser::parse_hgvs;
     use crate::hgvs::variant::Accession;
     use crate::reference::MockProvider;
+
+    // ------------------------------------------------------------------
+    // Exon-junction guard on the derivation input (#1450)
+    // ------------------------------------------------------------------
+
+    /// The guard is asserted here, next to the code, rather than only through
+    /// `normalize()`. An integration assertion cannot isolate it: the derivation
+    /// returns `Some` only when its result *differs* from what the per-member
+    /// pipeline already produced, so a same-exon pair — the case that must stay
+    /// admitted — declines for an unrelated reason and would make an
+    /// integration-level "still derived" test pass vacuously.
+    ///
+    /// `MockProvider::with_test_data`'s `NM_001234.1` has exons at transcript
+    /// 1-15 / 16-30 / 31-44 and `cds_start = 5`, so the axis-to-transcript delta
+    /// is 4 and the junctions sit at `c.11|c.12` and `c.26|c.27`.
+    #[test]
+    fn the_exon_junction_guard_fires_only_across_a_junction() {
+        let provider = MockProvider::with_test_data();
+        let frame = AxisFrame {
+            delta: 4,
+            reading_frame: true,
+        };
+        let crosses =
+            |lo, hi| crosses_exon_junction(CisKind::Cds, "NM_001234.1", &provider, &frame, lo, hi);
+
+        // Spans that cross a junction — the defect.
+        assert!(
+            crosses(10, 13),
+            "c.10..c.13 crosses the exon-1/exon-2 junction"
+        );
+        assert!(
+            crosses(11, 12),
+            "the junction itself is crossed by its two flanking bases"
+        );
+        assert!(
+            crosses(13, 30),
+            "c.13..c.30 crosses the exon-2/exon-3 junction"
+        );
+
+        // Spans wholly inside one exon must stay admitted, or the guard would
+        // remove the sequence-first path from the transcript axes altogether.
+        assert!(!crosses(6, 11), "c.6..c.11 is inside exon 1");
+        assert!(
+            !crosses(12, 26),
+            "c.12..c.26 is exactly exon 2, edge to edge"
+        );
+        assert!(!crosses(27, 34), "c.27..c.34 is inside exon 3");
+        assert!(!crosses(20, 20), "a single position cannot cross anything");
+    }
+
+    /// The genomic axes have no exons, so the guard must never fire for them —
+    /// the whole `g.`/`m.` corpus depends on the derivation continuing to run.
+    #[test]
+    fn the_exon_junction_guard_never_fires_on_a_genomic_axis() {
+        let provider = MockProvider::with_test_data();
+        let frame = AxisFrame {
+            delta: 0,
+            reading_frame: false,
+        };
+        for kind in [CisKind::Genome, CisKind::Mt] {
+            assert!(
+                !crosses_exon_junction(kind, "NM_001234.1", &provider, &frame, 1, 10_000),
+                "a genomic axis has no exon junctions to cross"
+            );
+        }
+    }
 
     // ------------------------------------------------------------------
     // In-bounds seam oracle (#1353)

--- a/tests/it/issue_1450_derivation_exon_junction.rs
+++ b/tests/it/issue_1450_derivation_exon_junction.rs
@@ -1,0 +1,94 @@
+//! #1450 — the sequence-first derivation must not move a member across an
+//! exon/exon junction that the per-member pipeline would clamp.
+//!
+//! `general.md:44` exempts deletions and duplications around exon/exon junctions
+//! from the 3' rule on the `c.`, `r.` and `n.` axes. The per-member pipeline
+//! honours it. The sequence-first cis path did not, so the *same* member was
+//! clamped when described alone and shifted across two junctions when described
+//! beside a sibling — a confluence defect in which whether a member is clamped
+//! depended on whether it had a sibling.
+//!
+//! `NM_001234.1` from `MockProvider::with_test_data` has exons at transcript
+//! 1-15 / 16-30 / 31-44 and `cds_start = 5`, with a G-run spanning c.9-c.33 —
+//! one homopolymer crossing both junctions, which is what makes the shift
+//! reachable at all.
+
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+fn normalized(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::with_test_data());
+    let variant = parse_hgvs(input).expect("input parses");
+    normalizer
+        .normalize(&variant)
+        .expect("normalization succeeds")
+        .to_string()
+}
+
+/// The lone spellings, which never left the per-member pipeline and are the
+/// reference answer the pair has to agree with. Pinned here so a regression in
+/// the clamp itself cannot be mistaken for a change in the pair below.
+#[test]
+fn a_lone_member_still_clamps_at_its_exon_junction() {
+    assert_eq!(normalized("NM_001234.1:c.10del"), "NM_001234.1:c.11del");
+    assert_eq!(normalized("NM_001234.1:c.13del"), "NM_001234.1:c.26del");
+}
+
+/// The defect. Each member must land where it lands alone, rather than both
+/// being carried past their junctions and merged into one 2-base deletion in the
+/// third exon.
+#[test]
+fn a_cis_pair_does_not_shift_its_members_across_exon_junctions() {
+    assert_eq!(
+        normalized("NM_001234.1:c.[10del;13del]"),
+        "NM_001234.1:c.[11del;26del]"
+    );
+}
+
+/// The same pair spelled from a different starting position. `c.9del` and
+/// `c.10del` are the same variant (both delete one G from the run), so this must
+/// reach the same answer — the confluence half of the defect.
+#[test]
+fn the_same_pair_spelled_from_another_position_agrees() {
+    assert_eq!(
+        normalized("NM_001234.1:c.[9del;13del]"),
+        "NM_001234.1:c.[11del;26del]"
+    );
+}
+
+/// `general.md:44` names the `r.` axis too, and it went through the same path.
+#[test]
+fn the_rna_axis_carries_the_same_exception() {
+    assert_eq!(
+        normalized("NM_001234.1:r.[10del;13del]"),
+        "NM_001234.1:r.[11del;26del]"
+    );
+}
+
+/// The `n.` axis, which `general.md:44` names alongside `c.` and `r.` and which
+/// the guard covers through the same `CisKind` arm.
+///
+/// Spelled in transcript coordinates, so these are the `c.` cases above shifted
+/// by the delta of 4: `n.14`/`n.17` are `c.10`/`c.13`, and the junctions sit at
+/// `n.15|n.16` and `n.30|n.31`. Pinned rather than assumed equal to the `c.`
+/// arm — the two reach the guard through different frames (`axis_frame` gives
+/// `delta: 0` here against `4` there), which is exactly the kind of difference
+/// that has hidden an axis-specific defect before.
+#[test]
+fn the_noncoding_axis_carries_the_same_exception() {
+    // The lone spellings first, as the reference answer.
+    assert_eq!(normalized("NM_001234.1:n.14del"), "NM_001234.1:n.15del");
+    assert_eq!(normalized("NM_001234.1:n.17del"), "NM_001234.1:n.30del");
+
+    assert_eq!(
+        normalized("NM_001234.1:n.[14del;17del]"),
+        "NM_001234.1:n.[15del;30del]",
+        "each member must land where it lands alone, rather than being carried \
+         past its junction and merged with its sibling (#1450)"
+    );
+    // And the confluence half: a different spelling of the same variant.
+    assert_eq!(
+        normalized("NM_001234.1:n.[13del;17del]"),
+        "NM_001234.1:n.[15del;30del]"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -16,6 +16,7 @@ mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
 mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
+mod issue_1450_derivation_exon_junction;
 mod issue_1453_noncoding_rna_repeated_member;
 mod issue_1472_zero_length_read;
 mod repeat_input_idempotency;


### PR DESCRIPTION
Refs #1450 — **deliberately does not close it.** This PR takes the conservative half of that issue's Scope: it stops the derivation crossing an exon junction, so the reported outputs are correct. It does *not* make the derivation exon-*aware*, which is what the Scope asks for ("segment the block at exon edges, or re-place pieces into their originating exons"). See [Remaining half](#remaining-half) at the bottom.

## The defect

`general.md:44` exempts deletions and duplications around an exon/exon junction from the 3' rule on the `c.`/`n.`/`r.` axes. The per-member pipeline honours it; the sequence-first cis path did not. The same member was therefore clamped when described alone and carried past two junctions when described beside a sibling — whether a member is clamped depended on whether it had a sibling.

On `NM_001234.1` from `MockProvider::with_test_data` (exons at transcript 1-15 / 16-30 / 31-44, `cds_start = 5`, G-run spanning c.9-c.33), at `origin/main` `2ddc25b9`:

| input | before | after |
|---|---|---|
| `c.10del` | `c.11del` | `c.11del` (unchanged) |
| `c.13del` | `c.26del` | `c.26del` (unchanged) |
| `c.[10del;13del]` | **`c.32_33del`** | **`c.[11del;26del]`** |
| `c.[9del;13del]` | **`c.32_33del`** | **`c.[11del;26del]`** |
| `r.[10del;13del]` | **`r.32_33del`** | **`r.[11del;26del]`** |

## The fix, and why it sits where it does

Instrumenting the pass is what located it. The members arrive at the derivation **already correctly clamped**:

```
DERIVED from [c.11del; c.26del] -> [c.32_33del]
```

`[c.11del;c.26del]` is precisely the expected answer. The per-member pipeline had already produced it, and the derivation re-merged it across both junctions.

So the guard refuses when the members' own **input span** crosses a junction, before the window is built. It cannot go anywhere later:

- After `trim_common_flanks`, the two deletions have collapsed into a single G-run and **which exon each came from is no longer recoverable** from the resulting sequence.
- The merged piece then sits **wholly inside exon 3**, so no check on the block, the partition or the shift can see that a junction was crossed.
- `shift_pieces` in particular moves nothing for this shape (measured on #1450), so a clamp there is unreachable — which is why the first attempt at this issue changed nothing.

**Declining rather than deriving per exon.** The per-member result that survives a refusal *is* the expected answer, so this shape loses nothing by refusing, and refusal is this function's established convention. Segmenting the block at exon edges — #1450's other option — would additionally buy confluence for genuinely cross-junction alleles, but carries the `ref`/`alt` index-alignment risk that issue describes.

## Unchanged on purpose

- **The genomic axes.** `crosses_exon_junction` returns `false` for `Genome`/`Mt` before touching the provider, pinned by `the_exon_junction_guard_never_fires_on_a_genomic_axis`.
- **Same-exon spans**, including one that is exactly an exon edge to edge (`c.12..c.26`), pinned by `the_exon_junction_guard_fires_only_across_a_junction`.
- **A transcript the provider cannot serve** reports "not crossing", so the derivation is no worse off than before this check existed — the same fallback `axis_frame` takes.

Those two are unit tests next to the code rather than integration assertions, deliberately: the derivation returns `Some` only when its result *differs* from what the per-member pipeline already produced, so a same-exon pair declines for an unrelated reason and an integration-level "still derived" test would pass vacuously. That is stated in the test's own doc comment.

## Representation stability

**0 of 33,808 corpus rows move — and that zero is structural, not evidence.** `dump_normalized_corpus`'s coding provider builds a **single-exon** transcript (`Exon::with_genomic(1, 1, tx_len, …)`), so no corpus row can cross an exon junction and this guard can never fire on one. This is a third instance of the blindness class #1456 (shape) and #1460 (scale) are about, now on transcript structure — already tracked as **#1478**, which names #1450 specifically as one of the shapes it cannot reach.

The real evidence is the suite: **9,440 tests pass with no test re-blessed**, which for a change that moves normalized output is the strong signal — every existing expectation, including both hermetic oracles (`mutalyzer_normalize_tests::gate_normalized_snapshot`, `biocommons_normalize_tests::axis_normalized_hermetic`), already agreed with the clamped answer. The outputs that move are the ones no oracle had covered.

Downstream impact is confined to cis alleles whose members sit in different exons on a transcript axis, and for those the new answer is the one each member already had alone.

## Verification

```
cargo fmt --all --check                                        # clean
cargo clippy --all-features --all-targets -- -D warnings       # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev
# Summary [431.092s] 9440 tests run: 9440 passed (3 slow), 145 skipped
```

Test-first: the four integration tests were written against #1450's stated expectation and failed on `main` with `left: "NM_001234.1:c.32_33del"` / `right: "NM_001234.1:c.[11del;26del]"`.

## Follow-on

This unblocks #1477 (widening `is_splittable_single_member` to lone `c.`/`n.`/`r.` members), which was blocked precisely because the derivation lacked this clamp — six `issue_334_exon_junction_exception` tests plus the biocommons oracle. That widening is still its own measured pass and is not attempted here.

## Remaining half

#1450 stays open for the part this does not do: a cis allele whose members sit in **different
exons** is now declined by the derivation and keeps its per-member spelling, rather than being
re-derived from the resulting sequence within each exon. Concretely, `c.[10del;13del]` is correct
but is no longer a *derived* form — it is the per-member form, which happens to be the right one.

What is still owed to #1450:

- **Confluence across a junction.** Two spellings of one cross-junction variant can still settle on
  different forms, because neither is re-derived. This PR does not make that worse — before it,
  both were re-derived to the same *wrong* answer — but it does not fix it either.
- The two implementations its Scope names (segment at exon edges, or re-place pieces into their
  originating exons), and the `ref`/`alt` index-alignment risk that comes with the first.
- Measuring any of it needs #1478 first: the representation corpus builds a single-exon
  transcript, so it cannot produce a cross-junction row at all.
