### PR TITLE
fix(normalize): typing may not widen a member past its asserted span

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7997,7 +7997,10 @@ pub(crate) fn demote_repeats_spanning_siblings<P: ReferenceProvider>(
         ) {
             continue;
         }
-        let Some(source) = cis_axis_parts(&before[i], kind).and_then(|(_, _, _, _, e)| match e {
+        // The *differential* reading of what the repeat grew out of: how many
+        // bases the asserted member added or removed. `None` for anything else,
+        // which is where the state-based route below takes over.
+        let differential = cis_axis_parts(&before[i], kind).and_then(|(_, _, _, _, e)| match e {
             // A deletion removes the bases under its span.
             NaEdit::Deletion { .. } => Some((RepeatSource::Removed, b.end - b.start + 1)),
             // A duplication adds a copy of the bases under its span.
@@ -8009,11 +8012,8 @@ pub(crate) fn demote_repeats_spanning_siblings<P: ReferenceProvider>(
                 .and_then(|n| i64::try_from(n).ok())
                 .map(|n| (RepeatSource::Added, n)),
             _ => None,
-        }) else {
-            continue;
-        };
-        let (source, length) = source;
-        if length <= 0 || b.region != a.region {
+        });
+        if differential.is_some_and(|(_, length)| length <= 0 || b.region != a.region) {
             continue;
         }
         // Does the tract actually swallow a sibling? Both snapshots, so a
@@ -8035,17 +8035,103 @@ pub(crate) fn demote_repeats_spanning_siblings<P: ReferenceProvider>(
                 .flatten()
                 .filter(|s| s.region == a.region && s.accession == a.accession)
         };
-        let spans_sibling_bases = siblings()
-            .filter(|s| s.claims_bases)
-            .any(|s| s.start <= a.end && s.end >= a.start);
-        let spans_sibling_junction = siblings()
-            .filter(|s| !s.claims_bases)
-            .filter_map(|s| s.junction)
-            .any(|junction| junction >= a.start && junction < a.end);
+        let spans_bases_of = |t: &MemberSpan| {
+            siblings()
+                .filter(|s| s.claims_bases)
+                .any(|s| s.start <= t.end && s.end >= t.start)
+        };
+        let spans_junction_of = |t: &MemberSpan| {
+            siblings()
+                .filter(|s| !s.claims_bases)
+                .filter_map(|s| s.junction)
+                .any(|junction| junction >= t.start && junction < t.end)
+        };
+        let spans_sibling_bases = spans_bases_of(a);
+        let spans_sibling_junction = spans_junction_of(a);
         let spans_sibling = spans_sibling_bases || spans_sibling_junction;
         if !spans_sibling {
             continue;
         }
+        let Some((source, length)) = differential else {
+            // No differential source, because the widening was not a repeat
+            // spelling of a `del`/`dup`/`ins`. Typing still widened this
+            // member's rendered extent — from the span the input's partition
+            // asserted to the whole tandem tract — and that is a boundary move,
+            // so it needs a licence whatever the asserted member was spelled as.
+            //
+            // The measured shape is `TEMPLATE:g.[2_3dup;5_6insA]` on the nine-`T`
+            // tract under a 5' shuffle, reaching the allele a second time from
+            // `canonicalize_from_sequence`: the partition-preserving
+            // re-derivation hands the member back as `before = g.1delinsTTT`,
+            // which names no duplicated or deleted length, and typing widens it
+            // to `after = g.1_9T[11]` — a tract containing the sibling's `5|6`
+            // junction.
+            //
+            // The repeat states its own growth, so re-spell that growth as an
+            // insertion — **at the asserted member's own junction**, which is
+            // the boundary the partition fixed.
+            //
+            // Scoped to a widening this pass can attribute to typing, and only
+            // to one. An **authored** overlap is a different question with a
+            // settled, opposite answer: ferro reports the conflict and hands the
+            // description back rather than picking an order the spec does not
+            // rank (#395, #486, #1004). `g.[263_265A[7];264_265insC]` and
+            // `g.[1005_1009inv;1005_1006A[4]]` are exactly that — the repeat
+            // arrives already spanning its sibling, `before == after`, and
+            // nothing here widened it — so both gates below must hold: the
+            // rendered extent has to reach outside the asserted one, and the
+            // asserted one must not have spanned a sibling already.
+            //
+            // Deliberately not at the tract's 3' junction, and not as the
+            // 3'-most duplication the differential routes below emit. Those are
+            // safe only because `clamp_sibling_crossing_shifts` and
+            // `clamp_sibling_crossing_junctions` run immediately after and pull
+            // the member back off the sibling — and both refuse a member whose
+            // span *grew* relative to its snapshot, which is exactly the
+            // geometry here (a one-base `delins` re-spelled as a two-base
+            // `dup`). Measured: targeting the tract's 3' end turns
+            // `g.[2_3dup;5_6insA]` into `g.[5_6insA;8_9dup]` — disjoint,
+            // re-parsing, warning-free and denoting a different sequence, which
+            // is strictly worse than the overlap it replaced.
+            let widened = a.start < b.start || a.end > b.end;
+            if !widened || spans_bases_of(b) || spans_junction_of(b) {
+                continue;
+            }
+            let Some((payload, unit)) = repeat_growth_as_insertion(&after[i], kind, a) else {
+                continue;
+            };
+            let Ok(unit_len) = i64::try_from(unit.len()) else {
+                continue;
+            };
+            // A base-claiming member's junction is the interbase immediately 3'
+            // of its last base; a junction-carrying one names its own.
+            let gap = b.junction.unwrap_or(b.end);
+            // Inside the tract, or flush against either end of it. Outside it
+            // the payload is not the tract's own sequence and inserting it there
+            // would state bases the repeat never asserted.
+            if gap < a.start - 1 || gap > a.end {
+                continue;
+            }
+            // A tandem tract repeats with period `unit_len`, so the payload —
+            // whole copies of the unit — denotes the same sequence at any
+            // in-phase junction and a *rotated* sequence anywhere else. Refuse
+            // the out-of-phase junctions rather than rotate: a homopolymer, the
+            // shape every measured case has, is trivially in phase.
+            if (gap - (a.start - 1)) % unit_len != 0 {
+                continue;
+            }
+            respell_at_gap(
+                &mut after[i],
+                a,
+                gap,
+                NaEdit::Insertion {
+                    sequence: InsertedSequence::Literal(Sequence::new(payload)),
+                },
+                provider,
+                TerminalOverrun::RespellAtBoundary,
+            );
+            continue;
+        };
         // Either way the equivalent edit sits on the 3'-most `length` bases of
         // the tract: removing them, or duplicating them.
         let start = a.end - length + 1;
@@ -10572,20 +10658,28 @@ mod tests {
             "the demotion left a tract repeat containing its sibling's junction: {rendered:?}"
         );
 
-        // THE DEFECT, characterised. The pass is *differential*: it compares a
-        // `before` snapshot against an `after` one and re-spells a repeat back to
-        // the edit it *grew from*. So it can only undo a respelling it has just
-        // observed. Hand it the swallowing form as BOTH snapshots — which is what
-        // a re-normalization does, since the form is a fixed point — and there is
-        // no growth to read, so it declines and the overlap stands.
+        // ADJUDICATED, and this half now pins a deliberate limit rather than an
+        // open defect. The pass is *differential*: it compares a `before`
+        // snapshot against an `after` one and re-spells a repeat back to the edit
+        // it grew from, so it can only undo a respelling it has just observed.
+        // Hand it the swallowing form as BOTH snapshots and there is no growth to
+        // read.
         //
-        // That is why the repair is structurally unavailable for this shape, and
-        // why `members_claim_the_same_territory` (a state predicate, not a
-        // differential one) is the right shape of check. What is NOT yet decided
-        // is where to apply it on this path: refusing the repeat spelling at
-        // source, or demoting unconditionally when territory is claimed. Both are
-        // output-moving and need their own measurement, so this test pins the
-        // mechanism rather than pre-judging the fix.
+        // The state-based fallback added for the *widening* path deliberately
+        // does not fire here, and both of its gates are why: nothing widened
+        // (`before == after`), and the asserted member already spanned its
+        // sibling. That is an **authored** conflict, and ferro's standing answer
+        // to one is to report it and hand the description back rather than pick
+        // an order the spec does not rank (#395, #486, #1004) — repairing it here
+        // would launder a strict-rejected input into a strict-accepted output,
+        // which is the #1307 failure mode. `repeat_lowering_sibling_junction` and
+        // `idempotency_tests::test_overlap_conflicting_allele_is_idempotent_across_respellings`
+        // pin two such alleles as preserved; `typing_must_not_widen_a_member`
+        // pins this one.
+        //
+        // So a repair reaching this call is a *regression* against that answer,
+        // not the closure of a defect. What was closed is the widening path,
+        // where `before` is the pre-typing member — see the fallback's own notes.
         let fixed_point = [
             crate::parse_hgvs("NC_TEST.1:g.1_9T[11]").expect("parses"),
             crate::parse_hgvs("NC_TEST.1:g.5_6insA").expect("parses"),
@@ -10600,8 +10694,8 @@ mod tests {
         );
         assert!(
             members_claim_the_same_territory(&after, CisKind::Genome, &provider),
-            "if this now repairs, the differential blindness is fixed — delete this \
-             half of the test and close the defect rather than re-blessing it"
+            "an authored conflict must be handed back, not repaired — a repair here \
+             launders a strict-rejected input into a strict-accepted output (#1307)"
         );
     }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -442,6 +442,7 @@ mod supernumerary;
 mod sweep_filter_invariant;
 mod tool_support_matrix;
 mod trans_mosaic_mixed;
+mod typing_must_not_widen_a_member;
 mod uta_loader_tests;
 mod variantvalidator_tests;
 mod web_service_tests;

--- a/tests/it/multi_member_cis_axis.rs
+++ b/tests/it/multi_member_cis_axis.rs
@@ -637,6 +637,34 @@ fn measure_axis(provider: &Arc<MultiFastaProvider>) -> AxisCensus {
 /// `respelling_converged` must only ever go up; `not_idempotent` and
 /// `sequence_changed` are asserted at zero on their own before the comparison,
 /// so a regression there names itself rather than surfacing as a moved tuple.
+///
+/// # LOWERED BY TWO, 376 -> 374, and the direction is deliberate
+///
+/// This is the one place the ratchet has been turned back, so it needs its
+/// reason recorded next to the number rather than in a commit message.
+///
+/// The typing-widening repair in this change stops a rendered member covering
+/// territory its asserted span did not claim — the shape where `g.[2_3dup;5_6insA]`
+/// came out as `g.[1_9T[11];5_6insA]`, a tract containing the sibling's `5|6`
+/// junction. Two of these 461 rows reached their converged form *through* such a
+/// widening, so refusing it costs their convergence.
+///
+/// That trade is what `adjudication-precedence-order` ranks, and it is not close:
+/// an allele whose members claim the same territory **denotes no single
+/// sequence**, so emitting one is a rank-(1) validity failure, while convergence
+/// is rank (2). Rank (1) is absolute and never traded, so two lost convergences
+/// is the correct price and not a regression to be argued down. It is also *not*
+/// a `PRECEDENCE_ESCALATIONS` entry: an escalation is confluence overriding the
+/// recommended form, and here validity simply outranks confluence, which is the
+/// ordinary case the ladder describes.
+///
+/// What would make this a real regression, and is separately asserted above:
+/// `sequence_changed` rising. The rejected alternative repair — re-spelling the
+/// growth at the *tract's* 3' junction rather than the asserted member's — turned
+/// `g.[2_3dup;5_6insA]` into `g.[5_6insA;8_9dup]`, which is disjoint,
+/// warning-free, re-parses, and denotes a **different sequence**. It would have
+/// raised this ratchet while corrupting data. Convergence going up is therefore
+/// not on its own evidence of an improvement here.
 const AXIS_CENSUS: AxisCensus = AxisCensus {
     rows: 592,
     declined: 0,
@@ -644,7 +672,7 @@ const AXIS_CENSUS: AxisCensus = AxisCensus {
     unwindowed: 96,
     sequence_changed: 0,
     respellable: 461,
-    respelling_converged: 376,
+    respelling_converged: 374,
 };
 
 #[test]

--- a/tests/it/typing_must_not_widen_a_member.rs
+++ b/tests/it/typing_must_not_widen_a_member.rs
@@ -1,0 +1,320 @@
+//! Typing may widen a member's rendered extent — but not onto a sibling.
+//!
+//! The partition model's invariant is that **a member's boundaries come from the
+//! input's asserted partition and its bases come from the derived sequence**.
+//! `partition_block_preserving` honours it structurally: it takes each member's
+//! span from the description and reads that member's payload out of the applied
+//! window.
+//!
+//! There is a third stage after partitioning, and it is not covered by that
+//! guarantee: **typing**, which decides whether a `(span, payload)` pair renders
+//! as `dup`, `ins`, `delins`, `inv` or a repeat. `repeated.md` B2 spells an edit
+//! inside a tandem tract as a copy count over the **whole tract**, so typing can
+//! *widen* a member's rendered extent — the asserted member is `g.2_3dup`, the
+//! rendered member is `g.1_9T[11]`. Same bases, same asserted member, wider
+//! rendered span. Under the ruling that the partition is the unit of
+//! normalization, that widening is a **boundary change**, and it needs the same
+//! licence any other boundary move needs.
+//!
+//! Widening as such is legal and must stay legal — a lone member has no sibling
+//! to reach, and `a_widening_with_no_sibling_on_the_tract_is_still_licensed`
+//! pins that. What is not licensed is widening **into territory a sibling
+//! claims**:
+//!
+//! ```text
+//! TTTTTTTTTAATATATTTTA
+//!   g.[2_3dup;5_6insA]   ->  g.[1_9T[11];5_6insA]   junction 5|6 inside 1_9
+//!   g.[2dup;4dup;6T>A]   ->  g.[1_9T[11];6T>A]      base 6 inside 1_9
+//! ```
+//!
+//! The pair claims one interbase point twice, so it denotes no single sequence
+//! at all: `parse_hgvs` accepts it, the SPDI apply oracle declines it. That is a
+//! defect and not a reading — an overlapping allele has no clause to weigh —
+//! so nothing here is re-blessable.
+//!
+//! # Where the widening was caught, and why the repair is where it is
+//!
+//! Measured by instrumenting every per-member correction pass in
+//! `Normalizer::normalize_allele` and printing each member's rendered extent
+//! after each stage, for `TEMPLATE:g.[2_3dup;5_6insA]` under a 5' shuffle. Two
+//! distinct widenings, one repaired and one not:
+//!
+//! | stage | member before | member after | repaired? |
+//! |---|---|---|---|
+//! | `normalize_core` (`rules::duplication_to_repeat`) | `g.2_3dup` | `g.1_9T[11]` | yes |
+//! | `canonical_split_for_variant` → `normalize_core` (`rules::insertion_to_repeat`) | `g.1delinsTTT` | `g.1_9T[11]` | **no** |
+//!
+//! The second reaches the allele a second time, from
+//! `Normalizer::canonicalize_from_sequence`: the re-derivation hands the member
+//! back as `g.1delinsTTT`, and `merge::demote_repeats_spanning_siblings` is
+//! *differential* — it reads the length from the pre-normalization member's edit
+//! type (`Deletion` / `Duplication` / `Insertion`) — so a `delins` yields
+//! nothing to re-spell to and the pass declines. It declines a second time on
+//! the fixed point, where `before == after == g.1_9T[11]` and there is no growth
+//! to difference at all. Both declines were observed directly, not inferred.
+//!
+//! Typing itself is sibling-blind by construction — `normalize_core` sees one
+//! member — so the licence check has to sit where siblings are visible, which is
+//! that same pass. It now falls back to reading the growth off the repeat and
+//! re-spells it at **the asserted member's own junction**.
+//!
+//! # The near-miss, and why the negative half names it
+//!
+//! The first cut re-spelled the growth at the tract's 3' junction, which is what
+//! the pass's differential routes do — safe there only because the clamps that
+//! run immediately after pull the member back off the sibling. Both clamps refuse
+//! a member whose span *grew* relative to its snapshot, and a one-base `delins`
+//! re-spelled as a two-base `dup` is exactly that geometry, so nothing bounded
+//! it. The result was `g.[5_6insA;8_9dup]`: disjoint, re-parsing, warning-free,
+//! in bounds, and denoting a different sequence.
+//!
+//! That cut turned every overlapping row in the three exhaustive sweeps in
+//! `cis_junction_crossing_shift.rs` into a *sequence-changing* row — strictly
+//! worse, because a consumer can reject an overlap and cannot see this. The
+//! sweeps' `overlapping.is_empty()` assertion went green on it. So the negative
+//! half below names that string too: a guard that only asserts the right answer
+//! would have reported the wrong fix as progress.
+
+use crate::common::cis_apply_oracle::{apply, member_interbase_spans, normalize_in};
+use ferro_hgvs::ShuffleDirection;
+
+/// Nine `T` at positions 1-9 — a tract long enough to canonicalise to a repeat,
+/// with non-`T` bases after it so the tract has a definite 3' end. The same
+/// constant the three exhaustive sweeps use.
+const TRACT: &str = "TTTTTTTTTAATATATTTTA";
+
+#[test]
+fn a_typed_repeat_does_not_widen_over_a_siblings_junction() {
+    // The asserted `2_3dup` types as `1_9T[11]`, whose tract contains the
+    // sibling's `5|6` junction. Re-spelled at the boundary the partition
+    // asserted and then clamped, the pair settles two members apart.
+    assert_eq!(
+        normalize_in(
+            TRACT,
+            "TEMPLATE:g.[2_3dup;5_6insA]",
+            ShuffleDirection::FivePrime
+        ),
+        "TEMPLATE:g.[3_4dup;5_6insA]"
+    );
+}
+
+#[test]
+fn a_typed_repeat_does_not_widen_over_a_siblings_bases() {
+    // Same widening, reached from two duplications that merge; the sibling
+    // claims base 6 rather than a junction.
+    assert_eq!(
+        normalize_in(
+            TRACT,
+            "TEMPLATE:g.[2dup;4dup;6T>A]",
+            ShuffleDirection::FivePrime
+        ),
+        "TEMPLATE:g.6_7insTA"
+    );
+}
+
+/// Both answers denote what the input denoted, checked through the SPDI applier
+/// rather than through the normalizer.
+///
+/// The two rows above pin strings, which is a *canonical form* claim. This is
+/// the claim that actually cannot be re-blessed: an overlapping allele denotes no
+/// sequence, and a disjoint allele denoting the wrong one is the silent failure
+/// the near-miss produced.
+#[test]
+fn the_repaired_answers_denote_the_input_sequence() {
+    for input in ["TEMPLATE:g.[2_3dup;5_6insA]", "TEMPLATE:g.[2dup;4dup;6T>A]"] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let output = normalize_in(TRACT, input, direction);
+            let want = apply(TRACT, input).expect("the input denotes a sequence");
+            let got = apply(TRACT, &output).unwrap_or_else(|| {
+                panic!("{input} [{direction:?}] -> {output} denotes no single sequence")
+            });
+            assert_eq!(got, want, "{input} [{direction:?}] -> {output}");
+        }
+    }
+}
+
+/// The forbidden outputs, named exactly.
+///
+/// Two shapes, and both must be named. The first two strings are the swallowing
+/// form this defect is: a tract-wide copy count containing a sibling. The third
+/// is the near-miss described in the module docs — disjoint, so every oracle in
+/// the tree is blind to it except an apply comparison, and produced by re-spelling
+/// the growth at the tract's 3' end instead of at the asserted boundary.
+#[test]
+fn the_swallowing_and_near_miss_forms_are_never_emitted() {
+    for (input, forbidden) in [
+        (
+            "TEMPLATE:g.[2_3dup;5_6insA]",
+            "TEMPLATE:g.[1_9T[11];5_6insA]",
+        ),
+        ("TEMPLATE:g.[2_3dup;5_6insA]", "TEMPLATE:g.[5_6insA;8_9dup]"),
+        ("TEMPLATE:g.[2dup;4dup;6T>A]", "TEMPLATE:g.[1_9T[11];6T>A]"),
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let output = normalize_in(TRACT, input, direction);
+            assert_ne!(
+                output, forbidden,
+                "{input} [{direction:?}] emitted the forbidden form"
+            );
+        }
+    }
+}
+
+/// The negative control the repair must not break: widening is what
+/// `repeated.md` B2 asks for, and with no sibling on the tract there is nothing
+/// to swallow.
+///
+/// Both entries are lone members, which is the only configuration in which the
+/// full tract-wide extent is unambiguously right. If either of these starts
+/// reporting a narrower spelling, the licence check has become a ban.
+#[test]
+fn a_widening_with_no_sibling_on_the_tract_is_still_licensed() {
+    assert_eq!(
+        normalize_in(TRACT, "TEMPLATE:g.1_2dup", ShuffleDirection::FivePrime),
+        "TEMPLATE:g.1_9T[11]"
+    );
+    assert_eq!(
+        normalize_in(TRACT, "TEMPLATE:g.2_3insTT", ShuffleDirection::FivePrime),
+        "TEMPLATE:g.1_9T[11]"
+    );
+}
+
+/// The scope boundary, and the reason the repair carries two gates rather than
+/// one.
+///
+/// An **authored** overlap is a different question with a settled and opposite
+/// answer: ferro reports the conflict and hands the description back rather than
+/// picking an order the spec does not rank (#395, #486, #1004). So the swallowing
+/// form entered *as input* must survive verbatim — typing did not widen it, it
+/// arrived that way — and the repair must not launder it into a tidy single
+/// member that strict mode would then accept.
+///
+/// This is what the repair's `widened` and "the asserted member did not already
+/// span a sibling" gates buy. Without them the same fallback also rewrites
+/// `g.[263_265A[7];264_265insC]` and `g.[1005_1009inv;1005_1006A[4]]`, which are
+/// pinned as preserved by `repeat_lowering_sibling_junction` and
+/// `idempotency_tests` respectively.
+#[test]
+fn an_authored_swallowing_allele_is_still_preserved_verbatim() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize_in(TRACT, "TEMPLATE:g.[1_9T[11];5_6insA]", direction),
+            "TEMPLATE:g.[1_9T[11];5_6insA]",
+            "an authored conflict must be reported, not repaired ({direction:?})"
+        );
+    }
+}
+
+/// The invariant itself, over the whole family the defect lives in, stated
+/// without naming a single output string.
+///
+/// For every pairing of a tract-growing first member with a sibling — a junction
+/// member, a base-claiming member, in both shuffle directions — the rendered
+/// members must occupy **pairwise disjoint interbase territory**, and the allele
+/// must denote what it denoted. Reading extents from `member_interbase_spans`
+/// rather than from the printed endpoints is what makes "rendered extent" mean
+/// the same thing here as in the diagnosis: `a_b ins` names two positions while
+/// occupying one junction, and a repeat names its tract.
+///
+/// Deliberately a property and not a table. The three exhaustive sweeps in
+/// `cis_junction_crossing_shift.rs` already enumerate far more shapes; what this
+/// adds is the *extent* reading, so a future widening that denotes the right
+/// sequence while claiming a sibling's territory fails here even where an apply
+/// comparison would pass.
+#[test]
+fn no_rendered_member_claims_a_siblings_territory() {
+    let mut checked = 0usize;
+    let mut violations: Vec<String> = Vec::new();
+
+    for first_start in 1..=6usize {
+        for first_len in 1..=2usize {
+            let first_end = first_start + first_len - 1;
+            let span = if first_len == 1 {
+                format!("{first_start}")
+            } else {
+                format!("{first_start}_{first_end}")
+            };
+            // `dup` and `ins` both reach the tract through a junction, and both
+            // type as a copy count over it. `del` is the shape the differential
+            // route already covered.
+            for first in [format!("{span}dup"), format!("{span}del")] {
+                for second_pos in first_end + 2..=9usize {
+                    for second in [
+                        format!("{second_pos}_{}insA", second_pos + 1),
+                        format!("{second_pos}T>A"),
+                        format!("{second_pos}del"),
+                        format!("{second_pos}dup"),
+                    ] {
+                        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                        {
+                            let input = format!("TEMPLATE:g.[{first};{second}]");
+                            // An input that denotes no sequence has nothing to
+                            // preserve; the generator can emit one at the tract
+                            // edges.
+                            let Some(want) = apply(TRACT, &input) else {
+                                continue;
+                            };
+                            let output = normalize_in(TRACT, &input, direction);
+                            checked += 1;
+
+                            let spans = member_interbase_spans(TRACT, &output);
+                            for (i, first) in spans.iter().enumerate() {
+                                for second in &spans[i + 1..] {
+                                    if claims_same_territory(*first, *second) {
+                                        violations.push(format!(
+                                            "{input} [{direction:?}] -> {output} \
+                                             claims {first:?} and {second:?} at once"
+                                        ));
+                                    }
+                                }
+                            }
+                            match apply(TRACT, &output) {
+                                Some(got) if got == want => {}
+                                Some(got) => violations.push(format!(
+                                    "{input} [{direction:?}] -> {output} \
+                                     (want {want}, got {got})"
+                                )),
+                                None => violations.push(format!(
+                                    "{input} [{direction:?}] -> {output} denotes no sequence"
+                                )),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // A floor, so the enumeration cannot go hollow while the assertion below
+    // stays green. The loop bounds are fixed, so this is a structural count and
+    // not a measured one.
+    assert!(
+        checked > 400,
+        "the family went hollow: only {checked} cases enumerated"
+    );
+    assert!(
+        violations.is_empty(),
+        "rendered members claim one another's territory in {checked} cases: {violations:#?}"
+    );
+}
+
+/// Do two half-open interbase spans claim the same territory?
+///
+/// Flush adjacency (`hi == other_lo`) is **not** an overlap — that is the #999
+/// adjacency the collapse pass exists to catch, and treating it as one would make
+/// this guard reject the correct answers. Three things are:
+///
+/// * two *zero-length* spans at one interbase, since nothing orders the two
+///   payloads (#1286);
+/// * a zero-length span strictly inside a non-empty one, which is this defect —
+///   a copy count over a tract cannot express another member adding sequence
+///   among those bases (#1287);
+/// * two non-empty spans that intersect at all.
+fn claims_same_territory((lo, hi): (u64, u64), (other_lo, other_hi): (u64, u64)) -> bool {
+    match (lo == hi, other_lo == other_hi) {
+        (true, true) => lo == other_lo,
+        (true, false) => lo > other_lo && lo < other_hi,
+        (false, true) => other_lo > lo && other_lo < hi,
+        (false, false) => lo < other_hi && other_lo < hi,
+    }
+}


### PR DESCRIPTION
Base is #1570 (`test/partition-model-adjudications`), not `main`. Full chain at the bottom.

`TEMPLATE:g.[2_3dup;5_6insA]` on a nine-`T` tract normalized to `TEMPLATE:g.[1_9T[11];5_6insA]`, whose repeat tract contains the sibling insertion's `5|6` junction. The pair claims one interbase point twice, so it **denotes no single sequence**. Ten such outputs in the two-member sweep of 46,080.

This is the defect #1565 pins the mechanism for and #1570 leaves red on purpose (`cause-unverified`, three exhaustive sweeps, 187,776 cases). This PR is the fix, and the three sweeps go green here.

## The mechanism, measured rather than reasoned

The partition model fixes each member's boundaries from the input's asserted partition and reads its bases from the derived sequence — which is what makes sequence preservation *structural* rather than checked. But a **third stage** runs after partitioning: **typing**, which decides whether `(span, payload)` renders as `dup`, `ins`, `delins`, `inv` or a repeat, and which may **widen** the rendered extent. So the partition fixed the boundary and typing moved it back, asking no licence.

Caught in the act. Under a 5′ shuffle the allele reaches `canonicalize_from_sequence` a second time, and the partition-preserving re-derivation hands the member back as `before = g.1delinsTTT` — which names **no duplicated or deleted length**. `demote_repeats_spanning_siblings` is *differential*: it re-spells a repeat back to the edit it grew out of. With no length to read it declined, and the widened tract shipped.

This adds the state-based route for exactly that case: where typing widened a member's rendered extent past its asserted span, **and** the asserted span did not already span a sibling, the repeat's own stated growth is re-spelled as an insertion at the **asserted member's** junction.

## Two boundaries the repair deliberately does not cross

- **An authored overlap is a different question with a settled, opposite answer.** Ferro reports the conflict and hands the description back rather than picking an order the spec does not rank (#395, #486, #1004). `g.[263_265A[7];264_265insC]` arrives already spanning its sibling — `before == after`, nothing widened it. Both gates must hold.
- **Re-spelling at the *tract's* 3′ junction was measured and rejected.** It turns `g.[2_3dup;5_6insA]` into `g.[5_6insA;8_9dup]`: disjoint, warning-free, re-parses — and **denotes a different sequence**. It would have *raised* the convergence ratchet while corrupting data, which is the sharpest available reminder that convergence going up is not on its own evidence of an improvement.

## The convergence ratchet is turned back, 376 -> 374

The only time it has gone down, with the reason recorded beside the number rather than in a commit message. Two of the 461 respellable rows reached their converged form *through* such a widening, so refusing it costs their convergence.

Under `adjudication-precedence-order` that trade is not close: an allele whose members claim the same territory denotes no single sequence, so emitting one is a **rank-(1) validity** failure, while convergence is **rank (2)**. Rank (1) is absolute and never traded. Two lost convergences is the price, not a regression to argue down.

Explicitly **not** a `PRECEDENCE_ESCALATIONS` entry: an escalation is confluence overriding the *recommended form*. Here validity outranks confluence, which is the ordinary case the ladder describes.

## Verification — measured before the 2026-08-09 restack

- All three `cis_junction_crossing_shift` sweeps go green, plus 7 new tests in `typing_must_not_widen_a_member` with a negative half naming the exact forbidden strings.
- **32 -> 30 failures**, name lists diffed rather than counts compared.
- **Identical 30 under a debug run with `FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS` all set — zero oracle-only failures.** Worth stating because those three are `#[cfg(debug_assertions)]`, so a release-only gate compiles them out and cannot see them.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets` clean.

**The parent has since moved.** The restack rebased this branch onto `7df520ed`, so the absolute 32 -> 30 counts are due a re-run; the claims to re-establish are "three sweeps green", "zero newly red" and "identical set under the three seam oracles", not the number 30.

<!---GHSTACKOPEN-->
### Stacked PR Chain: partition-normalizer

Seven PRs, one arc: implement the partitioner, measure it, fix it with the measurements. Verified mechanically on 2026-08-09 with `git merge-base --is-ancestor` across all six links, after a restack that moved every head except #1565's — so any measurement in these descriptions taken before that restack is flagged where it appears rather than left reading as current.

| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#1565|feat(normalize): make the partition rule govern every block|**N/A** (`main`)|
|#1566|chore(normalize): restate the comment the partition rule made false|#1565|
|#1568|feat(normalize): split an equal-length protein delins whose interior is unchanged|#1566|
|#1567|feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases|#1568|
|#1570|test(normalize): adjudicate the rows the partition model moved|#1567|
|#1571|fix(normalize): typing may not widen a member past its asserted span|#1570|
|#1572|feat(conformance): an exhaustive spec-derived corpus, and the burn-down it measures|#1571|

Merge order is top to bottom. #1565 owns the whole stack's representation move — it carries the `FERRO_PARTITION` default flip to `preserve`, and `FERRO_PARTITION=live` restores every pinned census exactly.

<!---GHSTACKCLOSE-->

Representation-Change: 10 previously-invalid outputs in the two-member sweep of 46,080 are repaired, and 2 rows of `multi_member_cis_axis`' 461 respellable real-data rows lose their converged form (`respelling_converged` 376 -> 374). The repaired outputs were never valid descriptions — an allele claiming one interbase point twice denotes no sequence — so no consumer can hold a correct stored string for them. The 2 convergence losses are the disclosed cost of that repair, and the direction is fixed by `adjudication-precedence-order`: validity is rank (1), convergence is rank (2). This is the per-PR delta on top of #1565's stack-wide move and is not additive with it; #1565's separate `main` -> this-branch measurement of 6,851 of 78,298 rows already includes these.
