### PR TITLE
ci: make the workflow linter requireable, and correct the branch-protection note

### DIFF
--- a/.github/workflows/audit-pr-runs.yml
+++ b/.github/workflows/audit-pr-runs.yml
@@ -24,12 +24,22 @@
 # workflow addresses the class rather than a cause: whatever the reason, a PR
 # whose head has never been built should be visible as a problem.
 #
-# Why a scheduled audit and not a required status check: a required check is
-# the stronger fix, since it blocks the merge rather than reporting after the
-# fact — but `main` is not a protected branch, so adopting one is a repository
-# policy decision rather than a workflow change. This is the part that can be
-# fixed in-repo, and it stays useful afterwards as the thing that tells you
-# *why* a merge is blocked.
+# Why a scheduled audit *as well as* required status checks. `main` does carry
+# required checks, and they already block this failure mode: the required
+# contexts never report for a head with no run, so the PR sits on "Expected —
+# waiting for status to be reported" and cannot be merged. That is the stronger
+# fix and it is in place. What it does not do is *explain* — a PR blocked that
+# way is indistinguishable from one whose CI is merely slow, and nothing names
+# the head SHA that never got a run. This audit is what turns the block into a
+# report.
+#
+# An earlier version of this comment claimed `main` was not a protected branch
+# and that adopting a required check was therefore a policy decision rather than
+# a workflow change. That was wrong, and the way it was wrong is worth recording:
+# protection here is a repository *ruleset*, and the classic endpoint
+# `gh api /repos/{owner}/{repo}/branches/main/protection` does not see rulesets —
+# it answers `404 Branch not protected` on a fully protected branch. Ask
+# `gh api /repos/{owner}/{repo}/rulesets` instead.
 #
 # The recovery, once this audit flags a PR: confirm the head SHA on the PR still
 # matches what you pushed and that no run exists for it, then close and reopen.

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -8,12 +8,19 @@ on:
       - '.github/actionlint.yaml'
   # No `branches:` filter — see the note in `ci.yml`. It matches the pull
   # request's base, so a stacked PR editing a workflow skipped actionlint
-  # entirely. The `paths:` filter below is kept: it matches changed files,
-  # not the base, and is the point of this workflow.
+  # entirely.
+  #
+  # And no `paths:` filter, deliberately, even though this job only ever has
+  # something to say about `.github/`. A `paths:` filter that does not match
+  # means the workflow never runs, and a workflow that never runs reports no
+  # check at all — which is indistinguishable, to a required-status-check rule,
+  # from a check that simply has not finished. So while the filter was here,
+  # making `zizmor + actionlint` a required context on `main` left every PR that
+  # touched no workflow stuck on "Expected — waiting for status to be reported"
+  # and permanently unmergeable. Linting the workflows on a PR that changed none
+  # of them costs well under a minute and buys a context that always reports,
+  # which is the price of being able to require it.
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/actionlint.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
`main`'s ruleset requires eight status contexts. This makes a ninth candidate — `zizmor + actionlint` — actually requireable, and corrects a comment that asserted the ruleset does not exist.

**`lint-workflows.yml`: drop the `paths:` filter on `pull_request`.** The filter meant the workflow never ran for a PR that touched nothing under `.github/`, and a workflow that never runs creates no check. To a required-status-check rule that is indistinguishable from a check that has not finished, so adding `zizmor + actionlint` to the ruleset left every non-workflow PR on "Expected — waiting for status to be reported" and unmergeable. Measured directly: the context was added to the ruleset and removed again minutes later for exactly this reason. The filter stays on `push`, where there is no merge to gate. Cost is one sub-minute job on PRs that changed no workflow.

**`audit-pr-runs.yml`: correct the header.** It said `main` is not a protected branch and that a required check was therefore a policy decision rather than an available fix. `main` does carry a ruleset with required contexts, and that ruleset already blocks the no-run failure mode the audit was written for. The audit keeps its real value — explaining *why* a PR is blocked, since a blocked-on-never-reported PR looks exactly like one whose CI is slow. The comment now also records the trap that produced the error: `gh api /repos/{owner}/{repo}/branches/main/protection` answers `404 Branch not protected` for a branch protected by a *ruleset*; `/rulesets` is the endpoint that sees it.

No behavior change to any check's contents — only when `Lint Workflows` runs. `actionlint` passes on both edited files; the representation-change checker reports "No file under a watched directory changed; no declaration needed."

Follow-up once this merges: add `zizmor + actionlint` to the ruleset's required contexts.