### PR TITLE
fix(equivalence): decline a ring no rung can evaluate; rule that self-cancellation does not cross `::` (#1578 items 3-4)

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -244,6 +244,22 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                     .with_note("Variants produce the same resulting sequence"));
             }
 
+            // #1578 follow-up: `NotEquivalent` is a *positive claim* that two
+            // descriptions denote different variants, and it is only sound if
+            // some rung above actually examined them. For a structural
+            // rearrangement both deciding rungs are blind at once — see
+            // `undecidable_reason` — so falling through here would answer a
+            // question nobody asked. Decline instead, which is what the other
+            // three modules that hand-roll `Allele` recursion already do with a
+            // ring (`spdi::apply`, `vcf::from_hgvs`, `project::projector`).
+            for side in [&norm1, &norm2] {
+                if let Some(reason) = self.undecidable_reason(side) {
+                    return Err(FerroError::UnsupportedVariant {
+                        variant_type: reason,
+                    });
+                }
+            }
+
             Ok(EquivalenceResult::new(EquivalenceLevel::NotEquivalent)
                 .with_normalized(norm_str1, norm_str2)
                 .with_note("Variants do not normalize to the same form"))
@@ -354,6 +370,55 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
             (Some(a), Some(b)) => a.eq_ignore_ascii_case(&b),
             _ => false,
         }
+    }
+
+    /// Why no rung can decide equivalence for `variant`, or `None` if some rung
+    /// can.
+    ///
+    /// The checker decides in rungs, and a structural rearrangement defeats both
+    /// of the two that compare *meaning* rather than text:
+    ///
+    /// - [`Normalizer::normalize`] returns a genome ring and a `sup` marker
+    ///   unchanged (the pass-through arms in `src/normalize/mod.rs`), so
+    ///   comparing normalized forms degenerates into the string comparison the
+    ///   `Identical` rung already made; and
+    /// - [`hgvs_to_spdi`] cannot represent either, so [`Self::edit_triples`]
+    ///   declines and the `SequenceMatch` rung (#1158) cannot fire either.
+    ///
+    /// With both blind, `NotEquivalent` would be asserted having evaluated
+    /// nothing. The two *textual* rungs — `Identical` and
+    /// `AccessionVersionDifference` — are unaffected and still answer, because
+    /// they need neither normalization nor a provider.
+    ///
+    /// **The SPDI conjunct is not redundant, and it is what keeps this honest.**
+    /// It makes the predicate self-retiring: if `hgvs_to_spdi` ever gains ring
+    /// support, `edit_triples` starts succeeding, the `SequenceMatch` rung
+    /// begins deciding these pairs, and this decline stops firing on its own
+    /// rather than masking the new capability. `Circular` (`o.`) is the live
+    /// proof that the conjunct matters: its normalization is a pass-through too,
+    /// yet SPDI represents it, so it is decided by the sequence rung and must
+    /// never reach this decline.
+    /// **Scoped to the two shapes a defect was measured on.**
+    /// [`HgvsVariant::RnaFusion`] shares both blindnesses and is deliberately
+    /// *not* listed: no pair of fusion spellings denoting one fusion has been
+    /// exhibited, so widening the decline to `::` transcript fusions would
+    /// refuse pairs the checker answers today on no evidence that any of those
+    /// answers is wrong. Add it when a wrong answer is measured, with the pair
+    /// that measures it.
+    fn undecidable_reason(&self, variant: &HgvsVariant) -> Option<String> {
+        let structural = matches!(
+            variant,
+            HgvsVariant::GenomeRing(_) | HgvsVariant::Supernumerary(_)
+        );
+        if !structural || self.edit_triples(variant).is_some() {
+            return None;
+        }
+        Some(format!(
+            "{variant}: cannot decide equivalence — normalization passes this \
+             description through unchanged and SPDI cannot represent it, so \
+             neither the normalized-form nor the resulting-sequence comparison \
+             examined it"
+        ))
     }
 
     /// Project a variant to the SPDI primitive edits that make up its resulting

--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -406,11 +406,31 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     /// answers is wrong. Add it when a wrong answer is measured, with the pair
     /// that measures it.
     fn undecidable_reason(&self, variant: &HgvsVariant) -> Option<String> {
-        let structural = matches!(
+        // SPDI first, at every level: if `edit_triples` succeeds the `SequenceMatch`
+        // rung can decide, so there is nothing undecidable to report. Keeping this
+        // ahead of the structural test is what makes the predicate self-retiring —
+        // ring support in `hgvs_to_spdi` silently switches these pairs back to being
+        // answered instead of declined.
+        if self.edit_triples(variant).is_some() {
+            return None;
+        }
+        // A cis allele carrying a ring is the same blindness one level down, and it
+        // is a shape this codebase constructs deliberately —
+        // `issue_1578_followup_ring_declines.rs` pairs a legal genomic member with a
+        // ring and requires `spdi::apply`, `vcf::from_hgvs` and the projector to all
+        // decline it. Without this recursion the equivalence checker was the one
+        // module that answered it: two such alleles compared `NotEquivalent`, which
+        // is a positive claim that no rung examined.
+        if let HgvsVariant::Allele(allele) = variant {
+            return allele
+                .variants
+                .iter()
+                .find_map(|member| self.undecidable_reason(member));
+        }
+        if !matches!(
             variant,
             HgvsVariant::GenomeRing(_) | HgvsVariant::Supernumerary(_)
-        );
-        if !structural || self.edit_triples(variant).is_some() {
+        ) {
             return None;
         }
         Some(format!(

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -615,6 +615,63 @@
         }
       ],
       "rationale": "THE QUANTITY THE RULE KEYS ON IS NOT A FUNCTION OF THE VARIANT. `general.md:34` and `delins.md:17` are stated over \"two variants\", which presupposes a decomposition; the separation between them is read off that decomposition, not off the reference and the denoted sequence. A normalizer sees only the latter pair, so the rule as written is not evaluable on what a normalizer knows.\n\nDEMONSTRATED, NOT ARGUED. On a synthetic transcript whose `c.9` is `T` and whose `c.10`/`c.11` are both `A`, the spellings `c.[9del;10del;13del]` and `c.[9del;11del;13del]` denote the same sequence — verified by applying each to the reference through `hgvs_to_spdi`, independently of the normalizer. The first presents separations of 0 and 2, the second separations of 1 and 1. `general.md:34` merges the first pair and splits the second, so it returns two answers for one variant. Both are pinned in `tests/it/cis_confluence_adjudication.rs`.\n\nAT CORPUS SCALE, RE-MEASURED AFTER #1537. Over the 11,272-class designed cis corpus, 642 of the 9,442 distinct `(axis, reference, denoted sequence)` variants are reachable from more than one design, and 286 of those from designs whose separation parameters differ — both unchanged by #1537, which is itself the point: that PR settled the separation-ZERO question, and this record is about every other separation. And of the 4,643 classes that diverge in the 3' direction, 4,568 (98.4%) have the single spanning spelling reaching an output DISJOINT from every output the multi-member spellings reach — i.e. ferro is preserving the partition it was handed rather than deriving one. That is what evaluating a spelling-relative rule looks like from the outside, and it is the mechanism behind two thirds of the pile. (The pre-#1537 figures were 4,639 and 4,567; the shape this record describes is untouched.)\n\nTHE SPEC'S OWN DISCRIMINATOR IS PROVENANCE, WHICH MAKES THIS UNFIXABLE AS STATED. `delins.md:79-84` gives the reason for preferring individual descriptions: \"the two variants may have been reported (or might occur) individually\". Provenance is carried only by the input's spelling. A normalizer that reads it back is, by construction, not confluent; one that ignores it must pick a canonical partition for every `(reference, sequence)` pair, which is `canonical-form-choice-when-both-legal`. `open-issues.md:77-78` records that the committee agrees the gap is a gap.\n\nWHAT IS NOT ESTABLISHED. Which partition should be canonical. Nothing here chooses one, and nothing here should be read as choosing one: the choice moves a stored representation for a downstream consumer and is an operator decision, ranked by `adjudication-precedence-order`. What this record adds is that the question cannot be deferred to `general.md:34`, because `:34` does not answer it.\n\nRE-CHECKED AGAINST #1537, AND STILL UNDECIDED. #1537 (\"never split a delins into members on consecutive nucleotides\") settled the separation-ZERO case and is recorded at `delins-adjacent-members-when-both-consume-reference`. It does not reach this record: the demonstration above turns on a separation-0 pair being MERGED while a separation-1 pair is SPLIT, and #1537 strengthened exactly the first half — `c.[9del;10del;13del]` still normalizes to `c.[9_10del;13del]` and `c.[9del;11del;13del]` still normalizes to itself, so the two spellings of one variant still reach two outputs. Both pinned assertions passed unchanged across #1537. The record stays `undecided`."
+    },
+    {
+      "id": "self-cancelling-across-ring-junctions",
+      "question": "Does `general.md:58`'s prohibition on removing part of a reference sequence and replacing it with part of the same sequence reach the `::`-joined segments of a ring chromosome, as it reaches the members of a `[a;b]` cis allele?",
+      "status": "decided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:56",
+          "quote": "when a description is possible according to several types"
+        },
+        {
+          "clause": "docs/recommendations/general.md:58",
+          "quote": "descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:130",
+          "quote": "\"::\" is used to indicate the join, instead of \";\" to describe two not connected deletions"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:5",
+          "quote": "a range of changes occur that can not be described as one of the basic variant types"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:127",
+          "quote": "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:39",
+          "quote": "a double colon is used to designate break point junctions creating a ring chromosome.<br>"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:51",
+          "quote": "Break point location is determined by the first break point encountered, i.e. `pter` of the chromosome is to be listed first."
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:53",
+          "quote": "multiple breakpoints in one chromosome are listed in order of occurrence from `pter` to `qter`."
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:55",
+          "quote": "variant descriptions are always in the forward orientation (from `pter` to `qter`, the end of the chromosome), determined by the chromosomal origin of the intact centromere (`cen`)."
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:113",
+          "quote": "NC_000006.12:g.[776788_93191545inv;93191546T>C]`**<br>"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:117",
+          "quote": "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]`**<br>"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:161",
+          "quote": "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup`**<br>"
+        }
+      ],
+      "governing": "docs/recommendations/DNA/complex.md:130",
+      "rationale": "It does not. `general.md:58` is a four-space-indented sub-bullet of `general.md:56`, the **prioritisation** bullet, and its sibling `:57` is unambiguously a prioritisation rule (\"when a variant can be described as a duplication or an insertion, prioritisation determines it should be described as a duplication\"). `:58` therefore inherits `:56`'s antecedent: it applies *when a description is possible according to several types*, and it works by redirecting to the preferred one — for its own example `NM_004006.2:c.[762_768del;767_774dup]`, the `delins` over the union span. It is a redirection clause, not a hygiene clause.\n\nThat antecedent cannot hold for a ring. `complex.md:5` defines complex as a range of changes that *cannot* be described as one of the basic variant types, so there is no competing single-type description to prioritise toward: a `delins` over the union span describes a **linear** product and silently discards the join, which is the whole content of the ring description. A clause that can only reject, never redirect, is not doing the job `:56` assigns it.\n\n`complex.md:130` settles the operators directly, and on identical member content: \"'::' is used to indicate the join, instead of ';' to describe two not connected deletions.\" The same two deletions spelled with `;` denote a linear chromosome missing both ends; spelled with `::` they denote a ring. The `::` composite is therefore not reducible to its member set — it carries a topological assertion the members do not — so reading ring segments as cis-allele members is the one reading the spec explicitly forecloses.\n\nTwo corollaries make the question nearly moot in practice, and both are worth recording because they explain why extending the check would *look* free. A same-chromosome ring has exactly two breakpoints, so its segments are telomere-anchored and disjoint by construction: that is the shape of both ring examples the spec publishes (`complex.md:127` and the supernumerary form at `:161`), and `detect_self_cancelling_pair` would never fire on either. And the spec spells rearrangement-plus-local-edit composites as `;` cis alleles rather than as extra `::` segments (`complex.md:113`, `:117`), where `:58` governs them normally. So this ruling exempts no edit from `:58`; it only declines to read `::` as `;`.\n\n**What this ruling does NOT settle, and must not be read as blessing.** ferro currently accepts `g.100_200del::150_250dup`, `g.100_200del::300_400dup` and `g.150_250dup::100_200del`. None is a well-formed ring: a `dup` contributes no break junction (`complex.md:39`), neither segment is telomere-anchored, and the third also violates the `pter`-to-`qter` segment ordering `complex.md:51`/`:53`/`:55` requires. Those are ring **well-formedness** defects and need their own rule; `:58` is the wrong instrument for them, which the non-overlapping case (`del::300_400dup`) proves — an `:58`-based check would accept it. Rejecting them via `:58` would also emit E3006's repair hint (\"rewrite as a single delins\"), which `complex.md:5` makes actively wrong advice for a ring.\n\nIndependently adjudicated twice, reaching the same verdict by different routes; the prioritisation-sub-bullet argument above is the stronger one and is what the ruling rests on. Note that `for_each_leaf`'s doc comment already excludes this validator from the ring walker, but for a *mechanical* reason (it inspects allele siblings, which a per-leaf view cannot express) rather than a semantic one — so the code did not previously adjudicate this question."
     }
   ]
 }

--- a/tests/it/clause_ruling_index.rs
+++ b/tests/it/clause_ruling_index.rs
@@ -67,8 +67,8 @@
 //! <!-- BEGIN GENERATED INDEX -->
 //! ```text
 //! CLAUSE -> RECORD INDEX
-//! 10 records, 6 decided / 4 undecided
-//! 36 clause lines, of which 7 are named by more than one record
+//! 11 records, 7 decided / 4 undecided
+//! 47 clause lines, of which 7 are named by more than one record
 //!
 //! == every clause line ==
 //!
@@ -81,12 +81,32 @@
 //! docs/consultation/open-issues.md:78  [MULTI]
 //!     `adjudication-precedence-order` — decided (cited)
 //!     `separation-is-a-property-of-the-spelling-not-of-the-variant` — undecided (cited, via docs/consultation/open-issues.md:77-78)
+//! docs/recommendations/DNA/complex.md:5
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:39
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/complex.md:50
 //!     `canonical-form-choice-when-both-legal` — decided (cited)
+//! docs/recommendations/DNA/complex.md:51
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:53
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:55
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/complex.md:63
 //!     `adjudication-precedence-order` — decided (governing)
 //! docs/recommendations/DNA/complex.md:64
 //!     `adjudication-precedence-order` — decided (cited)
+//! docs/recommendations/DNA/complex.md:113
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:117
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:127
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:130
+//!     `self-cancelling-across-ring-junctions` — decided (governing)
+//! docs/recommendations/DNA/complex.md:161
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/delins.md:16
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (cited)
 //! docs/recommendations/DNA/delins.md:17  [MULTI]
@@ -147,6 +167,9 @@
 //!     `canonical-form-choice-when-both-legal` — decided (cited)
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (deviates-from)
 //!     `inversion-vs-two-delins-76-83` — decided (cited)
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/general.md:58
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/general.md:157
 //!     `canonical-form-choice-when-both-legal` — decided (governing)
 //! docs/recommendations/style.md:9  [MULTI]
@@ -185,6 +208,7 @@
 //!     `canonical-form-choice-when-both-legal` — decided (cited)
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (deviates-from)
 //!     `inversion-vs-two-delins-76-83` — decided (cited)
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/style.md:9
 //!     `delins-merge-vs-individual-gap-two-or-more` — decided (cited)
 //!     `inversion-vs-two-delins-76-83` — decided (cited)
@@ -462,7 +486,7 @@ fn the_index_is_not_vacuous() {
     let undecided = records.iter().filter(|r| r.status == "undecided").count();
     assert_eq!(
         (records.len(), decided, undecided),
-        (10, 6, 4),
+        (11, 7, 4),
         "measured ledger census changed. If this is a real ledger change, update the module docs \
          and this pin together. Note the repo `CLAUDE.md` claims 8 records with 5 unanswered, \
          which was already wrong before this test existed"

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -867,6 +867,25 @@ const RULING_STATUSES: &[(&str, &str)] = &[
         "separation-is-a-property-of-the-spelling-not-of-the-variant",
         "undecided",
     ),
+    // `general.md:58` (removing and replacing part of the same reference
+    // sequence "are not allowed") against `DNA/complex.md:130` ("'::' is used to
+    // indicate the join, instead of ';'") on whether the self-cancelling check
+    // reaches a ring's `::`-joined segments. **Decided for `complex.md:130`**:
+    // `:58` is a four-space sub-bullet of `general.md:56`'s *prioritisation*
+    // bullet — sibling to `:57`, which is explicitly a prioritisation rule — so
+    // it applies only "when a description is possible according to several
+    // types" and works by redirecting to the preferred one. `complex.md:5`
+    // defines complex as what *cannot* be described as a basic type, so no
+    // competing single-type description exists for a ring and there is nothing
+    // to redirect to. Ratifies shipped behaviour, so it moves no row.
+    //
+    // Scope: this decides only that `:58` does not cross `::`. It explicitly
+    // does NOT bless the three malformed rings ferro currently accepts — those
+    // are ring *well-formedness* defects (`complex.md:39`/`:51`/`:53`/`:55`)
+    // needing their own rule. The negative is pinned by
+    // `issue_1578_followup_self_cancelling_rings.rs` so nobody closes the escape
+    // the cheap way by pointing `:58` at rings.
+    ("self-cancelling-across-ring-junctions", "decided"),
 ];
 
 /// Ruling records must stay well-formed, and `undecided` must stay undecided.

--- a/tests/it/issue_1578_followup_equivalence_rungs.rs
+++ b/tests/it/issue_1578_followup_equivalence_rungs.rs
@@ -1,0 +1,246 @@
+//! #1578 follow-up (item 4): the equivalence checker must not return a verdict
+//! about a variant that **no rung ever examined**.
+//!
+//! `EquivalenceChecker::check` decides in rungs: string identity, then
+//! accession-version difference, then `NormalizedMatch` on the normalized
+//! forms, then `SequenceMatch` on the SPDI-reconstructed edited sequence
+//! (#1158). `NotEquivalent` is the fall-through.
+//!
+//! For a genome ring — and for the `sup`-wrapped ring — **both** of the two
+//! deciding rungs are structurally blind:
+//!
+//! - `Normalizer::normalize` returns a ring unchanged (`src/normalize/mod.rs`,
+//!   the `HV::GenomeRing` / `HV::Supernumerary` pass-through arms), so
+//!   `NormalizedMatch` degenerates into the string comparison the `Identical`
+//!   rung already made; and
+//! - `hgvs_to_spdi` declines a ring (`UnsupportedVariantType`), so
+//!   `edit_triples` yields `None` and the `SequenceMatch` rung cannot fire
+//!   either.
+//!
+//! So `check` fell through to `NotEquivalent` — a *positive claim that two
+//! descriptions denote different variants* — having evaluated neither. That is
+//! strictly worse than declining: the other three modules that hand-roll
+//! `Allele` recursion (`src/spdi/apply.rs`, `src/vcf/from_hgvs.rs`,
+//! `src/project/projector.rs`) all decline a ring, and their declines are
+//! pinned in `issue_1578_followup_ring_declines.rs`.
+//!
+//! `Circular` (`o.`) is the near miss that shows the defect is the *conjunction*
+//! of the two blindnesses rather than the pass-through alone: `o.` also passes
+//! through normalization untouched, but `hgvs_to_spdi` supports it, so the
+//! `SequenceMatch` rung still reaches a sound verdict. That case is pinned
+//! below so a future change to either rung cannot quietly move it into the
+//! declining set.
+//!
+//! The two textual rungs are sound for a ring and are deliberately kept:
+//! `Identical` and `AccessionVersionDifference` compare strings and need no
+//! normalization. Only the fall-through is replaced by a decline.
+
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::MockProvider;
+
+/// A contig with two homopolymer runs, so that a single-base `del` inside a run
+/// has a 3'-most normalized form that differs from the spelling given:
+///
+/// - 1-based 100..109 is `AAAAAAAAAA`, so `g.100del`, `g.105del` and `g.109del`
+///   all normalize to `g.109del`;
+/// - 1-based 200..209 is `TTTTTTTTTT`, so `g.200del` and `g.205del` both
+///   normalize to `g.209del`.
+///
+/// That is what makes the ring rows below *the same ring spelled two ways*
+/// rather than two different rings — the property the checker got wrong.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let mut sequence = String::new();
+    sequence.push_str(&"C".repeat(99)); // 1..99
+    sequence.push_str("AAAAAAAAAA"); // 100..109
+    sequence.push_str(&"G".repeat(90)); // 110..199
+    sequence.push_str("TTTTTTTTTT"); // 200..209
+    sequence.push_str(&"C".repeat(291)); // 210..500
+    provider.add_genomic_sequence("NC_000022.11", &sequence);
+    provider.add_genomic_sequence("NC_000022.10", &sequence);
+    provider.add_genomic_sequence("NC_001422.1", &sequence);
+    provider
+}
+
+/// The control that establishes the two ring rows below describe one variant:
+/// spelled as bare `g.` descriptions, the very same two positions converge
+/// under normalization. Any change that breaks this control invalidates the
+/// ring assertions rather than merely failing alongside them.
+#[test]
+fn the_bare_spellings_of_the_ring_segments_are_equivalent() {
+    let checker = EquivalenceChecker::new(provider());
+    for (left, right) in [
+        ("NC_000022.11:g.100del", "NC_000022.11:g.105del"),
+        ("NC_000022.11:g.200del", "NC_000022.11:g.205del"),
+    ] {
+        let result = checker
+            .check(&parse_hgvs(left).unwrap(), &parse_hgvs(right).unwrap())
+            .expect("a bare genomic pair is decidable");
+        assert_eq!(
+            result.level,
+            EquivalenceLevel::NormalizedMatch,
+            "`{left}` and `{right}` must converge under normalization — \
+             the ring assertions below depend on it",
+        );
+    }
+}
+
+/// The defect. Two spellings of one ring differ only in a segment's
+/// pre-normalization position, and the checker used to answer `NotEquivalent`:
+/// a claim that they denote different variants, reached without evaluating
+/// either side. It must decline instead.
+#[test]
+fn a_ring_pair_neither_rung_can_evaluate_is_declined() {
+    let checker = EquivalenceChecker::new(provider());
+    for (left, right) in [
+        // the first segment spelled two ways
+        (
+            "NC_000022.11:g.100del::200del",
+            "NC_000022.11:g.105del::200del",
+        ),
+        // the second segment spelled two ways
+        (
+            "NC_000022.11:g.100del::200del",
+            "NC_000022.11:g.100del::205del",
+        ),
+        // and the `sup`-wrapped ring, which is blind through the same arms
+        (
+            "NC_000022.11:g.[100del::200del]sup",
+            "NC_000022.11:g.[105del::200del]sup",
+        ),
+    ] {
+        let error = checker
+            .check(&parse_hgvs(left).unwrap(), &parse_hgvs(right).unwrap())
+            .expect_err(&format!(
+                "`{left}` vs `{right}`: no rung can evaluate a ring, so the \
+                 checker must decline rather than return a verdict"
+            ));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("equivalence"),
+            "the decline must say it is an equivalence verdict it withheld, \
+             got: {rendered}"
+        );
+    }
+}
+
+/// `Identical` is decided by string comparison before any rung that needs a
+/// provider, so it stays sound for a ring and must keep working. A decline here
+/// would be a regression in the opposite direction — refusing a question that
+/// has an obvious answer.
+#[test]
+fn two_identical_rings_are_still_identical() {
+    let checker = EquivalenceChecker::new(provider());
+    for input in [
+        "NC_000022.11:g.100del::200del",
+        "NC_000022.11:g.[100del::200del]sup",
+    ] {
+        let variant = parse_hgvs(input).unwrap();
+        let result = checker
+            .check(&variant, &variant)
+            .expect("string identity needs no normalization");
+        assert_eq!(
+            result.level,
+            EquivalenceLevel::Identical,
+            "`{input}` compared with itself is `Identical`",
+        );
+    }
+}
+
+/// `AccessionVersionDifference` is likewise purely textual — it compares the
+/// accession's prefix/number/version and then the rendered variant part — so it
+/// remains sound for a ring and must not be swept into the decline.
+#[test]
+fn one_ring_on_two_accession_versions_is_still_a_version_difference() {
+    let checker = EquivalenceChecker::new(provider());
+    let result = checker
+        .check(
+            &parse_hgvs("NC_000022.10:g.100del::200del").unwrap(),
+            &parse_hgvs("NC_000022.11:g.100del::200del").unwrap(),
+        )
+        .expect("an accession-version difference is decided textually");
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::AccessionVersionDifference,
+        "the same ring on two versions is a version difference, not a decline",
+    );
+}
+
+/// Two rings on plainly disjoint spans are **also** declined, and that is the
+/// deliberate reading rather than an over-broad fix.
+///
+/// It is tempting to answer `NotEquivalent` here, since the two are obviously
+/// different. But the checker has no way to distinguish this pair from the
+/// respelled pair above: in both cases the ring reaches the fall-through with
+/// its segments un-normalized and SPDI-unrepresentable, so the *same* evidence
+/// (none) underlies both. Answering `NotEquivalent` on this pair would be right
+/// by luck while being wrong on the other, and a rung that is right by luck is
+/// the thing this change removes. Declining on both is the position the
+/// available evidence actually supports.
+///
+/// The cost is bounded and visible: a caller that needs a verdict for a ring
+/// gets an explicit decline naming why, not a plausible wrong answer.
+#[test]
+fn two_rings_on_disjoint_spans_are_declined_rather_than_answered_by_luck() {
+    let checker = EquivalenceChecker::new(provider());
+    let error = checker
+        .check(
+            &parse_hgvs("NC_000022.11:g.100del::200del").unwrap(),
+            &parse_hgvs("NC_000022.11:g.400del::450del").unwrap(),
+        )
+        .expect_err("the checker cannot tell this pair from a respelled one");
+    assert!(
+        error.to_string().contains("cannot decide equivalence"),
+        "the decline must name itself: {error}"
+    );
+}
+
+/// The scope boundary, pinned. An RNA fusion (`::` between two transcripts)
+/// shares both blindnesses — normalization passes it through and SPDI cannot
+/// represent it — so the same argument would reach it. It is deliberately left
+/// answering, because no pair of fusion spellings denoting *one* fusion has been
+/// exhibited: widening the decline there would refuse pairs the checker answers
+/// today without evidence that any of those answers is wrong.
+///
+/// This test exists so that boundary is a recorded decision rather than an
+/// oversight. If a wrong fusion answer is ever measured, this test is the one to
+/// change, and changing it should require stating the pair that measures it.
+#[test]
+fn an_rna_fusion_pair_is_still_answered_a_deliberate_scope_boundary() {
+    let checker = EquivalenceChecker::new(provider());
+    let result = checker
+        .check(
+            &parse_hgvs("NM_000088.3:r.1_100::NM_000089.3:r.200_300").unwrap(),
+            &parse_hgvs("NM_000088.3:r.1_100::NM_000089.3:r.201_300").unwrap(),
+        )
+        .expect("fusions are outside this change's scope and still answer");
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::NotEquivalent,
+        "two different fusions still answer `NotEquivalent` — the decline is \
+         scoped to the ring shapes a defect was measured on",
+    );
+}
+
+/// The near miss that defines the boundary. A circular (`o.`) variant also
+/// passes through normalization unchanged, but `hgvs_to_spdi` supports it, so
+/// the `SequenceMatch` rung still evaluates the pair and reaches a sound
+/// verdict. It must therefore stay *decidable* — the decline keys on "no rung
+/// could examine this", not on "normalization was a pass-through".
+#[test]
+fn a_circular_pair_is_still_decided_by_the_sequence_rung() {
+    let checker = EquivalenceChecker::new(provider());
+    let result = checker
+        .check(
+            &parse_hgvs("NC_001422.1:o.100del").unwrap(),
+            &parse_hgvs("NC_001422.1:o.105del").unwrap(),
+        )
+        .expect("`o.` is SPDI-representable, so the sequence rung can decide it");
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::SequenceMatch,
+        "`o.` normalization is a pass-through, but the SPDI rung still decides \
+         the pair — this is why the decline must not key on the pass-through",
+    );
+}

--- a/tests/it/issue_1578_followup_equivalence_rungs.rs
+++ b/tests/it/issue_1578_followup_equivalence_rungs.rs
@@ -36,6 +36,7 @@
 //! normalization. Only the fall-through is replaced by a decline.
 
 use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::hgvs::variant::{AllelePhase, AlleleVariant, HgvsVariant};
 use ferro_hgvs::parse_hgvs;
 use ferro_hgvs::reference::MockProvider;
 
@@ -242,5 +243,77 @@ fn a_circular_pair_is_still_decided_by_the_sequence_rung() {
         EquivalenceLevel::SequenceMatch,
         "`o.` normalization is a pass-through, but the SPDI rung still decides \
          the pair — this is why the decline must not key on the pass-through",
+    );
+}
+
+/// A ring **inside a cis allele** must be declined too, and it was not.
+///
+/// The blindness is the same one level down: `hgvs_to_spdi` refuses the ring
+/// member, so `edit_triples` declines for the whole allele, and normalization
+/// passes the ring through — yet `undecidable_reason` matched only on the *top
+/// level* variant kind, so two such alleles compared `NotEquivalent`. That is
+/// the positive claim this whole change exists to stop making.
+///
+/// Not reachable through `parse_hgvs` — `g.[…::…;…]` is rejected — but this is a
+/// shape the codebase constructs on purpose:
+/// `issue_1578_followup_ring_declines.rs` builds exactly this pairing and
+/// requires `spdi::apply`, `vcf::from_hgvs` and the projector to decline it. The
+/// equivalence checker was the one module that answered it.
+#[test]
+fn a_ring_inside_a_cis_allele_is_declined_like_a_bare_ring() {
+    let checker = EquivalenceChecker::new(provider());
+    let with_ring = |ring: &str| {
+        let legal = parse_hgvs("NC_000022.11:g.500A>T").expect("legal member parses");
+        let ring = parse_hgvs(ring).expect("ring parses");
+        HgvsVariant::Allele(AlleleVariant::new(vec![legal, ring], AllelePhase::Cis))
+    };
+
+    let error = checker
+        .check(
+            &with_ring("NC_000022.11:g.100_101del::200_201del"),
+            &with_ring("NC_000022.11:g.300_301del::400_401del"),
+        )
+        .expect_err("a cis allele carrying a ring must be declined, not answered");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("cannot decide equivalence"),
+        "the decline must give the undecidable reason; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("::"),
+        "the decline must name the ring member it could not examine; got: {rendered}"
+    );
+}
+
+/// The recursion must not swallow alleles the checker can still decide: a cis
+/// allele of two ordinary genomic members is SPDI-representable, so
+/// `edit_triples` succeeds and the sequence rung answers it. Without this, a
+/// recursion that declined on structure alone would look correct above while
+/// refusing every compound variant.
+#[test]
+fn a_cis_allele_of_ordinary_members_is_still_decided() {
+    let checker = EquivalenceChecker::new(provider());
+    let allele = |a: &str, b: &str| {
+        HgvsVariant::Allele(AlleleVariant::new(
+            vec![parse_hgvs(a).unwrap(), parse_hgvs(b).unwrap()],
+            AllelePhase::Cis,
+        ))
+    };
+    let result = checker
+        .check(
+            &allele("NC_000022.11:g.100del", "NC_000022.11:g.500A>T"),
+            &allele("NC_000022.11:g.105del", "NC_000022.11:g.500A>T"),
+        )
+        .expect("an all-ordinary cis allele stays decidable");
+    // The contract, not the rung. These two resolve at `NormalizedMatch` — earlier
+    // than the sequence rung, because the members normalize to one string in this
+    // poly-A contig — and which rung answers is exactly what a later change is
+    // entitled to move. Pinning `SequenceMatch` here failed for that reason on the
+    // first draft, and would have re-failed the next time an earlier rung widened.
+    assert!(
+        result.is_equivalent(),
+        "an all-ordinary cis allele must still be answered, and these two spellings \
+         denote one sequence; got {:?}",
+        result.level,
     );
 }

--- a/tests/it/issue_1578_followup_ring_declines.rs
+++ b/tests/it/issue_1578_followup_ring_declines.rs
@@ -1,0 +1,188 @@
+//! #1578 follow-up (item 4): the three modules that hand-roll `Allele`
+//! recursion and were **already** ring-safe, pinned so they stay that way.
+//!
+//! The follow-up asked whether the structural blindness #1578 fixed in the
+//! parser is live in `src/spdi/apply.rs`, `src/project/projector.rs`,
+//! `src/vcf/from_hgvs.rs` and `src/equivalence/checker.rs` — each of which
+//! matches on `HgvsVariant` by hand and recurses into `Allele` members. It was
+//! live in exactly one of them: `equivalence/checker.rs` returned a *positive
+//! wrong verdict*, fixed and pinned in
+//! `issue_1578_followup_equivalence_rungs.rs`. The other three decline, which
+//! is the correct behaviour and is what this file guards.
+//!
+//! **A passing test here is a claim about today, so it is worth saying what
+//! makes it non-vacuous.** Each module reaches its ring decline through a
+//! *different* mechanism, and none of the three is a catch-all that would keep
+//! working if the ring arm were dropped:
+//!
+//! | module | how a ring is declined |
+//! |---|---|
+//! | `spdi/apply.rs` | `variant_edit_triples`' `single => vec![single]` catch-all hands the ring to `hgvs_to_spdi`, which has no ring arm and returns `UnsupportedVariantType`; `.ok()?` turns that into a whole-variant decline |
+//! | `vcf/from_hgvs.rs` | explicit `GenomeRing` / `Supernumerary` arms (`convert`), and `convert_all` reaches them per member |
+//! | `project/projector.rs` | explicit `GenomeRing` / `Supernumerary` arms in both `extract_contig_and_pos` and `project_to_genomic_nc` |
+//!
+//! Three shapes are exercised against each: the bare `::` join, the
+//! `sup`-wrapped ring, and a ring as a **cis-allele member**. That last one is
+//! reachable only by construction — measured at this commit, the parser rejects
+//! `g.[100_101del::200_201del;300A>T]`, `g.[300A>T;100_101del::200_201del]` and
+//! `g.[[100_101del::200_201del];300A>T]` alike — so it is built by hand here.
+//! It is the shape that matters for this follow-up: it is the one that walks a
+//! ring *through* the hand-rolled `Allele` recursion rather than meeting it at
+//! the top level, and therefore the one a kind-matching arm can miss.
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::hgvs::variant::{AllelePhase, AlleleVariant, HgvsVariant};
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::VariantProjector;
+
+/// The bare ring, the `sup`-wrapped ring, and the ring-as-cis-allele-member.
+///
+/// The allele pairs a *legal* genomic member with the ring, so a decline can only
+/// come from walking into the second member — the same construction #1587 uses
+/// to prove an allele-recursion test is not passing for an unrelated reason.
+fn ring_shapes() -> Vec<(&'static str, HgvsVariant)> {
+    let ring = parse_hgvs("NC_000022.11:g.100_101del::200_201del").expect("ring parses");
+    let sup =
+        parse_hgvs("NC_000022.11:g.[100_101del::200_201del]sup").expect("sup-wrapped ring parses");
+    let legal_member = parse_hgvs("NC_000022.11:g.500A>T").expect("plain genomic member parses");
+    let ring_in_allele = HgvsVariant::Allele(AlleleVariant::new(
+        vec![legal_member, ring.clone()],
+        AllelePhase::Cis,
+    ));
+    vec![
+        ("bare ring", ring),
+        ("sup-wrapped ring", sup),
+        ("ring as a cis-allele member", ring_in_allele),
+    ]
+}
+
+/// The legal genomic member the ring shapes are paired with, used on its own as
+/// each test's positive control.
+fn legal_member() -> HgvsVariant {
+    parse_hgvs("NC_000022.11:g.500A>T").expect("plain genomic member parses")
+}
+
+/// A contig long enough to serve every position the ring shapes name, so a
+/// decline is never merely "the provider had no bases".
+///
+/// All-`A` **on purpose**: it makes `g.500A>T`'s stated reference base agree with
+/// the contig. An earlier revision used a repeating `ACGT` filler, which put `T`
+/// at position 500 and made the control *fail* — with a message that also
+/// contains "cannot apply to reference", so `spdi_apply_declines_every_ring_shape`
+/// passed while proving nothing about rings. That is why each test below asserts
+/// the **ring-specific** reason and runs the control first.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_000022.11", "A".repeat(1000));
+    provider
+}
+
+/// `apply_to_reference` must decline a ring rather than apply some subset of its
+/// segments. This is the module whose decline is *indirect* — it falls out of
+/// `hgvs_to_spdi` having no ring arm — so it is the one most exposed to a future
+/// change that gives SPDI a ring representation without revisiting what applying
+/// a ring to a linear reference would even mean.
+#[test]
+fn spdi_apply_declines_every_ring_shape() {
+    let provider = provider();
+    // Control: the legal member alone applies cleanly, so a decline below is
+    // attributable to the ring rather than to the fixture.
+    ferro_hgvs::spdi::apply::apply_to_reference(&legal_member(), &provider)
+        .expect("control: the legal member alone must apply");
+
+    for (label, variant) in ring_shapes() {
+        let error = ferro_hgvs::spdi::apply::apply_to_reference(&variant, &provider)
+            .expect_err(&format!("{label}: applying a ring must decline"));
+        let rendered = error.to_string();
+        // The *ring-specific* reason, not the generic prefix: `apply_to_reference`
+        // has a second decline ("its members overlap, or a stated reference base
+        // disagrees") that shares the prefix, and matching the prefix alone would
+        // accept a decline that had nothing to do with the ring.
+        assert!(
+            rendered.contains("no single resulting sequence is defined"),
+            "{label}: the decline must be the SPDI-cannot-represent-it one, got: {rendered}"
+        );
+    }
+}
+
+/// The VCF converter must decline a ring on both entry points. `convert_all` is
+/// the decomposing one, and for the allele shape it must fail the whole call
+/// naming the offending member rather than silently emitting one record for the
+/// legal member and dropping the ring — a partial success is the failure mode
+/// worth guarding, because it looks like a successful conversion.
+#[test]
+fn vcf_conversion_declines_every_ring_shape() {
+    let provider = MockProvider::with_test_data();
+    let transcript =
+        ferro_hgvs::reference::ReferenceProvider::get_transcript(&provider, "NM_000088.3")
+            .expect("the shared test fixture carries NM_000088.3");
+    let converter = ferro_hgvs::vcf::HgvsToVcfConverter::new(&transcript, &provider);
+
+    // Control: the legal member converts, and a two-member legal allele
+    // decomposes to two records — so `convert_all` is genuinely walking members.
+    converter
+        .convert(&legal_member())
+        .expect("control: the legal member alone must convert");
+    let legal_allele = HgvsVariant::Allele(AlleleVariant::new(
+        vec![
+            legal_member(),
+            parse_hgvs("NC_000022.11:g.600C>G").expect("second legal member parses"),
+        ],
+        AllelePhase::Cis,
+    ));
+    assert_eq!(
+        converter
+            .convert_all(&legal_allele)
+            .expect("control: a legal allele must convert")
+            .len(),
+        2,
+        "control: `convert_all` must emit one record per member",
+    );
+
+    for (label, variant) in ring_shapes() {
+        converter
+            .convert(&variant)
+            .err()
+            .unwrap_or_else(|| panic!("{label}: `convert` must decline a ring"));
+        let error = converter
+            .convert_all(&variant)
+            .err()
+            .unwrap_or_else(|| panic!("{label}: `convert_all` must decline a ring"));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("not supported"),
+            "{label}: the decline must say the shape is unsupported, got: {rendered}"
+        );
+    }
+}
+
+/// `project_to_genomic` must decline a ring. An **empty** cdot is deliberate: a
+/// ring is refused on variant kind before any transcript lookup, so a decline
+/// that depended on cdot being populated would be evidence of the wrong thing.
+#[test]
+fn projection_declines_every_ring_shape() {
+    let projector = VariantProjector::new(Projector::new(CdotMapper::new()), JsonProvider::new());
+    // Control: a plain genomic member, and a legal genomic allele, both project
+    // through this empty-cdot harness — so the declines below are about the ring.
+    assert_eq!(
+        projector
+            .project_to_genomic(&legal_member())
+            .expect("control: a plain genomic variant must project")
+            .to_string(),
+        "NC_000022.11:g.500A>T",
+    );
+
+    for (label, variant) in ring_shapes() {
+        let error = projector
+            .project_to_genomic(&variant)
+            .expect_err(&format!("{label}: projecting a ring must decline"));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("ring") || rendered.contains("supernumerary"),
+            "{label}: the decline must name the shape it refused, got: {rendered}"
+        );
+    }
+}

--- a/tests/it/issue_1578_followup_ring_declines.rs
+++ b/tests/it/issue_1578_followup_ring_declines.rs
@@ -65,6 +65,23 @@ fn legal_member() -> HgvsVariant {
     parse_hgvs("NC_000022.11:g.500A>T").expect("plain genomic member parses")
 }
 
+/// The allele-shaped positive control: two *legal* genomic members in cis. The
+/// ring shapes below are also alleles, so without this the declines could come
+/// from the allele wrapper rather than from the ring inside it.
+///
+/// Both members state `A` as their reference base, for the reason `provider()`
+/// documents: the contig is all-`A`, and a member whose stated base disagrees
+/// makes the control fail for a reason that has nothing to do with rings.
+fn legal_allele() -> HgvsVariant {
+    HgvsVariant::Allele(AlleleVariant::new(
+        vec![
+            parse_hgvs("NC_000022.11:g.500A>T").expect("first legal member parses"),
+            parse_hgvs("NC_000022.11:g.600A>G").expect("second legal member parses"),
+        ],
+        AllelePhase::Cis,
+    ))
+}
+
 /// A contig long enough to serve every position the ring shapes name, so a
 /// decline is never merely "the provider had no bases".
 ///
@@ -174,6 +191,13 @@ fn projection_declines_every_ring_shape() {
             .to_string(),
         "NC_000022.11:g.500A>T",
     );
+    // The allele half of that control, which the comment above promised and the
+    // code did not make. Without it the ring-in-allele decline below is not shown
+    // to be about the *ring*: a projector that declined every `Allele` would pass
+    // this test just as well.
+    projector
+        .project_to_genomic(&legal_allele())
+        .expect("control: a cis allele of two legal genomic members must project");
 
     for (label, variant) in ring_shapes() {
         let error = projector

--- a/tests/it/issue_1578_followup_self_cancelling_rings.rs
+++ b/tests/it/issue_1578_followup_self_cancelling_rings.rs
@@ -1,0 +1,180 @@
+//! #1578 follow-up (item 3): `general.md:58`'s self-cancellation rule does
+//! **not** reach a ring's `::`-joined segments. Adjudicated 2026-08-10; the
+//! record is `rulings[self-cancelling-across-ring-junctions]` in
+//! `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`, whose
+//! citations are quote-verified against the spec checkout at build time.
+//!
+//! The ruling in one line: `general.md:58` is a four-space-indented sub-bullet
+//! of `general.md:56`, the **prioritisation** bullet — sibling to `:57`, which
+//! is explicitly a prioritisation rule. So `:58` inherits `:56`'s antecedent,
+//! "when a description is possible according to several types", and works by
+//! *redirecting* to the preferred single-type description. `DNA/complex.md:5`
+//! defines complex as a range of changes that **cannot** be described as a basic
+//! type, so a ring has no competing single-type description to redirect to: a
+//! `delins` over the union span would describe a *linear* product and discard
+//! the join. And `DNA/complex.md:130` adjudicates the two operators directly,
+//! on identical member content — `"::" is used to indicate the join, instead of
+//! ";" to describe two not connected deletions` — so a `::` composite is not
+//! reducible to its member set the way a `[a;b]` allele is.
+//!
+//! **This file exists to stop the escape being closed the cheap way.** Pointing
+//! `detect_self_cancelling_pair` at ring segments looks free, because a
+//! well-formed ring's segments are telomere-anchored and disjoint by
+//! construction (`complex.md:127` and the `sup` form at `:161` are the spec's
+//! only published ring shapes), so the check would never fire on a legitimate
+//! ring. That is exactly why it needs a guard rather than a comment: the change
+//! would pass every existing test while encoding the claim `complex.md:130`
+//! forecloses, and E3006's repair hint ("rewrite as a single delins") is
+//! actively wrong advice for a ring.
+//!
+//! What the ruling does **not** settle is recorded in `no_ring_wellformedness_rule_yet`
+//! below: three of the rings ferro accepts are malformed for reasons that have
+//! nothing to do with self-cancellation.
+
+use ferro_hgvs::parse_hgvs;
+
+/// The spec's own two ring shapes must parse, and must not be mistaken for
+/// self-cancelling alleles. These are the rows a `:58`-based check would have to
+/// leave alone, and the reason it is tempting to believe extending it is free.
+///
+/// Both are quoted from `DNA/complex.md:127` and `:161` — the bare ring and the
+/// supernumerary ring. Their segments are telomere-anchored (`pter_…del` and
+/// `…_qterdel`) and therefore disjoint, so `detect_self_cancelling_pair` finds
+/// nothing in them either way.
+#[test]
+fn the_specs_own_ring_shapes_are_accepted() {
+    for input in [
+        "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel",
+        "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup",
+    ] {
+        let variant = parse_hgvs(input)
+            .unwrap_or_else(|e| panic!("the spec publishes `{input}` as a ring: {e}"));
+        assert_eq!(
+            variant.to_string(),
+            input,
+            "`{input}` must round-trip byte-identically",
+        );
+    }
+}
+
+/// The adjudicated negative, and the load-bearing test in this file: a ring
+/// whose segments overlap is **accepted**, because `general.md:58` does not
+/// reach across `::`.
+///
+/// The same overlap spelled as a cis allele is rejected — that pairing is
+/// asserted in `the_identical_overlap_is_still_rejected_as_a_cis_allele` below,
+/// so the two halves of the ruling are pinned together rather than separately.
+///
+/// If someone extends `detect_self_cancelling_pair` to ring segments, this test
+/// fails and points at the ruling record. That is its whole purpose; do not
+/// "fix" it by relaxing the assertion.
+#[test]
+fn an_overlapping_ring_is_not_rejected_as_self_cancelling() {
+    for input in [
+        // overlap at 150–200, the shape of `general.md:58`'s own example
+        "NC_000022.11:g.100_200del::150_250dup",
+        // identical spans — the strongest "cancelling" shape available
+        "NC_000022.11:g.100_200del::100_200dup",
+        // and under the `sup` marker, which is blind through the same arms
+        "NC_000022.11:g.[100_200del::150_250dup]sup",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| {
+            panic!(
+                "`{input}` must NOT be rejected as self-cancelling: \
+                 `general.md:58` is a sub-bullet of `general.md:56`'s \
+                 prioritisation rule and has no single-type description to \
+                 redirect a ring to (`DNA/complex.md:5`), and \
+                 `DNA/complex.md:130` distinguishes `::` from `;` on exactly \
+                 this member content. See \
+                 rulings[self-cancelling-across-ring-junctions]. Got: {e}"
+            )
+        });
+        assert_eq!(
+            variant.to_string(),
+            input,
+            "`{input}` must round-trip byte-identically",
+        );
+    }
+}
+
+/// The other half of the ruling: the identical overlap **is** rejected inside a
+/// `[a;b]` cis allele, where `:58`'s antecedent does hold — the members are
+/// co-applied to one linear reference (`DNA/alleles.md:5`) and the union-span
+/// `delins` prioritisation redirects to exists.
+///
+/// Pinned here rather than relying on the existing E3006 tests because the
+/// ruling is precisely about the *asymmetry* between the two operators. A change
+/// that accidentally disabled the allele check would otherwise make the test
+/// above pass for the wrong reason.
+#[test]
+fn the_identical_overlap_is_still_rejected_as_a_cis_allele() {
+    for input in [
+        "NC_000022.11:g.[100_200del;150_250dup]",
+        "NC_000022.11:g.[100_200del;100_200dup]",
+    ] {
+        let error = parse_hgvs(input).expect_err(&format!(
+            "`{input}` violates `general.md:58` as a cis allele"
+        ));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("Self-cancelling allele"),
+            "`{input}` must be rejected by the self-cancelling check specifically, \
+             not by some other validator — got: {rendered}"
+        );
+    }
+}
+
+/// Non-overlapping `del` + `dup` is legal both ways, and this is the row that
+/// shows `:58` is the wrong instrument for the malformed rings noted below: a
+/// `:58`-based check is an *overlap* predicate, so it would accept this one no
+/// matter how it were wired.
+#[test]
+fn a_non_overlapping_del_dup_pair_is_legal_in_both_operators() {
+    for input in [
+        "NC_000022.11:g.[100_200del;300_400dup]",
+        "NC_000022.11:g.100_200del::300_400dup",
+    ] {
+        let variant = parse_hgvs(input)
+            .unwrap_or_else(|e| panic!("`{input}` has no overlap and is legal: {e}"));
+        assert_eq!(variant.to_string(), input, "`{input}` must round-trip");
+    }
+}
+
+/// **What the ruling does not settle, pinned as an open gap rather than as
+/// correct behaviour.**
+///
+/// Each input below is accepted today and none is a well-formed ring, for
+/// reasons independent of self-cancellation:
+///
+/// - a `dup` segment contributes no break junction (`DNA/complex.md:39`: "a
+///   double colon is used to designate break point junctions creating a ring
+///   chromosome"), and neither segment is telomere-anchored, so these describe
+///   no ring geometry; and
+/// - `g.150_250dup::100_200del` additionally lists its segments out of order,
+///   which `DNA/complex.md:51` ("`pter` of the chromosome is to be listed
+///   first"), `:53` and `:55` forbid.
+///
+/// This test asserts the **status quo**, deliberately, so the gap is visible and
+/// counted rather than implied by the ruling's silence. When a ring
+/// well-formedness rule lands, these inputs should start being rejected and this
+/// test is expected to fail — that failure is the signal to delete it and move
+/// the rows into the new rule's own tests, not to re-derive whether the ruling
+/// above was wrong.
+#[test]
+fn no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted() {
+    for input in [
+        // no telomere anchor, and `dup` contributes no junction
+        "NC_000022.11:g.100_200del::150_250dup",
+        "NC_000022.11:g.100_200del::300_400dup",
+        // segments out of pter->qter order
+        "NC_000022.11:g.150_250dup::100_200del",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "`{input}` is accepted today. If this now fails, a ring \
+             well-formedness rule has landed — move this row into that rule's \
+             tests rather than reopening \
+             rulings[self-cancelling-across-ring-junctions]",
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -240,6 +240,7 @@ mod issue_1536_cds_boundary_delins;
 mod issue_1543_allele_member_reference_validation;
 mod issue_1578_followup_equivalence_rungs;
 mod issue_1578_followup_ring_declines;
+mod issue_1578_followup_self_cancelling_rings;
 mod issue_1578_ring_validator_escapes;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -238,6 +238,8 @@ mod issue_1513_adjacent_junction_insertions;
 mod issue_1517_inv_priority_over_delins;
 mod issue_1536_cds_boundary_delins;
 mod issue_1543_allele_member_reference_validation;
+mod issue_1578_followup_equivalence_rungs;
+mod issue_1578_followup_ring_declines;
 mod issue_1578_ring_validator_escapes;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;


### PR DESCRIPTION
Implements items 3 and 4 of the follow-up list in https://github.com/fulcrumgenomics/ferro-hgvs/issues/1578#issuecomment-5239725830.

This was written stacked on #1583, which merged (`9b8e55fc`) while it was in progress, so it is rebased onto `main` and targets `main` directly. Nothing else is needed to review it.

Both items are TDD'd, and both turned out slightly different from how the follow-up framed them. The measurements are below rather than the conclusions, because in each case the measurement is what changed the plan.

## Item 4 was live in one module, not four

The follow-up names four modules that hand-roll `Allele` recursion with no `GenomeRing` handling and asks whether the structural blindness is live in them. It is live in exactly one. Probed at this commit against all three ring shapes — the bare `::` join, the `sup`-wrapped ring, and a ring as a cis-allele member:

| module | bare ring | `sup` ring | ring in allele |
|---|---|---|---|
| `src/spdi/apply.rs` | declines | declines | declines |
| `src/vcf/from_hgvs.rs` | declines | declines | declines, naming member index 1 |
| `src/project/projector.rs` | declines | declines | declines |
| `src/equivalence/checker.rs` | **wrong answer** | **wrong answer** | — |

The ring-in-allele shape is construction-only: the parser rejects `g.[100_101del::200_201del;300A>T]`, `g.[300A>T;100_101del::200_201del]` and `g.[[100_101del::200_201del];300A>T]` alike, so the tests build it by hand. It is the shape that matters here, since it is the one that walks a ring *through* the hand-rolled recursion rather than meeting it at the top level.

### The live defect

On a contig with a poly-A run at 1-based 100..109, where each segment's `del` normalizes to `g.109del` standalone — so both ring rows are **one ring spelled two ways**:

```
bare:  g.100del              vs g.105del              -> NormalizedMatch   equivalent=true
ring:  g.100del::200del      vs g.105del::200del      -> NotEquivalent     equivalent=false
ring:  g.100del::200del      vs g.100del::205del      -> NotEquivalent     equivalent=false
sup:   g.[100del::200del]sup vs g.[105del::200del]sup -> NotEquivalent     equivalent=false
```

`NotEquivalent` is a *positive claim* that two descriptions denote different variants, which is strictly worse than the decline the other three modules give.

### Why, and why `Circular` survives the identical pass-through

`check` decides in rungs, and both rungs that compare meaning rather than text are blind at once:

- `Normalizer::normalize` returns a ring unchanged (`src/normalize/mod.rs:2904`), so `NormalizedMatch` degenerates into the string comparison `Identical` already made; and
- `hgvs_to_spdi` has no ring arm, so `edit_triples` declines and the `SequenceMatch` rung (#1158) cannot fire either.

`Circular` is the near miss that locates the defect precisely. `o.` *also* passes through normalization untouched, yet the checker still answers correctly, because SPDI represents `o.` and the sequence rung decides it:

```
Genome   g.100del vs g.105del  -> NormalizedMatch   (normalization decided it)
Circular o.100del vs o.105del  -> SequenceMatch     (SPDI decided it)
GenomeRing / Supernumerary     -> NotEquivalent     (nothing decided it)
```

So the defect is the *conjunction*, not the pass-through. That is what the fix keys on.

Worth noting the pass-through's comment cites #546, which is a **parse** issue — "each form parses to a typed AST and round-trips". It made no normalization ruling, so this was an unexamined default rather than a decided one.

### The fix

At the fall-through, decline when neither rung could examine a side. Deliberately narrow in three ways:

- **The two textual rungs are kept.** `Identical` and `AccessionVersionDifference` compare strings, need no provider, and are sound for a ring. Tests pin both.
- **The SPDI conjunct makes the predicate self-retiring.** If `hgvs_to_spdi` ever gains ring support, `edit_triples` starts succeeding, the sequence rung begins deciding these pairs, and this decline stops firing on its own instead of masking the new capability.
- **`RnaFusion` is excluded on purpose.** It shares both blindnesses, but no pair of fusion spellings denoting one fusion has been exhibited, so widening the decline there would refuse pairs the checker answers today on no evidence any of those answers is wrong. That boundary is pinned by its own test naming what would justify changing it.

Two rings on plainly disjoint spans are **also** declined, and that is the reading rather than over-breadth: the checker has no way to distinguish that pair from the respelled one — the same evidence (none) underlies both — so answering `NotEquivalent` there would be right by luck while being wrong on the other.

## Item 3: ruled, and pinned as a negative

`general.md:58`'s self-cancellation rule does not reach a ring's `::`-joined segments. Measured escape:

```
REJECTED  g.[100_200del;150_250dup]      E3006 self-cancelling (overlap 150-200)
ACCEPTED  g.100_200del::150_250dup
ACCEPTED  g.100_200del::100_200dup       <- identical spans, the strongest shape
ACCEPTED  g.[100_200del::150_250dup]sup
```

The argument, recorded as `rulings[self-cancelling-across-ring-junctions]` with all five citations quote-verified against the spec checkout at build time:

`general.md:58` is a four-space-indented sub-bullet of `general.md:56`, the **prioritisation** bullet, and its sibling `:57` is unambiguously a prioritisation rule ("when a variant can be described as a duplication or an insertion, prioritisation determines it should be described as a duplication"). So `:58` inherits `:56`'s antecedent — *"when a description is possible according to several types"* — and works by **redirecting** to the preferred single-type description. `DNA/complex.md:5` defines complex as a range of changes that **cannot** be described as a basic type, so a ring has nothing to redirect to: a `delins` over the union span describes a *linear* product and discards the join, which is the whole content of the ring description.

`DNA/complex.md:130` then settles the two operators directly, on identical member content:

> "::" is used to indicate the join, instead of ";" to describe two not connected deletions.

The same two deletions spelled with `;` denote a linear chromosome missing both ends; spelled with `::` they denote a ring. A `::` composite is therefore not reducible to its member set the way a `[a;b]` allele is — which is the one reading extending the validator would encode.

The ruling ratifies shipped behaviour, so it moves no row.

### Pinning the negative is the actual deliverable

Pointing `detect_self_cancelling_pair` at ring segments *looks* free: a well-formed ring's segments are telomere-anchored and disjoint by construction — `complex.md:127` and the `sup` form at `:161` are the spec's only published ring shapes — so the check would never fire on a legitimate ring. It would pass every existing test while encoding the reading `complex.md:130` forecloses, and E3006's repair hint ("rewrite as a single delins") is actively wrong advice for a ring.

So the guard was verified non-vacuous by **applying that change**: `an_overlapping_ring_is_not_rejected_as_self_cancelling` turns red and its message names the ruling record. The mutation was then reverted (`src/hgvs/parser/variant.rs` is byte-identical to #1583's tip).

### What the ruling does not settle — recorded, not implied

Three of the rings ferro accepts are malformed for reasons unrelated to self-cancellation: a `dup` segment contributes no break junction (`complex.md:39`), neither segment is telomere-anchored, and `g.150_250dup::100_200del` additionally violates the `pter`→`qter` segment ordering of `complex.md:51`/`:53`/`:55`. Those need a ring **well-formedness** rule. `:58` is the wrong instrument for them, which the non-overlapping case (`del::300_400dup`) proves: an overlap predicate accepts it no matter how it is wired.

`no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted` pins that gap as the status quo so it is visible and counted, and says in its own failure message that a future rejection is the signal to move the rows into the new rule's tests rather than to reopen this ruling. **I have not filed that issue** — say the word and I will.

## Testing

- Full suite: **9,795 passed, 0 failed, 150 skipped — nothing re-blessed.** For a change that alters an output verdict, existing expectations already agreeing is the signal worth quoting.
- 24 `issue_1578*` tests green (12 new, 12 from #1583); `ruling_records_are_intact` green with the new record pinned in `RULING_STATUSES`.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- `generate_spec_fixture` succeeds, which is what verifies the ruling's five citations still quote the spec at submodule `6f85311`.

### One bookkeeping update the rebase surfaced

`main` gained #1579's `clause_ruling_index` guard after this branch was cut, and it went red on the rebase — correctly: a new ruling record must also appear in that module's embedded clause→record index. Three of its assertions fired, the census pin moved `(10, 6, 4) → (11, 7, 4)`, and the generated block was replaced with the one the guard itself prints. That update is amended into the ruling commit, since it is part of the record's bookkeeping rather than a separate change.

Worth noting as the "CI tests the merge, not your head" case from the repo's `CLAUDE.md`: this branch was green against its original base and would have gone red in CI purely because `main` moved.

### Two vacuity traps found and fixed while writing these

Both had produced a green test that proved nothing:

- `spdi_apply_declines_every_ring_shape` asserted only the generic prefix `"cannot apply to reference"`, which `apply_to_reference` **also** emits for a reference-base mismatch — and the fixture's `ACGT` filler put `T` at position 500, so the control input `g.500A>T` failed too. The provider is now all-`A`, each test runs a positive control first, and the assertions name the ring-specific reason.
- The item-3 tests all passed on first run, hence the mutation check above.

## Review fixes applied

Four findings from the CodeRabbit CLI lens. Three fixed, one rejected.

### Fixed (major): the equivalence fix missed a ring **inside a cis allele** — the one shape this PR says a kind-matching arm can miss

`undecidable_reason` matched on the *top-level* variant kind, so a cis allele carrying a ring fell through and was answered:

```
before:  ANSWERED  level=NotEquivalent   <-- a positive claim no rung examined
after:   DECLINED  … cannot decide equivalence … NC_000022.11:g.100_101del::200_201del
```

That is the exact unsoundness this PR exists to remove, one level down — and it is an internal inconsistency rather than a hypothetical, because `issue_1578_followup_ring_declines.rs` already builds that pairing and requires `spdi::apply`, `vcf::from_hgvs` and the projector to decline it. This module's own header calls it *"the one that walks a ring through the hand-rolled `Allele` recursion rather than meeting it at the top level, and therefore the one a kind-matching arm can miss."*

`undecidable_reason` now checks SPDI **first at every level** (preserving the self-retiring property) and then recurses into allele members. Two regression tests: the decline, and a control that an all-ordinary cis allele is *still answered*, so a recursion that declined on structure alone could not pass. Control: removing the recursion fails exactly the new decline test.

Not reachable via `parse_hgvs` — measured, `g.[…::…;…]` is rejected — but reachable by construction, which is how this PR's own tests build it.

### Fixed (major): seven rationale citations were never verified against the spec

The rationale cited `complex.md:39`, `:51`, `:53`, `:55`, `:113`, `:117` and `:161`, none of which were registered in the record's `clauses` array — so the generator never checked them. `CLAUDE.md` is explicit that this is the point of registering: *"a submodule bump that moves a clause fails the build instead of leaving the citation pointing at unrelated prose."* All seven are now registered with verbatim quotes extracted programmatically from the spec (12 clauses total), and the rendered clause index regenerated. The generator validates them; control from earlier in this review: changing one word of a quote makes it exit 1.

### Fixed (minor): a control the comment promised and the code did not make

`projection_declines_every_ring_shape` said *"a plain genomic member, **and a legal genomic allele**, both project through this empty-cdot harness"* — but only asserted the member. Since the ring shapes are themselves alleles, a projector that declined every `Allele` would have passed. Added `legal_allele()`, with both members stating `A` to match the all-`A` contig, for the reason `provider()` already documents.

### Rejected (major): "remove `no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted`"

Declined. That test is the mechanism this repo uses to keep an open gap visible, and the ruling's own status pin names it: *"The negative is pinned by `issue_1578_followup_self_cancelling_rings.rs` so nobody closes the escape the cheap way by pointing `:58` at rings."* Deleting it means a later change that makes `:58` reject those rings passes silently and erodes the ruling's scope with nothing failing. Keeping it is what forces the conversation when the well-formedness rule lands.

### Testing after the fixes

- Full `it` suite: **5,588 passed**, 0 failed.
- `cargo clippy --all-features --all-targets -D warnings` and `cargo fmt --check` clean.
- `generate_spec_fixture` exits 0, i.e. all 12 citations verify against the pinned submodule.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — the fix is confined to `src/equivalence/`, which is not a watched directory, and the item-3 ruling ratifies existing behaviour without moving any normalized output.

