### PR TITLE
fix(spdi): normalise the reference window before searching a repeat tract

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1576,14 +1576,20 @@ where
             // nothing" — so widening here makes the two sites agree rather
             // than introducing a third answer.
             let (del_start, del_end) = match provider {
-                Some(p) if start_one_based == end_one_based => {
-                    resolve_repeat_tract_span(p, &sequence, start_one_based, unit_str.as_bytes())?
-                }
+                Some(p) if start_one_based == end_one_based => resolve_repeat_tract_span(
+                    p,
+                    &sequence,
+                    start_one_based,
+                    unit_str.as_bytes(),
+                    alphabet,
+                )?,
                 _ => (start_one_based, end_one_based),
             };
             let spdi_pos = del_start - 1;
-            let del_raw = match provider {
-                Some(p) => fetch_reference_bases(p, &sequence, del_start, del_end)?,
+            let del_str = match provider {
+                Some(p) => {
+                    fetch_normalized_reference_bases(p, &sequence, del_start, del_end, alphabet)?
+                }
                 None => {
                     return Err(unspelled_bases_error(
                         UnspelledBases::RepeatTract,
@@ -1592,7 +1598,6 @@ where
                     ));
                 }
             };
-            let del_str = apply_alphabet(&del_raw, alphabet);
             // The HGVS recommendations require the interval to span an
             // integer number of repeat units. Reject non-divisible spans
             // with a clear message rather than silently emitting nonsense.
@@ -1758,11 +1763,29 @@ fn unspelled_bases_error(
 /// unit does not match the reference there — so the caller's existing
 /// "does not match repeat unit" diagnostic is what reports it, rather than a
 /// second error for one condition.
+///
+/// **The window is normalised before it is searched** (#1452). `unit` arrives
+/// having already been through [`apply_alphabet`], so searching the raw window
+/// would compare a soft-masked (lowercase) reference against an uppercase unit
+/// and find no run at all. That did not surface as an error: the no-run
+/// fallback above returns the *unit-wide* span, whose bases the caller then
+/// uppercases, so the unit-match check passed and a truncated triple was
+/// emitted. On a 3-copy lowercase `cag` tract, `g.259CAG[5]` came out as
+/// `258:CAG:CAGCAGCAGCAGCAG` — seven copies once the two untouched tract
+/// units are counted — while the range spelling `g.259_267CAG[5]` correctly
+/// gave `258:CAGCAGCAG:CAGCAGCAGCAGCAG`. Both spellings converted; they just
+/// denoted different sequences.
+///
+/// Normalising with [`apply_alphabet`] rather than a bare `to_ascii_uppercase`
+/// is what keeps the two comparisons provably identical: on the `r.` axis the
+/// unit has had `U` rewritten to `T`, so an uppercase-only window would still
+/// miss a `U`-spelled tract and truncate it by the same route.
 fn resolve_repeat_tract_span<P>(
     provider: &P,
     accession: &str,
     anchor_one_based: u64,
     unit: &[u8],
+    alphabet: AlphabetMode,
 ) -> Result<(u64, u64), ConversionError>
 where
     P: ReferenceProvider + ?Sized,
@@ -1811,7 +1834,13 @@ where
         let window_end = anchor_one_based
             .saturating_add(half_width)
             .min(sequence_length);
-        let window = fetch_reference_bases(provider, accession, window_start, window_end)?;
+        let window = fetch_normalized_reference_bases(
+            provider,
+            accession,
+            window_start,
+            window_end,
+            alphabet,
+        )?;
         let bytes = window.as_bytes();
         let anchor_offset = (anchor_one_based - window_start) as usize;
 
@@ -1855,6 +1884,56 @@ where
         }
         half_width = half_width.saturating_mul(2);
     }
+}
+
+/// [`fetch_reference_bases`] with [`apply_alphabet`] already applied, so the
+/// caller never holds a window in the reference's own case convention (#1452).
+///
+/// Reference FASTAs are routinely soft-masked, and the repeat arm compares the
+/// fetched bases against a unit that has been through `apply_alphabet` — twice,
+/// at two sites. Normalising at the fetch is what stops those two sites from
+/// disagreeing: the tract search and the unit-match check now see the same
+/// bytes by construction rather than by each remembering to fold. This mirrors
+/// how `normalize::merge::canonical_base_byte` centralises the `r.` uracil /
+/// thymine equivalence instead of spreading it over its comparison sites.
+///
+/// The byte offsets a caller computes against the returned string stay valid:
+/// `apply_alphabet` rewrites ASCII bytes one-for-one and leaves everything else
+/// alone, so the length is preserved. `normalizing_a_window_preserves_its_length`
+/// pins that, since a length change would silently mis-map the anchor offset in
+/// [`resolve_repeat_tract_span`] rather than fail.
+///
+/// **Only the repeat arm uses this, and the other arms are not an oversight.**
+/// The Duplication / Deletion / Delins / Identity / Inversion arms each fetch
+/// through the plain [`fetch_reference_bases`] and fold *after* the `match`,
+/// because the bases they fold may instead have come from the description
+/// itself (`Some(seq) => sequence_to_string(seq)`, which is a bare
+/// `to_string()` and does not fold). Their trailing `apply_alphabet` covers
+/// **both** branches. Swapping those fetches to this function would therefore
+/// not let the trailing fold be removed — it would only normalize the fetched
+/// branch twice, and removing the fold along with it would silently stop
+/// normalizing author-spelled bases. This arm is different precisely because it
+/// has no author-spelled branch: an unspelled repeat tract is the only way in,
+/// so the fetch is the single source and folding there is what makes the tract
+/// search and the unit-match check agree by construction.
+fn fetch_normalized_reference_bases<P>(
+    provider: &P,
+    accession: &str,
+    start_one_based: u64,
+    end_one_based: u64,
+    alphabet: AlphabetMode,
+) -> Result<String, ConversionError>
+where
+    P: ReferenceProvider + ?Sized,
+{
+    let raw = fetch_reference_bases(provider, accession, start_one_based, end_one_based)?;
+    let normalized = apply_alphabet(&raw, alphabet);
+    debug_assert_eq!(
+        normalized.len(),
+        raw.len(),
+        "alphabet normalization must preserve byte length"
+    );
+    Ok(normalized)
 }
 
 fn fetch_reference_bases<P>(
@@ -2559,6 +2638,64 @@ mod tests {
         assert_eq!(spdi.position, 99);
         assert_eq!(spdi.deletion, "A");
         assert_eq!(spdi.insertion, "A");
+    }
+
+    // ------------------------------------------------------------------
+    // Reference-window normalization (#1452)
+    //
+    // The soft-masking behaviour these underwrite is graded end-to-end in
+    // `tests/it/issue_1452_soft_masked_repeat_span.rs`. What lives here are
+    // the two properties that cannot be isolated from there: the length
+    // invariant the anchor offset depends on, and the `r.` axis, which the
+    // integration suite reaches only through a full transcript projection.
+    // ------------------------------------------------------------------
+
+    /// `resolve_repeat_tract_span` computes `anchor_offset` as a byte index
+    /// into the normalized window, so a normalization that changed the byte
+    /// length would silently point the tract search at the wrong base rather
+    /// than fail. Both `apply_alphabet` arms rewrite ASCII one-for-one and
+    /// leave every other byte alone, and this is what holds them to it.
+    #[test]
+    fn normalizing_a_window_preserves_its_length() {
+        for window in ["acgtACGT", "uuuUUU", "acgunACGUN", "", "nnnn"] {
+            for alphabet in [AlphabetMode::Dna, AlphabetMode::Rna] {
+                assert_eq!(
+                    apply_alphabet(window, alphabet).len(),
+                    window.len(),
+                    "`{window}` changed length under {alphabet:?}"
+                );
+            }
+        }
+    }
+
+    /// The window is normalized with `apply_alphabet`, not `to_ascii_uppercase`,
+    /// and on the `r.` axis that is the difference between finding a tract and
+    /// truncating it.
+    ///
+    /// A repeat unit reaches `resolve_repeat_tract_span` having already had `U`
+    /// rewritten to `T` for SPDI's DNA alphabet, so a `u`-spelled reference must
+    /// get the same rewrite or the search compares `T` against `U` and finds no
+    /// run — the identical silent-truncation route #1452 fixed for case. The
+    /// `Dna` row is the control: there `U` is not `T`, so no tract exists and
+    /// the unit-wide fallback is the right answer.
+    #[test]
+    fn a_uracil_spelled_tract_is_found_on_the_rna_axis() {
+        let mut provider = MockProvider::new();
+        // A 4-copy `u` tract at 3..=6, lower-case as well, so this covers both
+        // normalizations at once.
+        provider.add_genomic_sequence("NR_TEST.1", "GGuuuuGG".to_string());
+
+        assert_eq!(
+            resolve_repeat_tract_span(&provider, "NR_TEST.1", 3, b"T", AlphabetMode::Rna).unwrap(),
+            (3, 6),
+            "the `r.` axis must see the tract its unit was rewritten to match"
+        );
+        assert_eq!(
+            resolve_repeat_tract_span(&provider, "NR_TEST.1", 3, b"T", AlphabetMode::Dna).unwrap(),
+            (3, 3),
+            "on the DNA axis `U` is not `T`, so no tract exists and the \
+             unit-wide fallback stands"
+        );
     }
 
     /// A 28-base `ACGT…` contig, so a 1-based position `p` holds

--- a/tests/it/issue_1452_soft_masked_repeat_span.rs
+++ b/tests/it/issue_1452_soft_masked_repeat_span.rs
@@ -1,0 +1,242 @@
+//! #1452 — a soft-masked repeat tract made the two spellings of one repeat
+//! denote different sequences again.
+//!
+//! This is the #1431 defect reopened by a different door. #1431 taught
+//! `hgvs_to_spdi` that a single-position anchor (`g.259CAG[5]`) names the whole
+//! tandem run, not one unit of it, by searching the reference for that run. The
+//! search compares raw reference bytes against a unit that has already been
+//! upper-cased for SPDI output, so on a **soft-masked** (lowercase) tract it
+//! matched nothing.
+//!
+//! What makes it worth a regression test rather than a one-line fold is that it
+//! did **not** surface as an error. The no-run branch falls back to the
+//! unit-wide span at the anchor — deliberately, so the caller's
+//! "does not match repeat unit" diagnostic reports a genuine mismatch — and the
+//! caller then upper-cases those bases before checking them. One unit always
+//! matches one unit, so the check passed and a **truncated** triple came out:
+//!
+//! | spelling | uppercase `CAGCAGCAG` | soft-masked `cagcagcag` |
+//! |---|---|---|
+//! | `g.259CAG[5]` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` | `258:CAG:CAGCAGCAGCAGCAG` |
+//! | `g.259_267CAG[5]` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` |
+//!
+//! The masked anchored form applies to seven copies, not five: the two tract
+//! units the truncated span left untouched survive the replacement. Both
+//! spellings converted, both parse, both are in bounds and both are fixed
+//! points — so, exactly as in #1431, none of `FERRO_ASSERT_REPARSE`,
+//! `FERRO_ASSERT_IN_BOUNDS` or `FERRO_ASSERT_IDEMPOTENT` can see it.
+//!
+//! Measured over anchored conversions of `A`/`AT`/`CAG`/`GATC` tracts of 2..=5
+//! copies at every anchor position and two target counts, 560 rows in all. 336
+//! of those anchor out of phase with the tract and are refused — identically in
+//! both case conventions, which the test below pins. Of the 224 that remain,
+//! 112 are soft-masked and 112 are not, and the split was total: **every
+//! soft-masked row disagreed with its range spelling; no unmasked row did**.
+//! After the fix, neither does.
+//!
+//! **The issue's stated cause is not the one that was firing.** #1452 named two
+//! case-sensitive comparisons, the unit-match check
+//! (`del_str != unit_str.repeat(pre_count)`) and the tract search. The
+//! unit-match check is *already* case-insensitive — both of its operands go
+//! through `apply_alphabet`, which upper-cases — so the explicit-range spelling
+//! was never affected and no failure here is a conversion *error*. Only the
+//! tract search was folding-blind, and its symptom is a wrong answer rather
+//! than a refusal. The issue's warning that fixing one of the two comparisons
+//! alone would be worse than fixing neither therefore does not apply: there is
+//! one site, and folding it is what makes the two spellings agree.
+//!
+//! Reference FASTAs are routinely soft-masked and masked bytes reach this
+//! codebase's normalization from ordinary input
+//! (`issue_1318_soft_masked_delins.rs`), so this is not a synthetic condition.
+
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+/// 256 `N`s, so core position 1 is `g.257`. Borrowed from
+/// `issue_1431_single_position_repeat_anchor.rs`: `N` matches no unit used
+/// here, so the flanks can never look like part of a tract.
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{PAD}{core}{PAD}")
+}
+
+fn provider(sequence: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", sequence.to_string());
+    provider
+}
+
+/// The SPDI triple, rendered.
+fn spdi(sequence: &str, input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    hgvs_to_spdi(&variant, &provider(sequence))
+        .unwrap_or_else(|e| panic!("`{input}` must convert to SPDI: {e}"))
+        .to_string()
+}
+
+/// The conversion error, for the cases that must still be refused.
+fn spdi_err(sequence: &str, input: &str) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    match hgvs_to_spdi(&variant, &provider(sequence)) {
+        Ok(triple) => panic!("`{input}` must not convert, got {triple}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// A 3-copy `CAG` tract at 259-267, soft-masked; `GG` flanks keep it isolated.
+const MASKED_CAG: &str = "GGcagcagcagGG";
+/// The byte-identical tract with no masking, as the control.
+const UPPER_CAG: &str = "GGCAGCAGCAGGG";
+
+/// The headline: on a soft-masked tract the two spellings of one repeat still
+/// denote one sequence.
+///
+/// Before the fix the anchored form gave `258:CAG:CAGCAGCAGCAGCAG` here — a
+/// one-unit deletion span, so the replacement left the tract at seven copies
+/// while the description said five.
+#[test]
+fn the_two_spellings_agree_on_a_soft_masked_tract() {
+    let seq = padded(MASKED_CAG);
+    let expected = "TEMPLATE:258:CAGCAGCAG:CAGCAGCAGCAGCAG";
+    assert_eq!(spdi(&seq, "TEMPLATE:g.259CAG[5]"), expected);
+    assert_eq!(spdi(&seq, "TEMPLATE:g.259_267CAG[5]"), expected);
+}
+
+/// Masking is not information: the triple must not depend on it.
+///
+/// Stated as an equality against the uppercase twin rather than as a second
+/// literal, because the property is "the reference's case convention does not
+/// reach the output", and a literal on each side would pass even if both had
+/// moved together.
+#[test]
+fn a_soft_masked_tract_converts_as_its_uppercase_twin() {
+    let masked = padded(MASKED_CAG);
+    let upper = padded(UPPER_CAG);
+    for input in [
+        "TEMPLATE:g.259CAG[5]",
+        "TEMPLATE:g.259_267CAG[5]",
+        // A count *below* the reference count contracts the tract; the tract
+        // still has to be found at its full extent for that to be right.
+        "TEMPLATE:g.259CAG[1]",
+        "TEMPLATE:g.259_267CAG[1]",
+    ] {
+        assert_eq!(
+            spdi(&masked, input),
+            spdi(&upper, input),
+            "`{input}` must not depend on the reference's masking"
+        );
+    }
+}
+
+/// The same, for a single-base unit — the shape where the truncation is easiest
+/// to mistake for a correct answer, because a one-base span looks like exactly
+/// what a one-position anchor should produce.
+#[test]
+fn a_soft_masked_single_base_tract_spans_the_whole_run() {
+    let seq = padded("GGaaaGG");
+    let expected = "TEMPLATE:258:AAA:AAAAA";
+    assert_eq!(spdi(&seq, "TEMPLATE:g.259A[5]"), expected);
+    assert_eq!(spdi(&seq, "TEMPLATE:g.259_261A[5]"), expected);
+}
+
+/// The discriminating case: folding the window must not make a span that is
+/// genuinely not the declared repeat convert anyway.
+///
+/// The obvious over-general fix — relax the unit-match check instead of the
+/// search — would accept this, because the fallback span is one unit wide and
+/// one unit always matches itself. `ATGCAT` is divisible by `AT` and is not
+/// `AT[3]`, so it must still be refused, in either case convention.
+#[test]
+fn a_non_repeat_span_is_still_refused_when_soft_masked() {
+    for core in ["GGatgcatGG", "GGATGCATGG"] {
+        let seq = padded(core);
+        let err = spdi_err(&seq, "TEMPLATE:g.259_264AT[3]");
+        assert!(
+            err.contains("does not match repeat unit"),
+            "`{core}` must still be refused as a non-repeat span, got: {err}"
+        );
+    }
+}
+
+/// The second discriminating case: an anchor that lands out of phase with the
+/// tract is refused, and is refused *identically* whether or not the reference
+/// is masked.
+///
+/// This is the pre-existing behaviour the fix must leave alone. `g.260CAG[5]`
+/// points at the second base of the run, where no `CAG` copy begins, so the
+/// search finds nothing and the unit-wide fallback span (`AGC`) is correctly
+/// judged a mismatch. Pinning it here keeps a later widening of the search from
+/// quietly inventing a tract at an anchor the spec's start-only format does not
+/// name.
+#[test]
+fn an_out_of_phase_anchor_is_refused_in_both_case_conventions() {
+    let masked = spdi_err(&padded(MASKED_CAG), "TEMPLATE:g.260CAG[5]");
+    let upper = spdi_err(&padded(UPPER_CAG), "TEMPLATE:g.260CAG[5]");
+    assert_eq!(masked, upper, "masking must not change the diagnostic");
+    assert!(
+        masked.contains("repeat span TEMPLATE:260-262 does not match repeat unit CAG"),
+        "unexpected diagnostic: {masked}"
+    );
+}
+
+/// The whole census the module doc quotes, as a standing check: no anchored
+/// conversion of a tandem tract may disagree with the range spelling of that
+/// same tract, on either case convention.
+///
+/// Written as a sweep rather than as more literals because the defect was
+/// uniform across units and copy counts — it was 112 rows, not one shape — and
+/// a per-shape test would have been satisfied by a fix that only handled the
+/// unit it was written for.
+#[test]
+fn no_anchored_conversion_disagrees_with_its_range_spelling() {
+    let mut compared = 0usize;
+    let mut disagreed = Vec::new();
+
+    for unit in ["A", "AT", "CAG", "GATC"] {
+        for copies in 2..=5usize {
+            let tract = unit.repeat(copies);
+            for masked in [false, true] {
+                let core = if masked {
+                    format!("GG{}GG", tract.to_ascii_lowercase())
+                } else {
+                    format!("GG{tract}GG")
+                };
+                let seq = padded(&core);
+                let tract_start = 259u64;
+                let tract_end = tract_start + tract.len() as u64 - 1;
+
+                for n_post in [1usize, copies + 2] {
+                    let ranged = format!("TEMPLATE:g.{tract_start}_{tract_end}{unit}[{n_post}]");
+                    let expected = spdi(&seq, &ranged);
+                    // Only in-phase anchors name a tract start; an out-of-phase
+                    // one is refused, which the test above pins.
+                    for anchor in (tract_start..=tract_end).step_by(unit.len()) {
+                        let anchored = format!("TEMPLATE:g.{anchor}{unit}[{n_post}]");
+                        compared += 1;
+                        let actual = spdi(&seq, &anchored);
+                        if actual != expected {
+                            disagreed.push(format!(
+                                "{core}: {anchored} -> {actual}, {ranged} -> {expected}"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        disagreed.is_empty(),
+        "{} anchored conversions disagree with their range spelling:\n{}",
+        disagreed.len(),
+        disagreed.join("\n")
+    );
+    // Second, and only after the substantive assertion: a floor on the corpus,
+    // so a generator change that quietly stops emitting cases cannot turn this
+    // into a green test that compares nothing.
+    assert_eq!(compared, 224, "corpus size changed; re-read the census");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -218,6 +218,7 @@ mod issue_1429_derivation_honours_shuffle_direction;
 mod issue_1431_single_position_repeat_anchor;
 mod issue_1437_dup_read_span_interior_sibling;
 mod issue_1448_partial_span_overlap;
+mod issue_1452_soft_masked_repeat_span;
 mod issue_1491_soft_masked_repeat_normalization;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1452.

## The defect — and a corrected diagnosis

#1452 reports that `hgvs_to_spdi` **cannot convert** a soft-masked repeat, "on any spelling — anchored or explicit-range", naming two case-sensitive comparisons. Measured on `origin/main` at `a530cdaf`, neither half of that holds, and the real behaviour is worse than a refusal.

**The unit-match check is already case-insensitive.** Both of its operands (`del_str`, `unit_str`) go through `apply_alphabet`, which upper-cases. So the explicit-range spelling was never affected, and no failure on this path is a conversion *error*.

**The anchored spelling does not fail — it silently emits a truncated span.** Only the tract search (`normalize::rules::count_tandem_repeats`, called from `resolve_repeat_tract_span`) compares raw reference bytes, and it compares them against a unit that has already been upper-cased. On a soft-masked tract it therefore matches nothing, and the no-run branch falls back — deliberately, so a genuine mismatch is reported by the caller's one diagnostic — to the **unit-wide** span at the anchor. The caller then upper-cases those bases, one unit trivially matches one unit, and the check passes:

| spelling | uppercase `CAGCAGCAG` | soft-masked `cagcagcag` |
|---|---|---|
| `g.259CAG[5]` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` | `258:CAG:CAGCAGCAGCAGCAG` |
| `g.259_267CAG[5]` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` | `258:CAGCAGCAG:CAGCAGCAGCAGCAG` |

The masked anchored form applies to **seven** copies, not the five it says: the two tract units the truncated span left untouched survive the replacement.

In other words, soft-masking silently drops the anchored spelling back to the **pre-#1431 reading** — the same "the anchor names one unit" answer that #1431 was filed to remove. It is #1431 reopened by a different door, which is why the issue's "pre-existing and independent of #1431" framing is not quite right either: the truncation-by-failed-search route is specific to the tract search #1431 added.

Invisible to every oracle, for the same reasons #1431 was: both forms parse (`FERRO_ASSERT_REPARSE`), both are in bounds (`FERRO_ASSERT_IN_BOUNDS`), and both are fixed points (`FERRO_ASSERT_IDEMPOTENT`).

### Census

Anchored conversions of `A` / `AT` / `CAG` / `GATC` tracts, 2..=5 copies, every anchor position, two target counts — 560 rows. 336 anchor out of phase with the tract and are refused, identically in both case conventions. Of the 224 that remain, 112 are soft-masked and 112 are not, and the split was total:

| | disagrees with the range spelling | before | after |
|---|---|---|---|
| soft-masked, in phase | 112 | **112 (all)** | 0 |
| uppercase, in phase | 112 | 0 | 0 |
| out of phase (either) | 336 | refused, unchanged | refused, unchanged |

## The fix

Normalise the fetched window **once, at the fetch** — `fetch_normalized_reference_bases` — as the issue's "suggested shape" asks, so the tract search and the unit-match check see the same bytes by construction rather than by each remembering to fold. This mirrors how `normalize::merge::canonical_base_byte` centralises the `r.` uracil/thymine equivalence.

The issue warns that folding one of the two comparisons alone would be worse than folding neither. That warning does not apply, because there are not two sites: the unit-match check already folds. There is one blind site, and folding it is exactly what makes the two spellings agree.

Normalising with `apply_alphabet` rather than a bare `to_ascii_uppercase` is deliberate and does one thing more than the issue asked for: on the `r.` axis the unit has had `U` rewritten to `T`, so an uppercase-only window would still miss a `U`-spelled tract and truncate it by the identical route. `a_uracil_spelled_tract_is_found_on_the_rna_axis` pins both directions of that.

Scope: one file, `src/spdi/convert.rs`.

## Unchanged on purpose

Two discriminating tests, because the obvious wider fix — relax the unit-match check instead of the search — passes every happy-path assertion above:

- `a_non_repeat_span_is_still_refused_when_soft_masked` — `ATGCAT` is divisible by `AT` and is not `AT[3]`; it must still be refused, in either case convention. A relaxed unit check would accept it, since the fallback span is one unit wide and one unit always matches itself.
- `an_out_of_phase_anchor_is_refused_in_both_case_conventions` — `g.260CAG[5]` names the second base of the run, where no copy begins. It was refused before and is refused now, with a byte-identical diagnostic on masked and unmasked references. This keeps a later widening of the search from quietly inventing a tract at an anchor the spec's start-only format does not name.

## Representation stability

**No normalized HGVS string can move.** The change is confined to `src/spdi/convert.rs`, and nothing in normalization's canonical path reaches it: `src/normalize/merge.rs` names `hgvs_to_spdi` only in doc comments (lines 5418, 8894), never calls it.

Three leaf surfaces do reach it, and all three move:

| surface | route | pre-fix symptom on an anchored repeat over a soft-masked tract |
|---|---|---|
| `Normalizer::to_spdi` (`src/normalize/mod.rs:1746`), public `hgvs_to_spdi`, the Python binding | direct | a truncated SPDI triple |
| `Normalizer::apply_to_reference` (`src/normalize/mod.rs:1705`) and its Python binding (`src/python.rs:1468`) | `spdi::apply::variant_edit_triples` (`src/spdi/apply.rs:457`) | **the wrong applied nucleotide sequence** — the one-unit deletion span left the tract at seven copies while the description said five |
| `EquivalenceChecker` | `src/equivalence/checker.rs:386` | an anchored-vs-range comparison over a masked tract could return the wrong equivalence verdict |

`apply_to_reference` is the loudest of the three: it returns bases, not a triple, so the truncation surfaced as a corrupted sequence rather than as a coordinate a reader might sanity-check. All three move in the correcting direction — the characterisation below applies unchanged to each.

`examples/dump_normalized_corpus.rs` was **not** run, because it is structurally blind to this change and a `0 moved` from it would be evidence of the corpus, not of the diff: it measures normalized HGVS output, which this cannot touch, and its providers serve uppercase sequences, so it cannot build the input condition either. Per the "a corpus zero is a claim about the corpus" note in the layout `CLAUDE.md`, reporting that zero would be the dishonest form.

What *does* move is SPDI output (and, through `apply_to_reference`, the applied sequence derived from it). Characterised exactly:

- **only** anchored (`g.<pos><unit>[n]`) repeats, **only** where the reference tract is soft-masked or `U`-spelled;
- every such row was **already wrong** — it denoted a different sequence than the range spelling of the same variant — so this is a correctness fix with no stable-form casualties, not a tie broken against a shipped representation;
- **0 uppercase rows move**, which is the whole shipped surface for any consumer whose reference is not soft-masked.

The real evidence, in place of the corpus: the full suite green with **nothing re-blessed**. For an output-moving change that is the strong signal — every existing expectation already agreed with the new answer.

## Verification

```
cargo fmt --all --check                                        # clean
cargo clippy --all-features --all-targets -- -D warnings       # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  FERRO_SWEEP_SEEDS=full cargo nextest run --features dev
#   Summary [1888.020s] 9531 tests run: 9531 passed (16 slow), 145 skipped
```

All three oracles, and the full sweep corpus rather than the 4-seed default prefix. No Python surface is touched, so the `python-lint` / `python-wheel-test` / `abi3-floor` additions do not apply.

