### PR TITLE
fix(normalize): bound the junction of a member that reduces to an insertion

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7828,7 +7828,19 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         // on **sequence** coordinates (#1482); reading it from `cis_axis_parts`
         // instead yields the written axis number, which no longer compares
         // against `s.start`/`s.end`.
-        let (Some(before_junction), Some(after_junction)) = (b.junction, a.junction) else {
+        let Some(after_junction) = a.junction else {
+            continue;
+        };
+        // A member that arrived claiming bases has no stated junction, and used
+        // to be skipped here — which was #1592, because
+        // `clamp_sibling_crossing_shifts` has already declined it for growing
+        // (see there) and hands exactly this shape over. Falling through both
+        // passes let its junction sweep as far as the tract allowed, over any
+        // number of siblings' bases, changing what the allele denotes.
+        let Some(before_junction) = b
+            .junction
+            .or_else(|| reduced_before_junction(b, after_junction))
+        else {
             continue;
         };
         if before_junction == after_junction || b.region != a.region {
@@ -8039,6 +8051,80 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
         if delta != 0 {
             translate_junction_member(&mut after[i], delta, kind, a, provider);
         }
+    }
+}
+
+/// Where the shift started, for a member that arrived **claiming bases** and
+/// normalized into a junction-inserting form; `None` when there is nothing for
+/// [`clamp_sibling_crossing_junctions`] to bound.
+///
+/// A `delins` does not occupy a junction, which is why [`junction_of`] gives it
+/// none, and that is right about the *stated* form. It is wrong about the member:
+/// `g.264delinsGAT` on a `G` is one two-base insertion wearing a span, and once
+/// the per-member pipeline reduces it the payload lands at a junction and shifts
+/// like any other. Without a `before` value the clamp skipped such a member
+/// entirely (#1592) and — since `clamp_sibling_crossing_shifts` refuses a member
+/// that *grew*, deliberately, and defers this shape here — nothing bounded it at
+/// all:
+///
+/// ```text
+/// reference   ("ACGT" x 64) + "TCCAGCAGATAT" + ("ACGT" x 64)   core base 1 at g.257
+/// g.[262_263insAG;264G>T;266T>A]  ->  g.265A[3]
+///   intended  C A G A T A A A T
+///   emitted   C A G A A A T A T     <- the payload crossed the 266T>A
+/// ```
+///
+/// The junction is not stated, but it is **bounded**: reducing a span `[s, e]`
+/// to a pure insertion trims a common prefix or a common suffix, so the payload
+/// lands somewhere in `[s - 1, e]` — the member's own footprint. Take the edge
+/// of that footprint on the side the member travelled *from*, which is the
+/// weakest bound the clamp can be given:
+///
+/// * it is at or 3' of the true start under a 3' shift (at or 5' of it under a
+///   5' one), so the clamp never pulls a member back past where it began — the
+///   walk in `clamp_sibling_crossing_junctions` stops at `before_junction`;
+/// * a junction strictly inside the footprint therefore reports no crossing at
+///   all, which is the conservative answer for a member that never left its own
+///   span. Only a sibling **outside** the footprint can bound it, and such a
+///   sibling was genuinely swept over however the reduction trimmed.
+///
+/// Not restricted to `delins`: a repeat member re-spelled as a duplication
+/// reaches this the same way, and so would any future edit that reduces.
+///
+/// # Which clamp owns which shape
+///
+/// The two passes have to partition the space between them, or a shape falls
+/// through — which is the whole of #1592. After this, by the `before` form and
+/// the `after` form:
+///
+/// | before | after | [`clamp_sibling_crossing_shifts`] | [`clamp_sibling_crossing_junctions`] |
+/// |---|---|---|---|
+/// | claims bases | claims bases | **owns** (translated or shrank) | inert — `after` has no junction |
+/// | claims bases | pure `ins` | inert — `blocks_shift` is false for an insertion | **owns**, via this function |
+/// | claims bases | `dup`/`dupins`, grew | declines — the #1266/#1279 refusal | **owns**, via this function |
+/// | claims bases | `dup`/`dupins`, shrank | bounds the span | also bounds the junction |
+/// | `ins`/`dup` | `ins`/`dup` | bounds a `dup` that translated | **owns** |
+///
+/// Row four is the only one both act on, and they compose: each pass walks the
+/// member back **toward** where it started and neither may pass that point, so
+/// applying both cannot overshoot. The junction pass re-reads its `post` spans
+/// from `after` after the span pass has mutated it, so the second bound is
+/// measured against the first's result rather than against a stale snapshot.
+///
+/// Row two and row three are the ones that previously had no owner.
+fn reduced_before_junction(before: &MemberSpan, after_junction: i64) -> Option<i64> {
+    // An edit that claims no bases and states no junction — there is no
+    // footprint to read a starting junction off.
+    if !before.claims_bases {
+        return None;
+    }
+    if after_junction > before.end {
+        Some(before.end)
+    } else if after_junction < before.start - 1 {
+        Some(before.start - 1)
+    } else {
+        // Still inside its own footprint: nothing was crossed.
+        None
     }
 }
 

--- a/tests/it/issue_1592_reduced_member_junction_clamp.rs
+++ b/tests/it/issue_1592_reduced_member_junction_clamp.rs
@@ -1,0 +1,177 @@
+//! A member that *reduces* to an insertion must still be bounded by its siblings.
+//!
+//! The two sibling clamps in `normalize_allele` have complementary jobs, and
+//! #1592 is the shape that fell between them.
+//!
+//! * `clamp_sibling_crossing_shifts` governs a member that consumes the bases
+//!   under its span, and refuses one that **grew** — deliberately, per
+//!   #1266/#1279: an insertion canonicalising to a duplication moves its span
+//!   and its junction together, so bounding the span mis-places the copy. It
+//!   hands that shape to the junction clamp.
+//! * `clamp_sibling_crossing_junctions` governs a member that adds sequence at a
+//!   junction — but it needs a junction on *both* snapshots, and `junction_of`
+//!   reports one only for `ins` / `dup` / `dupins`.
+//!
+//! So a member that arrives as a `delins` and normalizes into a `dup` has no
+//! `before` junction, is skipped by the pass that owns it, and has already been
+//! declined by the pass that could see it. Its junction then sweeps as far as
+//! the tract allows — straight over a sibling's bases:
+//!
+//! ```text
+//! reference   ("ACGT" x 64) + "TCCAGCAGATAT" + ("ACGT" x 64)   core base 1 at g.257
+//! g.[262_263insAG;264G>T;266T>A]  ->  g.265A[3]
+//!   intended  C A G A T A A A T
+//!   emitted   C A G A A A T A T     <- the payload crossed the 266T>A
+//! ```
+//!
+//! The output is well-formed, its members are disjoint, no warning is raised,
+//! and it is a fixed point that re-parses and is in bounds — so all three seam
+//! oracles (`FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE`,
+//! `FERRO_ASSERT_IN_BOUNDS`) pass on it. None of them compares the sequence the
+//! output denotes with the sequence the input denotes, which is the only
+//! property this defect violates. That is why every assertion here goes through
+//! `cis_apply_oracle::apply_with`, which splices the reference from each
+//! member's SPDI triple **without** the normalizer.
+//!
+//! The junction a reducing member's payload lands at is not stated anywhere, but
+//! it is bounded: it lies inside the member's own footprint `[start - 1, end]`.
+//! Taking the edge of that footprint on the side the member travelled from is
+//! the conservative before-junction the clamp needs, and it is what the fix
+//! supplies.
+//!
+//! # What the pinned strings below are, and are not
+//!
+//! Each test asserts an **exact** output string, so it is worth being explicit
+//! about which half of that assertion is the guard and where the other half's
+//! authority comes from — the two are not the same, and reading the string as
+//! self-justifying is the failure mode this note exists to prevent.
+//!
+//! * **The question.** A member that reduces to an insertion can legally be
+//!   spelled at more than one position in a tract: every landing site inside the
+//!   swept window denotes bases, and several of them denote the *same* bases.
+//!   Sequence equivalence therefore establishes **validity, not canonicality** —
+//!   `apply_with` can tell you an output is wrong, and can never tell you it is
+//!   the one to emit.
+//! * **The ruling.** The junction is bounded at the sibling's edge: it may reach
+//!   that edge but not pass it. That is the #1267 rule, stated on
+//!   `clamp_sibling_crossing_junctions` in `src/normalize/merge.rs` and applied
+//!   symmetrically in both shuffle directions — which is why
+//!   `the_crossing_is_bounded_under_a_five_prime_shuffle_too` asserts the mirror
+//!   rather than assuming it.
+//! * **The authority.** House rule, not a spec clause, and it should be cited as
+//!   such. No clause in `assets/hgvs-nomenclature` speaks about one cis member
+//!   bounding another's shift; the governing record is
+//!   `rulings[canonical-form-choice-when-both-legal]` — *re-derivation governs*,
+//!   so among legal spellings ferro emits what falls out of the resulting
+//!   sequence subject to the explicit tie-breaks, rather than the input's
+//!   spelling or the previously-shipped string. The clamp is what keeps that
+//!   re-derivation from selecting a spelling that denotes different bases.
+//!
+//! So: the **sequence identity** in `normalized_preserving_in` is the load-bearing
+//! assertion, and it fails if the allele stops denoting its input's bases. The
+//! string equality is a *record* of the canonical choice under the rule above —
+//! a change to it is a representation change to be declared and re-blessed
+//! deliberately, not a test to repair by pasting the new output.
+
+use crate::common::cis_apply_oracle::apply_with;
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::{parse_hgvs, Normalizer, ShuffleDirection};
+
+/// The core every case here is drawn against. Two lone `A`s two bases apart
+/// (`g.265` and `g.267`) inside an `AT` tract is what makes a mis-anchored
+/// repeat member land on the wrong one while still rendering legally.
+const CORE: &str = "TCCAGCAGATAT";
+
+/// Normalize `input` against [`CORE`] in `direction`, assert the output denotes
+/// the same bases the input does, and return the rendered output.
+///
+/// The sequence check runs **before** the caller compares strings, which is the
+/// opposite of `assert_normalizes_preserving_in`'s order and deliberate: a
+/// string mismatch there means its sequence check never ran, so a re-blessed
+/// expectation can silently carry a changed sequence with it. Here the sequence
+/// is the assertion and the string is the record.
+fn normalized_preserving_in(input: &str, direction: ShuffleDirection) -> String {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    let reference = padded(CORE);
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        ferro_hgvs::NormalizeConfig::default().with_direction(direction),
+    );
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let from_input = apply_with(&provider, &reference, input).expect("input applies");
+    let from_output = apply_with(&provider, &reference, &output).unwrap_or_else(|| {
+        panic!("`{input}` -> `{output}` has no resulting sequence (overlapping or unconvertible)")
+    });
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` denotes a different sequence"
+    );
+    output
+}
+
+/// [`normalized_preserving_in`] in the default 3' direction.
+fn normalized_preserving(input: &str) -> String {
+    normalized_preserving_in(input, ShuffleDirection::ThreePrime)
+}
+
+#[test]
+fn a_member_reducing_to_an_insertion_stops_at_its_sibling() {
+    // The minimal reproducer. The `262_263insAG` merges with the `264G>T` into
+    // `264delinsGAT`, which reduces to a pure two-base insertion and 3'-shifts
+    // through the `ATATA` tract — past the `266T>A`, which is the crossing.
+    let output = normalized_preserving("NC_TEST.1:g.[262_263insAG;264G>T;266T>A]");
+    assert_eq!(output, "NC_TEST.1:g.267A[3]");
+}
+
+#[test]
+fn the_spanning_delins_spelling_reaches_the_same_answer() {
+    // The same haplotype written as one `delins`. It takes the sequence-first
+    // derivation rather than the per-member merge, so it is a second entrance to
+    // the same defect: `g.[259del;265A[3]]` on `main`, naming the lone `A` at
+    // 265 instead of the one at 267.
+    let output = normalized_preserving("NC_TEST.1:g.258_266delinsCAGCAGATAA");
+    assert_eq!(output, "NC_TEST.1:g.[259del;267A[3]]");
+}
+
+#[test]
+fn the_bracketed_spelling_of_that_haplotype_agrees() {
+    // The spelling the confluence proptest draws. It already reached the right
+    // answer — the weight bound in `canonicalize_from_sequence` declines the
+    // derivation for it — and is pinned here so the fix is shown to converge the
+    // two spellings rather than merely to move one of them.
+    let output = normalized_preserving("NC_TEST.1:g.[258del;266_267insAA]");
+    assert_eq!(output, "NC_TEST.1:g.[259del;267A[3]]");
+}
+
+#[test]
+fn the_crossing_is_bounded_under_a_five_prime_shuffle_too() {
+    // The clamp is direction-symmetric, so the mirror is asserted rather than
+    // assumed. Only the sequence identity is load-bearing here; the string is
+    // recorded so a change to it is visible.
+    let output = normalized_preserving_in(
+        "NC_TEST.1:g.[262_263insAG;264G>T;266T>A]",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(output, "NC_TEST.1:g.267A[3]");
+}
+
+#[test]
+fn the_answer_does_not_depend_on_the_authored_member_order() {
+    let forward = normalized_preserving("NC_TEST.1:g.[262_263insAG;264G>T;266T>A]");
+    let reverse = normalized_preserving("NC_TEST.1:g.[266T>A;264G>T;262_263insAG]");
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn a_member_with_no_sibling_in_its_way_still_reaches_its_three_prime_most_form() {
+    // The guard on the fix: the bound must come from a sibling, not from the
+    // reducing member's own shape. Drop the `266T>A` and the same merged
+    // `264delinsGAT` is free to travel the whole `ATATA` tract, which it must
+    // still do.
+    let output = normalized_preserving("NC_TEST.1:g.[262_263insAG;264G>T]");
+    assert_eq!(output, "NC_TEST.1:g.268_269dup");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -22,6 +22,7 @@ mod issue_1454_split_member_inversion_typing;
 mod issue_1472_zero_length_read;
 mod issue_1524_adjacent_split_members;
 mod issue_1539_split_member_separation;
+mod issue_1592_reduced_member_junction_clamp;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
A normalized description that, applied to the reference, yields **different bases than its input does**. Not a spelling choice — nothing downstream can recover from it.

Against the padded synthetic contig `NC_TEST.1` built from core `TCCAGCAGATAT` (core base 1 at `g.257`), on `main` at `9b8e55fc`, with no environment flags:

```
input   NC_TEST.1:g.[262_263insAG;264G>T;266T>A]
before  NC_TEST.1:g.265A[3]              denotes ...CAGAAATAT...
after   NC_TEST.1:g.267A[3]              denotes ...CAGATAAAT...      = the input's own bases

input   NC_TEST.1:g.258_266delinsCAGCAGATAA
before  NC_TEST.1:g.[259del;265A[3]]     denotes ...TCAGCAGAAATAT...
after   NC_TEST.1:g.[259del;267A[3]]     denotes ...TCAGCAGATAAAT...  = the input's own bases
```

`265A[3]` names the lone `A` at 265; the payload belongs to the lone `A` at 267, two bases 3'.

Two corrections to how this defect was first framed, both of which raise its severity:

- **It is live on `main` today.** It was found under a bypass of the weight bound in `canonicalize_from_sequence` and reported as latent, masked by that bound. That is true only of the *bracketed* spelling. A spanning `delins` spelling of the same haplotype passes the bound and reaches the same broken derivation with nothing set — the second reproducer above.
- **It is not in repeat re-spelling.** `A[3]` is only the final spelling of a member that was already mis-placed.

## Root cause

The two sibling clamps in `normalize_allele` have complementary jobs, and this shape falls between them.

`clamp_sibling_crossing_shifts` (`src/normalize/merge.rs:7121`) refuses a member that **grew** — deliberately, per #1266/#1279: "an insertion canonicalising to a duplication moves its span and its junction together, so bounding the span mis-places the copy". It defers that shape to the junction clamp.

`clamp_sibling_crossing_junctions` (`src/normalize/merge.rs:7748`) opened with

```rust
let (Some(before_junction), Some(after_junction)) = (b.junction, a.junction) else { continue; };
```

and `junction_of` (`src/normalize/merge.rs:7964`) reports a junction only for `Insertion` / `Duplication` / `DupIns`. So a member whose **before** form claims bases has no `before_junction` and the pass skips it entirely.

A member that arrives as a `delins` and normalizes into a `dup` is therefore bounded by **neither** pass, and its junction sweeps as far as the tract allows:

```
pass=0  [262_263insAG;264G>T;266T>A]
        per-member                        -> [264_265dup;264G>T;266T>A]
        clamp_sibling_crossing_junctions  -> [263_264insGA;264G>T;266T>A]   (fires: before form is an ins)
pass=1  merge_consecutive_edits           -> [264delinsGAT;266T>A]
        canonical_split + normalize_core  -> [268_269dup;266T>A]            <-- junction 264 -> 269,
                                                                                over the 266T>A sibling
        clamp_sibling_crossing_shifts     :  declines (the member grew)
        clamp_sibling_crossing_junctions  :  declines (before has no junction)
```

## The fix

`junction_of` is right that a `delins` does not *occupy* a junction. It is wrong about the member: `g.264delinsGAT` on a `G` is one two-base insertion wearing a span, and once reduced its payload lands at a junction and shifts like any other. That junction is not stated, but it is bounded — reducing a span `[s, e]` to a pure insertion trims a common prefix or a common suffix, so the payload lands somewhere in `[s - 1, e]`, the member's own footprint.

New `reduced_before_junction` supplies the edge of that footprint on the side the member travelled *from*. It is the weakest bound the clamp can be given: it never pulls a member back past where it began, and a junction still inside the footprint reports no crossing at all, so only a sibling genuinely outside the footprint can bound anything.

Its doc comment carries the ownership table for the two clamps, per before/after form, since the whole defect is a shape neither owned. One row — a claims-bases member reducing to a *shrinking* `dup` — is now reached by both, and they compose: each walks the member back only as far as where it started, so applying both cannot overshoot, and the junction pass re-reads its spans after the span pass has mutated the list.

## Sibling sweep

A wrong-anchor bug is unlikely to be unique to one shape, so the corpus was swept for any output whose applied sequence differs from its input's. The applier is a transcription of `cis_apply_oracle::apply_parsed_reason`, independent of the normalizer; the corpus is the eight deterministic 20-mers the committed sweeps already generate.

| arm | 3-member alleles | seq-changed | no resulting seq | spanning-delins | seq-changed | no resulting seq |
|---|---:|---:|---:|---:|---:|---:|
| `main` | 2,885,120 | **388** | 273 | 2,743,882 | **15** | 14 |
| this PR | 2,885,120 | **82** | 237 | 2,743,882 | **0** | **0** |

Unique failing inputs **534 -> 206**, with **zero new** (`comm -13` over the two arms' sorted input sets). Strictly monotone.

Dumping every one of the 5,629,002 rows on both arms and diffing them line by line, **371 rows move** — and the two accounts reconcile exactly:

| moved rows | were | |
|---:|---|---:|
| 306 | denoting the wrong bases (3-member) | 388 -> 82 |
| 36 | denoting no sequence at all, members overlapping (3-member) | 273 -> 237 |
| 15 | denoting the wrong bases (spanning delins) | 15 -> 0 |
| 14 | denoting no sequence at all (spanning delins) | 14 -> 0 |
| **371** | **total** | |

So **every row that moves was already broken**, and no row that already denoted its input's bases changes. This is a correctness repair with no respelling component on this corpus.

**The first version of this sweep reported a false zero on both arms**, and that is worth stating rather than hiding. With a member menu whose insertion payload is one base chosen to differ from both neighbours — exactly how the committed `cis_junction_crossing_shift` sweep chooses it — the shape is structurally unbuildable: it needs a **two-base** insertion whose first base equals the reference base a sibling substitution sits on, because only then does the merged `delins` have a common prefix and reduce to a pure insertion. That, plus the committed sweep being two-member only, is why 380k committed cases never saw this.

The residual 206 are pre-existing, are a different root cause, and are filed as #1597 rather than fixed here: 196 are two junction-occupying members with a substitution between them (the #1286/#1290/#1308/#1312 payload-order family), and 10 are a member re-spelled as a repeat whose widened tract swallows a sibling, which `demote_repeats_spanning_siblings` does not catch.

## Why the seam oracles missed a wrong-sequence output

`FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS` all pass on both reproducers. The outputs are fixed points, they re-parse, and they are in bounds. **None of the three compares the sequence the output denotes with the sequence the input denotes**, which is the only property violated — so this class is structurally invisible to all three, not merely missed by them.

`canonicalize_from_sequence` does carry that comparison (`reapplied != result`, plus a `debug_assert`), but it covers only the members that pass builds. The corruption here happens afterwards, in the per-member re-normalization the caller runs on the derived members, which is outside that guard.

That is an argument for a **fourth seam oracle** at `normalize_core_checked` — apply input and output to the reference and compare — which would also have caught #1254, #1281, #1290, #1304, #1308 and #1312. It is not added here: it needs a provider at that seam and a decision about an input that denotes no single sequence, which is more than this fix should carry.

## Tests

`tests/it/issue_1592_reduced_member_junction_clamp.rs`, six tests, every assertion routed through `cis_apply_oracle::apply_with` — the SPDI-splicing applier — with the sequence identity checked **before** the string comparison, so a re-blessed expectation cannot carry a changed sequence with it. `EquivalenceChecker` is deliberately not used: it normalizes both sides, so comparing a normalized result against anything returns `Identical` tautologically.

Four of the six fail on `main`. The two that pass are pinned deliberately: the bracketed spelling that already reached the right answer, so the fix is shown to *converge* the two spellings rather than merely move one, and a member with no sibling in its way, so the bound is shown to come from a sibling rather than from the reducing member's own shape.

## Verification

- `cargo nextest run --features dev --no-fail-fast`, `FERRO_MANIFEST` unset: **9786 run, 9786 passed, 0 failed, 150 skipped**. Nothing re-blessed — for an output-moving change, every existing expectation already agreed with the new answer.
- The same with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1`: **9786 passed**, no oracle fires.
- The same with `FERRO_MANIFEST` pointed at a prepared reference: **9785 passed, 1 failed** — `multi_member_cis_axis::axis_normalized`, which is deliberately red on `main` with a manifest set (census 395 against a pinned 376) and whose census reports `sequence_changed: 0` either way.
- `cargo fmt --all --check` and `cargo clippy --features dev --all-targets` clean.
- No `*_strategy()` function is touched, so no pinned proptest seed is invalidated; `tests/proptest-regressions/` is unchanged.

Closes #1592

Representation-Change: 371 rows move of 5,629,002 swept; all 371 were previously incorrect — 321 denoted the wrong bases outright and 50 denoted no sequence at all because their members overlapped. This is a correctness repair, not a respelling: no row that already denoted its input's bases changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected normalization for span-consuming variants that reduce to insertions at junctions.
  * Prevented normalized variants from incorrectly crossing sibling boundaries while preserving valid shifting behavior.
  * Ensured consistent results regardless of authored member order and maintained sequence equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->