### PR TITLE
test(confluence): record two adjudications from the divergent cis classes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,6 +351,16 @@ required-features = ["dev"]
 [[example]]
 name = "dump_partitions"
 required-features = ["dev"]
+
+# `test = true` because the target carries `#[cfg(test)]` unit tests pinning the
+# separation arithmetic — the one thing here that has already published numbers
+# that were wrong. Cargo does not build a target's tests unless it opts in, so
+# without this they silently never run.
+[[example]]
+name = "dump_confluence_divergences"
+required-features = ["dev"]
+test = true
+
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/examples/dump_confluence_divergences.rs
+++ b/examples/dump_confluence_divergences.rs
@@ -1,0 +1,903 @@
+//! Dump the **divergent** confluence classes measured by
+//! `tests/it/cis_confluence_axis.rs`, one record per class, and census them by
+//! *shape*.
+//!
+//! # Why
+//!
+//! The axis test pins a census — 11 272 classes, 6 629 converged in the 3'
+//! direction — and prints ten worst offenders. That is enough to detect a
+//! regression and nowhere near enough to *adjudicate* the 4 643 that diverge.
+//! Adjudicating them one row at a time is not feasible and is not the right
+//! unit anyway: the prior campaign
+//! (`campaigns/2026-08-06-separation-rule-adjudication.md`) collapsed 1 957 rows
+//! to ~32 shapes with the top nine covering 91%, and the same collapse works
+//! here.
+//!
+//! So this emits, per divergent class, every spelling and what it normalized
+//! to, plus a **shape key** derived from the disagreement itself rather than
+//! from the class's design parameters:
+//!
+//! ```text
+//! 1×delins | 2×[delins,delins]
+//! ```
+//!
+//! meaning one spelling reached a single spanning `delins` and another reached
+//! a two-member allele of two `delins`. Shapes are what a spec clause can be
+//! applied to; individual rows are not.
+//!
+//! # Geometry, and the arithmetic trap it exists to avoid
+//!
+//! An insertion consumes **no** reference position. Each member is modelled as
+//! a closed interval `[lo, hi]` over the reference, with an insertion left
+//! *empty* (`lo = A + 1`, `hi = A`), so that
+//!
+//! ```text
+//! separation = next.lo - prev.hi - 1
+//! ```
+//!
+//! holds uniformly across every edit kind. Treating an insertion's `A_B` anchor
+//! as a consumed two-base span double-counts and has already invalidated one
+//! published distribution.
+//!
+//! The intervals come from `hgvs_to_spdi`, which applies the description to the
+//! reference — the same normalizer-independent oracle the corpus generator used
+//! to establish ground truth. Nothing here asks the normalizer what a member
+//! covers.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --features dev --example dump_confluence_divergences -- --stats
+//! cargo run --features dev --example dump_confluence_divergences -- --out /tmp/div.json
+//! cargo run --features dev --example dump_confluence_divergences -- --direction 5prime --stats
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Kept in step with `examples/generate_cis_confluence_corpus.rs` and
+/// `tests/it/cis_confluence_axis.rs`; all three must agree on the padding, the
+/// accessions and the CDS or the coordinates mean different things.
+const PAD_OFFSET: usize = 256;
+const GENOMIC_CONTIG: &str = "NC_TEST.1";
+const TX_ACCESSION: &str = "NM_TEST.1";
+const TX_CONTIG: &str = "chr_synth";
+const CDS_START: u64 = 1;
+const CDS_END: u64 = 63;
+
+const DEFAULT_CORPUS: &str = "tests/fixtures/cis/cis_confluence_corpus.json";
+
+#[derive(Parser, Debug)]
+#[command(about = "Dump and census the divergent cis confluence classes")]
+struct Cli {
+    /// The corpus written by `generate_cis_confluence_corpus`.
+    #[arg(long, default_value = DEFAULT_CORPUS)]
+    corpus: PathBuf,
+    /// Write the per-class records here as JSON.
+    #[arg(long)]
+    out: Option<PathBuf>,
+    /// Print the shape census only.
+    #[arg(long)]
+    stats: bool,
+    /// `3prime` (default) or `5prime`.
+    #[arg(long, default_value = "3prime")]
+    direction: String,
+    /// How many shapes to list in the census.
+    #[arg(long, default_value_t = 40)]
+    top: usize,
+    /// How many exemplar classes to print per shape.
+    #[arg(long, default_value_t = 0)]
+    examples: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct Class {
+    id: String,
+    axis: String,
+    core: String,
+    denoted: String,
+    members: usize,
+    separation: usize,
+    payload: usize,
+    pattern: String,
+    block_start: usize,
+    reference_block: String,
+    alt_block: String,
+    spellings: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct Corpus {
+    classes: Vec<Class>,
+}
+
+/// The confluence question asked one level up: a **variant** is one reference
+/// and one denoted sequence, and several classes can denote the same one by
+/// different designs. `cis_confluence_axis` compares outputs only *within* a
+/// class, so a variant two classes describe differently is invisible to it.
+///
+/// This matters beyond bookkeeping, because the design parameter the separation
+/// rule keys on is exactly what differs between such classes: two members one
+/// nucleotide apart and four members zero apart can denote the same sequence.
+/// `(axis, reference core, denoted sequence)` — one *variant*, regardless of how
+/// many designs reach it.
+type VariantKey = (String, String, String);
+
+/// Every output any class of one variant reached, whether every one of those
+/// classes converged internally, and how many classes there were.
+type VariantOutputs = (BTreeSet<String>, bool, usize);
+
+/// Everything the pass declined to measure.
+///
+/// Printed unconditionally by [`render_census`], and every field is expected to
+/// be **zero**: the spellings come from the corpus generator and the outputs
+/// from a successful `normalize`. That is the argument for printing them, not
+/// for omitting them. A silently-dropped spelling leaves its class with fewer
+/// surviving outputs, and a class reduced to one survivor is then recorded as
+/// *converged* — so an uncounted drop does not merely shrink the sample, it
+/// moves a class from the divergent side of the census to the converged side.
+/// A printed `0` turns that into evidence; silence is indistinguishable from a
+/// run where it was not zero.
+#[derive(Default)]
+struct Drops {
+    /// Spellings `parse_hgvs` rejected.
+    unparsed_spellings: usize,
+    /// Spellings normalization errored or panicked on.
+    unnormalized_spellings: usize,
+    /// Divergent classes excluded because some output's member spans could not
+    /// be resolved, so the class's geometry was never measured. Excluded rather
+    /// than classified: see [`members_of`].
+    unresolved_classes: usize,
+}
+
+struct CrossClass {
+    /// Distinct `(axis, reference, denoted)` variants in the corpus.
+    variants: usize,
+    /// Variants reachable from more than one class.
+    multi_class: usize,
+    /// Multi-class variants whose classes do not agree on a single output.
+    multi_class_divergent: usize,
+    /// … of those, the ones where **every** class converged internally, so the
+    /// disagreement is visible only across classes.
+    hidden_by_the_class_boundary: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// One normalized output, with the geometry the adjudication turns on.
+#[derive(Serialize, Clone)]
+struct Output {
+    text: String,
+    /// Number of cis members.
+    arity: usize,
+    /// Per-member edit kind. Ordered by [`Output::spans`], not by written
+    /// order — the two are one member order so that `kinds[i]` and `spans[i]`
+    /// always describe the same member.
+    kinds: Vec<String>,
+    /// Per-member closed reference interval `[lo, hi]`, 0-based over the core,
+    /// ascending. An insertion is empty (`lo = hi + 1`), so a separation
+    /// computed as `next.lo - prev.hi - 1` is uniform across kinds.
+    spans: Vec<(i64, i64)>,
+    /// Gaps between consecutive members, from the spans above. Empty for a
+    /// single-member output.
+    separations: Vec<i64>,
+    /// Which of the class's spellings reached this output.
+    from: Vec<String>,
+}
+
+/// One divergent class.
+#[derive(Serialize)]
+struct Record {
+    id: String,
+    axis: String,
+    /// The design's own parameters, so a shape can be cross-tabbed against them.
+    design_members: usize,
+    design_separation: usize,
+    design_payload: usize,
+    design_pattern: String,
+    core: String,
+    denoted: String,
+    block_start: usize,
+    reference_block: String,
+    alt_block: String,
+    /// The fine shape key: the sorted arity/kind signature of the distinct
+    /// outputs. Useful for exemplars; too fine to adjudicate against (663
+    /// distinct values over 4 643 classes).
+    shape: String,
+    /// The coarse shape key the adjudication is written against:
+    /// `<relation>/<gap class>`. See [`Record::relation`] and
+    /// [`Record::gap_class`].
+    family: String,
+    /// `typing` when every output partitions the reference identically and only
+    /// the edit kinds differ; `partition` when the member boundaries differ.
+    disagreement: String,
+    /// How the outputs' arities relate: `spanning-vs-split` when one output is
+    /// a single member and another is not; `split-vs-split` when they are all
+    /// multi-member but of different arity; `same-arity` when the arities agree
+    /// and only the boundaries or the kinds move — which includes the case
+    /// where every output is a single spanning member.
+    relation: String,
+    /// Every distinct output arity, ascending.
+    arities: Vec<usize>,
+    /// The interior gaps of the **most split** output — the one the merge
+    /// question is asked about. Every gap, not only the first: checking only
+    /// the first under-counted a prior distribution by 54 per arm.
+    split_gaps: Vec<i64>,
+    /// Bucketed from [`Record::split_gaps`]: `all-0` (every interior gap is
+    /// adjacency), `has-0` (some but not all), `min-1` (smallest gap is one
+    /// nucleotide), `min-2+` (every gap is two or more). This is the quantity
+    /// `general.md:34-35` and `DNA/delins.md:16-18` key on.
+    gap_class: String,
+    /// True when every output's arity equals the member count of every spelling
+    /// that reached it — i.e. the normalizer preserved the input's partition
+    /// rather than re-deriving one. This is the mechanism behind the divergence
+    /// and it is worth stating separately from the shape.
+    input_partition_preserving: bool,
+    outputs: Vec<Output>,
+}
+
+// ---------------------------------------------------------------------------
+// Providers — the same construction the generator and the axis test use
+// ---------------------------------------------------------------------------
+
+fn padded(core: &str) -> String {
+    let pad = "ACGT".repeat(PAD_OFFSET / 4);
+    format!("{pad}{core}{pad}")
+}
+
+fn reference_for(class: &Class) -> (MockProvider, String) {
+    if class.axis == "g" {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence(GENOMIC_CONTIG, padded(&class.core));
+        return (provider, padded(&class.core));
+    }
+    let mut provider = MockProvider::new();
+    let tx_len = class.core.len() as u64;
+    let g_start = PAD_OFFSET as u64 + 1;
+    let g_end = PAD_OFFSET as u64 + tx_len;
+    let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+    let transcript = Transcript::new(
+        TX_ACCESSION.to_string(),
+        Some("SYNTH".to_string()),
+        Strand::Plus,
+        class.core.clone(),
+        Some(CDS_START),
+        Some(CDS_END),
+        vec![exon],
+        Some(TX_CONTIG.to_string()),
+        Some(g_start),
+        Some(g_end),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_genomic_sequence(TX_CONTIG, padded(&class.core));
+    provider.add_transcript(transcript);
+    (provider, class.core.clone())
+}
+
+fn axis_offset(axis: &str) -> i64 {
+    if axis == "g" {
+        PAD_OFFSET as i64
+    } else {
+        0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+/// Classify one rendered member by its edit kind. Textual because the question
+/// asked is which *notation* the normalizer chose, which is exactly what the
+/// downstream consumer stores.
+fn kind_of(member: &str) -> &'static str {
+    let body = member.rsplit(':').next().unwrap_or(member);
+    if body.contains("delins") {
+        "delins"
+    } else if body.contains('>') {
+        "sub"
+    } else if body.ends_with("inv") {
+        "inv"
+    } else if body.ends_with("dup") {
+        "dup"
+    } else if body.ends_with("del") {
+        "del"
+    } else if body.contains("ins") {
+        "ins"
+    } else if body.ends_with('=') {
+        "identity"
+    } else if body.contains('[') {
+        "repeat"
+    } else {
+        "other"
+    }
+}
+
+/// Split a normalized description into its cis members' rendered text, dropping
+/// the accession and axis prefix.
+fn member_texts(text: &str) -> Vec<String> {
+    let body = match text.split_once(':') {
+        Some((_, rest)) => rest,
+        None => text,
+    };
+    let body = match body.split_once('.') {
+        Some((_, rest)) => rest,
+        None => body,
+    };
+    let body = body.trim();
+    if let Some(inner) = body.strip_prefix('[').and_then(|b| b.strip_suffix(']')) {
+        inner.split(';').map(|s| s.trim().to_string()).collect()
+    } else {
+        vec![body.to_string()]
+    }
+}
+
+/// Each member's rendered text paired with its closed reference interval, from
+/// `hgvs_to_spdi`, in **one** member order: ascending by interval. An insertion
+/// is returned empty (`lo = hi + 1`) so a separation is uniform across kinds.
+///
+/// The single order is the point. `kinds` and `spans` used to be derived
+/// separately — the former from [`member_texts`], which preserves the order the
+/// members are *written* in, the latter sorted by coordinate — and then paired
+/// positionally, so for any allele whose members are not already written in
+/// coordinate order `kinds[i]` and `spans[i]` described different members. The
+/// decided ruling's rationale enumerates adjacency **kind-pairs**, which is
+/// exactly that join, so the mismatch reached a record rather than only a
+/// fixture.
+///
+/// Returns `None` — never a partial answer — when any member's span cannot be
+/// resolved. An empty `Vec` would flow on into `separations` and
+/// [`classify_gaps`], which reports `no-gaps` for it, so a multi-member output
+/// whose geometry was never measured would be filed as having no interior gaps.
+fn members_of(
+    provider: &MockProvider,
+    text: &str,
+    offset: i64,
+) -> Option<Vec<(String, (i64, i64))>> {
+    let members: Vec<HgvsVariant> = match parse_hgvs(text).ok()? {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let texts = member_texts(text);
+    if texts.len() != members.len() {
+        return None;
+    }
+    let mut pairs = Vec::with_capacity(members.len());
+    for (member, member_text) in members.iter().zip(texts) {
+        let triple = hgvs_to_spdi(member, provider).ok()?;
+        let lo = i64::try_from(triple.position).ok()? - offset;
+        let hi = lo + triple.deletion.len() as i64 - 1;
+        pairs.push((member_text, (lo, hi)));
+    }
+    pairs.sort_by_key(|(_, span)| *span);
+    Some(pairs)
+}
+
+/// `next.lo - prev.hi - 1` over consecutive members. Uniform because an
+/// insertion's interval is empty.
+fn separations(spans: &[(i64, i64)]) -> Vec<i64> {
+    spans.windows(2).map(|w| w[1].0 - w[0].1 - 1).collect()
+}
+
+/// Bucket a split output's interior gaps into the classes the separation rule
+/// distinguishes. **Every** gap is considered — a codon or adjacency test
+/// applied only to the first gap under-counts.
+fn classify_gaps(gaps: &[i64]) -> String {
+    if gaps.is_empty() {
+        return "no-gaps".to_string();
+    }
+    let min = gaps.iter().copied().min().unwrap_or(0);
+    if gaps.iter().all(|g| *g <= 0) {
+        "all-0".to_string()
+    } else if min <= 0 {
+        "has-0".to_string()
+    } else if min == 1 {
+        "min-1".to_string()
+    } else {
+        "min-2+".to_string()
+    }
+}
+
+/// How a class's distinct output arities relate. `arities` must be **sorted and
+/// deduplicated**, and this is only asked of a class with two or more distinct
+/// outputs.
+///
+/// `spanning-vs-split` asserts that one output is a single spanning member and
+/// another is split, so it needs both a `1` and something else — hence
+/// `contains(&1)` rather than `first() == Some(&1)`. The latter filed a class
+/// whose outputs are *all* single-member (`arities == [1]`, two spellings of one
+/// spanning member) as `spanning-vs-split`, asserting a split that is not there,
+/// and made `same-arity` unreachable at arity 1. `spanning-vs-split/min-2+` is
+/// the headline family and the module's central mechanism claim is stated over
+/// it, so a class that does not belong to the claim must not be counted in it.
+fn relation_of(arities: &[usize]) -> &'static str {
+    if arities.len() > 1 && arities.contains(&1) {
+        "spanning-vs-split"
+    } else if arities.len() > 1 {
+        "split-vs-split"
+    } else {
+        "same-arity"
+    }
+}
+
+fn signature(arity: usize, kinds: &[String]) -> String {
+    if arity == 1 {
+        format!("1x{}", kinds[0])
+    } else {
+        format!("{arity}x[{}]", kinds.join(","))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let direction = match cli.direction.as_str() {
+        "3prime" => ShuffleDirection::ThreePrime,
+        "5prime" => ShuffleDirection::FivePrime,
+        other => {
+            eprintln!("error: --direction must be 3prime or 5prime, got {other}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let text = match std::fs::read_to_string(&cli.corpus) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!(
+                "error: reading {}: {e}\nGenerate it with:\n  cargo run --features dev \
+                 --example generate_cis_confluence_corpus",
+                cli.corpus.display()
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let corpus: Corpus = match serde_json::from_str(&text) {
+        Ok(corpus) => corpus,
+        Err(e) => {
+            eprintln!("error: parsing {}: {e}", cli.corpus.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let (records, cross, drops) = collect(&corpus, direction);
+    print!(
+        "{}",
+        render_census(&corpus, &records, &cross, &drops, cli.top, cli.examples)
+    );
+
+    if cli.stats {
+        return ExitCode::SUCCESS;
+    }
+    let Some(path) = cli.out else {
+        return ExitCode::SUCCESS;
+    };
+    let mut rendered = match serde_json::to_string_pretty(&records) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!("error: serializing: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    rendered.push('\n');
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("error: creating {}: {e}", parent.display());
+            return ExitCode::FAILURE;
+        }
+    }
+    if let Err(e) = std::fs::write(&path, rendered) {
+        eprintln!("error: writing {}: {e}", path.display());
+        return ExitCode::FAILURE;
+    }
+    println!(
+        "wrote {} divergent classes to {}",
+        records.len(),
+        path.display()
+    );
+    ExitCode::SUCCESS
+}
+
+fn collect(corpus: &Corpus, direction: ShuffleDirection) -> (Vec<Record>, CrossClass, Drops) {
+    let classes = &corpus.classes;
+    let mut records = Vec::new();
+    let mut drops = Drops::default();
+    // Keyed by `(axis, reference, denoted)` — one entry per *variant*, holding
+    // every output any of its classes reached and whether each class converged.
+    let mut variants: BTreeMap<VariantKey, VariantOutputs> = BTreeMap::new();
+    // Classes sharing a reference are contiguous by id, so one provider per
+    // group rather than per class — the same optimization the axis test makes.
+    let mut start = 0usize;
+    while start < classes.len() {
+        let mut end = start + 1;
+        while end < classes.len()
+            && classes[end].axis == classes[start].axis
+            && classes[end].core == classes[start].core
+        {
+            end += 1;
+        }
+        let (provider, _reference) = reference_for(&classes[start]);
+        let normalizer = Normalizer::with_config(
+            provider.clone(),
+            NormalizeConfig::default().with_direction(direction),
+        );
+        let offset = axis_offset(&classes[start].axis);
+
+        for class in &classes[start..end] {
+            let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            for spelling in &class.spellings {
+                let Ok(variant) = parse_hgvs(spelling) else {
+                    drops.unparsed_spellings += 1;
+                    continue;
+                };
+                let normalized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    normalizer.normalize(&variant)
+                }));
+                let Ok(Ok(value)) = normalized else {
+                    drops.unnormalized_spellings += 1;
+                    continue;
+                };
+                grouped
+                    .entry(value.to_string())
+                    .or_default()
+                    .push(spelling.clone());
+            }
+            let entry = variants
+                .entry((
+                    class.axis.clone(),
+                    class.core.clone(),
+                    class.denoted.clone(),
+                ))
+                .or_insert_with(|| (BTreeSet::new(), true, 0));
+            entry.0.extend(grouped.keys().cloned());
+            entry.1 &= grouped.len() <= 1;
+            entry.2 += 1;
+
+            if grouped.len() < 2 {
+                continue;
+            }
+
+            let mut outputs = Vec::with_capacity(grouped.len());
+            let mut unresolved = false;
+            for (text, from) in grouped {
+                let Some(members) = members_of(&provider, &text, offset) else {
+                    unresolved = true;
+                    break;
+                };
+                let kinds: Vec<String> = members
+                    .iter()
+                    .map(|(member, _)| kind_of(member).to_string())
+                    .collect();
+                let spans: Vec<(i64, i64)> = members.iter().map(|(_, span)| *span).collect();
+                let separations = separations(&spans);
+                outputs.push(Output {
+                    arity: kinds.len(),
+                    kinds,
+                    spans,
+                    separations,
+                    from,
+                    text,
+                });
+            }
+            // Excluded, not classified. Every downstream quantity — the gap
+            // class, the partition comparison behind `disagreement`, the
+            // adjacency kind-pairs — is read off the geometry, so a class one
+            // of whose outputs could not be measured has no honest shape.
+            if unresolved {
+                drops.unresolved_classes += 1;
+                continue;
+            }
+
+            let mut signatures: Vec<String> = outputs
+                .iter()
+                .map(|o| signature(o.arity, &o.kinds))
+                .collect();
+            signatures.sort();
+            let shape = signatures.join(" | ");
+
+            let partitions: BTreeSet<Vec<(i64, i64)>> =
+                outputs.iter().map(|o| o.spans.clone()).collect();
+            let disagreement = if partitions.len() == 1 {
+                "typing".to_string()
+            } else {
+                "partition".to_string()
+            };
+
+            let mut arities: Vec<usize> = outputs.iter().map(|o| o.arity).collect();
+            arities.sort_unstable();
+            arities.dedup();
+            let relation = relation_of(&arities).to_string();
+
+            let split_gaps = outputs
+                .iter()
+                .max_by_key(|o| o.arity)
+                .map(|o| o.separations.clone())
+                .unwrap_or_default();
+            let gap_class = classify_gaps(&split_gaps);
+            let family = format!("{relation}/{gap_class}");
+            let input_partition_preserving = outputs
+                .iter()
+                .all(|o| o.from.iter().all(|s| member_texts(s).len() == o.arity));
+
+            records.push(Record {
+                id: class.id.clone(),
+                axis: class.axis.clone(),
+                design_members: class.members,
+                design_separation: class.separation,
+                design_payload: class.payload,
+                design_pattern: class.pattern.clone(),
+                core: class.core.clone(),
+                denoted: class.denoted.clone(),
+                block_start: class.block_start,
+                reference_block: class.reference_block.clone(),
+                alt_block: class.alt_block.clone(),
+                shape,
+                family,
+                disagreement,
+                relation,
+                arities,
+                split_gaps,
+                gap_class,
+                input_partition_preserving,
+                outputs,
+            });
+        }
+        start = end;
+    }
+
+    let multi: Vec<_> = variants.values().filter(|v| v.2 > 1).collect();
+    let cross = CrossClass {
+        variants: variants.len(),
+        multi_class: multi.len(),
+        multi_class_divergent: multi.iter().filter(|v| v.0.len() > 1).count(),
+        hidden_by_the_class_boundary: multi.iter().filter(|v| v.0.len() > 1 && v.1).count(),
+    };
+    (records, cross, drops)
+}
+
+fn render_census(
+    corpus: &Corpus,
+    records: &[Record],
+    cross: &CrossClass,
+    drops: &Drops,
+    top: usize,
+    examples: usize,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "classes: {}  divergent: {}",
+        corpus.classes.len(),
+        records.len()
+    );
+    let _ = writeln!(
+        out,
+        "  dropped (expected 0 everywhere): {} spellings unparsed, {} spellings unnormalized, \
+         {} divergent classes excluded for unresolved member spans",
+        drops.unparsed_spellings, drops.unnormalized_spellings, drops.unresolved_classes
+    );
+
+    let _ = writeln!(
+        out,
+        "  cross-class: {} distinct (axis, reference, denoted) variants; {} reachable from more \
+         than one class, of which {} do not agree on one output — {} of those have every class \
+         converging internally, so the class boundary is the only thing hiding them",
+        cross.variants,
+        cross.multi_class,
+        cross.multi_class_divergent,
+        cross.hidden_by_the_class_boundary
+    );
+
+    let mut by_disagreement: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut by_gap_class: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut by_axis: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut by_design_sep: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut by_shape: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut by_family: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut by_family_axis: BTreeMap<String, usize> = BTreeMap::new();
+    let mut preserving = 0usize;
+    for record in records {
+        *by_disagreement
+            .entry(record.disagreement.as_str())
+            .or_default() += 1;
+        *by_gap_class.entry(record.gap_class.as_str()).or_default() += 1;
+        *by_axis.entry(record.axis.as_str()).or_default() += 1;
+        *by_design_sep.entry(record.design_separation).or_default() += 1;
+        *by_shape.entry(record.shape.as_str()).or_default() += 1;
+        *by_family.entry(record.family.as_str()).or_default() += 1;
+        *by_family_axis
+            .entry(format!("{} [{}]", record.family, record.axis))
+            .or_default() += 1;
+        if record.input_partition_preserving {
+            preserving += 1;
+        }
+    }
+    let _ = writeln!(
+        out,
+        "  input-partition-preserving: {preserving} ({:.1}%)",
+        100.0 * preserving as f64 / records.len().max(1) as f64
+    );
+
+    let section = |title: &str, rows: Vec<(String, usize)>, out: &mut String| {
+        let _ = writeln!(out, "  {title}:");
+        for (key, count) in rows {
+            let _ = writeln!(
+                out,
+                "    {key}: {count} ({:.1}%)",
+                100.0 * count as f64 / records.len().max(1) as f64
+            );
+        }
+    };
+    section(
+        "by disagreement",
+        by_disagreement
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), *v))
+            .collect(),
+        &mut out,
+    );
+    section(
+        "by axis",
+        by_axis
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), *v))
+            .collect(),
+        &mut out,
+    );
+    section(
+        "by gap class of the most-split output",
+        by_gap_class
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), *v))
+            .collect(),
+        &mut out,
+    );
+    section(
+        "by design separation",
+        by_design_sep
+            .iter()
+            .map(|(k, v)| (k.to_string(), *v))
+            .collect(),
+        &mut out,
+    );
+    let mut families: Vec<(&str, usize)> = by_family.into_iter().collect();
+    families.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+    let mut cumulative = 0usize;
+    let _ = writeln!(
+        out,
+        "  FAMILIES (the adjudication unit): {}",
+        families.len()
+    );
+    for (family, count) in &families {
+        cumulative += count;
+        let _ = writeln!(
+            out,
+            "    {count:6} ({:5.1}%, cum {:5.1}%)  {family}",
+            100.0 * *count as f64 / records.len().max(1) as f64,
+            100.0 * cumulative as f64 / records.len().max(1) as f64,
+        );
+    }
+    section(
+        "family x axis",
+        by_family_axis.into_iter().collect(),
+        &mut out,
+    );
+
+    let mut shapes: Vec<(&str, usize)> = by_shape.into_iter().collect();
+    shapes.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+    let _ = writeln!(out, "  shapes: {} distinct", shapes.len());
+    let mut cumulative = 0usize;
+    for (shape, count) in shapes.iter().take(top) {
+        cumulative += count;
+        let _ = writeln!(
+            out,
+            "    {count:6} ({:5.1}%, cum {:5.1}%)  {shape}",
+            100.0 * *count as f64 / records.len().max(1) as f64,
+            100.0 * cumulative as f64 / records.len().max(1) as f64,
+        );
+        for record in records.iter().filter(|r| r.shape == *shape).take(examples) {
+            let _ = writeln!(out, "        {} [{}]", record.id, record.disagreement);
+            for output in &record.outputs {
+                let _ = writeln!(out, "          {}   <- {:?}", output.text, output.from);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The separation arithmetic is the one thing here that has already
+    /// produced published numbers that were wrong, so it is pinned directly:
+    /// an insertion consumes no reference position, so its interval is empty
+    /// and `next.lo - prev.hi - 1` stays uniform across kinds.
+    #[test]
+    fn an_insertion_consumes_no_reference_position() {
+        // A deletion of [10, 12] followed by an insertion at interbase 15,
+        // i.e. between reference bases 14 and 15: the empty interval is
+        // (15, 14), so the gap is 15 - 12 - 1 = 2.
+        let spans = [(10, 12), (15, 14)];
+        assert_eq!(separations(&spans), vec![2]);
+        // Two adjacent members leave a gap of zero.
+        assert_eq!(separations(&[(10, 12), (13, 15)]), vec![0]);
+        // An insertion flush against the end of a deletion: interbase 13, so
+        // the empty interval is (13, 12) and the gap is 13 - 12 - 1 = 0.
+        assert_eq!(separations(&[(10, 12), (13, 12)]), vec![0]);
+        // Every interior gap is reported, not only the first.
+        assert_eq!(separations(&[(1, 1), (3, 3), (9, 9)]), vec![1, 5]);
+    }
+
+    #[test]
+    fn members_and_kinds_are_read_off_the_rendered_form() {
+        assert_eq!(
+            member_texts("NM_TEST.1:c.[10_12delinsAA;15dup]"),
+            vec!["10_12delinsAA".to_string(), "15dup".to_string()]
+        );
+        assert_eq!(member_texts("NC_TEST.1:g.266_268del"), vec!["266_268del"]);
+        assert_eq!(kind_of("10_12delinsAA"), "delins");
+        assert_eq!(kind_of("266_268del"), "del");
+        assert_eq!(kind_of("266_267insAA"), "ins");
+        assert_eq!(kind_of("266dup"), "dup");
+        assert_eq!(kind_of("266A>G"), "sub");
+        assert_eq!(kind_of("266_270inv"), "inv");
+    }
+
+    /// `spanning-vs-split` names the headline family, over which the module's
+    /// central mechanism claim is stated, so it must not absorb classes that do
+    /// not have a split at all.
+    #[test]
+    fn an_all_spanning_class_is_not_filed_as_a_spanning_vs_split() {
+        // The regression: `arities == [1]` is two spellings reaching two
+        // *different* single spanning members. Nothing is split.
+        assert_eq!(relation_of(&[1]), "same-arity");
+        assert_eq!(relation_of(&[3]), "same-arity");
+        // A `1` present alongside anything else is the real shape.
+        assert_eq!(relation_of(&[1, 2]), "spanning-vs-split");
+        assert_eq!(relation_of(&[1, 2, 4]), "spanning-vs-split");
+        // Differing arities with no lone spanning member.
+        assert_eq!(relation_of(&[2, 3]), "split-vs-split");
+    }
+
+    /// An output whose geometry could not be measured must not reach
+    /// [`classify_gaps`]: an empty span list is indistinguishable there from a
+    /// genuinely single-member output, which is how an unmeasured multi-member
+    /// output used to leave the `has-0` population.
+    #[test]
+    fn no_gaps_is_what_an_unmeasured_output_would_have_looked_like() {
+        assert_eq!(classify_gaps(&[]), "no-gaps");
+        assert_eq!(classify_gaps(&[0, 4]), "has-0");
+        assert_eq!(classify_gaps(&[3, 4]), "min-2+");
+        assert_eq!(classify_gaps(&[1, 4]), "min-1");
+    }
+
+    #[test]
+    fn a_signature_names_the_arity_and_the_kinds_in_order() {
+        assert_eq!(signature(1, &["delins".to_string()]), "1xdelins");
+        assert_eq!(
+            signature(2, &["del".to_string(), "ins".to_string()]),
+            "2x[del,ins]"
+        );
+    }
+}

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -193,6 +193,25 @@
       "note": "Same shape as the `235_237` class and the same carve-out, but here the spec does mark the split spelling invalid — so the split member is a `false-acceptance` row. Note the spec's own layout is off: the `:42` NOTE sits under the `c.9002_9009delinsTTT` bullet while the variant it names belongs to the `:37` bullet (`c.145_147` is `CGC`; `145C>T` + `147C>G` gives `TGG`). The two members are cited separately for that reason. This class is what the `false-acceptance` census cannot say: ferro not only accepts a spelling the spec forbids, it keeps it as a second fixed point for a variant it already has a form for."
     },
     {
+      "id": "dna-delins-vs-two-substitutions-79-80",
+      "reference": "LRG_199t1",
+      "members": [
+        "LRG_199t1:c.79_80delinsTT",
+        "c.[79G>T;80C>T]"
+      ],
+      "citations": [
+        {
+          "clause": "docs/recommendations/DNA/substitution.md:30",
+          "quote": "`LRG_199t1:c.79_80delinsTT`"
+        },
+        {
+          "clause": "docs/recommendations/DNA/substitution.md:32",
+          "quote": "changes involving two or more consecutive nucleotides are described as deletion-insertion (delins) so the description <code class=\"invalid\">c.[79G>T;80C>T]</code> is not correct"
+        }
+      ],
+      "note": "SEPARATION ZERO, which is what distinguishes this class from every other one here. `c.79` and `c.80` are consecutive — no unchanged nucleotide between them — where the `145_147` and `235_237` classes are separation ONE (`c.146`, `c.236` unchanged) and fall under the codon carve-out `delins-codon-carve-out-gap-one`. Ruling `delins-adjacent-members-when-both-consume-reference` is about separation zero and cited `145-147` before this class existed, which associated a decided ruling with the exemplar of a different one. The class is built from that ruling's own governing clause: `substitution.md:32` renders the split spelling `class=\"invalid\"` and calls it \"not correct\" in as many words, which is the strongest verdict the recommendations pass on any spelling this project has litigated."
+    },
+    {
       "id": "rna-delins-vs-two-substitutions-142-144",
       "members": [
         "r.142_144delinsugg",
@@ -537,6 +556,65 @@
       "rationale": "The two clauses are five lines apart in one document and cannot both hold. `:22` states the rule: a description carrying both a range and a unit is invalid because the range already fixes the unit — its example is `r.-125_-123cug[4]`. `:27` then publishes `NM_024312.4:r.-6_-3g[6]`, which is the same shape (range `-6_-3` plus unit `g`), as the worked example of the UTR carve-out to the multiple-of-3 restriction. Whatever `:27` is demonstrating, it demonstrates it using a spelling `:22` forbids.\n\nMEASURED, 2026-08-07: ferro answers BOTH WAYS depending on input-hygiene mode, which is worth recording precisely because it looks like one behaviour and is not. Through the plain library path (`parse_hgvs`, no preprocessing) the published form is left alone: `r.-6_-3g[6]` in, `r.-6_-3g[6]` out — the `:27` answer. Through `--error-mode lenient` the preprocessor strips the redundant label (W3013 RedundantRepeatLabel) and normalization emits `r.-6_-3[6]` — the `:22` answer. Through `--error-mode strict` the same repair becomes a rejection. So the divergence lives in the INPUT-HYGIENE layer, not in the normalizer, and the three modes are three different readings of the same conflict.\n\nWHAT IS NOT ESTABLISHED. Following the rule at `:22` over the example at `:27` is the defensible reading — a rule generalises and an example does not, and `:22` gives its reason — and that is what the lenient path does. But it is a reading, and it is not the project's to make: the conflict is upstream's, and either clause could be the one that is wrong. Nobody has ruled, so all three behaviours are pinned as observations in tests/fixtures/spec-worked-examples/cases.json rather than reconciled, and ferro is NOT being 'fixed' to match an example its own document forbids.\n\nWhat would settle it: an upstream correction. Owed as a #466 entry against the HGVS nomenclature repository — either `:22` should carve out the UTR case, or `:27` should be respelled as `r.-6_-3[6]`.\n\nNote this record is about SPELLING REDUNDANCY only. The multiple-of-3 restriction that `:24-27` is actually about is not in doubt: ferro implements it exactly, including the UTR carve-out, and all six of the spec's worked examples for it reproduce.",
       "applies_to": [],
       "equivalence_classes": []
+    },
+    {
+      "id": "delins-adjacent-members-when-both-consume-reference",
+      "question": "When a normalized cis allele leaves two members with no unchanged nucleotide between them, and both members consume reference bases, is that a description the recommendations admit?",
+      "status": "decided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/DNA/delins.md:16",
+          "quote": "changes involving two or more consecutive nucleotides are described as deletion/insertion (delins) variants"
+        },
+        {
+          "clause": "docs/recommendations/DNA/substitution.md:32",
+          "quote": "changes involving two or more consecutive nucleotides are described as deletion-insertion (delins) so the description <code class=\"invalid\">c.[79G>T;80C>T]</code> is not correct"
+        },
+        {
+          "clause": "docs/recommendations/general.md:34",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/general.md:56",
+          "quote": "the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion"
+        },
+        {
+          "clause": "docs/recommendations/DNA/duplication.md:18",
+          "quote": "when a variant can be described as a duplication, it **must** be described as a duplication and not as, e.g., an insertion"
+        }
+      ],
+      "governing": "docs/recommendations/DNA/substitution.md:32",
+      "deviates_from": [
+        "docs/recommendations/general.md:56"
+      ],
+      "rationale": "NO CLAUSE LICENSES A SPLIT AT SEPARATION ZERO, AND THE SPEC MARKS ONE INVALID BY NAME. `general.md:34` and `delins.md:17` govern members separated by ONE OR MORE nucleotides; they say nothing about members separated by none. `delins.md:16` covers that case directly — two or more consecutive changed nucleotides are ONE delins — and `substitution.md:32` supplies the worked counterexample: for `LRG_199t1:c.79_80delinsTT` the split spelling `c.[79G>T;80C>T]` is rendered `class=\"invalid\"` and called \"not correct\" in as many words. That is why `substitution.md:32` and not `:16` is named governing: it is the one place the spec adjudicates the shape rather than defining a type.\n\nTHE ONE CLAUSE THAT COULD BE READ THE OTHER WAY IS `general.md:56`, and it is deviated from. Prioritisation ranks substitution first, so a reader can argue that a one-base changed column adjacent to a delins should stay a substitution. It should not: `:56` ranks the type of ONE description of ONE change, `delins` is absent from its list entirely, and `substitution.md:32` is that argument's own counterexample.\n\nSCOPE, WHICH IS LOAD-BEARING. This settles only the case where BOTH adjacent members consume reference bases — `sub`, `del`, `delins` or `inv` on each side. Where either member is a `dup` or an `ins` the ruling does not reach, because `duplication.md:18` requires a variant describable as a duplication to be described as one, and merging would destroy it. That is a real second conflict and it is left open here. The re-measurement below turned up a THIRD shape the scope clause did not contemplate: an adjacent pair one side of which is a repeat expansion (`NC_TEST.1:g.[266_273del;274_278T[1];280_283del]`). Repeat notation is outside this ruling as written; it is named here rather than quietly folded in, and it is also left open.\n\nTHIS IS AN ADJUDICATED-CORRECT RECORD, AND IT WAS NOT ONE WHEN IT WAS FIRST WRITTEN. The first revision framed the ruling as pinning a DEVIATION: ferro normalized `NM_TEST.1:c.10_13delinsTAAT` to `c.[10_12delinsTAA;13A>T]`, cutting the block at the codon boundary between codon 4 (`c.10_12`) and codon 5 (`c.13_15`) and leaving the halves flush, so the test asserted the WRONG form to keep the gap visible. PR #1537 (\"never split a delins into members on consecutive nucleotides\") merged and closed #1524 before this record was pushed, and ferro now emits the merged `c.10_13delinsTAAT`. The pinned test therefore asserts the SPEC'S form and passes: it is a regression guard against a decided answer, not a deviation marker. The two kinds are not interchangeable, so the record says which it is.\n\nTHE FIGURES MOVED WITH IT, AND THE OLD ONES ARE KEPT BECAUSE THE MEASUREMENT KILLED THE CLAIM. Measured before #1537 over the 11,272-class designed cis corpus (`examples/generate_cis_confluence_corpus.rs`) in the 3' direction: 4,639 divergent classes; 104 of them left an interior gap of zero in a normalized output; 65 of the 104 had an adjacent pair in which both members consume reference — ALL 65 on the `c.` axis and none on `g.`, which is what identified the codon-precision splitter as the producer. Re-measured after #1537 on the same corpus and the same direction: 4,643 divergent classes; 36 leave a zero interior gap in any output (31 counting only the most-split output, which is the shape census's `has-0` bucket); and ZERO fall in this ruling's scope. Every surviving zero-gap adjacency is carved out — 33 classes with a `dup` or an `ins` on one side, 3 with a repeat — so the whole remaining population is precisely the part this record declined to reach. The headline \"65 classes, all on the coding axis\" is dead, and the axis argument that rode on it is dead with it; #1537 removed the shape rather than moving it to another axis.\n\nTHE RULING GENERALISES; IT WAS NOT FITTED TO ONE REPRODUCER. This record's shape census found the defect on the designed cis corpus independently of issue #1524, which had already filed it at 61 rows / 59 distinct over a different corpus — two disjoint corpora, one clause, the same answer, which is the evidence that the reading is about the description rather than about one generator. (Note #1524's title and body cite `DNA/delins.md:15`, the one-nucleotide substitution clause; the text they mean is at `:16`.) Mutalyzer was not consulted and would not be the authority here in any case: the spec states this answer in as many words at `substitution.md:32`, and both precedence orders on record in `adjudication-precedence-order` rank the spec first where it speaks, so this ruling does not depend on which of them is chosen.",
+      "equivalence_classes": [
+        "dna-delins-vs-two-substitutions-79-80"
+      ]
+    },
+    {
+      "id": "separation-is-a-property-of-the-spelling-not-of-the-variant",
+      "question": "The separation rule keys on the number of unchanged nucleotides between two variants, but two spellings of one variant can present different separations. On which of them is the rule to be evaluated?",
+      "status": "undecided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:34",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/DNA/delins.md:17",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/DNA/delins.md:79-84",
+          "quote": "the two variants may have been reported (or might occur) individually"
+        },
+        {
+          "clause": "docs/consultation/open-issues.md:77-78",
+          "quote": "one variant can be described using different formats. This is undesired; HGVS recommendations should be extended by specifying when to use which format."
+        }
+      ],
+      "rationale": "THE QUANTITY THE RULE KEYS ON IS NOT A FUNCTION OF THE VARIANT. `general.md:34` and `delins.md:17` are stated over \"two variants\", which presupposes a decomposition; the separation between them is read off that decomposition, not off the reference and the denoted sequence. A normalizer sees only the latter pair, so the rule as written is not evaluable on what a normalizer knows.\n\nDEMONSTRATED, NOT ARGUED. On a synthetic transcript whose `c.9` is `T` and whose `c.10`/`c.11` are both `A`, the spellings `c.[9del;10del;13del]` and `c.[9del;11del;13del]` denote the same sequence — verified by applying each to the reference through `hgvs_to_spdi`, independently of the normalizer. The first presents separations of 0 and 2, the second separations of 1 and 1. `general.md:34` merges the first pair and splits the second, so it returns two answers for one variant. Both are pinned in `tests/it/cis_confluence_adjudication.rs`.\n\nAT CORPUS SCALE, RE-MEASURED AFTER #1537. Over the 11,272-class designed cis corpus, 642 of the 9,442 distinct `(axis, reference, denoted sequence)` variants are reachable from more than one design, and 286 of those from designs whose separation parameters differ — both unchanged by #1537, which is itself the point: that PR settled the separation-ZERO question, and this record is about every other separation. And of the 4,643 classes that diverge in the 3' direction, 4,568 (98.4%) have the single spanning spelling reaching an output DISJOINT from every output the multi-member spellings reach — i.e. ferro is preserving the partition it was handed rather than deriving one. That is what evaluating a spelling-relative rule looks like from the outside, and it is the mechanism behind two thirds of the pile. (The pre-#1537 figures were 4,639 and 4,567; the shape this record describes is untouched.)\n\nTHE SPEC'S OWN DISCRIMINATOR IS PROVENANCE, WHICH MAKES THIS UNFIXABLE AS STATED. `delins.md:79-84` gives the reason for preferring individual descriptions: \"the two variants may have been reported (or might occur) individually\". Provenance is carried only by the input's spelling. A normalizer that reads it back is, by construction, not confluent; one that ignores it must pick a canonical partition for every `(reference, sequence)` pair, which is `canonical-form-choice-when-both-legal`. `open-issues.md:77-78` records that the committee agrees the gap is a gap.\n\nWHAT IS NOT ESTABLISHED. Which partition should be canonical. Nothing here chooses one, and nothing here should be read as choosing one: the choice moves a stored representation for a downstream consumer and is an operator decision, ranked by `adjudication-precedence-order`. What this record adds is that the question cannot be deferred to `general.md:34`, because `:34` does not answer it.\n\nRE-CHECKED AGAINST #1537, AND STILL UNDECIDED. #1537 (\"never split a delins into members on consecutive nucleotides\") settled the separation-ZERO case and is recorded at `delins-adjacent-members-when-both-consume-reference`. It does not reach this record: the demonstration above turns on a separation-0 pair being MERGED while a separation-1 pair is SPLIT, and #1537 strengthened exactly the first half — `c.[9del;10del;13del]` still normalizes to `c.[9_10del;13del]` and `c.[9del;11del;13del]` still normalizes to itself, so the two spellings of one variant still reach two outputs. Both pinned assertions passed unchanged across #1537. The record stays `undecided`."
     }
   ]
 }

--- a/tests/it/cis_confluence_adjudication.rs
+++ b/tests/it/cis_confluence_adjudication.rs
@@ -1,0 +1,356 @@
+//! Adjudication records for the divergent cis confluence classes.
+//!
+//! `tests/it/cis_confluence_axis.rs` measures the pile — 11 272 designed classes,
+//! **4 643** of which reach more than one normalized output in the 3' direction,
+//! with `declined` and `sequence_changed` both zero. That census says how large
+//! the disagreement is and nothing about what the right answer would be. This
+//! module carries the answers that have been reached, and names the ones that
+//! have not, on concrete inputs rather than on aggregate counts.
+//!
+//! The shape census behind these records is produced by
+//! `examples/dump_confluence_divergences.rs`, which clusters the 4 643 by the
+//! *disagreement* — how the competing outputs' arities relate, and what interior
+//! gaps the more-split one leaves — rather than by the design parameters. Eight
+//! families result; the top four cover **92.6 %**:
+//!
+//! ```text
+//!   3066 (66.0%)  spanning-vs-split/min-2+
+//!    696 (15.0%)  spanning-vs-split/min-1
+//!    271 ( 5.8%)  split-vs-split/min-2+
+//!    267 ( 5.8%)  split-vs-split/min-1
+//!    181 ( 3.9%)  same-arity/min-2+
+//!    131 ( 2.8%)  same-arity/min-1
+//!     28 ( 0.6%)  spanning-vs-split/has-0
+//!      3 ( 0.1%)  split-vs-split/has-0
+//! ```
+//!
+//! **These are the post-#1537 figures, and the movement is the point.** Before
+//! that PR the census read 4 639 classes over *nine* families with a
+//! `same-arity/has-0` arm, and the three `has-0` arms held 104 classes between
+//! them. #1537 ("never split a delins into members on consecutive nucleotides")
+//! merged the flush members, so the `has-0` arms collapsed to 31 and the
+//! `same-arity/has-0` family disappeared entirely. What remains under `has-0` is
+//! the carve-out — see `a_dup_flush_against_a_del_is_left_alone`.
+//!
+//! **One mechanism accounts for 4 568 of the 4 643 (98.4 %)**: the single
+//! spanning spelling reaches an output disjoint from every output the
+//! multi-member spellings reach. Ferro re-partitions a lone `delins` from the
+//! sequence and preserves the member boundaries it is handed otherwise, so two
+//! spellings of one variant keep two partitions. Only 205 classes (4.4 %) have
+//! two *multi-member* spellings disagreeing with each other, and in every one of
+//! those the disagreeing spellings have the same member count — a placement
+//! disagreement, not a partitioning one.
+//!
+//! Four records live here, in **three kinds**. They are not interchangeable
+//! (see the repository `CLAUDE.md`), so each test states its own:
+//!
+//!  - **One adjudicated-correct.**
+//!    `two_adjacent_members_that_both_consume_reference_are_one_delins` pins the
+//!    exact form a cited clause requires, so it fails if behaviour regresses
+//!    away from a decided answer.
+//!  - **One scope carve-out.** `a_dup_flush_against_a_del_is_left_alone` pins
+//!    the limit of that same ruling. Ferro's output there is not adjudicated
+//!    right; it is adjudicated *out of scope*, which is a third thing.
+//!  - **Two pinned open disagreements.**
+//!    `the_separation_two_members_present_is_not_a_property_of_the_variant`
+//!    demonstrates a question its record leaves `undecided`, and
+//!    `a_spanning_delins_and_its_aligned_split_are_two_fixed_points` pins the
+//!    largest family with the ruling it waits on named, so a future session does
+//!    not re-derive it.
+//!
+//! Nothing in this module asserts a behaviour change: every expectation below
+//! is ferro's output on `main` today.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// The synthetic transcript every case here is drawn against, taken verbatim
+/// from `examples/generate_cis_confluence_corpus.rs`'s first core so the cases
+/// are the corpus's own rather than newly invented ones. Its first bases are
+///
+/// ```text
+///   c.  1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+///       T T T T T T T T T  A  A  T  A  T  A  T  T
+/// ```
+///
+/// which is what makes the `c.9`/`c.10`/`c.11` cases below hand-checkable: the
+/// `A` at `c.10` and the `A` at `c.11` are one two-base run, so deleting either
+/// denotes the same sequence.
+const CORE: &str = "TTTTTTTTTAATATATTTTAATATAATTAAAAAAATAATTTTTATAAATATATTATTTTAAAAA";
+
+const TX_ACCESSION: &str = "NM_TEST.1";
+const TX_CONTIG: &str = "chr_synth";
+const PAD_OFFSET: usize = 256;
+const CDS_START: u64 = 1;
+const CDS_END: u64 = 63;
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let tx_len = CORE.len() as u64;
+    let g_start = PAD_OFFSET as u64 + 1;
+    let g_end = PAD_OFFSET as u64 + tx_len;
+    let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+    let transcript = Transcript::new(
+        TX_ACCESSION.to_string(),
+        Some("SYNTH".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        Some(CDS_START),
+        Some(CDS_END),
+        vec![exon],
+        Some(TX_CONTIG.to_string()),
+        Some(g_start),
+        Some(g_end),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+    let pad = "ACGT".repeat(PAD_OFFSET / 4);
+    provider.add_genomic_sequence(TX_CONTIG, format!("{pad}{CORE}{pad}"));
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalized(provider: &MockProvider, description: &str) -> String {
+    let variant = parse_hgvs(description).unwrap_or_else(|e| panic!("{description}: {e}"));
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("{description}: {e}"))
+        .to_string()
+}
+
+/// The sequence a description denotes, established by applying it to the
+/// reference through `hgvs_to_spdi` — the corpus's own ground-truth oracle, and
+/// the only one in the repository that is independent of the normalizer by
+/// construction. Every "these two spellings are one variant" claim below is
+/// checked with this rather than asserted.
+fn denotes(provider: &MockProvider, description: &str) -> String {
+    let members: Vec<HgvsVariant> = match parse_hgvs(description).expect("parses") {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let mut triples: Vec<(usize, String, String)> = members
+        .iter()
+        .map(|member| {
+            let triple = hgvs_to_spdi(member, provider).expect("applies");
+            (
+                usize::try_from(triple.position).expect("non-negative"),
+                triple.deletion.clone(),
+                triple.insertion.clone(),
+            )
+        })
+        .collect();
+    // 3' to 5', longer deletion first — the `cis_apply_oracle` walk, so a member
+    // is never spliced over one that has already been applied.
+    triples.sort_by_key(|t| (std::cmp::Reverse(t.0), std::cmp::Reverse(t.1.len())));
+    let mut edited = CORE.as_bytes().to_vec();
+    for (position, deletion, insertion) in &triples {
+        let end = position + deletion.len();
+        assert_eq!(
+            &CORE.as_bytes()[*position..end],
+            deletion.as_bytes(),
+            "{description}: stated bases disagree with the reference"
+        );
+        edited.splice(*position..end, insertion.bytes());
+    }
+    String::from_utf8(edited).expect("ascii")
+}
+
+// ---------------------------------------------------------------------------
+// Record 1 — settled: separation is a property of the spelling
+// ---------------------------------------------------------------------------
+
+/// **Adjudication.** `general.md:34` and `DNA/delins.md:17` — "two variants
+/// separated by one or more nucleotides should be described individually and
+/// **not** as a 'delins'" — key on a quantity the *variant* does not carry.
+/// Two spellings of one variant can present different separations, so the rule
+/// returns two answers for one variant and cannot be evaluated confluently.
+///
+/// **Authority.** Ruling record
+/// `separation-is-a-property-of-the-spelling-not-of-the-variant`, status
+/// `undecided` as to which partition should be canonical — this test pins the
+/// *demonstration*, which is settled, not the choice, which is not.
+///
+/// The case: `c.10` and `c.11` are both `A`, so deleting one or the other is the
+/// same edit. `c.[9del;10del;13del]` therefore denotes exactly what
+/// `c.[9del;11del;13del]` denotes — checked here through the apply oracle, not
+/// assumed. But the first spells its members at separations 0 and 2 and the
+/// second at 1 and 1, and `general.md:34` merges a separation-0 pair while
+/// splitting a separation-1 pair. Ferro follows it, and produces two outputs.
+#[test]
+fn the_separation_two_members_present_is_not_a_property_of_the_variant() {
+    let provider = provider();
+    let adjacent = "NM_TEST.1:c.[9del;10del;13del]";
+    let apart = "NM_TEST.1:c.[9del;11del;13del]";
+    let spanning = "NM_TEST.1:c.9_13delinsAT";
+
+    // One variant: verified by application, independently of the normalizer.
+    let sequence = denotes(&provider, adjacent);
+    assert_eq!(denotes(&provider, apart), sequence);
+    assert_eq!(denotes(&provider, spanning), sequence);
+
+    // Three outputs. The separation each spelling presents is what selects them,
+    // and no two spellings present the same one.
+    assert_eq!(
+        normalized(&provider, adjacent),
+        "NM_TEST.1:c.[9_10del;13del]",
+        "separations 0 and 2: `delins.md:16` merges the adjacent pair"
+    );
+    assert_eq!(
+        normalized(&provider, apart),
+        "NM_TEST.1:c.[9del;11del;13del]",
+        "separations 1 and 1: `general.md:34` keeps all three individual"
+    );
+    assert_eq!(
+        normalized(&provider, spanning),
+        "NM_TEST.1:c.9_13delinsAT",
+        "no members at all, so no separation to read: the spanning form survives"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Record 2 — settled, and ferro conforms: adjacent members
+// ---------------------------------------------------------------------------
+
+/// **Adjudication.** A normalized allele must not leave two members with no
+/// unchanged nucleotide between them when both consume reference bases.
+/// `DNA/delins.md:16` covers consecutive changed nucleotides — they are one
+/// delins — and `DNA/substitution.md:32` marks the split spelling of exactly
+/// that shape `class="invalid"`, saying of `LRG_199t1:c.79_80delinsTT` that
+/// "the description `c.[79G>T;80C>T]` is not correct". `general.md:34` does not
+/// compete: it governs members separated by *one or more* nucleotides and says
+/// nothing about members separated by none.
+///
+/// **Authority.** Ruling record
+/// `delins-adjacent-members-when-both-consume-reference`, status `decided`,
+/// governing `DNA/substitution.md:32`, deviating from `general.md:56`.
+///
+/// **Adjudicated-correct**, and it did not start that way. When this record was
+/// first written ferro cut `c.10_13delinsTAAT` at the codon boundary between
+/// codon 4 (`c.10_12`) and codon 5 (`c.13_15`) and emitted
+/// `c.[10_12delinsTAA;13A>T]` — two flush members — so the test asserted the
+/// wrong form and labelled it a deviation. **PR #1537 fixed it and closed
+/// #1524**, so this now asserts the form the spec states and fails if that
+/// regresses. The corpus figure that came with the old framing — all 65 classes
+/// with this shape on the `c.` axis, none on `g.` — is gone with it: after
+/// #1537 the count in this ruling's scope is **zero**.
+///
+/// **Scope.** Both adjacent members must consume reference bases; see
+/// `a_dup_flush_against_a_del_is_left_alone` for the other side of that line.
+#[test]
+fn two_adjacent_members_that_both_consume_reference_are_one_delins() {
+    let provider = provider();
+    let spanning = "NM_TEST.1:c.10_13delinsTAAT";
+    let authored = "NM_TEST.1:c.[9dup;13del]";
+
+    assert_eq!(denotes(&provider, spanning), denotes(&provider, authored));
+
+    // `c.10_12` and `c.13` would be adjacent — no unchanged nucleotide between
+    // them — so `delins.md:16` asks for the single delins this input already
+    // was, and `substitution.md:32` marks the split invalid by name.
+    assert_eq!(
+        normalized(&provider, spanning),
+        "NM_TEST.1:c.10_13delinsTAAT",
+        "adjudicated CORRECT against `DNA/substitution.md:32`; fixed by #1537, closing #1524"
+    );
+    // The other spelling of the same variant still keeps its own partition, so
+    // the class remains divergent. That residue is not this record's — it is
+    // `separation-is-a-property-of-the-spelling-not-of-the-variant`, undecided.
+    assert_eq!(normalized(&provider, authored), "NM_TEST.1:c.[9dup;13del]");
+}
+
+// ---------------------------------------------------------------------------
+// Record 3 — the scope limit of record 2, pinned on a real corpus class
+// ---------------------------------------------------------------------------
+
+/// **Adjudication.** The merge above stops where `DNA/duplication.md:18` starts:
+/// "when a variant can be described as a duplication, it **must** be described
+/// as a duplication and not as, e.g., an insertion". Merging a `dup` into a
+/// flush neighbour destroys the duplication, so the ruling does not reach an
+/// adjacency with a `dup` or an `ins` on either side. That conflict is real and
+/// is deliberately left open.
+///
+/// **Authority.** The `SCOPE` paragraph of ruling record
+/// `delins-adjacent-members-when-both-consume-reference` — a carve-out from a
+/// `decided` record, not a deviation from it. Ferro's output here is not
+/// adjudicated right; it is adjudicated *out of scope*.
+///
+/// The case is corpus class `s00-c-m4-sep3-p8-rot3`, taken verbatim rather than
+/// invented, and it is one of the 33 classes that still leave a zero interior
+/// gap after #1537. `c.16_23dup` and `c.24_31del` are flush and stay flush.
+#[test]
+fn a_dup_flush_against_a_del_is_left_alone() {
+    let provider = provider();
+    let authored = "NM_TEST.1:c.[9T>A;13_20dup;24_31del;34_35insCACCAAAA]";
+
+    assert_eq!(
+        normalized(&provider, authored),
+        "NM_TEST.1:c.[9T>A;16_23dup;24_31del;34_35insCACCAAAA]",
+        "separation 0 between `16_23dup` and `24_31del`, and `DNA/duplication.md:18` \
+         competes — outside the scope of the adjacency ruling, not a deviation from it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Record 4 — open on the split-input side: the spanning delins against its
+// aligned split
+// ---------------------------------------------------------------------------
+
+/// **Not settled on the side this test pins, and it names the record that turns
+/// on.** This is the largest family in the pile — 3 066 of 4 643 classes,
+/// 66.0 % — and it is
+/// the spec's own `DNA/delins.md:44-47` shape reproduced synthetically: parts of
+/// the inserted sequence align with the reference, giving an alternative
+/// description as separate members. `:17` read literally demands the split;
+/// `:47` recommends the delins three lines later, in the spec's own worked
+/// example.
+///
+/// **Authority.** Ruling record `delins-merge-vs-individual-gap-two-or-more`,
+/// whose committed status is **`decided`** — for `:47`, and *scoped*. It
+/// settles only "a MINIMAL single `delins` that would be split because payload
+/// bases coincide with reference bases", and says in as many words that it is
+/// "NOT a general licence to merge changes separated by two or more
+/// nucleotides". Ferro emitting `:47`'s form from the spanning spelling is that
+/// ruling working. What is **not** settled is the other side: whether the scope
+/// reaches a spelling that arrives already split, so that
+/// `c.[9_12del;14_17del]` ought to converge on the delins too. Nothing here
+/// decides that — both outputs are pinned as observations, and converging them
+/// is a representation change for a stored library. The equivalence class
+/// `dna-delins-vs-aligned-split-850-901` is the spec's own instance of the pair.
+///
+/// (An earlier revision of this comment described that record as `undecided`.
+/// It was already `decided` when this test was written; only the status word
+/// is corrected here, not the disposition of the case.)
+///
+/// The premise of `:44-47` — that parts of the payload align with the
+/// reference — holds for **every** class in this corpus, not just this family:
+/// two spellings can only denote one sequence if the coarser one's payload
+/// re-states the finer one's interior gap bases. So the whole 4 643 is one
+/// question wearing eight shapes, and this record is where it is named.
+#[test]
+fn a_spanning_delins_and_its_aligned_split_are_two_fixed_points() {
+    let provider = provider();
+    let spanning = "NM_TEST.1:c.9_17delinsA";
+    let split = "NM_TEST.1:c.[9_12del;14_17del]";
+
+    assert_eq!(denotes(&provider, spanning), denotes(&provider, split));
+
+    // `:47` recommends this one.
+    assert_eq!(normalized(&provider, spanning), "NM_TEST.1:c.9_17delinsA");
+    // `:17` and `general.md:34` demand this one — the members are two unchanged
+    // nucleotides apart, and `general.md:35`'s codon exception needs a gap of
+    // exactly one, so it cannot rescue either side here.
+    assert_eq!(
+        normalized(&provider, split),
+        "NM_TEST.1:c.[9_12del;15_18del]",
+        "pinned as an observation: whether `delins-merge-vs-individual-gap-two-or-more`'s \
+         scope reaches a spelling that arrives already split is not settled"
+    );
+}

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -595,6 +595,18 @@ const EQUIVALENCE_CLASS_VERDICTS: &[(&str, &str)] = &[
     // acceptance but cannot see that it is also a second fixed point.
     ("dna-delins-vs-two-substitutions-145-147", "non-confluent"),
     ("rna-delins-vs-two-substitutions-142-144", "non-confluent"),
+    // Separation ZERO, and the only class here at that separation — the three
+    // above are all separation one. `substitution.md:32` marks the split
+    // spelling `class="invalid"`, and ferro merges it: both members reach
+    // `LRG_199t1:c.79_80delinsTT`. So this is the positive control for ruling
+    // `delins-adjacent-members-when-both-consume-reference`, which is `decided`
+    // and which ferro conforms to as of #1537.
+    //
+    // Note it is `confluent` where its separation-one siblings are not, and the
+    // reason is not that the ruling is stronger: this merge needs no reading
+    // frame, so the empty-provider limit documented above does not bite. Do not
+    // read the contrast as evidence about the carve-out.
+    ("dna-delins-vs-two-substitutions-79-80", "confluent"),
     // Spelled-out run vs repeat count for an unspecified insertion. Nothing in
     // the spec ranks the two, so no rule is being broken — but a single variant
     // still has two stable outputs.
@@ -832,6 +844,27 @@ const RULING_STATUSES: &[(&str, &str)] = &[
     // answers both ways depending on input-hygiene mode. Upstream's conflict to
     // settle (#466), not ferro's.
     ("rna-repeat-range-plus-unit-redundancy", "undecided"),
+    // A normalized allele must not leave two members flush against each other
+    // when both consume reference bases. `substitution.md:32` marks exactly that
+    // spelling `class="invalid"` for `LRG_199t1:c.79_80delinsTT`, and
+    // `general.md:34` does not compete — it governs members separated by one or
+    // more nucleotides, not by none. Ferro CONFORMS as of #1537, which closed
+    // #1524; `cis_confluence_adjudication.rs` pins the spec's form as a
+    // regression guard, not the deviation the record was first written against.
+    (
+        "delins-adjacent-members-when-both-consume-reference",
+        "decided",
+    ),
+    // The separation `general.md:34` keys on is read off a decomposition, and
+    // two spellings of one variant can present different ones — demonstrated,
+    // not argued, in `cis_confluence_adjudication.rs`. #1537 settled the
+    // separation-ZERO half and left this untouched: both pinned spellings still
+    // reach two outputs. Undecided as to which partition should then be
+    // canonical; that is `canonical-form-choice-when-both-legal`.
+    (
+        "separation-is-a-property-of-the-spelling-not-of-the-variant",
+        "undecided",
+    ),
 ];
 
 /// Ruling records must stay well-formed, and `undecided` must stay undecided.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -45,6 +45,7 @@ mod bulk_fixture_tests;
 mod case_harvest;
 mod cds_utr3_crossing_shift_idempotency;
 mod cis_allele_confluence_proptest;
+mod cis_confluence_adjudication;
 mod cis_confluence_axis;
 mod cis_junction_crossing_shift;
 mod cis_spelling_confluence_gap;


### PR DESCRIPTION
Two ruling records for the divergent cis confluence classes, plus the shape-census harness that produced them. One record is decided and ferro conforms; the other is honestly undecided.

## What the decided record says now

`delins-adjacent-members-when-both-consume-reference` — a normalized allele must not leave two members with no unchanged nucleotide between them when both consume reference bases. `general.md:34` and `DNA/delins.md:17` govern members separated by *one or more* nucleotides and say nothing about members separated by none. `DNA/delins.md:16` covers that case, and `DNA/substitution.md:32` adjudicates it by name: for `LRG_199t1:c.79_80delinsTT` it renders `c.[79G>T;80C>T]` `class="invalid"` and calls it "not correct" in as many words. `substitution.md:32` governs; `general.md:56` is the one clause readable the other way and is deviated from.

The scope is load-bearing and unchanged: this reaches only `sub`/`del`/`delins`/`inv` on both sides. Where a `dup` or an `ins` is one side, `DNA/duplication.md:18` genuinely competes and the ruling declines. A third shape turned up in re-measurement — a repeat expansion flush against a neighbour — and is named as outside the scope rather than folded in.

## #1537 overtook the original framing

The record was written against a tree where ferro emitted `NM_TEST.1:c.[10_12delinsTAA;13A>T]` for `c.10_13delinsTAAT`, cutting at the codon boundary between codon 4 and codon 5 and leaving the halves flush. It was framed as pinning a **deviation**, and the test asserted the wrong form on purpose.

#1537 ("never split a delins into members on consecutive nucleotides") merged and closed #1524 before this branch was pushed. Ferro now emits the merged form. The record is therefore re-authored as **adjudicated-correct**: the test asserts the spec's form and is a regression guard against a decided answer. Those two kinds are not interchangeable, so the record and the `RULING_STATUSES` comment both say which one it is.

The record is not deleted and not weakened — it is vindicated. It found #1524's defect independently, on the designed cis corpus, while #1524 had filed it at 61 rows / 59 distinct over a different corpus. Two disjoint corpora reaching one clause is the evidence that the reading is about the description rather than about one generator. Mutalyzer was not consulted and is not the authority here; both precedence orders on record in `adjudication-precedence-order` rank the spec first where it speaks.

## The corrected figures

Re-measured with `examples/dump_confluence_divergences.rs` over the 11,272-class designed cis corpus, 3' direction, at `3ab10a09`. Old figures are the ones this branch originally committed, measured pre-#1537.

| | committed claim (pre-#1537) | re-measured now |
|---|---:|---:|
| divergent classes | 4,639 | **4,643** |
| largest family (`spanning-vs-split/min-2+`) | 3,056 (65.9%) | **3,066 (66.0%)** |
| families | 9 | **8** (`same-arity/has-0` is gone) |
| zero interior gap, most-split output (`has-0` census bucket) | 104 | **31** |
| zero interior gap in any output | — | **36** |
| **in this ruling's scope** | **65, all `c.`, none `g.`** | **0** |
| carved out — `dup`/`ins` on one side | 39 | **33** |
| a repeat on one side (uncontemplated) | — | **3** |
| spanning output disjoint from every multi-member output | 4,567 (98.4%) | **4,568 (98.4%)** |

The headline "65 classes, all on the coding axis" is dead, and the codon-splitter attribution that rode on it is dead with it. #1537 removed the shape rather than moving it to another axis: every one of the 36 surviving zero-gap adjacencies is in the carve-out the record explicitly declined to reach. That is recorded in the rationale rather than quietly overwritten, because a measurement that kills a claim is worth as much as the ruling.

The 4,643 agrees exactly with the committed `THREE_PRIME` census in `cis_confluence_axis.rs` (4,509 + 115 + 19), which #1537 already re-pinned on `main`.

**Note on one figure that was reported to me as moving and does not.** A hand-off table described the post-#1537 governed set as splitting 11 `c.` / 17 `g.` / 3 other. That is the axis breakdown of the `has-0` *family buckets* (`spanning-vs-split/has-0` 11 `c.` + 17 `g.`, `split-vs-split/has-0` 3 `g.`), not of the set this ruling governs. Enumerating the adjacency kind-pairs directly, the governed set is empty: the zero-gap adjacencies that remain are `dup`/`sub` ×18, `ins`/`repeat` ×7, `delins`/`dup` ×6, `del`/`dup` ×2, `repeat`/`repeat` ×2, `del`/`repeat` ×1, `repeat`/`sub` ×1. Not one is a pair of reference-consuming members.

## The undecided record still holds

`separation-is-a-property-of-the-spelling-not-of-the-variant` stays `undecided`, re-checked rather than assumed. Its demonstration turns on a separation-0 pair being merged while a separation-1 pair is split: on the corpus's own transcript `c.[9del;10del;13del]` and `c.[9del;11del;13del]` denote one sequence (verified through the apply oracle) and present separations {0,2} and {1,1}. #1537 strengthened the merge half and left the split half alone, so both pinned assertions passed across it unchanged and the two spellings still reach two outputs. Its corpus figures are re-measured (642 of 9,442 variants multi-design, 286 of differing separation, 4,568 spanning-disjoint) and the rationale now records the re-check.

## Tests

Four pinned cases, each stating whether it is adjudicated-correct, a scope carve-out, or a pinned open disagreement:

- `the_separation_two_members_present_is_not_a_property_of_the_variant` — the undecided record's demonstration.
- `two_adjacent_members_that_both_consume_reference_are_one_delins` — the decided record, now a conformance guard (was `a_codon_boundary_cut_leaves_two_adjacent_members_which_the_spec_marks_invalid`).
- `a_dup_flush_against_a_del_is_left_alone` — **new.** The scope limit, pinned on real corpus class `s00-c-m4-sep3-p8-rot3` rather than an invented input: `c.16_23dup` and `c.24_31del` are flush and stay flush, because `duplication.md:18` competes.
- `a_spanning_delins_and_its_aligned_split_are_two_fixed_points` — the largest family, blocked on `delins-merge-vs-individual-gap-two-or-more`.

The first three verify their spellings denote one sequence through `hgvs_to_spdi` before comparing normalized outputs, so none can pass on a false premise.

## Verification

- `cargo run --features dev --bin generate_spec_fixture` — clean; it is what validates the edited records (quote-checks every citation against the spec checkout, and refuses an `undecided` record naming a governing clause or citing fewer than two).
- `cargo nextest run --features dev -E 'test(ruling_records_are_intact)'` — `1 test run: 1 passed`.
- `cargo fmt --all -- --check` — clean. `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev -E 'binary(it)'` — `5448 tests run: 5448 passed, 145 skipped`. **Nothing re-blessed.** For an output-touching record that is the strong signal: every existing expectation already agreed.

## Review fixes (dual-review sweep)

All seven confirmed findings are fixed, amended into the commit that introduced each.

**F1 — three unit tests had never run.** The `[[example]]` entry for `dump_confluence_divergences` lacked `test = true`, so cargo never built the target's tests: `cargo nextest run --features dev -E 'binary(dump_confluence_divergences)'` reported `0 tests run`. Added, and all three pass — including `an_insertion_consumes_no_reference_position`, the pin on the arithmetic that has already published wrong numbers. Nothing was hiding behind them. Two further tests are added below.

**F2 — three uncounted silent-drop paths.** A `Drops` struct now counts spellings `parse_hgvs` rejects, spellings normalization errors or panics on, and divergent classes excluded because a member's spans could not be resolved. `render_census` prints all three unconditionally. A failed span resolution used to become `unwrap_or_default()` → `[]` → `classify_gaps` → `no-gaps`, so a multi-member output whose geometry was never measured left the `has-0` population silently; such a class is now excluded and counted rather than classified. **Measured: `0 spellings unparsed, 0 spellings unnormalized, 0 divergent classes excluded`.**

**F3 — `relation` misclassified arity-`[1]` classes.** `arities.first() == Some(&1)` filed a class whose outputs are all single-member as `spanning-vs-split`, asserting a split that is not there and making `same-arity` unreachable at arity 1. Now `arities.len() > 1 && arities.contains(&1)`, extracted as `relation_of` and pinned by a new unit test. **Measured: the arity-`[1]` population is 0, so the headline family was not in fact contaminated.**

**F4 — `spans` were coordinate-sorted while `kinds` stayed in text order**, then paired positionally, so for any allele not already written in coordinate order the two described different members — and the decided record's adjacency kind-pair enumeration is exactly that join. `spans_of` is replaced by `members_of`, which returns rendered text paired with its interval in one order. **Measured: no record changes, so no allele in this corpus writes its members out of coordinate order.**

**F5 — two stale pre-#1537 figures** in a doc comment (`3 056 of 4 639`, `nine shapes`) corrected to `3 066 of 4 643` and `eight shapes`. Three more of the same vintage were found in the generator's own header and corrected too (`6 633` → `6 629` converged, `4 639` → `4 643`, `673` → `663` distinct shapes).

**F6 — the record cited a separation-ONE equivalence class.** Fixed the preferred way rather than by dropping the association: a new class `dna-delins-vs-two-substitutions-79-80` is built from the ruling's own governing clause, `DNA/substitution.md:32`, which renders `c.[79G>T;80C>T]` `class="invalid"` for `LRG_199t1:c.79_80delinsTT`. It is the fixture's only separation-zero class, and `delins-adjacent-members-when-both-consume-reference` now points at it instead of at `145-147` (which remains where it belongs, on `delins-codon-carve-out-gap-one`). It resolves **`confluent`** — both spellings reach `LRG_199t1:c.79_80delinsTT` — so it is a positive control for the decided ruling rather than another pinned failure.

**F7 — the module header's two-and-two tally** is replaced by the three kinds the tests actually are: one adjudicated-correct, one scope carve-out, two pinned open disagreements.

**An eighth, found while fixing F5/F7 and not raised by either lens.** Test 4's doc comment described ruling `delins-merge-vs-individual-gap-two-or-more` as status **`undecided`**. It was already `decided` at this branch's own base — decided for `:47` and *scoped*. Only the status word and the framing around it are corrected: the record settles the spanning side, and what this test pins as open is the other side, whether that scope reaches a spelling arriving already split. Nothing here decides that; both outputs stay pinned as observations.

## Census: re-measured after the fixes, and unchanged

F2 and F3 can legitimately move the numbers these records quote, so the generator was re-run and diffed against the pre-fix run. **The census output is byte-identical.** Every figure the two ruling records and the module doc comment quote stands:

| figure | before fixes | after fixes |
|---|---:|---:|
| divergent classes | 4 643 | 4 643 |
| families | 8 | 8 |
| largest, `spanning-vs-split/min-2+` | 3 066 (66.0%) | 3 066 (66.0%) |
| `has-0` arms | 28 + 3 = 31 | 28 + 3 = 31 |
| `input-partition-preserving` | 3 189 (68.7%) | 3 189 (68.7%) |
| distinct shapes | 663 | 663 |
| dropped | *not reported* | 0 / 0 / 0 |

The three defects were real but each had an **empty population on this corpus** — 0 arity-`[1]` classes, 0 unresolved spans, 0 records changed by the join fix. Reporting that as a structural zero rather than as evidence of safety: the corpus is what makes them inert, not the code, and the counters now make a future non-zero visible instead of silent.

## Conflict note

Rebased onto `origin/main` after #1544 landed. That PR appends to the same `rulings` array and the same `RULING_STATUSES` tail, so both files conflicted and were hand-resolved as a **union** — #1544's two `undecided` records and this branch's two both survive, in the JSON and in `RULING_STATUSES`, which `ruling_records_are_intact` checks stay in sync. Ten records total. `hgvs_spec_normalization_overrides.json` is committed, not generated, so nothing was regenerated to resolve it. The diff against `main` is purely additive.

Representation-Change: none. No file under `src/` is touched — the diff is one fixture JSON, one new test module, and one test-registry comment. Measured rather than assumed: the full `it` suite passes with zero re-blessed expectations, and the committed `THREE_PRIME`/`FIVE_PRIME` censuses in `cis_confluence_axis.rs` are unchanged. The one output this branch's expectations moved (`c.10_13delinsTAAT`) was moved by #1537, which declared it; this PR only stops asserting the pre-#1537 form.

Closes nothing; #1524 was closed by #1537.
