### PR TITLE
fix(normalize): refuse an unknown FERRO_PARTITION instead of serving live

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,24 +270,50 @@ This works on a **stock release build** — the switch is not behind a build fea
 
 ### Two traps worth knowing
 
-**A misspelled value looks like success, and nothing tells you.** An unrecognised value falls back to `live`, so `FERRO_PARTITION=canonicl` produces a clean, empty diff that reads as "the candidate changes nothing".
+**A misspelled value is refused, loudly.** `FERRO_PARTITION=canonicl` aborts at the first variant ferro normalizes, naming the value you gave and the arms this build has:
 
-The fallback does emit a warning through the `log` facade — but the `ferro` CLI installs no logger, so **that warning is not visible from the command line, and `RUST_LOG` will not surface it**. There is no signal at all.
-
-The defence is a positive control on an input **known** to differ — not on your own corpus, where a zero is ambiguous between "the switch is not taking effect" and "this corpus has no affected variants".
-
-These three run against the built-in test data, so they need no `--reference` and no prepared reference directory:
-
-```bash
-printf 'NM_001234.1:c.[2del;9del]\nNM_001234.1:c.[3del;9del]\nNM_001234.1:c.[2del;9dup]\n' > control.txt
-
-ferro normalize --input control.txt --format tsv --error-mode lenient | cut -f3
-#   NM_001234.1:c.[2del;11del]   <- live
-FERRO_PARTITION=canonical ferro normalize --input control.txt --format tsv --error-mode lenient | cut -f3
-#   NM_001234.1:c.[2del;33del]   <- canonical
+```
+FERRO_PARTITION="canonicl" is not a partitioner this build has. This build's arms
+are: live, shadow, canonical, canonical-coalesced. Refusing rather than falling
+back to `live`, because a bake-off served the shipped rule under a candidate's
+name reports that the candidate changes nothing.
 ```
 
-If those two produce the same output, the variable is not reaching ferro and any comparison you run is meaningless. Only once the control differs is a zero on your own corpus informative.
+Naming *this build's* arms is the point: a value that exists on some other branch, or that used to exist, is reported as absent here rather than quietly answered as `live`.
+
+Builds up to and including v0.13.1 fell back to `live` instead, and produced a clean, empty diff that read as "the candidate changes nothing". The fallback emitted a warning through the `log` facade, but the `ferro` CLI installs no logger, so that warning reached no stream and `RUST_LOG` could not surface it — there was no signal at all. If you are on an older build, treat every empty diff as unproven.
+
+A positive control on an input **known** to differ is still worth running, because it catches the other way a comparison can be vacuous: a variable that never reached the process at all (a lost `export`, a `sudo` that scrubbed the environment, a container that did not forward it). That case is indistinguishable from `unset`, which is legitimately `live`, so no amount of validation inside ferro can catch it. On your own corpus a zero remains ambiguous between "the switch is not taking effect" and "this corpus has no affected variants".
+
+These three inputs run against the built-in test data, so they need no `--reference` and no prepared reference directory. Between them they separate all four arms — every pair of arms disagrees on at least one row, so the control tells you *which* arm you got, not merely that something changed:
+
+```bash
+printf 'NM_001234.1:c.[5_6insAC;9del]\nNM_001234.1:c.[2del;5del]\nNM_001234.1:c.[2del;9del]\n' > control.txt
+
+for arm in live shadow canonical canonical-coalesced; do
+  echo "== $arm"
+  if FERRO_PARTITION=$arm ferro normalize --input control.txt --format tsv \
+       --error-mode lenient > "control.$arm.tsv"; then
+    tail -n +2 "control.$arm.tsv" | cut -f3
+  else
+    echo "   FAILED (exit $?) -- ferro did not produce this arm's column"
+  fi
+done
+```
+
+The status check is not boilerplate. An unrecognised arm now aborts the process, and a pipeline reports the exit status of its *last* command — so `ferro … | tail | cut` reports `cut`'s success and the loop prints an empty column under the arm's heading. An empty column and an aborted run look identical, which is the same "a broken measurement reads as a result" failure this whole section is about. Redirecting first and testing the status makes the abort say so.
+
+| input | `live` | `shadow` | `canonical` | `canonical-coalesced` |
+|---|---|---|---|---|
+| `c.[5_6insAC;9del]` | `c.6_9delinsACCAA` | `c.[5_6insAC;11del]` | `c.[5_6insAC;11del]` | `c.[5_6insAC;11del]` |
+| `c.[2del;5del]` | `c.[2del;6del]` | `c.[2del;6del]` | `c.2_4delinsG` | `c.2_4delinsG` |
+| `c.[2del;9del]` | `c.[2del;11del]` | `c.[2del;11del]` | `c.[2del;11del]` | `c.2_9delinsGCCCAA` |
+
+Row 1 separates `live` from the other three, row 2 separates `{live, shadow}` from `{canonical, canonical-coalesced}`, and row 3 separates `canonical` from `canonical-coalesced`.
+
+If the arm you selected does not produce its column above, the variable is not reaching ferro and any comparison you run is meaningless. Only once the control behaves is a zero on your own corpus informative.
+
+> The control this section used to give did not work. It offered `c.[2del;9del]`, `c.[3del;9del]`, `c.[2del;9dup]` and claimed `canonical` answers `c.[2del;33del]`; on those three inputs **no arm differs from `live`**, so the documented check failed for a correct setup and would have been read as "the variable is not reaching ferro". The table above is verified against both a debug and a release build.
 
 **From Python, it must be set before the first normalization.** The value is read once per process and cached, so:
 

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -235,11 +235,12 @@ UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
                canonical, plus the delins.md:44-47 merge -- a split whose
                payload realigns as one block becomes a single delins
 
-  An unrecognised value falls back to `live`, so a misspelling looks exactly
-  like 'the candidate changes nothing'. The fallback logs a warning through the
-  `log` facade, but this CLI installs no logger, so that warning is NOT visible
-  here and RUST_LOG will not surface it. The only defence is to confirm your
-  comparison reports some differences before concluding it reports none.
+  An unrecognised value is REFUSED: the process aborts at the first variant it
+  normalizes, naming the value you gave and the arms this build has. It does not
+  fall back to `live`. It used to, which made a misspelling look exactly like
+  'the candidate changes nothing' -- and the warning that fallback logged went
+  through the `log` facade, which this CLI installs no logger for, so it reached
+  no stream and RUST_LOG could not surface it.
 
   It is read once per process and cached, so it cannot be changed after the
   first variant is normalized. That is also why this is an environment variable
@@ -3887,6 +3888,10 @@ mod tests {
     ///
     /// Pinned against the rendered help rather than the source string, so a
     /// clap attribute that silently stopped being applied would also fail.
+    ///
+    /// The help no longer carries the "confirm you see some differences"
+    /// workaround, because an unrecognised value is now refused outright. It
+    /// still has to name every arm: the arms are what the rejection offers.
     #[test]
     fn normalize_help_documents_every_partition_value() {
         use clap::CommandFactory;
@@ -3901,7 +3906,8 @@ mod tests {
                 help.contains(value),
                 "`normalize --help` does not mention the `{value}` partition rule; \
                  every value `partition_rule_from_env` accepts has to appear here, \
-                 because an unrecognised one falls back to `live` silently"
+                 because an unrecognised one is refused and this list is how a \
+                 reader learns which arms the build has"
             );
         }
         assert!(

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2134,31 +2134,99 @@ enum PartitionRule {
     CanonicalCoalesced,
 }
 
+/// Every `FERRO_PARTITION` value this build recognises, in the order the
+/// diagnostic lists them.
+///
+/// Named rather than spelled inline so the error message, the `normalize --help`
+/// text and the tests cannot drift apart — an arm added to [`PartitionRule`]
+/// without a name here is an arm the diagnostic would not offer.
+const PARTITION_RULE_NAMES: [&str; 4] = ["live", "shadow", "canonical", "canonical-coalesced"];
+
 /// Read a [`PartitionRule`] from what `FERRO_PARTITION` was set to.
 ///
-/// Unset, empty, or unrecognised all yield [`PartitionRule::Live`], so no
-/// environment can make ferro emit something other than its shipped
-/// representation by accident. An unrecognised value is warned about rather than
-/// rejected: this is a measurement knob, and a typo that silently selected a
-/// different partitioner would poison a bake-off far more quietly than one that
-/// silently ran the default and said so.
+/// Unset and empty yield [`PartitionRule::Live`], the shipped rule. Anything
+/// else that is not an arm name is an **error**, not a fallback.
 ///
-/// Split out from [`partition_rule`] so the mapping is testable without an
-/// environment variable — the cached read below can only ever be exercised once
-/// per process.
-fn partition_rule_from_env(value: Option<&str>) -> PartitionRule {
+/// # Why this refuses rather than warning
+///
+/// The knob's only purpose is to compare arms, so a value that quietly means
+/// "the default" is a measurement instrument that manufactures agreement: the
+/// candidate column is served by `live`, the diff comes back empty, and the run
+/// reads as *"the candidate changes nothing"*. There is no output that
+/// distinguishes that from the real thing.
+///
+/// It used to warn through the `log` facade and return [`PartitionRule::Live`].
+/// **That warning reached nobody.** This repository installs no logger anywhere
+/// — no `env_logger`, no `log::set_logger` — so every `log::warn!` in it is
+/// discarded by the facade's no-op default, `RUST_LOG` included. The CLI's own
+/// `normalize --help` said so in as many words. A diagnostic on a channel with
+/// no sink is indistinguishable from silence, and a warning that *did* reach
+/// stderr would still be the wrong shape here, because these runs are batch
+/// measurements whose stderr is redirected or discarded.
+///
+/// Two harvested measurement rows are the evidence: one records a `Preserve`
+/// arm, which exists only on an unmerged branch and never on `main`, and one
+/// records an output form no arm on this commit produces. Both were served by
+/// `live`. The message below names the offending value and the arms that exist
+/// **on this build**, so `FERRO_PARTITION=preserve` reports that no such arm is
+/// here rather than silently answering as `live`.
+///
+/// The cost of refusing is the trade this accepts: an unrecognised value now
+/// aborts the process at the first normalized variant (see [`partition_rule`])
+/// rather than degrading. That is confined to runs which *set* the variable — a
+/// process that leaves it unset, which is every production and CI path, cannot
+/// reach this error at all.
+///
+/// Split out from [`partition_rule`] so the mapping is testable without touching
+/// a process-global environment variable — the cached read below can only ever
+/// be exercised once per process.
+fn partition_rule_from_env(value: Option<&str>) -> Result<PartitionRule, String> {
     match value {
-        None | Some("") | Some("live") => PartitionRule::Live,
-        Some("shadow") => PartitionRule::Shadow,
-        Some("canonical") => PartitionRule::Canonical,
-        Some("canonical-coalesced") => PartitionRule::CanonicalCoalesced,
-        Some(other) => {
-            log::warn!(
-                "FERRO_PARTITION={other} is not one of \
-                 live|shadow|canonical|canonical-coalesced; using live"
-            );
-            PartitionRule::Live
-        }
+        None | Some("") | Some("live") => Ok(PartitionRule::Live),
+        Some("shadow") => Ok(PartitionRule::Shadow),
+        Some("canonical") => Ok(PartitionRule::Canonical),
+        Some("canonical-coalesced") => Ok(PartitionRule::CanonicalCoalesced),
+        Some(other) => Err(format!(
+            "FERRO_PARTITION={other:?} is not a partitioner this build has. \
+             This build's arms are: {}. \
+             Refusing rather than falling back to `live`, because a bake-off \
+             served the shipped rule under a candidate's name reports that the \
+             candidate changes nothing.",
+            PARTITION_RULE_NAMES.join(", ")
+        )),
+    }
+}
+
+/// The string [`partition_rule_from_env`] should see, from a raw environment read.
+///
+/// Split out from [`partition_rule`] for the same reason
+/// [`partition_rule_from_env`] is: the cached read below can only ever be
+/// exercised once per process, so the mapping has to be testable without it.
+///
+/// # Why this is not `.ok()`
+///
+/// [`std::env::var`] returns `Err` for two unrelated reasons and `.ok()`
+/// collapses both to `None` — but `None` is the **unset** case, which is
+/// legitimately `live`. So a value that *was* set, to bytes that are not UTF-8,
+/// selected the shipped rule and said nothing: exactly the silent fallback the
+/// rejection in [`partition_rule_from_env`] exists to remove, reachable through
+/// a door that function never sees. A bake-off whose `FERRO_PARTITION` was
+/// mangled in transit (a locale-mismatched shell, a mis-encoded CI variable)
+/// reads as "the candidate changes nothing".
+///
+/// Only [`VarError::NotPresent`] means unset. A [`VarError::NotUnicode`] value
+/// is rendered lossily and handed to the parser so it is refused *and* quoted in
+/// the diagnostic. The U+FFFD replacements that rendering inserts cannot collide
+/// with an arm name, because a value needing no replacement would have decoded
+/// as UTF-8 and never reached this arm.
+///
+/// [`VarError::NotPresent`]: std::env::VarError::NotPresent
+/// [`VarError::NotUnicode`]: std::env::VarError::NotUnicode
+fn partition_rule_env_value(read: Result<String, std::env::VarError>) -> Option<String> {
+    match read {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(raw)) => Some(raw.to_string_lossy().into_owned()),
     }
 }
 
@@ -2168,9 +2236,24 @@ fn partition_rule_from_env(value: Option<&str>) -> PartitionRule {
 /// [`seqfirst_shadow_enabled`], so the default path pays one relaxed atomic load
 /// per canonicalized block and nothing else; with the variable unset the result
 /// is byte-identical to having no switch at all.
+///
+/// # Panics
+///
+/// If `FERRO_PARTITION` names an arm this build does not have. Both call sites
+/// are inside `canonicalize_from_sequence`, which is infallible and sits deep
+/// under every public normalization entry point, so there is no `Result` to
+/// return the rejection through without threading one the length of the
+/// pipeline. A panic here is the honest alternative: it fires once, at the first
+/// normalized variant, before any output exists to be mistaken for a
+/// measurement. See [`partition_rule_from_env`] for why silence was not an
+/// option, and [`partition_rule_env_value`] for why the raw read is matched
+/// rather than `.ok()`-ed.
 fn partition_rule() -> PartitionRule {
     static RULE: std::sync::OnceLock<PartitionRule> = std::sync::OnceLock::new();
-    *RULE.get_or_init(|| partition_rule_from_env(std::env::var("FERRO_PARTITION").ok().as_deref()))
+    *RULE.get_or_init(|| {
+        let value = partition_rule_env_value(std::env::var("FERRO_PARTITION"));
+        partition_rule_from_env(value.as_deref()).unwrap_or_else(|message| panic!("{message}"))
+    })
 }
 
 /// The unchanged-base separation threshold an axis merges runs below.
@@ -11516,51 +11599,161 @@ mod tests {
             );
         }
 
-        /// Unset means `live`, and so does anything the knob does not recognise.
+        /// Only *absence* means `live` — an unset or empty variable.
         ///
-        /// This is the property the default path depends on. A knob that fell
-        /// through to a different rule on an empty string, or that treated a
-        /// typo (`FERRO_PARTITION=cannonical`) as an instruction rather than as
-        /// noise, would silently re-partition every block for whoever set it —
-        /// which for this repo is a representation change, not a configuration.
+        /// This is the property the default path depends on: leaving the knob
+        /// alone, which is every production and CI path, must reach the shipped
+        /// rule. Distinguished from a typo deliberately, because the two used to
+        /// share an answer; see the sibling test below.
         #[test]
-        fn unset_and_unrecognised_values_select_the_live_rule() {
+        fn an_absent_value_selects_the_live_rule() {
             for value in [None, Some(""), Some("live")] {
                 assert_eq!(
                     partition_rule_from_env(value),
-                    PartitionRule::Live,
+                    Ok(PartitionRule::Live),
                     "{value:?}"
-                );
-            }
-            for typo in ["cannonical", "LIVE", "shadow ", "1", "true"] {
-                assert_eq!(
-                    partition_rule_from_env(Some(typo)),
-                    PartitionRule::Live,
-                    "{typo} must not select a rule"
                 );
             }
         }
 
-        /// The two non-default rules are reachable, and only by their own names.
+        /// **Every** arm name this build has still resolves, and to its own rule.
+        ///
+        /// The guard on the guard: refusing unknown values is only safe if it
+        /// cannot also refuse a real arm. Driven off [`PARTITION_RULE_NAMES`] —
+        /// the same list the rejection message prints — so an arm that the
+        /// diagnostic advertises but the parser does not accept fails here
+        /// rather than at somebody's bake-off.
         #[test]
-        fn the_alternative_rules_are_selected_by_name() {
+        fn every_advertised_arm_name_resolves() {
+            let expected = [
+                ("live", PartitionRule::Live),
+                ("shadow", PartitionRule::Shadow),
+                ("canonical", PartitionRule::Canonical),
+                ("canonical-coalesced", PartitionRule::CanonicalCoalesced),
+            ];
             assert_eq!(
-                partition_rule_from_env(Some("shadow")),
-                PartitionRule::Shadow
+                expected.map(|(name, _)| name),
+                PARTITION_RULE_NAMES,
+                "the advertised names and the names under test have drifted"
+            );
+            for (name, rule) in expected {
+                assert_eq!(
+                    partition_rule_from_env(Some(name)),
+                    Ok(rule),
+                    "{name} must still select its own rule"
+                );
+            }
+        }
+
+        /// An unrecognised value is **refused**, and must not produce `live`.
+        ///
+        /// The defect this pins is not "a typo picks the wrong rule" — it is
+        /// that a typo used to pick the *shipped* rule and say nothing, so a
+        /// bake-off measured `live` against `live` and reported that the
+        /// candidate changes nothing. The `log::warn!` that stood here was a
+        /// no-op: this repository installs no logger, so nothing reached any
+        /// stream, `RUST_LOG` included.
+        ///
+        /// Asserted on the concrete behaviour, not merely on non-`Ok`: the
+        /// message must quote the offending value verbatim and list the arms
+        /// this build actually has. `preserve` is in the list because it is one
+        /// of the two values a harvested measurement row recorded — it exists
+        /// only on an unmerged branch, so on this commit the message has to be
+        /// what tells the operator that.
+        #[test]
+        fn an_unrecognised_value_is_refused_and_never_falls_back_to_live() {
+            for bad in [
+                "cannonical",
+                "LIVE",
+                "shadow ",
+                "1",
+                "true",
+                "preserve",
+                "Canonical",
+                "none",
+            ] {
+                let outcome = partition_rule_from_env(Some(bad));
+                let message = match outcome {
+                    Ok(rule) => panic!(
+                        "FERRO_PARTITION={bad} silently selected {rule:?}; \
+                         an unrecognised arm must be refused, not defaulted"
+                    ),
+                    Err(message) => message,
+                };
+                assert!(
+                    message.contains(bad),
+                    "the rejection must quote the offending value verbatim, got: {message}"
+                );
+                for name in PARTITION_RULE_NAMES {
+                    assert!(
+                        message.contains(name),
+                        "the rejection must list the `{name}` arm so the reader \
+                         can see what this build has, got: {message}"
+                    );
+                }
+            }
+        }
+
+        /// An **unset** variable is the only thing that reads as unset.
+        ///
+        /// The two `Err` arms of [`std::env::VarError`] mean opposite things
+        /// here, and the collapse that `.ok()` performs on them is the defect
+        /// [`partition_rule_env_value`] exists to prevent — see its notes.
+        #[test]
+        fn only_a_missing_variable_reads_as_unset() {
+            assert_eq!(
+                partition_rule_env_value(Err(std::env::VarError::NotPresent)),
+                None,
+                "an unset FERRO_PARTITION is the legitimate `live` case"
             );
             assert_eq!(
-                partition_rule_from_env(Some("canonical")),
-                PartitionRule::Canonical
+                partition_rule_env_value(Ok("canonical".to_owned())),
+                Some("canonical".to_owned()),
+                "a readable value must reach the parser unaltered"
             );
-            // The rule this change adds. Without it the knob's newest value was
-            // the one value nothing exercised, so a typo in the match arm would
-            // have surfaced only as a silent fallback to `Live` during a
-            // bake-off — exactly the failure the knob's own doc says it is
-            // designed to make loud.
-            assert_eq!(
-                partition_rule_from_env(Some("canonical-coalesced")),
-                PartitionRule::CanonicalCoalesced
+        }
+
+        /// A **non-UTF-8** value is refused, and must not produce `live`.
+        ///
+        /// The sibling of `an_unrecognised_value_is_refused_and_never_falls_back_to_live`,
+        /// covering the door that test cannot reach: its subject is the parser,
+        /// which only ever sees a `str`, so a value that fails to decode was
+        /// silently `live` no matter what the parser did. Bytes chosen to spell
+        /// a *valid* arm followed by one invalid byte, so the assertion cannot
+        /// pass merely because the value was unrecognisable anyway.
+        ///
+        /// Unix-only because constructing a non-UTF-8 `OsString` is
+        /// platform-specific; the mapping under test is not.
+        #[cfg(unix)]
+        #[test]
+        fn a_non_unicode_value_is_refused_and_never_falls_back_to_live() {
+            use std::os::unix::ffi::OsStringExt;
+
+            let raw = std::ffi::OsString::from_vec(vec![b'l', b'i', b'v', b'e', 0xff]);
+            let value = partition_rule_env_value(Err(std::env::VarError::NotUnicode(raw)))
+                .expect("a set-but-undecodable value must reach the parser, not read as unset");
+
+            let message = match partition_rule_from_env(Some(&value)) {
+                Ok(rule) => panic!(
+                    "a non-UTF-8 FERRO_PARTITION silently selected {rule:?}; \
+                     a value that was set but cannot be decoded must be refused, \
+                     not treated as unset"
+                ),
+                Err(message) => message,
+            };
+            assert!(
+                message.contains(&value),
+                "the rejection must quote the offending value, mangled bytes and \
+                 all, so the reader can see it was the encoding that broke, \
+                 got: {message}"
             );
+            for name in PARTITION_RULE_NAMES {
+                assert!(
+                    message.contains(name),
+                    "the rejection must list the `{name}` arm so the reader \
+                     can see what this build has, got: {message}"
+                );
+            }
         }
 
         /// This suite's expectations are the live rule's, and the cached read


### PR DESCRIPTION
Representation-Change: none. Env-var validation and documentation only; no normalized output moves.

## Why this is rank 1 despite being a test knob

`FERRO_PARTITION` is not a feature — it is the A/B instrument the entire partition investigation was measured with. Its only purpose is to compare partitioner arms. And an unrecognised value fell through to `PartitionRule::Live`, the shipped default.

So a typo, or an arm named from a branch this build does not have, produced **live output under the candidate's name**: an empty diff that reads as *"the candidate changes nothing"*. The knob manufactures agreement. There is no output that distinguishes a real null result from a misspelling, which makes it strictly worse than a knob that does not work at all — a broken knob announces itself.

This is not hypothetical. Two rows in the project's measurement harvest record arms that match no arm existing on this commit: one records a `Preserve` arm (`preserve` exists only on an unmerged stack, never on `main`), and one records a third output form that no arm produces. Both were almost certainly served by `live`. It reaches backwards too: a sweep on `main` that enumerated *five* arms had its fifth column silently served by `live`, which puts a caveat on any conclusion of the form "all arms agree". This PR does not re-run those sweeps — it makes the next one impossible to get wrong this way.

### The warning that was already there reached nobody

The fallback did call `log::warn!`. That is a complete no-op in this tree: **no logger is installed anywhere** — no `env_logger`, no `log::set_logger`; the only subscriber is `tracing_subscriber` in the unrelated `ferro-web` binary. So the facade discarded it, `RUST_LOG` included. The CLI's own `normalize --help` said so verbatim: *"this CLI installs no logger, so that warning is NOT visible here and RUST_LOG will not surface it."* A diagnostic on a channel with no sink is silence.

## The change

Parsing site: `src/normalize/merge.rs`, `partition_rule_from_env` (the fallback arm, and the cached `partition_rule` read below it).

`partition_rule_from_env` now returns `Result<PartitionRule, String>`. Unset and empty still yield `Live`; anything that is not an arm name is an error.

```
FERRO_PARTITION="preserve" is not a partitioner this build has. This build's arms
are: live, shadow, canonical, canonical-coalesced. Refusing rather than falling
back to `live`, because a bake-off served the shipped rule under a candidate's
name reports that the candidate changes nothing.
```

The message names the offending value verbatim and lists the arms **this build** has, sourced from a `PARTITION_RULE_NAMES` const shared with the tests. That is the sentence that would have prevented both harvested rows: someone naming `preserve` on `main` learns from the message alone that no such arm is here.

### A non-UTF-8 value is refused too (added in review)

The first cut of this PR left the same fallback reachable through a door the parser never sees. `std::env::var("FERRO_PARTITION").ok()` collapses **both** `VarError` arms to `None` — and `None` is the *unset* case, which is legitimately `live`. So a variable that *was* set, to bytes that are not UTF-8, still selected the shipped rule and said nothing.

That is the identical failure this PR exists to remove, so `partition_rule_env_value` now matches the raw read instead: `NotPresent` is the only thing that reads as unset, and a `NotUnicode` value is rendered lossily and handed to the parser so it is refused *and* quoted, mangled bytes and all. It is a separate pure function for the same reason `partition_rule_from_env` is — the `OnceLock` read can only be exercised once per process, so the mapping is testable without process-global state or test ordering.

Two Unix regressions cover it (`only_a_missing_variable_reads_as_unset`, `a_non_unicode_value_is_refused_and_never_falls_back_to_live`); the second fails against the old `.ok()` mapping, verified by reverting.

The README's validation control was hardened in the same pass: an unrecognised arm now aborts, and a pipeline reports its *last* command's status, so `ferro … | tail | cut` reported `cut`'s success and printed an empty column where a run had died. It redirects per arm and tests the status instead.

### Refuse vs warn, and the trade-off

**Refuse.** Both call sites are inside `canonicalize_from_sequence`, which is infallible and sits deep under every public normalization entry point, so returning the rejection cleanly would mean threading a `Result` the length of the normalize pipeline for a dev-only knob. The rejection is therefore a **panic at the cached read**.

That cost is bounded and worth naming explicitly:

- It is reachable **only** by a process that explicitly *sets* `FERRO_PARTITION`. Unset and empty still yield `Live`, so every production path, every CI job and every wheel consumer is untouched.
- It fires once, at the first normalized variant — before any output exists to be mistaken for a measurement.

A warning was rejected on its merits as well as on the missing-logger fact: these are batch measurement runs whose stderr is routinely redirected or discarded, so even a *working* stderr warning is the wrong shape for this knob.

### Tests

- `an_absent_value_selects_the_live_rule` — unset/empty/`live` still reach the shipped rule.
- `every_advertised_arm_name_resolves` — every arm still resolves to its own rule, driven off the same `PARTITION_RULE_NAMES` the diagnostic prints, so an arm the message advertises but the parser rejects fails here rather than at somebody's bake-off. This is the guard on the guard: refusing unknown values is only safe if it cannot also refuse a real arm.
- `an_unrecognised_value_is_refused_and_never_falls_back_to_live` — asserts on the concrete behaviour: the `Ok` arm panics naming the rule it wrongly selected, and the message must contain the offending value verbatim *and* every arm name. Not `is_err()`, not `Ok(_) | Err(_)`, no assertion nested inside a branch that may not run.

All three call the mapping directly, so they mutate no process-global environment and are safe under parallel execution. Testing through `partition_rule()` is impossible by construction — it caches in a `OnceLock`, so one process can only ever observe one arm.

Local gate: `cargo fmt --check` clean, `cargo clippy --features dev --all-targets -- -D warnings` clean, `cargo nextest run --features dev` **9731 passed / 0 failed, with nothing re-blessed**.

## A second defect, found while verifying the first

The README's positive control — described there as the *only* defence against the silent fallback — **did not work**. It gave three inputs and claimed `canonical` answers `c.[2del;33del]`. Measured on this commit, in both debug and release builds, **no arm differs from `live`** on any of those three inputs. So the documented check failed for a correctly configured setup, and the README instructs the reader to interpret that as *"the variable is not reaching ferro and any comparison you run is meaningless"*. It was a false negative pointing the opposite way from the defect above. Pre-existing, introduced alongside the control in #1483.

Replaced with a control verified against both build profiles whose three rows separate **all four arms pairwise**:

| input | `live` | `shadow` | `canonical` | `canonical-coalesced` |
|---|---|---|---|---|
| `c.[5_6insAC;9del]` | `c.6_9delinsACCAA` | `c.[5_6insAC;11del]` | `c.[5_6insAC;11del]` | `c.[5_6insAC;11del]` |
| `c.[2del;5del]` | `c.[2del;6del]` | `c.[2del;6del]` | `c.2_4delinsG` | `c.2_4delinsG` |
| `c.[2del;9del]` | `c.[2del;11del]` | `c.[2del;11del]` | `c.[2del;11del]` | `c.2_9delinsGCCCAA` |

Row 1 separates `live` from the rest, row 2 separates `{live, shadow}` from `{canonical, canonical-coalesced}`, row 3 separates `canonical` from `canonical-coalesced`. So the control now tells you *which* arm you got, not merely that something changed.

It is deliberately **not** pinned by a test: `partition_rule` caches in a `OnceLock`, so exercising four arms needs four processes, which the repo already tracks as a follow-up needing an isolated process per rule. Worth knowing that this table can rot the same way the last one did.

The control is still worth running even with refusal in place, because it catches the one vacuity ferro cannot detect from the inside: a variable that never reached the process at all — a lost `export`, a `sudo` that scrubbed the environment, a container that did not forward it. That is indistinguishable from unset, which is legitimately `live`.

## Sibling-knob audit

`FERRO_PARTITION` was not the only knob parsed this way. Audited every `FERRO_*` variable in the tree. **Nothing outside `FERRO_PARTITION` is changed in this PR** — this is a report.

Grading note: since no logger is installed, every `log::warn!` grades as **silent**, not as a warning.

| variable | parse site | verdict | consequence of a bad value |
|---|---|---|---|
| `FERRO_ASSERT_IDEMPOTENT` | `src/normalize/mod.rs` | **silent default** | oracle silently does not run |
| `FERRO_ASSERT_REPARSE` | `src/normalize/mod.rs` | **silent default** | oracle silently does not run |
| `FERRO_ASSERT_IN_BOUNDS` | `src/normalize/mod.rs` | **silent default** | oracle silently does not run |
| `FERRO_SEQFIRST_SHADOW` | `src/normalize/merge.rs` | **silent default** | audit silently disabled; reports also go to `log::debug!` |
| `FERRO_SEQUENCE_CACHE_BYTES` | `src/reference/multi_fasta.rs` | **silent default** | unparseable size silently gets the default; its doc comment claims otherwise |
| `FERRO_BENCH_CORPUS` | `benches/benchmarks.rs` | path | name typo silently falls back to the in-tree fixture |
| `FERRO_MANIFEST` | ~15 sites | path | three *different* missing-path policies: assert, `eprintln!`+skip, and silent skip |
| `FERRO_SWEEP_SEEDS` | `tests/it/common/cis_apply_oracle.rs` | **refuses** | panics on a bad value — clean |
| `FERRO_PREBUILT_EXAMPLES` | none | dead | mentioned in a comment; nothing reads it |

### The one worth scoping a follow-up for

**The three assertion oracles are the same defect as this one, three times over, on the flags CI depends on most.** All three are

```rust
std::env::var("FERRO_ASSERT_…").map(|v| !v.is_empty() && v != "0").unwrap_or(false)
```

A misspelled variable **name** is `VarError::NotPresent` → `unwrap_or(false)` → the oracle never runs, and the job is green and indistinguishable from an armed one. There is no startup line and no "N normalizations checked" counter anywhere, so nothing downstream can tell an armed run from a disarmed one. These gate the `test-oracle` and `sweeps` jobs and the nightly. Compounding it, all three are `#[cfg(debug_assertions)]`, so a release run is silently unoracled even when spelled correctly. (A bad *value* — `=yes` — is fail-safe: it still enables.)

The cheap fix is symmetric to this PR: refuse anything that is not an explicit on/off token, and print one line at first use naming which oracles are armed.

Two more worth noting. `FERRO_SEQFIRST_SHADOW` is doubly silent — it tests `== Ok("1")`, so `true`/`yes`/`on` disable it quietly, *and* its reports go through `log::debug!` into the sinkless facade, so armed and disarmed are byte-identically observable; any "the shadow audit found nothing" conclusion drawn from it is currently unfalsifiable. And `FERRO_SEQUENCE_CACHE_BYTES` carries a doc comment asserting that a typo warns rather than being silently ignored, which is false in this tree — a live documentation defect.

The good news, contrary to the hypothesis going in: **`FERRO_SWEEP_SEEDS` is clean.** A value that is neither numeric nor `full` panics, pinned by a `#[should_panic]` test; `full` is case-insensitive, numbers are trimmed, and non-UTF-8 panics rather than degrading. CI's exhaustive-sweeps job cannot report success on a reduced corpus because of a bad value. The residual gap there is structural rather than a parse bug: a misspelled variable *name* still falls to the 4-seed default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `FERRO_PARTITION` values now fail clearly instead of silently falling back to `live`.
  * Error messages identify the supplied value and list the partitioning modes supported by the current build.
  * Default behavior remains unchanged when the variable is not set.
* **Documentation**
  * Updated configuration guidance to explain validation, historical fallback behavior, environment-variable limitations, and expected outputs for all partitioning modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
