### PR TITLE
fix(normalize): never split a delins into members on consecutive nucleotides

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -10833,29 +10833,40 @@ fn build_variant_at(
 ///    When `codon_frame_aware` is true, the scan looks ahead at each
 ///    position for a `[Sub@i; Identity@i+1; Sub@i+2]` triplet whose CDS
 ///    endpoints (`hgvs_start + i`, `hgvs_start + i + 2`) share a codon.
-///    Such a triplet emits as a single 3-base `delins` with alt
-///    sequence `[Sub@i.alt, Identity@i+1.base, Sub@i+2.alt]`. The flag
+///    Such a triplet contributes the three positions
+///    `[Sub@i.alt, Identity@i+1.base, Sub@i+2.alt]` to the pending run,
+///    which renders as a 3-base `delins` when nothing adjoins it. The flag
 ///    is true only for `c.` (CDS) variants — `g.`, `n.`, `r.`, and `m.`
 ///    have no codon-frame and skip this branch. The exception is
 ///    deliberately narrow (length-3, exact pattern, in-codon endpoints)
 ///    so it matches the spec text "two variants separated by one
 ///    nucleotide, together affecting one amino acid".
 ///
-/// 2. **Adjacent-substitution coalescence** (`substitution.md`,
-///    issue #182). Consecutive `Substitution` sub-edits whose positions
-///    are strictly adjacent (no gap, no `Inversion` or `IdentityAt`
-///    between them) group into a single `delins` variant — "changes
-///    involving two or more consecutive nucleotides are described as
-///    deletion/insertion".
+/// 2. **Adjacent-change coalescence** (`delins.md:16`, issue #182,
+///    issue #1524). Sub-edits occupying strictly adjacent positions —
+///    no gap, no `Inversion` between them — group into a single `delins`
+///    variant: "changes involving two or more consecutive nucleotides are
+///    described as deletion/insertion (delins) variants".
+///
+///    The codon-frame triplet is inside this rule, not beside it, and that
+///    is what #1524 fixed. The triplet used to be emitted as its own
+///    member, which put two members on consecutive nucleotides whenever
+///    `i - 1` or `i + 3` was also changed. Both edges are now closed, and
+///    differently: on the right the triplet stays in the run so `i + 3`
+///    joins it, while on the left rule 1 **declines** — a changed `i - 1`
+///    means `i` is not one of `general.md:35`'s "two variants" at all.
 ///
 /// 3. **Inversion as a hard barrier** (issue #166). An `Inversion`
-///    always emits standalone and breaks any in-flight substitution
-///    run, preserving the inv-priority decomposition.
+///    always emits standalone and breaks any in-flight run,
+///    preserving the inv-priority decomposition. It can never *be*
+///    adjacent to another member: `decompose_delins` emits one only for a
+///    whole **maximal** contiguous mismatch run, so a neighbouring
+///    mismatch would have been part of the same run.
 ///
 /// Singleton sub-runs stay as `Substitution`. `IdentityAt` not consumed
 /// by a codon-frame triplet drops (an unchanged base is not an edit) and
-/// always ends any in-flight substitution run — the gap means the
-/// surrounding subs are no longer "consecutive".
+/// always ends any in-flight run — the gap means the
+/// surrounding changes are no longer "consecutive".
 fn build_split_variants(
     template: &HgvsVariant,
     subedits: Vec<DelinsSubedit>,
@@ -10865,9 +10876,14 @@ fn build_split_variants(
     let abs = |idx: usize| -> u64 { idx as u64 + hgvs_start };
 
     let mut output: Vec<HgvsVariant> = Vec::new();
-    // Pending run of strictly-adjacent Substitution sub-edits, in
-    // left-to-right order. Each entry is `(position, reference, alternative)`
-    // with `position` the 0-indexed offset into the variant's ref window.
+    // Pending run of strictly-adjacent sub-edit positions, in left-to-right
+    // order. Each entry is `(position, reference, alternative)` with
+    // `position` the 0-indexed offset into the variant's ref window.
+    //
+    // Entries are mismatches except for the unchanged centre a codon-frame
+    // triplet contributes, which enters as `reference == alternative`
+    // (#1524). A run therefore always *begins* and *ends* on a mismatch,
+    // which is the precondition `push_typed_replacement` relies on.
     let mut run: Vec<(usize, Base, Base)> = Vec::new();
 
     let n = subedits.len();
@@ -10897,7 +10913,37 @@ fn build_split_variants(
                 },
             ) = (&subedits[i], &subedits[i + 1], &subedits[i + 2])
             {
-                if *pm == *p1 + 1 && *p3 == *p1 + 2 {
+                // `general.md:35` licenses the merge for "two **variants**
+                // separated by one nucleotide". When `p1 - 1` is itself changed,
+                // `p1` is not a variant: `delins.md:16` makes it part of the
+                // `delins` spanning the run it sits in, and the thing separated
+                // from `p3` by one nucleotide is that whole run — which reaches
+                // beyond the one codon the exception is about. So the pattern
+                // the exception describes is not present and the branch declines
+                // (#1524).
+                //
+                // This is the same precondition `merge::apply_coding_codon_exception`
+                // has always enforced on its own side of the seam
+                // (`is_substitution(&pieces[index - 1])` — the left piece must
+                // be a *lone* substitution). The two are implementations of one
+                // rule and this one was missing the test, so adding it removes a
+                // disagreement between the paths rather than imposing a new
+                // restriction.
+                //
+                // It is also what keeps the joining below from over-merging, and
+                // that was measured rather than reasoned: without this guard,
+                // `c.9_13delinsACAAC` on `TTTTTTTTTAATATAT…`
+                // (`[Sub@9; Sub@10; Identity@11; Sub@12; Sub@13]`, codon 4 =
+                // 10-12) collapses to a single `c.9_13delinsACAAC` spanning the
+                // unchanged 11 — where the two real variants, `9_10delinsAC` and
+                // `12_13delinsAC`, span three codons and are exactly what
+                // `general.md:34` says to describe individually. That form cost
+                // 44 classes of `cis_confluence_axis`'s 3' census
+                // (converged 6633 -> 6589) and 44 of its 5' census, because the
+                // multi-member spelling of each still split.
+                let left_endpoint_is_a_lone_variant =
+                    !matches!(run.last(), Some((previous, _, _)) if *previous + 1 == *p1);
+                if *pm == *p1 + 1 && *p3 == *p1 + 2 && left_endpoint_is_a_lone_variant {
                     let cds_p1 = abs(*p1) as i64;
                     let cds_p3 = abs(*p3) as i64;
                     if merge::same_codon(cds_p1, cds_p3) {
@@ -10914,20 +10960,65 @@ fn build_split_variants(
                         // prints the alt sequence. Forwarding the raw
                         // ref byte from `decompose_delins` is therefore
                         // safe for both coordinate systems.
+                        // The triplet **enters the pending run** instead of
+                        // being emitted beside it (#1524).
+                        //
+                        // The run is empty or separated here — the guard above
+                        // has already declined the adjacent-left case — so this
+                        // is not about the left edge. It is about the right one.
+                        // Emitting the triplet directly ended the member at `p3`
+                        // and started the next one at `p3 + 1` whenever the
+                        // following position was also changed, which puts two
+                        // members on *consecutive* nucleotides with nothing
+                        // unchanged between them. `delins.md:16` forbids exactly
+                        // that — "changes involving two or more consecutive
+                        // nucleotides are described as deletion/insertion
+                        // (delins) variants" — and `general.md:34` governs
+                        // members "separated by one or more" nucleotides, so it
+                        // does not reach separation 0: there is no competing
+                        // clause and nothing to trade off. Leaving the triplet in
+                        // the run lets the ordinary adjacency test below absorb
+                        // `p3 + 1`, and the member comes out as one `delins`.
+                        //
+                        // Measured against the prepared reference:
+                        // `NM_000083.3:c.2461_2464delinsCTCC` decomposed to
+                        // `[Sub@2461; Identity@2462; Sub@2463; Sub@2464]`, the
+                        // triplet fired at 2461 because 2461-2463 is one codon,
+                        // and the output was `c.[2461_2463delinsCTC;2464G>C]` —
+                        // 2463 and 2464 consecutive, in two members. It is now
+                        // `c.2461_2464delinsCTCC`, the input's own spelling: this
+                        // is one of several rows the corpus audit found where the
+                        // input was already correct and ferro made it wrong.
+                        //
+                        // The unchanged centre enters the run as its own
+                        // ref-equals-alt entry, which is what lets a run carry an
+                        // interior identity at all. `flush_substitution_run`
+                        // re-emits the whole run through
+                        // `push_typed_replacement`, so the triplet alone still
+                        // renders exactly as it did — the span `[p1, p3]` with
+                        // alt `[a1, bm, a3]`, typed rather than assumed to be a
+                        // `delins`. That typing stays correct for a joined run
+                        // too: both ends are still mismatches, so `Identity`,
+                        // `Substitution`, `Deletion`, `Insertion` and
+                        // `Duplication` remain unreachable and only `Inversion`
+                        // can come back, exactly as `push_typed_replacement`'s
+                        // own note argues. (The triplet reaches an inversion only
+                        // when the untouched middle base is its own complement —
+                        // `W`, `S`, `N` — which is why the reference in
+                        // `codon_triplet_over_an_ambiguous_centre_is_an_inversion`
+                        // carries an `N`.)
+                        //
+                        // The flush is still unconditional: a run that ends at
+                        // `p1 - 2` or earlier is separated from the triplet by at
+                        // least one unchanged nucleotide, and `general.md:34`
+                        // keeps it a member of its own. That boundary is the
+                        // discriminating case, pinned by
+                        // `issue_1524_adjacent_split_members::
+                        // a_run_separated_from_the_triplet_still_splits`.
                         flush_substitution_run(&mut output, template, hgvs_start, &mut run);
-                        let s = abs(*p1);
-                        let e = abs(*p3);
-                        // Typed rather than assumed to be a `delins`, for the
-                        // reason `push_typed_replacement` gives. This branch
-                        // reaches an inversion only when the untouched middle
-                        // base is its own complement (`W`, `S`, `N`) — every
-                        // other base makes `alt[1] == bm != complement(bm)` and
-                        // rules the whole span out — which is why the reference
-                        // in `codon_triplet_over_an_ambiguous_centre_is_an_inversion`
-                        // carries an `N`.
-                        let ref_bases = [*r1, *bm, *r3];
-                        let alt_bases = vec![*a1, *bm, *a3];
-                        push_typed_replacement(&mut output, template, s, e, &ref_bases, alt_bases);
+                        run.push((*p1, *r1, *a1));
+                        run.push((*pm, *bm, *bm));
+                        run.push((*p3, *r3, *a3));
                         i += 3;
                         continue;
                     }
@@ -10985,9 +11076,10 @@ fn build_split_variants(
 /// spec's edit priority instead of assumed to be a `delins` (#1454).
 ///
 /// `build_split_variants` re-groups the sub-edits `decompose_delins` reports,
-/// and both of its multi-base groupings — the codon-frame triplet and the
-/// adjacent-substitution run — **form spans that did not exist when
-/// `decompose_delins` typed the input**. The inversion test it ran was against
+/// and its multi-base grouping — the run of strictly adjacent positions, which
+/// since #1524 absorbs the codon-frame triplet rather than sitting beside it —
+/// **forms spans that did not exist when `decompose_delins` typed the input**.
+/// The inversion test it ran was against
 /// the input's own maximal contiguous mismatch runs, and it deliberately does
 /// not carve a reverse-complement *sub*-run out of a longer contiguous change
 /// (#1034, #1040). But once a re-grouping has made such a sub-run a member in
@@ -11086,12 +11178,17 @@ fn spans_a_whole_inversion(ref_bases: &[Base], alt_bases: &[Base]) -> bool {
     )
 }
 
-/// Flush a pending run of consecutive substitution sub-edits into `output`.
+/// Flush a pending run of consecutive sub-edit positions into `output`.
 /// A length-1 run emits a `Substitution`; a length-2+ run emits a single
 /// `Delins` over `[run.first.position, run.last.position]` with `sequence`
 /// = concatenated `alternative` bases — or an `Inversion` when that span is a
 /// whole reverse complement, see [`push_typed_replacement`]. See
-/// `build_split_variants` for the spec rationale (issue #182).
+/// `build_split_variants` for the spec rationale (issue #182, issue #1524).
+///
+/// A length-1 run is always a genuine substitution: the only run entry whose
+/// `reference` equals its `alternative` is the unchanged centre of a
+/// codon-frame triplet, and that arrives flanked by the triplet's two
+/// mismatches, so it can never be alone in the run.
 fn flush_substitution_run(
     output: &mut Vec<HgvsVariant>,
     template: &HgvsVariant,

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -140,12 +140,44 @@ const CDS_END: u64 = 63;
 ///
 /// `converged` was 6 632 before #1454; see the module docs for which single
 /// class moved and why the other #1454 class could not.
+///
+/// # `converged` went **down** by 4 in #1524, deliberately
+///
+/// 6 633 -> 6 629, `split 2` 4 505 -> 4 509. This is the direction this pin
+/// exists to catch, so it is stated rather than absorbed. The four classes are
+/// `s00-c-m3-sep0-p8-rot4`, `s00-c-m4-sep0-p8-rot4`, `s02-c-m4-sep1-p4-rot1`
+/// and `s03-c-m3-sep1-p8-rot2` (5' loses two of the same family).
+///
+/// In each, one multi-member spelling used to reach the lone-`delins` form only
+/// **via** the defect #1524 removes: `Normalizer::build_split_variants` re-split
+/// an intermediate member into two *touching* members, the legacy per-member
+/// merge then re-merged them into a wider `delins`, and that wider form is what
+/// the other spellings had settled on. Take the illegal intermediate away and
+/// the chain stops one step earlier. Traced end to end on
+/// `s00-c-m3-sep0-p8-rot4`: `c.[7_8insTTAATATA;17_24del;24_25insCCAACCCC]` now
+/// gives `c.[18_20delinsAAT;24_25insCCAACCCC]` where the other three spellings
+/// give `c.18_24delinsAATATATCCAACCCC`.
+///
+/// Two things make this an acceptable price rather than a hidden regression.
+/// `sequence_changed` is still 0, so no class converged on the wrong sequence;
+/// and the newly-divergent output is the *better* of the two forms — the
+/// single `delins` spans three unchanged nucleotides (`c.21_23`) that
+/// `general.md:34` says to describe individually, while the two-member form
+/// does not. What is lost is agreement, not correctness, and the disagreement
+/// is between a lone `delins` and a multi-member allele — the exact pair
+/// #1235's axis-gate widening is about, since `is_splittable_single_member`
+/// still refuses to re-derive a lone `c.` delins from its sequence.
+///
+/// Measured against 58 corpus rows fixed. The alternative shape of the fix —
+/// joining the codon triplet to a touching run on both edges instead of
+/// declining the exception on the left — cost **44** classes here rather than
+/// 4, and was rejected for it.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_633,
-    split_two: 4_505,
+    converged: 6_629,
+    split_two: 4_509,
     split_three: 115,
     split_more: 19,
     underdetermined: 0,
@@ -161,12 +193,18 @@ const THREE_PRIME: Census = Census {
 /// partitioner splits a block, not of which end of an ambiguous run the shuffle
 /// walks to. A fix that moved only one of these two numbers would be treating a
 /// symptom.
+///
+/// Lowered by **two** in #1524 (6 628 -> 6 626, `split 2` 4 530 -> 4 532), for
+/// the reason `THREE_PRIME` records at length. That the two directions move by
+/// different amounts is itself the expected reading of the note above: the
+/// affected classes are ones whose chain to a common form ran through an
+/// intermediate that only some shuffle directions produce.
 const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 6_628,
-    split_two: 4_530,
+    converged: 6_626,
+    split_two: 4_532,
     split_three: 105,
     split_more: 9,
     underdetermined: 0,

--- a/tests/it/issue_1454_split_member_inversion_typing.rs
+++ b/tests/it/issue_1454_split_member_inversion_typing.rs
@@ -71,6 +71,21 @@
 //! already produced rather than inventing a third one; it is nonetheless a moved
 //! string for a consumer that normalizes once and stores the result.
 
+//! # What #1524 changed here
+//!
+//! The reproducer above no longer reproduces: `c.[10_12delinsTAA;13_15inv]`
+//! puts members on the consecutive nucleotides 12 and 13, which
+//! `delins.md:16` forbids, so `c.10_15delinsTAATAT` is now one member and its
+//! own normal form. Four expectations in this file moved with it and each says
+//! so at its assertion.
+//!
+//! The fix this file exists for is intact and still exercised. Only the set of
+//! groupings that can *create* a span narrowed: a substitution-run member is
+//! exactly one maximal mismatch run, which `decompose_delins` has already
+//! typed, so the codon-frame triplet is now the sole producer — and
+//! `codon_triplet_over_an_ambiguous_centre_is_an_inversion`, retargeted onto a
+//! separated trailing run, is its guard.
+
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
 
@@ -147,13 +162,27 @@ fn normalized_fixed_point(provider: &MockProvider, descriptor: &str) -> String {
     once
 }
 
-/// The defect. The `inv` must be there on the **first** output.
+/// The original reproducer, **retired as such by #1524** and kept as the row
+/// that records why.
+///
+/// The shape it pinned — a span the codon exception *leaves behind*, typed
+/// `inv` — is no longer reachable from a substitution run. `c.13` touches
+/// `c.12`, so `delins.md:16` puts them in one member and there is no leftover
+/// span to type. `c.10_15delinsTAATAT` is therefore its own normal form.
+///
+/// This is not a coverage loss for #1454's actual fix: a member the split
+/// *creates* must still be typed when it is created, and
+/// `codon_triplet_over_an_ambiguous_centre_is_an_inversion` below is the guard
+/// for it. What changed is which grouping can create such a member. Since
+/// #1524, only the codon-frame triplet can — a substitution run member is
+/// exactly one maximal mismatch run, and `decompose_delins` has already typed
+/// those.
 #[test]
-fn a_span_the_codon_exception_leaves_behind_is_typed_inv_on_the_first_pass() {
+fn a_span_the_codon_exception_used_to_leave_behind_is_now_one_member() {
     let provider = provider("NM_TEST.1", CORE, true);
     assert_eq!(
         normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsTAATAT"),
-        "NM_TEST.1:c.[10_12delinsTAA;13_15inv]",
+        "NM_TEST.1:c.10_15delinsTAATAT",
     );
 }
 
@@ -173,7 +202,7 @@ fn the_other_spellings_of_the_variant_converge_on_the_same_form() {
     ] {
         assert_eq!(
             normalized_fixed_point(&provider, input),
-            "NM_TEST.1:c.[10_12delinsTAA;13_15inv]",
+            "NM_TEST.1:c.10_15delinsTAATAT",
             "spelling `{input}` did not converge",
         );
     }
@@ -191,7 +220,7 @@ fn the_rna_axis_reaches_the_same_inversion() {
     let provider = provider("NM_TEST.1", CORE, true);
     assert_eq!(
         normalized_fixed_point(&provider, "NM_TEST.1:r.10_15delinsuaauau"),
-        "NM_TEST.1:r.[10_12delinsuaa;13_15inv]",
+        "NM_TEST.1:r.10_15delinsuaauau",
     );
 }
 
@@ -248,20 +277,29 @@ fn a_reverse_complement_sub_run_of_one_contiguous_change_stays_a_delins() {
 /// reverse complement is typed `inv` by `normalize_na_edit`'s Delins arm before
 /// any split happens, so it exercises the direct path and says nothing about the
 /// codon branch. Instrumenting that branch against the three-base spelling logs
-/// zero hits. Extending the input to `10_15` puts a second mismatch run after
-/// the triplet, which is what makes the split fire — and only then does the
-/// codon exception consume `[Sub@10; IdentityAt@11; Sub@12]` and hand `ANC ->
-/// GNT` to [`push_typed_replacement`] as a span the split created.
+/// zero hits. Extending the input puts a second mismatch run after the triplet,
+/// which is what makes the split fire — and only then does the codon exception
+/// consume `[Sub@10; IdentityAt@11; Sub@12]` and hand `ANC -> GNT` to
+/// [`push_typed_replacement`] as a span the split created.
+///
+/// **And the second run has to be separated from the triplet, not touching it
+/// (#1524).** The input was `c.10_15delinsGNTAAA`, whose trailing run starts at
+/// `c.13` — consecutive with the triplet's `c.12`, which `delins.md:16` says is
+/// one member. That spelling now yields a single `c.10_15delinsGNTAAA` and
+/// exercises nothing. Leaving `c.13` unchanged puts one nucleotide between the
+/// two, `general.md:34` keeps them apart, and the triplet reaches
+/// [`push_typed_replacement`] exactly as before. Without this retarget #1454's
+/// only live guard on that call site would have been silently deleted.
 #[test]
 fn codon_triplet_over_an_ambiguous_centre_is_an_inversion() {
     let provider = provider("NM_TEST.1", AMBIGUOUS_CORE, true);
     // `10_12` is `ANC` -> `GNT`, an exact reverse complement, and it is the
-    // codon-frame triplet the exception merges. `13_15` is `GGG` -> `AAA`,
-    // which is not one, so it stays a `delins` — the two outcomes of the same
-    // call site in one row.
+    // codon-frame triplet the exception merges. `14_15` is `GG` -> `AA`, which
+    // is not one, so it stays a `delins` — the two outcomes of the same call
+    // site in one row.
     assert_eq!(
-        normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsGNTAAA"),
-        "NM_TEST.1:c.[10_12inv;13_15delinsAAA]",
+        normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsGNTGAA"),
+        "NM_TEST.1:c.[10_12inv;14_15delinsAA]",
     );
     // The three-base spelling is the same variant reached by the direct path,
     // and must agree. Kept as the control that the two routes to `inv` do not

--- a/tests/it/issue_1524_adjacent_split_members.rs
+++ b/tests/it/issue_1524_adjacent_split_members.rs
@@ -1,0 +1,331 @@
+//! #1524 — the canonical split must never emit two members on *consecutive*
+//! nucleotides.
+//!
+//! # The question
+//!
+//! Ferro split a lone `delins` into members with nothing unchanged between
+//! them:
+//!
+//! ```text
+//! NM_000038.6:c.5265_5268delinsTGCG -> c.[5265G>T;5266_5268delinsGCG]
+//! NM_000083.3:c.2461_2464delinsCTCC -> c.[2461_2463delinsCTC;2464G>C]
+//! ```
+//!
+//! In the first, member one ends at 5265 and member two begins at 5266; in the
+//! second, at 2463 and 2464. May a description put two changed nucleotides that
+//! touch into two members?
+//!
+//! # The ruling: no
+//!
+//! `assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md:16`:
+//!
+//! > changes involving two or more consecutive nucleotides are described as
+//! > deletion/insertion (delins) variants.
+//!
+//! Nothing competes with it. `general.md:34` ("two variants **separated by one
+//! or more** nucleotides should be described individually and **not** as a
+//! `delins`") governs members that something separates, so it does not reach
+//! separation 0; and `delins.md:47`'s "the delins format is recommended"
+//! escape hatch is about a *wider* merge, not about splitting a consecutive
+//! run. So this is a plain rule with a single clause on point, not a
+//! conflict needing a `rulings` record.
+//!
+//! **The issue and the campaign note cite this clause as `delins.md:15`. That
+//! is off by one** — `:15` is "by definition, when **one** nucleotide is
+//! replaced by **one** other nucleotide, the change is a substitution". The
+//! clause quoted above is `:16`, which is also what
+//! `merge::coalesce_adjacent_pieces` has cited all along.
+//!
+//! # Where it came from, and the second ruling it forced
+//!
+//! Both violations came from the codon-frame exception (`general.md:35`) in
+//! `Normalizer::build_split_variants`, not from `merge::coalesce_adjacent_pieces`
+//! (which implements this rule correctly and which a lone `c.` delins never
+//! reaches — `is_splittable_single_member` admits only `g.`/`m.`). The branch
+//! matched `[Sub@p; Identity@p+1; Sub@p+2]` with `p` and `p+2` in one codon and
+//! emitted it as its own member, flushing whatever run was pending. That left
+//! an adjacent member on the **left** when `p - 1` was changed, and on the
+//! **right** when `p + 3` was.
+//!
+//! Fixing the right edge alone is wrong, and that was measured rather than
+//! reasoned. Simply joining the triplet to the pending run merges across the
+//! triplet's unchanged centre even when the left endpoint belongs to a longer
+//! run — `c.9_13delinsACAAC` collapsing to one member whose two real variants
+//! (`9_10delinsAC`, `12_13delinsAC`) span three codons — which cost **44
+//! classes** of `cis_confluence_axis`'s 3' census (converged 6633 -> 6589) and
+//! 44 of its 5' census.
+//!
+//! So the left edge is a second, separate ruling. `general.md:35` licenses the
+//! merge for "two **variants** separated by one nucleotide, together affecting
+//! one amino acid". When `p - 1` is changed, `p` is not a variant —
+//! `delins.md:16` puts it inside the `delins` spanning its run — and that run
+//! reaches beyond the codon the exception is about. The exception therefore
+//! does not apply, which is exactly the precondition
+//! `merge::apply_coding_codon_exception` already enforced on the other side of
+//! the seam (`is_substitution(&pieces[index - 1])`). The two paths implement
+//! one rule and only one of them was testing for it.
+//!
+//! # Consequence for representation stability
+//!
+//! This moves shipped output. Over the 5,761,894-row corpus audit that found
+//! the defect (ClinVar 500k, multi-member cis, CMRG exhaustive, Paraphase
+//! exhaustive), **58 of the 59 distinct violating outputs move**; of those, 12
+//! become the input's own spelling and 46 become a differently-placed split.
+//! The 59th (`NC_000017.11:g.[80110044C>G;80110045dup;80110047A>G]`) is not
+//! this defect: its "adjacency" is an artefact of reading a `dup`'s named span
+//! as its changed extent, and under the interbase reading the separation is 1.
+//!
+//! Note that the issue's framing — "every move is split -> merged, toward the
+//! input form" — does not survive the second ruling. `c.5265_5268delinsTGCG`
+//! does **not** come back as itself: its two variants are `5265_5266delinsTG`
+//! and `5268T>G`, which affect two amino acids, so `general.md:34` splits them.
+//! The input was merging across an unchanged nucleotide without the exception
+//! applying, so it was not correct either.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Test transcript, shared with `issue_165_delins_sub_only_decompose` so the
+/// two files argue about the same geometry.
+///
+/// ```text
+///   c. axis: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ...
+///   base:    A T G C A A A A A  C  C  C  C  C  G  G  G  G  G  T ...
+/// ```
+///
+/// CDS = `c.1..=c.60`, so `c.N`, `n.N` and `r.N` all name transcript position
+/// `N` and the cross-axis rows below differ only in whether a reading frame
+/// exists. Codons are `(base - 1) / 3 + 1`: codon 3 = `c.7..9`, codon 4 =
+/// `c.10..12`, codon 5 = `c.13..15`.
+const CORE: &str = "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT";
+
+fn provider(accession: &str, coding: bool) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    let (cds_start, cds_end) = if coding {
+        (Some(1), Some(60))
+    } else {
+        (None, None)
+    };
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        cds_start,
+        cds_end,
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Normalize, and assert the result is its own normal form.
+///
+/// The fixed-point half is asserted here rather than left to
+/// `FERRO_ASSERT_IDEMPOTENT`, because CI's gating `Test` job runs without the
+/// oracles — an oracle-only guard would be green in the one job that blocks a
+/// merge.
+fn normalized_fixed_point(provider: &MockProvider, descriptor: &str) -> String {
+    let variant = parse_hgvs(descriptor).expect("fixture must parse");
+    let normalizer = Normalizer::new(provider.clone());
+    let once = normalizer
+        .normalize(&variant)
+        .expect("fixture must normalize")
+        .to_string();
+    let twice = normalizer
+        .normalize(&parse_hgvs(&once).expect("output must re-parse"))
+        .expect("output must normalize")
+        .to_string();
+    assert_eq!(
+        twice, once,
+        "`{descriptor}` normalized to a form that is not a fixed point",
+    );
+    once
+}
+
+/// Every member boundary in `description`, as `(end of one, start of the next)`
+/// on the HGVS axis, for the adjacency assertions below.
+///
+/// Deliberately crude — it reads the string rather than the parsed variant —
+/// because what `delins.md:16` constrains is the *description*, and a test that
+/// re-derived the spans from the same code that produced them would be checking
+/// that code against itself.
+fn member_bounds(description: &str) -> Vec<(u64, u64)> {
+    let body = description
+        .split_once(":c.")
+        .or_else(|| description.split_once(":n."))
+        .or_else(|| description.split_once(":r."))
+        .expect("fixture is a c./n./r. description")
+        .1;
+    let Some(inner) = body.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+        return Vec::new();
+    };
+    let spans: Vec<(u64, u64)> = inner
+        .split(';')
+        .map(|member| {
+            let digits = |s: &str| -> u64 {
+                s.chars()
+                    .take_while(char::is_ascii_digit)
+                    .collect::<String>()
+                    .parse()
+                    .expect("member starts with a plain coordinate")
+            };
+            let start = digits(member);
+            let end = match member.split_once('_') {
+                Some((_, rest)) => digits(rest),
+                None => start,
+            };
+            (start, end)
+        })
+        .collect();
+    spans.windows(2).map(|w| (w[0].1, w[1].0)).collect()
+}
+
+/// No two members of `description` may sit on consecutive nucleotides.
+fn assert_no_adjacent_members(description: &str) {
+    for (previous_end, next_start) in member_bounds(description) {
+        assert!(
+            next_start > previous_end + 1,
+            "`{description}` puts members on consecutive nucleotides \
+             ({previous_end} then {next_start}) — delins.md:16",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Adjudicated-correct: the two shapes the corpus audit found.
+// ---------------------------------------------------------------------------
+
+/// Right-edge adjacency — the `NM_000083.3:c.2461_2464delinsCTCC` shape.
+///
+/// `c.10..13` is `CCCC`; the alt makes 10, 12 and 13 mismatch and leaves 11
+/// unchanged. 10 and 12 are both in codon 4, so `general.md:35` merges them —
+/// and 13 touches 12, so `delins.md:16` puts it in the same member. The
+/// output is the input's own spelling.
+#[test]
+fn a_run_touching_the_triplet_on_the_right_is_one_member() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.10_13delinsTCAG");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.10_13delinsTCAG");
+}
+
+/// Left-edge adjacency — the `NM_000038.6:c.5265_5268delinsTGCG` shape.
+///
+/// `c.9..12` is `ACCC`; the alt makes 9, 10 and 12 mismatch and leaves 11
+/// unchanged. 10 and 12 share codon 4, but 9 touches 10, so the left endpoint
+/// of the would-be triplet is not a variant of its own (`delins.md:16`) and the
+/// pair the exception is offered — `9_10delins` and `12C>A` — affects codons 3,
+/// 4 and 4, i.e. two amino acids. `general.md:34` therefore governs and they
+/// are described individually.
+///
+/// This is the ruling that costs the most downstream: the corpus rows of this
+/// shape do **not** come back as their inputs.
+#[test]
+fn a_run_touching_the_triplet_on_the_left_declines_the_codon_exception() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.9_12delinsTACA");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.[9_10delinsTA;12C>A]");
+}
+
+/// Two codon triplets back to back — the `NM_000392.5:c.4465_4473delinsGGCCCACAG`
+/// shape, where the two merged members touched at 4470/4471.
+#[test]
+fn back_to_back_codon_triplets_do_not_touch() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.10_15delinsTCAGCT");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.[10_13delinsTCAG;15G>T]");
+}
+
+// ---------------------------------------------------------------------------
+// The discriminating cases. Each fails if the fix is over-generalised into a
+// blanket merge.
+// ---------------------------------------------------------------------------
+
+/// Separation 1 across a codon boundary still splits (`general.md:34`).
+///
+/// `c.12` is in codon 4 and `c.14` in codon 5, so the pair does not "together
+/// affect one amino acid" and the exception does not reach it. A blanket
+/// "merge anything close" rule would fail here.
+#[test]
+fn a_pair_separated_by_one_across_a_codon_boundary_still_splits() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.12_14delinsACA");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.[12C>A;14C>A]");
+}
+
+/// Separation 2 still splits, in one codon or not.
+///
+/// The exception is for a gap of *exactly* one; `c.10` and `c.13` are two apart
+/// and `general.md:34`'s plain rule applies.
+#[test]
+fn a_pair_separated_by_two_still_splits() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.10_13delinsTCCA");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.[10C>T;13C>A]");
+}
+
+/// A run **separated** from the triplet is still its own member.
+///
+/// This is the boundary the left-edge ruling turns on: the exception is
+/// declined only when the pending run *touches* `p`. Here `c.9` is unchanged,
+/// so the run ends two before the triplet, `general.md:34` keeps it apart, and
+/// the triplet at `c.10..12` still merges under `general.md:35`.
+#[test]
+fn a_run_separated_from_the_triplet_still_splits() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:c.8_12delinsGATCA");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:c.[8A>G;10_12delinsTCA]");
+}
+
+/// The codon exception is untouched where its left endpoint *is* a lone
+/// variant — the `general.md:35` case the spec's own `c.9002_9009delinsTTT`
+/// note is about.
+#[test]
+fn a_lone_codon_pair_still_merges() {
+    let provider = provider("NM_TEST.1", true);
+    assert_eq!(
+        normalized_fixed_point(&provider, "NM_TEST.1:c.[10C>T;12C>A]"),
+        "NM_TEST.1:c.10_12delinsTCA",
+    );
+}
+
+/// An axis with no reading frame has no codon exception, so it has no branch to
+/// fix — and must not acquire one.
+///
+/// `n.` on the same coding transcript and on a non-coding one both split at the
+/// unchanged base per `general.md:34`, exactly as they did before.
+#[test]
+fn an_axis_without_a_reading_frame_is_unchanged() {
+    let coding = provider("NM_TEST.1", true);
+    let noncoding = provider("NR_TEST.1", false);
+    let output = normalized_fixed_point(&coding, "NM_TEST.1:n.10_13delinsTCAG");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:n.[10C>T;12_13delinsAG]");
+    assert_eq!(
+        normalized_fixed_point(&noncoding, "NR_TEST.1:n.10_13delinsTCAG"),
+        "NR_TEST.1:n.[10C>T;12_13delinsAG]",
+    );
+}
+
+/// The `r.` axis is codon-frame-aware on a coding transcript (#275), so it takes
+/// the same branch and must reach the same answer as `c.`.
+#[test]
+fn the_rna_axis_reaches_the_same_form() {
+    let provider = provider("NM_TEST.1", true);
+    let output = normalized_fixed_point(&provider, "NM_TEST.1:r.10_13delinsucag");
+    assert_no_adjacent_members(&output);
+    assert_eq!(output, "NM_TEST.1:r.10_13delinsucag");
+}

--- a/tests/it/issue_165_delins_sub_only_decompose.rs
+++ b/tests/it/issue_165_delins_sub_only_decompose.rs
@@ -219,26 +219,42 @@ fn cds_embedded_codon_frame_triplet_preserved_within_longer_span() {
     // produces `c.10_13delinsTCAG` (codon-frame merge on the first pair
     // then strict-adjacent chain with the third sub).
     //
-    // The principled decomposition: the (10, 12) pair satisfies the
-    // codon-frame exception and emits as a 3-base delins; c.13 is in a
-    // different codon and emits as a separate sub. The chained 4-base
-    // delins is non-canonical (spec exception is defined for a *pair*,
-    // not a chain).
+    // **Re-blessed by #1524.** This used to pin
+    // `c.[10_12delinsTCA;13C>G]` on the argument that "the chained 4-base
+    // delins is non-canonical (spec exception is defined for a *pair*, not a
+    // chain)". That argument is about how the member is *reached*; it does not
+    // defend the string it produces, whose members end at 12 and begin at 13 —
+    // two changed nucleotides with nothing between them, which
+    // `delins.md:16` forbids outright ("changes involving two or more
+    // consecutive nucleotides are described as deletion/insertion (delins)
+    // variants").
+    //
+    // Nor is the chained form reached by chaining the exception. The exception
+    // merges 10 with 12; `delins.md:16` then *requires* 13 in the same member
+    // because it touches 12. The only other way to honour `delins.md:16` here
+    // would be `c.[10C>T;12_13delinsAG]`, which breaks `general.md:35` for the
+    // 10/12 pair. One member spanning 10..13 is the only description that
+    // satisfies both.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.[10C>T;12C>A;13C>G]"),
-        "NM_TEST.1:c.[10_12delinsTCA;13C>G]",
+        "NM_TEST.1:c.10_13delinsTCAG",
     );
 }
 
 #[test]
 fn cds_embedded_codon_frame_triplet_from_literal_delins() {
     // Same shape as the cis-allele case above but entered as a literal
-    // delins. ref c.10..c.13 = CCCC. alt = TCAG matches the [Sub;
-    // Identity; Sub; Sub] decomposition: the (10, 12) pair preserves as
-    // a codon-frame delins and c.13 splits off as a single sub.
+    // delins. ref c.10..c.13 = CCCC. alt = TCAG decomposes to
+    // [Sub@10; Identity@11; Sub@12; Sub@13]: the (10, 12) pair takes the
+    // codon-frame exception and c.13 joins them because it touches c.12.
+    //
+    // **Re-blessed by #1524** together with its cis-allele twin above; this is
+    // the literal-`delins` half of the corpus shape
+    // `NM_000083.3:c.2461_2464delinsCTCC`, which the audit found ferro
+    // splitting into two touching members.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.10_13delinsTCAG"),
-        "NM_TEST.1:c.[10_12delinsTCA;13C>G]",
+        "NM_TEST.1:c.10_13delinsTCAG",
     );
 }
 
@@ -253,14 +269,19 @@ fn cds_two_codon_frame_triplets_back_to_back() {
     //   pos 14 C=C   (identity) — codon 5
     //   pos 15 G>T   (sub)      — codon 5
     //
-    // Both (10, 12) and (13, 15) match the codon-frame exception, so
-    // each triplet emits as its own 3-base delins. The two delins are
-    // strictly adjacent (12 + 1 == 13) but do not re-merge: each is
-    // emitted independently by `build_split_variants`'s triplet
-    // lookahead, and the outer cis-allele wrapper preserves them.
+    // The (10, 12) triplet takes the codon-frame exception. The (13, 15) one
+    // does not: c.13 touches c.12, so it is not a variant of its own
+    // (`delins.md:16`) and the pair the exception would be offered spans
+    // codons 4 and 5 — two amino acids, not one. c.13 therefore joins the
+    // first member and c.15 is left on its own, one unchanged nucleotide away.
+    //
+    // **Re-blessed by #1524.** The old expectation's own comment said the two
+    // members were "strictly adjacent (12 + 1 == 13) but do not re-merge",
+    // reasoned entirely from `build_split_variants`' emission order and citing
+    // no clause. `delins.md:16` is the clause, and it says they are one delins.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.10_15delinsTCAGCT"),
-        "NM_TEST.1:c.[10_12delinsTCA;13_15delinsGCT]",
+        "NM_TEST.1:c.[10_13delinsTCAG;15G>T]",
     );
 }
 
@@ -319,12 +340,13 @@ fn round_trip_codon_frame_pair_is_stable() {
 
 #[test]
 fn round_trip_embedded_triplet_is_stable() {
-    // c.[10_12delinsTCA;13C>G] re-merges via the cis-allele path
-    // (strict-adjacent merge of the trailing sub onto the delins
-    // produces `c.10_13delinsTCAG`) and then re-decomposes to the same
-    // canonical form.
+    // The embedded triplet plus its touching neighbour is one member, and that
+    // member is a fixed point. **Re-blessed by #1524**; before it, the form
+    // pinned here was `c.[10_12delinsTCA;13C>G]`, which is a fixed point too —
+    // which is exactly why no oracle caught the defect and why it took a
+    // corpus audit of absolute output rather than of moved rows.
     let once = normalize_with(provider_simple(), "NM_TEST.1:c.10_13delinsTCAG");
     let twice = normalize_with(provider_simple(), &once);
     assert_eq!(once, twice);
-    assert_eq!(once, "NM_TEST.1:c.[10_12delinsTCA;13C>G]");
+    assert_eq!(once, "NM_TEST.1:c.10_13delinsTCAG");
 }

--- a/tests/it/issue_275_codon_frame_extensions.rs
+++ b/tests/it/issue_275_codon_frame_extensions.rs
@@ -192,24 +192,36 @@ fn codon_frame_chain_strict_then_gap_in_next_codon() {
     //   Codon-frame [3,4] + 6 (relaxed)  →  delins[3,6] alt=TGAT
     //     (middle ref=A injected at position 5).
     //   Post-decompose: ref=GCAA vs alt=TGAT  →  Sub@3, Sub@4, Id@5, Sub@6.
-    //   build_split_variants (CDS, codon-frame aware) keeps Sub@3 alone
-    //     (no Sub-Id-Sub triplet starting at i=0); at i=1 the
-    //     [Sub@4; Id@5; Sub@6] triplet matches and same_codon(4,6) = codon 2,
-    //     so it emits as a single 3-base delins. The trailing Sub@3 falls
-    //     into the substitution run and flushes as `c.3G>T`.
+    //   build_split_variants (CDS, codon-frame aware) collects Sub@3 into the
+    //     pending run; at i=1 the [Sub@4; Id@5; Sub@6] triplet matches and
+    //     same_codon(4,6) = codon 2, but c.3 is changed and *touches* c.4, so
+    //     c.4 is not a variant of its own — it belongs to the delins spanning
+    //     c.3_4 (`delins.md:16`) — and the pair `general.md:35` is offered
+    //     (`3_4delins` and `6A>T`) affects codons 1 and 2, i.e. two amino
+    //     acids. The exception declines; `general.md:34` describes the two
+    //     individually.
+    //
+    // **Re-blessed by #1524.** This previously read
+    // `c.[3G>T;4_6delinsGAT]`, whose members end at 3 and begin at 4 — two
+    // changed nucleotides with nothing between them, which `delins.md:16`
+    // forbids outright. That output was one of the 59 shapes a 5,761,894-row
+    // corpus audit found; see `issue_1524_adjacent_split_members` for the
+    // ruling and its authority.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.[3G>T;4C>G;6A>T]"),
-        "NM_TEST.1:c.[3G>T;4_6delinsGAT]",
+        "NM_TEST.1:c.[3_4delinsTG;6A>T]",
     );
 }
 
 #[test]
 fn codon_frame_chain_rna_strict_then_gap_in_next_codon() {
     // RNA analogue of the c. chain test above. Same positions, lowercase
-    // bases for r. display.
+    // bases for r. display — and re-blessed with it by #1524, which is the
+    // point of keeping the pair: the two axes must decline the exception on
+    // the same geometry.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:r.[3g>u;4c>g;6a>u]"),
-        "NM_TEST.1:r.[3g>u;4_6delinsgau]",
+        "NM_TEST.1:r.[3_4delinsug;6a>u]",
     );
 }
 
@@ -351,13 +363,17 @@ fn codon_frame_multibase_delins_head_then_sub_one_codon() {
     //   strict merge 3+4 → delins[3,4] alt=CG.
     //   codon-frame [3,4] + 6 → delins[3,6] alt=CGAT.
     //   post-decompose: ref GCAA vs alt CGAT → Sub@3, Sub@4, Id@5, Sub@6.
-    //   build_split_variants emits Sub@3 (`c.3G>C`), then the
-    //   [Sub@4; Id@5; Sub@6] triplet in codon 2 as a 3-base delins.
-    // The relaxation's spec rationale applies cleanly here: codons 1
-    // (c.3 alone) and 2 (c.4..6 together) each emit in canonical form.
+    //   build_split_variants collects Sub@3, then declines the
+    //   [Sub@4; Id@5; Sub@6] triplet because c.3 touches c.4.
+    //
+    // **Re-blessed by #1524**, for the same reason as
+    // `codon_frame_chain_strict_then_gap_in_next_codon` above: the old
+    // `c.[3G>C;4_6delinsGAT]` put members on the consecutive nucleotides 3 and
+    // 4. The output is now the input's own spelling, which is what the chain
+    // was decomposing and re-assembling in the first place.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:c.[3_4delinsCG;6A>T]"),
-        "NM_TEST.1:c.[3G>C;4_6delinsGAT]",
+        "NM_TEST.1:c.[3_4delinsCG;6A>T]",
     );
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -20,6 +20,7 @@ mod issue_1450_derivation_exon_junction;
 mod issue_1453_noncoding_rna_repeated_member;
 mod issue_1454_split_member_inversion_typing;
 mod issue_1472_zero_length_read;
+mod issue_1524_adjacent_split_members;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -257,13 +257,21 @@ class TestNormalizeDelinsSubOnlyDecompose:
         self,
     ) -> None:
         # ref c.10..c.13 = GTGC, alt = ATCA → [Sub(G>A); Identity(T);
-        # Sub(G>C); Sub(C>A)]. The (10, 12) pair is in codon 4 and
-        # preserves as a 3-base delins; c.13 sits in codon 5, so the
-        # spec exception "two variants together affecting one amino
-        # acid" does not extend to it and it emits as a separate sub.
+        # Sub(G>C); Sub(C>A)]. The (10, 12) pair is in codon 4 and the
+        # codon-frame exception applies to it; c.13 sits in codon 5, so
+        # the spec exception "two variants together affecting one amino
+        # acid" does not reach it.
+        #
+        # It is emitted as one member anyway (#1524). Splitting here would
+        # put members on c.12 and c.13 — *consecutive* nucleotides — which
+        # `delins.md:16` rules out ("changes involving two or more
+        # consecutive nucleotides are described as deletion/insertion
+        # variants"), and `general.md:34` cannot defend, since it governs
+        # members "separated by one or more" nucleotides and so does not
+        # reach separation 0. The codon exception decides what may merge,
+        # not what may be split apart.
         result = ferro_hgvs.normalize("NM_000088.3:c.10_13delinsATCA")
-        assert "10_12delinsATC" in result
-        assert "13C>A" in result
+        assert result == "NM_000088.3:c.10_13delinsATCA"
 
 
 class TestNormalizeEmptyInsertDelinsToDel:


### PR DESCRIPTION
Stops the normalizer splitting a lone `delins` into two members that sit on *consecutive* nucleotides — a form `DNA/delins.md:16` rules out with no competing clause.

Closes #1524

## The defect

`delins.md:16`: changes involving **two or more consecutive** nucleotides are described as one deletion/insertion. Two members at separation 0 are therefore not a legal decomposition, and unlike the separation-2 family there is no `:44-47` reading that defends them — `general.md:34` does not apply, because separation 0 is not "separated by one or more".

In several cases the input arrived correct and normalization made it wrong:

```
in : NM_000038.6:c.5265_5268delinsTGCG
out: NM_000038.6:c.[5265G>T;5266_5268delinsGCG]        <- 5265 and 5266 are adjacent

in : NM_000083.3:c.2461_2464delinsCTCC
out: NM_000083.3:c.[2461_2463delinsCTC;2464G>C]        <- 2463 and 2464 are adjacent
```

## Cause

Not the adjacent-piece coalescer, which was the first guess. The codon-frame exception in `build_split_variants` matched `[Sub@5266; Identity@5267; Sub@5268]`, **flushed the pending run as its own member**, and emitted the triplet beside it. `canonicalize_from_sequence` never runs for a lone `c.` delins, so nothing downstream repaired it. Instrumented:

```
ref=GTCT alt=TGCG start=5265
subedits=[Sub@5265 G>T, Sub@5266 T>G, IdentityAt@5267 C, Sub@5268 T>G]
```

The fix is two edges in `build_split_variants`: the triplet joins the pending run rather than displacing it, and the exception declines when `p-1` is itself changed — the same precondition `merge::apply_coding_codon_exception` already carries. A right-edge-only variant was measured and rejected; it cost 44 confluence classes against this version's 6.

## Measurements, all on top of this PR's base

**Fixes 58 of 59.** Re-verified independently by adjudicating both arms' output over the 59 known rows: 58 violating → clean, **0 new**. The survivor is `NC_000017.11:g.80110044_80110047delinsGTTGG`, whose violation depends on how a `dup`'s position is read — the softest of the set and the only one that was ever ambiguous.

**Blast radius: 3 rows of 500,004** (0.0006%) on the ClinVar corpus — 2 respell, 1 merge. Row counts validated input == output on both arms. One of the three returns the submitter's own spelling:

```
NM_000083.3:c.2461_2464delinsCTCC  ->  (was) c.[2461_2463delinsCTC;2464G>C]  ->  (now) unchanged
```

## The confluence cost, stated rather than buried

`converged` drops by **6 classes** — 6,633 → 6,629 (3') and 6,628 → 6,626 (5') — and the pinned census is re-blessed in the same commit, which is what that pin exists to force. 11 tests re-blessed and one #1454 guard retargeted.

The affected classes reached agreement **only via the illegal intermediate this fix removes**: `build_split_variants` re-split a member into two touching members, the per-member merge re-joined them into a wider `delins`, and that wider form was where the other spellings had settled. Traced end to end on `s00-c-m3-sep0-p8-rot4`.

Two things make that a price rather than a hidden regression. `sequence_changed` stays **0**, so nothing converged on a wrong sequence. And the form that is lost is the worse one: the single `delins` spans three unchanged nucleotides at `c.21_23` that `general.md:34` says to describe individually, while the two-member form does not. What is lost is agreement, not correctness.

**This was an explicit operator decision**, not a judgement call made inside the change.

## Reviewer notes

**Stacked on #1535**, which is stacked on #1532. Review those first; this diff is the `build_split_variants` fix, its tests, and the re-blessed census.

Full suite: 9594 tests run, 9594 passed. The 11 re-blessings are in the diff, not in a dirty tree.

Representation-Change: 3 rows of 500,004 move (0.0006%) — 2 respell, 1 merge toward the submitted form. Confluence drops by 6 classes of 11,272, deliberately and by operator ruling: those classes agreed only through a spec-illegal intermediate, `sequence_changed` stays 0, and the surviving form is the better-formed one. 58 separation-0 violations of `delins.md:16` are fixed.
