### PR TITLE
refactor: retire the `parallel` feature gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,7 +348,11 @@ Never commit machine-specific absolute paths (e.g. `/Volumes/...`, `/Users/...`,
 - `python` - PyO3 Python bindings (build with maturin)
 - `benchmark` - ferro-benchmark binary and tool comparison
 - `validation` - Hash-based validation with ahash
-- `parallel` - Rayon-based parallelism
+- `parallel` - **no-op alias, retained for compatibility.** Rayon-based parallelism
+  (`ferro_hgvs::parallel`, and `BatchProcessor`'s `*_parallel`/`*_streaming` methods)
+  is unconditional — rayon is a non-optional dependency, so there is nothing to enable.
+  It formerly gated that API's visibility, which read as a capability gate and was
+  misread as one (#1504, #1507).
 - `web-service` - HTTP API server
 
 ## Key Patterns

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,13 @@ lru = "0.12.5"
 [features]
 default = []
 dhat-heap = ["dep:dhat"]
-# rayon is now an unconditional dependency (the CLI `-j` batch drivers use it);
-# this feature is retained as a no-op alias and to gate the library `parallel`
-# module's public API.
+# rayon is an unconditional dependency (the CLI `-j` batch drivers use it), so
+# this feature enables nothing and excludes no code from any build. It once
+# gated the library `parallel` module's public API; because that gate could not
+# express a capability difference, only a visibility one, it read as "this
+# build cannot do parallelism" and was misread that way (#1504, #1507). The API
+# is now unconditional and this is a no-op alias retained so `--features
+# parallel` and the `python` feature below keep resolving.
 parallel = []
 validation = ["dep:ahash"]
 # The Python batch API parallelizes across a rayon pool, so the `parallel`

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -46,18 +46,19 @@
 //! - **Progress Tracking**: Optional callbacks for monitoring long-running batches
 //! - **Error Aggregation**: Collect all errors without stopping the batch
 //! - **Statistics**: Detailed success/failure counts and processing rates
-//! - **Parallel Support**: Enable `parallel` feature for multi-threaded processing
+//! - **Parallel Support**: multi-threaded processing via the `*_parallel` and
+//!   `*_streaming` methods, available in every build
 
 mod processor;
 
-// Gated to match its only consumers, both of which are `parallel`-only: the
-// `#[cfg(feature = "parallel")]` impl block in `processor.rs` and the streaming
-// functions in `crate::parallel`. `default = []`, so without this the module
-// compiles in a featureless build with nothing constructing `StreamingMap` —
-// dead code that `dead_code`'s warn-by-default level let through every existing
-// clippy job (they all pass `--features dev` or `--all-features`). The
-// release-profile lint added in this PR is what surfaced it.
-#[cfg(feature = "parallel")]
+// Ungated, matching its consumers: the streaming impl block in `processor.rs`
+// and the streaming functions in `crate::parallel`. Both were once
+// `#[cfg(feature = "parallel")]` and this followed them, which made the module
+// dead in a featureless build — dead code that `dead_code`'s warn-by-default
+// level let through every clippy job, since they all pass `--features dev` or
+// `--all-features`. #1507 removed those gates (rayon is unconditional, so they
+// gated visibility rather than capability), which removes the dead-code
+// condition at its source.
 pub(crate) mod streaming;
 
 pub use processor::{

--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -492,7 +492,6 @@ impl<P: ReferenceProvider> BatchProcessor<P> {
 /// dedicated pool of `N` threads. These have no progress-callback variants —
 /// ordered progress under parallelism is ill-defined; use the serial
 /// `*_with_progress` methods when a callback is needed.
-#[cfg(feature = "parallel")]
 impl<P: ReferenceProvider + Sync> BatchProcessor<P> {
     /// Parse multiple HGVS strings in parallel. Order-preserving; equivalent to
     /// [`parse`](Self::parse) but spread across `num_threads` workers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ pub mod legacy;
 pub mod liftover;
 pub mod mave;
 pub mod normalize;
-#[cfg(feature = "parallel")]
 pub mod parallel;
 /// Performance-comparison table types + rendering (used by the
 /// `generate_perf_tables` example and its tests).

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,13 +1,12 @@
 //! Parallel processing support for ferro-hgvs
 //!
 //! This module provides parallel variants of parsing and normalization
-//! operations using rayon. Enable with the `parallel` feature.
+//! operations using rayon. It is available in every build — rayon is an
+//! unconditional dependency, so there is no feature to enable.
 //!
 //! # Example
 //!
 //! ```no_run
-//! # #[cfg(feature = "parallel")]
-//! # fn main() {
 //! use ferro_hgvs::parallel::{parse_hgvs_parallel, normalize_parallel};
 //! use ferro_hgvs::{JsonProvider, Normalizer};
 //!
@@ -27,9 +26,6 @@
 //! let provider = JsonProvider::with_test_data();
 //! let normalizer = Normalizer::new(provider);
 //! let _normalized = normalize_parallel(&normalizer, &parsed);
-//! # }
-//! # #[cfg(not(feature = "parallel"))]
-//! # fn main() {}
 //! ```
 
 use rayon::prelude::*;
@@ -121,7 +117,6 @@ pub fn parse_and_normalize_parallel<P: ReferenceProvider + Sync, S: AsRef<str> +
 /// function would have produced at that position.
 ///
 /// ```no_run
-/// # #[cfg(feature = "parallel")]
 /// # fn main() -> std::io::Result<()> {
 /// use std::io::{BufRead, BufReader};
 /// use ferro_hgvs::parallel::parse_hgvs_streaming;
@@ -135,8 +130,6 @@ pub fn parse_and_normalize_parallel<P: ReferenceProvider + Sync, S: AsRef<str> +
 /// }
 /// # Ok(())
 /// # }
-/// # #[cfg(not(feature = "parallel"))]
-/// # fn main() {}
 /// ```
 pub fn parse_hgvs_streaming<I, S>(
     variants: I,

--- a/tests/it/clinvar_hgvs_tests.rs
+++ b/tests/it/clinvar_hgvs_tests.rs
@@ -6,7 +6,6 @@
 
 use ferro_hgvs::parse_hgvs;
 use flate2::read::GzDecoder;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -89,20 +88,9 @@ fn test_clinvar_hgvs_500k_benchmark() {
     eprintln!("Total test cases: {}", total);
 
     let start = Instant::now();
-    #[cfg(feature = "parallel")]
     let case_failures: Vec<(&str, String)> = fixture
         .test_cases
         .par_iter()
-        .filter_map(|case| {
-            parse_hgvs(case.input)
-                .err()
-                .map(|e| (case.input, e.to_string()))
-        })
-        .collect();
-    #[cfg(not(feature = "parallel"))]
-    let case_failures: Vec<(&str, String)> = fixture
-        .test_cases
-        .iter()
         .filter_map(|case| {
             parse_hgvs(case.input)
                 .err()
@@ -210,20 +198,9 @@ fn test_clinvar_hgvs_unique_benchmark() {
     eprintln!("Total test cases: {}", total);
 
     let start = Instant::now();
-    #[cfg(feature = "parallel")]
     let case_failures: Vec<(&str, String)> = fixture
         .test_cases
         .par_iter()
-        .filter_map(|case| {
-            parse_hgvs(case.input)
-                .err()
-                .map(|e| (case.input, e.to_string()))
-        })
-        .collect();
-    #[cfg(not(feature = "parallel"))]
-    let case_failures: Vec<(&str, String)> = fixture
-        .test_cases
-        .iter()
         .filter_map(|case| {
             parse_hgvs(case.input)
                 .err()

--- a/tests/it/cmrg_exhaustive_tests.rs
+++ b/tests/it/cmrg_exhaustive_tests.rs
@@ -7,7 +7,6 @@
 
 use ferro_hgvs::parse_hgvs;
 use flate2::read::GzDecoder;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -82,23 +81,12 @@ fn test_cmrg_exhaustive_benchmark() {
     eprintln!("Total test cases: {}", total);
 
     let start = Instant::now();
-    // Parse all cases (parallel with rayon when available). For each
-    // failure capture (input, error_string) so the per-input expectations
-    // framework can categorize it.
-    #[cfg(feature = "parallel")]
+    // Parse all cases with rayon. For each failure capture
+    // (input, error_string) so the per-input expectations framework can
+    // categorize it.
     let case_failures: Vec<(&str, String)> = fixture
         .test_cases
         .par_iter()
-        .filter_map(|case| {
-            parse_hgvs(case.input)
-                .err()
-                .map(|e| (case.input, e.to_string()))
-        })
-        .collect();
-    #[cfg(not(feature = "parallel"))]
-    let case_failures: Vec<(&str, String)> = fixture
-        .test_cases
-        .iter()
         .filter_map(|case| {
             parse_hgvs(case.input)
                 .err()

--- a/tests/it/paraphase_exhaustive_tests.rs
+++ b/tests/it/paraphase_exhaustive_tests.rs
@@ -7,7 +7,6 @@
 
 use ferro_hgvs::parse_hgvs;
 use flate2::read::GzDecoder;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -79,20 +78,9 @@ fn test_paraphase_exhaustive_benchmark() {
     eprintln!("Total test cases: {}", total);
 
     let start = Instant::now();
-    #[cfg(feature = "parallel")]
     let case_failures: Vec<(&str, String)> = fixture
         .test_cases
         .par_iter()
-        .filter_map(|case| {
-            parse_hgvs(case.input)
-                .err()
-                .map(|e| (case.input, e.to_string()))
-        })
-        .collect();
-    #[cfg(not(feature = "parallel"))]
-    let case_failures: Vec<(&str, String)> = fixture
-        .test_cases
-        .iter()
         .filter_map(|case| {
             parse_hgvs(case.input)
                 .err()


### PR DESCRIPTION
Closes #1507.

`parallel = []` enables no dependencies. `rayon` is declared unconditionally (`Cargo.toml:104`, no `optional = true`) because the CLI `-j` batch drivers use it. So every `#[cfg(feature = "parallel")]` in the tree excluded no code from any build — it decided only whether names were reachable.

That is a gate which cannot express a capability difference, only a visibility one, and it was misread as the former. #1504 is an external contributor whose `cargo test` — the command at `README.md:433` — died with 4× E0599 on `main`. This removes the gate instead of matching it.

## What changed

- Dropped `#[cfg(feature = "parallel")]` from `src/lib.rs` (`pub mod parallel`), `src/batch/processor.rs` (the `*_parallel`/`*_streaming` impl block) and `src/batch/mod.rs` (`pub(crate) mod streaming`).
- Kept `parallel = []` as a documented no-op alias, so `--features parallel` and `python = ["dep:pyo3", "parallel"]` keep resolving. This is the same treatment `mmap = []` already gets two lines below it.
- Collapsed four now-dead `#[cfg(not(feature = "parallel"))]` serial fallbacks that duplicated their `par_iter` twin verbatim: `tests/it/clinvar_hgvs_tests.rs` (×2), `tests/it/cmrg_exhaustive_tests.rs`, `tests/it/paraphase_exhaustive_tests.rs`. Net −60 lines of duplicated body.
- Removed the `# #[cfg(feature = "parallel")]` / `# #[cfg(not(...))]` scaffolding from the `src/parallel.rs` doc examples, which existed only to keep them compiling in both configurations.
- Rewrote the `src/batch/mod.rs` gating comment and the `parallel` entry in `CLAUDE.md`'s feature list, both of which described the old arrangement.

## Relationship to #1504

Same defect, different depth. #1504 adds `#[cfg(feature = "parallel")]` to the test so the featureless build compiles; this removes the gate the test tripped over, so the test **runs** there instead of being filtered out:

```
$ cargo test --lib streaming_batch_matches_the_vec_api_exactly      # no features
test batch::processor::tests::streaming_batch_matches_the_vec_api_exactly ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3797 filtered out
```

Under #1504 that same command reports `0 passed; ... 3798 filtered out` — a correctness-equivalence test skipped in the default build to work around a gate that was not protecting anything. Both unbreak `cargo test`; only this one keeps the coverage. #1504's one-line change is subsumed here, so this supersedes it — happy to land #1504 first and rebase this on top if the faster unblock is worth more.

`main` is genuinely red on this today, so the before/after is directly observable:

```
# on origin/main (a530cdaf), no local changes
$ cargo clippy --all-targets -- -D warnings
error[E0599]: no method named `parse_parallel` found ...
error[E0599]: no method named `parse_streaming` found ...
error[E0599]: no method named `parse_and_normalize_parallel` found ...
error[E0599]: no method named `parse_and_normalize_streaming` found ...
error: could not compile `ferro-hgvs` (lib test) due to 4 previous errors

$ cargo clippy --all-targets -- -D warnings     # this branch
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.68s
```

The CI blind spot that let it ship is #1505, which this does not address — a follow-up adds the guard.

## Representation stability

No normalizer change; no normalized output moves. This is feature-gating, docs and dead-code removal only. `cargo nextest run --features dev` passes with **nothing re-blessed** — no fixture, ledger or census updated in this diff.

## API impact

The public API **widens** in default builds: `ferro_hgvs::parallel` and the `BatchProcessor` `*_parallel`/`*_streaming` methods become available without `--features parallel`. That is additive — everything that compiles today still compiles, since the API was already reachable under the feature, and the feature still exists as an alias. Nothing is removed or renamed.

## Verification

| check | result |
|---|---|
| `cargo clippy --all-targets -- -D warnings` (**no features** — red on `main`) | pass |
| `cargo clippy --features dev --all-targets -- -D warnings` | pass |
| `cargo clippy --all-features --all-targets -- -D warnings` | pass |
| `cargo check --features python` | pass |
| `cargo test --no-run --lib` (the `README.md:433` path) | pass |
| `cargo fmt --check` | pass |
| `cargo test --no-run --lib --bins` | pass |
| `cargo nextest run --features dev` | **9,523 / 9,523 passed**, 145 skipped |

Exit codes captured directly rather than through a pipe. Nothing was re-blessed: `git status --porcelain` after the suite lists only the nine files in this diff.
