### PR TITLE
fix(normalize): demote a tract-wide repeat that a reducing delins grew

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7357,9 +7357,19 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
 /// Re-spell as the plain edit it grew from any cis member whose repeat notation
 /// spans a sibling's bases.
 ///
-/// Covers all three sources, not deletions alone: a repeat grown from a
+/// Covers all four sources, not deletions alone: a repeat grown from a
 /// `Deletion` re-spells as a deletion, and one grown from a `Duplication` or an
-/// `Insertion` as a duplication over the tract's 3'-most bases. Demoting an
+/// `Insertion` as a duplication over the tract's 3'-most bases. A `Delins` goes
+/// **either** way, decided by its net length change rather than by its edit
+/// type: net-positive takes `RepeatSource::Added` and re-spells as a
+/// duplication, net-negative takes `RepeatSource::Removed` and re-spells as a
+/// **deletion**, and net-zero is no growth at all so the member is skipped
+/// here entirely.
+/// The `Delins` source is #1600 and is the one that makes this pass complete
+/// rather than nearly so: the two sibling clamps hand a tract-wide repeat here
+/// because neither can bind one (see the ownership table on
+/// [`reduced_before_junction`]), so any `before` form this match does not
+/// recognise is a shape no pass bounds at all. Demoting an
 /// insertion to a *duplication* rather than back to an insertion is deliberate
 /// and load-bearing: a duplication's payload is read from the reference under
 /// its span, so it is in phase at whatever position it lands on, whereas an
@@ -7446,6 +7456,31 @@ pub(crate) fn demote_repeats_spanning_siblings<P: ReferenceProvider>(
                 .len()
                 .and_then(|n| i64::try_from(n).ok())
                 .map(|n| (RepeatSource::Added, n)),
+            // A `delins` is the #1592 family's signature, one step further
+            // along: the per-member pipeline reduces it to the pure insertion
+            // or deletion it stands for, that reduction lands in a tandem
+            // tract, and `deletion_to_repeat`/`insertion_to_repeat` then spell
+            // the result as a copy count over the **whole** tract. Skipping it
+            // here left the tract spanning a sibling with no pass able to see
+            // it: a repeat states no junction, so
+            // `clamp_sibling_crossing_junctions` has nothing to bound, and
+            // `clamp_sibling_crossing_shifts` declines a member that grew
+            // (#1266/#1279), deferring to exactly that clamp.
+            //
+            // The quantity the three arms above compute is the member's **net
+            // length change** — bases removed for a deletion, bases added for
+            // a duplication or an insertion — and a `delins` states it
+            // directly, as its payload length against its own span. An equal
+            // exchange changes no length, so no repeat can have grown or shrunk
+            // out of it and there is nothing to re-spell.
+            NaEdit::Delins { sequence, .. } => sequence
+                .len()
+                .and_then(|n| i64::try_from(n).ok())
+                .and_then(|alt_len| match alt_len - (b.end - b.start + 1) {
+                    0 => None,
+                    net if net > 0 => Some((RepeatSource::Added, net)),
+                    net => Some((RepeatSource::Removed, -net)),
+                }),
             _ => None,
         }) else {
             continue;
@@ -8104,14 +8139,29 @@ pub(crate) fn clamp_sibling_crossing_junctions<P: ReferenceProvider>(
 /// | claims bases | `dup`/`dupins`, grew | declines — the #1266/#1279 refusal | **owns**, via this function |
 /// | claims bases | `dup`/`dupins`, shrank | bounds the span | also bounds the junction |
 /// | `ins`/`dup` | `ins`/`dup` | bounds a `dup` that translated | **owns** |
+/// | claims bases | `repeat` | declines if it grew | inert — a repeat states no junction |
 ///
-/// Row four is the only one both act on, and they compose: each pass walks the
-/// member back **toward** where it started and neither may pass that point, so
-/// applying both cannot overshoot. The junction pass re-reads its `post` spans
-/// from `after` after the span pass has mutated it, so the second bound is
-/// measured against the first's result rather than against a stale snapshot.
+/// Row four is the only one the two clamps both act on, and they compose: each
+/// pass walks the member back **toward** where it started and neither may pass
+/// that point, so applying both cannot overshoot. The junction pass re-reads its
+/// `post` spans from `after` after the span pass has mutated it, so the second
+/// bound is measured against the first's result rather than against a stale
+/// snapshot.
 ///
 /// Row two and row three are the ones that previously had no owner.
+///
+/// **Row six is owned by neither clamp, and that is not a gap — it is a third
+/// pass.** `insertion_to_repeat` / `deletion_to_repeat` spell a reduction that
+/// lands in a tandem tract as a copy count over the *whole* tract, and a repeat
+/// states no junction at all, so nothing here can bound it. What restores a
+/// bindable form is [`demote_repeats_spanning_siblings`], which runs *before*
+/// both clamps and re-spells such a repeat as the plain `dup`/`del` it grew out
+/// of — after which the row becomes row three or row four and is owned as
+/// usual. So the partition is only complete while that pass covers every
+/// `before` form that can reduce into a tract: it was keyed on
+/// `Deletion`/`Duplication`/`Insertion` alone, which excluded the very
+/// `delins` this function exists for, and #1600 is the resulting fall-through
+/// (`g.261_267delinsGCAGAAAC` -> `g.[261del;266_267insCA]`, different bases).
 fn reduced_before_junction(before: &MemberSpan, after_junction: i64) -> Option<i64> {
     // An edit that claims no bases and states no junction — there is no
     // footprint to read a starting junction off.

--- a/tests/it/issue_1600_reduced_delins_tract_demotion.rs
+++ b/tests/it/issue_1600_reduced_delins_tract_demotion.rs
@@ -1,0 +1,193 @@
+//! A reducing `delins` that lands in a tandem tract must not swallow a sibling.
+//!
+//! #1600 is #1592's family one step further along, and it is a **wrong-sequence**
+//! defect: on `main` a spanning `delins` normalizes to a description that denotes
+//! different bases than its input.
+//!
+//! ```text
+//! reference   ("ACGT" x 64) + "GAACAGCAGAAGCGA" + ("ACGT" x 64)   core base 1 at g.257
+//! ref 257..272 = GAACAGCAGAAGCGAA
+//!
+//! g.261_267delinsGCAGAAAC  ->  g.[261del;266_267insCA]
+//!   intended  ... G A A C   G C A G A A   A C   G C G A ...
+//!   emitted   ... G A A C   G C A G A     C A   A G C G A ...
+//! ```
+//!
+//! The mechanism runs through three passes, each individually right:
+//!
+//! 1. the sequence-first derivation reaches `g.[261del;263_264insAG;265G>A;267A>C]`,
+//!    and its round-trip guard confirms that denotes the input's sequence;
+//! 2. `merge_consecutive_edits` merges the insertion with the neighbouring
+//!    substitution into `g.265delinsGAA` — a **`delins` that reduces**, which is
+//!    #1592's signature;
+//! 3. the per-member pipeline reduces it to a two-base insertion at gap 265,
+//!    3'-shifts it through the `A` tract to gap 267, and `insertion_to_repeat`
+//!    spells the result as a copy count over the whole tract: `g.266_267A[4]`.
+//!    That span covers `g.267`, which the sibling `267A>C` claims.
+//!
+//! Nothing then pulls it back. `clamp_sibling_crossing_shifts` declines a member
+//! that grew (`[265,265]` -> `[266,267]`), deliberately, per #1266/#1279;
+//! `clamp_sibling_crossing_junctions` needs a junction and `junction_of` reports
+//! none for a `Repeat`; and `demote_repeats_spanning_siblings` — the pass that
+//! exists to convert such a repeat into a form the clamps *can* see — detected
+//! the spanning correctly and then bailed, because its `RepeatSource` match had
+//! arms for `Deletion`, `Duplication` and `Insertion` only. A `delins` before-form
+//! yielded no source, so the member was skipped by all three.
+//!
+//! The output is well-formed, its members are disjoint, no warning is raised, and
+//! it re-parses, is in bounds and is a fixed point — so all three seam oracles
+//! (`FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS`)
+//! pass on it. None of them compares the denoted sequence, which is the only
+//! property it violates, so every assertion here goes through
+//! `cis_apply_oracle::apply_with`: it splices the reference from each member's
+//! SPDI triple **without** the normalizer. `EquivalenceChecker` cannot serve —
+//! `check()` normalizes both operands, so comparing a normalized result against
+//! anything returns `Identical` tautologically.
+//!
+//! # What the pinned strings are, and where their authority comes from
+//!
+//! Each test below asserts an **exact** output. Two different claims are stacked
+//! in that one assertion and they have different warrants, so they are worth
+//! separating — reading the string as self-justifying is the trap.
+//!
+//! * **The question.** Once the reduced insertion lands in the `AA` tract, more
+//!   than one rendering denotes the input's bases. Sequence equivalence settles
+//!   **validity, not canonicality**: `apply_with` can prove an output wrong, and
+//!   can never prove it is the one to emit. That is exactly the defect this
+//!   module documents — every wrong output above is *also* well-formed,
+//!   in-bounds, re-parsing and idempotent.
+//! * **The ruling.** A repeat whose tract spans a sibling's bases is demoted to
+//!   the plain edit it grew from, so the sibling stays visible to the clamps;
+//!   the member is then bounded rather than allowed to sweep the tract. #1600 is
+//!   the `Delins` source of that rule and #1592 is its sibling.
+//! * **The authority.** A house rule, **not** a spec clause — no clause in
+//!   `assets/hgvs-nomenclature` speaks about one cis member bounding another's
+//!   shift, and per `CLAUDE.md` the cross-zone comparison this rests on is
+//!   ferro's policy rather than compliance. The governing record is
+//!   `rulings[canonical-form-choice-when-both-legal]` (`decided`): among legal
+//!   descriptions ferro re-derives from the resulting sequence and emits what
+//!   falls out, rather than preserving the input's spelling or the
+//!   previously-shipped string.
+//!
+//! So the **sequence identity** is the load-bearing assertion and fails if the
+//! allele stops denoting its input's bases; the string equality is a *record* of
+//! the canonical choice under that rule. A change to it is a representation
+//! change to declare and re-bless deliberately — not a test to repair by pasting
+//! in the new output.
+
+use crate::common::cis_apply_oracle::apply_with;
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// The core every case here is drawn against.
+///
+/// Two features make the shape reachable: the `AGCAGAAG` stretch gives the
+/// sequence-first derivation an interior alignment match to split on, and the
+/// `AA` at `g.266_267` is the two-base tract the reduced insertion shifts into
+/// and gets spelled as a copy count over.
+const CORE: &str = "GAACAGCAGAAGCGA";
+
+/// Normalize `input` against [`CORE`] in `direction`, assert the output denotes
+/// the same bases the input does, and return the rendered output.
+///
+/// The sequence check runs **before** the caller compares strings, matching
+/// `issue_1592_reduced_member_junction_clamp.rs` and for the same reason: a
+/// string mismatch asserted first would mean the sequence check never ran, so a
+/// re-blessed expectation could silently carry a changed sequence with it. Here
+/// the sequence is the assertion and the string is the record.
+fn normalized_preserving_in(input: &str, direction: ShuffleDirection) -> String {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    let reference = padded(CORE);
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(direction),
+    );
+    let output = normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string();
+
+    let from_input = apply_with(&provider, &reference, input).expect("input applies");
+    let from_output = apply_with(&provider, &reference, &output).unwrap_or_else(|| {
+        panic!("`{input}` -> `{output}` has no resulting sequence (overlapping or unconvertible)")
+    });
+    assert_eq!(
+        from_output, from_input,
+        "`{input}` -> `{output}` denotes a different sequence"
+    );
+    output
+}
+
+/// [`normalized_preserving_in`] in the default 3' direction.
+fn normalized_preserving(input: &str) -> String {
+    normalized_preserving_in(input, ShuffleDirection::ThreePrime)
+}
+
+#[test]
+fn a_reducing_delins_landing_in_a_tract_stops_at_its_sibling() {
+    // The reproducer. On `main` this emits `g.[261del;266_267insCA]`, which
+    // denotes `...GCAGA CA A GCGA...` where the input denotes
+    // `...GCAGAA AC GCGA...` — the `apply_with` comparison in the helper is what
+    // fails there, before the string is ever compared.
+    let output = normalized_preserving("NC_TEST.1:g.261_267delinsGCAGAAAC");
+    assert_eq!(output, "NC_TEST.1:g.[261del;267_268insAC]");
+}
+
+#[test]
+fn the_bracketed_spelling_of_that_haplotype_agrees() {
+    // The same haplotype written as two members. It was already correct — the
+    // input-relative weight bound in `canonicalize_from_sequence` declines the
+    // re-derivation for this spelling — and is pinned here so the fix is shown to
+    // *converge* the two spellings rather than merely to move one of them.
+    let output = normalized_preserving("NC_TEST.1:g.[261del;267_268insAC]");
+    assert_eq!(output, "NC_TEST.1:g.[261del;267_268insAC]");
+}
+
+#[test]
+fn a_wider_spanning_delins_over_the_same_block_agrees_too() {
+    // Padding the `delins` with unchanged flanks on both sides is a different
+    // window and a different input weight, and must not be a different answer.
+    let output = normalized_preserving("NC_TEST.1:g.260_268delinsCGCAGAAACG");
+    assert_eq!(output, "NC_TEST.1:g.[261del;267_268insAC]");
+}
+
+#[test]
+fn the_crossing_is_bounded_under_a_five_prime_shuffle_too() {
+    // The 5' direction reached a *different* wrong answer on `main`
+    // (`g.[261del;265_266insAC]`), so the mirror is asserted rather than assumed.
+    let output = normalized_preserving_in(
+        "NC_TEST.1:g.261_267delinsGCAGAAAC",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(output, "NC_TEST.1:g.[261del;267_268insAC]");
+}
+
+#[test]
+fn the_answer_does_not_depend_on_the_authored_member_order() {
+    let forward = normalized_preserving("NC_TEST.1:g.[261del;267_268insAC]");
+    let reverse = normalized_preserving("NC_TEST.1:g.[267_268insAC;261del]");
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn a_lone_reducing_delins_still_reaches_its_repeat_spelling() {
+    // The guard against over-clamping, and the reason the fix belongs in
+    // `demote_repeats_spanning_siblings` rather than in the tract spelling: with
+    // no sibling under the tract, the copy-count form is correct and must
+    // survive. `g.265delinsGAA` is the exact member step 2 above builds.
+    let output = normalized_preserving("NC_TEST.1:g.265delinsGAA");
+    assert_eq!(output, "NC_TEST.1:g.266_267A[4]");
+}
+
+#[test]
+fn a_sibling_clear_of_the_tract_does_not_bound_it() {
+    // Same member, now in an allele — but with the sibling outside the tract, so
+    // the demotion must not fire and the repeat spelling must still stand. This
+    // is the case that fails if the new `Delins` arm is made unconditional
+    // instead of gated on the tract actually spanning a sibling.
+    let output = normalized_preserving("NC_TEST.1:g.[261del;265delinsGAA]");
+    assert_eq!(output, "NC_TEST.1:g.[261del;266_267A[4]]");
+
+    let distant = normalized_preserving("NC_TEST.1:g.[258A>T;265delinsGAA]");
+    assert_eq!(distant, "NC_TEST.1:g.[258A>T;266_267A[4]]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -23,6 +23,7 @@ mod issue_1472_zero_length_read;
 mod issue_1524_adjacent_split_members;
 mod issue_1539_split_member_separation;
 mod issue_1592_reduced_member_junction_clamp;
+mod issue_1600_reduced_delins_tract_demotion;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Stacked on **#1598**. Same defect family, and the two touch the same clamp cluster, so this rebases onto `main` once #1598 lands.

`main` normalizes a spanning `delins` into a description that denotes **different bases** than its input.

```
reference   ("ACGT" x 64) + "GAACAGCAGAAGCGA" + ("ACGT" x 64)   core base 1 at g.257
ref 257..272 = GAACAGCAGAAGCGAA

g.261_267delinsGCAGAAAC  ->  g.[261del;266_267insCA]      (3')
g.261_267delinsGCAGAAAC  ->  g.[261del;265_266insAC]      (5')

  intended  ... G A A C   G C A G A A   A C   G C G A ...
  emitted   ... G A A C   G C A G A     C A   A G C G A ...
```

## Reachability, measured before choosing where the fix lands

This was the first question, because it decides whether the fix belongs here or on the branch that removes the input-relative weight bound.

**It is live on `origin/main` today.** Byte-identical outputs at `origin/main` (`112ef784`) and at #1598's head (`04e38d69`), for every spanning spelling of the haplotype:

| input (each denotes the intended sequence) | `origin/main`, 3' | 5' |
|---|---|---|
| `g.[261del;267_268insAC]` | fixed point, correct | fixed point, correct |
| **`g.261_267delinsGCAGAAAC`** | **`g.[261del;266_267insCA]`, wrong bases** | **`g.[261del;265_266insAC]`, wrong bases** |
| `g.260_268delinsCGCAGAAACG` | same wrong output | same wrong output |
| `g.261_268delinsGCAGAAACG` | same wrong output | same wrong output |

So this is an independent bug fix, handled exactly as #1592 was, rather than something folded into the weight-bound branch. That branch only *widens* the exposure: with the bound gone the bracketed spelling reaches the same path, at roughly 1 in 3,750 draws of `cis_allele_confluence_proptest::an_indel_haplotype_normalizes_to_its_own_sequence`.

It is also a non-confluence — the bracketed spelling is already correct, so the two spellings disagree about the sequence, not merely about the string.

## Mechanism

`canonicalize_from_sequence` is not at fault; its round-trip guard holds at every pass. The corruption is in the per-member pipeline it alternates with:

1. the sequence-first derivation reaches `g.[261del;263_264insAG;265G>A;267A>C]` — correct;
2. `merge_consecutive_edits` merges the insertion with the neighbouring substitution into `g.265delinsGAA` — correct, and a **`delins` that reduces**, which is #1592's signature;
3. the per-member pipeline reduces it to a two-base insertion at gap 265, 3'-shifts it through the `A` tract to gap 267, and `insertion_to_repeat` spells the result as a copy count over the whole tract: `g.266_267A[4]`. That span covers `g.267`, which the sibling `267A>C` claims. The allele now overlaps, and the next sequence-first pass reads the overlap and seals in the wrong bases.

Nothing pulls it back, because all three sibling passes decline it:

| pass | why |
|---|---|
| `clamp_sibling_crossing_shifts` | the member **grew** (`[265,265]` → `[266,267]`) — the deliberate #1266/#1279 refusal, which defers the shape to the junction clamp |
| `clamp_sibling_crossing_junctions` | `junction_of` reports a junction only for `Insertion`/`Duplication`/`DupIns`; a `Repeat` has none |
| `demote_repeats_spanning_siblings` | detects the spanning correctly, then bails: its `RepeatSource` match had arms for `Deletion`, `Duplication` and `Insertion` only, so a `Delins` before-form yields no source |

#1598 added `reduced_before_junction` with an ownership table stating how the two clamps partition the space by (before form, after form). **That table had no `after = repeat` row.** Repeat notation is not owned by either clamp — it is handled by the third pass above, which converts it into a form a clamp *can* bind — so the partition is complete only while that pass covers every `before` form that can reduce into a tract. It did not cover the very `delins` `reduced_before_junction` exists for.

## Fix

Give `demote_repeats_spanning_siblings`' `RepeatSource` match a `NaEdit::Delins` arm. The quantity its three existing arms compute is the member's **net length change** — bases removed for a deletion, bases added for a duplication or an insertion — and a `delins` states it directly as its payload length against its own span. An equal exchange changes no length, so no repeat can have grown or shrunk out of it and there is nothing to re-spell.

`g.266_267A[4]` then demotes to `g.266_267dup`, `clamp_sibling_crossing_junctions` bounds that to `g.266_267insAA`, and the allele settles on `g.[261del;267_268insAC]` — the sequence the input denotes, and the string the bracketed spelling already reached, in both directions.

The ownership table gains the missing row and names this pass as its owner, since the table's claim to partition the space is what made the fall-through invisible.

## Representation-Change

The declaration is the `Representation-Change:` trailer at the **end** of this description — it has to be the last thing here, because GitHub builds the squash commit body from this description and `release-plz.toml` matches the trailer as a commit **footer**. A trailer buried mid-body (as this one was, inside a code fence) is found by `check_representation_change.py` but not by git-cliff, so the commit is filed outside the **Representation changes** section and `Changelog grouping audit` fails.

`examples/dump_normalized_corpus.rs` reports **`0 of 78,298`** against `04e38d69`, across all 16 shape families. **Do not read that as evidence.** The property this change keys on is a `delins` (or a pair that merges into one) whose reduction lands in a tandem tract carrying a sibling, and the corpus cannot build it: `delins` inputs come only from `split_vs_spanning_delins` (9,216), `delins_hiding_an_inversion` (8,640) and `separated_revcomp_runs` (180), and **none of those families ever yields repeat notation** — the 2,670 rows whose output carries a copy count all come from `adjacent_junction_ins`, `dup_plus_sub`, `dup_plus_ins`, `junction_interior_to_span`, `del_plus_sub` and `repeat_expansion`, none of which builds a `delins`. The two halves never meet, so the zero is a claim about the corpus. Adding that family is worth doing and is not done here.

**Direction of the move, stated explicitly.** Every row this changes previously denoted **different bases than its input**; afterwards it denotes the input's bases. So the move is toward correctness on the one oracle that can adjudicate it — `cis_apply_oracle::apply_with`, which splices the reference from each member's SPDI triple *without* the normalizer, and is therefore genuinely independent of the code under test. There is no correct stored string to migrate away from, because the strings that move were wrong.

Deliberately **not** claimed: agreement with Mutalyzer or biocommons. That was not measured here, and per `CLAUDE.md` Mutalyzer is a method to emulate rather than a spec oracle — its normalizer minimises a weighted description length with constants dated 2014 — so asserting an oracle direction on this shape would be an unmeasured claim. The sequence the description denotes is the authority that applies.

The evidence that *is* load-bearing:

- **9,793 tests pass with `FERRO_SWEEP_SEEDS=full` and nothing re-blessed.** For an output-moving change that is the strong signal: every existing expectation already agreed with the new answer.
- **The new arm is exercised and its reach is bounded.** Instrumented over the full suite with full sweeps, the `Delins` arm is entered **113** times (111 `Added`, 2 `Removed` — the latter from `cis_confluence_axis::three_prime_confluence_census`, so both branches are live corpus-covered code), and reaches the demotion **4** times, all of them the two distinct members of this PR's own reproducer. Everything else bails on `spans_sibling`, which by construction fires only where the tract meets a sibling's span or junction in one of the two snapshots — i.e. only on descriptions that are overlapping in at least one snapshot.

## Tests

`tests/it/issue_1600_reduced_delins_tract_demotion.rs`, 7 tests. Every assertion goes through `cis_apply_oracle::apply_with`, which splices the reference from each member's SPDI triple **without** the normalizer, and the sequence is asserted **before** the string, so a re-blessed expectation cannot silently carry a changed sequence. `EquivalenceChecker` cannot serve here — `check()` normalizes both operands, so comparing a normalized result against anything returns `Identical` tautologically (`issue_1234_sibling_clamped_shift.rs:198`).

Without the fix: **3 fail on the sequence assertion, 4 controls pass**. Two of the controls are the anti-over-clamping guards — a lone `g.265delinsGAA` must still reach `g.266_267A[4]`, and so must the same member beside a sibling that is clear of the tract.

Note what none of the seam oracles can see: the defective output is well-formed, disjoint, warning-free, in bounds, re-parses and is a fixed point, so `FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS` all pass on it. Oracle-clean is necessary and nowhere near sufficient for this defect class.

## Verification

- `cargo nextest run --features dev` with `FERRO_SWEEP_SEEDS=full`: **9,793 passed, 150 skipped, 0 failed.**
- The same run with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1`: **9,793 passed, 0 failed**, none of the three fired.
- `cargo fmt --all --check` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean.
- `PROPTEST_CASES=30000 cargo nextest run -E 'test(cis_allele_confluence_proptest)'`: all 9 pass. `tests/proptest-regressions/` is **untouched** (`git status --porcelain` empty), and no strategy was changed, so no pinned seed is invalidated.

## Two findings for the weight-bound branch, measured here

**This unblocks it, on the evidence available.** With the input-relative weight bound deleted in this worktree *and* this fix applied, `an_indel_haplotype_normalizes_to_its_own_sequence` passes at **20,000 cases** — against a reported rate of about 1 in 3,750, so roughly five expected hits.

**The `clamp_sibling_crossing_shifts` 5' junction filter is still guarded on this base, and unguarded only once the bound goes.** Deleting `.filter(|_| a.junction.is_none())` here fails `cis_junction_crossing_shift::a_third_member_clear_of_the_tract_keeps_the_duplication_reaching_its_five_prime_most_position`. Deleting the weight bound moves that test's pin (to `g.[5_10delinsCTATAT;16A[3]]`), and with the bound gone, removing the filter as well leaves the failure set **byte-identical** — 27 failures either way over the full-sweep suite. So the coverage loss is real but belongs to the branch that causes it; no guard is added here, because a guard for that configuration cannot be validated on this one. Filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeat normalization for sequence changes that replace or remove a DNA segment.
  * Correctly represents net sequence growth as a duplication and shrinkage as a deletion.
  * Preserves valid repeat spellings while preventing normalization from crossing unrelated sequence regions.

* **Tests**
  * Added coverage for normalization across tandem repeats, including multiple representations, directions, and member orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Representation-Change: the wrong-sequence outputs this fixes move — each previously denoted different bases than its input, so there is no correct stored string to migrate from. The committed corpus measures 0 changed of 78,298 rows compared, which is a STRUCTURAL zero for the reasons given above, and not evidence of safety.
