### PR TITLE
docs(changelog): state what v0.13.1 moved, in the released section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Representation changes
 
+**3 stored strings move — 3 of 500,004 ClinVar rows (0.0006%).** Two are respelled
+and one merges back to the form the submitter wrote. These inputs were **previously
+accepted**, so a consumer who normalized them under v0.13.0 holds the old string:
+a real migration, if a very small one. The merge, end to end:
+
+```
+NM_000083.3:c.2461_2464delinsCTCC
+  v0.13.0 ->  c.[2461_2463delinsCTC;2464G>C]
+  v0.13.1 ->  NM_000083.3:c.2461_2464delinsCTCC   (unchanged — the submitted spelling)
+```
+
+Both entries below are the same fix in different directions, and only the first
+moves anything. [#1535] moves **0 rows over 5,761,302 real expressions** (ClinVar
+500,004 / Paraphase 435,235 / CMRG 4,826,063), and that zero is *structural* rather
+than reassuring: those corpora contain no instance of the shape it converts, so the
+measurement could not have found a move. Where the shape does occur the split
+spelling moves onto `inv`.
+
+One deliberate cost, recorded because it is the property this project ranks above
+stability: **confluence drops by 6 classes of 11,272** in [#1537], by operator
+ruling. Those classes agreed only by way of a spec-illegal intermediate the fix
+removes; `sequence_changed` stays 0, so nothing converged on a wrong sequence, and
+the surviving form is the better-formed one. What was lost is agreement, not
+correctness. The same change fixes 58 of 59 known `delins.md:16` separation
+violations.
+
+[#1535]: https://github.com/fulcrumgenomics/ferro-hgvs/pull/1535
+[#1537]: https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537
+
 - *(normalize)* never split a delins into members on consecutive nucleotides ([#1537](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537))
 - *(normalize)* type the whole-block inversion by what it competes with ([#1535](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1535))
 


### PR DESCRIPTION
The released **Representation changes** section names two changes and quantifies neither. A consumer reading it cannot tell that **3 stored strings moved** and need re-mapping — which is the one fact in the whole section they would act on.

This is #1556 in practice: the changelog carries the commit subject only, and the trailer's own text is unreachable from the template, so the numbers have to be written by hand — exactly as v0.13.0's section was, after the fact.

## What it adds

- **Which rows moved**: 3 of 500,004 ClinVar rows (0.0006%), 2 respell / 1 merge, with the worked example showing the merge returning the submitter's own spelling.
- **Previously accepted, so a real migration.** `CONTRIBUTING.md` calls this the fact "nobody reading the diff in six months can tell", and neither trailer states it. It is recoverable now because the rows moved rather than newly-normalized — a consumer who normalized under v0.13.0 holds the old string.
- **#1535's zero is structural.** `0 rows over 5,761,302` reads as reassurance; it is not. Those corpora contain no instance of the shape that change converts, so the measurement could not have found a move. Reported as such per this repo's own rule about corpus zeros.
- **The confluence cost**: 6 classes of 11,272, by operator ruling. Recorded because this project ranks confluence *above* stability, so a cost paid in the higher-ranked property should not be the one thing omitted. `sequence_changed` stays 0 and the surviving form is the better-formed one — what was lost is agreement, not correctness.

## Why editing a released section is safe

release-plz only prepends to `CHANGELOG.md` — v0.12.0's release commit was a single +63/−0 insertion at the top — so an already-released section is never regenerated. `CONTRIBUTING.md` documents this as the escape hatch for exactly this case. The GitHub release body is edited to match, since it is never revisited once its tag exists.

Verified: the `Changelog grouping audit` from #1560 still passes against the amended file (2 entries, correctly filed).

Representation-Change: none. Documentation only — one Markdown file, no code path, no normalized output can move. It *describes* a representation change that already shipped in v0.13.1 rather than making one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the v0.13.1 changelog with details about representation changes.
  * Added normalization examples, affected data measurements, confluence impact, and links to related pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->