### PR TITLE
fix(changelog): read a decline that gives a reason as a decline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.12.0...v0.13.0) - 2026-08-07
 
-### <!-- 0 -->Representation changes
+### Representation changes
 
 Normalization output is a shipped key: a downstream consumer stores read counts
 against the normalized HGVS string, so a form that moves between releases
@@ -71,7 +71,7 @@ consumer impact.
 [#1490]: https://github.com/fulcrumgenomics/ferro-hgvs/pull/1490
 [#1501]: https://github.com/fulcrumgenomics/ferro-hgvs/pull/1501
 
-### <!-- 1 -->Added
+### Added
 
 - *(dev)* add --verify-spdi to the normalized-corpus harness ([#1515](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1515))
 - *(normalize)* record provenance when reported members are coalesced ([#1486](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1486))
@@ -81,7 +81,7 @@ consumer impact.
 - *(normalize)* make the sequence-first derivation authoritative for cis alleles ([#1392](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1392))
 - *(effect)* [**breaking**] drop the dead inversion validator that contradicted the live one ([#1359](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1359))
 
-### <!-- 5 -->Fixed
+### Fixed
 
 - *(normalize)* apply a junction barrier the translate cannot express ([#1516](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1516))
 - *(spdi)* name the caller's anchor when a repeat names no tract ([#1496](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1496))
@@ -123,7 +123,7 @@ consumer impact.
 - *(spdi)* [**breaking**] give an identity edit the span it claims ([#1363](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1363))
 - *(normalize)* stop a terminal duplication respelling past the contig end ([#1365](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1365))
 
-### <!-- 7 -->Other
+### Other
 
 - *(msto)* pin the reported family's expected outputs and link its guards ([#1520](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1520))
 - *(normalize)* correct the coincidence statistics behind the density gate ([#1521](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1521))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,19 @@ those directories move no output at all (a comment, a doc, a new unit test), and
 expected case. What the check rejects is *silence*, because an absent trailer is
 indistinguishable from an unconsidered one.
 
+**The verdict is the first word, and a reason may follow it** — `none. Tests only; no watched
+file is touched.` A full stop, semicolon, colon or dash introduces the reason; a comma does not,
+because it usually introduces a qualification that changes the answer ("none, except two rows"),
+which is filed as a real change. This was the #1555 defect: the value used to be anchored, so
+declining *with a reason* was read as a disclosure. It is not a corner case — in the v0.13.1
+cycle 8 of the 14 declines gave a reason, and the section listed 10 entries of which 2 were real.
+
+**Two limits of the section itself.** It carries the commit subject only — the trailer's text is
+unreachable from the changelog template (#1556), so the rejected-vs-accepted fact lives in the PR
+description. And a declining commit is filed under **Other** whatever its type, so a declining
+`fix:` is missing from **Fixed** (#1557); git-cliff evaluates a parser's fields as OR, not AND, so
+this cannot be repaired by adding `message` to the exclusion rule.
+
 **It must be in the PR description, not only in a commit message.** GitHub builds the squash
 commit body from the description, and `release-plz.toml`'s parsers match the commit *footer*; a
 trailer on an intermediate commit is discarded by the squash and never reaches the changelog.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,24 @@ ci: pin the workflow's action hashes
 Representation-Change: none
 ```
 
-`none`, `no`, `n/a` and `na` all count, in any casing. A declining trailer is
+`none`, `no`, `n/a` and `na` all count, in any casing. **Say why, if it is not
+obvious** — the verdict is the first word, and a full stop, semicolon, colon or
+dash may introduce a reason:
+
+```
+test(conformance): gate the harvested unguarded cases on every PR
+
+Representation-Change: none. Test-only plus two new `src/conformance/`
+  modules; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or
+  `src/project/` is touched, and no existing expectation was re-blessed.
+```
+
+A comma is *not* a terminator, because it usually introduces a qualification
+that changes the verdict ("none, except two rows") — that reads as a description
+of a move, and is filed as one. Same for `no rows move`: no terminator, so the
+verdict is not `no`. Both err toward listing a change rather than hiding one.
+
+A declining trailer is
 excluded from the changelog's **Representation changes** section, so declaring it
 costs the reader nothing while leaving the judgement on the record. CI enforces
 the distinction: a change touching `src/normalize/`, `src/hgvs/`, `src/spdi/` or
@@ -127,9 +144,19 @@ Two related habits, from `CLAUDE.md`:
 
 Commits carrying the trailer are collected into a **Representation changes**
 section at the top of the changelog, and that section is surfaced on the release
-PR — see [Changelog](#changelog) below. Nothing enforces the trailer today: a
-change that moves output without one is simply invisible, which is why the
-release PR states the section even when it is empty.
+PR — see [Changelog](#changelog) below. The release PR states the section even
+when it is empty, so that a cycle in which nothing was declared is visible rather
+than silent.
+
+Two limits of that section are worth knowing before you rely on it. It carries
+the commit **subject** only — the trailer's own text does not reach the changelog
+([#1556]), so the four facts above live in your PR description and a reader has
+to follow the link for them. And a declining commit is filed under **Other**
+whatever its type, so a `fix:` that correctly declined is not listed under
+**Fixed** ([#1557]).
+
+[#1556]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1556
+[#1557]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1557
 
 ### Changelog
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -40,9 +40,14 @@ Reviewer checklist:
 
 - [ ] Either that section lists every output-moving change in this cycle, or
       there were none and it is absent.
-- [ ] Each entry says whether the affected inputs were previously **rejected**
-      (no stored string, so free) or previously **accepted** (a real migration
-      for the consumer).
+- [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
+      none`, optionally followed by a reason, and belongs under its own type —
+      not here. Spot-check two entries against their PR descriptions.
+- [ ] For each entry, that PR's description says whether the affected inputs
+      were previously **rejected** (no stored string, so free) or previously
+      **accepted** (a real migration for the consumer). The bullet below carries
+      only the commit subject: the trailer's own text cannot reach the changelog
+      (fulcrumgenomics/ferro-hgvs#1556), so this one has to be read from the PRs.
 
 A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` that
 moved output without declaring it means the trailer is missing. Fix that before
@@ -115,9 +120,31 @@ commit_parsers = [
   # case-insensitive); without the flag an uppercase decline is grouped as a real change,
   # which is this bug in miniature. Verified against git-cliff 2.13.1.
   #
-  # The decline vocabulary is kept in step with `NONE_VALUES` in
-  # `scripts/check_representation_change.py` by `test_decline_vocabulary_matches_the_changelog_config`.
-  { footer = "(?i)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*$", group = "<!-- 7 -->Other" },
+  # **The verdict is the first word; a reason may follow it** (#1555). The value used to be
+  # anchored -- `(none|no|n/a|na)$` -- so `none. No file under src/ is touched` was not a
+  # decline and rendered as a real change. That is not a corner case: in the v0.13.1 cycle
+  # 14 of 16 commits declined, 8 of them gave a reason on the same line, and all 8 landed
+  # under "Representation changes". The section listed 10 entries of which 2 were real.
+  #
+  # Explaining a decline is the behaviour to encourage, so the punctuation that introduces
+  # the explanation must not silently invert the verdict. `,` is deliberately NOT a
+  # terminator: a comma most often introduces a qualification that changes the answer
+  # ("none, except two rows"), where a full stop or a dash closes it.
+  #
+  # The decline vocabulary and this terminator set are kept in step with `NONE_VALUES` and
+  # `DECLINE_TERMINATORS` in `scripts/check_representation_change.py` by
+  # `test_decline_vocabulary_matches_the_changelog_config` and
+  # `test_the_two_decline_rules_agree_value_by_value`.
+  { footer = "(?i)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*(?:[.;:—–][\\s\\S]*)?$", group = "<!-- 7 -->Other" },
+  # A declining commit lands in `Other` whatever its type, so a `fix:` that correctly
+  # declined is not listed under `Fixed` (#1557). That is a known cost of the ordering
+  # above, not an oversight, and the obvious repair does not work: **git-cliff evaluates a
+  # parser's fields as OR, not AND** (measured against 2.13.1). Adding `message = "^fix"`
+  # to this rule matches every `fix:` commit regardless of its trailer -- including the
+  # ones declaring a real move -- which empties the section below. Omitting `group` does
+  # not fall through to a later parser either; the commit keeps `group = None` and
+  # git-cliff falls back to the raw conventional type, rendering headings as `fix`/`test`.
+  #
   # `(?i)` here too, and not only on the exclusion above: the checker accepts any casing,
   # so a lowercase `representation-change: 577 rows move` is a REAL disclosure that a
   # case-sensitive rule drops silently into `Other`. Verified against git-cliff 2.13.1.
@@ -130,3 +157,18 @@ commit_parsers = [
   { message = "^security", group = "<!-- 6 -->Security" },
   { message = "^.*", group = "<!-- 7 -->Other" },
 ]
+
+# Strip the group-ordering prefix out of the rendered headings.
+#
+# The `<!-- N -->` prefixes above exist only to order the groups, and the comment on them
+# used to claim git-cliff strips them from the heading. It does not: release-plz's default
+# body renders `### {{ group | upper_first }}`, with no `striptags`, so every released
+# section since v0.13.0 carries `### <!-- 0 -->Representation changes` in the file. It is
+# an HTML comment, so GitHub renders it invisibly -- which is why it survived two releases.
+#
+# A postprocessor is used rather than a `body` override because `body` would replace
+# release-plz's default wholesale, and that default supplies the compare link, the
+# `[**breaking**]` marker and the PR links. Restating all of it to change one filter is a
+# large surface to get subtly wrong for a cosmetic fix; this is one line that cannot touch
+# anything else. Anchored to the heading so a `<!-- ... -->` in a commit subject survives.
+postprocessors = [{ pattern = "(?m)^(#+) <!-- [0-9]+ -->", replace = "${1} " }]

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -64,6 +64,39 @@ TRAILER_RE = re.compile(
 #: what moved, which is what lands in the changelog.
 NONE_VALUES = frozenset({"none", "no", "n/a", "na"})
 
+#: Punctuation that may separate a decline from the reason for it, so that
+#: `none. Tests only; no src/ file is touched` still reads as a decline (#1555).
+#:
+#: Requiring a bare verdict punished the contributors who explained themselves: in the
+#: v0.13.1 cycle 8 commits declined *with a reason* and every one of them was grouped as a
+#: real representation change. Explaining a decline is the habit to encourage.
+#:
+#: `,` is deliberately absent. A comma usually introduces a qualification that changes the
+#: verdict -- "none, except two rows" -- where a full stop, semicolon, colon or dash closes
+#: it. This set is mirrored in `release-plz.toml`'s exclusion rule and pinned by
+#: `test_the_two_decline_rules_agree_value_by_value`.
+DECLINE_TERMINATORS = ".;:—–"
+
+#: A declination: one of `NONE_VALUES`, alone or followed by a reason. Built from the two
+#: constants above so the vocabulary has one definition rather than a regex restating it.
+#: `DOTALL` so a reason spanning lines does not defeat the trailing `.*`.
+DECLINE_RE = re.compile(
+    r"^(?:"
+    + "|".join(re.escape(value) for value in sorted(NONE_VALUES))
+    + r")[ \t]*(?:["
+    + re.escape(DECLINE_TERMINATORS)
+    + r"].*)?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def declines(declaration: str) -> bool:
+    """Return whether `declaration` is a decline rather than a description of a move.
+
+    The verdict is the first word; anything after a terminator is the reason for it.
+    """
+    return DECLINE_RE.match(declaration.strip()) is not None
+
 
 def watched_files(changed: list[str]) -> list[str]:
     """Return the changed paths that sit under a watched directory."""
@@ -106,7 +139,7 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
             "Measure with: cargo run --release --features dev --example dump_normalized_corpus"
         )
 
-    if declaration.strip().lower() in NONE_VALUES:
+    if declines(declaration):
         return (
             True,
             f"Declared `Representation-Change: {declaration}` over {len(watched)} watched file(s).",

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -141,6 +141,58 @@ def test_decline_spellings_all_pass(value: str) -> None:
     assert ok
 
 
+# ---------------------------------------------------------------------------
+# A decline may give its reason (#1555)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "none. Tests only; no file under a watched directory is touched.",
+        "none: comments only",
+        "none; the diff is one fixture JSON and one new test module",
+        "none — 0 of 950 real cis-allele rows move their normalized string",
+        "None. Ruling records and their status pins only.",
+        "no. Nothing here can reach a normalizer.",
+        "n/a: docs",
+        "na. generated artifact only",
+        "none.\n  A reason spanning two lines.",
+    ],
+)
+def test_a_decline_may_give_its_reason(value: str) -> None:
+    """The verdict is the first word; what follows a terminator explains it.
+
+    Requiring a bare `none` punished exactly the contributors who explained themselves:
+    8 commits in the v0.13.1 cycle declined with a reason and all 8 were then listed as
+    representation changes.
+    """
+    assert check_representation_change.declines(value), f"{value!r} declines a move"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "577 rows move, 360 merge / 205 split / 12 respell",
+        "3 rows of 500,004 move (0.0006%) — 2 respell, 1 merge",
+        "0 rows move over 5,761,302 real expressions",
+        "no rows move",
+        "nothing moves under src/normalize/",
+        "not measured yet",
+        "none, except two rows that merge",
+    ],
+)
+def test_a_description_of_a_move_is_not_a_decline(value: str) -> None:
+    """The failure that matters here is the silent one: a real disclosure read as a decline
+    disappears from the changelog, and nobody is told.
+
+    `no rows move` and `none, except …` are the near misses. Both begin with a decline word,
+    and neither is one — the first has no terminator, and `,` is not a terminator precisely
+    because it usually introduces a qualification that changes the verdict.
+    """
+    assert not check_representation_change.declines(value), f"{value!r} describes a move"
+
+
 def test_an_empty_trailer_does_not_scavenge_the_next_line() -> None:
     """`\\s` spans newlines, so a permissive class would read `none` off the line below and
     call an empty trailer a declaration."""
@@ -185,6 +237,75 @@ def test_decline_vocabulary_matches_the_changelog_config() -> None:
         f"release-plz.toml excludes {sorted(configured)} but the checker treats "
         f"{sorted(check_representation_change.NONE_VALUES)} as declines; a word in one and "
         "not the other either leaks a non-change into the changelog or hides a real one"
+    )
+
+
+def test_the_two_decline_rules_agree_value_by_value() -> None:
+    """The vocabulary test above compares word lists; this one compares *verdicts*.
+
+    #1555 is the reason both are needed. The two rules named the same four words and still
+    disagreed, because the changelog rule anchored the value (`none$`) while the checker
+    lowercased and compared it — so `none. Tests only.` passed CI as a decline and then
+    rendered as a representation change. A word-list comparison cannot see that; only
+    running both rules over the same values can.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    # Anchored on the trailer name, not on `{ footer = "`: the first such literal in the file
+    # is git-cliff's `^changelog: ?ignore` example, quoted in a comment.
+    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
+    assert rules, "no Representation-Change exclusion rule found in release-plz.toml"
+    # The rule is a TOML basic string, so its backslashes are escaped in the file.
+    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"), re.MULTILINE)
+
+    values = [
+        "none",
+        "NONE",
+        "none.",
+        "none. Tests only; nothing under a watched directory.",
+        "none: comments only",
+        "none; one fixture JSON",
+        "none — 0 of 950 rows move",
+        "no. Nothing reaches a normalizer.",
+        "n/a: docs",
+        "na. generated artifact only",
+        "577 rows move, 360 merge / 205 split",
+        "0 rows move over 5,761,302 real expressions",
+        "no rows move",
+        "none, except two rows that merge",
+        "nothing moves",
+    ]
+    for value in values:
+        by_changelog = changelog_rule.search(f"Representation-Change: {value}") is not None
+        by_checker = check_representation_change.declines(value)
+        assert by_changelog == by_checker, (
+            f"{value!r}: release-plz.toml calls it "
+            f"{'a decline' if by_changelog else 'a real change'} and the checker calls it "
+            f"{'a decline' if by_checker else 'a real change'}; the changelog and CI must "
+            "agree, or a PR passes the check and is then filed as its opposite"
+        )
+
+
+def test_the_ordering_prefix_is_stripped_from_rendered_headings() -> None:
+    """`<!-- N -->` orders the groups; it must not survive into the changelog text.
+
+    Without the postprocessor every released section carries `### <!-- 0 -->Representation
+    changes` in the file. It is an HTML comment, so GitHub renders it invisibly — which is
+    how it survived two releases unnoticed.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    match = re.search(
+        r'postprocessors = \[\{ pattern = "((?:[^"\\]|\\.)*)", replace = "([^"]*)"', config
+    )
+    assert match is not None, "no postprocessor found; the ordering prefix would be rendered"
+    pattern = re.compile(match.group(1).replace("\\\\", "\\"), re.MULTILINE)
+    replacement = match.group(2).replace("${1}", r"\1")
+
+    rendered = "### <!-- 0 -->Representation changes\n### <!-- 7 -->Other\n"
+    assert pattern.sub(replacement, rendered) == "### Representation changes\n### Other\n"
+
+    subject = "- *(docs)* explain the <!-- 0 --> marker\n"
+    assert pattern.sub(replacement, subject) == subject, (
+        "the rule must be anchored to a heading; a marker quoted in a commit subject is text"
     )
 
 


### PR DESCRIPTION
The **Representation changes** section of the v0.13.1 changelog lists 10 entries. Two of them are representation changes. This makes the section report what it actually contains, before the release goes out.

Closes #1555. Records #1556 and #1557, which are limits of the same section that this does not fix.

## A decline that gives a reason was read as a disclosure

`release-plz.toml`'s exclusion rule anchored the trailer's value:

```
footer = "(?i)^Representation-Change:[^\S\r\n]*(none|no|n/a|na)[^\S\r\n]*$"
```

So `Representation-Change: none` was a decline and `Representation-Change: none. Tests only; nothing under a watched directory is touched.` was not. `NONE_VALUES` in `scripts/check_representation_change.py` had the same shape, so the checker also reported those as "Declared a representation change".

Measured over `v0.13.0..main` with git-cliff 2.13.1, the version release-plz runs:

| | commits |
|---|---|
| in the cycle (after release-plz's package filter drops two `.github/`-only commits) | 16 |
| declined | 14 |
| **declined with a reason on the same line, and were listed as changes** | **8** |
| genuinely declared a move | 2 |

The two real ones are #1537 (3 rows of 500,004 move) and #1535 (0 rows move over 5,761,302 real expressions, a structural zero it states as such). The eight are #1538 #1544 #1545 #1546 #1547 #1548 #1549 #1540.

This is #1526 from the opposite side — that bug listed a decline as a change, and #1527 fixed it only for the bare spelling. It also punished exactly the behaviour worth encouraging: the six authors who wrote a bare `none` were filed correctly, and the eight who explained themselves were not.

## What changed

**The verdict is the first word; a reason may follow it.** `.`, `;`, `:` and dashes introduce the reason. A comma does not, because it usually introduces a qualification that changes the answer — `none, except two rows that merge` is filed as a real change, as is `no rows move`, which has no terminator. Both near misses err toward listing a change rather than hiding one, which is the safe direction for this particular section.

**The two rules are pinned value by value.** `test_decline_vocabulary_matches_the_changelog_config` compares word lists, and that was not enough: the two rules named the same four words and still disagreed on `none. Tests only.`. `test_the_two_decline_rules_agree_value_by_value` extracts the regex from `release-plz.toml` and runs both over the same 15 values.

**The `<!-- N -->` ordering prefix is stripped from headings.** The comment on those prefixes claimed git-cliff removed them. It does not — release-plz's default body renders `### {{ group | upper_first }}` with no `striptags` — so every section since v0.13.0 carries `### <!-- 0 -->Representation changes` in the file. It is an HTML comment, which is why GitHub renders it invisibly and it survived two releases. Done with a `postprocessor` rather than a `body` override: overriding `body` replaces release-plz's default wholesale, including the compare link, the `[**breaking**]` marker and the PR links, which is a large surface to restate for a cosmetic fix. The four historical headings are cleaned up to match, since release-plz only prepends and would otherwise leave the file inconsistent.

## Verified against the real config, not a paraphrase

The rendering below comes from feeding this branch's own `commit_parsers` and `postprocessors` — read out of `release-plz.toml`, not retyped — to git-cliff 2.13.1 over `v0.13.0..HEAD`:

```
### Representation changes
- never split a delins into members on consecutive nucleotides (#1537)
- type the whole-block inversion by what it competes with (#1535)

### Other
- ... the other 16
```

Also: 45 tests in `test_representation_change_trailer.py` and 752 in `tests/python/` pass; ruff and mypy are clean; and the checker was exercised end to end on a reasoned decline (exit 0), a real disclosure (exit 0, reported as a change) and silence (exit 1).

## What this does not fix

Both are filed, and both are visible in this diff as documentation rather than as code:

- **#1556** — the trailer's text never reaches the changelog, so the release PR's checklist item asking each entry to state rejected-vs-accepted cannot be satisfied by any PR. Three extraction routes were measured and all fail: `commit.footers` is mis-parsed by git_conventional (7 bogus "footers" for one commit, the first swallowing the entire body), `commit.body` does not contain the trailer at all (0 matches for both real disclosures), and splitting on the unanchored literal returns the prose *mentions* — for #1534 it extracted a paragraph discussing the trailer, which would have shipped as if it were the declaration. The checklist now asks for that fact from the PR descriptions and says why.
- **#1557** — a declining `fix:` is filed under Other rather than Fixed. Adding `message = "^fix"` to the exclusion rule does not fix it: **git-cliff evaluates a parser's fields as OR, not AND**, so that rule matches every `fix:` commit regardless of its trailer and empties the section. Omitting `group` does not fall through either — the commit keeps `group = None` and git-cliff falls back to the raw conventional type. Both measurements are recorded in the config so the next person does not re-derive them.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — the diff is the release configuration, the declaration checker, its tests, and documentation. No normalized output can move.
