### PR TITLE
fix(changelog): make the audit agree with the checker, and anchor its range to the merge ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,19 +272,42 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           printf '%s (#%s)\n\n%s\n' "$PR_TITLE" "$PR_NUMBER" "$PR_BODY" > squash-message.txt
+          # Resolve the tag BEFORE the reset, and hand it to the audit explicitly.
+          #
+          # `base.sha` is the base tip as of the last PR event, while the merge ref GitHub
+          # builds uses the *current* base — so after a release lands, an un-resynchronized
+          # PR resets to a commit from which the new tag is unreachable. `describe` would
+          # then answer with the PREVIOUS tag and silently widen the range back over an
+          # entire already-released cycle, re-judging merged work the PR author cannot
+          # touch. Measured: pre-reset `describe` gives v0.14.0, post-reset gives v0.13.1.
+          # Guarded because `describe` exits 128 on a tagless history and must not be what
+          # fails the job under `set -e`.
+          if AUDIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "AUDIT_RANGE=$AUDIT_TAG..HEAD" >> "$GITHUB_ENV"
+          else
+            echo "no tag reachable from the merge ref; the audit will resolve its own range"
+          fi
           git reset --soft "$PR_BASE_SHA"
           git -c user.name='github-actions' -c user.email='github-actions@github.com' \
             commit --allow-empty --no-verify --quiet --file squash-message.txt
           echo "auditing this squash-equivalent commit:"
           git --no-pager log -1 --format='%H%n%s'
-          # Guarded: `describe` exits non-zero on a tagless history, and this echo is a
-          # debugging aid — it must not be what fails the job under `set -e`.
-          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
-            echo "audited range ($tag..HEAD) now contains:"
-            git --no-pager log --format='  %h %s' "$tag..HEAD"
+          if [ -n "${AUDIT_TAG:-}" ]; then
+            echo "audited range ($AUDIT_TAG..HEAD) now contains:"
+            git --no-pager log --format='  %h %s' "$AUDIT_TAG..HEAD"
           fi
       - name: Audit the Representation changes section
-        run: python scripts/check_changelog_grouping.py
+        # `AUDIT_RANGE` is set by the step above from the tag resolved on the merge ref,
+        # before the soft reset moved HEAD's ancestry. Empty on a push to `main` (no
+        # synthesis step runs) and on a tagless history, where the script resolves its own
+        # range — so this is an override, not a requirement.
+        run: |
+          if [ -n "${AUDIT_RANGE:-}" ]; then
+            echo "auditing $AUDIT_RANGE"
+            python scripts/check_changelog_grouping.py --range "$AUDIT_RANGE"
+          else
+            python scripts/check_changelog_grouping.py
+          fi
 
   clippy:
     name: Clippy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,20 @@ ordering prefix. It deliberately shares **no code** with the checker — #1555 p
 to catch it precisely because that test compared the two halves against each other and they were
 wrong together, so a second opinion is only worth having when it is derived differently.
 
+**"Derived differently" means the derivation, not the verdict — and reading it the other way shipped
+a defect.** The audit's rule was originally made deliberately *coarser* than the checker's (first
+word, punctuation stripped, no terminator logic) on that reasoning. The result was a rule that
+disagreed with `release-plz.toml` on trailer forms `CONTRIBUTING.md` documents as **correct**:
+`no rows move` and `none, except two rows that merge` are filed as real changes by design, and the
+audit called them declines, so **no trailer text could satisfy both halves** — and once such a
+commit is on `main` the job is red for every open PR until the next release tag. The reverse also
+bit: `none.Tests only.` (a missing space) split to `none.Tests`, which the checker called a decline
+and the audit called a move. The two now agree on the verdict, pinned by
+`test_the_audit_and_the_checker_agree_on_every_documented_form`; what stays independent is that
+this check *renders the changelog through real git-cliff and reads the result*, which is the
+question no vocabulary-comparison test was asking. A disagreement is not a second opinion, it is an
+unsatisfiable build.
+
 Contributor-facing guidance is in `CONTRIBUTING.md`. The checker is
 `scripts/check_representation_change.py` and the audit is
 `scripts/check_changelog_grouping.py`; the decline vocabulary is pinned against

--- a/scripts/check_changelog_grouping.py
+++ b/scripts/check_changelog_grouping.py
@@ -53,10 +53,49 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 #: prefix is stripped, so it survives a change to the `<!-- N -->` numbering.
 REPRESENTATION_GROUP = "Representation changes"
 
-#: Words that mean "this moves nothing", as a *first word*. Deliberately a plain prefix
-#: test with no terminator logic: `scripts/check_representation_change.py` owns the precise
-#: rule, and a second opinion derived the same way is not a second opinion.
+#: Words that mean "this moves nothing", as the *verdict*.
 DECLINE_WORDS = frozenset({"none", "no", "n/a", "na"})
+
+#: Punctuation that may introduce the reason for a decline. A comma is deliberately absent,
+#: matching `CONTRIBUTING.md`: it usually introduces a qualification that changes the answer
+#: ("none, except two rows"), which is filed as a real change.
+DECLINE_TERMINATORS = ".;:—–"
+
+#: A decline: a verdict word, optionally followed by a terminator and a reason, and nothing
+#: else. Built from the two constants above.
+#:
+#: **This rule agrees with `scripts/check_representation_change.py` on the verdict, and it
+#: has to.** An earlier revision was deliberately coarser — first word, punctuation stripped,
+#: no terminator logic — on the reasoning that "a second opinion derived the same way is not
+#: a second opinion". That reasoning confused *deriving the answer differently* with *giving
+#: a different answer*, and the coarse rule failed CI on trailer forms `CONTRIBUTING.md`
+#: documents as correct, in both directions:
+#:
+#: - `no rows move` and `none, except two rows that merge` are filed as real changes **by
+#:   design** (`CONTRIBUTING.md`: "Both err toward listing a change rather than hiding one"),
+#:   and the coarse rule called them declines — so the audit failed, and no trailer text
+#:   could satisfy both halves at once.
+#: - `none.Tests only.` — a missing space after the terminator — went the other way:
+#:   `split()[0]` yields `none.Tests`, which strips to neither a decline nor a description,
+#:   so the checker called it a decline and the audit called it a move.
+#:
+#: Either direction turns `Changelog grouping audit` red for **every** open PR once such a
+#: commit is on `main`, until the next release tag, and no PR author can fix it.
+#:
+#: What stays independent is the *derivation*, which is where the value always was: this
+#: check renders the changelog through real git-cliff with the real config and reads the
+#: result, where the checker regexes the PR body. #1555 slipped past a test that compared
+#: the two halves' **vocabulary** and found them agreeing; rendering is what that test could
+#: not do. Sharing no code is still pinned by
+#: `test_the_rule_shares_no_vocabulary_with_the_checker`.
+DECLINE_RULE = re.compile(
+    r"^(?:"
+    + "|".join(re.escape(word) for word in sorted(DECLINE_WORDS, key=len, reverse=True))
+    + r")[ \t]*(?:["
+    + re.escape(DECLINE_TERMINATORS)
+    + r"].*)?$",
+    re.IGNORECASE | re.DOTALL,
+)
 
 #: A body template that renders one commit id per line under its group heading. Rendering
 #: ids rather than messages makes the mapping back to commits exact, and keeps this check
@@ -200,9 +239,18 @@ def commit_bodies(commit_range: str, repo: Path) -> dict[str, str]:
 
 
 def trailer_value(message: str) -> str | None:
-    """Return the `Representation-Change:` value in `message`, or None."""
+    """Return the `Representation-Change:` value in `message`, or None.
+
+    **Column 0, matching `scripts/check_representation_change.py` (#1573).** This pattern
+    allowed `^[ \\t]*` before the token, which git and git-cliff both treat as a
+    *continuation* of the value above it — so the two halves counted different trailers. A PR
+    description that quotes the declining example above its own real disclosure was the live
+    divergence: the checker read the column-0 disclosure and this read the indented `none`,
+    then reported the commit as a decline filed under **Representation changes** and failed
+    the build.
+    """
     match = re.search(
-        r"^[ \t]*Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
+        r"^Representation-Change:[ \t]*(?P<value>\S.*?)[ \t]*$",
         message,
         re.IGNORECASE | re.MULTILINE,
     )
@@ -210,13 +258,14 @@ def trailer_value(message: str) -> str | None:
 
 
 def opens_with_a_decline(value: str) -> bool:
-    """Return whether `value`'s first word means "nothing moved".
+    """Return whether `value`'s verdict means "nothing moved".
 
-    Punctuation is stripped from the first word, so `none.`, `none:` and `none —` all read
-    as declines. This is the whole rule: no terminator logic, no vocabulary sharing.
+    The verdict is the first word; a terminator from `DECLINE_TERMINATORS` may introduce a
+    reason after it. Anything else following the word — another word, or a comma — makes it a
+    description of a move. See `DECLINE_RULE` for why this agrees with the checker rather
+    than being deliberately coarser.
     """
-    first_word = value.strip().split()[0] if value.strip() else ""
-    return first_word.strip(".,;:!—–").lower() in DECLINE_WORDS
+    return DECLINE_RULE.match(value.strip()) is not None
 
 
 def check(commit_range: str, repo: Path) -> tuple[bool, list[str]]:
@@ -286,14 +335,26 @@ def check(commit_range: str, repo: Path) -> tuple[bool, list[str]]:
 
 
 def latest_tag(repo: Path) -> str:
-    """Return the most recent tag reachable from HEAD."""
+    """Return the most recent tag reachable from HEAD.
+
+    Raises `RuntimeError` naming the fix rather than surfacing a `CalledProcessError`
+    traceback: on a shallow clone or a history with no tags, `describe` exits 128, and the
+    workflow already guards its own `describe` against exactly that.
+    """
     result = subprocess.run(
         ["git", "describe", "--tags", "--abbrev=0"],
         cwd=repo,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "no tag is reachable from HEAD, so the audited range cannot be derived: "
+            f"`git describe --tags --abbrev=0` exited {result.returncode} "
+            f"({result.stderr.strip()}). Pass an explicit `--range`, or fetch tags "
+            "(`fetch-depth: 0`) if this is a shallow clone."
+        )
     return result.stdout.strip()
 
 

--- a/tests/python/test_changelog_grouping.py
+++ b/tests/python/test_changelog_grouping.py
@@ -46,9 +46,11 @@ trailer_value = check_changelog_grouping.trailer_value
         "no — nothing reaches a normalizer",
         "n/a: docs",
         "na. generated artifact only",
-        # Not a decline by the *checker's* rule (no terminator), and that is the point:
-        # this rule is coarser on purpose, so that a shared mistake cannot hide.
-        "none, except two rows that merge",
+        # A missing space after the terminator is an ordinary typo, and it used to flip the
+        # verdict: `split()[0]` yielded `none.Tests`, so the checker called this a decline
+        # and the audit called it a move — a red build on a correct trailer.
+        "none.Tests only.",
+        "none—no watched file is touched",
     ],
 )
 def test_a_leading_decline_word_is_a_decline(value: str) -> None:
@@ -63,19 +65,88 @@ def test_a_leading_decline_word_is_a_decline(value: str) -> None:
         "3 rows of 500,004 move",
         "nothing moves under src/normalize/",
         "not measured yet",
+        # `CONTRIBUTING.md:103-105` documents both of these as filed as real changes: a comma
+        # is not a terminator, and `no rows move` has no terminator at all. "Both err toward
+        # listing a change rather than hiding one." The audit used to call them declines,
+        # which made them unsatisfiable — release-plz filed them one way and the audit failed
+        # them the other, with no trailer text able to satisfy both.
+        "none, except two rows that merge",
+        "no rows move",
     ],
 )
 def test_a_description_of_a_move_is_not_a_decline(value: str) -> None:
     assert not opens_with_a_decline(value)
 
 
+def test_the_audit_and_the_checker_agree_on_every_documented_form() -> None:
+    """The two halves must reach the same verdict, or CI is unsatisfiable.
+
+    This is the guard the audit shipped without. Its rule was deliberately coarser than the
+    checker's — first word, punctuation stripped, no terminator logic — on the reasoning that
+    a second opinion derived the same way is worth nothing. But a *disagreement* is not a
+    second opinion, it is a red build: `no rows move` and `none, except two rows that merge`
+    are filed as real changes by design (`CONTRIBUTING.md:103-105`) and the audit called them
+    declines, so no trailer text could satisfy both halves. Once such a commit is on `main`
+    the job is red for every open PR until the next release tag.
+
+    What is still independent is the derivation — this check renders the changelog through
+    real git-cliff and reads the result; the checker regexes the PR body. That is pinned
+    separately by `test_the_rule_shares_no_vocabulary_with_the_checker`. Agreement on the
+    verdict and independence of derivation are different properties, and #1555 is the reason
+    to want both: a test comparing only vocabulary found the two halves agreeing while both
+    were wrong.
+    """
+    checker_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "check_representation_change.py"
+    )
+    spec = importlib.util.spec_from_file_location("_checker_for_agreement", checker_path)
+    assert spec is not None and spec.loader is not None
+    checker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(checker)
+
+    for value in [
+        # declines, including every terminator CONTRIBUTING.md names
+        "none",
+        "NONE",
+        "none.",
+        "none. Tests only; nothing under a watched directory.",
+        "none: comments only",
+        "none; one fixture JSON",
+        "none — 0 of 950 rows move",
+        "none.Tests only.",
+        "no. Nothing reaches a normalizer.",
+        "n/a: docs",
+        "na. generated artifact only",
+        # real changes, including the two the coarse rule got wrong
+        "577 rows move, 360 merge / 205 split",
+        "0 rows move over 5,761,302 real expressions",
+        "no rows move",
+        "none, except two rows that merge",
+        "nothing moves",
+        "not measured yet",
+    ]:
+        assert opens_with_a_decline(value) == checker.declines(value), (
+            f"{value!r}: the audit calls it "
+            f"{'a decline' if opens_with_a_decline(value) else 'a move'} and the checker calls "
+            f"it {'a decline' if checker.declines(value) else 'a move'}. A disagreement is a "
+            "red build on a correct trailer, not a useful second opinion — the independence "
+            "that matters is how each derives its answer, not that they answer differently."
+        )
+
+
 def test_the_rule_shares_no_vocabulary_with_the_checker() -> None:
-    """This is the whole design of the audit, so it is pinned rather than left to comments.
+    """The audit must not *import* the checker's rule, so the two can be wrong separately.
 
     #1555 survived a test written to catch exactly it, because that test compared the two
-    halves against *each other* and they were wrong together. A second opinion has to be
-    derived differently to be worth anything — here, a plain first-word test with no
-    terminator logic.
+    halves against *each other* and they were wrong together.
+
+    Note what this does and does not buy, because the original framing over-claimed and that
+    over-claim is what shipped the defect above. It keeps the implementations separate. It
+    does **not** make the audit's *verdict* independent — the verdict has to agree, or CI is
+    unsatisfiable (`test_the_audit_and_the_checker_agree_on_every_documented_form`). The
+    independence that catches a shared mistake is in the *derivation*: this check renders the
+    changelog through real git-cliff and reads the result, which is the question no
+    vocabulary-comparison test was asking.
     """
     source = _MODULE_PATH.read_text(encoding="utf-8")
     for borrowed in ("import check_representation_change", "NONE_VALUES", "DECLINE_RE"):
@@ -200,7 +271,20 @@ def test_ci_synthesizes_the_squash_commit_before_auditing() -> None:
     # Scoped to the synthesis step itself, not to everything above the audit. Asserting
     # against the whole preamble would let a match come from an unrelated step — and it is
     # the *dataflow inside this step* that carries the property.
-    step = workflow[synthesis:audit]
+    raw_step = workflow[synthesis:audit]
+
+    # And with `#`-comment lines removed, because YAML comments are not code. Adversarial
+    # review found three mutants that passed both this test and `actionlint` purely by
+    # matching comment text: commenting the reset out (`# git reset --soft "$PR_BASE_SHA"`)
+    # restored the pre-fix behaviour silently, and `# was: git reset --soft "$PR_BASE_SHA"`
+    # above a `reset --soft HEAD~0` did the same. Commenting a line out to debug is an
+    # ordinary edit, so the assertions must not be satisfiable by the prose that explains
+    # them. `step` is what every assertion below reads.
+    step = "\n".join(line for line in raw_step.splitlines() if not line.lstrip().startswith("#"))
+    assert "#" in raw_step and len(step) < len(raw_step), (
+        "comment stripping matched nothing, so it is not protecting anything — the step's "
+        "explanatory comments were expected to be present and removed"
+    )
 
     # The subject and body must both come from the PR, and through `env` — a PR title is
     # attacker-controlled text and `${{ }}` inside `run` would splice it into the shell.
@@ -213,6 +297,18 @@ def test_ci_synthesizes_the_squash_commit_before_auditing() -> None:
     # every PR regardless of its declaration. That is the exact failure this test exists to
     # prevent, so pin the whole chain: env var -> message file -> commit.
     message_file = "squash-message.txt"
+
+    # Written exactly once. `[^>]*` below is positional, so a second redirect appended after
+    # the good `printf` — `printf 'ci: preview\n' > squash-message.txt` — clobbers the file
+    # while the first match still succeeds. Adversarial review found that mutant surviving
+    # both this test and `actionlint`.
+    writes = len(re.findall(r">\s*" + re.escape(message_file), step))
+    assert writes == 1, (
+        f"{message_file} is redirected to {writes} times in this step; a second write "
+        "clobbers the message assembled from the PR and the audit then judges a commit that "
+        "never carried the trailer"
+    )
+
     written_from = re.search(
         r"printf\s+\S+\s+(?P<args>[^>]*)>\s*" + re.escape(message_file),
         step,
@@ -254,4 +350,27 @@ def test_ci_synthesizes_the_squash_commit_before_auditing() -> None:
     )
     assert step.index(reset.group(0)) < step.index("commit --allow-empty"), (
         "the reset must precede the commit, or the commit lands on the merge ref"
+    )
+
+    # The tag must be resolved on the MERGE REF, i.e. before the reset moves HEAD's
+    # ancestry, and handed to the audit explicitly.
+    #
+    # `base.sha` is the base tip as of the last PR event while the merge ref uses the
+    # *current* base, so once a release lands, an un-resynchronized PR resets to a commit
+    # from which the new tag is unreachable. `describe` then answers with the PREVIOUS tag
+    # and the audit silently widens back over an entire released cycle, re-judging merged
+    # work the PR author cannot touch. Measured: 3 commits audited that way against 1.
+    describe = re.search(r"(?P<var>[A-Z_]+)=\$\(git describe --tags --abbrev=0", step)
+    assert describe is not None, (
+        "the step must resolve the latest tag itself; leaving it to the audit resolves it "
+        "after the reset, against the wrong ancestry"
+    )
+    assert step.index(describe.group(0)) < step.index(reset.group(0)), (
+        "the tag must be resolved BEFORE the soft reset — after it, a release that landed "
+        "since the PR's base.sha is unreachable and `describe` silently returns the previous "
+        "tag, rewinding the audited range over an already-released cycle"
+    )
+    assert "AUDIT_RANGE=" in step and "GITHUB_ENV" in step, (
+        "the resolved range must be exported (AUDIT_RANGE -> $GITHUB_ENV) so the audit step "
+        "uses it rather than re-deriving it from the reset HEAD"
     )


### PR DESCRIPTION
#1560's `Changelog grouping audit` fails CI on trailer forms `CONTRIBUTING.md` documents as **correct**, in both directions. Once such a commit is on `main` the job is red for **every** open PR until the next release tag, and no PR author can fix it. Found by an adversarial review of #1560 after it merged.

## The audit and the checker had to agree, and did not

The audit's decline rule was made deliberately *coarser* than the checker's — first word, punctuation stripped, no terminator logic — on the reasoning that "a second opinion derived the same way is not a second opinion". That reasoning confused **deriving the answer differently** with **giving a different answer**.

`CONTRIBUTING.md:103-105`: *"A comma is not a terminator … ('none, except two rows') — that reads as a description of a move, and is filed as one. Same for `no rows move` … Both err toward listing a change rather than hiding one."*

So release-plz files both as real changes, by design — and the audit called them declines:

```
3 commits in v0.0.1..HEAD; 2 listed as representation changes
f27dd04a is filed under Representation changes but its trailer opens with a decline: 'no rows move'
986e4ccd is filed under Representation changes but its trailer opens with a decline: 'none, except two rows that merge'
exit=1
```

`check_representation_change.py` passes both. **No trailer text satisfied both halves.**

The reverse bit too. `split()[0]` treats `none.Tests` as one word, so an ordinary missing space flipped the verdict the other way:

```
'none.Tests only.'                  checker declines()=True   audit opens_with_a_decline()=False
'none—no watched file is touched'   checker declines()=True   audit opens_with_a_decline()=False
```

The rule now reads the verdict and admits a terminator from `.;:—–` (comma still excluded), agreeing with the checker in verdict while **sharing no code with it** — `test_the_rule_shares_no_vocabulary_with_the_checker` still passes. What stays independent, and is where the value always was: this check renders the changelog through real git-cliff and reads the result. A disagreement is not a second opinion, it is an unsatisfiable build.

Pinned by a new `test_the_audit_and_the_checker_agree_on_every_documented_form` over 17 forms, and end-to-end through git-cliff all three previously-failing trailers now exit 0.

## Three more from the same review

**`trailer_value` regressed #1573's column-0 rule.** It allowed `^[ \t]*` before the token — what git and git-cliff treat as a *continuation*. A PR description quoting the declining example above its own real disclosure diverged:

```
checker find_declarations (column-0 only): ['3 rows move, 2 respell']
audit  trailer_value      (allows indent): 'none'      -> filed as a decline -> exit 1
```

**The audited range was resolved after the soft reset.** `base.sha` is the base tip as of the last PR event while the merge ref uses the *current* base, so once a release lands, an un-resynchronized PR resets to a commit from which the new tag is unreachable — `describe` then returns the **previous** tag and the audit silently widens back over an entire released cycle, re-judging merged work the PR author cannot touch. Measured on a simulated merge ref with a release landing after `base.sha`:

| | audited range | commits |
|---|---|---|
| before | `v0.13.1..HEAD` | **3** — including `fix: released work`, `feat: more released work` |
| after | `v0.14.0..HEAD` | **1** — the PR's own squash preview |

The tag is now captured *on the merge ref*, before the reset, and passed to the audit as `--range` via `$GITHUB_ENV`. Guarded, so a tagless history still falls back to the script resolving its own range.

**`latest_tag` raised `CalledProcessError`** on a tagless history — the condition the workflow already guards its own `describe` against. It now raises a `RuntimeError` naming the fix.

## Every fix has a control that fails without it

Including three mutants that previously passed **both** the test and `actionlint`:

| mutant | before | after |
|---|---|---|
| `# git reset --soft "$PR_BASE_SHA"` (commented out) | passed | **fails** |
| `# was: …` + `git reset --soft HEAD~0` | passed | **fails** |
| second `printf … > squash-message.txt` clobbering the first | passed | **fails** |
| `git reset --hard` instead of `--soft` | fails | fails |
| tag resolved *after* the reset | n/a | **fails** |

The first two worked purely by matching **comment text**, so the assertions now read the step with `#`-comment lines stripped — and that stripping is itself asserted to have removed something, since a no-op strip protects nothing. The third was `[^>]*` being positional, so the message file is now asserted to be written exactly once.

Worth recording: my first attempt at the `--hard` control reported the assertion *passing* a hard reset, which would have meant a useless assertion. The control was invalid — it rewrote the phrase `reset --soft` in the surrounding comment rather than the command. The harness now asserts the anchor occurs exactly once before replacing it. A bad control is indistinguishable from a passing one.

## Testing

- **105 tests pass** in the two trailer/grouping modules.
- `ruff check` / `ruff format --check` clean; `actionlint` clean; `ci.yml` parses.
- The audit is clean against real history: `10 commits in v0.13.1..HEAD; 2 listed as representation changes`.
- The shipped workflow script executed against a simulated merge ref under `bash -euo pipefail`: exit 0, correct range, PR tree intact.

`CLAUDE.md`'s description of the audit is corrected in step — it stated the "shares no code" property in a way that invited exactly this over-reading.

Representation-Change: none. CI scripts, one workflow job, their tests and documentation; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched.
