### PR TITLE
fix(changelog): stop grouping a declined change as a representation change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,22 @@ Representation-Change: c.<cds_end>_*1ins<A> now renders as
   anyone normalizing to a fixed point sees no change.
 ```
 
+**If your change moves nothing, say that** — `Representation-Change: none` is a
+first-class answer, not a way of opting out:
+
+```
+ci: pin the workflow's action hashes
+
+Representation-Change: none
+```
+
+`none`, `no`, `n/a` and `na` all count, in any casing. A declining trailer is
+excluded from the changelog's **Representation changes** section, so declaring it
+costs the reader nothing while leaving the judgement on the record. CI enforces
+the distinction: a change touching `src/normalize/`, `src/hgvs/`, `src/spdi/` or
+`src/project/` with no trailer at all fails the `Representation change declared`
+check, because an absent trailer is indistinguishable from an unconsidered one.
+
 **Indent continuation lines**, as above. Git only folds a multi-line trailer
 value into the trailer when the continuations are whitespace-prefixed: measured
 against git-cliff 2.13.1, the unindented form still groups correctly (its footer

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -96,7 +96,32 @@ releasing, not after.
 # The trailer is what gets a note in automatically, at release time.
 [changelog]
 commit_parsers = [
-  { footer = "^Representation-Change:", group = "<!-- 0 -->Representation changes" },
+  # `Representation-Change: none` declares that a change moves NO output, so it must not
+  # be listed as one. git-cliff matches a footer rule on the trailer's *presence*, not its
+  # value, so without this exclusion #1523 -- a CI-only change that correctly declined --
+  # rendered under "Representation changes" in v0.13.1 (#1526).
+  #
+  # That matters as much as the opposite failure. v0.13.0 under-reported (nothing declared,
+  # section empty, disclosure reconstructed by hand from a 5.7M-row corpus diff, #1522);
+  # listing non-changes is the same loss of trust from the other side, and it compounds,
+  # because declining is the COMMON case for changes under those directories.
+  #
+  # Ordering is load-bearing: git-cliff takes the FIRST matching parser, so this exclusion
+  # must precede the inclusion below. `[^\S\r\n]` is horizontal-only whitespace -- `\s`
+  # would span the newline into the next trailer and let `Representation-Change:` followed
+  # by a line reading `none` count as a decline.
+  #
+  # `(?i)` because the checker accepts `NONE`/`None` as declines (its own regex is
+  # case-insensitive); without the flag an uppercase decline is grouped as a real change,
+  # which is this bug in miniature. Verified against git-cliff 2.13.1.
+  #
+  # The decline vocabulary is kept in step with `NONE_VALUES` in
+  # `scripts/check_representation_change.py` by `test_decline_vocabulary_matches_the_changelog_config`.
+  { footer = "(?i)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*$", group = "<!-- 7 -->Other" },
+  # `(?i)` here too, and not only on the exclusion above: the checker accepts any casing,
+  # so a lowercase `representation-change: 577 rows move` is a REAL disclosure that a
+  # case-sensitive rule drops silently into `Other`. Verified against git-cliff 2.13.1.
+  { footer = "(?i)^Representation-Change:", group = "<!-- 0 -->Representation changes" },
   { message = "^feat", group = "<!-- 1 -->Added" },
   { message = "^changed", group = "<!-- 2 -->Changed" },
   { message = "^deprecated", group = "<!-- 3 -->Deprecated" },

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -11,6 +11,7 @@ make this check pass on exactly the changes it exists to catch.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -157,3 +158,85 @@ def test_both_streams_on_stdin_is_rejected() -> None:
     with pytest.raises(SystemExit) as excinfo:
         check_representation_change.main(["--changed-files", "-", "--declaration-file", "-"])
     assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# The changelog consumer must agree with this checker about what "declining" means
+# ---------------------------------------------------------------------------
+
+
+def test_decline_vocabulary_matches_the_changelog_config() -> None:
+    """`release-plz.toml`'s exclusion rule and `NONE_VALUES` must accept the same words.
+
+    They are two halves of one decision and they drift silently. If the checker accepts a
+    decline the changelog rule does not, that PR passes CI and then renders under
+    **Representation changes** as if it moved output — which is #1526, the bug this test
+    was written for. If the changelog excludes a word the checker rejects, a contributor
+    is told to declare something the changelog then hides.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    match = re.search(r'footer = "\(\?i\)\^Representation-Change:[^"]*?\(([^)]+)\)', config)
+    assert match is not None, (
+        "no case-insensitive Representation-Change exclusion rule found in release-plz.toml; "
+        "the decline vocabulary cannot be checked"
+    )
+    configured = frozenset(match.group(1).split("|"))
+    assert configured == check_representation_change.NONE_VALUES, (
+        f"release-plz.toml excludes {sorted(configured)} but the checker treats "
+        f"{sorted(check_representation_change.NONE_VALUES)} as declines; a word in one and "
+        "not the other either leaks a non-change into the changelog or hides a real one"
+    )
+
+
+def test_both_representation_change_rules_are_case_insensitive() -> None:
+    """A case-sensitive *inclusion* rule drops a lowercase `representation-change:` — a real
+    disclosure — silently into `Other`, since the checker accepts any casing."""
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
+    assert len(rules) == 2, f"expected an exclusion and an inclusion rule, found {rules}"
+    for rule in rules:
+        assert rule.startswith("(?i)"), (
+            f"rule {rule!r} is case-sensitive; the checker's own trailer regex is not, so the "
+            "two disagree about whether `REPRESENTATION-CHANGE:` is a declaration"
+        )
+
+
+def test_contributing_documents_the_same_decline_vocabulary() -> None:
+    """CONTRIBUTING.md is the third place these words appear, and prose drifts fastest.
+
+    A contributor reads the doc, not the config or this script, so a word documented here
+    but not accepted by both is guidance that fails CI, and one accepted but not documented
+    is a decline nobody knows they can make.
+    """
+    doc = (Path(__file__).resolve().parents[2] / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    documented = {
+        word
+        for word in re.findall(r"`([a-z/]+)`(?=[,\s]|$)", doc)
+        if word in check_representation_change.NONE_VALUES
+    }
+    assert documented == check_representation_change.NONE_VALUES, (
+        f"CONTRIBUTING.md documents {sorted(documented)} as declines but the checker accepts "
+        f"{sorted(check_representation_change.NONE_VALUES)}"
+    )
+
+
+def test_the_decline_exclusion_precedes_the_inclusion() -> None:
+    """git-cliff takes the FIRST matching parser, so swapping these two lines silently
+    restores #1526 in full.
+
+    Verified against git-cliff 2.13.1 rather than assumed: with the exclusion second, all
+    four trailers -- `none`, `NONE`, and both real disclosures -- group under
+    **Representation changes**. Every other guard in this file still passes in that state,
+    which is why the ordering needs one of its own.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
+    assert len(rules) == 2, f"expected an exclusion and an inclusion rule, found {rules}"
+    exclusion, inclusion = rules
+    assert any(word in exclusion for word in check_representation_change.NONE_VALUES), (
+        f"the first Representation-Change rule is {exclusion!r}, which does not name a decline "
+        "value; the exclusion must come first or every decline is grouped as a real change"
+    )
+    assert not any(word in inclusion for word in check_representation_change.NONE_VALUES), (
+        f"the second rule is {inclusion!r}, which looks like the exclusion -- the two are reversed"
+    )


### PR DESCRIPTION
Closes #1526.

git-cliff matches a footer rule on the trailer's **presence**, not its value, so `Representation-Change: none` — the declaration that a change moves *no* output — was grouped into the changelog's **Representation changes** section exactly as a real disclosure would be. #1523 is a CI-only change that correctly declined, and it rendered under that heading in the v0.13.1 release PR (#1525).

## Why this is worth fixing before v0.13.1 ships

It is the v0.13.0 failure inverted. That release **under-reported** — nothing declared, section empty, and the disclosure had to be reconstructed by hand from a 5,761,302-row corpus diff (#1522). Listing non-changes costs the same trust from the other side: a consumer reading it goes looking for keys to re-map and finds none. And it compounds, because declining is the *common* case for changes under those directories, so the section would fill with noise until the real entries were hard to find.

## The fix

An exclusion parser above the inclusion. **Ordering is load-bearing** — git-cliff takes the first matching parser, so the exclusion must come first. `[^\S\r\n]` keeps the whitespace horizontal, so `Representation-Change:` followed by a line reading `none` is not read as a decline.

## A second bug, found while testing the first

Both rules are now `(?i)`. The inclusion rule was case-sensitive while `scripts/check_representation_change.py` accepts any casing — so a lowercase `representation-change: 577 rows move` is a **real disclosure** that got dropped silently into `Other`. That one predates this PR and #1523; it surfaced only because testing the exclusion against real git-cliff meant enumerating casings.

## Verification, against git-cliff 2.13.1 rather than a simulation

A scratch repo with four commits, run through the shipped parser config:

| commit trailer | rendered under |
|---|---|
| `Representation-Change: 577 rows move…` | **Representation changes** ✅ |
| `representation-change: 42 rows move` | **Representation changes** ✅ (was `Other` — the second bug) |
| `Representation-Change: none` | `Other` ✅ (was **Representation changes** — this bug) |
| `Representation-Change: NONE` | `Other` ✅ |

## Guards, negative-tested rather than assumed

Two halves of one decision that drift silently, so both are pinned — and each was confirmed to **fail** when its half is narrowed, not merely to pass as written:

- `test_decline_vocabulary_matches_the_changelog_config` — the config's exclusion vocabulary must equal `NONE_VALUES`. Narrowing the config to `(none|no)` → **CAUGHT**.
- `test_both_representation_change_rules_are_case_insensitive` — stripping `(?i)` from the inclusion → **CAUGHT**.

25 tests pass; `ruff check` / `format` clean.

## Note on #1525

The v0.13.1 release PR currently carries the bad line. Once this merges, release-plz regenerates it on the next push to `main` and the line goes away on its own — no hand-edit needed, unlike v0.13.0.

Representation-Change: none
