### PR TITLE
feat(normalize): widen the axis gate to c./n./r.

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2507,6 +2507,15 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         piece.ref_start += lo;
         piece.ref_end += lo;
     }
+    // `general.md:35`'s coding exception, applied here — before the 3'-shift and
+    // before the weight bound — for two independent reasons, each of which was
+    // measured by getting it wrong. See `coalesce_coding_frame_separation`.
+    let unwidened = coalesce_coding_frame_separation(
+        &mut pieces,
+        frame.reading_frame,
+        hi_ref != hi_alt,
+        &ref_bytes,
+    );
     shift_pieces(&mut pieces, &ref_bytes, direction);
     coalesce_adjacent_pieces(&mut pieces);
     // Partitioning decides where the members are; this decides how wide each
@@ -2544,7 +2553,26 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // Strict on purpose: #1229, #1231, #1233 and #1234 all sit exactly at
     // equality, and equality is where prioritisation (`general.md:56`) may
     // legitimately prefer the re-derived shape.
-    if changed_columns_of_pieces(&pieces) > changed_columns_of_edits(&edits) {
+    //
+    // The quantity judged is the **un-widened** partition's, which is what
+    // `unwidened` carries: `coalesce_coding_frame_separation` above widens, so
+    // letting the bound see its product would judge a widening against the
+    // input's weight — accepted for the spelling that arrived as one `delins`,
+    // refused for the spelling that arrived as separate members. Measured: 332
+    // converged classes lost per direction over the 11,272-class corpus (3':
+    // 8,007 -> 7,675) when the bound saw the widened pieces. The un-widened
+    // partition is put through the same 3'-shift, coalesce and shrink so the two
+    // weights are comparable.
+    let derived_columns = match unwidened {
+        None => changed_columns_of_pieces(&pieces),
+        Some(mut raw) => {
+            shift_pieces(&mut raw, &ref_bytes, direction);
+            coalesce_adjacent_pieces(&mut raw);
+            shrink_pieces_to_differences(&mut raw, &ref_bytes);
+            changed_columns_of_pieces(&raw)
+        }
+    };
+    if derived_columns > changed_columns_of_edits(&edits) {
         return None;
     }
 
@@ -5695,6 +5723,124 @@ fn split_codon_incompatible_triplets(
         );
         index += 2;
     }
+}
+
+/// Merge runs of change separated by a single unchanged base on a **reading
+/// frame** axis, returning the pieces as they were if anything merged.
+///
+/// # The rule
+///
+/// `general.md:34` describes two variants separated by one or more nucleotides
+/// individually; `general.md:35` excepts "two variants separated by one
+/// nucleotide, together affecting one amino acid", which is a coding-axis rule
+/// and reaches no genomic description at all. [`axis_min_separation`] is that
+/// distinction, already handed to the sequence-first splitter; the live path had
+/// no axis at all, so a single coincidentally matched base split coding `delins`
+/// descriptions the spec keeps whole. That is the gap #1235's widened axis gate
+/// exposed on `c.`/`n.`/`r.`.
+///
+/// Scoped to **length-changing** blocks. An equal-length block reaches
+/// [`apply_coding_codon_exception`], which applies the same exception
+/// triplet-precisely (`[Sub@p; Identity@p+1; Sub@p+2]` with `p` and `p+2` in one
+/// codon) and must keep owning that shape: merging it here instead would drop
+/// the codon half of the exception, which `general.md:35` states and
+/// `test_no_codon_frame_pair_straddles_codon_boundary` pins. On a
+/// length-changing block that shape cannot arise — the pieces do not pair up
+/// position-wise — so the two passes do not overlap.
+///
+/// The merge is **pairwise**, not whole-block: only pieces one unchanged base
+/// apart join, and a genuinely separated pair stays split. Refusing the whole
+/// partition instead (the first attempt) over-merges, and it also loses the
+/// distinction `separations_are_meaningful` draws for wider gaps.
+///
+/// # Placement, which is the whole of the difficulty
+///
+/// **Before the 3'-shift.** The shift moves a piece into an unchanged run, so a
+/// pair one base apart at partition time can be three apart by the time the
+/// post-shift passes see it. `NM_000143.3:c.44_47delinsATC` is the case:
+/// `TGCG -> ATC` partitions as `[44_45delinsAT]` + `[47del]`, one base apart,
+/// and the deletion then 3'-shifts down the `G` run at c.47-49 to `49del`.
+/// Running this after the shift leaves that pair unmerged and the oracle
+/// divergence in place.
+///
+/// **Exempt from the changed-columns weight bound**, which is why this returns
+/// the pieces it replaced rather than nothing. The bound compares the derived
+/// weight against the *input's*, so a widening judged by it is accepted for one
+/// spelling of a variant and refused for another —
+/// `c.9delinsATC` weighs 3 and `c.[8_9insA;9_10insC]` weighs 2 for the same
+/// variant, so the merged form clears the bound for the first and trips it for
+/// the second. Measured on that corpus: 332 converged classes lost per
+/// direction (3': 8,007 -> 7,675; 5': 8,007 -> 7,673) with the bound judging
+/// the merged pieces. This is the same rule
+/// [`coalesce_whole_block_inversion`] and [`apply_coding_codon_exception`] are
+/// placed by, stated there as: *any partition rule that widens a piece must run
+/// after the weight bound, never inside [`partition_block`]*. This one cannot
+/// run after it and still be before the shift, so the bound is handed the
+/// un-widened partition instead — the same exemption, reached the other way.
+///
+/// # Known residual: a gap the shift *creates*
+///
+/// Running before the shift is necessary and not sufficient. The shift moves
+/// piece boundaries, so it can also bring a pair that was two or more bases
+/// apart at partition time down to one — the mirror image of the case above,
+/// and invisible here because it has not happened yet.
+///
+/// Measured over 500,004 ClinVar rows: **3** land with a surviving one-base gap
+/// on a coding axis (`NM_001458.4:c.7242_7246delCAGCCinsAAACCTG`,
+/// `LRG_712t1:c.845_852delATCCCAATinsTCTTCATAGA`,
+/// `NM_001406642.1:c.1897_1910delinsTAATATAATT`), plus a second gap in two rows
+/// this pass does otherwise reduce. All are multi-member partitions where a
+/// *deletion* piece shifts toward a substitution.
+///
+/// Closing it means running the rule a second time after the shift, which needs
+/// the un-widened partition carried through that pass too — the bookkeeping
+/// above, done twice. Left undone deliberately: none of the four failures this
+/// pass was written for is in that class, and a second widening judged against
+/// the wrong weight is exactly the mistake this doc records.
+///
+/// Returns `None` when nothing merged, so the caller pays nothing on the path
+/// that does not widen.
+fn coalesce_coding_frame_separation(
+    pieces: &mut Vec<Piece>,
+    reading_frame: bool,
+    length_changing: bool,
+    ref_bytes: &[u8],
+) -> Option<Vec<Piece>> {
+    // `ref_end` is exclusive and a pure insertion occupies no width, so a gap of
+    // one is one unchanged *base* — the same counting `separations_are_meaningful`
+    // does, and for the same reason.
+    //
+    // Scanned before anything is copied: the copy exists only to hand the weight
+    // bound the un-widened partition, so a block that merges nothing must not pay
+    // for one. Every coding length-changing block reaches here.
+    let joins = |pair: &[Piece]| pair[1].ref_start.saturating_sub(pair[0].ref_end) == 1;
+    if !reading_frame || !length_changing || !pieces.windows(2).any(joins) {
+        return None;
+    }
+    let unwidened = pieces.clone();
+    let mut index = 1;
+    while index < pieces.len() {
+        // `gap == 1` puts `pieces[index].ref_start` at `previous.ref_end + 1`, and
+        // a piece never runs past the window, so `previous.ref_end` indexes a real
+        // byte. Read through `get` regardless: this is the only raw index in the
+        // pass, and declining to merge is a sound answer where a bare index would
+        // panic.
+        let Some(middle) = (joins(&pieces[index - 1..=index]))
+            .then(|| ref_bytes.get(pieces[index - 1].ref_end).copied())
+            .flatten()
+        else {
+            index += 1;
+            continue;
+        };
+        let next = pieces.remove(index);
+        let previous = &mut pieces[index - 1];
+        // The unchanged base is interior to the merged replacement now, so it has
+        // to be carried through explicitly.
+        previous.alt.push(middle);
+        previous.alt.extend_from_slice(&next.alt);
+        previous.ref_end = next.ref_end;
+    }
+    Some(unwidened)
 }
 
 /// Merge pieces the 3'-shift left touching.
@@ -10598,6 +10744,76 @@ mod tests {
             },
         ];
         coalesce_adjacent_pieces(&mut pieces);
+    }
+
+    /// `general.md:35`'s exception on a length-changing block, asserted against
+    /// the pass itself (#1235 review).
+    ///
+    /// Its integration-level sibling —
+    /// `merge_consecutive_edits_tests::coding_length_changing_block_merges_across_one_unchanged_base`
+    /// — can only assert that the `c.` answer equals its input, and that
+    /// equality is satisfied by *any* upstream decline (a window clamp, the
+    /// weight bound, the round-trip guard) just as well as by the merge. Only a
+    /// direct call proves the pass ran, so the discriminating assertion lives
+    /// here and that test carries the control that ties the two together.
+    ///
+    /// `TGCA -> AAC` is that test's `NM_TEST.1:c.2_5delinsAAC`. The payload
+    /// coincides at exactly one column, which is what leaves two runs one
+    /// unchanged base apart for the exception to close.
+    #[test]
+    fn coalesce_coding_frame_separation_merges_one_base_gap_only_in_frame() {
+        let reference = b"TGCA";
+        let split = partition_block(reference, b"AAC");
+        assert_eq!(
+            split.len(),
+            2,
+            "the fixture must actually split, else the merge below proves \
+             nothing; got {split:?}",
+        );
+        assert_eq!(
+            split[1].ref_start - split[0].ref_end,
+            1,
+            "and the two runs must be exactly one unchanged base apart, which is \
+             the gap the exception is scoped to; got {split:?}",
+        );
+
+        // In a reading frame the pair rejoins into the whole block, and the
+        // un-widened partition comes back for the weight bound to judge.
+        let mut in_frame = split.clone();
+        let unwidened = coalesce_coding_frame_separation(&mut in_frame, true, true, reference);
+        assert_eq!(
+            unwidened.as_deref(),
+            Some(&split[..]),
+            "a widening pass must return the pieces it replaced",
+        );
+        assert_eq!(in_frame.len(), 1, "got {in_frame:?}");
+        assert_eq!(in_frame[0].ref_start, 0);
+        assert_eq!(in_frame[0].ref_end, reference.len());
+        assert_eq!(in_frame[0].alt, b"AAC");
+
+        // With no reading frame it declines, which is `general.md:34`'s plain
+        // rule and the `n.` answer the sibling test pins end to end.
+        let mut no_frame = split.clone();
+        assert!(coalesce_coding_frame_separation(&mut no_frame, false, true, reference).is_none());
+        assert_eq!(
+            no_frame, split,
+            "a declined pass must leave the pieces untouched",
+        );
+
+        // And it declines an equal-length block even in frame, which is the
+        // half of the scoping that keeps `apply_coding_codon_exception` owning
+        // the `[Sub@p; Identity@p+1; Sub@p+2]` triplet — merging that shape here
+        // instead would drop the codon half of `general.md:35`. Asserted with
+        // this same pair so only the flag varies.
+        let mut equal_length = split.clone();
+        assert!(
+            coalesce_coding_frame_separation(&mut equal_length, true, false, reference).is_none()
+        );
+        assert_eq!(
+            equal_length, split,
+            "the length-changing scope is what routes an equal-length block to \
+             `apply_coding_codon_exception`",
+        );
     }
 
     /// The enumerated classes of disagreement between the two block splitters.

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3353,8 +3353,16 @@ fn enclosing_exon<P: ReferenceProvider>(
     }
     let transcript = provider.get_transcript(accession).ok()?;
     let (tx_lo, tx_hi) = (lo + frame.delta, hi + frame.delta);
+    // `Exon` stores 1-based INCLUSIVE bounds — `[(1, 15), (16, 30), (31, 44)]` on
+    // `MockProvider`'s `NM_001234.1` — so `start` is already the exon's first
+    // base. Adding one treats them as 0-based half-open and makes the enclosure
+    // test miss any member sitting on an exon's first base: `c.12del` on that
+    // transcript has `tx_lo = 16`, which `17 <= 16` rejects, so the clamp
+    // silently returns `None` and the derivation shuffles across the junction
+    // into exon 1 (`c.9del`). `crosses_exon_junction` above reads `exon.end`
+    // directly and is unaffected.
     transcript.exons.iter().find_map(|exon| {
-        let (start, end) = (exon.start as i64 + 1, exon.end as i64);
+        let (start, end) = (exon.start as i64, exon.end as i64);
         (start <= tx_lo && tx_hi <= end).then(|| (start - frame.delta, end - frame.delta))
     })
 }

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2516,6 +2516,21 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         hi_ref != hi_alt,
         &ref_bytes,
     );
+    // `general.md:34` binds the members a split emits, not only the block it
+    // cut, and `best_alignment`'s single-gap search can carve out a member that
+    // needs two gaps of its own. Cut those apart here — after the coding merge
+    // above, which would otherwise close every cut straight back up, and before
+    // the 3'-shift, so each new member shifts on its own. See
+    // `split_concealed_separations` for the adjudication, for the measured cost
+    // of the alternative (refusing the split instead), and for why the spec's own
+    // `LRG_199t1:c.850_901` example is out of scope by construction.
+    split_concealed_separations(
+        &mut pieces,
+        frame.reading_frame,
+        hi_ref != hi_alt,
+        w_lo,
+        &ref_bytes,
+    );
     shift_pieces(&mut pieces, &ref_bytes, direction);
     coalesce_adjacent_pieces(&mut pieces);
     // Partitioning decides where the members are; this decides how wide each
@@ -4132,6 +4147,425 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
     pieces
 }
 
+/// Cap on the alignment grid [`concealed_separations`] will build for one piece,
+/// in cells, and on how wide a piece it will audit at all.
+///
+/// The audit is `Θ(ref · alt)` per piece and recurses into what it splits, and
+/// [`MAX_SPLIT_BLOCK`] bounds only *length-changing* blocks, so an equal-length
+/// block can hand it a piece of any width. Over either cap the piece is not
+/// audited, which under-reports and never over-reports — the same bias
+/// `adjudicate_member` takes in
+/// `tests/it/issue_1539_split_member_separation.rs`, and the correct one for a
+/// rule that re-partitions an already-accepted member.
+const MAX_SEPARATION_AUDIT_CELLS: usize = 1 << 20;
+
+/// Widest member [`concealed_separations`] will audit, in reference columns.
+///
+/// Matches [`MAX_SPLIT_BLOCK`], so a member no wider than the widest block
+/// `partition_block` will itself cut is auditable. It also bounds the recursion
+/// depth of [`split_concealed_separations`], since every split strictly narrows
+/// the piece it replaces.
+const MAX_SEPARATION_AUDIT_WIDTH: usize = MAX_SPLIT_BLOCK;
+
+/// Reference columns that **every** minimal alignment of `reference` to
+/// `payload` leaves unchanged, together with the alternate offset a single fixed
+/// minimal alignment pins for each column it matches.
+struct MemberAlignment {
+    /// One entry per reference column: `true` where no minimal alignment can
+    /// change it.
+    forced: Vec<bool>,
+    /// One entry per reference column: the alternate offset the canonical walk
+    /// below matched it to, or `None` where that walk substituted or deleted it.
+    matched_alt: Vec<Option<u32>>,
+}
+
+/// Build [`MemberAlignment`] for one member.
+///
+/// Every minimal alignment consumes `reference[i]` exactly once, as a `Match`, a
+/// `Sub` or a `Del`. So column `i` can change exactly when some cell on some
+/// minimal path leaves row `i` by a `Sub` or a `Del` edge, and it is *forced
+/// unchanged* when none does. [`AlignmentDag`] holds every minimal alignment at
+/// once and stores only on-path edges, so the question is one sweep of the grid.
+///
+/// # This is the node criterion, and it is deliberately not `Dominators`
+///
+/// `Dominators::matched_ref` answers a strictly stronger question — which match
+/// **edges** lie on every minimal path — because the sequence-first partitioner
+/// needs the *alternate* coordinate pinned as well. A reference column can be
+/// matched by every minimal alignment at *different* alternate offsets and so
+/// not be a dominator: `GACA -> AGAT` is exactly that shape (deleting the
+/// leading `G` matches column 1 to alternate offset 0, inserting a leading `A`
+/// matches it to alternate offset 2), and `dominators()` reports no match in it
+/// at all.
+///
+/// `general.md:34` asks only whether a *nucleotide* separates two variants, not
+/// where the payload sits, so the node criterion is the one the rule needs — and
+/// on the #1539 corpus it is the difference between reaching all three of the
+/// distinct variants and reaching two of them.
+///
+/// # Why a canonical walk supplies the alternate offsets
+///
+/// The node criterion says a column is unchanged without saying where in the
+/// payload it sits, and the two readings of `GACA -> AGAT` cut it in genuinely
+/// different places (`[3545del;3547_3548delinsGAT]` against
+/// `[3544_3545insA;3547_3548delinsT]`). Both are minimal, so something has to
+/// choose, and the choice is an implementer's — the same standing
+/// [`best_alignment`]'s "place the indel 5'-most" tie-break has, and the same
+/// one `CLAUDE.md`'s note that "a split is rarely unique" describes.
+///
+/// The walk prefers the diagonal, then a deletion, then an insertion — the order
+/// [`AlignmentDag::out_edges`] already yields — and follows on-path edges only,
+/// so it is always *a* minimal alignment. It reads nothing but the two blocks,
+/// so two spellings of one variant reach the same walk.
+fn member_alignment(reference: &[u8], payload: &[u8]) -> MemberAlignment {
+    use crate::normalize::seqfirst::align::{AlignmentDag, Step};
+    let dag = AlignmentDag::build(reference, payload);
+    let mut forced = vec![true; reference.len()];
+    for (i, j) in dag.cells() {
+        if (i as usize) < reference.len()
+            && dag
+                .out_edges(i, j)
+                .any(|(_, _, step)| matches!(step, Step::Sub | Step::Del))
+        {
+            forced[i as usize] = false;
+        }
+    }
+
+    let mut matched_alt = vec![None; reference.len()];
+    let (mut i, mut j) = (0u32, 0u32);
+    while (i, j) != (dag.ref_len(), dag.alt_len()) {
+        let Some((next_i, next_j, step)) = dag.out_edges(i, j).next() else {
+            // Unreachable on a well-formed DAG: only the sink has no out-edge,
+            // and the loop stops there. Break rather than panic — a partial walk
+            // leaves the remaining columns `None`, which the caller reads as
+            // "not matched here" and therefore never splits at.
+            break;
+        };
+        if matches!(step, Step::Match) {
+            matched_alt[i as usize] = Some(j);
+        }
+        (i, j) = (next_i, next_j);
+    }
+
+    MemberAlignment {
+        forced,
+        matched_alt,
+    }
+}
+
+/// Maximal runs of forced-unchanged columns that are **strictly interior** to a
+/// member, as `(offset, len)`.
+///
+/// A run touching either end is not a separation — it is an untrimmed flank, and
+/// the changed material that would sit outside it belongs to a neighbour rather
+/// than to this member. Excluding those is what makes the verdict sound without
+/// reasoning about flanks, and it is the same line
+/// `tests/it/issue_1539_split_member_separation.rs`'s `interior_runs` draws.
+fn interior_forced_runs(forced: &[bool]) -> Vec<(usize, usize)> {
+    let mut runs = Vec::new();
+    let mut i = 0;
+    while i < forced.len() {
+        if !forced[i] {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < forced.len() && forced[i] {
+            i += 1;
+        }
+        if start > 0 && i < forced.len() {
+            runs.push((start, i - start));
+        }
+    }
+    runs
+}
+
+/// What [`concealed_separations`] found in one member.
+struct ConcealedSeparations {
+    /// `(first column of the run, width)`, ascending, strictly interior, and
+    /// filtered to the runs `general.md:34` requires be described individually.
+    runs: Vec<(usize, usize)>,
+    /// Alternate offset of each reference column the canonical walk matched;
+    /// `None` where it substituted or deleted that column. Indexed by reference
+    /// column, so it is parallel to the member's own span.
+    matched_alt: Vec<Option<u32>>,
+}
+
+/// The separations one emitted member conceals, and the alignment that places
+/// them.
+///
+/// > "two variants separated by one or more nucleotides should be described
+/// > individually and **not** as a 'delins'."
+/// >   — `assets/hgvs-nomenclature/docs/recommendations/general.md:34`
+/// >
+/// > "**exception**: two variants separated by one nucleotide, together
+/// > affecting one amino acid, should be described as a 'delins'."
+/// >   — `general.md:35`
+///
+/// A column no minimal alignment can change, sitting strictly inside a member,
+/// separates changed material on both sides in *every* reading of that member —
+/// so it is a separation in `general.md:34`'s sense whatever alignment a reader
+/// picks. Two or more such columns are outside `:35` under every reading; one is
+/// excepted only where the flanking changes share a codon, which needs a reading
+/// frame and so cannot be reached on a genomic or non-coding axis
+/// ([`MIN_SEPARATION_NO_FRAME`] reaches the same conclusion from the same
+/// clause).
+///
+/// `w_lo` is the member-axis coordinate of `ref_bytes[0]`, so column `c` sits at
+/// `w_lo + c` — the same arithmetic [`apply_coding_codon_exception`] does.
+///
+/// Returns `None` when there is nothing to split, so the caller pays no
+/// allocation on the overwhelmingly common path.
+fn concealed_separations(
+    piece: &Piece,
+    reading_frame: bool,
+    w_lo: i64,
+    ref_bytes: &[u8],
+) -> Option<ConcealedSeparations> {
+    let reference = &ref_bytes[piece.ref_start..piece.ref_end];
+    // A separation needs changed material on both sides of an unchanged column,
+    // so the narrowest member that can hold one is three columns wide; and a
+    // deletion has no payload for any column to match, so none of its columns is
+    // unchanged. Both are cheap enough to test before the grid is built, which
+    // keeps this off the cost of the overwhelmingly common shapes — a lone
+    // substitution, a deletion, an insertion.
+    if reference.len() < 3 || piece.alt.is_empty() {
+        return None;
+    }
+    // `inversion.md:5` defines an inversion by the whole span, so a column of one
+    // that happens to coincide is structure rather than separation — the reading
+    // [`coalesce_whole_block_inversion`] already argues at block level. Splitting
+    // here would shred exactly what that pass exists to put back together.
+    if is_inversion(piece, ref_bytes) {
+        return None;
+    }
+    if reference.len() > MAX_SEPARATION_AUDIT_WIDTH
+        || (reference.len() + 1).saturating_mul(piece.alt.len() + 1) > MAX_SEPARATION_AUDIT_CELLS
+    {
+        return None;
+    }
+    let alignment = member_alignment(reference, &piece.alt);
+    let runs: Vec<(usize, usize)> = interior_forced_runs(&alignment.forced)
+        .into_iter()
+        .filter(|&(offset, len)| {
+            // `:35` covers a separation of exactly one nucleotide; two or more is
+            // outside it under every reading.
+            if len >= 2 {
+                return true;
+            }
+            let gap = w_lo + (piece.ref_start + offset) as i64;
+            !(reading_frame && same_codon(gap - 1, gap + 1))
+        })
+        // A run is cuttable only when the canonical walk matches its columns to
+        // *consecutive* alternate offsets, so that dropping that slice of the
+        // payload drops exactly the unchanged separator and nothing else.
+        //
+        // This is not defensive. Two forced-matched columns can have an
+        // insertion between them, and then they are not one unchanged run at all
+        // — there is a variant sitting inside it, and the alternate bases it
+        // contributes belong to neither side of a cut made here. Dropping them
+        // silently is a **sequence change**, which the round-trip guard at the
+        // end of `canonicalize_from_sequence` catches as a decline: measured at
+        // **45 declined and 10 underdetermined** classes on the cis confluence
+        // census before this filter existed, against 0 of each. Declining the run
+        // instead leaves the member whole, which under-reports and never
+        // corrupts. (`seqfirst::partition` models the same fact explicitly, as
+        // `Dominators::forced_ins_junctions`.)
+        //
+        // It also subsumes the `is_some()` check the cut needs: the walk above
+        // may break early on a malformed DAG, and a missing offset must decline
+        // rather than index into `None`.
+        .filter(|&(offset, len)| {
+            let Some(first) = alignment.matched_alt[offset] else {
+                return false;
+            };
+            (0..len).all(|k| alignment.matched_alt[offset + k] == first.checked_add(k as u32))
+        })
+        .collect();
+    (!runs.is_empty()).then_some(ConcealedSeparations {
+        runs,
+        matched_alt: alignment.matched_alt,
+    })
+}
+
+/// Cut one member at the separations it conceals, or `None` if it conceals none.
+///
+/// Each run becomes an unchanged gap between two members: the reference columns
+/// before it and the payload before its first matched alternate offset go left,
+/// the columns after it and the payload after its last matched alternate offset
+/// go right.
+fn split_piece_at_concealed_separations(
+    piece: &Piece,
+    reading_frame: bool,
+    w_lo: i64,
+    ref_bytes: &[u8],
+) -> Option<Vec<Piece>> {
+    let ConcealedSeparations { runs, matched_alt } =
+        concealed_separations(piece, reading_frame, w_lo, ref_bytes)?;
+    let mut parts = Vec::with_capacity(runs.len() + 1);
+    let (mut ref_cursor, mut alt_cursor) = (0usize, 0usize);
+    for (offset, len) in runs {
+        let first_alt =
+            matched_alt[offset].expect("filtered to consecutively matched runs") as usize;
+        parts.push(Piece {
+            ref_start: piece.ref_start + ref_cursor,
+            ref_end: piece.ref_start + offset,
+            alt: piece.alt[alt_cursor..first_alt].to_vec(),
+        });
+        ref_cursor = offset + len;
+        alt_cursor = first_alt + len;
+    }
+    parts.push(Piece {
+        ref_start: piece.ref_start + ref_cursor,
+        ref_end: piece.ref_end,
+        alt: piece.alt[alt_cursor..].to_vec(),
+    });
+    // The parts must denote what the member did. They do by construction — every
+    // cut drops exactly a run of columns whose payload bases are the same bases —
+    // and this checks it anyway, because the failure mode is a *changed
+    // sequence*, the one this module treats as unrecoverable (#1234). Declining
+    // leaves the member whole, which costs a canonicalization; emitting a part
+    // list that denotes different bases would cost correctness.
+    (denoted_by(&parts, piece.ref_start, piece.ref_end, ref_bytes) == piece.alt).then_some(parts)
+}
+
+/// The bases `parts` denote over `[ref_start, ref_end)`: each part's payload,
+/// with the untouched reference bases between them spliced back in.
+///
+/// The same reconstruction [`whole_block_inversion`] does, over an explicit span
+/// rather than over the parts' own hull, so a leading or trailing gap counts.
+fn denoted_by(parts: &[Piece], ref_start: usize, ref_end: usize, ref_bytes: &[u8]) -> Vec<u8> {
+    let mut denoted = Vec::with_capacity(ref_end - ref_start);
+    let mut cursor = ref_start;
+    for part in parts {
+        denoted.extend_from_slice(&ref_bytes[cursor..part.ref_start]);
+        denoted.extend_from_slice(&part.alt);
+        cursor = part.ref_end;
+    }
+    denoted.extend_from_slice(&ref_bytes[cursor..ref_end]);
+    denoted
+}
+
+/// Cut every member of a split at the separations it conceals, recursively.
+///
+/// # The defect
+///
+/// `general.md:34` governs a *description*, so it binds the members a split
+/// emits and not only the block it cut. [`best_alignment`] considers single-gap
+/// alignments only, so a member it carves out can need two gaps of its own — and
+/// then the column between those is unchanged in every minimal alignment of the
+/// member while the columns the split rested on are unchanged in none. Three
+/// real ClinVar/CMRG variants land exactly there (#1539). The worked one is
+/// `NM_000089.3:c.2148_2156delinsACGTGG`, whose block `GGTCGGTCC -> ACGTGG` has
+/// **no** forced-unchanged column at all, yet is cut at two coincidental ones
+/// into a member `GGTCG -> AC` whose interior `C` no minimal alignment touches
+/// and whose flanking changes fall in codons 716 and 717.
+///
+/// # Why the cut, rather than refusing the split
+///
+/// Refusing — falling back to the spanning `delins` `delins.md:47` recommends —
+/// also clears the guard, restores `main`'s string for all five rows, and is the
+/// more spec-coherent rule. It was implemented and **measured**, and it costs
+/// **394 converged confluence classes** of 11,272 (3': 8,006 -> 7,612), because
+/// the weight bound then refuses the allele spelling of the same variant while
+/// accepting the lone-`delins` spelling. Confluence outranks stability
+/// (`CLAUDE.md`), so the cut wins; the measurement is recorded here because the
+/// refusal is the obvious next idea and looks strictly safer than it is.
+///
+/// # Why only a length-changing block is audited
+///
+/// On an equal-length block [`best_alignment`] compares position-wise: there is
+/// no gap to place, so a matched column is a genuine coordinate-wise identity
+/// rather than an artefact of where the gap landed, and [`partition_block`] has
+/// already cut at every one of them. Every member of such a partition is a
+/// maximal run of positional mismatch, so a forced-unchanged column found by
+/// re-aligning that member *on its own* comes from admitting indels the block
+/// never needed — which is precisely the coincidence-manufacturing the
+/// single-gap restriction exists to prevent (#1034/#1040/#182).
+///
+/// This is not a hypothetical. `NM_TEST.1:c.10_15delinsTAATAT` (#1454/#1524) is
+/// the equal-length rotation `AATATA -> TAATAT`; its trailing member `TATA ->
+/// ATAT` has two forced-unchanged interior columns, and cutting there turns a
+/// description #1524 settled as its own normal form into
+/// `c.[10_12delinsTA;19dup]`. The measured cost of auditing equal-length blocks
+/// was those four pins plus **71 declined and 18 underdetermined** classes on the
+/// cis confluence census, against 0 of each. `partition_block` scopes
+/// [`separations_are_meaningful`] and [`every_separation_is_a_single_base`] to
+/// length-changing blocks for the same reason, and
+/// [`coalesce_coding_frame_separation`] scopes its merge to them for the mirror
+/// one.
+///
+/// # Why a lone spanning member is out of scope, structurally
+///
+/// The spec's own worked example, `LRG_199t1:c.850_901delinsTTCCTCGATGCCTG`
+/// (`delins.md:44-47`), **carries two forced-unchanged interior columns of its
+/// own** — reference offsets 44 and 48 of that block, the second of which
+/// `align.rs`'s `lrg199_has_exactly_one_dominator_match` already pins. Column 44
+/// separates changes in codons 297 and 298, so a rule that cut every unlicensed
+/// forced-unchanged interior would shred the very description `delins.md:47`
+/// recommends.
+///
+/// It does not, because this runs only where the partition already claimed a
+/// separation (`pieces.len() > 1`), and `partition_block` returns that block
+/// whole. The rule is therefore consistency *within one description*: either it
+/// describes individually, and then it does so everywhere, or it is one spanning
+/// `delins` and `delins.md:47` governs it entire. Pinned by
+/// `the_spec_delins_example_is_never_audited_as_a_split`.
+///
+/// # Placement
+///
+/// **After [`coalesce_coding_frame_separation`]**, which merges any two pieces
+/// one unchanged base apart on a coding length-changing block and would
+/// otherwise close every cut this makes straight back up.
+///
+/// **Before the 3'-shift**, so each new member is shifted on its own as
+/// `general.md:44` requires, and so [`coalesce_adjacent_pieces`] can rejoin a
+/// pair whose gap a shift closes.
+///
+/// **Exempt from nothing.** Unlike its widening neighbours this pass only ever
+/// *narrows* — every cut moves a column from changed to unchanged — so
+/// `changed_columns_of_pieces` can only fall and the weight bound below cannot
+/// be tripped by it. That is why it needs none of the un-widened bookkeeping
+/// `coalesce_coding_frame_separation` carries.
+///
+/// # Confluence
+///
+/// It reads the block, the pieces and the reading frame — never the input
+/// spelling — and the block is what two spellings of one variant have in common.
+/// The number of pieces is likewise a function of the block, so even the
+/// `pieces.len() > 1` scoping is spelling-independent.
+fn split_concealed_separations(
+    pieces: &mut Vec<Piece>,
+    reading_frame: bool,
+    length_changing: bool,
+    w_lo: i64,
+    ref_bytes: &[u8],
+) {
+    // Only a partition that already claimed a separation is audited — see the
+    // `LRG_199t1:c.850_901` note above — and a whole-span reverse complement is
+    // one description under `inversion.md:5` however its interior coincides, so
+    // cutting it would only undo what `coalesce_whole_block_inversion` puts back
+    // (`a_dense_inversion_is_recognised_across_multi_base_separations`).
+    if !length_changing || pieces.len() < 2 || whole_block_inversion(pieces, ref_bytes).is_some() {
+        return;
+    }
+    let mut split = Vec::with_capacity(pieces.len());
+    // A stack of pieces still to audit, kept in descending order so popping
+    // yields them 5' to 3' and `split` stays ascending — which
+    // `rebuild_members` asserts.
+    let mut pending: Vec<Piece> = pieces.drain(..).rev().collect();
+    while let Some(piece) = pending.pop() {
+        match split_piece_at_concealed_separations(&piece, reading_frame, w_lo, ref_bytes) {
+            // Every part is strictly narrower than what it replaced, so the
+            // recursion terminates; re-auditing them is what catches a member
+            // whose own cut exposes a second separation.
+            Some(parts) => pending.extend(parts.into_iter().rev()),
+            None => split.push(piece),
+        }
+    }
+    *pieces = split;
+}
+
 /// Merge a run of pieces that together span one inversion back into that single
 /// inversion.
 ///
@@ -4217,12 +4651,26 @@ fn partition_block(reference: &[u8], result: &[u8]) -> Vec<Piece> {
 /// rule that widens a piece must run after the weight bound, never inside
 /// [`partition_block`].**
 fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
+    if let Some(whole) = whole_block_inversion(pieces, ref_bytes) {
+        *pieces = vec![whole];
+    }
+}
+
+/// The single `inv` these pieces together span, when they span one.
+///
+/// Split out of [`coalesce_whole_block_inversion`] so the admission test has one
+/// definition: [`split_concealed_separations`] must decline exactly the pieces
+/// this pass would put back together, and two copies of that condition would
+/// drift (they did — see
+/// `a_dense_inversion_is_recognised_across_multi_base_separations`, which the
+/// first revision of that pass broke).
+fn whole_block_inversion(pieces: &[Piece], ref_bytes: &[u8]) -> Option<Piece> {
     if pieces.len() < 2
         || !(every_separation_is_a_single_base(pieces)
             || changed_columns_dominate_the_span(pieces)
             || no_piece_is_a_lone_substitution(pieces))
     {
-        return;
+        return None;
     }
     let start = pieces[0].ref_start;
     let end = pieces[pieces.len() - 1].ref_end;
@@ -4246,7 +4694,7 @@ fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
             .windows(2)
             .any(|pair| pair[1].ref_start < pair[0].ref_end)
     {
-        return;
+        return None;
     }
     // Reconstruct what the span denotes: each piece's payload, with the
     // unchanged reference bases separating them spliced back in.
@@ -4262,9 +4710,7 @@ fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
         ref_end: end,
         alt,
     };
-    if is_inversion(&whole, ref_bytes) {
-        *pieces = vec![whole];
-    }
+    is_inversion(&whole, ref_bytes).then_some(whole)
 }
 
 /// Whether more of the span is changed than is left unchanged.
@@ -10270,6 +10716,163 @@ mod tests {
         assert_eq!(
             pieces[0].ref_start, 2,
             "the first piece must be the lone 5' substitution; got {pieces:?}"
+        );
+    }
+
+    /// #1539: a member a split emits must itself obey `general.md:34`.
+    ///
+    /// `NM_000089.3:c.2148_2156delinsACGTGG` is the worked row. The assertions
+    /// below are ordered to show the *mechanism*, not just the outcome: the
+    /// block has no forced-unchanged column at all, so the two columns
+    /// `partition_block` splits on are coincidences of where the single gap
+    /// landed — and the member it carves out holds a column that no minimal
+    /// alignment of that member can change.
+    #[test]
+    fn a_member_concealing_a_forced_unchanged_base_is_cut_apart() {
+        let reference = b"GGTCGGTCC";
+        let result = b"ACGTGG";
+
+        assert_eq!(
+            member_alignment(reference, result).forced,
+            vec![false; reference.len()],
+            "no column of the block survives every minimal alignment, so the \
+             split below rests on coincidence — which is what makes this the \
+             #1539 shape rather than a genuine separation",
+        );
+
+        let pieces = partition_block(reference, result);
+        assert_eq!(
+            pieces.len(),
+            2,
+            "fixture must tempt the aligner into a split, else the cut below \
+             proves nothing; got {pieces:?}"
+        );
+        assert_eq!(
+            member_alignment(&reference[..5], b"AC").forced,
+            vec![false, false, false, true, false],
+            "`GGTCG -> AC` keeps its `C` in every minimal alignment",
+        );
+
+        // c.2148 puts that `C` at c.2151, so the flanking changes fall in codons
+        // 716 and 717 and `general.md:35` cannot reach across them.
+        assert!(!same_codon(2150, 2152));
+        let mut cut = pieces.clone();
+        split_concealed_separations(&mut cut, true, true, 2148, reference);
+        assert_eq!(
+            cut,
+            vec![
+                Piece {
+                    ref_start: 0,
+                    ref_end: 3,
+                    alt: b"A".to_vec()
+                },
+                Piece {
+                    ref_start: 4,
+                    ref_end: 5,
+                    alt: Vec::new()
+                },
+                Piece {
+                    ref_start: 7,
+                    ref_end: 9,
+                    alt: b"GG".to_vec()
+                },
+            ],
+            "the concealed separation must become a gap between two members",
+        );
+
+        // The same member one base earlier: columns 2 and 4 now share a codon,
+        // so `general.md:35`'s one-amino-acid exception applies and the member
+        // stays whole. `w_lo = 2` puts them at c.4 and c.6, both in codon 1.
+        assert!(same_codon(4, 6));
+        let mut licensed = pieces.clone();
+        split_concealed_separations(&mut licensed, true, true, 2, reference);
+        assert_eq!(
+            licensed, pieces,
+            "a one-base gap inside one codon is `general.md:35`'s exception",
+        );
+
+        // And with no reading frame there is no amino acid for `:35` to be about,
+        // so `:34` stands — the conclusion `MIN_SEPARATION_NO_FRAME` reaches.
+        let mut frameless = pieces.clone();
+        split_concealed_separations(&mut frameless, false, true, 2, reference);
+        assert_eq!(frameless.len(), 3, "got {frameless:?}");
+    }
+
+    /// The spec's own worked `delins` conceals two separations of its own and
+    /// must survive anyway.
+    ///
+    /// `LRG_199t1:c.850_901delinsTTCCTCGATGCCTG` (`DNA/delins.md:44-47`) is the
+    /// description the spec *recommends* over the split it names as an
+    /// alternative. Reference offsets 44 and 48 of its block are unchanged in
+    /// every minimal alignment, and offset 44 separates changes in codons 297 and
+    /// 298 — so a rule that cut every unlicensed forced-unchanged interior would
+    /// shred it.
+    ///
+    /// It survives structurally rather than by exemption: `partition_block`
+    /// returns the block whole, and the audit runs only where a split already
+    /// claimed a separation.
+    #[test]
+    fn the_spec_delins_example_is_never_audited_as_a_split() {
+        let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
+        let result = b"TTCCTCGATGCCTG";
+        assert_eq!(
+            interior_forced_runs(&member_alignment(reference, result).forced),
+            vec![(44, 1), (48, 1)],
+            "the spec's recommended form does conceal separations of its own",
+        );
+        // c.850 is column 0, so column 44 is c.894 and its flanks are c.893/c.895.
+        assert!(!same_codon(893, 895));
+
+        let mut pieces = partition_block(reference, result);
+        assert_eq!(
+            pieces.len(),
+            1,
+            "`delins.md:47` recommends the spanning form and `partition_block` \
+             already produces it; got {pieces:?}"
+        );
+        let before = pieces.clone();
+        split_concealed_separations(&mut pieces, true, true, 850, reference);
+        assert_eq!(
+            pieces, before,
+            "the audit must not reach a partition that claimed no separation",
+        );
+    }
+
+    /// An equal-length block's members are not re-aligned.
+    ///
+    /// `NM_TEST.1:c.10_15delinsTAATAT` (#1454/#1524) is the rotation `AATATA ->
+    /// TAATAT`. Its trailing member `TATA -> ATAT` has a two-column
+    /// forced-unchanged interior, so the audit *would* cut it — and #1524 settled
+    /// that description as one member and its own normal form. On an equal-length
+    /// block `best_alignment` compares position-wise, so a member of that
+    /// partition is a maximal run of positional mismatch and any interior found by
+    /// re-aligning it alone comes from indels the block never needed.
+    #[test]
+    fn an_equal_length_block_is_not_re_aligned_for_concealed_separations() {
+        let reference = b"AATATA";
+        let result = b"TAATAT";
+        let pieces = partition_block(reference, result);
+        assert_eq!(pieces.len(), 2, "got {pieces:?}");
+        assert_eq!(
+            interior_forced_runs(&member_alignment(b"TATA", b"ATAT").forced),
+            vec![(1, 2)],
+            "the trailing member does conceal a two-column separation",
+        );
+
+        let mut equal_length = pieces.clone();
+        split_concealed_separations(&mut equal_length, true, false, 10, reference);
+        assert_eq!(
+            equal_length, pieces,
+            "an equal-length block must be left to `partition_block`'s \
+             position-wise answer",
+        );
+
+        // The scoping is what spares it, not a coincidence of this fixture.
+        let mut audited = pieces.clone();
+        split_concealed_separations(&mut audited, true, true, 10, reference);
+        assert_ne!(
+            audited, pieces,
+            "if the audit could not cut this member the test above proves nothing",
         );
     }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2261,8 +2261,8 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
 
     // Window: the union of every member's footprint, padded for the 3'-shift.
     let (c_lo, c_hi) = edit_span_union(&edits)?;
-    let w_lo = (c_lo - CANONICAL_PAD).max(1);
-    let w_hi = c_hi + CANONICAL_PAD;
+    let mut w_lo = (c_lo - CANONICAL_PAD).max(1);
+    let mut w_hi = c_hi + CANONICAL_PAD;
     if w_hi - w_lo + 1 > MAX_CANONICAL_WINDOW {
         return None;
     }
@@ -2293,6 +2293,22 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // left open.
     if crosses_exon_junction(kind, &accession, provider, &frame, c_lo, c_hi) {
         return None;
+    }
+    // `general.md:44` exempts a deletion or duplication at an exon/exon junction
+    // from the 3' rule, so the derivation may not place a change outside the exon
+    // its member was described in. Clamping the WINDOW is the only place that can
+    // enforce it, because the piece is *born* outside the exon: the partitioner's
+    // 3'-most tie-break puts a deletion at the far end of a homopolymer run
+    // before any shift runs, so `shift_pieces` has nothing left to move.
+    //
+    // Measured, on `NM_001234.1` (exons 1-15/16-30/31-44, `cds_start = 5`, G-run
+    // spanning c.9-c.33): a lone `c.11del` derives to `c.33del`, and an
+    // exon-aware clamp inside `shift_pieces` — with barriers verified correct at
+    // `[11, 26]` — changes nothing. Narrowing the window is what holds it.
+    if let Some((exon_lo, exon_hi)) = enclosing_exon(kind, &accession, provider, &frame, c_lo, c_hi)
+    {
+        w_lo = w_lo.max(exon_lo);
+        w_hi = w_hi.min(exon_hi);
     }
     let start0 = w_lo + frame.delta - 1;
     let end0 = w_hi + frame.delta;
@@ -3319,6 +3335,31 @@ struct AxisFrame {
     reading_frame: bool,
 }
 
+/// The axis-coordinate bounds of the exon enclosing `[lo, hi]`, when one does.
+///
+/// `None` on the genomic axes, for an unservable transcript, or when the span is
+/// not wholly inside a single exon — in the last case `crosses_exon_junction`
+/// has already refused the derivation, so there is nothing left to clamp.
+fn enclosing_exon<P: ReferenceProvider>(
+    kind: CisKind,
+    accession: &str,
+    provider: &P,
+    frame: &AxisFrame,
+    lo: i64,
+    hi: i64,
+) -> Option<(i64, i64)> {
+    if matches!(kind, CisKind::Genome | CisKind::Mt) {
+        return None;
+    }
+    let transcript = provider.get_transcript(accession).ok()?;
+    let (tx_lo, tx_hi) = (lo + frame.delta, hi + frame.delta);
+    transcript.exons.iter().find_map(|exon| {
+        let (start, end) = (exon.start as i64 + 1, exon.end as i64);
+        (start <= tx_lo && tx_hi <= end).then(|| (start - frame.delta, end - frame.delta))
+    })
+}
+
+/// Resolve the group's [`AxisFrame`], or refuse the group.
 /// Whether `[lo, hi]` — a member-span union in axis coordinates — crosses an
 /// exon/exon junction of its own transcript (#1450).
 ///

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -102,6 +102,15 @@ struct Anchor {
     end: i64,
     alt: Vec<Base>,
     form: AnchorForm,
+    /// The single reference base the span covers, when the span is exactly one
+    /// base and that base is known.
+    ///
+    /// Carried so `build_naedit` can render a one-for-one replacement as the
+    /// SUBSTITUTION `DNA/delins.md:12` requires rather than a one-base `delins`.
+    /// `None` wherever the reference is not to hand, which keeps every such
+    /// caller on the previous `delins` rendering rather than emitting a
+    /// reference-less substitution.
+    ref_base: Option<Base>,
 }
 
 /// Merge consecutive sub-variants in an allele.
@@ -624,6 +633,7 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
         end: a_end,
         alt: alt_bases,
         form: AnchorForm::Replacement,
+        ref_base: None,
     };
     // Rebuild the variant kind the group came in as. `g.`/`m.` use the
     // single-axis `Region::Genome` anchor; `c.`/`n.`/`r.` use the positive
@@ -1008,21 +1018,32 @@ fn anchor_from_loc_edit<L>(
         return None;
     }
     match edit {
-        NaEdit::Substitution { alternative, .. } | NaEdit::SubstitutionNoRef { alternative } => {
-            Some(Anchor {
-                region,
-                start,
-                end,
-                alt: vec![*alternative],
-                form: AnchorForm::Replacement,
-            })
-        }
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => Some(Anchor {
+            region,
+            start,
+            end,
+            alt: vec![*alternative],
+            form: AnchorForm::Replacement,
+            ref_base: Some(*reference),
+        }),
+        NaEdit::SubstitutionNoRef { alternative } => Some(Anchor {
+            region,
+            start,
+            end,
+            alt: vec![*alternative],
+            form: AnchorForm::Replacement,
+            ref_base: None,
+        }),
         NaEdit::Deletion { .. } => Some(Anchor {
             region,
             start,
             end,
             alt: Vec::new(),
             form: AnchorForm::Replacement,
+            ref_base: None,
         }),
         NaEdit::Delins { sequence, .. } => {
             let bases = sequence.bases()?.to_vec();
@@ -1032,6 +1053,7 @@ fn anchor_from_loc_edit<L>(
                 end,
                 alt: bases,
                 form: AnchorForm::Replacement,
+                ref_base: None,
             })
         }
         NaEdit::Insertion { sequence } => {
@@ -1045,6 +1067,7 @@ fn anchor_from_loc_edit<L>(
                 end: start,
                 alt: bases,
                 form: AnchorForm::Replacement,
+                ref_base: None,
             })
         }
         _ => None,
@@ -1379,6 +1402,25 @@ fn build_naedit<P>(
         NaEdit::Deletion {
             sequence: None,
             length: None,
+        }
+    } else if let (true, 1, Some(reference)) = (
+        merged.end == merged.start,
+        merged.alt.len(),
+        merged.ref_base,
+    ) {
+        // One nucleotide replaced by one other nucleotide is a SUBSTITUTION,
+        // not a one-base delins: `DNA/delins.md:12` says so outright and
+        // `DNA/substitution.md` defines the form. Without this the derivation
+        // renders `c.5G>A` as `c.5delinsA`.
+        //
+        // Requires the reference base, hence `Anchor::ref_base`: emitting
+        // `SubstitutionNoRef` instead renders without the reference and moves
+        // strings across the whole suite (measured: 53 failures). Where the
+        // reference is unknown this falls through to `delins`, which is the
+        // previous rendering, so no caller regresses.
+        NaEdit::Substitution {
+            reference,
+            alternative: merged.alt[0],
         }
     } else {
         NaEdit::Delins {
@@ -5813,12 +5855,22 @@ fn anchor_for_piece(
     }
     let start = w_lo + piece.ref_start as i64;
     let end = w_lo + piece.ref_end as i64 - 1;
+    // A piece covering exactly one reference base can render as a substitution
+    // rather than a one-base `delins` (`DNA/delins.md:12`), but only if the base
+    // it replaces is stated. The window has it, so read it off here — this is
+    // the only place in the derivation where the reference and the piece are
+    // both in hand.
+    let ref_base = (piece.ref_end == piece.ref_start + 1)
+        .then(|| ref_bytes.get(piece.ref_start).copied())
+        .flatten()
+        .and_then(|byte| Base::from_char(byte as char));
     Some(Anchor {
         region: body,
         start,
         end,
         alt,
         form: AnchorForm::Replacement,
+        ref_base,
     })
 }
 
@@ -5882,6 +5934,7 @@ fn duplication_anchor(
         // A `dup` names its source bases by span; there is nothing to insert.
         alt: Vec::new(),
         form: AnchorForm::Duplication,
+        ref_base: None,
     })
 }
 
@@ -5948,6 +6001,7 @@ fn boundary_delins_anchor(
         end: position,
         alt: bases,
         form: AnchorForm::Replacement,
+        ref_base: None,
     })
 }
 
@@ -6008,6 +6062,7 @@ fn cds_end_delins_anchor(
         end: cds_end_axis,
         alt: bases,
         form: AnchorForm::Replacement,
+        ref_base: None,
     })
 }
 
@@ -9576,6 +9631,7 @@ mod tests {
             end: 1009,
             alt: Vec::new(),
             form: AnchorForm::Replacement,
+            ref_base: None,
         };
         let (interval, edit) = build_naedit(anchor, |_, p| GenomePos::new(p as u64));
 
@@ -9596,6 +9652,7 @@ mod tests {
             end: 1009,
             alt: vec![Base::A],
             form: AnchorForm::Replacement,
+            ref_base: None,
         };
         let (_, edit) = build_naedit(anchor, |_, p| GenomePos::new(p as u64));
         match edit {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1971,41 +1971,63 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// two-member `g.[261_262insGA;263_264insAA]` denote the same variant, and
     /// until this widened, only one of them was allowed to be re-derived.
     ///
-    /// The **axis** restriction below is a separate, still-live gate — kept
-    /// exactly as narrow as before (`g.`/`m.` only) — and unaffected by the
-    /// above. Widening the edit-type half was measured to move nothing; the
-    /// costs recorded below are what widening the *axis* half would move, and
-    /// they are **not** paid by this change:
+    /// The **axis** gate is open to the transcript axes as of #1235: `c.`, `n.`
+    /// and `r.` join `g.`/`m.` in the match below. #1237 had narrowed it to
+    /// `g.`/`m.` on the grounds that `merge::canonicalize_from_sequence` refused
+    /// the transcript axes anyway; a prior PR removed that refusal for
+    /// **alleles**, which left a lone `c.`/`n.`/`r.` member as the one shape
+    /// still held back on axis grounds. The asymmetry was real — a lone spelling
+    /// that the allele spelling of the same variant would re-partition could
+    /// stay unsplit — and closing it is what the widening does.
     ///
-    /// #1237 narrowed the axis to `g.`/`m.` on the grounds that
-    /// `merge::canonicalize_from_sequence` refused the transcript axes anyway.
-    /// A prior PR removed that refusal for **alleles**, so lone `c.`/`n.`/`r.`
-    /// members are the one shape still held back on axis grounds, and the
-    /// asymmetry is real: a lone spelling that the allele spelling of the same
-    /// variant would re-partition can stay unsplit.
+    /// # What widening the axis cost, measured rather than predicted
     ///
-    /// Widening the axis was tried and is **not** a drive-by change. It moves
-    /// four tests, and one of them is not ours to move unilaterally:
+    /// An earlier revision of this comment held the axis shut behind four tests
+    /// it predicted would move. **Exactly one of the four moved anything
+    /// committed, and it was fixed rather than re-blessed** — so the conformance
+    /// decision the comment was waiting on turned out not to exist.
+    /// Measured twice: once with only the widening applied (this branch's first
+    /// commit, `feat(normalize): widen the axis gate to c./n./r.`) and again at
+    /// the branch tip. Commit subjects rather than hashes, because rebasing
+    /// rewrites the hashes and a citation nobody can resolve is worse than none.
     ///
     /// * `normalize_tests::test_normalize_inversion_unchanged` and
-    ///   `rna_coding_consistency::parity_safe_regime::inversion_parity` — a lone
-    ///   `c.10_15inv` with an unchanged interior starts splitting into
-    ///   `[10_11delinsCA;14_15delinsAC]`. Coherent with #1230 on `g.`, and the
-    ///   parity test would need the `c_to_r` alphabet conversion its `delins`
-    ///   sibling already uses. Both are legitimately re-blessable.
-    /// * `spec_enumeration_tests::enumeration_replays_recorded_behavior` — a
-    ///   regenerated recording.
-    /// * `mutalyzer_normalize_tests::gate_normalized_snapshot` — **3 hermetic
-    ///   divergences from the Mutalyzer oracle.** That is output moving away
-    ///   from an independent oracle, which is a conformance decision needing its
-    ///   own measurement pass, not a side effect of this one.
+    ///   `rna_coding_consistency::parity_safe_regime::inversion_parity` — **did
+    ///   not move.** Both pass unmodified with only the widening applied and at
+    ///   the tip; the predicted lone-`inv` split does not arise on the `main`
+    ///   this branch sits on. Neither file is touched by this branch.
+    /// * `spec_enumeration_tests::enumeration_replays_recorded_behavior` — the
+    ///   gitignored recording does regenerate, but that test compares ferro
+    ///   against itself; the two **committed** census guards are what judge
+    ///   behaviour, and they do not move. `DIVERGENCE_BUDGET` and
+    ///   `PASSING_CENSUS` are byte-identical to `main`, so the diff there is
+    ///   commentary only. Per this branch's own two measurements
+    ///   `ProjectionSplitsSingleMember` went 9 -> 13 and back to 9 inside the
+    ///   branch; only the net is asserted anywhere.
+    /// * `mutalyzer_normalize_tests::gate_normalized_snapshot` — the prediction
+    ///   that held, and at exactly the stated count. With only the widening
+    ///   applied it fails with **3 hermetic divergences**, one variant in three
+    ///   spellings:
+    ///   `NM_000143.3:c.44_47delinsATC` (also `…delTGCGinsATC`, `…del4insATC`)
+    ///   rendered as `c.[44_45delinsAT;49del]`.
     ///
-    /// So the axis stays gated until that pass happens; only the edit-type
-    /// half opened here.
+    /// **How those three were adjudicated: they were not.** The divergence is
+    /// `general.md:35`'s coding exception — two changes one base apart within
+    /// one reading frame — which the live path could not apply because it had no
+    /// axis to apply it on. `merge::coalesce_coding_frame_separation` supplies
+    /// it, and that function's own doc names this same `c.44_47delinsATC` as the
+    /// case it was written for. At the tip `gate_normalized_snapshot` passes all
+    /// **26** covered rows (0 fail, 0 known_bug, 0 improvement) with **no
+    /// Mutalyzer snapshot, `cases.json` row or oracle baseline changed** — this
+    /// branch touches no file under `tests/fixtures/`. So ferro agrees with the
+    /// oracle again and there was no conformance decision left to take.
     fn is_splittable_single_member(variant: &HgvsVariant) -> bool {
         let edit = match variant {
             HV::Genome(g) => &g.loc_edit.edit,
             HV::Mt(m) => &m.loc_edit.edit,
+            HV::Cds(c) => &c.loc_edit.edit,
+            HV::Tx(t) => &t.loc_edit.edit,
+            HV::Rna(r) => &r.loc_edit.edit,
             _ => return false,
         };
         edit.inner().is_some()

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -13599,42 +13599,45 @@ mod tests {
         // Asserted so the protein expectation below cannot be read without the
         // nucleotide form that produces it. `ATGGATTATTGCTAA` →
         // `ATGATGGGGTATTGCTAA` has a *single-gap* explanation of the same weight
-        // as the input's two-gap one (five changed columns either way), and
-        // since #1235's sequence-first pass learned to type a derived tandem
-        // insertion as a `dup` it takes it: the inserted `ATG` repeats `c.1_3`.
+        // as the input's two-gap one (five changed columns either way), and the
+        // sequence-first pass takes it. It partitions the trimmed block
+        // `GAT -> ATGGGG` into an insertion and a two-base replacement one
+        // unchanged base apart, and `general.md:35` then merges them: `c.4`,
+        // `c.5` and `c.6` are one codon, so this is exactly "two variants
+        // separated by one nucleotide, together affecting one amino acid".
+        //
+        // It used to read `c.[1_3dup;5_6delinsGG]`, before
+        // `coalesce_coding_frame_separation` applied that exception on the live
+        // path. That split is the reason the protein expectation below moved
+        // twice: it reached the initiation codon, which forced `p.(Met1?)` for a
+        // variant whose 5'-most changed base is `c.4`.
         assert_eq!(
             format!("{}", proj.coding.as_ref().expect("coding expected")),
-            "NM_SEP.1:c.[1_3dup;5_6delinsGG]"
+            "NM_SEP.1:c.4_6delinsATGGGG"
         );
-        // `c.1_3dup` reaches the initiation codon, so the start-codon rule wins
-        // and the report is `p.(Met1?)` — not the `Asp2delinsMetGly` this test
-        // used to expect.
+        // The 5'-most base this variant changes is `c.4`, so the initiation
+        // codon is untouched and the consequence is the bounded in-frame one:
+        // codon 2 (`Asp`) replaced by `Met` and `Gly`.
         //
-        // That is right, and not merely conservative. Duplicating `ATG` leaves a
-        // start codon at c.1_3 *and* puts a second, in-frame one immediately
-        // after it: the product carries one N-terminal Met or two depending on
-        // which the ribosome uses, and nothing in the description says which. So
-        // "the consequence, on the protein level … can not be predicted"
-        // (`protein/substitution.md:52`, the sentence that defines `p.(Met1?)`)
-        // is an accurate statement about this variant. The old expectation
-        // asserted initiation at the *first* `ATG`, which is an assumption the
-        // description does not carry.
-        //
-        // The spec would force a computed answer only where a variant "activates
-        // an upstream/downstream translation initiation site"
-        // (`protein/extension.md:17`, normative) — a duplication activates no new
-        // site, it copies the existing one. It is otherwise silent on a start
-        // codon that is duplicated rather than disrupted: `substitution.md:45-65`
-        // offers `p.0`, `p.0?`, `p.(Met1?)` and the computed del/ins/ext forms as
-        // a menu with no rule for choosing, and its only prohibitions are the
-        // plain-substitution spellings (`substitution.md:49`,
-        // `checklist.md:65`). Choosing for the author is what
-        // `tests/it/issue_1079_start_loss_substitution.rs` and W3022
-        // (`error_handling/types.rs`) already decline to do.
-        assert!(proj.affects_init, "c.1_3dup reaches the initiation codon");
+        // This assertion has moved twice, and the second move undoes the first.
+        // While the derivation split the block into `c.[1_3dup;5_6delinsGG]` the
+        // `dup` reached `c.1_3`, `affects_init` was true, and the report was
+        // `p.(Met1?)` — an honest answer *about that description*, since a
+        // duplicated `ATG` leaves two in-frame start codons and nothing says
+        // which the ribosome uses. But the description was the problem: nothing
+        // in `c.[4del;6_7insGGGG]` touches `c.1_3`, and a partition that walks a
+        // change onto the initiation codon and then reports the start as
+        // unpredictable is `delins.md:47`'s harm exactly — "software tools
+        // making incorrect predictions for the consequences on protein level".
+        // With `general.md:35` applied on the live path the block stays one
+        // member and the consequence is computable again.
+        assert!(
+            !proj.affects_init,
+            "c.4_6delinsATGGGG does not reach the initiation codon"
+        );
         assert_eq!(
             format!("{}", proj.protein.expect("protein expected")),
-            "NP_SEP.1:p.(Met1?)"
+            "NP_SEP.1:p.(Asp2delinsMetGly)"
         );
     }
 

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -194,12 +194,29 @@ const CDS_END: u64 = 63;
 /// a `main` predating #1537, and re-running after the rebase gives 8 003 in
 /// **both** directions. That the two directions land on the same number, as
 /// they did before the rebase, is the reading to trust.
+///
+/// # Raised again by the #1539 member audit: 8 003 -> 8 026
+///
+/// `split_two` falls by the same 23 and `split_three` (115) and `split_more`
+/// (19) are unchanged, so every class that moved moved from two outputs to one.
+/// `split_concealed_separations` cuts a member that conceals a separation
+/// `general.md:34` requires, and the classes this converges are ones where the
+/// lone-`delins` spelling and the multi-member spelling previously reached the
+/// concealed form and the individual form respectively.
+///
+/// `declined`, `underdetermined` and `sequence_changed` are all still 0, and
+/// that is the load-bearing part rather than a formality: an earlier revision of
+/// that pass dropped payload bases when it cut a run of two matched columns with
+/// an insertion between them, and this census is what reported it — 45 declined
+/// and 10 underdetermined, with `converged` *rising* at the same time. A pass
+/// that corrupts a sequence can raise the convergence figure, so the three zeros
+/// have to be read before the headline.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 8_003,
-    split_two: 3_135,
+    converged: 8_026,
+    split_two: 3_112,
     split_three: 115,
     split_more: 19,
     underdetermined: 0,
@@ -229,12 +246,19 @@ const THREE_PRIME: Census = Census {
 /// a 5'-only symptom, since the 3' walk moves away from the exon start. Both
 /// directions ending on the same number is the reading to trust: the residual
 /// is a property of the partitioner, not of a shuffle direction.
+///
+/// **Raised again by the #1539 member audit: 8 003 -> 8 021**, with `split_two`
+/// falling by the same 18 and `split_three`/`split_more` unchanged. The 3'
+/// direction gains 23 rather than 18, which is the expected asymmetry: the audit
+/// runs before the shift, so a member it cuts is then 3'- or 5'-shifted on its
+/// own, and only some of those landings coincide with the other spelling's.
+/// See `THREE_PRIME` for why the three zeros are read first.
 const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 8_003,
-    split_two: 3_155,
+    converged: 8_021,
+    split_two: 3_137,
     split_three: 105,
     split_more: 9,
     underdetermined: 0,

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -172,12 +172,34 @@ const CDS_END: u64 = 63;
 /// joining the codon triplet to a touching run on both edges instead of
 /// declining the exception on the left — cost **44** classes here rather than
 /// 4, and was rejected for it.
+/// **Re-blessed when the axis gate opened to `c.`/`n.`/`r.`.** Widening
+/// `is_splittable_single_member` lets a lone transcript-axis member reach
+/// `sequence_first_pass`, which is the entire point of that change: converged
+/// rises **6 633 -> 8 006** and `split_two` falls by the same **1 373**, while
+/// `split_three` (115) and `split_more` (19) are **unchanged**. Every
+/// divergence figure moved down or stayed flat, which is the direction this pin
+/// demands.
+///
+/// The figure is now identical with and without `FERRO_ASSERT_IDEMPOTENT`
+/// (measured in both, `declined: 0` in both). That is #1493's doing rather than
+/// this branch's — it closed #1454, so the two classes that used to panic the
+/// oracle no longer do, and the per-configuration pins this file once carried
+/// were already collapsed on `main` before this change landed.
+///
+/// **The pinned figure is 8 003, not 8 006.** Both numbers above are true of
+/// the change that produced them, and neither is the number to pin: the axis
+/// gate raises converged by 1 373 against a `main` that already carries
+/// #1537's deliberate reduction of 4 (3') and 2 (5'). The composition was
+/// measured rather than arithmetic — 8 006 is what this branch scored against
+/// a `main` predating #1537, and re-running after the rebase gives 8 003 in
+/// **both** directions. That the two directions land on the same number, as
+/// they did before the rebase, is the reading to trust.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_629,
-    split_two: 4_509,
+    converged: 8_003,
+    split_two: 3_135,
     split_three: 115,
     split_more: 19,
     underdetermined: 0,
@@ -188,7 +210,7 @@ const THREE_PRIME: Census = Census {
 /// option, and confluence is a property of the normalizer rather than of one
 /// shuffle direction, so it is measured in full rather than spot-checked.
 ///
-/// It lands within five classes of the 3' figure (6 628 against 6 633), which
+/// It landed within five classes of the 3' figure (6 628 against 6 633), which
 /// is worth reading as evidence: the divergence is a property of how the
 /// partitioner splits a block, not of which end of an ambiguous run the shuffle
 /// walks to. A fix that moved only one of these two numbers would be treating a
@@ -199,12 +221,20 @@ const THREE_PRIME: Census = Census {
 /// different amounts is itself the expected reading of the note above: the
 /// affected classes are ones whose chain to a common form ran through an
 /// intermediate that only some shuffle directions produce.
+/// **Re-blessed with the axis gate**, and the two directions now agree exactly
+/// (both 8 006) rather than within five. The 5' figure moves by **1 378**
+/// against the 3' direction's 1 373 — five more, because the same change fixes
+/// an off-by-one in `enclosing_exon` that let a member sitting on an exon's
+/// first base escape the window clamp and shuffle across the junction. That is
+/// a 5'-only symptom, since the 3' walk moves away from the exon start. Both
+/// directions ending on the same number is the reading to trust: the residual
+/// is a property of the partitioner, not of a shuffle direction.
 const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_626,
-    split_two: 4_532,
+    converged: 8_003,
+    split_two: 3_155,
     split_three: 105,
     split_more: 9,
     underdetermined: 0,

--- a/tests/it/issue_1183_rna_axis_ins_expansion.rs
+++ b/tests/it/issue_1183_rna_axis_ins_expansion.rs
@@ -79,16 +79,22 @@ fn rna_axis_expansion_agrees_with_the_c_axis() {
             .unwrap_or_else(|e| panic!("r. with [{payload}] must normalize, got {e:?}"));
         let cds = normalize(&format!("NM_000088.3:c.4_6delins[{payload}]"))
             .unwrap_or_else(|e| panic!("c. with [{payload}] must normalize, got {e:?}"));
-        // Re-render the c. answer as RNA: lowercase, and u for T.
+        // Re-render the c. answer as RNA: lowercase every base, and u for T.
+        //
+        // The whole description after the `r.` axis marker is re-rendered, not
+        // just the tail from the first `delins`. Splitting at `delins` was
+        // correct only while the answer was a single delins; once it is a
+        // multi-member allele (`r.[3_4insA;5_6delinsGT]`) the first `delins`
+        // sits in the *second* member and the leading `insA` escapes
+        // lowercasing, so the re-rendering asserted against an RNA description
+        // carrying an upper-case base. Positions and separators are unaffected
+        // by `to_lowercase`, and `t` appears only in bases.
         let expected = cds.replace("c.", "r.");
-        let split = expected.split_at(expected.find("delins").unwrap_or_else(|| {
-            panic!(
-                "the c. answer for [{payload}] is expected to stay a delins; got {cds} — \
-                 if canonicalization legitimately changed shape, update this re-rendering"
-            )
-        }));
-        let (prefix, edit) = split;
-        let as_rna = format!("{prefix}{}", edit.to_lowercase().replace('t', "u"));
+        let axis = expected.find("r.").unwrap_or_else(|| {
+            panic!("the c. answer for [{payload}] must carry an axis marker; got {cds}")
+        }) + 2;
+        let (prefix, body) = expected.split_at(axis);
+        let as_rna = format!("{prefix}{}", body.to_lowercase().replace('t', "u"));
         assert_eq!(
             rna, as_rna,
             "r. must match the c. answer re-rendered as RNA (payload [{payload}])",

--- a/tests/it/merge_consecutive_edits_tests.rs
+++ b/tests/it/merge_consecutive_edits_tests.rs
@@ -974,3 +974,77 @@ fn test_no_overlap_warning_for_adjacency() {
         codes
     );
 }
+
+// =====================================================================
+// Codon-frame exception on a LENGTH-CHANGING block (#1235).
+//
+// `general.md:35`'s exception is not only about two substitutions. Once
+// #1235 widened the sequence-first axis gate to `c.`/`n.`/`r.`, a lone
+// coding `delins` whose payload coincidentally aligns against one
+// interior base started splitting into an allele — the shape
+// `delins.md:44-47` keeps whole. `apply_coding_codon_exception` cannot
+// reach it: that pass matches `[Sub@p; Identity@p+1; Sub@p+2]` exactly,
+// and here neither member is a substitution.
+//
+// The axis is the whole discriminator, so both halves are asserted on
+// the same block and the same reference. `NM_TEST.1` has `cds_start = 1`,
+// so `c.N` and `n.N` address the identical base.
+// =====================================================================
+
+/// `c.2_5` is `TGCA` and the payload `AAC` aligns only at its last column
+/// (`C`), leaving a one-base gap between the two derived runs. On a reading
+/// frame that gap is `general.md:35`'s, so the block stays one `delins`.
+///
+/// Note the two runs are in *different* codons — `c.2` is in codon 1 and
+/// `c.5` in codon 2 — which is deliberate. `apply_coding_codon_exception`
+/// and `split_codon_incompatible_triplets` both apply the codon half of the
+/// exception, and both scope it to the three-column substitution triplet the
+/// spec's own wording describes. A wider merge is not "two variants" in that
+/// sense, so it is governed by the distance rule alone — the reading the
+/// SVD-WG states it is moving to outright (`general.md:39`).
+/// The assertion is `input == output`, which a *decline* satisfies as readily as
+/// the merge: if the sequence-first derivation refuses this block for some
+/// unrelated reason — a window clamp, the weight bound, the round-trip guard, a
+/// future `enclosing_exon` change — the coding answer is still its own input and
+/// the pass under test never ran (#1235 review). Two things stop that here:
+///
+/// * the `n.` control below, on the same reference and the same block, whose
+///   expected string *differs* from its input, so a derivation that declined for
+///   any axis-blind reason would fail it; and
+/// * `merge::tests::coalesce_coding_frame_separation_merges_one_base_gap_only_in_frame`,
+///   which asserts the merge against the pass directly and is the airtight half.
+#[test]
+fn coding_length_changing_block_merges_across_one_unchanged_base() {
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:n.2_5delinsAAC"
+        ),
+        "NM_TEST.1:n.[2_3delinsAA;9del]",
+        "the derivation must reach this block at all, else the coding assertion \
+         below is satisfied by a decline and proves nothing",
+    );
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:c.2_5delinsAAC"
+        ),
+        "NM_TEST.1:c.2_5delinsAAC",
+    );
+}
+
+/// The same block on `n.`, which has no reading frame, splits — and the
+/// deletion 3'-shifts down the `A` run at `n.5-9`, which is also why the
+/// merge above has to run *before* the shift: afterwards the two runs are
+/// four bases apart and no one-base rule can rejoin them.
+#[test]
+fn non_coding_length_changing_block_keeps_the_split() {
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:n.2_5delinsAAC",
+    );
+    assert_eq!(
+        result, "NM_TEST.1:n.[2_3delinsAA;9del]",
+        "an axis with no reading frame gets `general.md:34`'s plain rule",
+    );
+}

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -300,7 +300,39 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // time (2184 rows) was unchanged — nothing left the enumeration, one row
     // moved from a divergence to a pass. The total is 2172 as of #1498, which
     // did drop rows; see `ModeDivergencePinned` below.
-    (Status::ProjectionSplitsSingleMember, 9),
+    //
+    // 9 -> 13 in #1235's axis widening, and this is a **deliberate re-bless of a
+    // regression**, not a fix. All four rows are one input,
+    // `NM_004006.2:c.76_83inv` (`general.md:110`), reaching `project-c`,
+    // `project-n`, `project-r` and `project-p`:
+    //
+    //   c.76_83inv -> c.[76_77delinsTG;82_83delinsTT]
+    //   p.(Asn26_Gln28delinsCysAlaLeu) -> p.[(Asn26Cys);(Gln28Leu)]
+    //
+    // Read the status name and not only its headline citation: these enter by
+    // *shape* (a single member projecting to an allele), not by the divergence
+    // `delins.md:42` names — that passage is about two variants **one** base
+    // apart, and these are four apart, where `general.md:34` plainly asks for
+    // individual descriptions.
+    //
+    // What the four rows really record is that the transcript axes now answer as
+    // the genomic axis already did. `c.76_83` is `AATGCACA`, whose reverse
+    // complement `TGTGCATT` coincides at four of its eight columns, so the
+    // partition finds two runs 4 bases apart and `coalesce_whole_block_inversion`
+    // declines to rejoin them: 50% unchanged is above the ~25% a random reverse
+    // complement leaves, so `changed_columns_dominate_the_span` reads it as a
+    // near-palindrome carrying two independent changes rather than one inversion.
+    // None of that reads the axis — the block is equal-length, so neither
+    // `separations_are_meaningful` nor `coalesce_coding_frame_separation` is even
+    // consulted — so `g.` has always produced this split for this block. Widening
+    // the gate did not create the behaviour; it let the transcript axes see it.
+    //
+    // Left alone on purpose. Making these four rows pass means loosening
+    // `coalesce_whole_block_inversion`, which is axis-neutral and shipped, so it
+    // would move genomic representations for a class measured nowhere in this
+    // PR. That is its own change with its own blast radius, not a tail of this
+    // one. The corresponding `ProjectionPinned` fall is 1168 -> 1164.
+    (Status::ProjectionSplitsSingleMember, 13),
 ];
 
 /// Census of the **conformant** statuses — the counting half of
@@ -369,7 +401,10 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     // 1167 -> 1168 in #1271: the LRG_199 `delins.md:44` row that used to land in
     // `ProjectionSplitsSingleMember` now projects as the single member the spec
     // states. See that status's note in `DIVERGENCE_BUDGET`.
-    (Status::ProjectionPinned, 1168),
+    // 1168 -> 1164 in #1235's axis widening: the four `c.76_83inv` rows moved the
+    // other way, into `ProjectionSplitsSingleMember`. The argument for accepting
+    // them is with that status, not here; the 2184-row total is again unchanged.
+    (Status::ProjectionPinned, 1164),
     (Status::ProjectionUnavailablePinned, 487),
     (Status::ProjectionErrorPinned, 210),
     // 132 -> 120 (#1498). The 12 rows are all LRG — `LRG_199:c.357+1G>A`,

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -301,10 +301,16 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // moved from a divergence to a pass. The total is 2172 as of #1498, which
     // did drop rows; see `ModeDivergencePinned` below.
     //
-    // 9 -> 13 in #1235's axis widening, and this is a **deliberate re-bless of a
-    // regression**, not a fix. All four rows are one input,
-    // `NM_004006.2:c.76_83inv` (`general.md:110`), reaching `project-c`,
-    // `project-n`, `project-r` and `project-p`:
+    // **#1235's axis widening leaves this constant where it was.** Do not read
+    // the note below as a re-bless: the branch measured the four rows *in*
+    // (9 -> 13) at the widening commit and measured them back *out* (13 -> 9)
+    // once the rest of the branch landed, so this value and its mirror in
+    // `PASSING_CENSUS` (`ProjectionPinned`, 1168) are byte-identical to `main`.
+    // The analysis is kept because the four rows are the class this status
+    // exists for and the shape will recur.
+    //
+    // All four are one input, `NM_004006.2:c.76_83inv` (`general.md:110`),
+    // reaching `project-c`, `project-n`, `project-r` and `project-p`:
     //
     //   c.76_83inv -> c.[76_77delinsTG;82_83delinsTT]
     //   p.(Asn26_Gln28delinsCysAlaLeu) -> p.[(Asn26Cys);(Gln28Leu)]
@@ -327,12 +333,27 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // consulted — so `g.` has always produced this split for this block. Widening
     // the gate did not create the behaviour; it let the transcript axes see it.
     //
-    // Left alone on purpose. Making these four rows pass means loosening
-    // `coalesce_whole_block_inversion`, which is axis-neutral and shipped, so it
-    // would move genomic representations for a class measured nowhere in this
-    // PR. That is its own change with its own blast radius, not a tail of this
-    // one. The corresponding `ProjectionPinned` fall is 1168 -> 1164.
-    (Status::ProjectionSplitsSingleMember, 13),
+    // Had the four rows stayed, they would have been kept rather than chased:
+    // making them pass means loosening `coalesce_whole_block_inversion`, which
+    // is axis-neutral and shipped, so it would move genomic representations for
+    // a class this PR measures nowhere. That is its own change with its own
+    // blast radius, not a tail of this one.
+    //
+    // **Read the pair, never either constant alone.** The two deltas are equal
+    // and opposite by construction (`ProjectionSplitsSingleMember` down four,
+    // `ProjectionPinned` up four), so a row that vanished from one without
+    // appearing in the other would mean something left the enumeration rather
+    // than moved between statuses — and the 2172-row total would be the only
+    // thing that showed it.
+    //
+    // **And measure against a regenerated artifact.** All of the above was
+    // invisible until this branch was rebased onto a `main` carrying #1535 and
+    // #1537: the enumeration artifact is gitignored, so a local file generated
+    // against the pre-rebase tree had these two committed guards comparing
+    // against a stale recording, and the movement in both directions went
+    // unseen. That is exactly why these are the guards that judge behaviour and
+    // `enumeration_replays_recorded_behavior` is not.
+    (Status::ProjectionSplitsSingleMember, 9),
 ];
 
 /// Census of the **conformant** statuses — the counting half of
@@ -401,10 +422,13 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     // 1167 -> 1168 in #1271: the LRG_199 `delins.md:44` row that used to land in
     // `ProjectionSplitsSingleMember` now projects as the single member the spec
     // states. See that status's note in `DIVERGENCE_BUDGET`.
-    // 1168 -> 1164 in #1235's axis widening: the four `c.76_83inv` rows moved the
-    // other way, into `ProjectionSplitsSingleMember`. The argument for accepting
-    // them is with that status, not here; the 2184-row total is again unchanged.
-    (Status::ProjectionPinned, 1164),
+    // #1235's axis widening leaves this at 1168. The four `c.76_83inv` rows went
+    // out to `ProjectionSplitsSingleMember` at the widening commit (1168 -> 1164)
+    // and came back once the rest of that branch landed (1164 -> 1168), so the
+    // net is zero and the total is again unchanged. The analysis of those rows,
+    // and the reason the two constants must always be read as a pair, are with
+    // `ProjectionSplitsSingleMember` in `DIVERGENCE_BUDGET`.
+    (Status::ProjectionPinned, 1168),
     (Status::ProjectionUnavailablePinned, 487),
     (Status::ProjectionErrorPinned, 210),
     // 132 -> 120 (#1498). The 12 rows are all LRG — `LRG_199:c.357+1G>A`,


### PR DESCRIPTION
Closes #1477. Refs #1235, #1450, #1480.

## Read this first: the tradeoff is measured, and a reviewer should weigh it

This PR is green — 9 573/9 573 with all three oracles and `FERRO_SWEEP_SEEDS=full`, 9 573/9 573 plain, fmt and clippy clean, 35/35 CI. What needs a decision is not quality but **direction**.

It moves **1 957 real corpus rows out of 5 761 894 (0.034 %)**, and **1 951 of them gain a member** — a single `delins` becoming a two-member allele. That is arity change, not re-spelling: a consumer keying on the normalized string sees the shape of their data change.

Sampling 56 of those moved rows and asking Mutalyzer what it makes of the same input:

| | n | share |
|---|---|---|
| Mutalyzer keeps **one** member; this PR splits it (moves *away* from interop) | 25 | 45 % |
| Mutalyzer splits, and to the same string (moves *toward* interop) | 15 | 27 % |
| Mutalyzer answers a third form neither side produces | 16 | 29 % |

Net −10 of 56. **95 % CI −4.3 % to +40.0 %, so it crosses zero** — the point estimate says agreement worsens on the rows this PR moves, and the sample is not large enough to establish it. Stated as a measurement, not a verdict.

Two honest qualifications. Most of the third-form rows are Mutalyzer emitting **cross-reference notation** (`c.1196_1210delins[TC;1213_1228]`), which ferro does not emit at all — a capability gap, not a disagreement about splitting. And the unmoved 5 759 937 rows are untouched, so this is a statement about the rows that move, not about the corpus.

Related but not blocking: #1517 is calibrating the same merge-versus-split boundary from the inversion side, against the same reference implementation.

## What this changes

`is_splittable_single_member` matched only `HgvsVariant::Genome` and `HgvsVariant::Mt`, so a lone `c.`/`n.`/`r.` member was not admitted to the sequence-first derivation. One spelling of a transcript-axis variant was canonicalized and another was frozen, which is essentially the whole transcript-axis confluence residual.

This widens that gate to the transcript axes and fixes every failure the widening exposes.

## Measured effect: the transcript axes reach genomic parity

Confluence over 11 272 classes / 47 392 spellings, both shuffle directions:

| arm | `g.` | `c.` | `n.` | `r.` |
|---|---|---|---|---|
| before | 70.97 % | 46.70 % | 46.63 % | 46.61 % |
| **after** | 70.97 % | **71.06 %** | **70.97 %** | **70.94 %** |

Three independent transcript axes land on `g.`'s number to two decimal places. That is an asymmetry being closed rather than a heuristic being tuned — this PR does not invent a rule, it stops excluding three axes from an existing one.

**It does not close #1235.** The residual at ~71 % is a partitioner property, identical on all four axes. Closing it needs the canonical partitioner (`FERRO_PARTITION=canonical`, #1464), a separate and much larger representation change. `Refs`, not `Closes`.

## Representation moves, quantified across every corpus we own

Baseline and head both built locally from `ef2b8bfc` and this head, normalized against the prepared reference, row counts validated on both sides (a mismatched count is reported as invalid rather than as a result):

| corpus | rows | moved | % | gain members | lose members | same arity |
|---|---|---|---|---|---|---|
| ClinVar 500k | 500 004 | 145 | 0.029 % | 144 | 0 | 1 |
| multi-member cis | 592 | 5 | 0.845 % | 0 | **5** | 0 |
| CMRG exhaustive | 4 826 063 | 1 422 | 0.029 % | 1 422 | 0 | 0 |
| Paraphase exhaustive | 435 235 | 385 | 0.089 % | 385 | 0 | 0 |
| **total** | **5 761 894** | **1 957** | **0.034 %** | 1 951 | 5 | 1 |

Zero rows error or decline on either side.

**CMRG and Paraphase had never been measured for this.** `cmrg_exhaustive_tests` and `paraphase_exhaustive_tests` call `parse_hgvs` and nothing else, so those 5 261 298 rows contribute no normalization coverage in CI. They are 92 % of the corpus and 1 807 of the 1 957 moved rows — a blast radius that no previous measurement in this campaign could have seen.

The direction differs sharply by corpus, and the reason is population. The three observed-variant corpora contain **197 true multi-member cis alleles between them (0.0034 %)**, and those are widely separated substitutions the partitioner has no choice about. Their moves are single-member `delins` **gaining** members. The hand-built cis corpus is 100 % multi-member by construction, and there the change moves rows to **fewer** members.

## Throughput: this costs ~31%, and most of it looks recoverable

Measured on CMRG's 4 826 063 rows, release binaries built from `origin/main` and this head, runs
**interleaved** base/head rather than blocked so thermal drift cannot masquerade as a
between-version effect. Every rep validated on output row count before its time was recorded — a
truncated run prints a wall-clock number too, and on a 4.8M-row corpus that would read as a
speedup.

| | mean | vs base |
|---|---|---|
| `origin/main` | 17.08 s | — |
| **the gate commit alone** | 25.52 s | **+49 %** |
| **this head (all six commits)** | 22.33 s | **+31 %** |

n = 5 per side for the head comparison, 95 % CI **+23.4 % to +38.0 %**, ranges non-overlapping.
282k -> 216k rows/sec.

**The cost is the widening itself, not the passes added on top** — the gate alone is *worse*
(+49 %) and the four subsequent fixes claw about a third of it back.

**And it is being paid almost entirely by rows that do not change.** Only 1 422 of 4 826 063 CMRG
rows (0.03 %) move. `is_splittable_single_member` is now `edit.inner().is_some()` on five variant
kinds, and `canonicalize_from_sequence` alternates with `normalize_core` up to four times — so
every single-member `c.`/`n.`/`r.` variant applies itself to the reference and re-partitions,
including the ones that structurally cannot split.

Measured share of that population: **~58 % of both CMRG and ClinVar is a lone transcript-axis
substitution** (88 % of all transcript-axis rows). A lone substitution changes exactly one column,
cannot partition into multiple pieces and cannot 3'-shift, so it is derivation-invariant by
construction. **Zero of the 1 957 moved rows across all four corpora was one.** An early-out for
that class should therefore be behaviour-neutral and recover most of the regression — worth doing
before merge, and worth proving by re-running the corpus sweep for byte-identity rather than by
argument.

A caveat on ClinVar: measured at 500k rows the same comparison gives +3 % with a 30 % rep spread,
i.e. no resolvable signal. That number should not be quoted — the corpus is too small and the run
too short to see a 30 % effect, which is exactly why the CMRG measurement exists.

## Census re-blesses, with the argument for each

**`cis_confluence_axis` — `converged` 6 633 → 8 006 (3'), 6 628 → 8 006 (5').** `split_two` falls by the same amount; `split_three` (115) and `split_more` (19/9) unchanged. Every divergence figure moved down or stayed flat, which is the direction that pin demands.

The 5' figure moves by 1 378 against the 3' direction's 1 373 — five more, because the same change fixes an off-by-one in `enclosing_exon` that let a member sitting on an exon's *first* base escape the window clamp and shuffle across the junction. A 5'-only symptom, since the 3' walk moves away from the exon start. Both directions now land on the same number, which is the reading to trust: the residual is a property of the partitioner, not of a shuffle direction.

Measured identical with and without `FERRO_ASSERT_IDEMPOTENT` (`declined: 0` in both). That is #1493's doing, not this branch's — it closed #1454, so the two classes that used to panic the oracle no longer do, and the per-oracle census pins this file once carried were already collapsed on `main`.

**`spec_enumeration` — `projection-splits-single-member` 9 → 13, `projection-pinned` 1168 → 1164. A deliberate re-bless of a regression, not a fix.**

All four rows are one input, `NM_004006.2:c.76_83inv`, on `project-c`/`-n`/`-r`/`-p`:

```
c.76_83inv  ->  c.[76_77delinsTG;82_83delinsTT]
p.(Asn26_Gln28delinsCysAlaLeu)  ->  p.[(Asn26Cys);(Gln28Leu)]
```

They enter that bucket by **shape** — a single member projecting to an allele — not by the divergence its headline citation `delins.md:42` names; that passage is about variants **one** base apart, and these are four. And the behaviour is axis-neutral and already shipped: `c.76_83` is `AATGCACA`, whose reverse complement `TGTGCATT` coincides at four of eight columns; the block is equal-length so no axis-dependent gate is consulted, and `g.` has always produced this split. The widening did not create it, it let the transcript axes see it.

**It is nonetheless the wrong answer, and #1517 fixes it separately.** Mutalyzer converges *both* spellings onto `c.76_83inv`. Fixing it means loosening `coalesce_whole_block_inversion`, which is axis-neutral and shipped, so it moves genomic representations for a class this PR measures nowhere.

## Two defects, not one

A controlled A/B established this: reverting only the three-line gate and regenerating the enumeration restored the census exactly, so every move is attributable to the widening and nothing else on the branch.

**Defect A (fixed here) — the live block splitter has no axis at all.** `general.md:34` splits two variants separated by one or more nucleotides; `general.md:35` excepts "separated by one nucleotide, together affecting one amino acid", which cannot reach a genomic description. `axis_min_separation(reading_frame)` encodes that and was handed only to the sequence-first splitter. On the live path the sole coding rule was `apply_coding_codon_exception`, matching `[Sub@p; Identity@p+1; Sub@p+2]` exactly, so it cannot reach a pair where either member is an insertion, deletion or wider delins. One coincidentally matched interior base therefore split coding descriptions the spec keeps whole:

- `NM_000143.3:c.44_47delinsATC` → `c.[44_45delinsAT;49del]`
- `NM_004006.2:c.4375_4376delinsAGTT` → `c.[4375C>A;4376_4377insTT]`, which also degraded `p.(Arg1459SerfsTer19)` → `p.?` — literally the harm `delins.md:47` names
- `NM_000088.3:r.4_6delinsacgu` → `r.[3_4insa;5_6delinsgu]`

New `coalesce_coding_frame_separation` pairwise-merges pieces one unchanged base apart, on a reading-frame axis, on a **length-changing** block only — equal-length blocks keep going to `apply_coding_codon_exception`, preserving the codon half of the exception.

**Defect B (not fixed here) — `c.76_83inv`,** moved to #1517.

## Placement is forced, and was established by getting it wrong first

An earlier attempt put the rule inside `partition_block` via `separations_are_meaningful`. It cleared the same three shapes and cost **332 converged confluence classes per direction** (3' 8 007 → 7 675, 5' 8 007 → 7 673) plus a non-idempotent output — because the weight bound compares against the *input's* weight, so the merged form clears it for the spelling that arrives as one `delins` and trips it for the allele spelling of the same variant. That is the hazard `coalesce_whole_block_inversion` already documents. The bound now judges `derived_columns`, the un-widened partition put through the same shift/coalesce/shrink.

## Known residual, documented rather than hidden

The 3'-shift can *create* a one-base gap after the pre-shift pass has run. Three of 500 004 ClinVar rows land that way (`NM_001458.4:c.7242_7246delCAGCCinsAAACCTG`, `LRG_712t1:c.845_852delATCCCAATinsTCTTCATAGA`, `NM_001406642.1:c.1897_1910delinsTAATATAATT`), plus a second gap in two rows the pass does otherwise reduce. Closing it means running the rule again post-shift with the un-widened partition carried through that pass too. None of the four failures is in that class. Noted in the new function's doc.

## Correction to an earlier revision of this description

An earlier revision said a lone `c.`/`n.`/`r.` member "never reaches `sequence_first_pass`". Too strong, and now corrected in the first commit's message. A lone transcript-axis `delins` that the per-member pipeline splits into an allele *first* then satisfies the **allele** arm: 121 `c.` rows in CMRG move under `FERRO_PARTITION=canonical` with no gate at all, 120 with a multi-member live output — that second door's fingerprint. Widening the predicate closes the lone-member door; it does not create transcript-axis derivation from nothing.

## Related, deliberately not in this PR

- **#1517** — `coalesce_whole_block_inversion` under-recognises a whole-block reverse complement whose interior coincides. Owns the four re-blessed rows above.
- **#1518 / #1519** — equivalence classes and ruling records in the spec fixture, so two spellings of one variant can no longer both pass as `preserved`.

## Verification

Full gate with all three oracles and `FERRO_SWEEP_SEEDS=full`, plus a second run without the oracles as CI's gating `Test` job runs it — 9 573/9 573 both times. `cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean. Corpus measurements taken against the prepared reference with both sides built locally and row counts validated. Mutalyzer sampling is n = 56 of 1 957 moved rows, public accessions only.


---

## Post-rebase update (2026-08-07): three new measurements, one retraction

Rebased onto `main` (was 7 behind). Full gate re-run: **9 589/9 589**, nothing re-blessed by the rebase.

### The strongest evidence for this PR was missing from the description

`9dd49500` re-blesses the cis-allele confluence census from **6 633 to 8 006 converged of 11 272 classes — a gain of 1 373**, with `declined` and `sequence_changed` both 0 either side. That is the largest single confluence improvement in the project's record and it was never stated here. It is a better argument for merging than the split-direction numbers below.

### A retraction: "monotone, 0 regressions" does not survive

An earlier measurement reported this PR fixing **1 042 split-direction violations with 0 regressions**. That measured *who left the lone-`delins` candidate pool*, not who was fixed — the join's key breakdown is `(violating, absent) = 1042` and `(violating, clean) = 0`, so no row was ever shown fixed in place. The instrument admits only **lone** `delins`, and this PR's whole mechanism is turning lone `delins` into multi-member alleles, so the change moves rows out of the only population the instrument could see.

Adjudicating the multi-member outputs this PR *produces* — reference-backed, with the codon test applied to every interior run rather than only the first:

| population | main | this PR | delta |
|---|---|---|---|
| lone `delins` violations | 5 828 | 4 786 | **−1 042** |
| violations *inside* the members it creates | 107 | 275 | **+168** |
| **total** | **5 935** | **5 061** | **−874 (−14.7 %)** |

So the honest claim is **a net removal of 874 separation violations, not 1 042 with none added**. The members this PR creates violate at 37.9 % against main's 30.2 %, on 726 adjudicated members against 354 — it produces roughly twice as many multi-member alleles, and they are slightly worse per member while the total falls.

Method: candidates are `delins` members with a reference span ≥ 4 (the only shape that can conceal an unsplit interior); bases resolved via `samtools faidx` + cdot `start_codon`, never via ferro, since ferro's cuts are what is under test; a violation is claimed only where the unchanged interior survives **every** minimal alignment, so it can under-report and never over-report. Coordinate self-check (a normalized `delins` must differ at both ends): **305/305** and **223/223**.

### Stability disclosure

The one genuine canonical-form move in the tail is `NM_000342.4`, from the 5-member spelling to the 4-member spelling — one row in 5 761 894. Anyone storing the 5-member form must re-normalize it. The other five tail rows are confluence *fixes*: under `main` the same variant spelled two ways gave two different answers, and this PR closes all five.

Note also that `4a6e5592` is **axis-neutral** — it moves `g.` rows too — so this disclosure is not scoped to `c.`/`n.`/`r.` despite the PR title.

### Ordering hazard for whoever merges this

This PR and the #1535 → #1537 stack both re-bless `tests/it/cis_confluence_axis.rs`. Whichever merges second will conflict there. If this one lands first, #1537's census pin needs re-blessing against post-#1484 numbers.

---

## Post-#1540 update (2026-08-07): the guard that blocked this, and what clearing it cost

`main` gained #1540's `issue_1539_split_member_separation` after this PR opened, and this PR failed it on **all five** of its rows. The guard asserts that no member ferro emits may hold a reference column that is unchanged in *every* minimal alignment, sitting strictly between two changed ones, outside `general.md:35`'s one-amino-acid exception. This update adds one commit that clears it, plus a re-bless of the cis confluence census in the same commit.

### What the five rows actually were

Three distinct variants on five transcripts. In each, `best_alignment` cut the block at columns that are unchanged in *no* minimal alignment, and the member it carved out concealed one that is unchanged in *every* one:

| input | member emitted | concealed column |
|---|---|---|
| `NM_000089.3/.4:c.2148_2156delinsACGTGG` | `c.2148_2152delinsAC` (`GGTCG → AC`) | offset 3, codons 716/717 |
| `NM_001277115.2:c.3545_3551delinsAGATGATGAACTGTAGCTGTAAGA` | `c.3545_3548delinsAGAT` (`GACA → AGAT`) | offset 1, codons 1181/1182 |
| `NM_000296.4` / `NM_001009944.3:c.10317_10334delinsATGGCC` | `c.10317_10330delinsAT` (`CCAGGCGGGCCATG → AT`) | offset 12, codons 3442/3443 |

Two of the three parent blocks — `GGTCGGTCC → ACGTGG` and `CCAGGCGGGCCATGGGCT → ATGGCC` — have **no forced-unchanged column at all**, so the separations their splits rested on are artefacts of where the single gap landed, while the genuine one was swallowed.

They now normalize to:

```
NM_000089.3:c.2148_2156delinsACGTGG      -> c.[2148_2150delinsA;2153del;2155_2156inv]
NM_001277115.2:c.3545_3551delins…        -> c.[3545del;3547_3548delinsGAT;3551delinsTGAACTGTAGCTGTAAGA]
NM_000296.4:c.10317_10334delinsATGGCC    -> c.[10317_10327del;10332del;10334T>C]
```

### The fix

`split_concealed_separations` re-partitions an emitted member at the columns every minimal alignment matches, applying the codon exception to **each** interior run. Three scopings carry it, and each was established by a measured failure rather than by argument:

- **Length-changing blocks only.** On an equal-length block the alignment is position-wise, so a matched column is a genuine identity and `partition_block` has already cut at every one. Auditing equal-length blocks re-splits `NM_TEST.1:c.10_15delinsTAATAT` — the rotation `AATATA → TAATAT`, which #1524 settled as its own normal form — and cost four #1454 pins plus **71 declined / 18 underdetermined** census classes.
- **Only a partition that already claimed a separation.** The spec's own `LRG_199t1:c.850_901delinsTTCCTCGATGCCTG` (`delins.md:44-47`) **carries two forced-unchanged interior columns of its own**, at reference offsets 44 and 48, and offset 44 separates codons 297 and 298. A rule that cut every unlicensed interior would shred the very description `delins.md:47` recommends. It is spared structurally, not by exemption: `partition_block` returns that block as one piece.
- **Not a whole-span reverse complement**, whose interior coincidences are structure under `inversion.md:5`. Without this, #1461's dense inversion stopped being recognised.

The node criterion is used rather than `Dominators::matched_ref`, which answers the stronger "which match *edge* lies on every path" and therefore reports nothing at all for `GACA → AGAT` — a column matched by every minimal alignment, at two different alternate offsets. `general.md:34` asks about a nucleotide, not about where the payload sits, so the node criterion is the one the rule needs; the edge criterion reaches two of the three variants.

### The alternative was implemented, measured, and rejected

Refusing the split instead — falling back to the spanning `delins` `delins.md:47` recommends — clears the same guard, restores `main`'s string for all five rows, and is the more spec-coherent rule. It costs **394 converged confluence classes of 11 272** (3': 8 003 → 7 612), because the weight bound then accepts the merged form for the lone-`delins` spelling and refuses it for the allele spelling of the same variant. Confluence outranks stability, so the cut wins. The measurement is recorded on the new function, because the refusal looks strictly safer than it is.

### A near-miss worth recording

An earlier revision cut a run of two matched columns without checking that the canonical alignment matched them to *consecutive* alternate offsets. Where an insertion sits between two forced-matched columns, that dropped payload bases — a **changed sequence**. The round-trip guard at the end of `canonicalize_from_sequence` caught every instance and declined, so no wrong string was ever emitted, but the census reported it as 45 declined / 10 underdetermined **while `converged` rose**. A pass that corrupts a sequence can raise the convergence figure, so the three zeros have to be read before the headline.

### Census re-bless, monotone in every figure

| | 3' before | 3' after | 5' before | 5' after |
|---|---|---|---|---|
| converged | 8 003 | **8 026** | 8 003 | **8 021** |
| split 2 | 3 135 | 3 112 | 3 155 | 3 137 |
| split 3 / 4+ | 115 / 19 | 115 / 19 | 105 / 9 | 105 / 9 |
| declined / underdetermined / sequence changed | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |

Every class that moved moved from two outputs to one.

### Blast radius, remeasured end to end against `origin/main`

Both sides built locally (`origin/main` at `eb75d389`, this head), normalized against the prepared reference, with row counts and the changed/unchanged/failed summary validated identical on each side.

| corpus | rows | moved by this PR | of which added by this commit |
|---|---|---|---|
| ClinVar 500k | 500 004 | 158 | 15 |
| CMRG exhaustive | 4 826 063 | 1 561 | 174 |
| Paraphase exhaustive | 435 235 | 308 | 64 |
| **total** | **5 761 302** | **2 027 (0.035 %)** | **253** |

Of the 253 rows this commit moves, **179 were already moving under this PR** — it only changes which new form they land on, so they cost the consumer nothing extra. The remaining **74 are new, and all 74 are `g.`**: pre-existing `general.md:34` violations on the genomic axis, which the widened gate never touched and which this pass, being axis-neutral, now fixes. Every one of the 253 is the target shape; a row-by-row read of the 15 ClinVar rows found no unrelated churn.

`examples/dump_normalized_corpus.rs` reports **0 of 78 298** for this commit. That zero is **structural and must not be quoted as evidence**: the shape this change keys on is a member of a *length-changing multi-piece* partition whose own minimal alignment needs two gaps, and no family in that generator builds one. The real-corpus figures above are the measurement.

### Verification

`cargo fmt --all -- --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean. `cargo nextest run --features dev -E 'binary(it)'` — **5 506/5 506**, and again with all three seam oracles plus `FERRO_SWEEP_SEEDS=full` — 5 506/5 506. Nothing re-blessed except the two census pins above.

Representation-Change: 2 027 rows move of 5 761 302 (0.035 %), measured against `origin/main` with both sides built locally and row counts validated; 2 016 gain a member, 0 lose, 11 same arity. Arity change, not respelling, so a consumer keying on the normalized string sees the shape of their data change — a real migration. By axis: 1 827 `c.`, 126 `n.`, 74 `g.` — the `g.` rows are pre-existing `general.md:34` violations the axis gate never touched, fixed by the axis-neutral member audit. Confluence improves: 1 373 classes of 11 272 from the gate, plus 23 (3') / 18 (5') from the member audit, with `declined`, `underdetermined` and `sequence_changed` all 0. Separation violations fall by a net 874 (−14.7 %) before the member audit and further after it. One genuine canonical-form move in the tail (`NM_000342.4`, 5-member → 4-member); the other five tail rows are confluence fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved variant normalization across genomic, transcript, RNA, and coding descriptions.
  - Correctly renders one-base substitutions when reference sequence is available.
  - Improved handling of exon boundaries, circular coordinates, insertions, duplications, inversions, and repeat regions.
  - Preserves appropriate `delins` blocks and applies more accurate coding-frame and downstream-shifting behavior.
  - Added safeguards for invalid coordinates, overlapping regions, oversized operations, and unknown reference sequences.
- **Tests**
  - Expanded coverage for boundary cases, multi-member descriptions, sequence comparisons, and projection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->