### PR TITLE
docs: document FERRO_PARTITION as an unstable evaluation switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,81 @@ ignore = ["W1001", "W2001"]  # Silently correct these
 reject = ["W3003"]           # Always reject these
 ```
 
+## Comparing normalization rules (`FERRO_PARTITION`)
+
+> **Unstable.** `FERRO_PARTITION` is an evaluation switch, **not** a supported feature. It is not covered by semantic versioning, its values may change, and it is expected to be removed once the normalization rule is settled. Do not depend on it in production pipelines.
+
+Normalization cuts each changed region of sequence into allele members. `FERRO_PARTITION` selects which rule does that cutting, so a candidate rule can be measured against the shipped one over a real corpus before anything changes for users.
+
+| Value | Rule |
+|-------|------|
+| unset / empty / `live` | The shipped rule. This is what every normal invocation uses. |
+| `shadow` | Cut only at alignment steps common to *every* minimal alignment. |
+| `canonical` | The member-count-minimal minimal alignment. |
+| `canonical-coalesced` | `canonical`, plus the `delins.md:44-47` merge: a split whose payload realigns as one block is re-spelled as a single `delins`. Applied after the downstream passes rather than at partition time, so it cuts identically to `canonical` and differs only in what survives. |
+
+With the variable unset — or set to the empty string — output is byte-identical to a build with no switch at all.
+
+### Running an A/B comparison
+
+Run the same input twice and diff the normalized descriptions. In `tsv` format the columns are `line, input, normalized, changed, status, detail`, so column 3 is the normalized string:
+
+```bash
+# 1. the shipped behaviour
+ferro normalize --input variants.txt --reference /path/to/reference \
+  --format tsv --error-mode lenient -j 10 > shipped.tsv
+
+# 2. the candidate rule
+FERRO_PARTITION=canonical ferro normalize --input variants.txt --reference /path/to/reference \
+  --format tsv --error-mode lenient -j 10 > candidate.tsv
+
+# 3. what moved
+diff <(cut -f3 shipped.tsv) <(cut -f3 candidate.tsv) | head
+
+# 4. how many moved, counting only rows that succeeded on both sides
+#    (columns 3/5 are `normalized`/`status`; a row that failed carries no
+#     normalized string, so comparing column 3 alone would score two different
+#     failures as identical)
+paste <(cut -f3,5 shipped.tsv) <(cut -f3,5 candidate.tsv) \
+  | awk -F'\t' '$2 == "ok" && $4 == "ok" && $1 != $3' | wc -l
+
+# and, separately, rows whose status itself changed
+paste <(cut -f5 shipped.tsv) <(cut -f5 candidate.tsv) | awk -F'\t' '$1 != $2' | wc -l
+```
+
+This works on a **stock release build** — the switch is not behind a build feature, so no special binary or wheel is needed.
+
+### Two traps worth knowing
+
+**A misspelled value looks like success, and nothing tells you.** An unrecognised value falls back to `live`, so `FERRO_PARTITION=canonicl` produces a clean, empty diff that reads as "the candidate changes nothing".
+
+The fallback does emit a warning through the `log` facade — but the `ferro` CLI installs no logger, so **that warning is not visible from the command line, and `RUST_LOG` will not surface it**. There is no signal at all.
+
+The defence is a positive control on an input **known** to differ — not on your own corpus, where a zero is ambiguous between "the switch is not taking effect" and "this corpus has no affected variants".
+
+These three run against the built-in test data, so they need no `--reference` and no prepared reference directory:
+
+```bash
+printf 'NM_001234.1:c.[2del;9del]\nNM_001234.1:c.[3del;9del]\nNM_001234.1:c.[2del;9dup]\n' > control.txt
+
+ferro normalize --input control.txt --format tsv --error-mode lenient | cut -f3
+#   NM_001234.1:c.[2del;11del]   <- live
+FERRO_PARTITION=canonical ferro normalize --input control.txt --format tsv --error-mode lenient | cut -f3
+#   NM_001234.1:c.[2del;33del]   <- canonical
+```
+
+If those two produce the same output, the variable is not reaching ferro and any comparison you run is meaningless. Only once the control differs is a zero on your own corpus informative.
+
+**From Python, it must be set before the first normalization.** The value is read once per process and cached, so:
+
+```python
+import os
+os.environ["FERRO_PARTITION"] = "canonical"   # must precede the first normalize call
+import ferro_hgvs
+```
+
+Setting it after any variant has been normalized silently does nothing, and it cannot be changed within a running process. Comparing two rules therefore means two separate processes (or two CLI runs, as above), not two calls in one script.
+
 ## Why ferro-hgvs?
 
 ferro-hgvs provides the most comprehensive HGVS variant normalization across all pattern types, with performance orders of magnitude faster than alternatives.

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -218,6 +218,42 @@ enum Commands {
     },
 
     /// Normalize HGVS variants
+    #[command(long_about = "Normalize HGVS variants (3'/5' shifting).
+
+UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
+
+  Selects which rule cuts a changed block into allele members. It exists so a
+  candidate normalization can be measured against the shipped one on a real
+  corpus, and it is NOT covered by semantic versioning: the values may change
+  or the variable may be removed once the choice is settled. Do not depend on
+  it in production.
+
+    live       the shipped rule (default; also used when unset or empty)
+    shadow     cut at the steps common to every minimal alignment
+    canonical  the member-count-minimal minimal alignment
+    canonical-coalesced
+               canonical, plus the delins.md:44-47 merge -- a split whose
+               payload realigns as one block becomes a single delins
+
+  An unrecognised value falls back to `live`, so a misspelling looks exactly
+  like 'the candidate changes nothing'. The fallback logs a warning through the
+  `log` facade, but this CLI installs no logger, so that warning is NOT visible
+  here and RUST_LOG will not surface it. The only defence is to confirm your
+  comparison reports some differences before concluding it reports none.
+
+  It is read once per process and cached, so it cannot be changed after the
+  first variant is normalized. That is also why this is an environment variable
+  and not a command-line flag — a real flag would need the value threaded
+  through the call path rather than read from a process-global.
+
+  To compare the shipped output against a candidate, run twice and diff column
+  3 (the normalized description) of the TSV output:
+
+    ferro normalize -i variants.txt --reference DIR -f tsv -j 10 > shipped.tsv
+    FERRO_PARTITION=canonical \\
+      ferro normalize -i variants.txt --reference DIR -f tsv -j 10 > candidate.tsv
+    diff <(cut -f3 shipped.tsv) <(cut -f3 candidate.tsv)
+")]
     Normalize {
         /// HGVS variant to normalize
         variant: Option<String>,
@@ -3839,6 +3875,41 @@ fn run_build_transcript(
 
 #[cfg(test)]
 mod tests {
+    /// `normalize --help` must name every `FERRO_PARTITION` value the parser
+    /// accepts.
+    ///
+    /// This documentation went stale within an hour of being written: the
+    /// `canonical-coalesced` rule landed while the PR describing the switch was
+    /// open, and nothing connected the two. That matters more than an ordinary
+    /// doc drift, because the help text itself warns that an unrecognised value
+    /// falls back to `live` with no CLI-visible signal — so a reader who does
+    /// not find a value here reasonably concludes it does not exist.
+    ///
+    /// Pinned against the rendered help rather than the source string, so a
+    /// clap attribute that silently stopped being applied would also fail.
+    #[test]
+    fn normalize_help_documents_every_partition_value() {
+        use clap::CommandFactory;
+        let mut command = super::Cli::command();
+        let mut normalize = command
+            .find_subcommand_mut("normalize")
+            .expect("`normalize` subcommand")
+            .clone();
+        let help = normalize.render_long_help().to_string();
+        for value in ["live", "shadow", "canonical", "canonical-coalesced"] {
+            assert!(
+                help.contains(value),
+                "`normalize --help` does not mention the `{value}` partition rule; \
+                 every value `partition_rule_from_env` accepts has to appear here, \
+                 because an unrecognised one falls back to `live` silently"
+            );
+        }
+        assert!(
+            help.contains("FERRO_PARTITION"),
+            "the switch itself must be named in the help"
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
`FERRO_PARTITION` selects which rule cuts a changed block into allele members. It exists so a candidate normalization can be measured against the shipped one over a real corpus — but it was undocumented, so using it meant reading `merge.rs`. This writes it down.

Docs only: `README.md` plus a `long_about` on the `normalize` subcommand. No logic change.

## Documented as unstable, deliberately

Writing an environment variable down makes it something people script against. It is labelled explicitly as **not covered by semantic versioning** and expected to be removed once the rule is settled, so we can retire it without a breaking-change argument.

Values documented are the ones that exist on `main`: `live`, `shadow`, `canonical`.

> **For the reviewer:** PR #1470 adds a fourth value, `canonical-coalesced`. It is deliberately **not** documented here, because it does not exist on `main` yet. When #1470 lands, a one-row addition to the table in `README.md` and to the list in the `long_about` is needed. Worth noting in that PR rather than trusting memory.

## Two silent traps, both called out

**A misspelled value looks like success.** An unrecognised value falls back to `live`, so `FERRO_PARTITION=canonicl` yields a clean empty diff that reads as "the candidate changes nothing".

The fallback does log a warning — but **the CLI installs no logger at all**. `log` is the only logging dependency in `Cargo.toml`; there is no `env_logger` or `tracing-subscriber`, and `src/bin/ferro.rs` calls no `init()`. So the warning goes to a no-op sink, and `RUST_LOG` does not surface it. I checked this because my first draft told readers to set `RUST_LOG=warn`, which is false. The README now gives a positive-control count as the only real defence.

That is arguably a small defect in its own right — a measurement knob whose misuse is undetectable — but fixing it means adding a logger to the CLI, which is out of scope here.

**From Python it must be set before the first normalization.** `partition_rule()` caches in a `OnceLock`, so setting it later silently does nothing and it cannot change within a process. Comparing two rules is two processes, not two calls.

The same caching is why this is help text rather than a real `--partition` flag: a flag would need the value threaded through the call path instead of read from a process-global. That is a refactor, not a doc change, and is left for a follow-up if the switch ever needs to be supported properly.

## Verified by running it, not by reading it

- **Rendered help** — pasted below.
- **TSV header** — `line  input  normalized  changed  status  detail`, confirming the recipe's column 3 is the normalized description.
- **The recipe**, against the real prepared reference:
  ```
  < NC_000001.10:g.240370952_240370985delinsT
  > NC_000001.10:g.[240370952del;240370954_240370985del]
  ```
  positive-control count: **1**.
- **The typo trap** — `FERRO_PARTITION=canonicl` gives a count of **0**, with no warning shown. Reproduced exactly as documented.

## Rendered `ferro normalize --help`

```
Normalize HGVS variants (3'/5' shifting).

UNSTABLE EVALUATION SWITCH: FERRO_PARTITION

  Selects which rule cuts a changed block into allele members. It exists so a
  candidate normalization can be measured against the shipped one on a real
  corpus, and it is NOT covered by semantic versioning: the values may change
  or the variable may be removed once the choice is settled. Do not depend on
  it in production.

    live       the shipped rule (default; also used when unset or empty)
    shadow     cut at the steps common to every minimal alignment
    canonical  the member-count-minimal minimal alignment

  An unrecognised value falls back to `live` and only logs a warning, so a
  misspelling looks exactly like 'nothing changed'. Set RUST_LOG=warn to see it.

  It is read once per process and cached, so it cannot be changed after the
  first variant is normalized. That is also why this is an environment variable
  and not a command-line flag — a real flag would need the value threaded
  through the call path rather than read from a process-global.

  To compare the shipped output against a candidate, run twice and diff column
  3 (the normalized description) of the TSV output:

    ferro normalize -i variants.txt --reference DIR -f tsv -j 10 > shipped.tsv
    FERRO_PARTITION=canonical \
      ferro normalize -i variants.txt --reference DIR -f tsv -j 10 > candidate.tsv
    diff <(cut -f3 shipped.tsv) <(cut -f3 candidate.tsv)


Usage: ferro normalize [OPTIONS] [VARIANT]
```

## Gate

`cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean.

```
Summary [ 166.516s] 9466 tests run: 9466 passed (11 slow), 145 skipped
```

Refs #1235, #1444
