### PR TITLE
fix(normalize): type a split-created span inv on the first pass

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -10882,8 +10882,8 @@ fn build_split_variants(
             if let (
                 DelinsSubedit::Substitution {
                     position: p1,
+                    reference: r1,
                     alternative: a1,
-                    ..
                 },
                 DelinsSubedit::IdentityAt {
                     position: pm,
@@ -10891,8 +10891,8 @@ fn build_split_variants(
                 },
                 DelinsSubedit::Substitution {
                     position: p3,
+                    reference: r3,
                     alternative: a3,
-                    ..
                 },
             ) = (&subedits[i], &subedits[i + 1], &subedits[i + 2])
             {
@@ -10916,18 +10916,17 @@ fn build_split_variants(
                         flush_substitution_run(&mut output, template, hgvs_start, &mut run);
                         let s = abs(*p1);
                         let e = abs(*p3);
+                        // Typed rather than assumed to be a `delins`, for the
+                        // reason `push_typed_replacement` gives. This branch
+                        // reaches an inversion only when the untouched middle
+                        // base is its own complement (`W`, `S`, `N`) — every
+                        // other base makes `alt[1] == bm != complement(bm)` and
+                        // rules the whole span out — which is why the reference
+                        // in `codon_triplet_over_an_ambiguous_centre_is_an_inversion`
+                        // carries an `N`.
+                        let ref_bases = [*r1, *bm, *r3];
                         let alt_bases = vec![*a1, *bm, *a3];
-                        output.push(build_variant_at(
-                            template,
-                            s,
-                            e,
-                            NaEdit::Delins {
-                                sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
-                                deleted: None,
-                                deleted_length: None,
-                                substitution_reference: None,
-                            },
-                        ));
+                        push_typed_replacement(&mut output, template, s, e, &ref_bases, alt_bases);
                         i += 3;
                         continue;
                     }
@@ -10981,11 +10980,117 @@ fn build_split_variants(
     output
 }
 
+/// Emit one split member spanning `[start_1based, end_1based]`, typed under the
+/// spec's edit priority instead of assumed to be a `delins` (#1454).
+///
+/// `build_split_variants` re-groups the sub-edits `decompose_delins` reports,
+/// and both of its multi-base groupings — the codon-frame triplet and the
+/// adjacent-substitution run — **form spans that did not exist when
+/// `decompose_delins` typed the input**. The inversion test it ran was against
+/// the input's own maximal contiguous mismatch runs, and it deliberately does
+/// not carve a reverse-complement *sub*-run out of a longer contiguous change
+/// (#1034, #1040). But once a re-grouping has made such a sub-run a member in
+/// its own right, `general.md:56` applies to it directly: inversion outranks
+/// deletion-insertion, and `delins.md:5` defines a delins as a replacement
+/// "which is not a substitution or inversion", so `delins` over a
+/// reverse-complement span is not a description the spec admits at all. The
+/// same argument `merge::coalesce_whole_block_inversion` makes for the
+/// derivation's pieces, made here for the split's members.
+///
+/// Before this, that typing arrived one normalization pass late. The member was
+/// emitted as a `delins`, and the *next* pass's per-member pipeline re-typed it
+/// through `normalize_na_edit`'s Delins arm — the same
+/// [`rules::canonicalize_delins`] called here — so the first output was not a
+/// fixed point:
+///
+/// ```text
+/// NM_TEST.1:c.10_15delinsTAATAT
+///   pass 1 -> NM_TEST.1:c.[10_12delinsTAA;13_15delinsTAT]
+///   pass 2 -> NM_TEST.1:c.[10_12delinsTAA;13_15inv]
+/// ```
+///
+/// The typing authority is [`rules::canonicalize_delins`] rather than an
+/// open-coded reverse-complement test, precisely so this pass and the next one
+/// cannot disagree: reaching the fixed point in one pass means answering the
+/// question the second pass would ask, with the function it would ask it of.
+///
+/// Only `Inversion` can come back for these inputs, which is what makes the
+/// narrow match sound rather than lossy. Both groupings hand over equal-length
+/// slices whose first and last positions are mismatches, so `Identity`
+/// (needs every position equal), `Duplication` (needs `alt.len() == 2 *
+/// ref.len()`), `Insertion`/`Deletion` (need an empty side) and `Substitution`
+/// (needs a length-1 post-trim range, but greedy shared-affix trimming cannot
+/// consume a mismatched end) are all unreachable. Anything else is therefore a
+/// change in that function's contract, and falling through to `delins` — the
+/// form this code emitted unconditionally before — is the safe reading of it.
+fn push_typed_replacement(
+    output: &mut Vec<HgvsVariant>,
+    template: &HgvsVariant,
+    start_1based: u64,
+    end_1based: u64,
+    ref_bases: &[Base],
+    alt_bases: Vec<Base>,
+) {
+    debug_assert_eq!(
+        ref_bases.len(),
+        alt_bases.len(),
+        "a split member replaces its span base for base"
+    );
+    let edit = if spans_a_whole_inversion(ref_bases, &alt_bases) {
+        // Canonical form states neither the inverted bases nor the length
+        // (`inversion.md`, #352), matching `canonicalize_edit`'s own arm.
+        NaEdit::Inversion {
+            sequence: None,
+            length: None,
+        }
+    } else {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
+            deleted: None,
+            deleted_length: None,
+            substitution_reference: None,
+        }
+    };
+    output.push(build_variant_at(template, start_1based, end_1based, edit));
+}
+
+/// Whether replacing `ref_bases` with `alt_bases` inverts the **whole** span.
+///
+/// `U` is folded to `T` on both sides before the comparison, exactly as
+/// `apply_canonical_split` does before calling `decompose_delins`: on the `r.`
+/// axis the alt bases come from the author's literal (so they may be `U`) while
+/// the transcript reference is `T`, and [`rules::is_revcomp`]'s complement table
+/// maps `A` to `T`, never to `U`. Without the fold an `r.` inversion reads as an
+/// ordinary delins and the axis silently keeps the defect this closes.
+///
+/// A partial match is rejected rather than emitted narrower: a shortened range
+/// would leave the peeled outer bases undescribed, and this function's callers
+/// have no way to emit them. It cannot arise for their inputs — a peelable
+/// outer pair means `alt[first] == ref[first]`, i.e. an identity where both
+/// callers guarantee a mismatch — so the guard costs nothing and is the
+/// conservative reading if that ever stops holding.
+fn spans_a_whole_inversion(ref_bases: &[Base], alt_bases: &[Base]) -> bool {
+    // `inversion.md` requires more than one nucleotide; a one-base complement is
+    // a substitution, which `flush_substitution_run` already emits directly.
+    if ref_bases.len() < 2 || ref_bases.len() != alt_bases.len() {
+        return false;
+    }
+    let to_bytes =
+        |bases: &[Base]| normalize_t_u(&bases.iter().map(|base| *base as u8).collect::<Vec<u8>>());
+    let ref_bytes = to_bytes(ref_bases);
+    let alt_bytes = to_bytes(alt_bases);
+    matches!(
+        rules::canonicalize_delins(&ref_bytes, 0, ref_bytes.len(), &alt_bytes),
+        rules::DelinsCanonical::Inversion { start, end } if start == 0 && end == ref_bytes.len()
+    )
+}
+
 /// Flush a pending run of consecutive substitution sub-edits into `output`.
 /// A length-1 run emits a `Substitution`; a length-2+ run emits a single
 /// `Delins` over `[run.first.position, run.last.position]` with `sequence`
-/// = concatenated `alternative` bases. See `build_split_variants` for the
-/// spec rationale (issue #182).
+/// = concatenated `alternative` bases — or an `Inversion` when that span is a
+/// whole reverse complement, see [`push_typed_replacement`]. See
+/// `build_split_variants` for the spec rationale (issue #182).
 fn flush_substitution_run(
     output: &mut Vec<HgvsVariant>,
     template: &HgvsVariant,
@@ -11012,18 +11117,9 @@ fn flush_substitution_run(
     }
     let s = abs(run.first().unwrap().0);
     let e = abs(run.last().unwrap().0);
-    let alt_bases: Vec<Base> = run.drain(..).map(|(_, _, a)| a).collect();
-    output.push(build_variant_at(
-        template,
-        s,
-        e,
-        NaEdit::Delins {
-            sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
-            deleted: None,
-            deleted_length: None,
-            substitution_reference: None,
-        },
-    ));
+    let (ref_bases, alt_bases): (Vec<Base>, Vec<Base>) =
+        run.drain(..).map(|(_, r, a)| (r, a)).unzip();
+    push_typed_replacement(output, template, s, e, &ref_bases, alt_bases);
 }
 
 /// Normalize DNA `T` and RNA `U` to a single byte (`T`) so byte-wise

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -45,15 +45,52 @@
 //! just works. Its parameters are what the pins are measured over: regenerating
 //! with different `--seeds` re-rolls every number here.
 //!
-//! # The pins are per oracle configuration
+//! # The pins were once per oracle configuration, and no longer are (#1454)
 //!
-//! Each direction carries two pinned censuses, selected by [`expected_census`]:
-//! one for a plain run and one for `FERRO_ASSERT_IDEMPOTENT=1`. Two classes
-//! normalize to a non-fixed-point output (#1454), so the oracle turns them into
-//! panics that are counted `declined` instead of two distinct outputs. CI runs
-//! both configurations — `Test` without the oracles, `test-oracle` with them —
-//! so one pin could only ever be green in one job. Both collapse to a single
-//! constant once #1454 is fixed.
+//! Each direction used to carry two pinned censuses, selected by an
+//! `expected_census` helper: one for a plain run and one for
+//! `FERRO_ASSERT_IDEMPOTENT=1`. Two classes normalized to a non-fixed-point
+//! output (#1454), so the oracle turned them into panics that were counted
+//! `declined` rather than two distinct outputs, and one pin could only ever be
+//! green in one of CI's two jobs.
+//!
+//! #1454 is fixed, `declined` is 0 in both configurations, and the two censuses
+//! are now byte-identical — so there is one constant per direction again.
+//!
+//! **The collapse did not land where this module predicted, and the difference
+//! is the useful part.** The old text expected `converged` to rise by two. It
+//! rises by *one* per direction (3': 6632 -> 6633; 5': 6627 -> 6628), and it
+//! *falls* by one against the oracle pins (6634 -> 6633; 6629 -> 6628).
+//!
+//! Measured per class rather than inferred from the net figure — a `+1` is also
+//! what "converged three, broke two" looks like, and the two must be told apart.
+//! Diffing every class's output set across the fix: **exactly one class changes
+//! convergence status, and none regresses.**
+//!
+//! ```text
+//! s04-c-m2-sep3-p4-rot4   the pure #1454 class
+//!   before  [13_15delinsTAA;16_19delinsTAAT] | [13_15delinsTAA;16_19inv]
+//!   after   [13_15delinsTAA;16_19inv]                            CONVERGED
+//!
+//! s00-c-m2-sep5-p1-rot4   the issue's own reproducer
+//!   before  [10_12delinsTAA;13_15delinsTAT]  | [9dup;15del]
+//!   after   [10_12delinsTAA;13_15inv]        | [9dup;15del]      still splits
+//! ```
+//!
+//! The second class had the #1454 defect too, and the fix corrects it — that
+//! member is a fixed point now. The class nonetheless still splits, because its
+//! competing output is a different **partition** of the same variant rather than
+//! a different typing of one member, and no amount of inversion typing merges
+//! `[9dup;15del]` with a two-member delins. That residual belongs to the
+//! #1235 / #1419-#1421 partition-non-uniqueness family and is deliberately left
+//! alone here: choosing between those two partitions moves shipped
+//! representations, which is its own measurement.
+//!
+//! So the `+2` was never reachable by fixing #1454. It was an artifact: under
+//! the oracle, `s00-c-m2-sep5-p1-rot4`'s delins spelling *panicked*, leaving
+//! `[9dup;15del]` as the only surviving outcome, and a class with one outcome
+//! scores as `converged`. The oracle was crediting the defect with a convergence
+//! that was really a suppressed output.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -89,7 +126,7 @@ const CDS_END: u64 = 63;
 /// figure is a baseline that must only ever go down, and `converged` a floor
 /// that must only ever go up.
 ///
-/// **58.8% of designed classes converge** (6 632 of 11 272). The 4 640 that do
+/// **58.8% of designed classes converge** (6 633 of 11 272). The 4 639 that do
 /// not are the measurement this module exists to make: nothing in the repo
 /// could state that number before, because only 650 real rows reach the
 /// partitioner at all — and `multi_member_cis_axis` measures 82% convergence
@@ -100,43 +137,15 @@ const CDS_END: u64 = 63;
 /// zero, so every divergence is two well-formed, sequence-preserving outputs
 /// for one variant. That is the confluence defect itself, not a parse failure
 /// or a corrupted sequence wearing its clothes.
+///
+/// `converged` was 6 632 before #1454; see the module docs for which single
+/// class moved and why the other #1454 class could not.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_632,
-    split_two: 4_506,
-    split_three: 115,
-    split_more: 19,
-    underdetermined: 0,
-    sequence_changed: 0,
-};
-
-/// The same corpus measured with `FERRO_ASSERT_IDEMPOTENT=1`.
-///
-/// **The census is oracle-dependent, and that is a finding rather than a
-/// nuisance.** Two classes normalize to an output that is not a fixed point —
-/// `c.10_15delinsTAATAT` yields `c.[10_12delinsTAA;13_15delinsTAT]`, whose
-/// second member is re-typed `13_15inv` only on the following pass (#1454).
-/// With the oracle off those two classes produce two distinct outputs and land
-/// in `split_two`. With it on they panic, are recorded as `declined`, and their
-/// class collapses to a single outcome — so `converged` rises by two and
-/// `split_two` falls by two.
-///
-/// Pinning both configurations is deliberate. CI's gating `Test` job runs
-/// without the oracles and `test-oracle` runs with them, so a single pin can
-/// only ever be green in one of them; and a census that silently reported a
-/// different number depending on an environment variable is exactly the
-/// profile-dependent pin `CLAUDE.md` warns about for `FERRO_SWEEP_SEEDS`.
-///
-/// **When #1454 is fixed these two constants collapse into one.** That is the
-/// signal to delete this one and [`expected_census`] with it.
-const THREE_PRIME_UNDER_IDEMPOTENCY_ORACLE: Census = Census {
-    classes: 11_272,
-    spellings: 47_392,
-    declined: 2,
-    converged: 6_634,
-    split_two: 4_504,
+    converged: 6_633,
+    split_two: 4_505,
     split_three: 115,
     split_more: 19,
     underdetermined: 0,
@@ -147,7 +156,7 @@ const THREE_PRIME_UNDER_IDEMPOTENCY_ORACLE: Census = Census {
 /// option, and confluence is a property of the normalizer rather than of one
 /// shuffle direction, so it is measured in full rather than spot-checked.
 ///
-/// It lands within five classes of the 3' figure (6 627 against 6 632), which
+/// It lands within five classes of the 3' figure (6 628 against 6 633), which
 /// is worth reading as evidence: the divergence is a property of how the
 /// partitioner splits a block, not of which end of an ambiguous run the shuffle
 /// walks to. A fix that moved only one of these two numbers would be treating a
@@ -156,42 +165,13 @@ const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_627,
-    split_two: 4_531,
+    converged: 6_628,
+    split_two: 4_530,
     split_three: 105,
     split_more: 9,
     underdetermined: 0,
     sequence_changed: 0,
 };
-
-/// The 5' census under `FERRO_ASSERT_IDEMPOTENT=1`. Same two #1454 classes, same
-/// +2 / -2 shift as [`THREE_PRIME_UNDER_IDEMPOTENCY_ORACLE`]; see its docs.
-const FIVE_PRIME_UNDER_IDEMPOTENCY_ORACLE: Census = Census {
-    classes: 11_272,
-    spellings: 47_392,
-    declined: 2,
-    converged: 6_629,
-    split_two: 4_529,
-    split_three: 105,
-    split_more: 9,
-    underdetermined: 0,
-    sequence_changed: 0,
-};
-
-/// Picks the pin matching the oracle configuration this run was launched under.
-///
-/// Reads the environment directly rather than caching: the census tests run once
-/// each, so there is no hot path to protect, and a `OnceLock` here would make the
-/// choice depend on which test happened to touch it first.
-fn expected_census(
-    without_oracle: &'static Census,
-    with_oracle: &'static Census,
-) -> &'static Census {
-    match std::env::var("FERRO_ASSERT_IDEMPOTENT") {
-        Ok(v) if v != "0" && !v.is_empty() => with_oracle,
-        _ => without_oracle,
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Corpus
@@ -503,18 +483,10 @@ fn the_corpus_is_a_dense_set_of_real_confluence_classes() {
 
 #[test]
 fn three_prime_confluence_census() {
-    assert_census(
-        ShuffleDirection::ThreePrime,
-        "3prime",
-        expected_census(&THREE_PRIME, &THREE_PRIME_UNDER_IDEMPOTENCY_ORACLE),
-    );
+    assert_census(ShuffleDirection::ThreePrime, "3prime", &THREE_PRIME);
 }
 
 #[test]
 fn five_prime_confluence_census() {
-    assert_census(
-        ShuffleDirection::FivePrime,
-        "5prime",
-        expected_census(&FIVE_PRIME, &FIVE_PRIME_UNDER_IDEMPOTENCY_ORACLE),
-    );
+    assert_census(ShuffleDirection::FivePrime, "5prime", &FIVE_PRIME);
 }

--- a/tests/it/issue_1454_split_member_inversion_typing.rs
+++ b/tests/it/issue_1454_split_member_inversion_typing.rs
@@ -1,0 +1,273 @@
+//! #1454 — a member the canonical split *creates* must be typed when it is
+//! created, not one normalization pass later.
+//!
+//! ```text
+//! NM_TEST.1:c.10_15delinsTAATAT
+//!   on main   -> NM_TEST.1:c.[10_12delinsTAA;13_15delinsTAT]
+//!   pass 2    -> NM_TEST.1:c.[10_12delinsTAA;13_15inv]
+//! ```
+//!
+//! `c.13_15` is `ATA` and `revcomp(ATA)` is `TAT`, so the second member is an
+//! exact inversion. The first output was therefore not a fixed point, which
+//! `FERRO_ASSERT_IDEMPOTENT=1` catches and the other two seam oracles do not —
+//! the string re-parses and every coordinate is in range.
+//!
+//! # The mechanism is in the split, not in the derivation
+//!
+//! The issue attributes this to the alternation loop in
+//! `merge::canonicalize_from_sequence`. That loop never runs for this input:
+//! `Normalizer::sequence_first_pass` admits a lone member only on `g.`/`m.`
+//! (`is_splittable_single_member`), so a lone `c.` delins declines on its first
+//! line. Instrumenting the loop against the reproducer logs nothing.
+//!
+//! The split comes from `apply_canonical_split` instead:
+//!
+//! 1. `rules::decompose_delins` reports
+//!    `[Sub@10; IdentityAt@11; Sub@12; Sub@13; Sub@14; Sub@15]`. It types an
+//!    inversion only when a **whole** maximal contiguous mismatch run is a
+//!    reverse complement, and deliberately does not carve a reverse-complement
+//!    *sub*-run out of a longer contiguous change (#1034, #1040). Positions
+//!    12-15 are one run, `TATA -> ATAT`, which is not one.
+//! 2. `build_split_variants` then applies the codon-frame exception
+//!    (`general.md:35-38`) and **consumes** `[Sub@10; IdentityAt@11; Sub@12]`
+//!    into `10_12delinsTAA`.
+//! 3. That leaves `Sub@13,14,15` — a span that did not exist when step 1 typed
+//!    the input, and which *is* a whole reverse complement. It fell to
+//!    `flush_substitution_run`, which emitted `Delins` unconditionally.
+//!
+//! So the re-grouping creates spans, and nothing re-typed them. `general.md:56`
+//! ranks inversion above deletion-insertion and `delins.md:5` defines a delins
+//! as a replacement "which is not a substitution or inversion", so `delins` over
+//! a reverse-complement span is not a description the spec admits at all.
+//!
+//! The fix routes both of `build_split_variants`' multi-base groupings through
+//! `rules::canonicalize_delins` — the same function the *next* pass reaches via
+//! `normalize_na_edit`'s Delins arm. Answering the question the second pass
+//! would ask, with the function it would ask it of, is what makes the two passes
+//! unable to disagree.
+//!
+//! # Measurements
+//!
+//! Over 479,682 rows — every `delins` of length 3, 4 and 5 at every position of
+//! three 63/64 nt cores, on the `c.` and `n.` axes, counted as
+//! `normalize(normalize(x)) != normalize(x)`:
+//!
+//! | | on `main` (`a530cdaf`) | with the fix |
+//! |---|---|---|
+//! | outputs that are not fixed points | 267 | **0** |
+//!
+//! All 267 are the one shape: a two-member split whose trailing member is an
+//! exact reverse complement, re-typed `inv` only on the following pass. They
+//! span 188 distinct payload pairs and both the 2 nt and 3 nt inversion widths
+//! (`c.1_5delinsATCAA -> c.[1_3delinsATC;4_5delinsAA]`, whose `4_5` is `TT`).
+//! Every row of the census sits on the `c.` axis; the `n.` half contributes
+//! none, for the reason `an_axis_without_a_reading_frame_is_not_re_split` pins.
+//!
+//! Representation stability, via `examples/dump_normalized_corpus.rs` against
+//! `a530cdaf`: **52 of 78,028 rows moved (0.1%)**, all of them in the
+//! `delins_hiding_an_inversion` family and all of the same shape — a trailing
+//! `delins` member becoming `inv`. Every moved row is an output that `main`
+//! itself rewrote on a second pass, so this converges on the string ferro
+//! already produced rather than inventing a third one; it is nonetheless a moved
+//! string for a consumer that normalizes once and stores the result.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The issue's core. Positions 10-15 are `AATATA`; `c.13_15` is `ATA`, whose
+/// reverse complement is `TAT`.
+const CORE: &str = "TTTTTTTTTAATATATTTTAATATAATTAAAAAAATAATTTTTATAAATATATTATTTTAAAAA";
+
+/// Positions 10/11/12 are `A`/`N`/`C`.
+///
+/// `N` is its own complement, which is what makes the codon-frame branch of the
+/// fix reachable at all: that branch emits `[Sub@i; IdentityAt@i+1; Sub@i+2]` as
+/// one three-base member whose centre is unchanged, so `alt[1] == ref[1]`, and a
+/// reverse complement needs `alt[1] == complement(ref[1])`. Only the
+/// self-complementary IUPAC codes (`W`, `S`, `N`) satisfy both. The endpoints
+/// are `A` and `C` rather than a complementary pair, so the span is a genuine
+/// inversion instead of collapsing to an identity.
+const AMBIGUOUS_CORE: &str = "GGGGGGGGGANCGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG";
+
+/// One transcript carrying `core`, coding or not.
+///
+/// The coding arm sets the CDS to the whole transcript so `c.N`, `n.N` and `r.N`
+/// all name transcript position `N` — which is what makes the cross-axis
+/// comparisons below controlled: the records differ only in whether a reading
+/// frame exists, never in which bases a position names.
+fn provider(accession: &str, core: &str, coding: bool) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = core.to_string();
+    let length = sequence.len() as u64;
+    let (cds_start, cds_end) = if coding {
+        (Some(1), Some(length))
+    } else {
+        (None, None)
+    };
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        sequence,
+        cds_start,
+        cds_end,
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(provider: &MockProvider, descriptor: &str) -> String {
+    let variant = parse_hgvs(descriptor).expect("fixture must parse");
+    Normalizer::new(provider.clone())
+        .normalize(&variant)
+        .expect("fixture must normalize")
+        .to_string()
+}
+
+/// Normalize, and assert the result is its own normal form.
+///
+/// The fixed-point half is asserted rather than left to
+/// `FERRO_ASSERT_IDEMPOTENT`, so these tests fail in a plain `cargo nextest run`
+/// too. CI's gating `Test` job runs without the oracles, so an oracle-only guard
+/// for #1454 would be green in the one job that blocks a merge.
+fn normalized_fixed_point(provider: &MockProvider, descriptor: &str) -> String {
+    let once = normalize(provider, descriptor);
+    let twice = normalize(provider, &once);
+    assert_eq!(
+        twice, once,
+        "`{descriptor}` normalized to a form that is not a fixed point",
+    );
+    once
+}
+
+/// The defect. The `inv` must be there on the **first** output.
+#[test]
+fn a_span_the_codon_exception_leaves_behind_is_typed_inv_on_the_first_pass() {
+    let provider = provider("NM_TEST.1", CORE, true);
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsTAATAT"),
+        "NM_TEST.1:c.[10_12delinsTAA;13_15inv]",
+    );
+}
+
+/// Every spelling of the variant reaches that one form, including the two-member
+/// spelling and the already-typed one.
+///
+/// Pinned as convergence rather than as three independent strings: a test that
+/// pinned only the first would go green if a later change moved the others onto
+/// a different form, which is the opposite of what this issue is about.
+#[test]
+fn the_other_spellings_of_the_variant_converge_on_the_same_form() {
+    let provider = provider("NM_TEST.1", CORE, true);
+    for input in [
+        "NM_TEST.1:c.10_15delinsTAATAT",
+        "NM_TEST.1:c.[10_12delinsTAA;13_15delinsTAT]",
+        "NM_TEST.1:c.[10_12delinsTAA;13_15inv]",
+    ] {
+        assert_eq!(
+            normalized_fixed_point(&provider, input),
+            "NM_TEST.1:c.[10_12delinsTAA;13_15inv]",
+            "spelling `{input}` did not converge",
+        );
+    }
+}
+
+/// The `r.` axis reaches the same `inv`, which is what pins the `U`/`T` fold.
+///
+/// `r.` is codon-frame-aware on a coding transcript (#275), so it takes the same
+/// branch as `c.`. Its alt bases come from the author's literal and so are `u`,
+/// while the transcript reference is `T`; `rules::is_revcomp` maps `A` to `T`
+/// and never to `U`, so without the fold this member reads as an ordinary delins
+/// and the `r.` axis silently keeps the defect.
+#[test]
+fn the_rna_axis_reaches_the_same_inversion() {
+    let provider = provider("NM_TEST.1", CORE, true);
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:r.10_15delinsuaauau"),
+        "NM_TEST.1:r.[10_12delinsuaa;13_15inv]",
+    );
+}
+
+/// The discriminating case for *where* the fix fires, and the reason the two
+/// tests above pin a reading-frame axis specifically.
+///
+/// Without a reading frame there is no codon-frame exception, so nothing
+/// consumes part of a maximal mismatch run and no new span is ever created —
+/// `decompose_delins` has already tested the only spans that reach
+/// `flush_substitution_run`, and its verdict stands. The same core and the same
+/// span therefore split differently and produce no `inv` at all.
+///
+/// This is what an over-general fix would break: a rule that typed *any*
+/// multi-base member as `inv` whenever its payload happened to be a reverse
+/// complement would have to change this row too, and it must not.
+#[test]
+fn an_axis_without_a_reading_frame_is_not_re_split() {
+    let coding = provider("NM_TEST.1", CORE, true);
+    let noncoding = provider("NR_TEST.1", CORE, false);
+    assert_eq!(
+        normalized_fixed_point(&coding, "NM_TEST.1:n.10_15delinsTAATAT"),
+        "NM_TEST.1:n.[10A>T;12_15delinsATAT]",
+    );
+    assert_eq!(
+        normalized_fixed_point(&noncoding, "NR_TEST.1:n.10_15delinsTAATAT"),
+        "NR_TEST.1:n.[10A>T;12_15delinsATAT]",
+    );
+}
+
+/// The #1034 / #1040 control: a reverse-complement **sub**-run of one contiguous
+/// change is still not carved out.
+///
+/// `c.12_15` is `TATA -> CTAT`, one contiguous mismatch run that is not itself a
+/// reverse complement, even though `13_15` (`ATA -> TAT`) inside it is. The fix
+/// types spans the split *creates*; it must not create one.
+#[test]
+fn a_reverse_complement_sub_run_of_one_contiguous_change_stays_a_delins() {
+    let provider = provider("NM_TEST.1", CORE, true);
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:c.12_15delinsCTAT"),
+        "NM_TEST.1:c.12_15delinsCTAT",
+    );
+}
+
+/// The second call site: the codon-frame triplet itself can be an inversion.
+///
+/// See [`AMBIGUOUS_CORE`] for why this needs a self-complementary centre — every
+/// other base makes the merged three-base member's middle column disagree with
+/// its own reverse complement, which rules the span out. Reachable rather than
+/// defensive, which is why the branch is typed instead of assumed.
+///
+/// **The input has to be longer than the triplet itself.** A lone
+/// `c.10_12delinsGNT` never reaches `build_split_variants` at all: a whole-span
+/// reverse complement is typed `inv` by `normalize_na_edit`'s Delins arm before
+/// any split happens, so it exercises the direct path and says nothing about the
+/// codon branch. Instrumenting that branch against the three-base spelling logs
+/// zero hits. Extending the input to `10_15` puts a second mismatch run after
+/// the triplet, which is what makes the split fire — and only then does the
+/// codon exception consume `[Sub@10; IdentityAt@11; Sub@12]` and hand `ANC ->
+/// GNT` to [`push_typed_replacement`] as a span the split created.
+#[test]
+fn codon_triplet_over_an_ambiguous_centre_is_an_inversion() {
+    let provider = provider("NM_TEST.1", AMBIGUOUS_CORE, true);
+    // `10_12` is `ANC` -> `GNT`, an exact reverse complement, and it is the
+    // codon-frame triplet the exception merges. `13_15` is `GGG` -> `AAA`,
+    // which is not one, so it stays a `delins` — the two outcomes of the same
+    // call site in one row.
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsGNTAAA"),
+        "NM_TEST.1:c.[10_12inv;13_15delinsAAA]",
+    );
+    // The three-base spelling is the same variant reached by the direct path,
+    // and must agree. Kept as the control that the two routes to `inv` do not
+    // disagree, not as coverage of the branch above.
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:c.10_12delinsGNT"),
+        "NM_TEST.1:c.10_12inv",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -18,6 +18,7 @@ mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
 mod issue_1450_derivation_exon_junction;
 mod issue_1453_noncoding_rna_repeated_member;
+mod issue_1454_split_member_inversion_typing;
 mod issue_1472_zero_length_read;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;


### PR DESCRIPTION
Closes #1454.

## The defect

A single-member `delins` normalized to a two-member allele whose second member was spelled `delins` when it was an exact inversion. Normalizing again re-typed it, so the first output was not a fixed point:

```
NM_TEST.1:c.10_15delinsTAATAT
  pass 1 -> NM_TEST.1:c.[10_12delinsTAA;13_15delinsTAT]
  pass 2 -> NM_TEST.1:c.[10_12delinsTAA;13_15inv]
```

`c.13_15` is `ATA` and `revcomp(ATA)` is `TAT`. `general.md:56` ranks inversion above deletion-insertion, and `delins.md:5` defines a delins as a replacement "which is not a substitution or inversion" — so `delins` over a reverse-complement span is not a description the spec admits at all. Pass 2 was right and pass 1 was wrong.

Only `FERRO_ASSERT_IDEMPOTENT` catches it; the output re-parses and every coordinate is in range.

## The mechanism is not where the issue says it is

The issue attributes this to the alternation loop in `merge::canonicalize_from_sequence`. **That loop never runs for this input.** `Normalizer::sequence_first_pass` admits a lone member only on `g.`/`m.` (`is_splittable_single_member`), so a lone `c.` delins declines on its first line — instrumenting the loop against the reproducer logs nothing. `merge.rs` is untouched by this PR.

The split comes from `apply_canonical_split`:

1. `rules::decompose_delins` reports `[Sub@10; IdentityAt@11; Sub@12; Sub@13; Sub@14; Sub@15]`. It types an inversion only when a **whole** maximal contiguous mismatch run is a reverse complement, and deliberately does not carve a reverse-complement *sub*-run out of a longer contiguous change (#1034, #1040). Positions 12-15 are one run, `TATA -> ATAT`, which is not one.
2. `build_split_variants` applies the codon-frame exception (`general.md:35-38`) and **consumes** `[Sub@10; IdentityAt@11; Sub@12]` into `10_12delinsTAA`.
3. That leaves `Sub@13,14,15` — a span that did not exist when step 1 typed the input, and which *is* a whole reverse complement. It fell to `flush_substitution_run`, which emitted `Delins` unconditionally.

The re-grouping creates spans; nothing re-typed them.

## The fix, and why it is scoped there

Both of `build_split_variants`' multi-base groupings now go through `rules::canonicalize_delins` — the same function the *next* pass reaches via `normalize_na_edit`'s Delins arm. Answering the question the second pass would ask, with the function it would ask it of, is what makes the two passes unable to disagree, rather than an open-coded reverse-complement test that could drift from it.

Only `Inversion` can come back for these inputs, which is what makes the narrow match sound rather than lossy: both groupings hand over equal-length slices whose first and last positions are mismatches, so `Identity`, `Duplication`, `Insertion`/`Deletion` and `Substitution` are all unreachable. Anything else is a contract change, and falling through to `delins` is the safe reading of it.

## Unchanged on purpose

- **A reverse-complement sub-run of one contiguous change stays a `delins`** — the #1034/#1040 control. `c.12_15delinsCTAT` is unchanged, even though `13_15` inside it is a reverse complement. The fix types spans the split *creates*; it must not create one.
- **Axes without a reading frame are untouched.** Without the codon exception nothing consumes part of a run, so no new span is ever created and `decompose_delins`' verdict stands. `n.10_15delinsTAATAT` splits to `[10A>T;12_15delinsATAT]` on both coding and non-coding records, before and after. Every row of the census below that moved is on the `c.` axis.

## Representation stability

`examples/dump_normalized_corpus.rs`, `a530cdaf` -> this branch:

| | rows |
|---|---|
| total | 78,028 |
| **moved** | **52 (0.1%)** |

All 52 are in `delins_hiding_an_inversion` — the family added for this issue, so the corpus is not structurally blind here — and all are one shape, a trailing `delins` member becoming `inv`:

```
before: NM_TEST.1:c.[1_3delinsGGG;4_6delinsCAT]
after : NM_TEST.1:c.[1_3delinsGGG;4_6inv]
```

**Read the direction, not the count.** Every moved row is an output `main` itself rewrote on a second pass, so this converges on the string ferro already produced rather than inventing a third one — the cheap direction of a confluence fix. It is nonetheless a moved string: a consumer that normalizes once and stores the result holds the old `delins` form. The harness's "0 previously accepted" column is a statement about *inputs* and does not say otherwise.

## Census

479,682 rows — every `delins` of length 3, 4 and 5 at every position of three 63/64 nt cores, on the `c.` and `n.` axes, counting `normalize(normalize(x)) != normalize(x)`:

| | `main` (`a530cdaf`) | with the fix |
|---|---|---|
| outputs that are not fixed points | **267** | **0** |

All 267 are the one shape, spanning 188 distinct payload pairs and both the 2 nt and 3 nt inversion widths.

## Re-blessed pins, and a prediction that did not hold

`cis_confluence_axis`'s two per-oracle censuses are now byte-identical, so `expected_census` and both `*_UNDER_IDEMPOTENCY_ORACLE` constants are deleted, as that module said to do when #1454 was fixed.

That module also predicted `converged` would rise by **two**. It rises by **one** per direction (3': 6632 -> 6633; 5': 6627 -> 6628). Measured per class rather than inferred from the net figure — a `+1` is also what "converged three, broke two" looks like — **exactly one class changes convergence status and none regresses**:

```
s04-c-m2-sep3-p4-rot4   the pure #1454 class
  before  [13_15delinsTAA;16_19delinsTAAT] | [13_15delinsTAA;16_19inv]
  after   [13_15delinsTAA;16_19inv]                            CONVERGED

s00-c-m2-sep5-p1-rot4   the issue's own reproducer
  before  [10_12delinsTAA;13_15delinsTAT]  | [9dup;15del]
  after   [10_12delinsTAA;13_15inv]        | [9dup;15del]      still splits
```

The second class had the #1454 defect too and the fix corrects it — that member is a fixed point now. The class still splits because its competing output is a different **partition** of the same variant rather than a different typing, and no inversion typing merges `[9dup;15del]` with a two-member delins. That residual belongs to the #1235 / #1419-#1421 partition-non-uniqueness family and is deliberately left alone: choosing between those two partitions moves shipped representations and needs its own measurement.

So the `+2` was never reachable by fixing #1454. It was an artifact — under the oracle, that class's delins spelling *panicked*, leaving `[9dup;15del]` as the only surviving outcome, and a class with one outcome scores as `converged`. The oracle was crediting the defect with a convergence that was really a suppressed output.

## Verification

```
cargo fmt --all --check                                         pass
cargo clippy --all-features --all-targets -- -D warnings         pass
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev                               9529 tests
```

The full-gate run was green except the two `cis_confluence_axis` census pins re-blessed here; both now pass in both oracle configurations.

Six new tests in `tests/it/issue_1454_split_member_inversion_typing.rs`, each asserting the fixed-point property directly rather than relying on `FERRO_ASSERT_IDEMPOTENT` — CI's gating `Test` job runs without the oracles, so an oracle-only guard would be green in the one job that blocks a merge. Two of them pin branches that would otherwise be untested: the `r.` axis reaches the same `inv` (which is what makes the `U`/`T` fold load-bearing), and the codon-frame triplet is itself reachable as an inversion over a self-complementary centre.

**The codon-triplet test needs an input longer than the triplet, and the first draft of it did not have one.** A lone `c.10_12delinsGNT` is a whole-span reverse complement, so `normalize_na_edit`'s Delins arm types it `inv` before any split happens — it exercises the direct path and never enters `build_split_variants`. Instrumenting the codon branch confirmed it: **0 hits** for that spelling against **11** for `a_span_the_codon_exception_leaves_behind_is_typed_inv_on_the_first_pass`. It also survived a sabotage (forcing `push_typed_replacement` to always emit `delins`) that correctly failed the other three inversion tests, which is what surfaced it.

The test now uses `c.10_15delinsGNTAAA` -> `c.[10_12inv;13_15delinsAAA]`. The trailing `GGG -> AAA` run is what forces the split, so the codon exception actually consumes `[Sub@10; IdentityAt@11; Sub@12]` and hands `ANC -> GNT` to `push_typed_replacement` as a span the split created. Verified discriminating: under the same sabotage it now fails with `10_12delinsGNT`. The three-base spelling is kept alongside it as an explicit control that the two routes to `inv` agree.
