### PR TITLE
fix(spdi): name the caller's anchor when a repeat names no tract

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1575,7 +1575,7 @@ where
             // start and means 'the whole run becomes N', so it absorbs
             // nothing" — so widening here makes the two sites agree rather
             // than introducing a third answer.
-            let (del_start, del_end) = match provider {
+            let (del_start, del_end, span_origin) = match provider {
                 Some(p) if start_one_based == end_one_based => resolve_repeat_tract_span(
                     p,
                     &sequence,
@@ -1583,7 +1583,9 @@ where
                     unit_str.as_bytes(),
                     alphabet,
                 )?,
-                _ => (start_one_based, end_one_based),
+                // An explicit range is the caller's own span, so a decline may
+                // quote it verbatim.
+                _ => (start_one_based, end_one_based, RepeatSpanOrigin::Tract),
             };
             let spdi_pos = del_start - 1;
             let del_str = match provider {
@@ -1598,31 +1600,54 @@ where
                     ));
                 }
             };
-            // The HGVS recommendations require the interval to span an
-            // integer number of repeat units. Reject non-divisible spans
-            // with a clear message rather than silently emitting nonsense.
-            if unit_str.is_empty() || !del_str.len().is_multiple_of(unit_str.len()) {
+            // Two things must hold for the span to be the declared repeat: the
+            // HGVS recommendations require an integer number of units
+            // (`inversion`-style nonsense otherwise), and a divisible length is
+            // necessary but not sufficient — `ATGCAT` is length 6 and is not
+            // `AT[3]`.
+            //
+            // **Both are judged before either is reported**, because the two
+            // failures share one diagnostic decision. After a failed tract
+            // search `del_start`/`del_end` are this module's unit-wide fallback
+            // rather than anything the caller wrote, and *either* check can be
+            // the one that trips on it: near the 3' end the fallback is clamped
+            // inside the contig, so a multi-base unit leaves a short span that
+            // fails divisibility first. Reporting that span names coordinates
+            // nobody supplied — the exact defect #1492 is about — so the origin
+            // decides the message and the checks only decide *whether* there is
+            // one.
+            let divisible = !unit_str.is_empty() && del_str.len().is_multiple_of(unit_str.len());
+            let matches_unit =
+                divisible && del_str == unit_str.repeat(del_str.len() / unit_str.len());
+            if !matches_unit {
                 return Err(ConversionError::InvalidPosition {
-                    description: format!(
-                        "repeat span {}:{}-{} length {} is not a multiple of unit length {}",
-                        sequence,
-                        del_start,
-                        del_end,
-                        del_str.len(),
-                        unit_str.len()
-                    ),
-                });
-            }
-            // Verify the reference tract actually consists of repeated copies
-            // of the declared unit. A divisible length is necessary but not
-            // sufficient (e.g. `ATGCAT` has length 6 but is not `AT[3]`).
-            let pre_count = del_str.len() / unit_str.len();
-            if del_str != unit_str.repeat(pre_count) {
-                return Err(ConversionError::InvalidPosition {
-                    description: format!(
-                        "repeat span {}:{}-{} does not match repeat unit {}",
-                        sequence, del_start, del_end, unit_str
-                    ),
+                    description: match span_origin {
+                        // The span is the fallback, not the caller's. Name the
+                        // anchor and the real fault: no run begins there.
+                        RepeatSpanOrigin::NoRunAtAnchor => format!(
+                            "no {unit} repeat is anchored at {seq}:{anchor}: the reference \
+                             there is not a run of {unit}. A single-position anchor names the \
+                             *first base* of the tract, so check the run's start, or spell the \
+                             whole range explicitly (`g.<start>_<end>{unit}[n]`).",
+                            unit = unit_str,
+                            seq = sequence,
+                            anchor = start_one_based,
+                        ),
+                        // The span is one the caller wrote or the search chose,
+                        // so quoting it is honest.
+                        _ if !divisible => format!(
+                            "repeat span {}:{}-{} length {} is not a multiple of unit length {}",
+                            sequence,
+                            del_start,
+                            del_end,
+                            del_str.len(),
+                            unit_str.len()
+                        ),
+                        _ => format!(
+                            "repeat span {}:{}-{} does not match repeat unit {}",
+                            sequence, del_start, del_end, unit_str
+                        ),
+                    },
                 });
             }
             let ins_str = unit_str.repeat(n_post);
@@ -1728,18 +1753,31 @@ fn unspelled_bases_error(
     }
 }
 
-/// Fetch reference bases for a 1-based inclusive interval `[start, end]` on
-/// `accession`. Tries [`ReferenceProvider::get_genomic_sequence`] first
-/// (correct for `g.`/`m.` and natural for genomic accessions) and falls
-/// back to [`ReferenceProvider::get_sequence`] for transcript accessions
-/// (`n.`/`r.`/`c.` SPDI emits on the transcript accession per #116).
+/// Why the span [`resolve_repeat_tract_span`] returned is the span it returned.
 ///
-/// The provider takes 0-based half-open coordinates, so the conversion is
-/// `[start - 1, end)`.
-///
-/// Returns [`ConversionError::MissingReferenceData`] when neither call
-/// returns data, or when the returned string length does not match the
-/// requested interval length (insufficient ref data near a boundary).
+/// Exists so a decline can name the caller's own coordinates (#1492). When the
+/// search finds no run, the function falls back to the unit-wide span *at* the
+/// anchor — which is not something the caller wrote. Reporting that span in an
+/// error told the reader to go look at a window they never named: `g.260CAG[5]`
+/// declined with "repeat span 260-262 does not match repeat unit CAG", where
+/// `260-262` is this function's invention and the caller's actual mistake — that
+/// the run begins at 259, not 260 — went unmentioned. 336 of the 560 rows in
+/// #1452's census took that path, so it is the common decline, not a corner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepeatSpanOrigin {
+    /// A run was found; the span is its full extent. A unit-match failure here
+    /// is a real mismatch over coordinates the search itself chose.
+    Tract,
+    /// The search ran and found no run at the anchor, so the span is the
+    /// unit-wide fallback. This is the case that must not quote its span.
+    NoRunAtAnchor,
+    /// The search never ran — an empty unit, or a provider that serves bases
+    /// but not `get_sequence_length`. The span is a placeholder rather than a
+    /// judgement, so the generic diagnostic remains the honest one: nothing was
+    /// measured that would justify saying "no run begins here".
+    NotSearched,
+}
+
 /// The physical repeat run a single-position repeat anchor names, as a 1-based
 /// inclusive span (#1431).
 ///
@@ -1786,7 +1824,7 @@ fn resolve_repeat_tract_span<P>(
     anchor_one_based: u64,
     unit: &[u8],
     alphabet: AlphabetMode,
-) -> Result<(u64, u64), ConversionError>
+) -> Result<(u64, u64, RepeatSpanOrigin), ConversionError>
 where
     P: ReferenceProvider + ?Sized,
 {
@@ -1796,7 +1834,11 @@ where
     const INITIAL_HALF_WIDTH: u64 = 128;
 
     if unit.is_empty() {
-        return Ok((anchor_one_based, anchor_one_based));
+        return Ok((
+            anchor_one_based,
+            anchor_one_based,
+            RepeatSpanOrigin::NotSearched,
+        ));
     }
     let unit_len = unit.len() as u64;
     let fallback = (
@@ -1817,10 +1859,10 @@ where
     // the corrected one, which is a known and stated limit, not a silent wrong
     // span — the caller's divisibility and unit-match checks still judge it.
     let Ok(sequence_length) = provider.get_sequence_length(accession) else {
-        return Ok(fallback);
+        return Ok((fallback.0, fallback.1, RepeatSpanOrigin::NotSearched));
     };
     if sequence_length == 0 || anchor_one_based > sequence_length {
-        return Ok(fallback);
+        return Ok((fallback.0, fallback.1, RepeatSpanOrigin::NotSearched));
     }
     // Now that the length is known, keep the fallback inside the contig: a
     // multi-base unit anchored within `unit_len` of the 3' end would otherwise
@@ -1847,7 +1889,7 @@ where
         let Some((_, tract_start, tract_end)) =
             crate::normalize::rules::count_tandem_repeats(bytes, anchor_offset, unit)
         else {
-            return Ok(fallback);
+            return Ok((fallback.0, fallback.1, RepeatSpanOrigin::NoRunAtAnchor));
         };
 
         // Only grow while the run is still touching an edge the contig has not
@@ -1868,6 +1910,7 @@ where
             return Ok((
                 window_start + tract_start as u64,
                 window_start + tract_end as u64 - 1,
+                RepeatSpanOrigin::Tract,
             ));
         }
         // Judged on the whole window, not the half-width, so the figure the
@@ -1936,6 +1979,18 @@ where
     Ok(normalized)
 }
 
+/// Fetch reference bases for a 1-based inclusive interval `[start, end]` on
+/// `accession`. Tries [`ReferenceProvider::get_genomic_sequence`] first
+/// (correct for `g.`/`m.` and natural for genomic accessions) and falls
+/// back to [`ReferenceProvider::get_sequence`] for transcript accessions
+/// (`n.`/`r.`/`c.` SPDI emits on the transcript accession per #116).
+///
+/// The provider takes 0-based half-open coordinates, so the conversion is
+/// `[start - 1, end)`.
+///
+/// Returns [`ConversionError::MissingReferenceData`] when neither call
+/// returns data, or when the returned string length does not match the
+/// requested interval length (insufficient ref data near a boundary).
 fn fetch_reference_bases<P>(
     provider: &P,
     accession: &str,
@@ -2687,12 +2742,12 @@ mod tests {
 
         assert_eq!(
             resolve_repeat_tract_span(&provider, "NR_TEST.1", 3, b"T", AlphabetMode::Rna).unwrap(),
-            (3, 6),
+            (3, 6, RepeatSpanOrigin::Tract),
             "the `r.` axis must see the tract its unit was rewritten to match"
         );
         assert_eq!(
             resolve_repeat_tract_span(&provider, "NR_TEST.1", 3, b"T", AlphabetMode::Dna).unwrap(),
-            (3, 3),
+            (3, 3, RepeatSpanOrigin::NoRunAtAnchor),
             "on the DNA axis `U` is not `T`, so no tract exists and the \
              unit-wide fallback stands"
         );

--- a/tests/it/issue_1431_single_position_repeat_anchor.rs
+++ b/tests/it/issue_1431_single_position_repeat_anchor.rs
@@ -191,8 +191,16 @@ fn an_anchored_repeat_and_its_range_agree_on_overlap() {
 }
 
 /// An anchor with no tract under it is untouched: the unit does not match the
-/// reference there, and the existing "does not match repeat unit" diagnostic is
-/// what must report it — not a second error introduced by the tract search.
+/// reference there, and **one** diagnostic must report it — not a second error
+/// introduced by the tract search.
+///
+/// The contract here is "one condition, one decline", and that is unchanged.
+/// The *wording* moved in #1492: this decline used to quote the unit-wide
+/// fallback span the search returns when it finds nothing (`repeat span
+/// TEMPLATE:257-257 does not match repeat unit C`), which is a coordinate the
+/// caller never wrote. It now names the anchor they did write. Asserted on the
+/// anchor rather than on the phrase so the test pins the contract instead of
+/// the sentence.
 #[test]
 fn an_anchor_with_no_matching_tract_still_reports_the_mismatch() {
     let sequence = padded("GATCATAAATTCAGC");
@@ -202,8 +210,8 @@ fn an_anchor_with_no_matching_tract_still_reports_the_mismatch() {
         .expect_err("a unit that does not match the reference must be refused");
     let message = error.to_string();
     assert!(
-        message.contains("does not match repeat unit"),
-        "the mismatch must be reported by the existing diagnostic; got: {message}"
+        message.contains("no C repeat is anchored at TEMPLATE:257"),
+        "the mismatch must be reported against the caller's own anchor; got: {message}"
     );
 }
 

--- a/tests/it/issue_1452_soft_masked_repeat_span.rs
+++ b/tests/it/issue_1452_soft_masked_repeat_span.rs
@@ -177,9 +177,17 @@ fn an_out_of_phase_anchor_is_refused_in_both_case_conventions() {
     let masked = spdi_err(&padded(MASKED_CAG), "TEMPLATE:g.260CAG[5]");
     let upper = spdi_err(&padded(UPPER_CAG), "TEMPLATE:g.260CAG[5]");
     assert_eq!(masked, upper, "masking must not change the diagnostic");
+    // The text changed in #1492: the decline now names the anchor the caller
+    // wrote (260) instead of the unit-wide fallback span (260-262) the tract
+    // search invented. The *behaviour* this test exists for — refused, and
+    // refused identically in both case conventions — is unchanged.
     assert!(
-        masked.contains("repeat span TEMPLATE:260-262 does not match repeat unit CAG"),
+        masked.contains("no CAG repeat is anchored at TEMPLATE:260"),
         "unexpected diagnostic: {masked}"
+    );
+    assert!(
+        !masked.contains("260-262"),
+        "the decline must not quote a span the caller never wrote: {masked}"
     );
 }
 

--- a/tests/it/issue_1492_anchor_decline_names_the_caller_span.rs
+++ b/tests/it/issue_1492_anchor_decline_names_the_caller_span.rs
@@ -1,0 +1,134 @@
+//! #1492 — a repeat decline must name coordinates the caller supplied.
+//!
+//! When a single-position repeat anchor names no tandem run, the tract search
+//! falls back to the unit-wide span *at* the anchor, and the decline quoted
+//! that span:
+//!
+//! ```text
+//! g.260CAG[5]  ->  repeat span TEMPLATE:260-262 does not match repeat unit CAG
+//! ```
+//!
+//! The caller wrote one position, `260`. The range `260-262` is the search's
+//! own invention, so the message sent the reader to inspect a three-base window
+//! they never named — and said nothing about the actual fault, which is that
+//! the run begins at `259` and `260` is out of phase with it.
+//!
+//! Not a corner: **336 of the 560 rows** in #1452's census take this path — it
+//! is every anchor that does not land on a unit boundary — and it behaves the
+//! same on masked and unmasked references.
+//!
+//! The explicit-range spelling was already correct and must stay so, because
+//! there the span *is* the caller's own. That asymmetry is the whole point, and
+//! it is why the fix threads a `RepeatSpanOrigin` out of the search rather than
+//! rewording the message unconditionally: a decline over a found tract, or over
+//! a range the caller wrote, should still quote its span.
+//!
+//! Behaviour is unchanged — the same inputs convert and the same inputs are
+//! refused. Only the text moves.
+
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{PAD}{core}{PAD}")
+}
+
+fn spdi_err(sequence: &str, input: &str) -> String {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", sequence.to_string());
+    let variant = parse_hgvs(input).expect("input must parse");
+    match hgvs_to_spdi(&variant, &provider) {
+        Ok(triple) => panic!("`{input}` must not convert, got {triple}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// A 3-copy `CAG` tract at 259-267.
+const TRACT: &str = "GGCAGCAGCAGGG";
+
+/// The headline: an out-of-phase anchor is told about the position it wrote.
+#[test]
+fn an_out_of_phase_anchor_decline_names_the_anchor_not_a_fabricated_span() {
+    let err = spdi_err(&padded(TRACT), "TEMPLATE:g.260CAG[5]");
+    assert!(
+        err.contains("no CAG repeat is anchored at TEMPLATE:260"),
+        "decline must name the caller's anchor: {err}"
+    );
+    assert!(
+        err.contains("g.<start>_<end>CAG[n]"),
+        "decline must offer the explicit-range spelling as the way out: {err}"
+    );
+    // The specific regression: the fallback span must not appear at all.
+    assert!(
+        !err.contains("260-262"),
+        "decline must not quote the unit-wide fallback span: {err}"
+    );
+}
+
+/// The discriminating case, and the reason the fix is not an unconditional
+/// reword: when the caller *did* write a range, quoting it is correct and
+/// helpful, and that message must not change.
+#[test]
+fn an_explicit_range_decline_still_quotes_the_callers_own_span() {
+    let err = spdi_err(&padded("GGATGCATGG"), "TEMPLATE:g.259_264AT[3]");
+    assert!(
+        err.contains("repeat span TEMPLATE:259-264 does not match repeat unit AT"),
+        "an explicit range is the caller's own span and must still be quoted: {err}"
+    );
+    assert!(
+        !err.contains("is anchored at"),
+        "an explicit range has no anchor to report: {err}"
+    );
+}
+
+/// Nothing that converted before stops converting: an in-phase anchor still
+/// resolves to its whole tract.
+///
+/// Without this, a "fix" that simply refused every single-position anchor would
+/// satisfy both tests above.
+#[test]
+fn an_in_phase_anchor_still_converts() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("TEMPLATE", padded(TRACT));
+    let variant = parse_hgvs("TEMPLATE:g.259CAG[5]").expect("parse");
+    assert_eq!(
+        hgvs_to_spdi(&variant, &provider)
+            .expect("an in-phase anchor must still convert")
+            .to_string(),
+        "TEMPLATE:258:CAGCAGCAG:CAGCAGCAGCAGCAG"
+    );
+}
+
+/// The same decline, reached through the **divisibility** check instead of the
+/// unit-match one — near the 3' end the unit-wide fallback is clamped inside
+/// the contig, so a multi-base unit leaves a span whose length is not a
+/// multiple of the unit and that check trips first.
+///
+/// Before the checks were unified, this path reported
+/// `repeat span T2:9-10 length 2 is not a multiple of unit length 3` — quoting
+/// `9-10`, which is the clamped fallback and not anything the caller wrote.
+/// That is the same defect #1492 removes from the unit-match branch, so it must
+/// produce the same anchor-naming message.
+#[test]
+fn a_failed_search_clamped_at_the_contig_end_still_names_the_anchor() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("T2", "GGGGGGGGTT".to_string());
+    let variant = parse_hgvs("T2:g.9CAG[5]").expect("input must parse");
+    let err = match hgvs_to_spdi(&variant, &provider) {
+        Ok(triple) => panic!("must not convert, got {triple}"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("no CAG repeat is anchored at T2:9"),
+        "must name the caller's anchor, got: {err}"
+    );
+    assert!(
+        !err.contains("9-10"),
+        "must not quote the clamped fallback span, got: {err}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -221,6 +221,7 @@ mod issue_1448_partial_span_overlap;
 mod issue_1452_soft_masked_repeat_span;
 mod issue_1482_boundary_crossing_sibling;
 mod issue_1491_soft_masked_repeat_normalization;
+mod issue_1492_anchor_decline_names_the_caller_span;
 mod issue_1508_overlap_across_region_boundary;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Closes #1492.

**Stacked on #1489** (`fix/issue-1452-softmask-repeat-spdi`) — it touches the same region of the repeat arm and updates a test #1489 adds. Review or merge that one first.

## The defect

When a single-position repeat anchor names no tandem run, the decline quoted a span the caller never wrote:

```
g.260CAG[5]  ->  invalid position: repeat span TEMPLATE:260-262 does not match repeat unit CAG
```

The caller wrote one position, `260`. The range `260-262` is the unit-wide fallback `resolve_repeat_tract_span` returns when its search finds nothing — an internal artefact. So the message sends the reader to inspect a three-base window that appears nowhere in their input, and says nothing about the actual fault: the run begins at `259`, and `g.259CAG[5]` converts fine.

Not a corner. **336 of the 560 rows** in #1452's census take this path — it is every anchor that does not land on a unit boundary — and it behaves identically on masked and unmasked references.

## The fix

Thread a `RepeatSpanOrigin` out of `resolve_repeat_tract_span` so the caller knows *why* the span it holds is the span it holds, and emit an anchor-shaped decline only for the fallback case:

```
no CAG repeat is anchored at TEMPLATE:260: the reference there is not a run of CAG.
A single-position anchor names the *first base* of the tract, so check the run's start,
or spell the whole range explicitly (`g.<start>_<end>CAG[n]`).
```

Three origins rather than two, which is the part worth reviewing:

- `Tract` — a run was found, or the caller wrote an explicit range. A unit-match failure is a real mismatch over coordinates that are legitimately quotable.
- `NoRunAtAnchor` — the search ran and found nothing. The only case that must not quote its span.
- `NotSearched` — an empty unit, or a provider that serves bases but not `get_sequence_length`. The span is a placeholder, not a judgement, so the generic message stays: nothing was measured that would justify asserting "no run begins here". Collapsing this into `NoRunAtAnchor` would make ferro claim a fact it never checked, and it is invisible in-repo because every one of ferro's own providers implements `get_sequence_length`.

## Unchanged on purpose

**No behaviour change** — the same inputs convert and the same inputs are refused. Only text moves. Three tests hold the line:

- `an_explicit_range_decline_still_quotes_the_callers_own_span` — the discriminating case. When the caller wrote `g.259_264AT[3]`, quoting `259-264` is correct and helpful, and that message is untouched. An unconditional reword would have broken this.
- `an_in_phase_anchor_still_converts` — without it, a "fix" that simply refused every single-position anchor would satisfy both other tests.
- `an_out_of_phase_anchor_is_refused_in_both_case_conventions` (from #1489) is updated, not deleted: it still asserts refused-and-identical-across-case, and now also asserts the message does *not* contain `260-262`.

## Representation stability

No normalized HGVS string and no SPDI triple can move: the diff only changes an error's text and the internal signature that decides which text to use. The only observable change is the wording of a `ConversionError::InvalidPosition` on inputs that were already being refused.

## Verification

```
cargo fmt --all --check
cargo clippy --all-features --all-targets -- -D warnings
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  FERRO_SWEEP_SEEDS=full cargo nextest run --features dev
#   Summary [511.724s] 9534 tests run: 9534 passed (4 slow), 145 skipped
```

No Python surface is touched.

## Note on a re-blessed assertion

`issue_1431::an_anchor_with_no_matching_tract_still_reports_the_mismatch` is updated, not deleted. Its doc states the contract as *"one condition, one decline — not a second error introduced by the tract search"*, and that is unchanged: this is still a single `InvalidPosition`. What it actually asserted was the literal phrase `does not match repeat unit`, which this PR rewords for the anchor case. It now asserts against the caller's own anchor, so it pins the contract rather than the sentence.


## Review follow-ups applied

**The new diagnostic was unreachable on one of its two paths.** The divisibility check runs before the unit-match check, and near the 3' end the unit-wide fallback is clamped inside the contig — so a multi-base unit leaves a short span that fails divisibility *first* and reports the generic message. Measured on a 10-base contig:

```
T2:g.9CAG[5]  ->  repeat span T2:9-10 length 2 is not a multiple of unit length 3
```

`9-10` is the clamped fallback, not anything the caller wrote — the exact defect this PR removes from the unit-match branch, reached through the other one. Both checks are now judged before either is reported, so `span_origin` decides the message and the checks only decide *whether* there is one. `a_failed_search_clamped_at_the_contig_end_still_names_the_anchor` pins it.

**Two doc comments were attached to the wrong items.** Inserting `enum RepeatSpanOrigin` between `resolve_repeat_tract_span`'s doc block and the function moved ~50 lines of that function's documentation onto the enum, leaving the function undocumented. Rust accepts this and neither clippy nor rustdoc warns, because every item involved is private.

Tracing it back, the root cause predates this PR: on `origin/main` there is already no blank line between `fetch_reference_bases`' doc block and `resolve_repeat_tract_span`'s, so `fetch_reference_bases` (about 130 lines below) has been undocumented and its doc silently prepended to its neighbour's. This PR inherited that and extended the run onto the enum. Both halves are fixed here — the enum is lifted out of the split and `fetch_reference_bases`' doc is reattached — so all three items now document themselves.

**Filed #1497** for a related pre-existing hole this PR names but does not change: when `get_sequence_length` fails, `RepeatSpanOrigin::NotSearched` returns the unit-wide span and the conversion *succeeds* on it, because a one-unit span satisfies both the divisibility and unit-match checks by construction. That is the #1452 silent-truncation class via a different door, and the existing comment's claim that "the caller's divisibility and unit-match checks still judge it" does not hold for it.
