### PR TITLE
test(parser): cover the last three allele-recursion arms

### DIFF
--- a/tests/it/issue_1079_immediate_ter_frameshift.rs
+++ b/tests/it/issue_1079_immediate_ter_frameshift.rs
@@ -26,6 +26,7 @@
 //! author wrote — a frameshift becomes a substitution — so it is surfaced
 //! rather than performed.
 
+use ferro_hgvs::error::ErrorCode;
 use ferro_hgvs::error_handling::ErrorConfig;
 use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
 use ferro_hgvs::parse_hgvs;
@@ -108,4 +109,38 @@ fn nonsense_substitution_still_parses() {
     for input in ["NP_003997.1:p.Tyr4Ter", "NP_003997.1:p.Tyr4*"] {
         assert!(parse_hgvs(input).is_ok(), "{input:?} must parse");
     }
+}
+
+// =====================================================================
+// Inside allele brackets — the validator's `Allele` recursion
+// =====================================================================
+//
+// `validate_no_immediate_ter_frameshift` walks `HgvsVariant::Allele` members and re-applies
+// itself to each. That recursion arm had no test: neutering it left the whole
+// `it` suite green (5,547 tests), so the mutant survived. #1576 closed the same
+// gap for three sibling rules; these are the remaining three of the eleven
+// validators that share the arm.
+//
+// The assertion is on the contract — rejected, with a structured code and the
+// spec citation — not on which mechanism rejected it, so it survives a refactor
+// that moves the check.
+
+#[test]
+fn rejects_immediate_ter_frameshift_inside_a_cis_allele() {
+    let err = parse_hgvs("NP_003997.1:p.[Arg76Ser;Tyr4TerfsTer1]")
+        .expect_err("a bracketed member is still bound by protein/frameshift.md:22");
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "the allele member rejection must carry a structured InvalidEdit code"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("protein/frameshift.md:22"),
+        "the allele member must earn the immediate-Ter-frameshift diagnostic; got: {msg}"
+    );
+    assert!(
+        msg.contains("p.Tyr4Ter"),
+        "the diagnostic should still name the nonsense repair; got: {msg}"
+    );
 }

--- a/tests/it/issue_1079_residues_after_stop.rs
+++ b/tests/it/issue_1079_residues_after_stop.rs
@@ -29,6 +29,7 @@
 //! which needs the reference sequence. Truncating would swap one
 //! non-canonical description for another.
 
+use ferro_hgvs::error::ErrorCode;
 use ferro_hgvs::error_handling::ErrorConfig;
 use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
 use ferro_hgvs::parse_hgvs;
@@ -109,4 +110,38 @@ fn stop_position_insertion_form_is_untouched() {
     ] {
         assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
     }
+}
+
+// =====================================================================
+// Inside allele brackets — the validator's `Allele` recursion
+// =====================================================================
+//
+// `validate_no_residues_after_stop` walks `HgvsVariant::Allele` members and re-applies
+// itself to each. That recursion arm had no test: neutering it left the whole
+// `it` suite green (5,547 tests), so the mutant survived. #1576 closed the same
+// gap for three sibling rules; these are the remaining three of the eleven
+// validators that share the arm.
+//
+// The assertion is on the contract — rejected, with a structured code and the
+// spec citation — not on which mechanism rejected it, so it survives a refactor
+// that moves the check.
+
+#[test]
+fn rejects_residues_after_stop_inside_a_cis_allele() {
+    let err = parse_hgvs("NP_004371.2:p.[Arg76Ser;Asn47delinsSerSerTerAlaAsp]")
+        .expect_err("a bracketed member is still bound by protein/delins.md:45");
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "the allele member rejection must carry a structured InvalidEdit code"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("protein/delins.md:45"),
+        "the allele member must earn the residues-after-stop diagnostic; got: {msg}"
+    );
+    assert!(
+        msg.contains("delinsSerSerTer"),
+        "the diagnostic should still name the truncated peptide; got: {msg}"
+    );
 }

--- a/tests/it/issue_1079_single_nucleotide_inversion.rs
+++ b/tests/it/issue_1079_single_nucleotide_inversion.rs
@@ -21,6 +21,7 @@
 //! which the parser does not have — so there is no canonical form to rewrite
 //! to and every mode rejects.
 
+use ferro_hgvs::error::ErrorCode;
 use ferro_hgvs::error_handling::ErrorConfig;
 use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
 use ferro_hgvs::parse_hgvs;
@@ -106,4 +107,38 @@ fn inverted_insertion_source_is_untouched() {
     ] {
         assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
     }
+}
+
+// =====================================================================
+// Inside allele brackets — the validator's `Allele` recursion
+// =====================================================================
+//
+// `validate_no_single_nucleotide_inversion` walks `HgvsVariant::Allele` members and re-applies
+// itself to each. That recursion arm had no test: neutering it left the whole
+// `it` suite green (5,547 tests), so the mutant survived. #1576 closed the same
+// gap for three sibling rules; these are the remaining three of the eleven
+// validators that share the arm.
+//
+// The assertion is on the contract — rejected, with a structured code and the
+// spec citation — not on which mechanism rejected it, so it survives a refactor
+// that moves the check.
+
+#[test]
+fn rejects_single_nucleotide_inversion_inside_a_cis_allele() {
+    let err = parse_hgvs("NC_000023.11:g.[100A>T;234inv]")
+        .expect_err("a bracketed member is still bound by DNA/inversion.md:16");
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "the allele member rejection must carry a structured InvalidEdit code"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("DNA/inversion.md:16"),
+        "the allele member must earn the single-nucleotide-inversion diagnostic; got: {msg}"
+    );
+    assert!(
+        msg.contains("substitution"),
+        "the diagnostic should still point at the substitution form; got: {msg}"
+    );
 }


### PR DESCRIPTION
Eleven post-parse validators in `src/hgvs/parser/variant.rs` share one `HgvsVariant::Allele` arm that re-applies the validator to each bracketed member. #1576 added cis-allele tests for three of them, found by mutation testing. This covers the remaining three.

## The gap was measured, not guessed

Neutering an arm — keeping the loop, dropping the recursive call — is the mutant:

```rust
HgvsVariant::Allele(allele) => {
    for inner in &allele.variants {
        let _ = inner; // MUTANT: validate_no_residues_after_stop(inner)?;
    }
}
```

Doing that to all eleven arms at once and running the `it` suite attributes each arm to the tests that guard it. Eight arms had a failing test. Three had none:

| validator | arm | guarded before |
|---|---|---|
| `validate_no_residues_after_stop` | `variant.rs:8131` | **no** |
| `validate_no_immediate_ter_frameshift` | `variant.rs:8213` | **no** |
| `validate_no_single_nucleotide_inversion` | `variant.rs:8369` | **no** |

Neutering only those three left the **entire suite green — 5,547 passed, 0 failed**. All three mutants survived.

## Each new test kills exactly its own mutant

With the three mutants re-introduced and the new tests in place, **exactly three tests fail and nothing else does** — 5,547 passed, 3 failed:

```
FAIL issue_1079_immediate_ter_frameshift::rejects_immediate_ter_frameshift_inside_a_cis_allele
FAIL issue_1079_residues_after_stop::rejects_residues_after_stop_inside_a_cis_allele
FAIL issue_1079_single_nucleotide_inversion::rejects_single_nucleotide_inversion_inside_a_cis_allele
```

One failure per mutant, no collateral. That is the property a mutation-derived test has to have and the reason to state it here rather than assert it: a test that passes for an unrelated reason looks identical in CI.

## Asserting the contract, not the mechanism

Each test asserts that the bracketed member is rejected, that the error carries a structured `ErrorCode::InvalidEdit`, and that the diagnostic cites the spec clause and still names the canonical repair. It does **not** assert which mechanism rejected it. A refactor that moves where the check fires should not turn these red, and asserting the rung rather than the contract is what made the #1157/#1158 pair flip red on landing order.

The inputs pair a legal member with an illegal one, so the rejection can only come from walking into the second member:

- `NP_004371.2:p.[Arg76Ser;Asn47delinsSerSerTerAlaAsp]` → `protein/delins.md:45`
- `NP_003997.1:p.[Arg76Ser;Tyr4TerfsTer1]` → `protein/frameshift.md:22`
- `NC_000023.11:g.[100A>T;234inv]` → `DNA/inversion.md:16`

## Testing

- Full `it` suite: **5,550 passed, 0 failed** (5,547 before, +3).
- `cargo clippy --all-features --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `src/` is untouched — verified byte-identical to `HEAD` after the mutation experiments (`diff` against `git show HEAD:src/hgvs/parser/variant.rs`).

Representation-Change: none. Tests only; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched.
