### PR TITLE
feat(conformance): refuse to write an artifact built from a partial generator pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,87 @@ is **spec-explicit > Mutalyzer > our judgement**. Where the spec is explicit and
 that is a deliberate divergence and it gets a record saying so — otherwise the next person
 measures Mutalyzer, finds a mismatch, and "fixes" a conformance decision.
 
+### A generator must account for what it dropped
+
+This is the mechanized half of **"a corpus zero is a claim about the corpus, not about the
+change"** — the doctrine that a generator's `0` reads as *"this is safe"* when it usually means
+*"the corpus could not build the thing you changed"*. That doctrine covers a zero the generator
+*reports*. The same trap one level down is a population the generator **silently drops**: a
+fallible step whose failure is representable as a legitimate value —
+`spans_of(..).unwrap_or_default()` classifying as "no gaps", `else { continue }` skipping exactly
+the record that had a problem, a discarded `Result`. Nothing counts it, so a partial run and a
+clean run write indistinguishable artifacts and the only thing separating them is whether a
+reviewer read the right five lines.
+
+**Route the population through `CaptureLedger`** (`src/conformance/completeness.rs`, #1550):
+
+```rust
+use ferro_hgvs::conformance::completeness::{Allowance, CaptureLedger};
+
+let mut ledger = CaptureLedger::new("transcript windows");
+for accession in &accessions {
+    // Replaces `let Ok(t) = resolve(a) else { continue };` — same control flow,
+    // but the drop is now accounted for.
+    // `record`'s subject is `impl Into<String>`, which `&String` does not
+    // satisfy and does not auto-deref to — hence `as_str()`.
+    let Some(transcript) = ledger.record(accession.as_str(), resolve(accession)) else {
+        continue;
+    };
+    capture(transcript);
+}
+// `finish` refuses on any shortfall, and on a pass that attempted nothing.
+// Waiving one means naming it: `finish_with(Allowance::at_most(1, "why"))`.
+let counts = ledger.finish()?;
+```
+
+Three things follow. **Only one of them is enforced by a test; the other two are conventions, and
+saying otherwise here would be the exact defect this section is about** — a claim that reads as
+coverage while providing none:
+
+- **A generator carrying `#[cfg(test)]` must set `test = true` on its cargo target.** Enforced by
+  `it::generator_completeness::examples_with_unit_tests_opt_into_running_them`, whose two halves
+  are not equally strong: the manifest is *parsed* as TOML, so `test = true` is read rather than
+  guessed, but `#[cfg(test)]` is found by scanning the compiled sources for that literal token —
+  which matches it inside a doc comment and misses `#[cfg(all(test, feature = "dev"))]`. Say
+  "parsed manifest, token scan", not "exact". Cargo does not build a target's tests unless it
+  opts in, so without the flag they never run — and a committed test that has never executed is
+  worse than none, because it reads as coverage. `report_conformance_reference_gaps` shipped one
+  for months.
+- **Refuse, do not report.** A convention, backed by the *type* rather than by a guard over your
+  code. `finish()` returns a `Result` you must handle before reaching your `fs::write`, and
+  `CaptureCounts` has no `Default`, so `finish().unwrap_or_default()` does not compile. Nothing
+  stops `let _ = ledger.finish();`.
+- **Stamp the counts into the artifact.** A convention, enforced by **nothing**. `CaptureCounts`
+  is serde-serializable so a fixture *can* carry its own completeness claim and a consuming test
+  *can* assert on it — no test anywhere checks that any artifact does.
+
+`tests/it/generator_completeness.rs` holds the `test = true` invariant above and a second guard:
+a generator that looks like it writes an artifact must look like it routes its population through
+the ledger, or name itself in `LEDGER_EXEMPT`. **Read that second one as a floor, not a proof.**
+Both of its sides are substring scans over source text — `fs::write(`, `File::create(`,
+`OpenOptions::new(`, `from_path(` on one side; on the other, a `use` line naming
+`conformance::completeness`, the word `CaptureLedger`, and a `finish` call, all three in the
+generator's own entry point. A writer using an idiom outside that list is invisible to it, and
+"routes its population through" is a semantic question a grep cannot answer. What it does buy: a
+generator written the way every generator in this repo is currently written cannot be added in
+silence, and the question gets asked. The semantic guarantee is carried by the ledger and by
+review.
+
+The allowlist is **shrink-only** — a row whose generator has been deleted, stopped matching the
+write idioms, or now imports the ledger and calls `finish` fails the test — so it cannot rot into
+a blanket exemption. The "now uses the ledger" direction is deliberately hard to trip by accident,
+because acting on it *deletes* a row: an earlier revision keyed on the bare word `CaptureLedger`
+anywhere in the compiled sources, and one comment appended to the shared
+`examples/common/recording.rs` marked three unrelated generators as migrated and demanded their
+rows be removed. Adding a row is a legitimate answer, in the same way
+`Representation-Change: none` is; what neither check tolerates is silence.
+
+**And note what the ledger itself does not claim.** It accounts for the step you route through
+it, not for the artifact: `succeeded` is never compared against the rows that reach the file, so a
+pass with a second unaccounted fallible step can stamp
+`{"attempted":10,"succeeded":10,"dropped":0}` onto an artifact holding five rows. Route the
+*last* fallible step before the write, not the first.
+
 ### Python Tests
 ```bash
 pytest tests/python/ -v              # Run all Python tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,64 @@ test count the script prints is a weaker signal than the manifest check.
 FERRO_MANIFEST=/path/to/manifest.json scripts/run_conformance_axis.sh
 ```
 
+### Adding or changing a generator under `examples/`
+
+Generators build the corpora, fixtures and tables the rest of the suite adjudicates
+against, and they share one failure mode: a fallible step whose failure is
+representable as a legitimate value — `unwrap_or_default()`, `else { continue }`, a
+discarded `Result`. The dropped population is never counted, so a partial run and a
+clean run write indistinguishable artifacts. This is the same trap as the
+"a corpus zero is a claim about the corpus, not about the change" rule in `CLAUDE.md`,
+one level down: there the misleading number is *reported*, here it is never computed.
+
+Two rules, with two very different amounts of machinery behind them —
+`tests/it/generator_completeness.rs` (#1550) has a guard for each, and **neither guard is
+exact end to end**. Rule 2 parses the manifest but only token-scans the source; rule 1 is a
+substring heuristic on both sides. It matters that you know which half you are leaning on:
+
+1. **A generator that writes an artifact routes its population through
+   `CaptureLedger`** (`src/conformance/completeness.rs`). Record a success or a drop
+   for every record — `ledger.record(id, fallible())` is a drop-in for
+   `let Ok(v) = fallible() else { continue };` — and call `finish()` before writing.
+   It returns a `Result` and refuses on any shortfall, including a pass that attempted
+   nothing. An expected shortfall is waived by naming it:
+   `finish_with(Allowance::at_most(2, "bare LRG_ ids have no versioned index entry"))`.
+   The counts are serializable, so stamp them into the artifact and let the consuming
+   test assert on them.
+
+   Route the **last** fallible step before the write, not the first. The ledger accounts
+   for the step you hand it and nothing else — it never sees the artifact, so a second
+   unaccounted `else { continue }` downstream will happily let you stamp
+   `{"attempted":10,"succeeded":10,"dropped":0}` onto a file holding five rows.
+
+   If you are not adopting the ledger, add your generator to `LEDGER_EXEMPT` in that
+   test with a reason. That is a legitimate answer — what the check rejects is silence.
+   The list is shrink-only: a row that is no longer needed fails the test.
+
+   **The guard behind this rule is a heuristic floor.** It asks whether your source
+   contains one of a few write idioms (`fs::write(`, `File::create(`,
+   `OpenOptions::new(`, `from_path(`) and, if so, whether your entry point carries a
+   `use` line naming `conformance::completeness`, the word `CaptureLedger`, and a
+   `finish` call — all three in that one file. Both sides are substring scans: write a
+   file some other way and the ratchet never notices, import the ledger through a
+   fully-qualified path or a rustfmt-wrapped `use` group and it reads as un-adopted,
+   and "routes its population through" is not something a grep can check. So treat a green test as "the
+   question got asked", not as "this generator is accounted for" — the accounting is
+   yours and your reviewer's to get right. Nothing checks that any artifact actually
+   carries its `CaptureCounts`, either; stamping them is a convention.
+
+2. **A generator carrying `#[cfg(test)]` sets `test = true` on its `[[example]]` or
+   `[[bin]]` entry in `Cargo.toml`.** Cargo does not build a target's tests unless it
+   opts in, so without it they silently never run — which reads as coverage while
+   providing none. **The manifest side is exact and the source side is a token
+   scan**: `test = true` is read out of parsed TOML, but `#[cfg(test)]` is
+   detected by looking for that literal token, so gating your tests as
+   `#[cfg(all(test, feature = "dev"))]` slips past it. `#[path]` includes are
+   followed transitively (`test = true` is a per-target flag, so a `#[cfg(test)]`
+   in a shared `examples/common/` module is dead in every target that does not opt
+   in). A plain `mod helper;` include is the one boundary — the repo uses `#[path]`
+   throughout.
+
 ## Code Style
 
 - Format with `cargo fmt`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,15 @@ tempfile = "3.14"
 rstest = "0.23"
 serde_yaml = "0.9"
 anyhow = "1"
+# Used by tests/it/generator_completeness.rs to read this manifest's own
+# `[[example]]`/`[[bin]]` tables. The invariant it enforces is a property OF
+# Cargo.toml (`test = true` on every generator carrying `#[cfg(test)]`), so it
+# has to parse the manifest rather than substring-match it — a `test = true`
+# inside a comment, or under a `[[bench]]`, must not count. `toml` is already an
+# optional runtime dependency (`web-service`); it is repeated here because
+# `tests/it` compiles without `--features dev`, so the optional copy is not
+# guaranteed to be enabled. Cargo unifies the two for test targets.
+toml = "0.8"
 # Used by examples/build_conformance_snapshot.rs to record a per-entry SHA-256 of
 # the harvested bases (snapshot provenance). Examples have access to
 # dev-dependencies, so this stays out of the runtime dependency tree.
@@ -311,6 +320,12 @@ test = true
 [[example]]
 name = "extract_spec_worked_example_windows"
 required-features = ["dev"]
+# `#[path]`-includes `examples/common/recording.rs`, which carries `#[cfg(test)]`
+# units; `test = true` is a per-target flag, so without it those units are dead
+# in *this* target however many siblings enable them. Caught by
+# `it::generator_completeness::examples_with_unit_tests_opt_into_running_them`
+# (#1550), which is why the invariant resolves `#[path]` includes transitively.
+test = true
 
 [[example]]
 name = "derive_tx_placements"
@@ -332,9 +347,13 @@ name = "extract_case_harvest_windows"
 required-features = ["dev"]
 test = true
 
+# `test = true` because the target `#[path]`-includes `examples/common/recording.rs`,
+# whose `#[cfg(test)]` units are dead in any target that does not opt in — `test = true`
+# is a per-target flag, not a per-file one.
 [[example]]
 name = "extract_split_member_separation_windows"
 required-features = ["dev"]
+test = true
 
 [[example]]
 name = "generate_conformance_summary"
@@ -347,6 +366,11 @@ required-features = ["dev"]
 [[example]]
 name = "report_conformance_reference_gaps"
 required-features = ["dev"]
+# Carries `#[cfg(test)]` unit tests; without this cargo never builds them.
+# Pinned by `it::generator_completeness::examples_with_unit_tests_opt_into_running_them`
+# (#1550), which is what finally caught this one after it shipped a `#[test]`
+# that had never executed.
+test = true
 
 [[example]]
 name = "dump_partitions"

--- a/src/conformance/completeness.rs
+++ b/src/conformance/completeness.rs
@@ -1,0 +1,914 @@
+//! Completeness accounting for corpus and fixture generators (#1550).
+//!
+//! Every generator under `examples/` walks a population — corpus rows, spec
+//! strings, transcripts, reference accessions — and writes an artifact derived
+//! from it. They share one failure mode: **a fallible step whose failure is
+//! representable as a legitimate value**. `spans_of(..).unwrap_or_default()`
+//! yields an empty vec that classifies as "no gaps"; `else { continue }` skips
+//! exactly the record that had a problem; a discarded `Result` reports nothing
+//! at all. The dropped population is never counted, so a partial run and a clean
+//! run produce indistinguishable output and the only thing separating them is
+//! whether a reviewer read the right five lines.
+//!
+//! A grep cannot find these. Measured on `main`, the idioms above occur at ~145
+//! sites across `examples/` and `src/conformance/`, overwhelmingly legitimately;
+//! what makes one a defect is not the idiom but that its failure flows into a
+//! value that is then *counted*, which is a composition no lint can see. So the
+//! mechanical half stays narrow (`tests/it/generator_completeness.rs`) and the
+//! semantic half is carried by a type.
+//!
+//! [`CaptureLedger`] is that type. It is
+//! `examples/extract_split_member_separation_windows.rs`'s refusal — *"Refusing
+//! to write a fixture built from a partial pass"* — promoted out of one file:
+//!
+//! ```
+//! use ferro_hgvs::conformance::completeness::CaptureLedger;
+//!
+//! let mut ledger = CaptureLedger::new("transcript windows");
+//! for accession in ["NM_000088.3", "NM_003002.2"] {
+//!     let resolved: Result<&str, String> = Ok(accession);
+//!     ledger.record(accession, resolved);
+//! }
+//! // `finish` is the gate: it refuses on any shortfall, and the counts it
+//! // returns are serializable so the artifact carries its own claim.
+//! let counts = ledger.finish().expect("a complete pass");
+//! assert_eq!(counts.attempted, 2);
+//! assert_eq!(counts.dropped, 0);
+//! ```
+//!
+//! Three properties are deliberate:
+//!
+//! - **`finish` refuses rather than reports.** A printed count is read by a
+//!   human who already believes the run worked. `finish` returns a `Result` the
+//!   caller must handle before it can reach its `fs::write`.
+//! - **A shortfall is waived only by naming it.** [`Allowance`] takes a cap and
+//!   a justification, and is constructed at the call site, so an expected drop
+//!   is a declaration in the source rather than an absence.
+//! - **An empty pass is a shortfall too.** A generator that attempted nothing
+//!   writes an artifact whose emptiness reads as "there was nothing to find" —
+//!   the corpus-zero hazard, where a structural blindness is indistinguishable
+//!   from a safe result. Waiving it needs
+//!   [`Allowance::permitting_an_empty_pass`].
+//!
+//! # What the ledger accounts for, and what it does not
+//!
+//! **It accounts for the step you route through it — not for the artifact.**
+//! `succeeded` counts records that got past *one* fallible step. It is never
+//! compared against the number of rows that actually reach the file, and the
+//! type has no way to make that comparison: it never sees the artifact. So a
+//! generator can use this exactly as prescribed and still write a partial
+//! artifact carrying a spotless claim:
+//!
+//! ```ignore
+//! let mut ledger = CaptureLedger::new("rows");
+//! for row in rows {
+//!     let Some(v) = ledger.record(row.id(), parse(row)) else { continue };
+//!     let Ok(span) = spans_of(v) else { continue };  // second step, unaccounted
+//!     artifact.push(span);
+//! }
+//! let counts = ledger.finish()?;   // {"attempted":10,"succeeded":10,"dropped":0}
+//! ```                              // …stamped onto an artifact holding 5 rows
+//!
+//! That is the *exact* shape #1550 cites for `dump_confluence_divergences.rs`
+//! (`spans_of(..)` failing downstream of a successful capture), so it is worth
+//! being blunt about: **route the last fallible step before the artifact, not
+//! the first.** If a pass has several fallible steps, either route them all
+//! through one ledger — `record_drop` at each — or give each its own ledger and
+//! `finish` each. A claim scoped to one loop is still worth stamping; it is just
+//! a claim about that loop, and an artifact that says so is honest where one
+//! that implies more is not.
+//!
+//! The two mechanical guards in `tests/it/generator_completeness.rs` are
+//! narrower still: substring heuristics over generator source text, which catch
+//! the common case and prove nothing. See that file's module docs.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// One dropped record: what was being processed, and why it did not make it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DroppedRecord {
+    /// The thing that was being captured — an accession, an input string, a row
+    /// id. Named rather than counted so a failure report says *which*.
+    pub subject: String,
+    /// Why it was dropped. Grouped verbatim in [`CaptureCounts::dropped_by_reason`],
+    /// so prefer a small closed vocabulary over an interpolated error string.
+    ///
+    /// [`CaptureLedger::record`] does not, and cannot — it has only the error to
+    /// go on. See its docs for when to reach for
+    /// [`CaptureLedger::record_drop`] instead.
+    pub reason: String,
+}
+
+/// A declared allowance for a shortfall, constructed at the call site.
+///
+/// The justification is required rather than optional: an allowance without one
+/// is indistinguishable from having never considered the question, which is the
+/// state this whole module exists to make impossible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Allowance {
+    max_dropped: usize,
+    empty_pass_permitted: bool,
+    justification: String,
+}
+
+impl Allowance {
+    /// Permit up to `max_dropped` drops, for the stated reason.
+    ///
+    /// `Allowance::at_most(0, ..)` is meaningful and is *not* the same as
+    /// [`CaptureLedger::finish`]: it still refuses a drop, but it records in the
+    /// artifact that the question was asked and answered.
+    ///
+    /// # Panics
+    ///
+    /// If `justification` is empty or only whitespace. "Required" was previously
+    /// presence rather than content, so `Allowance::at_most(0, "")` was accepted —
+    /// an allowance carrying no reason is exactly the "indistinguishable from
+    /// having never considered the question" state the type exists to prevent.
+    pub fn at_most(max_dropped: usize, justification: impl Into<String>) -> Self {
+        let justification = justification.into();
+        assert!(
+            !justification.trim().is_empty(),
+            "an Allowance needs a justification: an empty one is indistinguishable \
+             from having never considered the question",
+        );
+        Self {
+            max_dropped,
+            empty_pass_permitted: false,
+            justification,
+        }
+    }
+
+    /// Also permit a pass that attempted nothing.
+    ///
+    /// Needed only by generators whose population is legitimately optional (an
+    /// absent input file, a corpus filtered to empty by a CLI flag). For anything
+    /// that ships a committed artifact, an empty pass is the corpus-zero hazard
+    /// and should stay a refusal.
+    #[must_use]
+    pub fn permitting_an_empty_pass(mut self) -> Self {
+        self.empty_pass_permitted = true;
+        self
+    }
+}
+
+/// The allowance as stamped into an artifact, so a reader of the fixture sees
+/// the waiver rather than having to find the generator that granted it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AllowanceNote {
+    /// The declared ceiling on drops.
+    pub max_dropped: usize,
+    /// Whether a pass that attempted nothing was permitted.
+    pub empty_pass_permitted: bool,
+    /// Why the shortfall is acceptable.
+    pub justification: String,
+}
+
+/// The completeness claim of one capture pass, serializable so a generator can
+/// stamp it into the artifact it writes.
+///
+/// A fixture that carries its counts can be asserted on by the tests that
+/// consume it, which is the difference between a completeness claim and a
+/// completeness *hope*: the claim survives the generator run and travels with
+/// the data.
+///
+/// # There is deliberately no `Default`
+///
+/// `Default` was derived here in the first revision, and
+/// `ledger.finish().unwrap_or_default()` therefore compiled clean — fabricating
+/// `{"attempted":0,"succeeded":0,"dropped":0}`, which serializes as a *tidier*
+/// claim than a real one and reads as clean to anyone diffing a fixture. That is
+/// `unwrap_or_default()`, the archetypal defect this module's opening paragraph
+/// names, applied to the type meant to kill it. Without the derive, that line no
+/// longer compiles and the caller has to say what it wants. Do not re-add it:
+/// there is no meaningful "default completeness claim", and the empty one is the
+/// most misleading value the type can hold.
+///
+/// ```compile_fail
+/// use ferro_hgvs::conformance::completeness::CaptureLedger;
+///
+/// let mut ledger = CaptureLedger::new("rows");
+/// ledger.record_success();
+/// // `CaptureCounts: Default` would make this compile and discard the refusal.
+/// let _counts = ledger.finish().unwrap_or_default();
+/// ```
+///
+/// `let _ = ledger.finish();` is still silent — that one is unavoidable in Rust,
+/// and `#[must_use]` on `Shortfall`'s `Result` is what argues against it.
+///
+/// # The arithmetic invariant does not survive deserialization
+///
+/// `attempted == succeeded + dropped` holds by construction *through
+/// [`CaptureLedger`]* — `attempted()` is derived, so no caller can break it. It
+/// is **not** re-checked by `Deserialize`, and deserialization is exactly how a
+/// consuming test reads a stamped claim. Use [`CaptureCounts::is_self_consistent`]
+/// if you are reading counts you did not just produce.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaptureCounts {
+    /// Records the pass tried to capture. Equal to `succeeded + dropped` by
+    /// construction — the ledger has no way to increment one without the other.
+    pub attempted: usize,
+    /// Records that made it into the artifact.
+    pub succeeded: usize,
+    /// Records that did not.
+    pub dropped: usize,
+    /// Drops grouped by reason, so an artifact records the *shape* of a waived
+    /// shortfall and not merely its size.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dropped_by_reason: BTreeMap<String, usize>,
+    /// The allowance under which a shortfall was accepted, when there was one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowance: Option<AllowanceNote>,
+}
+
+impl CaptureCounts {
+    /// Whether the pass captured everything it attempted, and attempted
+    /// something.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.dropped == 0 && self.attempted > 0
+    }
+
+    /// Whether the arithmetic holds: `attempted == succeeded + dropped`, and the
+    /// per-reason tally sums to `dropped`.
+    ///
+    /// Always true of counts produced by [`CaptureLedger`]. Worth asserting on
+    /// counts read back out of an artifact, where nothing enforced it — a
+    /// hand-edited or truncated claim is otherwise indistinguishable from a real
+    /// one.
+    ///
+    /// Both sums are checked, because the input this method exists for is the
+    /// input nothing validated: a claim holding two near-`usize::MAX` counts
+    /// panics a debug build on `succeeded + dropped` and wraps a release one,
+    /// and a wrapped sum can land back on `attempted` — reporting a claim as
+    /// consistent *because* it overflowed. Overflow is treated as inconsistent.
+    #[must_use]
+    pub fn is_self_consistent(&self) -> bool {
+        let total = self.succeeded.checked_add(self.dropped);
+        let by_reason = self
+            .dropped_by_reason
+            .values()
+            .try_fold(0usize, |sum, count| sum.checked_add(*count));
+        total == Some(self.attempted) && by_reason == Some(self.dropped)
+    }
+}
+
+/// The detail of a [`Shortfall::Dropped`].
+///
+/// Split out and boxed because it is the `Err` half of every `finish`, and an
+/// inline variant this size makes each of them a large-`Result` clippy denial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroppedShortfall {
+    /// What was being captured, for the message.
+    pub subject: String,
+    /// The counts as they stood at `finish`.
+    pub counts: CaptureCounts,
+    /// Every dropped record, in the order they were recorded.
+    pub records: Vec<DroppedRecord>,
+    /// The ceiling that was exceeded, when an allowance was declared.
+    pub allowed: Option<usize>,
+}
+
+/// Why [`CaptureLedger::finish`] refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Shortfall {
+    /// The pass attempted no records at all.
+    NothingAttempted {
+        /// What was being captured, for the message.
+        subject: String,
+    },
+    /// The pass dropped records.
+    Dropped(Box<DroppedShortfall>),
+}
+
+impl Shortfall {
+    /// What was being captured.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        match self {
+            Self::NothingAttempted { subject } => subject,
+            Self::Dropped(detail) => &detail.subject,
+        }
+    }
+
+    /// The dropped records, empty for [`Shortfall::NothingAttempted`].
+    #[must_use]
+    pub fn dropped_records(&self) -> &[DroppedRecord] {
+        match self {
+            Self::NothingAttempted { .. } => &[],
+            Self::Dropped(detail) => &detail.records,
+        }
+    }
+}
+
+/// How many dropped subjects a message names before summarising the rest. Enough
+/// to see the shape of a failure without a 20,000-line panic.
+const MAX_NAMED_SUBJECTS: usize = 10;
+
+/// How many distinct drop reasons a message lists before summarising the rest.
+///
+/// This cap is not decoration. [`CaptureLedger::record`] — the documented
+/// adoption path — sets `reason` to `error.to_string()`, and for an
+/// `io::Error`/`anyhow::Error` that is typically unique per record, so
+/// `dropped_by_reason` degenerates to one bucket per drop. Printing that map in
+/// full defeated [`MAX_NAMED_SUBJECTS`] entirely: measured at 2000 drops, the
+/// refusal message was 2,014 lines and 71 KB — precisely the "20,000-line panic"
+/// the subject cap exists to prevent (#1551 review). Both halves are capped now,
+/// and the totals are stated exactly either way, because a summary that hid the
+/// count would reintroduce the ambiguity this module removes.
+const MAX_NAMED_REASONS: usize = 10;
+
+impl fmt::Display for Shortfall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NothingAttempted { subject } => write!(
+                f,
+                "{subject}: the pass attempted 0 records, so an artifact written from it \
+                 would claim an empty population rather than report that it found none. \
+                 Refusing to write a fixture built from a partial pass. If an empty pass \
+                 is legitimate here, declare it with \
+                 `Allowance::at_most(0, ..).permitting_an_empty_pass()`."
+            ),
+            Self::Dropped(detail) => {
+                let DroppedShortfall {
+                    subject,
+                    counts,
+                    records,
+                    allowed,
+                } = detail.as_ref();
+                write!(
+                    f,
+                    "{subject}: {} of {} records were dropped",
+                    counts.dropped, counts.attempted
+                )?;
+                match allowed {
+                    Some(max) => write!(f, ", exceeding the declared allowance of {max}")?,
+                    None => write!(f, " and no allowance was declared")?,
+                }
+                write!(
+                    f,
+                    ". Refusing to write a fixture built from a partial pass, because a \
+                     partial pass and a clean one produce indistinguishable output.\n  \
+                     by reason ({} distinct):",
+                    counts.dropped_by_reason.len()
+                )?;
+                for (reason, count) in counts.dropped_by_reason.iter().take(MAX_NAMED_REASONS) {
+                    write!(f, "\n    {reason}: {count}")?;
+                }
+                if counts.dropped_by_reason.len() > MAX_NAMED_REASONS {
+                    let hidden: usize = counts
+                        .dropped_by_reason
+                        .values()
+                        .skip(MAX_NAMED_REASONS)
+                        .sum();
+                    write!(
+                        f,
+                        "\n    … and {} more reasons covering {hidden} drops",
+                        counts.dropped_by_reason.len() - MAX_NAMED_REASONS,
+                    )?;
+                }
+                write!(f, "\n  dropped:")?;
+                for record in records.iter().take(MAX_NAMED_SUBJECTS) {
+                    write!(f, "\n    {} ({})", record.subject, record.reason)?;
+                }
+                if records.len() > MAX_NAMED_SUBJECTS {
+                    write!(f, "\n    … and {} more", records.len() - MAX_NAMED_SUBJECTS)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for Shortfall {}
+
+/// Tracks what a capture pass attempted, captured and dropped, and refuses to
+/// certify a pass that fell short.
+///
+/// See the [module docs](self) for why this exists and what it deliberately does
+/// not try to do.
+#[derive(Debug, Clone)]
+pub struct CaptureLedger {
+    subject: String,
+    succeeded: usize,
+    dropped: Vec<DroppedRecord>,
+}
+
+impl CaptureLedger {
+    /// Start a ledger for `subject` — a short noun phrase naming the population,
+    /// used verbatim in failure messages (`"transcript windows"`, `"spec rows"`).
+    pub fn new(subject: impl Into<String>) -> Self {
+        Self {
+            subject: subject.into(),
+            succeeded: 0,
+            dropped: Vec::new(),
+        }
+    }
+
+    /// Record a captured record.
+    pub fn record_success(&mut self) {
+        self.succeeded += 1;
+    }
+
+    /// Record a dropped record and why.
+    ///
+    /// `reason` is grouped verbatim, so keep it a short closed-vocabulary phrase
+    /// (`"no stored sequence"`) and put the varying part in `subject`.
+    pub fn record_drop(&mut self, subject: impl Into<String>, reason: impl Into<String>) {
+        self.dropped.push(DroppedRecord {
+            subject: subject.into(),
+            reason: reason.into(),
+        });
+    }
+
+    /// Record the outcome of a fallible step, returning its value on success.
+    ///
+    /// This is the adoption path for the idioms this module exists to replace:
+    /// `let Ok(v) = f() else { continue };` becomes
+    /// `let Some(v) = ledger.record(id, f()) else { continue };`, which drops the
+    /// same record but can no longer do so silently.
+    ///
+    /// **It trades reason quality for convenience, on purpose.** `reason` becomes
+    /// `error.to_string()`, and for an `io::Error` or an `anyhow::Error` that is
+    /// usually unique per record — so
+    /// [`dropped_by_reason`](CaptureCounts::dropped_by_reason) degenerates to one
+    /// bucket per drop and stops being a grouping. That is an acceptable default
+    /// (the detail is the useful thing when a run first refuses), and the
+    /// [`Display`](Shortfall) impl caps what it prints so a wide error vocabulary
+    /// cannot produce an unreadable panic. When the *shape* of a drop matters —
+    /// a shortfall you expect to waive under an [`Allowance`] and read back out
+    /// of an artifact — call [`record_drop`](Self::record_drop) with a short
+    /// closed-vocabulary reason instead, and keep the varying detail in
+    /// `subject`.
+    pub fn record<T, E: fmt::Display>(
+        &mut self,
+        subject: impl Into<String>,
+        outcome: Result<T, E>,
+    ) -> Option<T> {
+        match outcome {
+            Ok(value) => {
+                self.record_success();
+                Some(value)
+            }
+            Err(error) => {
+                self.record_drop(subject, error.to_string());
+                None
+            }
+        }
+    }
+
+    /// Records attempted so far.
+    #[must_use]
+    pub fn attempted(&self) -> usize {
+        self.succeeded + self.dropped.len()
+    }
+
+    /// Records captured so far.
+    #[must_use]
+    pub fn succeeded(&self) -> usize {
+        self.succeeded
+    }
+
+    /// Records dropped so far.
+    #[must_use]
+    pub fn dropped(&self) -> usize {
+        self.dropped.len()
+    }
+
+    /// The counts as they stand, without adjudicating them.
+    ///
+    /// For progress reporting only — reading these instead of calling
+    /// [`finish`](Self::finish) is precisely the printed-count pattern that lets
+    /// a partial pass reach `fs::write`.
+    #[must_use]
+    pub fn counts(&self) -> CaptureCounts {
+        let mut dropped_by_reason: BTreeMap<String, usize> = BTreeMap::new();
+        for record in &self.dropped {
+            *dropped_by_reason.entry(record.reason.clone()).or_insert(0) += 1;
+        }
+        CaptureCounts {
+            attempted: self.attempted(),
+            succeeded: self.succeeded,
+            dropped: self.dropped.len(),
+            dropped_by_reason,
+            allowance: None,
+        }
+    }
+
+    /// Close the ledger, refusing on any shortfall.
+    ///
+    /// # Errors
+    ///
+    /// [`Shortfall::NothingAttempted`] if the pass attempted no records;
+    /// [`Shortfall::Dropped`] if it dropped any.
+    pub fn finish(self) -> Result<CaptureCounts, Shortfall> {
+        self.close(None)
+    }
+
+    /// Close the ledger under a declared [`Allowance`].
+    ///
+    /// The allowance is stamped into the returned counts, so an artifact records
+    /// the waiver alongside the shortfall it waived.
+    ///
+    /// # Errors
+    ///
+    /// [`Shortfall::Dropped`] if the drops exceed the allowance's ceiling, and
+    /// [`Shortfall::NothingAttempted`] if the pass attempted nothing and the
+    /// allowance did not permit that.
+    pub fn finish_with(self, allowance: Allowance) -> Result<CaptureCounts, Shortfall> {
+        self.close(Some(allowance))
+    }
+
+    fn close(self, allowance: Option<Allowance>) -> Result<CaptureCounts, Shortfall> {
+        let mut counts = self.counts();
+        let empty_permitted = allowance.as_ref().is_some_and(|a| a.empty_pass_permitted);
+        if counts.attempted == 0 && !empty_permitted {
+            return Err(Shortfall::NothingAttempted {
+                subject: self.subject,
+            });
+        }
+        let ceiling = allowance.as_ref().map_or(0, |a| a.max_dropped);
+        counts.allowance = allowance.map(|a| AllowanceNote {
+            max_dropped: a.max_dropped,
+            empty_pass_permitted: a.empty_pass_permitted,
+            justification: a.justification,
+        });
+        if counts.dropped > ceiling {
+            let allowed = counts.allowance.as_ref().map(|a| a.max_dropped);
+            return Err(Shortfall::Dropped(Box::new(DroppedShortfall {
+                subject: self.subject,
+                counts,
+                records: self.dropped,
+                allowed,
+            })));
+        }
+        Ok(counts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A ledger whose every record succeeded certifies, and reports counts that
+    /// add up. `attempted == succeeded + dropped` is an invariant of the type,
+    /// not something a caller can get wrong: there is no way to increment
+    /// `attempted` on its own.
+    #[test]
+    fn a_complete_pass_certifies() {
+        let mut ledger = CaptureLedger::new("transcript windows");
+        ledger.record_success();
+        ledger.record_success();
+
+        let counts = ledger.finish().expect("a complete pass certifies");
+        assert_eq!(counts.attempted, 2);
+        assert_eq!(counts.succeeded, 2);
+        assert_eq!(counts.dropped, 0);
+        assert!(counts.dropped_by_reason.is_empty());
+        assert!(counts.allowance.is_none());
+        assert!(counts.is_complete());
+    }
+
+    /// The core refusal: one dropped record and `finish` is an `Err`, however
+    /// many succeeded. This is what the printed count could not do.
+    #[test]
+    fn a_single_drop_refuses() {
+        let mut ledger = CaptureLedger::new("transcript windows");
+        for _ in 0..999 {
+            ledger.record_success();
+        }
+        ledger.record_drop("NM_003002.2", "no stored sequence");
+
+        let error = ledger.finish().expect_err("one drop must refuse");
+        match &error {
+            Shortfall::Dropped(detail) => {
+                assert_eq!(detail.subject, "transcript windows");
+                assert_eq!(detail.counts.attempted, 1000);
+                assert_eq!(detail.counts.succeeded, 999);
+                assert_eq!(detail.counts.dropped, 1);
+                assert_eq!(detail.records.len(), 1);
+                assert_eq!(detail.records[0].subject, "NM_003002.2");
+                assert_eq!(detail.allowed, None);
+            }
+            other => panic!("expected a Dropped shortfall, got {other:?}"),
+        }
+    }
+
+    /// The refusal must name the subject, the arithmetic and the reason, and
+    /// must say it is refusing — a reader who sees only "3 of 5" cannot tell
+    /// whether the generator went on to write.
+    #[test]
+    fn the_refusal_names_what_was_lost_and_that_it_refused() {
+        let mut ledger = CaptureLedger::new("spec rows");
+        ledger.record_success();
+        ledger.record_drop("LRG_199t1:c.850del", "unresolvable accession");
+        ledger.record_drop("NM_007294.3:c.2077delins", "unresolvable accession");
+
+        let message = ledger.finish().expect_err("must refuse").to_string();
+        assert!(message.contains("spec rows"), "{message}");
+        assert!(message.contains("2 of 3 records were dropped"), "{message}");
+        assert!(message.contains("no allowance was declared"), "{message}");
+        assert!(
+            message.contains("Refusing to write a fixture built from a partial pass"),
+            "{message}"
+        );
+        assert!(message.contains("unresolvable accession: 2"), "{message}");
+        assert!(message.contains("LRG_199t1:c.850del"), "{message}");
+    }
+
+    /// Long failures are truncated so a panic stays readable, but the total is
+    /// still stated exactly — a summary that hid the count would reintroduce the
+    /// very ambiguity this module removes.
+    #[test]
+    fn a_long_refusal_is_truncated_but_still_states_the_total() {
+        let mut ledger = CaptureLedger::new("corpus rows");
+        for i in 0..(MAX_NAMED_SUBJECTS + 5) {
+            ledger.record_drop(format!("row-{i}"), "parse failed");
+        }
+
+        let message = ledger.finish().expect_err("must refuse").to_string();
+        assert!(
+            message.contains("15 of 15 records were dropped"),
+            "{message}"
+        );
+        assert!(message.contains("row-0"), "{message}");
+        assert!(!message.contains("row-14"), "{message}");
+        assert!(message.contains("and 5 more"), "{message}");
+    }
+
+    /// An allowance waives a shortfall up to its ceiling, and the waiver is
+    /// carried in the counts so the artifact records who permitted what.
+    #[test]
+    fn a_declared_allowance_waives_up_to_its_ceiling() {
+        let mut ledger = CaptureLedger::new("reference accessions");
+        ledger.record_success();
+        ledger.record_drop("LRG_199", "unversioned reference");
+
+        let counts = ledger
+            .finish_with(Allowance::at_most(
+                1,
+                "bare LRG_ ids have no versioned index entry",
+            ))
+            .expect("within the declared allowance");
+        assert_eq!(counts.dropped, 1);
+        // Borrowed, not moved: the assertion below has to be about the counts
+        // the ledger produced. An earlier revision moved the allowance out here
+        // and then asserted on a hand-built `CaptureCounts`, which held whatever
+        // `finish_with` returned — including a complete claim (#1551 review).
+        let note = counts
+            .allowance
+            .as_ref()
+            .expect("the allowance is recorded");
+        assert_eq!(note.max_dropped, 1);
+        assert_eq!(
+            note.justification,
+            "bare LRG_ ids have no versioned index entry"
+        );
+        // Still not a complete pass — an allowance permits a shortfall, it does
+        // not turn one into a full capture.
+        assert!(!counts.is_complete());
+    }
+
+    /// An allowance is a ceiling, not a licence: one drop past it still refuses,
+    /// and the message states the ceiling that was exceeded.
+    #[test]
+    fn an_allowance_is_a_ceiling_not_a_licence() {
+        let mut ledger = CaptureLedger::new("reference accessions");
+        ledger.record_drop("LRG_199", "unversioned reference");
+        ledger.record_drop("LRG_200", "unversioned reference");
+
+        let error = ledger
+            .finish_with(Allowance::at_most(1, "at most one bare LRG_ id"))
+            .expect_err("two drops exceed a ceiling of one");
+        assert!(matches!(&error, Shortfall::Dropped(detail) if detail.allowed == Some(1)));
+        assert!(
+            error
+                .to_string()
+                .contains("exceeding the declared allowance of 1"),
+            "{error}"
+        );
+    }
+
+    /// `Allowance::at_most(0, ..)` is meaningful: it records that the question
+    /// was asked, and still refuses a drop.
+    #[test]
+    fn a_zero_allowance_records_the_question_and_still_refuses() {
+        let mut clean = CaptureLedger::new("rows");
+        clean.record_success();
+        let counts = clean
+            .finish_with(Allowance::at_most(0, "no drop is acceptable here"))
+            .expect("a clean pass passes under a zero allowance");
+        assert_eq!(
+            counts
+                .allowance
+                .expect("the allowance is recorded even at zero")
+                .max_dropped,
+            0
+        );
+
+        let mut lossy = CaptureLedger::new("rows");
+        lossy.record_drop("row-0", "parse failed");
+        assert!(lossy
+            .finish_with(Allowance::at_most(0, "no drop is acceptable here"))
+            .is_err());
+    }
+
+    /// A pass that attempted nothing is a shortfall of its own. An empty
+    /// artifact reads as "there was nothing to find", which is exactly how a
+    /// structural blindness disguises itself as a safe result.
+    #[test]
+    fn an_empty_pass_refuses_unless_it_is_permitted() {
+        let error = CaptureLedger::new("corpus rows")
+            .finish()
+            .expect_err("an empty pass must refuse");
+        assert!(matches!(error, Shortfall::NothingAttempted { .. }));
+        assert!(error.to_string().contains("attempted 0 records"), "{error}");
+        assert!(error.dropped_records().is_empty());
+
+        // A bare allowance does not waive it — permitting drops says nothing
+        // about permitting an empty population.
+        assert!(CaptureLedger::new("corpus rows")
+            .finish_with(Allowance::at_most(5, "some rows may fail"))
+            .is_err());
+
+        let counts = CaptureLedger::new("corpus rows")
+            .finish_with(
+                Allowance::at_most(0, "the corpus is optional here").permitting_an_empty_pass(),
+            )
+            .expect("an explicitly permitted empty pass");
+        assert_eq!(counts.attempted, 0);
+        assert!(!counts.is_complete());
+    }
+
+    /// `record` is the adoption path for `let Ok(v) = .. else { continue }`: it
+    /// returns the same `Option` the caller was already branching on, and the
+    /// drop is accounted for on the way past.
+    #[test]
+    fn record_accounts_for_a_fallible_step_and_yields_its_value() {
+        let mut ledger = CaptureLedger::new("transcripts");
+        let ok: Result<u32, String> = Ok(7);
+        let err: Result<u32, String> = Err("no stored sequence".to_string());
+
+        assert_eq!(ledger.record("NM_000088.3", ok), Some(7));
+        assert_eq!(ledger.record("NM_003002.2", err), None);
+        assert_eq!(ledger.attempted(), 2);
+        assert_eq!(ledger.succeeded(), 1);
+        assert_eq!(ledger.dropped(), 1);
+
+        let error = ledger.finish().expect_err("the drop must refuse");
+        assert_eq!(error.dropped_records()[0].reason, "no stored sequence");
+    }
+
+    /// The counts are the artifact's completeness claim, so they must survive a
+    /// JSON round trip — a claim a fixture cannot carry is not a claim a
+    /// consuming test can assert on.
+    #[test]
+    fn counts_round_trip_through_json_so_an_artifact_can_carry_them() {
+        let mut ledger = CaptureLedger::new("windows");
+        ledger.record_success();
+        ledger.record_drop("NM_003002.2", "no stored sequence");
+        let counts = ledger
+            .finish_with(Allowance::at_most(1, "one transcript is not provisioned"))
+            .expect("within the allowance");
+
+        let json = serde_json::to_string(&counts).expect("serialize counts");
+        let parsed: CaptureCounts = serde_json::from_str(&json).expect("deserialize counts");
+        assert_eq!(parsed, counts);
+        assert_eq!(parsed.dropped_by_reason["no stored sequence"], 1);
+        assert_eq!(
+            parsed.allowance.expect("allowance survives").justification,
+            "one transcript is not provisioned"
+        );
+    }
+
+    /// The refusal message stays bounded even when every drop carries its own
+    /// reason — which is what [`CaptureLedger::record`] produces for an error
+    /// type whose `Display` interpolates the record.
+    ///
+    /// Before `MAX_NAMED_REASONS`, `MAX_NAMED_SUBJECTS` was defeated by exactly
+    /// this: the subject list was capped at 10 while `dropped_by_reason` printed
+    /// in full, so 2000 drops rendered a 2,014-line, 71 KB panic (#1551 review).
+    #[test]
+    fn a_wide_reason_vocabulary_cannot_produce_an_unbounded_refusal() {
+        let mut ledger = CaptureLedger::new("corpus rows");
+        let drops = 2000;
+        for i in 0..drops {
+            let outcome: Result<(), String> = Err(format!("row {i} failed to resolve"));
+            ledger.record(format!("row-{i}"), outcome);
+        }
+
+        let message = ledger.finish().expect_err("must refuse").to_string();
+        let lines = message.lines().count();
+        assert!(
+            lines <= MAX_NAMED_SUBJECTS + MAX_NAMED_REASONS + 8,
+            "refusal must stay readable, got {lines} lines:\n{message}"
+        );
+        // The totals survive the truncation on both axes — a summary that hid
+        // the count would reintroduce the ambiguity this module removes.
+        assert!(
+            message.contains(&format!("{drops} of {drops} records were dropped")),
+            "{message}"
+        );
+        assert!(
+            message.contains(&format!("by reason ({drops} distinct)")),
+            "{message}"
+        );
+        assert!(
+            message.contains(&format!(
+                "and {} more reasons covering {} drops",
+                drops - MAX_NAMED_REASONS,
+                drops - MAX_NAMED_REASONS
+            )),
+            "{message}"
+        );
+    }
+
+    /// An allowance with a blank justification is the state [`Allowance`]'s own
+    /// doc calls indistinguishable from never having considered the question, so
+    /// "required" has to mean content and not merely presence.
+    #[test]
+    #[should_panic(expected = "an Allowance needs a justification")]
+    fn an_allowance_with_a_blank_justification_is_refused() {
+        let _ = Allowance::at_most(0, "   ");
+    }
+
+    /// `attempted == succeeded + dropped` holds by construction through the
+    /// ledger, but nothing re-checks it on the way back out of an artifact — and
+    /// deserializing a stamped claim is exactly how a consuming test reads one.
+    #[test]
+    fn self_consistency_is_checkable_on_counts_read_back_from_an_artifact() {
+        let mut ledger = CaptureLedger::new("windows");
+        ledger.record_success();
+        ledger.record_drop("NM_003002.2", "no stored sequence");
+        let counts = ledger
+            .finish_with(Allowance::at_most(1, "one transcript is not provisioned"))
+            .expect("within the allowance");
+        assert!(counts.is_self_consistent());
+
+        // Arithmetic consistency is not artifact verification, and this is the
+        // limitation the module documents rather than a case the checker
+        // catches: 100 == 100 + 0 holds, so a claim invented wholesale passes.
+        // What `is_self_consistent` rules out is a claim that contradicts
+        // *itself*, never one that contradicts the file it is stamped onto.
+        let internally_consistent_but_unverifiable: CaptureCounts = serde_json::from_str(
+            r#"{"attempted":100,"succeeded":100,"dropped":0,"dropped_by_reason":{}}"#,
+        )
+        .expect("deserialize");
+        assert!(internally_consistent_but_unverifiable.is_self_consistent());
+
+        let inconsistent: CaptureCounts =
+            serde_json::from_str(r#"{"attempted":100,"succeeded":10,"dropped":0}"#)
+                .expect("deserialize");
+        assert!(!inconsistent.is_self_consistent());
+    }
+
+    /// The counts this method exists to check are the ones nothing enforced, so
+    /// its own arithmetic has to survive whatever a file holds. `succeeded +
+    /// dropped` on two near-`usize::MAX` values panics in debug and wraps in
+    /// release, and a wrapped sum can land back on `attempted` — reporting a
+    /// claim as consistent *because* it overflowed (#1551 review).
+    #[test]
+    fn self_consistency_treats_overflowing_counts_as_inconsistent() {
+        let overflowing: CaptureCounts = serde_json::from_str(&format!(
+            r#"{{"attempted":1,"succeeded":{max},"dropped":{max}}}"#,
+            max = usize::MAX
+        ))
+        .expect("deserialize");
+        assert!(!overflowing.is_self_consistent());
+
+        let overflowing_reasons: CaptureCounts = serde_json::from_str(&format!(
+            r#"{{"attempted":{max},"succeeded":0,"dropped":{max},
+                 "dropped_by_reason":{{"a":{max},"b":{max}}}}}"#,
+            max = usize::MAX
+        ))
+        .expect("deserialize");
+        assert!(!overflowing_reasons.is_self_consistent());
+
+        // The case the wrap actually costs something on: `MAX + 2` wraps to 1,
+        // which *is* `attempted`, and the per-reason tally agrees. A release
+        // build of the unchecked version called this claim consistent.
+        let wraps_onto_attempted: CaptureCounts = serde_json::from_str(&format!(
+            r#"{{"attempted":1,"succeeded":{max},"dropped":2,
+                 "dropped_by_reason":{{"unversioned reference":2}}}}"#,
+            max = usize::MAX
+        ))
+        .expect("deserialize");
+        assert!(!wraps_onto_attempted.is_self_consistent());
+    }
+
+    /// A clean pass's counts stay compact in the artifact: no empty reason map,
+    /// no null allowance. A fixture diff should show the claim, not the absence
+    /// of one.
+    #[test]
+    fn a_clean_claim_serializes_without_empty_fields() {
+        let mut ledger = CaptureLedger::new("windows");
+        ledger.record_success();
+        let json = serde_json::to_string(&ledger.finish().expect("clean")).expect("serialize");
+        assert_eq!(json, r#"{"attempted":1,"succeeded":1,"dropped":0}"#);
+    }
+}

--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -14,6 +14,7 @@ pub mod accession_inventory;
 pub mod audited_provider;
 pub mod biocommons;
 pub mod case_harvest;
+pub mod completeness;
 pub mod hgvs_rs_projection;
 pub mod mutalyzer;
 pub mod reference_snapshot;

--- a/tests/it/generator_completeness.rs
+++ b/tests/it/generator_completeness.rs
@@ -1,0 +1,608 @@
+//! Generator completeness invariants (#1550).
+//!
+//! Generators under `examples/` build the corpora, fixtures and tables the rest
+//! of the suite adjudicates against. They share one failure mode: a fallible
+//! step whose failure is representable as a legitimate value — `unwrap_or_default()`,
+//! `else { continue }`, a discarded `Result` — drops part of the population and
+//! the generator writes its artifact anyway. A partial run and a clean run then
+//! produce indistinguishable output, and the only thing separating them is
+//! whether a reviewer read the right five lines.
+//!
+//! Two mechanical guards live here. Neither can see a *semantic* drop; that is
+//! what [`CaptureLedger`](ferro_hgvs::conformance::completeness::CaptureLedger)
+//! is for, and the second guard is the prompt that points generators at it.
+//!
+//! 1. [`examples_with_unit_tests_opt_into_running_them`] — a generator carrying
+//!    `#[cfg(test)]` must set `test = true` on its cargo target, because cargo
+//!    does not build a target's tests unless it opts in. `Cargo.toml` has stated
+//!    this rule in prose since the two spec generators became `[[bin]]`s;
+//!    nothing checked it, and `report_conformance_reference_gaps` shipped a
+//!    `#[test]` that had never once executed. **Only half of this one is
+//!    exact.** The manifest side is parsed as TOML, so `test = true` is read
+//!    rather than guessed; the source side is a scan for the token
+//!    `#[cfg(test)]`, which matches it in a doc comment or a string literal and
+//!    — the direction that costs something — misses the equivalent
+//!    `#[cfg(all(test, feature = "dev"))]`. A generator gating its tests that
+//!    way is invisible to this guard.
+//! 2. [`artifact_writers_use_the_capture_ledger_or_are_allowlisted`] — a
+//!    generator whose source *looks like* it writes a file must either look like
+//!    it routes its population through the ledger, or name itself in
+//!    [`LEDGER_EXEMPT`] against #1550.
+//!
+//! **Read the second guard's reach honestly, because this file's whole subject
+//! is a check that reads as stronger than it is.** It is a pair of substring
+//! heuristics over source text — see [`appears_to_write_an_artifact`] and
+//! [`appears_to_route_through_the_ledger`] for exactly which strings, and for
+//! the write idioms it is known to miss. It is a **floor that catches the common
+//! case**: a generator that writes with `std::fs::write` and never mentions the
+//! ledger cannot be added in silence. It is *not* a proof that every writer is
+//! accounted for, and it cannot be — deciding whether a population was routed
+//! through the ledger is a semantic question, and answering it mechanically
+//! would mean parsing and type-resolving Rust for a three-line rule. The
+//! semantic guarantee is carried by the type and by review; this guard's job is
+//! to make sure the question gets asked.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+// ---------------------------------------------------------------------------
+// Reading the manifest and the generator sources
+// ---------------------------------------------------------------------------
+
+/// One cargo target whose source lives under `examples/`.
+#[derive(Debug, Clone)]
+struct GeneratorTarget {
+    /// Cargo target name (`report_conformance_reference_gaps`).
+    name: String,
+    /// Which table declared it — `[[example]]` or `[[bin]]` — quoted verbatim in
+    /// failures so the fix names the block to edit.
+    table: &'static str,
+    /// Repo-relative source path (`examples/report_conformance_reference_gaps.rs`).
+    source: PathBuf,
+    /// Whether the target sets `test = true`.
+    builds_tests: bool,
+}
+
+/// Every `[[example]]` and `[[bin]]` target whose source lives under `examples/`.
+///
+/// Parsed as TOML rather than substring-matched: `Cargo.toml` discusses
+/// `test = true` at length in comments, and a `[[bench]]` setting it would be a
+/// false positive for the rule this file enforces.
+fn generator_targets() -> Vec<GeneratorTarget> {
+    let manifest_text =
+        std::fs::read_to_string(repo_root().join("Cargo.toml")).expect("read Cargo.toml");
+    let manifest: toml::Value = manifest_text.parse().expect("parse Cargo.toml as TOML");
+
+    let mut targets = Vec::new();
+    for (key, table) in [("example", "[[example]]"), ("bin", "[[bin]]")] {
+        let Some(entries) = manifest.get(key).and_then(toml::Value::as_array) else {
+            continue;
+        };
+        for entry in entries {
+            let name = entry
+                .get("name")
+                .and_then(toml::Value::as_str)
+                .unwrap_or_else(|| panic!("a {table} target with no `name`"))
+                .to_string();
+            // An `[[example]]` without an explicit `path` is `examples/<name>.rs`
+            // by cargo's own convention; the two spec generators are `[[bin]]`s
+            // that name their `examples/` source explicitly.
+            let source = match entry.get("path").and_then(toml::Value::as_str) {
+                Some(path) => PathBuf::from(path),
+                None if key == "example" => PathBuf::from("examples").join(format!("{name}.rs")),
+                None => continue,
+            };
+            if !source.starts_with("examples") {
+                continue;
+            }
+            targets.push(GeneratorTarget {
+                name,
+                table,
+                builds_tests: entry
+                    .get("test")
+                    .and_then(toml::Value::as_bool)
+                    .unwrap_or(false),
+                source,
+            });
+        }
+    }
+    targets
+}
+
+/// Every `examples/*.rs` that is a generator entry point (top level, so the
+/// `common/` modules that are `#[path]`-included into them are excluded).
+///
+/// **Scope difference worth knowing:** this reads the *directory*, while
+/// [`generator_targets`] reads the *manifest*. A declared target whose `path`
+/// points into a subdirectory (`examples/sub/gen.rs`) would therefore be seen by
+/// the `test = true` invariant and not by the artifact-writer ratchet. No such
+/// target exists today, and
+/// [`every_generator_source_is_declared_as_a_cargo_target`] keeps the two views
+/// in agreement for everything at the top level.
+fn generator_sources_on_disk() -> BTreeSet<PathBuf> {
+    std::fs::read_dir(repo_root().join("examples"))
+        .expect("read examples/")
+        .map(|entry| entry.expect("examples/ dir entry").path())
+        .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .map(|path| PathBuf::from("examples").join(path.file_name().expect("example file name")))
+        .collect()
+}
+
+/// The `#[path = "…"]` module includes declared in `text`, resolved relative to
+/// `containing_dir`.
+///
+/// A one-line scan rather than a parse: the includes are all of the literal form
+/// `#[path = "common/x.rs"]`, and a test that needed `syn` to enforce a
+/// three-line rule would not be worth its own maintenance.
+///
+/// **Boundary, stated rather than implied:** only `#[path]` is followed. A plain
+/// `mod helper;` — cargo's own `examples/<target>/helper.rs` convention — is not
+/// resolved, so `#[cfg(test)]` reached that way is invisible to the guards
+/// below. There is no such target today; the repo uses `#[path]` throughout, and
+/// the day one appears this comment is the thing to read.
+fn path_includes(text: &str, containing_dir: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    for line in text.lines() {
+        let Some(rest) = line.trim().strip_prefix("#[path") else {
+            continue;
+        };
+        let Some(open) = rest.find('"') else { continue };
+        let Some(close) = rest[open + 1..].find('"') else {
+            continue;
+        };
+        found.push(containing_dir.join(&rest[open + 1..open + 1 + close]));
+    }
+    found
+}
+
+/// Every source file compiled into a target: its own file plus, transitively,
+/// the `common/` modules it `#[path]`-includes.
+///
+/// The transitive walk is the point. `test = true` is a property of the *target*,
+/// so a `#[cfg(test)]` in a shared `common/` module is equally dead in every
+/// target that includes it without opting in — and reading only the entry point
+/// would miss exactly that.
+///
+/// An unreadable source **panics** rather than being skipped. Skipping it would
+/// be `else { continue }` on a fallible step, in the file whose module doc names
+/// that idiom as the failure mode: an entry point that failed to read would
+/// yield no sources, and a target with no sources reads as carrying no
+/// `#[cfg(test)]` and writing nothing — so *both* guards would pass silently for
+/// exactly the file nobody could read (#1550 review).
+fn compiled_sources(entry_point: &Path) -> Vec<(PathBuf, String)> {
+    let root = repo_root();
+    let mut queue = vec![entry_point.to_path_buf()];
+    let mut seen = BTreeSet::new();
+    let mut sources = Vec::new();
+    while let Some(relative) = queue.pop() {
+        if !seen.insert(relative.clone()) {
+            continue;
+        }
+        let absolute = root.join(&relative);
+        let text = std::fs::read_to_string(&absolute).unwrap_or_else(|error| {
+            panic!(
+                "cannot read a generator source reached from {}: {} ({error}). \
+                 Skipping it would make both guards in this file pass vacuously \
+                 for that target.",
+                entry_point.display(),
+                absolute.display(),
+            )
+        });
+        let containing_dir = relative.parent().unwrap_or(Path::new("")).to_path_buf();
+        queue.extend(path_includes(&text, &containing_dir));
+        sources.push((relative, text));
+    }
+    sources
+}
+
+// ---------------------------------------------------------------------------
+// 1. A generator with unit tests must opt into running them
+// ---------------------------------------------------------------------------
+
+/// Cargo does not build an example's or a binary's `#[cfg(test)]` code unless
+/// the target sets `test = true`, so a generator that carries unit tests without
+/// it ships a test that has never executed. That is worse than no test, because
+/// it reads as coverage: `Cargo.toml`'s own comment on the two spec generators
+/// says so, most generator targets already set the flag, and
+/// `report_conformance_reference_gaps` still shipped a `#[test]` that
+/// `cargo nextest run -E 'binary(report_conformance_reference_gaps)'` reported
+/// as `0 tests run` (#1550).
+///
+/// No count is quoted here on purpose. An earlier draft said "six targets", which
+/// was true when #1550 was filed and stale by the time this branch rebased twice —
+/// a comment that rots with every new generator, in a PR about claims that stop
+/// being true. The test itself is the count.
+///
+/// The manifest side of this is parsed; the source side is a token scan for
+/// `#[cfg(test)]` and misses `#[cfg(all(test, ..))]`. See the module docs — the
+/// claim that this guard is exact end-to-end was itself an overclaim (#1551
+/// review), which is the defect this whole file is about.
+#[test]
+fn examples_with_unit_tests_opt_into_running_them() {
+    let mut violations = Vec::new();
+    for target in generator_targets() {
+        let carriers: Vec<String> = compiled_sources(&target.source)
+            .into_iter()
+            .filter(|(_, text)| text.contains("#[cfg(test)]"))
+            .map(|(path, _)| path.display().to_string())
+            .collect();
+        if carriers.is_empty() || target.builds_tests {
+            continue;
+        }
+        violations.push(format!(
+            "{} `{}` compiles #[cfg(test)] code in {} but does not set `test = true`, \
+             so those tests never run",
+            target.table,
+            target.name,
+            carriers.join(", "),
+        ));
+    }
+    assert!(
+        violations.is_empty(),
+        "every generator target carrying #[cfg(test)] must set `test = true` in \
+         Cargo.toml — cargo does not build a target's tests unless it opts in:\n  {}",
+        violations.join("\n  "),
+    );
+}
+
+/// `autoexamples = false`, so a generator that is not declared is not built at
+/// all — the whole-file version of the silent drop this file is about. It would
+/// also make the guard above vacuous for that file.
+#[test]
+fn every_generator_source_is_declared_as_a_cargo_target() {
+    let declared: BTreeSet<PathBuf> = generator_targets()
+        .into_iter()
+        .map(|target| target.source)
+        .collect();
+    let undeclared: Vec<String> = generator_sources_on_disk()
+        .difference(&declared)
+        .map(|path| path.display().to_string())
+        .collect();
+    assert!(
+        undeclared.is_empty(),
+        "`autoexamples = false`, so an undeclared generator is never built and \
+         its tests never run; declare each in Cargo.toml: {undeclared:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. The artifact-writer ratchet
+// ---------------------------------------------------------------------------
+
+/// Generators that write an artifact without routing their population through
+/// [`CaptureLedger`], each recorded against #1550.
+///
+/// **This list may only shrink**, and the two shrink directions are not equally
+/// trustworthy — say which you are relying on:
+///
+/// - A row whose generator has been **deleted**, or which **no longer matches
+///   [`appears_to_write_an_artifact`]**, fails the test below. The first is a
+///   fact; the second is a heuristic, so it can also fire because the generator
+///   switched to a write idiom the predicate does not know.
+/// - A row whose generator now **matches [`appears_to_route_through_the_ledger`]**
+///   also fails, and that direction is the one that can *lose* a row. It is
+///   deliberately hard to trip by accident (entry point only, import plus a
+///   `finish` call — see that function), because deleting a row on the strength
+///   of a substring would put a generator permanently outside this list on
+///   evidence nobody checked. If it fires, confirm the generator really does
+///   account for its population before deleting the row; if it does not, the
+///   right fix is the generator, not the list.
+///
+/// Migrating these is deliberately *not* #1550's job: #1544, #1545 and #1549 own
+/// several of these files, and rewriting them here would mix mechanical churn
+/// into a new contract and conflict with three open PRs.
+///
+/// Adding a row is a legitimate act — it is the "I considered this and declined"
+/// answer, exactly as `Representation-Change: none` is. What is not legitimate is
+/// silence: a new generator that *the predicate can see* writing an artifact, and
+/// that does neither, fails the build.
+const LEDGER_EXEMPT: &[(&str, &str)] = &[
+    (
+        "examples/build_conformance_snapshot.rs",
+        "#1550: pre-existing; harvests snapshot bases per corpus accession",
+    ),
+    (
+        "examples/derive_ng_placements.rs",
+        "#1550: pre-existing; derives NG_ placements from the prepared reference",
+    ),
+    (
+        "examples/derive_tx_placements.rs",
+        "#1550: pre-existing; derives transcript placements from cdot",
+    ),
+    (
+        "examples/dump_confluence_divergences.rs",
+        "#1550: landed with #1549 while this contract was in review; migrating it \
+         belongs to that generator's own change",
+    ),
+    (
+        "examples/dump_normalized_corpus.rs",
+        "#1550: pre-existing; the representation-change measurement harness",
+    ),
+    (
+        "examples/extract_biocommons_windows.rs",
+        "#1550: pre-existing; records the reference windows one pass touched",
+    ),
+    (
+        "examples/extract_case_harvest_windows.rs",
+        "#1550: landed with #1545 while this contract was in review; migrating it \
+         belongs to that generator's own change",
+    ),
+    (
+        "examples/extract_mutalyzer_genomic_windows.rs",
+        "#1550: pre-existing; records the reference windows one pass touched",
+    ),
+    (
+        "examples/extract_spec_enumeration_windows.rs",
+        "#1550: pre-existing; records the reference windows one pass touched",
+    ),
+    (
+        "examples/extract_spec_worked_example_windows.rs",
+        "#1550: landed with #1544 while this contract was in review; migrating it \
+         belongs to that generator's own change",
+    ),
+    (
+        "examples/extract_split_member_separation_windows.rs",
+        "#1550: landed with #1549 while this contract was in review; it already \
+         implements this refusal by hand — it is the file `CaptureLedger` was \
+         promoted out of — so migrating it belongs to that generator's own change",
+    ),
+    (
+        "examples/generate_cis_confluence_corpus.rs",
+        "#1550: pre-existing; synthesises the cis-confluence corpus",
+    ),
+    (
+        "examples/generate_conformance_summary.rs",
+        "#1550: pre-existing; renders the failure-pattern views",
+    ),
+    (
+        "examples/generate_perf_tables.rs",
+        "#1550: pre-existing; renders the README performance tables",
+    ),
+    (
+        "examples/generate_spec_enumeration.rs",
+        "#1550: pre-existing; harvests the spec checkout into the enumeration",
+    ),
+    (
+        "examples/generate_spec_fixture.rs",
+        "#1550: pre-existing; harvests the spec checkout into the fixture",
+    ),
+    (
+        "examples/generate_tool_support_tables.rs",
+        "#1550: pre-existing; renders the committed tool-support tables",
+    ),
+    (
+        "examples/harvest_multi_member_cis.rs",
+        "#1550: pre-existing; harvests multi-member cis rows into a fixture",
+    ),
+    (
+        "examples/projector-bench.rs",
+        "#1550: pre-existing; writes benchmark output, not a committed corpus",
+    ),
+];
+
+/// Write idioms this file can recognise. **Not exhaustive, and cannot be** —
+/// there is no closed set of ways to write a file in Rust.
+///
+/// The rule for what belongs here is "the call **names a path**", which is what
+/// separates opening an artifact from wrapping a sink somebody else opened.
+/// `BufWriter::new(` and `serde_json::to_writer(` are therefore deliberately
+/// *out*: they say nothing about whether the destination is a file (the only
+/// `BufWriter` in `examples/` that is not already wrapping a `File::create` is
+/// over `stdout`), and every file-backed use of them passes through one of the
+/// four below anyway.
+///
+/// Measured misses, recorded so nobody rediscovers them the hard way (#1551
+/// review): the first revision listed only `fs::write(` and `File::create(`, so
+/// `OpenOptions::new()…open()` + `write_all` and `csv::Writer::from_path(..)`
+/// were both **invisible** to the ratchet. Those two are now covered. What is
+/// still not covered is anything that reaches a writer through a helper's return
+/// value, a trait object, or a crate whose constructor is spelled some other way.
+const WRITE_IDIOMS: &[&str] = &[
+    "fs::write(",
+    "File::create(",
+    "OpenOptions::new(",
+    "from_path(",
+];
+
+/// Whether a generator's compiled sources *look like* they write a file.
+///
+/// A substring scan over source text, deliberately: see [`WRITE_IDIOMS`] for the
+/// list and for what it is known to miss. Two consequences worth being explicit
+/// about, because the PR that introduced this check originally claimed more than
+/// it delivers:
+///
+/// - A **false negative** (a writer using an idiom not in the list) is invisible
+///   to the ratchet. So "a new artifact-writing generator cannot be added
+///   without one of the two deliberate acts" is **not** what this enforces. What
+///   it enforces is that the *common* way of writing a file — the way every
+///   generator in this repo currently writes — cannot be added in silence.
+/// - A **false positive** (a `from_path(` that opens something for reading) makes
+///   a non-writer ask the question anyway, which costs a `LEDGER_EXEMPT` row and
+///   nothing else. That asymmetry is the right way round for a floor.
+///
+/// The semantic question — "did this write get built from a complete pass?" — is
+/// what no grep can answer and what the ledger exists to carry.
+fn appears_to_write_an_artifact(sources: &[(PathBuf, String)]) -> bool {
+    sources
+        .iter()
+        .any(|(_, text)| WRITE_IDIOMS.iter().any(|idiom| text.contains(idiom)))
+}
+
+/// Whether a generator's **own entry point** looks like it routes a population
+/// through [`CaptureLedger`] — an import of the module *and* a call to one of
+/// the closing methods, both in that one file.
+///
+/// This is still a substring scan and still cannot see whether the population
+/// actually flows through the ledger. Two restrictions make it hard to satisfy by
+/// accident, and both exist because of a demonstrated laundering path (#1551
+/// review):
+///
+/// - **Entry point only, not the transitive `#[path]` includes.** Appending a
+///   single comment mentioning `CaptureLedger` to the shared
+///   `examples/common/recording.rs` previously marked *three* separate
+///   generators as having adopted the ledger, and the shrink-only half then
+///   demanded their [`LEDGER_EXEMPT`] rows be deleted as stale — removing three
+///   generators from the list on the strength of one line in a file they merely
+///   share. `recording.rs` is exactly the module the #1544/#1545 migrations will
+///   touch, so that was a live hazard, not a hypothetical one.
+/// - **A `use` line, plus the type name, plus a `finish` call.** A bare mention
+///   of the module — in a comment, in a doc link, in a `//` note pointing a
+///   reader at the type — is not evidence of adoption, and `.finish()` on its
+///   own is the terminal call of half the builders in the ecosystem
+///   (`csv::Writer`, `indicatif`, encoders), so either string alone is cheap to
+///   produce by accident. Requiring an actual `use` declaration naming
+///   `conformance::completeness`, the [`CaptureLedger`] type somewhere in the
+///   file, *and* the call that is the whole point of the type (`finish` is the
+///   gate; reading `counts()` instead is the printed-count pattern the type
+///   replaces) means the cheapest way to satisfy this predicate is to actually
+///   use it (#1551 review).
+///
+/// The cost of the entry-point restriction, stated: a generator that genuinely
+/// delegates its accounting to a shared `common/` module reads as *not*
+/// ledgered here and keeps its [`LEDGER_EXEMPT`] row. The `use`-line
+/// restriction costs the same way, and it is worth naming the two shapes it
+/// misses rather than leaving them to be discovered: a fully-qualified
+/// `ferro_hgvs::conformance::completeness::CaptureLedger::new(..)` at the call
+/// site with no import, and a nested import group broken across lines by
+/// rustfmt. Both read as *not* ledgered. That is the direction to err in — a
+/// row that is kept too long is a visible line of text, and a row deleted
+/// wrongly is a generator that silently leaves the list.
+fn appears_to_route_through_the_ledger(sources: &[(PathBuf, String)], entry_point: &Path) -> bool {
+    let Some((_, text)) = sources.iter().find(|(path, _)| path == entry_point) else {
+        return false;
+    };
+    let imports_the_module = text
+        .lines()
+        .map(str::trim)
+        .any(|line| line.starts_with("use ") && line.contains("conformance::completeness"));
+    let names_the_type = text.contains("CaptureLedger");
+    let closes_a_ledger = text.contains(".finish()") || text.contains(".finish_with(");
+    imports_the_module && names_the_type && closes_a_ledger
+}
+
+/// The predicate above is the half of the ratchet that *deletes* a row, so the
+/// shapes it must not accept are worth pinning rather than leaving to the next
+/// reader of the doc comment. The accidental-adoption case is a doc link plus an
+/// unrelated builder's `.finish()` — both strings present, nothing imported.
+#[test]
+fn a_mention_and_an_unrelated_finish_do_not_read_as_ledger_adoption() {
+    let entry_point = PathBuf::from("examples/plausible.rs");
+    let route = |text: &str| {
+        appears_to_route_through_the_ledger(
+            &[(entry_point.clone(), text.to_string())],
+            &entry_point,
+        )
+    };
+
+    // A doc link naming the module and the type, and a `.finish()` belonging to
+    // some other builder entirely. Every substring the old predicate looked for
+    // is present.
+    assert!(!route(
+        "//! Accounting is described in `conformance::completeness` (`CaptureLedger`).\n\
+         fn main() { let w = csv::Writer::from_path(p).unwrap(); w.finish().unwrap(); }\n"
+    ));
+    // An import with no closing call is a generator that reads its `counts()`
+    // and writes anyway — the printed-count pattern the ledger replaces.
+    assert!(!route(
+        "use ferro_hgvs::conformance::completeness::CaptureLedger;\n\
+         fn main() { let l = CaptureLedger::new(\"rows\"); dbg!(l.counts()); }\n"
+    ));
+    // Real adoption: an import, the type, and the gate.
+    assert!(route(
+        "use ferro_hgvs::conformance::completeness::CaptureLedger;\n\
+         fn main() { let l = CaptureLedger::new(\"rows\"); let c = l.finish().unwrap(); }\n"
+    ));
+    // …and via the allowance path, which is the other closing call.
+    assert!(route(
+        "use ferro_hgvs::conformance::completeness::{Allowance, CaptureLedger};\n\
+         fn main() { let l = CaptureLedger::new(\"rows\"); \
+         let c = l.finish_with(Allowance::at_most(1, \"why\")).unwrap(); }\n"
+    ));
+}
+
+/// A **heuristic** ratchet, not a proof. Read
+/// [`appears_to_write_an_artifact`] and [`appears_to_route_through_the_ledger`]
+/// before quoting what this test guarantees: both sides are substring scans over
+/// source text, so this catches the common case and says nothing about the rest.
+/// What it does buy is that the question cannot go unasked for a generator
+/// written the way every generator in this repo is currently written.
+#[test]
+fn artifact_writers_use_the_capture_ledger_or_are_allowlisted() {
+    let exempt: BTreeMap<&str, &str> = LEDGER_EXEMPT.iter().copied().collect();
+    assert_eq!(
+        exempt.len(),
+        LEDGER_EXEMPT.len(),
+        "LEDGER_EXEMPT has a duplicate entry",
+    );
+
+    let mut undeclared = Vec::new();
+    let mut stale = Vec::new();
+    let mut covered = BTreeSet::new();
+
+    for source in generator_sources_on_disk() {
+        let key = source.display().to_string();
+        let sources = compiled_sources(&source);
+        let writes = appears_to_write_an_artifact(&sources);
+        let ledgered = appears_to_route_through_the_ledger(&sources, &source);
+        match exempt.get(key.as_str()) {
+            Some(_) => {
+                covered.insert(key.clone());
+                if !writes {
+                    stale.push(format!(
+                        "{key}: no longer matches any idiom in WRITE_IDIOMS, so it no \
+                         longer looks like an artifact writer"
+                    ));
+                } else if ledgered {
+                    stale.push(format!(
+                        "{key}: its entry point now imports \
+                         `conformance::completeness` and calls `finish`"
+                    ));
+                }
+            }
+            None if writes && !ledgered => undeclared.push(key),
+            None => {}
+        }
+    }
+
+    // Shrink-only, half one: an entry that has outlived its subject must go, or
+    // the list stops describing the tree and starts excusing files nobody
+    // checked. Reported before the additions so a migration's own PR is told to
+    // delete its row rather than being told twice about the same file.
+    let deleted: Vec<&str> = exempt
+        .keys()
+        .filter(|key| !covered.contains(**key))
+        .copied()
+        .collect();
+    assert!(
+        deleted.is_empty(),
+        "LEDGER_EXEMPT names generators that no longer exist; delete these rows: {deleted:?}",
+    );
+    // …and half two, which is a *heuristic* observation and says so, because
+    // acting on it deletes a row. Both predicates are substring scans; a row that
+    // is deleted wrongly puts its generator outside this list with nothing left
+    // to notice.
+    assert!(
+        stale.is_empty(),
+        "LEDGER_EXEMPT is shrink-only, and these rows look like they are no longer \
+         needed. Confirm the generator really does account for its population — \
+         both checks below are substring heuristics, not usage analysis — and then \
+         delete the row. If it does not, fix the generator rather than the list:\n  {}",
+        stale.join("\n  "),
+    );
+
+    // A new artifact writer must make one of the two deliberate choices. Silence
+    // is what this file exists to make harder — not impossible: a writer using an
+    // idiom outside WRITE_IDIOMS is invisible here, and closing that would mean
+    // resolving Rust rather than reading it.
+    assert!(
+        undeclared.is_empty(),
+        "these generators look like they write an artifact without routing their \
+         population through `ferro_hgvs::conformance::completeness::CaptureLedger`. \
+         Either adopt the ledger, or add a row to LEDGER_EXEMPT in this file saying \
+         why not: {undeclared:?}",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -92,6 +92,7 @@ mod fast_path_drift_scope;
 mod fast_path_flip_bench;
 mod gene_selector_display_preserve;
 mod gene_selector_roundtrip;
+mod generator_completeness;
 mod genome_ring_join;
 mod gnomad_validation;
 mod grammar_conformance;


### PR DESCRIPTION
Closes #1550

**This change moves no normalized output.** Nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, no generator is migrated, and no artifact is regenerated — it adds a library type, three invariant tests, `Cargo.toml` flags and documentation. Declared as `Representation-Change: none` in the footer below.

## The contract

Generators under `examples/` build the corpora, fixtures and tables the rest of the suite adjudicates against, and they share one failure mode: **a fallible step whose failure is representable as a legitimate value**. `spans_of(..).unwrap_or_default()` yields an empty vec that classifies as "no gaps"; `else { continue }` skips exactly the record that had a problem; a discarded `Result` reports nothing at all. Nothing counts the dropped population, so a partial run and a clean run write indistinguishable artifacts and the only thing separating them is whether a reviewer read the right five lines.

This PR makes that a contract rather than one file's good judgement.

### 1. `src/conformance/completeness.rs` — `CaptureLedger`

`examples/extract_split_member_separation_windows.rs` already implements this refusal for itself — *"Refusing to write a fixture built from a partial pass"*. Promoted into a shared type:

- **Attempted / succeeded / dropped, with a reason per drop.** `attempted == succeeded + dropped` holds by construction; there is no API to increment one alone. (It is *not* re-checked by `Deserialize`, which is how a consuming test reads a stamped claim — `CaptureCounts::is_self_consistent` exists for that side.)
- **`finish()` returns `Result` and refuses on any shortfall.** A `Result` the caller must handle before it can reach its `fs::write`, rather than a count printed to someone who already believes the run worked. `CaptureCounts` deliberately has **no `Default`**, so `finish().unwrap_or_default()` — the module's own archetypal defect, applied to the type meant to kill it — does not compile; a `compile_fail` doctest pins that.
- **A shortfall is waived only by naming it.** `Allowance::at_most(n, justification)` is constructed at the call site and the justification is required — and required means non-empty, not merely present.
- **An empty pass is a shortfall of its own**, needing `Allowance::permitting_an_empty_pass` to waive — the corpus-zero hazard, where a structural blindness is indistinguishable from a safe result.
- **`CaptureCounts` is serde-serializable**, so a generator *can* stamp its completeness claim into the artifact and a consuming test can assert on it. Nothing enforces that it does; stamping is a convention, and the docs now say so.

`ledger.record(id, fallible())` is a drop-in for `let Ok(v) = fallible() else { continue };` — same control flow, but the drop is now accounted for. That is the intended adoption path.

**What the ledger does not claim, stated in its own module docs:** it accounts for *the step you route through it*, not for the artifact. `succeeded` is never compared against the rows that reach the file, so a pass with a second unaccounted fallible step can stamp `{"attempted":10,"succeeded":10,"dropped":0}` onto an artifact holding five rows — the exact shape #1550 cites for `dump_confluence_divergences.rs`. Route the *last* fallible step before the write, not the first.

**Tests:** fourteen unit tests in the module plus two doctests (one of them `compile_fail`). All of them execute (`conformance::completeness::tests::*`). They were verified to be discriminating rather than merely present: with `close()` stubbed to the "report a count and write anyway" behaviour the module exists to replace, **7 of the 11** original tests fail; with the real implementation, all pass.

### 2. The `test = true` invariant — red on `main`, green here

`tests/it/generator_completeness.rs::examples_with_unit_tests_opt_into_running_them`.

Cargo does not build an example's or a binary's `#[cfg(test)]` code unless the target sets `test = true`. `Cargo.toml` has stated this in prose since the two spec generators became `[[bin]]`s, and most generator targets already set the flag — but nothing checked it, so `examples/report_conformance_reference_gaps.rs` shipped a `#[cfg(test)] mod tests` that had **never once executed**. Before:

```
$ cargo nextest run --features dev -E 'binary(report_conformance_reference_gaps)'
    Starting 0 tests across 0 binaries (13 binaries skipped)
     Summary [   0.000s] 0 tests run: 0 passed, 0 skipped
error: no tests to run
```

The new test, written first, is red on that tree and names the culprit:

```
every generator target carrying #[cfg(test)] must set `test = true` in Cargo.toml —
cargo does not build a target's tests unless it opts in:
  [[example]] `report_conformance_reference_gaps` compiles #[cfg(test)] code in
  examples/report_conformance_reference_gaps.rs but does not set `test = true`,
  so those tests never run
```

Adding the flag turns the invariant green **and** brings the dead test to life. It passes on its first-ever execution.

So there is no pre-existing bug hiding behind it — the guard it had claimed to provide was simply never provided.

**This is the one guard here that is exact.** The manifest is parsed as TOML rather than substring-matched, because `Cargo.toml` discusses `test = true` at length in comments and a `[[bench]]` setting it would be a false positive. `#[path]` includes are resolved transitively, because `test = true` is a property of the *target*: a `#[cfg(test)]` in a shared `examples/common/` module is equally dead in every target that includes it without opting in. The one boundary is a plain `mod helper;` include, which is not resolved — noted in the code; the repo uses `#[path]` throughout.

**Two further live instances turned up during review, three days apart.** Rebasing onto the tip that landed #1544/#1545, the invariant went red on `extract_spec_worked_example_windows`, which `#[path]`-includes `examples/common/recording.rs` and did not set `test = true` — six `recording::tests::*` units dead *in that target* while its siblings ran them. Rebasing again onto the tip that landed #1549, it went red on `extract_split_member_separation_windows` for the same reason. `test = true` added in both; all pass on their first execution. That is the transitive-include half of the check earning its keep twice, on generators that landed after the issue was filed.

A sibling test, `every_generator_source_is_declared_as_a_cargo_target`, covers the whole-file version of the same drop — `autoexamples = false`, so an undeclared generator is never built at all, which would also make the guard above vacuous for that file.

### 3. The artifact-writer ratchet — a heuristic floor, and it says so

`tests/it/generator_completeness.rs::artifact_writers_use_the_capture_ledger_or_are_allowlisted`.

A generator whose sources *look like* they write a file must either look like they route their population through `CaptureLedger`, or name itself in `LEDGER_EXEMPT`, each row annotated with `#1550`. Nineteen current writers are listed — fifteen from the tree the issue was filed against, plus the four that landed while this was in review (#1544, #1545, and two from #1549). Migrating those belongs to their own generators' changes, not here.

**Both sides are substring scans, and the code, the test's own failure messages and both policy documents now say so.** An earlier revision of this PR described the ratchet as making it so "a new generator cannot be added without one of the two deliberate acts". That claim was **false and is withdrawn** — it was demonstrated false in review by adding an artifact writer that used `OpenOptions` and by adding one whose entire `CaptureLedger` "usage" was a comment. What the guard actually buys is that a generator written the way every generator in this repo is currently written cannot be added in *silence*, and that the question gets asked. The semantic guarantee is carried by the type and by review.

Two hardenings came out of that, neither of which pretends to close the gap:

- The write-idiom list gained `OpenOptions::new(` and `from_path(` — two measured misses — and is documented as non-exhaustive, with the rule for what belongs on it ("the call names a path") stated so it can be extended consistently.
- The ledger predicate now requires an import of `conformance::completeness` **and** a `finish` call, **in the generator's own entry point**. That closes a demonstrated laundering path: one comment mentioning `CaptureLedger` appended to the shared `examples/common/recording.rs` marked *three* unrelated generators as migrated, and the shrink-only half then *required* deleting their rows — removing three generators from the contract on the strength of one line in a file they merely share. `recording.rs` is exactly what the #1544/#1545 migrations will touch.

**Shrink-only, in both directions.** A row whose generator has since adopted the ledger, stopped writing, or been deleted **fails the test**, so the list cannot rot into a blanket exemption — a migration PR is told to delete its own row. And a generator that looks like it writes and is neither ledgered nor listed fails the build. The "now uses the ledger" direction is the one that can *lose* a row, so its failure message says the row *looks* stale and to confirm before deleting.

Adding a row is a legitimate answer, in exactly the way `Representation-Change: none` is. What neither check tolerates is silence.

### 4. Docs

`CLAUDE.md` and `CONTRIBUTING.md` both state the rule, attached to the existing **"a corpus zero is a claim about the corpus, not about the change"** doctrine, of which this is the mechanized half: that rule covers a misleading number a generator *reports*, this one covers a population it silently drops.

Both are written to be **true of the code as written**, which is the whole point of a policy document in this repo. They name which of the three follow-on rules is enforced by a test (one: `test = true`) and which two are conventions (refuse-don't-report, backed by the type; stamp-the-counts, backed by nothing), and they describe the ratchet as a heuristic floor rather than a proof. An earlier revision claimed "each is enforced by a test"; shipping that in *this* PR would have been self-refuting.

## Deliberately out of scope

- **No generator is migrated to the ledger.** #1544, #1545 and #1549 own `dump_confluence_divergences.rs`, `extract_case_harvest_windows.rs`, `extract_spec_worked_example_windows.rs` and `extract_split_member_separation_windows.rs`. Migrating them here would conflict with open PRs and mix mechanical churn into a new contract. That is what the allowlist is for, and why it shrinks as those PRs land.
- **No AST-based usage analysis.** The alternative to narrowing the ratchet's claim was to make the predicate real — parse Rust, resolve the ledger's actual usage. That was considered and rejected: chasing a perfect predicate for a three-line rule is how you overclaim a second time, and the honest answer to "a grep cannot tell whether a population was routed through the ledger" is to say so, not to build a bigger grep.
- **No blanket idiom lint.** Re-measured on this branch across `examples/` + `src/conformance/`: `unwrap_or_default()` 17, `.ok()?` 18, `unwrap_or(` 22, `let _ =` 74, `continue;` 62 — ~193 candidate sites, overwhelmingly legitimate. What makes one a defect is not the idiom but that its failure flows into a value that is then counted, a composition grep cannot see. Noisy gates get allowlisted into irrelevance, so the mechanical half stays narrow and the semantic half is carried by the type.

## Notes for review

- `toml` joins `[dev-dependencies]`. It is already an optional runtime dependency (`web-service`), but `tests/it` compiles without `--features dev`, so the optional copy is not guaranteed to be enabled; cargo unifies the two for test targets.
- `Shortfall::Dropped` boxes its payload to stay under clippy's `result_large_err` threshold, since it is the `Err` half of every `finish`.
- The refusal message caps its *reason* list as well as its subject list. `record()` sets `reason = error.to_string()`, which for an `io::Error` is unique per record, so an uncapped reason map defeated `MAX_NAMED_SUBJECTS` entirely — measured at 2000 drops, a 2,014-line / 71 KB panic. Both totals stay exact in the truncated form.

---

Closes #1550

Representation-Change: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added completeness tracking for generated records, including successes, dropped records, drop reasons, allowances, and serialized capture counts.
  * Added clear errors when generation captures nothing or drops records without an approved allowance.

* **Tests**
  * Added automated checks to verify generators account for dropped records and use correct test-target configuration.

* **Documentation**
  * Added guidance for implementing completeness tracking, handling justified exceptions, and validating generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->