### PR TITLE
Repairs 'cargo test'

### DIFF
--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -838,6 +838,7 @@ mod tests {
     /// The streaming batch methods must agree item-for-item with the `Vec`-based
     /// ones (#975), across the thread settings that select different engines
     /// (serial, global pool, dedicated pool).
+    #[cfg(feature = "parallel")]
     #[test]
     fn streaming_batch_matches_the_vec_api_exactly() {
         let processor = processor();


### PR DESCRIPTION
I was seeing build errors when running `cargo test` as per the README. After deciding it wasn't operator error due to my unfamiliarity with Rust I dug in a bit. **NB** I'm trusting my robot companion here but can attest it went from not working to working. It appears the underlying issue was that CI does not actually run `cargo test` and thus missed this.

I'm diving into the deep end of the pool on how rust's testing infra works but it looks like [parallel was added](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1372/changes#diff-c7a2fa680bdc992311f6212492803e8d4d94285f7b9e639d9792b5bf53b692ffR841) but not added to the test suite properly?

#### Claude's error description

  The bug: src/batch/processor.rs:841 — streaming_batch_matches_the_vec_api_exactly calls four methods (parse_parallel, parse_streaming,
  parse_and_normalize_parallel, parse_and_normalize_streaming) that live in an impl block gated #[cfg(feature = "parallel")] at line 495. The test module (line
  653) is plain #[cfg(test)]. So cargo test — the exact command at README.md:433 — died with 4×E0599 before running anything.

  Introduced by #1372 (c9e4cca, 2026-08-04). CI never noticed because every job passes --features dev, which enables parallel.
