### PR TITLE
docs(readme): state the project's normalization ruleset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,24 @@ fix(normalize): correct boundary detection for UTR regions
 
 ### Declaring a representation change
 
-**Representation stability is a shipped guarantee.** The downstream consumer keys
-its read counts on the normalized HGVS string, so what matters is not which
-representation ferro picks but whether the pick *moves*. A canonical form that
-churns between releases silently re-buckets every stored design — a
-re-normalization of the consumer's whole library, not a bugfix they can ignore.
+This section is the mechanism for rule 7 of the project's
+[normalization rules](README.md#normalization-rules); read that section for what has to be
+disclosed, and this one for how to declare it.
+
+**Disclosure is the shipped guarantee — stability is not.** A downstream consumer
+keys its read counts on the normalized HGVS string, so a canonical form that
+churns between releases silently re-buckets everything already stored: a
+re-normalization of that consumer's whole library, not a bugfix they can ignore.
+That is why a move must never be silent — and *silent* is the part the project
+promises to avoid.
+
+It does **not** promise the string stays put. Every fix to rule 3 (*confluent*)
+picks a winner between two spellings, and whichever side loses is a
+representation change for someone; a project that refused to move a string could
+not converge on one. So the ranking is **confluence, then disclosure, then
+stability**. Where the spec permits either form *and confluence is unaffected
+either way*, the already-shipped representation is a reasonable tiebreaker — but
+it is a tiebreaker of last resort, never an argument against a confluence fix.
 
 So if your change can alter any normalized output string, say so in the commit,
 with a `Representation-Change:` trailer:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,84 @@ print(str(result.result))                      # the same normalized string
 print([(w.code, w.message) for w in result.warnings])
 ```
 
+## Normalization rules
+
+ferro's normalizer follows four rules about its output, and three about how it handles the gaps.
+
+### The output contract
+
+1. **Conformant.** Output follows the HGVS recommendations. *Absolute — never traded.*
+   Scope: the `syntax.yaml` grammar, plus every prohibition, read from **prose force** rather than
+   keyword casing — "not allowed", "not correct", "can not be used", "by definition", the
+   `class="invalid"` markup, and the set `checklist.md` enumerates.
+
+2. **Recommended form.** Where the spec prefers among conformant forms, ferro produces it.
+   *Best effort.*
+   Scope: "recommended", "preferred", lowercase "should", the 3' rule. A preference clause outranks
+   maintainer judgment.
+
+3. **Confluent.** Inputs denoting one variant produce one output. *Best effort.*
+   Every rule is evaluated over the **resulting sequence**, never over the input's spelling.
+
+4. **Deterministic.** Same input, same output. *Absolute.*
+   Note that 4 does not imply 3 — a deterministic normalizer can be arbitrarily non-confluent.
+
+### The procedure
+
+5. **Where the spec is silent, ambiguous, or self-contradictory:** the issue is filed upstream
+   **first** and cited, and only then does ferro ship a provisional choice.
+    - **Self-contradictory** — two clauses that cannot both hold — is a **defect**. Every conforming
+      tool must pick a side and none of them can be right, so filing is a bug report and is not
+      optional.
+    - **Silent** is merely incomplete. Ferro decides under rule 6 and violates nothing; filing is a
+      feature request, worth making but never a reason to hold a release.
+
+6. **Among multiple conformant forms:** the maintainers choose. **There are no user options for
+   normalization form.** Options remain available for orthogonal axes — error mode, 3'/5' direction.
+
+7. **Disclosure.** Any change to these rules, and any different choice made under 5 or 6, is
+   disclosed: in the changelog before v1, by a major version bump after. Output that *violates*
+   rules 1-4 is a **bug**, not a disclosure.
+
+### Why 2 and 3 are best effort, and 1 and 4 are not
+
+Rules 1 and 4 are always achievable. Conformance is checkable against the spec text, and
+determinism is a property of ferro's own code; nothing external can prevent us honouring them.
+
+Rules 2 and 3 depend on the spec **determining an answer**, and sometimes it does not:
+
+- **No preference exists.** The spec ranks substitution, deletion, inversion, duplication and
+  insertion, but says nothing about competing `delins` forms.
+- **Two preferences disagree.** `general.md` ranks duplication above insertion; `DNA/inversion.md`
+  prefers an insertion for inverted copies. No single output satisfies both.
+- **The same clause has two versions.** `general.md`'s current text and its forthcoming NOTE give
+  opposite answers for variants separated by one nucleotide.
+- **The variant's decomposition is not recoverable.** For an equal-length block the column
+  correspondence is unique, so "two variants separated by N nucleotides" is a fact about the
+  variant. For an unequal-length block there is no correspondence — recovering one means *choosing*
+  an alignment, and the spec does not say which. There is no derivable form to converge on.
+
+**"Best effort" is bounded by the spec's determinacy, not by ferro's implementation quality.** A
+failure of rule 2 or 3 caused by ferro's code is a **bug** under rule 7. Only a failure caused by
+the spec not determining an answer falls under best effort — and that triggers rule 5.
+
+### A worked example of reading force from prose
+
+`DNA/duplication.md` says a variant that *can* be described as a duplication **must** be — but the
+"must" is scoped by the preceding clause, which defines when a duplication *can* be used at all:
+only when the additional copy is directly 3'-flanking the original. So the rule ranks the *label*
+for one span; it does not require that a partition be chosen so as to produce a duplication.
+Reading the force without the scope inverts the rule.
+
+### Known limitation
+
+ferro cannot today guarantee that every input form is normalized according to these rules. They are
+enforced intent, not a claim of current completeness.
+
+Rule 7's disclosure mechanism — the `Representation-Change:` trailer and how it reaches the
+changelog — is documented in
+[CONTRIBUTING.md](CONTRIBUTING.md#declaring-a-representation-change).
+
 ## Supported HGVS Syntax
 
 | Type | Prefix | Example |

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -415,6 +415,7 @@ mod protein_silent_eq;
 mod protein_stop_codon_canonicalization;
 mod protein_substitution_alternatives;
 mod protein_unknown_roundtrip;
+mod readme_normalization_rules;
 mod real_data_normalization_tests;
 mod reject_coord_system_mismatch;
 mod reject_dupins;

--- a/tests/it/readme_normalization_rules.rs
+++ b/tests/it/readme_normalization_rules.rs
@@ -1,0 +1,249 @@
+//! Drift guard for the **Normalization rules** section of `README.md`.
+//!
+//! That section is the project's stated contract for what the normalizer's output
+//! is allowed to be: four rules about the output, three about the gaps. It is cited
+//! by rule number — from PR descriptions, from ruling records, and from
+//! `CONTRIBUTING.md`, whose "Declaring a representation change" section is rule 7's
+//! mechanism. A silent renumbering or a dropped rule turns every one of those
+//! citations into a pointer at the wrong text, and prose carries no compiler.
+//!
+//! This follows the shape of `tests/python/test_representation_change_trailer.py`,
+//! which pins the decline vocabulary across `release-plz.toml`, `CONTRIBUTING.md`
+//! and `scripts/check_representation_change.py` for the same reason: three copies of
+//! one statement drift, and the prose copy drifts first.
+//!
+//! Deliberately **not** a markdown parser. It asserts that seven known rule openers
+//! are present, exactly once each, in ascending order, and each under the subsection
+//! that classifies it — enough that an edit to the ruleset has to be deliberate, and
+//! little enough that rewording the body of a rule does not fail the build.
+//!
+//! Every assertion is scoped to the section it is about ([`section`]) rather than
+//! to the whole file, and the two cross-links are matched as whole Markdown tokens
+//! rather than as bare `#anchor` fragments. Both are the difference between "this
+//! string exists in a long document" and "the ruleset states this" — a guard
+//! satisfiable from a code block or an unrelated section is one that passes while
+//! the thing it guards is broken.
+//!
+//! Scoping is applied on **both** sides of each claim, which is a strictly stronger
+//! test than scoping one side. Pinning the rules' order without binding each rule to
+//! its half lets rule 4 be reclassified from the output contract to the procedure
+//! with every assertion still green; asserting CONTRIBUTING.md's backlink against
+//! the whole file lets it migrate out of the section a reader arriving from rule 7
+//! actually lands in.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+/// The Markdown section introduced by `heading`, up to the next heading at the
+/// same or a shallower level (or end of input).
+///
+/// Every assertion below runs against a slice rather than the whole file,
+/// because a whole-file search answers a weaker question than the one being
+/// asked. `README.md` is long and full of HGVS prose and fenced examples, so a
+/// rule opener or an organising heading appearing *anywhere* — a later section,
+/// a code block, a changelog snippet — would satisfy a whole-file `find` while
+/// the ruleset itself was incomplete or renumbered. That is the failure this
+/// guard exists to catch, so it must not be satisfiable from outside the
+/// section it guards.
+///
+/// The match is **line-anchored** (the whole trimmed line must equal `heading`)
+/// rather than a substring `find`. A substring search for `## Normalization
+/// rules` also matches inside a `### Normalization rules` heading, since `##`
+/// is a prefix of `###` — so a deeper heading added later would silently move
+/// where the slice begins.
+fn section<'a>(text: &'a str, heading: &str) -> &'a str {
+    let level = heading.chars().take_while(|c| *c == '#').count();
+    assert!(level > 0, "`{heading}` is not a Markdown heading");
+
+    let mut start = None;
+    let mut end = text.len();
+    let mut offset = 0usize;
+    for line in text.split_inclusive('\n') {
+        if start.is_none() {
+            if line.trim_end() == heading {
+                start = Some(offset);
+            }
+        } else {
+            // A heading at the same or a shallower level closes this section.
+            let depth = line.chars().take_while(|c| *c == '#').count();
+            if depth > 0 && depth <= level && line[depth..].starts_with(' ') {
+                end = offset;
+                break;
+            }
+        }
+        offset += line.len();
+    }
+
+    let start = start.unwrap_or_else(|| panic!("no `{heading}` heading found"));
+    &text[start..end]
+}
+
+/// The section heading, and the subsection headings that organise it.
+///
+/// Listed in the order they must appear: the two halves of the ruleset first
+/// (`The output contract` holds rules 1-4, `The procedure` holds 5-7), then the
+/// explanatory material.
+const HEADINGS: &[&str] = &[
+    "## Normalization rules",
+    "### The output contract",
+    "### The procedure",
+    "### Why 2 and 3 are best effort, and 1 and 4 are not",
+    "### A worked example of reading force from prose",
+    "### Known limitation",
+];
+
+/// The seven rules, by number and name, exactly as the README opens each one.
+///
+/// The name is part of the guard because the numbers alone are what a renumbering
+/// preserves: swapping two rules keeps `1.`..`7.` intact and silently re-points
+/// every "rule 5" citation in the repository.
+const RULE_OPENERS: &[&str] = &[
+    "1. **Conformant.**",
+    "2. **Recommended form.**",
+    "3. **Confluent.**",
+    "4. **Deterministic.**",
+    "5. **Where the spec is silent, ambiguous, or self-contradictory:**",
+    "6. **Among multiple conformant forms:**",
+    "7. **Disclosure.**",
+];
+
+#[test]
+fn readme_states_all_seven_normalization_rules() {
+    let readme = read("README.md");
+    let rules = section(&readme, "## Normalization rules");
+    let mut cursor = 0usize;
+    for opener in RULE_OPENERS {
+        assert_eq!(
+            rules.matches(opener).count(),
+            1,
+            "the `## Normalization rules` section must state `{opener}` exactly once; \
+             a rule was dropped, duplicated, or reworded"
+        );
+        let at = rules
+            .find(opener)
+            .expect("checked to occur exactly once just above");
+        assert!(
+            at >= cursor,
+            "the `## Normalization rules` section states `{opener}` out of order; \
+             the rules are cited by number, so reordering them re-points every \
+             existing citation"
+        );
+        cursor = at;
+    }
+}
+
+/// Each rule must sit under the subsection that classifies it.
+///
+/// [`readme_states_all_seven_normalization_rules`] pins the openers' *order*,
+/// which is a strictly weaker claim than the one the module doc makes: it walks
+/// the rules with one cursor and the headings with another, and the two never
+/// meet. Rule 4 could move below `### The procedure` — reclassifying an
+/// **Absolute** output-contract guarantee as procedure — and both walks would
+/// still pass, because the relative order of every opener and every heading is
+/// unchanged. The half a rule lives in is what says whether it is a promise
+/// about output or a step in handling a gap, so it is the part worth pinning.
+#[test]
+fn each_rule_sits_under_the_heading_that_classifies_it() {
+    const OUTPUT_CONTRACT: usize = 4; // rules 1-4; the rest belong to the procedure
+
+    let readme = read("README.md");
+    let rules = section(&readme, "## Normalization rules");
+    let output_contract = section(rules, "### The output contract");
+    let procedure = section(rules, "### The procedure");
+
+    let (contract_rules, procedure_rules) = RULE_OPENERS.split_at(OUTPUT_CONTRACT);
+    for (half, openers) in [
+        ("### The output contract", contract_rules),
+        ("### The procedure", procedure_rules),
+    ] {
+        let slice = if half == "### The output contract" {
+            output_contract
+        } else {
+            procedure
+        };
+        for opener in openers {
+            assert_eq!(
+                slice.matches(opener).count(),
+                1,
+                "`{opener}` must be stated exactly once under `{half}`; a rule that \
+                 crosses between the two halves changes what it claims — the output \
+                 contract binds ferro's output, the procedure only binds how gaps \
+                 are handled"
+            );
+        }
+    }
+}
+
+#[test]
+fn readme_keeps_the_headings_that_organise_the_rules() {
+    let readme = read("README.md");
+    let rules = section(&readme, "## Normalization rules");
+    let mut cursor = 0usize;
+    for heading in HEADINGS {
+        // Exactly once, not merely present: a duplicated organising heading
+        // splits the ruleset into two places, and `find` would happily anchor on
+        // whichever came first.
+        assert_eq!(
+            rules.matches(heading).count(),
+            1,
+            "the `## Normalization rules` section must carry the heading `{heading}` \
+             exactly once"
+        );
+        let at = rules
+            .find(heading)
+            .expect("checked to occur exactly once just above");
+        assert!(
+            at >= cursor,
+            "the `## Normalization rules` section states `{heading}` out of order"
+        );
+        cursor = at;
+    }
+}
+
+#[test]
+fn the_ruleset_and_its_disclosure_mechanism_point_at_each_other() {
+    // `CONTRIBUTING.md`'s trailer section is rule 7's mechanism, and rule 7 is that
+    // section's reason for existing. Either pointer going stale leaves a reader on
+    // one half of one statement.
+    let readme = read("README.md");
+    let contributing = read("CONTRIBUTING.md");
+
+    // Whole Markdown link tokens, not bare fragments: `contains("…#anchor")`
+    // also passes on prose that merely names the anchor, or on a stale reference
+    // left behind after the link itself was deleted.
+    //
+    // Both sides are asserted **inside** the section the link belongs to. The
+    // README side must sit in the ruleset, since rule 7 is what it belongs to;
+    // the CONTRIBUTING side must sit in `Declaring a representation change`,
+    // since that section is rule 7's mechanism. A whole-file `contains` on
+    // either side passes while the backlink has migrated somewhere the reader
+    // arriving from the other document will never reach — which is precisely
+    // the drift these two pointers exist to prevent.
+    //
+    // `section()` panics with a clear message when its heading is absent, so
+    // each call below doubles as the "the anchor still exists" assertion; the
+    // link targets are the two headings themselves.
+    let rules = section(&readme, "## Normalization rules");
+    let declaring = section(&contributing, "### Declaring a representation change");
+
+    assert!(
+        rules.contains("[CONTRIBUTING.md](CONTRIBUTING.md#declaring-a-representation-change)"),
+        "the `## Normalization rules` section must link to CONTRIBUTING.md's \
+         `Declaring a representation change` section, which is rule 7's mechanism"
+    );
+    assert!(
+        declaring.contains("[normalization rules](README.md#normalization-rules)"),
+        "CONTRIBUTING.md's `Declaring a representation change` section must link \
+         back to the README's normalization rules, so the trailer's purpose is \
+         reachable from the trailer's instructions"
+    );
+}


### PR DESCRIPTION
Adds the project's normalization ruleset to `README.md` as a new top-level **Normalization rules** section, placed immediately before **Supported HGVS Syntax**. Four rules about the normalizer's output — conformant, recommended form, confluent, deterministic — and three about how it handles the gaps: file upstream first, maintainers choose among conformant forms, disclose every change. It states which rules are absolute and which are best effort, and why the split falls where it does.

The ruleset was previously only implicit, spread across ruling records, `CONTRIBUTING.md`, and PR discussions. Rules are cited by number from all three, so giving them a single numbered home is the point of the change.

## Every spec claim in the section was verified against the pinned submodule

`assets/hgvs-nomenclature` @ `6f85311`. No line numbers went into the README — those rot, and line-precise citations belong in the ruling records — but each claim was checked:

| claim | verified at |
|---|---|
| a variant that can be described as a duplication **must** be | `DNA/duplication.md:18` |
| that "must" is scoped by "directly 3'-flanking" | `DNA/duplication.md:17`, the parent bullet of `:18`; restated at `:153` |
| the spec ranks substitution, deletion, inversion, duplication, insertion — and not `delins` | `general.md:56` |
| `general.md` ranks duplication above insertion | `general.md:56`, `:57`, `:109` |
| `DNA/inversion.md` prefers an insertion for inverted copies | `DNA/inversion.md:19`, with the reasoning in the Q&A at `:64-69` |
| current text and forthcoming NOTE disagree at a one-nucleotide separation | `general.md:34-35` (describe individually, exception only when together affecting one amino acid) against the NOTE at `:36-39` ("two variants separated by less than two nucleotides should be described as a delins") |
| `syntax.yaml` grammar, `checklist.md` prohibition set | `docs/syntax.yaml`; `docs/recommendations/checklist.md` |

One qualification on rule 1's scope list, reported rather than silently edited. Four of the five prohibition phrasings it names appear verbatim in `docs/recommendations/` — "not allowed" (21), "not correct" (31), "can not be used" (1), "by definition" (24). **"is invalid" does not appear as that exact string.** The spec marks invalid descriptions with `class="invalid"` markup instead (171 uses), and uses "invalid" in prose only in `grammar.md:23` and `consultation/SVD-WG011.md:21`. The rule's substance is unaffected — it says prohibitions are read from prose force rather than keyword casing, and that markup is exactly such a signal — but the phrase is an indicative example, not a quotation.

## Cross-links, both directions

`CONTRIBUTING.md`'s "Declaring a representation change" section is rule 7's mechanism. It now opens by saying so and links to the ruleset; the ruleset links back to it. Neither restates the other.

## Drift guard

`tests/it/readme_normalization_rules.rs` asserts the seven rules are present with their exact headings and numbering, in order, exactly once each, under the subsection headings that organise them — plus that the two cross-links and both of their anchors still exist.

It follows the shape of `tests/python/test_representation_change_trailer.py`, which pins the decline vocabulary across `release-plz.toml`, `CONTRIBUTING.md` and `scripts/check_representation_change.py` for the same reason: several copies of one statement drift, and the prose copy drifts first. Rules cited by number are the specific hazard — a renumbering keeps `1.`..`7.` intact while silently re-pointing every "rule 5" reference in the repository, so each rule's *name* is pinned alongside its number.

Deliberately not a markdown parser. Rewording the body of a rule does not fail the build; dropping, duplicating or reordering one does.

## Verification

- `cargo nextest run --features dev` — full suite green
- `cargo fmt --all --check` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo run --features dev --example generate_tool_support_tables -- --check` — exit 0, so the generated README tables are untouched by the insertion
- The inserted section was diffed byte-for-byte against the approved source text; the only difference is the blank line separating it from the cross-link paragraph that follows.

Representation-Change: none. Docs plus one new integration test; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched and no expectation was re-blessed.

---

## Answers #1099

This section is the project's answer to https://github.com/fulcrumgenomics/ferro-hgvs/issues/1099 —
*"how heavily does this project rely on 'spec compliance' as the primary bar for design decisions,
and to what extent is the project comfortable with opinionated decisions vs deferring choices like
this to the user via options?"* — asked 2026-07-22 and unanswered since.

Rules 1 and 2 answer the first half: spec compliance is the primary bar and is never traded, but it
cannot be the only bar, because the recommendations frequently determine no answer. Rules 5 and 6
answer the second half: where several forms are conformant the maintainers pick one, gaps go
upstream before a provisional choice ships, and there are no user options for normalization form —
a knob there would make confluence a property of *(input, config)* rather than of an input.

The issue is closed, so this PR does not comment on it. The README section stands as the answer and
can be linked whenever the question recurs.

## One correction to the approved text

Rule 1's scope list originally read `"is invalid"`. That exact string does **not** appear in
`docs/recommendations/` — invalid descriptions are marked with `class="invalid"` **markup** (171
uses), with prose "invalid" appearing only in `grammar.md` and `consultation/SVD-WG011.md`. The
other four phrasings are verbatim: "not allowed" (21), "not correct" (31), "can not be used" (1),
"by definition" (24).

Changed to name the markup instead. That is both accurate and stronger: structured markup is the
most reliable prohibition signal in the corpus, which makes rule 1 more actionable rather than less.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation describing ferro’s normalization rules, output guarantees, specification-gap handling, disclosure requirements, limitations, and examples.
  * Added contributor guidance linking the representation-change policy to the normalization rules.
* **Tests**
  * Added automated checks to verify the documented rules, headings, ordering, and reciprocal references remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->