### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
+
+### Representation changes
+
+- *(normalize)* never split a delins into members on consecutive nucleotides ([#1537](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537))
+- *(normalize)* type the whole-block inversion by what it competes with ([#1535](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1535))
+
+### Other
+
+- *(changelog)* read a decline that gives a reason as a decline ([#1558](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1558))
+- *(confluence)* record two adjudications from the divergent cis classes ([#1549](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1549))
+- *(normalize)* guard that emitted members obey general.md:34 ([#1539](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1539)) ([#1540](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1540))
+- *(spec)* run the spec's own worked examples against real bases, and record #1536 ([#1544](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1544))
+- *(conformance)* gate the harvested unguarded cases on every PR ([#1545](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1545))
+- *(normalize)* validate a cis-allele member's stated reference bases before a merge can consume them ([#1547](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1547))
+- *(rulings)* decide the precedence order and the canonical-form choice ([#1548](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1548))
+- *(corpus)* add a separated reverse-complement family and three real oracles ([#1546](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1546))
+- *(rulings)* restore the delins.md:47 decision dropped by #1532's squash ([#1538](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1538))
+- *(spec-fixture)* close the review-sweep follow-ups from #1519/#1520/#1521 ([#1533](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1533))
+- record every adjudication as a test in the same change ([#1531](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1531))
+- record the unrecorded adjudications and correct two ruling rationales ([#1532](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1532))
+- *(claude)* document the required Representation-Change trailer ([#1534](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1534))
+- *(changelog)* stop grouping a declined change as a representation change ([#1527](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1527))
+- require a Representation-Change declaration on output-bearing changes ([#1523](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1523))
+
 ## [0.13.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.12.0...v0.13.0) - 2026-08-07
 
 ### Representation changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION
## Representation stability

Any PR that moves a normalized output should carry a `Representation-Change:`
trailer (see CONTRIBUTING.md). Those are collected into the **Representation
changes** section of the changelog below.

Reviewer checklist:

- [ ] Either that section lists every output-moving change in this cycle, or
      there were none and it is absent.
- [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
      none`, optionally followed by a reason, and belongs under its own type —
      not here. Spot-check two entries against their PR descriptions.
- [ ] For each entry, that PR's description says whether the affected inputs
      were previously **rejected** (no stored string, so free) or previously
      **accepted** (a real migration for the consumer). The bullet below carries
      only the commit subject: the trailer's own text cannot reach the changelog
      (fulcrumgenomics/ferro-hgvs#1556), so this one has to be read from the PRs.

A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` that
moved output without declaring it means the trailer is missing. Fix that before
releasing, not after.

---


### [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
### Representation changes

- *(normalize)* never split a delins into members on consecutive nucleotides ([#1537](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537))
- *(normalize)* type the whole-block inversion by what it competes with ([#1535](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1535))

### Other

- *(changelog)* read a decline that gives a reason as a decline ([#1558](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1558))
- *(confluence)* record two adjudications from the divergent cis classes ([#1549](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1549))
- *(normalize)* guard that emitted members obey general.md:34 ([#1539](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1539)) ([#1540](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1540))
- *(spec)* run the spec's own worked examples against real bases, and record #1536 ([#1544](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1544))
- *(conformance)* gate the harvested unguarded cases on every PR ([#1545](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1545))
- *(normalize)* validate a cis-allele member's stated reference bases before a merge can consume them ([#1547](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1547))
- *(rulings)* decide the precedence order and the canonical-form choice ([#1548](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1548))
- *(corpus)* add a separated reverse-complement family and three real oracles ([#1546](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1546))
- *(rulings)* restore the delins.md:47 decision dropped by #1532's squash ([#1538](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1538))
- *(spec-fixture)* close the review-sweep follow-ups from #1519/#1520/#1521 ([#1533](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1533))
- record every adjudication as a test in the same change ([#1531](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1531))
- record the unrecorded adjudications and correct two ruling rationales ([#1532](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1532))
- *(claude)* document the required Representation-Change trailer ([#1534](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1534))
- *(changelog)* stop grouping a declined change as a representation change ([#1527](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1527))
- require a Representation-Change declaration on output-bearing changes ([#1523](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1523))


#### cargo-semver-checks

compatible


