### PR TITLE
feat(normalize): record provenance when reported members are coalesced

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1459,6 +1459,7 @@ class ErrorType(_NativeEnum):
     IntronicOnBareTranscript: ErrorType  # 43
     IncompleteCdsStartReference: ErrorType  # 44
     InsertionWithoutInsertedSequence: ErrorType  # 45
+    MembersCoalescedFromReportedForm: ErrorType  # 46
 
 class ErrorOverride(_NativeEnum):
     """Override behavior for a specific error type."""

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -461,6 +461,33 @@ pub enum ErrorType {
     /// projection-side decline (#972).
     IncompleteCdsStartReference,
 
+    /// Normalization returned FEWER cis members than the input described —
+    /// two or more separately-reported variants were coalesced into one.
+    ///
+    /// Purely informational: the normalized string is unchanged by this
+    /// warning's existence, and no mode rejects on it.
+    ///
+    /// It exists because `DNA/delins.md:79-84` gives the spec's reason for
+    /// describing nearby variants individually — *"the two variants may have
+    /// been reported (or might occur) individually"* — and names the concrete
+    /// risk: "an overlap with the description of the combined variant might be
+    /// missed in the annotation step (database queries)". That is
+    /// **provenance**, and it lives in the input's spelling; the reference and
+    /// the observed bases carry no trace of it.
+    ///
+    /// ferro cannot answer it in the canonical string. Making the output depend
+    /// on which spelling arrived is the definition of non-confluence, which is
+    /// what #1235 exists to remove — and the cost is measured, not assumed: a
+    /// single input-relative comparand in the normalizer's weight bound cost 427
+    /// converged classes per shuffle direction over the 11,272-class corpus.
+    ///
+    /// So the spelling-dependence goes where it is harmless. The string stays a
+    /// function of the denoted sequence; this warning carries how the variant
+    /// was reported. Two spellings of one variant still normalize to one string
+    /// — they simply carry different diagnostics, which is exactly what lets a
+    /// downstream query recover the individually-reported form.
+    MembersCoalescedFromReportedForm,
+
     /// An insertion with no inserted sequence — a bare `ins` (e.g.
     /// `c.100_101ins`).
     ///
@@ -530,6 +557,7 @@ impl ErrorType {
             ErrorType::IntronicOnBareTranscript => "W4007",
             ErrorType::IncompleteCdsStartReference => "W5004",
             ErrorType::InsertionWithoutInsertedSequence => "W3027",
+            ErrorType::MembersCoalescedFromReportedForm => "W5005",
         }
     }
 
@@ -587,6 +615,7 @@ impl ErrorType {
         ErrorType::TranscriptFlankNotDescribable,
         ErrorType::IntronicOnBareTranscript,
         ErrorType::IncompleteCdsStartReference,
+        ErrorType::MembersCoalescedFromReportedForm,
     ];
 
     /// Parse a warning code (e.g. `"W3007"`) into its `ErrorType`.
@@ -689,6 +718,9 @@ impl ErrorType {
             ErrorType::InsertionWithoutInsertedSequence => {
                 "insertion with no inserted sequence (a bare `ins`)"
             }
+            ErrorType::MembersCoalescedFromReportedForm => {
+                "separately-reported variants were coalesced into fewer members"
+            }
         }
     }
 
@@ -789,6 +821,9 @@ impl ErrorType {
             // The inserted bases are simply absent; ferro cannot invent them,
             // and an insertion of nothing is not a variant. All modes reject.
             ErrorType::InsertionWithoutInsertedSequence => false,
+            // Nothing to correct: the coalesced form is the canonical one. This
+            // records provenance the string deliberately does not carry.
+            ErrorType::MembersCoalescedFromReportedForm => false,
         }
     }
 
@@ -878,7 +913,8 @@ impl ErrorType {
             | ErrorType::NonConformantBracketCardinality
             | ErrorType::IntronicOnBareTranscript
             | ErrorType::IncompleteCdsStartReference
-            | ErrorType::InsertionWithoutInsertedSequence => true,
+            | ErrorType::InsertionWithoutInsertedSequence
+            | ErrorType::MembersCoalescedFromReportedForm => true,
         }
     }
 
@@ -969,6 +1005,10 @@ impl ErrorType {
             ErrorType::IncompleteCdsStartReference => (
                 "ENST00000381176.3:c.10A>G (transcript is cds_start_NF)",
                 "(no auto-correct; use the genomic g. or non-coding n. representation)",
+            ),
+            ErrorType::MembersCoalescedFromReportedForm => (
+                "g.[100del;102_105del] reported as 2 members",
+                "g.100_105delinsAC (1 member; provenance carried by W5005)",
             ),
             ErrorType::InsertionWithoutInsertedSequence => (
                 "c.100_101ins",
@@ -1399,6 +1439,7 @@ mod tests {
             ErrorType::IntronicOnBareTranscript,
             ErrorType::IncompleteCdsStartReference,
             ErrorType::InsertionWithoutInsertedSequence,
+            ErrorType::MembersCoalescedFromReportedForm,
         ];
         // Exhaustiveness probe: if a new variant is added to the enum,
         // this match fails to compile until `every_variant` is extended.
@@ -1450,7 +1491,8 @@ mod tests {
                 | ErrorType::NonConformantBracketCardinality
                 | ErrorType::IntronicOnBareTranscript
                 | ErrorType::IncompleteCdsStartReference
-                | ErrorType::InsertionWithoutInsertedSequence => {}
+                | ErrorType::InsertionWithoutInsertedSequence
+                | ErrorType::MembersCoalescedFromReportedForm => {}
             }
             assert!(
                 ErrorType::ALL.contains(&v),

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -857,6 +857,25 @@ pub enum NormalizationWarning {
         edit_kinds: Vec<String>,
     },
 
+    /// Normalization returned FEWER cis members than the input described: two
+    /// or more separately-reported variants were coalesced into one.
+    /// Code: `MEMBERS_COALESCED_FROM_REPORTED_FORM` (W5005).
+    ///
+    /// Purely informational — the normalized string is identical whether or not
+    /// this warning is produced. It carries the *provenance* the canonical form
+    /// deliberately does not: see `ErrorType::MembersCoalescedFromReportedForm`
+    /// for why that separation is the point rather than a compromise.
+    MembersCoalesced {
+        /// Accession the coalesced members sit on.
+        accession: String,
+        /// Coordinate system: "g" | "c" | "n" | "r" | "m"
+        coordinate_system: String,
+        /// How many cis members the INPUT described.
+        reported_members: usize,
+        /// How many the normalized form describes.
+        normalized_members: usize,
+    },
+
     /// A telomere/centromere marker could not be resolved to a concrete base.
     /// Currently only `cen` (a centromere is an assembly-annotated region, not a
     /// sequence-derivable nucleotide). The input is preserved verbatim.
@@ -1123,12 +1142,58 @@ fn intronic_on_bare_transcript_warning(variant: &HgvsVariant) -> Option<Normaliz
     }
 }
 
+/// The number of cis members a variant describes.
+///
+/// A cis allele reports its member count; everything else is one member. A
+/// `trans`/unphased group is deliberately NOT counted — its members are on
+/// different molecules, so they were never candidates for coalescing and a
+/// change in their number would mean something else entirely. An `uncertain`
+/// group is excluded for the same reason: `(...)` marks a predicted grouping
+/// rather than a set of separately-reported observations.
+fn cis_member_count(variant: &HgvsVariant) -> usize {
+    match variant {
+        HgvsVariant::Allele(allele)
+            if allele.phase == crate::hgvs::variant::AllelePhase::Cis && !allele.uncertain =>
+        {
+            allele.variants.len()
+        }
+        _ => 1,
+    }
+}
+
+/// The accession and coordinate-system letter to report a coalesce against.
+///
+/// Reads the first leaf carrying an accession, so a cis allele reports the
+/// accession its members share rather than `None`.
+fn accession_and_axis(variant: &HgvsVariant) -> Option<(String, String)> {
+    let leaf = crate::hgvs::variant::first_leaf_with_accession(variant)?;
+    let accession = leaf.accession()?.to_string();
+    let axis = match leaf {
+        HgvsVariant::Genome(_) => "g",
+        HgvsVariant::Cds(_) => "c",
+        HgvsVariant::Tx(_) => "n",
+        HgvsVariant::Rna(_) => "r",
+        HgvsVariant::Mt(_) => "m",
+        // Protein too: a `p.` cis allele coalesces just as the nucleotide axes
+        // do — `p.[Ala100Gly;Ala101Gly]` normalizes to
+        // `p.Ala100_Ala101delinsGlyGly`, two reported members becoming one —
+        // and the provenance `DNA/delins.md:79-84` is about is exactly as
+        // unrecoverable from that string. Omitting it dropped the warning
+        // silently on the axis where a database query is most likely to be
+        // looking for the individually reported form.
+        HgvsVariant::Protein(_) => "p",
+        _ => return None,
+    };
+    Some((accession, axis.to_string()))
+}
+
 impl NormalizationWarning {
     /// The warning's user-facing code string.
     pub fn code(&self) -> &'static str {
         match self {
             Self::RefSeqMismatch { .. } => "REFSEQ_MISMATCH",
             Self::OverlapConflict { .. } => "OVERLAP_CONFLICTING_EDITS",
+            Self::MembersCoalesced { .. } => "MEMBERS_COALESCED_FROM_REPORTED_FORM",
             Self::UnresolvableSpecialPosition { .. } => "UNRESOLVABLE_SPECIAL_POSITION",
             Self::TranscriptFlankNotDescribable { .. } => "TRANSCRIPT_FLANK_NOT_DESCRIBABLE",
             Self::CanonicalSplitSkipped { .. } => "CANONICAL_SPLIT_SKIPPED",
@@ -1184,6 +1249,18 @@ impl std::fmt::Display for NormalizationWarning {
                 coordinate_system,
                 location,
                 edit_kinds.join(", "),
+            ),
+            Self::MembersCoalesced {
+                accession,
+                coordinate_system,
+                reported_members,
+                normalized_members,
+            } => write!(
+                f,
+                "{accession}:{coordinate_system}. — input described {reported_members} cis \
+                 members, normalized form describes {normalized_members}; the individually \
+                 reported form is not recoverable from the normalized string \
+                 (DNA/delins.md:79-84)"
             ),
             Self::UnresolvableSpecialPosition { accession, marker } => write!(
                 f,
@@ -2463,6 +2540,37 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         self.assert_seam_oracles(variant, &result.result);
+
+        // Provenance (#1235, `DNA/delins.md:79-84`). If the input described more
+        // cis members than the normalized form does, two or more separately
+        // reported variants have been coalesced, and that fact is not
+        // recoverable from the output string — by design, since making the
+        // string depend on the input's spelling is precisely the
+        // non-confluence #1235 removes.
+        //
+        // Emitted here rather than at any single coalescing site on purpose:
+        // several passes can reduce the member count (the live rule's adjacency
+        // coalesce, the prioritisation collapse, the sequence-first
+        // re-derivation), and the caller cares that it happened, not which pass
+        // did it. Comparing the counts at the one exit catches all of them and
+        // cannot drift as those passes change.
+        //
+        // It never rejects and never alters `result.result`.
+        let mut result = result;
+        let reported_members = cis_member_count(variant);
+        let normalized_members = cis_member_count(&result.result);
+        if normalized_members < reported_members {
+            if let Some((accession, coordinate_system)) = accession_and_axis(variant) {
+                result
+                    .warnings
+                    .push(NormalizationWarning::MembersCoalesced {
+                        accession,
+                        coordinate_system,
+                        reported_members,
+                        normalized_members,
+                    });
+            }
+        }
 
         Ok((result.result, result.warnings))
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -4094,6 +4094,14 @@ pub enum PyErrorType {
     // insertion with no inserted sequence); rejected in every mode, since the
     // missing bases are not recoverable from the description (#1162).
     InsertionWithoutInsertedSequence = 45,
+    // 46 is W5005 MembersCoalescedFromReportedForm — normalization returned
+    // fewer cis members than the input described. Purely informational: the
+    // normalized string is identical whether or not it is emitted. It carries
+    // the provenance `DNA/delins.md:79-84` asks about ("the two variants may
+    // have been reported ... individually"), which the canonical string
+    // deliberately does not, since making the output depend on the input's
+    // spelling is the non-confluence #1235 removes.
+    MembersCoalescedFromReportedForm = 46,
 }
 
 native_enum_pymethods! {
@@ -4144,6 +4152,7 @@ native_enum_pymethods! {
         43 => IntronicOnBareTranscript,
         44 => IncompleteCdsStartReference,
         45 => InsertionWithoutInsertedSequence,
+        46 => MembersCoalescedFromReportedForm,
     },
 }
 
@@ -4196,6 +4205,9 @@ impl From<ErrorType> for PyErrorType {
             ErrorType::TranscriptFlankNotDescribable => PyErrorType::TranscriptFlankNotDescribable,
             ErrorType::IntronicOnBareTranscript => PyErrorType::IntronicOnBareTranscript,
             ErrorType::IncompleteCdsStartReference => PyErrorType::IncompleteCdsStartReference,
+            ErrorType::MembersCoalescedFromReportedForm => {
+                PyErrorType::MembersCoalescedFromReportedForm
+            }
             ErrorType::InsertionWithoutInsertedSequence => {
                 PyErrorType::InsertionWithoutInsertedSequence
             }
@@ -4252,6 +4264,9 @@ impl From<PyErrorType> for ErrorType {
             PyErrorType::TranscriptFlankNotDescribable => ErrorType::TranscriptFlankNotDescribable,
             PyErrorType::IntronicOnBareTranscript => ErrorType::IntronicOnBareTranscript,
             PyErrorType::IncompleteCdsStartReference => ErrorType::IncompleteCdsStartReference,
+            PyErrorType::MembersCoalescedFromReportedForm => {
+                ErrorType::MembersCoalescedFromReportedForm
+            }
             PyErrorType::InsertionWithoutInsertedSequence => {
                 ErrorType::InsertionWithoutInsertedSequence
             }
@@ -6320,6 +6335,15 @@ mod tests {
                     edit_kinds: vec!["sub".to_string(), "sub".to_string()],
                 },
                 "OVERLAP_CONFLICTING_EDITS",
+            ),
+            (
+                crate::normalize::NormalizationWarning::MembersCoalesced {
+                    accession: "NC_000001.11".to_string(),
+                    coordinate_system: "g".to_string(),
+                    reported_members: 2,
+                    normalized_members: 1,
+                },
+                "MEMBERS_COALESCED_FROM_REPORTED_FORM",
             ),
             (
                 crate::normalize::NormalizationWarning::PositionPastEnd {

--- a/tests/it/coalesced_members_diagnostic.rs
+++ b/tests/it/coalesced_members_diagnostic.rs
@@ -1,0 +1,229 @@
+//! W5005 — provenance for members the input reported separately.
+//!
+//! `DNA/delins.md:79-84` gives the spec's reason for describing nearby variants
+//! individually: *"the two variants may have been reported (or might occur)
+//! individually"*, and names the concrete risk — "an overlap with the
+//! description of the combined variant might be missed in the annotation step
+//! (database queries)". That is **provenance**: it lives in the input's
+//! spelling, and neither the reference nor the observed bases carry any trace
+//! of it.
+//!
+//! The normalized string cannot answer it. Making the output depend on which
+//! spelling arrived is the definition of non-confluence, which is what #1235
+//! exists to remove — and the cost is measured rather than assumed: a single
+//! input-relative comparand in the normalizer's weight bound cost 427 converged
+//! classes per shuffle direction over the 11,272-class corpus.
+//!
+//! So the spelling-dependence goes where it is harmless. The canonical string
+//! stays a function of the denoted sequence; this diagnostic carries how the
+//! variant was reported. Two spellings of one variant still normalize to one
+//! string — they simply carry different diagnostics, and that is what lets a
+//! downstream query recover the individually-reported form.
+//!
+//! The assertions below pin both halves of that contract: the warning appears
+//! when members are coalesced, and **the normalized string is identical whether
+//! or not it does**.
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// A genome-capable provider over one contig of cyclic `ACGT`, with `payload`
+/// written 1-based at `pos1`.
+fn provider(contig: &str, len: usize, pos1: usize, payload: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(len).collect();
+    for (i, b) in payload.bytes().enumerate() {
+        bases[pos1 - 1 + i] = b;
+    }
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: String::from_utf8(bases).unwrap() },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// `(normalized string, W5005 codes emitted)`.
+fn normalize(p: &JsonProvider, input: &str) -> (String, Vec<String>) {
+    let variant = parse_hgvs(input).unwrap();
+    let result = Normalizer::new(p.clone())
+        .normalize_with_diagnostics(&variant)
+        .unwrap();
+    let codes = result
+        .warnings
+        .iter()
+        .filter(|w| w.code() == "MEMBERS_COALESCED_FROM_REPORTED_FORM")
+        .map(|w| w.to_string())
+        .collect();
+    (result.result.to_string(), codes)
+}
+
+/// How many `;`-separated members a rendered allele carries.
+fn members(rendered: &str) -> usize {
+    match (rendered.find('['), rendered.rfind(']')) {
+        (Some(open), Some(close)) if close > open => rendered[open + 1..close].split(';').count(),
+        _ => 1,
+    }
+}
+
+/// Two adjacent substitutions the normalizer merges into one `delins`: the
+/// input reported two members, the output describes one.
+#[test]
+fn coalescing_two_reported_members_emits_the_diagnostic() {
+    let p = provider("c", 400, 200, "GCA");
+    let (rendered, codes) = normalize(&p, "c:g.[200G>T;201C>G]");
+
+    assert_eq!(
+        members(&rendered),
+        1,
+        "precondition: this input must coalesce ({rendered})"
+    );
+    assert_eq!(codes.len(), 1, "expected exactly one W5005 ({codes:?})");
+    let message = &codes[0];
+    assert!(
+        message.contains("input described 2 cis members"),
+        "message must state the reported count: {message}"
+    );
+    assert!(
+        message.contains("describes 1"),
+        "message must state the normalized count: {message}"
+    );
+}
+
+/// The load-bearing property: the diagnostic is *informational*. The normalized
+/// string is what it was; nothing about emitting a warning moves it.
+///
+/// Asserted by normalizing the same input through both public exits — the one
+/// that collects diagnostics and the one that does not — and requiring them to
+/// agree byte for byte.
+#[test]
+fn the_diagnostic_does_not_change_the_normalized_string() {
+    let p = provider("c", 400, 200, "GCA");
+    for input in [
+        "c:g.[200G>T;201C>G]",
+        "c:g.200_201delinsTG",
+        "c:g.[100T>C;300T>G]",
+        "c:g.200G>T",
+    ] {
+        let variant = parse_hgvs(input).unwrap();
+        let plain = Normalizer::new(p.clone())
+            .normalize(&variant)
+            .unwrap()
+            .to_string();
+        let (with_diagnostics, _) = normalize(&p, input);
+        assert_eq!(
+            plain, with_diagnostics,
+            "the diagnostics exit moved the string for {input}"
+        );
+    }
+}
+
+/// Two spellings of one variant: the strings converge (confluence), and the
+/// diagnostics differ (provenance). That is the whole design in one assertion —
+/// the spelling-dependence lives in the metadata, never in the string.
+#[test]
+fn equivalent_spellings_converge_while_their_provenance_differs() {
+    let p = provider("c", 400, 200, "GCA");
+    let (split_form, split_codes) = normalize(&p, "c:g.[200G>T;201C>G]");
+    let (span_form, span_codes) = normalize(&p, "c:g.200_201delinsTG");
+
+    assert_eq!(
+        split_form, span_form,
+        "the two spellings must normalize to one string"
+    );
+    assert_eq!(split_codes.len(), 1, "the split spelling was coalesced");
+    assert!(
+        span_codes.is_empty(),
+        "the span spelling reported one member and was not coalesced ({span_codes:?})"
+    );
+}
+
+/// A member count that does not fall emits nothing. Guards against the warning
+/// firing on every multi-member allele, which would make it useless noise.
+#[test]
+fn an_allele_whose_members_survive_emits_nothing() {
+    let p = provider("c", 400, 200, "GCA");
+    let (rendered, codes) = normalize(&p, "c:g.[100T>C;300T>G]");
+    assert_eq!(
+        members(&rendered),
+        2,
+        "precondition: these members are far apart and must survive ({rendered})"
+    );
+    assert!(codes.is_empty(), "unexpected W5005: {codes:?}");
+}
+
+/// A single-member input can never coalesce, so it can never warn — whatever
+/// the normalizer does to its spelling.
+#[test]
+fn a_single_member_input_never_warns() {
+    let p = provider("c", 400, 200, "GCA");
+    for input in ["c:g.200G>T", "c:g.200_202delinsTGC", "c:g.200_201del"] {
+        let (_, codes) = normalize(&p, input);
+        assert!(codes.is_empty(), "unexpected W5005 for {input}: {codes:?}");
+    }
+}
+
+/// A `trans` group is not a coalescing candidate: its members sit on different
+/// molecules, so a change in their number would mean something else entirely.
+#[test]
+fn a_trans_group_is_not_reported_as_coalesced() {
+    let p = provider("c", 400, 200, "GCA");
+    let (_, codes) = normalize(&p, "c:g.[200G>T];[201C>G]");
+    assert!(
+        codes.is_empty(),
+        "a trans group must not report coalescing: {codes:?}"
+    );
+}
+
+/// The W-code is stable and resolves both ways through the public registry, so
+/// a caller can select on `"W5005"` and get this warning back.
+#[test]
+fn the_w_code_round_trips_through_the_registry() {
+    use ferro_hgvs::error_handling::ErrorType;
+
+    let error_type = ErrorType::MembersCoalescedFromReportedForm;
+    assert_eq!(error_type.code(), "W5005");
+    assert_eq!(
+        ErrorType::from_code("W5005"),
+        Some(error_type),
+        "W5005 must resolve back to its ErrorType"
+    );
+    assert!(
+        !error_type.is_correctable(),
+        "there is nothing to correct: the coalesced form IS the canonical one"
+    );
+}
+
+/// The `p.` axis coalesces too, and must carry the same provenance.
+///
+/// `accession_and_axis` originally returned `None` for `Protein`, so the
+/// warning was dropped silently on exactly the axis where a database query is
+/// most likely to be looking for the individually reported form. Measured
+/// before the fix: `p.[Ala100Gly;Ala101Gly]` normalized to
+/// `p.Ala100_Ala101delinsGlyGly` — two reported members, one normalized — with
+/// `warnings=[]`.
+#[test]
+fn a_protein_cis_allele_carries_the_provenance_warning() {
+    use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+    let provider = MockProvider::with_test_data();
+    let variant = parse_hgvs("NP_000079.2:p.[Ala100Gly;Ala101Gly]").expect("fixture parses");
+    let result = Normalizer::new(provider)
+        .normalize_with_diagnostics(&variant)
+        .expect("normalization succeeds");
+    assert_eq!(
+        result.result.to_string(),
+        "NP_000079.2:p.Ala100_Ala101delinsGlyGly",
+        "two adjacent protein substitutions coalesce into one delins"
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "MEMBERS_COALESCED_FROM_REPORTED_FORM"),
+        "the coalesce must be reported on the `p.` axis as it is on the \
+         nucleotide axes; got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>()
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -58,6 +58,7 @@ mod clinvar_hgvs_tests;
 mod clinvar_tests;
 mod clinvar_validation;
 mod cmrg_exhaustive_tests;
+mod coalesced_members_diagnostic;
 mod coderabbit_config_paths;
 mod comma_products_allele;
 mod compound_cross_reference;


### PR DESCRIPTION
## Why

`DNA/delins.md:79-84` gives the spec's own reason for describing nearby variants individually — *"the two variants may have been reported (or might occur) individually"* — and names the concrete risk: **"an overlap with the description of the combined variant might be missed in the annotation step (database queries)"**.

That is **provenance**. It lives in the input's spelling; neither the reference nor the observed bases carry any trace of it. So the normalized string cannot answer it, and it should not try: making the output depend on which spelling arrived is the definition of non-confluence, which is what #1235 exists to remove.

That cost is measured, not assumed. A single input-relative comparand in the normalizer's weight bound — comparing derived pieces against the *input's own* edits — cost **427 converged classes per shuffle direction** over the 11,272-class corpus until the pass in #1470 was moved past it.

**So the spelling-dependence goes where it is harmless.** The canonical string stays a function of the denoted sequence; a diagnostic carries how the variant was reported. Two spellings of one variant still normalize to one string — they simply carry different diagnostics. That is precisely what lets a downstream query recover the individually-reported form, which is the spec's stated worry.

This is the follow-up #1470 names in its "known limit" test: three of the 592 real multi-member cis alleles are genuinely separate variants sitting as close together as a coincidental split, and no property of the sequence distinguishes them. This does not fix those — nothing can, from sequence alone — but it stops them being *silent*.

## What

`W5005 MembersCoalescedFromReportedForm`, emitted when normalization returns fewer cis members than the input described.

**W5xxx** because this is a reference-aware finding about a multi-member allele — the same neighbourhood as `W5002 OverlapConflictingEdits`, not a W3xxx input-form issue.

**Emitted at the single exit of `normalize_core_checked`**, not at any one coalescing site. Several passes can reduce the member count (the live rule's adjacency coalesce, the prioritisation collapse, the sequence-first re-derivation), and the caller cares *that* it happened rather than which pass did it. Comparing counts at the one exit catches all of them and cannot drift as those passes change. It also keeps the diff out of `src/normalize/merge.rs`, which several open branches are currently contending for.

Deliberately not counted:

- a **`trans`/unphased group** — its members sit on different molecules, so they were never coalescing candidates and a change in their number would mean something else entirely;
- an **`uncertain` group** — `(...)` marks a predicted grouping, not a set of separately-reported observations.

## API surface

**This adds a public warning code**, so it is an API change — additive only. `ErrorType::MembersCoalescedFromReportedForm` / `PyErrorType` discriminant 46, surfaced through `normalize_with_diagnostics` and the Python bindings alongside W4004/W5001/W5002. No existing code, discriminant or message changes.

## It moves no normalized string

The property the whole design rests on, verified against the real prepared reference on the default arm:

| corpus | rows | md5 before | md5 after | differing |
|---|---|---|---|---|
| ClinVar 500k | 500,004 | `9a7bc10c…` | `9a7bc10c…` | **0** |
| real multi-member cis | 592 | `683127e5…` | `683127e5…` | **0** |

`the_diagnostic_does_not_change_the_normalized_string` pins it in the suite too, by normalizing the same inputs through both public exits and requiring byte agreement.

## Tests

`tests/it/coalesced_members_diagnostic.rs` — 7 tests. The one worth reading is `equivalent_spellings_converge_while_their_provenance_differs`: two spellings of one variant produce **one string** and **different diagnostics**, which is the entire design in a single assertion. The rest pin that a surviving member count emits nothing, that single-member and `trans` inputs never warn, and that the W-code round-trips through the public registry.

Gate: `cargo fmt --check` and `clippy --all-features --all-targets -D warnings` clean; `cargo check --features python` clean; `9473 tests run: 9473 passed, 145 skipped` with all three oracles and `FERRO_SWEEP_SEEDS=full`; `700 passed` under `pytest tests/python/`.

Refs #1235, #1470
