### PR TITLE
feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,6 +385,14 @@ name = "dump_confluence_divergences"
 required-features = ["dev"]
 test = true
 
+# `test = true` because the target carries `#[cfg(test)]` unit tests pinning the
+# three verdicts and the vacuity guard — the parts that decide whether a printed
+# figure means anything. Cargo does not build a target's tests unless it opts in.
+[[example]]
+name = "measure_spdi_key_grouping"
+required-features = ["dev"]
+test = true
+
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/examples/measure_spdi_key_grouping.rs
+++ b/examples/measure_spdi_key_grouping.rs
@@ -1,0 +1,656 @@
+//! Measure whether [`spdi_key`] buckets the confluence divergences.
+//!
+//! # Why
+//!
+//! `src/equivalence/key.rs` claims that descriptions asserting different
+//! *partitions* of one edit — which this project's normalizer deliberately keeps
+//! in distinct canonical forms — nonetheless share one grouping key. The unit
+//! tests pin that on hand-written pairs. This asks it of the population that
+//! actually exhibits the divergence: every class
+//! `examples/dump_confluence_divergences.rs` reports, where two spellings of one
+//! designed variant reached two different normalized strings.
+//!
+//! The distinction matters because a hand-written pair proves the mechanism and
+//! says nothing about coverage. A claim of the form "the key groups the
+//! divergent classes" is a claim about a corpus, and this is the only thing that
+//! can settle it.
+//!
+//! # What is measured, and how it can be vacuous
+//!
+//! Per class: the key of every **distinct normalized output**. Those outputs are
+//! what a downstream consumer stores, and the class is in the input precisely
+//! because there is more than one of them. Four verdicts:
+//!
+//! - `grouped` — every output keyed, and to the same key. The divergence is
+//!   invisible to a consumer bucketing by key.
+//! - `split` — every output keyed, to two or more keys. The key does **not**
+//!   reconcile this class.
+//! - `undecided` — at least one output has no key, so the class cannot be
+//!   answered either way. Reported separately rather than folded into `split`:
+//!   those are different findings and one must not be read as the other.
+//! - `unmeasured` — at least one output could not be *asked*: it does not parse,
+//!   or keying it panicked. Split out from `undecided` for the same reason
+//!   `undecided` is split out from `split`. `undecided` is `spdi_key` declining,
+//!   which is evidence about the key; `unmeasured` is this harness failing,
+//!   which is evidence about the corpus. A run with any of these exits non-zero,
+//!   because every count in the report is then over a smaller population than
+//!   the input and a partial run would otherwise read as a clean one.
+//!
+//! **The vacuity check is printed unconditionally.** A run whose input holds no
+//! class with two or more distinct outputs measures nothing about grouping, and
+//! a `0 split` from such a run reads exactly like success. `multi_output` is
+//! that denominator; when it is zero the report says so instead of reporting a
+//! ratio.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --release --features dev --example generate_cis_confluence_corpus
+//! cargo run --release --features dev --example dump_confluence_divergences -- --out /tmp/div.json
+//! cargo run --release --features dev --example measure_spdi_key_grouping -- --divergences /tmp/div.json
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use serde::Deserialize;
+
+use ferro_hgvs::equivalence::spdi_key;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::spdi::canonical_spdi;
+
+/// Kept in step with `examples/dump_confluence_divergences.rs` and
+/// `examples/generate_cis_confluence_corpus.rs`; all three must agree on the
+/// padding, the accessions and the CDS or the coordinates mean different things.
+const PAD_OFFSET: usize = 256;
+const GENOMIC_CONTIG: &str = "NC_TEST.1";
+const TX_ACCESSION: &str = "NM_TEST.1";
+const TX_CONTIG: &str = "chr_synth";
+const CDS_START: u64 = 1;
+const CDS_END: u64 = 63;
+
+#[derive(Parser, Debug)]
+#[command(about = "Measure how the SPDI grouping key buckets the divergent confluence classes")]
+struct Cli {
+    /// The JSON written by `dump_confluence_divergences -- --out <path>`.
+    #[arg(long)]
+    divergences: PathBuf,
+    /// How many non-grouping exemplars to print per verdict.
+    #[arg(long, default_value_t = 5)]
+    examples: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Input — a subset of `dump_confluence_divergences`'s record
+// ---------------------------------------------------------------------------
+
+/// Only the fields the measurement needs; serde ignores the rest, so this does
+/// not have to track that generator's record shape.
+#[derive(Deserialize)]
+struct Record {
+    id: String,
+    axis: String,
+    core: String,
+    family: String,
+    outputs: Vec<Output>,
+}
+
+#[derive(Deserialize)]
+struct Output {
+    text: String,
+    /// The spellings that reached this output.
+    from: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Providers — the same construction the generator and the dump use
+// ---------------------------------------------------------------------------
+
+fn padded(core: &str) -> String {
+    let pad = "ACGT".repeat(PAD_OFFSET / 4);
+    format!("{pad}{core}{pad}")
+}
+
+fn reference_for(axis: &str, core: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    if axis == "g" {
+        provider.add_genomic_sequence(GENOMIC_CONTIG, padded(core));
+        return provider;
+    }
+    let tx_len = core.len() as u64;
+    let g_start = PAD_OFFSET as u64 + 1;
+    let g_end = PAD_OFFSET as u64 + tx_len;
+    let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+    let transcript = Transcript::new(
+        TX_ACCESSION.to_string(),
+        Some("SYNTH".to_string()),
+        Strand::Plus,
+        core.to_string(),
+        Some(CDS_START),
+        Some(CDS_END),
+        vec![exon],
+        Some(TX_CONTIG.to_string()),
+        Some(g_start),
+        Some(g_end),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_genomic_sequence(TX_CONTIG, padded(core));
+    provider.add_transcript(transcript);
+    provider
+}
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+/// What asking for a key produced, with the three cases kept apart.
+///
+/// Only [`KeyOutcome::Refused`] is a fact about `spdi_key`. The other two are
+/// facts about the *corpus* or about a bug, and folding them into the refusal
+/// count would report a measurement failure as an API limit — the shape
+/// `CLAUDE.md` names under "a generator must account for what it dropped": a
+/// fallible step whose failure is representable as a legitimate value, so a
+/// partial run and a clean run write indistinguishable output.
+enum KeyOutcome {
+    /// `spdi_key` produced a key.
+    Keyed(String),
+    /// `spdi_key` declined, for the stated reason. A documented refusal class.
+    Refused(String),
+    /// The question could not be asked at all: the row does not parse, or
+    /// keying it panicked. Not a refusal, and not evidence about the key.
+    Failed(&'static str),
+}
+
+/// What the key concluded about one class.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Verdict {
+    /// Every distinct output keyed, and to one key.
+    Grouped,
+    /// Every distinct output keyed, to two or more keys.
+    Split,
+    /// Some output has no key, so the class has no answer.
+    Undecided,
+    /// Some output could not be asked — unparseable, or it panicked. Ranked
+    /// apart from `Undecided` because that one is the key declining and this one
+    /// is the harness failing, and only the first says anything about `spdi_key`.
+    Unmeasured,
+}
+
+impl Verdict {
+    fn label(self) -> &'static str {
+        match self {
+            Verdict::Grouped => "grouped",
+            Verdict::Split => "split",
+            Verdict::Undecided => "undecided",
+            Verdict::Unmeasured => "unmeasured",
+        }
+    }
+}
+
+/// One class's outcome, keyed and censused.
+struct Measured {
+    id: String,
+    family: String,
+    verdict: Verdict,
+    /// Distinct normalized outputs the class reached.
+    outputs: usize,
+    /// Distinct keys those outputs produced, rendered, for an exemplar line.
+    keys: BTreeSet<String>,
+    /// Outputs that had no key, each paired with the reason.
+    ///
+    /// The reason is the whole value of an `undecided` row. Without it a reader
+    /// has to guess which of [`spdi_key`]'s documented refusal classes fired, and
+    /// a guess is what turns "declined for a stated reason" into "the key is
+    /// incomplete in some unspecified way".
+    declined: Vec<(String, String)>,
+    /// Outputs and spellings the harness could not ask about, each paired with
+    /// why — `unparseable` or `panicked`.
+    ///
+    /// Kept out of [`Measured::declined`] on purpose. A row the corpus cannot
+    /// parse says nothing about `spdi_key`, and counting it as a refusal both
+    /// overstates the refusal census and hides a broken corpus behind a number
+    /// that looks like a finding.
+    failed: Vec<(String, String)>,
+    /// The same question asked of the class's raw *spellings* rather than its
+    /// normalized outputs — `None` when any spelling declined.
+    ///
+    /// Tracked because the two are different claims and only one is about the
+    /// normalizer. A consumer keying its call set directly, never normalizing,
+    /// depends on the spellings agreeing; a consumer keying stored canonical
+    /// forms depends on the outputs agreeing.
+    spellings_grouped: Option<bool>,
+}
+
+fn measure(record: &Record) -> Measured {
+    let provider = reference_for(&record.axis, &record.core);
+    let key_of = |text: &str| {
+        let Ok(variant) = parse_hgvs(text) else {
+            return KeyOutcome::Failed("unparseable");
+        };
+        // The corpus is built to contain the shapes that break things, so one
+        // panicking row must not take the whole measurement with it.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            spdi_key(&variant, &provider)
+        })) {
+            Ok(Some(key)) => KeyOutcome::Keyed(key.to_string()),
+            // The reason is read here rather than on a second pass, so the
+            // refusal and its explanation come from one parse of one row.
+            // `spdi_key` is deliberately reason-free — it is the bucketing API —
+            // and `canonical_spdi` is the same decision carrying the described
+            // error, which is what the module docs point a caller at.
+            Ok(None) => KeyOutcome::Refused(
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    canonical_spdi(&variant, &provider)
+                })) {
+                    Ok(Err(e)) => e.to_string(),
+                    Ok(Ok(_)) => "no reason — it keys on a second attempt".to_string(),
+                    Err(_) => "panicked while explaining the refusal".to_string(),
+                },
+            ),
+            Err(_) => KeyOutcome::Failed("panicked"),
+        }
+    };
+
+    let mut keys = BTreeSet::new();
+    let mut declined = Vec::new();
+    let mut failed = Vec::new();
+    for output in &record.outputs {
+        match key_of(&output.text) {
+            KeyOutcome::Keyed(key) => {
+                keys.insert(key);
+            }
+            KeyOutcome::Refused(reason) => declined.push((output.text.clone(), reason)),
+            KeyOutcome::Failed(why) => failed.push((output.text.clone(), why.to_string())),
+        }
+    }
+
+    // The verdict is a statement about the *outputs*, so it is fixed here —
+    // before the spelling pass, whose failures are reported but must not restate
+    // themselves as a verdict about something they do not describe.
+    let outputs_unmeasurable = !failed.is_empty();
+
+    // The spelling pass gets the same three-way split, for the same reason: an
+    // unparseable spelling must not be reported as "the spellings do not group".
+    let mut spelling_keys = BTreeSet::new();
+    let mut spellings_unanswerable = false;
+    for spelling in record.outputs.iter().flat_map(|output| output.from.iter()) {
+        match key_of(spelling) {
+            KeyOutcome::Keyed(key) => {
+                spelling_keys.insert(key);
+            }
+            KeyOutcome::Refused(_) => spellings_unanswerable = true,
+            KeyOutcome::Failed(why) => {
+                spellings_unanswerable = true;
+                failed.push((spelling.clone(), why.to_string()));
+            }
+        }
+    }
+    let spellings_grouped = if spellings_unanswerable {
+        None
+    } else {
+        Some(spelling_keys.len() <= 1)
+    };
+
+    // Ordered so a class the harness could not measure never masquerades as one
+    // the key declined, and neither is counted as grouped or split.
+    let verdict = if outputs_unmeasurable {
+        Verdict::Unmeasured
+    } else if !declined.is_empty() {
+        Verdict::Undecided
+    } else if keys.len() <= 1 {
+        Verdict::Grouped
+    } else {
+        Verdict::Split
+    };
+
+    Measured {
+        id: record.id.clone(),
+        family: record.family.clone(),
+        verdict,
+        outputs: record.outputs.len(),
+        keys,
+        declined,
+        failed,
+        spellings_grouped,
+    }
+}
+
+fn render(measured: &[Measured], examples: usize) -> String {
+    let mut out = String::new();
+    let total = measured.len();
+    let multi_output = measured.iter().filter(|m| m.outputs > 1).count();
+
+    let _ = writeln!(out, "divergent classes read: {total}");
+    if multi_output == 0 {
+        let _ = writeln!(
+            out,
+            "\nVACUOUS: no class in this input has two or more distinct normalized outputs, \
+             so nothing here measures whether the key reconciles a divergence. Regenerate \
+             the divergence dump before reading any figure below."
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "classes with >1 distinct output (the population the claim is about): {multi_output}"
+        );
+    }
+
+    let mut by_verdict: BTreeMap<Verdict, usize> = BTreeMap::new();
+    for m in measured {
+        *by_verdict.entry(m.verdict).or_default() += 1;
+    }
+    let _ = writeln!(out, "\nverdict over all {total} classes:");
+    for verdict in [Verdict::Grouped, Verdict::Split, Verdict::Undecided] {
+        let count = by_verdict.get(&verdict).copied().unwrap_or(0);
+        let share = if total == 0 {
+            0.0
+        } else {
+            100.0 * count as f64 / total as f64
+        };
+        let _ = writeln!(out, "  {:<10} {count:>7}  ({share:.1}%)", verdict.label());
+    }
+
+    // The same question asked of the raw spellings. Printed separately because a
+    // consumer that never normalizes depends on this number and not the one
+    // above, and conflating them would let one carry the other's evidence.
+    let spelling_answered = measured
+        .iter()
+        .filter(|m| m.spellings_grouped.is_some())
+        .count();
+    let spelling_grouped = measured
+        .iter()
+        .filter(|m| m.spellings_grouped == Some(true))
+        .count();
+    let _ = writeln!(
+        out,
+        "\nraw spellings (not normalized) that key to one bucket: \
+         {spelling_grouped} of {spelling_answered} answerable classes"
+    );
+
+    let mut families: BTreeMap<(&str, Verdict), usize> = BTreeMap::new();
+    for m in measured {
+        *families.entry((m.family.as_str(), m.verdict)).or_default() += 1;
+    }
+    let _ = writeln!(out, "\nby family:");
+    let names: BTreeSet<&str> = measured.iter().map(|m| m.family.as_str()).collect();
+    for name in names {
+        let at = |v: Verdict| families.get(&(name, v)).copied().unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "  {name:<28} grouped {:>6}  split {:>6}  undecided {:>6}  unmeasured {:>6}",
+            at(Verdict::Grouped),
+            at(Verdict::Split),
+            at(Verdict::Undecided),
+            at(Verdict::Unmeasured)
+        );
+    }
+
+    // Census the refusals by reason, so the report answers "which documented
+    // refusal class fired" without the reader sampling exemplars and
+    // extrapolating. Reasons are the error's own trailing clause, since the
+    // leading part names the variant and would make every row unique.
+    let mut reasons: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in measured {
+        for (_, reason) in &m.declined {
+            let tail = reason
+                .rsplit_once(" — ")
+                .map_or(reason.as_str(), |(_, t)| t);
+            *reasons.entry(tail).or_default() += 1;
+        }
+    }
+    if !reasons.is_empty() {
+        let _ = writeln!(out, "\nrefusals by reason:");
+        for (reason, count) in &reasons {
+            let _ = writeln!(out, "  {count:>6}  {reason}");
+        }
+    }
+
+    // Reported separately from the refusals above, and loudly: these rows were
+    // never asked the question, so every count in this report is over a smaller
+    // population than the header implies. Silence here is what would let a
+    // partially-measured run read as a clean one.
+    let mut failures: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in measured {
+        for (_, why) in &m.failed {
+            *failures.entry(why.as_str()).or_default() += 1;
+        }
+    }
+    if !failures.is_empty() {
+        let total: usize = failures.values().sum();
+        let _ = writeln!(
+            out,
+            "\nUNMEASURED: {total} row(s) could not be asked, so they are excluded from every \
+             count above — they are not refusals:"
+        );
+        for (why, count) in &failures {
+            let _ = writeln!(out, "  {count:>6}  {why}");
+        }
+        for m in measured
+            .iter()
+            .filter(|m| !m.failed.is_empty())
+            .take(examples)
+        {
+            for (text, why) in &m.failed {
+                let _ = writeln!(out, "      {text}\n        {why}");
+            }
+        }
+    }
+
+    for verdict in [Verdict::Split, Verdict::Undecided] {
+        let exemplars: Vec<&Measured> = measured
+            .iter()
+            .filter(|m| m.verdict == verdict)
+            .take(examples)
+            .collect();
+        if exemplars.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "\n{} exemplars:", verdict.label());
+        for m in exemplars {
+            let _ = writeln!(out, "  {} [{}]", m.id, m.family);
+            for key in &m.keys {
+                let _ = writeln!(out, "      key {key}");
+            }
+            for (text, reason) in &m.declined {
+                let _ = writeln!(out, "      no key for {text}\n        because {reason}");
+            }
+        }
+    }
+    out
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let text = match std::fs::read_to_string(&cli.divergences) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!(
+                "error: reading {}: {e}\nGenerate it with:\n  cargo run --release --features dev \
+                 --example dump_confluence_divergences -- --out {}",
+                cli.divergences.display(),
+                cli.divergences.display()
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let records: Vec<Record> = match serde_json::from_str(&text) {
+        Ok(records) => records,
+        Err(e) => {
+            eprintln!("error: parsing {}: {e}", cli.divergences.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let measured: Vec<Measured> = records.iter().map(measure).collect();
+    print!("{}", render(&measured, cli.examples));
+
+    // Refuse, do not report. A row the harness could not ask about is a hole in
+    // the measurement, and exiting 0 with the census printed is precisely the
+    // "partial run and clean run are indistinguishable" failure this repository
+    // treats as a defect in the generator rather than a caveat in its output.
+    let unmeasured: usize = measured.iter().map(|m| m.failed.len()).sum();
+    if unmeasured > 0 {
+        eprintln!(
+            "error: {unmeasured} row(s) could not be measured (unparseable, or keying panicked); \
+             the counts above are over a smaller population than the input"
+        );
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(axis: &str, core: &str, outputs: &[(&str, &[&str])]) -> Record {
+        Record {
+            id: "test".to_string(),
+            axis: axis.to_string(),
+            core: core.to_string(),
+            family: "test-family".to_string(),
+            outputs: outputs
+                .iter()
+                .map(|(text, from)| Output {
+                    text: (*text).to_string(),
+                    from: from.iter().map(|s| (*s).to_string()).collect(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The core of the measurement: two normalized outputs that partition one
+    /// edit differently are `Grouped`, not `Split`.
+    ///
+    /// The core is written so its padded contig has the two spellings' bases
+    /// where the coordinates say they are — `reference_for` prepends
+    /// `PAD_OFFSET` bases, and the `g.` coordinates below are 1-based over the
+    /// padded contig.
+    #[test]
+    fn two_partitions_of_one_edit_measure_as_grouped() {
+        let core = "ATTACAG";
+        let start = PAD_OFFSET + 1;
+        let spanning = format!("{GENOMIC_CONTIG}:g.{start}_{}delinsGGCTA", start + 4);
+        let decomposed = format!(
+            "{GENOMIC_CONTIG}:g.[{start}A>G;{}T>G;{}T>C;{}A>T;{}C>A]",
+            start + 1,
+            start + 2,
+            start + 3,
+            start + 4
+        );
+        let record = record(
+            "g",
+            core,
+            &[(&spanning, &["a"][..]), (&decomposed, &["b"][..])],
+        );
+        let measured = measure(&record);
+        assert_eq!(
+            measured.verdict,
+            Verdict::Grouped,
+            "keys {:?}",
+            measured.keys
+        );
+        assert_eq!(measured.keys.len(), 1);
+    }
+
+    /// The control. Without it a `measure` that answered `Grouped` for
+    /// everything would satisfy the test above, which is the exact failure the
+    /// whole key is supposed to make impossible.
+    #[test]
+    fn two_genuinely_different_edits_measure_as_split() {
+        let start = PAD_OFFSET + 1;
+        let one = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let other = format!("{GENOMIC_CONTIG}:g.{start}A>C");
+        let record = record("g", "ATTACAG", &[(&one, &["a"][..]), (&other, &["b"][..])]);
+        assert_eq!(measure(&record).verdict, Verdict::Split);
+    }
+
+    /// An output with no key makes the class `Undecided`, never `Split` — the
+    /// two are different findings and folding them together would report a
+    /// missing answer as a wrong one.
+    #[test]
+    fn an_unkeyable_output_is_undecided_not_split() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let record = record(
+            "g",
+            "ATTACAG",
+            &[(&keyed, &["a"][..]), ("NC_ABSENT.1:g.5A>G", &["b"][..])],
+        );
+        let measured = measure(&record);
+        assert_eq!(measured.verdict, Verdict::Undecided);
+        assert_eq!(measured.declined.len(), 1);
+    }
+
+    /// An output the harness cannot even parse is `Unmeasured`, never
+    /// `Undecided`, and is kept out of the refusal census.
+    ///
+    /// The two look identical in a report that folds them together, and they are
+    /// opposite findings: `Undecided` says `spdi_key` declined — a fact about the
+    /// key — while this says the row never reached it. Counting an unparseable
+    /// row as a refusal overstates what the key refuses and hides a broken corpus
+    /// behind a number that reads like a result.
+    #[test]
+    fn an_unparseable_output_is_unmeasured_not_a_refusal() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        // Real spellings, so the only unmeasurable row is the one under test.
+        let record = record(
+            "g",
+            "ATTACAG",
+            &[
+                (&keyed, &[keyed.as_str()][..]),
+                ("this is not HGVS at all", &[keyed.as_str()][..]),
+            ],
+        );
+        let measured = measure(&record);
+        assert_eq!(measured.verdict, Verdict::Unmeasured);
+        assert_eq!(
+            measured.declined.len(),
+            0,
+            "an unparseable row is not a refusal by spdi_key"
+        );
+        assert_eq!(measured.failed.len(), 1, "failed was {:?}", measured.failed);
+        assert_eq!(measured.failed[0].1, "unparseable");
+    }
+
+    /// And the run says so on the way out, rather than printing a census over a
+    /// population it silently shrank.
+    #[test]
+    fn the_report_names_the_rows_it_could_not_measure() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let measured = vec![measure(&record(
+            "g",
+            "ATTACAG",
+            &[
+                (&keyed, &["a"][..]),
+                ("this is not HGVS at all", &["b"][..]),
+            ],
+        ))];
+        let report = render(&measured, 3);
+        assert!(report.contains("UNMEASURED"), "report was:\n{report}");
+        assert!(
+            report.contains("they are not refusals"),
+            "the report must not let an unmeasured row read as a refusal:\n{report}"
+        );
+    }
+
+    /// A run whose input has no multi-output class says so, because a `0 split`
+    /// from such a run is indistinguishable from success.
+    #[test]
+    fn a_single_output_input_reports_itself_vacuous() {
+        let start = PAD_OFFSET + 1;
+        let only = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let measured = vec![measure(&record("g", "ATTACAG", &[(&only, &["a"][..])]))];
+        assert!(render(&measured, 0).contains("VACUOUS"));
+    }
+}

--- a/src/equivalence/key.rs
+++ b/src/equivalence/key.rs
@@ -1,0 +1,451 @@
+//! A groupable, encoding-invariant key for "do these denote the same bases?".
+//!
+//! # Why this exists
+//!
+//! An HGVS descriptor asserts a **partition** of the reference, and this
+//! project's normalizer preserves that partition rather than re-deriving a
+//! minimal one from the resulting sequence. A deliberate consequence is that two
+//! spellings which partition the same bases differently reach *different*
+//! canonical forms — `g.8_14delinsGATTA` and `g.[8A>G;9G>A;11C>T;13_14del]` stay
+//! apart on purpose.
+//!
+//! That leaves a consumer who only wants to bucket variants — "how many distinct
+//! changes are in this call set?" — with no usable handle. Comparing normalized
+//! strings answers a different question, and it couples the consumer's stored
+//! buckets to the normalizer, so every future confluence fix churns them.
+//!
+//! The `canonical-form-choice-when-both-legal` ruling record
+//! (`tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`) names this
+//! module's job in the same breath as the design it is a consequence of:
+//! "Sequence-level equivalence still needs an answer for consumers who dedupe;
+//! that is `EquivalenceLevel::SequenceMatch` and a groupable SPDI key, not the
+//! canonical string." This is that key.
+//!
+//! [`crate::spdi::canonical_spdi`] already computes the right thing: apply every
+//! member to the reference, then read the difference back out of the resulting
+//! *bases*, where partitioning is not represented. This module is the grouping
+//! surface over it — a key type that is `Ord` + `Hash` so it can be a map key,
+//! a total `Option`-returning accessor, and a bucketing helper.
+//!
+//! ```
+//! use ferro_hgvs::equivalence::{group_by_spdi_key, spdi_key};
+//! use ferro_hgvs::{parse_hgvs, MockProvider};
+//!
+//! let mut provider = MockProvider::new();
+//! provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+//!
+//! // One edit, two partitions of it. They are two canonical forms by design …
+//! let spanning = parse_hgvs("NC_KEY.1:g.3_7delinsGGCTA").unwrap();
+//! let decomposed = parse_hgvs("NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]").unwrap();
+//! assert_ne!(spanning.to_string(), decomposed.to_string());
+//!
+//! // … and one bucket.
+//! assert_eq!(
+//!     spdi_key(&spanning, &provider),
+//!     spdi_key(&decomposed, &provider),
+//! );
+//!
+//! let grouped = group_by_spdi_key([&spanning, &decomposed], &provider);
+//! assert_eq!(grouped.group_count(), 1);
+//! assert!(grouped.unkeyable().is_empty());
+//! ```
+//!
+//! # What the key is, and what it is not
+//!
+//! **It is** equal exactly when two descriptions on one accession produce the
+//! same resulting bases, whatever their spelling, member count or member order.
+//! It is derived without consulting the normalizer, so it does not move when a
+//! canonical form does.
+//!
+//! **It is not** a canonical SPDI in NCBI's sense, and not a substitute for
+//! [`EquivalenceChecker`](crate::equivalence::EquivalenceChecker) — that answers
+//! a richer pairwise question (accession-version drift, for instance) which no
+//! single scalar key can carry. See [`crate::spdi::apply`]'s module docs for the
+//! exact guarantee.
+//!
+//! # What has no key
+//!
+//! [`spdi_key`] returns `None` rather than a key that would silently collide.
+//! **This is the load-bearing half of the contract**: a key that answered for
+//! everything would bucket unrelated variants together, which is worse than
+//! refusing. See [`spdi_key`] for the enumerated classes.
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::hgvs::variant::HgvsVariant;
+use crate::reference::ReferenceProvider;
+use crate::spdi::{canonical_spdi, SpdiVariant};
+
+/// A groupable key that is equal exactly when two descriptions denote the same
+/// bases on the same accession.
+///
+/// Rendered as an SPDI expression (`accession:position:deletion:insertion`, with
+/// a 0-based interbase `position`), which is what a consumer stores. Construct
+/// it with [`spdi_key`]; there is deliberately no public constructor from a
+/// [`SpdiVariant`], because an arbitrary triple is a *transliteration* of one
+/// spelling and carries none of the invariance the type name claims.
+///
+/// `Ord` is over `(accession, position, deletion, insertion)` — an ordering that
+/// exists so the key can index a `BTreeMap` and so a report can be printed
+/// deterministically. It sorts positionally within one accession, which is
+/// convenient, but nothing about the key's meaning depends on the order.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SpdiKey {
+    spdi: SpdiVariant,
+}
+
+impl SpdiKey {
+    /// The accession the key is on.
+    ///
+    /// Two keys on different accessions never compare equal, so this is the
+    /// axis along which a consumer partitions its buckets before comparing them.
+    pub fn accession(&self) -> &str {
+        &self.spdi.sequence
+    }
+
+    /// The key's structured form, for a caller who wants the coordinates rather
+    /// than the string.
+    pub fn as_spdi(&self) -> &SpdiVariant {
+        &self.spdi
+    }
+
+    /// Consume the key and yield its structured form.
+    pub fn into_spdi(self) -> SpdiVariant {
+        self.spdi
+    }
+}
+
+impl fmt::Display for SpdiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.spdi)
+    }
+}
+
+impl PartialOrd for SpdiKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SpdiKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Field by field rather than through a cloned tuple: a key is a map key,
+        // so `cmp` runs on every lookup and must not allocate.
+        self.spdi
+            .sequence
+            .cmp(&other.spdi.sequence)
+            .then_with(|| self.spdi.position.cmp(&other.spdi.position))
+            .then_with(|| self.spdi.deletion.cmp(&other.spdi.deletion))
+            .then_with(|| self.spdi.insertion.cmp(&other.spdi.insertion))
+    }
+}
+
+/// The grouping key for `variant`, or `None` when no single key describes it.
+///
+/// Two variants whose keys are `Some` and equal denote the same bases on the
+/// same accession. Two whose keys are `Some` and unequal denote different bases.
+/// `None` is **not** an equivalence class: two `None`s say nothing about each
+/// other, and a caller must not bucket them together.
+///
+/// # What returns `None`
+///
+/// Every case below is one where a key would have to be guessed. Refusing keeps
+/// the invariant that equal keys mean equal bases.
+///
+/// - **Protein descriptions** (`p.`). SPDI has no protein axis, and the amino
+///   acid consequence of an edit is not recoverable from a nucleotide key. This
+///   is a permanent exclusion, not a gap: a consumer bucketing protein variants
+///   needs a protein key, which this is not.
+/// - **Descriptions naming more than one molecule** — a trans, mosaic, chimeric
+///   or unknown-phase allele, and the null (`0`) and unknown (`?`) alleles.
+///   There is no single resulting sequence to read a key out of.
+/// - **Alleles spanning more than one accession.** A key is per-accession.
+/// - **Members that overlap**, or two coincident insertions at one interbase
+///   position. Applying them depends on an order the description does not state,
+///   so there is no one answer. (HGVS spells a stated order as a single ordered
+///   payload, `ins[A;C]`, which *does* key.)
+/// - **A stated deletion that disagrees with the reference** — the description
+///   and the provider cannot both be right, and picking one would key the
+///   variant off bases it does not describe.
+/// - **Edits SPDI cannot represent.** Inserted-range payloads
+///   (`g.10_11ins20_30`), uncertain or unspecified inserted lengths (`ins(10)`),
+///   named elements (`insAluYb8`), and intronic `c.`/`n.`/`r.` offsets, which
+///   SPDI has no notation for.
+/// - **Reference bases the provider cannot serve** — an absent accession, or a
+///   window it declines. A key derived from a truncated window is a *different*
+///   key, not a smaller one.
+/// - **Spans past the library's bounds** — wider than
+///   [`MAX_APPLY_WINDOW`](crate::spdi::MAX_APPLY_WINDOW), or sitting in a repeat
+///   tract still running past [`MAX_SHIFT_TRACT`](crate::spdi::MAX_SHIFT_TRACT)
+///   bases 3', where how far the change rolls depends on how much reference was
+///   read.
+///
+/// One residual is worth stating because it is a `Some` and not a `None`: a
+/// description that changes nothing (`g.3A>A`) keys at its own position, so two
+/// no-ops at different positions do not group. That is inherited from
+/// [`canonical_spdi`] and is documented there.
+///
+/// Use [`canonical_spdi`] directly when the *reason* for a refusal is wanted;
+/// it returns the same answer as a `Result` carrying a described error.
+pub fn spdi_key<P: ReferenceProvider + ?Sized>(
+    variant: &HgvsVariant,
+    provider: &P,
+) -> Option<SpdiKey> {
+    canonical_spdi(variant, provider)
+        .ok()
+        .map(|spdi| SpdiKey { spdi })
+}
+
+/// Variants bucketed by [`SpdiKey`], plus the ones that have no key.
+///
+/// The unkeyable list is a first-class part of the result rather than a silent
+/// drop. A consumer reading only `groups()` would under-count its call set and
+/// have no way to notice; reading `unkeyable()` tells it exactly how much of the
+/// input the buckets do not describe.
+#[derive(Debug, Clone)]
+pub struct SpdiKeyGrouping<T> {
+    groups: BTreeMap<SpdiKey, Vec<T>>,
+    unkeyable: Vec<T>,
+}
+
+impl<T> SpdiKeyGrouping<T> {
+    /// Each distinct key and the variants that share it, in key order.
+    pub fn groups(&self) -> impl Iterator<Item = (&SpdiKey, &[T])> {
+        self.groups
+            .iter()
+            .map(|(key, items)| (key, items.as_slice()))
+    }
+
+    /// The variants [`spdi_key`] declined, in input order.
+    ///
+    /// These are **not** one bucket — see [`spdi_key`] for why `None` is not an
+    /// equivalence class.
+    pub fn unkeyable(&self) -> &[T] {
+        &self.unkeyable
+    }
+
+    /// How many distinct keys the input reduced to.
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// The variants sharing `key`, or `None` if no input reached it.
+    pub fn get(&self, key: &SpdiKey) -> Option<&[T]> {
+        self.groups.get(key).map(Vec::as_slice)
+    }
+
+    /// Whether every keyable input landed in a single bucket.
+    ///
+    /// Vacuously `true` for an input with no keyable members, which is why
+    /// [`unkeyable`](Self::unkeyable) has to be read alongside it: "all one
+    /// bucket" over zero buckets is not evidence of agreement.
+    pub fn is_confluent(&self) -> bool {
+        self.groups.len() <= 1
+    }
+
+    /// The buckets and the refusals, for a caller that wants to own them.
+    pub fn into_parts(self) -> (BTreeMap<SpdiKey, Vec<T>>, Vec<T>) {
+        (self.groups, self.unkeyable)
+    }
+}
+
+/// Bucket `variants` by the bases they denote.
+///
+/// Accepts anything that borrows an [`HgvsVariant`] — owned variants, `&`
+/// variants, or a smart pointer — and hands the same items back inside the
+/// buckets, so a caller keeps whatever it put in.
+///
+/// Each variant is keyed independently; one that cannot be keyed lands in
+/// [`SpdiKeyGrouping::unkeyable`] rather than failing the call, because a
+/// consumer bucketing a call set wants the buckets it *can* have plus an honest
+/// count of what it could not place.
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::equivalence::group_by_spdi_key;
+/// use ferro_hgvs::{parse_hgvs, MockProvider};
+///
+/// let mut provider = MockProvider::new();
+/// provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+///
+/// let variants = [
+///     parse_hgvs("NC_KEY.1:g.13_14insT").unwrap(),
+///     parse_hgvs("NC_KEY.1:g.14dup").unwrap(),
+///     parse_hgvs("NC_KEY.1:g.3A>G").unwrap(),
+/// ];
+/// let grouped = group_by_spdi_key(&variants, &provider);
+/// assert_eq!(grouped.group_count(), 2);
+/// ```
+pub fn group_by_spdi_key<T, I, P>(variants: I, provider: &P) -> SpdiKeyGrouping<T>
+where
+    I: IntoIterator<Item = T>,
+    T: Borrow<HgvsVariant>,
+    P: ReferenceProvider + ?Sized,
+{
+    let mut groups: BTreeMap<SpdiKey, Vec<T>> = BTreeMap::new();
+    let mut unkeyable = Vec::new();
+    for variant in variants {
+        match spdi_key(variant.borrow(), provider) {
+            Some(key) => groups.entry(key).or_default().push(variant),
+            None => unkeyable.push(variant),
+        }
+    }
+    SpdiKeyGrouping { groups, unkeyable }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::parser::parse_hgvs;
+    use crate::reference::MockProvider;
+
+    /// The 40-base contig `spdi::apply`'s own tests use, so a key asserted here
+    /// can be checked against the bases by hand.
+    ///
+    ///  1-based: 1234567890...
+    ///           GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT
+    fn provider() -> MockProvider {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT");
+        provider.add_genomic_sequence("NC_OTHER.1", "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+        provider
+    }
+
+    fn key(descriptor: &str) -> Option<SpdiKey> {
+        let variant = parse_hgvs(descriptor).expect("fixture must parse");
+        spdi_key(&variant, &provider())
+    }
+
+    /// The property the module exists for: descriptions that assert *different
+    /// partitions* of one edit — and so reach different canonical forms by
+    /// design — share one key.
+    #[test]
+    fn different_partitions_of_one_edit_share_a_key() {
+        let spanning = key("NC_KEY.1:g.3_7delinsGGCTA").expect("keys");
+        let decomposed = key("NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]").expect("keys");
+        assert_eq!(spanning, decomposed);
+        assert_eq!(spanning.to_string(), "NC_KEY.1:2:ATTAC:GGCTA");
+        assert_eq!(spanning.accession(), "NC_KEY.1");
+    }
+
+    /// The control for the test above. Without it, every equality assertion here
+    /// would also pass for a key that collapsed everything into one bucket —
+    /// which is the failure mode the `None`-rather-than-collide rule is about.
+    #[test]
+    fn different_edits_do_not_share_a_key() {
+        assert_ne!(key("NC_KEY.1:g.3A>G"), key("NC_KEY.1:g.3A>C"));
+        assert_ne!(key("NC_KEY.1:g.3_5del"), key("NC_KEY.1:g.3_6del"));
+        // Same edit, different accession: a key is per-accession.
+        assert_ne!(key("NC_KEY.1:g.3A>G"), key("NC_OTHER.1:g.3T>G"));
+    }
+
+    /// The key is not the normalizer's output, so it groups across the axes the
+    /// canonical form deliberately keeps apart: member order, and a `dup` versus
+    /// the insertion that denotes it.
+    #[test]
+    fn the_key_ignores_spelling_and_member_order() {
+        assert_eq!(key("NC_KEY.1:g.[3A>G;7C>A]"), key("NC_KEY.1:g.[7C>A;3A>G]"));
+        assert_eq!(key("NC_KEY.1:g.13_14insT"), key("NC_KEY.1:g.14dup"));
+        // The same deletion spelled one base apart inside a tract.
+        assert_eq!(key("NC_KEY.1:g.3_5del"), key("NC_KEY.1:g.4_6del"));
+    }
+
+    /// Each documented refusal, exercised as the thing the doc claims.
+    ///
+    /// Written as a table with the reason attached because the value of this
+    /// test is the enumeration: a class that quietly started returning a key
+    /// would be a silent collision, which is the one failure the type is
+    /// supposed to make impossible.
+    #[test]
+    fn the_documented_classes_have_no_key() {
+        for (descriptor, why) in [
+            ("NP_000079.2:p.Gly1150Asp", "protein axis — SPDI has none"),
+            ("NC_KEY.1:g.[3A>G(;)7C>A]", "trans phase — two molecules"),
+            ("NC_KEY.1:g.[3_5del;4T>G]", "overlapping members"),
+            (
+                "NC_KEY.1:g.[5_6insA;5_6insC]",
+                "coincident insertions with no stated order",
+            ),
+            (
+                "[NC_KEY.1:g.3A>G;NC_OTHER.1:g.7T>G]",
+                "members on two accessions",
+            ),
+            (
+                "NC_KEY.1:g.3T>G",
+                "stated base disagrees with the reference",
+            ),
+            ("NC_ABSENT.1:g.3A>G", "the provider cannot serve the bases"),
+            ("NC_KEY.1:g.10_11ins20_30", "inserted-range payload"),
+            ("NC_KEY.1:g.10_11ins(10)", "unspecified inserted length"),
+        ] {
+            assert_eq!(
+                key(descriptor),
+                None,
+                "`{descriptor}` must have no key ({why}) — a key here is a silent collision"
+            );
+        }
+    }
+
+    /// A member with a stated order in one payload does key, which is what makes
+    /// the coincident-insertion refusal a refusal to *guess* rather than a gap.
+    #[test]
+    fn a_stated_insertion_order_still_keys() {
+        assert!(key("NC_KEY.1:g.5_6insAC").is_some());
+    }
+
+    #[test]
+    fn grouping_separates_buckets_from_refusals() {
+        let provider = provider();
+        let variants: Vec<HgvsVariant> = [
+            "NC_KEY.1:g.3_7delinsGGCTA",
+            "NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]",
+            "NC_KEY.1:g.13_14insT",
+            "NC_KEY.1:g.[3_5del;4T>G]",
+        ]
+        .iter()
+        .map(|d| parse_hgvs(d).expect("fixture must parse"))
+        .collect();
+
+        let grouped = group_by_spdi_key(&variants, &provider);
+        assert_eq!(grouped.group_count(), 2);
+        assert_eq!(grouped.unkeyable().len(), 1);
+        assert!(!grouped.is_confluent());
+
+        let (largest, members) = grouped
+            .groups()
+            .max_by_key(|(_, members)| members.len())
+            .expect("two buckets");
+        assert_eq!(members.len(), 2, "the two partitions of one edit");
+        assert_eq!(grouped.get(largest).map(<[_]>::len), Some(2));
+    }
+
+    /// `into_parts` hands back exactly what went in, so a caller can own the
+    /// buckets without re-deriving them.
+    #[test]
+    fn into_parts_preserves_every_input() {
+        let provider = provider();
+        let variants: Vec<HgvsVariant> = ["NC_KEY.1:g.3A>G", "NC_ABSENT.1:g.3A>G"]
+            .iter()
+            .map(|d| parse_hgvs(d).expect("fixture must parse"))
+            .collect();
+        let (groups, unkeyable) = group_by_spdi_key(variants.clone(), &provider).into_parts();
+        let returned = groups.values().map(Vec::len).sum::<usize>() + unkeyable.len();
+        assert_eq!(returned, variants.len());
+    }
+
+    /// Ordering exists so the key can index a `BTreeMap`; pin that it is
+    /// positional within an accession rather than an accident of the string.
+    #[test]
+    fn keys_order_positionally_within_an_accession() {
+        let mut keys = [
+            key("NC_KEY.1:g.7C>A").expect("keys"),
+            key("NC_KEY.1:g.3A>G").expect("keys"),
+        ];
+        keys.sort();
+        assert!(keys[0].as_spdi().position < keys[1].as_spdi().position);
+        assert_eq!(keys[0].clone().into_spdi().position, 2);
+    }
+}

--- a/src/equivalence/mod.rs
+++ b/src/equivalence/mod.rs
@@ -42,6 +42,19 @@
 //! - [HGVS Nomenclature](https://hgvs-nomenclature.org/)
 //! - [Variant Normalization](https://www.ncbi.nlm.nih.gov/variation/notation/)
 
+//! # Pairwise levels, or a groupable key
+//!
+//! [`EquivalenceChecker`] answers a rich question about **two** variants, and
+//! its answer is a level rather than a value — `AccessionVersionDifference` has
+//! no scalar a bucket could be keyed on. A consumer that wants to *count
+//! distinct changes* across a whole call set needs the other shape: one value
+//! per variant, equal exactly when the bases are. That is [`SpdiKey`], and it
+//! corresponds to the `SequenceMatch` rung — the one that fires precisely where
+//! ferro deliberately keeps two partitions of one edit in distinct canonical
+//! forms.
+
 mod checker;
+mod key;
 
 pub use checker::{EquivalenceChecker, EquivalenceLevel, EquivalenceResult};
+pub use key::{group_by_spdi_key, spdi_key, SpdiKey, SpdiKeyGrouping};


### PR DESCRIPTION
Base is #1568 (`feat/protein-axis-split-move`), not `main`. Full chain at the bottom.

## What this adds

The branch stack establishes that an HGVS descriptor asserts a **partition** of the reference and that normalization preserves it, with the deliberate consequence that two spellings partitioning the same bases reach different canonical forms. The `canonical-form-choice-when-both-legal` ruling names the missing counterpart in the same breath: *"Sequence-level equivalence still needs an answer for consumers who dedupe; that is `EquivalenceLevel::SequenceMatch` and a groupable SPDI key, not the canonical string."*

This is that key. It is a **grouping surface over the existing `spdi::canonical_spdi`** (#1374) — no new coordinate arithmetic, no normalizer dependency, and nothing under `src/normalize/`.

```rust
use ferro_hgvs::equivalence::{group_by_spdi_key, spdi_key, SpdiKey, SpdiKeyGrouping};

// One key per variant, equal exactly when the resulting bases are equal.
let key: Option<SpdiKey> = spdi_key(&variant, &provider);

// Bucket a call set. Refusals are a first-class part of the result.
let grouped: SpdiKeyGrouping<_> = group_by_spdi_key(&variants, &provider);
grouped.groups();        // (&SpdiKey, &[T]) in key order
grouped.unkeyable();     // what has no key — NOT a bucket
grouped.group_count();   // how many distinct changes the input reduced to
```

`SpdiKey` is `Ord` + `Hash` so it can index a `BTreeMap`/`HashMap`, `Display`s as an SPDI expression (what a consumer stores in a column), and exposes `accession()` / `as_spdi()` / `into_spdi()`. It has no public constructor from a raw `SpdiVariant`, because an arbitrary triple is a transliteration of one spelling and carries none of the invariance the name claims.

`spdi_key` returns `None` — never a key that could silently collide — for protein axes, multi-molecule and null/unknown alleles, mixed accessions, overlapping members, coincident insertions with no stated order, a stated base that disagrees with the reference, edits SPDI cannot represent (inserted-range payloads `g.10_11ins20_30`, unspecified lengths `ins(10)`, intronic offsets), references the provider cannot serve, and spans past `MAX_APPLY_WINDOW` / `MAX_SHIFT_TRACT`. **Every one of those classes is exercised as a table in `the_documented_classes_have_no_key`**, so a class that quietly starts returning a key fails loudly. `None` is documented as *not* an equivalence class: two `None`s say nothing about each other. `canonical_spdi` remains the way to get the *reason*.

## Measured, not asserted

The unit tests prove the mechanism on hand-written pairs, which says nothing about coverage. `examples/measure_spdi_key_grouping.rs` asks the question of the population that actually exhibits the divergence — every class `dump_confluence_divergences` reports:

| direction | divergent classes | grouped | split | undecided |
|---|---|---|---|---|
| 3' | 7,542 | **7,523 (99.7%)** | **0** | 19 (0.3%) |
| 5' | 7,465 | **7,437 (99.6%)** | **0** | 28 (0.4%) |

`split` — every output keyed, but to two or more keys — is **zero in both directions**. There is no class in this corpus where the key puts two of the normalizer's divergent forms into different buckets.

The `undecided` rows are `spdi_key` returning `None` for one of the class's outputs, and the harness censuses refusals by reason rather than leaving a reader to sample exemplars: **all 19 (and all 28) are the single documented "members overlap" class**, every one a repeat member whose resolved tract abuts a `dup`/`ins` sibling, e.g. `NC_TEST.1:g.[265dup;266_267A[4]]`. That is a refusal to guess an application order, not a gap in coverage. They are reported separately from `split` on purpose — a missing answer must not read as a wrong one.

Asked of the **raw spellings** instead of the normalized outputs (the question a consumer who never normalizes depends on): 7,086 of 7,086 answerable classes key to one bucket, 6,987 of 6,987 at 5'.

**Vacuity check.** A `0 split` is exactly the kind of zero this repo keeps recording as "the corpus could not build the thing you changed", so the harness prints its own denominator unconditionally: the property is *two or more distinct normalized outputs per class*, and **7,542 of 7,542** classes have it (7,465 of 7,465 at 5'). The zero is measured over a population that can vary the property, and a run whose input cannot prints `VACUOUS` instead of a ratio — pinned by `a_single_output_input_reports_itself_vacuous`.

These grouping figures are a property of the *partitioner under measurement*, so they move with the stack. They were taken on the pre-restack parent; the mechanism claim (`0 split`, refusals censused by reason) is what carries across, and the ratios are due a re-run against `8016c6e0`.

## Representation change

Verified by scope rather than by a corpus number, deliberately. The diff is **970 insertions, 0 deletions** across four files — `src/equivalence/key.rs` (new), `src/equivalence/mod.rs` (+13, a `mod` and a `pub use`), `examples/measure_spdi_key_grouping.rs` (new), `Cargo.toml` (+8, the example target). Nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — re-checked against the post-restack diff — so no code path that produces a normalized string is reachable from this change.

A `0 moved` from `dump_normalized_corpus` is *not* quoted here on purpose: that corpus cannot vary anything this change keys on, so its zero would be a structural zero dressed up as evidence. The file-scope argument is the stronger one, and the suite is the corroboration — the failure set is byte-identical before and after.

The declining trailer at the bottom is deliberately bare. `release-plz.toml`'s exclusion rule anchors on the trailer's value, so `none` followed by a reason is filed as a *real* representation change in the changelog — #1526 from the other side — which is why the reason lives in this paragraph instead.

## Tests — measured on the pre-restack parent

`cargo nextest run --release --features dev`: 9,753 -> 9,765 tests, 9,707 -> 9,719 passed, **46 failed before and 46 after — `diff` of the two failure name lists is empty**. All 46 were pre-existing on the parent as it then stood (the `cis_confluence_*` censuses and the partition-rule adjudications the stack is mid-way through re-blessing). The 12 new tests all pass and **nothing was re-blessed**. The baseline was captured by reverting this worktree to the base commit and running there, not with `git stash` (repo-global in this layout, and the stack has sibling worktrees live).

**That baseline is superseded.** The 2026-08-09 restack moved this branch's parent from the pre-restack `feat/protein-axis-split-move` head to `8016c6e0`, and #1570 has since fixed W58 further up the chain, so the absolute failure counts will differ on a re-run. The claim to re-establish is the empty name-list diff, not the number 46.

Also green: 2 new doctests (`cargo test --doc`), and `cargo doc` adds no intra-doc-link warning under these files.

`cargo check --features dev --all-targets`, `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` are clean.

## Not covered, stated rather than left to be discovered

- **Python bindings.** `canonical_spdi` is already exposed on the Python `Normalizer`; a `spdi_key` / `group_by_spdi_key` binding is the obvious follow-up for a consumer pipeline and is deliberately out of this PR's scope.
- **Protein axes** are a permanent exclusion, not a gap — a consumer bucketing protein variants needs a protein key, which this is not.
- **A no-op keys at its own position** (`g.3A>A` -> `3::`, `g.5T>T` -> `5::`), so two no-ops at different positions do not group. Inherited from `canonical_spdi`, documented there and re-stated on `spdi_key`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encoding-invariant SPDI keys for grouping equivalent HGVS variants that produce the same normalized sequence.
  * Added grouping results with access to equivalent groups, ungroupable variants, counts, and confluence status.
  * Added a development tool for measuring grouping behavior across confluence-divergence datasets, including clear outcome and failure reporting.

* **Tests**
  * Added coverage for equivalent and distinct edits, refused or unparseable results, grouping behavior, ordering, failure reporting, and single-result inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!---GHSTACKOPEN-->
### Stacked PR Chain: partition-normalizer

Seven PRs, one arc: implement the partitioner, measure it, fix it with the measurements. Verified mechanically on 2026-08-09 with `git merge-base --is-ancestor` across all six links, after a restack that moved every head except #1565's — so any measurement in these descriptions taken before that restack is flagged where it appears rather than left reading as current.

| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#1565|feat(normalize): make the partition rule govern every block|**N/A** (`main`)|
|#1566|chore(normalize): restate the comment the partition rule made false|#1565|
|#1568|feat(normalize): split an equal-length protein delins whose interior is unchanged|#1566|
|#1567|feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases|#1568|
|#1570|test(normalize): adjudicate the rows the partition model moved|#1567|
|#1571|fix(normalize): typing may not widen a member past its asserted span|#1570|
|#1572|feat(conformance): an exhaustive spec-derived corpus, and the burn-down it measures|#1571|

Merge order is top to bottom. #1565 owns the whole stack's representation move — it carries the `FERRO_PARTITION` default flip to `preserve`, and `FERRO_PARTITION=live` restores every pinned census exactly.

<!---GHSTACKCLOSE-->

Representation-Change: none
