### PR TITLE
fix(spec-fixture): close the review-sweep follow-ups from #1519/#1520/#1521

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,11 +277,13 @@ same description**. (This used to say "conflict at equal RFC 2119 strength", cit
 That framing is withdrawn — uppercase RFC 2119 keywords appear exactly once outside `style.md`
 itself, so essentially every clause in play is lowercase prose and keyword strength cannot rank
 them. See [Reading the spec](#reading-the-spec).) Each record names the clauses in tension, which
-one governs, which is deviated from, and why. `undecided` is a first-class state and the generator **refuses** to build a record
-that is `undecided` yet names a governing clause — an unsettled question must not be able to
-smuggle in a ruling nobody made. Every citation carries a verbatim quote that the generator checks
-against the spec checkout, so a submodule bump that moves a clause fails the build instead of
-leaving the citation pointing at unrelated prose.
+one governs, which is deviated from, and why. `undecided` is a first-class state and the generator
+**refuses** to build a record that is `undecided` yet names a governing *or* a deviated-from clause
+— either implies a side was chosen, and an unsettled question must not be able to smuggle in a
+ruling nobody made. It equally refuses an `undecided` record citing fewer than two clauses: such a
+record states no conflict, only a position it declines to name as one. Every citation carries a
+verbatim quote that the generator checks against the spec checkout, so a submodule bump that moves
+a clause fails the build instead of leaving the citation pointing at unrelated prose.
 
 Requires the `assets/hgvs-nomenclature` submodule (`git submodule update --init assets/hgvs-nomenclature`); without it the generator fails with `no HGVS strings harvested from …`, naming that command.
 

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -805,19 +805,104 @@ mod decisions {
     const NON_CONFLUENT: &str = "non-confluent";
     const NOT_EVALUABLE: &str = "not-evaluable";
 
+    /// True when `head` — the text before a target's first colon — is a
+    /// reference accession rather than the opening of a bare coordinate
+    /// fragment.
+    ///
+    /// HGVS puts the coordinate system immediately after the reference's colon,
+    /// so a fragment carrying no accession *begins* with one of the
+    /// single-letter descriptors followed by a dot. Anything else in that
+    /// position is the reference — accessions (`NC_000023.11`, `LRG_199t1`,
+    /// `NM_004006.2`) never take that shape.
+    fn is_accession(head: &str) -> bool {
+        !matches!(
+            head.as_bytes(),
+            [b'g' | b'o' | b'm' | b'c' | b'n' | b'r' | b'p', b'.', ..]
+        )
+    }
+
     /// Re-anchor `target` onto `reference`, replacing any accession it carries.
     ///
     /// The accession is everything before the **first** colon, which is where
     /// HGVS puts it; a colon later in the string belongs to an inner reference
     /// (`g.10_11ins[NC_…:g.20_30]`) and must be left alone.
+    ///
+    /// The first colon only delimits the accession when something
+    /// accession-shaped precedes it (#1530). A member that is a bare fragment
+    /// *and* carries an inner reference — `g.10_11ins[NC_2.1:g.20_30]` — puts
+    /// the inner colon first, and splitting there yields `X.1:g.20_30`: a
+    /// different, still well-formed variant, so nothing downstream would catch
+    /// it. Latent while every curated member reaches here with a leading
+    /// accession via `input_prefixed`; gated now rather than when it goes live.
+    ///
+    /// This is the same defect `spec_harvest::prefix::default_prefixed` fixed
+    /// for the harvester in #955 — an inner `[…:<sys>.…]` read as the variant's
+    /// own accession — arrived at from the opposite side: there a bare fragment
+    /// was wrongly judged *already* prefixed, here it is wrongly *re*-anchored.
     fn anchor(target: &str, reference: Option<&str>) -> String {
         match reference {
             None => target.to_string(),
             Some(accession) => match target.split_once(':') {
-                Some((_, rest)) => format!("{accession}:{rest}"),
-                None => format!("{accession}:{target}"),
+                Some((head, rest)) if is_accession(head) => format!("{accession}:{rest}"),
+                _ => format!("{accession}:{target}"),
             },
         }
+    }
+
+    /// Fail unless a ruling record is well formed *as a record* — everything
+    /// that can be judged from the record alone, with no spec checkout and no
+    /// fixture rows.
+    ///
+    /// Extracted so it can be unit-tested directly. The committed consumer
+    /// `ruling_records_are_intact` asserts exactly these properties; a gate that
+    /// is weaker than the test it backstops lets a malformed record into the
+    /// artifact and only fails later, at the far end of the build.
+    fn validate_ruling_shape(owner: &str, ruling: &overrides::Ruling) -> anyhow::Result<()> {
+        if ruling.rationale.trim().is_empty() {
+            anyhow::bail!("{owner}: a ruling record must say why");
+        }
+        if ruling.clauses.is_empty() {
+            anyhow::bail!("{owner}: a ruling record must cite at least one clause");
+        }
+        let cited: BTreeSet<&str> = ruling.clauses.iter().map(|c| c.clause.as_str()).collect();
+        for role in ruling.governing.iter().chain(ruling.deviates_from.iter()) {
+            if !cited.contains(role.as_str()) {
+                anyhow::bail!(
+                    "{owner}: names {role:?} as governing or deviated-from, but that clause is \
+                     not in `clauses` — every role must point at a cited, quote-verified clause"
+                );
+            }
+        }
+        match ruling.status {
+            overrides::RulingStatus::Decided if ruling.governing.is_none() => {
+                anyhow::bail!("{owner}: a `decided` ruling must name the clause it holds to govern")
+            }
+            // The whole point of the `undecided` state is that nobody has
+            // ruled. A governing clause — or a deviated-from one, which
+            // implies a side was chosen — is an invented ruling, so it is a
+            // build failure rather than a lint.
+            overrides::RulingStatus::Undecided
+                if ruling.governing.is_some() || !ruling.deviates_from.is_empty() =>
+            {
+                anyhow::bail!(
+                    "{owner}: an `undecided` ruling must not name a governing or deviated-from \
+                     clause — record the conflict, not a ruling nobody made"
+                )
+            }
+            // The other half of the same rule, and the half this gate was
+            // missing (#1530): `undecided` asserts that clauses *conflict*, so a
+            // record citing one clause states no conflict — it states a position
+            // while declining to name it as one. Only the `decided` arm may cite
+            // a single clause, where it is a settled carve-out naming the clause
+            // it applies.
+            overrides::RulingStatus::Undecided if ruling.clauses.len() < 2 => anyhow::bail!(
+                "{owner}: an `undecided` ruling cites {} clause(s); an unsettled question needs \
+                 both sides on the record",
+                ruling.clauses.len()
+            ),
+            _ => {}
+        }
+        Ok(())
     }
 
     /// Split a `path:line` or `path:start-end` clause into its parts.
@@ -972,41 +1057,9 @@ mod decisions {
             if !seen_rulings.insert(ruling.id.as_str()) {
                 anyhow::bail!("{owner}: duplicate id");
             }
-            if ruling.rationale.trim().is_empty() {
-                anyhow::bail!("{owner}: a ruling record must say why");
-            }
-            if ruling.clauses.is_empty() {
-                anyhow::bail!("{owner}: a ruling record must cite at least one clause");
-            }
+            validate_ruling_shape(&owner, ruling)?;
             for citation in &ruling.clauses {
                 verify_citation(spec_dir, &owner, citation)?;
-            }
-            let cited: BTreeSet<&str> = ruling.clauses.iter().map(|c| c.clause.as_str()).collect();
-            for role in ruling.governing.iter().chain(ruling.deviates_from.iter()) {
-                if !cited.contains(role.as_str()) {
-                    anyhow::bail!(
-                        "{owner}: names {role:?} as governing or deviated-from, but that clause is \
-                         not in `clauses` — every role must point at a cited, quote-verified clause"
-                    );
-                }
-            }
-            match ruling.status {
-                overrides::RulingStatus::Decided if ruling.governing.is_none() => anyhow::bail!(
-                    "{owner}: a `decided` ruling must name the clause it holds to govern"
-                ),
-                // The whole point of the `undecided` state is that nobody has
-                // ruled. A governing clause — or a deviated-from one, which
-                // implies a side was chosen — is an invented ruling, so it is a
-                // build failure rather than a lint.
-                overrides::RulingStatus::Undecided
-                    if ruling.governing.is_some() || !ruling.deviates_from.is_empty() =>
-                {
-                    anyhow::bail!(
-                        "{owner}: an `undecided` ruling must not name a governing or deviated-from \
-                         clause — record the conflict, not a ruling nobody made"
-                    )
-                }
-                _ => {}
             }
             for input in &ruling.applies_to {
                 if !by_input.contains_key(input.as_str()) {
@@ -1059,6 +1112,124 @@ mod decisions {
                 "X.1:c.235_237delinsTAT"
             );
             assert_eq!(anchor("NM_1.1:c.1del", None), "NM_1.1:c.1del");
+        }
+
+        /// The discriminating case for [`anchor`]: a member with **no** leading
+        /// accession whose only colon is an inner reference's. `split_once(':')`
+        /// alone splits there and returns a different variant
+        /// (`X.1:g.20_30`) — silently, since the result is still well-formed.
+        #[test]
+        fn anchor_prefixes_a_bare_fragment_that_carries_an_inner_reference() {
+            assert_eq!(
+                anchor("g.10_11ins[NC_2.1:g.20_30]", Some("X.1")),
+                "X.1:g.10_11ins[NC_2.1:g.20_30]"
+            );
+            // Every coordinate-system descriptor, so the shape test cannot be
+            // narrowed to the one letter this case happens to use.
+            for prefix in ["g", "o", "m", "c", "n", "r", "p"] {
+                assert_eq!(
+                    anchor(&format!("{prefix}.1_2ins[NC_2.1:g.20_30]"), Some("X.1")),
+                    format!("X.1:{prefix}.1_2ins[NC_2.1:g.20_30]")
+                );
+            }
+            // …and the converse still holds: a *real* leading accession is
+            // replaced, not prefixed, even though it too precedes a colon.
+            assert_eq!(
+                anchor("NC_1.1:g.10_11ins[NC_2.1:g.20_30]", Some("X.1")),
+                "X.1:g.10_11ins[NC_2.1:g.20_30]"
+            );
+        }
+
+        fn citation(clause: &str) -> overrides::Citation {
+            overrides::Citation {
+                clause: clause.to_string(),
+                quote: "quoted".to_string(),
+            }
+        }
+
+        fn ruling(
+            status: overrides::RulingStatus,
+            clauses: &[&str],
+            governing: Option<&str>,
+            deviates_from: &[&str],
+        ) -> overrides::Ruling {
+            overrides::Ruling {
+                id: "r".to_string(),
+                question: "q".to_string(),
+                status,
+                clauses: clauses.iter().map(|c| citation(c)).collect(),
+                governing: governing.map(str::to_string),
+                deviates_from: deviates_from.iter().map(|c| c.to_string()).collect(),
+                rationale: "because".to_string(),
+                applies_to: Vec::new(),
+                equivalence_classes: Vec::new(),
+            }
+        }
+
+        /// The gate this module exists to be: the *build* must refuse every
+        /// malformed ruling that `ruling_records_are_intact` refuses, or the
+        /// committed test is stricter than the generator that backstops it.
+        #[test]
+        fn an_undecided_ruling_must_put_both_sides_on_the_record() {
+            use overrides::RulingStatus::{Decided, Undecided};
+
+            // The one the generator used to let through: `undecided` is a claim
+            // that two clauses conflict, so a single citation states no conflict.
+            assert!(
+                validate_ruling_shape("r", &ruling(Undecided, &["a.md:1"], None, &[])).is_err()
+            );
+            assert!(validate_ruling_shape(
+                "r",
+                &ruling(Undecided, &["a.md:1", "b.md:2"], None, &[])
+            )
+            .is_ok());
+
+            // Already gated, re-asserted here so the arm cannot be rewritten in
+            // terms of the clause count alone.
+            assert!(validate_ruling_shape(
+                "r",
+                &ruling(Undecided, &["a.md:1", "b.md:2"], Some("a.md:1"), &[])
+            )
+            .is_err());
+            assert!(validate_ruling_shape(
+                "r",
+                &ruling(Undecided, &["a.md:1", "b.md:2"], None, &["a.md:1"])
+            )
+            .is_err());
+
+            // A `decided` record *may* cite one clause — a settled carve-out
+            // names only the clause it applies. The two-clause rule is the
+            // undecided arm's alone.
+            assert!(
+                validate_ruling_shape("r", &ruling(Decided, &["a.md:1"], Some("a.md:1"), &[]))
+                    .is_ok()
+            );
+            assert!(validate_ruling_shape("r", &ruling(Decided, &["a.md:1"], None, &[])).is_err());
+        }
+
+        #[test]
+        fn every_named_role_must_be_a_cited_clause() {
+            use overrides::RulingStatus::Decided;
+            assert!(
+                validate_ruling_shape("r", &ruling(Decided, &["a.md:1"], Some("z.md:9"), &[]))
+                    .is_err()
+            );
+            assert!(validate_ruling_shape(
+                "r",
+                &ruling(Decided, &["a.md:1"], Some("a.md:1"), &["z.md:9"])
+            )
+            .is_err());
+        }
+
+        #[test]
+        fn a_ruling_must_cite_a_clause_and_say_why() {
+            use overrides::RulingStatus::Decided;
+            assert!(
+                validate_ruling_shape("r", &ruling(Decided, &[], Some("a.md:1"), &[])).is_err()
+            );
+            let mut silent = ruling(Decided, &["a.md:1"], Some("a.md:1"), &[]);
+            silent.rationale = "   ".to_string();
+            assert!(validate_ruling_shape("r", &silent).is_err());
         }
 
         #[test]

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4028,17 +4028,33 @@ fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
 /// Column `i` of a whole-span reverse complement coincides exactly when column
 /// `n-1-i` does — both say `b[i] == complement(b[n-1-i])` — so the coincidences
 /// come in **mirror pairs**, and an odd `n` has a centre column that can never
-/// coincide. For a uniform random block the count of unchanged columns is
-/// therefore
+/// coincide. Both halves of that hold over a uniform A/C/G/T alphabet and not
+/// beyond it: [`crate::sequence::complement_base`] maps the self-complementary
+/// IUPAC codes to themselves (`N -> N`, `S -> S`, `W -> W`), so a centre column
+/// holding one of those *does* coincide, and real reference sequences carry `N`
+/// at assembly gaps. For a uniform random block the count of unchanged columns
+/// is therefore
 ///
 /// ```text
-/// U = 2 · Binomial(floor(n/2), 1/4)      E[U] = n/4      sd(U) = sqrt(3n/8)
+/// m = floor(n/2)                         the number of mirror pairs
+/// U = 2 · Binomial(m, 1/4)               E[U] = m/2      sd(U) = sqrt(3m/4)
 /// ```
 ///
-/// The mean is `n/4` — a quarter of the span — for **every** `n`. That is the
-/// part the earlier comment had right, and the part that misleads: it read a
-/// mean as if it were the whole distribution, and concluded that an observation
-/// above it was "far above chance". Measured against the actual distribution:
+/// Stated in `m`, not `n`, because the centre column of an odd span is not part
+/// of a pair: for even `n` the mean is `n/4` — a quarter of the span — but for
+/// odd `n` it is `(n−1)/4`, and the same `−1` runs through the standard
+/// deviation. An earlier revision of this comment gave only the even-`n` forms
+/// and asserted them for "every `n`"; #1461's span is 457, so the mean it
+/// implies is 114.25 rather than 114 and its `z` comes out at `+2.73` rather
+/// than the `+2.75` tabulated below. The table was computed correctly and only
+/// the prose over-generalised, which is exactly the failure #1461 is about — a
+/// statistic stated more broadly than it holds, then cited as evidence.
+/// [`the_unchanged_column_moments_reproduce_the_tabulated_z_scores`] now pins
+/// the two against each other so the generalisation cannot recur silently.
+///
+/// The other misreading, which the earlier revision also made, is to treat the
+/// mean as if it were the whole distribution and conclude that an observation
+/// above it is "far above chance". Measured against the actual distribution:
 ///
 /// | block | span | unchanged | z | P(at least this many) |
 /// |---|---|---|---|---|
@@ -4053,7 +4069,7 @@ fn coalesce_whole_block_inversion(pieces: &mut Vec<Piece>, ref_bytes: &[u8]) {
 /// nt, not because 32.8% is a low fraction.
 ///
 /// The discriminating quantity is `n`. The distribution's relative spread is
-/// `sd/mean = sqrt(6/n)`, so it is 100% of the mean at `n = 6` and 11.5% at
+/// `sd/mean = sqrt(3/m)`, so it is 100% of the mean at `n = 6` and 11.5% at
 /// `n = 457`: a density reading carries almost no information about a short
 /// block and a great deal about a long one. Any future rule that wants to argue
 /// from coincidence rates must scale with `n`; this one does not.
@@ -8830,6 +8846,59 @@ mod tests {
         // structurally above: the case to admit fails `every_separation_is_a_
         // single_base` (its widest real gap is 5) while the case to refuse has a
         // gap of 4, so no threshold on separation admits one without the other.
+    }
+
+    /// The moments quoted in [`changed_columns_dominate_the_span`]'s doc must
+    /// reproduce the z column of the table beneath them (#1530).
+    ///
+    /// That doc is the one place in this file that argues from a distribution
+    /// rather than from a pinned string, and its own thesis is that a statistic
+    /// stated more broadly than it holds gets cited later as evidence. It then
+    /// did exactly that: `E[U] = n/4` and `sd(U) = sqrt(3n/8)` are the **even**-`n`
+    /// case of `U = 2·Binomial(floor(n/2), 1/4)`, asserted for "**every** `n`" two
+    /// lines after the comment notes that an odd `n` has a centre column that can
+    /// never coincide. #1461's span is odd (457), so the displayed formulas give
+    /// `z = +2.73` where the table says `+2.75`.
+    ///
+    /// Pinned executably rather than corrected in prose alone, because prose is
+    /// what was wrong: the table was right the whole time, which is precisely
+    /// why nothing caught the generalisation.
+    #[test]
+    fn the_unchanged_column_moments_reproduce_the_tabulated_z_scores() {
+        /// `U = 2 · Binomial(m, 1/4)` where `m = floor(n/2)` is the number of
+        /// mirror pairs — the centre column of an odd span is not one, and over
+        /// an A/C/G/T alphabet can never coincide (a self-complementary IUPAC
+        /// code such as `N` does, which is why the model is stated over A/C/G/T).
+        fn moments(n: usize) -> (f64, f64) {
+            let m = (n / 2) as f64;
+            (m / 2.0, (3.0 * m / 4.0).sqrt())
+        }
+
+        // (span, unchanged columns, the z the doc's table states)
+        for (n, unchanged, tabulated) in [
+            (6usize, 4.0, 1.67), // `AAGCTA -> TAGCTT`, the #1040 control
+            (8, 4.0, 1.15),      // `AATGCACA -> TGTGCATT` (#1517)
+            (457, 150.0, 2.75),  // #1461, and the only odd span of the three
+        ] {
+            let (mean, sd) = moments(n);
+            let z = (unchanged - mean) / sd;
+            assert!(
+                (z - tabulated).abs() < 0.005,
+                "n = {n}: the stated moments give z = {z:.4}, but the table says {tabulated}"
+            );
+        }
+
+        // The discriminating half. Restating the moments in `n` alone is the
+        // mistake being fixed, so pin that the two forms genuinely disagree —
+        // otherwise the simpler-looking `n/4` reads as an equivalent rewrite.
+        assert_eq!(moments(8), (2.0, 3f64.sqrt()), "even n: m/2 == n/4");
+        let (odd_mean, _) = moments(457);
+        assert_eq!(odd_mean, 114.0);
+        assert_ne!(
+            odd_mean,
+            457.0 / 4.0,
+            "an odd span's centre column is unpaired, so `n/4` overstates the mean"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -54,9 +54,10 @@ struct EquivalenceClass {
     members: Vec<ClassMember>,
 }
 
-#[allow(dead_code)] // `input` is used only in failure messages
 #[derive(Debug, Deserialize)]
 struct ClassMember {
+    /// The harvested spelling. Read by the `by_input` lookup, and named in
+    /// every failure message so a mismatch identifies its member.
     input: String,
     /// The string ferro is run against — the member's row target, re-anchored
     /// onto the class's declared reference when it has one. Taken from the
@@ -819,6 +820,16 @@ fn ruling_records_are_intact() {
         .map(|r| (r.id.as_str(), r.status.as_str()))
         .collect();
     let pinned: std::collections::BTreeMap<&str, &str> = RULING_STATUSES.iter().copied().collect();
+    // Collecting into a map is last-wins, so a duplicated id silently drops one
+    // pin and `observed == pinned` can still hold on a malformed table — the id
+    // that survived is checked, the one it shadowed is not (#1530). Its sibling
+    // `EQUIVALENCE_CLASS_VERDICTS` already carries this; the generator checks
+    // duplicates on both of its own tables.
+    assert_eq!(
+        pinned.len(),
+        RULING_STATUSES.len(),
+        "RULING_STATUSES has a duplicate id"
+    );
     assert_eq!(
         observed, pinned,
         "the ruling records changed. Adding one is fine — pin it here. Changing an `undecided` \

--- a/tests/it/msto_regression_corpus.rs
+++ b/tests/it/msto_regression_corpus.rs
@@ -12,10 +12,13 @@
 //! [`MSTO_ISSUES`] enumerates every issue `msto` has filed against
 //! `fulcrumgenomics/ferro-hgvs` (`gh issue list --author msto --state all`)
 //! and, for each, the test functions that reference it by number
-//! (`issue_<N>`, `#<N>`, or `issue #<N>`, either in the function's own name
-//! or in a comment immediately above it). Where no such test exists, the
-//! `tests` slice is empty — that is itself the finding for a `high`-labeled
-//! issue, per [`no_high_priority_issue_is_unguarded_without_being_named`].
+//! (`issue_<N>`, `#<N>`, or `issue #<N>`) — in the function's own name, in a
+//! comment immediately above it, or, for a module that is one issue family end
+//! to end, in that module's doc. The two sections below record why the
+//! module-doc form was admitted and where it is *not* claimed. Where no such
+//! reference exists the `tests` slice is empty — that is itself the finding for
+//! a `high`-labeled issue, per
+//! [`no_high_priority_issue_is_unguarded_without_being_named`].
 //!
 //! ## Python guards count, and used not to
 //!
@@ -79,16 +82,19 @@
 //! pair at all. There is no string to pin.
 //!
 //! What it can be measured by is whether each of its three stages holds as a
-//! property, so its slice names one guard per stage rather than a reproduction.
+//! property, so its slice names one *or more* guards per stage rather than a
+//! reproduction — currently two, three and two, plus one whole-proposal census.
 //! See [`issue_1430_is_measured_by_a_property_not_by_an_expected_output`], which
 //! pins that reading so it cannot quietly be replaced by an ordinary
-//! input/expected row.
+//! input/expected row. What it requires is that no stage is left uncovered, not
+//! that any stage carry a particular number of guards.
 //!
 //! ## A citation is not a guarantee that the test guards the issue
 //!
-//! The attribution rule is mechanical — `#<N>` in the function's name or in the
-//! comment above it — and that is deliberate, because a judgement-based rule
-//! rots faster than the thing it describes. But mechanical means it also catches
+//! The attribution rule is mechanical — `#<N>` in the function's name, in the
+//! comment above it, or in the doc of a module that is one issue family end to
+//! end — and that is deliberate, because a judgement-based rule rots faster
+//! than the thing it describes. But mechanical means it also catches
 //! *cross-references*: a test whose comment names an issue to explain why the
 //! fixture was built a certain way, or as a historical aside, reads identically
 //! to a test that reproduces it.
@@ -164,8 +170,9 @@ struct MstoIssue {
     /// Issue state as of the last `gh issue list` enumeration.
     state: State,
     /// `(repo-relative file path, test function name)` pairs that reference
-    /// this issue number in the function's own name or in a comment
-    /// immediately above it. Empty means no such test was found.
+    /// this issue number in the function's own name, in a comment immediately
+    /// above it, or — where the whole module is one issue family — in that
+    /// module's doc. Empty means no such reference was found.
     tests: &'static [(&'static str, &'static str)],
     /// One-line mechanism note for the eleven issues the sequence-first
     /// migration review flagged as at risk. `None` for every other issue.
@@ -176,11 +183,17 @@ struct MstoIssue {
 /// (`gh issue list -R fulcrumgenomics/ferro-hgvs --state all --author msto`),
 /// mapped to the tests that reference it by number.
 ///
-/// Assembled by searching `tests/` and `src/` for `issue_<N>`, `#<N>`, and
-/// `issue #<N>` occurring in a test function's own name or in a comment
-/// directly above it. This is a name-based search: a test that exercises an
-/// issue's behavior without ever citing the issue number is not in this
-/// table.
+/// Assembled by searching `tests/` (Rust and Python) and `src/` for
+/// `issue_<N>`, `#<N>`, and `issue #<N>` occurring in a test function's own
+/// name, in a comment directly above it, or in the doc of a module that is one
+/// issue family end to end. This is a *citation*-based search: a test that
+/// exercises an issue's behavior without the number appearing in any of those
+/// three places is not in this table.
+///
+/// The module-doc form is not a loophole — it is claimed only where the module
+/// really is about one issue family, which is how the bindings' guards and the
+/// two `reported_*` tables are written. See the module doc for both cases and
+/// for the one it deliberately does not reach (#200).
 #[rustfmt::skip]
 static MSTO_ISSUES: &[MstoIssue] = &[
     MstoIssue { number: 30, high: false, state: State::Closed, tests: &[], note: None },
@@ -269,7 +282,8 @@ static MSTO_ISSUES: &[MstoIssue] = &[
     MstoIssue { number: 1419, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
     MstoIssue { number: 1420, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "reported_spans_change_the_columns_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
     MstoIssue { number: 1421, high: true, state: State::Open, tests: &[("tests/it/reported_confluence_pairs.rs", "every_reported_output_is_a_fixed_point"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged"), ("tests/it/reported_partition_verdicts.rs", "each_pair_reaches_its_canonical_form_from_exactly_one_spelling"), ("tests/it/reported_partition_verdicts.rs", "every_canonical_row_already_prints_its_wanted_form"), ("tests/it/reported_partition_verdicts.rs", "every_gap_row_is_returned_exactly_as_authored"), ("tests/it/reported_partition_verdicts.rs", "every_reported_pair_is_still_one_variant_by_equivalence"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_normalizes_as_recorded_under_five_prime"), ("tests/it/reported_partition_verdicts.rs", "every_reported_spelling_still_normalizes_as_the_reports_recorded"), ("tests/it/reported_partition_verdicts.rs", "only_the_named_rows_answer_differently_in_the_two_directions"), ("tests/it/reported_partition_verdicts.rs", "reference_bases_are_what_the_reports_state"), ("tests/it/reported_partition_verdicts.rs", "the_1421_spans_separate_by_two_nucleotides_not_one"), ("tests/it/reported_partition_verdicts.rs", "the_open_gap_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_spec_authority_census_holds"), ("tests/it/reported_partition_verdicts.rs", "the_two_reported_modules_describe_the_same_pairs"), ("tests/it/reported_partition_verdicts.rs", "the_wanted_form_of_every_gap_row_is_its_siblings_output")], note: None },
-    // #1430's slice is one guard per proposed stage, not a reproduction — see
+    // #1430's slice is one or more guards per proposed stage, not a
+    // reproduction — see
     // `issue_1430_is_measured_by_a_property_not_by_an_expected_output`.
     MstoIssue { number: 1430, high: true, state: State::Open, tests: &[("src/normalize/merge.rs", "the_coalesce_pass_merges_a_payload_alignment_split"), ("src/normalize/merge.rs", "the_coalesce_pass_reaches_the_spec_worked_example"), ("src/normalize/seqfirst/partition.rs", "canonical_members_claim_exactly_the_blocks_edit_distance"), ("src/normalize/seqfirst/partition.rs", "canonical_members_rebuild_the_alternate_block"), ("src/normalize/seqfirst/partition.rs", "round_trips_exhaustively_over_a_small_alphabet"), ("tests/it/reported_confluence_pairs.rs", "every_reported_pair_denotes_one_sequence"), ("tests/it/reported_confluence_pairs.rs", "no_reported_pair_normalizes_to_a_different_sequence"), ("tests/it/reported_confluence_pairs.rs", "the_reported_pair_census_is_unchanged")], note: None },
 ];


### PR DESCRIPTION
Closes #1530.

All eight items. **Nothing behavioural** — no normalized output moves, and the generated spec fixture is byte-identical.

## The defects

Three guards that can pass while being wrong (items 1–3), and five statements of a rule that the code no longer implements (items 4–8).

**1. The generator had no `clauses.len() >= 2` gate for an `undecided` ruling.** An `undecided` record is a claim that two clauses *conflict*, so a record citing one clause states no conflict — only a position it declines to name as one. `ruling_records_are_intact` asserts that; the generator asserted only the governing/deviated-from half. So the build gate was weaker than the test it exists to backstop, on exactly the rule the section was built to protect. The record-shape checks move into `validate_ruling_shape` — everything judgeable from the record alone, with no spec checkout and no fixture rows — which is unit tested directly, and the missing arm is added.

**2. `RULING_STATUSES` had no duplicate-id guard.** It is collected into a `BTreeMap` and compared, which is last-wins: a duplicated id silently drops one pin and `assert_eq!(observed, pinned)` still passes on a malformed table. Its sibling `EQUIVALENCE_CLASS_VERDICTS` already carries the length assert and the generator checks duplicates on *both* of its own tables, so this was the committed half missing the parity.

**3. `anchor` mis-split a member with no leading accession but an inner reference.** The doc states that a colon after the first belongs to an inner reference and must be left alone, but `split_once(':')` only delivers that when a leading accession is present. Given `g.10_11ins[NC_2.1:g.20_30]` it split at the *inner* colon and returned `X.1:g.20_30` — a different variant, and still well formed, so nothing downstream would catch it. The split is now accession-shape aware: a head beginning `<sys>.` is a bare fragment and gets prefixed, anything else is the reference and gets replaced.

This is the same defect #955 fixed for the harvester (`spec_harvest::prefix::default_prefixed`), reached from the opposite side — there a bare fragment was wrongly judged *already* prefixed, here it was wrongly *re*-anchored.

**4–8** are accuracy fixes to prose, detailed in the second commit's message: the msto attribution rule stated per-function in four places while #1520 widened it to module-doc attribution; "one guard per stage" where it is one *or more*; #1521's displayed moments being the even-`n` case asserted for every `n`; the corresponding `CLAUDE.md` sentence; and a stale `#[allow(dead_code)]` whose comment was wrong about which fields are live.

## Measured

| | |
|---|---|
| generated fixture, `origin/main` generator | md5 `0226b06a28044be56132d8b216488c3a` |
| generated fixture, this branch | md5 `0226b06a28044be56132d8b216488c3a` — byte-identical |
| curated class members that `anchor` mis-splits today | **0 of 24**, across 12 classes (4 declaring a `reference`) |
| ruling records rejected by the new gate | 0 of 3 — all three already cite both sides |

The zero on `anchor` is structural and is reported as such rather than as evidence of safety: every curated member reaches `anchor` with a leading accession via `input_prefixed`, so the corpus cannot currently build the shape the fix is about. It is gated now rather than when a curated member first arrives as a bare fragment carrying an inner reference — at which point it would fail silently rather than at the build gate.

The moments correction is arithmetic, not a measurement: `U = 2·Binomial(floor(n/2), 1/4)` gives mean `m/2` and sd `sqrt(3m/4)` for `m = floor(n/2)`. #1461's `n = 457` is odd, so the displayed `n/4` overstates the mean as 114.25 rather than 114 and yields `z = +2.73` where the table says `+2.75`. The table was right throughout — only the prose generalised, which is why nothing caught it.

## Unchanged on purpose

- **`decided` may still cite a single clause.** A settled carve-out names only the clause it applies, so the two-clause rule is the `undecided` arm's alone. Asserted explicitly so the arm cannot be rewritten in terms of the clause count.
- **`anchor` still *replaces* a real leading accession** rather than prefixing it, including when an inner reference follows. Asserted alongside the new case, since the obvious over-generalisation — "never split, always prefix" — passes every other assertion here.
- **The equivalence classes' outputs are still not pinned**, and citation paths are still not checked for `..`/absolute escapes. Both were raised in #1530 and deliberately recorded as not-work; neither is done here.

## Representation stability

No canonical form moves. `src/normalize/merge.rs` is touched only in a doc comment and a new `#[cfg(test)]` unit test; the generator's two changes are build-time gates whose artifact is byte-identical, verified by A/B with each generator separately rebuilt (distinct binary mtimes, `Compiling ferro-hgvs` on both). `examples/dump_normalized_corpus.rs` was not run, because there is no code path here that could move a row — the diff contains no change to any function reachable from `normalize()`.

## Verification

```
cargo fmt --all --check                                      # clean
cargo clippy --all-features --all-targets -- -D warnings     # clean
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \
  FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full \
  cargo nextest run --features dev
# 9586 tests run: 9586 passed (3 slow), 145 skipped
cargo run --features dev --bin generate_spec_fixture         # builds; overrides pass the new gate
```

**Nothing was re-blessed** — every pre-existing expectation already agreed with the new answers, which for a change that adds three gates is the signal that they are gates and not behaviour.

Each guard was also verified to actually fire, not just to exist:

- duplicating a `RULING_STATUSES` entry → `RULING_STATUSES has a duplicate id (left: 3, right: 4)`
- `the_unchanged_column_moments_reproduce_the_tabulated_z_scores` with the doc's displayed formulas → `n = 457: the stated moments give z = 2.7309, but the table says 2.75`
- `an_undecided_ruling_must_put_both_sides_on_the_record` did not compile before `validate_ruling_shape` existed


Representation-Change: none
