### PR TITLE
fix(normalize): fold case when counting a tandem repeat tract

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1919,6 +1919,39 @@ pub fn duplication_to_repeat(
 /// boundary-anchor behavior, so delegating here would silently drop valid
 /// tracts. The genuinely shared piece across the ins→repeat / repeat paths is
 /// the 3'-phase step `three_prime_align_tract` (#852), not the tract finder.
+///
+/// # Case
+///
+/// Both scans compare with [`slice::eq_ignore_ascii_case`], because `ref_seq`
+/// comes from the reference and `repeat_unit` comes from the description. A
+/// reference FASTA is routinely soft-masked and a description is conventionally
+/// written in upper case, so a raw byte comparison finds no run at all on a
+/// masked tract — and, since this returns coordinates rather than a verdict,
+/// that surfaces as a *different canonical form* rather than as an error
+/// (#1491). Four of fifteen repeat inputs measured changed answer with case
+/// alone: `g.259_267CAG[2]` lowered to `g.265_267del` on an upper-case
+/// reference and stayed an unlowered repeat on the soft-masked twin, and three
+/// single-position anchors widened to their tract on one and not the other.
+///
+/// This is the convention the rest of this module already follows — the dup,
+/// delins-trimming and inversion-typing comparisons all fold — and folding
+/// costs nothing on an unmasked reference, where `eq_ignore_ascii_case` and
+/// `==` agree by definition. Note also that only *coordinates* leave this
+/// function, so folding here cannot put a lower-case base into an emitted
+/// sequence.
+///
+/// **Case is all this folds — it is not alphabet normalization.**
+/// `eq_ignore_ascii_case` maps `u` to `U`, never `U` to `T`, so an `r.` tract
+/// whose reference is spelled with uracil is still invisible here. The SPDI
+/// call site handles that separately by running the fetched window through
+/// `apply_alphabet` before it ever calls this function (#1452,
+/// `spdi::convert::fetch_normalized_reference_bases`), which folds case *and*
+/// rewrites `U` to `T`. The two are complementary rather than redundant, and
+/// the overlap is easy to misread as duplication: with this fold in place,
+/// reverting the SPDI-side normalization leaves every soft-masking test green
+/// and fails exactly one — `a_uracil_spelled_tract_is_found_on_the_rna_axis`.
+/// That single test is what pins the difference, so do not "simplify" either
+/// site away on the grounds that the other covers it.
 pub fn count_tandem_repeats(
     ref_seq: &[u8],
     pos: usize,
@@ -1940,7 +1973,7 @@ pub fn count_tandem_repeats(
     let mut start = pos;
     while start >= unit_len {
         let candidate = &ref_seq[start - unit_len..start];
-        if candidate == repeat_unit {
+        if candidate.eq_ignore_ascii_case(repeat_unit) {
             start -= unit_len;
         } else {
             break;
@@ -1951,7 +1984,7 @@ pub fn count_tandem_repeats(
     let mut end = start;
     let mut count = 0u64;
     while end + unit_len <= ref_seq.len() {
-        if &ref_seq[end..end + unit_len] == repeat_unit {
+        if ref_seq[end..end + unit_len].eq_ignore_ascii_case(repeat_unit) {
             count += 1;
             end += unit_len;
         } else {

--- a/tests/it/issue_1491_soft_masked_repeat_normalization.rs
+++ b/tests/it/issue_1491_soft_masked_repeat_normalization.rs
@@ -1,0 +1,227 @@
+//! #1491 — the canonical form of a repeat must not depend on whether the
+//! reference happens to be soft-masked.
+//!
+//! `normalize::rules::count_tandem_repeats` compared reference bytes to the
+//! description's unit with raw slice equality. A reference FASTA is routinely
+//! soft-masked and a description is conventionally written upper-case, so on a
+//! masked tract the search found no run — and because the function returns
+//! *coordinates* rather than a verdict, that did not surface as an error. It
+//! surfaced as a different canonical form:
+//!
+//! | input | uppercase reference | soft-masked reference |
+//! |---|---|---|
+//! | `g.259_267CAG[2]` | `g.265_267del` | `g.259_267CAG[2]` |
+//! | `g.259CAG[5]` | `g.259_267CAG[5]` | `g.259CAG[5]` |
+//! | `g.259A[7]` | `g.259_263A[7]` | `g.259A[7]` |
+//! | `g.259AT[6]` | `g.259_266AT[6]` | `g.259AT[6]` |
+//!
+//! Two shapes. A **contraction fails to lower**: `CAG[2]` over a 3-copy tract
+//! is a deletion of one copy and becomes `g.265_267del` on an unmasked
+//! reference, but stayed an unlowered repeat on the masked twin. And a
+//! **single-position anchor is not widened to its tract**, which leaves the
+//! bare anchor standing where the whole-range form is the canonical answer.
+//!
+//! Measured 4 of 15 repeat inputs moved with case alone; the other 11 — plain
+//! `del`/`dup`/`ins`, and explicit-range repeats whose count is not a
+//! contraction — agreed, which is the control showing this is the tract search
+//! and not a general masking problem.
+//!
+//! No oracle could see it. Every masked output above is well-formed, in bounds
+//! and a fixed point, so `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and
+//! `FERRO_ASSERT_IDEMPOTENT` all pass on it. The violated property is *parity
+//! between two references differing only in case*, which nothing asserted —
+//! the same blind spot #1318 and #1250 were each filed against for a different
+//! comparison site.
+//!
+//! Reference FASTAs are routinely soft-masked and masked bytes reach
+//! normalization from ordinary input (`issue_1318_soft_masked_delins.rs`,
+//! `issue_1235_cis_allele_confluence.rs::soft_masked_reference_yields_the_same_canonical_form`).
+
+use std::io::Write;
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+
+/// 256 `N`s, so core position 1 is `g.257` and each tract below starts at 259.
+/// `N` matches no unit used here, so the flanks cannot look like part of a run.
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{PAD}{core}{PAD}")
+}
+
+fn provider_for(sequence: &str) -> JsonProvider {
+    let n = sequence.len() as u64;
+    let json = serde_json::json!({
+        "version": "1.0",
+        "transcripts": [{
+            "id": "TEMPLATE-gene.1",
+            "chromosome": "TEMPLATE",
+            "strand": "+",
+            "sequence": sequence,
+            "cds_start": 1,
+            "cds_end": n - (n % 3),
+            "genomic_start": 1,
+            "genomic_end": n,
+            "protein_id": "TEMPLATE-gene.1",
+            "exons": [{"number": 1, "start": 1, "end": n,
+                       "genomic_start": 1, "genomic_end": n}],
+        }],
+        "genomic_sequences": {"TEMPLATE": sequence},
+    });
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    write!(f, "{json}").expect("write json");
+    JsonProvider::from_json(f.path()).expect("load reference")
+}
+
+fn normalize_with(sequence: &str, input: &str) -> String {
+    let normalizer = Normalizer::new(provider_for(sequence));
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse `{input}`: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize `{input}`: {e}"))
+        .to_string()
+}
+
+/// The four inputs whose canonical form moved with case, each with the answer
+/// pinned as a literal.
+///
+/// Both assertions per row are needed, and the pinned literal is the primary
+/// one: a parity-only check is satisfied by two *equally wrong* answers, and
+/// the whole defect class here is one comparison folding case while its
+/// siblings do. The parity assertion is the supplement — it says the reason the
+/// answer is right is not "the uppercase path happens to agree today".
+#[test]
+fn a_repeats_canonical_form_does_not_depend_on_soft_masking() {
+    for (core, input, expected) in [
+        // A contraction: `CAG[2]` over a 3-copy tract deletes one copy.
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.259_267CAG[2]",
+            "TEMPLATE:g.265_267del",
+        ),
+        // Single-position anchors, widened to the run they name.
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.259CAG[5]",
+            "TEMPLATE:g.259_267CAG[5]",
+        ),
+        ("GGAAAAAGG", "TEMPLATE:g.259A[7]", "TEMPLATE:g.259_263A[7]"),
+        (
+            "GGATATATATGG",
+            "TEMPLATE:g.259AT[6]",
+            "TEMPLATE:g.259_266AT[6]",
+        ),
+    ] {
+        let masked = normalize_with(&padded(&core.to_ascii_lowercase()), input);
+        assert_eq!(
+            masked, expected,
+            "canonical form of `{input}` when soft-masked"
+        );
+        let upper = normalize_with(&padded(core), input);
+        assert_eq!(
+            masked, upper,
+            "soft-masking must not change the canonical form of `{input}`"
+        );
+    }
+}
+
+/// The control: the eleven inputs that already agreed must keep agreeing, and
+/// keep their current answers.
+///
+/// This is what says the fix is the tract search rather than a blanket
+/// case-fold that happened to move everything. `del`/`dup`/`ins` reach their
+/// own (already folded) comparison sites, and an explicit-range repeat whose
+/// count is not a contraction never needs the tract's extent.
+#[test]
+fn the_shapes_that_already_agreed_are_untouched() {
+    // The expected form is pinned alongside the parity check on purpose. Parity
+    // alone (`masked == upper`) is satisfied by *both* sides moving together,
+    // which is exactly the regression this control exists to rule out — the
+    // "blanket case-fold that happened to move everything" in the doc above
+    // would keep every row of this table equal to itself while changing all of
+    // them. Only the literal says the answers did not move.
+    for (core, input, expected) in [
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.259_267CAG[5]",
+            "TEMPLATE:g.259_267CAG[5]",
+        ),
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.259_267del",
+            "TEMPLATE:g.259_267del",
+        ),
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.259_261dup",
+            "TEMPLATE:g.265_267dup",
+        ),
+        // Converges on the same `dup` as the row above, from an `ins` spelling.
+        (
+            "GGCAGCAGCAGGG",
+            "TEMPLATE:g.267_268insCAG",
+            "TEMPLATE:g.265_267dup",
+        ),
+        (
+            "GGAAAAAGG",
+            "TEMPLATE:g.259_263A[7]",
+            "TEMPLATE:g.259_263A[7]",
+        ),
+        (
+            "GGAAAAAGG",
+            "TEMPLATE:g.259_263A[2]",
+            "TEMPLATE:g.259_263A[2]",
+        ),
+        ("GGAAAAAGG", "TEMPLATE:g.259dup", "TEMPLATE:g.263dup"),
+        ("GGAAAAAGG", "TEMPLATE:g.263_264insA", "TEMPLATE:g.263dup"),
+        (
+            "GGATATATATGG",
+            "TEMPLATE:g.259_266AT[6]",
+            "TEMPLATE:g.259_266AT[6]",
+        ),
+        (
+            "GGATATATATGG",
+            "TEMPLATE:g.259_266AT[2]",
+            "TEMPLATE:g.259_266AT[2]",
+        ),
+        (
+            "GGATATATATGG",
+            "TEMPLATE:g.259_260dup",
+            "TEMPLATE:g.265_266dup",
+        ),
+    ] {
+        let masked = normalize_with(&padded(&core.to_ascii_lowercase()), input);
+        assert_eq!(masked, expected, "canonical form of `{input}` when masked");
+        let upper = normalize_with(&padded(core), input);
+        assert_eq!(
+            masked, upper,
+            "`{input}` agreed across case before the fix and must still"
+        );
+    }
+}
+
+/// The discriminating case: folding must not invent a tract out of bases that
+/// are not the declared unit.
+///
+/// The over-general version of this fix — comparing only lengths, or treating
+/// any base as matching — would widen `g.259A[5]` over `ACGTA` into a run that
+/// is not there. `N` is the sharpest probe because it is neither the unit nor
+/// its lower-case form, and the pad is built from it.
+#[test]
+fn folding_does_not_invent_a_tract() {
+    // `A` appears at 259 and 263 but the run is one base long in both cases, so
+    // the one-copy tract at 259 is the whole run and the repeat stands as
+    // written. (Measured, not inferred: an earlier draft of this test guessed
+    // `g.259_260insAA` and was wrong.)
+    let core = "GGACGTAGG";
+    for seq in [padded(core), padded(&core.to_ascii_lowercase())] {
+        assert_eq!(
+            normalize_with(&seq, "TEMPLATE:g.259A[3]"),
+            "TEMPLATE:g.259A[3]",
+            "a single `A` must not become a longer tract"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -218,6 +218,7 @@ mod issue_1429_derivation_honours_shuffle_direction;
 mod issue_1431_single_position_repeat_anchor;
 mod issue_1437_dup_read_span_interior_sibling;
 mod issue_1448_partial_span_overlap;
+mod issue_1491_soft_masked_repeat_normalization;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1491.

## The defect

The canonical form of a repeat depended on whether the reference happened to be soft-masked. `normalize::rules::count_tandem_repeats` compared reference bytes to the description's unit with raw slice equality, so on a lowercase tract it found no run at all — and because the function returns *coordinates* rather than a verdict, that did not surface as an error. It surfaced as a different answer:

| input | uppercase reference | soft-masked reference |
|---|---|---|
| `g.259_267CAG[2]` | `g.265_267del` | `g.259_267CAG[2]` |
| `g.259CAG[5]` | `g.259_267CAG[5]` | `g.259CAG[5]` |
| `g.259A[7]` | `g.259_263A[7]` | `g.259A[7]` |
| `g.259AT[6]` | `g.259_266AT[6]` | `g.259AT[6]` |

Two shapes. A **contraction fails to lower** — `CAG[2]` over a 3-copy tract is a deletion of one copy and becomes `g.265_267del` on an unmasked reference, but stays an unlowered repeat on the masked twin. And a **single-position anchor is never widened to its tract**, leaving the bare anchor standing where the whole-range form is canonical.

Measured **4 of 15** repeat inputs moved with case alone. The other 11 — plain `del`/`dup`/`ins`, and explicit-range repeats whose count is not a contraction — agreed, which is the control showing this is the tract search rather than a general masking problem.

**No oracle could see it.** Every masked output above is well-formed, in bounds and a fixed point, so `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and `FERRO_ASSERT_IDEMPOTENT` all pass. The violated property is parity between two references differing only in case, which nothing asserts — the same blind spot #1318 and #1250 were each filed against for a different comparison site.

Reference FASTAs are routinely soft-masked and masked bytes reach normalization from ordinary input; `tests/it/issue_1318_soft_masked_delins.rs` and `issue_1235_cis_allele_confluence.rs::soft_masked_reference_yields_the_same_canonical_form` both exist for that reason.

## The fix

Fold both scans in `count_tandem_repeats` with `eq_ignore_ascii_case`.

This is the convention the rest of `src/normalize/rules.rs` already follows: dup detection (`:125`, `:132`), delins trimming (`:1459`, `:1487`) and inversion typing (`:1606`, `:1620`, `:1717`, `:1750`) all fold, and the file already carries soft-masking parity tests that build `upper` from `lower` (`:4692`, `:4725`, `:4748`). The repeat finder was the odd one out. Three non-test callers feed it raw reference bytes: `rules.rs:1867`, `rules.rs:2144`/`:2164`, `merge.rs:2918`.

Sibling to #1489, which fixed the same class at the SPDI call site by normalising the fetched window and deliberately left this shared routine alone — precisely because folding it can move normalized output, which is a stability question rather than a bugfix. This PR is that question, answered.

### Measured against #1489, because the overlap reads as redundancy and is not

`resolve_repeat_tract_span` calls this function, so with both PRs applied the SPDI path folds twice and #1489's window normalisation *looks* superseded. Tested by stacking this branch on #1489's head in a throwaway worktree and reverting only #1489's window normalisation on top:

| | result |
|---|---|
| all 11 tests from both PRs, stacked | **pass** — no red-together interaction |
| #1489's six soft-masking tests, with #1489 reverted | **pass** — this fold covers the case dimension |
| `a_uracil_spelled_tract_is_found_on_the_rna_axis`, same | **fails** (`left: (3, 3)`, `right: (3, 6)`) |

`eq_ignore_ascii_case` maps `u` to `U`, never `U` to `T`, so an `r.` tract spelled with uracil stays invisible to this function; #1489's `apply_alphabet` is what handles it. The two are complementary, and after both land **exactly one test pins the difference**. A note on `count_tandem_repeats` says so, so neither site gets removed on the grounds that the other covers it.

The only textual conflict between the two is the `mod` line in `tests/it/main.rs`, which is a union.

## Representation stability

**This moves normalized output**, so the disclosure matters. It is an unusually clean case, because a confluence fix normally has to pick a loser and this one does not:

- `eq_ignore_ascii_case` on two uppercase slices **is** `==`. Behaviour on an unmasked reference is therefore provably unchanged — no shipped form moves for any consumer whose reference is not soft-masked.
- `count_tandem_repeats` returns only `(count, start, end)` — never bases — so folding its comparison cannot leak a lowercase base into an emitted sequence.
- Rows that *do* move are soft-masked ones, and they move **onto the form the uppercase reference already produces**. The fix converges on the already-shipped representation rather than away from it, which is the free direction.

### The corpus measured zero, and the zero is structural

```
cargo run --features dev --example dump_normalized_corpus -- --out before.tsv   # baseline: rules.rs at origin/main
cargo run --features dev --example dump_normalized_corpus -- --out after.tsv    # candidate
cargo run --features dev --example dump_normalized_corpus -- --compare before.tsv --against after.tsv
```

| | rows |
|---|---|
| total | 78,028 |
| **moved** | **0 (0.0%)** |
| of which previously accepted (a migration) | 0 |
| of which previously not a fixed point (free) | 0 |

Zero across all 15 shape families, and the two dumps are byte-identical.

**Do not read that as evidence the change is safe.** It is a claim about the corpus: every sequence the generator builds comes from uppercase `ACGT`/`AT` literals (`examples/dump_normalized_corpus.rs:387`, `:596`, `:912`, `:930`, `:935`), so the harness cannot vary reference masking at all and is structurally blind to a case-fold. This is the same class of blindness recorded for #1456 (member geometry), #1460 (scale) and #1478 (transcript geometry); reporting the zero together with the reason is the honest form, following PR #1480's precedent.

**The real evidence is the suite: 9,526 tests passing with nothing re-blessed**, under all three oracles and `FERRO_SWEEP_SEEDS=full`. For an output-moving change that is the strong signal — every existing expectation already agreed with the new answer.

## Unchanged on purpose

- `the_shapes_that_already_agreed_are_untouched` — the 11 inputs that already agreed across case must keep agreeing. This is what says the fix is the tract search and not a blanket fold that happened to move everything.
- `folding_does_not_invent_a_tract` — the discriminating case. An over-general fix (comparing lengths only, or treating any base as matching) would widen a lone `A` into a run that is not there; `g.259A[3]` over `ACGTA` must stay `g.259A[3]`. That value is **measured, not inferred** — an earlier draft guessed `g.259_260insAA` and was wrong.

No `*_strategy()` was touched, so no proptest seed is invalidated (`git status --porcelain tests/proptest-regressions/` clean).

## Verification

```
cargo fmt --all --check                                        # clean
cargo clippy --all-features --all-targets -- -D warnings       # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  FERRO_SWEEP_SEEDS=full cargo nextest run --features dev
#   Summary [1067.452s] 9526 tests run: 9526 passed (13 slow), 145 skipped
```

No Python surface is touched.

