### PR TITLE
ci: require a Representation-Change declaration on output-bearing changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   # GitHub still rendered "All checks have passed" — a green badge that
   # carried no information. Run on every pull request whatever it targets.
   pull_request:
+    # `edited` is load-bearing for `representation-change` below: the declaration
+    # lives in the PR description, and the default activity set
+    # (opened/synchronize/reopened) does not fire when a description is edited. Without
+    # it, adding the trailer a red check just asked for re-runs nothing and the check
+    # stays red until an unrelated push.
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -158,6 +164,56 @@ jobs:
         run: uv run poe check-format
       - name: Run mypy
         run: uv run poe check-typing
+
+  # A change under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` can move
+  # the normalized string a downstream consumer stores read counts against, so it must say
+  # whether it does. `release-plz.toml` renders the changelog's **Representation changes**
+  # section from a `Representation-Change:` trailer on the squash commit (#1433) — the
+  # machinery works, but across the v0.13.0 cycle 87 commits landed carrying zero trailers
+  # while 46 touched those directories, and the section rendered empty. An empty section
+  # looks identical whether nothing moved or nobody declared, so it went unnoticed for ~90
+  # commits and the disclosure had to be reconstructed by hand before release (#1522).
+  #
+  # `Representation-Change: none` passes. The point is to force the judgement, not to force
+  # a disclosure; what this rejects is silence.
+  representation-change:
+    name: Representation change declared
+    runs-on: ubuntu-latest
+    # `pull_request` only. The check reads the PR description, which is what becomes the
+    # squash commit body and therefore what git-cliff's footer rule matches. A push to
+    # `main` has no equivalent to read, and by then the declaration is already merged.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Collect the changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # `--no-renames` so a rename reports BOTH paths. With git's rename detection
+          # on (the default), moving `src/normalize/foo.rs` out of a watched directory
+          # reports only the destination, so the change that removed it from
+          # `src/normalize/` would need no declaration -- exactly backwards.
+          git diff --name-only --no-renames "$BASE_SHA...$HEAD_SHA" > changed-files.txt
+          echo "changed files:"
+          cat changed-files.txt
+      - name: Capture the PR description
+        # Through `env`, never interpolated into the script body: a PR description is
+        # attacker-controlled text and `${{ }}` inside `run` would splice it into the shell.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > pr-body.txt
+      - name: Require a Representation-Change declaration
+        run: |
+          python scripts/check_representation_change.py \
+            --changed-files changed-files.txt \
+            --declaration-file pr-body.txt
 
   clippy:
     name: Clippy

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Require a `Representation-Change:` trailer on changes that can move normalized output.
+
+Normalized output is a shipped key: a downstream consumer stores read counts against
+the normalized HGVS string, so a canonical form that moves between releases re-buckets
+what they have already stored. `release-plz.toml` renders a **Representation changes**
+changelog section from a `Representation-Change:` trailer on the squash commit, and the
+release PR body carries a reviewer checklist for it (#1433).
+
+That machinery works. Nothing was feeding it: across the v0.13.0 cycle, 87 commits
+landed and **zero** carried the trailer, while 46 touched the directories below. The
+section rendered empty, and an empty section looks identical whether it is empty because
+nothing moved or because nobody declared anything — so it went unnoticed for ~90 commits
+and the disclosure had to be reconstructed by hand before release (#1522).
+
+This closes that loop: a change under a watched directory must *say* whether it moves
+output. Saying "no" is a first-class answer — `Representation-Change: none` — because the
+point is to force the judgement, not to force a disclosure. What is rejected is silence.
+
+Usage:
+    python scripts/check_representation_change.py \\
+        --changed-files changed.txt --declaration-file body.txt
+
+    # or with the declaration on stdin
+    git diff --name-only origin/main...HEAD > changed.txt
+    python scripts/check_representation_change.py --changed-files changed.txt -
+
+Exits 0 when the change is clear, 1 when a declaration is required and absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+#: Directories whose output a change can move. A variant's canonical form is decided in
+#: `normalize`; `hgvs` owns how it is spelled back out; `spdi` and `project` re-express it
+#: on another axis, and a consumer keys on those renderings too.
+WATCHED_PREFIXES: tuple[str, ...] = (
+    "src/normalize/",
+    "src/hgvs/",
+    "src/spdi/",
+    "src/project/",
+)
+
+#: The trailer git-cliff groups on. Matched at the start of a line, case-insensitively,
+#: because a trailer is prose written by a human and `representation-change:` is the same
+#: declaration as `Representation-Change:`.
+#:
+#: The value must open with a non-space and the surrounding whitespace classes are
+#: horizontal-only. Both matter: `\s*(?P<value>.+?)\s*$` under `MULTILINE` matches a lone
+#: space as the value, so a bare `Representation-Change:` with nothing after it counted as
+#: a declaration — the precise hole this check exists to close. And `\s` spans newlines, so
+#: a permissive class would let the value be scavenged from the *following* line.
+TRAILER_RE = re.compile(
+    r"^[ \t]*Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+#: Values that declare "this moves nothing". Anything else is read as a description of
+#: what moved, which is what lands in the changelog.
+NONE_VALUES = frozenset({"none", "no", "n/a", "na"})
+
+
+def watched_files(changed: list[str]) -> list[str]:
+    """Return the changed paths that sit under a watched directory."""
+    return [p for p in changed if any(p.startswith(prefix) for prefix in WATCHED_PREFIXES)]
+
+
+def find_declaration(text: str) -> str | None:
+    """Return the trailer's value, or `None` when the text carries no trailer."""
+    match = TRAILER_RE.search(text)
+    return match.group("value") if match else None
+
+
+def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
+    """
+    Decide whether `changed` is adequately declared by `declaration_text`.
+
+    Returns `(ok, message)`. `ok` is False only when a watched file changed and no
+    trailer is present at all — a trailer whose value is `none` passes, because
+    declining is a declaration.
+    """
+    watched = watched_files(changed)
+    if not watched:
+        return True, "No file under a watched directory changed; no declaration needed."
+
+    declaration = find_declaration(declaration_text)
+    if declaration is None:
+        listed = "\n".join(f"  {p}" for p in sorted(watched))
+        return False, (
+            f"{len(watched)} changed file(s) can move normalized output:\n{listed}\n\n"
+            "Add a `Representation-Change:` trailer to the PR description, which is what\n"
+            "becomes the squash commit body and what release-plz reads.\n\n"
+            "  Representation-Change: <what moved, in which direction, over how many rows,\n"
+            "                          and whether the affected inputs were previously\n"
+            "                          rejected (free) or accepted (a migration)>\n\n"
+            "If the change cannot move output — a comment, a doc, a test, a rename — say so\n"
+            "explicitly:\n\n"
+            "  Representation-Change: none\n\n"
+            "Declining is a declaration and passes this check. Silence does not, because an\n"
+            "absent trailer is indistinguishable from an unconsidered one.\n\n"
+            "Measure with: cargo run --release --features dev --example dump_normalized_corpus"
+        )
+
+    if declaration.strip().lower() in NONE_VALUES:
+        return (
+            True,
+            f"Declared `Representation-Change: {declaration}` over {len(watched)} watched file(s).",
+        )
+    return (
+        True,
+        f"Declared a representation change over {len(watched)} watched file(s): {declaration}",
+    )
+
+
+def read_text(path: str) -> str:
+    """Read `path`, or stdin when it is `-`."""
+    return sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="File holding one changed path per line, or `-` for stdin.",
+    )
+    parser.add_argument(
+        "--declaration-file",
+        required=True,
+        help="File holding the PR description / squash commit body, or `-` for stdin.",
+    )
+    args = parser.parse_args(argv)
+    if args.changed_files == "-" and args.declaration_file == "-":
+        parser.error("--changed-files and --declaration-file cannot both read stdin")
+
+    changed = [line.strip() for line in read_text(args.changed_files).splitlines() if line.strip()]
+    ok, message = check(changed, read_text(args.declaration_file))
+    print(message, file=sys.stdout if ok else sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -1,0 +1,159 @@
+"""
+Tests for `scripts/check_representation_change.py` (#1522).
+
+The check exists because an *absent* trailer and a *considered-and-declined* trailer
+looked identical for a whole release cycle. So the assertions that matter here are the
+ones separating those two states, and the one pinning that the watched set still matches
+`release-plz.toml`'s stated scope — a directory silently dropping out of that tuple would
+make this check pass on exactly the changes it exists to catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_representation_change.py"
+_SPEC = importlib.util.spec_from_file_location("check_representation_change", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+check_representation_change = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_representation_change"] = check_representation_change
+_SPEC.loader.exec_module(check_representation_change)
+
+check = check_representation_change.check
+find_declaration = check_representation_change.find_declaration
+watched_files = check_representation_change.watched_files
+WATCHED_PREFIXES = check_representation_change.WATCHED_PREFIXES
+
+
+# ---------------------------------------------------------------------------
+# The two states the whole check exists to separate
+# ---------------------------------------------------------------------------
+
+
+def test_watched_change_without_a_trailer_fails() -> None:
+    """Silence is what this rejects — the v0.13.0 cycle's actual failure mode."""
+    ok, message = check(["src/normalize/merge.rs"], "Fixes a thing.\n\nCloses #1.")
+    assert not ok
+    assert "src/normalize/merge.rs" in message
+    assert "Representation-Change: none" in message, "the message must name the way to decline"
+
+
+def test_watched_change_declaring_none_passes() -> None:
+    """Declining is a declaration. #1521 is the real example: 46 changed lines in
+    `src/normalize/merge.rs`, every one a comment."""
+    ok, _ = check(
+        ["src/normalize/merge.rs"],
+        "Comments only; zero non-comment lines change.\n\nRepresentation-Change: none",
+    )
+    assert ok
+
+
+def test_watched_change_declaring_a_move_passes() -> None:
+    ok, message = check(
+        ["src/spdi/mod.rs"],
+        "Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell",
+    )
+    assert ok
+    assert "577 rows move" in message
+
+
+# ---------------------------------------------------------------------------
+# Scope
+# ---------------------------------------------------------------------------
+
+
+def test_unwatched_change_needs_no_declaration() -> None:
+    ok, _ = check(["README.md", "tests/it/foo.rs", "src/cli/mod.rs"], "no trailer here")
+    assert ok
+
+
+def test_a_watched_file_among_unwatched_ones_still_requires_a_declaration() -> None:
+    """The trigger is *any* watched file, not a majority of them."""
+    ok, _ = check(["README.md", "docs/x.md", "src/project/projector.rs"], "no trailer")
+    assert not ok
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/normalize/merge.rs",
+        "src/hgvs/variant.rs",
+        "src/spdi/mod.rs",
+        "src/project/projector.rs",
+    ],
+)
+def test_every_watched_prefix_triggers(path: str) -> None:
+    assert watched_files([path]) == [path]
+    ok, _ = check([path], "no trailer")
+    assert not ok, f"{path} must require a declaration"
+
+
+def test_watched_prefixes_match_the_release_config() -> None:
+    """`release-plz.toml`'s reviewer checklist names the directories this must watch.
+
+    Pinned as a set comparison rather than a count: two compensating edits could keep the
+    count while swapping a directory out, which is exactly the drift that would make this
+    check pass on the changes it exists to catch.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    for prefix in WATCHED_PREFIXES:
+        directory = prefix.rstrip("/")
+        assert f"`{directory}/`" in config, (
+            f"{directory} is watched by the check but not named in release-plz.toml's "
+            "checklist; the two must describe the same scope"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Trailer parsing
+# ---------------------------------------------------------------------------
+
+
+def test_trailer_is_found_case_insensitively() -> None:
+    assert find_declaration("representation-change: none") == "none"
+    assert find_declaration("REPRESENTATION-CHANGE: none") == "none"
+
+
+def test_trailer_is_found_at_the_end_of_a_body() -> None:
+    body = "Some description.\n\nCloses #1522.\n\nRepresentation-Change: none\n"
+    assert find_declaration(body) == "none"
+
+
+def test_absent_trailer_reads_as_none_not_as_a_declaration() -> None:
+    assert find_declaration("Representation change: none") is None, (
+        "the hyphenated trailer is what git-cliff matches; prose must not satisfy it"
+    )
+
+
+def test_an_empty_trailer_value_is_not_a_declaration() -> None:
+    """`Representation-Change:` with nothing after it declares nothing."""
+    assert find_declaration("Representation-Change:   \n") is None
+
+
+@pytest.mark.parametrize("value", ["none", "None", "NONE", "no", "n/a", "na"])
+def test_decline_spellings_all_pass(value: str) -> None:
+    ok, _ = check(["src/normalize/merge.rs"], f"Representation-Change: {value}")
+    assert ok
+
+
+def test_an_empty_trailer_does_not_scavenge_the_next_line() -> None:
+    """`\\s` spans newlines, so a permissive class would read `none` off the line below and
+    call an empty trailer a declaration."""
+    assert find_declaration("Representation-Change:\nnone\n") is None
+
+
+def test_empty_trailer_on_a_watched_change_fails() -> None:
+    ok, _ = check(["src/normalize/merge.rs"], "Representation-Change:   \n")
+    assert not ok
+
+
+def test_both_streams_on_stdin_is_rejected() -> None:
+    """Reading both inputs from stdin would silently give the second an empty string,
+    which for the declaration reads as "no trailer" — a wrong failure, not an error."""
+    with pytest.raises(SystemExit) as excinfo:
+        check_representation_change.main(["--changed-files", "-", "--declaration-file", "-"])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
Closes #1522.

`release-plz.toml` renders the changelog's **Representation changes** section from a `Representation-Change:` trailer on the squash commit, and the release PR body carries a reviewer checklist for it (#1433). The machinery works. Nothing fed it.

## What went wrong, measured

| | commits | touching `src/{normalize,hgvs,spdi,project}/` | carrying a trailer |
|---|---|---|---|
| whole v0.13.0 cycle | 87 | 46 | **0** |
| after the mechanism landed (`fb63eae6`) | 47 | 25 | **0** |

The section rendered empty, and the release was one merge from shipping with no disclosure at all. It had to be reconstructed by hand — normalizing ClinVar 500k, Paraphase and CMRG (5,761,302 expressions) through v0.12.0 and v0.13.0 against the same prepared reference and diffing row by row. That found **577 stored strings moved**, **326,404 inputs newly normalized** (every one an LRG accession), and **2 now correctly rejected**. None of it was visible from the changelog as generated.

**An empty section cannot announce itself.** `release-plz.toml` emits it unconditionally on the stated grounds that this turns an undeclared change *"from silence into a visible false statement, which is the only version a reviewer can act on."* That reasoning is right, but it only pays off if someone acts on the false statement — and an empty section looks identical whether it is empty because nothing moved or because nobody declared anything. This cycle it went unnoticed for ~90 commits.

## What this adds

A `Representation change declared` job that fails a PR touching those four directories when the PR description carries no `Representation-Change:` trailer.

**`Representation-Change: none` passes.** The point is to force the judgement, not to force a disclosure — #1521 is the real example of a legitimate decline: 46 changed lines in `src/normalize/merge.rs`, every one a comment. What is rejected is *silence*, because an absent trailer is indistinguishable from an unconsidered one.

Design points worth review:

- **The trailer is read from the PR description, not from individual commits.** The squash commit body is what git-cliff's footer rule actually matches; a trailer on an intermediate commit is discarded by the squash. Checking commits would pass PRs whose declaration never reaches the changelog.
- **The PR body reaches the script through `env`, never `${{ }}` inside `run`.** A PR description is attacker-controlled text and interpolating it into a shell body is a script-injection hole.
- **`pull_request` only.** There is no PR description to read on a push to `main`, and by then the declaration is already merged.
- **The watched set is pinned against `release-plz.toml`.** `test_watched_prefixes_match_the_release_config` asserts each watched directory is still named in the config's checklist, as a per-directory membership check rather than a count — two compensating edits could hold the count while swapping a directory out, which is exactly the drift that would make this check pass on the changes it exists to catch.

## Verification

The test suite found a real bug in the first draft of the regex, which is left in as a regression test. `^\s*Representation-Change:\s*(?P<value>.+?)\s*$` under `MULTILINE` matches a **lone space** as the value, so a bare `Representation-Change:` with nothing after it counted as a declaration — precisely the hole this check exists to close. `\s` also spans newlines, so a permissive class would scavenge the value off the *following* line. Both are now pinned (`test_an_empty_trailer_value_is_not_a_declaration`, `test_an_empty_trailer_does_not_scavenge_the_next_line`).

Negative-tested end to end: a simulated `src/normalize/merge.rs` + `src/spdi/mod.rs` change with no trailer exits 1 and names both files; the same change with `Representation-Change: none` exits 0.

22 tests pass. `actionlint` clean on the modified workflow. `ruff check` and `ruff format --check` clean.

**This PR touches no watched directory**, so its own declaration is `none` — and the check confirms that against its real changed-file list rather than an empty one. (An earlier run of that self-check was vacuous: `git diff origin/main...HEAD` returned nothing because the files were not yet committed, so it passed on an empty list rather than on unwatched files. Re-run after committing.)

Representation-Change: none
