### PR TITLE
test(changelog): audit the Representation changes section against its trailers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,77 @@ jobs:
             --changed-files changed-files.txt \
             --declaration-file pr-body.txt
 
+  # Audit what the changelog's **Representation changes** section actually contains, by
+  # rendering it with the real `release-plz.toml` and checking the result against the
+  # trailers on the commits.
+  #
+  # The job above asks each PR to declare; this one asks whether the declarations end up
+  # where they claim. Both halves of that have shipped broken -- #1526 listed one decline
+  # as a change, #1555 listed eight -- and neither was caught, because the test written to
+  # catch exactly this compares the two halves against *each other* and they were wrong
+  # together. So this audit derives its own answer and shares no code with the checker.
+  #
+  # Runs on every PR rather than only at release time: the section is rebuilt from the
+  # whole range since the last tag, so a mis-filed trailer is visible the day it lands
+  # rather than in the release PR, when the fix is a rebase of somebody else's merged work.
+  changelog-grouping:
+    name: Changelog grouping audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Full history and tags: the audited range is `<latest tag>..HEAD`.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: taiki-e/install-action@a8fb21b85430c7a58551cf7ea87b03f355b826d9  # git-cliff
+      - name: Synthesize the squash commit this PR will become
+        # Without this the audit cannot see the commit it exists to judge. GitHub builds
+        # the squash subject from the PR title and the body from the PR description, and
+        # the `Representation-Change:` trailer lives in the description — so on a PR
+        # branch no commit in `<latest tag>..HEAD` carries it, and a PR whose merged form
+        # files a decline under **Representation changes** passes here and is caught only
+        # after it lands. The sibling `representation-change` job already reads the
+        # description for the same reason; this is the same fact, one step further on.
+        #
+        # `reset --soft` to the PR's base first, so the *history* is the preview and not
+        # just the message. On a `pull_request` event `actions/checkout` gives the MERGE
+        # ref, so `<latest tag>..HEAD` otherwise contains the branch's intermediate
+        # commits and the merge commit itself — none of which survive a squash. Measured
+        # on a simulated merge ref: 5 audited commits that way against 2 this way, where
+        # 2 is exactly post-merge `main`. Soft-resetting keeps the index and worktree, so
+        # the commit carries the PR's real tree and the audit still reads the PR's own
+        # `release-plz.toml` — this is the squash commit, not an approximation of it.
+        #
+        # `--allow-empty` is still needed: a PR that changes no files (a description-only
+        # edit re-running CI) would otherwise have nothing to commit.
+        if: github.event_name == 'pull_request'
+        # Through `env`, never interpolated into the script body: a PR title and
+        # description are attacker-controlled text and `${{ }}` inside `run` would splice
+        # them into the shell.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          printf '%s (#%s)\n\n%s\n' "$PR_TITLE" "$PR_NUMBER" "$PR_BODY" > squash-message.txt
+          git reset --soft "$PR_BASE_SHA"
+          git -c user.name='github-actions' -c user.email='github-actions@github.com' \
+            commit --allow-empty --no-verify --quiet --file squash-message.txt
+          echo "auditing this squash-equivalent commit:"
+          git --no-pager log -1 --format='%H%n%s'
+          # Guarded: `describe` exits non-zero on a tagless history, and this echo is a
+          # debugging aid — it must not be what fails the job under `set -e`.
+          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "audited range ($tag..HEAD) now contains:"
+            git --no-pager log --format='  %h %s' "$tag..HEAD"
+          fi
+      - name: Audit the Representation changes section
+        run: python scripts/check_changelog_grouping.py
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,8 +344,25 @@ deliberately enriched for churn-prone shapes, so quote its rate as *of the affec
 as a repo-wide figure — for consumer impact, normalize a real corpus through both revisions with
 `ferro normalize -i <inputs> --reference <dir> -f tsv` instead.
 
+**A decline that then describes a move is rejected.** `no. 3 rows move` reads as a decline —
+first word wins — so the disclosure would vanish silently, which is the worst direction this
+mechanism can fail in. The checker fails a declining trailer that also claims `<n> rows
+move|merge|split|respell` for non-zero `n`. Quantifying a *zero* is encouraged and passes
+(`none. 0 of 950 rows move`); the pattern requires the count to sit immediately before `rows`,
+which is what keeps #1547's `0 of 950 real cis-allele rows move` from tripping on the 950. It is a
+tripwire for the phrasing this repo actually uses, not a general contradiction detector.
+
+**The section itself is audited, not just each PR's trailer.** `Changelog grouping audit` renders
+the changelog with the real `release-plz.toml` over `<latest tag>..HEAD` and checks the result
+against the commits: nothing filed under **Representation changes** may open with a decline word,
+nothing that declares a move may be filed elsewhere, and no heading may still carry its `<!-- N -->`
+ordering prefix. It deliberately shares **no code** with the checker — #1555 passed the test written
+to catch it precisely because that test compared the two halves against each other and they were
+wrong together, so a second opinion is only worth having when it is derived differently.
+
 Contributor-facing guidance is in `CONTRIBUTING.md`. The checker is
-`scripts/check_representation_change.py`; its decline vocabulary is pinned against
+`scripts/check_representation_change.py` and the audit is
+`scripts/check_changelog_grouping.py`; the decline vocabulary is pinned against
 `release-plz.toml` and `CONTRIBUTING.md` by tests in
 `tests/python/test_representation_change_trailer.py`, because three copies of one list drift
 silently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,13 @@ that changes the verdict ("none, except two rows") — that reads as a descripti
 of a move, and is filed as one. Same for `no rows move`: no terminator, so the
 verdict is not `no`. Both err toward listing a change rather than hiding one.
 
+**Do not decline and then describe a move.** `no. 3 rows move` is filed as a
+decline, because the verdict is the first word — so the disclosure never reaches
+the changelog and nobody is told. CI rejects that combination: a declining
+trailer that also claims `<n> rows move` (or merge/split/respell, for any `n`
+other than zero) fails the check, and the message asks you to say which it is.
+Quantifying a zero is fine and encouraged — `none. 0 of 950 rows move` passes.
+
 A declining trailer is
 excluded from the changelog's **Representation changes** section, so declaring it
 costs the reader nothing while leaving the judgement on the record. CI enforces

--- a/scripts/check_changelog_grouping.py
+++ b/scripts/check_changelog_grouping.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Check that the changelog's **Representation changes** section contains what it claims.
+
+`release-plz.toml` routes commits carrying a `Representation-Change:` trailer into their own
+changelog section, and `scripts/check_representation_change.py` makes PRs carry one. Both
+halves have now been wrong in production, in opposite directions:
+
+- **#1526** listed a decline as a representation change (bare `none`).
+- **#1555** listed eight of them, because a decline that gave a reason -- `none. <why>` --
+  did not match a rule anchored on the bare word. The v0.13.1 section listed 10 entries of
+  which 2 were real.
+
+Neither was caught by CI, and the reason is worth stating because it shapes this check.
+#1527 added `test_decline_vocabulary_matches_the_changelog_config`, whose whole purpose is
+to stop those two halves drifting apart. It passed throughout #1555, because the two halves
+had **not** drifted: they named the same four words and were wrong together. An
+agreement-based test cannot see a shared mistake.
+
+So this check does not ask whether the two halves agree. It renders the changelog with the
+real configuration and asks a deliberately *simpler*, independent question of the result:
+
+    does anything filed under "Representation changes" begin with a word that means no?
+
+That rule shares no code with the checker, and it would have fired on all eight #1555 rows
+and on #1526 regardless of what either half believed at the time. It is coarse on purpose --
+a second opinion is only useful when it is derived differently.
+
+Usage:
+    python scripts/check_changelog_grouping.py                  # since the latest tag
+    python scripts/check_changelog_grouping.py --range v0.13.0..HEAD
+
+Exits 0 when the section is consistent, 1 when it is not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# `tomllib` is standard from 3.11. The workflow pins 3.12; ruff groups it as third-party
+# here only because the project's `target-version` is py310 for the published package.
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The group `release-plz.toml` routes trailered commits into. Matched after the ordering
+#: prefix is stripped, so it survives a change to the `<!-- N -->` numbering.
+REPRESENTATION_GROUP = "Representation changes"
+
+#: Words that mean "this moves nothing", as a *first word*. Deliberately a plain prefix
+#: test with no terminator logic: `scripts/check_representation_change.py` owns the precise
+#: rule, and a second opinion derived the same way is not a second opinion.
+DECLINE_WORDS = frozenset({"none", "no", "n/a", "na"})
+
+#: A body template that renders one commit id per line under its group heading. Rendering
+#: ids rather than messages makes the mapping back to commits exact, and keeps this check
+#: independent of message formatting, link parsers and preprocessors.
+#:
+#: `### {{ group | upper_first }}` reproduces how release-plz renders a heading today --
+#: with no `striptags`, which is why the ordering prefix reaches the file at all (#1558).
+BODY_TEMPLATE = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}{{ commit.id }}
+{% endfor %}{% endfor %}
+"""
+
+
+def load_changelog_config(path: Path) -> dict[str, Any]:
+    """Return the `[changelog]` table of a release-plz config."""
+    with path.open("rb") as handle:
+        config: dict[str, Any] = tomllib.load(handle)["changelog"]
+    return config
+
+
+def _toml_value(value: object) -> str:
+    """Render `value` as a TOML literal.
+
+    Written out rather than taken from a library because the standard library ships a TOML
+    reader and no writer, and the alternative is adding a dependency to a CI-only script.
+    """
+    if isinstance(value, str):
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+        )
+        return f'"{escaped}"'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, dict):
+        return "{ " + ", ".join(f"{k} = {_toml_value(v)}" for k, v in value.items()) + " }"
+    if isinstance(value, list):
+        return "[\n  " + ",\n  ".join(_toml_value(item) for item in value) + ",\n]"
+    raise TypeError(f"cannot render {type(value).__name__} as TOML")
+
+
+def write_cliff_config(changelog: dict[str, Any], destination: Path) -> None:
+    """Write a git-cliff config carrying the real parsers and postprocessors.
+
+    Only the fields that decide *grouping* are copied. The body is this module's own, so
+    that the rendered output is a list of commit ids rather than prose.
+    """
+    lines = ["[changelog]", 'header = ""', "trim = true", f"body = {_toml_value(BODY_TEMPLATE)}"]
+    if "postprocessors" in changelog:
+        lines.append(f"postprocessors = {_toml_value(changelog['postprocessors'])}")
+    lines += [
+        "",
+        "[git]",
+        "conventional_commits = true",
+        "filter_unconventional = false",
+        f"commit_parsers = {_toml_value(changelog['commit_parsers'])}",
+    ]
+    destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def render(commit_range: str, config: Path, repo: Path) -> str:
+    """Render the changelog for `commit_range` and return it verbatim."""
+    result = subprocess.run(
+        ["git-cliff", "--config", str(config), "--tag", "unreleased", commit_range],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git-cliff failed:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def parse_rendered_groups(rendered: str) -> dict[str, list[str]]:
+    """Return `{group name: [commit id, ...]}` from a rendered changelog.
+
+    The key is the heading with any `<!-- N -->` ordering prefix removed, so that a broken
+    postprocessor does not also break the lookup. Keeping them coupled made one failure
+    hide the other: with #1558 reverted, every heading kept its prefix, the section lookup
+    found nothing, and the check reported the two real disclosures as *unfiled* rather
+    than reporting the eight declines that were filed. Each failure now names itself.
+
+    Group headings are `###`; the `##` above them is the version, which is why the pattern
+    requires three hashes rather than one.
+    """
+    groups: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in rendered.splitlines():
+        heading = re.match(r"^#{3,}\s+(.*\S)\s*$", line)
+        if heading:
+            current = strip_ordering_prefix(heading.group(1))
+            groups.setdefault(current, [])
+        elif re.fullmatch(r"[0-9a-f]{40}", line.strip()) and current is not None:
+            groups[current].append(line.strip())
+    return groups
+
+
+def rendered_headings(rendered: str) -> list[str]:
+    """Return the heading lines verbatim, prefix included."""
+    return [m.group(1) for m in re.finditer(r"^#{3,}\s+(.*\S)\s*$", rendered, re.MULTILINE)]
+
+
+def strip_ordering_prefix(heading: str) -> str:
+    """Remove a `<!-- N -->` group-ordering prefix from `heading`."""
+    return re.sub(r"^<!--\s*\d+\s*-->\s*", "", heading).strip()
+
+
+def commit_bodies(commit_range: str, repo: Path) -> dict[str, str]:
+    """Return `{commit id: full message}` for every commit in `commit_range`.
+
+    Framed on NUL, by git itself. An earlier revision appended `\\x1e` after `%B` and split
+    on it, which a commit message is free to contain — and a message that did would
+    re-frame the records and silently mis-attribute a trailer to the wrong commit, in a
+    guard whose whole job is attributing trailers. NUL is the one byte a commit message
+    cannot hold, so `-z` (record terminator) plus `%x00` (field separator) makes the
+    framing git's problem rather than ours: the output is a flat NUL-separated
+    `id, message, id, message, …`.
+    """
+    result = subprocess.run(
+        ["git", "log", "-z", "--format=%H%x00%B", commit_range],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Trailing terminator yields one empty tail field; every real record is a pair.
+    fields = result.stdout.split("\x00")
+    if fields and fields[-1] == "":
+        fields.pop()
+    if len(fields) % 2 != 0:
+        raise RuntimeError(
+            f"git log -z returned {len(fields)} NUL-separated fields for {commit_range!r}, "
+            "which is not an id/message pairing; refusing to guess the framing"
+        )
+    return {fields[i]: fields[i + 1].strip("\n") for i in range(0, len(fields), 2)}
+
+
+def trailer_value(message: str) -> str | None:
+    """Return the `Representation-Change:` value in `message`, or None."""
+    match = re.search(
+        r"^[ \t]*Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
+        message,
+        re.IGNORECASE | re.MULTILINE,
+    )
+    return match.group("value") if match else None
+
+
+def opens_with_a_decline(value: str) -> bool:
+    """Return whether `value`'s first word means "nothing moved".
+
+    Punctuation is stripped from the first word, so `none.`, `none:` and `none —` all read
+    as declines. This is the whole rule: no terminator logic, no vocabulary sharing.
+    """
+    first_word = value.strip().split()[0] if value.strip() else ""
+    return first_word.strip(".,;:!—–").lower() in DECLINE_WORDS
+
+
+def check(commit_range: str, repo: Path) -> tuple[bool, list[str]]:
+    """Render the changelog and audit its Representation changes section.
+
+    Returns `(ok, messages)`.
+    """
+    changelog = load_changelog_config(repo / "release-plz.toml")
+    with tempfile.TemporaryDirectory() as tmp:
+        config = Path(tmp) / "cliff.toml"
+        write_cliff_config(changelog, config)
+        rendered = render(commit_range, config, repo)
+
+    groups = parse_rendered_groups(rendered)
+    headings = rendered_headings(rendered)
+    bodies = commit_bodies(commit_range, repo)
+    problems: list[str] = []
+    notes: list[str] = []
+
+    listed = groups.get(REPRESENTATION_GROUP, [])
+    notes.append(
+        f"{len(bodies)} commits in {commit_range}; {len(listed)} listed as representation changes"
+    )
+
+    # 1. Nothing that says "no" may be filed as a change. This is #1526 and #1555.
+    for commit_id in listed:
+        value = trailer_value(bodies.get(commit_id, ""))
+        if value is None:
+            problems.append(
+                f"{commit_id[:8]} is filed under {REPRESENTATION_GROUP} with no trailer at all"
+            )
+        elif opens_with_a_decline(value):
+            problems.append(
+                f"{commit_id[:8]} is filed under {REPRESENTATION_GROUP} but its trailer opens "
+                f"with a decline: {value[:80]!r}"
+            )
+
+    # 2. Nothing that declares a move may be filed anywhere else. The converse failure --
+    #    a real disclosure hidden in `Other` -- is the silent one, and is what an
+    #    over-eager decline rule would cause.
+    for commit_id, message in bodies.items():
+        value = trailer_value(message)
+        if value is None or opens_with_a_decline(value) or commit_id in listed:
+            continue
+        if commit_id in {c for ids in groups.values() for c in ids}:
+            problems.append(
+                f"{commit_id[:8]} declares a move but is not filed under "
+                f"{REPRESENTATION_GROUP}: {value[:80]!r}"
+            )
+        else:
+            # release-plz drops commits that touch no packaged file (`.github/` and the
+            # rest of Cargo.toml's `exclude`), so absence is not necessarily an error.
+            notes.append(
+                f"{commit_id[:8]} declares a move and is absent from the changelog "
+                f"(expected only if it touches no packaged file): {value[:60]!r}"
+            )
+
+    # 3. The ordering prefix must not survive into a heading (#1558).
+    for heading in headings:
+        if re.search(r"<!--\s*\d+\s*-->", heading):
+            problems.append(
+                f"heading {heading!r} still carries its ordering prefix; the postprocessor "
+                "in release-plz.toml no longer matches what release-plz renders"
+            )
+
+    return not problems, notes + problems
+
+
+def latest_tag(repo: Path) -> str:
+    """Return the most recent tag reachable from HEAD."""
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--range",
+        dest="commit_range",
+        help="Commit range to audit. Defaults to `<latest tag>..HEAD`.",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root holding release-plz.toml.",
+    )
+    args = parser.parse_args(argv)
+
+    commit_range = args.commit_range or f"{latest_tag(args.repo)}..HEAD"
+    try:
+        ok, messages = check(commit_range, args.repo)
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    for message in messages:
+        print(message, file=sys.stdout if ok else sys.stderr)
+    if ok:
+        print("Representation changes section is consistent with the trailers.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -109,6 +109,41 @@ def declines(declaration: str) -> bool:
     return DECLINE_RE.match(declaration.strip()) is not None
 
 
+#: A quantified movement claim -- "3 rows move", "577 rows merge", "2 rows respell",
+#: "3 rows of 500,004 move". Reading the verdict from the first word means a trailer can
+#: contradict itself in its own reason (`no. 3 rows move`), and that failure is silent and
+#: in the dangerous direction: the disclosure disappears from the changelog and nobody is
+#: told. This is the tripwire for it.
+#:
+#: Two deliberate limits, because a looser rule fails honest PRs. **Zero is excluded**: a
+#: good decline often quantifies its zero, and `0 rows move over 5,761,302 real
+#: expressions` (#1535) must not trip. Excluded by requiring a nonzero digit *somewhere in
+#: the count* rather than by rejecting a bare `0`, so `0,000` and `000` are zero here too —
+#: an anchored `(?!0\b)` read them as nonzero and failed the decline. **The count must sit
+#: immediately before `rows`**,
+#: which is what keeps `0 of 950 real cis-allele rows move their normalized string`
+#: (#1547) from tripping on the 950 -- a looser pattern fires on that exemplary decline,
+#: measured.
+#:
+#: It catches the phrasing this repository actually uses -- every quantified disclosure in
+#: the corpus takes this shape -- and it is not a general contradiction detector. Spelled
+#: out numbers and unquantified claims pass. It is a tripwire, not a proof.
+MOVEMENT_CLAIM_RE = re.compile(
+    r"\b(?=[\d,]*[1-9])\d[\d,]*\s+rows?(?:\s+of\s+[\d,]+)?\s+"
+    r"(?:move|moves|moved|merge|merges|merged|split|splits|"
+    r"respell|respells|respelled)\b",
+    re.IGNORECASE,
+)
+
+
+def contradicted_decline(declaration: str) -> str | None:
+    """Return the movement claim a declining `declaration` makes, if it makes one."""
+    if not declines(declaration):
+        return None
+    match = MOVEMENT_CLAIM_RE.search(declaration)
+    return match.group(0) if match else None
+
+
 def watched_files(changed: list[str]) -> list[str]:
     """Return the changed paths that sit under a watched directory."""
     return [p for p in changed if any(p.startswith(prefix) for prefix in WATCHED_PREFIXES)]
@@ -133,9 +168,20 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
     """
     Decide whether `changed` is adequately declared by `declaration_text`.
 
-    Returns `(ok, message)`. `ok` is False in two cases: a watched file changed and no
-    trailer is present at all, or the message carries more than one trailer. A trailer
-    whose value is `none` passes, because declining is a declaration.
+    Returns `(ok, message)`. `ok` is False in three cases:
+
+    1. the message carries **more than one** trailer (#1573) — checked first, and ahead of
+       the watched-file test, because two trailers are a disagreement with how the
+       *changelog* files the commit, which applies to every commit;
+    2. a watched file changed and **no** trailer is present at all;
+    3. the trailer **declines while describing a move** (`no. 3 rows move`).
+
+    A trailer whose value is `none` otherwise passes, because declining is a declaration.
+
+    Note case 3 is scoped to watched changes, unlike case 1: it sits after the
+    watched-file early return, so a docs-only commit whose voluntary trailer contradicts
+    itself is not refused. That is the narrower choice — the contradiction is the same
+    either way — and it keeps a gratuitous trailer on an unwatched change from failing CI.
     """
     # Refused BEFORE the watched-file test, and deliberately: the harm is in changelog
     # grouping, which applies to every commit, not only to the ones touching a watched
@@ -179,6 +225,21 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
         )
 
     if declines(declaration):
+        claim = contradicted_decline(declaration)
+        if claim is not None:
+            return False, (
+                f"This trailer declines and then describes a move:\n\n  {declaration}\n\n"
+                f"The verdict is the first word, so this is filed as `none` and the "
+                f"disclosure -- {claim!r} -- never reaches the changelog. Nobody is told, "
+                "which is the failure this whole mechanism exists to prevent.\n\n"
+                "Say which it is. If the change moves output, lead with what moved:\n\n"
+                "  Representation-Change: 3 rows of 500,004 move, 2 respell / 1 merge,\n"
+                "    all away from the already-shipped form. Previously-accepted inputs,\n"
+                "    so a real migration.\n\n"
+                "If it moves nothing and the number describes something else -- a corpus "
+                "that grew, a measurement quoted from another change -- say so without the "
+                "`N rows move` phrasing, which reads as this change's own disclosure."
+            )
         return (
             True,
             f"Declared `Representation-Change: {declaration}` over {len(watched)} watched file(s).",

--- a/tests/python/test_changelog_grouping.py
+++ b/tests/python/test_changelog_grouping.py
@@ -1,0 +1,257 @@
+"""
+Tests for `scripts/check_changelog_grouping.py`.
+
+The script renders the changelog with the real configuration and audits the result, so its
+end-to-end behaviour needs git-cliff and a commit range. What is unit-tested here is the
+part that decides *verdicts* — the independent decline rule, and the parsing that maps a
+rendered section back to commits — because that is where a mistake would make the audit
+silently agree with whatever it was handed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_changelog_grouping.py"
+_SPEC = importlib.util.spec_from_file_location("check_changelog_grouping", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+check_changelog_grouping = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_changelog_grouping"] = check_changelog_grouping
+_SPEC.loader.exec_module(check_changelog_grouping)
+
+opens_with_a_decline = check_changelog_grouping.opens_with_a_decline
+parse_rendered_groups = check_changelog_grouping.parse_rendered_groups
+rendered_headings = check_changelog_grouping.rendered_headings
+strip_ordering_prefix = check_changelog_grouping.strip_ordering_prefix
+trailer_value = check_changelog_grouping.trailer_value
+
+
+# ---------------------------------------------------------------------------
+# The independent decline rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "none",
+        "NONE",
+        "none.",
+        "none. Tests only; nothing under a watched directory.",
+        "no — nothing reaches a normalizer",
+        "n/a: docs",
+        "na. generated artifact only",
+        # Not a decline by the *checker's* rule (no terminator), and that is the point:
+        # this rule is coarser on purpose, so that a shared mistake cannot hide.
+        "none, except two rows that merge",
+    ],
+)
+def test_a_leading_decline_word_is_a_decline(value: str) -> None:
+    assert opens_with_a_decline(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "577 rows move, 360 merge / 205 split",
+        "0 rows move over 5,761,302 real expressions",
+        "3 rows of 500,004 move",
+        "nothing moves under src/normalize/",
+        "not measured yet",
+    ],
+)
+def test_a_description_of_a_move_is_not_a_decline(value: str) -> None:
+    assert not opens_with_a_decline(value)
+
+
+def test_the_rule_shares_no_vocabulary_with_the_checker() -> None:
+    """This is the whole design of the audit, so it is pinned rather than left to comments.
+
+    #1555 survived a test written to catch exactly it, because that test compared the two
+    halves against *each other* and they were wrong together. A second opinion has to be
+    derived differently to be worth anything — here, a plain first-word test with no
+    terminator logic.
+    """
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    for borrowed in ("import check_representation_change", "NONE_VALUES", "DECLINE_RE"):
+        assert borrowed not in source, (
+            f"the audit reuses {borrowed!r} from the checker; a shared rule cannot catch a "
+            "shared mistake, which is exactly how #1555 passed a test written to catch it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mapping a rendered section back to commits
+# ---------------------------------------------------------------------------
+
+
+_IDS = [prefix.ljust(40, "0") for prefix in ("5616cdb9", "d362a47d", "ea5bd8ce")]
+
+_RENDERED = f"""
+## [unreleased] - 2026-08-08
+
+### <!-- 0 -->Representation changes
+{_IDS[0]}
+{_IDS[1]}
+
+### <!-- 7 -->Other
+{_IDS[2]}
+"""
+
+
+def test_groups_are_keyed_without_the_ordering_prefix() -> None:
+    """A broken postprocessor must not also break the lookup.
+
+    Keeping them coupled made one failure hide the other: with the prefix present, the
+    section lookup found nothing and the audit reported the two real disclosures as
+    *unfiled* rather than reporting the declines that were filed. Each failure has to name
+    itself, so the key is normalised and the prefix is reported separately.
+    """
+    groups = parse_rendered_groups(_RENDERED)
+    assert set(groups) == {"Representation changes", "Other"}
+    assert groups["Representation changes"] == _IDS[:2]
+    assert groups["Other"] == _IDS[2:]
+
+
+def test_headings_are_reported_verbatim() -> None:
+    """The prefix check reads the raw headings, which is what release-plz writes."""
+    headings = rendered_headings(_RENDERED)
+    assert "<!-- 0 -->Representation changes" in headings
+
+
+@pytest.mark.parametrize(
+    ("heading", "expected"),
+    [
+        ("<!-- 0 -->Representation changes", "Representation changes"),
+        ("<!--0-->Other", "Other"),
+        ("Representation changes", "Representation changes"),
+    ],
+)
+def test_strip_ordering_prefix(heading: str, expected: str) -> None:
+    assert strip_ordering_prefix(heading) == expected
+
+
+# ---------------------------------------------------------------------------
+# Trailer extraction
+# ---------------------------------------------------------------------------
+
+
+def test_trailer_is_read_from_a_full_commit_message() -> None:
+    message = "fix(normalize): a thing\n\nBody.\n\nRepresentation-Change: 3 rows move\n"
+    assert trailer_value(message) == "3 rows move"
+
+
+def test_a_message_without_a_trailer_reads_as_none() -> None:
+    assert trailer_value("chore: something\n\nNo declaration here.\n") is None
+
+
+# ---------------------------------------------------------------------------
+# The squash-equivalent preview
+# ---------------------------------------------------------------------------
+#
+# On a `pull_request` the commit this audit must judge does not exist yet: GitHub builds
+# the squash subject from the PR title and the body from the PR description, and the
+# trailer lives in the description. `ci.yml` synthesizes that commit before running the
+# audit. These two pin the halves of that — the message shape the workflow builds, and the
+# fact that it builds one at all — because a PR whose merged form misfiles its declaration
+# would otherwise pass here and be caught only after it lands.
+
+
+def test_a_trailer_that_arrives_only_in_the_pr_description_is_read() -> None:
+    """The synthesized message is `<title> (#N)` + the description, verbatim.
+
+    The trailer ends up in the footer position the real squash gives it, which is what
+    `release-plz.toml`'s parsers match — so reading it here is the same question the
+    changelog will ask after the merge.
+    """
+    title = "fix(normalize): converge the two spellings"
+    body = "Why this changes.\n\nRepresentation-Change: 3 rows move, 2 merge / 1 respell"
+    squash = f"{title} (#1560)\n\n{body}\n"
+    assert trailer_value(squash) == "3 rows move, 2 merge / 1 respell"
+    assert not opens_with_a_decline(trailer_value(squash) or "")
+
+
+def test_a_declining_description_reads_as_a_decline_through_the_same_path() -> None:
+    squash = "test(changelog): audit the section (#1560)\n\nBody.\n\nRepresentation-Change: none. Tests only.\n"
+    value = trailer_value(squash)
+    assert value == "none. Tests only."
+    assert opens_with_a_decline(value)
+
+
+def test_ci_synthesizes_the_squash_commit_before_auditing() -> None:
+    """The audit is only as good as the history it is handed.
+
+    Pinned against the workflow text rather than left to review: dropping the synthesis
+    step turns this job into one that passes on every PR regardless of its declaration,
+    and nothing else in the suite would notice.
+    """
+    workflow = (Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    audit = workflow.index("Audit the Representation changes section")
+    synthesis = workflow.index("Synthesize the squash commit this PR will become")
+    assert synthesis < audit, "the synthesis step must precede the audit step"
+
+    # Scoped to the synthesis step itself, not to everything above the audit. Asserting
+    # against the whole preamble would let a match come from an unrelated step — and it is
+    # the *dataflow inside this step* that carries the property.
+    step = workflow[synthesis:audit]
+
+    # The subject and body must both come from the PR, and through `env` — a PR title is
+    # attacker-controlled text and `${{ }}` inside `run` would splice it into the shell.
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in step
+    assert "PR_BODY: ${{ github.event.pull_request.body }}" in step
+
+    # Declaring the variables is not using them. Without this, replacing the message with
+    # a literal — `commit --allow-empty -m 'ci: preview'` — leaves every assertion above
+    # true while the audit runs against a commit carrying no trailer, so it would pass
+    # every PR regardless of its declaration. That is the exact failure this test exists to
+    # prevent, so pin the whole chain: env var -> message file -> commit.
+    message_file = "squash-message.txt"
+    written_from = re.search(
+        r"printf\s+\S+\s+(?P<args>[^>]*)>\s*" + re.escape(message_file),
+        step,
+    )
+    assert written_from is not None, (
+        f"the synthesis step must build {message_file} with printf; without it the audit "
+        "judges a commit that never carried the PR's trailer"
+    )
+    for variable in ('"$PR_TITLE"', '"$PR_NUMBER"', '"$PR_BODY"'):
+        assert variable in written_from.group("args"), (
+            f"{variable} is defined in `env` but never reaches {message_file}; the synthesized "
+            "commit would not be the squash commit GitHub will write. Note the quotes are "
+            "part of the assertion: unquoted, a multi-word PR title word-splits."
+        )
+    assert re.search(
+        r"commit\s+--allow-empty(?:\s+\S+)*\s+--file\s+" + re.escape(message_file), step
+    ), (
+        f"the empty commit must be created from {message_file} (`--file`), or the message "
+        "assembled above is discarded"
+    )
+
+    # And the history must be the preview too, not just the message. `actions/checkout`
+    # hands us the MERGE ref on a pull_request, so without the soft reset the audited range
+    # carries the branch's intermediate commits and the merge commit — none of which
+    # survive a squash. Soft, so the PR's tree (and its `release-plz.toml`) is what gets
+    # committed and read.
+    assert "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in step, (
+        "the base sha must reach the step through `env` for the soft reset"
+    )
+    reset = re.search(r"git\s+reset\s+(?P<mode>--\S+)\s+\"\$PR_BASE_SHA\"", step)
+    assert reset is not None, (
+        'the step must `git reset` to "$PR_BASE_SHA" before committing, or the audit '
+        "judges commits the squash discards"
+    )
+    assert reset.group("mode") == "--soft", (
+        f"the reset must be --soft, not {reset.group('mode')}: a mixed or hard reset would "
+        "discard the PR's tree, so the audit would read the base's release-plz.toml and "
+        "the synthesized commit would not carry the PR's changes"
+    )
+    assert step.index(reset.group(0)) < step.index("commit --allow-empty"), (
+        "the reset must precede the commit, or the commit lands on the merge ref"
+    )

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -355,6 +355,82 @@ def test_decline_vocabulary_matches_the_changelog_config() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# A decline that describes a move contradicts itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "no. 3 rows move",
+        "none. 577 rows move, 360 merge / 205 split",
+        "none. 3 rows of 500,004 move",
+        "na — but 2 rows respell",
+        "none. 12,530 rows move in the synthetic corpus",
+        # The past tense of every verb, not only of `move`. `moved` was covered and
+        # `merged`/`respelled` were not, so a trailer could contradict itself in the
+        # tense a retrospective disclosure is most naturally written in.
+        "none. 3 rows merged",
+        "no. 12 rows respelled",
+        "none. 205 rows moved",
+    ],
+)
+def test_a_decline_that_describes_a_move_fails(value: str) -> None:
+    """Reading the verdict from the first word lets a trailer contradict its own reason.
+
+    The failure is silent and in the dangerous direction — filed as `none`, so the
+    disclosure never reaches the changelog and nobody is told.
+    """
+    ok, message = check(["src/normalize/merge.rs"], f"Representation-Change: {value}")
+    assert not ok, f"{value!r} declines and then describes a move"
+    assert "declines and then describes a move" in message
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # #1535, verbatim: a decline is entitled to quantify its zero.
+        "0 rows move over 5,761,302 real expressions",
+        # #1547, verbatim: the count that sits next to `rows` is 950, and it is not the
+        # moving set. A looser pattern fires here — measured — and this is an exemplary
+        # decline, so failing it would punish the phrasing worth encouraging.
+        "none. 0 of 950 real cis-allele rows move their normalized string; 1 of 950 "
+        "changes strict verdict from accept to reject, which is the defect being fixed.",
+        # #1546, verbatim in shape: the corpus grew; no shipped string moved.
+        "none. This change does grow the corpus, 78,028 -> 78,298 rows, which changes the "
+        "denominator of every future compare run against it.",
+        # #1538, verbatim in shape: a count of adjudicated rows, not of moved ones.
+        "none. The ruling ratifies shipped behaviour — v0.12.0 already emits the unsplit "
+        "form on 208 of 208 adjudicated rows.",
+        # A zero is a zero however it is spelled. The rule excludes zero by requiring a
+        # nonzero digit in the count; an anchored `(?!0\\b)` excluded only the bare `0`,
+        # so these read as nonzero and failed a decline that moves nothing.
+        "none. 0,000 rows move",
+        "none. 000 rows merged",
+    ],
+)
+def test_a_numerate_decline_is_not_a_contradiction(value: str) -> None:
+    """The guard must not fire on the declines this repository actually writes.
+
+    Every one of these is real, and they are numerate on purpose. Verified against the 15
+    declines of the v0.13.1 cycle: this rule fires on none of them.
+    """
+    assert check_representation_change.contradicted_decline(value) is None, (
+        f"{value!r} declines legitimately; failing it would punish a good disclosure"
+    )
+
+
+def test_a_real_disclosure_is_not_a_contradiction() -> None:
+    """The guard applies only to declines — a trailer that leads with the move is fine."""
+    assert (
+        check_representation_change.contradicted_decline(
+            "3 rows of 500,004 move (0.0006%) — 2 respell, 1 merge"
+        )
+        is None
+    )
+
+
 def test_the_two_decline_rules_agree_value_by_value() -> None:
     """The vocabulary test above compares word lists; this one compares *verdicts*.
 


### PR DESCRIPTION
#1558 fixed two instances of the changelog's **Representation changes** section lying about its contents. This guards the class.

Closes #1559.

## Why a new guard, when a test for this already exists

#1527 added `test_decline_vocabulary_matches_the_changelog_config` for exactly this drift. It passed throughout #1555, and would pass again on the next occurrence of the same shape, because the two halves it compares had **not** drifted — `release-plz.toml` and `scripts/check_representation_change.py` named the same four decline words and were wrong together. An agreement-based test cannot see a shared mistake.

Both bugs that reached a release were caught by a person reading the rendered section against the PRs. That was the only detector, and it only ran because someone looked before a release.

## What this adds

**A rendered-output audit** — `scripts/check_changelog_grouping.py`, run per PR as `Changelog grouping audit`. It renders the changelog with the real `release-plz.toml` over `<latest tag>..HEAD` and asserts three things of the result:

1. nothing filed under Representation changes opens with a word that means no;
2. nothing that declares a move is filed anywhere else;
3. no heading still carries its `<!-- N -->` ordering prefix.

Its decline rule is a plain first-word test that **shares no code with the checker** — pinned by `test_the_rule_shares_no_vocabulary_with_the_checker`, because that independence is the entire point and is the kind of property that gets quietly refactored away. It renders commit *ids* rather than messages, so the mapping back to commits is exact and independent of message formatting, link parsers and preprocessors.

**A contradiction guard** in the existing checker. `no. 3 rows move` is filed as a decline — the verdict is the first word — so the disclosure never reaches the changelog and nobody is told. That is the silent direction, the one #1522 is about.

## Verified by A/B, not by assertion

Rendering the branch's own script against the **pre-#1558** config:

```
19 commits in v0.13.0..HEAD; 11 listed as representation changes
671143e0 is filed under Representation changes but its trailer opens with a decline: 'none. The ruling ratifies shipped behaviour —'
3ab10a09 is filed under Representation changes but its trailer opens with a decline: 'none. The entire diff is one file,'
49c66162 is filed under Representation changes but its trailer opens with a decline: 'none. 0 of 950 real cis-allele rows move their'
… 9 in total …
heading '<!-- 0 -->Representation changes' still carries its ordering prefix; the postprocessor in release-plz.toml no longer matches what release-plz renders
heading '<!-- 7 -->Other' still carries its ordering prefix; …
exit=1
```

Against the current config: `19 commits in v0.13.0..HEAD; 2 listed as representation changes` → exit 0.

The two failure kinds are **decoupled on purpose**, and that was a real bug in the first draft: keying the section lookup on the raw heading meant a broken postprocessor also broke the lookup, so the audit reported the two real disclosures as *unfiled* rather than reporting the nine declines that were filed. One failure hiding another is precisely what this is meant to stop, so the key is normalised and the prefix is reported separately. Pinned by `test_groups_are_keyed_without_the_ordering_prefix`.

## The contradiction rule is narrow by measurement, not by taste

A loose pattern fires on #1547's real trailer — `none. 0 of 950 real cis-allele rows move their normalized string` — which is an **exemplary** decline, exactly the numerate phrasing worth encouraging. Failing it would punish the good case.

Measured over all 15 declines of the v0.13.1 cycle:

| pattern | false positives | catches |
|---|---|---|
| `\d+ …rows… move` (loose) | **#1547** | 5/5 |
| count immediately before `rows`, zero excluded | **none** | 5/5 |

So the shipped rule requires the count to sit immediately next to `rows` and excludes zero, since a good decline often quantifies its zero (#1535's `0 rows move over 5,761,302 real expressions`). Four real trailers are pinned verbatim as must-not-fire cases. It catches the phrasing this repository actually uses and is **not** a general contradiction detector — spelled-out numbers and unquantified claims pass. It is a tripwire, and the docstring says so rather than implying more.

## The guard immediately found a third instance — and #1574 fixed it

The audit went red on `main` as soon as this branch was rebased onto it: **`3ebcdddd` (#1551) declared a bare `Representation-Change: none` and was filed under Representation changes.**

git-conventional ends a footer's value at the next footer token, so a trailer that is the *last* one in the body has everything below it swallowed into its value — and something usually is below it, because GitHub builds the squash body from the PR description and CodeRabbit appends a release-notes block there. The value git-cliff actually matched was:

```
none


<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->
## Summary by CodeRabbit
…
```

so the `$` anchor was unreachable, the decline exclusion missed, and the inclusion rule took the commit. Measured by rendering git-cliff's own view of the footers rather than inferred from the regex.

**The repair has since shipped separately, in #1574.** This branch originally carried its own, which is why it conflicted: two independent fixes for one defect, arrived at from opposite ends — the detector found it here, and #1574 was filed against it directly.

The two differ only in how they stop constraining after the verdict:

| | approach | reason may span lines |
|---|---|---|
| this branch (dropped) | keep `(?i)`, narrow the same-line reason to `[^\r\n]*` and let `(?:[\r\n][\s\S]*)?` pass the rest | yes |
| **#1574 (merged)** | add the `m` flag, so `$` is end-of-*line* | yes |

Both read the verdict off the trailer's first line, which is the scope `scripts/check_representation_change.py` already reads at, and both leave `,` excluded so `none, except two rows` stays a real change. Since #1574 is in `main`, **the duplicate commit is dropped from this PR** rather than reconciled — carrying a second spelling of a shipped fix would be churn with no behavioural difference.

So this PR is now purely the **detector**, plus the contradiction guard. That is the cleaner division: #1574 is the fix, this is what would have caught it on the day it landed.

### The two halves verified against each other

Not asserted — run. With this branch's audit script against the real history:

| tree | audit result |
|---|---|
| merged `main` (#1574's fix live) | `9 commits in v0.13.1..HEAD; 1 listed as representation changes` — **consistent** |
| same, with only #1574's flag reverted | flags `3ebcdddd` — *"filed under Representation changes but its trailer opens with a decline: 'none'"* |

The detector fires on exactly the commit the fix addresses, and goes quiet when the fix is present. That is the property that makes it worth having.

### Why the existing tests did not catch it

`test_the_two_decline_rules_agree_value_by_value` fed only **single-line** values, so both halves agreed on every case it asked about — and it supplied `re.MULTILINE` itself, under which `$` matches at every line break, so a multi-line case would have passed there while failing in CI. git-cliff uses the Rust `regex` crate and the rule spelled no `(?m)`. **#1574 fixed that harness**, compiling the configured rule with no flags of its own so the rule under test is the rule that ships. This PR does not re-litigate it; the tests it adds here are the three contradiction cases, which are new ground.


## Review fixes applied

Four findings from the CodeRabbit CLI lens, all verified against the code before acting and each fix given a control that fails without it:

1. **`test_ci_synthesizes_the_squash_commit_before_auditing` pinned the wrong thing** (major, valid). It asserted `PR_TITLE`/`PR_BODY` are *defined* in `env`, never that the commit *consumes* them. Demonstrated rather than argued: replacing the message with `commit --allow-empty -m 'ci: preview'` and leaving the `env` block intact passes **all four** original assertions — while the audit then judges a commit carrying no trailer, so it would pass every PR regardless of its declaration. That is the exact failure the test's docstring claims to prevent. Now pins the chain env var → `printf` → `squash-message.txt` → `commit --file`, scoped to that step, and requires the variables be **quoted** (unquoted, a multi-word title word-splits).

2. **The audit judged commits the squash discards** (major, valid — fidelity, not a live bug). On a `pull_request` `actions/checkout` hands over the **merge** ref, so `<latest tag>..HEAD` carried the branch's intermediate commits and the merge commit. Measured on a simulated merge ref: **5 audited commits, against 2 with a `git reset --soft "$PR_BASE_SHA"` first — and 2 is exactly post-merge `main`.** Soft keeps the index and worktree, so the synthesized commit carries the PR's real tree and the audit still reads the PR's own `release-plz.toml`: it is the squash commit, not an approximation. The shipped script was then executed against a simulated merge ref under `bash -euo pipefail` — exit 0, range correct, tree intact.

   In fairness to the previous form: I could **not** construct an input where it produced a wrong verdict, because #1574 already files declines correctly. The cost was over-counting and the risk of attributing a branch-local misfiling to the PR. Reported as fidelity, not as a bug.

3. **`commit_bodies` framed records on `\x1e`** (minor, valid), a byte a commit message may legally contain — and one that did would re-frame the records and mis-attribute a trailer, in a guard whose entire job is attributing trailers. Now `git log -z --format=%H%x00%B`: NUL is the one byte a message cannot hold, so framing is git's problem. It refuses an odd field count rather than guessing. Control: a message containing `\x1e` now parses with its trailer read correctly and the byte preserved in the body.

4. **The guidance example omitted direction** (minor, valid). `CONTRIBUTING.md` asks for four things and the example gave three — direction was missing. It now reads "all away from the already-shipped form".

Controls for the workflow assertions: hard-instead-of-soft, reset-removed, and base-sha-not-from-the-event each fail the test. My first attempt at the hard-reset control was **invalid** — it rewrote the word `reset --soft` in the surrounding comment rather than the command — and is noted here because a bad control reads exactly like a passing one.

## Checks

**101 tests pass** in the two trailer/grouping modules after the restructure; `ruff check` / `ruff format --check` clean; `actionlint` clean on the workflow; `ci.yml` parses; the audit passes live against merged `main`. The new `taiki-e/install-action` pin is the `git-cliff` tag SHA, resolved via the API rather than copied.

Rebased onto `160b4f61` by dropping the duplicate-fix commit and cherry-picking the audit. The only conflict was the `check()` docstring, where #1574's duplicate-trailer refusal and this PR's contradiction guard both describe the failure cases — resolved by stating all three, and by recording that the contradiction guard is scoped to watched changes while the duplicate refusal is not.

Not added to `main`'s required contexts here — per this repo's own experience, adding a required context strands every open PR whose last run predates it, so that is worth doing deliberately when the queue is small rather than as a side effect of this PR.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — the diff is two CI scripts, their tests, one workflow job and documentation. No normalized output can move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated auditing to verify representation-change entries are correctly grouped and consistently disclosed in changelogs.
  - Added validation to reject decline statements that also claim nonzero moved rows.

- **Documentation**
  - Updated contribution guidance with representation-change disclosure requirements.

- **Tests**
  - Added coverage for changelog grouping, trailer validation, decline wording, and zero-movement exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

