### PR TITLE
ci: compile the default-feature unit tests so a gated call cannot ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,6 +881,30 @@ jobs:
       # would additionally compile every test and bench binary with optimisation
       # for no gain here.
       - run: cargo clippy --release -- -D warnings
+      # The featureless guard (#1505). Every other Rust job in this workflow
+      # either passes `--features dev` / `--all-features`, or is scoped to the
+      # integration binary (`test-build-soak`'s `--test it`). So the DEFAULT
+      # feature set's unit tests — the `#[cfg(test)]` modules under `src/` — are
+      # compiled NOWHERE in CI, and a call from one of them into feature-gated
+      # code cannot turn any job red.
+      #
+      # Not hypothetical: #1372 put exactly such a call on `main` and it survived
+      # until an external contributor ran the `cargo test` this repository's own
+      # README documents (`README.md:433`). Four `E0599`s, invisible to all 34
+      # checks, reported from outside the project.
+      #
+      # `--no-run` on purpose: the claim being defended is that the default
+      # feature set BUILDS, not that these tests run a second time. `--lib
+      # --bins` covers every `#[cfg(test)]` module under `src/`; the integration
+      # tree is already compiled featureless by `test-build-soak`.
+      #
+      # In THIS job rather than one of its own, for the reason the release-profile
+      # lint above gives at length: the repository sits near the 10 GiB Actions
+      # cache cap and #1218 records eviction cascades caused by adding cache keys.
+      # `build` already owns `build-release` and is already a required check, so
+      # the guard blocks a merge instead of only reddening an optional job.
+      - name: Unit tests compile with default features
+        run: cargo test --no-run --lib --bins
       - run: cargo build --release
       - name: Check binary size
         run: |

--- a/README.md
+++ b/README.md
@@ -430,8 +430,18 @@ See [docs/BENCHMARK_GUIDE.md](docs/BENCHMARK_GUIDE.md) for detailed usage.
 
 ```bash
 cargo build
-cargo test
+cargo test                        # default features
 cargo clippy -- -D warnings
+```
+
+The commands above use the default feature set, and CI keeps them compiling (see
+the `build` job). They do not cover the whole suite — the feature-gated tests and
+the integration tree need `dev`, which is what CI runs and what you want before
+opening a PR:
+
+```bash
+cargo nextest run --features dev
+cargo clippy --features dev --all-targets -- -D warnings
 ```
 
 ## License


### PR DESCRIPTION
Closes #1505.

> **Stacked on #1509** (base is `refactor/issue-1507-retire-parallel-gate`, not `main`). The guard added here is red on `main` today — that is the bug it guards against — so it cannot land first. Review #1509 first; this retargets to `main` automatically when that merges.

Every Rust job in `ci.yml` either passes `--features dev` / `--all-features`, or is scoped to the integration binary. So the default feature set's unit tests — the `#[cfg(test)]` modules under `src/` — are compiled **nowhere** in CI:

| invocation | features | scope |
|---|---|---|
| `cargo clippy --features dev --all-targets` | `dev` | everything |
| `cargo clippy --all-features --all-targets` | all | everything |
| `cargo nextest archive --features dev` | `dev` | everything |
| `cargo nextest archive --cargo-profile soak --test it` | **none** | `--test it` only |
| `cargo clippy --release` / `cargo build --release` | none | no test targets |

The featureless build exists, but only ever compiles `tests/it/`. A feature-gated call from an ungated `#[cfg(test)]` module in `src/**` is invisible until someone runs the documented command — which is how #1372's defect reached `main` and stayed there, found by an external contributor (#1504) rather than by the suite.

## The change

One step in the existing `build` job:

```yaml
- name: Unit tests compile with default features
  run: cargo test --no-run --lib --bins
```

- **`--no-run`** — the claim being defended is that the default feature set *builds*, not that these tests run a second time.
- **`--lib --bins`** — covers every `#[cfg(test)]` module under `src/`. The integration tree is already compiled featureless by `test-build-soak`, so the two together cover both halves.
- **In `build`, not a new job** — for the reason the release-profile lint immediately above it gives at length: the repository sits near the 10 GiB Actions cache cap and #1218 records eviction cascades from adding cache keys. `build` already owns `build-release` and is already a required check, so this blocks a merge rather than only reddening an optional job.

## It was verified to fire, not just to pass

A guard that passes proves nothing on its own. Restoring the pre-#1507 `src/batch/processor.rs` — the actual #1372 defect — and re-running the new step:

```
### guard on this branch
exit=0
### with main's gated impl block restored
exit=101          <- the guard fires
E0599 count: 5    <- the four original errors, plus the summary line
### restored
exit=0
```

`actionlint` passes on the modified workflow.

## Also

`README.md`'s Development block listed `cargo build` / `cargo test` / `cargo clippy` with no indication that they are the reduced feature set — the ambiguity #1505 flagged at the end. It now says so and points at the `--features dev` invocations CI actually runs. The bare commands stay correct, and this job is what keeps them that way.
