### PR TITLE
docs(normalize): correct the coincidence statistics behind the density gate

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3961,14 +3961,52 @@ fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
 /// [`every_separation_is_a_single_base`] breaks
 /// `a_whole_span_reverse_complement_is_not_merged_across_a_multi_base_separation`.
 ///
-/// Density does separate them, and for a reason rather than by fitting. Reverse
-/// complementing a random block leaves roughly a quarter of its positions
-/// coincidentally unchanged, which is what #1461's 32.8% looks like. The #1040
-/// control leaves 66.7% unchanged — far above chance, because that span is very
-/// nearly its own reverse complement and the two edits are independent changes
-/// sitting inside it, exactly as that test's comment argues. Requiring the
-/// changed columns to be the majority says the reverse-complement relation is
-/// doing work across the whole span instead of describing a near-palindrome.
+/// Density does separate the two rows of that table, and this rule is what
+/// admits #1461. What it is *not* is a test that the reverse-complement relation
+/// is real, and an earlier revision of this comment claimed it was. That claim
+/// is corrected here rather than deleted, because the mistake in it is an easy
+/// one to make again.
+///
+/// # Why an unchanged column count is weak evidence at small `n`
+///
+/// Unchanged columns are not independent, and they do not arrive one at a time.
+/// Column `i` of a whole-span reverse complement coincides exactly when column
+/// `n-1-i` does — both say `b[i] == complement(b[n-1-i])` — so the coincidences
+/// come in **mirror pairs**, and an odd `n` has a centre column that can never
+/// coincide. For a uniform random block the count of unchanged columns is
+/// therefore
+///
+/// ```text
+/// U = 2 · Binomial(floor(n/2), 1/4)      E[U] = n/4      sd(U) = sqrt(3n/8)
+/// ```
+///
+/// The mean is `n/4` — a quarter of the span — for **every** `n`. That is the
+/// part the earlier comment had right, and the part that misleads: it read a
+/// mean as if it were the whole distribution, and concluded that an observation
+/// above it was "far above chance". Measured against the actual distribution:
+///
+/// | block | span | unchanged | z | P(at least this many) |
+/// |---|---|---|---|---|
+/// | `AAGCTA -> TAGCTT` (the #1040 control) | 6 | 4 (66.7%) | +1.67 | **15.6%** |
+/// | `AATGCACA -> TGTGCATT` (#1517) | 8 | 4 (50.0%) | +1.15 | **26.2%** |
+/// | `NC_000013.10:g.100809575_100810031inv` (#1461) | 457 | 150 (32.8%) | +2.75 | **0.45%** |
+///
+/// So roughly **one in six** genuine 6 nt inversions leaves two thirds of its
+/// columns unchanged, and roughly **one in four** genuine 8 nt inversions leaves
+/// half of them unchanged. Neither is a near-palindrome signature; both are
+/// ordinary draws. Only #1461's is rare, and it is rare because the span is 457
+/// nt, not because 32.8% is a low fraction.
+///
+/// The discriminating quantity is `n`. The distribution's relative spread is
+/// `sd/mean = sqrt(6/n)`, so it is 100% of the mean at `n = 6` and 11.5% at
+/// `n = 457`: a density reading carries almost no information about a short
+/// block and a great deal about a long one. Any future rule that wants to argue
+/// from coincidence rates must scale with `n`; this one does not.
+///
+/// What this predicate honestly is, then, is a **length-correlated proxy** that
+/// separates the two cases in the table and is calibrated on them. It is not
+/// evidence about whether a given reverse-complement relation is structural, and
+/// no comment here should say that it is.
 ///
 /// Additive by construction: this is an `||` alternative to the single-base gate,
 /// so every block that coalesces today still coalesces. Only a block that is

--- a/tests/it/issue_1040_inv_overrecognition_probes.rs
+++ b/tests/it/issue_1040_inv_overrecognition_probes.rs
@@ -268,12 +268,18 @@ fn a_dense_inversion_is_recognised_across_multi_base_separations() {
     // is **4**. The inversion that must be recognised has the *wider* gaps, so
     // every threshold on separation either refuses #1461 or admits the control.
     //
-    // Density does separate them. Reverse complementing a random block leaves
-    // roughly a quarter of its positions coincidentally unchanged, which is what
-    // #1461's 32.8% looks like; the control leaves 66.7% unchanged because that
-    // span is very nearly its own reverse complement. Hence
-    // `changed_columns_dominate_the_span`, and hence this test: 8 of 12 columns
-    // change here, against 2 of 6 in the control.
+    // Density does separate them, which is `changed_columns_dominate_the_span`
+    // and hence this test: 8 of 12 columns change here, against 2 of 6 in the
+    // control.
+    //
+    // It separates them as a *length-correlated proxy*, though, and not because
+    // an unchanged fraction says whether a reverse complement is structural.
+    // Coincidences come in mirror pairs, so for a random block the unchanged
+    // count is `2 * Binomial(floor(n/2), 1/4)` — mean `n/4` at every `n`.
+    // Against that distribution the control's 66.7% is only +1.67 sd, which
+    // about **one in six** genuine 6 nt inversions reaches; #1461's 32.8% is
+    // +2.75 sd, which 0.45% reach. The separation comes from `n`, not from the
+    // fraction. `changed_columns_dominate_the_span`'s doc works this through.
     let core = "AACAACCGCGTG";
     let expected = format!("{G}:g.257_268inv");
     for input in [


### PR DESCRIPTION
Comments only. **Zero non-comment lines change** in either file, verified by diff; no behaviour change, no test expectation moves.

## The claim being corrected

`coalesce_whole_block_inversion`'s density gate is justified in its own doc comment like this: reverse complementing a random block leaves "roughly a quarter" of positions coincidentally unchanged, so a block leaving 50% is "far above chance" and is therefore a near-palindrome carrying two independent changes rather than one inversion.

That is a mean-versus-distribution error, and it matters because the comment is the stated reason a real block is refused.

## What is actually true

Coincidentally unchanged columns come in **mirror pairs** — column `i` coincides exactly when column `n-1-i` does — so the count is `U = 2 * Binomial(floor(n/2), 1/4)`, not `Binomial(n, 1/4)`. The pairing doubles the variance while leaving the mean at `n/4`. So "roughly a quarter" is right on average at every length, and the spread is far wider than the comment assumes:

| block | n | observed unchanged | z | share of genuine inversions at least this coincidental |
|---|---|---|---|---|
| `#1040`'s control (`AAGCTA`) | 6 | 66.7 % | +1.67 | **15.6 %** |
| `#1517`'s block (`AATGCACA`) | 8 | 50.0 % | +1.15 | **26.2 %** |
| `#1461`'s real inversion | 457 | 32.8 % | +2.75 | 0.45 % |

Roughly **one in four** genuine 8 nt inversions is at least as coincidental as the block the gate calls a near-palindrome. At 6 nt it is one in six.

The discriminating power in that table comes from **`n`**, not from density: the relative spread is `sd/mean = sqrt(6/n)`, so the same percentage means something very different at 6 nt than at 457 nt. The predicate is a length-correlated proxy, and the comment now says so.

## Why this is worth a commit on its own

The gate's behaviour is not being changed here and no judgement about it is being made. But the comment as written would be cited as evidence the next time this boundary is argued, and it would not hold. Two nearby files reasoned from it. The same error in `tests/it/issue_1040_inv_overrecognition_probes.rs` is corrected the same way.

Refs #1517, #1461, #1040.
