### PR TITLE
test(corpus): add a separated reverse-complement family and three real oracles

### DIFF
--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -72,6 +72,17 @@
 //!    scale is expensive in a way adding a family is not — check the dump cost
 //!    before crossing a kilobase core with anything.
 //!
+//! 5. **…and only at the sequence structure it builds them from** (`#1517`). The
+//!    families are drawn *on* the random cores, so any property of the reference
+//!    itself is whatever the xorshift produced. Where a reverse-complement block
+//!    coincides with its own reference is exactly such a property, and the one
+//!    family that built such a block —`delins_hiding_an_inversion` — emits its
+//!    pieces adjacent, so nothing in the corpus separated two multi-column runs of
+//!    an inversion and a gate keyed on that measured `0 of 78,028`.
+//!    `separated_revcomp_runs` is the answer, and like `long_block_inversion` it
+//!    brings its own designed references because a random core cannot be asked to
+//!    have a coincidence pattern.
+//!
 //! ## The corpus is deliberately independent of `tests/it/common/`
 //!
 //! An example cannot reach test helpers, so the reference construction below is its
@@ -504,6 +515,213 @@ fn near_palindromic_core(len: usize) -> String {
     String::from_utf8(seq).expect("ACGT is valid UTF-8")
 }
 
+/// The family drawn against the **reverse-complement designs**, and the one shape
+/// in this file whose point is the *distance between* its changed runs (#1454's
+/// shape, at a separation this corpus could not previously reach).
+///
+/// Kept out of [`FAMILIES`] for the same reason [`LONG_FAMILY`] is: it cannot be
+/// drawn on an arbitrary core. Whether a reverse-complement block coincides with
+/// its own reference at a given column is a property of the *sequence*, not of the
+/// description, so a family crossed with the random 20-mers gets whatever
+/// coincidence structure the xorshift happened to produce — which is why
+/// `delins_hiding_an_inversion`, the only other family that builds a
+/// reverse-complement block, emits its two pieces at **separation 0** and at no
+/// other separation. A gate that engages only at separation >= 2 with multi-column
+/// pieces therefore fires on no row of this corpus, and a change to one measures a
+/// blast radius of zero for structural reasons rather than for safe ones.
+///
+/// The designs below fix that by building the *reference* around the intended
+/// coincidence pattern instead of reading it off a random core — the same trade
+/// `long_corpus_sequences` makes for scale.
+const REVCOMP_FAMILY: (&str, &str) = (
+    "separated_revcomp_runs",
+    "a reverse-complement block whose changed runs are multi-column and separated \
+     by 0, 1, 2, 4 or 8 unchanged columns",
+);
+
+/// Reference columns in each changed run of a `separated_revcomp_runs` design.
+///
+/// **Two, never one**, and that is the whole point of the family. A one-column run
+/// is a substitution, and the separation rules for substitutions are already dense
+/// in this corpus (`three_member_allele`, `dup_plus_sub`, `del_plus_sub`). What no
+/// family builds is a *multi-column* changed run — a piece that has to be typed
+/// `delins` or `inv` rather than `>` — at a separation greater than zero.
+const REVCOMP_RUN_WIDTH: usize = 2;
+
+/// Unchanged reference columns between consecutive changed runs.
+///
+/// `0` is the merge case (`general.md:34`, `DNA/delins.md:16-18` — adjacent changes
+/// are one description), `1` is the codon carve-out (`general.md:35` — merged only
+/// when both changes fall inside one codon, which needs a reading frame and so can
+/// never apply on `g.`), and `2`/`4`/`8` are the split cases. `8` is also
+/// `COALESCE_MAX_SEPARATION`, so the sweep sits on that boundary rather than
+/// stopping short of it.
+const REVCOMP_SEPARATIONS: &[usize] = &[0, 1, 2, 4, 8];
+
+/// Offsets into the core at which a design's block is planted.
+///
+/// Three, because the *axis* geometry is what varies with the offset and not the
+/// block: at 0 the block starts in the `cx` reference's 5'UTR, at 8 it runs past
+/// `CDS_END` into the 3'UTR, and every offset crosses at least one of the two
+/// `EXON_SPANS` junctions. The block itself is identical at all three, so a
+/// difference between them is a difference the axis made.
+const REVCOMP_SPAN_OFFSETS: &[usize] = &[0, 4, 8];
+
+/// Length of a `separated_revcomp_runs` core.
+///
+/// The same 20 as [`corpus_sequences`] deliberately: `CDS_START`/`CDS_END` and
+/// `EXON_SPANS` are both tuned to a 20-base core, so matching it is what lets these
+/// designs run on all three axes rather than being restricted to `g.`/`c.` the way
+/// the kilobase cores are.
+const REVCOMP_CORE_LEN: usize = 20;
+
+/// One `separated_revcomp_runs` design: a reference, a block inside it, and the
+/// alternate that block's inversion produces.
+///
+/// Both sides are recorded because this family is the only one in the file that
+/// knows its own **ground truth**. Every other family is a set of descriptions and
+/// nothing more, so the harness can ask whether an output *moved* but never whether
+/// it is *right*. Here the generator built `alternate` itself, which is what makes
+/// the three oracles in the test module possible at all.
+struct RevcompDesign {
+    /// The dump's `reference` column. A label rather than the core, matching
+    /// [`long_corpus_sequences`], so a row names the design it came from.
+    label: String,
+    /// The 20-base reference sequence.
+    core: String,
+    /// 0-based offset of the block within `core`.
+    offset: usize,
+    /// Unchanged columns between consecutive changed runs.
+    separation: usize,
+    /// The block's reference bases: `core[offset..offset + span.len()]`.
+    span: String,
+    /// `revcomp(span)` — what the block reads after the inversion. This is the
+    /// **intended alternate**, and the apply oracle checks the normalized output
+    /// against it rather than against the input.
+    alternate: String,
+}
+
+/// The block of a design at `separation`, as literal reference bases.
+///
+/// Written out rather than generated, because each one is a small hand
+/// construction that a reader should be able to check by eye — and
+/// `the_designed_blocks_have_the_coincidence_structure_they_claim` re-derives the
+/// run structure from the string, so a typo fails rather than silently producing a
+/// different shape. `AATGCACA` (separation 4) is the worked case: it reverse
+/// complements to `TGTGCATT`, coinciding at its four interior columns and leaving
+/// two 2-base changes.
+///
+/// **Why the odd separation needs three runs.** A column of a block coincides with
+/// its own reverse complement iff `span[i] == complement(span[L-1-i])`, and
+/// complement is an involution — so column `i` coincides exactly when its mirror
+/// `L-1-i` does. The changed/unchanged pattern of *any* whole-block inversion is
+/// therefore a palindrome, and an odd-length block's centre column is its own
+/// mirror and can never coincide. Two changed runs separated by an odd gap would
+/// need that gap to straddle the centre of an even-length block (impossible: the
+/// gap is centred, so its length has the parity of the block) or to sit at the
+/// centre of an odd-length block (impossible: the centre column is always changed).
+/// So separation 1 is unreachable with two runs and reachable with three, whose
+/// two gaps are mirror images of each other. That is a fact about reverse
+/// complements, not a limitation of these five strings.
+fn revcomp_span(separation: usize) -> &'static str {
+    match separation {
+        0 => "ACCA",
+        1 => "AACTTGAA",
+        2 => "AACGAA",
+        4 => "AATGCACA",
+        8 => "AACGTATACGAA",
+        other => unreachable!("no design for separation {other}"),
+    }
+}
+
+/// The changed runs of a design at `separation`, as `(start, length)` block-local.
+///
+/// Derived from the parameters rather than from the sequence, because at separation
+/// **0** the two runs are adjacent and the sequence alone cannot tell them apart
+/// from one run of four — and telling them apart is the entire content of the
+/// merge case. `the_designed_blocks_have_the_coincidence_structure_they_claim`
+/// pins the two views against each other: the union of these runs must be exactly
+/// the set of columns the reverse complement actually changes.
+fn revcomp_runs(separation: usize) -> Vec<(usize, usize)> {
+    let count = if separation.is_multiple_of(2) { 2 } else { 3 };
+    let stride = REVCOMP_RUN_WIDTH + separation;
+    (0..count)
+        .map(|n| (n * stride, REVCOMP_RUN_WIDTH))
+        .collect()
+}
+
+/// The full design set: every separation at every offset.
+fn revcomp_designs() -> Vec<RevcompDesign> {
+    let mut designs = Vec::new();
+    for &separation in REVCOMP_SEPARATIONS {
+        let span = revcomp_span(separation);
+        for &offset in REVCOMP_SPAN_OFFSETS {
+            // A design whose block ran off the end of the core would silently
+            // produce a truncated span while its label still named the separation
+            // it no longer has.
+            assert!(
+                offset + span.len() <= REVCOMP_CORE_LEN,
+                "separation-{separation} block does not fit at offset {offset}"
+            );
+            designs.push(RevcompDesign {
+                label: format!("revcomp_sep{separation}_at{offset}"),
+                core: revcomp_core(offset, span),
+                offset,
+                separation,
+                span: span.to_string(),
+                alternate: revcomp(span),
+            });
+        }
+    }
+    designs
+}
+
+/// A design's core: filler everywhere, with `span` planted at `offset`.
+///
+/// The filler is period-4 `GCTA`, one rotation out of phase with the `ACGT` pad
+/// [`padded`] wraps a `g.` core in. That is deliberate — an in-phase filler would
+/// let the pad's own rotation continue straight through the flank, so a tract
+/// ending at the block edge could extend into the pad and a shift's stopping point
+/// would become a property of the padding rather than of the block.
+fn revcomp_core(offset: usize, span: &str) -> String {
+    let mut core: Vec<u8> = (0..REVCOMP_CORE_LEN).map(|i| b"GCTA"[i % 4]).collect();
+    core[offset..offset + span.len()].copy_from_slice(span.as_bytes());
+    String::from_utf8(core).expect("GCTA and the designed spans are valid UTF-8")
+}
+
+/// The three spellings of one design's variant, on `axis`.
+///
+/// All three denote the same bases by construction, so they are a **confluence
+/// class**: `the_three_spellings_of_a_design_converge` requires one output from
+/// all three, and the apply oracle requires that output to produce `alternate`.
+///
+/// The split spelling is the load-bearing one. It writes each changed run as its
+/// own `delins` member, which is the form the spec mandates at separation >= 2
+/// (`general.md:34`) and forbids at separation 0 (`DNA/delins.md:16-18`) — so
+/// across the five separations the same spelling is required, carved out, and
+/// forbidden in turn, and the normalizer has to tell those cases apart.
+fn revcomp_inputs_for(axis: &str, design: &RevcompDesign) -> Vec<String> {
+    let prefix = prefix_for(axis);
+    let p = |i: usize| hgvs_pos(axis, design.offset + i);
+    let last = design.span.len() - 1;
+    let members: Vec<String> = revcomp_runs(design.separation)
+        .iter()
+        .map(|&(start, len)| {
+            format!(
+                "{}_{}delins{}",
+                p(start),
+                p(start + len - 1),
+                &design.alternate[start..start + len]
+            )
+        })
+        .collect();
+    vec![
+        format!("{prefix}{}_{}inv", p(0), p(last)),
+        format!("{prefix}{}_{}delins{}", p(0), p(last), design.alternate),
+        format!("{prefix}[{}]", members.join(";")),
+    ]
+}
+
 fn complement(base: u8) -> u8 {
     match base {
         b'A' => b'T',
@@ -637,6 +855,26 @@ fn dump(seeds: u32) -> Vec<Row> {
                     axis,
                     direction: dir_label,
                     family: LONG_FAMILY.0,
+                    was_fixed_point: output == input,
+                    input,
+                    output,
+                });
+            }
+        }
+    }
+    // The reverse-complement designs are drawn against their own references for the
+    // same reason the long cores are: the property they vary — where a
+    // reverse-complement block coincides with its own reference — is a property of
+    // the sequence, so it cannot be crossed with the random cores below.
+    for design in revcomp_designs() {
+        for (axis, direction, dir_label) in axes_and_directions() {
+            for input in revcomp_inputs_for(axis, &design) {
+                let output = normalize_one(axis, &design.core, &input, direction);
+                rows.push(Row {
+                    reference: design.label.clone(),
+                    axis,
+                    direction: dir_label,
+                    family: REVCOMP_FAMILY.0,
                     was_fixed_point: output == input,
                     input,
                     output,
@@ -2135,6 +2373,95 @@ mod tests {
         assert!(
             !report.contains("No row moved"),
             "a report with a moved row must not claim a zero:\n{report}"
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // `separated_revcomp_runs` — the family
+    // ----------------------------------------------------------------------
+
+    /// The designed blocks really do have the run structure their parameters claim.
+    ///
+    /// Two views of the same thing are pinned against each other. [`revcomp_runs`]
+    /// derives the runs from `(width, separation)`; this re-derives them from the
+    /// **sequence**, by comparing the block with its own reverse complement column
+    /// by column. A typo in one of the five literals in [`revcomp_span`] moves the
+    /// second view and not the first, so it fails here rather than silently
+    /// contributing a design at a separation nobody asked for.
+    ///
+    /// Separation 0 is the one case where the two views legitimately differ: two
+    /// adjacent 2-column runs are indistinguishable *as a sequence* from one
+    /// 4-column run, which is exactly what "adjacent changes are one description"
+    /// means. So the sequence view is checked against the **union** of the runs,
+    /// and the count is checked only where a gap separates them.
+    #[test]
+    fn the_designed_blocks_have_the_coincidence_structure_they_claim() {
+        for &separation in REVCOMP_SEPARATIONS {
+            let span = revcomp_span(separation);
+            let alternate = revcomp(span);
+            let runs = revcomp_runs(separation);
+
+            let changed: Vec<usize> = (0..span.len())
+                .filter(|&i| span.as_bytes()[i] != alternate.as_bytes()[i])
+                .collect();
+            let designed: Vec<usize> = runs
+                .iter()
+                .flat_map(|&(start, len)| start..start + len)
+                .collect();
+            assert_eq!(
+                changed, designed,
+                "separation-{separation} block {span} inverts to {alternate}, which changes \
+                 columns {changed:?} — not the {designed:?} its run layout claims"
+            );
+            assert!(
+                runs.iter().all(|&(_, len)| len >= REVCOMP_RUN_WIDTH),
+                "separation-{separation} has a run narrower than {REVCOMP_RUN_WIDTH} columns, \
+                 so it is a substitution shape and not the multi-column one this family adds"
+            );
+            for pair in runs.windows(2) {
+                let [(start, len), (next, _)] = [pair[0], pair[1]];
+                assert_eq!(
+                    next - (start + len),
+                    separation,
+                    "runs of the separation-{separation} block are {} columns apart",
+                    next - (start + len)
+                );
+            }
+            assert_eq!(
+                runs.last().map(|&(s, l)| s + l),
+                Some(span.len()),
+                "the separation-{separation} block has unchanged columns outside its outermost \
+                 runs, so its stated span is not minimal"
+            );
+        }
+    }
+
+    /// The worked case is in the corpus, verbatim.
+    ///
+    /// `AATGCACA` reverse complements to `TGTGCATT`: a true inversion that coincides
+    /// with its own reference at its four interior columns, leaving two 2-base
+    /// changes separated by four unchanged ones. It is the shape the family exists
+    /// for, so it is pinned as a literal rather than left to be implied by the
+    /// parameters.
+    #[test]
+    fn the_worked_case_is_the_separation_four_design() {
+        assert_eq!(revcomp_span(4), "AATGCACA");
+        assert_eq!(revcomp("AATGCACA"), "TGTGCATT");
+        assert_eq!(revcomp_runs(4), vec![(0, 2), (6, 2)]);
+        // …and it reaches the dump, with both flanking runs multi-column.
+        let design = revcomp_designs()
+            .into_iter()
+            .find(|d| d.separation == 4 && d.offset == 0)
+            .expect("the separation-4 design exists");
+        assert!(design.core.starts_with("AATGCACA"));
+        assert_eq!(design.alternate, "TGTGCATT");
+        assert_eq!(
+            revcomp_inputs_for("g", &design),
+            vec![
+                "NC_TEST.1:g.257_264inv".to_string(),
+                "NC_TEST.1:g.257_264delinsTGTGCATT".to_string(),
+                "NC_TEST.1:g.[257_258delinsTG;263_264delinsTT]".to_string(),
+            ]
         );
     }
 

--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -83,6 +83,19 @@
 //!    brings its own designed references because a random core cannot be asked to
 //!    have a coincidence pattern.
 //!
+//! ## One family knows its own ground truth, and that buys three oracles
+//!
+//! Everything above measures **movement** — two dumps, one diff — and never
+//! whether an output is *right*. Thirteen of the fifteen families cannot be asked:
+//! they are sets of descriptions with no record of what the description was meant
+//! to denote. `separated_revcomp_runs` is built the other way round, choosing the
+//! alternate first and deriving the reference around it, so `(reference,
+//! alternate)` is exact for every row. The test module turns that into three real
+//! oracles — sequence preservation, confluence, and separation-rule conformance —
+//! and two of the three are currently red against `main`. Read their doc comments
+//! before quoting them; each records what it measured and which half of its
+//! finding is a settled defect and which is an open decision.
+//!
 //! ## The corpus is deliberately independent of `tests/it/common/`
 //!
 //! An example cannot reach test helpers, so the reference construction below is its
@@ -2377,8 +2390,45 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
-    // `separated_revcomp_runs` — the family
+    // `separated_revcomp_runs` — the family, and the three oracles it enables
     // ----------------------------------------------------------------------
+    //
+    // Everything above measures *movement*: two dumps, one diff, "did this change
+    // the output". Nothing above ever asks whether an output is **right**, and for
+    // thirteen of the fifteen families it cannot — they are sets of descriptions,
+    // with no record of what the description was meant to denote.
+    //
+    // `separated_revcomp_runs` is built the other way round: the generator picks
+    // the alternate first (`revcomp(span)`) and derives the reference around it, so
+    // `(reference, alternate)` is known exactly for every row. That makes three
+    // real oracles available for free, and each of them can catch a class of defect
+    // a movement count cannot see:
+    //
+    // 1. **apply** — the output denotes the intended bases. #1416, #1453 and #1431
+    //    were each an output that denoted the wrong sequence or none at all, and
+    //    each was found by hand.
+    // 2. **confluence** — the three spellings of one design agree, and their common
+    //    answer is a fixed point.
+    // 3. **separation** — the members obey `general.md:34`/`:35`, checked against
+    //    the sequence rather than against a pinned string.
+
+    /// Run `f` over every row `separated_revcomp_runs` contributes to a dump.
+    ///
+    /// Deliberately re-derives the rows rather than filtering [`dump`]: the oracles
+    /// need the *design* behind each row — its span, its intended alternate, its run
+    /// layout — and a `Row` carries only a label.
+    fn for_each_revcomp_row(
+        mut f: impl FnMut(&RevcompDesign, &'static str, &'static str, &str, &str),
+    ) {
+        for design in revcomp_designs() {
+            for (axis, direction, dir_label) in axes_and_directions() {
+                for input in revcomp_inputs_for(axis, &design) {
+                    let output = normalize_one(axis, &design.core, &input, direction);
+                    f(&design, axis, dir_label, &input, &output);
+                }
+            }
+        }
+    }
 
     /// The designed blocks really do have the run structure their parameters claim.
     ///
@@ -2462,6 +2512,888 @@ mod tests {
                 "NC_TEST.1:g.257_264delinsTGTGCATT".to_string(),
                 "NC_TEST.1:g.[257_258delinsTG;263_264delinsTT]".to_string(),
             ]
+        );
+    }
+
+    /// An odd separation needs three runs, and that is a fact about reverse
+    /// complements rather than a quirk of the five literals.
+    ///
+    /// Exhaustive over every block of length <= 8 with exactly two changed runs:
+    /// none of them has an odd gap. If this ever finds one, the argument in
+    /// [`revcomp_span`]'s docs is wrong and the three-run layout it justifies is
+    /// unnecessary.
+    #[test]
+    fn two_changed_runs_can_never_be_an_odd_number_of_columns_apart() {
+        let mut odd_gaps_seen: Vec<String> = Vec::new();
+        let mut spans: Vec<Vec<u8>> = vec![Vec::new()];
+        for _ in 0..8 {
+            spans = spans
+                .iter()
+                .flat_map(|span| {
+                    b"ACGT".iter().map(|base| {
+                        let mut wider = span.clone();
+                        wider.push(*base);
+                        wider
+                    })
+                })
+                .collect();
+            for span in &spans {
+                let text = std::str::from_utf8(span).expect("ACGT is valid UTF-8");
+                let alternate = revcomp(text);
+                let changed: Vec<bool> = span
+                    .iter()
+                    .zip(alternate.as_bytes())
+                    .map(|(r, a)| r != a)
+                    .collect();
+                let runs = changed_runs(&changed);
+                if runs.len() != 2 {
+                    continue;
+                }
+                let gap = runs[1].0 - (runs[0].0 + runs[0].1);
+                if !gap.is_multiple_of(2) {
+                    odd_gaps_seen.push(format!("{text} -> {alternate} (gap {gap})"));
+                }
+            }
+        }
+        assert!(
+            odd_gaps_seen.is_empty(),
+            "a two-run block with an odd gap exists, so `revcomp_span`'s parity argument — \
+             and the three-run layout it justifies — is wrong: {odd_gaps_seen:?}"
+        );
+    }
+
+    /// Maximal runs of `true`, as `(offset, length)` — edges included.
+    ///
+    /// The sibling of [`interior_runs`], which drops the edge runs on purpose. A
+    /// *changed* run at the edge of a block is ordinary (a minimal block starts and
+    /// ends changed), whereas an *unchanged* run at the edge is an untrimmed flank,
+    /// which is why the two functions differ.
+    fn changed_runs(flags: &[bool]) -> Vec<(usize, usize)> {
+        let mut runs = Vec::new();
+        let mut i = 0;
+        while i < flags.len() {
+            if !flags[i] {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < flags.len() && flags[i] {
+                i += 1;
+            }
+            runs.push((start, i - start));
+        }
+        runs
+    }
+
+    /// Gaps between **multi-column** changed runs of every reverse-complement block
+    /// `input` names, in unchanged reference columns.
+    ///
+    /// A member counts as a reverse-complement block when its inserted bases are the
+    /// reverse complement of the bases it replaces — however it is spelled, so an
+    /// `inv` and the `delins` that says the same thing both qualify. Only gaps whose
+    /// *both* flanking runs are at least [`REVCOMP_RUN_WIDTH`] columns are reported,
+    /// which is precisely the shape a gate keyed on "multi-column pieces at a
+    /// separation" engages on.
+    ///
+    /// A block with one changed run contributes nothing, so the separation-0 design
+    /// does not appear here — adjacency *is* one run, which is the content of the
+    /// merge rule rather than a gap in the measurement.
+    fn separated_revcomp_gaps(input: &str, core: &str) -> Vec<usize> {
+        let Ok(variant) = parse_hgvs(input) else {
+            return Vec::new();
+        };
+        let Ok(facts) = member_facts_of(&variant, &genomic_provider(core)) else {
+            return Vec::new();
+        };
+        let mut gaps = Vec::new();
+        for member in &facts {
+            if member.reference.is_empty() || member.alternate != revcomp(&member.reference) {
+                continue;
+            }
+            let changed: Vec<bool> = member
+                .reference
+                .bytes()
+                .zip(member.alternate.bytes())
+                .map(|(r, a)| r != a)
+                .collect();
+            gaps.extend(changed_runs(&changed).windows(2).filter_map(|pair| {
+                let ((start, len), (next, next_len)) = (pair[0], pair[1]);
+                (len >= REVCOMP_RUN_WIDTH && next_len >= REVCOMP_RUN_WIDTH)
+                    .then(|| next - (start + len))
+            }));
+        }
+        gaps
+    }
+
+    /// No other family builds a reverse-complement block whose multi-column changed
+    /// runs are separated at all.
+    ///
+    /// This is the structural claim the family exists to fix, asserted rather than
+    /// argued. `delins_hiding_an_inversion` is the only other family that builds a
+    /// reverse-complement piece and its pieces are three columns wide and adjacent;
+    /// `long_block_inversion` builds a kilobase one, but its perturbations are
+    /// *single*-column runs. So a gate keyed on multi-column pieces at a separation
+    /// engaged on no row of this corpus, and a change to one measured `0 of 78,028`
+    /// for structural reasons rather than safe ones.
+    ///
+    /// The second half is what keeps the first honest: the new family really does
+    /// reach every separation it claims. Separation 0 is excluded there because it
+    /// is not a gap — two adjacent runs are one run — and that is the merge case,
+    /// not a hole.
+    #[test]
+    fn only_this_family_separates_the_runs_of_a_reverse_complement_block() {
+        let core = &corpus_sequences(1)[0];
+        for (family, _) in FAMILIES {
+            for input in inputs_for(family, "g", core) {
+                assert!(
+                    separated_revcomp_gaps(&input, core).is_empty(),
+                    "family {family} already builds a separated reverse-complement block \
+                     ({input}), so the structural gap this family was added for has moved"
+                );
+            }
+        }
+        for (_, long_core) in long_corpus_sequences() {
+            for input in long_inputs_for("g", &long_core) {
+                assert!(
+                    separated_revcomp_gaps(&input, &long_core).is_empty(),
+                    "{} already builds a separated reverse-complement block",
+                    LONG_FAMILY.0
+                );
+            }
+        }
+
+        let reached: std::collections::BTreeSet<usize> = revcomp_designs()
+            .iter()
+            .flat_map(|design| {
+                revcomp_inputs_for("g", design)
+                    .into_iter()
+                    .flat_map(|input| separated_revcomp_gaps(&input, &design.core))
+            })
+            .collect();
+        assert_eq!(
+            reached,
+            REVCOMP_SEPARATIONS
+                .iter()
+                .copied()
+                .filter(|separation| *separation > 0)
+                .collect::<std::collections::BTreeSet<_>>(),
+            "the family does not reach every separation it claims"
+        );
+        // …and separation 0 is present as the one shape that has no gap at all.
+        let merged = revcomp_designs()
+            .into_iter()
+            .find(|design| design.separation == 0)
+            .expect("the separation-0 design exists");
+        let changed: Vec<bool> = merged
+            .span
+            .bytes()
+            .zip(merged.alternate.bytes())
+            .map(|(r, a)| r != a)
+            .collect();
+        assert_eq!(
+            changed_runs(&changed),
+            vec![(0, 2 * REVCOMP_RUN_WIDTH)],
+            "the separation-0 design must present as one run, which is what adjacency means"
+        );
+    }
+
+    // -- Oracle 1: sequence preservation -----------------------------------
+
+    /// Where a design's core sits inside the sequence `accession` serves.
+    ///
+    /// `None` for the multi-exon *contig*, where the core is interleaved with
+    /// introns and so is not one contiguous run — a single offset cannot describe
+    /// it, and guessing one would compare the wrong bases while still producing a
+    /// verdict.
+    fn reference_frame(accession: &str, core: &str) -> Option<(String, usize)> {
+        match accession {
+            GENOMIC_CONTIG | TX_CONTIG => Some((padded(core), PAD_OFFSET)),
+            TX_ACCESSION | TX_MULTI_ACCESSION => Some((core.to_string(), 0)),
+            _ => None,
+        }
+    }
+
+    /// What the apply oracle concluded about one row.
+    #[derive(Debug)]
+    enum ApplyVerdict {
+        /// Applying the normalized output to the reference reproduces the alternate
+        /// the generator intended.
+        Preserved,
+        /// It reproduces something else — the defect class this oracle exists for.
+        Wrong { got: String, want: String },
+        /// It could not be applied, so the question has no answer here. Not a
+        /// failure: `apply_to_reference` declines an allele whose members overlap,
+        /// and a normalized output can be a sentinel like `<declined>`.
+        Unapplicable(String),
+    }
+
+    /// Apply `output` to the design's reference and compare with `design.alternate`.
+    ///
+    /// This is the oracle a movement count cannot be: it asks what the output
+    /// *means*, against a ground truth the generator wrote down before the
+    /// normalizer ever ran. Comparing the output against its own input instead —
+    /// which is what `--verify-spdi` does — cannot catch a spelling that was already
+    /// wrong on the way in, and cannot say which of two disagreeing spellings is
+    /// the wrong one.
+    fn apply_verdict(axis: &str, design: &RevcompDesign, output: &str) -> ApplyVerdict {
+        let Ok(variant) = parse_hgvs(output) else {
+            return ApplyVerdict::Unapplicable(format!("output does not parse: {output}"));
+        };
+        let provider = provider_for(axis, &design.core);
+        let applied = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ferro_hgvs::spdi::apply_to_reference(&variant, &provider)
+        })) {
+            Ok(Ok(applied)) => applied,
+            Ok(Err(e)) => return ApplyVerdict::Unapplicable(e.to_string()),
+            Err(_) => return ApplyVerdict::Unapplicable("panicked while applying".to_string()),
+        };
+        let Some((sequence, base)) = reference_frame(&applied.accession, &design.core) else {
+            return ApplyVerdict::Unapplicable(format!(
+                "no contiguous frame for {}",
+                applied.accession
+            ));
+        };
+        let start = applied.start as usize;
+        let stop = start + applied.reference.len();
+        // A window that does not match the bases this frame serves means the two
+        // sides are talking about different sequences, and any verdict drawn from
+        // them would be about the wrong locus. Say so rather than compare.
+        if stop > sequence.len() || sequence[start..stop] != applied.reference {
+            return ApplyVerdict::Unapplicable(format!(
+                "the applied window {start}..{stop} does not match the reference frame"
+            ));
+        }
+        let got = format!(
+            "{}{}{}",
+            &sequence[..start],
+            applied.resulting,
+            &sequence[stop..]
+        );
+        let block = base + design.offset;
+        let want = format!(
+            "{}{}{}",
+            &sequence[..block],
+            design.alternate,
+            &sequence[block + design.span.len()..]
+        );
+        if got == want {
+            ApplyVerdict::Preserved
+        } else {
+            ApplyVerdict::Wrong { got, want }
+        }
+    }
+
+    /// **Oracle 1.** Every normalized output still denotes the bases the generator
+    /// intended.
+    ///
+    /// An output that denotes a different sequence — or none — is invisible to a
+    /// movement count, to the idempotency oracle (a wrong form can be a perfectly
+    /// stable fixed point) and to the re-parse oracle (a wrong form parses fine).
+    /// It has produced at least three filed defects here (#1416, #1453, #1431),
+    /// each found by hand. This is the check that sees it.
+    ///
+    /// **Green on the first run**: 270 of 270 rows applied and every one produced
+    /// the alternate the generator built; nothing was declined. That is a real
+    /// result rather than a vacuous one — the `preserved > 0` assertion below is
+    /// what stops a run where everything declined from reading as a clean bill of
+    /// health.
+    #[test]
+    fn every_normalized_output_denotes_the_intended_alternate() {
+        let mut preserved = 0usize;
+        let mut declined: Vec<String> = Vec::new();
+        let mut wrong: Vec<String> = Vec::new();
+        for_each_revcomp_row(|design, axis, direction, input, output| {
+            match apply_verdict(axis, design, output) {
+                ApplyVerdict::Preserved => preserved += 1,
+                // Kept, not merely counted: a run where *everything* declined
+                // would otherwise report a clean bill of health, and the reason
+                // is the only thing that distinguishes the two.
+                ApplyVerdict::Unapplicable(reason) => declined.push(reason),
+                ApplyVerdict::Wrong { got, want } => wrong.push(format!(
+                    "[{} {} {}] {input}\n      -> {output}\n      got  {got}\n      want {want}",
+                    design.label, axis, direction
+                )),
+            }
+        });
+        assert!(
+            wrong.is_empty(),
+            "{} normalized outputs denote bases other than the alternate the generator built \
+             ({preserved} preserved, {} unapplicable):\n{}",
+            wrong.len(),
+            declined.len(),
+            wrong.join("\n")
+        );
+        // A corpus where nothing could be applied would pass the assertion above
+        // while measuring nothing — the same "a zero is not a result" confusion the
+        // shape families were added to end, one level down.
+        assert!(
+            preserved > 0,
+            "no row could be applied at all, so this oracle measured nothing; the first \
+             declines were: {:?}",
+            declined.iter().take(5).collect::<Vec<_>>()
+        );
+    }
+
+    // -- Oracle 2: confluence ----------------------------------------------
+
+    /// **Oracle 2.** The three spellings of one design normalize to one string, and
+    /// that string is a fixed point.
+    ///
+    /// Both halves are needed and neither implies the other. Agreement alone is
+    /// satisfied by three spellings that all normalize to a form the normalizer
+    /// would move again on the next pass; a fixed point alone is satisfied by three
+    /// *different* stable answers. Asserting the pair is what makes this a
+    /// confluence property rather than a table of expected strings — nothing here
+    /// says which of the three forms should win.
+    /// **Currently red, deliberately.** Measured on the first run of this oracle,
+    /// over the 90 confluence classes the family builds (15 designs x 3 axes x 2
+    /// directions): **38 do not converge**, and **0 outputs fail the fixed-point
+    /// half**. So the failure is entirely disagreement between spellings, never
+    /// drift within one.
+    ///
+    /// The 38 fall out by axis, and the split is the finding:
+    ///
+    /// | axis | non-confluent classes of 30 |
+    /// |---|---:|
+    /// | `g.` | **0** |
+    /// | `c.` (single exon) | 14 |
+    /// | `cx.` (three exons, 5'UTR) | 24 |
+    ///
+    /// A reverse-complement block converges on the genomic axis and stops
+    /// converging on a coding reference, and every failing class crosses a CDS
+    /// boundary. Smallest reproducer — the separation-0 design at offset 0, whose
+    /// block is four bases and whose three spellings are three *distinct fixed
+    /// points*:
+    ///
+    /// ```text
+    /// NM_TESTX.1:c.-3_1inv                       ->  NM_TESTX.1:c.-3_1inv
+    /// NM_TESTX.1:c.-3_1delinsTGGT                ->  NM_TESTX.1:c.-3_1delinsTGGT
+    /// NM_TESTX.1:c.[-3_-2delinsTG;-1_1delinsGT]  ->  unchanged
+    /// ```
+    ///
+    /// The same three spellings on the single-exon coding reference all converge to
+    /// `NM_TEST.1:c.1_4inv`, so the block is not the problem — the 5'UTR crossing
+    /// is. At separation 1 the same thing happens one level down:
+    /// `NM_TEST.1:c.[9_10delinsTT;12_13delinsAA;15_*1delinsTT]` re-types the first
+    /// two members `inv` and leaves the third, the one straddling `CDS_END`, as a
+    /// `delins`.
+    ///
+    /// Part of this is #1517 (an `inv` spelling and a split spelling that are both
+    /// fixed points), but the axis dependence is not: #1517 is axis-neutral by its
+    /// own scope note, and `g.` is clean here. That half is unfiled.
+    ///
+    /// **Not weakened to pass.** Both halves are asserted together on purpose; a
+    /// version that only checked the fixed-point half would be green and would be
+    /// measuring nothing this family was added for.
+    #[test]
+    #[ignore = "red on first run: 38 of 90 confluence classes disagree, all on coding \
+                axes crossing a CDS boundary; see this test's docs"]
+    fn the_three_spellings_of_a_design_converge_to_one_fixed_point() {
+        let mut split: Vec<String> = Vec::new();
+        let mut drifting: Vec<String> = Vec::new();
+        for design in revcomp_designs() {
+            for (axis, direction, dir_label) in axes_and_directions() {
+                let inputs = revcomp_inputs_for(axis, &design);
+                let outputs: Vec<String> = inputs
+                    .iter()
+                    .map(|input| normalize_one(axis, &design.core, input, direction))
+                    .collect();
+                let distinct: std::collections::BTreeSet<&str> =
+                    outputs.iter().map(String::as_str).collect();
+                if distinct.len() > 1 {
+                    split.push(format!(
+                        "[{} {axis} {dir_label}] {} distinct outputs:\n{}",
+                        design.label,
+                        distinct.len(),
+                        inputs
+                            .iter()
+                            .zip(&outputs)
+                            .map(|(i, o)| format!("      {i}\n        -> {o}"))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    ));
+                }
+                for output in &outputs {
+                    let again = normalize_one(axis, &design.core, output, direction);
+                    if &again != output {
+                        drifting.push(format!(
+                            "[{} {axis} {dir_label}] {output}\n        -> {again}",
+                            design.label
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(
+            split.is_empty() && drifting.is_empty(),
+            "{} designs do not converge and {} outputs are not fixed points\n\
+             --- non-confluent ---\n{}\n--- not a fixed point ---\n{}",
+            split.len(),
+            drifting.len(),
+            split.join("\n"),
+            drifting.join("\n")
+        );
+    }
+
+    // -- Oracle 3: separation-rule conformance ------------------------------
+
+    /// One member of a normalized output, in its accession's own 0-based frame.
+    ///
+    /// **An insertion consumes no reference position.** Modelling every member as
+    /// the closed interval `[lo, hi]` and leaving an insertion's interval *empty*
+    /// (`lo = A + 1`, `hi = A`) is what makes the single formula
+    /// `sep = next.lo - prev.hi - 1` hold for every pair. Treating `A_B` as a
+    /// two-base consumed span instead double-counts the junction and shifts every
+    /// separation in the distribution by one — which invalidates the whole census,
+    /// not just the insertion rows.
+    struct MemberFacts {
+        lo: i64,
+        hi: i64,
+        reference: String,
+        alternate: String,
+    }
+
+    /// Read every member of `variant` as a [`MemberFacts`].
+    ///
+    /// Via SPDI rather than by decoding each `NaEdit` by hand: SPDI is already the
+    /// `(position, deleted, inserted)` triple this needs, it resolves the short
+    /// forms that name no bases (`del`, `dup`, `inv`) against the reference, and it
+    /// puts every axis in one frame — so a `c.` allele and a `g.` allele are
+    /// measured by the same arithmetic instead of by two decoders that can drift.
+    fn member_facts_of(
+        variant: &ferro_hgvs::HgvsVariant,
+        provider: &MockProvider,
+    ) -> Result<Vec<MemberFacts>, String> {
+        use ferro_hgvs::HgvsVariant;
+        let members: Vec<&HgvsVariant> = match variant {
+            HgvsVariant::Allele(allele) => allele.variants.iter().collect(),
+            other => vec![other],
+        };
+        let mut facts = Vec::with_capacity(members.len());
+        for member in members {
+            let spdi = ferro_hgvs::spdi::hgvs_to_spdi(member, provider)
+                .map_err(|e| format!("{member}: {e}"))?;
+            let lo = spdi.position as i64;
+            facts.push(MemberFacts {
+                lo,
+                hi: lo + spdi.deletion.len() as i64 - 1,
+                reference: spdi.deletion,
+                alternate: spdi.insertion,
+            });
+        }
+        facts.sort_by_key(|f| (f.lo, f.hi));
+        Ok(facts)
+    }
+
+    /// Which reference columns of `reference` are matched in **every** minimal
+    /// alignment of `reference` against `alternate`.
+    ///
+    /// A `delins` of unequal length has many minimal alignments, so "unchanged
+    /// interior" is alignment-dependent and a naive column-by-column comparison
+    /// invents violations that the description does not commit to. The rule used
+    /// here is the conservative one: a column counts as unchanged only when **no**
+    /// minimal-cost path consumes it — neither by deleting it nor by substituting
+    /// it. Forward and backward Levenshtein DP give exactly that, since a path
+    /// through column `i` costs `prefix(i, j) + step + suffix(i + 1, j')`, and the
+    /// column is free to be changed iff some `(j, step)` reaches the optimum.
+    ///
+    /// An insertion is deliberately not a way to "consume" a reference column: it
+    /// advances only the alternate, so it leaves the column matched.
+    ///
+    /// The direction of the conservatism matters. This can **under**-report — a
+    /// column changed in every alignment a human would draw may still be reachable
+    /// by some exotic minimal path — and it must never **over**-report, because a
+    /// violation claimed here is a claim that the description is wrong.
+    fn forced_unchanged(reference: &[u8], alternate: &[u8]) -> Vec<bool> {
+        let (n, m) = (reference.len(), alternate.len());
+        let idx = |i: usize, j: usize| i * (m + 1) + j;
+
+        let mut prefix = vec![0usize; (n + 1) * (m + 1)];
+        for i in 0..=n {
+            prefix[idx(i, 0)] = i;
+        }
+        for j in 0..=m {
+            prefix[idx(0, j)] = j;
+        }
+        for i in 1..=n {
+            for j in 1..=m {
+                let cost = usize::from(reference[i - 1] != alternate[j - 1]);
+                prefix[idx(i, j)] = (prefix[idx(i - 1, j)] + 1)
+                    .min(prefix[idx(i, j - 1)] + 1)
+                    .min(prefix[idx(i - 1, j - 1)] + cost);
+            }
+        }
+
+        let mut suffix = vec![0usize; (n + 1) * (m + 1)];
+        for i in 0..=n {
+            suffix[idx(i, m)] = n - i;
+        }
+        for j in 0..=m {
+            suffix[idx(n, j)] = m - j;
+        }
+        for i in (0..n).rev() {
+            for j in (0..m).rev() {
+                let cost = usize::from(reference[i] != alternate[j]);
+                suffix[idx(i, j)] = (suffix[idx(i + 1, j)] + 1)
+                    .min(suffix[idx(i, j + 1)] + 1)
+                    .min(suffix[idx(i + 1, j + 1)] + cost);
+            }
+        }
+
+        let distance = prefix[idx(n, m)];
+        (0..n)
+            .map(|i| {
+                let changeable = (0..=m).any(|j| {
+                    let before = prefix[idx(i, j)];
+                    // Delete reference[i].
+                    if before + 1 + suffix[idx(i + 1, j)] == distance {
+                        return true;
+                    }
+                    // Substitute reference[i] for alternate[j].
+                    j < m
+                        && reference[i] != alternate[j]
+                        && before + 1 + suffix[idx(i + 1, j + 1)] == distance
+                });
+                !changeable
+            })
+            .collect()
+    }
+
+    /// Maximal runs of `true` with a `false` on both sides, as `(offset, length)`.
+    ///
+    /// Interior only: a leading or trailing run of unchanged columns is a
+    /// description that failed to trim its own flanks, which is a different defect
+    /// with a different rule, and folding the two together would make each
+    /// unreadable.
+    fn interior_runs(flags: &[bool]) -> Vec<(usize, usize)> {
+        let mut runs = Vec::new();
+        let mut i = 0;
+        while i < flags.len() {
+            if !flags[i] {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < flags.len() && flags[i] {
+                i += 1;
+            }
+            if start > 0 && i < flags.len() {
+                runs.push((start, i - start));
+            }
+        }
+        runs
+    }
+
+    /// The codon a reference column falls in, or `None` when it has no frame.
+    ///
+    /// `general.md:35`'s carve-out is about a single amino acid, so it needs a real
+    /// reading frame: never on `g.`, and never in a UTR of a coding reference. A
+    /// column with no codon cannot license a merge across an unchanged base, which
+    /// is the half of the rule that is easy to lose.
+    fn codon_index(axis: &str, accession: &str, column: i64) -> Option<i64> {
+        if accession != TX_ACCESSION && accession != TX_MULTI_ACCESSION {
+            return None;
+        }
+        let (cds_start, cds_end) = cds_bounds(axis);
+        let transcript_position = column + 1;
+        if transcript_position < cds_start as i64 || transcript_position > cds_end as i64 {
+            return None;
+        }
+        Some((transcript_position - cds_start as i64) / 3)
+    }
+
+    /// A way one description can merge more than the spec allows.
+    ///
+    /// All three are **over**-merges, which is the direction the rules constrain:
+    /// `general.md:34` compels one description for adjacent changes and separate
+    /// ones past a single unchanged base, and `general.md:35` is the one carve-out.
+    /// Splitting further than required is not a violation of either.
+    #[derive(Debug)]
+    enum SeparationFinding {
+        /// Two members with no unchanged reference column between them
+        /// (`general.md:34`, `DNA/delins.md:16-18`).
+        AdjacentMembersLeftSplit { at: i64 },
+        /// One member spans two or more forced-unchanged columns
+        /// (`general.md:34`).
+        MergedAcrossUnchangedInterior {
+            at: i64,
+            length: usize,
+            inversion: bool,
+        },
+        /// One member spans a single forced-unchanged column with no codon to
+        /// license it (`general.md:35`).
+        MergedAcrossOneColumnWithoutACodon { at: i64, inversion: bool },
+    }
+
+    impl SeparationFinding {
+        /// How the offending member reads, which is what decides whether the
+        /// finding is settled or contested.
+        ///
+        /// A member whose payload is the exact reverse complement of its own span
+        /// is an **inversion**, and `general.md:56` ranks inversion above the
+        /// residual `delins` — which is the argument #1517 makes for preferring
+        /// `inv` over the split. `general.md:34` says "and **not** as a delins",
+        /// so it does not literally reach an `inv`. A member that is *not* an
+        /// inversion has no such defence: it is a delins, and the clause names it.
+        fn spelling(inversion: bool) -> &'static str {
+            if inversion {
+                "member, itself an exact inversion (the contested #1517 class),"
+            } else {
+                "`delins` member"
+            }
+        }
+
+        /// Whether this finding's offending member is an exact inversion.
+        fn is_inversion(&self) -> bool {
+            match self {
+                Self::AdjacentMembersLeftSplit { .. } => false,
+                Self::MergedAcrossUnchangedInterior { inversion, .. }
+                | Self::MergedAcrossOneColumnWithoutACodon { inversion, .. } => *inversion,
+            }
+        }
+
+        /// The finding as a line a reader can act on: what was violated, where,
+        /// and which clause says so.
+        ///
+        /// Spelled out rather than left to `{:?}` because the column is the
+        /// reproducer — a finding without its 0-based reference column cannot be
+        /// checked by hand against the block it came from.
+        fn describe(&self) -> String {
+            match self {
+                Self::AdjacentMembersLeftSplit { at } => format!(
+                    "general.md:34 — members meet at reference column {at} with no unchanged \
+                     base between them, so they are one description"
+                ),
+                Self::MergedAcrossUnchangedInterior {
+                    at,
+                    length,
+                    inversion,
+                } => format!(
+                    "general.md:34 — one {} spans {length} unchanged reference columns from \
+                     {at}, which no minimal alignment can consume",
+                    Self::spelling(*inversion)
+                ),
+                Self::MergedAcrossOneColumnWithoutACodon { at, inversion } => format!(
+                    "general.md:35 — one {} spans the unchanged reference column {at} with \
+                     no codon shared by the changes flanking it",
+                    Self::spelling(*inversion)
+                ),
+            }
+        }
+    }
+
+    /// Judge one normalized output against the separation rules.
+    ///
+    /// `Err` means the output could not be read as a set of reference footprints at
+    /// all — a sentinel, an unparseable string, an edit SPDI declines — and is
+    /// counted as unevaluated rather than silently passed.
+    fn separation_findings(
+        axis: &str,
+        core: &str,
+        output: &str,
+    ) -> Result<Vec<SeparationFinding>, String> {
+        let variant = parse_hgvs(output).map_err(|e| format!("{output}: {e}"))?;
+        let provider = provider_for(axis, core);
+        let named = match &variant {
+            ferro_hgvs::HgvsVariant::Allele(allele) => allele.variants.first().unwrap_or(&variant),
+            other => other,
+        };
+        let accession = named
+            .accession()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let facts = member_facts_of(&variant, &provider)?;
+        let mut findings = Vec::new();
+        for pair in facts.windows(2) {
+            if pair[1].lo - pair[0].hi - 1 == 0 {
+                findings.push(SeparationFinding::AdjacentMembersLeftSplit { at: pair[1].lo });
+            }
+        }
+        for member in &facts {
+            let inversion =
+                !member.reference.is_empty() && member.alternate == revcomp(&member.reference);
+            let flags = forced_unchanged(member.reference.as_bytes(), member.alternate.as_bytes());
+            for (offset, length) in interior_runs(&flags) {
+                let at = member.lo + offset as i64;
+                if length >= 2 {
+                    findings.push(SeparationFinding::MergedAcrossUnchangedInterior {
+                        at,
+                        length,
+                        inversion,
+                    });
+                    continue;
+                }
+                // A single unchanged column is merged across only when the changes
+                // on either side of it sit in one codon. Both flanks are read, not
+                // just one: a merge is licensed by the amino acid the pair shares,
+                // so a pair straddling a codon boundary is not licensed even though
+                // each half has a frame.
+                let before = codon_index(axis, &accession, at - 1);
+                let after = codon_index(axis, &accession, at + 1);
+                if before.is_none() || before != after {
+                    findings.push(SeparationFinding::MergedAcrossOneColumnWithoutACodon {
+                        at,
+                        inversion,
+                    });
+                }
+            }
+        }
+        Ok(findings)
+    }
+
+    /// The forced-unchanged DP behaves, on cases whose answers are computable by
+    /// hand — including the two that make it non-trivial.
+    #[test]
+    fn the_forced_unchanged_dp_only_claims_columns_no_minimal_alignment_moves() {
+        let flags = |r: &str, a: &str| forced_unchanged(r.as_bytes(), a.as_bytes());
+
+        // The worked case: equal lengths, so the only minimal alignment is the
+        // column-by-column one and the four interior columns are all forced.
+        assert_eq!(
+            flags("AATGCACA", "TGTGCATT"),
+            vec![false, false, true, true, true, true, false, false]
+        );
+        assert_eq!(interior_runs(&flags("AATGCACA", "TGTGCATT")), vec![(2, 4)]);
+
+        // Unequal lengths, where a naive column comparison invents a violation.
+        // `AAA` -> `AA` deletes any one of the three A's, so no column is forced.
+        assert!(flags("AAA", "AA").iter().all(|forced| !forced));
+
+        // …and where the shift genuinely cannot reach the middle: `CAG` -> `TAG`
+        // has one minimal alignment (substitute the C), so `A` and `G` are forced,
+        // but neither is *interior* — there is no changed column after them.
+        assert_eq!(flags("CAG", "TAG"), vec![false, true, true]);
+        assert!(interior_runs(&flags("CAG", "TAG")).is_empty());
+
+        // An insertion does not consume a reference column, so the reference is
+        // wholly matched and no interior run exists.
+        assert!(flags("AC", "AGC").iter().all(|forced| *forced));
+
+        // A genuine spanning delins over an unchanged single base: `CAG` -> `TAT`
+        // has cost 2, and the middle `A` cannot be consumed by any 2-cost path.
+        assert_eq!(flags("CAG", "TAT"), vec![false, true, false]);
+        assert_eq!(interior_runs(&flags("CAG", "TAT")), vec![(1, 1)]);
+    }
+
+    /// The member model puts an insertion on an empty interval, so one separation
+    /// formula covers every pair.
+    #[test]
+    fn an_insertion_consumes_no_reference_column() {
+        let core = &corpus_sequences(1)[0];
+        let provider = genomic_provider(core);
+        let variant = parse_hgvs("NC_TEST.1:g.[257_258del;258_259insTT]").expect("parses");
+        let facts = member_facts_of(&variant, &provider).expect("both members convert");
+        assert_eq!(facts.len(), 2);
+        // The deletion consumes 0-based 256..=257; the insertion sits at the
+        // junction after 257 and consumes nothing, so its interval is empty.
+        assert_eq!((facts[0].lo, facts[0].hi), (256, 257));
+        assert_eq!((facts[1].lo, facts[1].hi), (258, 257));
+        // …and the uniform formula reads that junction as adjacent, not as a
+        // two-base span that would put the two members one column apart.
+        assert_eq!(facts[1].lo - facts[0].hi - 1, 0);
+    }
+
+    /// **Oracle 3.** No normalized output merges across more than the spec allows.
+    ///
+    /// Checked against the sequence, not against a pinned string: because
+    /// `(reference, alternate)` is known by construction, every member's own
+    /// `(deleted, inserted)` pair is recoverable and the rule can be evaluated
+    /// directly. `general.md:34` — changes separated by one or more unchanged
+    /// nucleotides are described individually, and adjacent ones as a single
+    /// description. `general.md:35` — the one carve-out, a single unchanged
+    /// nucleotide inside one codon, which needs a reading frame and so cannot apply
+    /// on `g.` or in a UTR. `DNA/delins.md:16-18` for the merged form itself.
+    /// **Currently red, deliberately.** Measured on the first run of this oracle,
+    /// over the 270 rows the family contributes: **138 of 270 outputs violate**,
+    /// 132 are clean, 0 unevaluated. The 176 findings partition into two classes
+    /// that are not the same claim, and the split is very lopsided:
+    ///
+    /// | class | findings | status |
+    /// |---|---:|---|
+    /// | the offending member is itself an **exact reverse complement** | 174 | **contested — #1517** |
+    /// | two adjacent members, neither an inversion, left split | 2 | settled; `general.md:34` |
+    ///
+    /// The contested class is #1517's own subject, read in the opposite direction.
+    /// `general.md:34` says two separated variants are described individually "and
+    /// **not** as a `delins`" — it does not name `inv`, and `general.md:56` ranks
+    /// inversion above the residual `delins`, which is exactly #1517's argument for
+    /// preferring `NM_004006.2:c.76_83inv` over the split. #1517 records the
+    /// counter-reading this oracle encodes as an available reading, not a settled
+    /// one. So these 174 are a decision the repository has not taken rather than a
+    /// defect this oracle found — and the classification is by the member's
+    /// *content*, not its spelling, so a whole-block reverse complement written
+    /// `delins` lands here too.
+    ///
+    /// The settled class is two rows, and it is new. The separation-0 design at
+    /// offset 0 on `cx`, in both directions:
+    ///
+    /// ```text
+    /// core  ACCAGCTAGCTAGCTAGCTA   (CDS_START_MULTI = 4, so c.-3 == transcript 1)
+    /// NM_TESTX.1:c.[-3_-2delinsTG;-1_1delinsGT]  ->  unchanged
+    /// NM_TEST.1:c.[1_2delinsTG;3_4delinsGT]      ->  NM_TEST.1:c.1_4inv
+    /// ```
+    ///
+    /// Neither member is an inversion on its own (`AC` -> `TG`, `CA` -> `GT`); only
+    /// their union is, so `general.md:56` offers no defence and `general.md:34`'s
+    /// plainest case applies — two adjacent changes are one description. The same
+    /// input merges on the single-exon coding reference and does not on the
+    /// multi-exon one, purely because the block starts in the 5'UTR.
+    ///
+    /// That axis dependence runs through the contested class too and is worth
+    /// separating from #1517, which its own scope note calls axis-neutral:
+    /// `NM_TEST.1:c.9_*5delinsTTCGTATACGTT` holds eight unchanged interior columns
+    /// inside one member, while the identical block on `g.` comes out as
+    /// `g.[265_266inv;275_276inv]`.
+    ///
+    /// **Not weakened to pass.** Narrowing this to the settled class alone would
+    /// still be red, and narrowing it to zero would make it documentation.
+    #[test]
+    #[ignore = "red on first run: 2 settled violations (a CDS-boundary split that the \
+                single-exon axis merges, unfiled) and 174 contested ones (#1517); see \
+                this test's docs"]
+    fn no_normalized_output_merges_across_an_unchanged_interior() {
+        let (mut clean, mut unevaluated) = (0usize, 0usize);
+        let (mut contested, mut settled) = (0usize, 0usize);
+        let mut violations: Vec<String> = Vec::new();
+        for_each_revcomp_row(|design, axis, direction, input, output| {
+            match separation_findings(axis, &design.core, output) {
+                Err(_) => unevaluated += 1,
+                Ok(findings) if findings.is_empty() => clean += 1,
+                Ok(findings) => {
+                    for finding in &findings {
+                        if finding.is_inversion() {
+                            contested += 1;
+                        } else {
+                            settled += 1;
+                        }
+                    }
+                    violations.push(format!(
+                        "[{} {} {}] {input}\n      -> {output}\n{}",
+                        design.label,
+                        axis,
+                        direction,
+                        findings
+                            .iter()
+                            .map(|f| format!("      {}", f.describe()))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    ));
+                }
+            }
+        });
+        assert!(
+            violations.is_empty(),
+            "{} of {} normalized outputs violate the separation rules ({clean} clean, \
+             {unevaluated} unevaluated); {settled} findings name a `delins` member and are \
+             settled, {contested} name an exact inversion and are #1517's open \
+             question:\n{}",
+            violations.len(),
+            violations.len() + clean + unevaluated,
+            violations.join("\n")
+        );
+        assert!(
+            clean > 0,
+            "no row could be evaluated at all, so this oracle measured nothing"
         );
     }
 


### PR DESCRIPTION
The synthetic corpus answers "did this output move?" and never "is this output right?". That is the correct instrument for drift and useless for correctness, and it is not a fixable property of thirteen of the fifteen families: they are sets of descriptions with no record of what the description was meant to denote.

This adds a sixteenth family built the other way round — the alternate is chosen first and the reference derived around it — so `(reference, alternate)` is exact for every one of its 270 rows, and three real oracles come essentially for free. **This is the branch that found #1536**; until it lands, that measurement has no home.

## The family: `separated_revcomp_runs`

`delins_hiding_an_inversion` was the only family that built a reverse-complement block, and it emits its two pieces at separation 0. Where such a block coincides with its own reference is a property of the *sequence*, not of the description, so a family crossed with the random 20-mers gets whatever coincidence pattern the xorshift produced — and none of them separates two multi-column changed runs. A gate that engages only at separation >= 2 with multi-column pieces therefore fires on no row, and a change to one measures a blast radius of **zero for structural reasons rather than safe ones**. This is the same class of corpus blindness as #1456 / #1460 / #1478.

Fifteen designs: separations 0, 1, 2, 4 and 8 between 2-column changed runs, each planted at three offsets so the axis geometry (5'UTR, CDS end, both exon junctions) varies under an identical block. Three spellings per design — the whole block as `inv`, the same as `delins`, and the runs written individually — which denote one variant by construction. 15 designs x 3 spellings x 6 axis/direction combinations = **270 rows; the corpus goes from 78,028 to 78,298.**

The separation-4 design is `AATGCACA` -> `TGTGCATT`, the block #1517 is about: a true reverse complement coinciding at its four interior columns, leaving two 2-base changes.

Two facts are pinned rather than argued. The run layout is derived from the parameters *and* re-derived from the sequence, and the two must agree, so a typo in one of the five literal blocks fails instead of silently contributing a design at a separation nobody asked for. And an odd separation needs three runs, not two: a column coincides with its own reverse complement exactly when its mirror does, so the changed/unchanged pattern of any whole-block inversion is a palindrome and a two-run block's gap always has even length.

Also asserted: no other family, including `long_block_inversion`, builds a reverse-complement block whose multi-column runs are separated at all — the structural gap this family was added for, stated as a test so it fails if some other family grows the shape.

## The three oracles

**1. Sequence preservation — PASSES, 270/270.** Apply the normalized output back to the reference via `spdi::apply_to_reference` and require the result to equal the alternate the generator intended. This is the class that produced #1416, #1453 and #1431, and that the three env-var oracles are all blind to: a wrong output can be a perfectly stable fixed point and it parses fine. 270 of 270 rows applied, none declined, none denoting anything other than the intended alternate.

**2. Confluence — RED, `#[ignore]`d, records #1536.** All three spellings of one design must normalize to one string, and that string must be a fixed point. Both halves are asserted, because neither implies the other and only the pair makes it a confluence property rather than a table of expected strings.

**3. Separation-rule conformance — RED, `#[ignore]`d, records #1517.** `general.md:34`/`:35` and `DNA/delins.md:16-18` evaluated against the sequence rather than a pinned string. Two correctness points carried deliberately: an insertion consumes no reference position, so members are closed intervals with an insertion left *empty* and one formula `sep = next.lo - prev.hi - 1` covers every pair; and a delins of unequal length has many minimal alignments, so an unchanged interior is claimed only when forward and backward Levenshtein DP agree that no minimal-cost path can consume the column — which can under-report and must never over-report.

**Both red oracles are ignored-red on purpose and must not be weakened to green.** Neither was narrowed to pass; narrowing either to its settled half leaves it red. A version of oracle 2 that checked only the fixed-point half would be green and would be measuring nothing this family was added for. Un-ignore each *with* the corresponding fix, in the same change.

## The counts in the `#[ignore]` strings are the first-run numbers and #1537 has since moved them

Read this before reviewing: the doc comments and `#[ignore]` reasons state what was measured **on the first run of each oracle**, before #1537 (`fix(normalize): never split a delins into members on consecutive nucleotides`, closing #1524) landed on `main`. Re-measured after rebasing onto `5616cdb9`, the *reasons* are unchanged and the named smallest reproducers still reproduce byte-identically; the aggregates have moved. I have deliberately left the committed strings alone — "on first run" is a historical framing and re-blessing it is the author's call, not a rebase chore — so here are both readings side by side.

Oracle 2, confluence — `38 of 90` in the string, **32 of 90** measured now, `0 outputs fail the fixed-point half` in both. So the failure is still entirely disagreement between spellings, never drift within one. By axis:

| axis | non-confluent classes of 30, first run | after #1537 |
|---|---:|---:|
| `g.` | 0 | **0** |
| `c.` (single exon) | 14 | **8** |
| `cx.` (three exons, 5'UTR) | 24 | **24** |

That is the most useful thing in this PR after the family itself: **#1537 converged 6 of the `c.` classes and left the `cx.` 24 completely untouched.** The boundary-crossing residue is exactly #1536, and it is now cleanly separated from the adjacent-member defect #1537 fixed. The smallest reproducer is unchanged — a four-base block whose three spellings are three distinct fixed points on `cx.` and converge on `c.`:

```text
NM_TESTX.1:c.-3_1inv                       ->  NM_TESTX.1:c.-3_1inv
NM_TESTX.1:c.-3_1delinsTGGT                ->  NM_TESTX.1:c.-3_1delinsTGGT
NM_TESTX.1:c.[-3_-2delinsTG;-1_1delinsGT]  ->  unchanged
```

Oracle 3, separation — `2 settled + 174 contested` in the string, **2 settled + 216 contested** now:

```
180 of 270 normalized outputs violate the separation rules (90 clean, 0 unevaluated);
2 findings name a `delins` member and are settled,
216 name an exact inversion and are #1517's open question
```

The settled pair is unchanged (two adjacent members, neither an inversion on its own, that the single-exon coding axis merges and the multi-exon one does not). The contested count grew because #1537 merges adjacent members, so more outputs are now whole-block exact inversions spanning an unchanged interior — which is #1517's open decision read in the opposite direction, not a defect and not a regression.

If the reviewer would rather the strings carry the current numbers, say so and I will re-bless both in place.

## Verification

Rebased onto `5616cdb9` — clean, no conflicts — and re-gated after the rebase.

- `cargo fmt --all -- --check` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo nextest run --features dev -E 'binary(it)'` — `Summary [38.150s] 5444 tests run: 5444 passed, 145 skipped`
- `cargo nextest run --features dev --run-ignored all -E 'binary(dump_normalized_corpus)'` — `Summary [1.144s] 35 tests run: 33 passed, 2 failed`, the two failures being exactly the two ignored-red oracles above

Note for reviewers rebasing this locally: `tests/fixtures/grammar/hgvs_spec_normalization.json` is gitignored and only regenerates when *missing*, so a stale copy survives a rebase and fails `ruling_records_are_intact` against ruling statuses `main` has since decided. Re-run `cargo run --features dev --bin generate_spec_fixture`.

Refs #1536, #1517, #1524, #1537.

Representation-Change: none. The entire diff is one file, `examples/dump_normalized_corpus.rs` — no `src/` file is touched, so there is no code path by which a normalized output could move, and 5,444 `it` tests pass with nothing re-blessed. The one thing worth stating explicitly rather than hiding behind `none`: this change **does** grow the corpus, 78,028 -> 78,298 rows, which changes the denominator of every future `compare` run against it. That is a change to what future measurements are taken over, not a change to any shipped representation — the 78,028 pre-existing rows normalize exactly as they did before, and the 270 new rows have never been normalized by a released version, so no stored downstream string can be keyed on them. Relatedly, no `0 moved` figure is quoted anywhere in this PR, because this branch is the *repair* of a structural zero rather than a consumer of one: the family exists precisely because the corpus could not previously build a reverse-complement block with separated multi-column runs, so every gate keyed on that shape measured 0 of 78,028 for structural reasons.
