### PR TITLE
chore(normalize): restate the comment the partition rule made false

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2909,12 +2909,19 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // which `crate::normalize::rules`' single-span typing renders as `inv` —
     // so there is nothing left for a veto to protect.
 
-    // There was a veto here, and it was the last gate in this pass that read the
-    // *input spelling* rather than the sequence: when the derivation produced
-    // fewer pieces than there were members, and any piece covered a base the
-    // input had left between two of them, the pass refused and returned the
-    // input verbatim. It cited `general.md:34` — two variants separated by one
-    // or more unchanged nucleotides are described individually.
+    // There was a veto here. It used to be described as "the last gate in this
+    // pass that read the *input spelling* rather than the sequence", and that
+    // description is now false in a way worth stating rather than deleting: under
+    // the partition rule the pass reads the input's spelling *by design*, because
+    // `partition_block_preserving` keeps the members the description asserted
+    // instead of re-deriving them. Reading the spelling is no longer the
+    // suspicious thing a lone remaining gate did; it is the model.
+    //
+    // What the veto did: when the derivation produced fewer pieces than there
+    // were members, and any piece covered a base the input had left between two
+    // of them, the pass refused and returned the input verbatim. It cited
+    // `general.md:34` — two variants separated by one or more unchanged
+    // nucleotides are described individually.
     //
     // The citation is sound and the mechanism was not. `general.md:34` is about
     // what the *sequence* separates; the veto measured what the *input's


### PR DESCRIPTION
Base is #1565 (`feat/partition-normalization-model`), not `main` — review that one first. #1568, #1567, #1570, #1571 and #1572 stack above this.

**This PR shrank in the 2026-08-09 restack, and its old title no longer described it.** It used to sit on an *older* generation of #1565 and carried two repairs; rebasing onto #1565's current head absorbed one of them, because #1565 had since been amended to include it. What is left is a single comment hunk in `src/normalize/merge.rs`. Retitled accordingly, and the absorbed half is recorded below rather than deleted, so a reviewer looking for it knows where it went.

One bookkeeping repair. No behaviour change: the diff is one file and every changed line is a comment.

### A comment that the partition rule made false

The veto note in `canonicalize_from_sequence` opened by describing the removed gate as *"the last gate in this pass that read the **input spelling** rather than the sequence"*.

Under the partition rule that reads backwards. The pass reads the input's spelling **by design** — `partition_block_preserving` keeps the members the description asserted instead of re-deriving them from the two sequences. Reading the spelling is the model now, not the last suspicious thing a lone gate did before it was removed.

Restated rather than deleted: the rest of the note is still the record of *why* the veto went (it measured what the input's spelling separated, not what the sequence separated, so two spellings of one variant were refused differently), and that reasoning is unaffected.

### What moved to #1565 — the MSTO catalog rename

`MSTO_ISSUES` listed `each_pair_reaches_its_canonical_form_from_exactly_one_spelling` under issues #1419, #1420 and #1421, and that test is now `each_pair_reaches_its_issues_form_from_the_recorded_number_of_spellings`. `every_cataloged_test_exists_in_its_source_file` exists to catch exactly that, and it was red — under **both** `FERRO_PARTITION=live` and `preserve`, so it was a rename that outran its catalog entry rather than a partition-rule effect.

That repair is now carried by **#1565**, whose diff contains the three `MSTO_ISSUES` entries and the doc-link updates in `tests/it/reported_partition_verdicts.rs`. It is fixed; it is simply fixed one PR lower down. Nothing was dropped.

### `PARTITION_MOVES`

Reviewed and deliberately left alone. Its self-check `every_partition_move_overrides_a_real_recorded_answer` is green and the table still matches `cases.json`, so there is nothing to repair. Noted here because it was on the cleanup list and an unexplained absence looks like an oversight.

### Representation change

Nothing moves. The diff is one comment block in `src/normalize/merge.rs`; no code path is altered and no normalized output changes. The declining trailer at the bottom is deliberately bare — `release-plz.toml`'s exclusion rule anchors on the value, so `none` followed by a reason is filed as a *real* representation change in the changelog, which is #1526 from the other side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal comments describing sequence canonicalization and partition preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!---GHSTACKOPEN-->
### Stacked PR Chain: partition-normalizer

Seven PRs, one arc: implement the partitioner, measure it, fix it with the measurements. Verified mechanically on 2026-08-09 with `git merge-base --is-ancestor` across all six links, after a restack that moved every head except #1565's — so any measurement in these descriptions taken before that restack is flagged where it appears rather than left reading as current.

| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#1565|feat(normalize): make the partition rule govern every block|**N/A** (`main`)|
|#1566|chore(normalize): restate the comment the partition rule made false|#1565|
|#1568|feat(normalize): split an equal-length protein delins whose interior is unchanged|#1566|
|#1567|feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases|#1568|
|#1570|test(normalize): adjudicate the rows the partition model moved|#1567|
|#1571|fix(normalize): typing may not widen a member past its asserted span|#1570|
|#1572|feat(conformance): an exhaustive spec-derived corpus, and the burn-down it measures|#1571|

Merge order is top to bottom. #1565 owns the whole stack's representation move — it carries the `FERRO_PARTITION` default flip to `preserve`, and `FERRO_PARTITION=live` restores every pinned census exactly.

<!---GHSTACKCLOSE-->

Representation-Change: none
