### PR TITLE
fix(changelog): read a decline as a decline when text follows the trailer

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -135,7 +135,22 @@ commit_parsers = [
   # `DECLINE_TERMINATORS` in `scripts/check_representation_change.py` by
   # `test_decline_vocabulary_matches_the_changelog_config` and
   # `test_the_two_decline_rules_agree_value_by_value`.
-  { footer = "(?i)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*(?:[.;:—–][\\s\\S]*)?$", group = "<!-- 7 -->Other" },
+  #
+  # **`m`, because git-cliff matches this against the whole footer value, which spans
+  # lines** (#1573). Without it `$` is end-of-*string*, so the rule only fires when the
+  # decline is the last thing in the message -- and anything appended after a BARE `none`
+  # defeats it. That is not hypothetical: CodeRabbit appends a release-notes block to the
+  # PR description, GitHub makes the description the squash body, and `3ebcdddd` (#1551)
+  # declined and was then filed under "Representation changes" in the v0.14.0 changelog.
+  # The `[.;:—–]` terminator above does not cover it, because the character following a
+  # bare decline is a newline rather than punctuation.
+  #
+  # With `m` the verdict is read off the trailer's own line, which is what the checker
+  # already does -- its `TRAILER_RE` is `re.IGNORECASE | re.MULTILINE` and takes the value
+  # from one line. The two halves now agree by construction rather than by coincidence.
+  # A reason may still span lines: `[\s\S]*` after a terminator is unchanged, and `,` is
+  # still excluded, so `none, except two rows` remains a real change.
+  { footer = "(?im)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*(?:[.;:—–][\\s\\S]*)?$", group = "<!-- 7 -->Other" },
   # A declining commit lands in `Other` whatever its type, so a `fix:` that correctly
   # declined is not listed under `Fixed` (#1557). That is a known cost of the ordering
   # above, not an oversight, and the obvious repair does not work: **git-cliff evaluates a

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -55,8 +55,19 @@ WATCHED_PREFIXES: tuple[str, ...] = (
 #: space as the value, so a bare `Representation-Change:` with nothing after it counted as
 #: a declaration — the precise hole this check exists to close. And `\s` spans newlines, so
 #: a permissive class would let the value be scavenged from the *following* line.
+#:
+#: **The token must sit at column 0** (#1573). The pattern used to allow `[ \t]*` before it,
+#: which made this checker recognise as a *trailer* what git and git-cliff both treat as a
+#: *continuation* of the value above it — and `CONTRIBUTING.md` documents indentation as
+#: exactly that continuation mechanism. The disagreement is only reachable when a
+#: continuation line itself opens with the token, i.e. when a PR description quotes a
+#: declining example under its own real disclosure, but there it is the whole defect: the
+#: quoted example became a second declaration here and stayed prose for git-cliff. Requiring
+#: column 0 makes both halves count the same trailers, which is what lets `check` refuse a
+#: genuine duplicate and pass an indented quotation. Measured over every open PR at the time
+#: of the change: no description carried an indented trailer, so nothing was reclassified.
 TRAILER_RE = re.compile(
-    r"^[ \t]*Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
+    r"^Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -103,25 +114,53 @@ def watched_files(changed: list[str]) -> list[str]:
     return [p for p in changed if any(p.startswith(prefix) for prefix in WATCHED_PREFIXES)]
 
 
+def find_declarations(text: str) -> list[str]:
+    """Return every trailer value in `text`, in the order they appear.
+
+    Plural because *how many* there are is itself a verdict — see `check`. One trailer is
+    the only shape whose meaning both this checker and `release-plz.toml` agree on.
+    """
+    return [match.group("value") for match in TRAILER_RE.finditer(text)]
+
+
 def find_declaration(text: str) -> str | None:
-    """Return the trailer's value, or `None` when the text carries no trailer."""
-    match = TRAILER_RE.search(text)
-    return match.group("value") if match else None
+    """Return the first trailer's value, or `None` when the text carries no trailer."""
+    declarations = find_declarations(text)
+    return declarations[0] if declarations else None
 
 
 def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
     """
     Decide whether `changed` is adequately declared by `declaration_text`.
 
-    Returns `(ok, message)`. `ok` is False only when a watched file changed and no
-    trailer is present at all — a trailer whose value is `none` passes, because
-    declining is a declaration.
+    Returns `(ok, message)`. `ok` is False in two cases: a watched file changed and no
+    trailer is present at all, or the message carries more than one trailer. A trailer
+    whose value is `none` passes, because declining is a declaration.
     """
+    # Refused BEFORE the watched-file test, and deliberately: the harm is in changelog
+    # grouping, which applies to every commit, not only to the ones touching a watched
+    # directory. This job already runs on every PR.
+    declarations = find_declarations(declaration_text)
+    if len(declarations) > 1:
+        listed = "\n".join(f"  Representation-Change: {value}" for value in declarations)
+        return False, (
+            f"{len(declarations)} `Representation-Change:` trailers found:\n{listed}\n\n"
+            "Keep exactly one. Two trailers do not mean anything consistent, because this\n"
+            "check and the changelog resolve them differently: this check reads the FIRST\n"
+            "trailer, while git-cliff matches its footer rule against EVERY footer and takes\n"
+            "the first rule that matches any of them -- so a decline anywhere wins there,\n"
+            "whatever its position. A message disclosing a move and then declining one\n"
+            "therefore passes here as a disclosure and is filed under `Other` in the\n"
+            "changelog, and the disclosure silently disappears.\n\n"
+            "Delete the superseded trailer, or indent it if it is quoted as an example --\n"
+            "an indented line is a continuation of the value above it, not a new trailer."
+        )
+
     watched = watched_files(changed)
     if not watched:
         return True, "No file under a watched directory changed; no declaration needed."
 
-    declaration = find_declaration(declaration_text)
+    declaration = declarations[0] if declarations else None
     if declaration is None:
         listed = "\n".join(f"  {p}" for p in sorted(watched))
         return False, (

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -26,6 +26,7 @@ _SPEC.loader.exec_module(check_representation_change)
 
 check = check_representation_change.check
 find_declaration = check_representation_change.find_declaration
+find_declarations = check_representation_change.find_declarations
 watched_files = check_representation_change.watched_files
 WATCHED_PREFIXES = check_representation_change.WATCHED_PREFIXES
 
@@ -135,10 +136,119 @@ def test_an_empty_trailer_value_is_not_a_declaration() -> None:
     assert find_declaration("Representation-Change:   \n") is None
 
 
+@pytest.mark.parametrize("indent", [" ", "  ", "\t", "    "])
+def test_an_indented_trailer_is_not_a_trailer(indent: str) -> None:
+    """The token must sit at column 0, because that is where git and git-cliff require it.
+
+    `CONTRIBUTING.md` documents indentation as the way to continue a trailer's *value* onto
+    another line, so a checker that read an indented line as a new trailer contradicted the
+    convention it enforces. A sole indented trailer now fails as absent — which is the
+    honest answer, since git-cliff would not group it either and the disclosure would be
+    lost rather than merely unread.
+    """
+    assert find_declaration(f"{indent}Representation-Change: none") is None
+    ok, message = check(["src/normalize/merge.rs"], f"{indent}Representation-Change: none")
+    assert not ok, "an indented trailer must not satisfy the check"
+    assert "Representation-Change: none" in message, "the message must show the column-0 form"
+
+
 @pytest.mark.parametrize("value", ["none", "None", "NONE", "no", "n/a", "na"])
 def test_decline_spellings_all_pass(value: str) -> None:
     ok, _ = check(["src/normalize/merge.rs"], f"Representation-Change: {value}")
     assert ok
+
+
+# ---------------------------------------------------------------------------
+# Exactly one trailer, because two do not mean anything consistent
+# ---------------------------------------------------------------------------
+
+#: A real disclosure followed by a *quoted* declining example at column 0. The shape is
+#: invited by `CONTRIBUTING.md`, which documents the declining form, and by a corrected
+#: trailer added without deleting the superseded one.
+_TWO_TRAILERS = (
+    "Representation-Change: 577 rows move, 360 merge.\n"
+    "\n"
+    "For contrast, a declining trailer looks like:\n"
+    "Representation-Change: none\n"
+)
+
+
+def test_two_trailers_are_refused() -> None:
+    """Neither half of the machinery can resolve two trailers the same way, so refuse.
+
+    Measured against git-cliff 2.13.1 with the real config: this message groups under
+    **Other**, because git-cliff matches its footer rule against *every* footer and takes
+    the first rule that matches any of them, so a decline wins wherever it sits. This
+    checker reads the *first* trailer and calls the same message a real disclosure. The
+    commit then passes CI as a disclosure and is filed as a decline, and the disclosure
+    disappears from the changelog — the under-reporting direction of #1522, one commit at
+    a time.
+
+    It is not an anchoring bug and #1573's `m` does not reach it: the shape reproduces
+    identically under `(?i)`, `(?im)` and `(?im)\\A`, because the second line is parsed as
+    its own footer and the rule matches at *that* footer's start.
+
+    Refusing rather than picking a winner keeps the rule that a decline must be *stated*,
+    never inferred from a message that also says the opposite.
+    """
+    ok, message = check(["src/normalize/merge.rs"], _TWO_TRAILERS)
+    assert not ok, "two trailers must not pass; the changelog and this check disagree on them"
+    assert "2 `Representation-Change:` trailers found" in message
+    assert "577 rows move, 360 merge." in message, "the message must show what it found"
+    assert "none" in message
+
+
+def test_two_trailers_are_refused_even_with_no_watched_file() -> None:
+    """The harm is in changelog grouping, which applies to every commit.
+
+    So this is refused ahead of the watched-file test — a docs-only commit reaches the
+    changelog exactly like a `src/normalize/` one.
+    """
+    ok, message = check(["README.md"], _TWO_TRAILERS)
+    assert not ok
+    assert "trailers found" in message
+
+
+def test_two_declining_trailers_are_still_refused() -> None:
+    """Even when both agree, one of them is unmaintained. Ambiguity is the defect."""
+    ok, _ = check(["src/hgvs/variant.rs"], "Representation-Change: none\nRepresentation-Change: no")
+    assert not ok
+
+
+def test_an_indented_second_trailer_is_a_continuation_not_a_second_trailer() -> None:
+    """The escape hatch the refusal message names must actually work.
+
+    Indenting makes the line a continuation of the value above it, which is also how
+    git-cliff sees it — measured, the indented form groups under **Representation
+    changes** where the column-0 form groups under **Other**. So the fix the message
+    recommends is the one that makes both halves agree.
+    """
+    body = (
+        "Representation-Change: 577 rows move, 360 merge.\n"
+        "\n"
+        "For contrast, a declining trailer looks like:\n"
+        "    Representation-Change: none\n"
+    )
+    assert find_declarations(body) == ["577 rows move, 360 merge."]
+    ok, _ = check(["src/normalize/merge.rs"], body)
+    assert ok
+
+
+def test_one_trailer_still_passes() -> None:
+    """The ordinary case, pinned so the refusal above cannot widen onto it."""
+    for body in (
+        "Representation-Change: none",
+        "Representation-Change: none. Tests only.",
+        "Some prose.\n\nCloses #1.\n\nRepresentation-Change: 577 rows move, 360 merge.\n",
+    ):
+        ok, _ = check(["src/normalize/merge.rs"], body)
+        assert ok, f"{body!r} carries exactly one trailer and must pass"
+
+
+def test_find_declarations_returns_every_value_in_order() -> None:
+    assert find_declarations("no trailer here") == []
+    assert find_declarations("Representation-Change: none") == ["none"]
+    assert find_declarations(_TWO_TRAILERS) == ["577 rows move, 360 merge.", "none"]
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +337,12 @@ def test_decline_vocabulary_matches_the_changelog_config() -> None:
     is told to declare something the changelog then hides.
     """
     config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    match = re.search(r'footer = "\(\?i\)\^Representation-Change:[^"]*?\(([^)]+)\)', config)
+    # `[a-z]*i[a-z]*` rather than `[a-z]+`: the flag group gained `m` in #1573, so matching
+    # `(?i)` literally would read as a rename -- but dropping the `i` requirement entirely
+    # would let this find a case-*sensitive* rule while asserting it found the opposite.
+    match = re.search(
+        r'footer = "\(\?[a-z]*i[a-z]*\)\^Representation-Change:[^"]*?\(([^)]+)\)', config
+    )
     assert match is not None, (
         "no case-insensitive Representation-Change exclusion rule found in release-plz.toml; "
         "the decline vocabulary cannot be checked"
@@ -255,7 +370,12 @@ def test_the_two_decline_rules_agree_value_by_value() -> None:
     rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
     assert rules, "no Representation-Change exclusion rule found in release-plz.toml"
     # The rule is a TOML basic string, so its backslashes are escaped in the file.
-    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"), re.MULTILINE)
+    #
+    # Compiled with NO flags of our own: whatever the rule needs it must declare inline,
+    # because git-cliff adds none either. Passing `re.MULTILINE` here -- as this test did
+    # until #1573 -- makes the harness kinder than production and hides exactly the class
+    # of anchoring bug it exists to catch.
+    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"))
 
     values = [
         "none",
@@ -283,6 +403,67 @@ def test_the_two_decline_rules_agree_value_by_value() -> None:
             f"{'a decline' if by_checker else 'a real change'}; the changelog and CI must "
             "agree, or a PR passes the check and is then filed as its opposite"
         )
+
+
+#: What a bot appends after the trailer. CodeRabbit posts a block like this on essentially
+#: every PR, and GitHub builds the squash commit body from the PR description, so it reaches
+#: the commit message verbatim and lands *after* the trailer.
+_APPENDED_BLOCK = (
+    "\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->\n"
+    "## Summary by CodeRabbit\n"
+    "- Tests: added coverage.\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "is_a_decline"),
+    [
+        ("none", True),
+        ("NONE", True),
+        ("none. Comment prose only.", True),
+        ("none; tests only", True),
+        ("n/a: docs", True),
+        ("577 rows move, 360 merge / 205 split.", False),
+        ("none, except two rows that merge.", False),
+    ],
+)
+def test_a_trailer_keeps_its_verdict_when_text_is_appended_after_it(
+    value: str, is_a_decline: bool
+) -> None:
+    """Trailing text must not invert the verdict — #1573, and #1526 in a new shape.
+
+    git-cliff matches the exclusion rule against the **whole footer value**, which spans
+    lines. Anchored with `$` and no `m` flag, the rule only fired when the decline was the
+    last thing in the message, so a bare `none` followed by an appended block was filed
+    under **Representation changes**. `3ebcdddd` (#1551) is the real instance: it declined,
+    CodeRabbit appended release notes, and the v0.14.0 changelog listed it as a change.
+
+    The reason-terminator set from #1555 does not cover this: after a bare decline the next
+    character is a newline, not one of `.;:—–`.
+
+    Every other guard in this file inspects the config as a *string* — vocabulary, casing,
+    ordering — and all of them passed throughout the bug, because anchoring is a behaviour.
+    """
+    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
+    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
+    assert rules, "no Representation-Change exclusion rule found in release-plz.toml"
+    # No flags of our own: git-cliff supplies none, so the rule must declare what it needs.
+    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"))
+
+    footer = f"Representation-Change: {value}{_APPENDED_BLOCK}"
+    assert (changelog_rule.search(footer) is not None) == is_a_decline, (
+        f"{value!r} followed by an appended block is filed as "
+        f"{'a real change' if is_a_decline else 'a decline'} by release-plz.toml; text "
+        "appended after a trailer must not change what the trailer says"
+    )
+
+    # And the checker must reach the same verdict on the same message, since disagreeing is
+    # what lets a PR pass CI and then render as its opposite.
+    declaration = find_declaration(footer)
+    assert declaration is not None, "the checker no longer finds a trailer it used to find"
+    assert check_representation_change.declines(declaration) == is_a_decline, (
+        f"{value!r}: the checker and release-plz.toml disagree once a block is appended"
+    )
 
 
 def test_the_ordering_prefix_is_stripped_from_rendered_headings() -> None:
@@ -316,7 +497,10 @@ def test_both_representation_change_rules_are_case_insensitive() -> None:
     rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
     assert len(rules) == 2, f"expected an exclusion and an inclusion rule, found {rules}"
     for rule in rules:
-        assert rule.startswith("(?i)"), (
+        # Read the inline flag group rather than matching `(?i)` literally, so that adding
+        # another flag -- `m`, in #1573 -- does not read as "the rule became case-sensitive".
+        flags = re.match(r"\(\?([a-z]+)\)", rule)
+        assert flags is not None and "i" in flags.group(1), (
             f"rule {rule!r} is case-sensitive; the checker's own trailer regex is not, so the "
             "two disagree about whether `REPRESENTATION-CHANGE:` is a declaration"
         )


### PR DESCRIPTION
A `Representation-Change: none` trailer stops being read as a decline as soon as anything is appended after it, and the commit is then filed under **Representation changes** as if it had moved output.

Closes #1573. Closes #1586.

## The mechanism

git-cliff matches a `footer` rule against the **whole footer value**, which can span lines. The exclusion rule declared `(?i)` and anchored with `$`, so `$` meant end-of-*string* and the rule only fired when the decline was the last thing in the message.

#1555 let a reason follow the verdict, terminated by one of `.;:—–`. That does not cover a **bare** decline, because the character after it is a newline rather than punctuation. So `none. Tests only.` was read correctly and plain `none` was not — as long as something followed it.

Something almost always follows it: CodeRabbit appends a release-notes block to essentially every PR description, and GitHub builds the squash commit body from the description.

## It is live in a shipping artifact

`3ebcdddd` (#1551) declared `Representation-Change: none`, CodeRabbit appended its block, and the open v0.14.0 release PR (#1563) lists it as a representation change:

```
### Representation changes

- *(normalize)* widen the axis gate to c./n./r. (#1484)
- *(conformance)* refuse to write an artifact built from a partial generator pass (#1551)   <- declined
```

One of those two entries is real. This is #1526 recurring in the shape #1555 did not reach.

## Why every existing guard passed

`scripts/check_representation_change.py` parses the trailer with `re.IGNORECASE | re.MULTILINE` and reads the value off the trailer's **own line**. It calls `3ebcdddd` a decline. The changelog rule calls the same commit a disclosure. The checker and the changelog give opposite verdicts on one commit, which is precisely the drift `test_decline_vocabulary_matches_the_changelog_config` was written for — and it passes, because the two halves agree on *vocabulary* and disagree on *anchoring*.

`test_the_two_decline_rules_agree_value_by_value` was the one guard positioned to catch it, and it could not, for a reason worth recording:

```python
changelog_rule = re.compile(rules[0].replace("\\\\", "\\"), re.MULTILINE)
```

It supplied `re.MULTILINE` itself. git-cliff supplies no flags, so the harness was strictly kinder than production and the rule under test was not the rule that ships. Every other guard in the file inspects the config as a *string* — vocabulary, casing, ordering — and anchoring is a behaviour.

## The change

Add `m` to the exclusion rule, so the verdict is read off the trailer's own line, which is what the checker already does. The two halves now agree by construction rather than by coincidence.

`[\s\S]*` after a terminator is untouched, so a reason may still span lines, and `,` is still excluded, so `none, except two rows` remains a real change.

The test now compiles the configured rule with **no flags of its own**, and a new case pins the verdict against text appended after the trailer.

## Verified by rendering, not by assertion

Ten trailer shapes through git-cliff 2.13.1 with the real config, `(?i)` versus `(?im)`, nothing else changed:

| # | trailer | want | `(?i)` | `(?im)` |
|---|---|---|---|---|
| 1 | `none` | Other | Other | Other |
| 2 | `none` + CodeRabbit block | Other | **Representation changes** | Other |
| 3 | `none. Comment prose only.` | Other | Other | Other |
| 4 | `none. <reason>` + block | Other | Other | Other |
| 5 | `none; tests only` | Other | Other | Other |
| 6 | `NONE` + block | Other | **Representation changes** | Other |
| 7 | `577 rows move, 360 merge / 205 split.` | Representation changes | Representation changes | Representation changes |
| 8 | real disclosure + block | Representation changes | Representation changes | Representation changes |
| 9 | real, multi-line indented continuation | Representation changes | Representation changes | Representation changes |
| 10 | `none, except two rows that merge.` | Representation changes | Representation changes | Representation changes |

Rows 2 and 6 are the bug. Rows 3–5 confirm #1555's reason-style declines are unaffected; row 10 confirms the deliberate exclusion of `,` survives.

End to end, over the real history — #1560's rendered-output audit run against `v0.13.1..HEAD`:

```
before:  3 commits in v0.13.1..HEAD; 2 listed as representation changes
         3ebcdddd is filed under Representation changes but its trailer opens with a decline: 'none'
after:   3 commits in v0.13.1..HEAD; 1 listed as representation changes
         Representation changes section is consistent with the trailers.
```

The new test fails on exactly the two bare-decline cases with the config reverted and nothing else changed, and 52 pass with the fix.

## Second fix, same family: two trailers in one message (#1586)

Found while verifying the above by rendering. It is the same "the two halves disagree" defect in the one shape `m` does not reach, so it is fixed here rather than left open.

The two halves resolve *duplicates* differently. This checker reads the **first** trailer (`TRAILER_RE.search`, singular). git-cliff matches its footer rule against **every** footer and takes the first rule that matches any of them, so a decline wins from wherever it sits. A message that discloses a move and then quotes a declining example therefore passes CI as a disclosure and is filed under **Other** — the disclosure silently disappears, which is #1522's under-reporting direction one commit at a time.

Measured against git-cliff 2.13.1 on the real config:

```
checker   -> '577 rows move, 360 merge.'  declines? False  => REAL CHANGE
git-cliff -> group = Other                                 => DECLINE
```

**It is not an anchoring bug, and `m` does not reach it.** It reproduces identically under `(?i)`, under `(?im)` as this PR ships it, and with `\A` substituted for `^`, because the second line is parsed as its own footer and the rule matches at *that* footer's start. So `\A` would buy nothing here and is not proposed.

| exclusion rule | bare `none` + appended block | two trailers |
|---|---|---|
| `(?i)` (before) | wrong | wrong |
| `(?im)` (this PR) | right | wrong |
| `(?im)\A` | right | wrong |

**Refuse rather than resolve.** git-cliff evaluates every footer, so "first trailer wins" cannot be expressed as a footer regex — there is no rule that makes it agree. `check` now fails on more than one trailer, ahead of the watched-file test, because changelog grouping applies to every commit and this job already runs on every PR. That also keeps the rule that a decline must be *stated*, never inferred from a message that also says the opposite.

**The trailer token must now sit at column 0.** The pattern allowed `[ \t]*` before it, so the checker read as a *trailer* what git and git-cliff treat as a *continuation* — and `CONTRIBUTING.md` documents indentation as exactly that mechanism. Aligning it is what makes the escape hatch in the refusal message true: an indented quotation is one trailer to both halves, while a column-0 duplicate is refused. A sole *indented* trailer now fails as absent, which is the honest answer, since git-cliff would not group it either.

Blast radius, measured over every open PR at the time of the change: **no description carries a duplicate or an indented trailer**, so nothing is reclassified.

All three shapes now agree:

| shape | git-cliff (measured) | checker |
|---|---|---|
| col-0 duplicate | Other | refused, never ships |
| indented quotation under a disclosure | Representation changes | Representation changes |
| bare decline + appended block | Other | Other |


## Relationship to #1559 / #1560

#1560 adds the rendered-output audit this class needs and its rule **does** flag this commit — I ran its script against current `main` to check. It is the detector; this is the fix, and the two are complementary. Worth knowing for sequencing: #1560's `Changelog grouping audit` is green only because that run predates #1551 landing on `main`. Rebasing it onto current `main` should turn it red until this merges.

## Testing

- `pytest tests/python/test_representation_change_trailer.py` — **62 pass** (52 before, 10 new for the duplicate-trailer and column-0 rules).
- Control: with only the config flag reverted, the two bare-decline cases fail.
- #1560's own audit script, run against real history (`v0.13.1..HEAD`): clean with this fix (`Representation changes section is consistent with the trailers`), and with only the flag reverted it flags `3ebcdddd`. So the detector and the fix are verified against each other, not just asserted to be complementary.
- `ruff check` / `ruff format --check` clean on `tests/python/`.
- The rest of `tests/python/` cannot be collected in a fresh worktree without `maturin develop --features python` (`ModuleNotFoundError: No module named 'ferro_hgvs'`); that is unrelated to this change, which touches only the TOML config and a stdlib-only test module.

Representation-Change: none. Changelog config, the trailer checker and their tests only; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched.

