### PR TITLE
feat(normalize): split an equal-length protein delins whose interior is unchanged

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2299,7 +2299,56 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &HgvsVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         let (normalized, warnings) = self.normalize_core(variant)?;
-        self.canonicalize_from_sequence(normalized, warnings)
+        let (normalized, warnings) = self.canonicalize_from_sequence(normalized, warnings)?;
+        Ok((self.split_protein_separation(normalized), warnings))
+    }
+
+    /// The protein-axis partition pass, run once at the top level.
+    ///
+    /// [`Self::try_protein_split_delins`] holds the rule and its citations; this
+    /// is only about **where** it runs. It runs here, beside
+    /// [`Self::canonicalize_from_sequence`] and for the same reason: the move
+    /// turns one member into several, so it belongs at the seam that sees the
+    /// whole description rather than in
+    /// [`normalize_protein`](Self::normalize_protein), which `normalize_allele`
+    /// re-enters once per member.
+    ///
+    /// Wiring it into `normalize_protein` was tried, and produced two defects
+    /// that every bare-description test passes straight over:
+    ///
+    /// ```text
+    ///   p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]
+    ///     -> [NP_003997.1:p.Ala60Gly;NP_003997.1:p.[Ser44Arg;Trp46Arg]]
+    ///   p.[Ser44_Trp46delinsArgLeuArg];[Ala60Gly]
+    ///     -> NP_003997.1:p.[Ser44Arg;Trp46Arg];[Ala60Gly]     (does not re-parse)
+    /// ```
+    ///
+    /// The first is a nested bracket carrying a repeated accession, which is not
+    /// a description at all. The second *is* legal HGVS — the DNA axis emits
+    /// `g.[A;B];[C]` and reads it back — but ferro's **protein** allele grammar
+    /// accepts only single-member arms, so normalization would emit a string
+    /// `parse_hgvs` refuses. That is exactly what `FERRO_ASSERT_REPARSE` exists to
+    /// catch, and its exemption list is closed on purpose.
+    ///
+    /// So the move applies to a whole `p.` description and **declines for a
+    /// member of one**: `p.[<separated delins>;…]` keeps its delins. Closing that
+    /// needs two decisions this pass deliberately does not take — where an inner
+    /// allele's `( )` marker goes once its members flatten into the outer bracket
+    /// (`protein/alleles.md:34` puts it per member, `:90` puts it round the group)
+    /// and a protein allele grammar that reads `p.[A;B];[C]`. Pinned by
+    /// `protein_axis_split_move::a_delins_inside_a_cis_allele_is_left_alone` and
+    /// its trans sibling.
+    fn split_protein_separation(&self, variant: HgvsVariant) -> HgvsVariant {
+        let HV::Protein(protein) = &variant else {
+            return variant;
+        };
+        match self.try_protein_split_delins(protein) {
+            Some(members) => {
+                let uncertain = protein.loc_edit.edit.is_uncertain();
+                wrap_allele_if_split(members.into_iter().map(HV::Protein).collect(), uncertain)
+            }
+            None => variant,
+        }
     }
 
     /// Normalize a variant, apply the strict-mode rejection ladder, and return
@@ -5750,6 +5799,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => final_variant,
         };
 
+        // NOTE: the protein-axis split move (`protein/delins.md:21`, `:64`) is
+        // deliberately NOT applied here. It turns one member into several, so it
+        // runs at the whole-description seam —
+        // [`Self::split_protein_separation`], called from
+        // `normalize_core_canonical` — which this method cannot be, because
+        // `normalize_allele` re-enters it once per member. That helper records
+        // what wiring it in here was measured to produce.
         Ok((HV::Protein(final_variant), warnings))
     }
 
@@ -6286,6 +6342,200 @@ impl<P: ReferenceProvider> Normalizer<P> {
             },
             Interval::new(dstart, dend),
         ))
+    }
+
+    /// The protein-axis split move: an **equal-length** `delins` whose interior
+    /// leaves at least one residue unchanged describes two or more separate
+    /// changes, not one `delins`.
+    ///
+    /// `recommendations/protein/delins.md:21` states it outright — "two variants
+    /// separated by one or more amino acids should be described individually and
+    /// not as a `delins`" — and `:64` publishes the worked answer:
+    /// `p.[Ser44Arg;Trp46Arg]`, with the explicit note that "the variant is
+    /// **not** described as `p.Ser44_Trp46delinsArgLeuArg`". This is the protein
+    /// analogue of the nucleotide separation rule (`general.md:34`) that
+    /// [`Self::apply_canonical_split`] applies via
+    /// [`rules::decompose_delins`](crate::normalize::rules::decompose_delins).
+    ///
+    /// # Why equal length, and only equal length
+    ///
+    /// A `delins` whose reference span and payload have the **same** length has
+    /// exactly one residue-wise correspondence, so "the middle residue is
+    /// unchanged" is a fact about the two sequences rather than a choice. An
+    /// unequal-length `delins` has no such correspondence: finding an unchanged
+    /// run inside it means first picking an alignment, and *which* alignment is
+    /// not determined by the reference and the payload — several are equally
+    /// good and they disagree about where the unchanged residue sits. On the
+    /// nucleotide axis that choice is settled by applying the edits to the
+    /// reference and re-deriving from the resulting sequence
+    /// (`canonical-form-choice-when-both-legal`), which is not available here:
+    /// there is no apply-to-reference on the protein axis, which is why
+    /// [`merge::cis_kind_of`](crate::normalize::merge) returns `None` for
+    /// `Protein`. With nothing to derive the answer from, ferro declines rather
+    /// than invent an alignment, and those are left as authored.
+    ///
+    /// The floor is **one** unchanged residue: `delins.md:21` says "separated by
+    /// one or more amino acids", and unlike the nucleotide axis there is no
+    /// codon carve-out here (`general.md:35-38` is a *reading-frame* exception,
+    /// and a protein description has no codons of its own to share).
+    ///
+    /// # Why this is not routed through the nucleotide canonicalizer
+    ///
+    /// [`merge::canonicalize_from_sequence`](crate::normalize::merge) applies the
+    /// edit set to a reference window and re-derives the partition from the
+    /// resulting sequence. There is no apply-to-reference on the protein axis —
+    /// [`merge::cis_kind_of`](crate::normalize::merge) returns `None` for
+    /// `Protein` for exactly that reason — so the move is implemented here, on
+    /// the reference residues themselves.
+    ///
+    /// # When it declines
+    ///
+    /// Returning `None` leaves the input `delins` exactly as authored. It
+    /// declines when:
+    ///
+    /// - the edit is not a `Delins`, or either endpoint is uncertain or a range
+    ///   (there is then no residue-wise correspondence to read);
+    /// - the payload length differs from the span, per the section above;
+    /// - the span is under three residues, which has no interior to be
+    ///   unchanged;
+    /// - **the protein reference is unavailable for this accession.** The
+    ///   unchanged middle residue is a claim about the *reference*, and the
+    ///   payload cannot testify to it: assuming `payload[i]` matches the
+    ///   reference is the guess this rule must never make. `has_protein_data()`
+    ///   is provider-wide, so the fetch itself is what decides (#1131);
+    /// - the reference span or the payload names an unknown residue (`Xaa`),
+    ///   where equality is not a statement about identity;
+    /// - **either side carries a `Ter`.** In the *payload*, a split across a stop
+    ///   would emit members 3' of it, which `delins.md:45` forbids ("amino acids
+    ///   after the translation termination codon are **not** listed"). In the
+    ///   *reference span*, a stop replaced by an ordinary residue is a
+    ///   **stop-loss**, and `extension.md:18` ranks it — "prioritisation: (1)
+    ///   extension, (2) frameshift or deletion-insertion" — so it is described
+    ///   with `ProteinEdit::Extension` (`:30`, `p.Ter110GlnextTer17`), never a
+    ///   substitution. Splitting `Ser-Leu-Ter` against a payload of
+    ///   `Ala-Leu-His` would emit `p.[Ser988Ala;Ter990His]`, which spells an
+    ///   extension as a substitution and states the wrong consequence. Both are
+    ///   the mirror of the `first_ter_pos` gate in
+    ///   [`merge::coalesce_protein_adjacent_changes`](crate::normalize::merge);
+    /// - **residue 1 is the changed one.** A member at the translation
+    ///   initiation codon renders as `p.Met1Xxx`, which `substitution.md:49`
+    ///   forbids ("not described as a substitution or as an extension") and
+    ///   which `parse_hgvs` refuses, so the split would emit a description ferro
+    ///   cannot read back. The correct description — `p.0`, `p.0?`,
+    ///   `p.(Met1?)`, or the insertion form when an upstream initiation site is
+    ///   activated — is a claim about the *consequence*, and two protein
+    ///   sequences do not settle which. The range input parses only because
+    ///   `validate_no_start_loss_substitution` keys on a single certain
+    ///   position; the illegality is created by the split, so the guard belongs
+    ///   here;
+    /// - fewer than two changed runs survive, i.e. the change really is one
+    ///   contiguous `delins`.
+    fn try_protein_split_delins(
+        &self,
+        variant: &crate::hgvs::variant::ProteinVariant,
+    ) -> Option<Vec<crate::hgvs::variant::ProteinVariant>> {
+        use crate::hgvs::edit::AminoAcidSeq;
+        use crate::hgvs::variant::{LocEdit, ProteinVariant};
+
+        let seq = match variant.loc_edit.edit.inner()? {
+            ProteinEdit::Delins { sequence } => sequence,
+            _ => return None,
+        };
+        // Certain single points only — same rationale as
+        // `try_protein_delins_canonicalize`.
+        let start_pos = match variant.loc_edit.location.start.as_single()? {
+            Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        let end_pos = match variant.loc_edit.location.end.as_single()? {
+            Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        if start_pos.number == 0 || end_pos.number < start_pos.number {
+            return None;
+        }
+        let span = (end_pos.number - start_pos.number + 1) as usize;
+        // Equal length, and at least one interior residue to be unchanged.
+        if span < 3 || span != seq.0.len() {
+            return None;
+        }
+        if seq.0.contains(&AminoAcid::Ter) || seq.0.contains(&AminoAcid::Xaa) {
+            return None;
+        }
+
+        // The reference residues, or nothing. Never the payload's own middle.
+        if !self.provider.has_protein_data() {
+            return None;
+        }
+        let accession = variant.accession.transcript_accession();
+        let ref_aas =
+            self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)?;
+        if ref_aas.len() != span
+            || ref_aas.contains(&AminoAcid::Xaa)
+            || ref_aas.contains(&AminoAcid::Ter)
+        {
+            return None;
+        }
+
+        // The translation initiation codon, changed. A member here would be
+        // `p.Met1Xxx`, which `substitution.md:49` forbids and `parse_hgvs`
+        // refuses — so the split would emit a description ferro cannot read
+        // back. Which description is correct (`p.0`, `p.0?`, `p.(Met1?)`, or
+        // the upstream-initiation insertion form) is a claim about the
+        // *consequence*, which two protein sequences cannot settle, so decline
+        // and leave the input as authored rather than guess.
+        if start_pos.number == 1 && ref_aas[0] != seq.0[0] {
+            return None;
+        }
+
+        // Maximal runs of residue-wise disagreement. Two or more runs means an
+        // unchanged residue separates them, which is the separation the clause
+        // is about.
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        let mut offset = 0usize;
+        while offset < span {
+            if ref_aas[offset] == seq.0[offset] {
+                offset += 1;
+                continue;
+            }
+            let lo = offset;
+            while offset < span && ref_aas[offset] != seq.0[offset] {
+                offset += 1;
+            }
+            runs.push((lo, offset - 1));
+        }
+        if runs.len() < 2 {
+            return None;
+        }
+
+        // One member per run: a single-residue run is a substitution
+        // (`general.md:56` ranks substitution above delins), a longer one the
+        // smaller delins it really is. Members are always certain — a predicted
+        // `p.(…)` input carries its marker onto the whole allele, which
+        // `wrap_allele_if_split` does.
+        let members = runs
+            .into_iter()
+            .map(|(lo, hi)| {
+                let member_start = ProtPos::new(ref_aas[lo], start_pos.number + lo as u64);
+                let member_end = ProtPos::new(ref_aas[hi], start_pos.number + hi as u64);
+                let edit = if lo == hi {
+                    ProteinEdit::Substitution {
+                        reference: ref_aas[lo],
+                        alternative: seq.0[lo],
+                    }
+                } else {
+                    ProteinEdit::Delins {
+                        sequence: AminoAcidSeq::new(seq.0[lo..=hi].to_vec()),
+                    }
+                };
+                ProteinVariant {
+                    accession: variant.accession.clone(),
+                    gene_symbol: variant.gene_symbol.clone(),
+                    loc_edit: LocEdit::new(Interval::new(member_start, member_end), edit),
+                }
+            })
+            .collect();
+        Some(members)
     }
 
     /// HGVS Prioritization: if a protein insertion is equivalent to a

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -414,6 +414,7 @@ mod predicted_cis_allele;
 mod projection;
 mod projection_coverage;
 mod property_tests;
+mod protein_axis_split_move;
 mod protein_cis_delins_decomposition;
 mod protein_construct_boundaries;
 mod protein_frameshift_alternatives;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -457,6 +457,7 @@ mod spec_enumeration_tests;
 // target rather than merely skipping these tests.
 #[cfg(feature = "dev")]
 mod spec_generator_preconditions;
+mod spec_worked_example_rules;
 mod spec_worked_examples;
 mod strict_del_size_suffix_mode;
 mod strict_explicit_seq_size_modes;

--- a/tests/it/protein_axis_split_move.rs
+++ b/tests/it/protein_axis_split_move.rs
@@ -1,0 +1,510 @@
+//! The protein-axis split move: an **equal-length** `delins` whose interior
+//! leaves a residue unchanged is two or more separate changes, not one `delins`.
+//!
+//! # The clause
+//!
+//! `recommendations/protein/delins.md:21` states it directly — "two variants
+//! separated by one or more amino acids should be described individually and not
+//! as a `delins`" — and `:62-64` publishes the worked answer,
+//! `p.[Ser44Arg;Trp46Arg]`, with the note that "the variant is **not** described
+//! as `p.Ser44_Trp46delinsArgLeuArg`". Unlike the DNA/RNA axes there is no codon
+//! carve-out to compete with it: `general.md:35-38` is a *reading-frame*
+//! exception, and a protein description has no codons of its own.
+//!
+//! The spec's own two rows (W48, W59) are executed against the hermetic spec
+//! fixtures in `spec_worked_example_rules.rs`. This file covers the parts of the
+//! move that the spec does not print an example for — the boundary at which it
+//! must **decline** — because that is where a split move goes wrong.
+//!
+//! # The negative half is the point
+//!
+//! Every case below that must not split names the exact string ferro must not
+//! emit. A positive-only suite would go green on an implementation that split
+//! everything in reach: the unequal-length case, the stop-codon case and the
+//! no-reference case all *look* like the W48 shape and all have a different
+//! right answer.
+//!
+//! Four declines carry an argument rather than a convention:
+//!
+//! - **Unequal length.** A `delins` whose span and payload are the same length
+//!   has exactly one residue-wise correspondence, so an interior unchanged
+//!   residue is a fact about the two sequences. An unequal-length one has none:
+//!   locating a run inside it means first choosing an alignment, and the
+//!   reference and payload do not determine which. The nucleotide axis settles
+//!   that by applying the edits and re-deriving from the resulting sequence;
+//!   the protein axis has no apply-to-reference, so there is nothing to derive
+//!   the answer from and ferro declines rather than invent one.
+//! - **No protein reference.** The unchanged middle residue is a claim about the
+//!   *reference*. The payload cannot testify to it, so an accession the provider
+//!   cannot serve is declined outright rather than split on the assumption that
+//!   `payload[i]` is what the reference holds.
+//! - **A `Ter` in the reference span.** Replacing the stop is a stop-loss, which
+//!   `protein/extension.md:18` ranks first — "prioritisation: (1) extension, (2)
+//!   frameshift or deletion-insertion" — and `:30` spells `p.Ter110GlnextTer17`.
+//!   Splitting would render it as a plain substitution and lose the extension.
+//! - **A `Ter` in the payload.** `protein/delins.md:47` publishes
+//!   `p.(Pro578_Lys579delinsLeuTer)`, so a stop-introducing change stays a
+//!   `delins` carrying its `Ter`, and the merge pass converges *toward* that
+//!   form. An interior `Ter` is not even authorable — `:45` ("amino acids after
+//!   the translation termination codon are **not** listed") is enforced by the
+//!   parser — so the whole family is left alone.
+//! - **A changed residue 1.** The member would render as `p.Met1Xxx`, which
+//!   `protein/substitution.md:49` forbids and the parser refuses, so the split
+//!   would emit a description ferro cannot read back. Unlike the three above,
+//!   this illegality is *created* by the split — the range input parses fine.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The accession every case is written against.
+const NP: &str = "NP_003997.1";
+
+/// An unrelated accession the provider also carries, so `has_protein_data()` is
+/// true even in the cases where `NP` itself is absent (#1131's shape).
+const OTHER: &str = "NP_999999.9";
+
+/// A protein whose residues 44, 45, 46 are `Ser`, `Leu`, `Trp` and whose 47 is
+/// `Glu` — the spec's W48 context, extended by one residue so a two-residue
+/// changed run can be exercised beside a single-residue one.
+///
+/// Residues 48..=60 are all `Ala`, which makes the sequence **60** residues long
+/// and residue 60 an `Ala`. That is load-bearing rather than padding: the allele
+/// cases below use `Ala60Gly` as the companion member sitting away from the
+/// delins, and the reference residue an allele member names is only checked when
+/// it is **in range** — a position past the end is passed through with no
+/// mismatch error and no warning. At 57 residues the `Ala60Gly` member was
+/// therefore never resolved against the reference at all, so `input == output`
+/// held without the companion member ever having been verified. Extending to 60
+/// makes the same assertion measure what it reads as: `Ala60Gly` now resolves,
+/// its `Ala` matches, and a wrong reference residue there would fail loudly
+/// (`Amino acid mismatch at position 60`) instead of passing silently.
+fn spec_w48_protein() -> String {
+    let mut seq = String::from("M");
+    seq.push_str(&"A".repeat(42)); // residues 2..=43
+    seq.push_str("SLWE"); // residues 44, 45, 46, 47
+    seq.push_str(&"A".repeat(13)); // residues 48..=60 — 60 is the `Ala` the allele cases name
+    seq
+}
+
+/// A provider carrying `NP`'s protein sequence.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(NP, spec_w48_protein());
+    provider
+}
+
+/// A protein whose residue 46 is the stop (`Ter`), residues 44 and 45 being
+/// `Ser` and `Leu` as above. Replacing that stop is a stop-loss, so this is the
+/// reference-side counterpart of the payload-`Ter` fixture.
+fn stop_at_46_protein() -> String {
+    let mut seq = String::from("M");
+    seq.push_str(&"A".repeat(42)); // residues 2..=43
+    seq.push_str("SL*"); // residues 44, 45, 46 — 46 is the stop
+    seq
+}
+
+/// A provider carrying a protein whose span ends at the stop codon.
+fn provider_with_a_reference_stop() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(NP, stop_at_46_protein());
+    provider
+}
+
+/// A provider with protein data for a *different* accession, so
+/// `has_protein_data()` is true while `NP` cannot be fetched.
+fn provider_without_the_accession() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(OTHER, "MAAAAKGSTVE");
+    provider
+}
+
+/// Normalize `input` through `provider`, rendered.
+fn normalize_with(provider: MockProvider, input: &str) -> String {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    Normalizer::new(provider)
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"))
+        .to_string()
+}
+
+/// Assert `input` normalizes to `expected` **and** that `expected` is a fixed
+/// point under the same provider. A split that re-merges on the next pass
+/// satisfies the first half and fails the second.
+fn splits_to(provider: MockProvider, input: &str, expected: &str) {
+    assert_eq!(
+        normalize_with(provider.clone(), input),
+        expected,
+        "for {input:?}"
+    );
+    assert_eq!(
+        normalize_with(provider, expected),
+        expected,
+        "{expected:?} is not a normalization fixed point"
+    );
+}
+
+/// Assert `input` is preserved verbatim, naming the split ferro must not make.
+fn must_not_split(provider: MockProvider, input: &str, forbidden: &str, clause: &str) {
+    let actual = normalize_with(provider, input);
+    assert_ne!(
+        actual, forbidden,
+        "{clause}: {input:?} must not be split into {forbidden:?}"
+    );
+    assert_eq!(actual, input, "{input:?} must be preserved as authored");
+}
+
+// ---------------------------------------------------------------------------
+// The positive half — the move fires
+// ---------------------------------------------------------------------------
+
+/// `protein/delins.md:64` — the spec's own worked example, on a hand-built
+/// reference rather than the spec-fixture provider.
+#[test]
+fn one_unchanged_residue_splits_into_two_substitutions() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+    );
+}
+
+/// `protein/delins.md:21` says "one **or more** amino acids", so a separation of
+/// two is the same rule, not a wider one. Residues 45 and 46 (`Leu`, `Trp`) are
+/// both carried through unchanged; only 44 and 47 change.
+#[test]
+fn two_unchanged_residues_split_the_same_way() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Glu47delinsArgLeuTrpLys"),
+        &format!("{NP}:p.[Ser44Arg;Glu47Lys]"),
+    );
+}
+
+/// A changed run longer than one residue stays a `delins` — a *smaller* one,
+/// over the residues it really claims. `general.md:56` ranks substitution above
+/// delins, so a one-residue run becomes a substitution and a two-residue run
+/// does not.
+#[test]
+fn a_multi_residue_run_becomes_a_smaller_delins_beside_a_substitution() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Ser44_Glu47delinsArgLeuAlaLys"),
+        &format!("{NP}:p.[Ser44Arg;Trp46_Glu47delinsAlaLys]"),
+    );
+}
+
+/// A predicted input keeps its `( )` — carried onto the whole allele, never onto
+/// the members (`protein/alleles.md:34`, and #1063 for the nucleotide analogue).
+#[test]
+fn a_predicted_delins_splits_inside_its_parentheses() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.(Ser44_Trp46delinsArgLeuArg)"),
+        &format!("{NP}:p.[(Ser44Arg;Trp46Arg)]"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The negative half — the move declines, and what it must not emit
+// ---------------------------------------------------------------------------
+
+/// An **unequal-length** `delins` has no residue-wise correspondence to read, so
+/// there is no unchanged interior residue to find — only an alignment somebody
+/// would have to choose. Left exactly as authored.
+#[test]
+fn an_unequal_length_delins_is_not_split() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArgLys"),
+        &format!("{NP}:p.[Ser44Arg;Trp46_Trp46delinsArgLys]"),
+        "protein/delins.md:21 does not license re-aligning a length-changing delins",
+    );
+}
+
+/// The reference is what says the middle residue is unchanged. With no protein
+/// data at all the question cannot be answered, and guessing from the payload is
+/// exactly the error the rule must not make.
+#[test]
+fn a_provider_with_no_protein_data_declines_rather_than_guessing() {
+    must_not_split(
+        MockProvider::new(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+        "the unchanged middle residue is a claim about the reference",
+    );
+}
+
+/// `has_protein_data()` is a **provider-wide** flag (#1131), so a provider that
+/// carries some other protein still cannot answer for this accession. The fetch,
+/// not the flag, is what decides.
+#[test]
+fn a_provider_missing_this_accession_declines_rather_than_guessing() {
+    must_not_split(
+        provider_without_the_accession(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Arg]"),
+        "a provider-wide capability flag is not a reference for this accession",
+    );
+}
+
+/// A `Ter` in the payload is declined. `protein/delins.md:47` publishes
+/// `p.(Pro578_Lys579delinsLeuTer)` — a stop-introducing change *stays* a `delins`
+/// carrying its `Ter` — and `merge::coalesce_protein_adjacent_changes` merges
+/// toward exactly that form, admitting a run whose last member is the earliest
+/// `Ter` (#1129). Splitting the same shape apart would have one axis pulling both
+/// ways at once, so the split move stays out of it.
+#[test]
+fn a_payload_carrying_a_stop_is_declined() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgLeuTer"),
+        &format!("{NP}:p.[Ser44Arg;Trp46Ter]"),
+        "protein/delins.md:47",
+    );
+}
+
+/// And an *interior* `Ter` is not reachable at all: `protein/delins.md:45` — "amino
+/// acids after the translation termination codon are **not** listed" — is enforced
+/// by the parser, so the shape the split move would have had to reason about
+/// cannot be authored. Asserted rather than assumed, because the decline above is
+/// only the whole story while this holds.
+#[test]
+fn an_interior_stop_is_refused_by_the_parser() {
+    let input = format!("{NP}:p.Ser44_Trp46delinsTerLeuArg");
+    assert!(
+        parse_hgvs(&input).is_err(),
+        "protein/delins.md:45: {input} lists residues after the stop and must be refused"
+    );
+    // The control that makes the refusal attributable to the stop's *position*
+    // rather than to anything else in the string: the same shape with the `Ter`
+    // last carries no residue after it and parses.
+    let trailing = format!("{NP}:p.Ser44_Trp46delinsArgLeuTer");
+    assert!(
+        parse_hgvs(&trailing).is_ok(),
+        "{trailing} lists nothing after the stop and must parse — without this the \
+         assertion above cannot tell an interior `Ter` from any other refusal"
+    );
+}
+
+/// A `Ter` in the **reference span** declines too, and for a different reason
+/// than the payload case above: replacing the stop is a **stop-loss**.
+///
+/// `protein/extension.md:18` ranks the descriptions — "prioritisation: (1)
+/// extension, (2) frameshift or deletion-insertion" — and `:30` publishes the
+/// form, `p.Ter110GlnextTer17`. So the residue that replaces a stop is described
+/// with an extension, never a substitution.
+///
+/// Without this guard the split fires on the reference `Ser-Leu-Ter` against a
+/// payload of `Ala-Leu-His` and emits `p.[Ser44Ala;Ter46His]`, which states the
+/// wrong consequence: it spells a stop-loss as an ordinary substitution and
+/// silently drops the extension. The payload guard cannot catch it — the payload
+/// here carries no `Ter` at all — which is why the reference span needs its own.
+#[test]
+fn a_reference_stop_is_not_split_into_a_substitution() {
+    must_not_split(
+        provider_with_a_reference_stop(),
+        &format!("{NP}:p.Ser44_Ter46delinsAlaLeuHis"),
+        &format!("{NP}:p.[Ser44Ala;Ter46His]"),
+        "protein/extension.md:18 — a stop-loss is an extension, not a substitution",
+    );
+}
+
+/// One contiguous changed run is a genuine `delins`. Nothing separates anything
+/// here, so the move must not fire — this is the case the whole rule is *not*
+/// about, and the one a too-eager splitter would break.
+#[test]
+fn a_fully_changed_run_stays_one_delins() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Trp46delinsArgAlaArg"),
+        &format!("{NP}:p.[Ser44Arg;Leu45Ala;Trp46Arg]"),
+        "protein/delins.md:19 — consecutive changed residues are one delins",
+    );
+}
+
+/// Two residues is the smallest `delins` there is and has no interior at all.
+/// Guarded so the run scan can never be relaxed into splitting an adjacent pair,
+/// which is the merge direction `protein/substitution.md:23` mandates.
+#[test]
+fn an_adjacent_pair_has_no_interior_to_split() {
+    must_not_split(
+        provider(),
+        &format!("{NP}:p.Ser44_Leu45delinsArgMet"),
+        &format!("{NP}:p.[Ser44Arg;Leu45Met]"),
+        "protein/substitution.md:23 — adjacent changes are one delins, not two members",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Where the move runs, and where it deliberately does not
+// ---------------------------------------------------------------------------
+
+/// A separated `delins` **inside a cis allele** keeps its delins.
+///
+/// The move runs at the whole-description seam
+/// (`Normalizer::split_protein_separation`), not per allele member: splitting a
+/// member would nest one bracket inside another, and flattening the pieces into
+/// the outer bracket first needs a decision about where the member's `( )`
+/// marker goes (`protein/alleles.md:34` puts it per member, `:90` round the
+/// group). Recorded as a limitation rather than left to emit a nested bracket —
+/// see that helper for the two measured outputs.
+#[test]
+fn a_delins_inside_a_cis_allele_is_left_alone() {
+    let input = format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]");
+    let actual = normalize_with(provider(), &input);
+    assert!(
+        !actual.contains("];"),
+        "a member's split must not nest a bracket inside the allele, got {actual}"
+    );
+    assert_eq!(
+        actual,
+        format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg;Ala60Gly]"),
+        "the separated delins stays a delins inside an allele"
+    );
+}
+
+/// The same for a **trans** allele, and here the reason is harder: the flat form
+/// `p.[Ser44Arg;Trp46Arg];[Ala60Gly]` is legal HGVS and the DNA axis both emits
+/// and reads `g.[A;B];[C]`, but ferro's protein allele grammar accepts only
+/// single-member arms — so emitting it would break the re-parse invariant
+/// (`FERRO_ASSERT_REPARSE`). The gap is asserted below so this decline stops
+/// being necessary the moment the parser closes it.
+#[test]
+fn a_delins_inside_a_trans_allele_is_left_alone() {
+    let input = format!("{NP}:p.[Ser44_Trp46delinsArgLeuArg];[Ala60Gly]");
+    assert_eq!(
+        normalize_with(provider(), &input),
+        input,
+        "the arm's split would produce a description ferro cannot read back"
+    );
+}
+
+/// The control the two allele declines above rest on: `Ala60Gly` is a member the
+/// reference really answers for, not a position past the end of the fixture.
+///
+/// This is not pedantry about a fixture length. An out-of-range protein position
+/// is passed through with **no** mismatch error and **no** warning, so an
+/// `input == output` assertion holds for a member the reference was never
+/// consulted about — which is the same "an assertion that cannot distinguish the
+/// failure from the success" shape the three `is_err()` sites in this file were
+/// already corrected for. Both halves are asserted, because either alone is
+/// satisfiable by the wrong thing: an *in-range* position is what makes the
+/// mismatch check run at all, and a matching residue is what makes the declines
+/// above measure the delins member rather than an error path.
+#[test]
+fn residue_sixty_is_a_residue_the_reference_answers_for() {
+    assert_eq!(
+        spec_w48_protein().len(),
+        60,
+        "the allele cases name residue 60; a shorter fixture makes them vacuous"
+    );
+    assert_eq!(
+        normalize_with(provider(), &format!("{NP}:p.Ala60Gly")),
+        format!("{NP}:p.Ala60Gly"),
+        "residue 60 is `Ala`, so the companion member the allele cases carry is sound"
+    );
+    // The half that proves the reference is *read* there: name the wrong residue
+    // and normalization must fail. At 57 residues this returned `Ok` unchanged.
+    let wrong = parse_hgvs(&format!("{NP}:p.Gly60Ala")).expect("parses");
+    let err = Normalizer::new(provider())
+        .normalize(&wrong)
+        .expect_err("a wrong reference residue at an in-range position must not pass");
+    assert!(
+        err.to_string().contains("position 60"),
+        "expected a reference mismatch naming position 60, got {err}"
+    );
+}
+
+/// The parser gap the trans decline rests on, asserted rather than assumed: a
+/// protein allele arm with two members is refused, while its DNA counterpart is
+/// accepted. If this ever starts parsing, revisit
+/// `a_delins_inside_a_trans_allele_is_left_alone`.
+#[test]
+fn the_protein_allele_grammar_reads_only_single_member_arms() {
+    assert!(
+        parse_hgvs(&format!("{NP}:p.[Ser44Arg;Trp46Arg];[Ala60Gly]")).is_err(),
+        "if `p.[A;B];[C]` now parses, the trans decline above is no longer needed"
+    );
+    // The control that pins the *arm's member count* as the cause: the same
+    // trans description with a single-member first arm parses, so the refusal
+    // above is not about the trans form, the accession or these residues.
+    assert!(
+        parse_hgvs(&format!("{NP}:p.[Ser44Arg];[Ala60Gly]")).is_ok(),
+        "a single-member protein arm must parse — without this the assertion above \
+         cannot tell a multi-member arm from any other refusal"
+    );
+    assert!(
+        parse_hgvs("NC_000001.11:g.[100A>T;102A>T];[200A>T]").is_ok(),
+        "the DNA axis reads a multi-member arm, which is why this is a protein-only gap"
+    );
+}
+
+/// And the whole-description case still splits, which is what makes the two
+/// declines above a *scope* rather than a regression.
+#[test]
+fn the_whole_description_case_still_splits() {
+    assert_eq!(
+        normalize_with(provider(), &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg")),
+        format!("{NP}:p.[Ser44Arg;Trp46Arg]")
+    );
+}
+
+/// A changed residue 1 is declined, because splitting it emits a description
+/// the parser refuses.
+///
+/// `p.Met1_Ala3delinsValAlaTrp` has the W48 shape exactly — equal length, an
+/// unchanged interior residue, two changed runs — so every other gate passes it
+/// through. But residue 1 is the translation initiation codon, and the member it
+/// would produce is `p.Met1Val`: `protein/substitution.md:49` says a variant
+/// changing the initiator is "not described as a substitution or as an
+/// extension", and `parse_hgvs` enforces that.
+///
+/// The input itself parses, because `validate_no_start_loss_substitution` keys
+/// on a single certain position and this is a range. So the illegality is
+/// **created by the split**, which is why the guard has to sit in the split
+/// rather than being inherited from the parser — and why the assertion below is
+/// on the *re-parse*, not just on the string.
+///
+/// Ferro declines rather than choosing among `p.0` / `p.0?` / `p.(Met1?)` /
+/// `p.Met1_Leu2ins…`: which of those is right is a claim about the consequence,
+/// and two protein sequences do not settle it.
+#[test]
+fn a_changed_initiation_codon_is_left_alone() {
+    let input = format!("{NP}:p.Met1_Ala3delinsValAlaTrp");
+    let out = normalize_with(provider(), &input);
+    assert_eq!(
+        out, input,
+        "splitting here would emit `p.[Met1Val;Ala3Trp]`, which is not a legal \
+         description of a start-loss (`protein/substitution.md:49`)"
+    );
+    assert!(
+        parse_hgvs(&out).is_ok(),
+        "the output must re-parse; {out:?} did not"
+    );
+    assert!(
+        parse_hgvs(&format!("{NP}:p.[Met1Val;Ala3Trp]")).is_err(),
+        "if the split form now parses, this decline needs revisiting rather than keeping"
+    );
+    // The control that pins `Met1` as the cause rather than the `p.[A;B]`
+    // bracket form: the same two-member cis allele off the initiator parses.
+    assert!(
+        parse_hgvs(&format!("{NP}:p.[Ala2Val;Ala3Trp]")).is_ok(),
+        "a two-member cis protein allele away from residue 1 must parse — without this \
+         the assertion above cannot tell a start-loss substitution from a refusal of \
+         the bracket form itself"
+    );
+}
+
+/// The guard is scoped to residue 1 *changing*, not to any span that reaches it.
+///
+/// Here residue 1 is unchanged and the changed runs are at 2 and 4, so no member
+/// lands on the initiator and the split proceeds. Without this, a guard written
+/// as "decline any span starting at 1" would look correct and silently stop
+/// splitting a family it has no business declining.
+#[test]
+fn a_span_reaching_residue_one_still_splits_when_residue_one_is_unchanged() {
+    splits_to(
+        provider(),
+        &format!("{NP}:p.Met1_Ala4delinsMetGlyAlaTrp"),
+        &format!("{NP}:p.[Ala2Gly;Ala4Trp]"),
+    );
+}

--- a/tests/it/spec_worked_example_rules.rs
+++ b/tests/it/spec_worked_example_rules.rs
@@ -1,0 +1,2325 @@
+//! The HGVS recommendations' worked examples, W1–W95, as executable guards.
+//!
+//! # What this file is
+//!
+//! `specs/2026-08-08-hgvs-rule-catalog.md` catalogues 162 rules from the
+//! vendored spec checkout and, in its Appendix A, the **95 input → published
+//! answer pairs** the spec prints for itself (W1–W95). Those pairs are the only
+//! rows in the corpus that need no interpretation: the spec names an input and
+//! prints, in the same sentence, the description to use instead. A divergence
+//! is therefore a defect or a spec self-conflict — never a matter of taste.
+//!
+//! This module executes every W-row that *can* be executed hermetically, and
+//! **records every row that cannot, with its reason**, so the size of what is
+//! not covered is itself pinned ([`UNEXECUTABLE`], [`the_roster_covers_every_one_of_the_95_worked_examples`]).
+//!
+//! It is a companion to `tests/it/spec_worked_examples.rs`, which already runs a
+//! hand-curated twelve rows (W33–W36, W65) through all three shipped error
+//! modes against real reference bases. Those rows are **not duplicated** here;
+//! they are listed in [`CROSS_REFERENCED`] and a test asserts they stay out of
+//! this file's tables.
+//!
+//! # Four hermetic fixtures, no skip path
+//!
+//! Every row runs with no `FERRO_MANIFEST`, no network, and no environment
+//! variable, so nothing here can pass by being skipped:
+//!
+//! - **[`Fixture::Slice`]** — the committed reference window beside
+//!   `spec_worked_examples`'s `cases.json` (`LRG_199t1`, `NM_024312.4`), i.e.
+//!   **real _DMD_ bases under the accession the spec itself cites**. Nearly
+//!   every `LRG_199t1`/`NM_004006.2` worked example lives on this transcript,
+//!   and [`the_slice_carries_the_bases_the_spec_quotes`] re-derives the spec's
+//!   own quoted context from it before any row is trusted.
+//! - **[`Fixture::Genomic`]**, **[`Fixture::Coding`]**, **[`Fixture::Protein`]** —
+//!   synthetic contigs, transcripts and protein sequences built from the
+//!   sequence the spec *prints beside the example* (`TGT`+`GC`+`CA`,
+//!   `MetLeuTrpTrpGlu`, …), under deliberately synthetic accessions
+//!   (`SPEC_W02.1`, `NM_SPECW16.1`, `NP_SPECW29.1`). Never a real accession
+//!   over invented bases.
+//!
+//! Where the accession had to change, the row carries [`Rebase::Accession`] and
+//! [`every_rebased_answer_differs_from_the_published_string_only_in_its_accession`]
+//! proves the answer is the spec's string with nothing but the accession
+//! swapped. Where the spec's example is a coordinate on a real chromosome and
+//! the fixture is a short synthetic contig, the row carries [`Rebase::Local`]
+//! and the same test checks the edit token is unchanged; the *position* is then
+//! pinned by [`PARTITIONS`], which is what the row is really about. Where the
+//! spec states its answer as prose rather than as a description ("a change of
+//! the `T` at position 4"), the row carries [`Rebase::Prose`] and a
+//! [`PARTITIONS`] entry is **required**, since the position is all there is.
+//!
+//! # Assertion policy
+//!
+//! - Exact equality on the **whole** output string. Never `contains`, never a
+//!   prefix.
+//! - Rows about a partition additionally pin **member count and every member's
+//!   span** ([`PARTITIONS`]), read back off the *parsed* output — a rendered
+//!   string can look right over a wrong partition.
+//! - **The forbidden half is asserted too.** [`NEGATIVE`] names the exact string
+//!   ferro must not emit for a legal input; [`REJECTED`] names the spellings the
+//!   parser must refuse. This is the half that was missing, and the half that
+//!   catches a manufactured separation.
+//! - No `#[ignore]`, and no test that can pass vacuously: a row whose fixture
+//!   cannot exhibit the property it tests is in [`UNEXECUTABLE`], not in a table.
+//!
+//! # Where ferro does not produce the spec's answer
+//!
+//! Two dispositions, kept apart on purpose:
+//!
+//! - [`DIVERGENT`] — pinned divergences. Each records ferro's actual output, the
+//!   spec's, and *why* the difference is not a defect (a spec self-conflict, or
+//!   a form the spec licenses in more than one spelling). Pinned in the style of
+//!   `KNOWN_DIVERGENT_INPUTS` in `hgvs_spec_normalization_tests.rs`: a fix that
+//!   makes one of these conform **fails**, rather than rotting unnoticed.
+//! - [`PARSE_GAPS`] — a form the spec publishes as *correct* that ferro's parser
+//!   refuses. A defect, pinned so that closing it fails loudly.
+//!
+//! There was a third, `FERRO_IS_WRONG` — the spec explicit, ferro disagreeing,
+//! no clause competing — and it held exactly two rows: the protein halves of
+//! W48 and W59, an equal-length `delins` whose middle residue is unchanged
+//! (`protein/delins.md:21`, `:64`). Ferro now emits the spec's answer for both,
+//! so they are ordinary [`WORKED`] rows, each with a [`NEGATIVE`] row naming the
+//! unsplit `delins` it must not fall back to and a [`PARTITIONS`] row pinning
+//! the two members, and [`the_protein_axis_splits_a_separation_one_delins`] pins
+//! both spellings converging. The table is gone rather than left empty: a test
+//! iterating an empty table passes vacuously, which the policy above forbids.
+//! Re-create it only for a row that is genuinely wrong.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ferro_hgvs::conformance::reference_window::{WindowFixture, WindowProvider};
+use ferro_hgvs::conformance::spec_worked_examples::WINDOWS_PATH;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::reference::provider::ReferenceProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The vendored spec checkout's `docs/` root, relative to the crate.
+const SPEC_DOCS: &str = "assets/hgvs-nomenclature/docs";
+
+/// How many worked examples Appendix A of the rule catalog records.
+const WORKED_EXAMPLE_COUNT: usize = 95;
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+/// Which hermetic reference a row is served by.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Fixture {
+    /// The committed spec worked-example window: real `LRG_199t1` /
+    /// `NM_024312.4` bases.
+    Slice,
+    /// A synthetic genomic contig carrying the sequence the spec prints.
+    Genomic,
+    /// A synthetic transcript (`c.`/`r.`/`n.`) carrying the printed sequence.
+    Coding,
+    /// A synthetic protein sequence carrying the printed residues.
+    Protein,
+}
+
+/// How far the row's expected string had to move off the spec's literal text.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Rebase {
+    /// The expected string is the spec's, byte for byte.
+    Same,
+    /// The spec's string with only the accession replaced by the hermetic
+    /// fixture's. Checked by
+    /// [`every_rebased_answer_differs_from_the_published_string_only_in_its_accession`].
+    Accession,
+    /// The spec states the sequence context but numbers it on a real
+    /// chromosome; the fixture is that context as its own short contig, so the
+    /// coordinates are local. The edit token must still match, and the position
+    /// is pinned by [`PARTITIONS`].
+    Local,
+    /// The spec gives its answer as prose ("a change of the `T` at position 4")
+    /// rather than as a description, so there is no string to compare. The
+    /// answer's *position* is what the row asserts, and [`PARTITIONS`] pins it.
+    Prose,
+}
+
+/// A worked example ferro satisfies.
+struct Worked {
+    /// The catalog's row id (`W1` … `W95`).
+    id: &'static str,
+    /// `path:line`, relative to `assets/hgvs-nomenclature/docs/`.
+    clause: &'static str,
+    /// A byte-exact substring of that line, checked by
+    /// [`every_row_quotes_the_spec_verbatim`].
+    quote: &'static str,
+    /// What is normalized.
+    input: &'static str,
+    /// The spec's published answer, verbatim.
+    published: &'static str,
+    /// What ferro must emit — `published`, rebased onto the hermetic fixture.
+    answer: &'static str,
+    rebase: Rebase,
+    fixture: Fixture,
+    /// Why the row is here and what it proves.
+    why: &'static str,
+}
+
+/// A legal input together with a description the spec forbids for it.
+struct Negative {
+    id: &'static str,
+    clause: &'static str,
+    quote: &'static str,
+    input: &'static str,
+    /// The exact string ferro must **not** emit for `input`.
+    forbidden: &'static str,
+    fixture: Fixture,
+    why: &'static str,
+}
+
+/// A spelling the spec bans outright, which the parser must refuse.
+struct Rejected {
+    id: &'static str,
+    clause: &'static str,
+    quote: &'static str,
+    /// The forbidden description.
+    input: &'static str,
+    why: &'static str,
+}
+
+/// The partition a description asserts: how many members, and where each sits.
+struct Partition {
+    id: &'static str,
+    clause: &'static str,
+    quote: &'static str,
+    input: &'static str,
+    /// One `(start, end)` per member, in rendered order.
+    members: &'static [(i64, i64)],
+    fixture: Fixture,
+    why: &'static str,
+}
+
+/// A row where ferro's answer is not the spec's, deliberately.
+struct Divergence {
+    id: &'static str,
+    clause: &'static str,
+    quote: &'static str,
+    input: &'static str,
+    /// The spec's answer, rebased onto the fixture.
+    spec_answer: &'static str,
+    /// What ferro actually emits, pinned.
+    ferro_answer: &'static str,
+    fixture: Fixture,
+    /// The classification, and the second clause where one is in tension.
+    why: &'static str,
+}
+
+/// A description the spec publishes as **correct** that ferro cannot parse.
+struct ParseGap {
+    id: &'static str,
+    clause: &'static str,
+    quote: &'static str,
+    input: &'static str,
+    why: &'static str,
+}
+
+/// A row this file does not execute, with the reason it cannot.
+struct Unexecutable {
+    id: &'static str,
+    reason: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// The rows ferro satisfies
+// ---------------------------------------------------------------------------
+
+/// Every worked example whose published answer ferro reproduces exactly.
+const WORKED: &[Worked] = &[
+    // -- type choice: consecutive changes are one delins ---------------------
+    Worked {
+        id: "W1",
+        clause: "recommendations/DNA/substitution.md:32",
+        quote: "changes involving two or more consecutive nucleotides are described as deletion-insertion (delins)",
+        input: "LRG_199t1:c.[79G>T;80C>T]",
+        published: "LRG_199t1:c.79_80delinsTT",
+        answer: "LRG_199t1:c.79_80delinsTT",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "separation 0 always merges — the uncontested end of the merge ladder",
+    },
+    Worked {
+        id: "W2",
+        clause: "recommendations/DNA/delins.md:77",
+        quote: "should be described as `g.4_5delinsTG`, i.e. a deletion/insertion (delins).",
+        input: "SPEC_W02.1:g.[4G>T;5C>G]",
+        published: "g.4_5delinsTG",
+        answer: "SPEC_W02.1:g.4_5delinsTG",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Genomic,
+        why: "the same merge on a genomic axis, where no codon can be invoked",
+    },
+    Worked {
+        id: "W3",
+        clause: "recommendations/DNA/substitution.md:90",
+        quote: "should be described as `NG_012232.1:g.12_13delinsTG`",
+        input: "SPEC_W03.1:g.[12G>T;13C>G]",
+        published: "NG_012232.1:g.12_13delinsTG",
+        answer: "SPEC_W03.1:g.12_13delinsTG",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Genomic,
+        why: "cis phase merges …",
+    },
+    Worked {
+        id: "W3",
+        clause: "recommendations/DNA/substitution.md:91",
+        quote: "When phase information is not available, the variant should be described as `NG_012232.1:g.12G>T(;)13C>G`",
+        input: "SPEC_W03.1:g.12G>T(;)13C>G",
+        published: "NG_012232.1:g.12G>T(;)13C>G",
+        answer: "SPEC_W03.1:g.12G>T(;)13C>G",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Genomic,
+        why: "… and unknown phase does not. Same two nucleotides, same bases: the \
+              merge is licensed by the asserted phase, not by the sequence. A \
+              normalizer that re-derived the partition from the resulting bases \
+              could not tell these two apart",
+    },
+    Worked {
+        id: "W4",
+        clause: "recommendations/RNA/delins.md:66",
+        quote: "should be described as `r.5_6delinsug`, i.e. a deletion/insertion (delins).",
+        input: "NM_SPECW04.1:r.[5g>u;6c>g]",
+        published: "r.5_6delinsug",
+        answer: "NM_SPECW04.1:r.5_6delinsug",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "the RNA axis merges consecutive substitutions like the DNA axis",
+    },
+    Worked {
+        id: "W5",
+        clause: "recommendations/protein/substitution.md:98",
+        quote: "should be described as `NP_003997.1:p.Trp24_Val25delinsCysArg`",
+        input: "NP_SPECW05.1:p.[Trp24Cys;Val25Arg]",
+        published: "NP_003997.1:p.Trp24_Val25delinsCysArg",
+        answer: "NP_SPECW05.1:p.Trp24_Val25delinsCysArg",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "and so does the protein axis, for adjacent residues \
+              (protein/substitution.md:23). Its separation-1 sibling is W48 — the \
+              two together locate the merge/split boundary exactly, and \
+              [`the_protein_axis_splits_a_separation_one_delins`] asserts both \
+              sides of it at once",
+    },
+    // -- type choice: preferred spellings ------------------------------------
+    Worked {
+        id: "W6",
+        clause: "recommendations/DNA/delins.md:29",
+        quote: "the recommendation is not to describe the variant as",
+        input: "LRG_199t1:c.4661delAinsTC",
+        published: "LRG_199t1:c.4661delinsTC",
+        answer: "LRG_199t1:c.4661delinsTC",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "the deleted base is redundant and is dropped (`delins.md:28` gives \
+              this c. form as the g. example's coding equivalent)",
+    },
+    Worked {
+        id: "W7",
+        clause: "recommendations/DNA/delins.md:34",
+        quote: "the recommendation is not to describe the variant as",
+        input: "LRG_199t1:c.6775_6777delGAGinsC",
+        published: "NM_004006.2:c.6775_6777delinsC",
+        answer: "LRG_199t1:c.6775_6777delinsC",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "the same rule over a range rather than one nucleotide",
+    },
+    Worked {
+        id: "W8",
+        clause: "recommendations/DNA/duplication.md:34",
+        quote: "it is **not** allowed to describe the variant as `c.19_20insT`",
+        input: "LRG_199t1:c.19_20insT",
+        published: "NM_004006.2:c.20dup",
+        answer: "LRG_199t1:c.20dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "prioritisation (general.md:57): a duplicating insertion is a dup",
+    },
+    Worked {
+        id: "W9",
+        clause: "recommendations/DNA/duplication.md:50",
+        quote: "the recommendation is not to describe the variant as",
+        input: "LRG_199t1:c.20_23dupTAGA",
+        published: "NM_004006.2:c.20_23dup",
+        answer: "LRG_199t1:c.20_23dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "the duplicated sequence is redundant and is dropped",
+    },
+    Worked {
+        id: "W10",
+        clause: "recommendations/RNA/duplication.md:30",
+        quote: "it is **not** allowed to describe the variant as",
+        input: "NM_SPECW10.1:r.6_7insu",
+        published: "r.7dup",
+        answer: "NM_SPECW10.1:r.7dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "prioritisation holds on the RNA axis too",
+    },
+    Worked {
+        id: "W15",
+        clause: "recommendations/DNA/inversion.md:28",
+        quote: "changing `..CA`<code class=\"sub\">TCAG</code>`CCT..` to `..CA`<code class=\"sub\">CTGA</code>`CCT..`",
+        input: "SPEC_W15.1:g.3_6delinsCTGA",
+        published: "NC_000023.10:g.32361330_32361333inv",
+        answer: "SPEC_W15.1:g.3_6inv",
+        rebase: Rebase::Local,
+        fixture: Fixture::Genomic,
+        why: "a whole-block reverse complement is an `inv`, not a `delins` \
+              (inversion.md:5, and the ruling `inversion-vs-two-delins-76-83`)",
+    },
+    Worked {
+        id: "W38",
+        clause: "recommendations/DNA/other.md:28",
+        quote: "the description <code class=\"invalid\">c.123C>C</code> is not allowed.",
+        input: "LRG_199t1:c.123C>C",
+        published: "LRG_199t1:c.123=",
+        answer: "LRG_199t1:c.123=",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "an unchanged nucleotide is `=`, never a self-substitution",
+    },
+    // -- merge vs split ------------------------------------------------------
+    Worked {
+        id: "W16",
+        clause: "recommendations/DNA/insertion.md:117",
+        quote: "the correct description is `c.9_32dup`",
+        input: "NM_SPECW16.1:c.1_24dup",
+        published: "c.9_32dup",
+        answer: "NM_SPECW16.1:c.9_32dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "a 24-nt block shifted 8 nt by the 3' rule — the claimed `c.1_24dup` \
+              is the same variant spelled 5'-most",
+    },
+    Worked {
+        id: "W43",
+        clause: "recommendations/DNA/delins.md:88",
+        quote: "The correct description of this variant is `NM_007294.3:c.2077delinsATA`.",
+        input: "NM_SPECW43.1:c.[2077G>A;2077_2078insTA]",
+        published: "NM_007294.3:c.2077delinsATA",
+        answer: "NM_SPECW43.1:c.2077delinsATA",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "abutting members merge unconditionally — `delins.md:89` records that \
+              the sentence permitting the two-member spelling was removed by the \
+              committee",
+    },
+    Worked {
+        id: "W44",
+        clause: "recommendations/RNA/delins.md:70",
+        quote: "The correct description of this variant is `NM_007294.3:r.2077delinsaua`.",
+        input: "NM_SPECW43.1:r.[2077g>a;2077_2078insua]",
+        published: "NM_007294.3:r.2077delinsaua",
+        answer: "NM_SPECW43.1:r.2077delinsaua",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "the RNA restatement of W43, on the same synthetic transcript",
+    },
+    Worked {
+        id: "W45",
+        clause: "recommendations/DNA/substitution.md:37",
+        quote: "two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\"",
+        input: "LRG_199t1:c.[145C>T;147C>G]",
+        published: "LRG_199t1:c.145_147delinsTGG",
+        answer: "LRG_199t1:c.145_147delinsTGG",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "the canonical separation-1 codon case (ruling \
+              `delins-codon-carve-out-gap-one`); `c.145`–`c.147` is codon 49",
+    },
+    Worked {
+        id: "W46",
+        clause: "recommendations/general.md:35",
+        quote: "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\".",
+        input: "LRG_199t1:c.[235A>T;237G>T]",
+        published: "c.235_237delinsTAT",
+        answer: "LRG_199t1:c.235_237delinsTAT",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "the general-page statement of the same exception, on its own example",
+    },
+    Worked {
+        id: "W47",
+        clause: "recommendations/RNA/delins.md:18",
+        quote: "should be described as a \"delins\" (e.g., `r.142_144delinsugg`",
+        input: "NM_SPECW47.1:r.[142c>u;144a>g]",
+        published: "r.142_144delinsugg",
+        answer: "NM_SPECW47.1:r.142_144delinsugg",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Coding,
+        why: "the codon exception on the RNA axis; `r.142`–`r.144` is codon 48. \
+              (`RNA/delins.md:41` prefers the split when either variant is a known \
+              polymorphism — a population fact no reference carries, so it is not \
+              executable; catalogued as conflict C4)",
+    },
+    Worked {
+        id: "W49",
+        clause: "recommendations/DNA/delins.md:47",
+        quote: "**The \"delins\" format is recommended**",
+        input: "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        published: "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        answer: "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "the spanning delins is kept, not decomposed into the aligning split \
+              `:46` names as its alternative — see \
+              `the_spanning_delins_and_its_published_split_are_two_fixed_points`",
+    },
+    Worked {
+        id: "W51",
+        clause: "recommendations/DNA/alleles.md:19",
+        quote: "`LRG_199t1:c.[2376G>C];[3103del]` is correct",
+        input: "LRG_199t1:c.[2376G>C];[3103del]",
+        published: "LRG_199t1:c.[2376G>C];[3103del]",
+        answer: "LRG_199t1:c.[2376G>C];[3103del]",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "two variants in trans stay two members on two alleles",
+    },
+    Worked {
+        id: "W52",
+        clause: "recommendations/DNA/alleles.md:60",
+        quote: "the other allele (chromosome) contains the reference sequence, `c.2376=`",
+        input: "LRG_199t1:c.[2376G>C];[2376=]",
+        published: "NM_004006.2:c.[2376G>C];[2376=]",
+        answer: "LRG_199t1:c.[2376G>C];[2376=]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "a positioned `=` on the second allele is preserved, and is not the \
+              same claim as a bare `[=]` (`alleles.md:61`)",
+    },
+    Worked {
+        id: "W55",
+        clause: "recommendations/protein/alleles.md:90",
+        quote: "this should be described as `p.[(Phe233Leu;Cys690Trp)]`",
+        input: "NP_SPECW48.1:p.[(Phe233Leu;Cys690Trp)]",
+        published: "p.[(Phe233Leu;Cys690Trp)]",
+        answer: "NP_SPECW48.1:p.[(Phe233Leu;Cys690Trp)]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "prediction parentheses sit inside the allele brackets, per member",
+    },
+    Worked {
+        id: "W56",
+        clause: "consultation/SVD-WG010.md:45",
+        quote: "separated by two nucleotides and described as separate variants, not as \"delins\"",
+        input: "LRG_199t1:c.235_238delinsTAGT",
+        published: "LRG_199t1:c.[235A>T;238G>T]",
+        answer: "LRG_199t1:c.[235A>T;238G>T]",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "separation 2 splits — and this is the *converging* direction: fed the \
+              merged spelling, ferro produces the spec's split. SVD-WG010, which \
+              would have merged it, was rejected (`SVD-WG010.md:5`), so \
+              `general.md:34` governs",
+    },
+    Worked {
+        id: "W56",
+        clause: "recommendations/general.md:34",
+        quote: "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\".",
+        input: "LRG_199t1:c.[235A>T;238G>T]",
+        published: "LRG_199t1:c.[235A>T;238G>T]",
+        answer: "LRG_199t1:c.[235A>T;238G>T]",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "and the split spelling is a fixed point, so the pair is confluent",
+    },
+    Worked {
+        id: "W58",
+        clause: "recommendations/general.md:34",
+        quote: "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\".",
+        input: "LRG_199t1:c.[992_1002del;1004T>C]",
+        published: "LRG_199t1:c.[992_1002del;1004T>C]",
+        answer: "LRG_199t1:c.[992_1002del;1004T>C]",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "SVD-WG010:51 would have merged a del and a substitution separated by \
+              one nucleotide; it was rejected. The in-force exception \
+              (`general.md:35`) is about two *variants* affecting one amino acid, \
+              and ferro restricts it to the sub/unchanged/sub shape (ruling \
+              `codon-carve-out-shape-restriction`), so the pair stays split",
+    },
+    Worked {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
+        input: "LRG_199t1:c.[2962T>G;2970A>T]",
+        published: "LRG_199t1:c.[2962T>G;2970A>T]",
+        answer: "LRG_199t1:c.[2962T>G;2970A>T]",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "the DNA half of the rejected SVD-WG010:53 example: separation 7 \
+              stays split. Its protein half is the row two below",
+    },
+    Worked {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:64",
+        quote: "the variant is not described as `p.Ser44_Trp46delinsArgLeuArg`.",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        published: "p.[Ser44Arg;Trp46Arg]",
+        answer: "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the spec's single clearest split-side worked example, and the protein \
+              analogue of W56/W58/W59 on `general.md:34`. The protein axis has no \
+              codon exception to carry the merge, and the span and the payload are \
+              the same length — so `Leu45` being unchanged is a fact about the \
+              input, not an alignment ferro picked",
+    },
+    Worked {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        published: "p.[Ser988Ala;Gln990His]",
+        answer: "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the protein half of the rejected SVD-WG010:53-54 example — the same \
+              shape at a second locus, which is what makes it systematic rather \
+              than a one-off",
+    },
+    // -- placement: the 3' rule and its exception ---------------------------
+    Worked {
+        id: "W60",
+        clause: "background/glossary.md:10",
+        quote: "HGVS describes this as a change of the `T` at position 4 (not the `T` at position 2 or 3)",
+        input: "SPEC_W60.1:g.2del",
+        published: "a change of the `T` at position 4",
+        answer: "SPEC_W60.1:g.4del",
+        rebase: Rebase::Prose,
+        fixture: Fixture::Genomic,
+        why: "the smallest 3'-rule example in the corpus, on its own bases \
+              (`ATT`+`T`+`G`). The spec states the answer as a position rather \
+              than as a description, so the position — not a string — is what \
+              carries it, and it is pinned in PARTITIONS",
+    },
+    Worked {
+        id: "W29",
+        clause: "recommendations/protein/deletion.md:107",
+        quote: "the description `p.Ser4del` is not correct",
+        input: "NP_SPECW29.1:p.Ser4del",
+        published: "p.Ser5del",
+        answer: "NP_SPECW29.1:p.Ser5del",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the 3' rule on the protein axis: in a Ser run the most C-terminal \
+              residue is the one described as deleted, and the DNA-level fact \
+              that codon 4 was the one removed must not be used",
+    },
+    Worked {
+        id: "W30",
+        clause: "recommendations/protein/duplication.md:98",
+        quote: "the description `p.Ser4dup` is not correct",
+        input: "NP_SPECW29.1:p.Ser4dup",
+        published: "p.Ser5dup",
+        answer: "NP_SPECW29.1:p.Ser5dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "the duplication half of the same run",
+    },
+    Worked {
+        id: "W31",
+        clause: "recommendations/protein/deletion.md:39",
+        quote: "for deletions in single amino acid stretches or tandem repeats, the most C-terminal residue is arbitrarily assigned",
+        input: "NP_SPECW31.1:p.Trp3del",
+        published: "NP_003997.2:p.Trp4del",
+        answer: "NP_SPECW31.1:p.Trp4del",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "`MetLeuTrp`+`Trp`+`Glu`: the deletion is assigned to Trp4, not Trp3",
+    },
+    Worked {
+        id: "W32",
+        clause: "recommendations/protein/duplication.md:40",
+        quote: "for duplications in single amino acid stretches or tandem repeats, the most C-terminal residue is arbitrarily assigned",
+        input: "NP_SPECW31.1:p.Trp4dup",
+        published: "NP_003997.2:p.Trp4dup",
+        answer: "NP_SPECW31.1:p.Trp4dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Protein,
+        why: "and the C-terminal-most spelling is already a fixed point",
+    },
+    Worked {
+        id: "W61",
+        clause: "recommendations/DNA/deletion.md:34",
+        quote: "the last A of the 8 nucleotide A-stretch running from position `c.5690` to `c.5697`",
+        input: "LRG_199t1:c.5690del",
+        published: "NM_004006.2:c.5697del",
+        answer: "LRG_199t1:c.5697del",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "the 3' rule inside a mononucleotide run, on the real _DMD_ A-stretch",
+    },
+    Worked {
+        id: "W61",
+        clause: "recommendations/DNA/duplication.md:39",
+        quote: "the last `A` of the 8 nucleotide A-stretch running from position `c.5690` to `c.5697`",
+        input: "LRG_199t1:c.5690dup",
+        published: "NM_004006.2:c.5697dup",
+        answer: "LRG_199t1:c.5697dup",
+        rebase: Rebase::Accession,
+        fixture: Fixture::Slice,
+        why: "the duplication half of the same run",
+    },
+    Worked {
+        id: "W64",
+        clause: "background/numbering.md:25",
+        quote: "the variant is described as `LRG_199t1:c.3921del`",
+        input: "LRG_199t1:c.3921del",
+        published: "LRG_199t1:c.3921del",
+        answer: "LRG_199t1:c.3921del",
+        rebase: Rebase::Same,
+        fixture: Fixture::Slice,
+        why: "the exon/exon junction exception to the 3' rule: the spec's own \
+              answer is a fixed point and is not shifted into the next exon. \
+              (Whether `c.3922del` should converge *back* onto it is the open \
+              ruling `exon-junction-dup-converge-from-the-far-side`, whose `dup` \
+              half is pinned in `spec_worked_examples.rs`)",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// The forbidden half
+// ---------------------------------------------------------------------------
+
+/// Legal inputs, each paired with the exact description the spec forbids.
+///
+/// A positive assertion already implies these, but only as long as the positive
+/// answer stays what it is. Naming the forbidden string makes the failure say
+/// *which rule* was broken, and it is the half that catches a normalizer
+/// manufacturing a separation or a merge it was not licensed to make.
+const NEGATIVE: &[Negative] = &[
+    Negative {
+        id: "W1",
+        clause: "recommendations/DNA/substitution.md:32",
+        quote: "so the description <code class=\"invalid\">c.[79G>T;80C>T]</code> is not correct",
+        input: "LRG_199t1:c.[79G>T;80C>T]",
+        forbidden: "LRG_199t1:c.[79G>T;80C>T]",
+        fixture: Fixture::Slice,
+        why: "two consecutive substitutions must not survive as two members",
+    },
+    Negative {
+        id: "W8",
+        clause: "recommendations/DNA/duplication.md:34",
+        quote: "it is **not** allowed to describe the variant as `c.19_20insT`",
+        input: "LRG_199t1:c.19_20insT",
+        forbidden: "LRG_199t1:c.19_20insT",
+        fixture: Fixture::Slice,
+        why: "a duplicating insertion must not stay an insertion",
+    },
+    Negative {
+        id: "W8",
+        clause: "recommendations/DNA/duplication.md:35",
+        quote: "the recommendation is not to describe the variant as <code class=\"invalid\">NM_004006.2:c.20dupT</code>",
+        input: "LRG_199t1:c.20dupT",
+        forbidden: "LRG_199t1:c.20dupT",
+        fixture: Fixture::Slice,
+        why: "and the duplicated base must not be restated",
+    },
+    Negative {
+        id: "W10",
+        clause: "recommendations/RNA/duplication.md:30",
+        quote: "it is **not** allowed to describe the variant as",
+        input: "NM_SPECW10.1:r.6_7insu",
+        forbidden: "NM_SPECW10.1:r.6_7insu",
+        fixture: Fixture::Coding,
+        why: "the RNA restatement of the same prohibition",
+    },
+    Negative {
+        id: "W13",
+        clause: "recommendations/DNA/inversion.md:56",
+        quote: "`TTCG` is only the **complement** of `AAGC`.",
+        input: "SPEC_W13.1:g.1_4delinsTTCG",
+        forbidden: "SPEC_W13.1:g.1_4inv",
+        fixture: Fixture::Genomic,
+        why: "a complement is not an inversion. This is the negative side of the \
+              `delins -> inv` canonicalisation W15 exercises: it must fire on the \
+              reverse complement and on nothing else",
+    },
+    Negative {
+        id: "W14",
+        clause: "recommendations/DNA/inversion.md:62",
+        quote: "`CGAA` is only the **reverse** of `AAGC`.",
+        input: "SPEC_W13.1:g.1_4delinsCGAA",
+        forbidden: "SPEC_W13.1:g.1_4inv",
+        fixture: Fixture::Genomic,
+        why: "nor is a reverse",
+    },
+    Negative {
+        id: "W16",
+        clause: "recommendations/DNA/insertion.md:118",
+        quote: "seems correct but neglects the **3'rule**",
+        input: "NM_SPECW16.1:c.1_24dup",
+        forbidden: "NM_SPECW16.1:c.1_24dup",
+        fixture: Fixture::Coding,
+        why: "the 5'-most spelling of a shiftable block must not survive",
+    },
+    Negative {
+        id: "W45",
+        clause: "recommendations/DNA/delins.md:42",
+        quote: "so the description <code class=\"invalid\">c.[145C>T;147C>G]</code> is not correct",
+        input: "LRG_199t1:c.[145C>T;147C>G]",
+        forbidden: "LRG_199t1:c.[145C>T;147C>G]",
+        fixture: Fixture::Slice,
+        why: "the separation-1 codon pair must not stay split. (This NOTE sits \
+              under an unrelated example, `c.9002_9009delinsTTT` — catalog \
+              conflict C8, a spec editing slip; the rule it states is the one \
+              `substitution.md:37` attaches to the right example)",
+    },
+    Negative {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:64",
+        quote: "the variant is not described as `p.Ser44_Trp46delinsArgLeuArg`.",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        forbidden: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        fixture: Fixture::Protein,
+        why: "the spec names the forbidden string in its own words, so the negative \
+              half is quotable verbatim: the separation-1 protein delins must not \
+              survive as itself",
+    },
+    Negative {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "two variants separated by one or more amino acids should be described individually and not as a \"delins\".",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        forbidden: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        fixture: Fixture::Protein,
+        why: "and the same at the second locus. A positive-only assertion would go \
+              green again the moment the split stopped firing and the input became \
+              its own answer",
+    },
+    Negative {
+        id: "W56",
+        clause: "consultation/SVD-WG010.md:45",
+        quote: "described as separate variants, not as \"delins\" (`c.235_238delinsTAGT`)",
+        input: "LRG_199t1:c.[235A>T;238G>T]",
+        forbidden: "LRG_199t1:c.235_238delinsTAGT",
+        fixture: Fixture::Slice,
+        why: "separation 2 must not merge. SVD-WG010 proposed exactly this merge \
+              and was rejected; `general.md:36-39` still announces it as \
+              forthcoming (catalog conflict C2), so a normalizer written to the \
+              general page's NOTE would fail here",
+    },
+    Negative {
+        id: "W57",
+        clause: "consultation/SVD-WG010.md:16",
+        quote: "is described as `g.3_4delinsGGT`, not as `g.[3C>G;7dup]`",
+        input: "SPEC_W57.1:g.[3C>G;7dup]",
+        forbidden: "SPEC_W57.1:g.3_4delinsGGT",
+        fixture: Fixture::Genomic,
+        why: "the rejected proposal's flagship example, read the way the rejection \
+              leaves it. SVD-WG010:15 is the only place in the corpus that would \
+              measure separation over the whole shift interval rather than at the \
+              canonical position; it is not in force, so a substitution at g.3 and \
+              a dup at g.7 stay two members",
+    },
+    Negative {
+        id: "W58",
+        clause: "consultation/SVD-WG010.md:51",
+        quote: "separated by fewer than two nucleotides and described as a \"delins\" variant",
+        input: "LRG_199t1:c.[992_1002del;1004T>C]",
+        forbidden: "LRG_199t1:c.992_1004delinsAC",
+        fixture: Fixture::Slice,
+        why: "the rejected proposal's answer must not be produced",
+    },
+    Negative {
+        id: "W60",
+        clause: "background/glossary.md:10",
+        quote: "not the `T` at position 2 or 3",
+        input: "SPEC_W60.1:g.2del",
+        forbidden: "SPEC_W60.1:g.2del",
+        fixture: Fixture::Genomic,
+        why: "the spec names the two wrong positions explicitly; this pins one of \
+              them, and the partition row pins the right one",
+    },
+    Negative {
+        id: "W61",
+        clause: "recommendations/DNA/deletion.md:30",
+        quote: "the recommendation is not to describe the variant as",
+        input: "LRG_199t1:c.5697delA",
+        forbidden: "LRG_199t1:c.5697delA",
+        fixture: Fixture::Slice,
+        why: "the deleted base must not be restated",
+    },
+    Negative {
+        id: "W64",
+        clause: "background/numbering.md:25",
+        quote: "**not as** `c.3922del`",
+        input: "LRG_199t1:c.3921del",
+        forbidden: "LRG_199t1:c.3922del",
+        fixture: Fixture::Slice,
+        why: "the junction exception must hold: a 3' shift here would cross into \
+              the next exon and, projected back, move 2,790 bp on the genome",
+    },
+];
+
+/// Spellings the spec bans outright: ferro must refuse them at the parser.
+///
+/// A prohibition ferro merely *normalizes away* still accepts the string; these
+/// rows assert the stronger thing, which is what the spec's wording ("is not
+/// allowed", "can not be used") states.
+const REJECTED: &[Rejected] = &[
+    Rejected {
+        id: "W1",
+        clause: "recommendations/DNA/substitution.md:33",
+        quote: "this change can not be described as a substitution like",
+        input: "LRG_199t1:c.79_80GC>TT",
+        why: "a substitution replaces one nucleotide by one other; a multi-base \
+              reference in a `>` is not a description ferro will read",
+    },
+    Rejected {
+        id: "W2",
+        clause: "recommendations/DNA/delins.md:73",
+        quote: "Can I describe a `GC` to `TG` variant as a di-nucleotide substitution",
+        input: "SPEC_W02.1:g.4GC>TG",
+        why: "the genomic form of the same prohibition",
+    },
+    Rejected {
+        id: "W4",
+        clause: "recommendations/RNA/delins.md:65",
+        quote: "By definition, a substitution changes **one** nucleotide into **one** other nucleotide",
+        input: "NM_SPECW04.1:r.4gc>ug",
+        why: "and the RNA form",
+    },
+    Rejected {
+        id: "W5",
+        clause: "recommendations/protein/substitution.md:96",
+        quote: "No, this is not allowed.",
+        input: "NP_SPECW05.1:p.TrpVal24CysArg",
+        why: "and the protein form — a two-residue substitution is a delins",
+    },
+    Rejected {
+        id: "W42",
+        clause: "recommendations/DNA/inversion.md:19",
+        quote: "not as <code class=\"invalid\">g.123_456dupinv</code>",
+        input: "SPEC_W42.1:g.123_234dupinv",
+        why: "an inverted duplication is an insertion carrying an `inv` payload \
+              (`duplication.md:20`), never a `dup` with a suffix. The cited clause \
+              is `inversion.md:19`, which marks `dupinv` itself invalid; this row \
+              previously cited `duplication.md:92`, whose prohibition is of \
+              `dupins` — a different malformed spelling, so the citation named a \
+              clause that does not reach this input and the verbatim-quote check \
+              cannot detect that (it verifies the quote is on the line, not that \
+              the line is about the input). `inversion.md:64` carries the same \
+              ruling at length in the Q&A, and the rest of the repo already cites \
+              `:19` for this form. The positive half of W42 — whether the payload \
+              is spelled as a coordinate range or as literal bases — is the same \
+              under-specification pinned at W11",
+    },
+    Rejected {
+        id: "W50",
+        clause: "recommendations/general.md:58",
+        quote: "descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed",
+        input: "LRG_199t1:c.[762_768del;767_774dup]",
+        why: "the spec's own forbidden example, and the strongest wording in the \
+              prioritisation family. Note ferro reads `:58` narrowly — as barring \
+              members that *overlap* on the reference — which is what lets it keep \
+              the disjoint aligning split `delins.md:46` publishes (catalog \
+              conflict C1). Both halves are asserted, so a future widening of \
+              either reading breaks a test rather than passing silently",
+    },
+    Rejected {
+        id: "W55",
+        clause: "recommendations/protein/alleles.md:34",
+        quote: "the description <code class=\"invalid\">p.([Ser68Arg;Asn594del])</code> is not correct",
+        input: "NP_SPECW48.1:p.([Phe233Leu;Cys690Trp])",
+        why: "prediction parentheses outside the allele brackets are not a legal \
+              spelling",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Partitions
+// ---------------------------------------------------------------------------
+
+/// The partition each description asserts, pinned member by member.
+///
+/// Read off the **parsed** output rather than the rendered text: an output can
+/// render plausibly over a wrong member count, and the member count is precisely
+/// what the merge/split rules decide.
+const PARTITIONS: &[Partition] = &[
+    Partition {
+        id: "W1",
+        clause: "recommendations/DNA/delins.md:16",
+        quote: "changes involving two or more consecutive nucleotides are described as deletion/insertion (delins) variants.",
+        input: "LRG_199t1:c.[79G>T;80C>T]",
+        members: &[(79, 80)],
+        fixture: Fixture::Slice,
+        why: "two members in, one member out, spanning both nucleotides",
+    },
+    Partition {
+        id: "W2",
+        clause: "recommendations/DNA/delins.md:77",
+        quote: "should be described as `g.4_5delinsTG`",
+        input: "SPEC_W02.1:g.[4G>T;5C>G]",
+        members: &[(4, 5)],
+        fixture: Fixture::Genomic,
+        why: "same shape on the genomic axis",
+    },
+    Partition {
+        id: "W3",
+        clause: "recommendations/DNA/substitution.md:91",
+        quote: "When phase information is not available",
+        input: "SPEC_W03.1:g.12G>T(;)13C>G",
+        members: &[(12, 12), (13, 13)],
+        fixture: Fixture::Genomic,
+        why: "unknown phase keeps two members on consecutive nucleotides — the one \
+              shape `delins.md:16` does not reach, because the two changes are not \
+              asserted to be on one molecule",
+    },
+    Partition {
+        id: "W43",
+        clause: "recommendations/DNA/delins.md:88",
+        quote: "The correct description of this variant is `NM_007294.3:c.2077delinsATA`.",
+        input: "NM_SPECW43.1:c.[2077G>A;2077_2078insTA]",
+        members: &[(2077, 2077)],
+        fixture: Fixture::Coding,
+        why: "an abutting substitution and insertion collapse to one member",
+    },
+    Partition {
+        id: "W45",
+        clause: "recommendations/DNA/substitution.md:37",
+        quote: "should be described as a \"delins\"",
+        input: "LRG_199t1:c.[145C>T;147C>G]",
+        members: &[(145, 147)],
+        fixture: Fixture::Slice,
+        why: "the merged member spans the unchanged c.146 between them",
+    },
+    Partition {
+        id: "W46",
+        clause: "recommendations/general.md:35",
+        quote: "together affecting one amino acid, should be described as a \"delins\"",
+        input: "LRG_199t1:c.[235A>T;237G>T]",
+        members: &[(235, 237)],
+        fixture: Fixture::Slice,
+        why: "same, one codon further along the same transcript",
+    },
+    Partition {
+        id: "W49",
+        clause: "recommendations/DNA/delins.md:46",
+        quote: "giving an alternative description like `c.[850_869del;874_881del;887_897del;901_902insG]`",
+        input: "LRG_199t1:c.[850_869del;874_881del;887_897del;901_902insG]",
+        members: &[(850, 869), (874, 881), (887, 897), (901, 902)],
+        fixture: Fixture::Slice,
+        why: "the split the spec names as legal survives with all four members and \
+              their gaps of 4, 5 and 3 nt intact — nothing is merged into the hull",
+    },
+    Partition {
+        id: "W49",
+        clause: "recommendations/DNA/delins.md:47",
+        quote: "**The \"delins\" format is recommended**",
+        input: "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG",
+        members: &[(850, 901)],
+        fixture: Fixture::Slice,
+        why: "and the recommended spanning form stays one member",
+    },
+    Partition {
+        id: "W51",
+        clause: "recommendations/DNA/alleles.md:17",
+        quote: "when two variants are identified in a gene that are **on different chromosomes** (in trans)",
+        input: "LRG_199t1:c.[2376G>C];[3103del]",
+        members: &[(2376, 2376), (3103, 3103)],
+        fixture: Fixture::Slice,
+        why: "a trans pair is two members on two alleles and never merges, whatever \
+              their separation",
+    },
+    Partition {
+        id: "W56",
+        clause: "consultation/SVD-WG010.md:45",
+        quote: "separated by two nucleotides and described as separate variants",
+        input: "LRG_199t1:c.235_238delinsTAGT",
+        members: &[(235, 235), (238, 238)],
+        fixture: Fixture::Slice,
+        why: "the split is where the spec puts it: at 235 and 238, not at the hull. \
+              A splitter that merely re-derived a minimal partition could reach the \
+              same rendered string by a different route; the spans say it did not",
+    },
+    Partition {
+        id: "W57",
+        clause: "recommendations/general.md:34",
+        quote: "should be described individually and **not** as a \"delins\"",
+        input: "SPEC_W57.1:g.[3C>G;7dup]",
+        members: &[(3, 3), (7, 7)],
+        fixture: Fixture::Genomic,
+        why: "the dup stays at its 3'-most position (the T-run is g.5–g.7) and the \
+              substitution stays its own member",
+    },
+    Partition {
+        id: "W58",
+        clause: "recommendations/general.md:34",
+        quote: "two variants separated by one or more nucleotides should be described individually",
+        input: "LRG_199t1:c.[992_1002del;1004T>C]",
+        members: &[(992, 1002), (1004, 1004)],
+        fixture: Fixture::Slice,
+        why: "an 11-nt deletion and a substitution one nucleotide apart",
+    },
+    Partition {
+        id: "W59",
+        clause: "recommendations/general.md:34",
+        quote: "should be described individually and **not** as a \"delins\"",
+        input: "LRG_199t1:c.[2962T>G;2970A>T]",
+        members: &[(2962, 2962), (2970, 2970)],
+        fixture: Fixture::Slice,
+        why: "separation 7 on the DNA axis",
+    },
+    Partition {
+        id: "W48",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "should be described individually and not as a \"delins\"",
+        input: "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+        members: &[(44, 44), (46, 46)],
+        fixture: Fixture::Protein,
+        why: "two single-residue members with `Leu45` between them and in neither. \
+              Read off the parsed output, because a two-member render over a \
+              44_46 span would be the wrong partition wearing the right string",
+    },
+    Partition {
+        id: "W59",
+        clause: "recommendations/protein/delins.md:21",
+        quote: "should be described individually and not as a \"delins\"",
+        input: "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+        members: &[(988, 988), (990, 990)],
+        fixture: Fixture::Protein,
+        why: "the same partition at the second locus",
+    },
+    Partition {
+        id: "W60",
+        clause: "background/glossary.md:10",
+        quote: "a change of the `T` at position 4",
+        input: "SPEC_W60.1:g.2del",
+        members: &[(4, 4)],
+        fixture: Fixture::Genomic,
+        why: "the 3'-rule position the spec names, asserted as a coordinate rather \
+              than as a rendered string",
+    },
+    Partition {
+        id: "W61",
+        clause: "recommendations/DNA/deletion.md:34",
+        quote: "the last A of the 8 nucleotide A-stretch",
+        input: "LRG_199t1:c.5690del",
+        members: &[(5697, 5697)],
+        fixture: Fixture::Slice,
+        why: "the run is c.5690–c.5697 and the deletion lands on its 3' end",
+    },
+    Partition {
+        id: "W64",
+        clause: "background/numbering.md:23",
+        quote: "the 3' rule is not applied when there is a deletion/duplication around exon/exon junctions",
+        input: "LRG_199t1:c.3921del",
+        members: &[(3921, 3921)],
+        fixture: Fixture::Slice,
+        why: "the exception holds the member at the exon's last nucleotide",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Recorded divergences
+// ---------------------------------------------------------------------------
+
+/// Rows where ferro's answer is not the spec's, and that is not a defect.
+///
+/// Pinned both ways: ferro must still produce `ferro_answer`, and it must still
+/// **not** produce `spec_answer`. If a change makes one of these conform, the
+/// test fails and the row must be promoted into [`WORKED`] deliberately.
+const DIVERGENT: &[Divergence] = &[
+    Divergence {
+        id: "W11",
+        clause: "recommendations/DNA/insertion.md:111",
+        quote: "The variant should be described as an insertion; `g.17_18ins5_16`.",
+        input: "SPEC_W11.1:g.17_18ins5_16",
+        spec_answer: "SPEC_W11.1:g.17_18ins5_16",
+        ferro_answer: "SPEC_W11.1:g.17_18insATCGATCGATCG",
+        fixture: Fixture::Genomic,
+        why: "**Spelling the spec leaves open.** `insertion.md:22` licenses the \
+              inserted sequence as literal bases *or* as an in-reference \
+              coordinate range, and `consultation/open-issues.md:72-78` records \
+              that the recommendations \"do not specify when to use which of these \
+              formats ... This is undesired\" (catalog conflict C11). Ferro \
+              resolves the range against the reference and emits the literal, \
+              which is the same variant in the other licensed spelling. What the \
+              spec is actually settling here — that this is an insertion and not \
+              a `dup`, because the copy is not directly 3'-flanking \
+              (`duplication.md:17`) — ferro gets right, and that is asserted \
+              below rather than left implied",
+    },
+    Divergence {
+        id: "W53",
+        clause: "recommendations/DNA/alleles.md:106",
+        quote: "which can be described as `LRG_199t1:c.[76A>C];[0]`",
+        input: "LRG_199t1:c.[76A>C];[0]",
+        spec_answer: "LRG_199t1:c.[76A>C];[0]",
+        ferro_answer: "[LRG_199t1:c.76A>C];[0]",
+        fixture: Fixture::Slice,
+        why: "**Render placement, not content.** Ferro puts the accession inside \
+              the first bracket where the spec puts it in front; the members, \
+              their phase and their positions are identical. The same deliberate \
+              choice is already pinned as class 2 of `KNOWN_DIVERGENT_INPUTS` in \
+              `hgvs_spec_normalization_tests.rs`; recorded here so the trans-plus- \
+              null-allele shape is covered by a worked example rather than only by \
+              the harvested fixture",
+    },
+];
+
+/// Descriptions the spec publishes as **correct** that ferro cannot parse.
+///
+/// A defect, not a divergence: there is no second reading under which refusing
+/// the spec's own published answer is right. Pinned as a gap so that closing it
+/// fails here and the row can be promoted into [`WORKED`].
+const PARSE_GAPS: &[ParseGap] = &[ParseGap {
+    id: "W12",
+    clause: "recommendations/protein/duplication.md:19",
+    quote: "duplication may only be used when the additional copy is **directly C-terminal**",
+    input: "NP_SPECW48.1:p.His7_Gln8insGly4_Ser6",
+    why: "`protein/duplication.md:87-91` and `protein/insertion.md:76-80` both \
+          publish `p.His7_Gln8insGly4_Ser6` as the correct description of a \
+          non-tandem extra copy — the protein analogue of W11. Ferro's parser \
+          rejects the residue-range payload (`Unexpected trailing characters: \
+          '4_Ser6'`), so the row cannot be executed as a normalization at all",
+}];
+
+// ---------------------------------------------------------------------------
+// The rows this file does not execute
+// ---------------------------------------------------------------------------
+
+/// Already executed, in all three shipped error modes, by
+/// `tests/it/spec_worked_examples.rs`. Deliberately not duplicated here.
+const CROSS_REFERENCED: &[(&str, &str)] = &[
+    (
+        "W33",
+        "spec_worked_examples: NM_024312.4:c.2686A[10] -> c.2692_2693dup",
+    ),
+    (
+        "W34",
+        "spec_worked_examples: NM_024312.4:c.1738TA[6] -> c.1741_1742insTATATATA",
+    ),
+    (
+        "W35",
+        "spec_worked_examples: NM_024312.4:c.-6_-3G[6] is valid in the 5'UTR",
+    ),
+    (
+        "W36",
+        "spec_worked_examples: the RNA analogues, r.2686a[10] / r.1738ua[6] / r.-6_-3g[6]",
+    ),
+    (
+        "W65",
+        "spec_worked_examples: LRG_199t1:c.3921dup, and the c.3922dup far-side pair",
+    ),
+];
+
+/// Worked examples that cannot be executed hermetically, each with its reason.
+///
+/// Pinned by [`the_unexecutable_census_is_pinned`]. Shrinking this list is the
+/// point; growing it silently is the failure mode this table exists to prevent.
+const UNEXECUTABLE: &[Unexecutable] = &[
+    // -- needs a derived protein consequence -------------------------------
+    Unexecutable { id: "W17", reason: "protein consequence of a DNA edit: needs translation of NM_004006-like CDS through a real transcript/protein pair" },
+    Unexecutable { id: "W18", reason: "frameshift consequence (p.Glu5ValfsTer5) derived from c.6_13dup: needs translation" },
+    Unexecutable { id: "W19", reason: "frameshift first-new-residue rule (p.Gln151Thrfs*9): needs the shifted reading frame" },
+    Unexecutable { id: "W20", reason: "dup inside the stop codon: the spec gives three different answers for this geometry (catalog conflict C6), so there is no single published answer to assert" },
+    Unexecutable { id: "W21", reason: "an upstream ATG created by c.-23A>T: needs 5'UTR translation" },
+    Unexecutable { id: "W22", reason: "start-loss activating an upstream initiation site: the prose says delins and the worked answer is an insertion (catalog conflict C7)" },
+    Unexecutable { id: "W23", reason: "protein consequence of NM_004380.2:c.139delinsTCATCATGAGCTG: needs translation" },
+    Unexecutable { id: "W24", reason: "protein consequence of NM_004380.2:c.138_139ins...: needs translation" },
+    Unexecutable { id: "W25", reason: "protein consequence of c.9_10insGGGTAG: needs translation" },
+    Unexecutable { id: "W26", reason: "protein consequence of NM_080877.2:c.1733_1735delinsTTT: needs translation" },
+    Unexecutable { id: "W27", reason: "protein consequence of NM_000222.3:c.1676_1684del: needs translation" },
+    Unexecutable { id: "W28", reason: "protein consequence of an inversion (NM_003079.4:c.374_395inv): needs translation" },
+    Unexecutable { id: "W37", reason: "the FMR1 mixed GGC/GGA repeat: needs the real NM_002024.5 5'UTR bases" },
+    Unexecutable { id: "W39", reason: "keyed on population variability ('when the repeat is variable in the population'), which no reference sequence carries" },
+    Unexecutable { id: "W40", reason: "same, on the RNA axis" },
+    Unexecutable { id: "W41", reason: "an L1 insertion whose payload cites an external accession and a target-site duplication; no hermetic stand-in for the inserted element" },
+    Unexecutable { id: "W54", reason: "two competing partitions of one evidence set joined by `^`, with the protein consequence of c.472A>G/c.473A>T: needs translation" },
+    Unexecutable { id: "W62", reason: "the g./c. pair for a minus-strand transcript: needs a real genome plus cdot alignment, not a transcript slice" },
+    Unexecutable { id: "W63", reason: "same, at NM_004006.1/NC_000023.10 coordinates" },
+    Unexecutable { id: "W66", reason: "the exon/intron border case (c.1704+1del): the committed slice serves no intronic bases at that junction, so a pass would be vacuous" },
+    Unexecutable { id: "W67", reason: "the intron/exon border case (c.1813del): same" },
+    Unexecutable { id: "W68", reason: "LRG_2t1:r.1034_1036del: that accession is not in any committed fixture" },
+    Unexecutable { id: "W69", reason: "the CFTR deltaF508 pair: needs real NM_000492.3 bases" },
+    Unexecutable { id: "W70", reason: "the same variant's full DNA/RNA/protein stack: needs translation" },
+    Unexecutable { id: "W71", reason: "LRG_232t1:c.1365_1373del projected to protein: needs translation" },
+    Unexecutable { id: "W72", reason: "a DMD exon-5 deletion projected to protein: needs translation and real exon structure" },
+    Unexecutable { id: "W73", reason: "the ATXN7 CAG->AGC unit rotation: needs real NM_000333.3 bases" },
+    Unexecutable { id: "W74", reason: "the FMR1 CGG->GGC rotation: needs real bases" },
+    Unexecutable { id: "W75", reason: "the HTT CAG->AGC rotation: needs real bases" },
+    Unexecutable { id: "W76", reason: "the CFTR intron-9 GT/T tract: needs real intronic bases" },
+    Unexecutable { id: "W77", reason: "the DAB1 repeat spelled differently on g. and c.: needs a real minus-strand genome/transcript pair" },
+    Unexecutable { id: "W78", reason: "origin-spanning del/dup on a circular molecule: needs full-length NC_012920.1 / J01749.1 contigs, and rebasing the coordinates onto a short contig would fabricate the published answer" },
+    Unexecutable { id: "W79", reason: "the pre-SVD-WG006 interim spelling m.[1del;16569del]: a superseded suggestion, not a published answer" },
+    Unexecutable { id: "W80", reason: "the 3' rule applied to an MLPA probe's ligation centre: an assay artefact, not a variant description" },
+    Unexecutable { id: "W81", reason: "the published answer is 'use genomic coordinates', not a string" },
+    Unexecutable { id: "W82", reason: "a numbering scheme (c.-15+1 ... c.-14-1), with no input/output pair" },
+    Unexecutable { id: "W83", reason: "same, for an intron immediately after the stop codon" },
+    Unexecutable { id: "W84", reason: "a pericentric inversion plus an abutting substitution at megabase coordinates; a short synthetic contig cannot carry it and rebasing would fabricate the answer" },
+    Unexecutable { id: "W85", reason: "same, with a 275 bp deletion and an anchorless insG" },
+    Unexecutable { id: "W86", reason: "a cross-axis g./c./r./p. quadruple: needs projection through a real reference" },
+    Unexecutable { id: "W87", reason: "an RNA consequence (r.(3277_3432del)) predicted from a coding substitution: needs splicing prediction" },
+    Unexecutable { id: "W88", reason: "alternative RNA products plus their protein consequences: needs projection and translation" },
+    Unexecutable { id: "W89", reason: "same shape at c.93G>T" },
+    Unexecutable { id: "W90", reason: "an RNA insertion whose payload cites intronic c. coordinates: needs a genomic reference" },
+    Unexecutable { id: "W91", reason: "same shape for c.831+2T>A, whose RNA answer inserts intronic sequence" },
+    Unexecutable { id: "W92", reason: "SVD-WG011 is an OPEN proposal, not in force" },
+    Unexecutable { id: "W93", reason: "SVD-WG011 again, for c.1704+2T>A: an OPEN proposal, not in force" },
+    Unexecutable { id: "W94", reason: "SVD-WG011 again, for c.8669-24_8669-19del: an OPEN proposal, not in force" },
+    Unexecutable { id: "W95", reason: "a predicted silent protein consequence of LRG_199t1:c.123C>T: needs translation" },
+];
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+/// The committed spec worked-example reference window, loaded once.
+fn slice_provider() -> &'static WindowProvider {
+    static SLICE: OnceLock<WindowProvider> = OnceLock::new();
+    SLICE.get_or_init(|| {
+        WindowFixture::from_json_path(&repo_path(WINDOWS_PATH))
+            .expect("load the committed spec worked-example reference slice")
+            .to_provider()
+    })
+}
+
+fn transcript(id: &str, sequence: &str, cds: Option<(u64, u64)>) -> Transcript {
+    let (cds_start, cds_end) = match cds {
+        Some((start, end)) => (Some(start), Some(end)),
+        None => (None, None),
+    };
+    Transcript::new(
+        id.to_string(),
+        Some("SPEC".to_string()),
+        Strand::Plus,
+        sequence.to_string(),
+        cds_start,
+        cds_end,
+        vec![Exon::new(1, 1, sequence.len() as u64)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+/// Cyclic `ACGT` filler with literal blocks planted at 1-based positions.
+///
+/// Used where a worked example names a coordinate far from any sequence it
+/// prints (`c.2077`, `r.142`): the printed context goes at the printed
+/// coordinate and the filler only has to be *something*.
+///
+/// **What the filler actually is**, because an earlier version of this comment
+/// claimed it was neither a homopolymer nor a tandem repeat and it is both.
+/// `(i * 7 + i / 4) % 4` has period 16 in `i` — `i * 7 % 4` has period 4 and
+/// `i / 4 % 4` has period 16 — so this emits the 16-mer `ATGCCATGGCATTGCA`
+/// repeated end to end, which is a perfect tandem repeat over the whole length
+/// and carries a two-base homopolymer run roughly every fourth base (599 of
+/// them in `planted(2400, &[])`).
+///
+/// So the filler is **not** what makes a row safe. What makes a row safe is
+/// that its answer is compared against the string the spec publishes
+/// ([`every_worked_example_produces_the_spec_published_answer`]), so a shift the
+/// example does not intend fails the row rather than passing quietly. A new
+/// `planted`-backed row therefore has to check its own flanking context rather
+/// than inherit a guarantee from this helper.
+fn planted(length: usize, blocks: &[(usize, &str)]) -> String {
+    let mut bases: Vec<u8> = (0..length).map(|i| b"ACGT"[(i * 7 + i / 4) % 4]).collect();
+    for (start, block) in blocks {
+        for (offset, base) in block.bytes().enumerate() {
+            bases[start - 1 + offset] = base;
+        }
+    }
+    String::from_utf8(bases).expect("planted sequences are ASCII")
+}
+
+/// A protein of `length` residues, `Ala` everywhere except the planted ones.
+fn protein(length: usize, residues: &[(usize, u8)]) -> String {
+    let mut sequence = vec![b'A'; length];
+    for (position, residue) in residues {
+        sequence[position - 1] = *residue;
+    }
+    String::from_utf8(sequence).expect("protein sequences are ASCII")
+}
+
+/// Every synthetic fixture, built once.
+///
+/// Each sequence is the one the spec prints beside its example, under an
+/// accession that cannot be mistaken for a real one.
+fn synthetic_provider() -> &'static MockProvider {
+    static SYNTHETIC: OnceLock<MockProvider> = OnceLock::new();
+    SYNTHETIC.get_or_init(|| {
+        let mut provider = MockProvider::new();
+
+        // W2  — `TGT` + `GC` + `CA` (DNA/delins.md:77): g.4_5 is the `GC`.
+        provider.add_genomic_sequence("SPEC_W02.1", "TGTGCCA");
+        // W3  — `..GAA` + `GC` + `CAG..` (DNA/substitution.md:90): g.12_13 is
+        //       the `GC`, g.9_11 the `GAA`, g.14_16 the `CAG`.
+        provider.add_genomic_sequence("SPEC_W03.1", "TTAGCTTAGAAGCCAGTTAC");
+        // W13/W14 — `AAGC` at g.1_4 (DNA/inversion.md:53-62).
+        provider.add_genomic_sequence("SPEC_W13.1", "AAGCTTGACCTG");
+        // W15 — `..CA` + `TCAG` + `CCT..` (DNA/inversion.md:28): g.3_6 inverts.
+        provider.add_genomic_sequence("SPEC_W15.1", "CATCAGCCT");
+        // W60 — `ATT` + `T` + `G` (glossary.md:10): the T-run is g.2_4.
+        provider.add_genomic_sequence("SPEC_W60.1", "ATTTG");
+        // W57 — `AG` + `C` + `GTTTAGC` (SVD-WG010.md:16): the T-run is g.5_7.
+        provider.add_genomic_sequence("SPEC_W57.1", "AGCGTTTAGC");
+        // W11 — `ATCG` + `ATCGATCGATCG` + `A` + `GGGTCCC` (DNA/insertion.md:109).
+        provider.add_genomic_sequence("SPEC_W11.1", "ATCGATCGATCGATCGAGGGTCCC");
+        // W42 — a plain contig long enough to carry the published coordinates.
+        provider.add_genomic_sequence("SPEC_W42.1", planted(300, &[]));
+
+        // W4  — `augu` + `gc` + `ca` (RNA/delins.md:66), served as DNA bases and
+        //       rendered on the r. axis.
+        provider.add_transcript(transcript("NM_SPECW04.1", "ATGTGCCAGGGGCCCAAA", None));
+        // W10 — `acuuacu` + `u` + `gcc` (RNA/duplication.md:29).
+        provider.add_transcript(transcript("NM_SPECW10.1", "ACTTACTGCCAGGGTTT", None));
+        // W16 — `cagc` + `ATGGAGCC` + `GGCGGCGGGGAGCAGC` + `ATGGAGCC` + `TTCG`
+        //       (DNA/insertion.md:117), CDS starting at the first `ATG`.
+        provider.add_transcript(transcript(
+            "NM_SPECW16.1",
+            "CAGCATGGAGCCGGCGGCGGGGAGCAGCATGGAGCCTTCGAAAAAAAAAAAAAAAAAAAA",
+            Some((5, 58)),
+        ));
+        // W43/W44 — BRCA1 `c.2074`–`c.2080` is `..CAT` + `G` + `ACA..`
+        //            (DNA/delins.md:86, RNA/delins.md:68).
+        provider.add_transcript(transcript(
+            "NM_SPECW43.1",
+            &planted(2400, &[(2074, "CATGACA")]),
+            Some((1, 2400)),
+        ));
+        // W47 — `r.142`–`r.144` is `cga`, one codon (RNA/delins.md:18); with the
+        //       CDS starting at position 1, r.142 opens codon 48.
+        provider.add_transcript(transcript(
+            "NM_SPECW47.1",
+            &planted(600, &[(142, "CGA")]),
+            Some((1, 600)),
+        ));
+
+        // W5  — `TrpVal` at p.24_25 (protein/substitution.md:98).
+        provider.add_protein("NP_SPECW05.1", protein(40, &[(24, b'W'), (25, b'V')]));
+        // W48/W55/W59 — `Ser44`, `Leu45`, `Trp46` and `Ser988`, `Leu989`,
+        //               `Gln990` (protein/delins.md:62-64, SVD-WG010.md:53-54),
+        //               plus `Phe233`/`Cys690` for W55.
+        provider.add_protein(
+            "NP_SPECW48.1",
+            protein(
+                1200,
+                &[
+                    (44, b'S'),
+                    (45, b'L'),
+                    (46, b'W'),
+                    (233, b'F'),
+                    (690, b'C'),
+                    (988, b'S'),
+                    (989, b'L'),
+                    (990, b'Q'),
+                ],
+            ),
+        );
+        // W29/W30 — `MetTrpSerSerSerHisAsp..` (general.md:159,
+        //           protein/duplication.md:97).
+        provider.add_protein("NP_SPECW29.1", "MWSSSHDKLMNPQRSTVWY");
+        // W31/W32 — `MetLeuTrpTrpGlu` (protein/deletion.md:38).
+        provider.add_protein("NP_SPECW31.1", "MLWWEKLMNPQRSTVWY");
+
+        provider
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Running a row
+// ---------------------------------------------------------------------------
+
+fn normalize_with<P: ReferenceProvider + Clone>(
+    provider: &P,
+    input: &str,
+) -> Result<String, String> {
+    let variant = parse_hgvs(input).map_err(|e| format!("parse error: {e}"))?;
+    Normalizer::new(provider.clone())
+        .normalize(&variant)
+        .map(|n| n.to_string())
+        .map_err(|e| format!("normalize error: {e}"))
+}
+
+/// Normalize `input` through the fixture `fixture` names.
+fn run(fixture: Fixture, input: &str) -> Result<String, String> {
+    match fixture {
+        Fixture::Slice => normalize_with(slice_provider(), input),
+        _ => normalize_with(synthetic_provider(), input),
+    }
+}
+
+/// Normalize and re-parse, returning the parsed normal form.
+fn normalized_variant(fixture: Fixture, input: &str) -> HgvsVariant {
+    let rendered = run(fixture, input).unwrap_or_else(|e| panic!("{input}: {e}"));
+    parse_hgvs(&rendered).unwrap_or_else(|e| {
+        panic!("{input} normalized to {rendered}, which does not re-parse: {e}")
+    })
+}
+
+/// The `(start, end)` of one member, on that member's own axis.
+fn span_of(variant: &HgvsVariant) -> Option<(i64, i64)> {
+    match variant {
+        HgvsVariant::Genome(v) => {
+            let location = &v.loc_edit.location;
+            Some((
+                location.start.inner()?.base as i64,
+                location.end.inner()?.base as i64,
+            ))
+        }
+        HgvsVariant::Mt(v) => {
+            let location = &v.loc_edit.location;
+            Some((
+                location.start.inner()?.base as i64,
+                location.end.inner()?.base as i64,
+            ))
+        }
+        HgvsVariant::Cds(v) => {
+            let location = &v.loc_edit.location;
+            Some((location.start.inner()?.base, location.end.inner()?.base))
+        }
+        HgvsVariant::Tx(v) => {
+            let location = &v.loc_edit.location;
+            Some((location.start.inner()?.base, location.end.inner()?.base))
+        }
+        HgvsVariant::Rna(v) => {
+            let location = &v.loc_edit.location;
+            Some((location.start.inner()?.base, location.end.inner()?.base))
+        }
+        HgvsVariant::Protein(v) => {
+            let location = &v.loc_edit.location;
+            Some((
+                location.start.inner()?.number as i64,
+                location.end.inner()?.number as i64,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Every member's span, in rendered order. A bare (single-member) description
+/// yields one span.
+fn member_spans(variant: &HgvsVariant) -> Vec<(i64, i64)> {
+    match variant {
+        HgvsVariant::Allele(allele) => allele.variants.iter().flat_map(member_spans).collect(),
+        other => span_of(other).into_iter().collect(),
+    }
+}
+
+/// Everything before the first `:`, i.e. the accession, or `""` when there is
+/// none (the spec often prints a bare `c.`/`p.` fragment).
+fn without_accession(description: &str) -> &str {
+    match description.split_once(':') {
+        Some((_, rest)) => rest,
+        None => description,
+    }
+}
+
+/// The trailing edit token of a description: `del`, `dup`, `inv`, `delinsTG`, …
+fn edit_token(description: &str) -> String {
+    description
+        .chars()
+        .rev()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the citations
+// ---------------------------------------------------------------------------
+
+/// Every row's quote is still on the line it cites.
+///
+/// A pinned answer with no authority behind it is a change detector, not a
+/// record. Verifying the quote byte-for-byte is what keeps the citation honest
+/// across a spec-submodule bump: a bare line number resolves against any file
+/// long enough to have that line.
+#[test]
+fn every_row_quotes_the_spec_verbatim() {
+    let docs = repo_path(SPEC_DOCS);
+    assert!(
+        docs.join("recommendations/general.md").is_file(),
+        "the vendored HGVS spec checkout at {SPEC_DOCS} is empty. Initialise it:\n    \
+         git submodule update --init assets/hgvs-nomenclature"
+    );
+
+    let mut citations: Vec<(&str, &str, &str)> = Vec::new();
+    for row in WORKED.iter() {
+        citations.push((row.id, row.clause, row.quote));
+    }
+    for row in NEGATIVE {
+        citations.push((row.id, row.clause, row.quote));
+    }
+    for row in REJECTED {
+        citations.push((row.id, row.clause, row.quote));
+    }
+    for row in PARTITIONS {
+        citations.push((row.id, row.clause, row.quote));
+    }
+    for row in DIVERGENT {
+        citations.push((row.id, row.clause, row.quote));
+    }
+    for row in PARSE_GAPS {
+        citations.push((row.id, row.clause, row.quote));
+    }
+
+    let mut broken = Vec::new();
+    for (id, clause, quote) in &citations {
+        let (path, line_number) = clause
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("{id}: citation {clause} is not `path:line`"));
+        let line_number: usize = line_number
+            .parse()
+            .unwrap_or_else(|_| panic!("{id}: citation {clause} has no line number"));
+        let text = match std::fs::read_to_string(docs.join(path)) {
+            Ok(text) => text,
+            Err(e) => {
+                broken.push(format!("{id}: cannot read {path}: {e}"));
+                continue;
+            }
+        };
+        match text.lines().nth(line_number - 1) {
+            None => broken.push(format!("{id}: {path} has no line {line_number}")),
+            Some(line) if !line.contains(quote) => broken.push(format!(
+                "{id}: {clause} no longer contains its quote\n    quote: {quote}\n    line:  {}",
+                line.trim()
+            )),
+            Some(_) => {}
+        }
+    }
+    assert!(
+        broken.is_empty(),
+        "{} citation(s) no longer quote the spec:\n{}",
+        broken.len(),
+        broken.join("\n")
+    );
+
+    assert!(
+        citations.len() >= 60,
+        "the citation set shrank to {} — rows are being dropped rather than moved",
+        citations.len()
+    );
+}
+
+/// Every row explains itself — in every table, not only in [`WORKED`].
+///
+/// Enumerated the same way [`every_row_quotes_the_spec_verbatim`] enumerates its
+/// citations, and for the same reason: the declines are the substance of this
+/// file, so a `NEGATIVE`, `REJECTED`, `PARTITIONS`, `DIVERGENT` or `PARSE_GAPS`
+/// row shipping with an empty `why` is the failure this test exists to prevent.
+/// Checking only two of the seven tables left that unenforced for the five that
+/// carry the arguments.
+#[test]
+fn every_row_records_why_it_is_here() {
+    let mut reasons: Vec<(&str, &str)> = Vec::new();
+    for row in WORKED.iter() {
+        reasons.push((row.id, row.why));
+    }
+    for row in NEGATIVE {
+        reasons.push((row.id, row.why));
+    }
+    for row in REJECTED {
+        reasons.push((row.id, row.why));
+    }
+    for row in PARTITIONS {
+        reasons.push((row.id, row.why));
+    }
+    for row in DIVERGENT {
+        reasons.push((row.id, row.why));
+    }
+    for row in PARSE_GAPS {
+        reasons.push((row.id, row.why));
+    }
+    for (id, why) in &reasons {
+        assert!(!why.trim().is_empty(), "{id} records no reason");
+    }
+    for row in UNEXECUTABLE {
+        assert!(
+            row.reason.len() > 20,
+            "{} gives no usable reason for being unexecutable",
+            row.id
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the fixtures are what the spec says they are
+// ---------------------------------------------------------------------------
+
+/// The committed slice really carries the bases the spec quotes.
+///
+/// Every `LRG_199t1` row below is only as good as this: if the slice's bases
+/// were not the ones the spec prints beside its example, a row could pass while
+/// describing a different variant. So the spec's own quoted contexts are
+/// re-derived from the fixture before anything else runs.
+#[test]
+fn the_slice_carries_the_bases_the_spec_quotes() {
+    let fixture = WindowFixture::from_json_path(&repo_path(WINDOWS_PATH))
+        .expect("load the committed spec worked-example reference slice");
+    let tx = fixture
+        .transcripts
+        .iter()
+        .find(|t| t.id == "LRG_199t1")
+        .expect("LRG_199t1 in the committed slice");
+    let sequence = tx.sequence.as_deref().expect("LRG_199t1 bases");
+    let cds_start = tx.cds_start.expect("LRG_199t1 CDS start") as usize;
+    // `c.n` is transcript position `cds_start + n - 1`, 1-based.
+    let context =
+        |from: usize, to: usize| -> &str { &sequence[cds_start + from - 2..cds_start + to - 1] };
+
+    // W1: c.79_80 is the `GC` replaced by `TT`.
+    assert_eq!(context(79, 80), "GC", "W1");
+    // W45: c.145_147 is `CGC` (delins.md:38 names it), replaced by `TGG`.
+    assert_eq!(context(145, 147), "CGC", "W45");
+    // W46/W56: c.235 is `A`, c.237 and c.238 are `G`.
+    assert_eq!(context(235, 238), "AAGG", "W46/W56");
+    // W8/W9: `AGAAG` + `TAGA` + `GG` around c.20.
+    assert_eq!(context(15, 25), "AGAAGTAGAGG", "W8/W9");
+    // W61: the 8-nt A-stretch from c.5690 to c.5697, inside `ATTGAAAAAAAA` + `TTA`.
+    assert_eq!(context(5686, 5700), "ATTGAAAAAAAATTA", "W61");
+    // W7: `..GGAA` + `GAG` + `TTGC..` at c.6775_6777.
+    assert_eq!(context(6771, 6780), "GGAAGAGTTG", "W7");
+    // W38: c.123 is a `C` (other.md:27).
+    assert_eq!(context(123, 123), "C", "W38");
+    // W51/W52: c.2376 is a `G`; W59: c.2962 is `T` and c.2970 is `A`.
+    assert_eq!(context(2376, 2376), "G", "W51/W52");
+    assert_eq!(context(2962, 2962), "T", "W59");
+    assert_eq!(context(2970, 2970), "A", "W59");
+    // W64: the exon boundary at c.3921, whose neighbour c.3922 carries the same
+    // base — which is why the junction exception exists at all.
+    assert_eq!(context(3920, 3922), "ATT", "W64");
+}
+
+/// The synthetic fixtures carry the sequence their worked example prints.
+#[test]
+fn the_synthetic_fixtures_carry_the_sequence_the_spec_prints() {
+    let provider = synthetic_provider();
+    let genomic = |accession: &str, from: u64, to: u64| -> String {
+        provider
+            .get_sequence(accession, from - 1, to)
+            .unwrap_or_else(|e| panic!("{accession}:{from}-{to}: {e}"))
+            .to_uppercase()
+    };
+    // W2: `TGT` + `GC` + `CA`.
+    assert_eq!(genomic("SPEC_W02.1", 1, 7), "TGTGCCA", "W2");
+    // W3: `..GAA` + `GC` + `CAG..` with the `GC` at g.12_13.
+    assert_eq!(genomic("SPEC_W03.1", 9, 16), "GAAGCCAG", "W3");
+    // W13/W14: `AAGC`.
+    assert_eq!(genomic("SPEC_W13.1", 1, 4), "AAGC", "W13/W14");
+    // W15: `..CA` + `TCAG` + `CCT..`; note `TCAG` reverse-complements to `CTGA`.
+    assert_eq!(genomic("SPEC_W15.1", 1, 9), "CATCAGCCT", "W15");
+    // W60: `ATT` + `T` + `G`.
+    assert_eq!(genomic("SPEC_W60.1", 1, 5), "ATTTG", "W60");
+    // W57: `AG` + `C` + `GTTTAGC`.
+    assert_eq!(genomic("SPEC_W57.1", 1, 10), "AGCGTTTAGC", "W57");
+    // W11: the 12-mer at g.5_16 is repeated at g.1_4 and is *not* immediately 5'
+    // of the insertion point g.17_18 — the whole point of the example.
+    assert_eq!(genomic("SPEC_W11.1", 5, 16), "ATCGATCGATCG", "W11");
+    assert_eq!(genomic("SPEC_W11.1", 17, 17), "A", "W11");
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the answers
+// ---------------------------------------------------------------------------
+
+/// Every worked example produces the spec's published answer, exactly.
+///
+/// Reported as one batch rather than row by row: when a normalizer change moves
+/// these, *which* rows moved together is the diagnosis.
+#[test]
+fn every_worked_example_produces_the_spec_published_answer() {
+    let mut failures = Vec::new();
+    for row in WORKED {
+        match run(row.fixture, row.input) {
+            Ok(actual) if actual == row.answer => {}
+            Ok(actual) => failures.push(format!(
+                "  [{}] {}\n    expected: {}\n    actual:   {}\n    {} — {}",
+                row.id, row.input, row.answer, actual, row.clause, row.why
+            )),
+            Err(e) => failures.push(format!(
+                "  [{}] {}\n    expected: {}\n    error:    {}\n    {}",
+                row.id, row.input, row.answer, e, row.clause
+            )),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} worked examples no longer produce the spec's answer:\n{}",
+        failures.len(),
+        WORKED.len(),
+        failures.join("\n")
+    );
+}
+
+/// A rebased answer is the spec's string with only the accession changed.
+///
+/// The hermetic fixtures force some rows off the spec's literal accession. This
+/// is what stops that concession from widening into "close enough": for a
+/// [`Rebase::Accession`] row the two strings must be identical after the
+/// accession, and for a [`Rebase::Local`] row — where the spec numbers its
+/// example on a real chromosome — the edit must at least be the same edit, with
+/// the position pinned separately by [`PARTITIONS`].
+#[test]
+fn every_rebased_answer_differs_from_the_published_string_only_in_its_accession() {
+    for row in WORKED.iter() {
+        match row.rebase {
+            Rebase::Same => assert_eq!(
+                row.answer, row.published,
+                "[{}] claims Rebase::Same but the strings differ",
+                row.id
+            ),
+            Rebase::Accession => {
+                assert_ne!(
+                    row.answer, row.published,
+                    "[{}] claims Rebase::Accession but nothing was rebased",
+                    row.id
+                );
+                assert_eq!(
+                    without_accession(row.answer),
+                    without_accession(row.published),
+                    "[{}] rebased more than the accession",
+                    row.id
+                );
+            }
+            Rebase::Local => {
+                // Equality, not `ends_with`: a suffix match accepts an answer
+                // whose edit token is contained in the spec's — `ins` against a
+                // published `delins`, `insATA` against `delinsATA` — which is
+                // moving the edit, the one thing this arm says a local rebase
+                // may never do.
+                let (answer, published) = (edit_token(row.answer), edit_token(row.published));
+                assert!(
+                    !answer.is_empty() && published == answer,
+                    "[{}] is Rebase::Local but its edit token ({answer}) is not the \
+                     spec's ({published}); a local rebase may move coordinates, never the edit",
+                    row.id
+                );
+            }
+            Rebase::Prose => {
+                assert!(
+                    parse_hgvs(row.published).is_err(),
+                    "[{}] claims the spec states its answer as prose, but {} is a \
+                     description — compare against it directly",
+                    row.id,
+                    row.published
+                );
+                assert!(
+                    PARTITIONS.iter().any(|p| p.id == row.id),
+                    "[{}] is Rebase::Prose, so its position is the whole content of \
+                     the row and must be pinned in PARTITIONS",
+                    row.id
+                );
+            }
+        }
+    }
+}
+
+/// Every answer is its own normal form.
+///
+/// Cheap, and worth having: each output is itself a legal description, so
+/// re-normalizing it must be a no-op. A rule that reaches the right answer by
+/// one shift too many and one back satisfies the test above and fails this.
+#[test]
+fn every_answer_is_a_fixed_point() {
+    let mut inputs: Vec<(&str, Fixture, &str)> = Vec::new();
+    for row in WORKED {
+        inputs.push((row.id, row.fixture, row.input));
+    }
+    for row in NEGATIVE {
+        inputs.push((row.id, row.fixture, row.input));
+    }
+    for row in PARTITIONS {
+        inputs.push((row.id, row.fixture, row.input));
+    }
+    for row in DIVERGENT {
+        inputs.push((row.id, row.fixture, row.input));
+    }
+    let total = inputs.len();
+    let mut errored = Vec::new();
+    let mut checked = 0usize;
+    for (id, fixture, input) in inputs {
+        let once = match run(fixture, input) {
+            Ok(once) => once,
+            Err(e) => {
+                errored.push(format!("  [{id}] {input}: {e}"));
+                continue;
+            }
+        };
+        let twice = run(fixture, &once);
+        assert_eq!(
+            twice.as_deref(),
+            Ok(once.as_str()),
+            "[{id}] {input} normalized to {once}, which is not a fixed point"
+        );
+        checked += 1;
+    }
+    // The `Err` arm used to `continue` with nothing counted, so a fixture or an
+    // accession regressing every row to an error would have reported success —
+    // against this file's own stated policy of "no test that can pass vacuously"
+    // and inconsistently with `the_forbidden_description_is_never_what_ferro_emits`,
+    // which already treats an `Err` as a violation over the same NEGATIVE rows.
+    assert!(
+        errored.is_empty(),
+        "{} of {total} fixed-point rows failed to normalize at all, so their \
+         idempotency went unchecked:\n{}",
+        errored.len(),
+        errored.join("\n")
+    );
+    assert_eq!(
+        checked, total,
+        "every row must be exercised, not skipped — {checked} of {total} reached the \
+         fixed-point comparison"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the forbidden half
+// ---------------------------------------------------------------------------
+
+/// The description the spec forbids is never the one ferro emits.
+#[test]
+fn the_forbidden_description_is_never_what_ferro_emits() {
+    let mut violations = Vec::new();
+    for row in NEGATIVE {
+        match run(row.fixture, row.input) {
+            Ok(actual) if actual == row.forbidden => violations.push(format!(
+                "  [{}] {} -> {}\n    forbidden by {} — {}",
+                row.id, row.input, actual, row.clause, row.why
+            )),
+            Ok(_) => {}
+            Err(e) => violations.push(format!(
+                "  [{}] {} failed to normalize: {e}",
+                row.id, row.input
+            )),
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "{} forbidden description(s) were produced:\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+/// The spellings the spec bans are refused by the parser.
+#[test]
+fn the_banned_spellings_are_refused_by_the_parser() {
+    let mut accepted = Vec::new();
+    for row in REJECTED {
+        if let Ok(variant) = parse_hgvs(row.input) {
+            accepted.push(format!(
+                "  [{}] {} parsed as {variant}\n    banned by {} — {}",
+                row.id, row.input, row.clause, row.why
+            ));
+        }
+    }
+    assert!(
+        accepted.is_empty(),
+        "{} banned spelling(s) are accepted by the parser:\n{}",
+        accepted.len(),
+        accepted.join("\n")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — partitions
+// ---------------------------------------------------------------------------
+
+/// Each description's normal form asserts the partition the spec asserts.
+///
+/// Member count first, then every member's span. The string-level tests above
+/// can be satisfied by a right answer reached over a wrong partition — most
+/// obviously where a member's rendered coordinates coincide with a different
+/// member's, which is exactly the shape `general.md:34` and `delins.md:16`
+/// legislate.
+#[test]
+fn the_normal_forms_assert_the_partitions_the_spec_asserts() {
+    let mut failures = Vec::new();
+    for row in PARTITIONS {
+        let normalized = normalized_variant(row.fixture, row.input);
+        let spans = member_spans(&normalized);
+        if spans.len() != row.members.len() {
+            failures.push(format!(
+                "  [{}] {} -> {normalized}\n    expected {} member(s), found {}: {:?}\n    {} — {}",
+                row.id,
+                row.input,
+                row.members.len(),
+                spans.len(),
+                spans,
+                row.clause,
+                row.why
+            ));
+            continue;
+        }
+        if spans != row.members {
+            failures.push(format!(
+                "  [{}] {} -> {normalized}\n    expected spans {:?}, found {:?}\n    {} — {}",
+                row.id, row.input, row.members, spans, row.clause, row.why
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} partitions moved:\n{}",
+        failures.len(),
+        PARTITIONS.len(),
+        failures.join("\n")
+    );
+}
+
+/// W11: the copy is not directly 3'-flanking, so the answer is an insertion.
+///
+/// The rendered payload is a recorded divergence (see [`DIVERGENT`]), which
+/// would let the *substance* of `duplication.md:17` go unasserted. It does not:
+/// this pins that the member is an insertion at `g.17_18` and not a `dup`,
+/// independently of how its payload is spelled.
+#[test]
+fn a_copy_that_is_not_directly_three_prime_flanking_is_an_insertion() {
+    let normalized = normalized_variant(Fixture::Genomic, "SPEC_W11.1:g.17_18ins5_16");
+    assert_eq!(
+        member_spans(&normalized),
+        vec![(17, 18)],
+        "the insertion must stay anchored between g.17 and g.18"
+    );
+    let rendered = normalized.to_string();
+    assert!(
+        !rendered.contains("dup"),
+        "`duplication.md:17`: a duplication may only be used when the additional \
+         copy is directly 3'-flanking, and here `g.17` intervenes. Got: {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — recorded divergences
+// ---------------------------------------------------------------------------
+
+/// The recorded divergences still diverge, exactly as recorded.
+///
+/// Both directions are asserted. A change that makes one of these produce the
+/// spec's answer fails here — which is the point: promoting a divergence to a
+/// conformance is a decision, and it should cost a deliberate edit rather than
+/// happening as a side effect.
+#[test]
+fn the_recorded_divergences_are_still_exactly_what_was_recorded() {
+    let mut moved = Vec::new();
+    for row in DIVERGENT {
+        match run(row.fixture, row.input) {
+            Ok(actual) if actual == row.ferro_answer => {}
+            Ok(actual) if actual == row.spec_answer => moved.push(format!(
+                "  [{}] {} now produces the spec's answer ({}). That may be right — \
+                 promote it into WORKED and say so.\n    {} — {}",
+                row.id, row.input, row.spec_answer, row.clause, row.why
+            )),
+            Ok(actual) => moved.push(format!(
+                "  [{}] {}\n    pinned: {}\n    actual: {}\n    {} — {}",
+                row.id, row.input, row.ferro_answer, actual, row.clause, row.why
+            )),
+            Err(e) => moved.push(format!("  [{}] {} errored: {e}", row.id, row.input)),
+        }
+    }
+    assert!(
+        moved.is_empty(),
+        "{} recorded divergence(s) moved:\n{}",
+        moved.len(),
+        moved.join("\n")
+    );
+}
+
+/// The parse gaps are still gaps.
+///
+/// Pinned as a failure so that closing one is loud. `PARSE_GAPS` is a defect
+/// list, not an exemption list.
+#[test]
+fn the_recorded_parse_gaps_are_still_gaps() {
+    for row in PARSE_GAPS {
+        assert!(
+            parse_hgvs(row.input).is_err(),
+            "[{}] {} now parses. The gap is closed — move the row into WORKED and \
+             assert its answer.\n    {} — {}",
+            row.id,
+            row.input,
+            row.clause,
+            row.why
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — non-confluence the spec's own examples expose
+// ---------------------------------------------------------------------------
+
+/// `DNA/delins.md:44-47`'s two descriptions of one variant are two fixed points.
+///
+/// Stated as an observation, not a requirement. `:44` gives the spanning
+/// `c.850_901delinsTTCCTCGATGCCTG`, `:46` names
+/// `c.[850_869del;874_881del;887_897del;901_902insG]` as an "alternative
+/// description" of the *same* variant, and `:47` recommends the delins. Ferro
+/// preserves both, so the pair is non-confluent — the spec's own worked example
+/// of the problem #1235 is about.
+///
+/// `canonical-form-choice-when-both-legal` is **decided** and directs ferro to
+/// derive from the resulting sequence "subject to every explicit spec
+/// tie-break". It does not settle this pair, because here there are *two*
+/// explicit tie-breaks and they point opposite ways: `:47` recommends the
+/// spanning form, `general.md:34` requires members separated by unchanged
+/// nucleotides to stay individual. The derivation therefore selects neither, and
+/// the pair stays two fixed points.
+///
+/// So this test is an observation, not a requirement. If a change *does*
+/// converge them, it fails — not because converging is wrong, but because it is
+/// a representation change that has to name which of the two clauses it is now
+/// reading, rather than landing as a side effect.
+#[test]
+fn the_spanning_delins_and_its_published_split_are_two_fixed_points() {
+    let delins = run(Fixture::Slice, "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG")
+        .expect("the spanning delins normalizes");
+    let split = run(
+        Fixture::Slice,
+        "LRG_199t1:c.[850_869del;874_881del;887_897del;901_902insG]",
+    )
+    .expect("the published alternative normalizes");
+    assert_eq!(delins, "LRG_199t1:c.850_901delinsTTCCTCGATGCCTG");
+    assert_eq!(
+        split,
+        "LRG_199t1:c.[850_869del;874_881del;887_897del;901_902insG]"
+    );
+    assert_ne!(
+        delins, split,
+        "the spec's own non-confluent pair converged. That may well be right — but \
+         `:47` and `general.md:34` point opposite ways here, so a change that \
+         picks one must say which, rather than land as a side effect."
+    );
+}
+
+/// SVD-WG010's example converges — on the conformant form, from both spellings.
+///
+/// `SVD-WG010.md:16` prints one variant twice — `g.3_4delinsGGT` and
+/// `g.[3C>G;7dup]` — and would have made the first canonical. The proposal was
+/// **rejected** (`:5`), so `general.md:34` governs and the split is the
+/// conformant form. This is the *sequence-identical* case: both spellings
+/// denote `AGGGTTTTAGC`.
+///
+/// Ferro reaches the split from both, so the pair is confluent *and* lands on
+/// the form the rejection leaves in force. That is the decided ruling
+/// `canonical-form-choice-when-both-legal` doing its work rather than a
+/// coincidence: it directs ferro to "derive the description from the RESULTING
+/// SEQUENCE and emit the form that falls out, subject to every explicit spec
+/// tie-break", and here the explicit tie-break is `general.md:34`.
+///
+/// **Contrast [`the_spanning_delins_and_its_published_split_are_two_fixed_points`]**,
+/// which is `DNA/delins.md:44-47`'s pair and does **not** converge. The
+/// difference is that `:47` recommends the *spanning* form while `general.md:34`
+/// requires the *split* one, so the two pairs are pulled in opposite directions
+/// by different clauses. Both are pinned, so a change that converges the second
+/// pair — or that un-converges this one — fails and has to say which clause it
+/// is now reading.
+#[test]
+fn the_two_svd_wg010_spellings_converge_on_the_conformant_split() {
+    const CONFORMANT: &str = "SPEC_W57.1:g.[3C>G;7dup]";
+    let split = run(Fixture::Genomic, CONFORMANT).expect("the split normalizes");
+    let delins = run(Fixture::Genomic, "SPEC_W57.1:g.3_4delinsGGT").expect("the delins normalizes");
+    assert_eq!(
+        split, CONFORMANT,
+        "the conformant split must be its own fixed point"
+    );
+    assert_eq!(
+        delins, CONFORMANT,
+        "the rejected proposal's spelling must re-derive to the conformant split \
+         (`general.md:34`, with `SVD-WG010.md:5` rejecting the merge), not stay as \
+         authored"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the protein-axis split move
+// ---------------------------------------------------------------------------
+
+/// Both spellings of the separation-1 protein change settle on the split form.
+///
+/// `protein/delins.md:21` — "two variants separated by one or more amino acids
+/// should be described individually and not as a 'delins'" — and its worked
+/// example `:62-64` publishes `p.[Ser44Arg;Trp46Arg]` and states, in the same
+/// breath, that "the variant is not described as
+/// `p.Ser44_Trp46delinsArgLeuArg`". The protein axis has **no codon exception**:
+/// unlike `general.md:35` on the DNA/RNA axes, nothing licenses merging across
+/// one unchanged residue.
+///
+/// This was red until the split move landed. It is kept as a *convergence*
+/// guard rather than folded into the [`WORKED`] loop, because the row-by-row
+/// tests read one direction each: the [`WORKED`] row proves the delins spelling
+/// reaches the spec's answer and the [`NEGATIVE`] row proves it does not stay
+/// itself, but neither says the *split* spelling is still a fixed point. A split
+/// move that also re-merged, or one that shifted the split spelling somewhere
+/// else, would satisfy both and leave the two spellings non-confluent.
+///
+/// Measured on a hermetic protein whose residue 45 is `Leu`, so the two
+/// spellings denote one protein sequence:
+///
+/// ```text
+///   p.[Ser44Arg;Trp46Arg]           -> p.[Ser44Arg;Trp46Arg]
+///   p.Ser44_Trp46delinsArgLeuArg    -> p.[Ser44Arg;Trp46Arg]
+/// ```
+///
+/// The adjacent case still merges the other way — `p.[Trp24Cys;Val25Arg]` to
+/// `p.Trp24_Val25delinsCysArg` (W5) — so the two moves meet at separation 0/1
+/// and neither has swallowed the other.
+#[test]
+fn the_protein_axis_splits_a_separation_one_delins() {
+    // (the split spelling, the delins spelling the spec forbids, the answer)
+    let cases = [
+        (
+            "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+            "NP_SPECW48.1:p.Ser44_Trp46delinsArgLeuArg",
+            "NP_SPECW48.1:p.[Ser44Arg;Trp46Arg]",
+        ),
+        (
+            "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+            "NP_SPECW48.1:p.Ser988_Gln990delinsAlaLeuHis",
+            "NP_SPECW48.1:p.[Ser988Ala;Gln990His]",
+        ),
+    ];
+    for (split, delins, answer) in cases {
+        assert_eq!(
+            run(Fixture::Protein, split).expect("the split spelling normalizes"),
+            answer,
+            "`protein/delins.md:21`: the split spelling of {split} must be a fixed point"
+        );
+        assert_eq!(
+            run(Fixture::Protein, delins).expect("the delins spelling normalizes"),
+            answer,
+            "`protein/delins.md:21`: {delins} must be split, not preserved"
+        );
+    }
+
+    // The merge direction is untouched: separation 0 still coalesces, so the
+    // split move has not been widened into the adjacent case.
+    assert_eq!(
+        run(Fixture::Protein, "NP_SPECW05.1:p.[Trp24Cys;Val25Arg]")
+            .expect("the adjacent pair normalizes"),
+        "NP_SPECW05.1:p.Trp24_Val25delinsCysArg",
+        "`protein/substitution.md:23`: two *consecutive* residue changes are still one delins"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the census
+// ---------------------------------------------------------------------------
+
+/// Every id named anywhere in this file, in one set.
+fn covered_ids() -> BTreeSet<&'static str> {
+    let mut ids = BTreeSet::new();
+    for row in WORKED.iter() {
+        ids.insert(row.id);
+    }
+    for row in NEGATIVE {
+        ids.insert(row.id);
+    }
+    for row in REJECTED {
+        ids.insert(row.id);
+    }
+    for row in PARTITIONS {
+        ids.insert(row.id);
+    }
+    for row in DIVERGENT {
+        ids.insert(row.id);
+    }
+    for row in PARSE_GAPS {
+        ids.insert(row.id);
+    }
+    ids
+}
+
+fn unexecutable_ids() -> BTreeSet<&'static str> {
+    UNEXECUTABLE.iter().map(|row| row.id).collect()
+}
+
+fn cross_referenced_ids() -> BTreeSet<&'static str> {
+    CROSS_REFERENCED.iter().map(|(id, _)| *id).collect()
+}
+
+/// All 95 worked examples are accounted for, one way or another.
+///
+/// This is the test that makes the coverage claim checkable. Without it, the
+/// honest way to raise the pass rate is to delete the hard rows — and nothing
+/// would notice.
+#[test]
+fn the_roster_covers_every_one_of_the_95_worked_examples() {
+    let executed = covered_ids();
+    let unexecutable = unexecutable_ids();
+    let cross_referenced = cross_referenced_ids();
+
+    let overlap: Vec<&str> = executed.intersection(&unexecutable).copied().collect();
+    assert!(
+        overlap.is_empty(),
+        "these rows are both executed and listed as unexecutable: {overlap:?}"
+    );
+    let duplicated: Vec<&str> = executed.intersection(&cross_referenced).copied().collect();
+    assert!(
+        duplicated.is_empty(),
+        "these rows are already covered by tests/it/spec_worked_examples.rs and must \
+         not be duplicated here: {duplicated:?}"
+    );
+
+    let mut all: BTreeSet<&str> = executed;
+    all.extend(&unexecutable);
+    all.extend(&cross_referenced);
+
+    let expected: BTreeSet<String> = (1..=WORKED_EXAMPLE_COUNT)
+        .map(|n| format!("W{n}"))
+        .collect();
+    let seen: BTreeSet<String> = all.iter().map(|id| (*id).to_string()).collect();
+    let missing: Vec<&String> = expected.difference(&seen).collect();
+    let unknown: Vec<&String> = seen.difference(&expected).collect();
+    assert!(
+        missing.is_empty() && unknown.is_empty(),
+        "the roster does not account for all {WORKED_EXAMPLE_COUNT} worked examples.\n  \
+         missing: {missing:?}\n  not in the catalog: {unknown:?}"
+    );
+}
+
+/// The size of what is *not* covered is pinned, in both directions.
+///
+/// Growing [`UNEXECUTABLE`] is how coverage silently rots; shrinking it without
+/// adding rows is how a hard row gets dropped. Either direction fails here.
+#[test]
+fn the_unexecutable_census_is_pinned() {
+    assert_eq!(
+        UNEXECUTABLE.len(),
+        49,
+        "the set of worked examples this file cannot execute changed size. Adding \
+         one means claiming a row is not executable hermetically — an argument, not \
+         a table edit. Removing one means it is now executed, so add it to a table."
+    );
+    assert_eq!(
+        CROSS_REFERENCED.len(),
+        5,
+        "the set of rows delegated to tests/it/spec_worked_examples.rs changed"
+    );
+    assert_eq!(
+        covered_ids().len(),
+        WORKED_EXAMPLE_COUNT - UNEXECUTABLE.len() - CROSS_REFERENCED.len(),
+        "the executed / unexecutable / delegated counts no longer partition the 95 rows"
+    );
+    assert_eq!(
+        (DIVERGENT.len(), PARSE_GAPS.len()),
+        (2, 1),
+        "the set of rows ferro does not satisfy changed. Each of these two tables \
+         is an adjudication — a divergence with a competing clause, or a parser \
+         defect — so a change here is a ruling, not a fixture edit. The third \
+         disposition, `FERRO_IS_WRONG`, was emptied by the protein-axis split move \
+         and removed; re-creating it is also a ruling."
+    );
+}


### PR DESCRIPTION
Two pieces salvaged from #1565's stack and rebased onto `main`. #1565 makes the input's asserted partition the unit of normalization; that model was reversed on 2026-08-09 in favour of re-derivation, so #1565 is being closed and everything stacked on it goes with it. Neither piece here depends on that model, and that was **measured before anything was written** rather than assumed — the numbers are under "How independence was checked".

Supersedes #1568, which is the same protein fix stranded behind that model in the same stack, and salvages the W1–W95 suite from #1565 itself, which carries it and exists nowhere else.

## What the spec publishes, and what ferro emitted

`protein/delins.md:21` states the rule outright — "two variants separated by one or more amino acids should be described individually and not as a `delins`" — and `:62-64` prints the worked answer, `p.[Ser44Arg;Trp46Arg]`, with the explicit note that "the variant is **not** described as `p.Ser44_Trp46delinsArgLeuArg`". Ferro emitted the merged form.

It is not a one-off. `SVD-WG010.md:53-54` carries the same shape at a second locus (`p.Ser988_Gln990delinsAlaLeuHis`), and there the merge was the *rejected* proposal. Two published rows, one behaviour.

The **merge** direction already worked on this axis — `p.[Trp24Cys;Val25Arg]` merges to `p.Trp24_Val25delinsCysArg` (W5) — so this is a missing half, not a wrong rule.

## Scope: equal length, and only equal length

An equal-length `delins` has exactly one residue-wise correspondence, so "the interior residue is unchanged" is a fact about the two sequences. An unequal-length one has none: locating an unchanged run inside it means first *choosing* an alignment, and the reference and the payload do not determine which.

The nucleotide axis settles that by applying the edits to the reference and re-deriving from the resulting sequence, which is what `canonical-form-choice-when-both-legal` directs. That is unavailable here — there is no apply-to-reference on the protein axis, which is why `merge::cis_kind_of` returns `None` for `Protein`. With nothing to derive the answer from, ferro declines rather than invent an alignment.

## The declines are the substance, and each carries an argument

A positive-only suite goes green on an implementation that splits everything in reach — the unequal-length case, the stop-codon case and the no-reference case all *look* like the W48 shape and all have a different right answer. So every decline names the exact string ferro must not emit:

| decline | why |
|---|---|
| unequal length | no residue-wise correspondence; see above |
| no protein reference | the unchanged residue is a claim about the **reference**, and the payload cannot testify to it. Assuming `payload[i]` is what the reference holds is the one guess this rule must never make |
| `Ter` in the payload | a split would emit members 3' of the stop, which `delins.md:45` forbids |
| `Ter` in the reference span | a stop replaced by an ordinary residue is a **stop-loss**, which `extension.md:18` ranks first and `:30` spells `p.Ter110GlnextTer17` — never a substitution |
| span under three | no interior to be unchanged |
| fewer than two changed runs | the change really is one contiguous `delins` |
| **residue 1 changed** | see below |

## The residue-1 guard is a defect the fix would otherwise introduce

`p.Met1_Ala3delinsValAlaTrp` has the W48 shape exactly, so every other gate passes it through — and the members it produces are `p.[Met1Val;Ala3Trp]`. `protein/substitution.md:49` says a variant changing the translation initiation codon is "not described as a substitution or as an extension", and `parse_hgvs` enforces that, so the split would emit a description ferro cannot read back.

The illegality is **created by the split**. The range input parses, because `validate_no_start_loss_substitution` keys on a single certain position — so the guard has to live in the split rather than being inherited from the parser. Measured on `main` at `7118eb2a`, through the public API with a synthetic provider:

| input | `main` | `main` + the split, ungarded | with the guard |
|---|---|---|---|
| `p.Met1_Ala3delinsValAlaTrp` | unchanged, re-parses | `p.[Met1Val;Ala3Trp]` — **refused by `parse_hgvs`** | unchanged, re-parses |

Ferro declines rather than choosing among `p.0`, `p.0?`, `p.(Met1?)` or the upstream-initiation insertion form: which of those is right is a claim about the *consequence*, and two protein sequences do not settle it.

The guard is scoped to residue 1 **changing**, not to any span reaching it — `a_span_reaching_residue_one_still_splits_when_residue_one_is_unchanged` pins that, because a guard written as "decline any span starting at 1" would look correct and silently stop splitting a family it has no business declining.

## The W1–W95 suite

The recommendations print 95 input → published-answer pairs for themselves. Those are the only rows in the corpus that need no interpretation: the spec names an input and prints, in the same sentence, the description to use instead, so a divergence is a defect or a spec self-conflict, never a matter of taste.

Every executable row runs hermetically — no `FERRO_MANIFEST`, no network, no environment variable — so nothing can pass by being skipped, and every row that *cannot* be executed is recorded with its reason, so the size of what is not covered is itself pinned. Assertions are exact equality on the whole output string; rows about a partition additionally pin member count and every member's span read off the **parsed** output, because a rendered string can look right over a wrong partition. The negative half is asserted too — the exact string ferro must not emit for a legal input, and the spellings the parser must refuse.

It is a companion to `spec_worked_examples.rs`, which runs a hand-curated twelve rows through all three error modes; those are cross-referenced, not duplicated, and a test keeps them out of this file's tables.

## One adjudication, recorded

`SVD-WG010.md:16` prints one variant twice — `g.3_4delinsGGT` and `g.[3C>G;7dup]`. The proposal was **rejected** (`:5`), so `general.md:34` governs and the split is the conformant form. Ferro re-derives the split from **both** spellings, so the pair is confluent *and* lands on the form the rejection leaves in force. That is `canonical-form-choice-when-both-legal` doing its work — derive from the resulting sequence, subject to every explicit spec tie-break — rather than a coincidence.

Contrasted in the same file with `DNA/delins.md:44-47`'s pair, which does **not** converge, because `:47` recommends the *spanning* form while `general.md:34` requires the *split* one. Both are pinned, so a change that converges the second pair, or un-converges the first, fails and has to say which clause it is now reading.

## How independence was checked

Before writing anything, `spec_worked_example_rules.rs` was copied onto `main` unmodified and run:

| tree | result |
|---|---|
| `main`, file unmodified | **16 / 18 pass** |
| `main` + this PR's `src/normalize/mod.rs` | **17 / 18** — the protein rows go green |
| this PR | **36 / 36** — the last one adjudicated above |

So the file is not model-dependent; it was stranded by its position in a stack, and its two failures on `main` are real `main` behaviours rather than artifacts. `src/normalize/mod.rs` is byte-identical between `main` and #1568's base, so the fix applied verbatim.

## Blast radius

**Three zeros, each with its reason, because a zero from a corpus is a claim about the corpus:**

- `examples/dump_normalized_corpus.rs` generates **no protein rows at all** — a structural zero, reported rather than quoted.
- ClinVar (`clinvar_hgvs_unique.json.gz`, 4,188,436 rows) holds **8,445** protein descriptions, so it is *not* blind to the axis, and exactly **2** protein `delins`: `NP_009225.1:p.Phe1036_Lys1037delinsPheTerArgfs` and `NP_000539.2:p.Cys189_Tyr190delinsCysPheThrfs`. Both are span-2 and both carry `Ter`, so both are declined on two independent gates. Candidate population **0**.
- The prepared reference carries `protein_fastas: []`, so `has_protein_data()` is false and the gate cannot fire against real reference data at all today.

The move is real and it is a **split, never a merge**; it is simply not reachable through any corpus currently available to measure it. The strong evidence for an output-moving change is therefore the suite: **9,869 tests pass with nothing re-blessed** — every existing expectation already agreed with the new answer.

## Not fixed here, and filed separately

A *declined* split still emits an illegal `p.Met1Val` on `main`. `p.Met1_Ala3delinsValAlaAla` has one changed run, so this rule never fires, and `main` produces `p.Met1Val` — which `parse_hgvs` refuses — from a different path. It is pre-existing, unchanged by this PR in either direction, and belongs to whatever owns that path.

## Verification

`cargo fmt --all --check` clean. `cargo clippy --features dev --all-targets -- -D warnings` clean. Full suite **9,869 passed, 0 failed, 150 skipped**, nothing re-blessed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Protein descriptions with eligible equal-length `delins` changes can now be split into separate top-level variants.
  - Split results may appear as individual substitutions or smaller `delins` changes.
  - Normalization supports sequence-based canonicalization before applying these splits.

- **Bug Fixes**
  - Added safeguards to preserve descriptions involving uncertain positions, unavailable references, contiguous changes, initiation-codon changes, stop or unknown residues, and other unsupported cases.

- **Tests**
  - Added comprehensive coverage for protein splitting, predicted descriptions, repeated normalization, and unsupported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Representation-Change: Protein axis only — an equal-length `p.` delins whose interior residue is unchanged now splits into its members, a split and never a merge. Measured blast radius is zero on all three corpora available, each for a stated reason (see Blast radius); the gate cannot fire against the prepared reference at all, since it carries no protein FASTAs.
