### PR TITLE
fix(normalize): apply a junction barrier the translate cannot express

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7622,13 +7622,39 @@ fn translate_junction_member<P: ReferenceProvider>(
 
     let original = variant.clone();
     translate_member(variant, delta, kind, from, provider);
-    if *variant == original {
-        return; // the translation was refused; nothing to repair
-    }
+    // A refused translation is **not** "nothing to repair" (#1513). It used to
+    // return here, and that turned a correctly-computed barrier into a silent
+    // no-op: the caller had already decided this member must not sit where it
+    // does, and returning leaves it exactly there.
+    //
+    // `translate_member` refuses whenever the destination has no spelling *as
+    // this edit kind* — and for a duplication near the 5' end of an axis with no
+    // zero, that is routine rather than exotic. On `TAAAATTATATTTATTATTT`,
+    // `c.[1_2insAA;2_3insTT]` shifts its insertion 3' to `c.4_5dup`, sweeping
+    // across the `insTT` junction it does not commute with;
+    // `clamp_sibling_crossing_junctions` computes the barrier correctly and asks
+    // for junction 1, which for a two-base `dup` means the span `c.0_1`. There
+    // is no `c.0`, so the write reverted, the member stayed at `4_5`, and the
+    // allele went on to merge into `c.2_3insTTAA` — a description of **different
+    // bases** than the input.
+    //
+    // The repair the caller wants exists: the member re-spelled as a plain
+    // insertion carrying `moved` at `destination`, which is what the rest of this
+    // function already does for a translation that landed but changed meaning.
+    // A zero-width junction has a spelling everywhere a span may not, so falling
+    // through reaches it. `respell_at_gap` reverts anything it cannot place, and
+    // the guard at the end restores `original` when it does, so a member that
+    // truly cannot be moved is left as it was — the old behaviour, now reached by
+    // failing to place rather than by declining to try.
+    let translation_refused = *variant == original;
     let landed = member_span(variant, kind, provider)
         .filter(|s| s.junction == Some(destination))
         .and_then(|s| junction_payload(variant, kind, &s, provider));
-    if landed.as_deref() == Some(moved.as_slice()) {
+    // Only meaningful when the translation actually happened: on a refusal the
+    // member is still `original`, so this reads the payload it carries *where it
+    // was*, and if the barrier asked for the position it already occupies there
+    // was nothing to do in the first place.
+    if !translation_refused && landed.as_deref() == Some(moved.as_slice()) {
         return; // the spelling still denotes the same bases
     }
     let edit = NaEdit::Insertion {

--- a/tests/it/issue_1513_adjacent_junction_insertions.rs
+++ b/tests/it/issue_1513_adjacent_junction_insertions.rs
@@ -1,0 +1,198 @@
+//! #1513 — two insertions at neighbouring junctions normalized to a description
+//! of **different bases** than the input.
+//!
+//! ```text
+//! core  TAAAATTATATTTATTATTT      NM_TEST.1, CDS 1..=15
+//!
+//! c.[1_2insAA;2_3insTT]   3' ->  c.2_3insTTAA
+//!                         5' ->  c.1_2insATTA
+//!   input  SPDI  NM_TEST.1:4::TTAA
+//!   output SPDI  NM_TEST.1:2::TTAA        <- a different sequence
+//! ```
+//!
+//! The members sit at *distinct, disjoint* junctions, so the allele is
+//! well-formed: the applier accepts it and strict mode accepts it. This is not
+//! the non-confluence of #1235 / #1419-#1421 — those are two spellings of one
+//! variant disagreeing. This was one spelling normalizing to a *different
+//! variant*.
+//!
+//! # The clamp was right and the write was silent
+//!
+//! Worth recording, because the pass that looked guilty was not.
+//!
+//! `c.1_2insAA` 3'-shifts through the `A` run to `c.4_5dup`, sweeping across the
+//! `insTT` junction at 2. `AA` and `TT` do not commute, so
+//! `clamp_sibling_crossing_junctions` bars the crossing and asks for junction 1
+//! — instrumented, it computes `limit = Some(1)`, `destination = Some(1)`,
+//! exactly right.
+//!
+//! Then nothing happened. Moving a **two-base `dup`** to junction 1 means the
+//! span `c.0_1`, and the CDS axis has no zero, so `translate_member` reverted;
+//! `translate_junction_member` read the unchanged variant as *"the translation
+//! was refused; nothing to repair"* and returned, leaving the member at `4_5`.
+//! The barrier was computed, and then dropped on the floor. The allele went on
+//! to merge into a single insertion at the wrong junction.
+//!
+//! The fix is that a refusal is not "nothing to repair": the member falls
+//! through to `respell_at_gap`, which writes it as a plain insertion carrying
+//! the rotated payload. A zero-width junction has a spelling everywhere a span
+//! may not.
+//!
+//! Note the sequence-first re-derivation is **not** implicated, though it looks
+//! like the obvious suspect. Disabling `canonicalize_from_sequence` only changes
+//! the spelling of the wrong answer: `c.[2_3insTT;4_5dup]`, which keys to the
+//! same wrong `2::TTAA`. The error is upstream of it.
+//!
+//! # No oracle saw it
+//!
+//! `FERRO_ASSERT_REPARSE` passes (the output is well-formed),
+//! `FERRO_ASSERT_IN_BOUNDS` passes (every coordinate exists), and
+//! `FERRO_ASSERT_IDEMPOTENT` passes (the output is a fixed point). The applier is
+//! not wired in as an oracle, so "denotes a different sequence" was invisible.
+//! It was found by #1514's `--verify-spdi`, which asks the corpus that question.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// An `A` run at 2-5 for the insertion to shift through, then `TT`.
+const CORE: &str = "TAAAATTATATTTATTATTT";
+
+fn coding_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        Some(1),
+        Some(15),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn genomic_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_TEST.1", CORE.to_string());
+    provider
+}
+
+fn normalizer(provider: MockProvider, direction: ShuffleDirection) -> Normalizer<MockProvider> {
+    Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(direction),
+    )
+}
+
+/// The property: the normalized output must denote the same bases as its input.
+///
+/// Asserted through `canonical_spdi` rather than against a pinned string.
+/// That key is derived from the bases a description *produces* and is maximally
+/// 3'-shifted, so two spellings of one edit key identically by construction —
+/// which makes this survive a later change to which spelling is canonical, while
+/// still failing the moment the meaning moves.
+fn assert_denotes_the_same_bases(provider: MockProvider, input: &str, direction: ShuffleDirection) {
+    let variant = parse_hgvs(input).expect("input must parse");
+    let normalizer = normalizer(provider, direction);
+    let output = normalizer
+        .normalize(&variant)
+        .expect("normalization must succeed");
+    let key_in = normalizer
+        .canonical_spdi(&variant)
+        .expect("the input's members are disjoint, so it applies");
+    let key_out = normalizer
+        .canonical_spdi(&output)
+        .expect("the output must apply too");
+    assert_eq!(
+        key_in.to_string(),
+        key_out.to_string(),
+        "{input} [{direction:?}] normalized to {output}, which denotes different bases"
+    );
+}
+
+/// The reported allele, both directions and both input orders.
+#[test]
+fn adjacent_junction_insertions_keep_their_sequence() {
+    for input in [
+        "NM_TEST.1:c.[1_2insAA;2_3insTT]",
+        "NM_TEST.1:c.[2_3insTT;1_2insAA]",
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert_denotes_the_same_bases(coding_provider(), input, direction);
+        }
+    }
+}
+
+/// The same shape on the genomic axis.
+///
+/// Not redundant: the corpus reports **zero** `g.` rows for this defect, which
+/// reads as "the genomic axis is fine" and is wrong — the corpus simply does not
+/// build this geometry there. Measured directly, `g.[1_2insAA;2_3insTT]` gave
+/// `g.2_3insTTAA` before the fix, exactly as the `c.` axis did. A corpus zero is
+/// a claim about the corpus.
+#[test]
+fn the_genomic_axis_is_affected_too() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_denotes_the_same_bases(
+            genomic_provider(),
+            "NC_TEST.1:g.[1_2insAA;2_3insTT]",
+            direction,
+        );
+    }
+}
+
+/// Two insertions far enough apart that neither sweeps the other, and two that
+/// share a junction.
+///
+/// The controls for a change that makes a clamp *fire* where it used to no-op:
+/// the risk is pulling members back that had no business moving. Both values
+/// were measured on the pre-fix revision and are unchanged by it.
+#[test]
+fn insertions_that_do_not_sweep_a_sibling_are_untouched() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        // Junctions two apart: the shift never crosses the sibling.
+        assert_denotes_the_same_bases(
+            coding_provider(),
+            "NM_TEST.1:c.[1_2insAA;3_4insTT]",
+            direction,
+        );
+        // A lone insertion still shifts all the way, with no sibling to bound it.
+        let normalizer = normalizer(coding_provider(), direction);
+        let lone = parse_hgvs("NM_TEST.1:c.1_2insAA").unwrap();
+        let expected = match direction {
+            ShuffleDirection::ThreePrime => "NM_TEST.1:c.4_5dup",
+            _ => "NM_TEST.1:c.2_3dup",
+        };
+        assert_eq!(
+            normalizer.normalize(&lone).unwrap().to_string(),
+            expected,
+            "an unbounded insertion must keep shifting"
+        );
+    }
+}
+
+/// Two insertions on one junction are left as authored, and still are.
+///
+/// That pair genuinely has no defined order, so it is an overlap conflict rather
+/// than something to merge — `detect_insertion_overlaps` reports it and the
+/// allele is preserved. This change must not turn it into a merge.
+#[test]
+fn same_junction_insertions_are_still_preserved() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let normalizer = normalizer(coding_provider(), direction);
+        let variant = parse_hgvs("NM_TEST.1:c.[2_3insAA;2_3insTT]").unwrap();
+        assert_eq!(
+            normalizer.normalize(&variant).unwrap().to_string(),
+            "NM_TEST.1:c.[2_3insAA;2_3insTT]",
+            "a same-junction pair has no defined order and is preserved verbatim"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -223,6 +223,7 @@ mod issue_1452_soft_masked_repeat_span;
 mod issue_1482_boundary_crossing_sibling;
 mod issue_1491_soft_masked_repeat_normalization;
 mod issue_1508_overlap_across_region_boundary;
+mod issue_1513_adjacent_junction_insertions;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1513

## The defect

Two insertions at **distinct, disjoint** junctions normalized to a description of different bases than the input:

```
core  TAAAATTATATTTATTATTT      NM_TEST.1, CDS 1..=15

c.[1_2insAA;2_3insTT]   3' ->  c.2_3insTTAA
                        5' ->  c.1_2insATTA
  input  SPDI  NM_TEST.1:4::TTAA
  output SPDI  NM_TEST.1:2::TTAA        <- a different sequence
```

The allele is well-formed — the applier accepts it, strict mode accepts it. This is **not** the non-confluence of #1235 / #1419–#1421, which is two spellings of one variant disagreeing. This was one spelling normalizing to a *different variant*.

## The clamp was right; the write was silent

The pass that looks guilty is not the one at fault, so it is worth stating what was measured.

`c.1_2insAA` 3'-shifts through the `A` run to `c.4_5dup`, sweeping across the `insTT` junction at 2. `AA` and `TT` do not commute, so `clamp_sibling_crossing_junctions` bars the crossing and asks for junction 1. Instrumented, it computes exactly that:

```
CLAMP[0] c.1_2insAA -> c.4_5dup  junction 1 -> 5
CLAMP[0]   limit=Some(1)  destination=Some(1)
```

Then nothing happened. Moving a **two-base `dup`** to junction 1 means the span `c.0_1`, and the CDS axis has no zero — so `translate_member` reverted its write, and `translate_junction_member` read the unchanged variant as *"the translation was refused; nothing to repair"* and returned. The member stayed at `4_5`, precisely where the barrier had just said it must not be, and the allele went on to merge into one insertion at the wrong junction.

**Not the sequence-first re-derivation**, though that is the obvious suspect for "an allele re-derived into the wrong thing". Disabling `canonicalize_from_sequence` only respells the wrong answer as `c.[2_3insTT;4_5dup]`, which keys to the same wrong `2::TTAA`. The error is upstream of it.

## The fix

A refusal is not "nothing to repair" — the caller has already decided this member may not stay put. Fall through to `respell_at_gap`, which writes the member as a plain insertion carrying the rotated payload at the destination. That is the repair this function already performs for a translation that *lands* but changes meaning; a zero-width junction has a spelling everywhere a span may not.

The old outcome is preserved for members that genuinely cannot move: `respell_at_gap` reverts anything it cannot place, and the existing guard restores `original` when it does. The difference is that it is now reached by failing to place rather than by declining to try.

One companion change: the `landed` early-return is gated on the translation having actually happened. On a refusal the member is still `original`, so that check reads the payload where it *was* — and if the barrier asked for the position it already occupies, there was nothing to do anyway.

## Blast radius

Measured over the 78,028-row corpus against `33e286fe` (this PR's parent), using #1514's `--verify-spdi`:

| | rows |
|---|---|
| total | 78,028 |
| **moved** | **47 (0.1%)** |

| family | rows | moved |
|---|---|---|
| `adjacent_junction_ins` | 4,608 | **47** |
| the other fourteen families | 73,420 | **0** |

and on the question that matters:

| | outputs denoting bases their input does not |
|---|---|
| `33e286fe` | 80 |
| this PR | **41** |
| **newly wrong** | **0** |

39 fixed, none broken, and every moved row is in the one family the change targets.

**It composes with #1506.** That PR fixes 35 of the same 80; the two fixed sets are **disjoint** (overlap 0, union 74 of 80), so together they would leave 6. Neither subsumes the other and they touch different code.

## Tests

`tests/it/issue_1513_adjacent_junction_insertions.rs` — 4 tests. **Both defect tests were run against `33e286fe` and fail there**; both controls pass on both, as their doc comments say.

- `adjacent_junction_insertions_keep_their_sequence` — the reported allele, both directions, both input orders. Asserted through `canonical_spdi` rather than a pinned string, so it survives a later change to which spelling is canonical while still failing the moment the *meaning* moves.
- `the_genomic_axis_is_affected_too` — not redundant. The corpus reports **zero** `g.` rows for this defect, which reads as "the genomic axis is fine" and is wrong: it simply does not build this geometry there. Measured directly, `g.[1_2insAA;2_3insTT]` gave `g.2_3insTTAA` before the fix, exactly as `c.` did. A corpus zero is a claim about the corpus.
- `insertions_that_do_not_sweep_a_sibling_are_untouched` and `same_junction_insertions_are_still_preserved` — the controls that matter for a change making a clamp *fire* where it used to no-op: junctions two apart still shift freely, a lone insertion still shifts all the way, and a same-junction pair (which has no defined order) is still preserved verbatim rather than merged.

Full local gate, green, **nothing re-blessed**:

```
cargo fmt --all --check                                     pass
cargo clippy --all-features --all-targets -- -D warnings    pass
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev                          9547 passed, 0 failed
```

For a change that moves 47 corpus rows in the most contested pass in the crate, no re-blessing is the signal worth having: every existing expectation already agreed.

## Why no oracle caught it

`FERRO_ASSERT_REPARSE` passes (the output is well-formed), `FERRO_ASSERT_IN_BOUNDS` passes (every coordinate exists), `FERRO_ASSERT_IDEMPOTENT` passes (the output is a fixed point). The applier is not wired in as an oracle, so "denotes a different sequence" was invisible — the same gap #1448 recorded for its own class, one step further along. It was found by #1514's `--verify-spdi`, which is the first thing to ask the corpus that question.
