### PR TITLE
feat(normalize): let normalizer warnings reach the caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ ferro check --reference ferro-reference --build-cache
 ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
 ```
 
+> **Read the warnings.** Normalization sometimes *repairs* a description in a way
+> the normalized string does not record — separately reported cis members merged
+> into one `delins` (`MEMBERS_COALESCED_FROM_REPORTED_FORM`), a `ins[100_110]`
+> reference-range payload replaced by the bases it denotes
+> (`INSERTED_SEQUENCE_EXPANDED`), a stated reference base that contradicted the
+> reference and was accepted anyway (`REFSEQ_MISMATCH`). Those are reported as
+> `warning[CODE]: message` on **stderr** (and in the `warnings` array under
+> `--format json`, the `detail` column under `--format tsv`), so a pipeline
+> reading only stdout will not see them. `--error-mode strict` is not a
+> substitute: it rejects a specific ladder of conditions and reports the rest
+> exactly as lenient does.
+
 > **Throughput tip:** when normalizing many variants, feed them **sorted by transcript accession (or by genomic position)**. ferro caches each resolved transcript, so consecutive variants on the same transcript skip the (dominant) cost of re-reading and re-building it from the reference. Sorted input keeps the relevant transcripts resident in the cache and is markedly faster on large batches — see [Performance Comparison](#performance-comparison).
 
 ### Optional reference data
@@ -146,6 +158,13 @@ print(str(variant))          # "NM_000088.3:c.459A>G"
 # Normalize with reference data
 normalizer = ferro_hgvs.Normalizer(reference_json="ferro-reference/cdot.json")
 normalized = normalizer.normalize("NM_000088.3:c.459del")
+
+# `normalize` returns only the string, so it cannot tell you that normalization
+# repaired something. `normalize_with_warnings` returns the same string plus the
+# diagnostics — as a free function, or as a Normalizer method.
+result = normalizer.normalize_with_warnings("NM_000088.3:c.459del")
+print(str(result.result))                      # the same normalized string
+print([(w.code, w.message) for w in result.warnings])
 ```
 
 ## Supported HGVS Syntax

--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -96,6 +96,7 @@ __all__ = [
     # Core functions
     "parse",
     "normalize",
+    "normalize_with_warnings",
     # SPDI functions
     "parse_spdi",
     "hgvs_to_spdi",
@@ -155,6 +156,7 @@ __all__ = [
     "ErrorConfig",
     "ParseResultWithWarnings",
     "NormalizationWarning",
+    "NormalizeResultWithWarnings",
     # Backtranslation classes
     "CodonChange",
     "CodonTable",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -54,6 +54,45 @@ def normalize(hgvs_string: str, direction: str = "3prime") -> str:
     """
     ...
 
+def normalize_with_warnings(
+    hgvs_string: str, direction: str = "3prime"
+) -> NormalizeResultWithWarnings:
+    """Normalize an HGVS variant string, returning the warnings with it.
+
+    The warning-bearing sibling of :func:`normalize`, which returns only the
+    string and so cannot tell a caller that normalization *repaired* something.
+    Several repairs are lossy in a way the returned string does not record —
+    ``MEMBERS_COALESCED_FROM_REPORTED_FORM`` (separately reported cis members
+    were merged), ``INSERTED_SEQUENCE_EXPANDED`` (a bracketed/range ``ins``
+    payload became a literal), ``REFSEQ_MISMATCH`` (a stated reference base was
+    corrected) — so on :func:`normalize` they look exactly like a clean pass.
+
+    The normalized string is identical to what :func:`normalize` returns; only
+    the diagnostics are added.
+
+    Args:
+        hgvs_string: The HGVS variant description to normalize
+        direction: Shuffle direction - "3prime" (default) or "5prime"
+
+    Returns:
+        A NormalizeResultWithWarnings.
+
+    Raises:
+        ParseError: If the HGVS string cannot be parsed (a subclass of
+            ValueError).
+        ValueError: If ``direction`` is not one of
+            "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+        NormalizationError: If normalization fails (a subclass of RuntimeError).
+
+    Example:
+        >>> result = normalize_with_warnings("NM_000088.3:c.100delA")
+        >>> str(result.result)
+        'NM_000088.3:c.100del'
+        >>> [w.code for w in result.warnings]
+        []
+    """
+    ...
+
 # ============================================================================
 # SPDI Functions
 # ============================================================================
@@ -2133,6 +2172,31 @@ class NormalizationWarning:
     @property
     def message(self) -> str:
         """Human-readable description of the warning."""
+        ...
+
+class NormalizeResultWithWarnings:
+    """A normalized variant together with the warnings normalization raised.
+
+    Returned by :func:`normalize_with_warnings` and by
+    :meth:`Normalizer.normalize_with_warnings`.
+    """
+
+    @property
+    def result(self) -> HgvsVariant:
+        """The normalized variant.
+
+        Identical to what the warning-free entry points return — collecting the
+        diagnostics does not move the normalized form.
+        """
+        ...
+
+    @property
+    def warnings(self) -> list[NormalizationWarning]:
+        """Warnings raised during normalization; empty when it was clean."""
+        ...
+
+    def has_warnings(self) -> bool:
+        """True when at least one warning was raised."""
         ...
 
 class VariantProjection:

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1606,10 +1606,14 @@ fn run_normalize(
         if let Some(rejection) = preprocess_result.take_rejection_error() {
             return failed(NormalizeTsvFailure::Preprocess, &rejection.to_string());
         }
-        let corrections: Vec<(&str, &str)> = preprocess_result
+        // Owned rather than borrowed from `preprocess_result`, because the
+        // normalizer's warnings are rendered on demand (`Display`) and so have
+        // nothing to borrow from. Both phases end up in one list; the code
+        // namespaces keep them apart (`W1001` vs `MEMBERS_COALESCED_…`).
+        let mut corrections: Vec<(String, String)> = preprocess_result
             .warnings
             .iter()
-            .map(|w| (w.error_type.code(), w.message.as_str()))
+            .map(|w| (w.error_type.code().to_string(), w.message.clone()))
             .collect();
         for warning in &preprocess_result.warnings {
             let _ = writeln!(
@@ -1623,15 +1627,31 @@ fn run_normalize(
             Ok(parsed) => parsed,
             Err(e) => return failed(NormalizeTsvFailure::Parse, &e.to_string()),
         };
-        match normalizer.normalize(&parsed) {
-            Ok(normalized) => {
+        // `normalize_with_diagnostics`, not `normalize`: the latter discards the
+        // normalizer's warnings (see its doc comment), which left every
+        // normalizer-generated diagnostic — W5005 coalescing, ins-payload
+        // expansion, W5001 lenient reference correction — unreachable from
+        // `ferro normalize` in every format and every error mode. The normalized
+        // variant is the same one either way; both exits share
+        // `normalize_core_checked`.
+        match normalizer.normalize_with_diagnostics(&parsed) {
+            Ok(diagnosed) => {
+                let normalized = diagnosed.result;
+                for warning in &diagnosed.warnings {
+                    let _ = writeln!(err, "warning[{}]: {}", warning.code(), warning);
+                    corrections.push((warning.code().to_string(), warning.to_string()));
+                }
                 let normalized_str = normalized.to_string();
+                let corrections_view: Vec<(&str, &str)> = corrections
+                    .iter()
+                    .map(|(code, message)| (code.as_str(), message.as_str()))
+                    .collect();
                 let row = normalize_tsv_row(
                     line,
                     v,
                     NormalizeTsvOutcome::Normalized {
                         normalized: normalized_str.as_str(),
-                        corrections: &corrections,
+                        corrections: &corrections_view,
                     },
                 );
                 // The verdict comes back from the renderer rather than being
@@ -1661,7 +1681,11 @@ fn run_normalize(
         }
 
         let parsed = parse_hgvs(&preprocess_result.preprocessed)?;
-        let normalized = normalizer.normalize(&parsed)?;
+        // `normalize_with_diagnostics`, not `normalize` — see the comment on the
+        // TSV path above. Same normalized variant, plus the warnings the quiet
+        // exit throws away.
+        let diagnosed = normalizer.normalize_with_diagnostics(&parsed)?;
+        let normalized = diagnosed.result;
         match format {
             "json" => {
                 let corrections: Vec<String> = preprocess_result
@@ -1675,12 +1699,29 @@ fn run_normalize(
                         )
                     })
                     .collect();
+                // A separate key from `corrections`, which is the preprocessor's
+                // population: these are raised by the normalizer and carry its
+                // own code namespace. Always emitted, `[]` included, so a
+                // consumer can index `.warnings` unconditionally — matching what
+                // `ferro project --format json` does (#1182).
+                let warnings: Vec<String> = diagnosed
+                    .warnings
+                    .iter()
+                    .map(|w| {
+                        format!(
+                            r#"{{"code":"{}","message":"{}"}}"#,
+                            w.code(),
+                            w.to_string().replace('"', "\\\"")
+                        )
+                    })
+                    .collect();
                 writeln!(
                     out,
-                    r#"{{"input": "{}", "output": "{}", "status": "ok", "corrections": [{}]}}"#,
+                    r#"{{"input": "{}", "output": "{}", "status": "ok", "corrections": [{}], "warnings": [{}]}}"#,
                     v,
                     normalized,
-                    corrections.join(",")
+                    corrections.join(","),
+                    warnings.join(",")
                 )
                 .map_err(|e| FerroError::Io { msg: e.to_string() })?;
             }
@@ -1694,6 +1735,15 @@ fn run_normalize(
                         warning.message
                     )
                     .map_err(|e| FerroError::Io { msg: e.to_string() })?;
+                }
+                // Then the normalizer's own, in the same shape. The two phases
+                // stay distinguishable by code namespace: the preprocessor's are
+                // `W`-numbered SVA codes, the normalizer's are the stable
+                // SCREAMING_SNAKE names (`MEMBERS_COALESCED_FROM_REPORTED_FORM`,
+                // `INSERTED_SEQUENCE_EXPANDED`, `REFSEQ_MISMATCH`, …).
+                for warning in &diagnosed.warnings {
+                    writeln!(err, "warning[{}]: {}", warning.code(), warning)
+                        .map_err(|e| FerroError::Io { msg: e.to_string() })?;
                 }
                 // Format the normalized variant once and reuse it for both the
                 // unchanged-vs-changed comparison and the written output. The

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1750,10 +1750,40 @@ impl<P: ReferenceProvider> Normalizer<P> {
         })
     }
 
-    /// Normalize a variant
+    /// Normalize a variant — **the quiet exit**.
     ///
-    /// In strict mode (default), rejects variants with reference mismatches.
-    /// Use `normalize_with_diagnostics` for lenient mode that corrects mismatches.
+    /// This returns the normalized variant and **discards every
+    /// [`NormalizationWarning`] the normalization raised**. The core produces
+    /// them (`normalize_core_checked` returns a `(variant, warnings)` pair); the
+    /// `.0` below throws the second half away. That is a deliberate signature
+    /// choice — the return type has nowhere to put them — but it means a caller
+    /// on this exit cannot learn that a repair happened.
+    ///
+    /// Several of those repairs are lossy in a way the output string does not
+    /// record: `MEMBERS_COALESCED_FROM_REPORTED_FORM` (the individually reported
+    /// members are gone), `INSERTED_SEQUENCE_EXPANDED` (the `[100_110]` payload
+    /// is now a literal), `REFSEQ_MISMATCH` with `corrected=true` (the caller's
+    /// stated base was wrong and was silently replaced). On this exit each of
+    /// those is indistinguishable from a clean normalization.
+    ///
+    /// **Use [`normalize_with_diagnostics`](Self::normalize_with_diagnostics)
+    /// unless you specifically want the quiet behaviour.** It routes through the
+    /// same `normalize_core_checked`, so the normalized variant is
+    /// byte-identical; it simply also hands back the warnings, plus the
+    /// info-grade shuffle signals. `ferro normalize`, `ferro project` and the
+    /// Python `normalize_with_warnings` bindings are all on that exit.
+    ///
+    /// `error_mode` is orthogonal and does **not** substitute for reading the
+    /// warnings: strict mode promotes a specific ladder of conditions to hard
+    /// errors, and every warning outside that ladder is raised identically in
+    /// strict and lenient — so a strict `Normalizer` on this exit drops exactly
+    /// the same diagnostics a lenient one does.
+    ///
+    /// # Errors
+    ///
+    /// In strict mode, rejects variants with reference mismatches and the rest
+    /// of the `should_reject_*` ladder. In the default lenient mode those
+    /// conditions become warnings — which this exit then discards.
     pub fn normalize(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
         // Thin wrapper: `normalize()` returns only the variant. Both the core
         // normalization AND the strict-mode rejection ladder live in

--- a/src/python.rs
+++ b/src/python.rs
@@ -640,6 +640,85 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
     Ok(normalized.to_string())
 }
 
+/// Normalize an HGVS variant description, returning the warnings with it.
+///
+/// The warning-bearing sibling of :func:`normalize`, which returns only the
+/// string and therefore cannot tell a caller that normalization *repaired*
+/// something. Several repairs are lossy in a way the returned string does not
+/// record — coalescing separately reported cis members
+/// (``MEMBERS_COALESCED_FROM_REPORTED_FORM``), expanding a bracketed/range
+/// ``ins`` payload to a literal (``INSERTED_SEQUENCE_EXPANDED``), correcting a
+/// stated reference base (``REFSEQ_MISMATCH``) — so on :func:`normalize` they
+/// are indistinguishable from a clean pass.
+///
+/// Same return type as :meth:`Normalizer.normalize_with_warnings`, which is the
+/// equivalent on a caller-configured reference.
+///
+/// **WARNING**: As :func:`normalize`, this uses built-in test data for reference
+/// sequences. For production use, create a Normalizer instance with your
+/// reference data.
+///
+/// Args:
+///     hgvs_string: The HGVS variant description to normalize
+///     direction: Shuffle direction - "3prime" (default) or "5prime"
+///
+/// Returns:
+///     NormalizeResultWithWarnings — `.result` is the normalized variant,
+///     `.warnings` the (possibly empty) list of NormalizationWarning.
+///
+/// Raises:
+///     ValueError: If the HGVS string cannot be parsed
+///     RuntimeError: If normalization fails
+#[pyfunction]
+#[pyo3(signature = (hgvs_string, direction="3prime"))]
+fn normalize_with_warnings(
+    py: Python<'_>,
+    hgvs_string: &str,
+    direction: &str,
+) -> PyResult<PyNormalizeResultWithWarnings> {
+    let variant = parse_hgvs(hgvs_string)
+        .map_err(|e| ferro_typed("ParseError", format!("Parse error: {e}"), &e))?;
+
+    // Lenient by design, exactly as `normalize` above: this convenience API
+    // takes no error-mode argument, and a lenient normalizer is precisely the
+    // one that produces warnings rather than errors — which is what this
+    // function exists to hand back.
+    let config = NormalizeConfig::for_entry_point(
+        parse_direction_or_raise(direction)?,
+        ErrorConfig::lenient(),
+    );
+    let provider = JsonProvider::with_test_data();
+    emit_reduced_capability_warning(
+        py,
+        provider.has_genomic_data(),
+        ProviderKind::TestData,
+        "normalize_with_warnings()",
+        "Normalizer.from_manifest(...)",
+    )?;
+    let normalizer = Normalizer::with_config(provider, config);
+
+    let result = py
+        .detach(|| normalizer.normalize_with_diagnostics(&variant))
+        .map_err(|e| {
+            ferro_typed(
+                "NormalizationError",
+                format!("Normalization error: {e}"),
+                &e,
+            )
+        })?;
+
+    Ok(PyNormalizeResultWithWarnings {
+        result: PyHgvsVariant {
+            inner: result.result,
+        },
+        warnings: result
+            .warnings
+            .iter()
+            .map(PyNormalizationWarning::from)
+            .collect(),
+    })
+}
+
 /// The coordinate axis (reference molecule / coordinate system) a variant's
 /// positions are expressed in.
 ///
@@ -6182,6 +6261,7 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Core functions
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(normalize, m)?)?;
+    m.add_function(wrap_pyfunction!(normalize_with_warnings, m)?)?;
 
     // SPDI functions
     m.add_function(wrap_pyfunction!(parse_spdi, m)?)?;

--- a/tests/it/cli_normalize_tsv.rs
+++ b/tests/it/cli_normalize_tsv.rs
@@ -281,7 +281,26 @@ fn a_successful_row_explains_a_correction_in_its_detail() {
     ]);
     assert!(run.success, "{}", run.stderr);
     let rows = run.rows();
-    assert_eq!(fields(rows[0])[5], "", "an uncorrected row has no detail");
+    // Row 0 is uncorrected *by the preprocessor*, which is the contrast this
+    // test draws — so what must be absent from its detail is the W3025 code,
+    // not all content.
+    //
+    // Its detail is no longer empty. `UNCHANGED` is `c.459` on the mock
+    // `NM_000088.3`, whose CDS is 60 bases, so the **normalizer** raises W4004
+    // for it — and always did. Until `ferro normalize` moved off
+    // `Normalizer::normalize` (the exit that discards warnings) that diagnostic
+    // was produced and dropped, which is why this row read as clean. It is
+    // pinned rather than dodged with a different fixture: an out-of-CDS position
+    // silently accepted is exactly the thing worth showing.
+    let uncorrected = fields(rows[0]);
+    assert!(
+        !uncorrected[5].contains("W3025"),
+        "row 0 must carry no preprocessor correction: {uncorrected:?}"
+    );
+    assert_eq!(
+        uncorrected[5], "POSITION_PAST_END: NM_000088.3:c.459 lies past the cds-end (bound 60)",
+        "the normalizer's own diagnostic belongs in the row that caused it"
+    );
 
     let corrected = fields(rows[1]);
     assert_eq!(corrected[3], "true");
@@ -546,6 +565,15 @@ fn parallel_tsv_output_is_byte_identical_to_serial() {
 fn text_and_json_output_is_untouched() {
     // The `tsv` addition must be purely additive: these are the exact byte
     // streams the two pre-existing formats produced before it existed.
+    //
+    // The json record has since gained one key — `warnings`, the normalizer's
+    // population, separate from the preprocessor's `corrections` — when
+    // `ferro normalize` was moved onto the diagnostics exit. It is present
+    // unconditionally so a consumer can index it without branching, which is why
+    // it shows here as `[]`: under `--error-mode silent` W4004 is suppressed, so
+    // these two rows raise nothing. (Under `lenient` the first row carries
+    // `POSITION_PAST_END` — see
+    // `a_successful_row_explains_a_correction_in_its_detail`.)
     let variants = [UNCHANGED, CHANGED_IN, "not-a-variant"];
     let tf = input_file(&variants);
     let path = tf.path().to_str().unwrap();
@@ -566,9 +594,9 @@ fn text_and_json_output_is_untouched() {
         json.stdout,
         format!(
             "{{\"input\": \"{UNCHANGED}\", \"output\": \"{UNCHANGED}\", \
-             \"status\": \"ok\", \"corrections\": []}}\n\
+             \"status\": \"ok\", \"corrections\": [], \"warnings\": []}}\n\
              {{\"input\": \"{CHANGED_IN}\", \"output\": \"{CHANGED_OUT}\", \
-             \"status\": \"ok\", \"corrections\": []}}\n"
+             \"status\": \"ok\", \"corrections\": [], \"warnings\": []}}\n"
         )
     );
     assert!(

--- a/tests/it/issue_1181_cli_error_mode.rs
+++ b/tests/it/issue_1181_cli_error_mode.rs
@@ -140,12 +140,26 @@ fn strict_rejects_a_reference_mismatch_that_lenient_accepts() {
 /// against a "fix" that hardwires strict everywhere.
 ///
 /// Note what is and is not distinct here. `strict` is distinguishable — it
-/// rejects, and names the mismatch. `lenient` and `silent` are **not**: for this
-/// input the CLI emits no normalizer diagnostic in either mode, so their
+/// rejects, and names the mismatch. `lenient` and `silent` are **not**: their
 /// combined stdout+stderr is byte-identical. That equality is asserted rather
 /// than glossed, because the tempting assertion — "silent omits the diagnostic
-/// that lenient prints" — is vacuously true (neither prints one) and would keep
-/// passing if the diagnostic disappeared everywhere.
+/// that lenient prints" — would keep passing if the diagnostic disappeared
+/// everywhere.
+///
+/// **What that equality now contains has changed.** It used to hold because
+/// neither mode printed a normalizer diagnostic at all: `ferro normalize` was on
+/// `Normalizer::normalize`, the exit that discards warnings. Since the CLI moved
+/// to `normalize_with_diagnostics`, both modes print
+/// `warning[REFSEQ_MISMATCH]`, so the equality is now "both disclose it
+/// identically" rather than "neither discloses anything". The assertion below
+/// pins the disclosure explicitly, so the equality can never again be satisfied
+/// by two silences.
+///
+/// That `silent` prints it is a genuine open question, recorded rather than
+/// decided here: `ErrorMode::emits_warnings()` says only `Lenient` should, but
+/// that predicate has no call site in `src/`, and `ferro project` (#1182) prints
+/// normalizer warnings in every mode. The two sibling commands are consistent
+/// with each other, which is the property this change preserved.
 #[test]
 fn strict_is_distinct_from_lenient_and_silent_at_the_cli() {
     let (_dir, reference, variant) = fixture();
@@ -158,13 +172,19 @@ fn strict_is_distinct_from_lenient_and_silent_at_the_cli() {
     assert!(!strict_ok, "strict must reject");
     assert!(lenient_ok, "lenient must accept");
     assert!(silent_ok, "silent must accept");
-    // Neither accepting mode surfaces a normalizer diagnostic for this input, so
-    // pin the equality as the fact it is. If lenient ever gains one, this fails
-    // and the distinction gets asserted properly instead of assumed.
+    // Both accepting modes surface the same normalizer diagnostic, so pin the
+    // equality as the fact it is. If they ever diverge, this fails and the
+    // distinction gets asserted properly instead of assumed.
     assert_eq!(
         lenient_out, silent_out,
         "lenient and silent are indistinguishable on this input; if that changes, \
          assert the actual difference rather than relaxing this"
+    );
+    // …and pin what they agree *on*, so the equality above cannot degenerate
+    // back into two silences without failing here.
+    assert!(
+        lenient_out.contains("warning[REFSEQ_MISMATCH]"),
+        "an accepted reference mismatch must be disclosed, not silently taken; got: {lenient_out}"
     );
     assert!(
         strict_out.contains("Reference mismatch"),

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -394,6 +394,7 @@ mod normalize_idempotency_proptest;
 mod normalize_property_tests;
 mod normalize_reparse_invariant;
 mod normalize_tests;
+mod normalize_warning_seam;
 mod paraphase_exhaustive_tests;
 mod parser_tests;
 mod pastcds_star_canonicalization;

--- a/tests/it/normalize_warning_seam.rs
+++ b/tests/it/normalize_warning_seam.rs
@@ -1,0 +1,387 @@
+//! The normalizer's warning channel, from the normalizer out to an ordinary caller.
+//!
+//! `Normalizer::normalize` returns `Result<HgvsVariant, FerroError>` — a return
+//! type with nowhere to put a warning. Its body is
+//! `Ok(self.normalize_core_checked(variant)?.0)`, and the `.0` discards the
+//! `Vec<NormalizationWarning>` the core hands back. Every warning the normalizer
+//! raises therefore existed and was thrown away before any caller on that exit
+//! could see it.
+//!
+//! That is not a cosmetic loss. Several of the repairs it reports are **lossy in
+//! a way the output string does not record**, so a caller cannot recover the
+//! fact from the result:
+//!
+//! - `MEMBERS_COALESCED_FROM_REPORTED_FORM` — the input described N cis members
+//!   and the canonical form describes fewer. `DNA/delins.md:79-84` names exactly
+//!   why that matters ("the two variants may have been reported (or might occur)
+//!   individually"), and the provenance is unrecoverable from the normalized
+//!   string.
+//! - `INSERTED_SEQUENCE_EXPANDED` — a `ins[120_130]` reference-range payload was
+//!   replaced by the literal bases it denotes. The output no longer says it came
+//!   from a range.
+//! - `REFSEQ_MISMATCH` — the caller's stated reference base disagreed with the
+//!   reference. Under a non-strict error mode the description is accepted anyway.
+//!
+//! `ferro project` was given this channel by #1182 (`src/bin/ferro.rs`'s
+//! `run_project` prints `warning[CODE]: message` for the normalization warnings
+//! its projection carried). `ferro normalize` was not: its only `warning[...]`
+//! prints iterated `preprocess_result.warnings`, which is the **preprocessor's**
+//! population — a different phase entirely. So the two sibling commands
+//! disagreed about whether a normalizer diagnostic is worth showing.
+//!
+//! These tests drive the **binary**, not the library, because the library was
+//! never the broken half: `normalize_with_diagnostics` has always returned these
+//! warnings and `coalesced_members_diagnostic.rs` has always asserted so. The
+//! defect lived purely in which exit the callers were on, and a library-level
+//! test passes against the bug.
+//!
+//! The last test is the other half of the contract, and the one that makes this
+//! a *disclosure* change rather than a behaviour change: the normalized strings
+//! are pinned to the bytes the pre-fix binary produced.
+
+use std::path::Path;
+use std::process::Command;
+
+use ferro_hgvs::prepare::manifest::ReferenceManifest;
+
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+/// The single contig in the fixture: 400 bases cycling `ACGT`.
+const CONTIG: &str = "NC_000001.11";
+const CONTIG_LEN: usize = 400;
+
+/// The base at 1-based position `pos` of the fixture contig.
+fn base_at(pos: usize) -> char {
+    ['A', 'C', 'G', 'T'][(pos - 1) % 4]
+}
+
+/// Write a minimal reference dir: an **indexed** genome FASTA with one contig,
+/// plus a manifest pointing at it. Modelled on `issue_1181_cli_error_mode.rs`,
+/// which needs the same thing — a real on-disk reference, because under the mock
+/// provider no reference-base work runs and the diagnostics under test never
+/// fire.
+fn minimal_genome_reference(dir: &Path) {
+    let seq: String = (1..=CONTIG_LEN).map(base_at).collect();
+    let header = format!(">{CONTIG}\n");
+    std::fs::write(dir.join("genome.fa"), format!("{header}{seq}\n")).unwrap();
+    std::fs::write(
+        dir.join("genome.fa.fai"),
+        format!(
+            "{CONTIG}\t{CONTIG_LEN}\t{}\t{CONTIG_LEN}\t{}\n",
+            header.len(),
+            CONTIG_LEN + 1
+        ),
+    )
+    .unwrap();
+
+    let mut manifest = ReferenceManifest {
+        reference_dir: dir.to_path_buf(),
+        genome_fasta: Some(std::path::PathBuf::from("genome.fa")),
+        transcript_count: 0,
+        available_prefixes: vec!["NC_".to_string()],
+        ..Default::default()
+    };
+    manifest.save().unwrap();
+}
+
+/// `(exit ok, stdout, stderr)` from one `ferro normalize` invocation.
+///
+/// stdout and stderr are returned **separately**, deliberately: the whole point
+/// of the fix is that the result stream stays exactly what it was while the
+/// diagnostics go to stderr. Merging them would make the byte-identity
+/// assertion below unable to see the difference.
+fn normalize(reference: &str, variant: &str, extra: &[&str]) -> (bool, String, String) {
+    let mut cmd = ferro();
+    cmd.args(["normalize", "--reference", reference]);
+    cmd.args(extra);
+    cmd.arg(variant);
+    let out = cmd.output().unwrap();
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Set up the fixture; returns (tempdir guard, reference path).
+fn fixture() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    minimal_genome_reference(dir.path());
+    let reference = dir.path().to_str().unwrap().to_string();
+    (dir, reference)
+}
+
+/// Two adjacent substitutions the normalizer merges into one `delins`. Bases at
+/// 201/202 are `A`/`C`, so `[201A>T;202C>G]` states the reference correctly and
+/// the only repair is the coalescing itself.
+const COALESCING_INPUT: &str = "NC_000001.11:g.[201A>T;202C>G]";
+
+/// A bracketed reference-range `ins` payload. Positions 120..=130 spell
+/// `TACGTACGTAC` on the fixture contig.
+const RANGE_INS_INPUT: &str = "NC_000001.11:g.100_101ins[120_130]";
+
+/// A substitution stating `C` where the contig actually carries `A`.
+const MISMATCHING_INPUT: &str = "NC_000001.11:g.201C>T";
+
+/// The fixture bases the three inputs above assume. Asserted rather than
+/// trusted, so a change to `CONTIG_LEN` or `base_at` fails here — where the
+/// cause is obvious — instead of somewhere downstream as a mystery.
+#[test]
+fn the_fixture_carries_the_bases_the_inputs_assume() {
+    assert_eq!(base_at(201), 'A');
+    assert_eq!(base_at(202), 'C');
+    let payload: String = (120..=130).map(base_at).collect();
+    assert_eq!(payload, "TACGTACGTAC");
+}
+
+/// W5005 reaches the CLI. Before the fix this produced the same stdout line with
+/// **no stderr diagnostic at all** — the coalescing was completely silent.
+#[test]
+fn the_coalesce_provenance_warning_reaches_the_cli() {
+    let (_dir, reference) = fixture();
+    let (ok, stdout, stderr) = normalize(&reference, COALESCING_INPUT, &[]);
+
+    assert!(ok, "must normalize successfully; stderr: {stderr}");
+    assert!(
+        stdout.contains("NC_000001.11:g.[201A>T;202C>G] -> NC_000001.11:g.201_202delinsTG"),
+        "precondition: the input must actually coalesce; stdout: {stdout}"
+    );
+    // The whole line, verbatim: a caller has to be able to select on the code
+    // AND read the reason, so both are pinned.
+    assert!(
+        stderr.contains(
+            "warning[MEMBERS_COALESCED_FROM_REPORTED_FORM]: NC_000001.11:g. — input described 2 \
+             cis members, normalized form describes 1; the individually reported form is not \
+             recoverable from the normalized string (DNA/delins.md:79-84)"
+        ),
+        "the coalesce must be disclosed with its code and its reason; stderr: {stderr}"
+    );
+}
+
+/// `INSERTED_SEQUENCE_EXPANDED` reaches the CLI, and the message names both the
+/// payload that was thrown away and the literal that replaced it — which is the
+/// only place the discarded `[120_130]` provenance now survives.
+#[test]
+fn the_inserted_sequence_expansion_warning_reaches_the_cli() {
+    let (_dir, reference) = fixture();
+    let (ok, stdout, stderr) = normalize(&reference, RANGE_INS_INPUT, &[]);
+
+    assert!(ok, "must normalize successfully; stderr: {stderr}");
+    assert!(
+        stdout
+            .contains("NC_000001.11:g.100_101ins[120_130] -> NC_000001.11:g.100_101insTACGTACGTAC"),
+        "precondition: the payload must actually be expanded; stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains(
+            "warning[INSERTED_SEQUENCE_EXPANDED]: NC_000001.11: ins payload [120_130] expanded \
+             to literal TACGTACGTAC"
+        ),
+        "the expansion must be disclosed, naming the original payload; stderr: {stderr}"
+    );
+}
+
+/// `REFSEQ_MISMATCH` reaches the CLI under a non-strict error mode — the case
+/// where the description is *accepted* despite contradicting the reference, and
+/// so the one where silence is most costly.
+///
+/// The rendered position is **not** pinned. On this input the message reads
+/// `at 100-100` for a variant at `g.201`, which looks like a window-relative
+/// offset leaking into a user-facing coordinate. That is recorded as a separate
+/// finding rather than frozen here: pinning it would make a legitimate fix to
+/// the coordinate fail this test for the wrong reason.
+///
+/// Confirmed and filed as **#1612**. It is built at `src/normalize/mod.rs:8806`
+/// from the *fetched window's* `start`/`end`, which nothing converts back onto
+/// the description's own axis — unlike the cis producer at
+/// `src/normalize/merge.rs:3362`, which re-bases through `region_sequence_delta`
+/// and documents itself as reporting the sequence-axis span. The field is not
+/// diagnostic-only: it is also the `location` of strict mode's
+/// `FerroError::ReferenceMismatch` (`mod.rs:2418`), so a fix has to move both
+/// renderings and stay agreed with the cis producer, whose warnings are built to
+/// be indistinguishable so the `position`-keyed dedupe at `mod.rs:2854` can drop
+/// the duplicate. That is why it is not repaired here, where the scope is the
+/// seam rather than the warning's contents.
+#[test]
+fn the_reference_mismatch_warning_reaches_the_cli() {
+    let (_dir, reference) = fixture();
+    let (ok, _stdout, stderr) =
+        normalize(&reference, MISMATCHING_INPUT, &["--error-mode", "lenient"]);
+
+    assert!(ok, "lenient must accept the mismatch; stderr: {stderr}");
+    assert!(
+        stderr.contains("warning[REFSEQ_MISMATCH]: reference sequence mismatch at "),
+        "the mismatch must be disclosed under its code; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(r#"stated "C", actual "A""#),
+        "the disclosure must name both bases, or a caller cannot act on it; stderr: {stderr}"
+    );
+}
+
+/// Strict mode is not a substitute for reading the warnings, which is the reason
+/// this fix is needed at all rather than "just use `--error-mode strict`".
+///
+/// For the coalescing input, strict and lenient produce **byte-identical stdout
+/// and byte-identical stderr**: the strict rejection ladder does not cover
+/// W5005, so strict rejects nothing and reports exactly what lenient does. A
+/// caller who picked strict specifically to be told about repairs was told
+/// nothing.
+#[test]
+fn strict_mode_mitigates_nothing_for_a_coalesced_allele() {
+    let (_dir, reference) = fixture();
+    let (strict_ok, strict_out, strict_err) =
+        normalize(&reference, COALESCING_INPUT, &["--error-mode", "strict"]);
+    let (lenient_ok, lenient_out, lenient_err) =
+        normalize(&reference, COALESCING_INPUT, &["--error-mode", "lenient"]);
+
+    assert!(strict_ok && lenient_ok, "both modes accept this input");
+    assert_eq!(
+        strict_out, lenient_out,
+        "strict does not change the normalized output for a coalesced allele"
+    );
+    assert_eq!(
+        strict_err, lenient_err,
+        "nor the diagnostics — strict promotes no rung that covers W5005"
+    );
+    assert!(
+        strict_err.contains("warning[MEMBERS_COALESCED_FROM_REPORTED_FORM]"),
+        "and both must disclose it; strict stderr: {strict_err}"
+    );
+}
+
+/// `--format json` carries the warnings in the record, under their own key.
+///
+/// `corrections` is the preprocessor's population and stays exactly what it was;
+/// `warnings` is the normalizer's, and is always present (`[]` included) so a
+/// consumer can index it unconditionally — the same contract
+/// `ferro project --format json` adopted in #1182.
+#[test]
+fn json_records_carry_the_warnings_under_their_own_key() {
+    let (_dir, reference) = fixture();
+
+    let (ok, stdout, stderr) = normalize(&reference, COALESCING_INPUT, &["--format", "json"]);
+    assert!(ok, "must normalize successfully; stderr: {stderr}");
+    assert!(
+        stdout.contains(r#""corrections": []"#),
+        "the preprocessor population must stay separate and stay empty here; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(r#""warnings": [{"code":"MEMBERS_COALESCED_FROM_REPORTED_FORM""#),
+        "the normalizer warning must be in the JSON record; stdout: {stdout}"
+    );
+
+    // The key is unconditional, so a clean input still carries an empty array
+    // rather than omitting it.
+    let (clean_ok, clean_stdout, _) =
+        normalize(&reference, "NC_000001.11:g.201A>T", &["--format", "json"]);
+    assert!(clean_ok);
+    assert!(
+        clean_stdout.contains(r#""warnings": []"#),
+        "a clean record must still carry the key; stdout: {clean_stdout}"
+    );
+}
+
+/// `--format tsv` correlates the warning to the row that caused it, via the
+/// `detail` column — the same column the preprocessor's corrections already use,
+/// and for the same reason ("greppable where it always was and correlatable to
+/// the row it explains").
+#[test]
+fn tsv_rows_carry_the_warning_in_the_detail_column() {
+    let (_dir, reference) = fixture();
+    let (ok, stdout, stderr) = normalize(&reference, COALESCING_INPUT, &["--format", "tsv"]);
+
+    assert!(ok, "must normalize successfully; stderr: {stderr}");
+    let row = stdout
+        .lines()
+        .find(|l| l.contains("NC_000001.11:g.[201A>T;202C>G]"))
+        .unwrap_or_else(|| panic!("no data row in tsv output: {stdout}"));
+    let detail = row
+        .split('\t')
+        .next_back()
+        .expect("a tsv row always has a last field");
+    assert!(
+        detail.starts_with("MEMBERS_COALESCED_FROM_REPORTED_FORM: "),
+        "the detail column must carry the warning; row: {row}"
+    );
+    // stderr keeps its copy too, so an existing `2>&1 | grep warning` pipeline
+    // sees it in the shape it always saw preprocessor warnings in.
+    assert!(
+        stderr.contains("warning[MEMBERS_COALESCED_FROM_REPORTED_FORM]"),
+        "tsv must also report on stderr, as the text format does; stderr: {stderr}"
+    );
+}
+
+/// **The disclosure moved no string.**
+///
+/// Every normalized form below is the byte-for-byte stdout the *pre-fix* binary
+/// produced for that input — captured by running `ferro normalize` at the
+/// campaign base (`35de96c8`) against this same fixture, before any of the
+/// changes in this test's PR existed. Routing the CLI from `normalize` to
+/// `normalize_with_diagnostics` cannot move the result, because both exits go
+/// through the same `normalize_core_checked` and return the same variant; this
+/// pins that claim to observed bytes rather than to the argument for it.
+///
+/// It covers all three formats, because each renders the result through a
+/// different path and only `text` shares code with the other two.
+#[test]
+fn the_disclosure_does_not_move_the_normalized_string() {
+    let (_dir, reference) = fixture();
+
+    // (input, exact stdout line the pre-fix binary emitted for `--format text`)
+    let pinned: [(&str, &str); 3] = [
+        (
+            COALESCING_INPUT,
+            "NC_000001.11:g.[201A>T;202C>G] -> NC_000001.11:g.201_202delinsTG",
+        ),
+        (
+            RANGE_INS_INPUT,
+            "NC_000001.11:g.100_101ins[120_130] -> NC_000001.11:g.100_101insTACGTACGTAC",
+        ),
+        // Unchanged: lenient accepts the contradicting base and preserves it.
+        (MISMATCHING_INPUT, "NC_000001.11:g.201C>T"),
+    ];
+
+    for (input, expected) in pinned {
+        let (ok, stdout, stderr) = normalize(&reference, input, &["--error-mode", "lenient"]);
+        assert!(ok, "{input} must normalize; stderr: {stderr}");
+        assert_eq!(
+            stdout.trim_end(),
+            expected,
+            "the result stream moved for {input} — this PR is a disclosure change \
+             and must not touch the normalized form"
+        );
+
+        // The same string, through the JSON renderer.
+        let normalized = expected.rsplit(" -> ").next().unwrap();
+        let (json_ok, json_stdout, _) = normalize(
+            &reference,
+            input,
+            &["--error-mode", "lenient", "--format", "json"],
+        );
+        assert!(json_ok, "{input} must normalize under --format json");
+        assert!(
+            json_stdout.contains(&format!(r#""output": "{normalized}""#)),
+            "json output moved for {input}: {json_stdout}"
+        );
+
+        // And through the TSV renderer, whose `normalized` column is field 3.
+        let (tsv_ok, tsv_stdout, _) = normalize(
+            &reference,
+            input,
+            &["--error-mode", "lenient", "--format", "tsv"],
+        );
+        assert!(tsv_ok, "{input} must normalize under --format tsv");
+        let row = tsv_stdout
+            .lines()
+            .find(|l| l.starts_with(&format!("\t{input}\t")))
+            .unwrap_or_else(|| panic!("no tsv row for {input}: {tsv_stdout}"));
+        assert_eq!(
+            row.split('\t').nth(2),
+            Some(normalized),
+            "tsv normalized column moved for {input}"
+        );
+    }
+}

--- a/tests/python/test_normalize_warning_seam.py
+++ b/tests/python/test_normalize_warning_seam.py
@@ -1,0 +1,105 @@
+"""The module-level `normalize()` had no warning-bearing sibling.
+
+`ferro_hgvs.normalize(...)` returns a `str`, so it can only report that
+normalization *happened* — never that it *repaired* something. Some of those
+repairs are lossy in a way the returned string does not record, the clearest
+being `MEMBERS_COALESCED_FROM_REPORTED_FORM`: an input describing two cis
+members comes back as one `delins`, and the individually-reported form is gone
+with no trace in the result.
+
+`Normalizer.normalize_with_warnings(...)` (issue #395 item 5) already gave the
+class-based route a channel. The free function did not, so the shortest Python
+path — the one the README and the docstrings put first — stayed silent.
+
+These tests cover the free function `normalize_with_warnings`, and pin the
+property that makes it a *disclosure* rather than a behaviour change: it returns
+the same normalized string `normalize` does.
+
+They run under `pytest tests/python/` after `maturin develop --features python`.
+"""
+
+import warnings
+
+import ferro_hgvs
+
+# Two adjacent protein substitutions on a transcript the bundled test data
+# carries. They coalesce into a single `delins`, so the input's two-member
+# provenance is unrecoverable from the output — which is exactly what W5005
+# reports. Also asserted in Rust by
+# `coalesced_members_diagnostic::a_protein_cis_allele_carries_the_provenance_warning`.
+COALESCING_INPUT = "NP_000079.2:p.[Ala100Gly;Ala101Gly]"
+COALESCED_OUTPUT = "NP_000079.2:p.Ala100_Ala101delinsGlyGly"
+
+# A clean input on the bundled `NM_000088.3` test transcript: `c.4C>G` matches
+# the reference base and stays in the CDS, so nothing is repaired.
+CLEAN_INPUT = "NM_000088.3:c.4C>G"
+
+
+def _normalize_with_warnings(variant: str):
+    """Call the free function, ignoring the one-time reduced-capability warning.
+
+    Both free functions use the bundled genome-less test data and emit a
+    `UserWarning` saying so (#1012). That is orthogonal to what is under test
+    here and fires at most once per process, so filtering it keeps the
+    assertions about `NormalizationWarning`s rather than about Python warnings.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return ferro_hgvs.normalize_with_warnings(variant)
+
+
+def _normalize(variant: str) -> str:
+    """The quiet free function, under the same UserWarning filter."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return ferro_hgvs.normalize(variant)
+
+
+class TestFreeFunctionNormalizeWithWarnings:
+    def test_the_coalesce_provenance_reaches_the_caller(self) -> None:
+        """W5005 is reachable from the module-level entry point.
+
+        Asserted on the warning's identity *and* its text, because a caller
+        needs both: the code to branch on, the message to act on.
+        """
+        result = _normalize_with_warnings(COALESCING_INPUT)
+
+        assert str(result.result) == COALESCED_OUTPUT, (
+            "precondition: this input must actually coalesce"
+        )
+        assert [w.code for w in result.warnings] == ["MEMBERS_COALESCED_FROM_REPORTED_FORM"]
+        assert result.has_warnings() is True
+        message = result.warnings[0].message
+        assert "input described 2 cis members" in message, message
+        assert "normalized form describes 1" in message, message
+        assert "not recoverable from the normalized string" in message, message
+
+    def test_the_string_is_identical_to_the_quiet_entry_point(self) -> None:
+        """The disclosure moves nothing.
+
+        `normalize` and `normalize_with_warnings` share
+        `normalize_core_checked`, so the normalized variant is the same object
+        either way. Pinned by comparison rather than by argument, over both a
+        repaired input and a clean one.
+        """
+        for variant in (COALESCING_INPUT, CLEAN_INPUT):
+            quiet = _normalize(variant)
+            loud = _normalize_with_warnings(variant)
+            assert quiet == str(loud.result), (
+                f"the warning-bearing exit moved the string for {variant}"
+            )
+
+    def test_a_clean_input_reports_nothing(self) -> None:
+        """Guards against a channel that warns on everything, which discloses
+        nothing useful."""
+        result = _normalize_with_warnings(CLEAN_INPUT)
+        assert result.warnings == []
+        assert result.has_warnings() is False
+        assert str(result.result) == CLEAN_INPUT
+
+    def test_it_is_exported_from_the_package(self) -> None:
+        """The function must be reachable as `ferro_hgvs.normalize_with_warnings`
+        and listed in `__all__`, or the type stubs and the runtime disagree."""
+        assert "normalize_with_warnings" in ferro_hgvs.__all__
+        assert "NormalizeResultWithWarnings" in ferro_hgvs.__all__
+        assert callable(ferro_hgvs.normalize_with_warnings)


### PR DESCRIPTION
Representation-Change: none. Additive disclosure only; every normalized output is byte-identical, verified A/B over 4,445 inputs in all three error modes.

## Why

`Normalizer::normalize` had no warning channel. It calls `normalize_core_checked` and returns `.0`, dropping the diagnostics on the floor. Every ordinary caller goes through it — the CLI, the Python binding, the library's documented entry point — so the warnings the normalizer produces were reaching nobody.

The measurement, A/B between the base binary and this branch over 4,445 inputs:

```
stderr warning lines:  0 -> 1,490   (lenient and silent)
                       0 -> 1,115   (strict)
```

**So 100% of normalizer diagnostics were previously unreachable.** Not rate-limited, not verbose-gated — unreachable. Any claim that a given repair is "warned rather than silent" was, for a CLI or Python caller, indistinguishable from silent.

That matters beyond tidiness. This project's disclosure obligations run through the changelog and the `Representation-Change:` trailer, and both depend on knowing which repairs happened. A repair that cannot be observed cannot be declared.

`ferro project` already printed these (#1182 fixed `project` and not `normalize`), so this brings `normalize` in line with its sibling rather than inventing a mechanism.

## What is now reachable

Verbatim, from the real binary on a hermetic 400 bp fixture:

```
warning[MEMBERS_COALESCED_FROM_REPORTED_FORM]: NC_000001.11:g. — input described 2 cis members, normalized form describes 1; the individually reported form is not recoverable from the normalized string (DNA/delins.md:79-84)
warning[INSERTED_SEQUENCE_EXPANDED]: NC_000001.11: ins payload [120_130] expanded to literal TACGTACGTAC
warning[REFSEQ_MISMATCH]: reference sequence mismatch at 100-100: stated "C", actual "A" (corrected=false)
```

A fourth, `POSITION_PAST_END` (W4004), turned up from a red test rather than from searching — which is the argument for fixing the seam rather than enumerating the warnings one at a time.

Routes: CLI text (stderr), CLI json (new additive `warnings` key), CLI tsv (`detail` column plus stderr); Python via a new module-level `normalize_with_warnings`; library via the existing `normalize_with_diagnostics`. `normalize()` keeps its signature and is now **documented as the quiet exit**, with the asymmetry pinned by tests so it cannot drift back into looking like an oversight.

## Output is unchanged, and that is measured rather than asserted

A/B over 4,445 inputs × 3 error modes:

- `text` stdout — byte-identical, all three modes
- `tsv` stdout columns 1–5 including `normalized` — byte-identical; only column 6 gains content
- `json` stdout — byte-identical after stripping the additive `warnings` key
- timing — 0.347/0.343 s before, 0.352/0.340 s after, so no warnings-only entry point was warranted

Two CLI expectation fixtures move, in the last commit, and only because the disclosure they were blind to now appears.

## Corrections to the record

Three call-site citations carried in this project's working notes were stale, and are corrected here for whoever greps them next:

- `Normalizer::normalize` is `src/normalize/mod.rs:1757`
- the quiet CLI sites are **`src/bin/ferro.rs:1625`** (tsv) and **`:1663`** (text/json) — not `:1635`
- `src/commands/mod.rs:265` and `src/python.rs:1506` were correct; `python.rs:632`, `:1030` and `:1483` are also quiet

## Found while here, deliberately not fixed

Each is a separate change with its own risk, and bundling them would make this PR's byte-identity claim harder to verify:

1. **`REFSEQ_MISMATCH` renders `at 100-100` for an input at `g.201`** — a window-relative offset appears to leak into a user-facing coordinate. Left out of the test assertions for that reason, so nothing here pins the wrong rendering.
2. **Warning suppression is inconsistent across error modes.** W4004 honours `--error-mode silent`; W5005, `REFSEQ_MISMATCH` and `INSERTED_SEQUENCE_EXPANDED` do not. `ErrorMode::emits_warnings()` (`src/error_handling/types.rs:46`) says only lenient should emit, and **has no call site in `src/` outside its own unit test**. This PR matches `ferro project`'s unconditional printing rather than silently deciding the question.
3. **`commands::normalize_batch` still drops warnings** — `VariantResult` has no field for them, and its only consumer is the benchmark harness, so no ordinary caller is affected. Adding one is a public-API change.
4. **`cli_normalize_tsv`'s `UNCHANGED` control fixture has always been out of CDS bounds** and silently accepted. The test read as clean only because the CLI was on the quiet exit — which is a small demonstration of the defect this PR fixes.

## Verification

`cargo nextest run --features dev` — 9,738 passed, 0 failed. Clippy clean on `dev`, `python` and `--all-features`. `fmt`, `ruff`, `mypy` clean. 7 pytest passing after `maturin develop`. `generate_tool_support_tables --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `normalize_with_warnings` for Python, returning normalized output alongside structured diagnostics.
  - CLI normalization now reports warnings in text, JSON, and TSV formats.
  - JSON output separates corrections from normalization warnings.

- **Bug Fixes**
  - Preserved normalized output while exposing warnings across lenient and silent modes.
  - Clarified strict-mode behavior and warning limitations.

- **Documentation**
  - Updated usage guidance and examples for normalization warnings and diagnostic outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->