### PR TITLE
fix(errors): LRG accessions are versionless, so stop demanding W3001

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -1166,22 +1166,18 @@ pub fn detect_missing_versions(input: &str) -> Vec<DetectedCorrection> {
                 .unwrap_or(false);
 
         if !has_version && !optional {
-            // LRG transcript (`LRG_NNNtM`) and protein (`LRG_NNNpM`) refs
-            // encode the version as an alphabetic suffix immediately after
-            // the numeric ID, not as `.<version>`. Skip them rather than
-            // flagging a false W3001.
-            let is_lrg_suffix_ref = accession_alpha == "LRG_"
-                && digit_end < bytes.len()
-                && bytes[digit_end].is_ascii_alphabetic();
-            if !is_lrg_suffix_ref {
-                hits.push(DetectedCorrection::new(
-                    ErrorType::MissingVersion,
-                    accession_full.to_string(),
-                    String::new(),
-                    prefix_start,
-                    digit_end,
-                ));
-            }
+            // `optional` now covers LRG wholesale (#1498), which subsumes the
+            // narrower carve-out that used to live here for `LRG_NNNtM` /
+            // `LRG_NNNpM` only. That carve-out was the tell: it exempted the
+            // two *suffixed* LRG spellings while leaving the bare genomic
+            // `LRG_NNN` — equally versionless — to be flagged.
+            hits.push(DetectedCorrection::new(
+                ErrorType::MissingVersion,
+                accession_full.to_string(),
+                String::new(),
+                prefix_start,
+                digit_end,
+            ));
         }
 
         i = digit_end;
@@ -1199,14 +1195,29 @@ pub fn detect_missing_versions(input: &str) -> Vec<DetectedCorrection> {
 /// Per HGVS `background/refseq.md` (L24-25) "RefSeq **and Ensembl** reference
 /// sequence identifiers use version numbers … variant descriptions lacking a
 /// version number are **not** valid" — so Ensembl (`ENST`/`ENSP`/`ENSG`/`ENSR`)
-/// requires a version just like RefSeq (#933). No family is version-optional;
-/// the flag is retained for shape/future use.
+/// requires a version just like RefSeq (#933).
+///
+/// **LRG is version-optional, and is the reason the flag exists** (#1498). The
+/// spec scopes the requirement to the databases that version at all — L23:
+/// "versioned reference sequence identifiers are required **only when** the
+/// reference sequence databases use versioning to distinguish between unique
+/// sequences" — and names RefSeq and Ensembl as those databases. LRG is listed
+/// separately (L66-69) with its canonical spellings `LRG_199`, `LRG_199t1`,
+/// `LRG_199p1`, none of which carry a version: an LRG record's sequence is
+/// frozen, so there is nothing for a version to distinguish.
+///
+/// Treating `LRG_` as version-required made strict mode reject
+/// `LRG_292:g.100del` — the *only* legal spelling — while still accepting
+/// `LRG_292.1:g.100del` and silently dropping the illegal suffix. Since
+/// `--error-mode` defaults to strict, that made every LRG genomic variant
+/// unusable by default.
 fn classify_accession_prefix(prefix: &str) -> (bool, bool) {
     match prefix {
-        "NM_" | "NP_" | "NC_" | "NG_" | "NR_" | "NT_" | "NW_" | "XM_" | "XP_" | "XR_" | "LRG_" => {
+        "NM_" | "NP_" | "NC_" | "NG_" | "NR_" | "NT_" | "NW_" | "XM_" | "XP_" | "XR_" => {
             (true, false)
         }
         "ENST" | "ENSP" | "ENSG" | "ENSR" => (true, false),
+        "LRG_" => (true, true),
         _ => (false, false),
     }
 }
@@ -4683,17 +4694,35 @@ mod tests {
         assert!(hits.is_empty());
     }
 
+    /// A bare `LRG_<N>` genomic accession is the **complete, correct** form —
+    /// LRG identifiers carry no version at all, so W3001 must not fire (#1498).
+    ///
+    /// `background/refseq.md` L23-25 scopes the requirement precisely: "versioned
+    /// reference sequence identifiers are required **only when** the reference
+    /// sequence databases use versioning to distinguish between unique
+    /// sequences", and then names RefSeq and Ensembl as the databases that do.
+    /// LRG is listed separately (L66-69) with its canonical spellings `LRG_199`,
+    /// `LRG_199t1`, `LRG_199p1` — none versioned. LRG's guarantee is that a
+    /// record's sequence never changes, so there is nothing to version.
+    ///
+    /// This test previously asserted the opposite (`hits.len() == 1`); it was
+    /// pinning the defect rather than a contract.
     #[test]
-    fn test_detect_missing_versions_lrg() {
+    fn test_detect_missing_versions_lrg_genomic_no_hit() {
         let hits = detect_missing_versions("LRG_199:c.100A>G");
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].original, "LRG_199");
+        assert!(
+            hits.is_empty(),
+            "a bare LRG genomic accession is complete and must not trigger W3001, got {hits:?}",
+        );
+        // The `g.` axis is the one the defect actually blocked in strict mode.
+        assert!(detect_missing_versions("LRG_292:g.160875del").is_empty());
     }
 
     #[test]
     fn test_detect_missing_versions_lrg_transcript_no_hit() {
-        // LRG transcript references (`LRG_NNNtM`) carry the version as a
-        // `t<digit>` suffix directly after the numeric ID, not as `.<digit>`.
+        // LRG transcript references (`LRG_NNNtM`) name the annotated transcript
+        // number, not a version (`refseq.md` L140: "an annotated transcript
+        // variant 1 is described as t1"). Either way, no `.<version>` is due.
         let hits = detect_missing_versions("LRG_292t1:c.100A>G");
         assert!(
             hits.is_empty(),
@@ -4709,6 +4738,30 @@ mod tests {
             hits.is_empty(),
             "LRG protein suffix should not trigger W3001, got {hits:?}",
         );
+    }
+
+    /// The discriminating case: exempting LRG must not exempt anything else.
+    /// The obvious over-broad fix — dropping the check, or marking every family
+    /// version-optional — passes every assertion above and fails these.
+    #[test]
+    fn test_detect_missing_versions_lrg_exemption_does_not_leak() {
+        for versioned_family in [
+            "NM_000088:c.100A>G",
+            "NG_012232:g.100del",
+            "NC_000023:g.100del",
+            "NP_003997:p.Ser68Arg",
+            "ENST00000380152:c.100A>G",
+        ] {
+            assert_eq!(
+                detect_missing_versions(versioned_family).len(),
+                1,
+                "{versioned_family} is a RefSeq/Ensembl accession and still requires a version",
+            );
+        }
+        // An inner accession inside an LRG-parented compound is still checked.
+        let hits = detect_missing_versions("LRG_199(NM_004006):c.93+1G>T");
+        assert_eq!(hits.len(), 1, "got {hits:?}");
+        assert_eq!(hits[0].original, "NM_004006");
     }
 
     // Accession prefix case tests

--- a/tests/it/lrg_inference_tests.rs
+++ b/tests/it/lrg_inference_tests.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_with_config};
 use ferro_hgvs::hgvs::variant::Accession;
 use ferro_hgvs::parse_hgvs;
 use rstest::rstest;
@@ -290,4 +292,88 @@ fn lrg_zero_and_leading_zero_discriminators_are_accepted() {
         Accession::new("LRG", "999999t999999", None).inferred_variant_type(),
         Some("c")
     );
+}
+
+// ---------------------------------------------------------------------------
+// Strict-mode acceptance of the versionless LRG spelling (#1498)
+// ---------------------------------------------------------------------------
+
+/// Strict mode must accept a bare `LRG_<N>` — it is the only legal spelling.
+///
+/// W3001 (`missing accession version`) is scoped by the spec to databases that
+/// version at all: `background/refseq.md` L23 requires a version "only when the
+/// reference sequence databases use versioning to distinguish between unique
+/// sequences", naming RefSeq and Ensembl. LRG is listed separately (L66-69) as
+/// `LRG_199` / `LRG_199t1` / `LRG_199p1`, none versioned.
+///
+/// Before #1498, strict mode — which is `ferro normalize`'s **default**
+/// `--error-mode` — rejected every one of these with "Accession 'LRG_292' is
+/// missing a version suffix", making LRG genomic variants unusable by default.
+#[test]
+fn strict_mode_accepts_versionless_lrg_accessions() {
+    for input in [
+        "LRG_292:g.160875del",
+        "LRG_1:g.50dup",
+        "LRG_199t1:c.79del",
+        "LRG_199p1:p.Ser68Arg",
+        "LRG_163t1:n.5C>T",
+    ] {
+        let parsed = parse_hgvs_with_config(input, ErrorConfig::strict());
+        assert!(
+            parsed.is_ok(),
+            "strict mode must accept the versionless LRG form {input}: {:?}",
+            parsed.err(),
+        );
+    }
+}
+
+/// The discriminating half: exempting LRG must not exempt RefSeq or Ensembl,
+/// which the spec explicitly does require to be versioned.
+#[test]
+fn strict_mode_still_rejects_versionless_refseq_and_ensembl() {
+    for (input, accession) in [
+        ("NM_000088:c.100A>G", "NM_000088"),
+        ("NG_012232:g.100del", "NG_012232"),
+        ("NC_000023:g.100del", "NC_000023"),
+        ("ENST00000380152:c.100A>G", "ENST00000380152"),
+    ] {
+        // Assert *which* error, not merely that there is one. A bare `is_err()`
+        // is satisfied by any unrelated parse failure, and this is the control
+        // that rules out the over-broad fix (marking every family
+        // version-optional, or dropping the check) — so it has to fail for the
+        // specific reason it names, or it stops discriminating.
+        let err = match parse_hgvs_with_config(input, ErrorConfig::strict()) {
+            Ok(v) => panic!("strict mode must still reject {input}, got {v:?}"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("missing a version suffix"),
+            "{input} must be rejected for its missing version, got: {err}"
+        );
+        assert!(
+            err.contains(accession),
+            "the diagnostic for {input} must name `{accession}`, got: {err}"
+        );
+    }
+}
+
+/// Lenient mode emits no W3001 for a versionless LRG either — the warning was
+/// as wrong as the rejection, it was just survivable.
+#[test]
+fn lenient_mode_emits_no_missing_version_warning_for_lrg() {
+    let parsed = parse_hgvs_lenient("LRG_292:g.160875del").unwrap();
+    assert!(
+        !parsed
+            .warnings
+            .iter()
+            .any(|w| w.error_type.code() == "W3001"),
+        "got warnings: {:?}",
+        parsed.warnings,
+    );
+    // Still fires for a genuinely versionless RefSeq accession.
+    let refseq = parse_hgvs_lenient("NM_000088:c.100A>G").unwrap();
+    assert!(refseq
+        .warnings
+        .iter()
+        .any(|w| w.error_type.code() == "W3001"));
 }

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -296,9 +296,10 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // 10 -> 9 in #1271: that LRG_199 row is the one this status was created to
     // surface, and extending `separations_are_meaningful` to net deletions is
     // what stops it splitting. The row it vacates reappears in
-    // `PASSING_CENSUS`'s `ProjectionPinned` (1167 -> 1168), so the 2184-row total
-    // is unchanged — nothing left the enumeration, one row moved from a
-    // divergence to a pass.
+    // `PASSING_CENSUS`'s `ProjectionPinned` (1167 -> 1168), so the total at that
+    // time (2184 rows) was unchanged — nothing left the enumeration, one row
+    // moved from a divergence to a pass. The total is 2172 as of #1498, which
+    // did drop rows; see `ModeDivergencePinned` below.
     (Status::ProjectionSplitsSingleMember, 9),
 ];
 
@@ -307,7 +308,7 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
 ///
 /// **Why this exists (#1272).** `divergence_budget_is_unchanged` iterates only
 /// [`DIVERGENCE_BUDGET`], so every status in `KNOWN_PASSING_STATUSES` was
-/// counted by nothing at all. That is 2136 of the enumeration's 2184 rows, free
+/// counted by nothing at all. That is 2125 of the enumeration's 2172 rows, free
 /// to move among themselves with no signal — a projection could go from
 /// rendering a string to erroring and no test would notice, because
 /// `every_observed_status_is_accounted_for` only rejects status names it has
@@ -337,9 +338,9 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     //    1 row   ProjectionErrorPinned -> ProjectionPinned
     //
     // Net: ProjectionPinned -13, ProjectionErrorPinned -5,
-    // ProjectionUnavailablePinned +18. The deltas cancel, so the 2184-row total
-    // across this census and `DIVERGENCE_BUDGET` is unchanged — nothing was
-    // dropped from the enumeration, only moved. Every row that moved to
+    // ProjectionUnavailablePinned +18. The deltas cancel, so the total at that
+    // time (2184 rows) across this census and `DIVERGENCE_BUDGET` was
+    // unchanged — nothing was dropped from the enumeration, only moved. Every row that moved to
     // `Unavailable` was a projection that had no business rendering:
     //
     // * `r.spl` / `r.spl?` / `r.0` are RNA-level *effects*, not sequence
@@ -371,7 +372,20 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     (Status::ProjectionPinned, 1168),
     (Status::ProjectionUnavailablePinned, 487),
     (Status::ProjectionErrorPinned, 210),
-    (Status::ModeDivergencePinned, 132),
+    // 132 -> 120 (#1498). The 12 rows are all LRG — `LRG_199:c.357+1G>A`,
+    // `LRG_199:g.954966C>T`, `LRG_199:g.981731G>A` and `LRG_476:g.4950_39800=`,
+    // one per mode — and **no row entered**, which is what says this is the LRG
+    // population and not a wider move. Diffed row-by-row against `origin/main`
+    // rather than inferred from the net, since a -12 is also what "13 left, 1
+    // arrived" looks like.
+    //
+    // They did not become conformant: with the bare-`LRG_<N>` version check
+    // fixed they now reach projection, where the committed reference slice
+    // cannot serve `LRG_199` / `LRG_163t1`, so they are excluded as a fixture
+    // gap. That is why the enumeration total drops 2184 -> 2172 rather than
+    // staying flat. The generator names the absent transcripts on every run, so
+    // the exclusion is reported rather than silent.
+    (Status::ModeDivergencePinned, 120),
 ];
 
 /// Does a projected string match the form the spec states? Mirrors


### PR DESCRIPTION
Closes #1498.

## The defect

Strict mode's missing-version check is inverted for bare `LRG_<N>` genomic accessions: it **rejects** the only legal spelling and **accepts** one that cannot exist. Measured on `origin/main` at `a530cdaf`, release `ferro`, no `--reference` needed:

```
$ ferro normalize "LRG_292:g.100del"
ERROR: LRG_292:g.100del - Parse error at position 0: Accession 'LRG_292' is missing a version suffix

$ ferro normalize "LRG_292.1:g.100del"
LRG_292.1:g.100del -> LRG_292:g.100del
```

The second form is accepted and the illegal version silently stripped — producing exactly the string the first was rejected for. `--error-mode` defaults to `strict`, so **no LRG genomic variant was usable by default**; any caller wanting one had to drop to `lenient`, disabling every other strict check with it.

Found while building the LRG measurement corpus for #1462 and worked around with `--error-mode lenient`, which is what makes it easy to miss.

## Why the rejected form is the correct one

The spec scopes the requirement to the databases that version at all — `background/refseq.md` L23: "versioned reference sequence identifiers are required **only when** the reference sequence databases use versioning to distinguish between unique sequences" — and then names RefSeq and Ensembl as those databases (L24-25). LRG is listed separately at L66-69 with its canonical spellings:

```
- LRG sequences with the prefixes `LRG_#`, `LRG_#t#`, `LRG_#p#`
    - gene/genomic region - `LRG_199`
    - coding transcript (or non-coding transcript) - `LRG_199t1`
    - protein - `LRG_199p1`
```

None versioned. An LRG record's sequence is frozen by design, so there is nothing for a version to distinguish. The codebase already says so in three places: `genomic_placement_on_build`'s `// e.g. "LRG_1" (LRG accessions carry no version)`, and the tests `lrg_version_is_dropped_on_construction` and `lrg_version_round_trip_drops_illegal_version`.

## The fix

Mark `LRG_` version-optional in `classify_accession_prefix`. That flag already existed and had never been used — its doc said "No family is version-optional; the flag is retained for shape/future use". LRG is what it was for.

That subsumes a narrower carve-out in `detect_missing_versions` which exempted `LRG_<N>t<M>` and `LRG_<N>p<M>` but left the equally versionless bare `LRG_<N>` to be flagged. **That asymmetry was the tell** — it exempted the two suffixed spellings and missed the one the spec lists first. The carve-out is removed as dead code.

Its comment also mis-stated why: it called the `t<M>` suffix "the version … as an alphabetic suffix". Per `refseq.md` L140 that is the annotated *transcript number*, not a version. Corrected in passing.

## A test that was pinning the defect

`test_detect_missing_versions_lrg` asserted `detect_missing_versions("LRG_199:c.100A>G")` returns **1** hit. That was pinning the defect, not a contract, so it is re-blessed to assert no hit and renamed to `test_detect_missing_versions_lrg_genomic_no_hit`. It is the only re-blessed expectation in this PR, and it is called out rather than folded in silently.

## Unchanged on purpose

The discriminating cases, all tested — the obvious over-broad fix (drop the check, or mark every family optional) passes the LRG assertions and fails these:

- `NM_000088`, `NG_012232`, `NC_000023`, `NP_003997`, `ENST00000380152` still each produce exactly one W3001.
- An inner accession inside an LRG-parented compound is still checked: `LRG_199(NM_004006):c.93+1G>T` flags `NM_004006`.
- Lenient mode still warns for a versionless RefSeq accession; it just no longer warns for LRG, where the warning was as wrong as the rejection, only survivable.

## Representation stability

**Rejected → accepted only, which is the free direction.** An input that previously errored has no stored normalized string, so nothing a consumer holds can move. No previously-accepted input changes its output: the fix only removes a rejection and a warning, and W3001 was `warn_accept` in lenient mode — it never rewrote `current`.

The second half of #1498 — whether `LRG_292.1:g.100del` should be **rejected** rather than silently corrected — is deliberately **not** taken here. That would be accepted → rejected, the expensive direction, and it contradicts the committed `lrg_version_round_trip_drops_illegal_version`. It needs its own measurement and its own decision.

**Spec-enumeration census: MOVED, by 12 rows. This PR is not green yet — see the note at the top.**

A clean regeneration of both artifacts (delete, then `generate_spec_fixture`, then `generate_spec_enumeration`, the order `ci.yml` uses) gives:

| | before | after |
|---|---|---|
| enumeration rows | 2184 | **2172** |
| `mode-divergence-pinned` | 132 | **120** |
| rows mentioning `LRG_` | 233 | **221** |

The 12 rows are 4 inputs x 3 dimensions, all bare `LRG_<N>` genomic accessions:

```
LRG_199:c.357+1G>A
LRG_199:g.954966C>T
LRG_199:g.981731G>A
LRG_476:g.4950_39800=
```

They leave the enumeration entirely rather than moving between statuses — but **not** for the reason an earlier draft of this section gave. It is not that "both modes now accept, so there is no divergence left to pin"; that is the wrong mechanism.

What actually happens: with the bare-`LRG_<N>` version check fixed, these rows get *further* than before. They now reach projection, and the committed reference slice cannot serve `LRG_199` / `LRG_163t1`, so the generator excludes them as a **fixture gap**. That is why the enumeration total drops 2184 -> 2172 rather than staying flat — a status move would have kept the total.

The generator names the absent transcripts on every run, so the exclusion is reported rather than silent:

```
projection: 6 transcript(s) referenced by the spec are absent from the committed
reference slice: LRG_163t1, LRG_199, LRG_199t61, NM_002111, NM_004007.2, NR_002196.1
```

It is still the fix working — the rows were pinning a defect and no longer do — but the honest description is "they became unservable by the committed slice", not "they became conformant". Extending the slice to carry `LRG_199` would return them to the corpus and is worth its own issue.

### The census delta is the LRG population, verified row-by-row

Diffed against `origin/main` rather than inferred from the net, because **-12 is also what "13 left, 1 arrived" looks like**:

```
left mode-divergence-pinned (12):   entered (0):
  LRG_199:c.357+1G>A    x3            (none)
  LRG_199:g.954966C>T   x3
  LRG_199:g.981731G>A   x3
  LRG_476:g.4950_39800= x3
```

Every row is LRG and nothing entered, so no non-LRG row moved. `PASSING_CENSUS` is re-blessed to 120 with that evidence recorded at the constant.

> Correcting myself: an earlier revision of this description claimed the census was *unmoved* and attributed the two failures to stale generated artifacts regenerated out of order. That was wrong. The manual regeneration I checked it against was itself stale, and the failure reproduces from a clean regenerate. The numbers above are from deleting both artifacts first.

## Verification

```
cargo fmt --all --check                                    # clean
cargo clippy --all-features --all-targets -- -D warnings   # clean
cargo nextest run --features dev -E 'test(detect_missing_versions)'   # 10/10
cargo nextest run --features dev -E 'test(lrg_inference)'             # 25/25
```

Full three-oracle gate, as CI runs it, with both spec artifacts regenerated first:

```
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
  FERRO_SWEEP_SEEDS=full cargo nextest run --features dev
  -> Summary [694.401s] 9527 tests run: 9525 passed, 2 failed, 145 skipped

  FAIL spec_enumeration_tests::passing_census_is_unchanged
       mode-divergence-pinned: census 132, actual 120
  FAIL spec_enumeration_tests::every_status_is_counted_by_exactly_one_table
       the two census tables cover 2184 rows but the enumeration has 2172
```

Those two are the outstanding work described in the warning above, and they are the only failures. No other expectation moved.

GitHub Actions was in a major outage while this PR was opened, so a red or cancelled job on it may be the outage rather than the change — but these two failures are real and reproduce locally.


## Review follow-ups applied

**`PASSING_CENSUS` re-blessed**, `ModeDivergencePinned` 132 -> 120, with the row-by-row evidence above recorded at the constant. Totals now `PASSING_CENSUS` 2125 + `DIVERGENCE_BUDGET` 47 = 2172, matching the generated enumeration. All 16 `spec_enumeration_tests` pass.

**The three `2184` prose references handled, not blanket-replaced.** Two describe #1271 and #1264 — historical statements about the total *at that time* — so rewriting the number would have falsified them; they are reworded to say so explicitly. The one genuinely stale present-tense claim, `2136 of the enumeration's 2184 rows`, is now `2125 of 2172`, verified by summing both tables rather than by subtracting 12.

**A discriminating control was weaker than its stated contract.** `strict_mode_still_rejects_versionless_refseq_and_ensembl` used a bare `.is_err()`, so any unrelated parse failure satisfied it — and this is the control the PR leans on to rule out the over-broad fix (marking every family version-optional, or dropping the check). It now asserts the error actually reports a missing version and names the accession.

### On the two failures reported in the earlier gate

`conformance::hgvs_rs_projection::tests::loads_cases_json` and `conformance::reference_snapshot::tests::to_cdot_drives_protein_projection` were failing with `read cases.json: NotFound`. **Not this PR, and not a missing fixture** — it is the stale `CARGO_MANIFEST_DIR` artifact: this worktree was renamed `issue-1498` -> `pr-1501` (its admin dir is still named `issue-1498`), and `env!("CARGO_MANIFEST_DIR")` is baked in at compile time, so cached test binaries still resolved the old path. `touch src/lib.rs` and both pass with no code change. The fixtures were present the whole time; the failure just reads like they are not.
