### PR TITLE
fix(error-handling): only read codon-aligned windows in the amino-acid case detector

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -525,48 +525,69 @@ fn is_amino_acid_like(s: &str) -> bool {
         && bytes[2].is_ascii_alphabetic()
 }
 
+/// Three-letter amino-acid codes, as (lowercase probe, canonical spelling).
+const AMINO_ACID_CODES: [(&str, &str); 23] = [
+    ("ala", "Ala"),
+    ("arg", "Arg"),
+    ("asn", "Asn"),
+    ("asp", "Asp"),
+    ("cys", "Cys"),
+    ("gln", "Gln"),
+    ("glu", "Glu"),
+    ("gly", "Gly"),
+    ("his", "His"),
+    ("ile", "Ile"),
+    ("leu", "Leu"),
+    ("lys", "Lys"),
+    ("met", "Met"),
+    ("phe", "Phe"),
+    ("pro", "Pro"),
+    ("sec", "Sec"),
+    ("ser", "Ser"),
+    ("thr", "Thr"),
+    ("trp", "Trp"),
+    ("tyr", "Tyr"),
+    ("val", "Val"),
+    ("ter", "Ter"),
+    ("xaa", "Xaa"),
+];
+
+/// Resolve a three-letter token to its canonical amino-acid spelling,
+/// ignoring case. Returns `None` when the token is not an amino-acid code.
+///
+/// Unlike [`correct_amino_acid_case`] this also answers for tokens that are
+/// *already* canonical (`Val` -> `Val`). That distinction is what lets
+/// [`correct_amino_acid_case_in_protein`] stay codon-aligned: a correctly
+/// spelled codon must still consume three bytes, or the scan slips out of
+/// frame and reads the next window across a codon boundary.
+fn canonical_amino_acid_code(token: &str) -> Option<&'static str> {
+    if token.len() != 3 || !token.is_char_boundary(3) {
+        return None;
+    }
+    let lower = token.to_lowercase();
+    AMINO_ACID_CODES
+        .iter()
+        .find(|(probe, _)| lower == *probe)
+        .map(|(_, canonical)| *canonical)
+}
+
 /// Correct lowercase amino acid codes to proper case.
 ///
 /// Converts `val` to `Val`, `GLU` to `Glu`, etc.
 ///
+/// Returns `None` for a token that is already canonical, so a caller that
+/// needs to know "is this an amino-acid code at all" should use
+/// [`canonical_amino_acid_code`] instead.
+///
 /// Used by `correct_amino_acid_case_in_protein` to classify individual
 /// three-letter tokens.
 pub fn correct_amino_acid_case(token: &str) -> Option<(String, ErrorType)> {
-    // Three-letter amino acid codes (case-insensitive check)
-    let amino_acids = [
-        ("ala", "Ala"),
-        ("arg", "Arg"),
-        ("asn", "Asn"),
-        ("asp", "Asp"),
-        ("cys", "Cys"),
-        ("gln", "Gln"),
-        ("glu", "Glu"),
-        ("gly", "Gly"),
-        ("his", "His"),
-        ("ile", "Ile"),
-        ("leu", "Leu"),
-        ("lys", "Lys"),
-        ("met", "Met"),
-        ("phe", "Phe"),
-        ("pro", "Pro"),
-        ("sec", "Sec"),
-        ("ser", "Ser"),
-        ("thr", "Thr"),
-        ("trp", "Trp"),
-        ("tyr", "Tyr"),
-        ("val", "Val"),
-        ("ter", "Ter"),
-        ("xaa", "Xaa"),
-    ];
-
-    let lower = token.to_lowercase();
-    for (pattern, correct) in amino_acids {
-        if lower == pattern && token != correct {
-            return Some((correct.to_string(), ErrorType::LowercaseAminoAcid));
+    match canonical_amino_acid_code(token) {
+        Some(canonical) if token != canonical => {
+            Some((canonical.to_string(), ErrorType::LowercaseAminoAcid))
         }
+        _ => None,
     }
-
-    None
 }
 
 /// Scan only the `p.` segment of an HGVS expression and rewrite three-letter
@@ -604,22 +625,39 @@ pub fn correct_amino_acid_case_in_protein(input: &str) -> (Cow<'_, str>, Vec<Det
             while run_end < len && bytes[run_end].is_ascii_alphabetic() {
                 run_end += 1;
             }
+            // Probe 3-letter windows, but only ever *accept* a window on a
+            // codon boundary. Once a window resolves to an amino-acid code the
+            // scan consumes all three of its bytes — whether or not the code
+            // needed correcting — so every subsequent window in this run stays
+            // in frame at offsets 0, 3, 6, ... from that codon.
+            //
+            // Advancing by 1 over an already-canonical code (the pre-#1591
+            // behaviour) let the scan read the *next* window across a codon
+            // boundary: in `delinsValAlaAla` it matched `alA` spanning
+            // `V|al|A`, "corrected" it to `Ala`, and rewrote a legal input into
+            // the unparseable `delinsVAlalaAla`. Strict mode rejected a valid
+            // description and lenient mode applied that rewrite and then failed
+            // to parse its own output.
             let mut j = i;
             while j + 3 <= run_end {
                 let token = &body[j..j + 3];
-                if let Some((canonical, error_type)) = correct_amino_acid_case(token) {
-                    let abs_start = start + j;
-                    corrections.push(DetectedCorrection::new(
-                        error_type,
-                        token.to_string(),
-                        canonical.clone(),
-                        abs_start,
-                        abs_start + 3,
-                    ));
-                    out.push_str(&canonical);
+                if let Some(canonical) = canonical_amino_acid_code(token) {
+                    if token != canonical {
+                        let abs_start = start + j;
+                        corrections.push(DetectedCorrection::new(
+                            ErrorType::LowercaseAminoAcid,
+                            token.to_string(),
+                            canonical.to_string(),
+                            abs_start,
+                            abs_start + 3,
+                        ));
+                    }
+                    // Consume the whole codon either way, keeping the frame.
+                    out.push_str(canonical);
                     j += 3;
                 } else {
-                    // Push one ASCII letter and advance.
+                    // Not an amino-acid code: push one ASCII letter and
+                    // advance, still hunting for the start of the codon run.
                     out.push(bytes[j] as char);
                     j += 1;
                 }
@@ -4429,6 +4467,149 @@ mod tests {
         let (twice, corrections) = correct_amino_acid_case_in_protein(&once);
         assert_eq!(twice, once);
         assert!(corrections.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // Codon alignment (#1591)
+    //
+    // A multi-codon run must be read at offsets 0, 3, 6, ... from the first
+    // recognised codon. Reading arbitrary 3-character substrings finds codes
+    // that straddle a codon boundary — `V|al|A` in `ValAla` reads as `alA` —
+    // and "correcting" one rewrites a legal description into an unparseable
+    // one.
+    // ------------------------------------------------------------------
+
+    /// The reported case: a correctly-cased multi-codon `delins` payload must
+    /// be left completely alone.
+    #[test]
+    fn canonical_multi_codon_delins_run_is_not_rewritten() {
+        let input = "NP_003997.1:p.Met1_Ala3delinsValAlaAla";
+        let (corrected, corrections) = correct_amino_acid_case_in_protein(input);
+        assert_eq!(
+            corrected, input,
+            "a canonical codon run must survive untouched; \
+             reading `alA` across the Val|Ala boundary produced `delinsVAlalaAla`"
+        );
+        assert!(corrections.is_empty(), "no correction is warranted");
+    }
+
+    /// The control from the same report — a run whose codon boundaries admit
+    /// no cross-boundary reading — must keep working.
+    #[test]
+    fn canonical_multi_codon_control_run_is_not_rewritten() {
+        let input = "NP_003997.1:p.Met1_Ala3delinsArgLeuArg";
+        let (corrected, corrections) = correct_amino_acid_case_in_protein(input);
+        assert_eq!(corrected, input);
+        assert!(corrections.is_empty());
+    }
+
+    /// Codon alignment must not cost the detector its real job: a genuinely
+    /// mis-cased run is still caught, with one correction per codon.
+    #[test]
+    fn miscased_multi_codon_run_is_still_corrected() {
+        for input in [
+            "NP_003997.1:p.Met1_Ala3delinsvalalaala",
+            "NP_003997.1:p.Met1_Ala3delinsVALALAALA",
+            "NP_003997.1:p.Met1_Ala3delinsVaLaLaAlA",
+        ] {
+            let (corrected, corrections) = correct_amino_acid_case_in_protein(input);
+            assert_eq!(
+                corrected, "NP_003997.1:p.Met1_Ala3delinsValAlaAla",
+                "mis-cased run {input} must be corrected"
+            );
+            assert_eq!(
+                corrections.len(),
+                3,
+                "one correction per mis-cased codon in {input}"
+            );
+        }
+    }
+
+    /// Exhaustive over the whole code table: every adjacent pair of canonical
+    /// codons must round-trip untouched, and every all-lower / all-upper
+    /// spelling of that pair must correct back to it.
+    ///
+    /// Pre-fix this failed on 7 of the 529 pairs — Arg|Lys, Gly|Sec, Gly|Ser,
+    /// Val|Ala, Val|Arg, Val|Asn and Val|Asp — each of which hides a further
+    /// code across its codon boundary.
+    #[test]
+    fn every_adjacent_canonical_codon_pair_is_stable() {
+        for (_, first) in AMINO_ACID_CODES {
+            for (_, second) in AMINO_ACID_CODES {
+                let run = format!("{first}{second}");
+                let canonical = format!("NP_000001.1:p.Met1_Ala3delins{run}");
+
+                let (out, corrections) = correct_amino_acid_case_in_protein(&canonical);
+                assert_eq!(
+                    out, canonical,
+                    "canonical pair {first}|{second} was rewritten"
+                );
+                assert!(
+                    corrections.is_empty(),
+                    "canonical pair {first}|{second} produced a spurious correction"
+                );
+
+                for spelling in [run.to_lowercase(), run.to_uppercase()] {
+                    let input = format!("NP_000001.1:p.Met1_Ala3delins{spelling}");
+                    let (out, corrections) = correct_amino_acid_case_in_protein(&input);
+                    assert_eq!(
+                        out, canonical,
+                        "mis-cased pair {spelling} must correct to {first}{second}"
+                    );
+                    assert_eq!(
+                        corrections.len(),
+                        2,
+                        "expected one correction per codon in {spelling}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A canonical codon run of any length is a fixed point, and correcting a
+    /// mis-cased run of any length lands on it.
+    #[test]
+    fn canonical_codon_runs_of_every_length_are_stable() {
+        for len in 1..=8 {
+            let run: String = AMINO_ACID_CODES
+                .iter()
+                .cycle()
+                .take(len)
+                .map(|(_, c)| *c)
+                .collect();
+            let canonical = format!("NP_000001.1:p.Met1_Ala3delins{run}");
+
+            let (out, corrections) = correct_amino_acid_case_in_protein(&canonical);
+            assert_eq!(
+                out, canonical,
+                "canonical run of {len} codons was rewritten"
+            );
+            assert!(corrections.is_empty());
+
+            let input = format!("NP_000001.1:p.Met1_Ala3delins{}", run.to_lowercase());
+            let (out, corrections) = correct_amino_acid_case_in_protein(&input);
+            assert_eq!(out, canonical);
+            assert_eq!(corrections.len(), len);
+        }
+    }
+
+    /// `canonical_amino_acid_code` answers for already-canonical tokens (which
+    /// is what keeps the frame), while `correct_amino_acid_case` still reports
+    /// only tokens that need changing.
+    #[test]
+    fn canonical_lookup_answers_for_already_canonical_codes() {
+        assert_eq!(canonical_amino_acid_code("Val"), Some("Val"));
+        assert_eq!(canonical_amino_acid_code("val"), Some("Val"));
+        assert_eq!(canonical_amino_acid_code("VAL"), Some("Val"));
+        assert_eq!(canonical_amino_acid_code("del"), None);
+        assert_eq!(canonical_amino_acid_code("Va"), None);
+        assert_eq!(canonical_amino_acid_code("Vall"), None);
+
+        assert!(correct_amino_acid_case("Val").is_none());
+        assert_eq!(
+            correct_amino_acid_case("val").map(|(s, _)| s),
+            Some("Val".to_string())
+        );
     }
 
     // Protein-scoped single-letter AA expansion (W1002) tests

--- a/tests/it/error_mode_tests.rs
+++ b/tests/it/error_mode_tests.rs
@@ -1912,3 +1912,129 @@ mod spec_mandated_rejections {
         assert!(get_code_info("W3015").is_some());
     }
 }
+
+// ============================================================================
+// W1001 codon alignment across the three modes (#1591)
+// ============================================================================
+
+/// The amino-acid case detector reads codon-aligned windows only, so a legal
+/// multi-codon payload is accepted identically in every mode.
+///
+/// Before the fix the detector matched `alA` across the `Val|Ala` boundary of
+/// `delinsValAlaAla`: strict **rejected** a valid description (suggesting the
+/// corrupted `delinsVAlalaAla`), and lenient/silent **applied** that rewrite
+/// and then failed to parse their own output with "Unexpected trailing
+/// characters: 'laAla'". Lenient turning a legal input into a parse failure is
+/// the worst of the three outcomes, which is why all three are pinned here.
+mod w1001_codon_alignment {
+    use super::*;
+
+    /// The reported input, plus the control from the same report.
+    const CANONICAL_INPUTS: [&str; 2] = [
+        "NP_003997.1:p.Met1_Ala3delinsValAlaAla",
+        "NP_003997.1:p.Met1_Ala3delinsArgLeuArg",
+    ];
+
+    #[test]
+    fn canonical_codon_runs_are_accepted_unchanged_in_every_mode() {
+        for config in [
+            ErrorConfig::strict(),
+            ErrorConfig::lenient(),
+            ErrorConfig::silent(),
+        ] {
+            let preprocessor = config.preprocessor();
+            for input in CANONICAL_INPUTS {
+                let result = preprocessor.preprocess(input);
+                assert!(
+                    result.success,
+                    "{input} must be accepted; got {:?}",
+                    result.error.as_ref().map(|e| e.to_string())
+                );
+                assert_eq!(result.preprocessed, input, "{input} must not be rewritten");
+                assert!(
+                    !result
+                        .warnings
+                        .iter()
+                        .any(|w| w.error_type == ErrorType::LowercaseAminoAcid),
+                    "{input} must not raise W1001"
+                );
+            }
+        }
+    }
+
+    /// Whatever the modes do with it, the preprocessor's output must parse —
+    /// the concrete failure was lenient emitting a string it could not parse.
+    #[test]
+    fn preprocessed_output_parses_in_every_mode() {
+        for config in [
+            ErrorConfig::strict(),
+            ErrorConfig::lenient(),
+            ErrorConfig::silent(),
+        ] {
+            let preprocessor = config.preprocessor();
+            for input in CANONICAL_INPUTS {
+                let result = preprocessor.preprocess(input);
+                assert!(result.success, "{input} must be accepted");
+                assert!(
+                    ferro_hgvs::parse_hgvs(&result.preprocessed).is_ok(),
+                    "preprocessor emitted an unparseable string for {input}: {}",
+                    result.preprocessed
+                );
+            }
+        }
+    }
+
+    /// Alignment must not cost the detector its real job: a genuinely
+    /// mis-cased run is still rejected by strict and still corrected (with a
+    /// W1001 per codon) by lenient.
+    #[test]
+    fn genuinely_miscased_runs_are_still_caught() {
+        let miscased = "NP_003997.1:p.Met1_Ala3delinsvalalaala";
+        let canonical = "NP_003997.1:p.Met1_Ala3delinsValAlaAla";
+
+        let strict = ErrorConfig::strict().preprocessor().preprocess(miscased);
+        assert!(!strict.success, "strict must still reject {miscased}");
+        // …and rejects it for the CASING, not for something incidental.
+        //
+        // `!success` alone passes for any rejection at all — an unparseable
+        // accession, a position out of range, a change to what `preprocess`
+        // rejects that has nothing to do with amino-acid case. The claim this
+        // test makes is that the alignment work did not cost the detector its
+        // real job, and only the code names which detector fired. Note the
+        // lenient half three lines down already keys on
+        // `ErrorType::LowercaseAminoAcid`; this was the weaker of two adjacent
+        // assertions about one behaviour.
+        //
+        // The strict ERROR and the lenient WARNING are different enumerations of
+        // the same finding — `ErrorCode::InvalidAminoAcid` (1008) on the refusal,
+        // `ErrorType::LowercaseAminoAcid` on the correction — so both are pinned
+        // rather than assuming one implies the other.
+        assert_eq!(
+            strict.error.as_ref().and_then(ferro_hgvs::FerroError::code),
+            Some(ferro_hgvs::error::ErrorCode::InvalidAminoAcid),
+            "strict rejected {miscased}, but not as a mis-cased amino acid: {:?}",
+            strict.error
+        );
+
+        let lenient = ErrorConfig::lenient().preprocessor().preprocess(miscased);
+        assert!(lenient.success, "lenient must correct {miscased}");
+        assert_eq!(lenient.preprocessed, canonical);
+        assert_eq!(
+            lenient
+                .warnings
+                .iter()
+                .filter(|w| w.error_type == ErrorType::LowercaseAminoAcid)
+                .count(),
+            3,
+            "one W1001 per mis-cased codon"
+        );
+
+        let silent = ErrorConfig::silent().preprocessor().preprocess(miscased);
+        assert!(silent.success);
+        assert_eq!(silent.preprocessed, canonical);
+        assert!(silent
+            .warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::LowercaseAminoAcid));
+    }
+}


### PR DESCRIPTION
## The defect

`correct_amino_acid_case_in_protein` scanned **every** 3-character substring of a letter run, advancing one byte at a time whenever a window resolved to a codon that was already correctly cased. The following window therefore straddled a codon boundary.

In `delinsValAlaAla` it read `alA` across `V|al|A`, reported it as a mis-cased `Ala`, and rewrote the description to `delinsVAlalaAla`.

Measured on `origin/main` @ `ef80f3ea`, all three modes are wrong on a legal input:

```
NP_003997.1:p.Met1_Ala3delinsValAlaAla
  strict  : ERROR at position 30: Lowercase or mis-cased amino-acid code 'alA', expected 'Ala'
            ...and it suggests the corrupted ...delinsVAlalaAla
  lenient : ERROR at position 35: Unexpected trailing characters: 'laAla'   (applies the suggestion, then cannot parse it)
  silent  : ERROR at position 35: Unexpected trailing characters: 'laAla'
```

Lenient taking a legal input, applying a bad repair, and emitting a string it cannot itself parse is worse than either accepting or refusing it.

The control from the same report, `NP_003997.1:p.Met1_Ala3delinsArgLeuArg`, is unaffected — its codon boundaries admit no cross-boundary reading.

## The fix

`src/error_handling/corrections.rs` — a window is only ever *accepted* on a codon boundary. When one resolves to an amino-acid code the scan consumes all three of its bytes, whether or not the code needed correcting, so every later window in that run stays in frame at offsets 0, 3, 6, … from the first recognised codon.

The detector's real job is untouched: `val`, `VAL` and `VaL` are still caught, one W1001 per codon, with the suggestion intact.

A new `canonical_amino_acid_code` helper carries the case-insensitive lookup (it answers for already-canonical tokens, which is what holds the frame); `correct_amino_acid_case` keeps its old contract of reporting only tokens that need changing.

## Blast radius

Exactly **7 of the 529** adjacent canonical codon pairs could hide a further code across their boundary: `Arg|Lys`, `Gly|Sec`, `Gly|Ser`, `Val|Ala`, `Val|Arg`, `Val|Asn`, `Val|Asp`.

Old vs new binary over **368,870** unique protein descriptions from `clinvar_hgvs_500k` + `clinvar_hgvs_unique`, keyed row by row:

| | strict | lenient |
|---|---|---|
| accepted → rejected | **0** | **0** |
| rejected → accepted | 82 | 82 |
| accepted both, corrected output changed | **0** | **0** |

All 82 newly-accepted rows were checked to tile exactly into canonical, correctly-cased codons — none is a mis-cased input slipping through. Nothing that used to be accepted is now rejected, and no previously-accepted row's corrected output moved, so no correction was lost.

One honest caveat on that corpus: only 86 of the 368,870 rows contain **any** mis-cased three-letter window, and 82 of those are the false positives being fixed. ClinVar is well-formed, so it is thin evidence that genuine mis-casing is still caught. That property is carried by the tests instead — in particular an exhaustive pass over all 23×23 pairs in both all-lower and all-upper spellings.

## Tests

Nine hermetic tests. Two of the three mode-level ones were confirmed to **fail** against `origin/main`'s `corrections.rs`, so they are guards rather than change detectors.

`src/error_handling/corrections.rs`:
- `canonical_multi_codon_delins_run_is_not_rewritten` — the reported string
- `canonical_multi_codon_control_run_is_not_rewritten` — the control
- `miscased_multi_codon_run_is_still_corrected` — lower, upper and mixed
- `every_adjacent_canonical_codon_pair_is_stable` — exhaustive 23×23, canonical stable and both mis-cased spellings corrected
- `canonical_codon_runs_of_every_length_are_stable` — 1..=8 codons
- `canonical_lookup_answers_for_already_canonical_codes`

`tests/it/error_mode_tests.rs`, `mod w1001_codon_alignment`:
- `canonical_codon_runs_are_accepted_unchanged_in_every_mode`
- `preprocessed_output_parses_in_every_mode` — pins that the preprocessor never emits a string it cannot parse
- `genuinely_miscased_runs_are_still_caught` — strict still rejects, lenient still corrects with three W1001s

Full suite: **9,789 passed, 0 failed**. `cargo fmt --all --check` clean; `cargo clippy --features dev --all-targets` silent.

Representation-Change: 82 previously-rejected inputs now parse; no normalized output moves. Measured over 368,870 ClinVar protein descriptions in both strict and lenient mode — nothing previously accepted is now rejected and no previously-accepted output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protein sequence handling for adjacent amino-acid codons.
  * Prevented incorrect corrections across already-valid codon sequences.
  * Continued normalizing genuinely misformatted lowercase codons.
  * Preserved codon alignment during scanning and correction.

* **Tests**
  * Added coverage for strict, lenient, and silent error-handling modes.
  * Added regression tests for multi-codon sequences, mixed casing, and variable-length inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->