### PR TITLE
docs: correct three stale claims, and disambiguate the two NormalizeConfig types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,11 +188,26 @@ uploaded xfail artifact as a FAILing case instead of failing the workflow. That
 applies equally to all three flags, and it is why a red oracle in the nightly must
 be read out of the xfail report rather than from the workflow conclusion.
 
-Red is not the same as blocked, though: `main`'s ruleset requires only eight
-checks — Build, Test, Clippy, Clippy (all features), Format, Python Lint, Python
-Wheel Test, abi3 floor — and neither `Test oracle` nor `Exhaustive sweeps` is
-among them. So an oracle fire shows up as a failed job that a human must not
-merge past, not as a ruleset-enforced merge block.
+Red is not the same as blocked, though: `main`'s ruleset requires only a subset
+of the jobs CI runs, and neither `Test oracle` nor `Exhaustive sweeps` is among
+them. So an oracle fire shows up as a failed job that a human must not merge
+past, not as a ruleset-enforced merge block.
+
+Read the required set from the ruleset rather than from a count written down
+here — it grows (`Representation change declared` and `zizmor + actionlint` were
+both added after this paragraph was first written), so any number quoted in prose
+is stale by the next contexts change:
+
+```bash
+gh api --paginate repos/fulcrumgenomics/ferro-hgvs/rulesets \
+  --jq '.[] | select(.target=="branch") | .id' \
+| xargs -I{} gh api repos/fulcrumgenomics/ferro-hgvs/rulesets/{} \
+  --jq 'select(.enforcement=="active")
+        | select(.conditions.ref_name.include
+                 | any(. == "refs/heads/main" or . == "~DEFAULT_BRANCH"))
+        | .rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+```
 
 #### Exhaustive cis sweeps: `FERRO_SWEEP_SEEDS`
 
@@ -698,30 +713,48 @@ individually" — which is **provenance**, recoverable only from the input's spe
 
 The `rulings` section of `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json` is the
 decision log, pinned by `ruling_records_are_intact` (ids **and** statuses; keep `RULING_STATUSES`
-in sync). **Five of its eight records are `undecided`**, and the first below is an operator
-decision that blocks other work — read them before re-deriving the same argument:
+in sync).
+
+**Do not trust a count of decided/undecided records written down here.** Both this file and its
+predecessors have carried one that had gone stale — the sentence this replaces said "five of its
+eight records are `undecided`" long after the ledger had grown and four of those five had been
+ruled on. The statuses are pinned in exactly one place, `RULING_STATUSES` in
+`tests/it/hgvs_spec_normalization_tests.rs`, and `ruling_records_are_intact` fails when the ledger
+and that list disagree. Read them from there, or straight off the ledger:
+
+```bash
+python3 -c "import json;d=json.load(open('tests/fixtures/grammar/hgvs_spec_normalization_overrides.json'));\
+[print(f\"{r['status']:<10} {r['id']}\") for r in d['rulings']]"
+```
+
+The table below lists the records that are **open**, with what each leaves unsettled. It is a
+description of the open questions, not a census — when a record is ruled on it moves out of this
+table, and the authority for which rows belong here is the ledger, not this list:
 
 | record | what is open |
 |---|---|
-| `adjudication-precedence-order` | **Two competing precedence orders are on record and neither is chosen.** It does not reopen the two records decided below, but it governs how the next such conflict is ranked |
-| `canonical-form-choice-when-both-legal` | Which of two legal forms ships. An open *product* decision |
 | `codon-carve-out-shape-restriction` | `delins.md:18` names no edit type; ferro applies it only to sub/unchanged/sub |
 | `exon-junction-dup-converge-from-the-far-side` | `LRG_199t1:c.3921dup` and `c.3922dup` denote one transcript sequence but are two fixed points, projecting 2,790 bp apart. `duplication.md:26` argues for converging them, `general.md:44` does not prescribe the 5' shift that would |
 | `rna-repeat-range-plus-unit-redundancy` | `RNA/repeated.md:22` calls range-plus-unit invalid, `:27` publishes exactly that shape as valid. Upstream's conflict (#466); ferro answers both ways depending on input-hygiene mode |
+| `separation-is-a-property-of-the-spelling-not-of-the-variant` | The separation rule keys on unchanged nucleotides "between two variants", which presupposes a decomposition a normalizer does not receive. Two spellings of one variant can present different separations, so the rule as written is not evaluable on what a normalizer knows |
 
-The three `decided` records, and the scope each was decided **at** — read the record before
-citing it, because both of the 2026-08-07 rulings are narrower than their one-line summary:
+The `decided` records, and the scope each was decided **at** — read the record before citing it,
+because several of these rulings are narrower than their one-line summary:
 
 | record | ruling |
 |---|---|
 | `delins-codon-carve-out-gap-one` | `delins.md:18` governs |
 | `delins-merge-vs-individual-gap-two-or-more` | `DNA/delins.md:44-47` governs `:17`, **scoped** to the alignment-coincidence shape `:44-47` describes. Where a separation of two or more arises from anything else, `general.md:34` still governs; unscoped the reading reaches roughly fifteen times the row set the argument was made on |
 | `inversion-vs-two-delins-76-83` | `inversion.md:5` governs: a whole-block reverse complement is one `inv` when the members it competes with are `delins`, since `general.md:56` ranks substitution but not `delins`. #1230's substitution case is untouched and still splits |
+| `adjudication-precedence-order` | What ranks next where the spec is silent. The order is (1) the spec where it speaks, (2) confluence, (3) re-derivation from the resulting sequence, (4) disclosure of any resulting move, (5) stability toward the already-shipped form, as a last-resort tiebreaker only. Mutalyzer appears nowhere in it |
+| `canonical-form-choice-when-both-legal` | Where two descriptions are legal and no clause selects between them, ferro derives from the **resulting sequence** and emits the form that falls out, subject to every explicit spec tie-break. It preserves neither the input's spelling nor the previously-shipped string |
+| `delins-adjacent-members-when-both-consume-reference` | `substitution.md:32` governs: at separation **zero** no clause licenses a split, and the spec marks one invalid by name — `c.[79G>T;80C>T]` for `LRG_199t1:c.79_80delinsTT` is rendered `class="invalid"` and called "not correct" |
 
 Two things follow for representation-stability work specifically. The repository's doctrine reads
 as "do not move a normalized output", while the downstream filer has said instability is
-acceptable **provided it is declared a breaking change** — different bars, and which one applies
-is part of what `adjudication-precedence-order` leaves open. And Mutalyzer is not a spec oracle:
+acceptable **provided it is declared a breaking change** — different bars, and
+`adjudication-precedence-order` now settles which applies: disclosure ranks above stability, and
+stability is a last-resort tiebreaker rather than a veto. And Mutalyzer is not a spec oracle:
 its normalizer re-derives a description by minimizing a **weighted description length** with
 constants dated 2014, and has no separation rule at all, so a separation disagreement with it is
 two objectives meeting rather than evidence it knows something the spec does not. The full

--- a/examples/harvest_multi_member_cis.rs
+++ b/examples/harvest_multi_member_cis.rs
@@ -207,10 +207,28 @@ fn harvest() -> Result<Fixture, String> {
         ));
     }
 
-    // Sorted and deduplicated: the same allele appears in more than one corpus
-    // (`clinvar_hgvs_unique` is a subset of the 500k by construction), and a
-    // fixture whose order depended on corpus iteration would churn its diff for
-    // no reason.
+    // Sorted and deduplicated: the same allele appears in more than one corpus,
+    // and a fixture whose order depended on corpus iteration would churn its
+    // diff for no reason.
+    //
+    // The dedup is load-bearing because the two ClinVar corpora genuinely
+    // overlap — **not** because either contains the other. They are drawn
+    // differently and neither is a subset of the other:
+    //
+    //   `clinvar_hgvs_500k`    a stratified sample of ClinVar HGVS *expressions*
+    //                          (a variant may contribute several)
+    //   `clinvar_hgvs_unique`  one expression per `VariationID`, across all of
+    //                          ClinVar — an order of magnitude larger
+    //
+    // Measured on the committed fixtures, their intersection is a small
+    // minority of either side, and each holds inputs the other does not; among
+    // the bracketed multi-member candidates this harvest cares about, a handful
+    // are shared and both corpora contribute rows the other lacks. So dropping
+    // either source would lose alleles, and skipping the dedup would double-count
+    // the shared ones.
+    //
+    // (This comment previously claimed `clinvar_hgvs_unique` was "a subset of
+    // the 500k by construction". It is not, in either direction.)
     rows.sort();
     rows.dedup_by(|a, b| a.input == b.input);
 

--- a/src/benchmark/normalize.rs
+++ b/src/benchmark/normalize.rs
@@ -29,7 +29,7 @@ pub fn normalize_ferro<P: AsRef<Path>>(
     let timing_output = timing_output.as_ref();
 
     // Use commands module for normalization
-    let config = commands::NormalizeConfig {
+    let config = commands::NormalizeCommandConfig {
         reference_dir: reference_dir.map(|p| p.as_ref().to_path_buf()),
         show_progress: true,
         workers: 1,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -89,7 +89,7 @@ pub struct BatchResults {
 /// same reason.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct NormalizeConfig {
+pub struct NormalizeCommandConfig {
     /// Reference directory (with manifest.json)
     pub reference_dir: Option<std::path::PathBuf>,
 
@@ -100,7 +100,7 @@ pub struct NormalizeConfig {
     pub workers: usize,
 }
 
-impl Default for NormalizeConfig {
+impl Default for NormalizeCommandConfig {
     fn default() -> Self {
         Self {
             reference_dir: None,
@@ -215,7 +215,7 @@ pub fn cdot_cache_load_source(
 /// Batch results with all normalize results and timing info.
 pub fn normalize_batch<P: AsRef<Path>>(
     input: P,
-    config: &NormalizeConfig,
+    config: &NormalizeCommandConfig,
 ) -> Result<BatchResults, FerroError> {
     let input = input.as_ref();
 

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -52,6 +52,14 @@ impl std::str::FromStr for ShuffleDirection {
 /// field directly. Mirrors the attribute on its result-side counterpart
 /// [`crate::normalize::NormalizeResult`], which #1033 marked for the same
 /// reason.
+///
+/// This is the type that carries the **error mode** — [`Default`] and
+/// [`NormalizeConfig::lenient`] both give it `ErrorConfig::lenient()`. Do not
+/// confuse it with [`crate::commands::NormalizeCommandConfig`], which
+/// configures the batch run around a normalization (reference directory,
+/// progress, workers) and has no error mode at all. The two used to share the
+/// name `NormalizeConfig`, so `NormalizeConfig::default()` resolved to
+/// whichever one a single `use` line had brought into scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct NormalizeConfig {

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -912,10 +912,24 @@ fn ruling_records_are_intact() {
     // that survived is checked, the one it shadowed is not (#1530). Its sibling
     // `EQUIVALENCE_CLASS_VERDICTS` already carries this; the generator checks
     // duplicates on both of its own tables.
+    //
+    // Both sides need the guard, not just the pinned one. The hazard above is
+    // symmetric, but only `RULING_STATUSES` was checked, so a duplicated id in
+    // the *fixture* stayed invisible here: the shadowed record's status is never
+    // compared against anything, which is the one property this assertion pair
+    // exists to enforce. (The loop below iterates `fx.rulings` directly, so a
+    // shadowed record still gets its clause/rationale/governing checks — it is
+    // specifically the id-to-status pin that could be evaded.)
     assert_eq!(
         pinned.len(),
         RULING_STATUSES.len(),
         "RULING_STATUSES has a duplicate id"
+    );
+    assert_eq!(
+        observed.len(),
+        fx.rulings.len(),
+        "the ruling fixture has a duplicate id; one record's status is shadowed and \
+         therefore unpinned"
     );
     assert_eq!(
         observed, pinned,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -390,6 +390,7 @@ mod mutalyzer_grammar_tests;
 mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;
 mod network_benchmark_tests;
+mod normalize_config_disambiguation;
 mod normalize_idempotency_proptest;
 mod normalize_property_tests;
 mod normalize_reparse_invariant;

--- a/tests/it/normalize_config_disambiguation.rs
+++ b/tests/it/normalize_config_disambiguation.rs
@@ -1,0 +1,70 @@
+//! The batch-run config and the normalizer config must stay distinguishable.
+//!
+//! Two public types were both called `NormalizeConfig`:
+//! [`ferro_hgvs::commands::NormalizeCommandConfig`] (reference directory, progress,
+//! workers — the shape of a batch *run*) and [`ferro_hgvs::normalize::NormalizeConfig`]
+//! (shuffle direction, window, and the **error mode**). With one name between them,
+//! `NormalizeConfig::default()` resolved to whichever a single `use` line happened to
+//! bring into scope, and the two defaults differ in what they even contain — so the
+//! mistake produced a config silently missing an error mode rather than a compile error.
+//!
+//! This file is the executable half of that rename. Both types are imported here **by
+//! their own names, in one scope**, so the rename cannot be undone silently: reverting it
+//! breaks this file's compilation — as `E0432: unresolved import` when the new name simply
+//! disappears (verified), or as a duplicate-import error if both types end up sharing a
+//! name again. Either way the build stops. *That* is the guard; the assertions below only
+//! document what each type carries.
+//!
+//! The `const` below pins `normalize_batch`'s signature for the same reason. A test that
+//! merely *called* the function would need a temp file and would exercise batch I/O this
+//! test has no interest in; coercing the function to a concrete `fn` pointer checks the
+//! parameter type at compile time and runs nothing.
+
+use ferro_hgvs::commands::{BatchResults, NormalizeCommandConfig};
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::NormalizeConfig;
+use ferro_hgvs::FerroError;
+
+/// `normalize_batch` must keep taking the *command* config, not the normalizer one.
+///
+/// Instantiated at the owned `PathBuf` rather than `&Path` deliberately: naming a
+/// reference type here would pin `P` to one concrete lifetime, and the resulting `fn`
+/// item is then less general than the `for<'a>` pointer this constant declares.
+const _NORMALIZE_BATCH_TAKES_THE_COMMAND_CONFIG: fn(
+    std::path::PathBuf,
+    &NormalizeCommandConfig,
+) -> Result<BatchResults, FerroError> = ferro_hgvs::commands::normalize_batch::<std::path::PathBuf>;
+
+#[test]
+fn the_batch_config_and_the_normalizer_config_are_distinct_types() {
+    let batch = NormalizeCommandConfig::default();
+    let normalizer = NormalizeConfig::default();
+
+    // Naming each config's own fields is what separates the two types here. Their
+    // default *values* are deliberately not pinned: nothing in this change claims a
+    // particular worker count, and a test called "are distinct types" going red
+    // because someone retuned a default would point at the wrong thing.
+    let _run_shape = (batch.workers, batch.show_progress, &batch.reference_dir);
+
+    // The normalizer config is the one that carries the error mode — the field the
+    // old shared name made it possible to lose by accident. This value *is* pinned,
+    // because `src/normalize/config.rs` states it: `Default` and
+    // `NormalizeConfig::lenient` both give it `ErrorConfig::lenient()`.
+    assert_eq!(normalizer.error_config.mode, ErrorMode::Lenient);
+}
+
+/// `NormalizeConfig::lenient()` and `NormalizeConfig::default()` agree on the error mode.
+///
+/// Named in the doc comment the rename added to `src/normalize/config.rs`, so it is worth
+/// having something check it rather than leaving it as prose.
+#[test]
+fn the_normalizer_config_is_lenient_by_default_and_by_constructor() {
+    assert_eq!(
+        NormalizeConfig::default().error_config.mode,
+        NormalizeConfig::lenient().error_config.mode
+    );
+    assert_eq!(
+        NormalizeConfig::lenient().error_config.mode,
+        ErrorMode::Lenient
+    );
+}


### PR DESCRIPTION
Three unrelated one-line-scale corrections, bundled because none of them warrants its own review cycle. Every claim was re-verified against `origin/main` before being changed.

## 1. The two ClinVar corpora are not nested

`examples/harvest_multi_member_cis.rs:211` justified its dedup with:

> the same allele appears in more than one corpus (`clinvar_hgvs_unique` is a subset of the 500k by construction)

Measured over the committed LFS fixtures, **neither corpus contains the other**:

| | distinct inputs |
|---|---|
| `clinvar_hgvs_500k` | 500,002 |
| `clinvar_hgvs_unique` | 4,187,411 |
| intersection | 50,274 |
| in 500k, not in unique | 449,728 |
| in unique, not in 500k | 4,137,137 |

They are drawn differently — 500k is a *stratified sample of ClinVar expressions* (a variant may contribute several), unique is *one expression per `VariationID`* across all of ClinVar — so neither construction implies containment. Both `NC_000013.11:g.32340866_32340868delinsATC` and `NC_000002.11:g.47639670_47639673delinsTT` are in 500k and in neither case in unique.

Restricted to the bracketed multi-member candidates this harvest actually selects: **13 shared, 3 500k-only, 898 unique-only.**

**No assertion depended on the belief.** The dedup is still correct and still load-bearing — the corpora genuinely overlap, which is what it exists for; only the stated *reason* was wrong. The pinned counts in `tests/it/multi_member_cis_axis.rs` (`accepted = 592`, `rows_scanned = 9_949_738`, and the census totals) are empirical outputs of the harvester run over all four corpora after dedup, so they are not derived from the containment claim and none of them moves. Dropping either source would lose alleles, and skipping the dedup would double-count the 13 shared ones — both of which the corrected comment now says explicitly.

## 2. `NormalizeConfig` named two different types

- `src/normalize/config.rs:57` — the normalizer's, whose `Default` sets `error_config: ErrorConfig::lenient()`
- `src/commands/mod.rs:92` — the CLI batch-run one: `reference_dir` / `show_progress` / `workers`, **no error mode at all**

`NormalizeConfig::default()` therefore resolved to a different type with a different meaning depending on one `use` line, and the field a wrong import silently swaps is the **error mode**.

The CLI type is renamed to `NormalizeCommandConfig`. It is the narrower and more local of the two, and the rename turned out to be small — **4 sites across 2 files** (`src/commands/mod.rs`, plus one struct literal in `src/benchmark/normalize.rs`), against 500+ references to the normalize-module type that are untouched. Both types now carry a doc comment naming the other and spelling out the error-mode difference.

`src/commands` is `pub`, so this is technically a public rename; pre-v1, and the type configures a CLI batch run rather than any normalization result.

## 3. Two stale counts in `CLAUDE.md`

**The ruling ledger.** The text said *"Five of its eight records are `undecided`"*. The ledger has **10 records — 6 decided, 4 undecided**:

```
decided    delins-merge-vs-individual-gap-two-or-more
decided    inversion-vs-two-delins-76-83
decided    adjudication-precedence-order
decided    canonical-form-choice-when-both-legal
undecided  codon-carve-out-shape-restriction
decided    delins-codon-carve-out-gap-one
undecided  exon-junction-dup-converge-from-the-far-side
undecided  rna-repeat-range-plus-unit-redundancy
decided    delins-adjacent-members-when-both-consume-reference
undecided  separation-is-a-property-of-the-spelling-not-of-the-variant
```

Rather than restate the denominator — which reads as a coverage claim and goes stale exactly the way the old one did — the section now points at the ledger and at `RULING_STATUSES`, which is where the statuses are pinned and where `ruling_records_are_intact` enforces them. It gives the one-line query for reading them.

The two tables are corrected against that ledger:

- `adjudication-precedence-order` was listed as open with *"neither is chosen"*. It is **decided**, and its ruling is the precedence order the rest of the file depends on — so the closing paragraph, which said the stability-versus-disclosure question was "part of what `adjudication-precedence-order` leaves open", is corrected too: disclosure ranks above stability, and stability is a last-resort tiebreaker.
- `canonical-form-choice-when-both-legal` was also listed as open. It is **decided** (derive from the resulting sequence).
- `delins-adjacent-members-when-both-consume-reference` was missing from the decided table.
- `separation-is-a-property-of-the-spelling-not-of-the-variant` was missing from the open table.

**The ruleset.** The file said `main`'s ruleset *"requires only eight checks"* and named them. It requires **10** — the eight named plus `Representation change declared` and `zizmor + actionlint`. Since that number grows, the paragraph now gives the `gh api` query instead of a count.

## Verification

Full suite **9,780 passed, 0 failed**. `cargo fmt --all --check` clean, `cargo clippy --features dev --all-targets` silent, `cargo doc --no-deps` raises nothing on the new intra-doc links.

Representation-Change: none. Comments, doc comments and `CLAUDE.md` only, plus a rename of a CLI batch-run config type that no normalization reads; no watched file changes behaviour.

BREAKING CHANGE: `ferro_hgvs::commands::NormalizeConfig` is renamed to `NormalizeCommandConfig`. The `commands` module is public, so any external caller that names the type or passes it to `normalize_batch` must update the name; fields, defaults and behaviour are unchanged. It was renamed because it collided with `ferro_hgvs::normalize::NormalizeConfig`, which is the type that carries the error mode — with one name between them, `NormalizeConfig::default()` resolved to whichever a single `use` line had brought into scope, yielding a config silently missing an error mode rather than a compile error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidance for interpreting adjudication records, including authoritative statuses, open versus decided records, and disclosure priorities.
  - Updated ClinVar harvest documentation to accurately explain overlap and deduplication.
  - Expanded normalization configuration documentation to distinguish error handling from batch execution settings.

- **Refactor**
  - Renamed the batch normalization configuration type for clearer distinction from normalization settings. Behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
