### PR TITLE
feat(normalize): split an equal-length protein delins whose interior is unchanged

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2254,7 +2254,56 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &HgvsVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         let (normalized, warnings) = self.normalize_core(variant)?;
-        self.canonicalize_from_sequence(normalized, warnings)
+        let (normalized, warnings) = self.canonicalize_from_sequence(normalized, warnings)?;
+        Ok((self.split_protein_separation(normalized), warnings))
+    }
+
+    /// The protein-axis partition pass, run once at the top level.
+    ///
+    /// [`Self::try_protein_split_delins`] holds the rule and its citations; this
+    /// is only about **where** it runs. It runs here, beside
+    /// [`Self::canonicalize_from_sequence`] and for the same reason: the move
+    /// turns one member into several, so it belongs at the seam that sees the
+    /// whole description rather than in
+    /// [`normalize_protein`](Self::normalize_protein), which `normalize_allele`
+    /// re-enters once per member.
+    ///
+    /// Wiring it into `normalize_protein` was tried, and produced two defects
+    /// that every bare-description test passes straight over:
+    ///
+    /// ```text
+    ///   p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]
+    ///     -> [NP_003997.1:p.Ala60Gly;NP_003997.1:p.[Ser44Arg;Trp46Arg]]
+    ///   p.[Ser44_Trp46delinsArgLeuArg];[Ala60Gly]
+    ///     -> NP_003997.1:p.[Ser44Arg;Trp46Arg];[Ala60Gly]     (does not re-parse)
+    /// ```
+    ///
+    /// The first is a nested bracket carrying a repeated accession, which is not
+    /// a description at all. The second *is* legal HGVS — the DNA axis emits
+    /// `g.[A;B];[C]` and reads it back — but ferro's **protein** allele grammar
+    /// accepts only single-member arms, so normalization would emit a string
+    /// `parse_hgvs` refuses. That is exactly what `FERRO_ASSERT_REPARSE` exists to
+    /// catch, and its exemption list is closed on purpose.
+    ///
+    /// So the move applies to a whole `p.` description and **declines for a
+    /// member of one**: `p.[<separated delins>;…]` keeps its delins. Closing that
+    /// needs two decisions this pass deliberately does not take — where an inner
+    /// allele's `( )` marker goes once its members flatten into the outer bracket
+    /// (`protein/alleles.md:34` puts it per member, `:90` puts it round the group)
+    /// and a protein allele grammar that reads `p.[A;B];[C]`. Pinned by
+    /// `protein_axis_split_move::a_delins_inside_a_cis_allele_is_left_alone` and
+    /// its trans sibling.
+    fn split_protein_separation(&self, variant: HgvsVariant) -> HgvsVariant {
+        let HV::Protein(protein) = &variant else {
+            return variant;
+        };
+        match self.try_protein_split_delins(protein) {
+            Some(members) => {
+                let uncertain = protein.loc_edit.edit.is_uncertain();
+                wrap_allele_if_split(members.into_iter().map(HV::Protein).collect(), uncertain)
+            }
+            None => variant,
+        }
     }
 
     /// Normalize a variant, apply the strict-mode rejection ladder, and return
@@ -5705,6 +5754,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => final_variant,
         };
 
+        // NOTE: the protein-axis split move (`protein/delins.md:21`, `:64`) is
+        // deliberately NOT applied here. It turns one member into several, so it
+        // runs at the whole-description seam —
+        // [`Self::split_protein_separation`], called from
+        // `normalize_core_canonical` — which this method cannot be, because
+        // `normalize_allele` re-enters it once per member. That helper records
+        // what wiring it in here was measured to produce.
         Ok((HV::Protein(final_variant), warnings))
     }
 
@@ -6241,6 +6297,171 @@ impl<P: ReferenceProvider> Normalizer<P> {
             },
             Interval::new(dstart, dend),
         ))
+    }
+
+    /// The protein-axis split move: an **equal-length** `delins` whose interior
+    /// leaves at least one residue unchanged describes two or more separate
+    /// changes, not one `delins`.
+    ///
+    /// `recommendations/protein/delins.md:21` states it outright — "two variants
+    /// separated by one or more amino acids should be described individually and
+    /// not as a `delins`" — and `:64` publishes the worked answer:
+    /// `p.[Ser44Arg;Trp46Arg]`, with the explicit note that "the variant is
+    /// **not** described as `p.Ser44_Trp46delinsArgLeuArg`". This is the protein
+    /// analogue of the nucleotide separation rule (`general.md:34`) that
+    /// [`Self::apply_canonical_split`] applies via
+    /// [`rules::decompose_delins`](crate::normalize::rules::decompose_delins).
+    ///
+    /// # Why equal length, and only equal length
+    ///
+    /// A `delins` whose reference span and payload have the **same** length has
+    /// exactly one residue-wise correspondence, so "the middle residue is
+    /// unchanged" is a fact about the input rather than a choice. An
+    /// unequal-length `delins` has no such correspondence: finding an unchanged
+    /// run inside it means first picking an alignment, and the partition model
+    /// exists precisely to avoid re-deriving an answer from a chosen alignment.
+    /// Those are left as authored.
+    ///
+    /// The floor is **one** unchanged residue: `delins.md:21` says "separated by
+    /// one or more amino acids", and unlike the nucleotide axis there is no
+    /// codon carve-out here (`general.md:35-38` is a *reading-frame* exception,
+    /// and a protein description has no codons of its own to share).
+    ///
+    /// # Why this is not routed through the nucleotide canonicalizer
+    ///
+    /// [`merge::canonicalize_from_sequence`](crate::normalize::merge) applies the
+    /// edit set to a reference window and re-derives the partition from the
+    /// resulting sequence. There is no apply-to-reference on the protein axis —
+    /// [`merge::cis_kind_of`](crate::normalize::merge) returns `None` for
+    /// `Protein` for exactly that reason — so the move is implemented here, on
+    /// the reference residues themselves.
+    ///
+    /// # When it declines
+    ///
+    /// Returning `None` leaves the input `delins` exactly as authored. It
+    /// declines when:
+    ///
+    /// - the edit is not a `Delins`, or either endpoint is uncertain or a range
+    ///   (there is then no residue-wise correspondence to read);
+    /// - the payload length differs from the span, per the section above;
+    /// - the span is under three residues, which has no interior to be
+    ///   unchanged;
+    /// - **the protein reference is unavailable for this accession.** The
+    ///   unchanged middle residue is a claim about the *reference*, and the
+    ///   payload cannot testify to it: assuming `payload[i]` matches the
+    ///   reference is the guess this rule must never make. `has_protein_data()`
+    ///   is provider-wide, so the fetch itself is what decides (#1131);
+    /// - the reference span or the payload names an unknown residue (`Xaa`),
+    ///   where equality is not a statement about identity;
+    /// - **either side carries a `Ter`.** In the *payload*, a split across a stop
+    ///   would emit members 3' of it, which `delins.md:45` forbids ("amino acids
+    ///   after the translation termination codon are **not** listed"). In the
+    ///   *reference span*, a stop replaced by an ordinary residue is a
+    ///   **stop-loss**, and `extension.md:18` ranks it — "prioritisation: (1)
+    ///   extension, (2) frameshift or deletion-insertion" — so it is described
+    ///   with `ProteinEdit::Extension` (`:30`, `p.Ter110GlnextTer17`), never a
+    ///   substitution. Splitting `Ser-Leu-Ter` against a payload of
+    ///   `Ala-Leu-His` would emit `p.[Ser988Ala;Ter990His]`, which spells an
+    ///   extension as a substitution and states the wrong consequence. Both are
+    ///   the mirror of the `first_ter_pos` gate in
+    ///   [`merge::coalesce_protein_adjacent_changes`](crate::normalize::merge);
+    /// - fewer than two changed runs survive, i.e. the change really is one
+    ///   contiguous `delins`.
+    fn try_protein_split_delins(
+        &self,
+        variant: &crate::hgvs::variant::ProteinVariant,
+    ) -> Option<Vec<crate::hgvs::variant::ProteinVariant>> {
+        use crate::hgvs::edit::AminoAcidSeq;
+        use crate::hgvs::variant::{LocEdit, ProteinVariant};
+
+        let seq = match variant.loc_edit.edit.inner()? {
+            ProteinEdit::Delins { sequence } => sequence,
+            _ => return None,
+        };
+        // Certain single points only — same rationale as
+        // `try_protein_delins_canonicalize`.
+        let start_pos = match variant.loc_edit.location.start.as_single()? {
+            Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        let end_pos = match variant.loc_edit.location.end.as_single()? {
+            Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        if start_pos.number == 0 || end_pos.number < start_pos.number {
+            return None;
+        }
+        let span = (end_pos.number - start_pos.number + 1) as usize;
+        // Equal length, and at least one interior residue to be unchanged.
+        if span < 3 || span != seq.0.len() {
+            return None;
+        }
+        if seq.0.contains(&AminoAcid::Ter) || seq.0.contains(&AminoAcid::Xaa) {
+            return None;
+        }
+
+        // The reference residues, or nothing. Never the payload's own middle.
+        if !self.provider.has_protein_data() {
+            return None;
+        }
+        let accession = variant.accession.transcript_accession();
+        let ref_aas =
+            self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)?;
+        if ref_aas.len() != span
+            || ref_aas.contains(&AminoAcid::Xaa)
+            || ref_aas.contains(&AminoAcid::Ter)
+        {
+            return None;
+        }
+
+        // Maximal runs of residue-wise disagreement. Two or more runs means an
+        // unchanged residue separates them, which is the separation the clause
+        // is about.
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        let mut offset = 0usize;
+        while offset < span {
+            if ref_aas[offset] == seq.0[offset] {
+                offset += 1;
+                continue;
+            }
+            let lo = offset;
+            while offset < span && ref_aas[offset] != seq.0[offset] {
+                offset += 1;
+            }
+            runs.push((lo, offset - 1));
+        }
+        if runs.len() < 2 {
+            return None;
+        }
+
+        // One member per run: a single-residue run is a substitution
+        // (`general.md:56` ranks substitution above delins), a longer one the
+        // smaller delins it really is. Members are always certain — a predicted
+        // `p.(…)` input carries its marker onto the whole allele, which
+        // `wrap_allele_if_split` does.
+        let members = runs
+            .into_iter()
+            .map(|(lo, hi)| {
+                let member_start = ProtPos::new(ref_aas[lo], start_pos.number + lo as u64);
+                let member_end = ProtPos::new(ref_aas[hi], start_pos.number + hi as u64);
+                let edit = if lo == hi {
+                    ProteinEdit::Substitution {
+                        reference: ref_aas[lo],
+                        alternative: seq.0[lo],
+                    }
+                } else {
+                    ProteinEdit::Delins {
+                        sequence: AminoAcidSeq::new(seq.0[lo..=hi].to_vec()),
+                    }
+                };
+                ProteinVariant {
+                    accession: variant.accession.clone(),
+                    gene_symbol: variant.gene_symbol.clone(),
+                    loc_edit: LocEdit::new(Interval::new(member_start, member_end), edit),
+                }
+            })
+            .collect();
+        Some(members)
     }
 
     /// HGVS Prioritization: if a protein insertion is equivalent to a

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -393,6 +393,7 @@ mod predicted_cis_allele;
 mod projection;
 mod projection_coverage;
 mod property_tests;
+mod protein_axis_split_move;
 mod protein_cis_delins_decomposition;
 mod protein_construct_boundaries;
 mod protein_frameshift_alternatives;

--- a/tests/it/protein_axis_split_move.rs
+++ b/tests/it/protein_axis_split_move.rs
@@ -1,0 +1,377 @@
+//! The protein-axis split move: an **equal-length** `delins` whose interior
+//! leaves a residue unchanged is two or more separate changes, not one `delins`.
+//!
+//! # The clause
+//!
+//! `recommendations/protein/delins.md:21` states it directly — "two variants
+//! separated by one or more amino acids should be described individually and not
+//! as a `delins`" — and `:62-64` publishes the worked answer,
+//! `p.[Ser44Arg;Trp46Arg]`, with the note that "the variant is **not** described
+//! as `p.Ser44_Trp46delinsArgLeuArg`". Unlike the DNA/RNA axes there is no codon
+//! carve-out to compete with it: `general.md:35-38` is a *reading-frame*
+//! exception, and a protein description has no codons of its own.
+//!
+//! The spec's own two rows (W48, W59) are executed against the hermetic spec
+//! fixtures in `spec_worked_example_rules.rs`. This file covers the parts of the
+//! move that the spec does not print an example for — the boundary at which it
+//! must **decline** — because that is where a split move goes wrong.
+//!
+//! # The negative half is the point
+//!
+//! Every case below that must not split names the exact string ferro must not
+//! emit. A positive-only suite would go green on an implementation that split
+//! everything in reach: the unequal-length case, the stop-codon case and the
+//! no-reference case all *look* like the W48 shape and all have a different
+//! right answer.
+//!
+//! Three declines carry an argument rather than a convention:
+//!
+//! - **Unequal length.** A `delins` whose span and payload are the same length
+//!   has exactly one residue-wise correspondence, so an interior unchanged
+//!   residue is a fact about the input. An unequal-length one has none: locating
+//!   a run inside it means first choosing an alignment, which is the
+//!   re-derivation the partition model exists to remove.
+//! - **No protein reference.** The unchanged middle residue is a claim about the
+//!   *reference*. The payload cannot testify to it, so an accession the provider
+//!   cannot serve is declined outright rather than split on the assumption that
+//!   `payload[i]` is what the reference holds.
+//! - **A `Ter` in the reference span.** Replacing the stop is a stop-loss, which
+//!   `protein/extension.md:18` ranks first — "prioritisation: (1) extension, (2)
+//!   frameshift or deletion-insertion" — and `:30` spells `p.Ter110GlnextTer17`.
+//!   Splitting would render it as a plain substitution and lose the extension.
+//! - **A `Ter` in the payload.** `protein/delins.md:47` publishes
+//!   `p.(Pro578_Lys579delinsLeuTer)`, so a stop-introducing change stays a
+//!   `delins` carrying its `Ter`, and the merge pass converges *toward* that
+//!   form. An interior `Ter` is not even authorable — `:45` ("amino acids after
+//!   the translation termination codon are **not** listed") is enforced by the
+//!   parser — so the whole family is left alone.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The accession every case is written against.
+const NP: &str = "NP_003997.1";
+
+/// An unrelated accession the provider also carries, so `has_protein_data()` is
+/// true even in the cases where `NP` itself is absent (#1131's shape).
+const OTHER: &str = "NP_999999.9";
+
+/// A protein whose residues 44, 45, 46 are `Ser`, `Leu`, `Trp` and whose 47 is
+/// `Glu` — the spec's W48 context, extended by one residue so a two-residue
+/// changed run can be exercised beside a single-residue one.
+fn spec_w48_protein() -> String {
+    let mut seq = String::from("M");
+    seq.push_str(&"A".repeat(42)); // residues 2..=43
+    seq.push_str("SLWE"); // residues 44, 45, 46, 47
+    seq.push_str(&"A".repeat(10));
+    seq
+}
+
+/// A provider carrying `NP`'s protein sequence.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(NP, spec_w48_protein());
+    provider
+}
+
+/// A protein whose residue 46 is the stop (`Ter`), residues 44 and 45 being
+/// `Ser` and `Leu` as above. Replacing that stop is a stop-loss, so this is the
+/// reference-side counterpart of the payload-`Ter` fixture.
+fn stop_at_46_protein() -> String {
+    let mut seq = String::from("M");
+    seq.push_str(&"A".repeat(42)); // residues 2..=43
+    seq.push_str("SL*"); // residues 44, 45, 46 — 46 is the stop
+    seq
+}
+
+/// A provider carrying a protein whose span ends at the stop codon.
+fn provider_with_a_reference_stop() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(NP, stop_at_46_protein());
+    provider
+}
+
+/// A provider with protein data for a *different* accession, so
+/// `has_protein_data()` is true while `NP` cannot be fetched.
+fn provider_without_the_accession() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(OTHER, "MAAAAKGSTVE");
+    provider
+}
+
+/// Normalize `input` through `provider`, rendered.
+fn normalize_with(provider: MockProvider, input: &str) -> String {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    Normalizer::new(provider)
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"))
+        .to_string()
+}
+
+/// Assert `input` normalizes to `expected` **and** that `expected` is a fixed
+/// point under the same provider. A split that re-merges on the next pass
+/// satisfies the first half and fails the second.
+fn splits_to(provider: MockProvider, input: &str, expected: &str) {
+    assert_eq!(
+        normalize_with(provider.clone(), input),
+        expected,
+        "for {input:?}"
+    );
+    assert_eq!(
+        normalize_with(provider, expected),
+        expected,
+        "{expected:?} is not a normalization fixed point"
+    );
+}
+
+/// Assert `input` is preserved verbatim, naming the split ferro must not make.
+fn must_not_split(provider: MockProvider, input: &str, forbidden: &str, clause: &str) {
+    let actual = normalize_with(provider, input);
+    assert_ne!(
+        actual, forbidden,
+        "{clause}: {input:?} must not be split into {forbidden:?}"
+    );
+    assert_eq!(actual, input, "{input:?} must be preserved as authored");
+}
+
+// ---------------------------------------------------------------------------
+// The positive half — the move fires
+// ---------------------------------------------------------------------------
+
+/// `protein/delins.md:64` — the spec's own worked example, on a hand-built
+/// reference rather than the spec-fixture provider.
+#[test]
+fn one_unchanged_residue_splits_into_two_substitutions() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+    );
+}
+
+/// `protein/delins.md:21` says "one **or more** amino acids", so a separation of
+/// two is the same rule, not a wider one. Residues 45 and 46 (`Leu`, `Trp`) are
+/// both carried through unchanged; only 44 and 47 change.
+#[test]
+fn two_unchanged_residues_split_the_same_way() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Glu47delinsArgLeuTrpLys"),
+        &format!("{NP}:p.[Ser44Arg;Glu47Lys]"),
+    );
+}
+
+/// A changed run longer than one residue stays a `delins` — a *smaller* one,
+/// over the residues it really claims. `general.md:56` ranks substitution above
+/// delins, so a one-residue run becomes a substitution and a two-residue run
+/// does not.
+#[test]
+fn a_multi_residue_run_becomes_a_smaller_delins_beside_a_substitution() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Glu47delinsArgLeuAlaLys"),
+        &format!("{NP}:p.[Ser44Arg;Trp46_Glu47delinsAlaLys]"),
+    );
+}
+
+/// A predicted input keeps its `( )` — carried onto the whole allele, never onto
+/// the members (`protein/alleles.md:34`, and #1063 for the nucleotide analogue).
+#[test]
+fn a_predicted_delins_splits_inside_its_parentheses() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.(Ser44_Trp46delinsArgLeuArg)"),
+        &format!("{NP}:p.[(Ser44Arg;Trp46Arg)]"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The negative half — the move declines, and what it must not emit
+// ---------------------------------------------------------------------------
+
+/// An **unequal-length** `delins` has no residue-wise correspondence to read, so
+/// there is no unchanged interior residue to find — only an alignment somebody
+/// would have to choose. Left exactly as authored.
+#[test]
+fn an_unequal_length_delins_is_not_split() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArgLys"),
+        &format!("{NP}:p.[Ser44Arg;Trp46_Trp46delinsArgLys]"),
+        "protein/delins.md:21 does not license re-aligning a length-changing delins",
+    );
+}
+
+/// The reference is what says the middle residue is unchanged. With no protein
+/// data at all the question cannot be answered, and guessing from the payload is
+/// exactly the error the rule must not make.
+#[test]
+fn a_provider_with_no_protein_data_declines_rather_than_guessing() {
+    must_not_split(
+        MockProvider::new(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+        "the unchanged middle residue is a claim about the reference",
+    );
+}
+
+/// `has_protein_data()` is a **provider-wide** flag (#1131), so a provider that
+/// carries some other protein still cannot answer for this accession. The fetch,
+/// not the flag, is what decides.
+#[test]
+fn a_provider_missing_this_accession_declines_rather_than_guessing() {
+    must_not_split(
+        provider_without_the_accession(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+        "a provider-wide capability flag is not a reference for this accession",
+    );
+}
+
+/// A `Ter` in the payload is declined. `protein/delins.md:47` publishes
+/// `p.(Pro578_Lys579delinsLeuTer)` — a stop-introducing change *stays* a `delins`
+/// carrying its `Ter` — and `merge::coalesce_protein_adjacent_changes` merges
+/// toward exactly that form, admitting a run whose last member is the earliest
+/// `Ter` (#1129). Splitting the same shape apart would have one axis pulling both
+/// ways at once, so the split move stays out of it.
+#[test]
+fn a_payload_carrying_a_stop_is_declined() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuTer"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Ter]"),
+        "protein/delins.md:47",
+    );
+}
+
+/// And an *interior* `Ter` is not reachable at all: `protein/delins.md:45` — "amino
+/// acids after the translation termination codon are **not** listed" — is enforced
+/// by the parser, so the shape the split move would have had to reason about
+/// cannot be authored. Asserted rather than assumed, because the decline above is
+/// only the whole story while this holds.
+#[test]
+fn an_interior_stop_is_refused_by_the_parser() {
+    let input = format!("{NP}:p.Ser44_Trp46delinsTerLeuArg");
+    assert!(
+        parse_hgvs(&input).is_err(),
+        "protein/delins.md:45: {input} lists residues after the stop and must be refused"
+    );
+}
+
+/// A `Ter` in the **reference span** declines too, and for a different reason
+/// than the payload case above: replacing the stop is a **stop-loss**.
+///
+/// `protein/extension.md:18` ranks the descriptions — "prioritisation: (1)
+/// extension, (2) frameshift or deletion-insertion" — and `:30` publishes the
+/// form, `p.Ter110GlnextTer17`. So the residue that replaces a stop is described
+/// with an extension, never a substitution.
+///
+/// Without this guard the split fires on the reference `Ser-Leu-Ter` against a
+/// payload of `Ala-Leu-His` and emits `p.[Ser44Ala;Ter46His]`, which states the
+/// wrong consequence: it spells a stop-loss as an ordinary substitution and
+/// silently drops the extension. The payload guard cannot catch it — the payload
+/// here carries no `Ter` at all — which is why the reference span needs its own.
+#[test]
+fn a_reference_stop_is_not_split_into_a_substitution() {
+    must_not_split(
+        provider_with_a_reference_stop(),
+        &format!("{NP}:p.Ser44_Ter46delinsAlaLeuHis"),
+        &format!("{NP}:p.[Ser44Ala;Ter46His]"),
+        "protein/extension.md:18 — a stop-loss is an extension, not a substitution",
+    );
+}
+
+/// One contiguous changed run is a genuine `delins`. Nothing separates anything
+/// here, so the move must not fire — this is the case the whole rule is *not*
+/// about, and the one a too-eager splitter would break.
+#[test]
+fn a_fully_changed_run_stays_one_delins() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgAlaArg"),
+        &format!("{NP}:p.[Ser44Arg;Leu45Ala;Trp46Arg]"),
+        "protein/delins.md:19 — consecutive changed residues are one delins",
+    );
+}
+
+/// Two residues is the smallest `delins` there is and has no interior at all.
+/// Guarded so the run scan can never be relaxed into splitting an adjacent pair,
+/// which is the merge direction `protein/substitution.md:23` mandates.
+#[test]
+fn an_adjacent_pair_has_no_interior_to_split() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Leu45delinsArgMet"),
+        &format!("{NP}:p.[Ser44Arg;Leu45Met]"),
+        "protein/substitution.md:23 — adjacent changes are one delins, not two members",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Where the move runs, and where it deliberately does not
+// ---------------------------------------------------------------------------
+
+/// A separated `delins` **inside a cis allele** keeps its delins.
+///
+/// The move runs at the whole-description seam
+/// (`Normalizer::split_protein_separation`), not per allele member: splitting a
+/// member would nest one bracket inside another, and flattening the pieces into
+/// the outer bracket first needs a decision about where the member's `( )`
+/// marker goes (`protein/alleles.md:34` puts it per member, `:90` round the
+/// group). Recorded as a limitation rather than left to emit a nested bracket —
+/// see that helper for the two measured outputs.
+#[test]
+fn a_delins_inside_a_cis_allele_is_left_alone() {
+    let input = format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]");
+    let actual = normalize_with(provider(), &input);
+    assert!(
+        !actual.contains("];"),
+        "a member's split must not nest a bracket inside the allele, got {actual}"
+    );
+    assert_eq!(
+        actual,
+        format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]"),
+        "the separated delins stays a delins inside an allele"
+    );
+}
+
+/// The same for a **trans** allele, and here the reason is harder: the flat form
+/// `p.[Ser44Arg;Trp46Arg];[Ala60Gly]` is legal HGVS and the DNA axis both emits
+/// and reads `g.[A;B];[C]`, but ferro's protein allele grammar accepts only
+/// single-member arms — so emitting it would break the re-parse invariant
+/// (`FERRO_ASSERT_REPARSE`). The gap is asserted below so this decline stops
+/// being necessary the moment the parser closes it.
+#[test]
+fn a_delins_inside_a_trans_allele_is_left_alone() {
+    let input = format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg];[Ala60Gly]");
+    assert_eq!(
+        normalize_with(provider(), &input),
+        input,
+        "the arm's split would produce a description ferro cannot read back"
+    );
+}
+
+/// The parser gap the trans decline rests on, asserted rather than assumed: a
+/// protein allele arm with two members is refused, while its DNA counterpart is
+/// accepted. If this ever starts parsing, revisit
+/// `a_delins_inside_a_trans_allele_is_left_alone`.
+#[test]
+fn the_protein_allele_grammar_reads_only_single_member_arms() {
+    assert!(
+        parse_hgvs(&format!("{NP}:p.[Ser44Arg;Trp46Arg];[Ala60Gly]")).is_err(),
+        "if `p.[A;B];[C]` now parses, the trans decline above is no longer needed"
+    );
+    assert!(
+        parse_hgvs("NC_000001.11:g.[100A>T;102A>T];[200A>T]").is_ok(),
+        "the DNA axis reads a multi-member arm, which is why this is a protein-only gap"
+    );
+}
+
+/// And the whole-description case still splits, which is what makes the two
+/// declines above a *scope* rather than a regression.
+#[test]
+fn the_whole_description_case_still_splits() {
+    assert_eq!(
+        normalize_with(provider(), &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg")),
+        format!("{NP}:p.[Ser44Arg;Trp46Arg]")
+    );
+}

--- a/tests/it/spec_worked_example_rules.rs
+++ b/tests/it/spec_worked_example_rules.rs
@@ -64,7 +64,7 @@
 //!
 //! # Where ferro does not produce the spec's answer
 //!
-//! Three dispositions, kept apart on purpose:
+//! Two dispositions, kept apart on purpose:
 //!
 //! - [`DIVERGENT`] — pinned divergences. Each records ferro's actual output, the
 //!   spec's, and *why* the difference is not a defect (a spec self-conflict, or
@@ -73,10 +73,17 @@
 //!   makes one of these conform **fails**, rather than rotting unnoticed.
 //! - [`PARSE_GAPS`] — a form the spec publishes as *correct* that ferro's parser
 //!   refuses. A defect, pinned so that closing it fails loudly.
-//! - [`FERRO_IS_WRONG`] — the spec is explicit, ferro disagrees, and there is no
-//!   conflicting clause. **[`the_protein_axis_must_split_a_separation_one_delins`]
-//!   is red on purpose.** See its doc comment; it is not a regression, and it
-//!   must not be "fixed" by pinning ferro's answer.
+//!
+//! There was a third, `FERRO_IS_WRONG` — the spec explicit, ferro disagreeing,
+//! no clause competing — and it held exactly two rows: the protein halves of
+//! W48 and W59, an equal-length `delins` whose middle residue is unchanged
+//! (`protein/delins.md:21`, `:64`). Ferro now emits the spec's answer for both,
+//! so they are ordinary [`WORKED`] rows, each with a [`NEGATIVE`] row naming the
+//! unsplit `delins` it must not fall back to and a [`PARTITIONS`] row pinning
+//! the two members, and [`the_protein_axis_splits_a_separation_one_delins`] pins
+//! both spellings converging. The table is gone rather than left empty: a test
+//! iterating an empty table passes vacuously, which the policy above forbids.
+//! Re-create it only for a row that is genuinely wrong.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -293,8 +300,10 @@ const WORKED: &[Worked] = &[
         rebase: Rebase::Accession,
         fixture: Fixture::Protein,
         why: "and so does the protein axis, for adjacent residues \
-              (protein/substitution.md:23). Its separation-1 sibling is the red \
-              row below — the two together locate the gap exactly",
+              (protein/substitution.md:23). Its separation-1 sibling is W48 — the \
+              two together locate the merge/split boundary exactly, and \
+              [`the_protein_axis_splits_a_separation_one_delins`] asserts both \
+              sides of it at once",
     },
     // -- type choice: preferred spellings ------------------------------------
     Worked {
@@ -547,7 +556,35 @@ const WORKED: &[Worked] = &[
         rebase: Rebase::Same,
         fixture: Fixture::Slice,
         why: "the DNA half of the rejected SVD-WG010:53 example: separation 7 \
-              stays split. Its protein half is the red row below",
+              stays split. Its protein half is the row two below",
+    },
+    Worked {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:64",
+        quote: "the variant is not described as `p.Ser44_Trp46delinsArgLeuArg`.",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        published: "p.[Ser44Arg;Trp46Arg]",
+        answer: "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the spec's single clearest split-side worked example, and the protein \
+              analogue of W56/W58/W59 on `general.md:34`. The protein axis has no \
+              codon exception to carry the merge, and the span and the payload are \
+              the same length — so `Leu45` being unchanged is a fact about the \
+              input, not an alignment ferro picked",
+    },
+    Worked {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        published: "p.[Ser988Ala;Gln990His]",
+        answer: "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the protein half of the rejected SVD-WG010:53-54 example — the same \
+              shape at a second locus, which is what makes it systematic rather \
+              than a one-off",
     },
     // -- placement: the 3' rule and its exception ---------------------------
     Worked {
@@ -736,6 +773,28 @@ const NEGATIVE: &[Negative] = &[
               under an unrelated example, `c.9002_9009delinsTTT` — catalog \
               conflict C8, a spec editing slip; the rule it states is the one \
               `substitution.md:37` attaches to the right example)",
+    },
+    Negative {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:64",
+        quote: "the variant is not described as `p.Ser44_Trp46delinsArgLeuArg`.",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        forbidden: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        fixture: Fixture::Protein,
+        why: "the spec names the forbidden string in its own words, so the negative \
+              half is quotable verbatim: the separation-1 protein delins must not \
+              survive as itself",
+    },
+    Negative {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        forbidden: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        fixture: Fixture::Protein,
+        why: "and the same at the second locus. A positive-only assertion would go \
+              green again the moment the split stopped firing and the input became \
+              its own answer",
     },
     Negative {
         id: "W56",
@@ -1012,6 +1071,26 @@ const PARTITIONS: &[Partition] = &[
         why: "separation 7 on the DNA axis",
     },
     Partition {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "should be described individually and not as a \"delins\"",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        members: &[(44, 44), (46, 46)],
+        fixture: Fixture::Protein,
+        why: "two single-residue members with `Leu45` between them and in neither. \
+              Read off the parsed output, because a two-member render over a \
+              44_46 span would be the wrong partition wearing the right string",
+    },
+    Partition {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "should be described individually and not as a \"delins\"",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        members: &[(988, 988), (990, 990)],
+        fixture: Fixture::Protein,
+        why: "the same partition at the second locus",
+    },
+    Partition {
         id: "W60",
         clause: "background/glossary.md:10",
         quote: "a change of the `T` at position 4",
@@ -1105,36 +1184,6 @@ const PARSE_GAPS: &[ParseGap] = &[ParseGap {
           rejects the residue-range payload (`Unexpected trailing characters: \
           '4_Ser6'`), so the row cannot be executed as a normalization at all",
 }];
-
-/// Rows where the spec is explicit, ferro disagrees, and no clause competes.
-///
-/// Executed by [`the_protein_axis_must_split_a_separation_one_delins`], which is
-/// **red on purpose**.
-const FERRO_IS_WRONG: &[Worked] = &[
-    Worked {
-        id: "W48",
-        clause: "recommendations/protein/delins.md:64",
-        quote: "the variant is not described as `p.Ser44_Trp46delinsArgLeuArg`.",
-        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
-        published: "p.[Ser44Arg;Trp46Arg]",
-        answer: "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
-        rebase: Rebase::Accession,
-        fixture: Fixture::Protein,
-        why: "the spec's single clearest split-side worked example",
-    },
-    Worked {
-        id: "W59",
-        clause: "recommendations/protein/delins.md:21",
-        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
-        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
-        published: "p.[Ser988Ala;Gln990His]",
-        answer: "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
-        rebase: Rebase::Accession,
-        fixture: Fixture::Protein,
-        why: "the same shape at a second locus, which is what makes it systematic \
-              rather than a one-off",
-    },
-];
 
 // ---------------------------------------------------------------------------
 // The rows this file does not execute
@@ -1495,7 +1544,7 @@ fn every_row_quotes_the_spec_verbatim() {
     );
 
     let mut citations: Vec<(&str, &str, &str)> = Vec::new();
-    for row in WORKED.iter().chain(FERRO_IS_WRONG) {
+    for row in WORKED.iter() {
         citations.push((row.id, row.clause, row.quote));
     }
     for row in NEGATIVE {
@@ -1555,7 +1604,7 @@ fn every_row_quotes_the_spec_verbatim() {
 /// Every row explains itself.
 #[test]
 fn every_row_records_why_it_is_here() {
-    for row in WORKED.iter().chain(FERRO_IS_WRONG) {
+    for row in WORKED.iter() {
         assert!(!row.why.trim().is_empty(), "{} records no reason", row.id);
     }
     for row in UNEXECUTABLE {
@@ -1686,7 +1735,7 @@ fn every_worked_example_produces_the_spec_published_answer() {
 /// the position pinned separately by [`PARTITIONS`].
 #[test]
 fn every_rebased_answer_differs_from_the_published_string_only_in_its_accession() {
-    for row in WORKED.iter().chain(FERRO_IS_WRONG) {
+    for row in WORKED.iter() {
         match row.rebase {
             Rebase::Same => assert_eq!(
                 row.answer, row.published,
@@ -2028,10 +2077,10 @@ fn the_two_svd_wg010_spellings_of_one_variant_are_two_fixed_points() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — the defect
+// Tests — the protein-axis split move
 // ---------------------------------------------------------------------------
 
-/// **RED ON PURPOSE.** The protein axis does not split a separation-1 delins.
+/// Both spellings of the separation-1 protein change settle on the split form.
 ///
 /// `protein/delins.md:21` — "two variants separated by one or more amino acids
 /// should be described individually and not as a 'delins'" — and its worked
@@ -2039,50 +2088,62 @@ fn the_two_svd_wg010_spellings_of_one_variant_are_two_fixed_points() {
 /// breath, that "the variant is not described as
 /// `p.Ser44_Trp46delinsArgLeuArg`". The protein axis has **no codon exception**:
 /// unlike `general.md:35` on the DNA/RNA axes, nothing licenses merging across
-/// one unchanged residue. So the merged spelling is not a legal description and
-/// must be split.
+/// one unchanged residue.
 ///
-/// Ferro preserves it. Both directions were measured on a hermetic protein whose
-/// residue 45 is `Leu`, so the two spellings denote one protein sequence:
+/// This was red until the split move landed. It is kept as a *convergence*
+/// guard rather than folded into the [`WORKED`] loop, because the row-by-row
+/// tests read one direction each: the [`WORKED`] row proves the delins spelling
+/// reaches the spec's answer and the [`NEGATIVE`] row proves it does not stay
+/// itself, but neither says the *split* spelling is still a fixed point. A split
+/// move that also re-merged, or one that shifted the split spelling somewhere
+/// else, would satisfy both and leave the two spellings non-confluent.
+///
+/// Measured on a hermetic protein whose residue 45 is `Leu`, so the two
+/// spellings denote one protein sequence:
 ///
 /// ```text
-///   p.[Ser44Arg;Trp46Arg]           -> p.[Ser44Arg;Trp46Arg]           (right)
-///   p.Ser44_Trp46delinsArgLeuArg    -> p.Ser44_Trp46delinsArgLeuArg    (wrong)
+///   p.[Ser44Arg;Trp46Arg]           -> p.[Ser44Arg;Trp46Arg]
+///   p.Ser44_Trp46delinsArgLeuArg    -> p.[Ser44Arg;Trp46Arg]
 /// ```
 ///
-/// It is not a rendering quirk and not a one-off: the same shape at
-/// `p.Ser988_Gln990delinsAlaLeuHis` (SVD-WG010.md:53-54, whose merge was
-/// *rejected*) behaves identically. The adjacent case is handled correctly —
-/// `p.[Trp24Cys;Val25Arg]` merges to `p.Trp24_Val25delinsCysArg` (W5) — so the
-/// merge direction works on this axis and only the split direction is missing.
-/// Under the partition model that split is one of the two licensed moves:
-/// an equal-length member whose interior holds an unchanged run reaching it
-/// (`general.md:34`, read backwards). The DNA axis performs it; the protein axis
-/// does not.
-///
-/// **Do not make this test pass by pinning ferro's answer.** There is no
-/// competing clause to cite, so this is not a `DIVERGENT` row. It is either
-/// fixed in `src/` or it stays red.
+/// The adjacent case still merges the other way — `p.[Trp24Cys;Val25Arg]` to
+/// `p.Trp24_Val25delinsCysArg` (W5) — so the two moves meet at separation 0/1
+/// and neither has swallowed the other.
 #[test]
-fn the_protein_axis_must_split_a_separation_one_delins() {
-    let mut failures = Vec::new();
-    for row in FERRO_IS_WRONG {
-        match run(row.fixture, row.input) {
-            Ok(actual) if actual == row.answer => {}
-            Ok(actual) => failures.push(format!(
-                "  [{}] {}\n    spec ({}): {}\n    ferro:   {}\n    {}",
-                row.id, row.input, row.clause, row.answer, actual, row.why
-            )),
-            Err(e) => failures.push(format!("  [{}] {} errored: {e}", row.id, row.input)),
-        }
+fn the_protein_axis_splits_a_separation_one_delins() {
+    // (the split spelling, the delins spelling the spec forbids, the answer)
+    let cases = [
+        (
+            "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+            "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+            "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+        ),
+        (
+            "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+            "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+            "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+        ),
+    ];
+    for (split, delins, answer) in cases {
+        assert_eq!(
+            run(Fixture::Protein, split).expect("the split spelling normalizes"),
+            answer,
+            "`protein/delins.md:21`: the split spelling of {split} must be a fixed point"
+        );
+        assert_eq!(
+            run(Fixture::Protein, delins).expect("the delins spelling normalizes"),
+            answer,
+            "`protein/delins.md:21`: {delins} must be split, not preserved"
+        );
     }
-    assert!(
-        failures.is_empty(),
-        "{} protein worked example(s) are not what the spec publishes. This is a \
-         known, unfixed defect — see this test's doc comment — not a regression, \
-         and not something to pin:\n{}",
-        failures.len(),
-        failures.join("\n")
+
+    // The merge direction is untouched: separation 0 still coalesces, so the
+    // split move has not been widened into the adjacent case.
+    assert_eq!(
+        run(Fixture::Protein, "NP_SPECW05.1:p.[Trp24Cys;Val25Arg]")
+            .expect("the adjacent pair normalizes"),
+        "NP_SPECW05.1:p.Trp24_Val25delinsCysArg",
+        "`protein/substitution.md:23`: two *consecutive* residue changes are still one delins"
     );
 }
 
@@ -2093,7 +2154,7 @@ fn the_protein_axis_must_split_a_separation_one_delins() {
 /// Every id named anywhere in this file, in one set.
 fn covered_ids() -> BTreeSet<&'static str> {
     let mut ids = BTreeSet::new();
-    for row in WORKED.iter().chain(FERRO_IS_WRONG) {
+    for row in WORKED.iter() {
         ids.insert(row.id);
     }
     for row in NEGATIVE {
@@ -2186,10 +2247,12 @@ fn the_unexecutable_census_is_pinned() {
         "the executed / unexecutable / delegated counts no longer partition the 95 rows"
     );
     assert_eq!(
-        (DIVERGENT.len(), PARSE_GAPS.len(), FERRO_IS_WRONG.len()),
-        (2, 1, 2),
-        "the set of rows ferro does not satisfy changed. Each of these three tables \
-         is an adjudication — a divergence with a competing clause, a parser defect, \
-         or a plain defect — so a change here is a ruling, not a fixture edit."
+        (DIVERGENT.len(), PARSE_GAPS.len()),
+        (2, 1),
+        "the set of rows ferro does not satisfy changed. Each of these two tables \
+         is an adjudication — a divergence with a competing clause, or a parser \
+         defect — so a change here is a ruling, not a fixture edit. The third \
+         disposition, `FERRO_IS_WRONG`, was emptied by the protein-axis split move \
+         and removed; re-creating it is also a ruling."
     );
 }


### PR DESCRIPTION
Base is #1566 (`chore/partition-model-cleanups`), not `main`. Full chain at the bottom.

## What the spec requires

`recommendations/protein/delins.md:21` states the rule and `:64` states the prohibition, in the strong form:

> two variants separated by one or more amino acids should be described individually and not as a "delins".

> **NOTE**: the variant is **not** described as `p.Ser44_Trp46delinsArgLeuArg`.

That second one is a prohibition on the unsplit spelling, not a preference between two legal forms — the same kind as the ~49 "not correct" / "is not allowed" clauses in `recommendations/checklist.md`. There is no codon carve-out competing with it on this axis: `general.md:35-38` is a *reading-frame* exception, and a protein description has no codons of its own to share.

Ferro preserved both spellings. Measured before this change, on the hermetic protein fixture whose residue 45 is `Leu` and residue 989 is `Leu`, so each pair of spellings denotes one protein sequence:

| row | input | ferro before | spec / ferro now |
|---|---|---|---|
| W48 | `NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg` | *unchanged* | `NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]` |
| W59 | `NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis` | *unchanged* | `NP_SPECW48.1:p.[Ser988Ala;Gln990His]` |

Those two were the entire contents of `spec_worked_example_rules.rs`'s `FERRO_IS_WRONG` table, executed by a test that was red on purpose.

## The move

An **equal-length** `delins` whose reference and payload agree on at least one interior residue is cut into the maximal runs of disagreement. A one-residue run becomes a substitution (`general.md:56` ranks substitution above delins); a longer one becomes the smaller `delins` it really is.

**Equal length, and only equal length.** A span and a payload of the same length have exactly one residue-wise correspondence, so "the middle residue is unchanged" is a fact about the input. An unequal-length `delins` has no such correspondence: locating a run inside it means first choosing an alignment, which is the re-derivation the partition model exists to remove. Those are left as authored.

**The reference decides, never the payload.** The unchanged middle residue is a claim about the *reference sequence*. An accession the provider cannot serve is declined outright rather than split on the assumption that `payload[i]` is what the reference holds — `has_protein_data()` is provider-wide, so the fetch is what decides (#1131). `Xaa` on either side is declined (equality there is not a statement about identity), and so is a `Ter` in the payload: `delins.md:47` publishes `p.(Pro578_Lys579delinsLeuTer)`, so a stop-introducing change stays a `delins` carrying its `Ter`, and `coalesce_protein_adjacent_changes` already converges toward that form.

**Not routed through the nucleotide canonicalizer.** `merge::canonicalize_from_sequence` applies the edit set to a reference window and re-derives the partition from the resulting sequence. The protein axis has no apply-to-reference — `merge::cis_kind_of` returns `None` for `Protein` for exactly that reason — so the move reads the reference residues directly. `cis_kind_of` and `is_splittable_single_member` are untouched.

## Where the pass runs, and one defect that found

It runs at the whole-description seam (`normalize_core_canonical`, beside `canonicalize_from_sequence`), **not** inside `normalize_protein`. Wiring it into the per-variant path was tried first and measured; it produced two defects that every bare-description test passes straight over:

```text
p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]
  -> [NP_003997.1:p.Ala60Gly;NP_003997.1:p.[Ser44Arg;Trp46Arg]]
p.[Ser44_Trp46delinsArgLeuArg];[Ala60Gly]
  -> NP_003997.1:p.[Ser44Arg;Trp46Arg];[Ala60Gly]        (does not re-parse)
```

The first is a nested bracket carrying a repeated accession, which is not a description. The second *is* legal HGVS — the DNA axis emits `g.[A;B];[C]` and reads it back — but ferro's **protein** allele grammar accepts only single-member arms, so normalization would emit a string `parse_hgvs` refuses. That is what `FERRO_ASSERT_REPARSE` exists to catch, and its exemption list is closed on purpose.

So the move applies to a whole `p.` description and **declines for a member of one**. Both declines are pinned as tests, as is the parser gap the trans one rests on (`the_protein_allele_grammar_reads_only_single_member_arms`), so the decline stops being necessary the moment the parser closes it. Closing it also needs a decision this PR does not take: where an inner allele's `( )` marker goes once its members flatten into the outer bracket — `protein/alleles.md:34` puts it per member, `:90` puts it round the group.

## Tests

- W48 and W59 move from `FERRO_IS_WRONG` into `WORKED`, each gaining a `NEGATIVE` row naming the exact unsplit `delins` it must not fall back to and a `PARTITIONS` row pinning the two members read off the *parsed* output.
- The red-on-purpose test becomes `the_protein_axis_splits_a_separation_one_delins`, a **convergence** guard: both spellings settle on the split form, and separation 0 still merges (`p.[Trp24Cys;Val25Arg]` -> `p.Trp24_Val25delinsCysArg`). The per-row tests each read one direction; this reads both, so a split move that also re-merged would satisfy them and fail this.
- `FERRO_IS_WRONG` is **removed**, not left empty — a test iterating an empty table passes vacuously, which that file's own policy forbids. The census pin drops from `(2, 1, 2)` to `(2, 1)`, which is a deliberate edit rather than a silent one.
- New `tests/it/protein_axis_split_move.rs`, 15 tests, covering the boundary the spec prints no example for. Positive: separation 1, separation 2, a two-residue run beside a substitution, the predicted `( )` wrapper, and a fixed-point check on every answer. Negative, each naming the exact forbidden string: unequal length, no protein data at all, protein data for a different accession, a `Ter` payload, a fully-changed run, an adjacent pair, and the two allele-member declines.

Nothing was re-blessed and no assertion was weakened.

## Verification — SUPERSEDED BY THE 2026-08-09 RESTACK, re-measurement pending

The table below was taken against **`1ae51110`**, which was #1566's head *before* the restack. That head no longer exists: #1566 is now `95e283e8`, rebased onto #1565's current generation, and this branch was rebased onto it. **The 46 -> 45 delta below therefore describes a parent that is gone**, and is kept only as the record of what was measured when. It needs re-running against `95e283e8` before this leaves draft. What the delta established — one row fixed, zero new — is the claim to re-establish, not to assume.

| | failures |
|---|---|
| baseline (`1ae51110`, superseded, `--release`) | 46 |
| this branch at that time (`--release`) | 45 |
| this branch at that time, `FERRO_ASSERT_{IDEMPOTENT,REPARSE,IN_BOUNDS}=1`, debug | 45 |

Set difference in both directions was exactly one row fixed — `spec_worked_example_rules::the_protein_axis_must_split_a_separation_one_delins`, the red-on-purpose row this PR closes — and **zero new**. The three sibling rows in that file (`every_worked_example_produces_the_spec_published_answer`, `the_forbidden_description_is_never_what_ferro_emits`, `the_normal_forms_assert_the_partitions_the_spec_asserts`) were red from the separate #1484 interaction, all three reporting only `[W58] LRG_199t1:c.[992_1002del;1004T>C]` — a row that #1570 has since fixed further up the stack, which is one reason the re-measurement is expected to land on different numbers rather than the same ones.

`cargo check --features dev --all-targets`, `cargo fmt --all --check`, `cargo clippy --all-features --all-targets` all clean at the time of that run.

## Blast radius

**Read the corpus numbers below as an upper bound on a shape, not as a measured move count** — and note first that the two committed harnesses are structurally blind here, which is why no `0 moved` figure is quoted:

- `examples/dump_normalized_corpus.rs` has **no protein axis** (`g`, `c`, `cx` only, no protein provider), so it cannot exhibit the property at all.
- The local prepared reference carries **`protein_fastas: []`**, so running the candidate rows through `ferro normalize --reference` reports `changed=0` for a reason that has nothing to do with this change.

What *can* be counted is how many rows are even in reach: an equal-length protein `delins` spanning ≥ 3 residues. Everything else on the protein axis, and the whole DNA/RNA side, is untouchable by this pass.

| committed corpus | protein `delins` ranges | equal-length | equal-length, span ≥ 3 |
|---|---|---|---|
| `clinvar_hgvs_unique` | 180 | 51 | **4** |
| `clinvar_hgvs_500k` | 414 | 91 | **5** |
| `cmrg_genes_exhaustive` | 5,553 | 1,519 | **190** |
| `paraphase_genes_exhaustive` | 1,139 | 359 | **36** |
| total | 7,286 | 2,020 | **235** |

So ~3.2 % of protein `delins` range descriptions are in reach, and each of those additionally needs an interior residue that matches its reference — which for a *derived* consequence (the CMRG/Paraphase rows) means the consequence was over-merged, i.e. the thing this rule fixes.

The evidence that carried weight was the suite: 9,768 tests, 45 failures, the set byte-identical to baseline minus this PR's own row, with **nothing re-blessed**. For an output-moving change that is the strong signal — every existing expectation already agreed with the new answer, and the only strings that moved are the two the spec publishes. That evidence is on the superseded parent and is being re-taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protein-level replacement variants can now be automatically separated into distinct substitutions or smaller replacements when unchanged residues clearly divide multiple changed regions.
  * Normalized descriptions preserve allele and termination semantics where applicable.

* **Bug Fixes**
  * Improved consistency between equivalent protein replacement and substitution spellings.
  * Variants that are ambiguous, unsupported, contiguous, unequal in length, or contain stop codons remain unchanged rather than being incorrectly split.

* **Tests**
  * Expanded coverage for normalization, allele syntax, edge cases, and worked examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!---GHSTACKOPEN-->
### Stacked PR Chain: partition-normalizer

Seven PRs, one arc: implement the partitioner, measure it, fix it with the measurements. Verified mechanically on 2026-08-09 with `git merge-base --is-ancestor` across all six links, after a restack that moved every head except #1565's — so any measurement in these descriptions taken before that restack is flagged where it appears rather than left reading as current.

| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#1565|feat(normalize): make the partition rule govern every block|**N/A** (`main`)|
|#1566|chore(normalize): restate the comment the partition rule made false|#1565|
|#1568|feat(normalize): split an equal-length protein delins whose interior is unchanged|#1566|
|#1567|feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases|#1568|
|#1570|test(normalize): adjudicate the rows the partition model moved|#1567|
|#1571|fix(normalize): typing may not widen a member past its asserted span|#1570|
|#1572|feat(conformance): an exhaustive spec-derived corpus, and the burn-down it measures|#1571|

Merge order is top to bottom. #1565 owns the whole stack's representation move — it carries the `FERRO_PARTITION` default flip to `preserve`, and `FERRO_PARTITION=live` restores every pinned census exactly.

<!---GHSTACKCLOSE-->

Representation-Change: protein axis only, split direction. An equal-length `p.` delins spanning >= 3 residues whose interior matches the reference now renders as a cis allele of the changes it describes (`p.Ser44_Trp46delinsArgLeuArg` -> `p.[Ser44Arg;Trp46Arg]`); the reverse merge and every other axis are unchanged. 2 rows move in the committed spec corpus, both to the form the spec publishes. Upper bound of ~235 rows across the four committed real corpora (7,286 protein delins ranges), each additionally requiring an interior reference match; not measurable locally because the prepared reference carries no protein FASTAs and the dump harness has no protein axis. Previously-accepted inputs, so a real migration for anyone storing protein delins strings. This is a per-PR declaration and is independent of the stack-wide move #1565 declares; the two do not overlap, since #1565's figures are DNA/transcript axes only.
