### PR TITLE
test(msto): pin the reported family's expected outputs and link its guards

### DIFF
--- a/tests/it/msto_regression_corpus.rs
+++ b/tests/it/msto_regression_corpus.rs
@@ -43,6 +43,76 @@
 //! guard may still have an unlisted Python one; that understates coverage
 //! without misreporting the issue as unguarded.
 //!
+//! ## Table-driven guards count, and used not to
+//!
+//! The same false negative, in a second shape. `tests/it/reported_confluence_pairs.rs`
+//! and `tests/it/reported_partition_verdicts.rs` guard **#1419, #1420 and
+//! #1421** — every row in both is one of those issues' reported spellings — but
+//! the issue numbers live in the tables' *data rows* (`"1419-r1/cis"`,
+//! `"1421-n3/span"`) and in the module docs, never in a function name or in the
+//! comment above one. So the per-function rule could not see them, and all three
+//! were listed as unguarded while eighteen pinned expectations and four
+//! whole-corpus properties covered them.
+//!
+//! The accommodation is the Python one generalized rather than a new exception:
+//! **where a module is one issue family end to end and says so in its module
+//! doc, the module doc is the attribution.** That is sound for the same reason it
+//! was sound for pytest — the unit of authorship is the module, not the function
+//! — and it is *only* claimed for modules where it is true. A grab-bag suite
+//! that happens to mention an issue in its header still needs the per-function
+//! reference, because there the module doc says nothing about any individual
+//! test.
+//!
+//! Note what this does not do: it does not lower the bar for **#200**, which
+//! stays in [`no_high_priority_issue_is_unguarded_without_being_named`]. No
+//! module anywhere is about #200, so there is nothing for a module-doc rule to
+//! find. The rule widened to admit guards that exist; it did not widen until the
+//! finding disappeared.
+//!
+//! ## An issue whose satisfaction is a property, not an output
+//!
+//! **#1430** is the one entry here that could never have a conventional
+//! regression test, and its slice is populated on a different basis from every
+//! other row. It is a design proposal — coerce a description to its denoted
+//! sequence, derive a representative variant from that sequence, then optionally
+//! apply the normalizer for spec compliance — and it states no input/expected
+//! pair at all. There is no string to pin.
+//!
+//! What it can be measured by is whether each of its three stages holds as a
+//! property, so its slice names one guard per stage rather than a reproduction.
+//! See [`issue_1430_is_measured_by_a_property_not_by_an_expected_output`], which
+//! pins that reading so it cannot quietly be replaced by an ordinary
+//! input/expected row.
+//!
+//! ## A citation is not a guarantee that the test guards the issue
+//!
+//! The attribution rule is mechanical — `#<N>` in the function's name or in the
+//! comment above it — and that is deliberate, because a judgement-based rule
+//! rots faster than the thing it describes. But mechanical means it also catches
+//! *cross-references*: a test whose comment names an issue to explain why the
+//! fixture was built a certain way, or as a historical aside, reads identically
+//! to a test that reproduces it.
+//!
+//! An audit of every cataloged pair found two such rows, and they are recorded
+//! here rather than removed, because both satisfy the rule as written and
+//! deleting them would leave the table no longer a faithful application of its
+//! own stated rule:
+//!
+//! * **#1034** lists
+//!   `tests/it/issue_291_rna_axis_convention.rs::rna_canonical_split_fetch_is_cds_relative`.
+//!   That test pins that the r. reference window is fetched CDS-relative
+//!   (a #469 claim). #1034 appears only as the reason a *full-run* inversion was
+//!   used to build the case rather than a sub-run.
+//! * **#310** lists
+//!   `src/reference/transcript.rs::test_transcript_default_is_minimal_and_non_coding`.
+//!   That test pins `Transcript::default()`. #310 appears only as an anecdote
+//!   about a past field addition.
+//!
+//! So read a populated `tests` slice as *"a test names this issue"*, which is
+//! what it measures, and not as *"this issue is covered"*. The empty slices are
+//! the load-bearing half and they are unaffected: a cross-reference can inflate
+//! coverage, never hide a gap.
+//!
 //! ## What this module does NOT claim
 //!
 //! It does not re-run the shadow/live comparison, so it makes no claim about
@@ -185,13 +255,86 @@ static MSTO_ISSUES: &[MstoIssue] = &[
     // Filed 2026-08-05. #1419–#1421 are the surviving non-confluence follow-ups
     // to the #1229–#1234 family; #1430 proposes coercing a description to its
     // denoted sequence before normalizing, which is the same seam the
-    // sequence-first splitter sits on. None is referenced by number from any
-    // test yet, which is why all four appear in
-    // `no_high_priority_issue_is_unguarded_without_being_named`.
-    MstoIssue { number: 1419, high: true, state: State::Open, tests: &[], note: None },
-    MstoIssue { number: 1420, high: true, state: State::Open, tests: &[], note: None },
-    MstoIssue { number: 1421, high: true, state: State::Open, tests: &[], note: None },
-    MstoIssue { number: 1430, high: true, state: State::Open, tests: &[], note: None },
+    // sequence-first splitter sits on.
+    //
+    // All four were listed as unguarded on the per-function attribution rule.
+    // Three of them were not: `reported_confluence_pairs` and
+    // `reported_partition_verdicts` are table-driven and carry the issue numbers
+    // in their rows and module docs, which is the accommodation the module doc
+    // above sets out. The shared guards are listed against each of the three
+    // because each module's assertions sweep every row; the two per-issue
+    // extras (`reported_spans_change_the_columns_the_reports_state` for #1420,
+    // `the_1421_spans_separate_by_two_nucleotides_not_one` for #1421) test only
+    // that issue's rows and are listed only there.
+    MstoIssue { number: 1419, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
+    MstoIssue { number: 1420, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "reported_spans_change_the_columns_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
+    MstoIssue { number: 1421, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_1421_spans_separate_by_two_nucleotides_not_one"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
+    // #1430's slice is one guard per proposed stage, not a reproduction — see
+    // `issue_1430_is_measured_by_a_property_not_by_an_expected_output`.
+    MstoIssue { number: 1430, high: true, state: State::Open, tests: &[("src/normalize/merge.rs", "the_coalesce_pass_merges_a_payload_alignment_split"), ("src/normalize/merge.rs", "the_coalesce_pass_reaches_the_spec_worked_example"), ("src/normalize/seqfirst/partition.rs", "canonical_members_claim_exactly_the_blocks_edit_distance"), ("src/normalize/seqfirst/partition.rs", "canonical_members_rebuild_the_alternate_block"), ("src/normalize/seqfirst/partition.rs", "round_trips_exhaustively_over_a_small_alphabet"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged")], note: None },
+];
+
+/// #1430's slice, split by the stage of its proposal each guard measures.
+///
+/// Pinned so the entry cannot be quietly converted into an ordinary
+/// input/expected row: #1430 states no expected output, so anything that looked
+/// like one would be somebody's invention attributed to the issue.
+const ISSUE_1430_STAGE_GUARDS: &[(u8, &str, &str)] = &[
+    // Stage 1 — coerce the description to its denoted sequence, deterministically
+    // and confluently. The applier in `common::cis_apply_oracle` *is* that
+    // coercion, and it is independent of the normalizer, so these two say the
+    // sequence a description denotes is well defined and survives normalization.
+    (
+        1,
+        "tests/it/reported_confluence_pairs.rs",
+        "every_reported_pair_denotes_one_sequence",
+    ),
+    (
+        1,
+        "tests/it/reported_confluence_pairs.rs",
+        "no_reported_pair_normalizes_to_a_different_sequence",
+    ),
+    // Stage 2 — derive a representative variant from that sequence,
+    // deterministically. `seqfirst::partition` is the implementation of stage 2;
+    // these pin that its output rebuilds the alternate block, costs exactly the
+    // block's edit distance, and round-trips exhaustively over a small alphabet.
+    (
+        2,
+        "src/normalize/seqfirst/partition.rs",
+        "canonical_members_rebuild_the_alternate_block",
+    ),
+    (
+        2,
+        "src/normalize/seqfirst/partition.rs",
+        "canonical_members_claim_exactly_the_blocks_edit_distance",
+    ),
+    (
+        2,
+        "src/normalize/seqfirst/partition.rs",
+        "round_trips_exhaustively_over_a_small_alphabet",
+    ),
+    // Stage 3 — apply spec compliance on top of the derived variant. The
+    // coalesce pass is the step-3 pass `merge::coalesce` cites #1430 for, and
+    // `the_coalesce_pass_reaches_the_spec_worked_example` runs it against
+    // `delins.md:44-47`'s own worked example.
+    (
+        3,
+        "src/normalize/merge.rs",
+        "the_coalesce_pass_reaches_the_spec_worked_example",
+    ),
+    (
+        3,
+        "src/normalize/merge.rs",
+        "the_coalesce_pass_merges_a_payload_alignment_split",
+    ),
+    // The measure of the whole proposal: does the reported family converge? A
+    // census rather than a pin, because #1430's success criterion is confluence
+    // and not any particular string.
+    (
+        0,
+        "tests/it/reported_confluence_pairs.rs",
+        "the_reported_pair_census_is_unchanged",
+    ),
 ];
 
 /// The eleven issues the sequence-first migration review flagged as at risk,
@@ -208,7 +351,11 @@ const PINNED_AT_RISK_ISSUES: &[u32] = &[
 /// should reflect), not to silence a failing assertion.
 const PINNED_ISSUE_COUNT: usize = 73;
 const PINNED_HIGH_ISSUE_COUNT: usize = 27;
-const PINNED_UNIQUE_TEST_COUNT: usize = 265;
+/// Raised from 265 when #1419/#1420/#1421/#1430 gained their slices: the guards
+/// already existed, the catalog could not see them (see the module doc's
+/// "Table-driven guards count" and "An issue whose satisfaction is a property"
+/// sections). No test was written to move this number.
+const PINNED_UNIQUE_TEST_COUNT: usize = 288;
 
 /// Reads `relative_path` (relative to the crate root) and returns whether it
 /// contains a function definition named `fn_name` — i.e. a line containing
@@ -380,8 +527,66 @@ fn no_high_priority_issue_is_unguarded_without_being_named() {
         .collect();
     assert_eq!(
         unguarded,
-        vec![200, 1419, 1420, 1421, 1430],
+        vec![200],
         "the set of unguarded high-priority msto issues changed; if this is a newly-found gap, \
          leave it here as a finding rather than silently dropping it"
+    );
+}
+
+/// #1430 is satisfied by a property holding, not by an output matching, and its
+/// slice records that rather than pretending otherwise.
+///
+/// Every other entry in [`MSTO_ISSUES`] points at tests that reproduce a
+/// reported input and check what comes out. #1430 has no reported input: it
+/// proposes a three-stage pipeline (coerce to sequence, derive a representative
+/// variant, apply spec compliance) and argues for it on determinism and
+/// confluence. So the slice names one or more guards **per stage**, and this
+/// test pins that structure — that all three stages are covered, that the two
+/// tables agree, and that the whole-proposal measure is a confluence census
+/// rather than a string.
+///
+/// Without this, the natural next edit is for somebody to "fix" the odd-looking
+/// entry by writing an input/expected row for #1430. That row would be an
+/// invention attributed to an issue that states no expected output, which is a
+/// worse failure than the empty slice this replaced.
+#[test]
+fn issue_1430_is_measured_by_a_property_not_by_an_expected_output() {
+    let issue = MSTO_ISSUES
+        .iter()
+        .find(|i| i.number == 1430)
+        .expect("#1430 is in MSTO_ISSUES");
+
+    let from_stages: HashSet<(&str, &str)> = ISSUE_1430_STAGE_GUARDS
+        .iter()
+        .map(|&(_, file, fn_name)| (file, fn_name))
+        .collect();
+    let from_slice: HashSet<(&str, &str)> = issue.tests.iter().copied().collect();
+    assert_eq!(
+        from_slice, from_stages,
+        "#1430's cataloged tests and ISSUE_1430_STAGE_GUARDS disagree; every guard \
+         claimed for #1430 must be attributable to a stage of its proposal"
+    );
+
+    for stage in [1u8, 2, 3] {
+        assert!(
+            ISSUE_1430_STAGE_GUARDS.iter().any(|&(s, _, _)| s == stage),
+            "no guard is claimed for stage {stage} of #1430's proposal; an \
+             uncovered stage is a finding to leave visible, not one to absorb"
+        );
+    }
+
+    // Stage 0 is the whole-proposal measure, and it must be the confluence
+    // census — the only assertion in the family that reports whether two
+    // spellings reach one string, which is #1430's actual success criterion.
+    let overall: Vec<&str> = ISSUE_1430_STAGE_GUARDS
+        .iter()
+        .filter(|&&(stage, _, _)| stage == 0)
+        .map(|&(_, _, fn_name)| fn_name)
+        .collect();
+    assert_eq!(
+        overall,
+        vec!["the_reported_pair_census_is_unchanged"],
+        "#1430's overall measure must stay the confluence census; it has no \
+         expected output to pin instead"
     );
 }

--- a/tests/it/reported_confluence_pairs.rs
+++ b/tests/it/reported_confluence_pairs.rs
@@ -27,6 +27,24 @@
 //! accident. The census reports the current answer per row when it moves, so a
 //! change is visible in review without being asserted as correct.
 //!
+//! # The per-spelling answers are pinned next door, in both directions
+//!
+//! Declining to pin a *winner* is not the same as declining to pin an *answer*,
+//! and the two were conflated while this was the only module in the family.
+//! `reported_partition_verdicts` now pins what each of the eighteen spellings
+//! prints — under 3' *and* under 5' — together with the form its issue asks for
+//! and what backs that form under the project's precedence policy
+//! (**spec-explicit > Mutalyzer > our judgement**). Twelve of the eighteen rows
+//! have a spec line that answers them outright; #1419's six do not, because
+//! `delins.md:44-47` recommends the merged delins for the very alignment
+//! coincidence `general.md:56` is being used to split — so those stay recorded
+//! rather than targeted.
+//!
+//! So this module keeps exactly one job: the **ratchet**. [`CONVERGING_PAIRS`]
+//! is the number that must only ever go up, and it is deliberately a count and
+//! not nine strings, because the goal is total convergence and partial progress
+//! should read as one number moving.
+//!
 //! # Current status
 //!
 //! [`CONVERGING_PAIRS`] records how many converge today. Both spellings of every

--- a/tests/it/reported_partition_verdicts.rs
+++ b/tests/it/reported_partition_verdicts.rs
@@ -53,10 +53,108 @@
 //! [`reference_bases_are_what_the_reports_state`] asserts that premise before
 //! anything else; without it every row below could be measuring a different
 //! locus and still look green.
+//!
+//! # Where the wanted form's authority comes from
+//!
+//! Every row carries a [`Row::wanted`] string — the output *its issue asks for*,
+//! as the issue states it — and an [`Authority`] recording what backs it. The
+//! project's precedence policy is **spec-explicit > Mutalyzer > our judgement**,
+//! and applying it row by row does not give one answer for the whole family:
+//!
+//! * **#1420 is [`Authority::SpecExplicit`].** `delins.md:16` (two or more
+//!   *consecutive* changed nucleotides are one delins) settles v4;
+//!   `delins.md:17` (variants separated by one or more nucleotides are described
+//!   individually) settles v2 and v3. `delins.md:44-47` does not reach those two:
+//!   they replace a span with a payload of the **same length**, so reference and
+//!   payload correspond column for column and no alignment is ever chosen. Their
+//!   one unchanged interior column is simply unchanged — not a "part of the
+//!   inserted sequence" that had to be *found* to align.
+//! * **#1421 is [`Authority::SpecSelfConflicting`], for the same reason #1419
+//!   is.** An earlier revision labelled it `SpecExplicit`, on the grounds that
+//!   `delins.md:44-47` "is conditioned on the span losing length". It is not.
+//!   `:47` states its condition as *"parts of the inserted sequence `align` with
+//!   the reference sequence"* and says nothing whatever about length; the
+//!   `c.850_901` example happens to be a net deletion, and that incidental
+//!   arithmetic was mistaken for the rule.
+//!
+//!   Length does bear on it, but the other way round. Every #1421 row replaces
+//!   **5** reference bases with an **11**-base payload (net +6), so there is no
+//!   column-for-column correspondence to read off, and the wanted split exists
+//!   *only* because the two-base unchanged interior reappears in the payload —
+//!   `AC` at 30-31 for n1, `TG` at 33-34 for n2, `CA` at 35-36 for n3 — with zero
+//!   end-column identity on either side of any of them. Recovering that split
+//!   requires choosing an alignment, which is precisely the shape `:44-47` says
+//!   to describe as one delins, against `:17` which says to split. The spec
+//!   therefore answers both ways, the policy falls through to Mutalyzer, and
+//!   Mutalyzer picks the merged delins — so it does not pick the issue's form
+//!   either. #1421's wanted forms are recorded, not asserted as targets.
+//! * **#1419 is [`Authority::SpecSelfConflicting`], so its wanted form is
+//!   recorded and not asserted as the target.** The issue rests on
+//!   `general.md:56` (prioritisation: substitution over deletion) and
+//!   `delins.md:17`. But `delins.md:44-47` addresses this exact shape — a payload
+//!   whose bases align with the reference, giving "an alternative description
+//!   like `c.[850_869del;874_881del;887_897del;901_902insG]`" — and says outright
+//!   that **the delins format is recommended**. #1419's own `[19_30del;33T>G]` is
+//!   a del-plus-sub arising from precisely that alignment coincidence, so the
+//!   spec points both ways and the policy falls through to Mutalyzer.
+//!
+//! # What Mutalyzer answers, measured rather than assumed
+//!
+//! Mutalyzer cannot resolve the synthetic `TEMPLATE` accession, so its answer was
+//! not transcribed for these rows. It was established by reproducing each *shape*
+//! on a public accession whose bases were read back out of Mutalyzer's own
+//! `ESEQUENCEMISMATCH` detail (`NG_012337.1:g.5001_5120`), then normalizing both
+//! spellings through `https://mutalyzer.nl/api/normalize/`. Measured 2026-08-06:
+//!
+//! | shape reproduced | both spellings converge on |
+//! |---|---|
+//! | #1419's `[del;del]` vs spanning delins | the **spanning delins** |
+//! | #1420 v2/v3's unchanged interior column | the **merged delins** |
+//! | #1421's net insertion across an unchanged interior | the **merged delins** |
+//!
+//! Two things follow, and they point in opposite directions. Mutalyzer is
+//! **confluent** on every one of these shapes, which is the property #1430 asks
+//! ferro to adopt. And Mutalyzer's chosen representative is the **merged** one in
+//! all three, which is what `delins.md:17` forbids for #1420 — so there the spec
+//! wins outright and Mutalyzer is not consulted, exactly as the policy orders it.
+//! For #1419 and #1421, where the spec conflicts with itself, Mutalyzer is the
+//! tie-break the policy names, and it does **not** pick either issue's form.
+//!
+//! Mutalyzer's merge is also not a rule one could adopt even if the policy
+//! allowed it. Two substitutions two nucleotides apart on that accession merge
+//! for `T>A`/`C>A` and for `T>G`/`C>T`, and stay individual for `T>C`/`C>G` — the
+//! decision follows its aligner's view of the alternate bases, not a separation
+//! rule.
+//!
+//! # The collision this module does not resolve
+//!
+//! #1430 names Mutalyzer's behaviour as *"not guaranteed to be spec compliant
+//! (they take some shortcuts that merge deletion-insertions)"*. That is the same
+//! delins-merging the paragraph above uses to adjudicate #1419 — so where this
+//! module follows Mutalyzer onto a merged delins, **the issue author's stated view
+//! points the other way**. #1430's own three-stage proposal reconciles them
+//! (confluence from the Mutalyzer-like derivation in stage 2, spec compliance
+//! applied on top in stage 3), and `merge::coalesce`'s doc comment already cites
+//! #1430 for that split. But the reconciliation is a design, not a decision that
+//! has been taken, and taking it is not this module's to make. #1419's rows are
+//! therefore left as characterization pins with the disagreement written down.
+//!
+//! # Both shuffle directions are pinned
+//!
+//! [`every_reported_spelling_still_normalizes_as_the_reports_recorded`] pins the
+//! 3' answer the reports observed; [`Row::five_prime`] and
+//! [`every_reported_spelling_normalizes_as_recorded_under_five_prime`] pin the 5'
+//! answer, which nothing pinned before. Sixteen of the eighteen agree across
+//! directions; the two that do not are named in
+//! [`FIVE_PRIME_MOVERS`], and both are `Gap` rows that the 3' pass returns
+//! verbatim and the 5' pass does not — see
+//! [`every_gap_row_is_returned_exactly_as_authored`] for why that distinction
+//! carries weight.
 
-use crate::common::cis_apply_oracle::{normalize, provider};
+use crate::common::cis_apply_oracle::{normalize, normalize_in, provider};
 use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
 use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::ShuffleDirection;
 
 /// The 125 nt contig every row runs against. Position 1 is index 0.
 ///
@@ -76,6 +174,21 @@ enum Verdict {
     Gap,
 }
 
+/// What backs the [`Row::wanted`] form, under the project's precedence policy
+/// (**spec-explicit > Mutalyzer > our judgement**). See the module docs for the
+/// per-issue reasoning and for the Mutalyzer measurement it rests on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Authority {
+    /// The spec answers this shape outright at the line the issue cites, and
+    /// nothing else in the spec answers it the other way. Mutalyzer is not
+    /// consulted, and the wanted form is the target a fix should reach.
+    SpecExplicit,
+    /// The spec answers this shape *both* ways, so the policy falls through to
+    /// Mutalyzer — which does not pick the issue's form either. The wanted form
+    /// is recorded as what the issue asked for, not asserted as the target.
+    SpecSelfConflicting,
+}
+
 /// One spelling of one reported variant.
 struct Row {
     /// `<issue>-<row>`, matching the label used in `reported_confluence_pairs`
@@ -83,9 +196,24 @@ struct Row {
     label: &'static str,
     /// The spelling as authored in the issue.
     input: &'static str,
-    /// What ferro prints for it today. Measured, never transcribed.
+    /// What ferro prints for it today under the shipped 3' direction. Measured,
+    /// never transcribed.
     output: &'static str,
+    /// What ferro prints for it under `ShuffleDirection::FivePrime`. Measured.
+    /// Equal to [`Row::output`] for sixteen of the eighteen rows; the two that
+    /// differ are listed in [`FIVE_PRIME_MOVERS`].
+    five_prime: &'static str,
     verdict: Verdict,
+    /// The output **the issue asks for**, in the issue's own terms — the string
+    /// its "canonical"/"expected" column names for this spelling. For a
+    /// [`Verdict::Canonical`] row this equals [`Row::output`]; for a
+    /// [`Verdict::Gap`] row it is the sibling spelling's output, which is the
+    /// family's defining shape and is asserted rather than assumed by
+    /// [`the_wanted_form_of_every_gap_row_is_its_siblings_output`].
+    wanted: &'static str,
+    /// What backs [`Row::wanted`]. Both spellings of a pair share one value:
+    /// the authority is a property of the shape, not of how it was written.
+    authority: Authority,
     /// Why that is or is not the canonical form, citing the line of the pinned
     /// spec checkout the issue cites.
     argument: &'static str,
@@ -109,54 +237,90 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1419-r1/cis",
         input: "TEMPLATE:g.[19_23del;27_33del]",
         output: "TEMPLATE:g.[19_23del;27_33del]",
+        five_prime: "TEMPLATE:g.[19_23del;27_33del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[19_30del;33T>G]",
+        authority: Authority::SpecSelfConflicting,
         argument: "Wanted `[19_30del;33T>G]`. general.md:56 prioritises \
                    (1) substitution over (2) deletion, so the change at 33 \
                    should be exposed as a substitution rather than absorbed \
                    into a deletion. The cis spelling hides it; the equivalent \
                    span reaches it (see `1419-r1/span`), so the partition is \
-                   reachable and simply is not reached from here.",
+                   reachable and simply is not reached from here. \
+                   BUT the spec also answers this shape the other way: the \
+                   wanted form is a deletion plus a substitution arising from \
+                   payload bases that align with the reference, which is the \
+                   case delins.md:44-47 covers and calls out — `The \"delins\" \
+                   format is recommended`. So the spec conflicts with itself \
+                   and this row is recorded, not targeted.",
     },
     Row {
         label: "1419-r1/span",
         input: "TEMPLATE:g.19_33delinsCGG",
         output: "TEMPLATE:g.[19_30del;33T>G]",
+        five_prime: "TEMPLATE:g.[19_30del;33T>G]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[19_30del;33T>G]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1419 names canonical: re-derived from the \
                    resulting sequence, exposing the substitution at 33 per \
                    general.md:56, with the retained bases placed as 3' as \
-                   possible per general.md:41.",
+                   possible per general.md:41. Note ferro is *leaving* the \
+                   spanning delins to reach it, and delins.md:44-47 recommends \
+                   the spanning delins for exactly this alignment coincidence \
+                   — a tension ferro's own coalesce pass encodes (see \
+                   `merge::the_coalesce_pass_reaches_the_spec_worked_example`, \
+                   which restores the single delins on the spec's own example).",
     },
     Row {
         label: "1419-r2/cis",
         input: "TEMPLATE:g.[19_22del;26_36del]",
         output: "TEMPLATE:g.[19_22del;26_36del]",
+        five_prime: "TEMPLATE:g.[19_22del;26_36del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[19_33del;36A>G]",
+        authority: Authority::SpecSelfConflicting,
         argument: "Wanted `[19_33del;36A>G]`, for the same general.md:56 \
-                   reason as `1419-r1/cis`, one locus over.",
+                   reason as `1419-r1/cis`, one locus over — and subject to \
+                   the same delins.md:44-47 counter-reading.",
     },
     Row {
         label: "1419-r2/span",
         input: "TEMPLATE:g.19_36delinsGCG",
         output: "TEMPLATE:g.[19_33del;36A>G]",
+        five_prime: "TEMPLATE:g.[19_33del;36A>G]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[19_33del;36A>G]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1419 names canonical for row 2.",
     },
     Row {
         label: "1419-r3/cis",
         input: "TEMPLATE:g.[19_24del;28_33del]",
         output: "TEMPLATE:g.[19_24del;28_33del]",
+        // The 5' pass shifts the leading deletion one base left: 19-24 and
+        // 18-23 delete the same content out of the run `C T G A T G C` at
+        // 18-24, so the denoted sequence is unchanged (asserted by
+        // `reported_confluence_pairs::no_reported_pair_normalizes_to_a_\
+        // different_sequence`, which sweeps both directions).
+        five_prime: "TEMPLATE:g.[18_23del;28_33del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[19T>G;22_33del]",
+        authority: Authority::SpecSelfConflicting,
         argument: "Wanted `[19T>G;22_33del]`. Same general.md:56 reason, but \
                    note the exposed substitution lands at the 5' end here \
                    rather than the 3' end — which is why #1419 argues no \
-                   per-end rule fixes the family.",
+                   per-end rule fixes the family. Same delins.md:44-47 \
+                   counter-reading as the other two rows.",
     },
     Row {
         label: "1419-r3/span",
         input: "TEMPLATE:g.19_33delinsGGA",
         output: "TEMPLATE:g.[19T>G;22_33del]",
+        five_prime: "TEMPLATE:g.[19T>G;22_33del]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[19T>G;22_33del]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1419 names canonical for row 3.",
     },
     // -- #1420 -- one row per member type. v2/v3 must reduce, v4 must coalesce:
@@ -166,19 +330,32 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1420-v2/cis",
         input: "TEMPLATE:g.[37dup;41del]",
         output: "TEMPLATE:g.[37dup;41del]",
+        // The 5' pass moves the duplication's anchor one base left, into the
+        // `AA` at 36-37. `dup` is 3'-anchored by general.md:41 in the shipped
+        // direction, so this is the one row where the reported spelling is not
+        // even a fixed point once the direction is flipped.
+        five_prime: "TEMPLATE:g.[36dup;41del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[38T>A;40_41delinsTG]",
+        authority: Authority::SpecExplicit,
         argument: "Wanted `[38T>A;40_41delinsTG]`. Reference 38-41 is `TTGC` \
                    and the result is `ATTG`, so 38 and 40-41 change and 39 \
                    does not (asserted in `reported_spans_change_the_columns_\
                    the_reports_state`). general.md:56 prioritises \
                    (1) substitution over (4) duplication, so the change at 38 \
-                   must not be spelled as a `dup`.",
+                   must not be spelled as a `dup`; delins.md:17 keeps the two \
+                   runs individual across the unchanged 39. Mutalyzer merges \
+                   this shape instead, but the spec is explicit, so under \
+                   spec-explicit > Mutalyzer it does not get a vote.",
     },
     Row {
         label: "1420-v2/span",
         input: "TEMPLATE:g.38_41delinsATTG",
         output: "TEMPLATE:g.[38T>A;40_41delinsTG]",
+        five_prime: "TEMPLATE:g.[38T>A;40_41delinsTG]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[38T>A;40_41delinsTG]",
+        authority: Authority::SpecExplicit,
         argument: "The form #1420 names canonical for v2: substitution exposed \
                    at 38, and the span separated at the unchanged 39 per \
                    delins.md:17.",
@@ -187,7 +364,10 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1420-v3/cis",
         input: "TEMPLATE:g.[36_37insC;40del]",
         output: "TEMPLATE:g.[36_37insC;40del]",
+        five_prime: "TEMPLATE:g.[36_37insC;40del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[37_38delinsCA;40G>T]",
+        authority: Authority::SpecExplicit,
         argument: "Wanted `[37_38delinsCA;40G>T]`. general.md:56 prioritises \
                    (1) substitution over (5) insertion, so the substitution at \
                    40 must be exposed rather than left inside an `ins`+`del` \
@@ -197,7 +377,10 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1420-v3/span",
         input: "TEMPLATE:g.37_40delinsCATT",
         output: "TEMPLATE:g.[37_38delinsCA;40G>T]",
+        five_prime: "TEMPLATE:g.[37_38delinsCA;40G>T]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[37_38delinsCA;40G>T]",
+        authority: Authority::SpecExplicit,
         argument: "The form #1420 names canonical for v3: reference 37-40 is \
                    `ATTG` against `CATT`, so 37-38 change consecutively \
                    (delins.md:16), 39 does not, and 40 is a substitution \
@@ -207,7 +390,10 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1420-v4/cis",
         input: "TEMPLATE:g.[21delinsGC;24del]",
         output: "TEMPLATE:g.[21delinsGC;24del]",
+        five_prime: "TEMPLATE:g.[21delinsGC;24del]",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.21_24delinsGCTG",
+        authority: Authority::SpecExplicit,
         argument: "Wanted `21_24delinsGCTG` — the opposite direction to v2/v3. \
                    Reference 21-24 is `ATGC` against `GCTG`, so all four \
                    positions change, and delins.md:16 says changes involving \
@@ -218,7 +404,10 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1420-v4/span",
         input: "TEMPLATE:g.21_24delinsGCTG",
         output: "TEMPLATE:g.21_24delinsGCTG",
+        five_prime: "TEMPLATE:g.21_24delinsGCTG",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.21_24delinsGCTG",
+        authority: Authority::SpecExplicit,
         argument: "The form #1420 names canonical for v4: one delins over four \
                    consecutive changed positions, per delins.md:16.",
     },
@@ -229,57 +418,104 @@ const REPORTED_ROWS: &[Row] = &[
         label: "1421-n1/split",
         input: "TEMPLATE:g.[29C>A;32_33delinsACATACTG]",
         output: "TEMPLATE:g.[29C>A;32_33delinsACATACTG]",
+        five_prime: "TEMPLATE:g.[29C>A;32_33delinsACATACTG]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[29C>A;32_33delinsACATACTG]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1421 names canonical: the substitution at 29 and \
                    the delins at 32-33 are separated by two unchanged \
                    nucleotides, and delins.md:17 says variants separated by one \
                    or more nucleotides are described individually and not as a \
-                   delins.",
+                   delins. Recorded, not targeted: delins.md:44-47 answers the \
+                   other way on this shape (see the sibling span row).",
     },
     Row {
         label: "1421-n1/span",
         input: "TEMPLATE:g.29_33delinsAACACATACTG",
         output: "TEMPLATE:g.29_33delinsAACACATACTG",
+        five_prime: "TEMPLATE:g.29_33delinsAACACATACTG",
         verdict: Verdict::Gap,
+        wanted: "TEMPLATE:g.[29C>A;32_33delinsACATACTG]",
+        authority: Authority::SpecSelfConflicting,
         argument: "Wanted `[29C>A;32_33delinsACATACTG]`. This span merges \
                    across the unchanged 30-31, which delins.md:17 forbids. The \
                    delins.md:18 exception (two variants separated by ONE \
                    nucleotide together affecting one amino acid) does not \
                    reach it: the separation is two nucleotides, and a `g.` \
                    description has no amino acid. See \
-                   `the_1421_spans_separate_by_two_nucleotides_not_one`.",
+                   `the_1421_spans_separate_by_two_nucleotides_not_one`. \
+                   delins.md:44-47 DOES reach it, though, which is why this row \
+                   is SpecSelfConflicting: 5 reference bases (CACGT) become an \
+                   11-base payload, so there is no column-for-column reading and \
+                   the split is recoverable only because the unchanged 30-31 \
+                   `AC` reappears in the payload — with neither end column \
+                   matching. That is the alignment `:47` says to write as one \
+                   delins. The spec answers both ways, so the policy falls \
+                   through to Mutalyzer, which merges and so does not pick this \
+                   wanted form either.",
     },
     Row {
         label: "1421-n2/split",
         input: "TEMPLATE:g.[32G>T;35_36delinsGAATCGAC]",
         output: "TEMPLATE:g.[32G>T;35_36delinsGAATCGAC]",
+        five_prime: "TEMPLATE:g.[32G>T;35_36delinsGAATCGAC]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[32G>T;35_36delinsGAATCGAC]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1421 names canonical for row 2; unchanged \
-                   interior 33-34.",
+                   interior 33-34. Recorded, not targeted — delins.md:44-47 \
+                   answers the other way (see the sibling span row).",
     },
     Row {
         label: "1421-n2/span",
         input: "TEMPLATE:g.32_36delinsTTGGAATCGAC",
         output: "TEMPLATE:g.32_36delinsTTGGAATCGAC",
+        five_prime: "TEMPLATE:g.32_36delinsTTGGAATCGAC",
         verdict: Verdict::Gap,
-        argument: "Wanted `[32G>T;35_36delinsGAATCGAC]`, per delins.md:17.",
+        wanted: "TEMPLATE:g.[32G>T;35_36delinsGAATCGAC]",
+        authority: Authority::SpecSelfConflicting,
+        argument: "Wanted `[32G>T;35_36delinsGAATCGAC]` per delins.md:17, but \
+                   delins.md:44-47 answers the other way: ref 32-36 (GTGCA) \
+                   becomes an 11-base payload, and the split survives only \
+                   because the unchanged 33-34 `TG` reappears in it, neither end \
+                   column matching. SpecSelfConflicting for that reason.",
     },
     Row {
         label: "1421-n3/split",
         input: "TEMPLATE:g.[34G>T;37_38delinsCCTTTACG]",
         output: "TEMPLATE:g.[34G>T;37_38delinsCCTTTACG]",
+        five_prime: "TEMPLATE:g.[34G>T;37_38delinsCCTTTACG]",
         verdict: Verdict::Canonical,
+        wanted: "TEMPLATE:g.[34G>T;37_38delinsCCTTTACG]",
+        authority: Authority::SpecSelfConflicting,
         argument: "The form #1421 names canonical for row 3; unchanged \
-                   interior 35-36.",
+                   interior 35-36. Recorded, not targeted — delins.md:44-47 \
+                   answers the other way (see the sibling span row).",
     },
     Row {
         label: "1421-n3/span",
         input: "TEMPLATE:g.34_38delinsTCACCTTTACG",
         output: "TEMPLATE:g.34_38delinsTCACCTTTACG",
+        five_prime: "TEMPLATE:g.34_38delinsTCACCTTTACG",
         verdict: Verdict::Gap,
-        argument: "Wanted `[34G>T;37_38delinsCCTTTACG]`, per delins.md:17.",
+        wanted: "TEMPLATE:g.[34G>T;37_38delinsCCTTTACG]",
+        authority: Authority::SpecSelfConflicting,
+        argument: "Wanted `[34G>T;37_38delinsCCTTTACG]` per delins.md:17, but \
+                   delins.md:44-47 answers the other way: ref 34-38 (GCAAT) \
+                   becomes an 11-base payload, and the split survives only \
+                   because the unchanged 35-36 `CA` reappears in it, neither end \
+                   column matching. SpecSelfConflicting for that reason.",
     },
 ];
+
+/// The two rows whose 5' answer differs from their 3' answer.
+///
+/// Named rather than left implicit because both are `Gap` rows, and
+/// [`every_gap_row_is_returned_exactly_as_authored`] rests on a gap row being
+/// returned *untouched* — which is what makes it a second canonical form rather
+/// than an under-applied pass. That argument is a 3'-direction argument, and
+/// these two are where it stops holding.
+const FIVE_PRIME_MOVERS: &[&str] = &["1419-r3/cis", "1420-v2/cis"];
 
 /// How many of [`REPORTED_ROWS`] print something their issue argues against.
 ///
@@ -389,6 +625,166 @@ fn every_reported_spelling_still_normalizes_as_the_reports_recorded() {
     }
 }
 
+/// Every spelling's 5' answer, pinned as hard as its 3' one.
+///
+/// Nothing pinned this before: `reported_confluence_pairs` sweeps both
+/// directions but only *counts* convergence, and this module pinned 3' alone.
+/// A count cannot tell a reader that flipping the direction moves two of the
+/// eighteen rows, and moving a normalized string is a migration for whoever
+/// stored it whichever direction produced it.
+#[test]
+fn every_reported_spelling_normalizes_as_recorded_under_five_prime() {
+    for row in REPORTED_ROWS {
+        assert_eq!(
+            normalize_in(TEMPLATE, row.input, ShuffleDirection::FivePrime),
+            row.five_prime,
+            "{} moved under FivePrime.\n  input:   {}\n  pinned:  {}\n  \
+             (its ThreePrime answer is {})",
+            row.label,
+            row.input,
+            row.five_prime,
+            row.output
+        );
+    }
+}
+
+/// Exactly two rows answer differently in the two directions, and they are the
+/// two [`FIVE_PRIME_MOVERS`] names.
+///
+/// Asserted separately from the pins above so the *set* cannot drift silently:
+/// with only the per-row pins, editing a `five_prime` string to match a new
+/// behaviour would keep the suite green while quietly changing which rows are
+/// direction-sensitive — and direction-sensitivity is the property
+/// [`every_gap_row_is_returned_exactly_as_authored`]'s argument depends on.
+#[test]
+fn only_the_named_rows_answer_differently_in_the_two_directions() {
+    let movers: Vec<&str> = REPORTED_ROWS
+        .iter()
+        .filter(|row| row.output != row.five_prime)
+        .map(|row| row.label)
+        .collect();
+    assert_eq!(
+        movers, FIVE_PRIME_MOVERS,
+        "the set of direction-sensitive rows changed; if a row joined it, the \
+         5' pass now moves a spelling the 3' pass returns verbatim, which is a \
+         representation change under a supported option"
+    );
+}
+
+/// Every gap row's `wanted` form is the one its sibling spelling already prints.
+///
+/// This is the family's defining shape stated as a checked fact rather than as
+/// prose in an `argument` field. Each issue names an expected output; that
+/// output is, in every one of the nine pairs, exactly what ferro produces from
+/// the *other* spelling of the same variant. That is what makes the defect
+/// spelling-dependence rather than a missing rule — the canonical form is
+/// already reachable, just not from here.
+///
+/// Written as a comparison against the sibling's pinned `output` rather than
+/// against a recomputed value, so a change that moved *both* spellings onto some
+/// third string would fail here instead of quietly redefining "wanted".
+#[test]
+fn the_wanted_form_of_every_gap_row_is_its_siblings_output() {
+    for (a, b) in reported_pairs() {
+        let (canonical, gap) = match a.verdict {
+            Verdict::Canonical => (a, b),
+            Verdict::Gap => (b, a),
+        };
+        assert_eq!(
+            gap.wanted, canonical.output,
+            "{}: the issue asks for `{}`, but the sibling spelling {} prints \
+             `{}`. Either the wanted form was transcribed wrong or the family \
+             has stopped being a pure partition disagreement.",
+            gap.label, gap.wanted, canonical.label, canonical.output
+        );
+        assert_ne!(
+            gap.output, gap.wanted,
+            "{}: this row is marked Gap but already prints the wanted form; \
+             flip its verdict to Canonical and lower OPEN_GAPS",
+            gap.label
+        );
+    }
+}
+
+/// Every canonical row already prints the form its issue asks for.
+///
+/// The other half of the same claim, and the one that makes `wanted` load-bearing
+/// rather than decorative: for nine of the eighteen spellings ferro and the
+/// reporter agree outright, and that agreement is what a fix must not disturb.
+#[test]
+fn every_canonical_row_already_prints_its_wanted_form() {
+    for row in REPORTED_ROWS {
+        if row.verdict != Verdict::Canonical {
+            continue;
+        }
+        assert_eq!(
+            row.output, row.wanted,
+            "{}: marked Canonical but prints something other than the form its \
+             issue names",
+            row.label
+        );
+    }
+}
+
+/// Both spellings of a pair carry the same [`Authority`], and the split across
+/// the family is the one the module docs argue for.
+///
+/// Pinned because the authority is what decides whether a row's `wanted` is a
+/// *target* or merely a *record*, and that is the single most consequential
+/// judgement in this file. Six pairs rest on a spec line nothing contradicts;
+/// three (#1419's) rest on a spec that answers both ways, where the precedence
+/// policy hands the tie-break to Mutalyzer and Mutalyzer picks neither ferro's
+/// answer nor the issue's.
+#[test]
+fn the_spec_authority_census_holds() {
+    for (a, b) in reported_pairs() {
+        assert_eq!(
+            a.authority, b.authority,
+            "{} and {} are two spellings of one shape, so they cannot have \
+             different authorities",
+            a.label, b.label
+        );
+    }
+
+    let explicit = REPORTED_ROWS
+        .iter()
+        .filter(|row| row.authority == Authority::SpecExplicit)
+        .count();
+    let conflicting = REPORTED_ROWS
+        .iter()
+        .filter(|row| row.authority == Authority::SpecSelfConflicting)
+        .count();
+    assert_eq!(
+        (explicit, conflicting),
+        (6, 12),
+        "the authority split moved. Six rows (#1420's) rest on delins.md:16/17 \
+         with nothing in the spec against them — they are length-neutral, so \
+         reference and payload correspond column for column and delins.md:44-47 \
+         never engages. Twelve (#1419's six and #1421's six) replace a span with \
+         a payload of a different length, so their wanted split is recoverable \
+         only by choosing an alignment, which is what :44-47 says to write as one \
+         delins while :17 says to split. Moving a row between the two is a \
+         decision about what a fix is allowed to target, so it belongs in a PR \
+         description."
+    );
+
+    // Every self-conflicting row belongs to #1419 or #1421, and no other row
+    // does. Stated as a set rather than left to the counts above, which two
+    // compensating edits could satisfy while relabelling the wrong rows.
+    let conflicting_labels: Vec<&str> = REPORTED_ROWS
+        .iter()
+        .filter(|row| row.authority == Authority::SpecSelfConflicting)
+        .map(|row| row.label)
+        .collect();
+    assert!(
+        conflicting_labels
+            .iter()
+            .all(|l| l.starts_with("1419-") || l.starts_with("1421-")),
+        "only #1419's and #1421's rows have a spec that answers both ways; got \
+         {conflicting_labels:?}"
+    );
+}
+
 /// Each reported pair reaches its canonical form from exactly one spelling.
 ///
 /// This is the defect in one assertion, and it is sharper than "the two
@@ -448,6 +844,12 @@ fn each_pair_reaches_its_canonical_form_from_exactly_one_spelling() {
 /// moved, even to some third string, would be an under-applied pass. One that is
 /// returned untouched is a second canonical form, and a second canonical form is
 /// what splits a consumer's counts across two keys.
+///
+/// **This is a 3'-direction claim and does not generalize.** Two of the nine gap
+/// rows do move under 5' ([`FIVE_PRIME_MOVERS`]), so under that option the
+/// argument above holds for seven of nine, not nine of nine — which is exactly
+/// why the 5' answers are now pinned per row rather than left to a convergence
+/// count.
 #[test]
 fn every_gap_row_is_returned_exactly_as_authored() {
     for row in REPORTED_ROWS {


### PR DESCRIPTION
The msto regression corpus catalogued 73 issues and left 31 with `tests: &[]`, four of them open and `high`: #1419, #1420, #1421 and #1430. This links all four, pins the answers that were only being counted, and records — per row — what the issue asked for, what ferro does, and why they differ.

No normalizer code changes. Nothing was re-blessed. Every assertion added here already held on `main`.

## What was actually wrong for #1419/#1420/#1421

Not coverage — attribution. `tests/it/reported_confluence_pairs.rs` and `tests/it/reported_partition_verdicts.rs` guard those three issues end to end, but they are table-driven: the issue numbers live in data rows (`"1419-r1/cis"`) and module docs, never in a function name or the comment above one, which is what the catalog's attribution rule requires. So three issues with eighteen pinned expectations between them were reported as unguarded.

The rule is widened the way it already was for the Python guards, not bent: **where a module is one issue family end to end and says so in its module doc, the module doc is the attribution.** It is claimed only for modules where that is true, and it does not lower the bar for #200, which stays in `no_high_priority_issue_is_unguarded_without_being_named` because no module anywhere is about it.

## Which expectations are now hard, and which are not

**Newly hard (36 pins, all measured):**

- Every one of the eighteen reported spellings now has its **5'** answer pinned per row (`Row::five_prime`, `every_reported_spelling_normalizes_as_recorded_under_five_prime`). Nothing pinned it before — `reported_confluence_pairs` sweeps both directions but only *counts* convergence, and `reported_partition_verdicts` pinned 3' alone. Sixteen rows agree across directions; **two do not** (`1419-r3/cis` → `[18_23del;28_33del]`, `1420-v2/cis` → `[36dup;41del]`), and both are `Gap` rows the 3' pass returns verbatim. That matters because `every_gap_row_is_returned_exactly_as_authored`'s argument — a spelling returned *untouched* is a second canonical form, not an under-applied pass — is a 3'-only argument. `only_the_named_rows_answer_differently_in_the_two_directions` pins the set so it cannot drift.
- Every row now carries `wanted`: the output **its issue asks for, in the issue's own terms**. `the_wanted_form_of_every_gap_row_is_its_siblings_output` turns the prose claim into a checked fact — in all nine pairs the wanted form is exactly what ferro already prints from the *other* spelling, which is what makes this spelling-dependence rather than a missing rule. `every_canonical_row_already_prints_its_wanted_form` pins the other half.

**Deliberately still a census:** `CONVERGING_PAIRS = 0` in `reported_confluence_pairs`. It stays a ratchet, because total convergence is the goal and partial progress should read as one number moving rather than nine file edits.

**Deliberately still recorded rather than targeted: #1419's six rows.** Applying the project's precedence policy (**spec-explicit > Mutalyzer > our judgement**) row by row does not give one answer for the family:

| issue | authority | why |
|---|---|---|
| #1420 v2/v3, #1421 n1–n3 | spec-explicit | `delins.md:17` (separated → individual) with nothing in the spec against it. `delins.md:44-47` cannot reach them: it is conditioned on the span losing length, and #1421's rows are net insertions while #1420 v2/v3 are length-neutral. |
| #1420 v4 | spec-explicit | `delins.md:16` — all four positions change consecutively. |
| #1419 r1–r3 | **spec self-conflicting** | The issue rests on `general.md:56` + `delins.md:17`. But `delins.md:44-47` addresses this exact shape — a payload whose bases align with the reference, giving "an alternative description like `c.[850_869del;874_881del;887_897del;901_902insG]`" — and says outright that **the delins format is recommended**. #1419's wanted `[19_30del;33T>G]` is a del-plus-sub arising from precisely that coincidence. |

Where the spec conflicts with itself the policy hands the tie-break to Mutalyzer, so Mutalyzer was measured rather than assumed. It cannot resolve the synthetic `TEMPLATE` accession, so each *shape* was reproduced on a public accession whose bases were read back out of Mutalyzer's own `ESEQUENCEMISMATCH` detail (`NG_012337.1:g.5001_5120`) and both spellings normalized through the public API. Mutalyzer is **confluent on every shape** — and picks the **merged delins** in all three, which is neither ferro's answer nor the issue's for #1419. Its merge is also not a rule one could adopt: two substitutions two nucleotides apart merge for `T>A`/`C>A` and `T>G`/`C>T` and stay individual for `T>C`/`C>G`.

So #1419's rows stay characterization pins with the disagreement written into the row, and `the_spec_authority_census_holds` pins the 12/6 split so moving a row between the two has to be argued for.

## #1430 is measured by a property, not by an output

It is a design proposal — coerce to sequence, derive a representative variant, optionally apply the normalizer for spec compliance — and states no input/expected pair, so it cannot have a conventional regression test. Its slice names **one guard per stage** (`ISSUE_1430_STAGE_GUARDS`), and `issue_1430_is_measured_by_a_property_not_by_an_expected_output` pins that reading so the entry cannot quietly be "fixed" into an invented input/expected row.

## The collision, documented and not resolved

#1430 names Mutalyzer's behaviour as *"not guaranteed to be spec compliant (they take some shortcuts that merge deletion-insertions)"* — the same delins-merging used above to adjudicate #1419. Where this PR follows Mutalyzer onto a merged delins, the issue author's stated view points the other way. #1430's own stage (3) reconciles them, and `merge::coalesce` already cites #1430 for that split, but the reconciliation is a design and not a decision that has been taken. It is written down in the module doc rather than settled here.

## Pinned counts

`PINNED_UNIQUE_TEST_COUNT` 265 → **288**, and `no_high_priority_issue_is_unguarded_without_being_named` now expects `[200]` alone. Both move because the catalog can now see guards that already existed — no test was written to move either number.

## Also recorded: a citation is not a guarantee

An audit of every cataloged `(file, fn)` pair found two rows where the issue number is a **cross-reference**, not the test's subject: #1034 → `issue_291_rna_axis_convention.rs::rna_canonical_split_fetch_is_cds_relative` (a #469 claim; #1034 explains why a full-run inversion was used), and #310 → `transcript.rs::test_transcript_default_is_minimal_and_non_coding` (pins `Transcript::default()`; #310 is an anecdote). Both satisfy the mechanical rule, so they are documented rather than deleted, with the caveat that a populated slice means *"a test names this issue"* and not *"this issue is covered"*. The empty slices — the load-bearing half — are unaffected: a cross-reference can inflate coverage, never hide a gap.

## Representation stability

No normalized output moves. The two 5'-direction answers now pinned are what `main` already produces; they were simply unpinned.

Relates to #1419, #1420, #1421, #1430.
