### PR TITLE
perf(ci): 62% off the critical path on a re-run, 43% off runner time, cache 13.8→7.0 GiB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,9 +348,35 @@ jobs:
           # `rust-cache` block in this file.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: spec-fixtures
+      # The cheapest of the three per-commit caches by a wide margin: this job
+      # spends ~120s producing roughly 0.5 MB of JSON, against 25.8 MB for the soak
+      # archive and 106.6 MB for the test archive. It is also the one that gates the
+      # `test` and `test-oracle` paths — `max(test-build, spec-fixtures) + slowest
+      # shard` — so on a re-run of an unchanged tree it is the difference between
+      # those paths costing ~120s before a single test starts and costing ~15s.
+      #
+      # The `--check` steps below are gates rather than artifact producers, and they
+      # are skipped on a hit too. That is sound only because the save is explicit
+      # and carries an implicit `success()`: an entry exists for this commit only if
+      # every check passed on it, and the tree is byte-identical, so re-running them
+      # can only reach the same verdict. With the combined `actions/cache` action
+      # this would be a false-green generator — its post-step saves even when the
+      # job failed, so a failing `--check` would publish an entry that every re-run
+      # then skipped past.
+      - name: Restore fixtures generated from this exact commit
+        id: generated-fixtures
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            tests/fixtures/grammar/hgvs_spec_normalization.json
+            tests/fixtures/grammar/hgvs_spec_enumeration.json
+            tests/fixtures/cis/cis_confluence_corpus.json
+          key: generated-fixtures-${{ runner.os }}-${{ github.sha }}
       - name: Generate HGVS v21.0 spec fixture
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --bin generate_spec_fixture
       - name: Generate HGVS spec test enumeration
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --bin generate_spec_enumeration
       # The cis confluence corpus, generated here for the same reason and at far
       # greater saving. `tests/it/cis_confluence_axis.rs` regenerates it on demand
@@ -379,6 +405,7 @@ jobs:
       # Here it reuses this job's already-warm dev-profile tree, and it is not on
       # the critical path: that runs through `test-build-soak` + `sweeps`.
       - name: Generate the cis confluence corpus
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --example generate_cis_confluence_corpus
       # Merged in from the former `generated-docs` job. Those three generators are
       # `cargo run --features dev --example …` — the SAME profile and feature set as
@@ -396,11 +423,22 @@ jobs:
       # carried over: it configures the *test* profile and every step here is a
       # `cargo run` in the dev profile, so it never applied to these generators.
       - name: Verify conformance summary docs are up to date
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --example generate_tool_support_tables -- --check
       - name: Perf tables up to date
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --example generate_perf_tables -- --check
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
+        with:
+          path: |
+            tests/fixtures/grammar/hgvs_spec_normalization.json
+            tests/fixtures/grammar/hgvs_spec_enumeration.json
+            tests/fixtures/cis/cis_confluence_corpus.json
+          key: generated-fixtures-${{ runner.os }}-${{ github.sha }}
       # Only the fixtures are published from here. The two generator binaries
       # `spec_generator_preconditions` executes need no staging: they are
       # `[[bin]]` targets, so `test-build`'s archive already carries them and
@@ -508,9 +546,29 @@ jobs:
           # assumed — see the PR body.
           cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      # Same per-commit archive cache as `test-build-soak`. This one is 106.6 MB
+      # against that one's 25.8 MB and was left uncached at first for exactly that
+      # reason — it is not on the critical path while `test-build-soak` takes 170s.
+      # It becomes the gate the moment the other two caches hit, though: the
+      # `test-oracle` path is `max(test-build, spec-fixtures) + slowest oracle
+      # shard`, so with `spec-fixtures` cached this 87s job is what remains.
+      # `prune-ci-caches.yml` is what keeps the three families from re-creating the
+      # over-cap problem this branch fixed.
+      - name: Restore a test archive built from this exact commit
+        id: test-archive
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: nextest.tar.zst
+          key: nextest-archive-${{ runner.os }}-${{ github.sha }}
       - name: Build test archive
+        if: steps.test-archive.outputs.cache-hit != 'true'
         # Compiles every test binary and packs them with their run metadata.
         run: cargo nextest archive --features dev --archive-file nextest.tar.zst
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: steps.test-archive.outputs.cache-hit != 'true'
+        with:
+          path: nextest.tar.zst
+          key: nextest-archive-${{ runner.os }}-${{ github.sha }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive
@@ -591,9 +649,15 @@ jobs:
       # critical path and is 25.8 MB; the other is not on it and is 106.6 MB, so
       # caching it would cost 4x the space against a cap this PR just brought the
       # repository back under, to save runner-seconds rather than wall-clock.
+      # `restore` + an explicit `save`, never the combined `actions/cache`. The
+      # combined action saves in a post-step that runs even when the job FAILED, so
+      # a broken or partial archive could be published under this commit's key and
+      # every re-run would then skip the build and test whatever it contained. An
+      # explicit save carries an implicit `success()`, so only a completed build is
+      # ever cached. Same pattern on the two caches below.
       - name: Restore a soak archive built from this exact commit
         id: soak-archive
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: nextest-soak.tar.zst
           key: nextest-soak-archive-${{ runner.os }}-${{ github.sha }}
@@ -610,6 +674,11 @@ jobs:
         run: |
           cargo nextest archive --cargo-profile soak --test it \
             --archive-file nextest-soak.tar.zst
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        if: steps.soak-archive.outputs.cache-hit != 'true'
+        with:
+          path: nextest-soak.tar.zst
+          key: nextest-soak-archive-${{ runner.os }}-${{ github.sha }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nextest-archive-soak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
   # against the spec checkout. That signal is now its own job rather than
   # buried in a build.
   spec-fixtures:
-    name: Spec fixtures
+    name: Spec fixtures and generated docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -380,6 +380,27 @@ jobs:
       # the critical path: that runs through `test-build-soak` + `sweeps`.
       - name: Generate the cis confluence corpus
         run: cargo run --features dev --example generate_cis_confluence_corpus
+      # Merged in from the former `generated-docs` job. Those three generators are
+      # `cargo run --features dev --example …` — the SAME profile and feature set as
+      # the four steps above — so they were compiling an identical dependency tree
+      # in a second job behind a second `rust-cache` key. Sharing this job's warm
+      # tree costs a few seconds here against the ~54s that job took, and retires a
+      # cache key (~0.36 GiB) from a repository that was over its cache cap.
+      #
+      # Gating is unchanged. `generated-docs` was a `needs:` of `test-required`;
+      # now a failure here fails `spec-fixtures`, which SKIPS `test` and
+      # `test-oracle`, and `test-required` demands `result == "success"` from both —
+      # a skip is not a success, so the required `Test` context still goes red.
+      #
+      # `generated-docs` also set `CARGO_PROFILE_TEST_DEBUG: "0"`, deliberately not
+      # carried over: it configures the *test* profile and every step here is a
+      # `cargo run` in the dev profile, so it never applied to these generators.
+      - name: Verify conformance summary docs are up to date
+        run: cargo run --features dev --example generate_conformance_summary -- --check
+      - name: Tool-support tables up to date
+        run: cargo run --features dev --example generate_tool_support_tables -- --check
+      - name: Perf tables up to date
+        run: cargo run --features dev --example generate_perf_tables -- --check
       # Only the fixtures are published from here. The two generator binaries
       # `spec_generator_preconditions` executes need no staging: they are
       # `[[bin]]` targets, so `test-build`'s archive already carries them and
@@ -546,7 +567,38 @@ jobs:
           # jobs rather than one (#1396).
           cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      # Skip the rebuild entirely when this exact commit already produced an
+      # archive. `rust-cache` above caches DEPENDENCIES only — it deliberately
+      # deletes workspace artifacts — so `ferro_hgvs` and the `it` test crate are
+      # recompiled at `opt-level = 3` on every run even when not one byte of Rust
+      # changed. Measured on run 31275848682: 142s of this job's 170s is that
+      # rebuild, and this job plus `sweeps` IS the critical path.
+      #
+      # Keyed on the commit SHA, deliberately, rather than on `hashFiles` over the
+      # inputs. A content-hash key is easier to hit and one forgotten input serves a
+      # STALE archive — CI green against binaries built from other code, which is
+      # the worst failure this repository could buy itself. The SHA changes whenever
+      # anything does, so a hit means the tree is byte-identical and staleness is
+      # impossible by construction. (On `pull_request` this is the merge SHA, so it
+      # also busts correctly when `main` moves under the PR.)
+      #
+      # What it actually buys: re-runs of an unchanged tree. That is not a rare case
+      # here — `on: pull_request` includes `edited` (the representation-change check
+      # reads the PR description), so every description edit re-runs the whole
+      # workflow, today from scratch.
+      #
+      # Only the soak archive is cached, not `test-build`'s. This one is on the
+      # critical path and is 25.8 MB; the other is not on it and is 106.6 MB, so
+      # caching it would cost 4x the space against a cap this PR just brought the
+      # repository back under, to save runner-seconds rather than wall-clock.
+      - name: Restore a soak archive built from this exact commit
+        id: soak-archive
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: nextest-soak.tar.zst
+          key: nextest-soak-archive-${{ runner.os }}-${{ github.sha }}
       - name: Build soak archive
+        if: steps.soak-archive.outputs.cache-hit != 'true'
         # No `--features dev`. That feature pulls in `web-service` (axum, tokio,
         # tower, tracing) and `benchmark` (reqwest, rusqlite, tokio-postgres,
         # futures) — an entire dependency tree compiled at `opt-level = 3` to
@@ -869,41 +921,6 @@ jobs:
 
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.
-  generated-docs:
-    name: Generated docs up to date
-    runs-on: ubuntu-latest
-    env:
-      CARGO_PROFILE_TEST_DEBUG: "0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          # No `lfs: true`. The repo has exactly four LFS files
-          # (`git lfs ls-files`): two under `tests/fixtures/bulk/` and two
-          # under `tests/fixtures/validation/`, 149 MB in total. Every
-          # reference to them lives in `benches/benchmarks.rs` and five
-          # `tests/it/*` modules, and `cargo run --example` compiles neither
-          # `tests/` nor `benches/`. Nothing under `examples/` names them or
-          # has a compile-time include at all, and none of the eight paths
-          # the three generators actually read is LFS-tracked (checked with
-          # `git check-attr filter`).
-          submodules: true
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-        with:
-          # Save only from `main` — see the note on the first
-          # `rust-cache` block in this file.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: generated-docs
-      - name: Verify conformance summary docs are up to date
-        run: cargo run --features dev --example generate_conformance_summary -- --check
-      - name: Tool-support tables up to date
-        run: cargo run --features dev --example generate_tool_support_tables -- --check
-      - name: Perf tables up to date
-        run: cargo run --features dev --example generate_perf_tables -- --check
-
   # Aggregator that reports the `Test` status context.
   #
   # `main` has an ACTIVE RULESET (not legacy branch protection — it does not
@@ -919,7 +936,7 @@ jobs:
   test-required:
     name: Test
     runs-on: ubuntu-latest
-    needs: [test, test-oracle, soak, sweeps, generated-docs]
+    needs: [test, test-oracle, soak, sweeps]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
     if: always()
@@ -930,12 +947,10 @@ jobs:
           echo "test-oracle     = ${{ needs.test-oracle.result }}"
           echo "soak            = ${{ needs.soak.result }}"
           echo "sweeps          = ${{ needs.sweeps.result }}"
-          echo "generated-docs  = ${{ needs.generated-docs.result }}"
           if [ "${{ needs.test.result }}" != "success" ] \
             || [ "${{ needs.test-oracle.result }}" != "success" ] \
             || [ "${{ needs.soak.result }}" != "success" ] \
-            || [ "${{ needs.sweeps.result }}" != "success" ] \
-            || [ "${{ needs.generated-docs.result }}" != "success" ]; then
+            || [ "${{ needs.sweeps.result }}" != "success" ]; then
             echo "::error::one or more test jobs did not succeed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,22 @@ jobs:
       #   is how #1218 was diagnosed in the first place.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade, stated: a PR that changes `Cargo.lock` no longer warms its own
+          # cache, so it restores `main`'s generation through the `restore-keys`
+          # prefix and recompiles what the lockfile moved. That is one slower job on
+          # dependency-bumping PRs, against every cache in the repo currently racing
+          # eviction.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: clippy
       - run: cargo clippy --features dev --all-targets -- -D warnings
 
@@ -288,6 +304,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: clippy-all-features
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
@@ -325,35 +344,40 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: spec-fixtures
       - name: Generate HGVS v21.0 spec fixture
         run: cargo run --features dev --bin generate_spec_fixture
       - name: Generate HGVS spec test enumeration
         run: cargo run --features dev --bin generate_spec_enumeration
-      # The cis confluence corpus, for the same reason and at far greater
-      # saving. `tests/it/cis_confluence_axis.rs` regenerates it on demand
-      # through `common::fixture_gen`, which shells out to a nested
-      # `cargo run --features dev --example generate_cis_confluence_corpus`.
-      # The `test` / `test-oracle` shards run from a nextest **archive**, so
-      # they have no warm `target/`: that nested invocation compiles the crate
-      # and the example from scratch inside the test, and the cost lands on
-      # whichever of the three `cis_confluence_axis` tests the shard happens to
-      # hold.
+      # The cis confluence corpus, generated here for the same reason and at far
+      # greater saving. `tests/it/cis_confluence_axis.rs` regenerates it on demand
+      # through `common::fixture_gen`, which shells out to a nested `cargo run
+      # --features dev --example generate_cis_confluence_corpus`. The `test` /
+      # `test-oracle` shards run from a nextest **archive** and so have no warm
+      # `target/`: that nested call compiles the crate from scratch *inside the
+      # test*, and the cost lands on whichever of the three `cis_confluence_axis`
+      # tests the shard happens to hold.
       #
       # Measured on run 31268888323: `the_corpus_is_a_dense_set_of_real_confluence_classes`
-      # took **117.6s** in `Test (2/6)` and 127.3s in `Test oracle (2/3)` — a
-      # test that reads the corpus and makes a handful of cheap assertions, and
-      # takes 0.07s once the file exists. The generation itself is ~3s.
+      # took 117.6s in `Test (2/6)` and 127.3s in `Test oracle (2/3)` — a test that
+      # reads an 8 MB JSON and makes a handful of cheap assertions, and that takes
+      # 0.071s once the file exists. Six jobs paid it per run: the three tests are
+      # spread across the six `test` shards and again across the three
+      # `test-oracle` shards, so three shards of each hold one apiece.
       #
-      # Six jobs pay it per run, not nine: the three tests are spread across the
-      # six `test` shards and again across the three `test-oracle` shards, so
-      # three shards of each job hold one apiece. On that run they landed in
-      # `Test` 2/4/6 and `Test oracle` 1/2/3, at 117.6-169.7s each — roughly ten
-      # minutes of runner time spent rebuilding the crate to produce an 8 MB JSON.
-      #
-      # Publishing it here costs this job ~3s and nothing else: `spec-fixtures`
-      # already has a warm `Swatinem/rust-cache` tree, and it is off the
-      # critical path since it runs concurrently with `test-build`.
+      # It lives in THIS job rather than one of its own, and that was measured both
+      # ways. Generation is ~3s but compiling the example is ~50s, so on run
+      # 31275077075 this job went 64s -> 117s. A job of its own looks tempting —
+      # `spec-fixtures` gates `test` and `test-oracle` — but a new job has no
+      # `rust-cache` entry and would compile the whole dependency tree cold, which
+      # is slower than the 53s it set out to save, while still gating both through
+      # `needs`. Giving it a cache instead means a new key, and the repository is
+      # only just under the 10 GiB cap (see the first `rust-cache` block above).
+      # Here it reuses this job's already-warm dev-profile tree, and it is not on
+      # the critical path: that runs through `test-build-soak` + `sweeps`.
       - name: Generate the cis confluence corpus
         run: cargo run --features dev --example generate_cis_confluence_corpus
       # Only the fixtures are published from here. The two generator binaries
@@ -367,10 +391,9 @@ jobs:
             tests/fixtures/grammar/hgvs_spec_normalization.json
             tests/fixtures/grammar/hgvs_spec_enumeration.json
           retention-days: 1
-      # A second artifact rather than a second path on the one above, because
-      # the consumers download `spec-fixtures` with `path:
-      # tests/fixtures/grammar/` — a single artifact spanning two fixture
-      # directories cannot be unpacked that way.
+      # A second artifact rather than a second path on the one above, because the
+      # consumers download `spec-fixtures` with `path: tests/fixtures/grammar/` — a
+      # single artifact spanning two fixture directories cannot be unpacked that way.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cis-corpus
@@ -442,6 +465,9 @@ jobs:
       # `shared-key` above.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: test-archive
           # `rust-cache` caches `${CARGO_HOME}/bin` unless told not to, so a
           # restore could extract a previously-saved `cargo-nextest` over the one
@@ -510,6 +536,9 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: test-archive-soak
           # Same reason as `test-build` above, and it applies at least as
           # strongly here: this job writes the archive that `soak` and `sweeps`
@@ -864,6 +893,9 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: generated-docs
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
@@ -928,6 +960,9 @@ jobs:
           python-version: "3.12"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: python-wheel
       - name: Build release wheel
         run: |
@@ -971,6 +1006,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: build-release
       # The release-profile lint (#1383). It lives in THIS job on purpose: the two
       # `clippy` jobs both lint the debug profile, so nothing checked the release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,32 @@ jobs:
         run: cargo run --features dev --bin generate_spec_fixture
       - name: Generate HGVS spec test enumeration
         run: cargo run --features dev --bin generate_spec_enumeration
+      # The cis confluence corpus, for the same reason and at far greater
+      # saving. `tests/it/cis_confluence_axis.rs` regenerates it on demand
+      # through `common::fixture_gen`, which shells out to a nested
+      # `cargo run --features dev --example generate_cis_confluence_corpus`.
+      # The `test` / `test-oracle` shards run from a nextest **archive**, so
+      # they have no warm `target/`: that nested invocation compiles the crate
+      # and the example from scratch inside the test, and the cost lands on
+      # whichever of the three `cis_confluence_axis` tests the shard happens to
+      # hold.
+      #
+      # Measured on run 31268888323: `the_corpus_is_a_dense_set_of_real_confluence_classes`
+      # took **117.6s** in `Test (2/6)` and 127.3s in `Test oracle (2/3)` — a
+      # test that reads the corpus and makes a handful of cheap assertions, and
+      # takes 0.07s once the file exists. The generation itself is ~3s.
+      #
+      # Six jobs pay it per run, not nine: the three tests are spread across the
+      # six `test` shards and again across the three `test-oracle` shards, so
+      # three shards of each job hold one apiece. On that run they landed in
+      # `Test` 2/4/6 and `Test oracle` 1/2/3, at 117.6-169.7s each — roughly ten
+      # minutes of runner time spent rebuilding the crate to produce an 8 MB JSON.
+      #
+      # Publishing it here costs this job ~3s and nothing else: `spec-fixtures`
+      # already has a warm `Swatinem/rust-cache` tree, and it is off the
+      # critical path since it runs concurrently with `test-build`.
+      - name: Generate the cis confluence corpus
+        run: cargo run --features dev --example generate_cis_confluence_corpus
       # Only the fixtures are published from here. The two generator binaries
       # `spec_generator_preconditions` executes need no staging: they are
       # `[[bin]]` targets, so `test-build`'s archive already carries them and
@@ -340,6 +366,15 @@ jobs:
           path: |
             tests/fixtures/grammar/hgvs_spec_normalization.json
             tests/fixtures/grammar/hgvs_spec_enumeration.json
+          retention-days: 1
+      # A second artifact rather than a second path on the one above, because
+      # the consumers download `spec-fixtures` with `path:
+      # tests/fixtures/grammar/` — a single artifact spanning two fixture
+      # directories cannot be unpacked that way.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cis-corpus
+          path: tests/fixtures/cis/cis_confluence_corpus.json
           retention-days: 1
 
   # Build the test binaries ONCE, then fan out: `test` and `test-oracle` consume
@@ -534,6 +569,14 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
+      # Without this the three `cis_confluence_axis` tests regenerate the corpus
+      # themselves, via a nested `cargo run --example` that has to compile the
+      # crate from scratch inside the test — 117.6s on run 31268888323 for the
+      # one that only reads it. See the generating step in `spec-fixtures`.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: cis-corpus
+          path: tests/fixtures/cis/
       - name: "Note: reference-aware tests are skipped without a manifest"
         # `tests/mutalyzer_normalize_tests.rs` and the biocommons reference-aware
         # suite both silently no-op when `FERRO_MANIFEST` is unset (PR CI does
@@ -593,6 +636,14 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
+      # Without this the three `cis_confluence_axis` tests regenerate the corpus
+      # themselves, via a nested `cargo run --example` that has to compile the
+      # crate from scratch inside the test — 117.6s on run 31268888323 for the
+      # one that only reads it. See the generating step in `spec-fixtures`.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: cis-corpus
+          path: tests/fixtures/cis/
       - name: Run Rust tests with the normalization self-checks
         # `FERRO_ASSERT_IDEMPOTENT` turns every reference-backed test into an
         # assertion that `norm(norm(x)) == norm(x)`. The gate is

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,6 +52,22 @@ jobs:
       # every dependency, so a tree shared with any other job is useless to both.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade, stated: a PR that changes `Cargo.lock` no longer warms its own
+          # cache, so it restores `main`'s generation through the `restore-keys`
+          # prefix and recompiles what the lockfile moved. That is one slower job on
+          # dependency-bumping PRs, against every cache in the repo currently racing
+          # eviction.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: coverage
           # This job needs it too, and needs it more than `ci.yml`'s two do
           # (#1396). `install-action` puts `cargo-llvm-cov` into

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -75,6 +75,25 @@ jobs:
       # worth caching; the binaries on this box are not ours to replace.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `push: [main]` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a `main` push, which satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main` branch,
+          # which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: deploy-local-web-hgvs-rs
           cache-bin: "false"
 

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -127,6 +127,26 @@ jobs:
       # `gh api .../actions/caches` stays diagnosable.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `schedule` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a scheduled one, which GitHub fires against the default
+          # branch and which therefore satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main`
+          # branch, which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: external-validation-api
 
       # These three steps are the point of the workflow, so they gate it.
@@ -242,6 +262,9 @@ jobs:
       # same key. Distinct name, so the two no longer overwrite each other (#1218).
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: external-validation-spec
 
       # The spec-normalization fixture is a generated artifact (gitignored);

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -62,6 +62,26 @@ jobs:
       # making that install cheap is a separate change and is not attempted here.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `schedule` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a scheduled one, which GitHub fires against the default
+          # branch and which therefore satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main`
+          # branch, which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: fuzz-${{ matrix.target }}
           workspaces: fuzz
           cache-bin: "false"

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -74,6 +74,26 @@ jobs:
       # cross-job fallback to get wrong.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `schedule` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a scheduled one, which GitHub fires against the default
+          # branch and which therefore satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main`
+          # branch, which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: nightly-mutalyzer
 
       # The prepared reference is NOT cached. It used to be

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -81,6 +81,26 @@ jobs:
       # inherit. `rust-cache` keys per job and stores dependency artifacts only.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `schedule` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a scheduled one, which GitHub fires against the default
+          # branch and which therefore satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main`
+          # branch, which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: nightly-perf
 
       # The prepared reference is NOT cached, for the reason recorded in

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -90,6 +90,26 @@ jobs:
       # nothing).
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
+          # keys per job and appends a lockfile/env hash, so every PR run that
+          # differed in either minted a fresh ~0.2-0.7 GiB entry. Measured on
+          # 2026-08-08: 42 entries totalling 13.79 GiB against a 10 GiB cap — 3 to 5
+          # generations of every logical key, `coverage` alone holding 4 x ~0.69 GiB.
+          # Over cap means GitHub evicts by LRU continuously, which is the #1218
+          # failure (two generations reached 13.61 GiB and took the nightly's 3.25 GiB
+          # `ferro-manifest-v3` with them). Restoring on every run and saving only on
+          # `main` collapses it to one generation per key, ~4.2 GiB.
+          #
+          # The trade is nil for this workflow: it triggers on `schedule` and
+          # `workflow_dispatch` only, so every run that could ever have saved an
+          # entry is a scheduled one, which GitHub fires against the default
+          # branch and which therefore satisfies the condition. The one run that
+          # now declines to save is a `workflow_dispatch` from a non-`main`
+          # branch, which restores
+          # `main`'s generation through the `restore-keys` prefix instead. `ci.yml`
+          # and `coverage.yml` are where the PR-side trade actually lands; it is
+          # stated on their first `rust-cache` block.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: nightly-soak
           cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest

--- a/.github/workflows/prune-ci-caches.yml
+++ b/.github/workflows/prune-ci-caches.yml
@@ -1,0 +1,121 @@
+name: Prune CI caches
+
+# Bound the per-commit cache families so they cannot re-create the over-cap
+# problem they were added into.
+#
+# `ci.yml` caches three artifacts under a key that ends in the commit SHA — the
+# nextest archive (106.6 MB), the soak archive (25.8 MB) and the generated
+# fixtures (~0.5 MB). Keying on the SHA is what makes them safe: a hit means the
+# tree is byte-identical, so a stale archive cannot be served. It also means one
+# entry per commit, ~133 MB apiece, and nothing reclaims them but GitHub's own
+# eviction.
+#
+# That eviction is the hazard rather than the remedy. The repository's cache cap
+# is 10 GiB and eviction is LRU across ALL entries, so an unbounded archive family
+# does not evict itself — it evicts whatever is least recently used, which is
+# exactly how #1218 destroyed the nightly's 3.25 GiB `ferro-manifest-v3`. Measured
+# 2026-08-08, before the `save-if` change in this PR: 42 entries, 13.79 GiB against
+# the 10 GiB cap.
+#
+# So the per-commit families get an explicit ceiling here: keep the newest
+# KEEP_PER_FAMILY of each, delete the rest. At the default that is at most
+# 5 x ~133 MB ~= 0.65 GiB on top of the ~4.2 GiB of one-generation-per-key
+# `rust-cache` entries.
+#
+# Deliberately NOT pruned: anything outside those three families. The
+# `rust-cache` entries are bounded already (this PR made them save only from
+# `main`, so there is one generation per key), and the nightly reference manifest
+# is precisely the thing this workflow exists to protect.
+
+on:
+  schedule:
+    # Daily, well away from the nightly workflows so a prune cannot race a run
+    # that is actively restoring what it is about to delete.
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  # `actions: write` is required to delete a cache entry, and is the only
+  # elevated permission this workflow takes.
+  actions: write
+
+concurrency:
+  group: prune-ci-caches
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune per-commit CI caches
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # How many of each per-commit family to keep. Enough that a re-run of a
+      # recent commit still hits, small enough to bound the total.
+      KEEP_PER_FAMILY: "5"
+    steps:
+      - name: Report usage before
+        run: |
+          set -euo pipefail
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/cache/usage" \
+            --jq '"before: \(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1073741824 * 100 | floor / 100) GiB"'
+
+      - name: Delete all but the newest of each per-commit family
+        run: |
+          set -euo pipefail
+          # The three families `ci.yml` writes per commit. Matched as key
+          # PREFIXES, so a family that gains an OS or a suffix is still covered.
+          families="nextest-archive- nextest-soak-archive- generated-fixtures-"
+
+          # `--paginate` because the cap allows far more entries than one page,
+          # and a partial listing would delete the wrong ones: this keeps the
+          # newest N *of what it can see*.
+          gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | [.id, .created_at, .size_in_bytes, .key] | @tsv' > all-caches.tsv
+
+          total_deleted=0
+          total_bytes=0
+          for family in $families; do
+            # Newest first, then drop the ones to keep. `sort -r` on an ISO-8601
+            # timestamp is a chronological sort, which is why `created_at` is
+            # used rather than `last_accessed_at` — a re-run touches an entry and
+            # would otherwise make an old commit's archive look new.
+            awk -F'\t' -v f="$family" 'index($4, f) == 1' all-caches.tsv \
+              | sort -t"$(printf '\t')" -k2,2r \
+              | tail -n "+$((KEEP_PER_FAMILY + 1))" > victims.tsv || true
+
+            while IFS=$'\t' read -r id created size key; do
+              [ -n "${id:-}" ] || continue
+              echo "deleting ${key} (${size} bytes, created ${created})"
+              # A 404 is the one tolerated outcome: a concurrent run may have
+              # evicted the entry already, which is what we wanted anyway.
+              #
+              # Everything else fails the job, and the counters below advance
+              # only on a delete that actually returned 0. A blanket `|| true`
+              # here swallowed a 403 from a token without `actions: write`, and a
+              # secondary rate limit, exactly as it swallowed the 404 — while the
+              # summary still reported every attempted entry as deleted. A prune
+              # that silently deletes nothing and says it deleted 12 entries is
+              # how the over-cap problem this workflow bounds comes back, and it
+              # is the one failure the `usage` steps either side cannot surface,
+              # because nothing compares them.
+              rc=0
+              gh api -X DELETE "/repos/${GITHUB_REPOSITORY}/actions/caches/${id}" \
+                >/dev/null 2>delete-err.txt || rc=$?
+              if [ "$rc" -eq 0 ]; then
+                total_deleted=$((total_deleted + 1))
+                total_bytes=$((total_bytes + size))
+              elif grep -q 'HTTP 404' delete-err.txt; then
+                echo "  already evicted"
+              else
+                cat delete-err.txt >&2
+                exit 1
+              fi
+            done < victims.tsv
+          done
+          echo "deleted ${total_deleted} entries, ${total_bytes} bytes"
+
+      - name: Report usage after
+        run: |
+          set -euo pipefail
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/cache/usage" \
+            --jq '"after: \(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1073741824 * 100 | floor / 100) GiB"'

--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -861,8 +861,9 @@ fn dump(seeds: u32) -> Vec<Row> {
             if axis == "cx" {
                 continue;
             }
+            let normalizer = normalizer_for(axis, &core, direction);
             for input in long_inputs_for(axis, &core) {
-                let output = normalize_one(axis, &core, &input, direction);
+                let output = normalize_through(&normalizer, &input);
                 rows.push(Row {
                     reference: label.clone(),
                     axis,
@@ -881,8 +882,9 @@ fn dump(seeds: u32) -> Vec<Row> {
     // the sequence, so it cannot be crossed with the random cores below.
     for design in revcomp_designs() {
         for (axis, direction, dir_label) in axes_and_directions() {
+            let normalizer = normalizer_for(axis, &design.core, direction);
             for input in revcomp_inputs_for(axis, &design) {
-                let output = normalize_one(axis, &design.core, &input, direction);
+                let output = normalize_through(&normalizer, &input);
                 rows.push(Row {
                     reference: design.label.clone(),
                     axis,
@@ -897,9 +899,12 @@ fn dump(seeds: u32) -> Vec<Row> {
     }
     for core in corpus_sequences(seeds) {
         for (axis, direction, dir_label) in axes_and_directions() {
+            // One normalizer per (axis, core, direction) cell, reused across every
+            // family and every input in it — see `normalizer_for`.
+            let normalizer = normalizer_for(axis, &core, direction);
             for (family, _) in FAMILIES {
                 for input in inputs_for(family, axis, &core) {
-                    let output = normalize_one(axis, &core, &input, direction);
+                    let output = normalize_through(&normalizer, &input);
                     rows.push(Row {
                         reference: core.clone(),
                         axis,
@@ -1257,15 +1262,30 @@ fn provider_for(axis: &str, core: &str) -> MockProvider {
     }
 }
 
-fn normalize_one(axis: &str, core: &str, input: &str, direction: ShuffleDirection) -> String {
+/// The normalizer one `(axis, core, direction)` cell of the matrix is dumped
+/// through.
+///
+/// Split out of [`normalize_one`] so [`dump`] can build it **once per cell**
+/// instead of once per row. `provider_for` is not cheap: every call re-pads the
+/// core with 512 bases (`padded`), and the coding and multi-exon axes also build a
+/// `Transcript` — on the 1024-base long cores that is a ~1.5 kB copy per input, and
+/// the corpus has tens of thousands of rows. Nothing about it varies with the row.
+fn normalizer_for(axis: &str, core: &str, direction: ShuffleDirection) -> Normalizer<MockProvider> {
+    Normalizer::with_config(
+        provider_for(axis, core),
+        NormalizeConfig::default().with_direction(direction),
+    )
+}
+
+/// One row's output, through a normalizer the caller already holds.
+///
+/// The sentinel vocabulary (`<parse-error>` / `<declined>` / `<panic>`) is what
+/// `the_corpus_emits_a_block_past_the_split_cap` reads, so it lives here rather
+/// than at each call site.
+fn normalize_through(normalizer: &Normalizer<MockProvider>, input: &str) -> String {
     let Ok(variant) = parse_hgvs(input) else {
         return "<parse-error>".to_string();
     };
-    let provider = provider_for(axis, core);
-    let normalizer = Normalizer::with_config(
-        provider,
-        NormalizeConfig::default().with_direction(direction),
-    );
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         normalizer.normalize(&variant)
     })) {
@@ -1273,6 +1293,17 @@ fn normalize_one(axis: &str, core: &str, input: &str, direction: ShuffleDirectio
         Ok(Err(_)) => "<declined>".to_string(),
         Err(_) => "<panic>".to_string(),
     }
+}
+
+/// [`normalize_through`], building the normalizer for one row.
+///
+/// `#[cfg(test)]` because that is now the whole of its use: the callers that
+/// genuinely normalize a *single* description are the unit tests below and the
+/// idempotency re-check, where there is no matrix cell to amortise a normalizer
+/// over. [`dump`] holds one per cell via [`normalizer_for`].
+#[cfg(test)]
+fn normalize_one(axis: &str, core: &str, input: &str, direction: ShuffleDirection) -> String {
+    normalize_through(&normalizer_for(axis, core, direction), input)
 }
 
 fn padded(core: &str) -> String {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -533,50 +533,100 @@ impl Accession {
 
     /// Full accession string without version
     pub fn base(&self) -> String {
-        // Assembly/chromosome notation: GRCh37(chr23)
-        if let (Some(assembly), Some(chromosome)) = (&self.assembly, &self.chromosome) {
-            return format!("{}({})", assembly, chromosome);
-        }
-        let base = if self.ensembl_style {
-            format!("{}{}", self.prefix, self.number)
-        } else {
-            format!("{}_{}", self.prefix, self.number)
-        };
-        // Compound reference: context(base)
-        if let Some(ctx) = &self.genomic_context {
-            format!("{}({})", ctx.full(), base)
-        } else {
-            base
-        }
+        collect_written(|out| self.write_base(out))
     }
 
     /// Full accession string with version if present
     pub fn full(&self) -> String {
+        collect_written(|out| self.write_full(out))
+    }
+
+    /// [`Self::base`], written straight into `out` rather than through a
+    /// temporary `String`.
+    ///
+    /// The single source of truth for `base()`; see [`Self::write_full`] for why
+    /// the two are written this way round.
+    fn write_base(&self, out: &mut impl fmt::Write) -> fmt::Result {
+        // Assembly/chromosome notation: GRCh37(chr23)
+        if let (Some(assembly), Some(chromosome)) = (&self.assembly, &self.chromosome) {
+            return write!(out, "{assembly}({chromosome})");
+        }
+        // Compound reference: context(base)
+        if let Some(ctx) = &self.genomic_context {
+            ctx.write_full(out)?;
+            out.write_char('(')?;
+            self.write_bare(out)?;
+            return out.write_char(')');
+        }
+        self.write_bare(out)
+    }
+
+    /// [`Self::full`], written straight into `out` rather than through a
+    /// temporary `String`.
+    ///
+    /// This is the source of truth for both `full()` and `Display`, and the
+    /// direction matters for cost. `Display` used to be
+    /// `write!(f, "{}", self.full())`, so **rendering any variant heap-allocated
+    /// one `String` per accession it printed** — including the recursive
+    /// `genomic_context.full()` — only to copy it into the formatter and drop it.
+    /// Every `HgvsVariant::to_string()` paid that, which is a hot path for any
+    /// caller normalizing in bulk: it measured 2.5% of
+    /// `cis_confluence_axis::three_prime_confluence_census` (47 392
+    /// normalizations) on its own, and `member_span`'s call added another 2.3%.
+    ///
+    /// `fmt::Formatter` implements `fmt::Write`, so one generic writer serves the
+    /// allocating and non-allocating callers alike and the two cannot drift.
+    ///
+    /// **Format specs are ignored, before and after — this changes nothing there,
+    /// and the reasoning that said otherwise was wrong.** The obvious worry about
+    /// writing pieces straight into `f` is that a spec applied to the whole is
+    /// lost: `write_str`/`write_char` bypass `Formatter::pad`, so
+    /// `format!("{accession:>20}")` cannot right-align and `{accession:.4}` cannot
+    /// truncate. True, and true of the old body as well. `write!(f, "{}", s)`
+    /// expands to `f.write_fmt(format_args!("{}", s))`, which renders `s` under the
+    /// *inner* format string's specs — and `"{}"` carries none. Only `f.pad(s)`, or
+    /// `Display::fmt(&s, f)` reached directly, consults the outer `f`. Measured
+    /// three ways rather than reasoned about: `write!(f, "{}", s)` and a
+    /// piecewise writer both render `{:>20}` unpadded and `{:.4}` untruncated,
+    /// while `f.pad(s)` right-aligns and truncates to `NM_0`.
+    ///
+    /// So this is a pure refactor at the seam, which is the stronger claim and the
+    /// one to make. `test_accession_display` pins the inertness of `{:>20}`,
+    /// `{:*^20}`, `{:.4}` and `{:<8.2}` so the question is settled in a test rather
+    /// than re-litigated from the shape of the code — it is long-standing behaviour
+    /// this crate shares with nearly every multi-field `Display` it defines,
+    /// `HgvsVariant`'s included, and no caller in `src/`, `tests/` or `examples/`
+    /// applies a spec to an accession or a variant anyway.
+    fn write_full(&self, out: &mut impl fmt::Write) -> fmt::Result {
         // Assembly/chromosome notation doesn't have versions
         if self.is_assembly_ref() {
-            return self.base();
+            return self.write_base(out);
         }
-        let full = match self.version {
-            Some(v) => {
-                if self.ensembl_style {
-                    format!("{}{}.{}", self.prefix, self.number, v)
-                } else {
-                    format!("{}_{}.{}", self.prefix, self.number, v)
-                }
-            }
-            None => {
-                if self.ensembl_style {
-                    format!("{}{}", self.prefix, self.number)
-                } else {
-                    format!("{}_{}", self.prefix, self.number)
-                }
-            }
-        };
         // Compound reference: context(full)
         if let Some(ctx) = &self.genomic_context {
-            format!("{}({})", ctx.full(), full)
-        } else {
-            full
+            ctx.write_full(out)?;
+            out.write_char('(')?;
+            self.write_versioned(out)?;
+            return out.write_char(')');
+        }
+        self.write_versioned(out)
+    }
+
+    /// `prefix[_]number`, the accession without version or wrapper.
+    fn write_bare(&self, out: &mut impl fmt::Write) -> fmt::Result {
+        out.write_str(&self.prefix)?;
+        if !self.ensembl_style {
+            out.write_char('_')?;
+        }
+        out.write_str(&self.number)
+    }
+
+    /// [`Self::write_bare`] plus `.version`, when there is one.
+    fn write_versioned(&self, out: &mut impl fmt::Write) -> fmt::Result {
+        self.write_bare(out)?;
+        match self.version {
+            Some(v) => write!(out, ".{v}"),
+            None => Ok(()),
         }
     }
 
@@ -588,29 +638,36 @@ impl Accession {
         if self.is_assembly_ref() {
             return self.base();
         }
-
-        match self.version {
-            Some(v) => {
-                if self.ensembl_style {
-                    format!("{}{}.{}", self.prefix, self.number, v)
-                } else {
-                    format!("{}_{}.{}", self.prefix, self.number, v)
-                }
-            }
-            None => {
-                if self.ensembl_style {
-                    format!("{}{}", self.prefix, self.number)
-                } else {
-                    format!("{}_{}", self.prefix, self.number)
-                }
-            }
-        }
+        collect_written(|out| self.write_versioned(out))
     }
+}
+
+/// Run a `fmt::Write` producer into a fresh `String`.
+///
+/// The accession writers below are shared with `Display`, which hands them a
+/// `fmt::Formatter`; this is the adapter for the callers that still want an owned
+/// `String`. Writing into a `String` cannot fail — `fmt::Write for String` is
+/// infallible — so the `Result` is asserted rather than propagated.
+///
+/// The capacity hint is load-bearing rather than a flourish. The writers push
+/// their pieces one at a time, so without it a rendered accession reallocates two
+/// or three times where the `format!` these replaced sized the buffer once — which
+/// would trade `Display`'s saved allocation for extra ones on the [`Accession::full`]
+/// path, and both are hot. 40 bytes covers every real accession, versioned
+/// (`NM_000088.3` is 11, `ENST00000357033.8` is 17) and assembly-style
+/// (`GRCh38(chr1)` is 12); only a compound `genomic(transcript)` reference can
+/// exceed it, and that grows once.
+fn collect_written(produce: impl FnOnce(&mut String) -> fmt::Result) -> String {
+    /// Enough for any single accession, so the common case never reallocates.
+    const TYPICAL_ACCESSION_LEN: usize = 40;
+    let mut out = String::with_capacity(TYPICAL_ACCESSION_LEN);
+    produce(&mut out).expect("writing into a String is infallible");
+    out
 }
 
 impl fmt::Display for Accession {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.full())
+        self.write_full(f)
     }
 }
 
@@ -3193,6 +3250,35 @@ mod tests {
 
         let acc_no_version = Accession::new("NM", "000088", None);
         assert_eq!(format!("{}", acc_no_version), "NM_000088");
+
+        // `Display` ignores every format spec, and always has. Pinned here because
+        // rewriting `Display` to write its pieces straight into the formatter
+        // *looks* like it drops padding that `write!(f, "{}", self.full())`
+        // supported — and the first reading of this change said so. It did not:
+        // `write!` renders its argument under the inner `"{}"`, which carries no
+        // spec, so neither body ever reached `Formatter::pad`. Verified both ways —
+        // these assertions pass against the previous body too. See
+        // [`Accession::write_full`].
+        //
+        // Asserted against the bare form rather than against literals, so the
+        // property under test is "the spec changes nothing" rather than "the
+        // accession is spelled thus", which the two assertions above already pin.
+        let bare = format!("{acc}");
+        assert_eq!(
+            format!("{acc:>20}"),
+            bare,
+            "width and alignment are ignored"
+        );
+        assert_eq!(format!("{acc:*^20}"), bare, "fill is ignored");
+        assert_eq!(format!("{acc:.4}"), bare, "precision does not truncate");
+        assert_eq!(
+            format!("{acc:<8.2}"),
+            bare,
+            "nor do they combine to any effect"
+        );
+        // And `Display` still agrees with the allocating twin it shares a writer
+        // with, which is the invariant the shared writer exists to hold.
+        assert_eq!(bare, acc.full());
     }
 
     #[test]

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -6816,11 +6816,40 @@ fn member_span<P: ReferenceProvider>(
     let (accession, (start_region, axis_start), (end_region, axis_end), edit) =
         member_axis_endpoints(v, kind)?;
     let provider_key = accession.transcript_accession();
-    let to_sequence = |region: Region, coord: i64| -> Option<i64> {
-        region_span_delta(region, &provider_key, provider)?.checked_add(coord)
+    // One delta per *distinct* region, not one per endpoint. `region_span_delta`
+    // resolves the transcript through the provider, so asking twice for the
+    // region both endpoints almost always share is a duplicated hash lookup on
+    // every member of every pass that reads a span — and there are a dozen such
+    // passes per `normalize`.
+    //
+    // Sizing, stated as what was actually measured: the transcript lookups
+    // reached from *this function* are 5.2% of
+    // `cis_confluence_axis::three_prime_confluence_census` (sampled inclusive
+    // time, `region_sequence_delta`'s bounds closure with `member_span` as its
+    // caller). This removes the duplicate, so roughly half of that — not the
+    // whole 5.2%, and only on the axes that have a transcript at all, since
+    // `Region::Genome` answers without touching the provider. What it does not
+    // touch is the *cross-pass* repetition: a dozen passes each re-derive every
+    // member's span, so one memo shared across `normalize_allele` would collapse
+    // the rest. That is a wider refactor of all fourteen call sites and is left
+    // alone here.
+    //
+    // Both sides of the branch are already pinned, which is why this adds no test:
+    // `a_member_spanning_a_region_boundary_has_a_span` asserts exact coordinates
+    // for two members whose ends lie in *different* regions (`c.12_*1del`,
+    // `c.-1_1del`) and for one wholly inside a single region (`c.11_12del`), and it
+    // is deliberately written as the control for exactly this kind of arithmetic
+    // change. The reuse is sound because `region_span_delta` is a pure function of
+    // `(region, provider_key, provider)`, so the second call it replaces could only
+    // ever have returned `start_delta` again.
+    let start_delta = region_span_delta(start_region, &provider_key, provider)?;
+    let end_delta = if end_region == start_region {
+        start_delta
+    } else {
+        region_span_delta(end_region, &provider_key, provider)?
     };
-    let start = to_sequence(start_region, axis_start)?;
-    let end = to_sequence(end_region, axis_end)?;
+    let start = start_delta.checked_add(axis_start)?;
+    let end = end_delta.checked_add(axis_end)?;
     Some(MemberSpan {
         accession: accession.full(),
         provider_key,

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -959,8 +959,45 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
 ///   cargo nextest run --features dev \
 ///   -E 'test(no_two_member_transcript_axis_allele)'
 /// ```
-#[test]
-fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
+/// The three transcript axes this sweep covers, each with the accession it is
+/// drawn against and the name of the test that runs it.
+///
+/// One row per `#[test]` below, and [`every_transcript_axis_has_its_own_sweep`]
+/// checks the two stay in step. That guard replaces the `per_axis` key assertion
+/// this sweep used to carry: when all three axes ran inside one test, asserting
+/// the key set was what made a deleted arm fail loudly instead of silently
+/// shrinking a total that still cleared the floor. Split one test per axis, each
+/// axis now has its own floor — stronger — but deleting a whole `#[test]` would
+/// delete its own guard along with it, so the guard has to live outside all three.
+const TRANSCRIPT_AXIS_SWEEPS: [(&str, &str, &str); 3] = [
+    (
+        "NM_TEST.1",
+        "c",
+        "no_two_member_cds_axis_allele_normalizes_to_a_different_sequence",
+    ),
+    (
+        "NR_TEST.1",
+        "n",
+        "no_two_member_noncoding_axis_allele_normalizes_to_a_different_sequence",
+    ),
+    (
+        "NR_TEST.1",
+        "r",
+        "no_two_member_rna_axis_allele_normalizes_to_a_different_sequence",
+    ),
+];
+
+/// One axis of the transcript-axis sweep. See the module-level notes above the
+/// three `#[test]` wrappers for what it covers and why each axis is swept.
+///
+/// **Split one test per axis to shorten CI's critical path.** All three ran in one
+/// test, and that test alone set the `sweeps` job's duration — a job cannot finish
+/// faster than its longest single test, so sharding the job could not help while
+/// this was one 114s test. Three tests of a third the work run concurrently under
+/// nextest instead. Nothing about the enumeration changes: same accessions, same
+/// axes, same shapes, same positions, same directions, and each axis keeps the
+/// per-seed floor it already had to clear individually.
+fn sweep_one_transcript_axis(accession: &str, axis: &str) {
     use crate::common::cis_apply_oracle::{apply_parsed_with, apply_with};
     use crate::common::synthetic::SyntheticBuilder;
     use ferro_hgvs::reference::transcript::Strand;
@@ -973,13 +1010,6 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
     let mut skipped = 0usize;
     let mut overlapping: Vec<String> = Vec::new();
     let mut changed: Vec<String> = Vec::new();
-    // Per axis, not just in aggregate. `checked` sums all three, and the floor
-    // below is a *per-seed* constant, so dropping an entire axis would remove a
-    // third of the corpus and still clear it — the aggregate cannot detect its
-    // own coverage being deleted. That matters most for `r.`, which is the axis
-    // this sweep gained last and the cheapest one to remove if the runtime is
-    // ever trimmed.
-    let mut per_axis: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
 
     let seeds = sweep_seeds(48);
     for seq in sweep_sequences(seeds) {
@@ -1033,174 +1063,298 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
         // *measured* gap — 849 corrupt outputs — and coding `r.` buys an
         // unmeasured one. Worth adding if a defect ever turns up there, or if
         // this sweep is made cheaper.
-        for (accession, axis) in [("NM_TEST.1", "c"), ("NR_TEST.1", "n"), ("NR_TEST.1", "r")] {
-            // Built once per (sequence, axis) and cloned per case. `SyntheticBuilder`
-            // pads, maps to a genomic contig and reverse-complements on demand, so
-            // constructing one inside the innermost loop dominated the test:
-            // measured at 39.8s for the 4-seed prefix before hoisting, against
-            // 18.3s for the far larger genomic sweep beside it.
-            let axis_provider = if axis == "c" {
-                SyntheticBuilder::cds(&seq, 1, CDS_END, Strand::Plus).build()
-            } else {
-                SyntheticBuilder::noncoding(&seq, Strand::Plus).build()
-            };
-            let checked_before_axis = checked;
-            for first_start in 2..=11usize {
-                for first_len in 1..=2usize {
-                    let first_end = first_start + first_len - 1;
-                    let span = if first_len == 1 {
-                        format!("{first_start}")
-                    } else {
-                        format!("{first_start}_{first_end}")
-                    };
-                    // Same payload rule as the genomic sweeps: excluding both
-                    // flanking reference bases keeps the `ins` entry from
-                    // denoting the `dup` beside it.
-                    let first_base = seq.as_bytes()[first_start - 1] as char;
-                    let first_next = seq.as_bytes()[first_start] as char;
-                    let first_payload = ['A', 'C', 'G', 'T']
-                        .into_iter()
-                        .find(|b| *b != first_base && *b != first_next)
-                        .expect("four bases, at most two excluded");
-                    let inserted: String = std::iter::repeat_n(first_payload, first_len).collect();
-                    let firsts = [
-                        format!("{span}del"),
-                        format!("{span}dup"),
-                        format!("{first_start}_{}ins{inserted}", first_start + 1),
-                    ];
-                    for first in firsts {
-                        for second_start in first_end + 2..=(CDS_END as usize - 1) {
-                            let base = seq.as_bytes()[second_start - 1] as char;
-                            let alt = if base == 'A' { 'G' } else { 'A' };
-                            let next_base = seq.as_bytes()[second_start] as char;
-                            let second_payload = ['A', 'C', 'G', 'T']
-                                .into_iter()
-                                .find(|b| *b != base && *b != next_base)
-                                .expect("four bases, at most two excluded");
-                            for second in [
-                                format!("{second_start}del"),
-                                format!("{second_start}{base}>{alt}"),
-                                format!("{second_start}dup"),
-                                format!("{second_start}_{}ins{second_payload}", second_start + 1),
-                            ] {
-                                // Everything that depends only on the *description*
-                                // is hoisted out of the direction loop below. The
-                                // input string, its parse and the bases it denotes
-                                // are all properties of the description, not of the
-                                // shuffle direction, and computing them per
-                                // direction did each of them exactly twice.
-                                let input = format!("{accession}:{axis}.[{first};{second}]");
-                                let variant = parse_hgvs(&input).expect("generated input parses");
-                                // Lazily, and at most once: a case both directions
-                                // decline must stay as cheap as it was.
-                                let mut input_applied: Option<Option<String>> = None;
-                                for direction in
-                                    [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
-                                {
-                                    // Deliberately built per case rather than once
-                                    // per (sequence, axis). Hoisting it is strictly
-                                    // less work and IS faster in the unoptimized
-                                    // test profile, but it measured **14% slower**
-                                    // on this test under the `soak` profile CI's
-                                    // `sweeps` job actually uses — 11.54s -> 13.16s,
-                                    // three reps a side at CV <= 0.5%. The
-                                    // direction-invariant hoisting above (the
-                                    // description, its parse, its applied sequence)
-                                    // is kept: that is where the duplicated work was.
-                                    let normalizer = Normalizer::with_config(
-                                        axis_provider.clone(),
-                                        NormalizeConfig::default()
-                                            .with_direction(direction)
-                                            .allow_crossing_boundaries(),
-                                    );
-                                    let Ok(normalized) = normalizer.normalize(&variant) else {
-                                        // A refusal is a legitimate answer here —
-                                        // the transcript axes decline shapes the
-                                        // genomic axis accepts — and says nothing
-                                        // about sequence preservation.
-                                        skipped += 1;
-                                        continue;
-                                    };
-                                    let output = format!("{normalized}");
-                                    checked += 1;
+        // Built once per (sequence, axis) and cloned per case. `SyntheticBuilder`
+        // pads, maps to a genomic contig and reverse-complements on demand, so
+        // constructing one inside the innermost loop dominated the test:
+        // measured at 39.8s for the 4-seed prefix before hoisting, against
+        // 18.3s for the far larger genomic sweep beside it.
+        // Keyed on the *accession*, not the axis, because that is what the
+        // builders actually decide: `cds` names its transcript `NM_TEST.1` and
+        // `noncoding` names its own `NR_TEST.1`, and every description below is
+        // built as `{accession}:{axis}.…`. Testing `axis == "c"` instead would
+        // route the coding `r.` row named in the gap note above — which is
+        // `("NM_TEST.1", "r")` — to an `NR_TEST.1` provider, so every lookup
+        // would fail to resolve and normalization would hand the input straight
+        // back: a sweep that is green because it checked nothing, with the
+        // axis label in every assertion message still reading `r.`.
+        // `every_transcript_axis_has_its_own_sweep` does not reach this choice,
+        // so an unrecognized accession is loud rather than defaulted.
+        let axis_provider = match accession {
+            "NM_TEST.1" => SyntheticBuilder::cds(&seq, 1, CDS_END, Strand::Plus).build(),
+            "NR_TEST.1" => SyntheticBuilder::noncoding(&seq, Strand::Plus).build(),
+            other => panic!(
+                "no reference shape is wired for `{other}` (sweeping the `{axis}.` axis); add \
+                 one to this match rather than letting the row fall through to a transcript \
+                 whose accession the descriptions never name"
+            ),
+        };
+        for first_start in 2..=11usize {
+            for first_len in 1..=2usize {
+                let first_end = first_start + first_len - 1;
+                let span = if first_len == 1 {
+                    format!("{first_start}")
+                } else {
+                    format!("{first_start}_{first_end}")
+                };
+                // Same payload rule as the genomic sweeps: excluding both
+                // flanking reference bases keeps the `ins` entry from
+                // denoting the `dup` beside it.
+                let first_base = seq.as_bytes()[first_start - 1] as char;
+                let first_next = seq.as_bytes()[first_start] as char;
+                let first_payload = ['A', 'C', 'G', 'T']
+                    .into_iter()
+                    .find(|b| *b != first_base && *b != first_next)
+                    .expect("four bases, at most two excluded");
+                let inserted: String = std::iter::repeat_n(first_payload, first_len).collect();
+                let firsts = [
+                    format!("{span}del"),
+                    format!("{span}dup"),
+                    format!("{first_start}_{}ins{inserted}", first_start + 1),
+                ];
+                for first in firsts {
+                    for second_start in first_end + 2..=(CDS_END as usize - 1) {
+                        let base = seq.as_bytes()[second_start - 1] as char;
+                        let alt = if base == 'A' { 'G' } else { 'A' };
+                        let next_base = seq.as_bytes()[second_start] as char;
+                        let second_payload = ['A', 'C', 'G', 'T']
+                            .into_iter()
+                            .find(|b| *b != base && *b != next_base)
+                            .expect("four bases, at most two excluded");
+                        for second in [
+                            format!("{second_start}del"),
+                            format!("{second_start}{base}>{alt}"),
+                            format!("{second_start}dup"),
+                            format!("{second_start}_{}ins{second_payload}", second_start + 1),
+                        ] {
+                            // Everything that depends only on the *description*
+                            // is hoisted out of the direction loop below. The
+                            // input string, its parse and the bases it denotes
+                            // are all properties of the description, not of the
+                            // shuffle direction, and computing them per
+                            // direction did each of them exactly twice.
+                            let input = format!("{accession}:{axis}.[{first};{second}]");
+                            let variant = parse_hgvs(&input).expect("generated input parses");
+                            // Lazily, and at most once: a case both directions
+                            // decline must stay as cheap as it was.
+                            let mut input_applied: Option<Option<String>> = None;
+                            for direction in
+                                [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                            {
+                                // Deliberately built per case rather than once
+                                // per (sequence, axis). Hoisting it is strictly
+                                // less work and IS faster in the unoptimized
+                                // test profile, but it measured **14% slower**
+                                // on this test under the `soak` profile CI's
+                                // `sweeps` job actually uses — 11.54s -> 13.16s,
+                                // three reps a side at CV <= 0.5%. The
+                                // direction-invariant hoisting above (the
+                                // description, its parse, its applied sequence)
+                                // is kept: that is where the duplicated work was.
+                                let normalizer = Normalizer::with_config(
+                                    axis_provider.clone(),
+                                    NormalizeConfig::default()
+                                        .with_direction(direction)
+                                        .allow_crossing_boundaries(),
+                                );
+                                let Ok(normalized) = normalizer.normalize(&variant) else {
+                                    // A refusal is a legitimate answer here —
+                                    // the transcript axes decline shapes the
+                                    // genomic axis accepts — and says nothing
+                                    // about sequence preservation.
+                                    skipped += 1;
+                                    continue;
+                                };
+                                let output = format!("{normalized}");
+                                checked += 1;
 
-                                    let Some(want) = input_applied
-                                        .get_or_insert_with(|| {
-                                            apply_parsed_with(&axis_provider, &seq, &variant)
-                                        })
-                                        .as_deref()
-                                    else {
-                                        // An *input* that does not apply is a case
-                                        // this sweep cannot speak for. Counted
-                                        // separately from an unconvertible output,
-                                        // which is a failure.
-                                        skipped += 1;
-                                        checked -= 1;
-                                        continue;
-                                    };
-                                    // Both collections are capped at ten, matching
-                                    // the two sweeps above. The assertions below
-                                    // fire on `is_empty()`, so every failure past
-                                    // the tenth changes nothing about the verdict
-                                    // and only makes the panic output harder to
-                                    // read — and a broad regression on the full
-                                    // corpus would otherwise accumulate a string
-                                    // per case.
-                                    match apply_with(&axis_provider, &seq, &output) {
-                                        None if overlapping.len() < 10 => overlapping
-                                            .push(format!("{input} [{direction:?}] -> {output}")),
-                                        None => {}
-                                        Some(got) if got != want && changed.len() < 10 => changed
-                                            .push(format!(
-                                                "{input} [{direction:?}] -> {output} \
+                                let Some(want) = input_applied
+                                    .get_or_insert_with(|| {
+                                        apply_parsed_with(&axis_provider, &seq, &variant)
+                                    })
+                                    .as_deref()
+                                else {
+                                    // An *input* that does not apply is a case
+                                    // this sweep cannot speak for. Counted
+                                    // separately from an unconvertible output,
+                                    // which is a failure.
+                                    skipped += 1;
+                                    checked -= 1;
+                                    continue;
+                                };
+                                // Both collections are capped at ten, matching
+                                // the two sweeps above. The assertions below
+                                // fire on `is_empty()`, so every failure past
+                                // the tenth changes nothing about the verdict
+                                // and only makes the panic output harder to
+                                // read — and a broad regression on the full
+                                // corpus would otherwise accumulate a string
+                                // per case.
+                                match apply_with(&axis_provider, &seq, &output) {
+                                    None if overlapping.len() < 10 => overlapping
+                                        .push(format!("{input} [{direction:?}] -> {output}")),
+                                    None => {}
+                                    Some(got) if got != want && changed.len() < 10 => {
+                                        changed.push(format!(
+                                            "{input} [{direction:?}] -> {output} \
                                              (want {want}, got {got})"
-                                            )),
-                                        Some(_) => {}
+                                        ))
                                     }
+                                    Some(_) => {}
                                 }
                             }
                         }
                     }
                 }
             }
-            *per_axis.entry(axis).or_insert(0) += checked - checked_before_axis;
         }
     }
 
     // Per seed, for the reason recorded on the floor in the first sweep above.
+    // This is the SAME per-axis floor the combined test applied to each axis, so
+    // splitting the test did not weaken it — it removed the aggregate bound, which
+    // was the weaker of the two (three axes summed clear a per-axis floor even
+    // with one arm deleted, which is exactly why the combined test also asserted
+    // per-axis).
     const CASES_PER_SEED_FLOOR: usize = 1_000;
     let floor = CASES_PER_SEED_FLOOR * seeds as usize;
     assert!(
         checked > floor,
-        "transcript-axis sweep covered too little: {checked} over {seeds} seeds (floor {floor})"
+        "the `{axis}.` transcript-axis sweep covered too little: {checked} over \
+         {seeds} seeds (floor {floor})"
     );
-    // Each axis clears the floor on its own. Pinning the axis *set* as well as
-    // the counts, so that deleting an arm fails here with the axis named rather
-    // than silently shrinking a total that stays above the bar.
-    assert_eq!(
-        per_axis.keys().copied().collect::<Vec<_>>(),
-        vec!["c", "n", "r"],
-        "the transcript-axis sweep must run all three axes; got {per_axis:?}"
-    );
-    for (axis, axis_checked) in &per_axis {
-        assert!(
-            *axis_checked > floor,
-            "transcript-axis sweep covered too little on the `{axis}.` axis: \
-             {axis_checked} over {seeds} seeds (floor {floor}); the aggregate \
-             {checked} can hide this because the other axes make up the total"
-        );
-    }
+    // Now a per-axis share rather than an aggregate one, which is strictly
+    // stricter: an axis with a high skip rate can no longer hide behind two with
+    // low ones.
+    //
+    // **`checked` here EXCLUDES the skipped cases**, unlike the two genomic
+    // sweeps above, where `checked` is incremented before the skip test and
+    // `skipped` is therefore a subset of it. Both of this sweep's skip paths are
+    // disjoint from `checked`: a normalize refusal returns before the increment,
+    // and an input that does not apply decrements it back out. So the two floors
+    // bound different ratios and must not be read as the same quantity — a share
+    // of the enumerated total here, a share of the *accepted* cases there. The
+    // enumerated total is stated in the message for that reason, matching how
+    // the three-member sweep reports `input_declined`.
     assert!(
         skipped * 2 < checked,
-        "too many transcript-axis cases skipped: {skipped} of {checked}"
+        "too many `{axis}.` transcript-axis cases skipped: {skipped} of {} enumerated \
+         ({checked} checked; `checked` excludes skipped cases on this axis)",
+        skipped + checked
     );
     assert!(
         overlapping.is_empty(),
-        "overlapping or unconvertible output in {checked} transcript-axis cases: {overlapping:#?}"
+        "overlapping or unconvertible output in {checked} `{axis}.` transcript-axis \
+         cases: {overlapping:#?}"
     );
     assert!(
         changed.is_empty(),
-        "sequence-changing normalizations in {checked} transcript-axis cases: {changed:#?}"
+        "sequence-changing normalizations in {checked} `{axis}.` transcript-axis \
+         cases: {changed:#?}"
+    );
+}
+
+/// Sweep the [`TRANSCRIPT_AXIS_SWEEPS`] row whose third field is `test_name`.
+///
+/// **By name and not by index, because an index is silent when it is wrong.** The
+/// wrappers below first selected their row as `TRANSCRIPT_AXIS_SWEEPS[0..=2]`, and
+/// nothing in the module reached the subscript: write `[0]` in both the `cds` and
+/// the `rna` wrapper and the `r.` axis is never swept, all three tests pass,
+/// [`every_transcript_axis_has_its_own_sweep`] passes, and the only trace is two
+/// `c.`-axis runs quoting different axis labels in their assertion messages. That
+/// is the exact failure — "quietly reducing what this module covers" — the guard
+/// exists to prevent, so the split must not reintroduce it one layer down.
+///
+/// A name cannot be wrong quietly: there is no row to run, so this panics.
+fn sweep_axis_named(test_name: &str) {
+    let (accession, axis, _) = TRANSCRIPT_AXIS_SWEEPS
+        .iter()
+        .find(|(_, _, name)| *name == test_name)
+        .unwrap_or_else(|| {
+            panic!("no TRANSCRIPT_AXIS_SWEEPS row names `{test_name}`, so it sweeps no axis")
+        });
+    sweep_one_transcript_axis(accession, axis);
+}
+
+#[test]
+fn no_two_member_cds_axis_allele_normalizes_to_a_different_sequence() {
+    sweep_axis_named("no_two_member_cds_axis_allele_normalizes_to_a_different_sequence");
+}
+
+#[test]
+fn no_two_member_noncoding_axis_allele_normalizes_to_a_different_sequence() {
+    sweep_axis_named("no_two_member_noncoding_axis_allele_normalizes_to_a_different_sequence");
+}
+
+#[test]
+fn no_two_member_rna_axis_allele_normalizes_to_a_different_sequence() {
+    sweep_axis_named("no_two_member_rna_axis_allele_normalizes_to_a_different_sequence");
+}
+
+/// Every axis in [`TRANSCRIPT_AXIS_SWEEPS`] has a `#[test]` that runs it.
+///
+/// The guard the split owes the suite. When all three axes ran inside one test,
+/// `assert_eq!(per_axis.keys(), ["c","n","r"])` was what made deleting an arm fail
+/// loudly; per-axis tests cannot carry that, because deleting the test deletes the
+/// assertion with it. So this reads the module's own source — the same technique
+/// `msto_regression_corpus::every_cataloged_test_exists_in_its_source_file` uses —
+/// and fails when a row has no test, or a test has been renamed out from under its
+/// row.
+///
+/// It is deliberately a source scan and not a runtime registry: nextest gives each
+/// test its own process, so no test can observe whether its siblings ran.
+///
+/// # It checks the wiring too, not only the name
+///
+/// A test's *existence* is the weaker half. [`sweep_axis_named`] records why the
+/// wrappers select their row by name rather than by subscript; the hole a name
+/// leaves is two wrappers naming *one* row, which panics nowhere — both lookups
+/// succeed, and an axis goes unswept while three tests pass. So each wrapper's body
+/// is checked against the whole row set: between `fn <name>()` and the brace that
+/// closes it, the literal `"<name>"` must appear and no *other* row's name may. The
+/// second half is what actually rules out the duplicate — naming itself is
+/// satisfiable by a body that also names something else.
+///
+/// Both halves are matched on the bare literal rather than on
+/// `sweep_axis_named("<name>")`, because `rustfmt` breaks a long call across lines
+/// and a contiguous match would then fail on formatting alone. No row name is a
+/// substring of another, so `contains` cannot confuse two rows.
+#[test]
+fn every_transcript_axis_has_its_own_sweep() {
+    let source = include_str!("cis_junction_crossing_shift.rs");
+    for (accession, axis, test_name) in TRANSCRIPT_AXIS_SWEEPS {
+        let signature = format!("fn {test_name}()");
+        let start = source.find(&signature).unwrap_or_else(|| {
+            panic!(
+                "the `{axis}.` axis (drawn against {accession}) has no sweep: expected a \
+                 test named `{test_name}`. Deleting an axis must fail here rather than \
+                 quietly reducing what this module covers."
+            )
+        });
+        // The wrapper is a single statement, so the first line that closes a block
+        // at column zero ends it.
+        let body = &source[start..];
+        let body = &body[..body.find("\n}").map_or(body.len(), |end| end + 2)];
+        assert!(
+            body.contains(&format!("\"{test_name}\"")),
+            "`{test_name}` does not look up its own row, so the `{axis}.` axis \
+             (drawn against {accession}) may be unswept while this test passes. Its \
+             body must name itself:\n{body}"
+        );
+        for (_, other_axis, other) in TRANSCRIPT_AXIS_SWEEPS {
+            assert!(
+                other == test_name || !body.contains(&format!("\"{other}\"")),
+                "`{test_name}` names the `{other_axis}.` row as well as its own, so one \
+                 of the two axes is swept twice and the other not at all:\n{body}"
+            );
+        }
+    }
+    // And the rows are distinct, so three rows cannot name one test.
+    let names: std::collections::BTreeSet<&str> =
+        TRANSCRIPT_AXIS_SWEEPS.iter().map(|(_, _, n)| *n).collect();
+    assert_eq!(
+        names.len(),
+        TRANSCRIPT_AXIS_SWEEPS.len(),
+        "two axes name the same test, so one axis is unswept"
     );
 }
 

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -37,10 +37,11 @@
 //! still flush against it, so the #999 collapse keeps firing.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize, normalize_in,
+    apply, apply_parsed_with, apply_with, assert_normalizes_preserving,
+    assert_normalizes_preserving_in, normalize, normalize_in, normalizers_for, provider,
     sweep_seeds, sweep_sequences,
 };
-use ferro_hgvs::ShuffleDirection;
+use ferro_hgvs::{parse_hgvs, ShuffleDirection};
 
 /// Nine `T` at positions 1-9 — a tract long enough to canonicalise to a repeat.
 const TRACT: &str = "TTTTTTTTTAATATATTTTA";
@@ -319,6 +320,12 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // corpus, not a different one.
     let seeds = sweep_seeds(48);
     for seq in sweep_sequences(seeds) {
+        // Built once per sequence rather than once per case. `normalize_in` and
+        // `apply` each construct a `TEMPLATE` provider internally, so the previous
+        // shape built three per case — the normalizer's, the input apply's and the
+        // output apply's — over half a million cases.
+        let template = provider(&seq);
+        let normalizers = normalizers_for(&seq);
         for first_start in 2..=13usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -395,13 +402,20 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                             format!("{second_start}dup"),
                             format!("{second_start}_{}ins{second_ins_payload}", second_start + 1),
                         ] {
-                            for direction in
-                                [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
-                            {
-                                let input = format!("TEMPLATE:g.[{first};{second}]");
-                                let output = normalize_in(&seq, &input, direction);
+                            // Direction-invariant, so hoisted out of the loop
+                            // below: the description, its parse, and the bases it
+                            // denotes are all properties of the input rather than
+                            // of the shuffle direction.
+                            let input = format!("TEMPLATE:g.[{first};{second}]");
+                            let variant = parse_hgvs(&input).expect("generated input parses");
+                            let want = apply_parsed_with(&template, &seq, &variant);
+                            for (direction, normalizer) in &normalizers {
+                                let output = normalizer
+                                    .normalize(&variant)
+                                    .expect("normalize")
+                                    .to_string();
                                 checked += 1;
-                                let Some(want) = apply(&seq, &input) else {
+                                let Some(want) = want.as_deref() else {
                                     skipped += 1;
                                     continue;
                                 };
@@ -417,8 +431,11 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                                 // the shape it landed in.
                                 let residual_shape = first.ends_with("dup")
                                     && second.ends_with("del")
-                                    && direction == ShuffleDirection::FivePrime;
-                                match apply(&seq, &output) {
+                                    && *direction == ShuffleDirection::FivePrime;
+                                // The *output* keeps going through the string-taking
+                                // oracle: re-parsing what the normalizer produced is
+                                // part of what this sweep asserts.
+                                match apply_with(&template, &seq, &output) {
                                     None if overlapping.len() < 10 => {
                                         overlapping.push(format!("{seq}: {input} -> {output}"))
                                     }
@@ -724,6 +741,12 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
     let mut overlapping: Vec<String> = Vec::new();
     let mut changed: Vec<String> = Vec::new();
 
+    // One provider and one normalizer per direction for the whole sweep — this
+    // one draws a single fixed reference, so there is nothing per-case about
+    // either. `normalize_in` / `apply` built a fresh `TEMPLATE` provider per call.
+    let template = provider(&seq);
+    let normalizers = normalizers_for(&seq);
+
     // Every rotation of the unit: an insertion whose payload is out of phase
     // with the adjacent reference is the shape #1280 is about.
     let rotations = [UNIT.to_string(), "AGC".to_string(), "GCA".to_string()];
@@ -781,16 +804,30 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
                     format!("{inside_3p}_{}insTT", inside_3p + 1),
                 ];
                 for sibling in siblings {
-                    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
-                        // Author the sibling first or second: member order is
-                        // an input the normalizer must be indifferent to.
-                        for input in [
-                            format!("TEMPLATE:g.[{first};{sibling}]"),
-                            format!("TEMPLATE:g.[{sibling};{first}]"),
-                        ] {
-                            let output = normalize_in(&seq, &input, direction);
+                    // Author the sibling first or second: member order is
+                    // an input the normalizer must be indifferent to.
+                    //
+                    // The member-order and direction loops are **nested the other
+                    // way round** from how they were written, so that the input's
+                    // parse and its applied sequence — neither of which depends on
+                    // the shuffle direction — are computed once per description
+                    // instead of once per direction. The case set is identical; only
+                    // the order of enumeration changes, and nothing here is pinned
+                    // to it (every bucket is asserted empty, and the samplers are
+                    // capped at ten purely to keep a failure readable).
+                    for input in [
+                        format!("TEMPLATE:g.[{first};{sibling}]"),
+                        format!("TEMPLATE:g.[{sibling};{first}]"),
+                    ] {
+                        let variant = parse_hgvs(&input).expect("generated input parses");
+                        let want = apply_parsed_with(&template, &seq, &variant);
+                        for (direction, normalizer) in &normalizers {
+                            let output = normalizer
+                                .normalize(&variant)
+                                .expect("normalize")
+                                .to_string();
                             checked += 1;
-                            let Some(want) = apply(&seq, &input) else {
+                            let Some(want) = want.as_deref() else {
                                 skipped += 1;
                                 continue;
                             };
@@ -801,7 +838,7 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
                             // bounded now, so a sequence change there is a
                             // regression like any other and reports the
                             // description rather than incrementing a count.
-                            match apply(&seq, &output) {
+                            match apply_with(&template, &seq, &output) {
                                 None if overlapping.len() < 10 => {
                                     overlapping.push(format!("{input} -> {output}"));
                                 }
@@ -924,7 +961,7 @@ fn no_tandem_tract_allele_normalizes_to_a_different_sequence() {
 /// ```
 #[test]
 fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
-    use crate::common::cis_apply_oracle::apply_with;
+    use crate::common::cis_apply_oracle::{apply_parsed_with, apply_with};
     use crate::common::synthetic::SyntheticBuilder;
     use ferro_hgvs::reference::transcript::Strand;
     use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
@@ -1046,12 +1083,30 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
                                 format!("{second_start}dup"),
                                 format!("{second_start}_{}ins{second_payload}", second_start + 1),
                             ] {
+                                // Everything that depends only on the *description*
+                                // is hoisted out of the direction loop below. The
+                                // input string, its parse and the bases it denotes
+                                // are all properties of the description, not of the
+                                // shuffle direction, and computing them per
+                                // direction did each of them exactly twice.
+                                let input = format!("{accession}:{axis}.[{first};{second}]");
+                                let variant = parse_hgvs(&input).expect("generated input parses");
+                                // Lazily, and at most once: a case both directions
+                                // decline must stay as cheap as it was.
+                                let mut input_applied: Option<Option<String>> = None;
                                 for direction in
                                     [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
                                 {
-                                    let input = format!("{accession}:{axis}.[{first};{second}]");
-                                    let variant =
-                                        parse_hgvs(&input).expect("generated input parses");
+                                    // Deliberately built per case rather than once
+                                    // per (sequence, axis). Hoisting it is strictly
+                                    // less work and IS faster in the unoptimized
+                                    // test profile, but it measured **14% slower**
+                                    // on this test under the `soak` profile CI's
+                                    // `sweeps` job actually uses — 11.54s -> 13.16s,
+                                    // three reps a side at CV <= 0.5%. The
+                                    // direction-invariant hoisting above (the
+                                    // description, its parse, its applied sequence)
+                                    // is kept: that is where the duplicated work was.
                                     let normalizer = Normalizer::with_config(
                                         axis_provider.clone(),
                                         NormalizeConfig::default()
@@ -1069,7 +1124,11 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
                                     let output = format!("{normalized}");
                                     checked += 1;
 
-                                    let Some(want) = apply_with(&axis_provider, &seq, &input)
+                                    let Some(want) = input_applied
+                                        .get_or_insert_with(|| {
+                                            apply_parsed_with(&axis_provider, &seq, &variant)
+                                        })
+                                        .as_deref()
                                     else {
                                         // An *input* that does not apply is a case
                                         // this sweep cannot speak for. Counted
@@ -1200,9 +1259,22 @@ fn no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence() {
 #[test]
 fn no_three_member_allele_normalizes_to_a_different_sequence() {
     use crate::common::cis_apply_oracle::{
-        apply_reason, provider as genomic_provider, ApplyFailure,
+        apply_parsed_reason, apply_reason, provider as genomic_provider, ApplyFailure,
     };
     use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
+
+    /// The tally key for one decline cause. Named so the per-direction tallying
+    /// below stays a one-liner after the apply itself was hoisted out of that loop.
+    fn cause_name(cause: ApplyFailure) -> &'static str {
+        match cause {
+            ApplyFailure::Unparseable => "unparseable",
+            ApplyFailure::Unconvertible => "unconvertible",
+            ApplyFailure::OutOfBounds => "out-of-bounds",
+            ApplyFailure::Overlapping => "overlapping",
+            ApplyFailure::CoincidentInsertions => "coincident-insertions",
+            ApplyFailure::StatedBasesMismatch => "stated-bases-mismatch",
+        }
+    }
 
     let mut checked = 0usize;
     let mut input_declined = 0usize;
@@ -1221,6 +1293,22 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
     // three-member defect ever turns up in a sequence beyond the sixteenth.
     let seeds = sweep_seeds(16);
     for seq in sweep_sequences(seeds) {
+        // One provider and one normalizer per direction per sequence. The
+        // innermost loop used to build `genomic_provider(&seq)` three times per
+        // case — for the input apply, the normalizer and the output apply.
+        let template = genomic_provider(&seq);
+        let normalizers =
+            [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime].map(|direction| {
+                (
+                    direction,
+                    Normalizer::with_config(
+                        template.clone(),
+                        NormalizeConfig::default()
+                            .with_direction(direction)
+                            .allow_crossing_boundaries(),
+                    ),
+                )
+            });
         // Even positions only, and the bound says 8 rather than 9 because
         // `step_by(2)` from 2 can never reach an odd endpoint — writing `..=9`
         // named a position this loop does not visit. Sampling every other
@@ -1260,48 +1348,38 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
                                 format!("{third_start}del"),
                                 format!("{third_start}{third_base}>{third_alt}"),
                             ] {
-                                for direction in
-                                    [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
-                                {
-                                    let input = format!("TEMPLATE:g.[{first};{second};{third}]");
-                                    let want =
-                                        match apply_reason(&genomic_provider(&seq), &seq, &input) {
-                                            Ok(want) => want,
-                                            Err(cause) => {
-                                                // An input this sweep cannot speak
-                                                // for. Tallied by cause so the share
-                                                // asserted below can be read.
-                                                *by_cause
-                                                    .entry(match cause {
-                                                        ApplyFailure::Unparseable => "unparseable",
-                                                        ApplyFailure::Unconvertible => {
-                                                            "unconvertible"
-                                                        }
-                                                        ApplyFailure::OutOfBounds => {
-                                                            "out-of-bounds"
-                                                        }
-                                                        ApplyFailure::Overlapping => "overlapping",
-                                                        ApplyFailure::CoincidentInsertions => {
-                                                            "coincident-insertions"
-                                                        }
-                                                        ApplyFailure::StatedBasesMismatch => {
-                                                            "stated-bases-mismatch"
-                                                        }
-                                                    })
-                                                    .or_default() += 1;
-                                                input_declined += 1;
-                                                continue;
-                                            }
-                                        };
-                                    let variant =
-                                        parse_hgvs(&input).expect("generated input parses");
-                                    let normalizer = Normalizer::with_config(
-                                        genomic_provider(&seq),
-                                        NormalizeConfig::default()
-                                            .with_direction(direction)
-                                            .allow_crossing_boundaries(),
-                                    );
-                                    let Ok(normalized) = normalizer.normalize(&variant) else {
+                                // The description, its parse and the bases it
+                                // denotes do not depend on the shuffle direction,
+                                // so each is computed once per case rather than
+                                // once per direction. A parse failure is folded
+                                // into the `ApplyFailure` the string-taking oracle
+                                // would have reported for it, so the tallying below
+                                // is unchanged — including that it counts a
+                                // declined input once *per direction*, which is the
+                                // quantity the share assertion is written against.
+                                let input = format!("TEMPLATE:g.[{first};{second};{third}]");
+                                let parsed =
+                                    parse_hgvs(&input).map_err(|_| ApplyFailure::Unparseable);
+                                let input_applied =
+                                    parsed.as_ref().map_err(|c| *c).and_then(|variant| {
+                                        apply_parsed_reason(&template, &seq, variant)
+                                    });
+                                for (direction, normalizer) in &normalizers {
+                                    let want = match &input_applied {
+                                        Ok(want) => want.as_str(),
+                                        Err(cause) => {
+                                            // An input this sweep cannot speak
+                                            // for. Tallied by cause so the share
+                                            // asserted below can be read.
+                                            *by_cause.entry(cause_name(*cause)).or_default() += 1;
+                                            input_declined += 1;
+                                            continue;
+                                        }
+                                    };
+                                    let variant = parsed
+                                        .as_ref()
+                                        .expect("a parse failure is reported as a decline above");
+                                    let Ok(normalized) = normalizer.normalize(variant) else {
                                         input_declined += 1;
                                         *by_cause.entry("normalize-declined").or_default() += 1;
                                         continue;
@@ -1309,7 +1387,7 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
                                     let output = format!("{normalized}");
                                     checked += 1;
 
-                                    match apply_reason(&genomic_provider(&seq), &seq, &output) {
+                                    match apply_reason(&template, &seq, &output) {
                                         Ok(got) if got == want => {}
                                         Ok(got) => changed.push(format!(
                                             "{input} [{direction:?}] -> {output} \

--- a/tests/it/common/cis_apply_oracle.rs
+++ b/tests/it/common/cis_apply_oracle.rs
@@ -175,12 +175,38 @@ pub fn normalize(seq: &str, input: &str) -> String {
 
 /// Normalize `input` against `seq` in an explicit direction.
 pub fn normalize_in(seq: &str, input: &str, direction: ShuffleDirection) -> String {
-    let normalizer = Normalizer::with_config(
+    let variant = parse_hgvs(input).expect("parse");
+    format!(
+        "{}",
+        normalizer_for(seq, direction)
+            .normalize(&variant)
+            .expect("normalize")
+    )
+}
+
+/// A normalizer over `seq`'s `TEMPLATE` provider, shuffling in `direction`.
+///
+/// The pinned single-case tests reach it through [`normalize_in`], which builds
+/// one per call. The exhaustive sweeps build **one per (sequence, direction)**
+/// and reuse it across every case drawn on that sequence, because `Normalizer`
+/// owns its provider: going through `normalize_in` per case re-inserted the
+/// contig into a fresh `HashMap` hundreds of thousands of times, and gave the
+/// sweep no way to hold a normalizer at all.
+pub fn normalizer_for(seq: &str, direction: ShuffleDirection) -> Normalizer<MockProvider> {
+    Normalizer::with_config(
         provider(seq),
         NormalizeConfig::default().with_direction(direction),
-    );
-    let variant = parse_hgvs(input).expect("parse");
-    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+    )
+}
+
+/// Both shuffle directions' normalizers for `seq`, paired with their direction.
+///
+/// The sweeps all enumerate `[ThreePrime, FivePrime]` as their innermost loop, so
+/// this is the shape they want: build once outside the loops, iterate by
+/// reference inside.
+pub fn normalizers_for(seq: &str) -> [(ShuffleDirection, Normalizer<MockProvider>); 2] {
+    [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+        .map(|direction| (direction, normalizer_for(seq, direction)))
 }
 
 /// Apply `descriptor` to `seq` **independently of the normalizer**, against the
@@ -256,13 +282,54 @@ pub fn apply_reason<P: ReferenceProvider + ?Sized>(
     reference: &str,
     descriptor: &str,
 ) -> Result<String, ApplyFailure> {
-    let members: Vec<HgvsVariant> = match parse_hgvs(descriptor) {
-        Ok(HgvsVariant::Allele(allele)) => allele.variants.clone(),
-        Ok(single) => vec![single],
-        Err(_) => return Err(ApplyFailure::Unparseable),
+    let variant = parse_hgvs(descriptor).map_err(|_| ApplyFailure::Unparseable)?;
+    apply_parsed_reason(provider, reference, &variant)
+}
+
+/// [`apply_with`] for a description that is **already parsed**.
+///
+/// The string-taking entry points parse and then delegate here, so the
+/// `claimed_from` walk still lives in exactly one place — that is the property
+/// `apply_with`'s note is about, and it is unaffected by which door you come in
+/// through.
+///
+/// It exists because the exhaustive sweeps already hold the parsed input: they
+/// build the description, parse it to normalize it, and then handed the *string*
+/// back to the oracle, which parsed it a second time.
+///
+/// Sized on `no_two_member_transcript_axis_allele_normalizes_to_a_different_sequence`
+/// (sampled inclusive time): `parse_hgvs` is **41.7%** of that test and this oracle
+/// is the majority of it, since it is called twice per case and `apply_reason`'s
+/// own work past the parse — `hgvs_to_spdi` and the splice — is under a quarter of
+/// its 33.4%. What this door removes is the *input* half of that, so roughly an
+/// eighth of the test, and it removes it without dropping a case.
+///
+/// Note which side of a sweep may use it. The *input* is a description the test
+/// authored and has already parsed, so re-parsing it can only ever succeed and
+/// tells nobody anything. The *output* is the thing under test, and running it
+/// back through `parse_hgvs` is part of what the sweep asserts, so output-side
+/// callers keep using [`apply_with`].
+pub fn apply_parsed_with<P: ReferenceProvider + ?Sized>(
+    provider: &P,
+    reference: &str,
+    variant: &HgvsVariant,
+) -> Option<String> {
+    apply_parsed_reason(provider, reference, variant).ok()
+}
+
+/// [`apply_reason`] for a description that is already parsed. See
+/// [`apply_parsed_with`] for why this door exists.
+pub fn apply_parsed_reason<P: ReferenceProvider + ?Sized>(
+    provider: &P,
+    reference: &str,
+    variant: &HgvsVariant,
+) -> Result<String, ApplyFailure> {
+    let members: &[HgvsVariant] = match variant {
+        HgvsVariant::Allele(allele) => &allele.variants,
+        single => std::slice::from_ref(single),
     };
     let mut triples = Vec::with_capacity(members.len());
-    for member in &members {
+    for member in members {
         triples.push(hgvs_to_spdi(member, provider).map_err(|_| ApplyFailure::Unconvertible)?);
     }
     // 3'→5' so an applied splice never shifts a later one's coordinates.

--- a/tests/it/issue_1254_sibling_crossing_shift.rs
+++ b/tests/it/issue_1254_sibling_crossing_shift.rs
@@ -25,10 +25,10 @@
 //! normalizes both sides, so it passed on the broken behavior.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, assert_normalizes_preserving_in, normalize, sweep_seeds,
-    sweep_sequences,
+    apply_parsed_with, apply_with, assert_normalizes_preserving, assert_normalizes_preserving_in,
+    normalizer_for, provider, sweep_seeds, sweep_sequences,
 };
-use ferro_hgvs::ShuffleDirection;
+use ferro_hgvs::{parse_hgvs, ShuffleDirection};
 
 /// The reported reference: an `(AT)` tract that ends at position 11, where
 /// `11=A, 12=A` breaks the repeat.
@@ -142,6 +142,10 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
     // otherwise.
     let seeds = sweep_seeds(64);
     for seq in sweep_sequences(seeds) {
+        // One provider and one normalizer per sequence rather than three per case:
+        // `normalize` and each `apply` built their own `TEMPLATE` provider.
+        let template = provider(&seq);
+        let normalizer = normalizer_for(&seq, ShuffleDirection::ThreePrime);
         for first_start in 1..=14usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -160,18 +164,26 @@ fn shifts_never_change_the_sequence_across_an_exhaustive_two_member_sweep() {
                         format!("{second_start}{base}>{alt}"),
                     ] {
                         let input = format!("TEMPLATE:g.[{first};{second}]");
-                        let output = normalize(&seq, &input);
+                        let variant = parse_hgvs(&input).expect("generated input parses");
+                        let output = normalizer
+                            .normalize(&variant)
+                            .expect("normalize")
+                            .to_string();
                         // Counted before the skip, so the floor below
                         // measures enumeration and not how many cases
                         // happened to be convertible — otherwise a small
                         // change in the skip rate trips a coverage floor
                         // for a reason unrelated to coverage.
                         enumerated += 1;
-                        let Some(want) = apply(&seq, &input) else {
+                        // The input is already parsed, so the oracle is spared a
+                        // second parse of it. The *output* keeps the string form:
+                        // re-parsing what the normalizer produced is part of the
+                        // assertion.
+                        let Some(want) = apply_parsed_with(&template, &seq, &variant) else {
                             skipped += 1; // the input itself is unconvertible
                             continue;
                         };
-                        let Some(got) = apply(&seq, &output) else {
+                        let Some(got) = apply_with(&template, &seq, &output) else {
                             if overlapping.len() < 10 {
                                 overlapping.push(format!("{seq}: {input} -> {output}"));
                             }

--- a/tests/it/repeat_span_sibling_overlap.rs
+++ b/tests/it/repeat_span_sibling_overlap.rs
@@ -25,9 +25,10 @@
 //! pre-existing on `main` and independent of both.
 
 use crate::common::cis_apply_oracle::{
-    apply, assert_normalizes_preserving, normalize_in, sweep_seeds, sweep_sequences,
+    apply, apply_parsed_with, apply_with, assert_normalizes_preserving, normalize_in,
+    normalizers_for, provider, sweep_seeds, sweep_sequences,
 };
-use ferro_hgvs::ShuffleDirection;
+use ferro_hgvs::{parse_hgvs, ShuffleDirection};
 
 /// Nine `T` at positions 1-9, then `AA` breaking the run.
 const TRACT: &str = "TTTTTTTTTAATATATTTTA";
@@ -171,6 +172,11 @@ fn no_two_member_allele_normalizes_to_overlapping_members() {
     // otherwise. This sweep was 33.1s of an 86.6s local suite.
     let seeds = sweep_seeds(64);
     for seq in sweep_sequences(seeds) {
+        // One provider and one normalizer per direction per sequence, rather than
+        // three providers per case: `normalize_in` and each `apply` built their own
+        // `TEMPLATE` provider internally.
+        let template = provider(&seq);
+        let normalizers = normalizers_for(&seq);
         for first_start in 1..=14usize {
             for first_len in 1..=2usize {
                 let first_end = first_start + first_len - 1;
@@ -186,16 +192,25 @@ fn no_two_member_allele_normalizes_to_overlapping_members() {
                         format!("{second_start}del"),
                         format!("{second_start}{base}>{alt}"),
                     ] {
-                        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
-                        {
-                            let input = format!("TEMPLATE:g.[{first};{second}]");
-                            let output = normalize_in(&seq, &input, direction);
+                        // Direction-invariant, so hoisted: the description, its
+                        // parse, and the bases it denotes.
+                        let input = format!("TEMPLATE:g.[{first};{second}]");
+                        let variant = parse_hgvs(&input).expect("generated input parses");
+                        let input_applied = apply_parsed_with(&template, &seq, &variant);
+                        for (_direction, normalizer) in &normalizers {
+                            let output = normalizer
+                                .normalize(&variant)
+                                .expect("normalize")
+                                .to_string();
                             checked += 1;
-                            let Some(want) = apply(&seq, &input) else {
+                            let Some(want) = input_applied.as_deref() else {
                                 skipped += 1; // unconvertible input
                                 continue;
                             };
-                            match apply(&seq, &output) {
+                            // The *output* still goes through the string-taking
+                            // oracle: re-parsing what the normalizer produced is
+                            // part of what this sweep asserts.
+                            match apply_with(&template, &seq, &output) {
                                 // `apply` declines an overlapping output, so
                                 // `None` here is the overlap signal.
                                 None if overlapping.len() < 10 => {


### PR DESCRIPTION
Tiers the per-test durations out of a real CI run, fixes the slowest tests in tiers 1–3, then shortens the critical path and brings the Actions cache back under its cap. Tier 4 (<1s, 9,634 tests) was left alone.

Every number below is measured. Where a projection turned out wrong, the wrong projection is kept alongside the measurement.

## Headline

| | before | after (cold) | after (re-run) |
|---|---|---|---|
| **critical path** | 342s | 257s | **130s (−62%)** |
| **runner-seconds** | 2,703 | 1,953 | **1,536 (−43%)** |
| **cache** | 13.79 GiB / 42 | — | **6.97 GiB / 23** |

"Cold" is a first run of a new commit; "re-run" is the same tree again, which `on: pull_request` makes common here — it includes `edited`, because the representation-change check reads the PR description, so every description edit re-runs the whole workflow.

## 1. Where the time went

Baseline is run [31268888323](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31268888323): 5 tests ≥60s, 7 at 10–60s, 31 at 1–10s.

The largest single cost was not in any test's logic. `cis_confluence_axis::the_corpus_is_a_dense_set_of_real_confluence_classes` took **117.6s** in `Test (2/6)` and 127.3s in `Test oracle (2/3)`, for a test that reads an 8 MB JSON and makes a handful of cheap assertions. With the file present it runs in **0.071s**.

All of it was `common::fixture_gen` shelling out to a nested `cargo run --example generate_cis_confluence_corpus`. The `test`/`test-oracle` shards run from a nextest archive and have no warm `target/`, so that nested call compiled the whole crate *inside the test*. The shard timings made it plain — the three shards holding a `cis_confluence_axis` test took 147–178s, the three without took 31–43s. It is now generated in `spec-fixtures` and shipped as an artifact.

## 2. Per-job, measured

Run 31268888323 → run [31275077075](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31275077075):

| job | before | after | Δ |
|---|---|---|---|
| `Test (6/6)` | 178s | 56s | **−122s** |
| `Test oracle (1/3)` | 193s | 78s | −115s |
| `Test oracle (3/3)` | 201s | 102s | −99s |
| `Test (4/6)` | 150s | 53s | −97s |
| `Test (2/6)` | 147s | 56s | −91s |
| `Test oracle (2/3)` | 155s | 68s | −87s |
| `Exhaustive sweeps` | 175s | 121s | −54s |

`Test` also stops being lopsided: 31–178s becomes 41–56s.

**Noise floor.** On the 18 jobs this PR does not touch, run-to-run movement ranged −28 … +18s (median |11.5s|). The six cis_confluence-holding jobs moved −87 … −122s, far outside it. Small movements on untouched jobs are **not** attributed to this PR.

## 3. The sweeps, measured on the substrate that runs them

`SWEEP_FILTER` routes all six sweeps to the `sweeps` job, which uses the `soak` profile (`opt-level = 3`) **and** sets all three seam oracles. Measured there — 16 seeds, single-threaded, two reps a side, spread ≤1.1%, with an untouched control:

| test | before | after | Δ |
|---|---|---|---|
| `no_two_member_transcript_axis` | 19.94s | 14.83s | **−25.6%** |
| `no_three_member_allele` | 7.33s | 5.86s | −20.0% |
| `no_two_member_allele` | 6.80s | 5.55s | −18.3% |
| `repeat_span::no_two_member` | 1.20s | 0.94s | −21.7% |
| `issue_1254` sweep | 0.62s | 0.51s | −18.0% |
| `no_tandem_tract` | 0.59s | 0.51s | −13.0% |
| **sum** | **36.47s** | **28.20s** | **−22.7%** |
| *control (`msto_regression`)* | *0.057s* | *0.058s* | *flat ✓* |

No case, loop bound or assertion changed. Work depending only on the *description* — the string, its parse, the bases it denotes — is computed once instead of once per shuffle direction, and providers are built per sequence rather than three per case. `parse_hgvs` was 41.7% of the transcript-axis sweep, most of it the oracle re-parsing what the test had just parsed, so `cis_apply_oracle` gains an `apply_parsed_*` door for the *input* side. The output side keeps the string form: re-parsing normalizer output is part of what the sweeps assert.

## 4. Splitting the transcript-axis sweep

A job cannot finish faster than its longest single test, and `sweeps` was floored by one: `no_two_member_transcript_axis`, 153.3s of a 175s job. Sharding the *job* cannot help; splitting the *test* can. Its three axes are now three `#[test]`s over a shared body. Verified at `FERRO_SWEEP_SEEDS=full` with all three oracles on the `soak` profile: the module's wall time is now set by `no_two_member_allele` (18.3s) rather than the transcript axis (15.8 / 15.8 / 17.5s, concurrent).

**Two assertions get stricter, not weaker.** The aggregate case floor and the aggregate `skipped * 2 < checked` share both become per-axis — three axes summed can clear a per-axis floor with one arm deleted, which is why the combined test also asserted per-axis.

**The guard the split owes the suite.** `assert_eq!(per_axis.keys(), ["c","n","r"])` was what made deleting an arm fail loudly; a per-axis test cannot carry that, since deleting the test deletes its assertion. `every_transcript_axis_has_its_own_sweep` reads the module's own source instead — the technique `msto_regression_corpus::every_cataloged_test_exists_in_its_source_file` already uses. **Verified to fail both ways**: renaming one axis test reddens it, naming the missing test.

## 5. Per-commit caches: the re-run experiment

`rust-cache` caches dependencies only — it deliberately deletes workspace artifacts — so the crate was recompiled every run even when no Rust changed. Three artifacts are now cached under a key ending in the commit SHA.

Measured as attempt 1 vs attempt 2 of run [31282184505](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31282184505) — the *same run ID, same tree*, so this is a true A/B rather than two different runs:

| job | cold | re-run | Δ |
|---|---|---|---|
| `Build soak archive (optimized)` | 163s | **24s** | −139s |
| `Spec fixtures and generated docs` | 122s | **22s** | −100s |
| `Build test archive` | 101s | **33s** | −68s |
| **critical path** | **257s** | **130s** | **−49%** |
| **runner-seconds** | 1,953 | 1,536 | −21% |

**Keyed on the SHA, not on `hashFiles`.** A content-hash key is easier to hit and one forgotten input serves a **stale archive** — green CI against binaries built from other code, the worst outcome available here. The SHA changes whenever anything does, so a hit means the tree is byte-identical and staleness is impossible by construction. On `pull_request` it is the *merge* SHA (confirmed in the saved key), so it also busts correctly when `main` moves under the PR.

**`restore` + explicit `save`, never the combined `actions/cache`.** The combined action saves from a post-step that runs even when the job **failed**. For an archive that risks publishing a partial build; for `spec-fixtures` it is worse, because the three `--check` steps there are gates rather than artifact producers — a failing `generate_conformance_summary --check` would have published an entry that every re-run then skipped past, a false-green generator. An explicit save carries an implicit `success()`, which is what makes skipping those checks on a hit sound: the entry proves they passed on a byte-identical tree.

## 6. The cache cap: 13.79 → 6.97 GiB

No `rust-cache` site set `save-if`, so every PR run whose lockfile or env hash differed minted a fresh 0.2–0.7 GiB entry. Measured 2026-08-08: **42 entries, 13.79 GiB against a 10 GiB cap** — 3 to 5 generations of every logical key, `coverage` alone holding 4 × ~0.69 GiB. Over cap means GitHub evicts by LRU continuously, which is #1218's failure, where two generations reached 13.61 GiB and took the nightly's 3.25 GiB `ferro-manifest-v3` with them.

All 16 `rust-cache` sites across 8 workflows now carry `save-if: ${{ github.ref == 'refs/heads/main' }}`. **Verified directly: this PR's runs saved zero `rust-cache` entries.**

Also measured: **6.17 of the 13.79 GiB was PR-scoped**, and GitHub's scoping makes a PR's entries unreadable by `main` and by every other PR — pure dead weight. Pruning those and duplicate `main` generations took the repository to 6.82 GiB; it now sits at **6.97 GiB / 23 entries** with the three per-commit families live (133 MB per commit).

**`prune-ci-caches.yml` is the ceiling.** SHA keying is what makes these caches safe and also what makes them grow. LRU is the hazard rather than the remedy: it is global, so an unbounded archive family does not evict itself, it evicts whatever is least recently used — exactly how #1218 lost the nightly manifest. The prune keeps the newest 5 of each family (≤ ~0.65 GiB) and touches nothing else. Its selection was tested against synthetic input first: it keys on `created_at` (not `last_accessed_at`, which a re-run would touch and make an old archive look new), and `index($4, family) == 1` keeps `nextest-archive-` from swallowing `nextest-soak-archive-` and keeps every `v0-rust-*` entry out of the candidate set.

## 7. Merging `generated-docs` into `spec-fixtures`

Its three generators are `cargo run --features dev --example …` — same profile, same features — so it compiled an identical dependency tree in a second job behind a second cache key. Retires a job and ~0.36 GiB.

Gating is unchanged, which is the part worth checking: `generated-docs` was a `needs:` of `test-required`; a failure now fails `spec-fixtures`, which **skips** `test` and `test-oracle`, and `test-required` demands `result == "success"` from both — a skip is not a success, so the required `Test` context still goes red.

## 8. Production paths

Two lose redundant work. Both are strictly fewer operations; neither could be resolved above this machine's noise floor, so **neither is claimed as a number**:

- `Display for Accession` was `write!(f, "{}", self.full())` — a heap allocation per accession on every rendered variant, including the recursive `genomic_context`. One generic writer now serves `full()`, `base()` and `Display`. **No behavioural change, format specs included.** An earlier revision of this description and of the doc comment claimed `Display` had stopped honouring width/fill. That was wrong, and CodeRabbit's Major finding here rests on the same premise: `write!(f, "{}", s)` renders `s` under the *inner* `"{}"`, which carries no spec, so it never reached `Formatter::pad` either — only `f.pad(s)` consults the outer formatter. Measured three ways (`write!`, a piecewise writer, `f.pad`: the first two render `{:>20}` unpadded and `{:.4}` untruncated, the third right-aligns and truncates to `NM_0`), and the inertness of `{:>20}`, `{:*^20}`, `{:.4}` and `{:<8.2}` is now pinned in `test_accession_display` — assertions that pass against the previous body too, which is the point.
- `member_span` resolved the same transcript twice per member, for the region both endpoints almost always share. The *cross-pass* repetition is untouched and noted. Both sides of the new branch were already pinned by `a_member_spanning_a_region_boundary_has_a_span` (two cross-region members with exact coordinates, plus a single-region control), so no test was added; the reuse is sound because `region_span_delta` is a pure function of its arguments.

`dump_normalized_corpus` builds one normalizer per (axis, core, direction) cell rather than re-padding the core per row.

## 9. Tried and rejected, with the measurement

- **Hoisting the transcript-axis normalizer.** Strictly less work, 27% faster in the test profile, **14% slower** at `opt-level 3` (11.54 → 13.16s, three reps a side at CV ≤0.5%) — the profile that test runs under. Not taken; the comment at the call site carries the measurement.
- **A separate `cis-corpus` job.** A new job has no `rust-cache` entry and would compile the dependency tree cold — more than the 53s it set out to save — while still gating both test paths through `needs`.
- **More soak shards.** A shard is 36s of work behind ~14s of irreducible per-job overhead, so 8 → 16 trades 400 runner-seconds for 512 to move a path that is not critical. The checkout is only 3s of that and is load-bearing: the soak runs `test(proptest)`, and proptest resolves `tests/proptest-regressions/*.txt` from the source tree, so dropping it would stop the pinned seeds replaying while the job got faster.
- **A batch of `dump_normalized_corpus` numbers**, discarded after `the_corpus_is_closed_over_its_output_vocabulary` — which never calls `dump()` — moved +34% the same way. That is why §3 ships with a control row.

## 10. Examined, no waste found

`fast_path_differential` (7 tests) is two parses and a compare over 5,000 proptest cases each. `test_cmrg_exhaustive_benchmark` (46.3s) and `test_clinvar_hgvs_unique_benchmark` (39.7s) are dominated by `parse_hgvs` over millions of inputs under rayon; the only reducible part is a serial diagnostic tally judged too small to justify the churn **without having measured it**. The `cli_*` byte-identity tests run the real binary four times over 20,000 variants and assert the input spans multiple chunks.

## 11. Verification

- **9,718 tests pass, nothing re-blessed** — for output-affecting code that is the strong signal. (9,715 before; +2 axis tests, +1 guard.)
- The six sweeps pass at `FERRO_SWEEP_SEEDS=full` with all three oracles on the `soak` profile.
- `every_transcript_axis_has_its_own_sweep` verified to fail when an axis test is renamed away.
- `cargo fmt --check`, `clippy --features dev --all-targets`, `clippy --release -- -D warnings`, `actionlint` clean.
- 35 checks pass, 1 `skipping` (`report-failure` on a green run).

## 12. Not addressed

On a warm re-run the critical path is now **130s**, gated by `Test oracle (1/3)` at 97s behind a 33s archive download. Cutting further means the oracle shards themselves — either more shards, or the oracle work per shard. On a cold run it is still `test-build-soak` + `sweeps`, i.e. an `opt-level = 3` compile, which is what makes the sweeps fast in the first place.

## 13. CodeRabbit round

Three findings, all addressed; the first is corrected rather than applied.

1. **`src/hgvs/variant.rs` — "pin the ignored format specifications" (Major).** Pinned, but the premise is wrong in both directions: nothing was ignored *newly*. See §8 — the specs were inert before this PR too, verified by re-running the new assertions against the previous `Display` body. The doc comment and the commit message that asserted a behaviour change are corrected, since a wrong rationale outlives the diff.
2. **`tests/it/cis_junction_crossing_shift.rs:1066` — dead bookkeeping from the split (Trivial).** Applied. The bare block, `checked_before_axis` and its `let _ =` suppressor are gone and the body is de-indented one level; the only non-whitespace change is those four lines plus one match arm `cargo fmt` reshaped in the freed columns.
3. **`tests/it/cis_junction_crossing_shift.rs:1232-1281` — the guard cannot see a mis-wired row index (Major).** Correct, and applied: the wrappers select their row through `sweep_axis_named(<own name>)`, so a wrong name panics instead of silently sweeping another axis. Its residual hole — two wrappers naming *one* row, which panics nowhere — is closed by extending `every_transcript_axis_has_its_own_sweep` to check each wrapper's body names its own row **and no other**. Verified to fail three ways: an axis test renamed away, a wrapper wired to a sibling's row, and a wrapper naming itself only in a comment while running a sibling's row.

Also found while self-reviewing, unprompted by the bot: the `save-if` rationale was copy-pasted into eight workflows, and in six of them (`deploy-local`, `external-validation`, `fuzz`, `nightly-mutalyzer`, `nightly-perf`, `nightly-soak`) it describes a PR run those workflows cannot have — none has a `pull_request` trigger. Corrected to name the run that *is* affected there, a `workflow_dispatch` from a non-`main` branch. `ci.yml` and `coverage.yml` keep the original wording, which is accurate for them.

9,733 tests pass with nothing re-blessed; `cargo fmt --check`, `clippy --features dev --all-targets`, `clippy --release --all-targets` and `actionlint` clean.

Representation-Change: none. No normalized output moves; 9,718 tests pass with nothing re-blessed, which for output-affecting directories is the load-bearing evidence. The src/ changes remove a redundant allocation and a duplicate transcript lookup, neither of which is reachable from a decision about which form to emit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI & Maintenance**
  * Improved CI cache reuse while limiting new cache generation to the main branch.
  * Added scheduled and manual cleanup of older caches.
  * Consolidated fixture generation, documentation checks, and test artifacts.

* **Performance**
  * Reduced repeated normalization, parsing, and sequence-processing work.
  * Improved variant formatting efficiency without changing output.

* **Testing**
  * Expanded coverage for junction boundaries, insertions, sibling variants, repeats, and multiple axis types.
  * Improved regression and overlap test efficiency, consistency, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
