### PR TITLE
fix(reference): serve LRG genomic bases from the LRG record, not the placement

### DIFF
--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1366,25 +1366,48 @@ impl MultiFastaProvider {
         })
     }
 
-    /// Resolve a sequence name, trying various forms
-    fn resolve_name(&self, name: &str) -> Option<String> {
-        // Direct lookup
+    /// The indexed FASTA record holding `name`'s **own** bases, or `None` when
+    /// the reference ships no record for that exact accession.
+    ///
+    /// This is the *substitution-free* half of [`resolve_name`](Self::resolve_name):
+    /// it accepts `name` itself, plus the one rename LRG's own file format
+    /// imposes — a bare `LRG_<N>` genomic accession is stored under the record
+    /// name `LRG_<N>g` (LRG's suffix convention; transcripts are `LRG_<N>t<k>`,
+    /// proteins `LRG_<N>p<k>`). That is a spelling of the same sequence, not a
+    /// fallback to a *different* one: LRG accessions carry no version, so
+    /// `LRG_<N>` denotes `LRG_<N>g` and nothing else. It deliberately omits
+    /// `resolve_name`'s version-strip and `chr`-alias fallbacks, which do serve
+    /// a different sequence than the one asked for.
+    ///
+    /// Callers use it to ask "do we ship this accession's own bases?" before
+    /// falling back to reconstructing them from somewhere else — see
+    /// `get_sequence` / `get_sequence_length`, where a bare `prepared.contains`
+    /// answered "no" for every `LRG_<N>` and so handed all 1294 LRG records to
+    /// chromosome synthesis instead of to their own frozen sequence — silently
+    /// wrong for the 165 whose placement is not an exact affine (#1462).
+    fn own_record(&self, name: &str) -> Option<String> {
         if self.prepared.contains(name) {
             return Some(name.to_string());
         }
-
-        // LRG genomic accession: HGVS `g.` variants reference the genomic
-        // sequence by its bare accession `LRG_<N>`, but the FASTA record is
-        // indexed under the LRG suffix convention `LRG_<N>g` (transcripts are
-        // `LRG_<N>t<k>`, proteins `LRG_<N>p<k>`, both of which match the index
-        // directly above). Map the bare genomic accession to its `g`-suffixed
-        // record so `LRG_<N>:g.` normalization can fetch reference bases
-        // instead of silently no-op'ing (issue #487).
         if is_bare_lrg_genomic_accession(name) {
             let genomic = format!("{name}g");
             if self.prepared.contains(&genomic) {
                 return Some(genomic);
             }
+        }
+        None
+    }
+
+    /// Resolve a sequence name, trying various forms
+    fn resolve_name(&self, name: &str) -> Option<String> {
+        // Direct lookup, plus the LRG bare-genomic → `LRG_<N>g` record rename
+        // (#487): HGVS `g.` variants name the genomic sequence by its bare
+        // accession `LRG_<N>`, but the FASTA indexes it under LRG's suffix
+        // convention. Both are "this accession's own bases", so they live
+        // together in `own_record`; everything below this point substitutes a
+        // *different* sequence and must stay after it.
+        if let Some(own) = self.own_record(name) {
+            return Some(own);
         }
 
         // Try chromosome alias FIRST (before version fallback)
@@ -1796,12 +1819,28 @@ impl MultiFastaProvider {
         // offset 0 is the parent's first base — parent coordinate
         // `parent_start`. The mapping below assumes `parent_start == 1` (it maps
         // the 0-based offset `start` to 1-based parent coordinate `start + 1`).
-        // The only reachable caller today is the FASTA-less #728 derived `NG_`,
-        // which always has `parent_start == 1` (`derived_placement.rs`); an
-        // LRG/RefSeqGene placement with `parent_start > 1` is never routed here.
-        // Guard the assumption in debug builds — a `parent_start > 1` placement
-        // would otherwise read the wrong window (or fail loud via `parent_to_nc`
-        // returning `None`) rather than corrupt bases.
+        // Reachable callers are parents that have a placement but no record of
+        // their own: the FASTA-less #728 derived `NG_`, which is constructed
+        // with `parent_start == 1` (`derived_placement.rs`), and a record-less
+        // LRG, which carries whatever its XML states (`LRG_998`, in the test
+        // below, is exactly that shape). So `parent_start == 1` is an
+        // assumption about the placement data, not an invariant this function
+        // can enforce.
+        //
+        // Until #1462 the set was far wider: every bare `LRG_<N>` was routed
+        // here, because the callers gated on `prepared.contains(id)`, which is
+        // `false` for `LRG_<N>` (the record is named `LRG_<N>g`). One real LRG
+        // placement carries `parent_start == 1049` and tripped this very
+        // assertion; a further 164 passed it and quietly served chromosome
+        // bases in place of the frozen LRG record. The callers now gate on
+        // `own_record`, so an LRG *with* a record never reaches here.
+        //
+        // Guard the assumption in debug builds. Note this does not make the
+        // release build safe: `parent_to_nc` declines only a position *below*
+        // `parent_start`, so a window low enough fails loud while a deeper one
+        // silently maps to the wrong bases. Hardening it to fail closed in
+        // release is #1494; this PR narrows who can reach it rather than
+        // changing what it does.
         debug_assert_eq!(
             placement.parent_start, 1,
             "synthesize_parent_sequence assumes parent_start == 1; offset the window \
@@ -3321,7 +3360,7 @@ impl ReferenceProvider for MultiFastaProvider {
         // before the version-fuzzy `resolve_name` fallback below so an absent
         // *exact* version is reconstructed rather than silently served a sibling
         // version's bases.
-        if !self.prepared.contains(id) {
+        if self.own_record(id).is_none() {
             if let Ok(("", acc)) = crate::hgvs::parser::accession::parse_accession(id) {
                 if let Some(placement) = self.genomic_placement(&acc) {
                     return self.synthesize_parent_sequence(&placement, start, end);
@@ -3380,7 +3419,7 @@ impl ReferenceProvider for MultiFastaProvider {
         // Mirror `get_sequence`: a placement-only parent (#728 derived `NG_`)
         // has no FASTA record, so its length is the placed span on the
         // chromosome. Checked before the version-fuzzy `sequence_length`.
-        if !self.prepared.contains(id) {
+        if self.own_record(id).is_none() {
             if let Ok(("", acc)) = crate::hgvs::parser::accession::parse_accession(id) {
                 if let Some(placement) = self.genomic_placement(&acc) {
                     return Ok(placement.nc_end - placement.nc_start + 1);
@@ -3685,6 +3724,108 @@ mod tests {
         // An NG_ parent with no loaded RefSeqGene alignments gets no placement.
         let ng = crate::hgvs::variant::Accession::new("NG", "007485", Some(1));
         assert!(provider.genomic_placement(&ng).is_none());
+    }
+
+    /// An LRG that has **both** its own FASTA record and a chromosomal
+    /// placement must be served from the record — #1462.
+    ///
+    /// LRG genomic sequences are frozen reference standards; that is the whole
+    /// point of the accession. The LRG↔chromosome mapping is only an affine
+    /// approximation (a real LRG XML lists the `mismatch`/`lrg_ins`/`other_ins`
+    /// diffs the affine cannot express), so synthesizing an LRG's bases from
+    /// the chromosome serves a *different* sequence — shifted wherever an indel
+    /// intervenes, and substituted wherever a mismatch does.
+    ///
+    /// It was reachable because `get_sequence` gated the synthesis path on
+    /// `prepared.contains(id)`, which is `false` for every bare `LRG_<N>`: the
+    /// record is indexed as `LRG_<N>g`. Measured against the prepared reference
+    /// (1294 LRG records), **164** served at least one wrong base — 2,017,282
+    /// bases in total, 44 of them at the wrong length — and a 165th carried a
+    /// placement with `parent_start == 1049`, tripping
+    /// `synthesize_parent_sequence`'s debug assertion outright.
+    /// `LRG_292:g.160875` served `T` for the record's `G`, a `+2` shift.
+    ///
+    /// The fixture mirrors that shape: a 12-base LRG record placed on a 10-base
+    /// chromosome window (a 2-base LRG insertion the affine cannot represent),
+    /// with disjoint alphabets so a single served base names which path ran.
+    #[test]
+    fn lrg_with_its_own_record_is_served_from_the_record_not_the_placement() {
+        let dir = tempdir().unwrap();
+        let fasta_path = dir.path().join("ref.fna");
+        let fai_path = dir.path().join("ref.fna.fai");
+        {
+            let mut f = File::create(&fasta_path).unwrap();
+            writeln!(f, ">NC_000017.11").unwrap();
+            writeln!(f, "AAAAAAAAAA").unwrap();
+            writeln!(f, ">LRG_999g").unwrap();
+            writeln!(f, "CGCGCGCGCGCG").unwrap();
+        }
+        {
+            // name<TAB>length<TAB>offset<TAB>line_bases<TAB>line_bytes.
+            // ">NC_000017.11\n" = 14 bytes → offset 14; 10 bases + "\n" ends at
+            // 25; ">LRG_999g\n" = 10 bytes → offset 35.
+            let mut f = File::create(&fai_path).unwrap();
+            writeln!(f, "NC_000017.11\t10\t14\t10\t11").unwrap();
+            writeln!(f, "LRG_999g\t12\t35\t12\t13").unwrap();
+        }
+        let mut provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+
+        // A placement does exist for LRG_999 — this is the discriminator. The
+        // fix must not work merely by there being nothing to synthesize from.
+        let xml_dir = dir.path().join("lrg");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        std::fs::write(
+            xml_dir.join("LRG_999.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_000017.11" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="12" other_start="1" other_end="10" strand="1" />
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        provider.lrg_xml_dir = Some(xml_dir);
+        let lrg = crate::hgvs::variant::Accession::new("LRG", "999", None);
+        assert!(
+            provider.genomic_placement(&lrg).is_some(),
+            "fixture is only discriminating if a placement is available to be preferred"
+        );
+
+        // Exact strings, not a predicate: the two paths disagree at every base,
+        // so `"CGCG"` can only have come from the record.
+        assert_eq!(
+            provider.get_sequence("LRG_999", 0, 4).unwrap(),
+            "CGCG",
+            "LRG_999 must serve its own frozen record, not the placed chromosome window"
+        );
+        assert_eq!(
+            provider.get_sequence("LRG_999", 8, 12).unwrap(),
+            "CGCG",
+            "the tail past the placed span must come from the record too"
+        );
+        // The record's length, not the placed span's (12 vs 10) — the shape
+        // that made 44 real records report a length they do not have.
+        assert_eq!(provider.get_sequence_length("LRG_999").unwrap(), 12);
+
+        // Unchanged on purpose: an LRG with a placement but *no* record of its
+        // own is still synthesized from the chromosome. This is the #728 path
+        // the guard exists for, and narrowing it is the obvious over-fix.
+        let orphan = crate::hgvs::variant::Accession::new("LRG", "998", None);
+        std::fs::write(
+            provider.lrg_xml_dir.as_ref().unwrap().join("LRG_998.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_000017.11" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="10" other_start="1" other_end="10" strand="1" />
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        assert!(provider.genomic_placement(&orphan).is_some());
+        assert_eq!(
+            provider.get_sequence("LRG_998", 0, 4).unwrap(),
+            "AAAA",
+            "an LRG with no FASTA record of its own is still synthesized from the placement"
+        );
+        assert_eq!(provider.get_sequence_length("LRG_998").unwrap(), 10);
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Closes #1462.

## The defect

`MultiFastaProvider::get_sequence` and `get_sequence_length` gate the chromosome-synthesis path on `self.prepared.contains(id)`. That is `false` for **every** bare `LRG_<N>`, because the FASTA record is indexed under LRG's own suffix convention as `LRG_<N>g` (`resolve_name` has mapped it since #487, but the guard runs *before* `resolve_name`). So every LRG genomic accession was served by reconstructing its bases from the chromosome through the single-affine placement parsed out of the LRG XML — never from its own frozen record.

The issue is right about the symptom and slightly off about the mechanism: nothing is placed wrongly. The affine is as good as an affine can be; it simply cannot express the `mismatch` / `lrg_ins` / `other_ins` diffs that the LRG XML itself lists alongside the mapping. `LRG_292` has 3 LRG-inserted bases and 1 chromosome-inserted base before the probed position, which is exactly the reported `+2`.

That also means this is not really a per-accession offset — a shift is only what it looks like when you probe one window past an indel. The general case is "the chromosome's sequence, not the LRG's", which also substitutes bases at every `mismatch` diff with no shift at all.

Measured over the 1294 LRG records in the prepared reference, comparing each `LRG_<N>` against its own `LRG_<N>g` record across the whole record:

| | before | after |
|---|---|---|
| records serving ≥1 wrong base | **164** | 0 |
| total wrong bases served | **2,017,282** | 0 |
| records reporting the wrong length | **44** | 0 |
| records panicking on the `parent_start == 1` debug assert | **1** | 0 |

The 165th record carries a placement with `parent_start == 1049` and tripped `synthesize_parent_sequence`'s debug assertion outright — whose doc comment asserted that "an LRG/RefSeqGene placement with `parent_start > 1` is never routed here". That sentence was false; the comment is corrected in this PR.

A 20-base windowed probe gives the offset histogram `{-8: 1, -5: 1, -1: 12, 0: 1269, +1: 3, +2: 2, +5: 2, +6: 2, +23: 1}`. That confirms all three accessions the issue reported second-hand and flagged as unverified: `LRG_292` at `+2`, `LRG_311` at `-1`, and a `+23`.

## The fix

Adds `own_record()` — the substitution-free half of `resolve_name`. It accepts the accession itself, plus the one record rename LRG's file format imposes (`LRG_<N>` → `LRG_<N>g`), and deliberately **not** `resolve_name`'s version-strip and `chr`-alias fallbacks, which do serve a genuinely different sequence than the one asked for. Both synthesis guards now ask `own_record(id).is_none()` instead of `!prepared.contains(id)`.

Scoped there rather than at `resolve_name` because the guard's ordering is load-bearing: it runs *before* `resolve_name` on purpose, so that a #728 derived `NG_` whose exact version is absent is reconstructed rather than silently served a sibling version's bases. `own_record` preserves that ordering while fixing the one case where "not in the index under this exact name" did not mean "we do not ship this accession's bases". `resolve_name` now delegates its first two clauses to it, so the two cannot drift apart.

The only behavioural change is for a bare `LRG_<N>` that has an `LRG_<N>g` record. Nothing else can reach the new clause: `NG_` accessions are versioned and never match `is_bare_lrg_genomic_accession`.

## Unchanged on purpose

- **An LRG with a placement but no FASTA record of its own is still synthesized from the chromosome.** That is the #728 derived-parent path the guard exists for, and removing it is the obvious over-fix. The regression test pins it explicitly (`LRG_998`).
- **`LRG_<N>t<k>` / `LRG_<N>p<k>`** still resolve directly and are never remapped to the genomic record — `is_bare_lrg_genomic_accession` already rejected them, and the existing #487 test still covers it.
- **The affine placement itself is untouched.** `VariantProjector::project_to_genomic` still uses it to re-express transcript coordinates in an LRG parent's frame, and remains approximate for the same 164 accessions. That is a distinct defect in coordinate *projection* rather than base *serving*; this PR does not widen scope into it.

## Representation stability

**This PR moves normalized output for LRG genomic variants, and the moves are migrations.** Measured release-to-release on a real corpus, not just against `main`: 3,882 deterministic `g.` variants (3 per LRG record with length ≥ 1000 — a `delinsA`, a `del` and a `dup` at fixed fractions of each record), normalized against the prepared reference by the pre-fix binary and the post-fix binary.

- **rows compared: 3,882 · rows moved: 42 (1.1%) · accessions affected: 31 of 1,294**
- **All 42 were previously accepted** (`ok` → `ok`), so every one is a stored string that changes. None were previously rejected. This is the expensive direction, and it is stated plainly.
- Shapes moved: 17 `delins`, 17 `dup`, 8 `del`.
- **Every move is a correction, not a tie broken the other way.** The before-strings named the chromosome's base or position; the after-strings name the LRG record's. Examples:

  ```
  LRG_62:g.10696delinsA   before: g.10696T>A     after: g.10696C>A   (wrong ref base)
  LRG_20:g.34999del       before: g.34999del     after: g.35003del   (wrong shift target)
  LRG_42:g.5625delinsA    before: g.5625G>A      after: g.5625=      (record's base IS A)
  ```

  The last is the sharpest: the LRG record already has `A` at 5625, so `delinsA` is an identity — reported as a substitution only because the chromosome has `G` there.

- **Spec position:** this is not a case where either form is admissible. An `LRG_<N>:g.<p>` coordinate is defined against the LRG record, which is a frozen reference standard; the previously-shipped strings denoted a different sequence. The stability rule says to break a genuine tie toward the shipped form — there is no tie here, so the shipped form loses.

**The committed synthetic harness measures `0 of 78,028`, and that zero is structural.** Run properly — dumped at the base (`a530cdaf`) in a detached worktree, dumped at this branch, and diffed by `--compare`:

```
| total                                            | 78028        |
| **moved**                                        | **0 (0.0%)** |
| of which previously **accepted** (a migration)   | 0            |
| of which previously **not** a fixed point (free) | 0            |
```

covering all 15 shape families (`adjacent_junction_ins`, `coincident_bounds`, `del_plus_sub`, `delins_hiding_an_inversion`, `dup_plus_ins`, `dup_plus_sub`, `identity_member`, `inv_member`, `junction_interior_to_span`, `long_block_inversion`, `nested_spans`, `partial_overlap_spans`, `repeat_expansion`, `split_vs_spanning_delins`, `three_member_allele`).

**Do not read that as evidence of safety.** Per `CLAUDE.md`, a corpus zero is a claim about the corpus. This one is guaranteed *a priori*: `dump_normalized_corpus.rs` constructs only `MockProvider`, and its own doc comment puts prepared references explicitly out of scope. This diff touches only `MultiFastaProvider`, so no edit to this code could move a row here. The harness is blind to the property under change — not through a missing shape family, but by driving a different provider type entirely.

The real-reference corpus above is the measurement that counts, and it is the one that found the 42 moved rows.

**Confluence guards:** unaffected — no partitioning, shifting or merge logic is touched, and the full suite passes with nothing re-blessed.

## Verification

```
cargo fmt --all --check                                              # clean
cargo clippy --all-features --all-targets -- -D warnings             # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  FERRO_SWEEP_SEEDS=full cargo nextest run --features dev
  -> Summary [1221.735s] 9524 tests run: 9524 passed (13 slow), 145 skipped
```

**Nothing was re-blessed.** For an output-moving change that is the strong signal: every existing expectation already agreed with the new answer, because no committed test pinned a synthesized-LRG base.

The new unit test is discriminating — verified by reverting only the two guard sites and re-running, which fails with `left: "AAAA", right: "CGCG"`. Its fixture supplies a placement on purpose, so the test cannot pass merely because there is nothing to synthesize from, and it mirrors the real `LRG_292` shape (a 12-base record placed on a 10-base chromosome window, i.e. a 2-base LRG insertion the affine cannot represent) with disjoint alphabets so a single served base names which path ran.

Reference-backed census numbers were measured with a throwaway probe against the prepared reference (`FERRO_MANIFEST`); the probe is not part of the diff, and the durable guard is the unit test.
