### PR TITLE
test(spec): assert equivalence classes converge and record contested spec readings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,30 @@ Two test modules actually read it — `tests/it/hgvs_spec_normalization_tests.rs
 |---|---|---|
 | `ferro_produces_the_form_the_spec_states` | `hgvs_spec_normalization_tests.rs` | ferro's output vs the **spec's** stated form, plus `KNOWN_DIVERGENT_INPUTS` |
 | `status_census_is_unchanged` | `hgvs_spec_normalization_tests.rs` | per-status row counts |
+| `spec_equivalence_classes_converge` | `hgvs_spec_normalization_tests.rs` | one normalized output per curated equivalence class, plus `EQUIVALENCE_CLASS_VERDICTS` |
+| `ruling_records_are_intact` | `hgvs_spec_normalization_tests.rs` | the ruling records' ids and decided/undecided statuses (`RULING_STATUSES`) |
 | `DIVERGENCE_BUDGET` / `PASSING_CENSUS` | `spec_enumeration_tests.rs` | per-status row counts, together totalling every row |
+
+**Statuses only ask whether ferro *changed* a string — never whether two rows are the same
+variant.** That is why the spec's own non-confluent pair
+(`LRG_199t1:c.850_901delinsTTCCTCGATGCCTG` and the `c.[850_869del;…]` split it names as that
+variant's "alternative description", `DNA/delins.md:44-47`) sat in the fixture as two `preserved`
+rows and passed. The `equivalence_classes` section of
+`hgvs_spec_normalization_overrides.json` closes that: it declares which harvested inputs denote
+one variant, and `spec_equivalence_classes_converge` fails when a class yields more than one
+output. The disagreements it currently finds are **expected and pinned** — converging them is
+#1235's job and a representation change for a downstream consumer, not something to fix in a test
+PR. Members that cannot be evaluated hermetically (`needs-reference`, or a description ferro
+refuses) are skipped rather than compared, so an error string never counts as a representation.
+
+The sibling `rulings` section is the decision log for clauses that **conflict at equal RFC 2119
+strength** (`style.md:9` binds the spec to RFC 2119; items 3 and 4 make RECOMMENDED == SHOULD and
+cover SHOULD NOT). Each record names the clauses in tension, which one governs, which is deviated
+from, and why. `undecided` is a first-class state and the generator **refuses** to build a record
+that is `undecided` yet names a governing clause — an unsettled question must not be able to
+smuggle in a ruling nobody made. Every citation carries a verbatim quote that the generator checks
+against the spec checkout, so a submodule bump that moves a clause fails the build instead of
+leaving the citation pointing at unrelated prose.
 
 Requires the `assets/hgvs-nomenclature` submodule (`git submodule update --init assets/hgvs-nomenclature`); without it the generator fails with `no HGVS strings harvested from …`, naming that command.
 

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -70,7 +70,8 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     let candidates = sources::discover(&cli.spec_dir)?;
     let overrides = overrides::load(&cli.overrides)?;
     let rows = runner::build_rows(&candidates, &overrides)?;
-    let rendered = render::render(&rows, &cli.spec_dir)?;
+    let decisions = decisions::resolve(&rows, &overrides, &cli.spec_dir)?;
+    let rendered = render::render(&rows, &decisions, &cli.spec_dir)?;
 
     if cli.check {
         check_up_to_date(&cli.output, &rendered, "fixture", "generate_spec_fixture")?;
@@ -99,6 +100,123 @@ mod overrides {
     pub struct Overrides {
         #[serde(default)]
         pub by_input: BTreeMap<String, OverrideEntry>,
+        /// Curated declarations that two or more harvested rows denote the
+        /// **same variant**. See [`EquivalenceClass`].
+        #[serde(default)]
+        pub equivalence_classes: Vec<EquivalenceClass>,
+        /// Curated records of how the project read the spec where its own
+        /// clauses conflict. See [`Ruling`].
+        #[serde(default)]
+        pub rulings: Vec<Ruling>,
+    }
+
+    /// A pointer into the vendored spec checkout, carrying the text it points at.
+    ///
+    /// `clause` is `<path-relative-to-spec-dir>:<line>` or `…:<start>-<end>` —
+    /// the same path form the harvester records in `source_paths`, so a citation
+    /// and a row's provenance are directly comparable.
+    ///
+    /// `quote` is what makes the citation self-verifying: the generator asserts
+    /// the text appears within the cited lines, so bumping the spec submodule in
+    /// a way that moves a clause fails the build instead of silently leaving a
+    /// citation pointing at unrelated prose. A bare line number would still
+    /// "resolve" against any file long enough to have that line.
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Citation {
+        pub clause: String,
+        pub quote: String,
+    }
+
+    /// Two or more harvested inputs that denote **one** variant.
+    ///
+    /// The classes cannot be derived: deciding that two descriptions denote one
+    /// variant means applying both to a reference sequence, which many rows
+    /// cannot do (the `needs-reference` bucket). So they are curated from the
+    /// spec's own equivalence statements — "alternatively", "can also be
+    /// described as", "giving an alternative description like" — exactly as the
+    /// `by_input` overrides are curated from its validity statements.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct EquivalenceClass {
+        /// Stable identifier. This is what the test consumer's pinned
+        /// known-non-confluent list keys on, so it must not be renamed casually.
+        pub id: String,
+        /// Row inputs, verbatim as harvested. Every one must exist as a row.
+        pub members: Vec<String>,
+        /// Accession all members are evaluated under, replacing whatever
+        /// accession each member's row would otherwise carry.
+        ///
+        /// Needed because the spec routinely writes one member of a pair as a
+        /// bare fragment (`c.[235A>T;237G>T]`), which the harvester prefixes
+        /// with the per-coordinate-system default rather than with the
+        /// accession of the worked example it sits under — and, twice, writes
+        /// the two members under *different* accession versions
+        /// (`NM_004006.2` / `NM_004006.1`, DNA/insertion.md:74). Comparing
+        /// members across different references would report a difference of
+        /// reference sequence as a difference of representation.
+        ///
+        /// Deliberately declared on the class rather than fixed by editing each
+        /// row's `input_prefixed`: that would move rows' `current` values and
+        /// the census pinned against them, for no gain outside this comparison.
+        #[serde(default)]
+        pub reference: Option<String>,
+        /// Where the spec says these are one variant. Must be non-empty.
+        pub citations: Vec<Citation>,
+        /// Why this is a class, in prose.
+        pub note: String,
+    }
+
+    /// Whether the project has taken a position on a contested reading.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub enum RulingStatus {
+        /// The project has ruled. `governing` names the clause held to govern.
+        Decided,
+        /// The project has **not** ruled. `governing` must be absent — an
+        /// undecided record states the conflict and stops there, so nobody can
+        /// read a ruling out of a record that never made one.
+        Undecided,
+    }
+
+    /// A record of how the project reads the spec where the spec conflicts with
+    /// itself, and of what it has *not* decided.
+    ///
+    /// `style.md:9` binds the spec to RFC 2119, and items 3 and 4 there make
+    /// "RECOMMENDED" equal to SHOULD and cover SHOULD NOT. Two SHOULD-strength
+    /// clauses can therefore reach the same description and point opposite ways,
+    /// with nothing in the text to break the tie — RFC 2119 instead licenses
+    /// deviation once the implications are weighed. This record is where that
+    /// weighing is written down.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Ruling {
+        /// Stable identifier; pinned by the test consumer.
+        pub id: String,
+        /// The contested question, in one sentence.
+        pub question: String,
+        pub status: RulingStatus,
+        /// Every clause the record is about, cited and quote-verified. A
+        /// conflict record names both sides; a settled carve-out may name one.
+        pub clauses: Vec<Citation>,
+        /// The `clause` string, drawn from [`Self::clauses`], held to govern.
+        /// Required when `decided`, forbidden when `undecided`.
+        #[serde(default)]
+        pub governing: Option<String>,
+        /// The `clause` strings, drawn from [`Self::clauses`], deviated from in
+        /// reaching the ruling. Necessarily empty when `undecided`: a record
+        /// that has not chosen a side has not deviated from one either.
+        #[serde(default)]
+        pub deviates_from: Vec<String>,
+        /// Why. For an undecided record: what the project has and has not
+        /// established, and what would settle it.
+        pub rationale: String,
+        /// Row inputs the ruling bears on. Every one must exist as a row.
+        #[serde(default)]
+        pub applies_to: Vec<String>,
+        /// Equivalence-class ids the ruling bears on, if any.
+        #[serde(default)]
+        pub equivalence_classes: Vec<String>,
     }
 
     /// `spec_expected` uses the doubly-optional pattern so the override file
@@ -459,6 +577,22 @@ mod runner {
         Ok(rows)
     }
 
+    /// A normalizer over the hermetic provider, for callers outside `build_rows`.
+    pub fn new_normalizer() -> Normalizer<MockProvider> {
+        Normalizer::new(MockProvider::new())
+    }
+
+    /// Run one description and report `(rendering, evaluated_cleanly)`.
+    ///
+    /// `false` means ferro refused it — the rendering is then the parse or
+    /// normalize error text, which is not a representation and must not be
+    /// compared against one.
+    pub fn observe(normalizer: &Normalizer<MockProvider>, target: &str) -> (String, bool) {
+        let outcome = run_ferro(normalizer, target);
+        let ok = outcome.parse_ok && outcome.normalize_ok;
+        (outcome.current, ok)
+    }
+
     fn run_ferro(normalizer: &Normalizer<MockProvider>, input: &str) -> FerroOutcome {
         let failed = |current: String, parse_ok: bool| FerroOutcome {
             current,
@@ -594,6 +728,356 @@ mod runner {
     }
 }
 
+// ---------- decisions ----------
+
+/// Resolution and validation of the two curated decision-log sections:
+/// equivalence classes (Task 1) and rulings (Task 2).
+///
+/// Everything here is a **build-time gate**. A class naming an input the
+/// harvester no longer produces, a citation whose quote has moved in the spec
+/// checkout, an `undecided` record that quietly grew a governing clause — each
+/// fails generation, which is the same guard the `by_input` overrides already
+/// get (`overrides reference unknown inputs`). The test consumer then re-derives
+/// the verdicts live; nothing downstream trusts what is written here.
+mod decisions {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    /// One member of a class, as evaluated.
+    #[derive(Debug, Serialize)]
+    pub struct ResolvedMember {
+        /// The harvested input, verbatim.
+        pub input: String,
+        /// What ferro was actually run against — the row's target, re-anchored
+        /// onto the class `reference` when the class declares one.
+        pub target: String,
+        /// ferro's rendering, or its refusal text when `evaluable` is false.
+        pub normalized: String,
+        /// False when this member cannot contribute to the comparison: it needs
+        /// real reference bases, or ferro refuses it outright. Such a member is
+        /// neither evidence of confluence nor of its absence.
+        pub evaluable: bool,
+        /// Why it is not evaluable. Absent when it is.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub skipped_because: Option<String>,
+    }
+
+    #[derive(Debug, Serialize)]
+    pub struct ResolvedClass {
+        pub id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reference: Option<String>,
+        pub citations: Vec<overrides::Citation>,
+        pub note: String,
+        pub members: Vec<ResolvedMember>,
+        /// The distinct renderings the evaluable members produced. One entry is
+        /// confluence; more than one is the defect the class exists to name.
+        pub distinct_outputs: Vec<String>,
+        pub verdict: &'static str,
+    }
+
+    #[derive(Debug, Serialize)]
+    pub struct ResolvedRuling {
+        pub id: String,
+        pub question: String,
+        pub status: overrides::RulingStatus,
+        pub clauses: Vec<overrides::Citation>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub governing: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub deviates_from: Vec<String>,
+        pub rationale: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub applies_to: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub equivalence_classes: Vec<String>,
+    }
+
+    #[derive(Debug, Serialize)]
+    pub struct Decisions {
+        pub equivalence_classes: Vec<ResolvedClass>,
+        pub rulings: Vec<ResolvedRuling>,
+    }
+
+    /// Verdict strings. Written on the row for readers; the test consumer
+    /// re-derives its own rather than reading these.
+    const CONFLUENT: &str = "confluent";
+    const NON_CONFLUENT: &str = "non-confluent";
+    const NOT_EVALUABLE: &str = "not-evaluable";
+
+    /// Re-anchor `target` onto `reference`, replacing any accession it carries.
+    ///
+    /// The accession is everything before the **first** colon, which is where
+    /// HGVS puts it; a colon later in the string belongs to an inner reference
+    /// (`g.10_11ins[NC_…:g.20_30]`) and must be left alone.
+    fn anchor(target: &str, reference: Option<&str>) -> String {
+        match reference {
+            None => target.to_string(),
+            Some(accession) => match target.split_once(':') {
+                Some((_, rest)) => format!("{accession}:{rest}"),
+                None => format!("{accession}:{target}"),
+            },
+        }
+    }
+
+    /// Split a `path:line` or `path:start-end` clause into its parts.
+    fn parse_clause(clause: &str) -> anyhow::Result<(&str, usize, usize)> {
+        let (path, lines) = clause
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow::anyhow!("citation {clause:?} is not `<path>:<line>`"))?;
+        let (first, last) = match lines.split_once('-') {
+            Some((a, b)) => (a, b),
+            None => (lines, lines),
+        };
+        let parse = |s: &str| {
+            s.parse::<usize>()
+                .map_err(|_| anyhow::anyhow!("citation {clause:?} has a non-numeric line"))
+        };
+        let (first, last) = (parse(first)?, parse(last)?);
+        if first == 0 || last < first {
+            anyhow::bail!("citation {clause:?} has an empty or inverted line range");
+        }
+        Ok((path, first, last))
+    }
+
+    /// Fail unless the citation resolves against the spec checkout **and** the
+    /// quoted text is still on the cited lines.
+    fn verify_citation(
+        spec_dir: &Path,
+        owner: &str,
+        citation: &overrides::Citation,
+    ) -> anyhow::Result<()> {
+        let (path, first, last) = parse_clause(&citation.clause)?;
+        let full = spec_dir.join(path);
+        let text = std::fs::read_to_string(&full).map_err(|e| {
+            anyhow::anyhow!(
+                "{owner}: citation {:?} names {} which cannot be read: {e}",
+                citation.clause,
+                full.display()
+            )
+        })?;
+        let lines: Vec<&str> = text.lines().collect();
+        if last > lines.len() {
+            anyhow::bail!(
+                "{owner}: citation {:?} runs past the end of {path} ({} lines)",
+                citation.clause,
+                lines.len()
+            );
+        }
+        if citation.quote.trim().is_empty() {
+            anyhow::bail!("{owner}: citation {:?} has an empty quote", citation.clause);
+        }
+        // Join on a space so a quote may span the cited lines. Both sides are
+        // whitespace-collapsed, so re-wrapping the spec's prose does not
+        // invalidate a citation while moving it elsewhere still does.
+        let collapse = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        let haystack = collapse(&lines[first - 1..last].join(" "));
+        if !haystack.contains(&collapse(&citation.quote)) {
+            anyhow::bail!(
+                "{owner}: citation {:?} no longer quotes the spec. Expected to find\n  {:?}\nwithin those lines, which currently read\n  {:?}\nThe spec submodule moved under this citation — re-point it rather than deleting the quote.",
+                citation.clause,
+                citation.quote,
+                haystack
+            );
+        }
+        Ok(())
+    }
+
+    pub fn resolve(
+        rows: &[runner::Row],
+        overrides: &overrides::Overrides,
+        spec_dir: &Path,
+    ) -> anyhow::Result<Decisions> {
+        let by_input: BTreeMap<&str, &runner::Row> =
+            rows.iter().map(|r| (r.input.as_str(), r)).collect();
+        let normalizer = runner::new_normalizer();
+
+        let mut seen_ids: BTreeSet<&str> = BTreeSet::new();
+        let mut classes = Vec::with_capacity(overrides.equivalence_classes.len());
+        for class in &overrides.equivalence_classes {
+            let owner = format!("equivalence class {:?}", class.id);
+            if !seen_ids.insert(class.id.as_str()) {
+                anyhow::bail!("{owner}: duplicate id");
+            }
+            if class.members.len() < 2 {
+                anyhow::bail!("{owner}: a class needs at least two members");
+            }
+            if class.citations.is_empty() {
+                anyhow::bail!(
+                    "{owner}: a class must cite where the spec says its members are one variant"
+                );
+            }
+            for citation in &class.citations {
+                verify_citation(spec_dir, &owner, citation)?;
+            }
+
+            let mut members = Vec::with_capacity(class.members.len());
+            let mut distinct: BTreeSet<String> = BTreeSet::new();
+            for input in &class.members {
+                let row = by_input.get(input.as_str()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{owner}: member {input:?} is not a fixture row (typo or spec drift)"
+                    )
+                })?;
+                let target = anchor(
+                    row.input_prefixed.as_deref().unwrap_or(&row.input),
+                    class.reference.as_deref(),
+                );
+                let (normalized, ok) = runner::observe(&normalizer, &target);
+                // Two ways a member cannot contribute. A row the auditor already
+                // marked reference-dependent is skipped without running, since
+                // the hermetic provider would only produce a lookup error; a row
+                // ferro refuses is skipped on the refusal itself.
+                let skipped_because =
+                    if row.status == "needs-reference" || row.requires_reference == Some(true) {
+                        Some("needs real reference bases".to_string())
+                    } else if !ok {
+                        Some(format!("ferro does not evaluate it: {normalized}"))
+                    } else {
+                        None
+                    };
+                if skipped_because.is_none() {
+                    distinct.insert(normalized.clone());
+                }
+                members.push(ResolvedMember {
+                    input: input.clone(),
+                    target,
+                    normalized,
+                    evaluable: skipped_because.is_none(),
+                    skipped_because,
+                });
+            }
+
+            let verdict = match distinct.len() {
+                0 | 1 if members.iter().filter(|m| m.evaluable).count() < 2 => NOT_EVALUABLE,
+                1 => CONFLUENT,
+                _ => NON_CONFLUENT,
+            };
+            classes.push(ResolvedClass {
+                id: class.id.clone(),
+                reference: class.reference.clone(),
+                citations: class.citations.clone(),
+                note: class.note.clone(),
+                members,
+                distinct_outputs: distinct.into_iter().collect(),
+                verdict,
+            });
+        }
+
+        let class_ids: BTreeSet<&str> = classes.iter().map(|c| c.id.as_str()).collect();
+        let mut seen_rulings: BTreeSet<&str> = BTreeSet::new();
+        let mut rulings = Vec::with_capacity(overrides.rulings.len());
+        for ruling in &overrides.rulings {
+            let owner = format!("ruling {:?}", ruling.id);
+            if !seen_rulings.insert(ruling.id.as_str()) {
+                anyhow::bail!("{owner}: duplicate id");
+            }
+            if ruling.rationale.trim().is_empty() {
+                anyhow::bail!("{owner}: a ruling record must say why");
+            }
+            if ruling.clauses.is_empty() {
+                anyhow::bail!("{owner}: a ruling record must cite at least one clause");
+            }
+            for citation in &ruling.clauses {
+                verify_citation(spec_dir, &owner, citation)?;
+            }
+            let cited: BTreeSet<&str> = ruling.clauses.iter().map(|c| c.clause.as_str()).collect();
+            for role in ruling.governing.iter().chain(ruling.deviates_from.iter()) {
+                if !cited.contains(role.as_str()) {
+                    anyhow::bail!(
+                        "{owner}: names {role:?} as governing or deviated-from, but that clause is \
+                         not in `clauses` — every role must point at a cited, quote-verified clause"
+                    );
+                }
+            }
+            match ruling.status {
+                overrides::RulingStatus::Decided if ruling.governing.is_none() => anyhow::bail!(
+                    "{owner}: a `decided` ruling must name the clause it holds to govern"
+                ),
+                // The whole point of the `undecided` state is that nobody has
+                // ruled. A governing clause — or a deviated-from one, which
+                // implies a side was chosen — is an invented ruling, so it is a
+                // build failure rather than a lint.
+                overrides::RulingStatus::Undecided
+                    if ruling.governing.is_some() || !ruling.deviates_from.is_empty() =>
+                {
+                    anyhow::bail!(
+                        "{owner}: an `undecided` ruling must not name a governing or deviated-from \
+                         clause — record the conflict, not a ruling nobody made"
+                    )
+                }
+                _ => {}
+            }
+            for input in &ruling.applies_to {
+                if !by_input.contains_key(input.as_str()) {
+                    anyhow::bail!(
+                        "{owner}: applies_to {input:?} is not a fixture row (typo or spec drift)"
+                    );
+                }
+            }
+            for id in &ruling.equivalence_classes {
+                if !class_ids.contains(id.as_str()) {
+                    anyhow::bail!("{owner}: names unknown equivalence class {id:?}");
+                }
+            }
+            rulings.push(ResolvedRuling {
+                id: ruling.id.clone(),
+                question: ruling.question.clone(),
+                status: ruling.status,
+                clauses: ruling.clauses.clone(),
+                governing: ruling.governing.clone(),
+                deviates_from: ruling.deviates_from.clone(),
+                rationale: ruling.rationale.clone(),
+                applies_to: ruling.applies_to.clone(),
+                equivalence_classes: ruling.equivalence_classes.clone(),
+            });
+        }
+
+        Ok(Decisions {
+            equivalence_classes: classes,
+            rulings,
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn anchor_replaces_only_the_leading_accession() {
+            assert_eq!(
+                anchor("NM_004006.2:c.[235A>T;237G>T]", Some("LRG_199t1")),
+                "LRG_199t1:c.[235A>T;237G>T]"
+            );
+            // A colon inside an inserted-range payload is not the accession.
+            assert_eq!(
+                anchor("NC_1.1:g.10_11ins[NC_2.1:g.20_30]", Some("NC_9.9")),
+                "NC_9.9:g.10_11ins[NC_2.1:g.20_30]"
+            );
+            assert_eq!(
+                anchor("c.235_237delinsTAT", Some("X.1")),
+                "X.1:c.235_237delinsTAT"
+            );
+            assert_eq!(anchor("NM_1.1:c.1del", None), "NM_1.1:c.1del");
+        }
+
+        #[test]
+        fn parses_single_lines_and_ranges() {
+            assert_eq!(
+                parse_clause("docs/recommendations/DNA/delins.md:47").unwrap(),
+                ("docs/recommendations/DNA/delins.md", 47, 47)
+            );
+            assert_eq!(
+                parse_clause("docs/recommendations/DNA/delins.md:44-47").unwrap(),
+                ("docs/recommendations/DNA/delins.md", 44, 47)
+            );
+            assert!(parse_clause("docs/recommendations/DNA/delins.md").is_err());
+            assert!(parse_clause("a.md:0").is_err());
+            assert!(parse_clause("a.md:9-4").is_err());
+        }
+    }
+}
+
 // ---------- render ----------
 
 mod render {
@@ -605,6 +1089,11 @@ mod render {
         spec: SpecBlock<'a>,
         generated_utc: String,
         summary: Summary,
+        /// Curated "these spellings are one variant" declarations, resolved
+        /// against ferro's current output. See `decisions`.
+        equivalence_classes: &'a [decisions::ResolvedClass],
+        /// Curated records of contested spec readings. See `decisions`.
+        rulings: &'a [decisions::ResolvedRuling],
         rows: &'a [runner::Row],
     }
 
@@ -621,6 +1110,10 @@ mod render {
         by_status: BTreeMap<String, usize>,
         by_coordinate_system: BTreeMap<String, usize>,
         by_source_kind: BTreeMap<String, usize>,
+        /// Equivalence-class verdicts, so the decision log's headline number
+        /// sits beside the row census rather than having to be counted by hand.
+        equivalence_classes_by_verdict: BTreeMap<String, usize>,
+        rulings_by_status: BTreeMap<String, usize>,
     }
 
     fn read_submodule_commit(spec_dir: &Path) -> anyhow::Result<String> {
@@ -647,12 +1140,29 @@ mod render {
         Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
     }
 
-    pub fn render(rows: &[runner::Row], spec_dir: &Path) -> anyhow::Result<String> {
+    pub fn render(
+        rows: &[runner::Row],
+        decisions: &decisions::Decisions,
+        spec_dir: &Path,
+    ) -> anyhow::Result<String> {
         let commit_sha = read_submodule_commit(spec_dir)?;
         let mut summary = Summary {
             total: rows.len(),
             ..Default::default()
         };
+        for c in &decisions.equivalence_classes {
+            *summary
+                .equivalence_classes_by_verdict
+                .entry(c.verdict.to_string())
+                .or_default() += 1;
+        }
+        for r in &decisions.rulings {
+            let key = serde_json::to_value(r.status)?
+                .as_str()
+                .unwrap_or("unknown")
+                .to_string();
+            *summary.rulings_by_status.entry(key).or_default() += 1;
+        }
         for r in rows {
             *summary.by_status.entry(r.status.clone()).or_default() += 1;
             *summary
@@ -666,8 +1176,12 @@ mod render {
         }
         let doc = Document {
             description:
-                "HGVS v21.0 spec normalization fixture - pins ferro's current normalize() output. \
-                          Companion to issue #84.",
+                "HGVS v21.0 spec normalization fixture - pins ferro's current normalize() output \
+                 for every variant string in the spec, plus the curated decision log: \
+                 `equivalence_classes` (spellings the spec states denote one variant, and whether \
+                 ferro converges them) and `rulings` (how the project reads clauses that conflict \
+                 at equal RFC 2119 strength, including what it has not decided). \
+                 Companion to issue #84.",
             spec: SpecBlock {
                 source: "https://github.com/HGVSnomenclature/hgvs-nomenclature",
                 tag: "21.0.0",
@@ -675,6 +1189,8 @@ mod render {
             },
             generated_utc: "fixture-byte-stable".to_string(),
             summary,
+            equivalence_classes: &decisions.equivalence_classes,
+            rulings: &decisions.rulings,
             rows,
         };
         let mut out = serde_json::to_string_pretty(&doc)?;

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -142,5 +142,261 @@
       "spec_expected": null,
       "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS. ferro rejects it; force spec-rejects (see #546). (#955)"
     }
-  }
+  },
+  "equivalence_classes": [
+    {
+      "id": "dna-delins-vs-aligned-split-850-901",
+      "reference": "LRG_199t1",
+      "members": [
+        "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        "c.[850_869del;874_881del;887_897del;901_902insG]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:44-47",
+          "quote": "parts of the inserted sequence \"align\" with the reference sequence, giving an alternative description like"
+        }
+      ],
+      "note": "The spec's own non-confluent pair, and the reason this section exists. It states outright that the bracketed split is \"an alternative description\" of the delins, i.e. one variant with two spellings. Both are `preserved`, so ferro has two stable fixed points for one variant and the row-level status bucket reports that as full conformance. The bare member is anchored on `LRG_199t1` because the spec writes it under that worked example; without the anchor the harvester's per-coordinate-system default (`NM_004006.2`) would make the two members differ by reference sequence as well as by representation. Governed by ruling `delins-merge-vs-individual-gap-two-or-more`."
+    },
+    {
+      "id": "dna-delins-vs-two-substitutions-235-237",
+      "members": [
+        "c.235_237delinsTAT",
+        "c.[235A>T;237G>T]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:19",
+          "quote": "two different substitutions at one position (e.g., `c.235_237delinsTAT` (`p.Lys79Tyr`) versus `c.[235A>T;237G>T]`"
+        }
+      ],
+      "note": "One codon, two substitutions one nucleotide apart: `235A>T` + `237G>T` over reference `A?G` is exactly `delinsTAT`. The spec presents the pair to argue that the split spelling makes tools predict conflicting protein consequences, so the delins spelling is the one it wants — but it marks neither `<code class=\"invalid\">`, and ferro preserves both. Falls inside the codon carve-out settled by ruling `delins-codon-carve-out-gap-one`."
+    },
+    {
+      "id": "dna-delins-vs-two-substitutions-145-147",
+      "reference": "LRG_199t1",
+      "members": [
+        "LRG_199t1:c.145_147delinsTGG",
+        "c.[145C>T;147C>G]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:37",
+          "quote": "`LRG_199t1:c.145_147delinsTGG`"
+        },
+        {
+          "clause": "docs/recommendations/DNA/delins.md:42",
+          "quote": "so the description <code class=\"invalid\">c.[145C>T;147C>G]</code> is not correct"
+        }
+      ],
+      "note": "Same shape as the `235_237` class and the same carve-out, but here the spec does mark the split spelling invalid — so the split member is a `false-acceptance` row. Note the spec's own layout is off: the `:42` NOTE sits under the `c.9002_9009delinsTTT` bullet while the variant it names belongs to the `:37` bullet (`c.145_147` is `CGC`; `145C>T` + `147C>G` gives `TGG`). The two members are cited separately for that reason. This class is what the `false-acceptance` census cannot say: ferro not only accepts a spelling the spec forbids, it keeps it as a second fixed point for a variant it already has a form for."
+    },
+    {
+      "id": "rna-delins-vs-two-substitutions-142-144",
+      "members": [
+        "r.142_144delinsugg",
+        "r.[142c>u;144a>g]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/RNA/delins.md:40",
+          "quote": "the variant can also be described as `r.[142c>u;144a>g]`, i.e. two substitutions"
+        }
+      ],
+      "note": "The RNA-level twin of the `145_147` class — the same variant on the same transcript, one coordinate system over. The spec goes further here than on the DNA side and says the split format is *preferred* when either substitution is a known polymorphism, which is a third, frequency-dependent tiebreak the description string cannot carry."
+    },
+    {
+      "id": "dna-insertion-n-run-vs-repeat-count-761-762",
+      "reference": "NM_004006.2",
+      "members": [
+        "NM_004006.2:c.761_762insNNNNN",
+        "NM_004006.1:c.761_762insN[5]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/DNA/insertion.md:74",
+          "quote": "`NM_004006.2:c.761_762insNNNNN` (alternatively `NM_004006.1:c.761_762insN[5]`)"
+        }
+      ],
+      "note": "Five unspecified nucleotides, written out or written as a repeat count. The spec's two spellings carry *different accession versions* (`.2` and `.1`) — plainly a typo in the spec, since the prose describes one insertion; the class anchors both on `NM_004006.2` so the comparison is about representation rather than about which transcript version was meant."
+    },
+    {
+      "id": "rna-insertion-n-run-vs-repeat-count-761-762",
+      "reference": "NM_004006.2",
+      "members": [
+        "NM_004006.2:r.761_762insnnnnn",
+        "r.761_762insn[5]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/RNA/insertion.md:38",
+          "quote": "`NM_004006.2:r.761_762insnnnnn` (alternatively `r.761_762insn[5]`)"
+        }
+      ],
+      "note": "RNA twin of `dna-insertion-n-run-vs-repeat-count-761-762`. Anchored because the spec writes the second spelling as a bare fragment under an `NM_004006.2` example, while the harvester's default `r.` accession is `NM_004006.3`."
+    },
+    {
+      "id": "rna-repeat-range-vs-unit-124",
+      "members": [
+        "r.-124_-123[14]",
+        "r.-124ug[14]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/RNA/repeated.md:31",
+          "quote": "`r.-124_-123[14]` (alternatively `r.-124ug[14]`)"
+        }
+      ],
+      "note": "One repeat, spelled by the span of its first unit or by the unit's own sequence. Both are HGVS-legal and the spec offers them as equals, so nothing in the text picks a canonical one — a representation choice ferro makes silently."
+    },
+    {
+      "id": "rna-repeat-range-vs-unit-124-two-alleles",
+      "members": [
+        "r.-124_-123[14];[18]",
+        "r.-124ug[14];[18]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/RNA/repeated.md:36",
+          "quote": "`r.-124_-123[14];[18]` (alternatively `r.-124ug[14];[18]`)"
+        }
+      ],
+      "note": "The same span-vs-unit choice as `rna-repeat-range-vs-unit-124`, carried onto a two-allele description. Listed separately because a per-allele form could in principle converge where the single-allele one does not."
+    },
+    {
+      "id": "protein-extension-stop-glyph-110",
+      "members": [
+        "p.Ter110GlnextTer17",
+        "p.*110Glnext*17"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/protein/extension.md:30",
+          "quote": "`p.Ter110GlnextTer17` (alternatively `p.*110Glnext*17`)"
+        }
+      ],
+      "note": "Positive control. `Ter` and `*` are co-equal stop spellings (`checklist.md:63`), and ferro already converges them onto `Ter`, so this class is expected to pass — it is here to show the assertion distinguishes a class ferro handles from one it does not, rather than failing on everything."
+    },
+    {
+      "id": "protein-extension-stop-glyph-327",
+      "members": [
+        "p.Ter327ArgextTer?",
+        "p.*327Argext*?"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/protein/extension.md:33",
+          "quote": "`p.Ter327ArgextTer?` (alternatively `p.*327Argext*?`)"
+        }
+      ],
+      "note": "Second positive control, with an unknown extension length. Same expectation as `protein-extension-stop-glyph-110`."
+    },
+    {
+      "id": "protein-insertion-xaa-run-vs-repeat-count-582-583",
+      "members": [
+        "NP_003997.1:p.(Val582_Asn583insXaa[5])",
+        "NP_003997.1:p.(Val582_Asn583insXaaXaaXaaXaaXaa)"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/protein/insertion.md:60",
+          "quote": "`NP_003997.1:p.(Val582_Asn583insXaa[5])` (alternatively `NP_003997.1:p.(Val582_Asn583insXaaXaaXaaXaaXaa)`)"
+        }
+      ],
+      "note": "The protein-level twin of the two `insN[5]` classes: an unspecified run written out or as a count. Both members carry their accession, so no anchor is needed."
+    },
+    {
+      "id": "protein-position-less-repeat-shorthand-gln21",
+      "members": [
+        "p.Gln[21]",
+        "p.Q[21]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/RNA/repeated.md:52",
+          "quote": "described as `p.Gln[21]` (alternatively `p.Q[21]`)"
+        }
+      ],
+      "note": "Both members are prose shorthand the spec does not treat as describable variants — a position-less protein repeat — and both are pinned `spec_expected: null` in `by_input`, so ferro rejects both and the class is skipped as not-evaluable. Kept deliberately: it records the equivalence, and if either spelling ever starts parsing the class stops being a no-op and begins asserting."
+    }
+  ],
+  "rulings": [
+    {
+      "id": "delins-merge-vs-individual-gap-two-or-more",
+      "question": "When two variants are separated by two or more nucleotides and part of an inserted sequence aligns with the reference, does the spec's SHOULD NOT against merging govern, or its RECOMMENDED for the delins format?",
+      "status": "undecided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:17",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/DNA/delins.md:47",
+          "quote": "**The \"delins\" format is recommended**"
+        },
+        {
+          "clause": "docs/recommendations/style.md:9",
+          "quote": "are to be interpreted as described in [RFC 2119]"
+        }
+      ],
+      "rationale": "The two clauses are the same RFC 2119 strength and point opposite ways at the same description. `style.md:9` binds the spec to RFC 2119; item 3 there makes \"RECOMMENDED\" equal to SHOULD and item 4 covers SHOULD NOT. The `:44-47` example's own alternative splits at gaps of 4, 5 and 3 nucleotides — every one at least 2 — so `:17` read literally demands exactly the individual description that `:47` rejects three lines later, and neither carries the greater weight. RFC 2119 does not break the tie; it licenses deviating from a SHOULD once the implications are weighed, which is a judgement the spec text leaves to the implementer. THE PROJECT HAS NOT MADE THAT JUDGEMENT. Nothing here should be read as one. What is established is only the cost: this reading governs roughly 138 of 208 adjudicated corpus rows, so whichever way it is settled is a representation change for a stored library, not a local fix. An operator ruling is what closes this record.",
+      "applies_to": [
+        "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        "c.[850_869del;874_881del;887_897del;901_902insG]"
+      ],
+      "equivalence_classes": [
+        "dna-delins-vs-aligned-split-850-901"
+      ]
+    },
+    {
+      "id": "inversion-vs-two-substitutions-76-83",
+      "question": "For `c.76_83inv`, where the reverse complement coincides with the reference at half its columns, does the SHOULD NOT against merging separated variants govern, or does prioritisation make it one inversion?",
+      "status": "undecided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:34",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/general.md:56",
+          "quote": "the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion"
+        },
+        {
+          "clause": "docs/recommendations/style.md:9",
+          "quote": "are to be interpreted as described in [RFC 2119]"
+        }
+      ],
+      "rationale": "`NM_004006.2:c.76_83` is `AATGCACA`; its reverse complement `TGTGCATT` agrees with the reference at 4 of the 8 columns, so the same edit is describable either as one inversion spanning 76_83 or as two changed runs separated by unchanged bases. `:56` ranks inversion above the alternatives once an inversion is admitted as a possible type; `:34` says separated variants are described individually. Both are SHOULD-strength under `style.md:9`. Which applies depends on whether the coinciding columns are read as part of the inversion or as gaps between two variants, and the spec does not say. THIS IS UNDER ACTIVE ADJUDICATION AND NO RULING HAS BEEN MADE. Recorded here so the question is visible rather than re-derived; the adjudication outcome, not this record, will decide it.",
+      "applies_to": [
+        "c.76_83inv"
+      ]
+    },
+    {
+      "id": "delins-codon-carve-out-gap-one",
+      "question": "Do two variants separated by exactly one nucleotide, together affecting one amino acid, merge into a delins?",
+      "status": "decided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:18",
+          "quote": "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\""
+        }
+      ],
+      "governing": "docs/recommendations/DNA/delins.md:18",
+      "rationale": "Unlike the two records above, the spec settles this one: `:18` is an explicit exception to the SHOULD NOT at `:17`, stated at the same place and with the same scope, so there is no conflict to weigh and no deviation to record. Merging is what the spec asks for, and the reason it gives at `:19` is exactly the confluence argument — leaving the two substitutions separate lets tools predict two conflicting consequences at one position. Note the carve-out is scoped to the coding sequence and to one amino acid; `general.md:36-39` records that the SVD-WG intends to replace it with a purely positional rule (\"separated by less than two nucleotides\"), which would widen it. Decided against the current text, to be revisited if that proposal is adopted.",
+      "applies_to": [
+        "c.235_237delinsTAT",
+        "c.[235A>T;237G>T]",
+        "LRG_199t1:c.145_147delinsTGG",
+        "c.[145C>T;147C>G]",
+        "r.142_144delinsugg",
+        "r.[142c>u;144a>g]"
+      ],
+      "equivalence_classes": [
+        "dna-delins-vs-two-substitutions-235-237",
+        "dna-delins-vs-two-substitutions-145-147",
+        "rna-delins-vs-two-substitutions-142-144"
+      ]
+    }
+  ]
 }

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -21,6 +21,14 @@
 //!   committed overrides, with [`KNOWN_DIVERGENT_INPUTS`] as the pinned
 //!   exception list.
 //! - [`status_census_is_unchanged`] — per-status row counts.
+//! - [`spec_equivalence_classes_converge`] — the question the statuses never
+//!   ask. `preserved` means only that ferro did not *change* a string; it says
+//!   nothing about whether two rows are the same variant, so the spec's own
+//!   non-confluent pair (`DNA/delins.md:44-47`) sat here as two `preserved`
+//!   rows and passed. Equivalence classes assert one output per variant.
+//! - [`ruling_records_are_intact`] — the curated record of how the project
+//!   reads the spec where the spec conflicts with itself, and of what it has
+//!   deliberately *not* decided.
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::{parse_hgvs, Normalizer};
@@ -30,6 +38,51 @@ use std::path::PathBuf;
 #[derive(Debug, Deserialize)]
 struct Fixture {
     rows: Vec<Row>,
+    /// Curated "these spellings denote one variant" declarations, resolved by
+    /// the generator. Read by [`spec_equivalence_classes_converge`].
+    #[serde(default)]
+    equivalence_classes: Vec<EquivalenceClass>,
+    /// Curated records of contested spec readings. Read by
+    /// [`ruling_records_are_intact`].
+    #[serde(default)]
+    rulings: Vec<Ruling>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EquivalenceClass {
+    id: String,
+    members: Vec<ClassMember>,
+}
+
+#[allow(dead_code)] // `input` is used only in failure messages
+#[derive(Debug, Deserialize)]
+struct ClassMember {
+    input: String,
+    /// The string ferro is run against — the member's row target, re-anchored
+    /// onto the class's declared reference when it has one. Taken from the
+    /// fixture for the same reason `input_prefixed` is: it is an *input* to the
+    /// comparison, not a claim about ferro's behaviour. What this test refuses
+    /// to take from the fixture is the output.
+    target: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Ruling {
+    id: String,
+    status: String,
+    clauses: Vec<Citation>,
+    #[serde(default)]
+    governing: Option<String>,
+    #[serde(default)]
+    deviates_from: Vec<String>,
+    rationale: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Citation {
+    clause: String,
+    #[allow(dead_code)] // verified in the generator, carried here for readers
+    quote: String,
 }
 
 #[allow(dead_code)] // many fields are present for downstream tooling, not the assertion
@@ -491,4 +544,313 @@ fn ferro_produces_the_form_the_spec_states() {
         unexpected_pass.len(),
         unexpected_pass
     );
+}
+
+/// Pinned verdict for every curated equivalence class, keyed by id.
+///
+/// **Why a verdict table and not a failure list.** Every transition matters in
+/// both directions: a class that starts disagreeing is a new non-confluence, one
+/// that stops disagreeing is an improvement whose pin must be released, and one
+/// that quietly becomes `not-evaluable` — because ferro started refusing a
+/// member — has disarmed itself while still looking present. A one-sided list
+/// catches only the first.
+///
+/// `non-confluent` entries are **expected and not defects to fix here**.
+/// Converging them is #1235's problem, and each is a representation change for a
+/// downstream consumer that keys on the normalized string, so it belongs in a
+/// deliberate migration rather than in a test-infrastructure PR. What this pin
+/// buys is that the *set* cannot grow silently.
+///
+/// The verdicts:
+///
+/// - `confluent` — every evaluable member normalizes to one string.
+/// - `non-confluent` — two or more distinct strings for one variant.
+/// - `not-evaluable` — fewer than two members can be evaluated hermetically
+///   (they need real reference bases, or ferro refuses them), so the class is
+///   evidence of nothing either way.
+const EQUIVALENCE_CLASS_VERDICTS: &[(&str, &str)] = &[
+    // The spec's own worked non-confluent pair: it calls the bracketed split an
+    // "alternative description" of the delins, and ferro keeps both. Which form
+    // should win is the undecided ruling `delins-merge-vs-individual-gap-two-or-more`.
+    ("dna-delins-vs-aligned-split-850-901", "non-confluent"),
+    // Codon carve-out, gap of one. The spec settles the *rule*
+    // (`delins-codon-carve-out-gap-one`) but ferro does not apply it: both
+    // spellings survive normalization.
+    ("dna-delins-vs-two-substitutions-235-237", "non-confluent"),
+    // Same carve-out, and here the spec marks the split spelling invalid — so
+    // this class overlaps the `false-acceptance` census, which counts the
+    // acceptance but cannot see that it is also a second fixed point.
+    ("dna-delins-vs-two-substitutions-145-147", "non-confluent"),
+    ("rna-delins-vs-two-substitutions-142-144", "non-confluent"),
+    // Spelled-out run vs repeat count for an unspecified insertion. Nothing in
+    // the spec ranks the two, so no rule is being broken — but a single variant
+    // still has two stable outputs.
+    (
+        "dna-insertion-n-run-vs-repeat-count-761-762",
+        "non-confluent",
+    ),
+    (
+        "rna-insertion-n-run-vs-repeat-count-761-762",
+        "non-confluent",
+    ),
+    // Repeat spelled by first-unit span vs by unit sequence; again co-equal in
+    // the spec and non-confluent in ferro.
+    ("rna-repeat-range-vs-unit-124", "non-confluent"),
+    ("rna-repeat-range-vs-unit-124-two-alleles", "non-confluent"),
+    (
+        "protein-insertion-xaa-run-vs-repeat-count-582-583",
+        "non-confluent",
+    ),
+    // Positive controls: co-equal stop glyphs, which ferro *does* converge.
+    // They are what shows this assertion can pass, so a change that made every
+    // class disagree could not hide in a wall of expected failures.
+    ("protein-extension-stop-glyph-110", "confluent"),
+    ("protein-extension-stop-glyph-327", "confluent"),
+    // Both members are prose shorthand the spec does not admit as a variant;
+    // ferro rejects both, so nothing is compared. Pinned so that a parser change
+    // which starts accepting them turns this into a live class rather than
+    // passing unnoticed.
+    (
+        "protein-position-less-repeat-shorthand-gln21",
+        "not-evaluable",
+    ),
+];
+
+/// Every curated equivalence class must reach **one** normalized string.
+///
+/// **The defect this closes.** Every other guard in this file asks whether ferro
+/// *changed* a string. None asks whether two rows are the same variant, so the
+/// spec's own non-confluent pair — `LRG_199t1:c.850_901delinsTTCCTCGATGCCTG` and
+/// the `c.[850_869del;…]` split the spec names as its "alternative description"
+/// — sat in the fixture as two `preserved` rows and passed. Two stable fixed
+/// points for one variant is exactly #1235's defect, and the row-level status
+/// bucket reported it as full conformance.
+///
+/// **Why the classes are curated.** Deciding that two descriptions denote one
+/// variant means applying both to a reference sequence, which 50 `needs-reference`
+/// rows cannot do. So the declarations live beside the other hand-curated spec
+/// judgements, in `hgvs_spec_normalization_overrides.json`, and the generator
+/// fails the build if a class names a row that no longer exists or cites spec
+/// text that has moved.
+///
+/// **Why this is not circular.** The class membership comes from the spec text,
+/// not from ferro, and the outputs are re-derived live here rather than read off
+/// the fixture — the same shape as [`ferro_produces_the_form_the_spec_states`].
+/// The fixture supplies only the *inputs* (which rows, under which accession).
+#[test]
+fn spec_equivalence_classes_converge() {
+    crate::common::spec_fixture::ensure_spec_fixture();
+    let text = std::fs::read_to_string(fixture_path()).expect("read fixture");
+    let fx: Fixture = serde_json::from_str(&text).expect("parse fixture");
+
+    let by_input: std::collections::HashMap<&str, &Row> =
+        fx.rows.iter().map(|r| (r.input.as_str(), r)).collect();
+    let normalizer = Normalizer::new(MockProvider::new());
+
+    // Verdict per class, plus the detail a failure needs to be actionable.
+    let mut observed: std::collections::BTreeMap<&str, &str> = std::collections::BTreeMap::new();
+    let mut detail: std::collections::BTreeMap<&str, String> = std::collections::BTreeMap::new();
+
+    for class in &fx.equivalence_classes {
+        let mut outputs: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut evaluable = 0usize;
+        let mut lines = Vec::new();
+        for member in &class.members {
+            let row = by_input.get(member.input.as_str()).unwrap_or_else(|| {
+                panic!(
+                    "class {:?} names {:?}, which is not a fixture row",
+                    class.id, member.input
+                )
+            });
+            let (normalized, _) = observe(&normalizer, &member.target);
+            // A member contributes only when it can be evaluated hermetically.
+            // Reference-dependent rows and rows ferro refuses are neither
+            // evidence of confluence nor of its absence, so they are dropped
+            // rather than compared — otherwise an error string would count as a
+            // distinct "representation" and every such class would fail for the
+            // wrong reason.
+            let skip = row.status == "needs-reference"
+                || row.requires_reference == Some(true)
+                || normalized.starts_with("parse error")
+                || normalized.starts_with("normalize error");
+            if skip {
+                lines.push(format!("      {} -> (skipped) {normalized}", member.target));
+                continue;
+            }
+            evaluable += 1;
+            outputs.insert(normalized.clone());
+            lines.push(format!("      {} -> {normalized}", member.target));
+        }
+
+        let verdict = if evaluable < 2 {
+            "not-evaluable"
+        } else if outputs.len() == 1 {
+            "confluent"
+        } else {
+            "non-confluent"
+        };
+        observed.insert(class.id.as_str(), verdict);
+        detail.insert(class.id.as_str(), lines.join("\n"));
+    }
+
+    let pinned: std::collections::BTreeMap<&str, &str> =
+        EQUIVALENCE_CLASS_VERDICTS.iter().copied().collect();
+    assert_eq!(
+        pinned.len(),
+        EQUIVALENCE_CLASS_VERDICTS.len(),
+        "EQUIVALENCE_CLASS_VERDICTS has a duplicate id"
+    );
+
+    let mut mismatches = Vec::new();
+    for (id, verdict) in &observed {
+        match pinned.get(id) {
+            None => mismatches.push(format!(
+                "  {id}: new class, verdict {verdict} — add it to EQUIVALENCE_CLASS_VERDICTS\n{}",
+                detail[id]
+            )),
+            Some(expected) if expected != verdict => mismatches.push(format!(
+                "  {id}: pinned {expected}, observed {verdict}\n{}",
+                detail[id]
+            )),
+            Some(_) => {}
+        }
+    }
+    for id in pinned.keys() {
+        if !observed.contains_key(id) {
+            mismatches.push(format!(
+                "  {id}: pinned but absent from the fixture — a curated class was deleted"
+            ));
+        }
+    }
+
+    eprintln!(
+        "spec equivalence classes: {} checked, {} non-confluent",
+        observed.len(),
+        observed.values().filter(|v| **v == "non-confluent").count()
+    );
+    assert!(
+        !observed.is_empty(),
+        "spec_equivalence_classes_converge exercised no classes — the fixture carries none, \
+         which means the curated declarations were lost, not that they all pass"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "{} equivalence-class verdict(s) moved.\n\n{}\n\n\
+         A class is a curated statement that its members are the SAME VARIANT, so more than one \
+         distinct output is non-confluence — two stable fixed points for one variant (#1235).\n\n\
+         `pinned confluent, observed non-confluent` or a new non-confluent class is a REGRESSION: \
+         a variant that used to have one representation now has two.\n\
+         `pinned non-confluent, observed confluent` is an IMPROVEMENT — but it is also a \
+         representation change for anyone storing the losing form, so release the pin in the same \
+         PR that says which form moved and how many corpus rows it touches.\n\
+         `observed not-evaluable` means ferro stopped evaluating a member; the class has disarmed \
+         itself and the reason is the thing to look at.",
+        mismatches.len(),
+        mismatches.join("\n"),
+    );
+}
+
+/// Pinned id and status for every ruling record.
+///
+/// A ruling records how the project reads the spec where the spec conflicts with
+/// itself. `undecided` means the project has **not** ruled — pinning the status
+/// is what stops one being upgraded to `decided` without a reviewable diff, and
+/// stops an inconvenient record being deleted.
+const RULING_STATUSES: &[(&str, &str)] = &[
+    // `delins.md:17` (SHOULD NOT merge separated variants) against `delins.md:47`
+    // ("the delins format is recommended"), both SHOULD-strength under
+    // `style.md:9`, both reaching the `:44-47` example. Undecided: it governs
+    // ~138 of 208 adjudicated corpus rows, so settling it either way is a
+    // migration, and no operator ruling has been made.
+    ("delins-merge-vs-individual-gap-two-or-more", "undecided"),
+    // `general.md:34` against `general.md:56` on `c.76_83inv`, whose reverse
+    // complement coincides with the reference at 4 of 8 columns. Undecided and
+    // under active adjudication.
+    ("inversion-vs-two-substitutions-76-83", "undecided"),
+    // The one the spec does settle: `delins.md:18`'s explicit exception for two
+    // variants one nucleotide apart affecting one amino acid.
+    ("delins-codon-carve-out-gap-one", "decided"),
+];
+
+/// Ruling records must stay well-formed, and `undecided` must stay undecided.
+///
+/// The generator enforces the same shape at build time (and additionally checks
+/// that every citation still quotes the spec checkout). This is the committed
+/// half: the generated fixture is gitignored and regenerated from the tree, so
+/// without a pin here a record could be softened, re-statused or dropped and
+/// nothing would notice.
+#[test]
+fn ruling_records_are_intact() {
+    crate::common::spec_fixture::ensure_spec_fixture();
+    let text = std::fs::read_to_string(fixture_path()).expect("read fixture");
+    let fx: Fixture = serde_json::from_str(&text).expect("parse fixture");
+
+    let observed: std::collections::BTreeMap<&str, &str> = fx
+        .rulings
+        .iter()
+        .map(|r| (r.id.as_str(), r.status.as_str()))
+        .collect();
+    let pinned: std::collections::BTreeMap<&str, &str> = RULING_STATUSES.iter().copied().collect();
+    assert_eq!(
+        observed, pinned,
+        "the ruling records changed. Adding one is fine — pin it here. Changing an `undecided` \
+         to `decided` means the project took a position, which must be a deliberate, reviewable \
+         edit, not a side effect."
+    );
+
+    for ruling in &fx.rulings {
+        assert!(
+            !ruling.clauses.is_empty(),
+            "ruling {:?} cites no clause",
+            ruling.id
+        );
+        assert!(
+            !ruling.rationale.trim().is_empty(),
+            "ruling {:?} has no rationale",
+            ruling.id
+        );
+        let cited: std::collections::BTreeSet<&str> =
+            ruling.clauses.iter().map(|c| c.clause.as_str()).collect();
+        match ruling.status.as_str() {
+            "decided" => {
+                let governing = ruling.governing.as_deref().unwrap_or_else(|| {
+                    panic!(
+                        "ruling {:?} is decided but names no governing clause",
+                        ruling.id
+                    )
+                });
+                assert!(
+                    cited.contains(governing),
+                    "ruling {:?} holds {governing:?} to govern, but does not cite it",
+                    ruling.id
+                );
+                for deviated in &ruling.deviates_from {
+                    assert!(
+                        cited.contains(deviated.as_str()),
+                        "ruling {:?} deviates from {deviated:?}, but does not cite it",
+                        ruling.id
+                    );
+                }
+            }
+            // The load-bearing half. An undecided record states a conflict and
+            // stops; if it names a governing clause it has smuggled in a ruling
+            // nobody made, which is precisely what these records exist to
+            // prevent being invented.
+            "undecided" => {
+                assert!(
+                    ruling.governing.is_none() && ruling.deviates_from.is_empty(),
+                    "ruling {:?} is undecided but names a governing or deviated-from clause — \
+                     an undecided record must not imply a ruling",
+                    ruling.id
+                );
+                assert!(
+                    ruling.clauses.len() >= 2,
+                    "ruling {:?} is undecided but names only one clause; an unsettled question \
+                     needs both sides on the record",
+                    ruling.id
+                );
+            }
+            other => panic!("ruling {:?} has unknown status {other:?}", ruling.id),
+        }
+    }
 }


### PR DESCRIPTION
Closes #1518.

The spec-normalization fixture's statuses ask one question — did ferro *change* the string? — and never ask whether two rows are the **same variant**. So the HGVS spec's own non-confluent pair sat in the fixture and passed as fully conformant:

```
preserved   LRG_199t1:c.850_901delinsTTCCTCGATGCCTG            -> unchanged
preserved   c.[850_869del;874_881del;887_897del;901_902insG]   -> unchanged
```

`DNA/delins.md:44-47` calls the second the "alternative description" of the first. Two stable fixed points for one variant — #1235's defect, green.

## Representation stability

**No normalizer behaviour changes.** Nothing under `src/` is touched; the diff is the generator, the committed overrides file, the test driver and `CLAUDE.md`. No normalized output moves, so there is no representation change and nothing for a downstream consumer to re-baseline. The nine disagreements this PR finds are *reported and pinned*, deliberately not fixed: converging any of them picks a winner between two spellings, which is a migration and belongs to #1235.

## Half one — equivalence classes

`hgvs_spec_normalization_overrides.json` gains an `equivalence_classes` section declaring which harvested inputs denote one variant. `spec_equivalence_classes_converge` re-derives every member's output **live** (the fixture supplies only the inputs, never the outputs) and fails when a class yields more than one string, printing each member's target and rendering.

Design points worth review:

- **Curated, not derived.** Establishing that two descriptions denote one variant means applying both to a reference sequence, which 50 `needs-reference` rows cannot do. So the declarations sit beside the other hand-curated spec judgements and are validated at generation time exactly as `by_input` is.
- **Every class carries a quote-verified citation.** `{"clause": "docs/recommendations/DNA/delins.md:44-47", "quote": "…"}` — the generator asserts the quote still appears within those lines. A bare line number would keep "resolving" against any file long enough to have that line; the quote makes a submodule bump that moves a clause fail the build instead of silently re-pointing the citation at unrelated prose.
- **An optional per-class `reference`.** The spec routinely writes one member of a pair as a bare fragment (`c.[235A>T;237G>T]`), which the harvester prefixes with the per-coordinate-system default rather than with the accession of the worked example it sits under — and twice writes the two members under *different accession versions* (`NM_004006.2` / `NM_004006.1`, `DNA/insertion.md:74`, plainly a typo since the prose describes one insertion). Without an anchor those classes would report a difference of *reference sequence* as a difference of representation. **Alternative considered and rejected:** fixing this by editing each bare member's `input_prefixed`, which is what that field is for. It would move those rows' `current` values and the censuses pinned against them, for no benefit outside this comparison — so the anchor is declared on the class instead and the row set is untouched.
- **Unevaluable members are skipped, not compared.** A `needs-reference` row, or one ferro refuses, is neither evidence of confluence nor of its absence; treating a parse-error string as a "representation" would fail such classes for the wrong reason.
- **Verdicts are pinned per class, not just counted.** `EQUIVALENCE_CLASS_VERDICTS` pins `confluent` / `non-confluent` / `not-evaluable` per id, so every transition fails: a new disagreement (regression), a disagreement that resolves (improvement, and a representation change to disclose), a class that quietly became unevaluable because ferro stopped accepting a member (self-disarming), and a class deleted outright.

**Twelve classes: 2 seeded from the issue, 10 found by search.** The search swept the spec for its equivalence phrasing — "alternatively", "can also be described as", "giving an alternative description like", "equivalent to", "the same variant". Results:

| class | verdict |
|---|---|
| `dna-delins-vs-aligned-split-850-901` (`delins.md:44-47`) | non-confluent |
| `dna-delins-vs-two-substitutions-235-237` (`delins.md:19`) | non-confluent |
| `dna-delins-vs-two-substitutions-145-147` (`delins.md:37`, `:42`) | non-confluent |
| `rna-delins-vs-two-substitutions-142-144` (`RNA/delins.md:40`) | non-confluent |
| `dna-insertion-n-run-vs-repeat-count-761-762` (`DNA/insertion.md:74`) | non-confluent |
| `rna-insertion-n-run-vs-repeat-count-761-762` (`RNA/insertion.md:38`) | non-confluent |
| `rna-repeat-range-vs-unit-124` (`RNA/repeated.md:31`) | non-confluent |
| `rna-repeat-range-vs-unit-124-two-alleles` (`RNA/repeated.md:36`) | non-confluent |
| `protein-insertion-xaa-run-vs-repeat-count-582-583` (`protein/insertion.md:60`) | non-confluent |
| `protein-extension-stop-glyph-110` (`protein/extension.md:30`) | **confluent** |
| `protein-extension-stop-glyph-327` (`protein/extension.md:33`) | **confluent** |
| `protein-position-less-repeat-shorthand-gln21` (`RNA/repeated.md:52`) | not-evaluable |

The two confluent ones are deliberate **positive controls**: `Ter` and `*` are co-equal stop spellings and ferro already converges them, so the assertion demonstrably can pass. Without them, a change that made every class disagree could hide in a wall of expected failures.

Three findings from the search worth calling out on their own:

1. **`dna-delins-vs-two-substitutions-145-147` overlaps the `false-acceptance` census and says something it cannot.** The census records that ferro accepts a spelling the spec marks invalid; the class records that ferro also keeps it as a *second fixed point* for a variant it already has a form for.
2. **The spec's own layout is off at `delins.md:42`.** That `NOTE` sits under the `c.9002_9009delinsTTT` bullet but the variant it names belongs to the `:37` bullet — `c.145_147` is `CGC`, and `145C>T` + `147C>G` gives `TGG`, i.e. `c.145_147delinsTGG`. The class cites both lines for that reason.
3. **`DNA/insertion.md:74` writes its two spellings under different accession versions** (`NM_004006.2` / `NM_004006.1`) while describing a single insertion.

Two families were found and deliberately **not** seeded, because they are reference-count-dependent and so not hermetically evaluable: `RNA/repeated.md:33-34` and `protein/repeated.md:22-23` ("when the reference sequence has 15 units, `r.-123ug[14]` is preferred over `r.-97_-96del`"). Worth revisiting once the manifest-backed loader can serve them.

## Half two — ruling records

A sibling `rulings` section records how the project reads clauses that conflict **at equal RFC 2119 strength** (`style.md:9` binds the spec to RFC 2119; items 3 and 4 make RECOMMENDED == SHOULD and cover SHOULD NOT). Each record names the clauses in tension, which one governs, which is deviated from, and why — all citations quote-verified against the checkout.

**`undecided` is a first-class state, enforced.** The generator *refuses to build* a record that is `undecided` yet names a governing or deviated-from clause, and `ruling_records_are_intact` re-asserts it from the committed side and additionally requires an undecided record to name at least two clauses. An unsettled question cannot acquire a ruling nobody made, and an inconvenient record cannot be deleted or re-statused without a reviewable diff.

Seeded with three:

1. **`delins-merge-vs-individual-gap-two-or-more` — undecided.** `delins.md:17` (SHOULD NOT merge separated variants) against `delins.md:47` ("the delins format is recommended"). Both reach the `:44-47` example, whose own alternative splits at gaps of 4, 5 and 3 — all at least 2 — so `:17` read literally demands the very split `:47` rejects three lines later. **No ruling has been made and none is implied here.** What the record establishes is the cost: this reading governs roughly 138 of 208 adjudicated corpus rows, so settling it either way is a migration. An operator ruling closes it.
2. **`inversion-vs-two-substitutions-76-83` — undecided.** `general.md:34` against `general.md:56` on `c.76_83inv`. `NM_004006.2:c.76_83` is `AATGCACA`; its reverse complement `TGTGCATT` agrees at 4 of 8 columns, so the same edit reads as one inversion or as two changed runs separated by unchanged bases. Under active adjudication; recorded so the question is visible rather than re-derived.
3. **`delins-codon-carve-out-gap-one` — decided.** `delins.md:18`'s explicit exception for two variants one nucleotide apart affecting one amino acid. The spec settles this one: `:18` is an exception to `:17` stated in the same place with the same scope, so there is no conflict to weigh and nothing to deviate from. The record notes `general.md:36-39`, where the SVD-WG says it intends to replace the carve-out with a purely positional rule, which would widen it.

## Verification

Both generator gates and the test guards were negative-tested rather than assumed:

- corrupting a citation quote → generation fails, printing the expected quote and what the cited lines currently read;
- adding `governing` to an `undecided` ruling → generation fails ("record the conflict, not a ruling nobody made");
- renaming a class member to a non-row → generation fails ("not a fixture row (typo or spec drift)");
- flipping one pinned verdict → `spec_equivalence_classes_converge` fails, naming the members and their two distinct outputs.

Row census unchanged: 934 rows, `preserved` 714 / `correctly-rejected` 99 / `false-acceptance` 52 / `needs-reference` 50 / `diverges` 19.

Full gate, rebased onto `92fd20f4`:

```
Summary [  84.377s] 9571 tests run: 9571 passed (1 slow), 145 skipped
```

`cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` are clean.
