### PR TITLE
fix(parser): require ring `::` segments to be ordered deletions

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7304,6 +7304,22 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
         Ok(())
     })?;
 
+    // Ring-level checks, LAST of the post-parse suite. Two placements matter:
+    //
+    // - Outside `for_each_leaf`, because that walk re-wraps each segment as a
+    //   standalone `g.` leaf, which erases both the segment *order* and the fact
+    //   that the leaves belong to one ring — the two things these rules are
+    //   about. Same reason `validate_no_self_cancelling` sits outside it.
+    // - *After* the per-leaf rules, so a segment that is both an illegal edit
+    //   form and a non-deletion reports the edit-form error. That is the more
+    //   specific and more actionable diagnostic, and it is what #1578's
+    //   error-parity tests pin: a ring segment must fail exactly like its
+    //   standalone spelling. Running the ring rules first would replace those
+    //   messages wholesale (measured: it turned 7 of
+    //   `issue_1578_ring_validator_escapes`'s tests red, since their fixtures
+    //   pair an illegal edit form with an `insG` segment).
+    validate_ring_segments_are_wellformed(&variant)?;
+
     Ok(variant)
 }
 
@@ -8603,6 +8619,175 @@ fn reject_insertion_without_inserted_sequence(input: &str) -> Result<(), FerroEr
 /// reported `pos: 0`.
 fn validate_no_self_cancelling(variant: &HgvsVariant, source: &str) -> Result<(), FerroError> {
     walk_self_cancelling(variant, source, 0)
+}
+
+/// Reject a `::`-join whose segments do not describe a ring chromosome.
+///
+/// Two rules, each with its own citation:
+///
+/// - **Ordering.** `DNA/complex.md:51` — "Break point location is determined by
+///   the first break point encountered, i.e. `pter` of the chromosome is to be
+///   listed first"; `:53` — "multiple breakpoints in one chromosome are listed
+///   in order of occurrence from `pter` to `qter`"; `:55` — "variant
+///   descriptions are always in the forward orientation".
+/// - **Junction-contributing segments.** `DNA/complex.md:39` — "a double colon
+///   is used to designate break point junctions creating a ring chromosome". A
+///   `dup`, `inv`, substitution or identity segment designates no junction, so
+///   there is nothing for `::` to join. The spec spells
+///   rearrangement-plus-local-edit composites as `;` cis alleles instead
+///   (`:113`, `:117`).
+///
+/// This is the rule `rulings[self-cancelling-across-ring-junctions]` said was
+/// needed and deliberately did not write. It is emphatically **not** an overlap
+/// check: overlap between `del` segments stays legal, because that ruling
+/// decided `general.md:58` does not cross `::`. Rejecting overlap here would
+/// re-open a decided ruling through the back door.
+///
+/// **Telomere anchoring is not enforced** — see
+/// `rulings[ring-telomere-anchoring]`, `undecided`. A ring loses both telomeres,
+/// so a well-formed ring is anchored at `pter` and `qter`, and both published
+/// ring shapes are (`:127`, `:161`) — but no clause says so, and enforcing it
+/// would legislate from two examples plus biology.
+///
+/// Both rules reject only what is **definitely** wrong; see
+/// [`ring_segment_start_bounds`] for why that matters for ordering.
+fn validate_ring_segments_are_wellformed(variant: &HgvsVariant) -> Result<(), FerroError> {
+    let ring = match variant {
+        HgvsVariant::GenomeRing(ring) => ring,
+        // A `sup`-wrapped ring is still a ring (`complex.md:161`).
+        HgvsVariant::Supernumerary(inner) => match inner.as_ref() {
+            HgvsVariant::GenomeRing(ring) => ring,
+            _ => return Ok(()),
+        },
+        _ => return Ok(()),
+    };
+
+    for segment in &ring.segments {
+        if !ring_segment_designates_a_junction(segment) {
+            return Err(ring_no_junction_error());
+        }
+    }
+
+    // Compare each segment against its predecessor rather than sorting: the
+    // rule is about the order they are *listed* in, so the first descending
+    // step is the one to report.
+    for pair in ring.segments.windows(2) {
+        let (earlier, later) = (&pair[0], &pair[1]);
+        let earlier_lower = ring_segment_start_bounds(&earlier.location).map(|(lower, _)| lower);
+        let later_upper = ring_segment_start_bounds(&later.location).map(|(_, upper)| upper);
+        if let (Some(earlier_lower), Some(later_upper)) = (earlier_lower, later_upper) {
+            if later_upper < earlier_lower {
+                return Err(ring_order_error());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether a ring segment's edit designates a break point junction, i.e. is a
+/// deletion (`DNA/complex.md:39`).
+///
+/// `Mu::Unknown` (`?`) carries no edit to judge, so it is accepted — the same
+/// "uncertainty is not grounds to reject" stance the ordering check takes.
+fn ring_segment_designates_a_junction(
+    segment: &LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>,
+) -> bool {
+    use crate::hgvs::edit::NaEdit;
+    match segment.edit.inner() {
+        Some(edit) => matches!(
+            edit,
+            // A plain deletion, and the N-padded form whose removed size is given
+            // as a count of unknown bases (`delN[15]`). The second is not an
+            // afterthought: both ring shapes the spec publishes are annotated
+            // "breakpoint not sequenced" (`DNA/complex.md:128`, `:163`), which is
+            // exactly what `delN[]` spells — so omitting it rejected the form the
+            // spec's own examples describe in prose. An earlier revision did.
+            NaEdit::Deletion { .. } | NaEdit::NPaddedDeletion { .. }
+        ),
+        // `Mu::Unknown` carries no edit to judge. Not reachable through the ring
+        // grammar (a `?` edit fails to parse inside a `::`-join), so this arm
+        // exists for programmatically constructed rings and is deliberately
+        // permissive: it declines to call something a non-deletion when there is
+        // nothing there to read.
+        None => true,
+    }
+}
+
+/// Lower and upper bounds on where a ring segment *starts*, as positions on the
+/// `pter`→`qter` axis, or `None` when the boundary carries no comparable
+/// position.
+///
+/// **Why bounds rather than a position.** `complex.md:127` — the spec's own ring
+/// — spells both segments with uncertain boundaries
+/// (`pter_(12200001_14700000)del::(37600001_410000000)_qterdel`), so a naive
+/// integer compare either has to pick an arbitrary representative or reject the
+/// spec's own example. Returning an interval lets the caller reject only when the
+/// later segment's start is *definitely* below the earlier one's, which no amount
+/// of uncertainty can trigger by accident.
+///
+/// `pter` is the axis minimum and `qter` the maximum. `cen` is `None`: the
+/// centromere's coordinate is not derivable from the description, so its order
+/// relative to a numbered position is undecidable here.
+fn ring_segment_start_bounds(location: &GenomeInterval) -> Option<(u64, u64)> {
+    use crate::hgvs::location::{GenomePos, SpecialPosition};
+    fn axis_position(pos: &GenomePos) -> Option<u64> {
+        match pos.special {
+            Some(SpecialPosition::Pter) => Some(u64::MIN),
+            Some(SpecialPosition::Qter) => Some(u64::MAX),
+            // `cen` has no coordinate in the description itself.
+            Some(_) => None,
+            None => Some(pos.base),
+        }
+    }
+    match &location.start {
+        UncertainBoundary::Single(mu) => {
+            let pos = axis_position(mu.inner()?)?;
+            Some((pos, pos))
+        }
+        // `(a_b)` — the boundary is somewhere in `a..=b`, so those are the
+        // bounds. A missing side widens to the axis limit rather than
+        // collapsing, which keeps the comparison conservative.
+        UncertainBoundary::Range { start, end } => {
+            let lower = start.inner().and_then(axis_position).unwrap_or(u64::MIN);
+            let upper = end.inner().and_then(axis_position).unwrap_or(u64::MAX);
+            Some((lower, upper))
+        }
+    }
+}
+
+/// `DNA/complex.md:39` — a segment that designates no break junction.
+fn ring_no_junction_error() -> FerroError {
+    use crate::error::{Diagnostic, ErrorCode};
+    FerroError::parse_with_diagnostic(
+        0,
+        "every segment of a `::`-join must designate a break point junction, so \
+         each must be a deletion (`del`, or `delN[..]` for an unsequenced \
+         breakpoint); this segment describes no junction for `::` to join \
+         (DNA/complex.md:39). A segment with no edit at all is the ISCN2016 form \
+         in which the deletion was implied by the coupling, withdrawn in ISCN2020 \
+         (DNA/complex.md:60-64, :72, :84)",
+        Diagnostic::new()
+            .with_code(ErrorCode::InvalidEdit)
+            .with_hint(
+                "describe a rearrangement plus a local edit as a cis allele \
+             (`g.[<rearrangement>;<edit>]`, DNA/complex.md:113) rather than as an \
+             extra `::` segment",
+            ),
+    )
+}
+
+/// `DNA/complex.md:51`/`:53`/`:55` — segments listed out of `pter`→`qter` order.
+fn ring_order_error() -> FerroError {
+    use crate::error::{Diagnostic, ErrorCode};
+    FerroError::parse_with_diagnostic(
+        0,
+        "the segments of a `::`-join must be listed in order of occurrence from \
+         pter to qter, with pter listed first (DNA/complex.md:51, :53, :55)",
+        Diagnostic::new()
+            .with_code(ErrorCode::InvalidEdit)
+            .with_hint("list the `::` segments in ascending genomic order"),
+    )
 }
 
 /// Inner helper: `search_from` is the byte offset within `source` at

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -771,6 +771,30 @@
         }
       ],
       "rationale": "NO RULING. The question is which STAGE an absolute prohibition is enforced at, and the spec does not address stages at all — it addresses descriptions. Recorded because ferro currently answers it three different ways for clauses of identical strength, and nothing distinguishes them.\n\nTHE INCONSISTENCY, MEASURED over the corpus's 164 prohibited rows (`tests/it/corpus_prohibited_inputs.rs`). Refused at PARSE, hence in every mode: `checklist.md:31` (`c.10insT`), `:49` (`del3`), `:26` (`c.20+2_+5del`), `general.md:96` (an internal space), `general.md:58` (a `del` beside an overlapping `dup`), and `checklist.md:16` for the `*` symbol. Refused at STRICT-MODE NORMALIZE only: `checklist.md:20`, and the conflicting-geometry class. Refused NOWHERE: `checklist.md:33` (`ins6`, 24 rows), `checklist.md:16` for `+` and `-` (8 rows), `standards.md:39` (`X`, 24 rows).\n\nTHE SHARPEST INSTANCE IS INTERNAL TO ONE CLAUSE. `checklist.md:16` names three symbols in one sentence — \"`+`, `-`, or `*`\" — and ferro refuses `g.*10del` at parse while accepting `g.266+2del` and `g.266-268del` in both modes. The second sharpest is internal to one numbered ITEM: item 3 (\"Insertions\") states `:31` and `:33` four lines apart, and only `:31` is enforced.\n\nTHE TWO SIDES, NEITHER OF WHICH THE SPEC PICKS. (A) PARSE. The clauses say \"is not allowed\" without qualification, and `adjudication-precedence-order` ranks validity first and says it is never traded; a mode flag that turns a validity check off is a trade. (B) STRICT-MODE NORMALIZE. `checklist.md:5` frames the whole list as \"the most frequently offended rules\", offered to an author \"while preparing a publication\" — an author-facing style guide, not a machine-readable grammar; software that refuses at parse cannot round-trip real-world corpora full of these spellings, and ferro already has an input-hygiene mode built precisely for clauses it wants to enforce without breaking such callers.\n\nWHY IT IS NOT COSMETIC. The stage is user-visible and irreversible in one direction: a parse-stage refusal cannot be opted out of, and every caller that stores or forwards such a description is affected on upgrade, whereas a strict-stage refusal is opt-in. Choosing (A) for the three currently-unenforced clauses would newly refuse inputs ferro accepts today.\n\nWHAT IS ALREADY SETTLED AND MUST NOT BE RE-ARGUED HERE. WHETHER each of those shapes is invalid — it is; see `alignment-only-symbol-in-a-description`, `conflicting-member-geometry-refusal-scope`, and the quoted clauses above. This record is only about where the refusal lives."
+    },
+    {
+      "id": "ring-telomere-anchoring",
+      "question": "Must a ring chromosome's first `::` segment start at `pter` and its last end at `qter`, so that a ring whose segments name only interior coordinates is refused?",
+      "status": "undecided",
+      "clauses": [
+        {
+          "clause": "docs/recommendations/DNA/complex.md:28",
+          "quote": "the start of the chromosome is described as `pter`, the end as `qter`, and the centromere as `cen`"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:127",
+          "quote": "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:161",
+          "quote": "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:13",
+          "quote": "the description of complex changes can become rather complicated and at some point, although literally correct, becomes effectively meaningless"
+        }
+      ],
+      "rationale": "**Undecided, and the reason it is not `decided` is the whole record.** A ring chromosome forms from two breaks whose ends fuse, so it loses both telomeres; a well-formed ring is therefore anchored at `pter` and `qter`, and both ring shapes the spec publishes are (`:127`, `:161`). That is an argument from biology plus two worked examples.\n\n**No clause states it.** `complex.md:28` defines what `pter`/`qter` *mean* and says nothing about requiring them, and `:13` warns that complex descriptions can be \"literally correct\" yet meaningless — which cuts against inventing a structural requirement the text does not carry. Two examples are a thin basis for a rejection rule: exactly the over-reach that a sibling rule in the same change was caught committing, when a junction rule generalised from `:39` alone and broke #1578's own published legal-edit control before the withdrawal argument at `:60-64` was found to support it. Only the argument's *strength* separated those two outcomes, which is why this one stays open rather than being decided by analogy.\n\n**What ferro does meanwhile, measured 2026-08-10:** accepts an unanchored ring. `g.100_200del::300_400del`, `g.pter_14700000del::37600001_40000000del` and `g.100_14700000del::37600001_qterdel` all parse and round-trip, pinned by `a_ring_with_no_telomere_anchor_is_still_accepted` in `tests/it/ring_segment_wellformedness.rs`. That is the status quo, not a ruling.\n\n**What would settle it.** Either a clause requiring the anchors, or a real description in which an unanchored `::` join is meaningful. A practical complication to weigh first: `:28`'s `(pter)_#` / `#_(qter)` forms and `cen` mean the predicate is not a simple \"is the first endpoint `pter`\" test, and `cen`-anchored segments do not currently parse at all — so the cost of enforcing is not only the risk of a false rejection."
     }
   ]
 }

--- a/tests/it/clause_ruling_index.rs
+++ b/tests/it/clause_ruling_index.rs
@@ -84,8 +84,8 @@
 //! <!-- BEGIN GENERATED INDEX -->
 //! ```text
 //! CLAUSE -> RECORD INDEX
-//! 15 records, 10 decided / 5 undecided
-//! 58 clause lines, of which 10 are named by more than one record
+//! 16 records, 10 decided / 6 undecided
+//! 60 clause lines, of which 12 are named by more than one record
 //!
 //! == every clause line ==
 //!
@@ -109,6 +109,10 @@
 //!     `conflicting-member-geometry-refusal-scope` — decided (governing)
 //! docs/recommendations/DNA/complex.md:5
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:13
+//!     `ring-telomere-anchoring` — undecided (cited)
+//! docs/recommendations/DNA/complex.md:28
+//!     `ring-telomere-anchoring` — undecided (cited)
 //! docs/recommendations/DNA/complex.md:39
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/complex.md:50
@@ -127,11 +131,13 @@
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/complex.md:117
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
-//! docs/recommendations/DNA/complex.md:127
+//! docs/recommendations/DNA/complex.md:127  [MULTI]
+//!     `ring-telomere-anchoring` — undecided (cited)
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/complex.md:130
 //!     `self-cancelling-across-ring-junctions` — decided (governing)
-//! docs/recommendations/DNA/complex.md:161
+//! docs/recommendations/DNA/complex.md:161  [MULTI]
+//!     `ring-telomere-anchoring` — undecided (cited)
 //!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/delins.md:16
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (cited)
@@ -231,6 +237,12 @@
 //! docs/consultation/open-issues.md:78
 //!     `adjudication-precedence-order` — decided (cited)
 //!     `separation-is-a-property-of-the-spelling-not-of-the-variant` — undecided (cited, via docs/consultation/open-issues.md:77-78)
+//! docs/recommendations/DNA/complex.md:127
+//!     `ring-telomere-anchoring` — undecided (cited)
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
+//! docs/recommendations/DNA/complex.md:161
+//!     `ring-telomere-anchoring` — undecided (cited)
+//!     `self-cancelling-across-ring-junctions` — decided (cited)
 //! docs/recommendations/DNA/delins.md:17
 //!     `delins-merge-vs-individual-gap-two-or-more` — decided (cited)
 //!     `separation-is-a-property-of-the-spelling-not-of-the-variant` — undecided (cited)
@@ -286,6 +298,15 @@
 //! the same line, so reading either alone gives a confident and half-wrong
 //! picture. The index does not adjudicate anything — it only tells you that more
 //! than one record is in play, which is the fact that was missing.
+//!
+//! `DNA/complex.md:127` and `:161` joined that set when the ring rules landed:
+//! they are the spec's two published ring shapes — the bare ring and the
+//! supernumerary one — and each is cited both by
+//! `self-cancelling-across-ring-junctions` (**decided**) and by
+//! `ring-telomere-anchoring` (**undecided**). That split is the honest state —
+//! the same examples settle one question about rings and are merely suggestive
+//! about another — and it is the case this block exists to surface, since citing
+//! either for "rings are anchored" would read a ruling out of the undecided half.
 //!
 //! The same-verdict lines are a much weaker signal: they are the clauses cited
 //! as background in nearly every conflict — `basics.md:38`, `general.md:56`,
@@ -550,7 +571,7 @@ fn the_index_is_not_vacuous() {
     let undecided = records.iter().filter(|r| r.status == "undecided").count();
     assert_eq!(
         (records.len(), decided, undecided),
-        (15, 10, 5),
+        (16, 10, 6),
         "measured ledger census changed. If this is a real ledger change, update the module docs \
          and this pin together. Note the repo `CLAUDE.md` claims 8 records with 5 unanswered, \
          which was already wrong before this test existed"
@@ -714,7 +735,7 @@ fn clauses_named_by_several_records_are_flagged() {
         index.iter().filter(|(_, c)| c.len() > 1).collect();
     assert_eq!(
         multi.len(),
-        10,
+        12,
         "measured count of multiply-named clause lines changed; update the module docs with it"
     );
 
@@ -732,7 +753,7 @@ fn clauses_named_by_several_records_are_flagged() {
         .collect();
     assert_eq!(
         mixed.len(),
-        6,
+        8,
         "measured count of mixed-verdict clause lines changed: {mixed:?}"
     );
 

--- a/tests/it/fast_path_differential.rs
+++ b/tests/it/fast_path_differential.rs
@@ -147,12 +147,21 @@ const DIFFERENTIAL_CASES: &[&str] = &[
     // deferral — if fast-path eligibility ever widened to reach a ring, the fast path
     // would mint a variant that skipped the validator, and `divergence` would catch it
     // here rather than in whatever consumer first failed to re-parse the result. The
-    // rejected rows agree by both-reject; the accepted rows agree by equal ASTs. ---
-    "NC_000022.11:g.100_101insATG::200_201insG", // valid ring: both accept, must agree
+    // rejected rows agree by both-reject; the `del::del` rows agree by equal ASTs.
+    //
+    // Every *insertion* row below now rejects: `validate_ring_segments_are_wellformed`
+    // requires each segment to designate a break point junction, i.e. to be a deletion
+    // (`DNA/complex.md:39`). They previously split accept/reject, so the `del::del`
+    // pair is not decoration — without it no ring reaches `divergence`'s
+    // `(Ok(a), Ok(b))` arm, and a fast path that accepted a ring while building a
+    // *different* `HgvsVariant` would agree-by-both-reject with nothing to compare. ---
+    "NC_000022.11:g.100_101insATG::200_201insG", // insertion segment: both reject
     "NC_000022.11:g.100_102insATG::200_201insG", // ring, non-adjacent anchor: both reject
     "NC_000022.11:g.100insATG::200_201insG",     // ring, single-position anchor: both reject
-    "NC_000022.11:g.[100_101insATG::200_201insG]sup", // valid `sup`-wrapped ring
+    "NC_000022.11:g.[100_101insATG::200_201insG]sup", // `sup`-wrapped insertion: both reject
     "NC_000022.11:g.[100_102insATG::200_201insG]sup", // `sup` recursion reaches the ring
+    "NC_000022.11:g.100_200del::300_400del",     // well-formed ring: both accept, equal ASTs
+    "NC_000022.11:g.[100_200del::300_400del]sup", // ditto, `sup`-wrapped
     // --- whitespace / trimming edges (ASCII and Unicode) ---
     "  NC_000001.11:g.12345A>G  ",
     "\tNM_000088.3:c.459A>G\n",

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -918,6 +918,17 @@ const RULING_STATUSES: &[(&str, &str)] = &[
     // `checklist.md:16` alone, `g.*10del` is refused at parse while `g.266+2del`
     // is refused nowhere.
     ("absolute-prohibition-enforcement-stage", "undecided"),
+    // Must a ring's first `::` segment start at `pter` and its last end at
+    // `qter`? **Undecided on purpose.** A ring loses both telomeres, and both
+    // published ring shapes are anchored (`complex.md:127`, `:161`) — but that is
+    // biology plus two examples, and no clause states it. `complex.md:28` only
+    // defines what the markers mean; `:13` warns that a complex description can
+    // be "literally correct" yet meaningless, which cuts against inventing a
+    // structural requirement. Its sibling junction rule *was* decided, on
+    // `:60-64`'s record that the committee withdrew `::` as a general join
+    // operator — a materially stronger argument, which is exactly why this one is
+    // not decided by analogy to it. Ferro accepts an unanchored ring today.
+    ("ring-telomere-anchoring", "undecided"),
 ];
 
 /// Every case where a preference the spec *states* was overridden, because the

--- a/tests/it/issue_1264_reparse_asymmetry.rs
+++ b/tests/it/issue_1264_reparse_asymmetry.rs
@@ -73,16 +73,43 @@ fn a_ring_segment_insertion_anchor_must_be_flanking() {
     }
 }
 
-/// The control for the test above: a ring whose insertion anchors *are*
-/// flanking stays valid, and still round-trips.
+/// The control for the test above: a ring whose insertion anchors *are* flanking
+/// is not rejected **by the anchor rule**.
 ///
 /// Without this, tightening the ring path could pass by rejecting every ring
-/// insertion.
+/// insertion for the wrong reason.
+///
+/// **The observable changed when `validate_ring_segments_are_wellformed` landed,
+/// and the guarantee did not.** This used to assert the input parses. It no longer
+/// does: an insertion segment designates no break point junction, so a ring may
+/// not contain one at all (`DNA/complex.md:39`, and `:60-64` on the committee
+/// withdrawing `::` as a general join operator). Every ring insertion is now
+/// rejected — deliberately — which makes "it parses" unavailable as evidence.
+///
+/// So the control asserts the *reason* instead: this input is rejected by the
+/// **ring** rule and not by the anchor rule, which is exactly the original claim
+/// — a flanking pair is not something the anchor rule refuses. Asserting the
+/// reason is in fact stronger than asserting acceptance was, because acceptance
+/// could have come from the anchor rule silently not running.
+///
+/// Note the sibling test above still fails for its own reason: the per-leaf
+/// validators run *before* the ring rules, so a non-flanking anchor is caught by
+/// the anchor rule and never reaches the junction check.
 #[test]
-fn a_ring_segment_with_flanking_anchors_still_parses() {
+fn a_ring_segment_with_flanking_anchors_is_not_rejected_by_the_anchor_rule() {
     let input = "NC_000022.11:g.100_101insATG::200_201insG";
-    let variant = parse_hgvs(input).expect("flanking ring anchors must stay valid");
-    assert_eq!(variant.to_string(), input);
+    let rendered = parse_hgvs(input)
+        .expect_err("an insertion segment designates no break junction")
+        .to_string();
+    assert!(
+        rendered.contains("break point junction"),
+        "`{input}`'s anchors are a flanking pair, so it must be the ring rule that \
+         refuses it, not the insertion-anchor rule; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("single-position insertion") && !rendered.contains("flanking"),
+        "the anchor rule must not be what rejects a flanking pair; got: {rendered}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/it/issue_1578_followup_self_cancelling_rings.rs
+++ b/tests/it/issue_1578_followup_self_cancelling_rings.rs
@@ -27,9 +27,19 @@
 //! forecloses, and E3006's repair hint ("rewrite as a single delins") is
 //! actively wrong advice for a ring.
 //!
-//! What the ruling does **not** settle is recorded in `no_ring_wellformedness_rule_yet`
-//! below: three of the rings ferro accepts are malformed for reasons that have
-//! nothing to do with self-cancellation.
+//! **The gap this file used to pin is now closed.**
+//! `no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted` lived
+//! here and asserted that `g.100_200del::150_250dup`, `g.100_200del::300_400dup`
+//! and `g.150_250dup::100_200del` were still accepted — the status quo the ruling
+//! declined to change, recorded so it was visible rather than implied. All three
+//! are now rejected by `validate_ring_segments_are_wellformed`, and
+//! `ring_segment_wellformedness.rs` owns those rows. The test was deleted rather
+//! than inverted, exactly as its own failure message instructed.
+//!
+//! The ruling is untouched: `general.md:58` still does not cross `::`, and the two
+//! tests here pin that with overlapping `del::del`, which the new rules
+//! deliberately leave alone. Both were `del::dup` originally; had they stayed so,
+//! they would now pass by being rejected for the *wrong* reason.
 
 use ferro_hgvs::parse_hgvs;
 
@@ -68,15 +78,24 @@ fn the_specs_own_ring_shapes_are_accepted() {
 /// If someone extends `detect_self_cancelling_pair` to ring segments, this test
 /// fails and points at the ruling record. That is its whole purpose; do not
 /// "fix" it by relaxing the assertion.
+///
+/// **The inputs are all-`del` deliberately.** They were originally `del::dup`
+/// pairs — the literal shape of `general.md:58`'s own example — but
+/// `validate_ring_segments_are_wellformed` now rejects a non-deletion segment on
+/// separate grounds (`DNA/complex.md:39`/`:60-64`), which would have made this
+/// test pass for the wrong reason: rejected, but by the junction rule rather than
+/// by `:58`. Overlapping `del::del` isolates the question this ruling answers,
+/// since the junction rule has nothing to say about it.
 #[test]
 fn an_overlapping_ring_is_not_rejected_as_self_cancelling() {
     for input in [
-        // overlap at 150–200, the shape of `general.md:58`'s own example
-        "NC_000022.11:g.100_200del::150_250dup",
+        // overlap at 150–200, the spec example's geometry with both segments
+        // spelled as deletions
+        "NC_000022.11:g.100_200del::150_250del",
         // identical spans — the strongest "cancelling" shape available
-        "NC_000022.11:g.100_200del::100_200dup",
+        "NC_000022.11:g.100_200del::100_200del",
         // and under the `sup` marker, which is blind through the same arms
-        "NC_000022.11:g.[100_200del::150_250dup]sup",
+        "NC_000022.11:g.[100_200del::150_250del]sup",
     ] {
         let variant = parse_hgvs(input).unwrap_or_else(|e| {
             panic!(
@@ -124,57 +143,22 @@ fn the_identical_overlap_is_still_rejected_as_a_cis_allele() {
     }
 }
 
-/// Non-overlapping `del` + `dup` is legal both ways, and this is the row that
-/// shows `:58` is the wrong instrument for the malformed rings noted below: a
-/// `:58`-based check is an *overlap* predicate, so it would accept this one no
-/// matter how it were wired.
+/// Non-overlapping members are legal, and this is the row that shows `:58` is an
+/// *overlap* predicate and therefore the wrong instrument for ring
+/// well-formedness — it accepts a non-overlapping pair however it is wired.
+///
+/// The `::` case is spelled `del::del` for the reason given above: the
+/// `del::dup` form this test originally used is now rejected by the junction rule
+/// (`DNA/complex.md:39`/`:60-64`), which is a different question. The cis-allele
+/// half keeps its `dup`, since `:58` is exactly what governs it there.
 #[test]
-fn a_non_overlapping_del_dup_pair_is_legal_in_both_operators() {
+fn a_non_overlapping_pair_is_legal_in_both_operators() {
     for input in [
         "NC_000022.11:g.[100_200del;300_400dup]",
-        "NC_000022.11:g.100_200del::300_400dup",
+        "NC_000022.11:g.100_200del::300_400del",
     ] {
         let variant = parse_hgvs(input)
             .unwrap_or_else(|e| panic!("`{input}` has no overlap and is legal: {e}"));
         assert_eq!(variant.to_string(), input, "`{input}` must round-trip");
-    }
-}
-
-/// **What the ruling does not settle, pinned as an open gap rather than as
-/// correct behaviour.**
-///
-/// Each input below is accepted today and none is a well-formed ring, for
-/// reasons independent of self-cancellation:
-///
-/// - a `dup` segment contributes no break junction (`DNA/complex.md:39`: "a
-///   double colon is used to designate break point junctions creating a ring
-///   chromosome"), and neither segment is telomere-anchored, so these describe
-///   no ring geometry; and
-/// - `g.150_250dup::100_200del` additionally lists its segments out of order,
-///   which `DNA/complex.md:51` ("`pter` of the chromosome is to be listed
-///   first"), `:53` and `:55` forbid.
-///
-/// This test asserts the **status quo**, deliberately, so the gap is visible and
-/// counted rather than implied by the ruling's silence. When a ring
-/// well-formedness rule lands, these inputs should start being rejected and this
-/// test is expected to fail — that failure is the signal to delete it and move
-/// the rows into the new rule's own tests, not to re-derive whether the ruling
-/// above was wrong.
-#[test]
-fn no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted() {
-    for input in [
-        // no telomere anchor, and `dup` contributes no junction
-        "NC_000022.11:g.100_200del::150_250dup",
-        "NC_000022.11:g.100_200del::300_400dup",
-        // segments out of pter->qter order
-        "NC_000022.11:g.150_250dup::100_200del",
-    ] {
-        assert!(
-            parse_hgvs(input).is_ok(),
-            "`{input}` is accepted today. If this now fails, a ring \
-             well-formedness rule has landed — move this row into that rule's \
-             tests rather than reopening \
-             rulings[self-cancelling-across-ring-junctions]",
-        );
     }
 }

--- a/tests/it/issue_1578_ring_validator_escapes.rs
+++ b/tests/it/issue_1578_ring_validator_escapes.rs
@@ -300,11 +300,30 @@ fn a_multi_member_allele_reports_the_first_member_in_error() {
 /// The control: a ring of legal edits stays valid and round-trips, in both
 /// spellings. Without this, tightening the ring path could pass by
 /// rejecting every ring.
+///
+/// **The control inputs changed from `g.100_101dup::200_201insG` to `del::del`**
+/// when `validate_ring_segments_are_wellformed` landed, and the reason is worth
+/// recording because the original pair is the one #1578's body names as its
+/// "legal-edit control".
+///
+/// It is still a legal-*edit* control — `dup` and `insG` violate none of the
+/// per-leaf edit-form rules this file is about, which is what it was chosen for.
+/// It is not a well-formed *ring*: `DNA/complex.md:60-64` records that the
+/// committee withdrew `::` as a general join operator precisely because it gave
+/// "one identical derivative chromosome … two different descriptions", and
+/// "recommends to describe translocations exclusively using a `delins` format".
+/// In current HGVS, `::` survives only for the ring chromosome (`:127`, `:161`),
+/// where `:130` says it marks two deletions as *connected*. So a non-deletion
+/// segment is withdrawn ISCN2016 syntax — the same ground on which
+/// `try_parse_genome_ring` already refuses a cross-accession segment.
+///
+/// The substitution preserves this test's whole purpose: `del::del` is a
+/// genuine ring, so a tightening that rejected every ring still fails here.
 #[test]
 fn a_ring_of_legal_edits_still_parses() {
     for input in [
-        "NC_000022.11:g.100_101dup::200_201insG",
-        "NC_000022.11:g.[100_101dup::200_201insG]sup",
+        "NC_000022.11:g.100_101del::200_201del",
+        "NC_000022.11:g.[100_101del::200_201del]sup",
     ] {
         let variant =
             parse_hgvs(input).unwrap_or_else(|e| panic!("`{input}` must stay valid: {e}"));

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -469,3 +469,4 @@ mod web_service_tests;
 mod weight_bound_worked_examples;
 
 mod reported_confluence_pairs;
+mod ring_segment_wellformedness;

--- a/tests/it/ring_segment_wellformedness.rs
+++ b/tests/it/ring_segment_wellformedness.rs
@@ -1,0 +1,271 @@
+//! A ring's `::`-joined segments must actually describe a ring: listed in
+//! `pter`→`qter` order, and each contributing a break junction.
+//!
+//! Follow-up to #1578 item 3. Adjudicating that `general.md:58`'s
+//! self-cancellation rule does **not** cross `::`
+//! (`rulings[self-cancelling-across-ring-junctions]`) left a hole it explicitly
+//! declined to fill: ferro accepted `g.100_200del::150_250dup`,
+//! `g.100_200del::300_400dup` and `g.150_250dup::100_200del`, none of which is a
+//! well-formed ring. `:58` is the wrong instrument for them — it is an *overlap*
+//! predicate, so it accepts the non-overlapping `del::300_400dup` however it is
+//! wired. These are the right instruments.
+//!
+//! **Two rules, with the citations they rest on:**
+//!
+//! - **Ordering.** `DNA/complex.md:51` — "Break point location is determined by
+//!   the first break point encountered, i.e. `pter` of the chromosome is to be
+//!   listed first"; `:53` — "multiple breakpoints in one chromosome are listed in
+//!   order of occurrence from `pter` to `qter`"; `:55` — "variant descriptions
+//!   are always in the forward orientation (from `pter` to `qter`, the end of the
+//!   chromosome)".
+//! - **Junction-contributing segments.** `DNA/complex.md:39` — "a double colon
+//!   is used to designate break point junctions creating a ring chromosome" —
+//!   read with `:60-64`, where the committee withdrew `::` as a general join
+//!   operator because it gave "one identical derivative chromosome … two
+//!   different descriptions". A `dup`, `inv`, substitution or identity segment
+//!   designates no junction, so it is not a thing `::` can join; the spec spells
+//!   rearrangement-plus-local-edit composites as `;` cis alleles instead
+//!   (`:113`, `:117`), where `general.md:58` governs them normally.
+//!
+//!   **Both deletion spellings count**, and this is the easy half to get wrong:
+//!   `delN[15]` is a deletion whose removed size is a count of unknown bases, and
+//!   an unsequenced breakpoint is precisely what the spec's ring examples describe
+//!   ("breakpoint not sequenced", `:128`/`:163`). A first cut matched only
+//!   `NaEdit::Deletion` and refused it.
+//!
+//! **What is deliberately NOT enforced: telomere anchoring.** A ring loses both
+//! telomeres, so a well-formed ring's first segment starts at `pter` and its last
+//! ends at `qter` — which is true of both ring shapes the spec publishes
+//! (`:127`, `:161`). But no clause *says* so, and enforcing it would be ferro
+//! legislating from two worked examples plus biology. Recorded as
+//! `rulings[ring-telomere-anchoring]`, status `undecided`, and
+//! `a_ring_with_no_telomere_anchor_is_still_accepted` pins that it stays
+//! accepted so the open question does not get quietly closed by a later change.
+//!
+//! **Both rules are conservative: they reject only what is *definitely* wrong.**
+//! Ordering compares an upper bound of the later segment's start against a lower
+//! bound of the earlier one's, so an uncertain boundary is never enough to
+//! reject — which is what keeps `:127`'s own `pter_(12200001_14700000)del::…`
+//! accepted. Junction-contributing skips a segment carrying no edit to judge —
+//! though note that is unreachable through the grammar (a `?` edit fails to parse
+//! inside a `::`-join, measured), so it guards programmatic construction only and
+//! is not exercised by a test here. A segment with no edit *at all* is a different
+//! thing and **is** rejected: that is the withdrawn ISCN2016 join, pinned by
+//! `a_position_only_segment_is_the_withdrawn_iscn2016_join_and_is_rejected`.
+
+use ferro_hgvs::parse_hgvs;
+
+/// The three shapes `rulings[self-cancelling-across-ring-junctions]` named as
+/// malformed-but-accepted. This test is the reason this change exists, and it
+/// replaces `no_ring_wellformedness_rule_yet_so_malformed_rings_are_still_accepted`
+/// in `issue_1578_followup_self_cancelling_rings.rs`, which pinned the gap.
+#[test]
+fn the_three_malformed_rings_the_ruling_named_are_now_rejected() {
+    for input in [
+        // a `dup` segment designates no break junction
+        "NC_000022.11:g.100_200del::150_250dup",
+        // …and non-overlapping, so `general.md:58` could never have caught it
+        "NC_000022.11:g.100_200del::300_400dup",
+        // segments listed out of `pter`->`qter` order
+        "NC_000022.11:g.150_250dup::100_200del",
+    ] {
+        parse_hgvs(input).expect_err(&format!(
+            "`{input}` is not a well-formed ring and must be rejected"
+        ));
+    }
+}
+
+/// Ordering, on its own. `DNA/complex.md:53` requires breakpoints "listed in
+/// order of occurrence from `pter` to `qter`", so a descending pair is wrong
+/// regardless of edit type — which is why this is checked with `del` segments
+/// that the junction rule accepts.
+#[test]
+fn ring_segments_listed_out_of_order_are_rejected() {
+    for input in [
+        "NC_000022.11:g.300_400del::100_200del",
+        "NC_000022.11:g.37600001_qterdel::pter_14700000del",
+        // three segments, only the last pair inverted
+        "NC_000022.11:g.100_200del::500_600del::300_400del",
+    ] {
+        let error =
+            parse_hgvs(input).expect_err(&format!("`{input}` lists its segments out of order"));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("pter") && rendered.contains("qter"),
+            "the diagnostic must name the ordering rule it enforces, got: {rendered}"
+        );
+    }
+}
+
+/// Junction-contributing, on its own: every non-`del` edit kind ferro's ring
+/// grammar accepts today, each in ascending order so the ordering rule cannot be
+/// what rejects it.
+#[test]
+fn a_ring_segment_that_designates_no_break_junction_is_rejected() {
+    for input in [
+        "NC_000022.11:g.100_200del::300_400dup",
+        "NC_000022.11:g.100_200del::300_400inv",
+        "NC_000022.11:g.100_200del::300_400delinsAT",
+        "NC_000022.11:g.100_200del::300A>T",
+        "NC_000022.11:g.100_200del::300_400=",
+        "NC_000022.11:g.100_200del::300_301insAT",
+        // and when the offending segment comes first
+        "NC_000022.11:g.100_200dup::300_400del",
+        "NC_000022.11:g.100A>T::300C>G",
+    ] {
+        let error = parse_hgvs(input).expect_err(&format!(
+            "`{input}` has a segment that designates no break junction"
+        ));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("break point junction") || rendered.contains("junction"),
+            "the diagnostic must name the junction rule it enforces, got: {rendered}"
+        );
+    }
+}
+
+/// The spec's own ring shapes must survive both rules, byte-identically. These
+/// are the rows the change is measured against — `:127` in particular carries
+/// **uncertain boundaries** on both segments, which is what forces the ordering
+/// comparison to be conservative rather than a naive integer compare.
+#[test]
+fn the_specs_own_ring_shapes_still_round_trip() {
+    for input in [
+        "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel",
+        "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup",
+        // the same shape with certain bounds, and the `chr`-prefixed corpus row
+        "NC_000022.11:g.pter_14700000del::37600001_qterdel",
+        "chr22:g.pter_10000000del::40000000_qterdel",
+    ] {
+        let variant = parse_hgvs(input)
+            .unwrap_or_else(|e| panic!("the spec publishes `{input}` as a ring: {e}"));
+        assert_eq!(
+            variant.to_string(),
+            input,
+            "`{input}` must round-trip byte-identically",
+        );
+    }
+}
+
+/// An ascending, all-`del` ring with no telomere anchor stays **accepted**: the
+/// telomere-anchoring rule is `undecided`, and this pins that it was left open
+/// rather than forgotten. See `rulings[ring-telomere-anchoring]`.
+///
+/// If a later change decides anchoring, this test is expected to fail — that is
+/// the signal to move it into that rule's tests with the ruling flipped to
+/// `decided`, not to relax it in place.
+#[test]
+fn a_ring_with_no_telomere_anchor_is_still_accepted() {
+    for input in [
+        "NC_000022.11:g.100_200del::300_400del",
+        "NC_000022.11:g.pter_14700000del::37600001_40000000del",
+        "NC_000022.11:g.100_14700000del::37600001_qterdel",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| {
+            panic!(
+                "`{input}` is ascending and all-`del`; telomere anchoring is \
+                 `undecided` (rulings[ring-telomere-anchoring]) so it must still \
+                 parse: {e}"
+            )
+        });
+        assert_eq!(variant.to_string(), input, "`{input}` must round-trip");
+    }
+}
+
+/// Overlap between `del` segments is **not** what these rules judge, and stays
+/// accepted. It is the question `rulings[self-cancelling-across-ring-junctions]`
+/// answered in the negative, so rejecting it here would re-open a decided
+/// ruling through the back door — the exact failure mode that ruling's guard was
+/// written to prevent.
+#[test]
+fn overlapping_del_segments_are_not_what_these_rules_judge() {
+    for input in [
+        "NC_000022.11:g.100_200del::150_250del",
+        "NC_000022.11:g.100_200del::100_200del",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| {
+            panic!(
+                "`{input}` is ascending and all-`del`; overlap is governed by \
+                 rulings[self-cancelling-across-ring-junctions], which ruled it \
+                 out of scope for `::`: {e}"
+            )
+        });
+        assert_eq!(variant.to_string(), input, "`{input}` must round-trip");
+    }
+}
+
+/// Ring rules must reach a `sup`-wrapped ring too — the same delivery #1578's
+/// walker established for the edit-form validators.
+#[test]
+fn the_rules_reach_a_sup_wrapped_ring() {
+    for input in [
+        "NC_000022.11:g.[100_200del::300_400dup]sup",
+        "NC_000022.11:g.[300_400del::100_200del]sup",
+    ] {
+        parse_hgvs(input).expect_err(&format!(
+            "`{input}`: a `sup`-wrapped ring is still a ring and must be checked"
+        ));
+    }
+}
+
+/// `delN[15]` is a **deletion** — one whose removed size is given as a count of
+/// unknown bases — so it designates a break point junction and must be accepted.
+///
+/// This was a live defect in the first cut of the junction rule, which matched
+/// only `NaEdit::Deletion` and so refused `NaEdit::NPaddedDeletion`. It is the
+/// worst possible case to get wrong here: both ring shapes the spec publishes are
+/// annotated *"breakpoint not sequenced"* (`DNA/complex.md:128`, `:163`), and an
+/// unsequenced breakpoint is precisely what `delN[]` spells. The rule was
+/// rejecting the form the spec's own examples describe in prose.
+///
+/// It also produced a diagnostic that misdescribed the input, calling it "a
+/// duplication, inversion, substitution or identity segment" when it was none of
+/// those.
+#[test]
+fn an_n_padded_deletion_segment_designates_a_junction() {
+    for input in [
+        "NC_000022.11:g.100_200delN[15]::300_400del",
+        "NC_000022.11:g.100_200del::300_400delN[15]",
+        "NC_000022.11:g.100_200delN[15]::300_400delN[20]",
+        "NC_000022.11:g.[100_200delN[15]::300_400del]sup",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| {
+            panic!(
+                "`{input}`: `delN[]` is a deletion with an unsequenced size, which \
+                 is exactly what the spec's ring examples describe \
+                 (\"breakpoint not sequenced\"): {e}"
+            )
+        });
+        assert_eq!(variant.to_string(), input, "`{input}` must round-trip");
+    }
+}
+
+/// A **position-only** segment — an interval with no edit at all — is rejected,
+/// and this is the shape that most directly vindicates the junction rule.
+///
+/// It is the withdrawn ISCN2016 join form. `DNA/complex.md:72` marks
+/// `NC_000002.12:g.pter_8247756::NC_000011.10:g.15825273_cen_qter` as
+/// `<code class="invalid">` and says it was "corrected" to the `delins` format;
+/// `:84` explains what such a coupling used to mean — "coupling
+/// `chr11:108111981` to `108111987` implies nucleotides `108111982_108111986` are
+/// deleted", i.e. the deletion was *implied* by the join rather than stated. That
+/// implicit-deletion reading is what `:60-64` withdrew, on the ground that one
+/// derivative chromosome was getting two descriptions.
+///
+/// So a position-only `::` segment is not an under-specified ring — it is the
+/// notation the committee removed.
+#[test]
+fn a_position_only_segment_is_the_withdrawn_iscn2016_join_and_is_rejected() {
+    for input in [
+        "NC_000022.11:g.pter_100::200_qter",
+        "NC_000022.11:g.100_200::300_400",
+    ] {
+        let error = parse_hgvs(input).expect_err(&format!(
+            "`{input}` is the withdrawn ISCN2016 join form (DNA/complex.md:72, :84)"
+        ));
+        assert!(
+            error.to_string().contains("junction"),
+            "the diagnostic must name the junction rule, got: {error}"
+        );
+    }
+}


### PR DESCRIPTION
Closes the gap `rulings[self-cancelling-across-ring-junctions]` named and deliberately did not fill. **Stacked on #1589** (base `fix/issue-1578-followups-ring-recursion`) — review that first; if it squash-merges, this needs a rebase onto `main`.

Follow-up to https://github.com/fulcrumgenomics/ferro-hgvs/issues/1578#issuecomment-5239725830.

## The gap

#1589 ruled that `general.md:58` does not cross `::`, and recorded that three rings ferro accepted were malformed for unrelated reasons. `:58` is an *overlap* predicate, so it could never have caught the non-overlapping one however it were wired:

```
g.100_200del::150_250dup     dup contributes no junction
g.100_200del::300_400dup     same, and non-overlapping
g.150_250dup::100_200del     segments out of pter->qter order
```

Ferro's ring grammar turned out to be near-unconstrained: measured at this commit it accepted `del::dup`, `del::inv`, `del::sub`, `sub::sub`, `del::identity`, `del::ins`, descending order, overlapping and identical segments, and 2–4 segments. Only `cen` anchoring was refused (a separate pre-existing gap, untouched here).

## Two rules, and why the second one took a second look

**Ordering** — `DNA/complex.md:51` (*"Break point location is determined by the first break point encountered, i.e. `pter` of the chromosome is to be listed first"*), `:53` (breakpoints *"are listed in order of occurrence from `pter` to `qter`"*), `:55` (*"variant descriptions are always in the forward orientation"*). Explicit and directly on point.

**Junction-contributing segments** — this is the one worth reading carefully, because my first justification for it was too weak and it broke a committed control before I found the real argument.

`DNA/complex.md:39` says *"a double colon is used to designate break point junctions creating a ring chromosome."* On its own that is an inference from a definitional sentence. What settles it is **`:60-64`, the committee adjudicating `::` itself**:

> **The description of translocations has changed.** In the original proposal (SVD-WG004), **one identical derivative chromosome** would receive **two different descriptions**, depending on whether it was identified in a balanced or an unbalanced case. In a balanced case, the description would use a `"::"` format joining the breakpoints, while in an unbalanced case, the description would use a `"delins"` format. HGVS recommendations try to avoid such conflicts wherever possible. **HGVS, therefore, recommends to describe translocations exclusively using a `"delins"` format.**

`::` as a general join operator was **withdrawn**, on a confluence argument — one chromosome, two spellings.

Classifying every `::` occurrence in `complex.md` confirms the consequence. Every HGVS-*shaped* `::` string is either marked `<code class="invalid">` or labelled "**ISCN**" for comparison; line 72 says the `::` translocation forms were "corrected" *to* `delins[...]`. In current HGVS notation `::` survives in exactly **two** places — `:127` and `:161`, both rings, both `del::del`. Every other rearrangement is `delins[...]`, `ins[...]` or a `;` cis allele, including ISCN structures whose *own* notation is full of `::` (e.g. `inv(2)(pter->p22.3::q31.1->p22.3::q31.1->qter)` renders as `g.[32310435_32310710del;32310711_171827243inv;insG]`).

And `:12` gives the governing principle: *"while ISCN describes the structure of the resulting chromosome(s), HGVS describes the **variant(s) detected**."* A ring's segment list is a list of detected variants — two terminal deletions — with `::` recording that they are connected (`:130`).

**Consistency clincher:** `try_parse_genome_ring` already refuses a cross-accession segment, with the comment *"a cross-chromosome `::` is ISCN2016, removed in ISCN2020, and spec-invalid."* That is the same withdrawal. Ferro enforced one half of it and not the other.

## A defect caught after the first push: `delN[]` is a deletion

Worth stating rather than burying, because it is the worst case to get wrong here. The junction predicate first matched only `NaEdit::Deletion`, so it refused `NaEdit::NPaddedDeletion` — `g.100_200delN[15]::300_400del`. But `delN[]` **is** a deletion, one whose removed size is a count of unknown bases, and *"breakpoint not sequenced"* is the annotation on **both** ring shapes the spec publishes (`:128`, `:163`). The rule was rejecting the form the spec's own examples describe in prose, and its diagnostic misdescribed the input as "a duplication, inversion, substitution or identity segment" when it was none of those.

Found by enumerating `NaEdit`'s twenty variants instead of reasoning about the ones I had in mind. Fixed, with tests over `delN[]` in first, second, both and `sup`-wrapped positions, and the diagnostic rewritten to name both accepted spellings.

The same enumeration turned up the row that most vindicates the rule: a **position-only** segment (`g.pter_100::200_qter`) is rejected, and that is the withdrawn ISCN2016 join itself — `:72` marks it `<code class="invalid">` and "corrected" to `delins`, and `:84` explains it meant the deletion was *implied* by the coupling. Pinned with its own test and citations.

Two other shapes checked and left alone: `Mu::Unknown` is unreachable through the ring grammar (a `?` edit fails to parse inside a `::`-join), so the permissive arm for it guards programmatic construction only and is documented as untested rather than claimed as covered; `con` and methylation segments are rejected as non-deletions.

## Both rules reject only what is *definitely* wrong

Ordering compares an **upper** bound of the later segment's start against a **lower** bound of the earlier one's, so no amount of uncertainty can trigger it. That is what keeps `:127`'s own `pter_(12200001_14700000)del::(37600001_410000000)_qterdel` accepted — a naive integer compare would have had to pick an arbitrary representative or reject the spec's own example. `pter` is the axis minimum, `qter` the maximum, `cen` undecidable. The junction check skips a segment whose edit is `?`.

## Telomere anchoring is NOT enforced

A ring loses both telomeres, so a well-formed ring is anchored at `pter`/`qter`, and both published shapes are. But **no clause says so**, `:28` only defines what the markers mean, and `:13` warns a complex description can be *"literally correct"* yet meaningless. Enforcing it would be legislating from two worked examples plus biology — and the junction rule above is a live demonstration of how that goes wrong (see below). Recorded as `rulings[ring-telomere-anchoring]`, **`undecided`**, with `a_ring_with_no_telomere_anchor_is_still_accepted` pinning that an unanchored ring still parses so the question is not closed by drift.

The two ring records now both cite `complex.md:127`, one `decided` and one `undecided` — which is exactly the mixed-verdict case `clause_ruling_index` exists to surface, so citing `:127` for "rings are anchored" reads a ruling out of the undecided half. That is stated in its docs.

## Where the check runs — this placement is load-bearing

Outside `for_each_leaf`, because that walk re-wraps each segment as a standalone `g.` leaf and erases both the segment order and the ring identity the rules are about. And **after** the per-leaf rules, so a segment that is both an illegal edit form and a non-deletion reports the edit-form error, which is the more specific and actionable one.

Measured, not assumed: running the ring rules *first* turned **7 of `issue_1578_ring_validator_escapes`** red, because their fixtures pair an illegal edit form with an `insG` segment. It is also what keeps #1264's insertion-anchor rejections failing for their own reason rather than being silently absorbed.

## Three pre-existing controls used non-deletion ring segments

Each is updated rather than deleted, and each keeps its guarantee. **Flagging this prominently because one of them is @geoffjentry's, from #1578's own body.**

- **`a_ring_of_legal_edits_still_parses` (#1583)** — `dup::insG` → `del::del`. #1578 names the original as its *"Legal-edit control, verified to parse and round-trip"*, and it **remains** a legal-edit control: `dup` and `insG` violate none of the per-leaf edit-form rules it was chosen to exercise. It is not a well-formed *ring*. Its stated purpose — *"tightening the ring path could pass by rejecting every ring"* — is fully served by `del::del`, which still fails under a blanket rejection. Jeff, if you read `:39`/`:60-64` differently, this is the line to push back on and I'll ship ordering-only instead.
- **`a_ring_segment_with_flanking_anchors_still_parses` (#1264)** → `..._is_not_rejected_by_the_anchor_rule`. Its premise ("every ring insertion" must not be rejected) is now deliberately false, so "it parses" is unavailable as evidence. It asserts the *reason* instead — rejected by the ring rule, not the anchor rule — which is **stronger** than the acceptance it replaced, since acceptance could have come from the anchor rule silently not running.
- **#1589's two overlap tests** move to `del::del`, isolating the `:58` question from the junction rule. Had they stayed `del::dup` they would now pass by being rejected for the *wrong* reason. Its status-quo test is deleted, exactly as its own failure message instructed.

## A fourth pre-existing control, in a file this PR otherwise does not touch

`tests/it/fast_path_differential.rs` hard-codes two of the nine flipped spellings and labelled them
*"valid ring: both accept, must agree"* and *"valid `sup`-wrapped ring"*. Both now reject, so both
comments asserted the opposite of the behaviour.

The suite stayed green throughout, which is what made it silent: `divergence` treats `(Err, Err)`
as agreement, so flipping a row from accept-and-agree to both-reject-and-agree passes. The real
loss was coverage — after this PR **no** ring input in that corpus reached `divergence`'s
`(Ok(a), Ok(b))` arm, which is the one that catches a fast path accepting a ring while building a
*different* AST. Both-reject rows cannot pin an AST.

Fixed by correcting the two comments and adding `g.100_200del::300_400del` and its `sup` form
(both verified accepted) so the equal-AST direction is exercised again. Found by enumerating the
nine flipped strings and grepping the whole tree for each; this was the only file outside the diff
still making a claim about any of them.

## Blast radius, stated as the structural zero it is

Of the spec corpus's 934 rows, 25 contain `::`: 17 correctly-rejected cross-accession translocations, 5 RNA fusions, and **3 `GenomeRing` rows** — all `preserved`, all telomere-anchored ascending `del::del`:

```
NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel
NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup
chr22:g.pter_10000000del::40000000_qterdel
```

So **zero corpus rows change** — but that is a *structural* zero in this repo's sense, not evidence of safety: the corpus contains only well-formed rings, so it cannot exhibit a malformed one. The real evidence is the full suite passing with three controls' observables changed and nothing else re-blessed.

## The long-term fix this is an increment toward

`GenomeRing.segments` is `Vec<LocEdit<GenomeInterval, NaEdit>>`, so a malformed ring stays constructible in the type system and every consumer has to re-derive the rule — which is how #1578's four-module blindness happened in the first place. Narrowing that payload to deletions moves the guarantee from a parser check to the type. That refactor is next and deliberately not here, since it touches the public type.

## Testing

- Full suite: **10,013 passed, 0 failed, 150 skipped.**
- Re-run with all three seam oracles armed under CI's own exclusion filter
  (`FERRO_ASSERT_IDEMPOTENT` / `_REPARSE` / `_IN_BOUNDS`, minus `ORACLE_EXCLUDE`
  and `SWEEP_FILTER`): **9,895 passed, 0 failed.** Worth stating because this PR
  changes what parses, and the re-parse oracle is the one that would notice a
  normalized ring that no longer round-trips.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- `generate_spec_fixture` succeeds, which verifies the new record's four citations still quote the spec at submodule `6f85311`.
- `clause_ruling_index` regenerated (census `(15,10,5) → (16,10,6)`, multiply-named 10→12, mixed-verdict 6→8) and `ruling_citation_currency` green — the latter caught a real slip where my prose wrapped `**undecided**` onto the *decided* record's line.

Representation-Change: none. This is a parse-time rejection of descriptions with no defined HGVS meaning; it moves no normalized output, and no corpus row's normalized form differs.

**Rejection change, measured rather than asserted: 9 previously-accepted spellings are now refused, all 9 by the junction rule and 0 by the ordering rule.** Method: harvest every `::`-shaped HGVS string from the `origin/main` tree (53 distinct), re-parse each at this HEAD, and classify. The denominator is deliberately `main`'s tree and not this branch's — at HEAD there are 75 such strings, but 26 of them are test inputs *this PR adds*, so classifying those would be circular and inflates the count to 19. The rule is purely additive (`validate_ring_segments_are_wellformed` is appended last in `parse_variant` and only ever returns `Err`), so "refused with a ring diagnostic at HEAD" is equivalent to "accepted on `main`"; `main`'s own committed tests assert 4 of the 9 parse, and the `self-cancelling-across-ring-junctions` rationale names 3 more as accepted.

All 9 are the repo's own test fixtures. Three of them are the rings the ruling explicitly named (`g.100_200del::150_250dup`, `g.100_200del::300_400dup`, `g.150_250dup::100_200del`); the other six are `g.100_101dup::200_201insG`, `g.100_101insATG::200_201insG`, `g.100_200del::100_200dup` and the three `sup`-wrapped forms. **The ordering rule refuses nothing that previously existed** — it is exercised only by inputs this PR adds.

