### PR TITLE
fix(normalize): validate a cis-allele member's stated reference bases before a merge can consume them

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3120,6 +3120,153 @@ fn stated_reference_bases_match(
     true
 }
 
+/// Every reference mismatch the **authored** members of a cis allele carry.
+///
+/// # Why this exists at all
+///
+/// The per-member pipeline validates a member's stated reference bases in
+/// `normalize_na_edit`, and that is where `RefSeqMismatch` (W5001) — and so
+/// strict mode's rejection and lenient mode's warning — comes from. But
+/// `normalize_allele` runs [`collapse_overlapping_cis_edits`] and
+/// [`merge_consecutive_edits`] over the raw members **before** any member
+/// reaches that validator, and a merge keeps only each member's *alt* bases:
+/// [`Anchor`] has no channel for the reference the submitter asserted. So a
+/// member consumed by a merge has its assertions dropped, unexamined, and the
+/// merged anchor is then rebuilt from the **real** bases — turning a
+/// description whose reference claims are false into a well-formed one, with
+/// `status=ok`, in the mode whose purpose is to reject exactly that (#1543).
+///
+/// Measured on `main` at `5616cdb9`, reference bases `c.1 = A`, `c.3 = G`:
+///
+/// ```text
+/// NM_000143.3:c.1G>T          -> rejected  (no sibling to merge with)
+/// NM_000143.3:c.[1G>T;500G>C] -> rejected  (sibling too far to merge)
+/// NM_000143.3:c.[1G>T;3T>A]   -> c.1_3delinsTTA, status=ok   <- the defect
+/// ```
+///
+/// The discriminator was merge distance and nothing else.
+///
+/// # Why here, and not at the merge sites
+///
+/// This is the sixth defect in one family — #1052 (substitutions), #1068 (the
+/// `m.` axis), #1092 (the parser discarded the bases), #1097 (multi-base range
+/// substitutions), #1352 ([`NaEdit::Identity`] omitted) — and each of the first
+/// five was fixed one shape at a time. A per-shape guard inside each merge pass
+/// would be the sixth such patch and would leave the same ordering hazard for
+/// the seventh: any future pass that consumes a member before the validator
+/// runs re-opens the hole.
+///
+/// So the question is asked **on the authored input**, once, before any pass
+/// has had the chance to strip anything. That is ordering-immune by
+/// construction: no rearrangement of the pipeline below can make this check
+/// vacuous, which is precisely what happened to [`stated_reference_bases_match`]
+/// — whose own doc comment predicted it.
+///
+/// Nothing about the merge itself changes, deliberately: the warnings this
+/// returns are *added* to the member-local ones, so no correctly-spelled input
+/// moves and the only behavioural change is that a false reference assertion is
+/// now reported wherever it was authored.
+///
+/// # Contract
+///
+/// Cis only — merging is cis-only, so that is the whole exposure, and a
+/// trans/unknown-phase allele already has every member normalized in isolation.
+/// The verdict itself comes from [`crate::normalize::validate::validate_reference`],
+/// the same function the per-member pipeline uses, so the channel list cannot
+/// drift between the two sites the way #1352's could.
+///
+/// Members this cannot answer for — an offset (intronic) position, a region
+/// with no served bases, an unreadable or short provider window — are skipped
+/// rather than guessed at, exactly as every other refusal in this module does.
+pub(crate) fn authored_member_reference_mismatches<P: ReferenceProvider>(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+    provider: &P,
+) -> Vec<crate::normalize::NormalizationWarning> {
+    if phase != AllelePhase::Cis {
+        return Vec::new();
+    }
+    variants
+        .iter()
+        .filter_map(|v| authored_reference_mismatch(v, provider))
+        .collect()
+}
+
+/// One member's authored reference mismatch, if it has one.
+///
+/// The returned warning is built to be **indistinguishable** from the one the
+/// per-member pipeline raises for the same member: same `position` (the
+/// sequence-axis span, via [`region_sequence_delta`]), same `corrected` flag,
+/// same `details` text. That is what lets the caller drop it when the member
+/// also reached the per-member validator, rather than reporting one finding
+/// twice.
+fn authored_reference_mismatch<P: ReferenceProvider>(
+    v: &HgvsVariant,
+    provider: &P,
+) -> Option<crate::normalize::NormalizationWarning> {
+    let kind = cis_kind_of(v)?;
+    let (accession, region, s, e, edit) = cis_axis_parts(v, kind)?;
+    // `r.` spells its bases in the RNA alphabet while the transcript is served
+    // as DNA, so a truthful `r.2u>a` over a `T` would otherwise read as a
+    // mismatch. `normalize_rna` makes the same rewrite before it validates
+    // (#736); making it here too is what keeps the two verdicts identical.
+    let rewritten = matches!(kind, CisKind::Rna)
+        .then(|| crate::normalize::rules::rna_uracil_to_thymine(edit))
+        .flatten();
+    let edit = rewritten.as_ref().unwrap_or(edit);
+
+    let provider_key = accession.transcript_accession();
+    let delta = region_sequence_delta(region, &provider_key, provider)?;
+    // Checked, like every other coordinate conversion in this file: `s`/`e`
+    // come off a parsed description and `delta` off the record's CDS bounds, so
+    // an adversarial span could otherwise overflow and panic in a debug build
+    // where declining is the answer.
+    let start = s.checked_add(delta)?;
+    let end = e.checked_add(delta)?;
+    if start < 1 || end < start {
+        return None;
+    }
+    let span = usize::try_from(end.checked_sub(start)?.checked_add(1)?).ok()?;
+    let bases = provider
+        .get_sequence(
+            &provider_key,
+            u64::try_from(start - 1).ok()?,
+            u64::try_from(end).ok()?,
+        )
+        .ok()?;
+    // A short read means the member runs off the end of the sequence. That is
+    // W4004 `PositionPastEnd`'s finding, not this one, so decline rather than
+    // compare against a truncated window.
+    if bases.len() != span {
+        return None;
+    }
+
+    // `1`/`span` rather than the member's own coordinates: `validate_reference`
+    // indexes `ref_seq` from `start`, and the window fetched above starts *at*
+    // the member. Every arm it dispatches to reads only `[start - 1, end)` or
+    // the span width, so re-basing the pair is equivalent to handing it the
+    // whole sequence and costs one small read instead of the entire transcript.
+    let result =
+        crate::normalize::validate::validate_reference(edit, bases.as_bytes(), 1, span as u64);
+    if result.valid {
+        return None;
+    }
+    // Mirrors the `corrected` reasoning in `normalize_na_edit`: the canonical
+    // `Display` keeps a substitution's stated base and a repeat's unit, so
+    // claiming those were corrected would be dishonest.
+    let corrected = !matches!(
+        edit,
+        NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. } | NaEdit::Substitution { .. }
+    );
+    Some(crate::normalize::NormalizationWarning::RefSeqMismatch {
+        stated_ref: result.stated_ref.unwrap_or_default(),
+        actual_ref: result.actual_ref.unwrap_or_default(),
+        position: format!("{start}-{end}"),
+        corrected,
+        details: result.warning,
+    })
+}
+
 /// Inclusive 1-based span covering every edit's reference footprint.
 fn edit_span_union(edits: &[GEdit]) -> Option<(i64, i64)> {
     let mut lo = i64::MAX;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2780,6 +2780,43 @@ impl<P: ReferenceProvider> Normalizer<P> {
             warnings.push(w);
         }
 
+        // A cis allele's members are merged *before* any of them reaches the
+        // per-member reference validator, and a merge keeps only their alt
+        // bases — so a member consumed by one has its reference assertions
+        // dropped without ever being checked (#1543). Ask the question here, on
+        // the authored input, where the assertions still exist.
+        //
+        // Deliberately outside `normalize_allele` rather than inside it: that
+        // function has several early returns, and the point of this guard is
+        // that no rearrangement of the pipeline below can make it vacuous. It
+        // adds warnings and changes nothing else, so the merged form a
+        // correctly-spelled allele produces is untouched.
+        if let HV::Allele(allele) = variant {
+            for warning in merge::authored_member_reference_mismatches(
+                &allele.variants,
+                allele.phase,
+                &self.provider,
+            ) {
+                // The per-member pipeline reports the same finding for any
+                // member a merge did *not* consume, and it gets there first.
+                // Position is the whole key: two `RefSeqMismatch` warnings over
+                // one sequence-axis span are one mismatch reported twice.
+                let NormalizationWarning::RefSeqMismatch { position, .. } = &warning else {
+                    continue;
+                };
+                let already = warnings.iter().any(|w| {
+                    matches!(
+                        w,
+                        NormalizationWarning::RefSeqMismatch { position: seen, .. }
+                            if seen == position
+                    )
+                });
+                if !already {
+                    warnings.push(warning);
+                }
+            }
+        }
+
         Ok((result, warnings))
     }
 

--- a/tests/it/issue_1543_allele_member_reference_validation.rs
+++ b/tests/it/issue_1543_allele_member_reference_validation.rs
@@ -1,0 +1,471 @@
+//! #1543 — a cis-allele member's stated reference bases must be validated
+//! whether or not a sibling is close enough to merge with it.
+//!
+//! # The question
+//!
+//! Strict mode rejects a substitution that misstates its reference base. It did
+//! **not** reject the same substitution when a sibling sat close enough for the
+//! two to merge. Measured on `main` at `5616cdb9` against the prepared
+//! reference, where `c.1 = A`, `c.3 = G` and `c.500 = G`:
+//!
+//! ```text
+//! NM_000143.3:c.1G>T            ->  normalize_error  Reference mismatch at 64-64
+//! NM_000143.3:c.[1G>T;500G>C]   ->  normalize_error  Reference mismatch at 64-64
+//! NM_000143.3:c.[1G>T;3T>A]     ->  NM_000143.3:c.1_3delinsTTA   status=ok
+//! ```
+//!
+//! The discriminator was **merge distance and nothing else**: the identical
+//! false `G` at `c.1` was caught with a sibling 499 nt away and missed with one
+//! 2 nt away. Worse than an ordinary validation gap, because the accepted output
+//! is built from the *real* bases — so ferro silently rewrote a description whose
+//! reference assertions were false into a well-formed, correct-looking one, with
+//! no warning, in the mode whose whole purpose is to reject such input.
+//!
+//! # The ruling: the verdict is a property of the member, not of its neighbours
+//!
+//! `DNA/substitution.md:26` reads a stated reference base as a claim about the
+//! reference — "a substitution of the `C` nucleotide at `g.33038255` by an `A`"
+//! — so a member whose stated base contradicts the reference is not a
+//! description of that reference at all, however its siblings are spelled.
+//!
+//! The operative authority here is not a spec conflict, though; it is ferro's
+//! own already-adjudicated contract, recorded verbatim at
+//! `merge::canonicalize_from_sequence` since #1052/#1097:
+//!
+//! > A member that misstates its reference base is a reference mismatch, not a
+//! > canonicalization problem: strict mode must still reject it and lenient mode
+//! > must still warn.
+//!
+//! This file pins that contract against the one input property that had been
+//! deciding it: the distance to the nearest sibling.
+//!
+//! # The mechanism, which is *not* the one the issue names
+//!
+//! The issue attributes the defect to `stated_reference_bases_match` being
+//! vacuous at `merge.rs`'s canonicalization guard. That guard is real and its
+//! doc comment does predict this class of failure, but it is not what let these
+//! inputs through — measured directly, and reported on the PR.
+//!
+//! `Normalizer::normalize_allele` runs `merge::collapse_overlapping_cis_edits`
+//! and `merge::merge_consecutive_edits` over the **raw** members *before* any
+//! member reaches `normalize_na_edit`, which is the only place `RefSeqMismatch`
+//! (W5001) is raised. A merge keeps each member's *alt* bases and nothing else —
+//! `merge::Anchor` has no channel for an asserted reference — so a member
+//! consumed by a merge had its assertions discarded before anything looked at
+//! them. The merged anchor was then rebuilt from the real bases, which is why
+//! the output looked correct. Everything downstream, the canonicalization guard
+//! included, was seeing a member that no longer stated anything.
+//!
+//! Two consequences the issue's framing understates, both pinned below:
+//!
+//! * it is not only the codon-frame merge (`general.md:35`, gap of one). Plain
+//!   **strict adjacency** loses the assertions just the same, so
+//!   `c.[1G>T;2A>C]` was accepted too;
+//! * it is not only substitutions, and not only `c.`. Every channel that can
+//!   carry an asserted reference — `delACG`, `delACinsGT`, `dupCA`, `invCCCCC` —
+//!   and every axis that merges — `g.`, `m.`, `c.`, `n.`, `r.` — was affected.
+//!
+//! # The fix, and why it is not at the merge site
+//!
+//! This is the sixth defect in one family: #1052 (substitutions), #1068 (the
+//! `m.` axis), #1092 (the parser discarded the stated bases), #1097 (multi-base
+//! range substitutions), #1352 (`NaEdit::Identity` omitted while the doc comment
+//! claimed the channel list was complete). Each of the five was fixed one shape
+//! at a time.
+//!
+//! So the question is asked on the **authored input**, in `normalize_core`,
+//! before any pass has had the chance to strip anything
+//! (`merge::authored_member_reference_mismatches`). That is ordering-immune by
+//! construction — no rearrangement of the merge pipeline can make it vacuous —
+//! and it reuses `normalize::validate::validate_reference`, the same function
+//! the per-member pipeline uses, so the channel list cannot drift between the
+//! two sites the way #1352's did.
+//!
+//! It adds warnings and changes nothing else. A correctly-spelled allele merges
+//! exactly as it did before, which is what
+//! [`the_correctly_spelled_sibling_still_merges`] exists to hold.
+
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::{NormalizationWarning, NormalizeConfig};
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Test sequence, shared by every fixture below.
+///
+/// ```text
+///   axis:  1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 ...  30
+///   base:  A T G C A A A A A  C  C  C  C  C  G  G ...   C
+/// ```
+///
+/// The first three bases reproduce the issue's transcript exactly — `c.1 = A`,
+/// `c.3 = G` — so `1G>T` and `3T>A` misstate the reference in the same way the
+/// reported `NM_000143.3` rows do, and `c.1_3delinsTTA` is the same accepted
+/// output. CDS = `c.1..=c.60`, so `c.N`, `n.N` and `r.N` all name transcript
+/// position `N`; codon 1 is `c.1..3`, which is what makes `c.1` and `c.3`
+/// eligible for the `general.md:35` codon-frame merge.
+const CORE: &str = "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT";
+
+/// The transcript accession every `c.`/`n.`/`r.` fixture uses.
+const TX: &str = "NM_TEST.1";
+
+/// A hermetic provider carrying [`CORE`] as a coding transcript, a plain contig
+/// (`CTG`, for `g.`) and a mitochondrial contig (`MITO`, for `m.`).
+///
+/// Synthetic on purpose: a test that needed `FERRO_MANIFEST` would be skipped on
+/// every PR and so would gate nothing.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    provider.add_transcript(Transcript::new(
+        TX.to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        Some(1),
+        Some(60),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider.add_genomic_sequence("CTG", CORE.to_string());
+    provider.add_genomic_sequence("MITO", CORE.to_string());
+    provider
+}
+
+/// Whether strict mode rejects `input`.
+fn strict_rejects(input: &str) -> bool {
+    Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default().with_error_mode(ErrorMode::Strict),
+    )
+    .normalize(&parse_hgvs(input).expect("fixture must parse"))
+    .is_err()
+}
+
+/// `input`'s lenient normalization, as a string.
+fn lenient(input: &str) -> String {
+    Normalizer::new(provider())
+        .normalize(&parse_hgvs(input).expect("fixture must parse"))
+        .expect("lenient mode must not reject")
+        .to_string()
+}
+
+/// Every `(stated_ref, actual_ref, position)` reference mismatch lenient mode
+/// reports for `input`.
+fn reference_mismatches(input: &str) -> Vec<(String, String, String)> {
+    Normalizer::new(provider())
+        .normalize_with_diagnostics(&parse_hgvs(input).expect("fixture must parse"))
+        .expect("lenient mode must not reject")
+        .warnings
+        .iter()
+        .filter_map(|w| match w {
+            NormalizationWarning::RefSeqMismatch {
+                stated_ref,
+                actual_ref,
+                position,
+                ..
+            } => Some((stated_ref.clone(), actual_ref.clone(), position.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The reported defect, and the two controls that keep a fix from being credited
+// to breaking something else.
+// ---------------------------------------------------------------------------
+
+/// The merged case: `c.[1G>T;3T>A]` is rejected in strict mode.
+///
+/// `c.1` is `A` and `c.3` is `G`, so both members misstate. They are one
+/// nucleotide apart inside codon 1, which is what `general.md:35` merges — and
+/// what used to make the two false assertions disappear into
+/// `c.1_3delinsTTA` with `status=ok`.
+#[test]
+fn the_merged_case_is_rejected_in_strict_mode() {
+    assert!(
+        strict_rejects(&format!("{TX}:c.[1G>T;3T>A]")),
+        "both members misstate the reference (c.1 is A, c.3 is G); strict mode \
+         must reject them whether or not they are close enough to merge (#1543)"
+    );
+}
+
+/// The unmerged control: `c.[1G>T;30G>C]` was *already* rejected, and still is.
+///
+/// The stand-in for the issue's `c.[1G>T;500G>C]`. It passed before the fix, so
+/// a fix cannot be credited to it — its job is to fail if the change ever
+/// stops rejecting the case that always worked.
+#[test]
+fn the_unmerged_control_is_still_rejected() {
+    assert!(
+        strict_rejects(&format!("{TX}:c.[1G>T;30G>C]")),
+        "a member 29 nt from its sibling reaches the per-member validator and \
+         was already rejected; that must not regress (#1543)"
+    );
+}
+
+/// The correctly-spelled sibling still merges, and still merges to the same
+/// string.
+///
+/// This is the regression the fix is most likely to cause: over-rejecting, or
+/// refusing the merge, for input whose reference assertions are *true*.
+/// `c.1 = A` and `c.3 = G`, so `c.[1A>T;3G>A]` states them correctly and must
+/// reach `c.1_3delinsTTA` — byte for byte the same output the defective build
+/// produced for the *mis*-spelled pair, which is exactly why the two are
+/// indistinguishable downstream and why the mis-spelled one has to be rejected.
+#[test]
+fn the_correctly_spelled_sibling_still_merges() {
+    let input = format!("{TX}:c.[1A>T;3G>A]");
+    assert!(
+        !strict_rejects(&input),
+        "`{input}` states c.1 = A and c.3 = G, which is what the reference \
+         holds; strict mode must accept it (#1543)"
+    );
+    assert_eq!(
+        lenient(&input),
+        format!("{TX}:c.1_3delinsTTA"),
+        "a correctly-spelled allele must merge exactly as it did before the \
+         #1543 guard was added"
+    );
+    assert!(
+        reference_mismatches(&input).is_empty(),
+        "`{input}` misstates nothing, so it must carry no RefSeqMismatch (#1543)"
+    );
+}
+
+/// Lenient mode warns and continues rather than rejecting.
+///
+/// Both halves matter. The warning is the one the per-member pipeline already
+/// raises for a lone misstating substitution (W5001 `RefSeqMismatch`, reused
+/// rather than reinvented), reported once per false member at the member's own
+/// position. And normalization still *completes*, producing the same string it
+/// produced before — the fix adds a diagnostic, it does not move output.
+#[test]
+fn lenient_mode_warns_and_continues() {
+    let input = format!("{TX}:c.[1G>T;3T>A]");
+    assert_eq!(
+        reference_mismatches(&input),
+        vec![
+            ("G".to_string(), "A".to_string(), "1-1".to_string()),
+            ("T".to_string(), "G".to_string(), "3-3".to_string()),
+        ],
+        "lenient mode must report both false assertions, each at its own \
+         position, exactly as the lone-substitution path does (#1543)"
+    );
+    assert_eq!(
+        lenient(&input),
+        format!("{TX}:c.1_3delinsTTA"),
+        "lenient mode warns and continues; the normalized form is unchanged"
+    );
+}
+
+/// A member that reaches the per-member validator is not reported twice.
+///
+/// The guard runs on the authored members, and the per-member pipeline reports
+/// the same finding for any member a merge did not consume. `c.[1G>T;30G>C]`
+/// merges nothing, so both members reach both — and must still yield exactly two
+/// warnings.
+#[test]
+fn an_unmerged_member_is_not_reported_twice() {
+    assert_eq!(
+        reference_mismatches(&format!("{TX}:c.[1G>T;30G>C]")),
+        vec![
+            ("G".to_string(), "A".to_string(), "1-1".to_string()),
+            ("G".to_string(), "C".to_string(), "30-30".to_string()),
+        ],
+        "one mismatch per false member; the authored-member guard must not \
+         duplicate what the per-member pipeline already reported (#1543)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The invariant: distance decides nothing.
+// ---------------------------------------------------------------------------
+
+/// Sibling positions spanning the merge threshold, with the base each one
+/// truthfully states.
+///
+/// `c.2 = T` (strictly adjacent, merges), `c.3 = G` (gap of one inside codon 1,
+/// merges via `general.md:35`), `c.4 = C` (gap of two, `general.md:34` splits),
+/// `c.5 = A`, `c.10 = C`, `c.30 = C` (far).
+const SIBLINGS: [(u32, char); 6] = [(2, 'T'), (3, 'G'), (4, 'C'), (5, 'A'), (10, 'C'), (30, 'C')];
+
+/// The verdict on a false `c.1G>T` does not depend on how far away its sibling
+/// sits.
+///
+/// This is the actual invariant — the defect's whole discriminator was merge
+/// distance — and it is what keeps the guard alive through a refactor of the
+/// merge threshold: a change to `general.md:34`/`:35` eligibility moves which
+/// rows merge, and this test does not care which those are.
+///
+/// The sweep is paired with a correctly-spelled control at every distance, for
+/// two reasons. It proves the rejections come from the false `c.1`, not from
+/// something about the sibling; and the controls' outputs are what show the
+/// sweep genuinely *spans* the threshold — a sweep entirely on one side of it
+/// would assert the invariant without ever testing it, which is how a distance
+/// sweep quietly stops covering anything.
+#[test]
+fn the_verdict_does_not_depend_on_merge_distance() {
+    let mut merged = 0usize;
+    let mut split = 0usize;
+    for (position, reference_base) in SIBLINGS {
+        // `c.1` is `A`, so `1G>T` is false at every distance.
+        let false_at_one = format!("{TX}:c.[1G>T;{position}{reference_base}>N]");
+        assert!(
+            strict_rejects(&false_at_one),
+            "`{false_at_one}` misstates c.1 as G when the reference holds A; \
+             a sibling {} nt away must not change that verdict (#1543)",
+            position - 1
+        );
+
+        // The same allele with `c.1` stated truthfully. Accepted at every
+        // distance, which is what makes the rejections above attributable to
+        // the false base rather than to the pair.
+        let true_at_one = format!("{TX}:c.[1A>T;{position}{reference_base}>N]");
+        assert!(
+            !strict_rejects(&true_at_one),
+            "`{true_at_one}` states every reference base correctly and must be \
+             accepted at every distance (#1543)"
+        );
+
+        if lenient(&true_at_one).contains('[') {
+            split += 1;
+        } else {
+            merged += 1;
+        }
+    }
+    assert!(
+        merged > 0 && split > 0,
+        "the sweep must straddle the merge threshold, or it asserts the \
+         distance-independence invariant without exercising it — got \
+         {merged} merged and {split} split of {} distances (#1543)",
+        SIBLINGS.len()
+    );
+}
+
+/// Strict adjacency loses the assertions too, not only the codon-frame merge.
+///
+/// `c.[1G>T;2A>C]` is the shape the issue's reproducer does not cover: `c.1 = A`
+/// and `c.2 = T`, both misstated, and the two members are *consecutive*, so they
+/// merge under `delins.md:16` rather than under the `general.md:35` codon
+/// exception. It was accepted as `c.1_2delinsTC` before the fix.
+#[test]
+fn strictly_adjacent_members_are_rejected_too() {
+    assert!(
+        strict_rejects(&format!("{TX}:c.[1G>T;2A>C]")),
+        "consecutive members merge under delins.md:16 and lost their reference \
+         assertions the same way the codon-frame pair did (#1543)"
+    );
+    assert!(
+        !strict_rejects(&format!("{TX}:c.[1A>T;2T>C]")),
+        "the same pair spelled correctly must still be accepted (#1543)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Coverage: every channel that can assert a reference, and every axis that
+// merges. #1352's lesson was that a channel list which claims to be complete
+// and is not fails silently, so each one is pinned rather than assumed.
+// ---------------------------------------------------------------------------
+
+/// Every `NaEdit` channel that can carry an asserted reference is validated.
+///
+/// Each row pairs a member misstating its reference with a sibling close enough
+/// to merge. The `del`/`delins`/`dup`/`inv` channels were all accepted before
+/// the fix; a substitution is included as the shape the issue reported.
+#[test]
+fn every_stated_reference_channel_is_validated() {
+    // `c.1_2` is `AT`, `c.4_5` is `CA`, `c.10_14` is `CCCCC`.
+    for input in [
+        format!("{TX}:c.[1G>T;3T>A]"),           // substitution
+        format!("{TX}:c.[1_2delAA;3T>A]"),       // deletion, stated bases
+        format!("{TX}:c.[1_2delAAinsGG;3T>A]"),  // delins, stated deleted bases
+        format!("{TX}:c.[4_5dupAA;6A>G]"),       // duplication, stated bases
+        format!("{TX}:c.[10_14invGGGGG;15G>T]"), // inversion, stated bases
+    ] {
+        assert!(
+            strict_rejects(&input),
+            "`{input}` asserts reference bases the reference contradicts; every \
+             channel that can carry them must be validated, not just \
+             substitutions (#1352, #1543)"
+        );
+    }
+
+    // The same five shapes spelled truthfully, which must all still be accepted.
+    for input in [
+        format!("{TX}:c.[1A>T;3G>A]"),
+        format!("{TX}:c.[1_2delAT;3G>A]"),
+        format!("{TX}:c.[1_2delATinsGG;3G>A]"),
+        format!("{TX}:c.[4_5dupCA;6A>G]"),
+        format!("{TX}:c.[10_14invCCCCC;15G>T]"),
+    ] {
+        assert!(
+            !strict_rejects(&input),
+            "`{input}` states its reference bases correctly and must be \
+             accepted (#1543)"
+        );
+    }
+}
+
+/// Every axis whose members merge is covered — including `m.` (#1068) and `r.`.
+///
+/// #1068 is in this family precisely because a fix applied on one axis and not
+/// another is the same defect twice. The guard runs on the shared cis-member
+/// path, so it reaches all five; each is pinned so a future axis-specific
+/// narrowing fails here.
+#[test]
+fn every_merging_axis_is_covered() {
+    for (input, corrected) in [
+        (format!("{TX}:c.[1G>T;2A>C]"), format!("{TX}:c.[1A>T;2T>C]")),
+        (format!("{TX}:n.[1G>T;2A>C]"), format!("{TX}:n.[1A>T;2T>C]")),
+        (format!("{TX}:r.[1g>u;3u>a]"), format!("{TX}:r.[1a>u;3g>a]")),
+        (
+            "CTG:g.[1G>T;2A>C]".to_string(),
+            "CTG:g.[1A>T;2T>C]".to_string(),
+        ),
+        (
+            "MITO:m.[1G>T;2A>C]".to_string(),
+            "MITO:m.[1A>T;2T>C]".to_string(),
+        ),
+    ] {
+        assert!(
+            strict_rejects(&input),
+            "`{input}` misstates its reference; the axis it is written on must \
+             not decide whether that is caught (#1068, #1543)"
+        );
+        assert!(
+            !strict_rejects(&corrected),
+            "`{corrected}` states its reference correctly and must be accepted \
+             on every axis (#1543)"
+        );
+    }
+}
+
+/// The `r.` axis is judged in its own alphabet, so a truthful `u` over a `T` is
+/// not a mismatch.
+///
+/// `r.` spells its bases as `a/c/g/u` while the transcript is served as DNA, so
+/// a validator comparing the two byte for byte would reject `r.2u>a` over a `T`
+/// — over-rejecting *correct* input, which is worse than the hole being closed.
+/// `normalize_rna` rewrites `u` to `T` before it validates (#736); the
+/// authored-member guard makes the same rewrite, and this pins it.
+#[test]
+fn the_rna_alphabet_is_not_read_as_a_mismatch() {
+    // `c.2` is `T`, i.e. `r.2` is `u`.
+    for input in [format!("{TX}:r.2u>a"), format!("{TX}:r.[2u>a;4c>g]")] {
+        assert!(
+            !strict_rejects(&input),
+            "`{input}` states the reference truthfully in the RNA alphabet; \
+             folding u/T is what keeps the #1543 guard from over-rejecting"
+        );
+        assert!(
+            reference_mismatches(&input).is_empty(),
+            "`{input}` must carry no RefSeqMismatch (#736, #1543)"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -227,6 +227,7 @@ mod issue_1492_anchor_decline_names_the_caller_span;
 mod issue_1508_overlap_across_region_boundary;
 mod issue_1513_adjacent_junction_insertions;
 mod issue_1517_inv_priority_over_delins;
+mod issue_1543_allele_member_reference_validation;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1543

Strict mode rejected a substitution that misstates its reference base, and accepted the same substitution when a sibling sat close enough for the two to merge. The discriminator was merge distance and nothing else.

## Before / after

Real prepared reference, `--error-mode strict`. Reference bases are `c.1 = A`, `c.3 = G`, `c.500 = G`.

| input | before | after |
|---|---|---|
| `NM_000143.3:c.1G>T` | `normalize_error` Reference mismatch at 64-64 | unchanged |
| `NM_000143.3:c.[1G>T;500G>C]` | `normalize_error` Reference mismatch at 64-64 | unchanged |
| `NM_000143.3:c.[1G>T;3T>A]` | `NM_000143.3:c.1_3delinsTTA`, **status=ok** | `normalize_error` Reference mismatch |
| `NM_000143.3:c.500G>C` | `NM_000143.3:c.500G>C`, status=ok | unchanged |

And the same defect turned up unprompted in ClinVar, on a shape the issue does not describe — a `Repeat` member in the 3'UTR whose declared tract does not divide its span:

```
NM_000287.4:c.*438TAAA[1]              -> normalize_error   (before AND after)
NM_000287.4:c.[*438TAAA[1];2578C>T]    -> ok  ->  normalize_error
```

The identical member, rejected alone and accepted beside a sibling. After the change both give the same verdict, which is the invariant.

## Mechanism — and it is not the one the issue names

The issue attributes this to `stated_reference_bases_match` (`src/normalize/merge.rs:3050`) being vacuous at the sequence-first canonicalization guard. That guard is real, and its doc comment does predict this class of failure, but **it is not what let these inputs through**. Verified by instrumented reproduction rather than by reading: on `5616cdb9` the merged input produces *no* `RefSeqMismatch` warning at all — only `MembersCoalesced` — so nothing was ever generated for the guard to be asked about.

`Normalizer::normalize_allele` runs `merge::collapse_overlapping_cis_edits` and `merge::merge_consecutive_edits` over the **raw** members before any member reaches `normalize_na_edit`, which is the only place `RefSeqMismatch` (W5001) is raised, and which the strict ladder reads to reject. A merge keeps each member's *alt* bases and nothing else — `merge::Anchor` has no channel for an asserted reference — so a member consumed by a merge had its assertions discarded before anything looked at them. The merged anchor was then rebuilt from the real bases, which is why the output looked correct. `canonicalize_from_sequence` runs *after* `normalize_core`, by which time the member no longer states anything, so the guard there was downstream of the loss rather than the cause of it.

Measuring it also showed the defect is broader than the report:

- **Not only the codon-frame merge.** Plain strict adjacency (`delins.md:16`) loses the assertions the same way, so `c.[1G>T;2A>C]` was accepted too.
- **Not only substitutions.** Every channel that can carry an asserted reference was affected: `delAA`, `delAAinsGG`, `dupAA`, `invGGGGG`, and `Repeat` (the ClinVar row above).
- **Not only `c.`** — `g.`, `m.`, `n.` and `r.` all merge and all lost them.

## The fix — general, not per-shape

This is the sixth defect in one family (#1052 substitutions, #1068 the `m.` axis, #1092 the parser discarding the bases, #1097 multi-base range substitutions, #1352 `NaEdit::Identity` omitted while the doc comment claimed the list was complete), and each of the five was fixed one shape at a time.

So the question is asked **on the authored input**, once, in `normalize_core`, before any pass has had the chance to strip anything (`merge::authored_member_reference_mismatches`). **This fixes the ordering generally, not this shape:** no rearrangement of the merge pipeline can make it vacuous, because it never looks at the pipeline's output. Two further properties keep it from drifting:

- The verdict comes from `normalize::validate::validate_reference`, the **same** function the per-member pipeline uses, so the channel list cannot diverge between the two sites the way #1352's did.
- The `r.` axis is folded to DNA with `rna_uracil_to_thymine` first, exactly as `normalize_rna` does before it validates (#736). Without that, a truthful `r.2u>a` over a `T` would be rejected — over-rejecting correct input, which is worse than the hole being closed. Pinned by `the_rna_alphabet_is_not_read_as_a_mismatch`.

Strict mode rejects and lenient mode warns and continues, both by reusing the existing `RefSeqMismatch` / W5001 path rather than inventing a code. Warnings are deduplicated by sequence-axis position, so a member a merge did *not* consume — which reaches the per-member validator on its own — is still reported exactly once.

**The `return None` at `merge.rs:2325` is kept.** It is not redundant: for members whose stated bases survive per-member normalization (a substitution keeps its reference base through `canonicalize_edit`), it still refuses to canonicalize an allele that misstates its reference, which is the contract #1052/#1097 recorded there. This change makes it reachable more often rather than less.

## Blast radius

Representation-Change: none. 0 of 950 real cis-allele rows move their normalized string; 1 of 950 changes strict verdict from accept to reject, which is the defect being fixed.

Measured, not assumed, over the four committed LFS corpora — ClinVar 500k, ClinVar unique, CMRG exhaustive, Paraphase exhaustive — normalized through both revisions against the real prepared reference:

| | |
|---|---|
| rows in the four corpora | 9,949,738 |
| of which cis-allele shaped — the only rows this change can reach | 1,178 (950 distinct) |
| **denominator: rows carrying a stated reference base that disagrees with the reference** | **3 of 950** |
| of those, already reported before this change | 2 |
| of those, laundered by a merge and now reported | **1** |
| lenient normalized strings that move | **0 of 950** |
| lenient status changes | **0 of 950** |
| strict status changes | **1 of 950** (`NM_000287.4:c.[*438TAAA[1];2578C>T]`, `ok` -> `normalize_error`) |

The one strict flip is not a representation change for a stored string: the input was never a valid description of that reference, and the lone form of the same member was already rejected. Nothing that was accepted-and-correct moves.

### The synthetic harness reports a structural zero, and it is reported as one

`examples/dump_normalized_corpus.rs` reports **0 of 78,028 rows moved** across all 15 shape families. **That zero proves nothing about this change and is not offered as evidence.** The corpus builds every substitution as `format!("{}{}>{}", p(i), base(i), other(i))` where `base(i)` reads the byte straight out of the reference, and every `del`/`dup`/`inv`/`delins` in the short form. So of its 27,656 rows that carry a stated reference base, **0 misstate one** — the corpus cannot express the input property this change keys on. It is blind here in the same way #1456/#1460/#1478 record.

The real evidence is the corpus table above (which has a non-zero denominator) and the suite: **9,609 tests pass with nothing re-blessed**, which for a change capable of moving output is the strong signal — every existing expectation already agreed.

## Verification

| check | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --features dev --all-targets -- -D warnings` | clean |
| `cargo nextest run --features dev -E 'test(issue_1543)'` | 10 passed |
| `cargo nextest run --features dev -E 'binary(it)'` | 5,454 passed, 0 failed |
| `cargo nextest run --features dev` (all binaries) | 9,609 passed, 0 failed |
| oracles (`FERRO_ASSERT_IDEMPOTENT` / `REPARSE` / `IN_BOUNDS`) | 5,454 passed, 0 failed |
| `generate_spec_fixture` + `generate_spec_enumeration`, then re-run | no drift; `DIVERGENCE_BUDGET` and `PASSING_CENSUS` unchanged |

**Nothing was re-blessed.** Six of the ten new tests fail on the parent commit; the other four are controls that already passed, so the fix cannot be credited to breaking them.

## Tests

`tests/it/issue_1543_allele_member_reference_validation.rs`, hermetic on a synthetic `MockProvider` transcript whose first three bases reproduce the issue's (`c.1 = A`, `c.3 = G`) — so `c.[1G>T;3T>A]` reaches the same `c.1_3delinsTTA` the report shows. No `FERRO_MANIFEST`, which would be skipped on every PR and gate nothing.

The distance sweep is the invariant worth keeping: the same false `c.1G>T` is rejected with siblings at six distances spanning the merge threshold, each paired with a correctly-spelled control that must be accepted. The controls' outputs are additionally asserted to straddle the threshold, so a sweep that drifted entirely to one side of it fails rather than quietly asserting distance-independence without testing it.
