### PR TITLE
fix(normalize): report cis overlaps across a region boundary

### DIFF
--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -11,9 +11,9 @@
 //! Two detectors run at different points in the allele pipeline:
 //!
 //! - [`detect_overlap_conflicts`] — *post-shift* coincident bounds: span edits
-//!   (`sub`/`del`/`delins`/`dup`/`inv`/`repeat`) whose `(region, start, end)`
-//!   keys are identical. Insertions are excluded here (they anchor at a
-//!   boundary, not a single-base span).
+//!   (`sub`/`del`/`delins`/`dup`/`inv`/`repeat`) whose ranked start/end keys are
+//!   identical. Insertions are excluded here (they anchor at a boundary, not a
+//!   single-base span).
 //! - [`detect_insertion_overlaps`] — *pre-merge* junction overlaps: two
 //!   junction-anchored edits at one junction, or one interior to a span edit
 //!   (mutalyzer `EOVERLAP`, #486). Must run before the normalizer's merge step
@@ -32,10 +32,100 @@ use crate::hgvs::variant::{AllelePhase, HgvsVariant, LocEdit};
 use crate::normalize::merge::Region;
 use crate::normalize::NormalizationWarning;
 
+/// One position on a transcript-relative axis, ordered the way the axis reads.
+///
+/// # Why a rank rather than a bare `(Region, i64)`
+///
+/// The `c.`/`r.`/`n.` axes are piecewise: three regions numbered by three
+/// independent integer sequences, so a bare coordinate does not order against
+/// one in another region — `c.*1` is the base immediately 3' of the last CDS
+/// base, and `1 < 15`. Both detectors in this module previously handled that by
+/// refusing to read a range whose two endpoints were in different regions
+/// (`if rs != re { return None }` in `cds_range` / `tx_range` / `rna_range`) and
+/// by comparing only members that shared a region.
+///
+/// That was not a decline. `None` reaches `let Some(..) = .. else { continue }`,
+/// so the member was dropped from the analysis rather than treated
+/// conservatively, and **strict mode silently accepted overlaps it rejects when
+/// the same pair sits inside one region** (#1508). Measured on a 20-base
+/// transcript with CDS `1..=15`:
+///
+/// ```text
+/// c.[11_12dup;12_13inv]      REJECTED  W5002
+/// c.[14_15dup;15_*1inv]      ACCEPTED            <-- same shape, across the boundary
+/// c.[11_12del;11_12inv]      REJECTED  W5002
+/// c.[15_*1del;15_*1inv]      ACCEPTED
+/// c.[11_12insAA;11_12insCC]  REJECTED  W5002
+/// c.[15_*1insAA;15_*1insCC]  ACCEPTED  -> c.[15delinsCAA;15_*1insCC]
+/// ```
+///
+/// Ranking the regions gives the whole axis one order, so the boundary stops
+/// being a place where members become invisible to each other.
+///
+/// # Why this is sound here and was rejected for `merge.rs`
+///
+/// #1482 considered exactly this key for `merge::MemberSpan` and rejected it:
+/// 42 sites there do *arithmetic* on a span, many computing `end - start + 1`
+/// as a length, and for `c.15_*1` that is `1 - 15`. A rank-ordered key would
+/// have made all 42 compile while silently producing wrong lengths, so that
+/// module converts onto the sequence axis with a provider instead.
+///
+/// This module has no provider and needs none, because it never takes a length
+/// or an offset — every use is a **comparison**: do two spans coincide, do they
+/// intersect, does a junction fall interior to a span. The one place that looked
+/// like arithmetic, `gap + 1 <= end`, is already written `gap < end`.
+///
+/// The ordering itself is the one [`crate::hgvs::variant`]'s `CanonicalPos`
+/// already gives the parser's E3006 self-cancelling check — which is why that
+/// check gets a cross-region `c.[14_15dup;15_*1del]` right while these
+/// detectors do not. This adopts the precedent rather than inventing an order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct AxisPos {
+    /// `0` = 5' of the body, `1` = the body, `2` = 3' of it. First in
+    /// declaration order so the derived `Ord` is lexicographic.
+    rank: u8,
+    /// The written coordinate, whose numeric order is already correct *within*
+    /// a region — including the 5' regions, where `-3 < -2 < -1` runs toward
+    /// the body exactly as the axis does.
+    coord: i64,
+}
+
+impl AxisPos {
+    fn new(region: Region, coord: i64) -> Self {
+        let rank = match region {
+            Region::FivePrimeUtr | Region::TxUpstream => 0,
+            Region::Genome | Region::Cds | Region::Rna | Region::Tx => 1,
+            Region::ThreePrimeUtr | Region::TxDownstream => 2,
+        };
+        Self { rank, coord }
+    }
+
+    /// Whether `next` is the position immediately 3' of `self`.
+    ///
+    /// Needed because an insertion's anchor is recognised by its two endpoints
+    /// being adjacent, and at a region boundary they are adjacent without being
+    /// consecutive integers: `c.15_*1insCC` anchors at the junction between the
+    /// last CDS base and the first 3'UTR base.
+    ///
+    /// Crossing *into* the body is fully checkable — the 5' regions end at `-1`.
+    /// Crossing *out* of it is not: whether `c.15` is the last CDS base depends
+    /// on the record, and this module holds no provider. HGVS insertion syntax
+    /// requires the two flanking positions to be adjacent, so the author's
+    /// spelling is taken at its word there — the same latitude the parser
+    /// already extends, since it accepts `c.15_*1insCC` without consulting a
+    /// reference either.
+    fn is_immediately_followed_by(self, next: Self) -> bool {
+        if self.rank == next.rank {
+            return next.coord == self.coord + 1;
+        }
+        next.rank == self.rank + 1 && next.coord == 1 && (self.rank != 0 || self.coord == -1)
+    }
+}
+
 /// Detect coincident-bounds groups in a cis allele.
 ///
 /// Returns one warning per group of `>= 2` same-accession sub-variants whose
-/// `(coordinate-system region, signed start, signed end)` keys are identical.
+/// ranked start/end positions ([`AxisPos`]) are identical.
 /// Insertions are excluded — they anchor at boundaries (`[end, start]`) and
 /// have no single-base location to coincide on. Trans / mosaic / chimeric /
 /// unknown phases short-circuit (the warning only applies to a same-haplotype
@@ -54,9 +144,11 @@ pub(crate) fn detect_overlap_conflicts(
         return Vec::new();
     }
 
-    // Group sub-variants by (accession, coord_system, region, start, end). The
-    // `Vec<usize>` collects 0-based indices into `variants` in input order so
-    // each group's `edit_kinds` reflect the source ordering of the conflict.
+    // Group sub-variants by (accession, coord_system, start, end), the endpoints
+    // ranked so a member spanning a region boundary groups with the rest rather
+    // than vanishing (#1508). The `Vec<usize>` collects 0-based indices into
+    // `variants` in input order so each group's `edit_kinds` reflect the source
+    // ordering of the conflict.
     let mut groups: BTreeMap<GroupKey, Vec<usize>> = BTreeMap::new();
     for (idx, variant) in variants.iter().enumerate() {
         let Some(key) = group_key(variant) else {
@@ -91,8 +183,8 @@ pub(crate) fn detect_overlap_conflicts(
 
     // Spans that *intersect* without coinciding (#1448).
     //
-    // The grouping above keys on exact `(accession, coord_system, region, start,
-    // end)` equality, so two members that overlap only partially — or that nest —
+    // The grouping above keys on exact `(accession, coord_system, start, end)`
+    // equality, so two members that overlap only partially — or that nest —
     // land in different groups and were reported by nothing. Strict mode
     // therefore accepted them, and they denote no sequence at all: the
     // independent applier declines them in either member order.
@@ -115,26 +207,25 @@ pub(crate) fn detect_overlap_conflicts(
     // an exactly-coincident pair is reported once — by the loop above, which
     // names every member of its group — rather than twice.
     for (i, first) in variants.iter().enumerate() {
-        let Some((coord_system, region, first_start, first_end)) = span_writer_footprint(first)
-        else {
+        let Some((coord_system, first_start, first_end)) = span_writer_footprint(first) else {
             continue;
         };
         let Some(first_accession) = first.accession().map(|a| a.to_string()) else {
             continue;
         };
         for (j, second) in variants.iter().enumerate().skip(i + 1) {
-            let Some((second_system, second_region, second_start, second_end)) =
-                span_writer_footprint(second)
+            let Some((second_system, second_start, second_end)) = span_writer_footprint(second)
             else {
                 continue;
             };
             let Some(second_accession) = second.accession().map(|a| a.to_string()) else {
                 continue;
             };
-            if first_accession != second_accession
-                || coord_system != second_system
-                || region != second_region
-            {
+            // No region-equality gate (#1508). It was never a molecule test —
+            // `coord_system` is that — and gating on it hid every pair one of
+            // whose members crosses a region boundary. Ranked positions compare
+            // across the boundary, so the geometry test below decides.
+            if first_accession != second_accession || coord_system != second_system {
                 continue;
             }
             // Coincident pairs belong to the grouped loop above.
@@ -186,7 +277,7 @@ pub(crate) fn detect_overlap_conflicts(
 ///   measured census.
 ///
 /// Both of those geometries belong to [`detect_insertion_overlaps`].
-fn span_writer_footprint(variant: &HgvsVariant) -> Option<(&'static str, Region, i64, i64)> {
+fn span_writer_footprint(variant: &HgvsVariant) -> Option<(&'static str, AxisPos, AxisPos)> {
     let edit = inner_edit(variant)?;
     if !matches!(
         edit,
@@ -287,17 +378,15 @@ fn junction_overlaps(
         idx: usize,
         accession: String,
         coord_system: &'static str,
-        region: Region,
-        gap: i64,
+        gap: AxisPos,
         kind: &'static str,
     }
     struct Span {
         idx: usize,
         accession: String,
         coord_system: &'static str,
-        region: Region,
-        start: i64,
-        end: i64,
+        start: AxisPos,
+        end: AxisPos,
         /// Whether the edit **removes** every base it spans, leaving nothing
         /// for an interior junction to be positioned against. See branch (b).
         removes_its_bases: bool,
@@ -306,7 +395,7 @@ fn junction_overlaps(
     let mut insertions: Vec<Insertion> = Vec::new();
     let mut spans: Vec<Span> = Vec::new();
     for (idx, variant) in variants.iter().enumerate() {
-        let Some((coord_system, region, start, end)) = simple_span(variant) else {
+        let Some((coord_system, start, end)) = simple_span(variant) else {
             continue;
         };
         let Some(accession) = variant.accession().map(|a| a.to_string()) else {
@@ -318,12 +407,18 @@ fn junction_overlaps(
         if matches!(edit, NaEdit::Insertion { .. }) {
             // A canonical insertion anchors at two adjacent positions; anything
             // else (e.g. a malformed single-position insertion) has no junction.
-            if end == start + 1 {
+            //
+            // Adjacency, not `end == start + 1` (#1508): at a region boundary
+            // the two flanking positions are adjacent without being consecutive
+            // integers, so the integer test silently declined to register
+            // `c.15_*1insCC` as occupying a junction at all — and two of those
+            // at one junction were accepted where the in-region pair is
+            // rejected.
+            if start.is_immediately_followed_by(end) {
                 insertions.push(Insertion {
                     idx,
                     accession,
                     coord_system,
-                    region,
                     gap: start,
                     kind: "ins",
                 });
@@ -342,7 +437,6 @@ fn junction_overlaps(
                     idx,
                     accession: accession.clone(),
                     coord_system,
-                    region,
                     gap: end,
                     kind,
                 });
@@ -385,7 +479,6 @@ fn junction_overlaps(
                 idx,
                 accession,
                 coord_system,
-                region,
                 start,
                 end,
                 removes_its_bases: matches!(edit, NaEdit::Deletion { .. }),
@@ -405,20 +498,20 @@ fn junction_overlaps(
     // writers). The same holds for the `repeat` spelling.
     // Each group carries `(index, kind)` so the warning can name every member by
     // its own spelling rather than labelling the whole group `ins`.
-    /// `(accession, coordinate system, region, gap)` — one zero-width junction
-    /// on one molecule.
-    type JunctionKey = (String, &'static str, Region, i64);
+    /// `(accession, coordinate system, gap)` — one zero-width junction on one
+    /// molecule. The ranked gap carries its own region (#1508).
+    type JunctionKey = (String, &'static str, AxisPos);
     /// The members writing at a junction, as `(index into `variants`, kind)`.
     type Occupants = Vec<(usize, &'static str)>;
 
     let mut by_junction: BTreeMap<JunctionKey, Occupants> = BTreeMap::new();
     for ins in &insertions {
         by_junction
-            .entry((ins.accession.clone(), ins.coord_system, ins.region, ins.gap))
+            .entry((ins.accession.clone(), ins.coord_system, ins.gap))
             .or_default()
             .push((ins.idx, ins.kind));
     }
-    for ((accession, coord_system, _region, _gap), occupants) in &by_junction {
+    for ((accession, coord_system, _gap), occupants) in &by_junction {
         if !include_same_junction || occupants.len() < 2 {
             continue;
         }
@@ -471,7 +564,6 @@ fn junction_overlaps(
             ins.idx != span.idx
                 && ins.accession == span.accession
                 && ins.coord_system == span.coord_system
-                && ins.region == span.region
                 && span.start <= ins.gap
                 // `gap + 1 <= end` (junction interior); `gap < end` for ints.
                 && ins.gap < span.end
@@ -507,9 +599,11 @@ fn junction_overlaps(
 struct GroupKey {
     accession: String,
     coord_system: &'static str,
-    region: Region,
-    start: i64,
-    end: i64,
+    /// Ranked endpoints, which subsume the old separate `region` field: two
+    /// members coincide only if both ends agree, and a ranked position already
+    /// carries which region it is in (#1508).
+    start: AxisPos,
+    end: AxisPos,
 }
 
 /// Build the group key for a sub-variant, or `None` if it can't participate
@@ -525,42 +619,39 @@ struct GroupKey {
 /// - positions with intronic offsets, `?` sentinels, or special anchors
 ///   (`pter`/`qter`/`cen`)
 fn group_key(variant: &HgvsVariant) -> Option<GroupKey> {
-    let (coord_system, region, start, end) = simple_range(variant)?;
+    let (coord_system, start, end) = simple_range(variant)?;
     edit_kind(variant)?;
     let accession = variant.accession()?.to_string();
     Some(GroupKey {
         accession,
         coord_system,
-        region,
         start,
         end,
     })
 }
 
-/// Extract `(coord_system, region, start, end)` for an overlap-eligible
+/// Extract `(coord_system, ranked start, ranked end)` for an overlap-eligible
 /// sub-variant. Mirrors [`super::merge::simple_range_for_variant`] but is
 /// more permissive on edit kind: `Duplication`, `Inversion`, and
 /// (single-base or range) `Repeat` all have a definite reference span and
 /// can collide with other edits, so they're included here. `Insertion` is
 /// excluded — its anchor is `[end, start]` (zero-width at a boundary) and
 /// the spec excludes insertions from this rule.
-fn simple_range(variant: &HgvsVariant) -> Option<(&'static str, Region, i64, i64)> {
+fn simple_range(variant: &HgvsVariant) -> Option<(&'static str, AxisPos, AxisPos)> {
     match variant {
-        HgvsVariant::Genome(g) => {
-            na_range(&g.loc_edit, genome_range).map(|(r, s, e)| ("g", r, s, e))
-        }
-        HgvsVariant::Cds(c) => na_range(&c.loc_edit, cds_range).map(|(r, s, e)| ("c", r, s, e)),
-        HgvsVariant::Tx(t) => na_range(&t.loc_edit, tx_range).map(|(r, s, e)| ("n", r, s, e)),
-        HgvsVariant::Rna(r) => na_range(&r.loc_edit, rna_range).map(|(rg, s, e)| ("r", rg, s, e)),
-        HgvsVariant::Mt(m) => na_range(&m.loc_edit, genome_range).map(|(r, s, e)| ("m", r, s, e)),
+        HgvsVariant::Genome(g) => na_range(&g.loc_edit, genome_range).map(|(s, e)| ("g", s, e)),
+        HgvsVariant::Cds(c) => na_range(&c.loc_edit, cds_range).map(|(s, e)| ("c", s, e)),
+        HgvsVariant::Tx(t) => na_range(&t.loc_edit, tx_range).map(|(s, e)| ("n", s, e)),
+        HgvsVariant::Rna(r) => na_range(&r.loc_edit, rna_range).map(|(s, e)| ("r", s, e)),
+        HgvsVariant::Mt(m) => na_range(&m.loc_edit, genome_range).map(|(s, e)| ("m", s, e)),
         _ => None,
     }
 }
 
 fn na_range<L>(
     loc_edit: &LocEdit<Interval<L>, NaEdit>,
-    range_fn: impl Fn(&Interval<L>) -> Option<(Region, i64, i64)>,
-) -> Option<(Region, i64, i64)> {
+    range_fn: impl Fn(&Interval<L>) -> Option<(AxisPos, AxisPos)>,
+) -> Option<(AxisPos, AxisPos)> {
     if !loc_edit.edit.is_certain() {
         return None;
     }
@@ -628,7 +719,7 @@ fn inner_edit(variant: &HgvsVariant) -> Option<&NaEdit> {
     }
 }
 
-/// Extract `(coord_system, region, start, end)` for a certain NaEdit-bearing
+/// Extract `(coord_system, ranked start, ranked end)` for a certain NaEdit-bearing
 /// variant *regardless of edit kind*.
 ///
 /// This is [`simple_range`] without the `is_overlap_edit` gate: insertion-
@@ -636,24 +727,22 @@ fn inner_edit(variant: &HgvsVariant) -> Option<&NaEdit> {
 /// which `simple_range` deliberately drops. Position-validity gates (special
 /// anchors, intronic offsets, `?` sentinels, region splits) still apply via
 /// the per-coordinate-system range helpers.
-fn simple_span(variant: &HgvsVariant) -> Option<(&'static str, Region, i64, i64)> {
+fn simple_span(variant: &HgvsVariant) -> Option<(&'static str, AxisPos, AxisPos)> {
     fn na_span<L>(
         loc_edit: &LocEdit<Interval<L>, NaEdit>,
-        range_fn: impl Fn(&Interval<L>) -> Option<(Region, i64, i64)>,
-    ) -> Option<(Region, i64, i64)> {
+        range_fn: impl Fn(&Interval<L>) -> Option<(AxisPos, AxisPos)>,
+    ) -> Option<(AxisPos, AxisPos)> {
         if !loc_edit.edit.is_certain() {
             return None;
         }
         range_fn(&loc_edit.location)
     }
     match variant {
-        HgvsVariant::Genome(g) => {
-            na_span(&g.loc_edit, genome_range).map(|(r, s, e)| ("g", r, s, e))
-        }
-        HgvsVariant::Cds(c) => na_span(&c.loc_edit, cds_range).map(|(r, s, e)| ("c", r, s, e)),
-        HgvsVariant::Tx(t) => na_span(&t.loc_edit, tx_range).map(|(r, s, e)| ("n", r, s, e)),
-        HgvsVariant::Rna(r) => na_span(&r.loc_edit, rna_range).map(|(rg, s, e)| ("r", rg, s, e)),
-        HgvsVariant::Mt(m) => na_span(&m.loc_edit, genome_range).map(|(r, s, e)| ("m", r, s, e)),
+        HgvsVariant::Genome(g) => na_span(&g.loc_edit, genome_range).map(|(s, e)| ("g", s, e)),
+        HgvsVariant::Cds(c) => na_span(&c.loc_edit, cds_range).map(|(s, e)| ("c", s, e)),
+        HgvsVariant::Tx(t) => na_span(&t.loc_edit, tx_range).map(|(s, e)| ("n", s, e)),
+        HgvsVariant::Rna(r) => na_span(&r.loc_edit, rna_range).map(|(s, e)| ("r", s, e)),
+        HgvsVariant::Mt(m) => na_span(&m.loc_edit, genome_range).map(|(s, e)| ("m", s, e)),
         _ => None,
     }
 }
@@ -780,10 +869,13 @@ fn render_boundary<P: std::fmt::Display>(boundary: &UncertainBoundary<P>) -> Str
 // six-line helpers would widen merge.rs's surface area for no real
 // benefit. The shared piece is `Region`, which is `pub(crate)`.
 
-fn genome_range(interval: &Interval<GenomePos>) -> Option<(Region, i64, i64)> {
+fn genome_range(interval: &Interval<GenomePos>) -> Option<(AxisPos, AxisPos)> {
     let s = simple_genome(interval.start.as_single()?)?;
     let e = simple_genome(interval.end.as_single()?)?;
-    Some((Region::Genome, s, e))
+    Some((
+        AxisPos::new(Region::Genome, s),
+        AxisPos::new(Region::Genome, e),
+    ))
 }
 
 fn simple_genome(mu: &Mu<GenomePos>) -> Option<i64> {
@@ -797,13 +889,13 @@ fn simple_genome(mu: &Mu<GenomePos>) -> Option<i64> {
     i64::try_from(pos.base).ok()
 }
 
-fn cds_range(interval: &Interval<CdsPos>) -> Option<(Region, i64, i64)> {
+fn cds_range(interval: &Interval<CdsPos>) -> Option<(AxisPos, AxisPos)> {
+    // No cross-region refusal (#1508): each endpoint keeps its own region and
+    // is ranked, so a span running from the body into a UTR is readable and
+    // therefore visible to the detectors above.
     let (rs, s) = simple_cds(interval.start.as_single()?)?;
     let (re, e) = simple_cds(interval.end.as_single()?)?;
-    if rs != re {
-        return None;
-    }
-    Some((rs, s, e))
+    Some((AxisPos::new(rs, s), AxisPos::new(re, e)))
 }
 
 fn simple_cds(mu: &Mu<CdsPos>) -> Option<(Region, i64)> {
@@ -826,13 +918,13 @@ fn simple_cds(mu: &Mu<CdsPos>) -> Option<(Region, i64)> {
     None
 }
 
-fn tx_range(interval: &Interval<TxPos>) -> Option<(Region, i64, i64)> {
+fn tx_range(interval: &Interval<TxPos>) -> Option<(AxisPos, AxisPos)> {
+    // No cross-region refusal (#1508): each endpoint keeps its own region and
+    // is ranked, so a span running from the body into a UTR is readable and
+    // therefore visible to the detectors above.
     let (rs, s) = simple_tx(interval.start.as_single()?)?;
     let (re, e) = simple_tx(interval.end.as_single()?)?;
-    if rs != re {
-        return None;
-    }
-    Some((rs, s, e))
+    Some((AxisPos::new(rs, s), AxisPos::new(re, e)))
 }
 
 fn simple_tx(mu: &Mu<TxPos>) -> Option<(Region, i64)> {
@@ -855,13 +947,13 @@ fn simple_tx(mu: &Mu<TxPos>) -> Option<(Region, i64)> {
     None
 }
 
-fn rna_range(interval: &Interval<RnaPos>) -> Option<(Region, i64, i64)> {
+fn rna_range(interval: &Interval<RnaPos>) -> Option<(AxisPos, AxisPos)> {
+    // No cross-region refusal (#1508): each endpoint keeps its own region and
+    // is ranked, so a span running from the body into a UTR is readable and
+    // therefore visible to the detectors above.
     let (rs, s) = simple_rna(interval.start.as_single()?)?;
     let (re, e) = simple_rna(interval.end.as_single()?)?;
-    if rs != re {
-        return None;
-    }
-    Some((rs, s, e))
+    Some((AxisPos::new(rs, s), AxisPos::new(re, e)))
 }
 
 fn simple_rna(mu: &Mu<RnaPos>) -> Option<(Region, i64)> {

--- a/tests/it/issue_1508_overlap_across_region_boundary.rs
+++ b/tests/it/issue_1508_overlap_across_region_boundary.rs
@@ -1,0 +1,236 @@
+//! #1508 — both cis overlap detectors were blind to a member whose span
+//! crosses a region boundary, so strict mode silently accepted overlaps it
+//! rejects when the same pair sits inside one region.
+//!
+//! Measured on `a530cdaf`, a 20-base transcript with CDS `1..=15`:
+//!
+//! ```text
+//! c.[11_12dup;12_13inv]      REJECTED  W5002
+//! c.[14_15dup;15_*1inv]      ACCEPTED            <-- same shape, across the boundary
+//! c.[11_12dup;12_13delinsAA] REJECTED  W5002
+//! c.[14_15dup;15_*1delinsAA] ACCEPTED
+//! c.[11_12del;11_12inv]      REJECTED  W5002
+//! c.[15_*1del;15_*1inv]      ACCEPTED
+//! c.[11_12insAA;11_12insCC]  REJECTED  W5002
+//! c.[15_*1insAA;15_*1insCC]  ACCEPTED  -> c.[15delinsCAA;15_*1insCC]
+//! ```
+//!
+//! Nothing about a pair changes when it moves across the boundary except that
+//! one member's span stops being readable. `cds_range` / `tx_range` /
+//! `rna_range` each ended with `if rs != re { return None }`, the same false
+//! premise #1482 found in `merge::join_pos`, and `None` there is not a decline:
+//! it reaches `let Some(..) = .. else { continue }`, so the member was dropped
+//! from the analysis rather than treated conservatively.
+//!
+//! # Why the parser is not the layer at fault
+//!
+//! `parse_hgvs` rejects `c.[14_15dup;15_*1del]` with E3006 across the boundary,
+//! correctly, because `detect_self_cancelling_pair` compares a region-ranked
+//! `CanonicalPos`. E3006 is deliberately narrow — it implements one spec rule
+//! (`general.md:58`, example `c.[762_768del;767_774dup]`) — and it implements it
+//! on both sides of a boundary. The general "two members claim the same
+//! positions" case is W5002's, and W5002 is the one that could not see across.
+//!
+//! # Blast radius
+//!
+//! This makes strict mode reject inputs it used to accept, so it was measured
+//! rather than assumed. Over 76,638 two-member cis alleles — 3 cores × 3 CDS
+//! layouts × every adjacent position pair spanning both boundaries × 5 edit
+//! spellings × both shuffle directions:
+//!
+//! | | count |
+//! |---|---|
+//! | strict-mode acceptances, before | 68,624 |
+//! | strict-mode acceptances, after | 67,497 |
+//! | **newly rejected** | **1,127** |
+//! | newly accepted | 0 |
+//!
+//! All 1,127 are alleles that denote no sequence: 1,062 have inputs the
+//! independent applier already declines, and for the remaining 65 the input
+//! applies but `main`'s own lenient *output* does not — checked one by one with
+//! `canonical_spdi`, 65 of 65. So the change reports real overlaps and invents
+//! none.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+const CORE: &str = "GCGCTAGTCTCGCCCTGTTA";
+
+/// A transcript with a real 5'UTR *and* a real 3'UTR, so both boundaries exist.
+fn provider(cds_start: u64, cds_end: u64) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        Some(cds_start),
+        Some(cds_end),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Whether strict mode accepts `input` — where "rejects" means **specifically
+/// the overlap**, not merely that something went wrong.
+///
+/// A bare `.is_ok()` would collapse every error to `false`, so a row asserting
+/// "this must be rejected" would be satisfied by an unrelated failure — a
+/// provider miss, a parse-level refusal, a coordinate check. That is exactly
+/// the outcome these tests must not accept, because the claim they defend is
+/// that the *overlap detector* now sees across the boundary. Any other error
+/// panics rather than quietly reading as a rejection.
+fn strict_accepts(provider: &MockProvider, input: &str, direction: ShuffleDirection) -> bool {
+    let variant = parse_hgvs(input).expect("input must parse");
+    match Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::strict().with_direction(direction),
+    )
+    .normalize(&variant)
+    {
+        Ok(_) => true,
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("W5002") || msg.contains("overlap"),
+                "`{input}` was rejected, but not for the overlap this test is about: {msg}"
+            );
+            false
+        }
+    }
+}
+
+/// The four shapes from the issue, each paired with the in-region control that
+/// was already rejected.
+///
+/// Written as pairs rather than as two lists because the control is the whole
+/// argument: these are the *same* geometries, and the only thing that changed
+/// was which side of the stop codon they sit on.
+#[test]
+fn an_overlap_is_reported_on_both_sides_of_the_cds_boundary() {
+    let provider = provider(1, 15);
+    for (across, inside) in [
+        (
+            "NM_TEST.1:c.[14_15dup;15_*1inv]",
+            "NM_TEST.1:c.[11_12dup;12_13inv]",
+        ),
+        (
+            "NM_TEST.1:c.[14_15dup;15_*1delinsAA]",
+            "NM_TEST.1:c.[11_12dup;12_13delinsAA]",
+        ),
+        (
+            "NM_TEST.1:c.[15_*1del;15_*1inv]",
+            "NM_TEST.1:c.[11_12del;11_12inv]",
+        ),
+        (
+            "NM_TEST.1:c.[15_*1insAA;15_*1insCC]",
+            "NM_TEST.1:c.[11_12insAA;11_12insCC]",
+        ),
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert!(
+                !strict_accepts(&provider, inside, direction),
+                "{inside} was already rejected before this change and must stay rejected"
+            );
+            assert!(
+                !strict_accepts(&provider, across, direction),
+                "{across} is the same geometry across the boundary and must be rejected too"
+            );
+        }
+    }
+}
+
+/// The 5'UTR/CDS boundary, which has its own arithmetic: the axis has no zero,
+/// so `c.-1` and `c.1` are adjacent while their coordinates differ by 2.
+#[test]
+fn the_five_prime_boundary_is_covered_too() {
+    let provider = provider(4, 15);
+    for input in [
+        "NM_TEST.1:c.[-2_-1dup;-1_1inv]",
+        "NM_TEST.1:c.[-1_1del;-1_1inv]",
+        "NM_TEST.1:c.[-1_1insAA;-1_1insCC]",
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert!(
+                !strict_accepts(&provider, input, direction),
+                "{input} overlaps across the 5'UTR/CDS boundary"
+            );
+        }
+    }
+}
+
+/// Members that merely *neighbour* a boundary, and members on opposite sides of
+/// one, are still accepted.
+///
+/// The control that matters most for a change that makes strict mode stricter:
+/// ranking the regions puts every member on one axis, and the risk is that
+/// pairs which were invisible to each other become *falsely* visible. Each of
+/// these is disjoint, and each is accepted before and after.
+#[test]
+fn disjoint_members_across_a_boundary_are_still_accepted() {
+    let provider = provider(1, 15);
+    for input in [
+        // A CDS member and a 3'UTR member with a gap between them.
+        "NM_TEST.1:c.[11_12del;*3_*4inv]",
+        // Flush on either side of the boundary, but not overlapping.
+        "NM_TEST.1:c.[14_15del;*1_*2dup]",
+        // A span ending at the boundary beside an insertion well 5' of it.
+        "NM_TEST.1:c.[13_14insAA;15_*1del]",
+        // Two members entirely inside the 3'UTR.
+        "NM_TEST.1:c.[*1_*2del;*4_*5inv]",
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert!(
+                strict_accepts(&provider, input, direction),
+                "{input} has disjoint members and must stay accepted"
+            );
+        }
+    }
+}
+
+/// A non-coding `n.` record, where the ranked regions are
+/// `TxUpstream` / `Tx` / `TxDownstream` rather than the UTRs.
+///
+/// `tx_range` carried the same refusal as `cds_range`, and the corpus harness
+/// emits no `n.` rows at all, so this axis is only covered by hand.
+#[test]
+fn the_transcript_axis_boundaries_are_covered() {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NR_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        None,
+        None,
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    for input in [
+        "NR_TEST.1:n.[19_20dup;20_*1inv]",
+        "NR_TEST.1:n.[20_*1del;20_*1inv]",
+        "NR_TEST.1:n.[-1_1del;-1_1inv]",
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert!(
+                !strict_accepts(&provider, input, direction),
+                "{input} overlaps across an `n.` region boundary"
+            );
+        }
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -219,6 +219,7 @@ mod issue_1431_single_position_repeat_anchor;
 mod issue_1437_dup_read_span_interior_sibling;
 mod issue_1448_partial_span_overlap;
 mod issue_1491_soft_masked_repeat_normalization;
+mod issue_1508_overlap_across_region_boundary;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1508

## The defect

Both cis overlap detectors in `src/normalize/overlap.rs` were blind to a member whose span crosses a region boundary, so **strict mode silently accepted overlaps it rejects when the same pair sits inside one region.** Measured on `a530cdaf`, a 20-base transcript with CDS `1..=15`:

```
c.[11_12dup;12_13inv]      REJECTED  W5002
c.[14_15dup;15_*1inv]      ACCEPTED            <-- same geometry, across the boundary
c.[11_12dup;12_13delinsAA] REJECTED  W5002
c.[14_15dup;15_*1delinsAA] ACCEPTED
c.[11_12del;11_12inv]      REJECTED  W5002
c.[15_*1del;15_*1inv]      ACCEPTED
c.[11_12insAA;11_12insCC]  REJECTED  W5002
c.[15_*1insAA;15_*1insCC]  ACCEPTED  ->  c.[15delinsCAA;15_*1insCC]
```

Nothing about a pair changes when it moves across the boundary except that one member's span stops being readable. The last row is the worst: strict mode not only accepts it but rewrites it into a `delins` claiming `c.15` beside an insertion at the junction interior to it.

The cause is the same false premise #1482 found in `merge::join_pos`, in a different module — `cds_range`, `tx_range` and `rna_range` each ended with:

```rust
if rs != re {
    return None;          // c.15_*1 is unreadable, so the member does not exist
}
```

`None` there is not a decline. It reaches `let Some(..) = .. else { continue }` and `span_writer_footprint` returns it the same way, so the member is **dropped from the analysis** rather than treated conservatively.

## The parser is the layer that already gets this right

`parse_hgvs` rejects `c.[14_15dup;15_*1del]` with E3006 across the boundary, correctly, because `AlleleVariant::detect_self_cancelling_pair` compares a region-ranked `CanonicalPos` instead of refusing to read a cross-region interval.

E3006's narrowness is therefore not the defect. It implements one specific spec rule — `recommendations/general.md:58`, "descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed", example `c.[762_768del;767_774dup]` — and it implements it on both sides of a boundary. The general "two cis members claim the same reference positions" case belongs to W5002, and W5002 is the one that could not see across.

## The fix

Rank the regions so the whole axis has one order — 5' of the body, the body, 3' of it, with the written coordinate second (`AxisPos`). That is the ordering `CanonicalPos` already gives the parser, so this adopts the existing precedent rather than inventing an order.

#1482 considered exactly this key for `merge::MemberSpan` and **rejected** it, which is worth stating because it looks like a contradiction. The distinction is what each module does with a span:

- `merge.rs` takes lengths and offsets at 42 sites, many computing `end - start + 1`; for `c.15_*1` that is `1 - 15`. A rank-ordered key would have compiled everywhere and produced wrong lengths for exactly the members just made visible, so that module converts onto the sequence axis with a provider.
- `overlap.rs` has no provider and needs none: every use is a comparison — do two spans coincide, do they intersect, does a junction fall interior to a span. The one arithmetic-looking test, `gap + 1 <= end`, was already written `gap < end`.

Insertion anchors need adjacency rather than ordering, so `AxisPos::is_immediately_followed_by` handles the case where two flanking positions are adjacent without being consecutive integers (`c.15_*1`, `c.-1_1`). Crossing *into* the body is fully checkable — the 5' regions end at `-1`; crossing *out* of it depends on the CDS length, which this module cannot know, so the author's spelling is taken at its word, the same latitude the parser already extends.

The now-redundant `region != second_region` gates are removed: region equality was never the molecule test (`coord_system` is), and gating on it is what hid every cross-boundary pair.

## Blast radius — strict mode

This makes strict mode reject inputs it currently accepts, so it was measured rather than assumed. Over **76,638** two-member cis alleles — 3 cores × 3 CDS layouts × every adjacent position pair spanning both boundaries × 5 edit spellings × both shuffle directions:

| | count |
|---|---|
| strict-mode acceptances, before | 68,624 |
| strict-mode acceptances, after | 67,497 |
| **newly rejected** | **1,127** |
| newly accepted | 0 |

**All 1,127 denote no sequence**, so the change reports real overlaps and invents none:

- **1,062** have inputs the independent applier already declines.
- **65** have inputs that apply — but `main`'s own *lenient output* for them does not, checked individually with `canonical_spdi`: 65 of 65 `out_applies=false`. My first pass measured appliability of the **input** and reported these as possible false positives; that was the wrong ground truth, since the detector runs post-shift. On the right one they are all true positives.

## Blast radius — lenient output

Not a strict-only change, which is worth stating because it is easy to assume it would be. `detect_overlap_conflicts` also gates whether an allele is preserved as authored (#395), so seeing more conflicts changes lenient output too. `examples/dump_normalized_corpus.rs`, 78,028 rows, against `c77267d0`:

| | rows |
|---|---|
| total | 78,028 |
| **moved** | **416 (0.5%)** |

| family | moved |
|---|---|
| `nested_spans` | 172 |
| `junction_interior_to_span` | 130 |
| `partial_overlap_spans` | 114 |
| the other twelve families | **0** |

Every moved row is in one of the three *conflicting* families, and **412 of the 416 now return the input verbatim** — the module's documented policy for a detected conflict ("preserves the input verbatim and emits one `OverlapConflict` per overlap") rather than the rewritten form `main` produced. Zero rows moved in any non-conflicting family, which is the shape a correct result has here.

The remaining **4** move the other way: `c.[5_6inv;5_6insCC]` on the poly-C `cx` core, where the insertion canonicalises into a repeat that crosses the 5'UTR/CDS boundary, goes from verbatim to `c.[-3_5C[10];5_6inv]`. Checked with `canonical_spdi`: the **input itself declines to apply** on both revisions, and so does each output — the members genuinely overlap either way, and both revisions raise the same W5002. So it is a spelling change between two forms that both denote nothing, not a correctness change. Recorded rather than smoothed over.

**For a downstream consumer keying on the normalized string:** every one of the 416 is an allele that strict mode rejects, before and after. Nothing moves for an allele whose members are disjoint.

## Tests

`tests/it/issue_1508_overlap_across_region_boundary.rs` — 4 tests. **The 3 defect tests were run against `main` and fail there**; the 4th is the must-stay-accepted control and passes on both, as its doc comment says.

- `an_overlap_is_reported_on_both_sides_of_the_cds_boundary` pairs each cross-boundary shape with the in-region control that was already rejected, because the control is the whole argument: same geometry, different side of the stop codon.
- `the_five_prime_boundary_is_covered_too` — different arithmetic, since the axis has no zero and `c.-1`/`c.1` are adjacent with coordinates two apart.
- `the_transcript_axis_boundaries_are_covered` — `n.` regions, which the corpus harness cannot reach at all (it emits `c`, `cx` and `g` rows only).
- `disjoint_members_across_a_boundary_are_still_accepted` — the control that matters most for a change making strict mode stricter: ranking the regions puts every member on one axis, so the risk is pairs becoming *falsely* visible to each other.

Full local gate, all green, **nothing re-blessed** — notable for a change that rejects 1,127 more alleles:

```
cargo fmt --all --check                                     pass
cargo clippy --all-features --all-targets -- -D warnings    pass
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev                          9527 passed, 0 failed
```

## Relationship to #1506

Independent and non-conflicting — #1506 is `src/normalize/merge.rs`, this is `src/normalize/overlap.rs` — but they are the same defect class, and #1506's fix is what makes some of the alleles this one now reports stop being produced in the first place. Either can merge first.
