### PR TITLE
feat(equivalence): expose a groupable SPDI key for bucketing by denoted bases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,6 +402,14 @@ name = "dump_confluence_divergences"
 required-features = ["dev"]
 test = true
 
+# `test = true` because the target carries `#[cfg(test)]` unit tests pinning the
+# three verdicts and the vacuity guard — the parts that decide whether a printed
+# figure means anything. Cargo does not build a target's tests unless it opts in.
+[[example]]
+name = "measure_spdi_key_grouping"
+required-features = ["dev"]
+test = true
+
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/examples/measure_spdi_key_grouping.rs
+++ b/examples/measure_spdi_key_grouping.rs
@@ -1,0 +1,944 @@
+//! Measure whether [`spdi_key`] buckets the confluence divergences.
+//!
+//! # Why
+//!
+//! `src/equivalence/key.rs` claims that descriptions asserting different
+//! *partitions* of one edit — which can reach distinct canonical forms, since
+//! the derivation is subject to spec tie-breaks that sometimes point opposite
+//! ways — nonetheless share one grouping key. The unit tests pin that on
+//! hand-written pairs. This asks it of the population that
+//! actually exhibits the divergence: every class
+//! `examples/dump_confluence_divergences.rs` reports, where two spellings of one
+//! designed variant reached two different normalized strings.
+//!
+//! The distinction matters because a hand-written pair proves the mechanism and
+//! says nothing about coverage. A claim of the form "the key groups the
+//! divergent classes" is a claim about a corpus, and this is the only thing that
+//! can settle it.
+//!
+//! # What is measured, and how it can be vacuous
+//!
+//! Per class: the key of every **distinct normalized output**. Those outputs are
+//! what a downstream consumer stores, and the class is in the input precisely
+//! because there is more than one of them. Four verdicts:
+//!
+//! - `grouped` — every output keyed, and to the same key. The divergence is
+//!   invisible to a consumer bucketing by key.
+//! - `split` — every output keyed, to two or more keys. The key does **not**
+//!   reconcile this class.
+//! - `undecided` — at least one output has no key, so the class cannot be
+//!   answered either way. Reported separately rather than folded into `split`:
+//!   those are different findings and one must not be read as the other.
+//! - `unmeasured` — at least one output could not be *asked*: it does not parse,
+//!   or keying it panicked. Split out from `undecided` for the same reason
+//!   `undecided` is split out from `split`. `undecided` is `spdi_key` declining,
+//!   which is evidence about the key; `unmeasured` is this harness failing,
+//!   which is evidence about the corpus. A run with any of these exits non-zero,
+//!   because every count in the report is then over a smaller population than
+//!   the input and a partial run would otherwise read as a clean one.
+//!
+//! The four verdicts are about a class's **outputs**. The same three-way split is
+//! applied to the class's raw *spellings*, and its failures are tracked and
+//! reported separately, because they have a different consequence: an unaskable
+//! spelling shrinks the spelling figure's denominator and leaves the verdict
+//! census intact. Both are fatal to the run; only the first is a hole in a
+//! verdict.
+//!
+//! **The vacuity check is printed unconditionally.** A run whose input holds no
+//! class with two or more distinct outputs measures nothing about grouping, and
+//! a `0 split` from such a run reads exactly like success. `multi_output` is
+//! that denominator; when it is zero the report says so instead of reporting a
+//! ratio.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --release --features dev --example generate_cis_confluence_corpus
+//! cargo run --release --features dev --example dump_confluence_divergences -- --out /tmp/div.json
+//! cargo run --release --features dev --example measure_spdi_key_grouping -- --divergences /tmp/div.json
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use serde::Deserialize;
+
+use ferro_hgvs::equivalence::spdi_key;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::spdi::canonical_spdi;
+
+/// Kept in step with `examples/dump_confluence_divergences.rs` and
+/// `examples/generate_cis_confluence_corpus.rs`; all three must agree on the
+/// padding, the accessions and the CDS or the coordinates mean different things.
+const PAD_OFFSET: usize = 256;
+const GENOMIC_CONTIG: &str = "NC_TEST.1";
+const TX_ACCESSION: &str = "NM_TEST.1";
+const TX_CONTIG: &str = "chr_synth";
+const CDS_START: u64 = 1;
+const CDS_END: u64 = 63;
+
+#[derive(Parser, Debug)]
+#[command(about = "Measure how the SPDI grouping key buckets the divergent confluence classes")]
+struct Cli {
+    /// The JSON written by `dump_confluence_divergences -- --out <path>`.
+    #[arg(long)]
+    divergences: PathBuf,
+    /// How many non-grouping exemplars to print per verdict.
+    #[arg(long, default_value_t = 5)]
+    examples: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Input — a subset of `dump_confluence_divergences`'s record
+// ---------------------------------------------------------------------------
+
+/// Only the fields the measurement needs; serde ignores the rest, so this does
+/// not have to track that generator's record shape.
+#[derive(Deserialize)]
+struct Record {
+    id: String,
+    axis: String,
+    core: String,
+    family: String,
+    outputs: Vec<Output>,
+}
+
+#[derive(Deserialize)]
+struct Output {
+    text: String,
+    /// The spellings that reached this output.
+    from: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Providers — the same construction the generator and the dump use
+// ---------------------------------------------------------------------------
+
+fn padded(core: &str) -> String {
+    let pad = "ACGT".repeat(PAD_OFFSET / 4);
+    format!("{pad}{core}{pad}")
+}
+
+fn reference_for(axis: &str, core: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    if axis == "g" {
+        provider.add_genomic_sequence(GENOMIC_CONTIG, padded(core));
+        return provider;
+    }
+    let tx_len = core.len() as u64;
+    let g_start = PAD_OFFSET as u64 + 1;
+    let g_end = PAD_OFFSET as u64 + tx_len;
+    let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+    let transcript = Transcript::new(
+        TX_ACCESSION.to_string(),
+        Some("SYNTH".to_string()),
+        Strand::Plus,
+        core.to_string(),
+        Some(CDS_START),
+        Some(CDS_END),
+        vec![exon],
+        Some(TX_CONTIG.to_string()),
+        Some(g_start),
+        Some(g_end),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_genomic_sequence(TX_CONTIG, padded(core));
+    provider.add_transcript(transcript);
+    provider
+}
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+/// What asking for a key produced, with the three cases kept apart.
+///
+/// Only [`KeyOutcome::Refused`] is a fact about `spdi_key`. The other two are
+/// facts about the *corpus* or about a bug, and folding them into the refusal
+/// count would report a measurement failure as an API limit — the shape
+/// `CLAUDE.md` names under "a generator must account for what it dropped": a
+/// fallible step whose failure is representable as a legitimate value, so a
+/// partial run and a clean run write indistinguishable output.
+enum KeyOutcome {
+    /// `spdi_key` produced a key.
+    Keyed(String),
+    /// `spdi_key` declined, for the stated reason. A documented refusal class.
+    Refused(String),
+    /// The question could not be asked at all: the row does not parse, or
+    /// keying it panicked. Not a refusal, and not evidence about the key.
+    Failed(&'static str),
+}
+
+/// What the key concluded about one class.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Verdict {
+    /// Every distinct output keyed, and to one key.
+    Grouped,
+    /// Every distinct output keyed, to two or more keys.
+    Split,
+    /// Some output has no key, so the class has no answer.
+    Undecided,
+    /// Some output could not be asked — unparseable, or it panicked. Ranked
+    /// apart from `Undecided` because that one is the key declining and this one
+    /// is the harness failing, and only the first says anything about `spdi_key`.
+    Unmeasured,
+}
+
+impl Verdict {
+    fn label(self) -> &'static str {
+        match self {
+            Verdict::Grouped => "grouped",
+            Verdict::Split => "split",
+            Verdict::Undecided => "undecided",
+            Verdict::Unmeasured => "unmeasured",
+        }
+    }
+}
+
+/// One class's outcome, keyed and censused.
+struct Measured {
+    id: String,
+    family: String,
+    verdict: Verdict,
+    /// How many **distinct** normalized output texts the class reached.
+    ///
+    /// Deduplicated rather than `record.outputs.len()`, which counts JSON rows.
+    /// The two agree on this generator's own output — `dump_confluence_divergences`
+    /// groups spellings into a `BTreeMap` keyed on the output text and emits one
+    /// row per key, then skips any class with fewer than two — so no figure this
+    /// harness has printed changes. What the dedupe buys is that the field means
+    /// what its name says for *any* input: this is the denominator the vacuity
+    /// check in [`render`] fires on, and a class holding one output twice would
+    /// otherwise pass for a measured divergence and suppress the `VACUOUS`
+    /// banner, which is the one thing that banner exists to prevent.
+    ///
+    /// Only the count is deduped, not the row loop: two rows sharing a text carry
+    /// *different* `from` spellings, and the spelling pass needs both. The keys
+    /// they produce are identical, so [`Measured::keys`] absorbs the repeat and
+    /// the verdict is unaffected either way.
+    outputs: usize,
+    /// Distinct keys those outputs produced, rendered, for an exemplar line.
+    keys: BTreeSet<String>,
+    /// Outputs that had no key, each paired with the reason.
+    ///
+    /// The reason is the whole value of an `undecided` row. Without it a reader
+    /// has to guess which of [`spdi_key`]'s documented refusal classes fired, and
+    /// a guess is what turns "declined for a stated reason" into "the key is
+    /// incomplete in some unspecified way".
+    declined: Vec<(String, String)>,
+    /// **Output** rows the harness could not ask about, each paired with why —
+    /// `unparseable` or `panicked`.
+    ///
+    /// Kept out of [`Measured::declined`] on purpose. A row the corpus cannot
+    /// parse says nothing about `spdi_key`, and counting it as a refusal both
+    /// overstates the refusal census and hides a broken corpus behind a number
+    /// that looks like a finding.
+    ///
+    /// Outputs only. A non-empty value here is exactly what makes the class
+    /// [`Verdict::Unmeasured`], which is what lets [`render`] say so of these
+    /// rows and only these — see [`Measured::spelling_failed`].
+    failed: Vec<(String, String)>,
+    /// **Spelling** rows the harness could not ask about, same pairing.
+    ///
+    /// Tracked apart from [`Measured::failed`] because the two have different
+    /// consequences and the report was asserting one consequence of both. The
+    /// verdict is a statement about the class's *outputs* and is fixed before the
+    /// spelling pass runs, so an unparseable spelling leaves it untouched — a
+    /// class can be `grouped` on its outputs while a spelling of it never
+    /// reached the key. Folded together, the `UNMEASURED` block claimed every row
+    /// it listed had its "class counted under the `unmeasured` verdict", which is
+    /// false for these and would send a reader looking for a verdict row that is
+    /// not there.
+    ///
+    /// What they *do* affect is [`Measured::spellings_grouped`], which goes
+    /// `None`, so the spelling figure's denominator shrinks and the run still
+    /// exits non-zero. That is a real hole in the measurement; it is just not the
+    /// hole the verdict census describes.
+    spelling_failed: Vec<(String, String)>,
+    /// The same question asked of the class's raw *spellings* rather than its
+    /// normalized outputs — `None` when any spelling declined.
+    ///
+    /// Tracked because the two are different claims and only one is about the
+    /// normalizer. A consumer keying its call set directly, never normalizing,
+    /// depends on the spellings agreeing; a consumer keying stored canonical
+    /// forms depends on the outputs agreeing.
+    spellings_grouped: Option<bool>,
+}
+
+fn measure(record: &Record) -> Measured {
+    let provider = reference_for(&record.axis, &record.core);
+    let key_of = |text: &str| {
+        let Ok(variant) = parse_hgvs(text) else {
+            return KeyOutcome::Failed("unparseable");
+        };
+        // The corpus is built to contain the shapes that break things, so one
+        // panicking row must not take the whole measurement with it.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            spdi_key(&variant, &provider)
+        })) {
+            Ok(Some(key)) => KeyOutcome::Keyed(key.to_string()),
+            // The reason is read here rather than on a second pass, so the
+            // refusal and its explanation come from one parse of one row.
+            // `spdi_key` is deliberately reason-free — it is the bucketing API —
+            // and `canonical_spdi` is the same decision carrying the described
+            // error, which is what the module docs point a caller at.
+            Ok(None) => KeyOutcome::Refused(
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    canonical_spdi(&variant, &provider)
+                })) {
+                    Ok(Err(e)) => e.to_string(),
+                    Ok(Ok(_)) => "no reason — it keys on a second attempt".to_string(),
+                    Err(_) => "panicked while explaining the refusal".to_string(),
+                },
+            ),
+            Err(_) => KeyOutcome::Failed("panicked"),
+        }
+    };
+
+    let mut keys = BTreeSet::new();
+    let mut declined = Vec::new();
+    let mut failed = Vec::new();
+    for output in &record.outputs {
+        match key_of(&output.text) {
+            KeyOutcome::Keyed(key) => {
+                keys.insert(key);
+            }
+            KeyOutcome::Refused(reason) => declined.push((output.text.clone(), reason)),
+            KeyOutcome::Failed(why) => failed.push((output.text.clone(), why.to_string())),
+        }
+    }
+
+    // The verdict is a statement about the *outputs*, so it is fixed here —
+    // before the spelling pass, whose failures are reported but must not restate
+    // themselves as a verdict about something they do not describe.
+    let outputs_unmeasurable = !failed.is_empty();
+
+    // The spelling pass gets the same three-way split, for the same reason: an
+    // unparseable spelling must not be reported as "the spellings do not group".
+    // Its failures land in their own bucket rather than in `failed`, because
+    // `failed` is what the verdict above was computed from and what the report
+    // describes as `unmeasured` — a spelling cannot retroactively make a class's
+    // *outputs* unmeasured.
+    let mut spelling_keys = BTreeSet::new();
+    let mut spellings_unanswerable = false;
+    let mut spelling_failed = Vec::new();
+    for spelling in record.outputs.iter().flat_map(|output| output.from.iter()) {
+        match key_of(spelling) {
+            KeyOutcome::Keyed(key) => {
+                spelling_keys.insert(key);
+            }
+            KeyOutcome::Refused(_) => spellings_unanswerable = true,
+            KeyOutcome::Failed(why) => {
+                spellings_unanswerable = true;
+                spelling_failed.push((spelling.clone(), why.to_string()));
+            }
+        }
+    }
+    let spellings_grouped = if spellings_unanswerable {
+        None
+    } else {
+        Some(spelling_keys.len() <= 1)
+    };
+
+    // Ordered so a class the harness could not measure never masquerades as one
+    // the key declined, and neither is counted as grouped or split.
+    let verdict = if outputs_unmeasurable {
+        Verdict::Unmeasured
+    } else if !declined.is_empty() {
+        Verdict::Undecided
+    } else if keys.len() <= 1 {
+        Verdict::Grouped
+    } else {
+        Verdict::Split
+    };
+
+    Measured {
+        id: record.id.clone(),
+        family: record.family.clone(),
+        verdict,
+        outputs: record
+            .outputs
+            .iter()
+            .map(|output| output.text.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        keys,
+        declined,
+        failed,
+        spelling_failed,
+        spellings_grouped,
+    }
+}
+
+fn render(measured: &[Measured], examples: usize) -> String {
+    let mut out = String::new();
+    let total = measured.len();
+    let multi_output = measured.iter().filter(|m| m.outputs > 1).count();
+
+    let _ = writeln!(out, "divergent classes read: {total}");
+    if multi_output == 0 {
+        let _ = writeln!(
+            out,
+            "\nVACUOUS: no class in this input has two or more distinct normalized outputs, \
+             so nothing here measures whether the key reconciles a divergence. Regenerate \
+             the divergence dump before reading any figure below."
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "classes with >1 distinct output (the population the claim is about): {multi_output}"
+        );
+    }
+
+    let mut by_verdict: BTreeMap<Verdict, usize> = BTreeMap::new();
+    for m in measured {
+        *by_verdict.entry(m.verdict).or_default() += 1;
+    }
+    let _ = writeln!(out, "\nverdict over all {total} classes:");
+    // All four, so the rows account for every class the header claims. Printing
+    // three of the four leaves the shares summing to under 100% with nothing
+    // naming the gap — which is the same "partial run reads as a clean one"
+    // failure this harness exits non-zero over, one level up in the report.
+    // Pinned by `the_verdict_census_accounts_for_every_class`.
+    for verdict in [
+        Verdict::Grouped,
+        Verdict::Split,
+        Verdict::Undecided,
+        Verdict::Unmeasured,
+    ] {
+        let count = by_verdict.get(&verdict).copied().unwrap_or(0);
+        let share = if total == 0 {
+            0.0
+        } else {
+            100.0 * count as f64 / total as f64
+        };
+        let _ = writeln!(out, "  {:<10} {count:>7}  ({share:.1}%)", verdict.label());
+    }
+
+    // The same question asked of the raw spellings. Printed separately because a
+    // consumer that never normalizes depends on this number and not the one
+    // above, and conflating them would let one carry the other's evidence.
+    let spelling_answered = measured
+        .iter()
+        .filter(|m| m.spellings_grouped.is_some())
+        .count();
+    let spelling_grouped = measured
+        .iter()
+        .filter(|m| m.spellings_grouped == Some(true))
+        .count();
+    let _ = writeln!(
+        out,
+        "\nraw spellings (not normalized) that key to one bucket: \
+         {spelling_grouped} of {spelling_answered} answerable classes"
+    );
+
+    let mut families: BTreeMap<(&str, Verdict), usize> = BTreeMap::new();
+    for m in measured {
+        *families.entry((m.family.as_str(), m.verdict)).or_default() += 1;
+    }
+    let _ = writeln!(out, "\nby family:");
+    let names: BTreeSet<&str> = measured.iter().map(|m| m.family.as_str()).collect();
+    for name in names {
+        let at = |v: Verdict| families.get(&(name, v)).copied().unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "  {name:<28} grouped {:>6}  split {:>6}  undecided {:>6}  unmeasured {:>6}",
+            at(Verdict::Grouped),
+            at(Verdict::Split),
+            at(Verdict::Undecided),
+            at(Verdict::Unmeasured)
+        );
+    }
+
+    // Census the refusals by reason, so the report answers "which documented
+    // refusal class fired" without the reader sampling exemplars and
+    // extrapolating. Reasons are the error's own trailing clause, since the
+    // leading part names the variant and would make every row unique.
+    let mut reasons: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in measured {
+        for (_, reason) in &m.declined {
+            let tail = reason
+                .rsplit_once(" — ")
+                .map_or(reason.as_str(), |(_, t)| t);
+            *reasons.entry(tail).or_default() += 1;
+        }
+    }
+    if !reasons.is_empty() {
+        let _ = writeln!(out, "\nrefusals by reason:");
+        for (reason, count) in &reasons {
+            let _ = writeln!(out, "  {count:>6}  {reason}");
+        }
+    }
+
+    // Reported separately from the refusals above, and loudly: these rows were
+    // never asked the question, so every count in this report is over a smaller
+    // population than the header implies. Silence here is what would let a
+    // partially-measured run read as a clean one.
+    let mut failures: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in measured {
+        for (_, why) in &m.failed {
+            *failures.entry(why.as_str()).or_default() += 1;
+        }
+    }
+    if !failures.is_empty() {
+        // Named `failed_rows` rather than shadowing `total`: everywhere else in
+        // this report `total` counts *classes*, and this counts rows.
+        let failed_rows: usize = failures.values().sum();
+        let _ = writeln!(
+            out,
+            "\nUNMEASURED: {failed_rows} row(s) could not be asked, so they are excluded from \
+             every per-row count above — their classes are counted under the `unmeasured` \
+             verdict, and they are not refusals:"
+        );
+        for (why, count) in &failures {
+            let _ = writeln!(out, "  {count:>6}  {why}");
+        }
+        for m in measured
+            .iter()
+            .filter(|m| !m.failed.is_empty())
+            .take(examples)
+        {
+            for (text, why) in &m.failed {
+                let _ = writeln!(out, "      {text}\n        {why}");
+            }
+        }
+    }
+
+    // The spelling half of the same hole, under its own heading. It has to be
+    // separate: the block above tells the reader these rows' classes sit under
+    // the `unmeasured` verdict, and for a spelling that is not true — the verdict
+    // is fixed off the outputs before any spelling is asked. Printed together,
+    // the stronger claim was silently made of both, sending a reader looking for
+    // a verdict row that does not exist. Pinned by
+    // `a_spelling_only_failure_is_reported_without_claiming_the_verdict_moved`.
+    let mut spelling_failures: BTreeMap<&str, usize> = BTreeMap::new();
+    for m in measured {
+        for (_, why) in &m.spelling_failed {
+            *spelling_failures.entry(why.as_str()).or_default() += 1;
+        }
+    }
+    if !spelling_failures.is_empty() {
+        let spelling_failed_rows: usize = spelling_failures.values().sum();
+        let _ = writeln!(
+            out,
+            "\nUNMEASURED SPELLINGS: {spelling_failed_rows} raw spelling(s) could not be asked, \
+             so the spelling figure above is over a smaller population than the input. These do \
+             **not** change any class verdict — the verdict is a statement about a class's \
+             normalized outputs, which were measured — and they are not refusals:"
+        );
+        for (why, count) in &spelling_failures {
+            let _ = writeln!(out, "  {count:>6}  {why}");
+        }
+        for m in measured
+            .iter()
+            .filter(|m| !m.spelling_failed.is_empty())
+            .take(examples)
+        {
+            let _ = writeln!(out, "      {} [{}] — {}", m.id, m.family, m.verdict.label());
+            for (text, why) in &m.spelling_failed {
+                let _ = writeln!(out, "        {text}\n          {why}");
+            }
+        }
+    }
+
+    for verdict in [Verdict::Split, Verdict::Undecided] {
+        let exemplars: Vec<&Measured> = measured
+            .iter()
+            .filter(|m| m.verdict == verdict)
+            .take(examples)
+            .collect();
+        if exemplars.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "\n{} exemplars:", verdict.label());
+        for m in exemplars {
+            let _ = writeln!(out, "  {} [{}]", m.id, m.family);
+            for key in &m.keys {
+                let _ = writeln!(out, "      key {key}");
+            }
+            for (text, reason) in &m.declined {
+                let _ = writeln!(out, "      no key for {text}\n        because {reason}");
+            }
+        }
+    }
+    out
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let text = match std::fs::read_to_string(&cli.divergences) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!(
+                "error: reading {}: {e}\nGenerate it with:\n  cargo run --release --features dev \
+                 --example dump_confluence_divergences -- --out {}",
+                cli.divergences.display(),
+                cli.divergences.display()
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let records: Vec<Record> = match serde_json::from_str(&text) {
+        Ok(records) => records,
+        Err(e) => {
+            eprintln!("error: parsing {}: {e}", cli.divergences.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let measured: Vec<Measured> = records.iter().map(measure).collect();
+    print!("{}", render(&measured, cli.examples));
+
+    // Refuse, do not report. A row the harness could not ask about is a hole in
+    // the measurement, and exiting 0 with the census printed is precisely the
+    // "partial run and clean run are indistinguishable" failure this repository
+    // treats as a defect in the generator rather than a caveat in its output.
+    //
+    // Counted in two independent halves, and both are fatal. An unaskable output
+    // shrinks the verdict census; an unaskable spelling shrinks only the spelling
+    // figure. Naming which is which is the point — a run that fails on the second
+    // has a sound verdict census, and a message that said "the counts above" of
+    // both would have the reader distrust a number that is fine.
+    let unmeasured_outputs: usize = measured.iter().map(|m| m.failed.len()).sum();
+    let unmeasured_spellings: usize = measured.iter().map(|m| m.spelling_failed.len()).sum();
+    if unmeasured_outputs > 0 {
+        eprintln!(
+            "error: {unmeasured_outputs} output row(s) could not be measured (unparseable, or \
+             keying panicked); the verdict census above is over a smaller population than the \
+             input"
+        );
+    }
+    if unmeasured_spellings > 0 {
+        eprintln!(
+            "error: {unmeasured_spellings} raw spelling(s) could not be measured (unparseable, or \
+             keying panicked); the spelling figure above is over a smaller population than the \
+             input, and no class verdict is affected"
+        );
+    }
+    if unmeasured_outputs > 0 || unmeasured_spellings > 0 {
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(axis: &str, core: &str, outputs: &[(&str, &[&str])]) -> Record {
+        Record {
+            id: "test".to_string(),
+            axis: axis.to_string(),
+            core: core.to_string(),
+            family: "test-family".to_string(),
+            outputs: outputs
+                .iter()
+                .map(|(text, from)| Output {
+                    text: (*text).to_string(),
+                    from: from.iter().map(|s| (*s).to_string()).collect(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The core of the measurement: two normalized outputs that partition one
+    /// edit differently are `Grouped`, not `Split`.
+    ///
+    /// The core is written so its padded contig has the two spellings' bases
+    /// where the coordinates say they are — `reference_for` prepends
+    /// `PAD_OFFSET` bases, and the `g.` coordinates below are 1-based over the
+    /// padded contig.
+    #[test]
+    fn two_partitions_of_one_edit_measure_as_grouped() {
+        let core = "ATTACAG";
+        let start = PAD_OFFSET + 1;
+        let spanning = format!("{GENOMIC_CONTIG}:g.{start}_{}delinsGGCTA", start + 4);
+        let decomposed = format!(
+            "{GENOMIC_CONTIG}:g.[{start}A>G;{}T>G;{}T>C;{}A>T;{}C>A]",
+            start + 1,
+            start + 2,
+            start + 3,
+            start + 4
+        );
+        let record = record(
+            "g",
+            core,
+            &[(&spanning, &["a"][..]), (&decomposed, &["b"][..])],
+        );
+        let measured = measure(&record);
+        assert_eq!(
+            measured.verdict,
+            Verdict::Grouped,
+            "keys {:?}",
+            measured.keys
+        );
+        assert_eq!(measured.keys.len(), 1);
+    }
+
+    /// The control. Without it a `measure` that answered `Grouped` for
+    /// everything would satisfy the test above, which is the exact failure the
+    /// whole key is supposed to make impossible.
+    #[test]
+    fn two_genuinely_different_edits_measure_as_split() {
+        let start = PAD_OFFSET + 1;
+        let one = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let other = format!("{GENOMIC_CONTIG}:g.{start}A>C");
+        let record = record("g", "ATTACAG", &[(&one, &["a"][..]), (&other, &["b"][..])]);
+        assert_eq!(measure(&record).verdict, Verdict::Split);
+    }
+
+    /// An output with no key makes the class `Undecided`, never `Split` — the
+    /// two are different findings and folding them together would report a
+    /// missing answer as a wrong one.
+    #[test]
+    fn an_unkeyable_output_is_undecided_not_split() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let record = record(
+            "g",
+            "ATTACAG",
+            &[(&keyed, &["a"][..]), ("NC_ABSENT.1:g.5A>G", &["b"][..])],
+        );
+        let measured = measure(&record);
+        assert_eq!(measured.verdict, Verdict::Undecided);
+        assert_eq!(measured.declined.len(), 1);
+    }
+
+    /// An output the harness cannot even parse is `Unmeasured`, never
+    /// `Undecided`, and is kept out of the refusal census.
+    ///
+    /// The two look identical in a report that folds them together, and they are
+    /// opposite findings: `Undecided` says `spdi_key` declined — a fact about the
+    /// key — while this says the row never reached it. Counting an unparseable
+    /// row as a refusal overstates what the key refuses and hides a broken corpus
+    /// behind a number that reads like a result.
+    #[test]
+    fn an_unparseable_output_is_unmeasured_not_a_refusal() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        // Real spellings, so the only unmeasurable row is the one under test.
+        let record = record(
+            "g",
+            "ATTACAG",
+            &[
+                (&keyed, &[keyed.as_str()][..]),
+                ("this is not HGVS at all", &[keyed.as_str()][..]),
+            ],
+        );
+        let measured = measure(&record);
+        assert_eq!(measured.verdict, Verdict::Unmeasured);
+        assert_eq!(
+            measured.declined.len(),
+            0,
+            "an unparseable row is not a refusal by spdi_key"
+        );
+        assert_eq!(measured.failed.len(), 1, "failed was {:?}", measured.failed);
+        assert_eq!(measured.failed[0].1, "unparseable");
+    }
+
+    /// And the run says so on the way out, rather than printing a census over a
+    /// population it silently shrank.
+    ///
+    /// The needles are the **output** block's own, not substrings it shares with
+    /// the spelling block. `"UNMEASURED"` is a prefix of `"UNMEASURED SPELLINGS"`
+    /// and `"they are not refusals"` ends both headings, so either one alone is
+    /// satisfied by a report that printed only the spelling block — and this
+    /// record's `from` lists are real spellings precisely so that block is *not*
+    /// printed here. Asserting the two together, plus the spelling block's
+    /// absence, is what makes this test able to fail if `render` ever stopped
+    /// emitting the block it is named for.
+    #[test]
+    fn the_report_names_the_rows_it_could_not_measure() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let measured = vec![measure(&record(
+            "g",
+            "ATTACAG",
+            &[
+                (&keyed, &[keyed.as_str()][..]),
+                ("this is not HGVS at all", &[keyed.as_str()][..]),
+            ],
+        ))];
+        let report = render(&measured, 3);
+        assert!(
+            report.contains("row(s) could not be asked"),
+            "the output-row block must be printed:\n{report}"
+        );
+        assert!(
+            report.contains("their classes are counted under the `unmeasured` verdict"),
+            "and it must be the output-row block, whose claim about the verdict is \
+             the one the spelling block may not make:\n{report}"
+        );
+        assert!(
+            report.contains("they are not refusals"),
+            "the report must not let an unmeasured row read as a refusal:\n{report}"
+        );
+        assert!(
+            !report.contains("UNMEASURED SPELLINGS"),
+            "every spelling here is real, so a spelling block would mean the two \
+             halves are still entangled:\n{report}"
+        );
+    }
+
+    /// The headline census must account for every class its own header says it
+    /// is over.
+    ///
+    /// It listed three of the four verdicts, so a run holding an `unmeasured`
+    /// class printed rows whose shares summed to under 100% with nothing naming
+    /// the gap — the same "a partial run reads as a clean one" failure the
+    /// non-zero exit exists to prevent, one level up in the report. The sum is
+    /// asserted rather than the labels' presence, because a label printed with
+    /// the wrong count is the same defect.
+    #[test]
+    fn the_verdict_census_accounts_for_every_class() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let measured = vec![
+            measure(&record("g", "ATTACAG", &[(&keyed, &[keyed.as_str()][..])])),
+            measure(&record(
+                "g",
+                "ATTACAG",
+                &[("this is not HGVS at all", &[keyed.as_str()][..])],
+            )),
+        ];
+        assert_eq!(measured[0].verdict, Verdict::Grouped);
+        assert_eq!(measured[1].verdict, Verdict::Unmeasured);
+
+        // `examples = 0` so no `<verdict> exemplars:` heading can be mistaken
+        // for a census row while the block is being located.
+        let report = render(&measured, 0);
+        let census = report
+            .split_once("verdict over all")
+            .expect("the census is printed")
+            .1
+            .split("\n\n")
+            .next()
+            .expect("the census block ends at the next section");
+
+        let counted: usize = [
+            Verdict::Grouped,
+            Verdict::Split,
+            Verdict::Undecided,
+            Verdict::Unmeasured,
+        ]
+        .iter()
+        .map(|verdict| {
+            let row = census
+                .lines()
+                .find(|line| line.trim_start().starts_with(verdict.label()))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "`{}` is missing from the census:\n{report}",
+                        verdict.label()
+                    )
+                });
+            row.split_whitespace()
+                .nth(1)
+                .and_then(|count| count.parse::<usize>().ok())
+                .unwrap_or_else(|| panic!("no count to read on `{row}`"))
+        })
+        .sum();
+        assert_eq!(
+            counted,
+            measured.len(),
+            "the census accounts for {counted} of {} classes:\n{report}",
+            measured.len()
+        );
+    }
+
+    /// A run whose input has no multi-output class says so, because a `0 split`
+    /// from such a run is indistinguishable from success.
+    #[test]
+    fn a_single_output_input_reports_itself_vacuous() {
+        let start = PAD_OFFSET + 1;
+        let only = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let measured = vec![measure(&record("g", "ATTACAG", &[(&only, &["a"][..])]))];
+        assert!(render(&measured, 0).contains("VACUOUS"));
+    }
+
+    /// One output text repeated across two rows is **one** distinct output, so
+    /// the class is vacuous rather than a measured divergence.
+    ///
+    /// The count used to be `record.outputs.len()`, which counts JSON rows. This
+    /// generator's own dump cannot produce such a row — it groups spellings into a
+    /// map keyed on the output text — so no printed figure was ever wrong. What
+    /// was wrong is that the *only* consumer of the count is the vacuity check,
+    /// and the one input shape that could defeat that check was the one it could
+    /// not see: two rows agreeing, which reads as `>1 distinct output` and
+    /// suppresses the banner while measuring nothing about grouping.
+    #[test]
+    fn one_output_repeated_across_rows_is_still_vacuous() {
+        let start = PAD_OFFSET + 1;
+        let only = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        // Distinct, parseable `from` lists, so the two rows differ in everything
+        // except the output text that the count is supposed to key on.
+        let measured = vec![measure(&record(
+            "g",
+            "ATTACAG",
+            &[(&only, &[only.as_str()][..]), (&only, &[only.as_str()][..])],
+        ))];
+        assert_eq!(measured[0].outputs, 1, "two rows, one distinct output");
+        let report = render(&measured, 0);
+        assert!(report.contains("VACUOUS"), "report was:\n{report}");
+    }
+
+    /// A spelling the harness cannot ask about is reported, and reported as not
+    /// touching the class verdict.
+    ///
+    /// The verdict is a statement about a class's normalized *outputs* and is
+    /// fixed before the spelling pass runs, so this class is `Grouped`. Spelling
+    /// failures used to be pushed into the same list as output failures, and that
+    /// list is printed under a heading asserting "their classes are counted under
+    /// the `unmeasured` verdict" — true of an output row, false of this one, and
+    /// it would send a reader hunting a census row that is not there.
+    #[test]
+    fn a_spelling_only_failure_is_reported_without_claiming_the_verdict_moved() {
+        let start = PAD_OFFSET + 1;
+        let keyed = format!("{GENOMIC_CONTIG}:g.{start}A>G");
+        let other = format!("{GENOMIC_CONTIG}:g.{start}_{}del", start + 1);
+        let measured = vec![measure(&record(
+            "g",
+            "ATTACAG",
+            &[
+                (&keyed, &[keyed.as_str()][..]),
+                // One real spelling and one the harness cannot parse, so the
+                // outputs are fully measured and only a spelling is missing.
+                (&other, &[other.as_str(), "this is not HGVS at all"][..]),
+            ],
+        ))];
+        assert_eq!(measured[0].verdict, Verdict::Split, "both outputs keyed");
+        assert!(
+            measured[0].failed.is_empty(),
+            "no *output* row failed: {:?}",
+            measured[0].failed
+        );
+        assert_eq!(measured[0].spelling_failed.len(), 1);
+        assert_eq!(measured[0].spelling_failed[0].1, "unparseable");
+        assert_eq!(
+            measured[0].spellings_grouped, None,
+            "an unaskable spelling makes the spelling question unanswerable"
+        );
+
+        let report = render(&measured, 3);
+        assert!(
+            report.contains("UNMEASURED SPELLINGS"),
+            "the hole must still be named:\n{report}"
+        );
+        assert!(
+            report.contains("do **not** change any class verdict"),
+            "and named as not moving the verdict:\n{report}"
+        );
+        assert!(
+            !report.contains("their classes are counted under the `unmeasured` verdict"),
+            "the output-row claim must not be made of a spelling row:\n{report}"
+        );
+    }
+}

--- a/src/equivalence/key.rs
+++ b/src/equivalence/key.rs
@@ -1,0 +1,614 @@
+//! A groupable, encoding-invariant key for "do these denote the same bases?".
+//!
+//! # Why this exists
+//!
+//! An HGVS descriptor asserts a **partition** of the reference, and two
+//! spellings that partition the same bases differently can reach *different*
+//! canonical forms. That is not a gap waiting to be closed. The decided ruling
+//! `canonical-form-choice-when-both-legal`
+//! (`tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`) directs
+//! ferro to derive from the resulting sequence "subject to every explicit spec
+//! tie-break" — and where two such tie-breaks point opposite ways, neither is
+//! selected and both forms survive. The spec supplies its own example:
+//! `DNA/delins.md:44` gives a spanning `delins`, `:46` names a four-member split
+//! as an "alternative description" of the *same* variant, `:47` recommends the
+//! spanning form, and `general.md:34` requires members separated by unchanged
+//! nucleotides to stay individual.
+//!
+//! That leaves a consumer who only wants to bucket variants — "how many distinct
+//! changes are in this call set?" — with no usable handle. Comparing normalized
+//! strings answers a different question, and it couples the consumer's stored
+//! buckets to the normalizer: confluence work moves canonical forms by design,
+//! and the project declares those moves as breaking rather than avoiding them,
+//! so buckets keyed on the string re-bucket on every such release.
+//!
+//! This is the handle that does not move: one value per variant, equal exactly
+//! when the denoted bases are, derived without consulting the normalizer.
+//!
+//! [`crate::spdi::canonical_spdi`] already computes the right thing: apply every
+//! member to the reference, then read the difference back out of the resulting
+//! *bases*, where partitioning is not represented. This module is the grouping
+//! surface over it — a key type that is `Ord` + `Hash` so it can be a map key,
+//! a total `Option`-returning accessor, and a bucketing helper.
+//!
+//! ```
+//! use ferro_hgvs::equivalence::{group_by_spdi_key, spdi_key};
+//! use ferro_hgvs::{parse_hgvs, MockProvider};
+//!
+//! let mut provider = MockProvider::new();
+//! provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+//!
+//! // One edit, two partitions of it — two distinct descriptions …
+//! let spanning = parse_hgvs("NC_KEY.1:g.3_7delinsGGCTA").unwrap();
+//! let decomposed = parse_hgvs("NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]").unwrap();
+//! assert_ne!(spanning.to_string(), decomposed.to_string());
+//!
+//! // … and one bucket. Note the key is read off the denoted bases, so this
+//! // holds whether or not the normalizer converges the pair — no `Normalizer`
+//! // is involved above.
+//! assert_eq!(
+//!     spdi_key(&spanning, &provider),
+//!     spdi_key(&decomposed, &provider),
+//! );
+//!
+//! let grouped = group_by_spdi_key([&spanning, &decomposed], &provider);
+//! assert_eq!(grouped.group_count(), 1);
+//! assert!(grouped.unkeyable().is_empty());
+//! ```
+//!
+//! # What the key is, and what it is not
+//!
+//! **It is** equal exactly when two descriptions on one accession produce the
+//! same resulting bases, whatever their spelling, member count or member order.
+//! It is derived without consulting the normalizer, so it does not move when a
+//! canonical form does.
+//!
+//! Read "the same bases" as case-insensitive, and on the `r.` axis as
+//! `U`-insensitive: the key's bases are folded before it is built, so a
+//! soft-masked FASTA and an uppercase one give one key for one locus even though
+//! their windows differ byte for byte. That fold is what makes the key a
+//! property of the sequence rather than of the provider; see
+//! [`crate::spdi::apply`]'s module docs for the guarantee and the one boundary it
+//! does not reach.
+//!
+//! **It is not** a canonical SPDI in NCBI's sense, and not a substitute for
+//! [`EquivalenceChecker`](crate::equivalence::EquivalenceChecker) — that answers
+//! a richer pairwise question (accession-version drift, for instance) which no
+//! single scalar key can carry. See [`crate::spdi::apply`]'s module docs for the
+//! exact guarantee.
+//!
+//! # What has no key
+//!
+//! [`spdi_key`] returns `None` rather than a key that would silently collide.
+//! **This is the load-bearing half of the contract**: a key that answered for
+//! everything would bucket unrelated variants together, which is worse than
+//! refusing. See [`spdi_key`] for the enumerated classes.
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::hgvs::variant::HgvsVariant;
+use crate::reference::ReferenceProvider;
+use crate::spdi::{canonical_spdi, SpdiVariant};
+
+/// A groupable key that is equal exactly when two descriptions denote the same
+/// bases on the same accession.
+///
+/// Rendered as an SPDI expression (`accession:position:deletion:insertion`, with
+/// a 0-based interbase `position`), which is what a consumer stores. Construct
+/// it with [`spdi_key`]; there is deliberately no public constructor from a
+/// [`SpdiVariant`], because an arbitrary triple is a *transliteration* of one
+/// spelling and carries none of the invariance the type name claims.
+///
+/// `Ord` is over `(accession, position, deletion, insertion)` — an ordering that
+/// exists so the key can index a `BTreeMap` and so a report can be printed
+/// deterministically. It sorts positionally within one accession, which is
+/// convenient, but nothing about the key's meaning depends on the order. It is
+/// delegated to [`SpdiVariant`]'s derived `Ord`, whose declaration order *is*
+/// that tuple, so a field added there joins the comparison rather than being
+/// silently dropped from it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SpdiKey {
+    spdi: SpdiVariant,
+}
+
+impl SpdiKey {
+    /// The accession the key is on.
+    ///
+    /// Two keys on different accessions never compare equal, so this is the
+    /// axis along which a consumer partitions its buckets before comparing them.
+    pub fn accession(&self) -> &str {
+        &self.spdi.sequence
+    }
+
+    /// The key's structured form, for a caller who wants the coordinates rather
+    /// than the string.
+    pub fn as_spdi(&self) -> &SpdiVariant {
+        &self.spdi
+    }
+
+    /// Consume the key and yield its structured form.
+    pub fn into_spdi(self) -> SpdiVariant {
+        self.spdi
+    }
+}
+
+impl fmt::Display for SpdiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.spdi)
+    }
+}
+
+impl PartialOrd for SpdiKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SpdiKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Delegated to `SpdiVariant`'s *derived* `Ord` rather than written out
+        // field by field. The derive is lexicographic in declaration order, which
+        // is the `(sequence, position, deletion, insertion)` order documented on
+        // the type — so this is the same comparison, and it stays the same
+        // comparison when a field is added. Spelling the four fields here type-
+        // checked and agreed with `Eq` on every value that existed at the time,
+        // and would have gone on doing both after a fifth field appeared while
+        // quietly no longer being total: two keys differing only in the new field
+        // would compare `Equal` and collapse into one `BTreeMap` bucket while
+        // `Eq` called them different. Neither allocates.
+        self.spdi.cmp(&other.spdi)
+    }
+}
+
+/// The grouping key for `variant`, or `None` when no single key describes it.
+///
+/// Two variants whose keys are `Some` and equal denote the same bases on the
+/// same accession. Two whose keys are `Some` and unequal denote different bases —
+/// **with one stated exception, the no-op residual below**, which is the only
+/// place this direction does not hold. `None` is **not** an equivalence class:
+/// two `None`s say nothing about each other, and a caller must not bucket them
+/// together.
+///
+/// # What returns `None`
+///
+/// Every case below is one where a key would have to be guessed. Refusing keeps
+/// the invariant that equal keys mean equal bases.
+///
+/// - **Protein descriptions** (`p.`). SPDI has no protein axis, and the amino
+///   acid consequence of an edit is not recoverable from a nucleotide key. This
+///   is a permanent exclusion, not a gap: a consumer bucketing protein variants
+///   needs a protein key, which this is not.
+/// - **Descriptions naming more than one molecule** — a trans, mosaic, chimeric
+///   or unknown-phase allele, and the null (`0`) and unknown (`?`) alleles.
+///   There is no single resulting sequence to read a key out of.
+/// - **Alleles spanning more than one accession.** A key is per-accession.
+/// - **Members that overlap**, or two coincident insertions at one interbase
+///   position. Applying them depends on an order the description does not state,
+///   so there is no one answer. (HGVS spells a stated order as a single ordered
+///   payload, `ins[A;C]`, which *does* key.)
+/// - **A stated deletion that disagrees with the reference** — the description
+///   and the provider cannot both be right, and picking one would key the
+///   variant off bases it does not describe.
+/// - **Edits SPDI cannot represent.** Inserted-range payloads
+///   (`g.10_11ins20_30`), uncertain or unspecified inserted lengths (`ins(10)`),
+///   named elements (`insAluYb8`), and intronic `c.`/`n.`/`r.` offsets, which
+///   SPDI has no notation for.
+/// - **Reference bases the provider cannot serve** — an absent accession, or a
+///   window it declines. A key derived from a truncated window is a *different*
+///   key, not a smaller one.
+/// - **Spans past the library's bounds** — wider than
+///   [`MAX_APPLY_WINDOW`](crate::spdi::MAX_APPLY_WINDOW), or sitting in a repeat
+///   tract still running past [`MAX_SHIFT_TRACT`](crate::spdi::MAX_SHIFT_TRACT)
+///   bases 3', where how far the change rolls depends on how much reference was
+///   read.
+///
+/// One residual is worth stating because it is a `Some` and not a `None`: a
+/// description that changes nothing (`g.3A>A`) keys at its own position, so two
+/// no-ops at different positions do not group. They denote the same bases — the
+/// unchanged reference — while keying unequally, which is why the second sentence
+/// above is qualified: this is the one class where unequal keys do *not* imply
+/// different bases. That is inherited from [`canonical_spdi`] and is documented
+/// there (`g.3A>A` keys as `3::`, `g.5T>T` as `5::`); giving the two one answer
+/// means choosing one, and nothing here needs it.
+///
+/// Use [`canonical_spdi`] directly when the *reason* for a refusal is wanted;
+/// it returns the same answer as a `Result` carrying a described error.
+pub fn spdi_key<P: ReferenceProvider + ?Sized>(
+    variant: &HgvsVariant,
+    provider: &P,
+) -> Option<SpdiKey> {
+    canonical_spdi(variant, provider)
+        .ok()
+        .map(|spdi| SpdiKey { spdi })
+}
+
+/// Variants bucketed by [`SpdiKey`], plus the ones that have no key.
+///
+/// The unkeyable list is a first-class part of the result rather than a silent
+/// drop. A consumer reading only `groups()` would under-count its call set and
+/// have no way to notice; reading `unkeyable()` tells it exactly how much of the
+/// input the buckets do not describe.
+#[derive(Debug, Clone)]
+pub struct SpdiKeyGrouping<T> {
+    groups: BTreeMap<SpdiKey, Vec<T>>,
+    unkeyable: Vec<T>,
+}
+
+impl<T> SpdiKeyGrouping<T> {
+    /// Each distinct key and the variants that share it, in key order.
+    pub fn groups(&self) -> impl Iterator<Item = (&SpdiKey, &[T])> {
+        self.groups
+            .iter()
+            .map(|(key, items)| (key, items.as_slice()))
+    }
+
+    /// The variants [`spdi_key`] declined, in input order.
+    ///
+    /// These are **not** one bucket — see [`spdi_key`] for why `None` is not an
+    /// equivalence class.
+    pub fn unkeyable(&self) -> &[T] {
+        &self.unkeyable
+    }
+
+    /// How many distinct keys the input reduced to.
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// The variants sharing `key`, or `None` if no input reached it.
+    pub fn get(&self, key: &SpdiKey) -> Option<&[T]> {
+        self.groups.get(key).map(Vec::as_slice)
+    }
+
+    /// Whether every keyable input landed in a single bucket.
+    ///
+    /// Vacuously `true` for an input with no keyable members, which is why
+    /// [`unkeyable`](Self::unkeyable) has to be read alongside it: "all one
+    /// bucket" over zero buckets is not evidence of agreement.
+    pub fn is_confluent(&self) -> bool {
+        self.groups.len() <= 1
+    }
+
+    /// The buckets and the refusals, for a caller that wants to own them.
+    pub fn into_parts(self) -> (BTreeMap<SpdiKey, Vec<T>>, Vec<T>) {
+        (self.groups, self.unkeyable)
+    }
+}
+
+/// Bucket `variants` by the bases they denote.
+///
+/// Accepts anything that borrows an [`HgvsVariant`] — owned variants, `&`
+/// variants, or a smart pointer — and hands the same items back inside the
+/// buckets, so a caller keeps whatever it put in.
+///
+/// Each variant is keyed independently; one that cannot be keyed lands in
+/// [`SpdiKeyGrouping::unkeyable`] rather than failing the call, because a
+/// consumer bucketing a call set wants the buckets it *can* have plus an honest
+/// count of what it could not place.
+///
+/// # Examples
+///
+/// ```
+/// use ferro_hgvs::equivalence::group_by_spdi_key;
+/// use ferro_hgvs::{parse_hgvs, MockProvider};
+///
+/// let mut provider = MockProvider::new();
+/// provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+///
+/// let variants = [
+///     parse_hgvs("NC_KEY.1:g.13_14insT").unwrap(),
+///     parse_hgvs("NC_KEY.1:g.14dup").unwrap(),
+///     parse_hgvs("NC_KEY.1:g.3A>G").unwrap(),
+/// ];
+/// let grouped = group_by_spdi_key(&variants, &provider);
+/// assert_eq!(grouped.group_count(), 2);
+/// ```
+pub fn group_by_spdi_key<T, I, P>(variants: I, provider: &P) -> SpdiKeyGrouping<T>
+where
+    I: IntoIterator<Item = T>,
+    T: Borrow<HgvsVariant>,
+    P: ReferenceProvider + ?Sized,
+{
+    let mut groups: BTreeMap<SpdiKey, Vec<T>> = BTreeMap::new();
+    let mut unkeyable = Vec::new();
+    for variant in variants {
+        match spdi_key(variant.borrow(), provider) {
+            Some(key) => groups.entry(key).or_default().push(variant),
+            None => unkeyable.push(variant),
+        }
+    }
+    SpdiKeyGrouping { groups, unkeyable }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::parser::parse_hgvs;
+    use crate::reference::MockProvider;
+
+    /// The 40-base contig `spdi::apply`'s own tests use, so a key asserted here
+    /// can be checked against the bases by hand.
+    ///
+    ///  1-based: 1234567890...
+    ///           GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT
+    fn provider() -> MockProvider {
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT");
+        provider.add_genomic_sequence("NC_OTHER.1", "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+        provider
+    }
+
+    fn key(descriptor: &str) -> Option<SpdiKey> {
+        let variant = parse_hgvs(descriptor).expect("fixture must parse");
+        spdi_key(&variant, &provider())
+    }
+
+    /// The property the module exists for: descriptions that assert *different
+    /// partitions* of one edit — and so reach different canonical forms by
+    /// design — share one key.
+    #[test]
+    fn different_partitions_of_one_edit_share_a_key() {
+        let spanning = key("NC_KEY.1:g.3_7delinsGGCTA").expect("keys");
+        let decomposed = key("NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]").expect("keys");
+        assert_eq!(spanning, decomposed);
+        assert_eq!(spanning.to_string(), "NC_KEY.1:2:ATTAC:GGCTA");
+        assert_eq!(spanning.accession(), "NC_KEY.1");
+    }
+
+    /// The control for the test above. Without it, every equality assertion here
+    /// would also pass for a key that collapsed everything into one bucket —
+    /// which is the failure mode the `None`-rather-than-collide rule is about.
+    #[test]
+    fn different_edits_do_not_share_a_key() {
+        assert_ne!(key("NC_KEY.1:g.3A>G"), key("NC_KEY.1:g.3A>C"));
+        assert_ne!(key("NC_KEY.1:g.3_5del"), key("NC_KEY.1:g.3_6del"));
+        // Same edit, different accession: a key is per-accession.
+        assert_ne!(key("NC_KEY.1:g.3A>G"), key("NC_OTHER.1:g.3T>G"));
+    }
+
+    /// The key is not the normalizer's output, so it groups across the axes the
+    /// canonical form deliberately keeps apart: member order, and a `dup` versus
+    /// the insertion that denotes it.
+    #[test]
+    fn the_key_ignores_spelling_and_member_order() {
+        assert_eq!(key("NC_KEY.1:g.[3A>G;7C>A]"), key("NC_KEY.1:g.[7C>A;3A>G]"));
+        assert_eq!(key("NC_KEY.1:g.13_14insT"), key("NC_KEY.1:g.14dup"));
+        // The same deletion spelled one base apart inside a tract.
+        assert_eq!(key("NC_KEY.1:g.3_5del"), key("NC_KEY.1:g.4_6del"));
+    }
+
+    /// Each documented refusal, exercised as the thing the doc claims.
+    ///
+    /// Written as a table with the reason attached because the value of this
+    /// test is the enumeration: a class that quietly started returning a key
+    /// would be a silent collision, which is the one failure the type is
+    /// supposed to make impossible.
+    #[test]
+    fn the_documented_classes_have_no_key() {
+        for (descriptor, why) in [
+            ("NP_000079.2:p.Gly1150Asp", "protein axis — SPDI has none"),
+            ("NC_KEY.1:g.[3A>G(;)7C>A]", "trans phase — two molecules"),
+            ("NC_KEY.1:g.[3_5del;4T>G]", "overlapping members"),
+            (
+                "NC_KEY.1:g.[5_6insA;5_6insC]",
+                "coincident insertions with no stated order",
+            ),
+            (
+                "[NC_KEY.1:g.3A>G;NC_OTHER.1:g.7T>G]",
+                "members on two accessions",
+            ),
+            (
+                "NC_KEY.1:g.3T>G",
+                "stated base disagrees with the reference",
+            ),
+            ("NC_ABSENT.1:g.3A>G", "the provider cannot serve the bases"),
+            ("NC_KEY.1:g.10_11ins20_30", "inserted-range payload"),
+            ("NC_KEY.1:g.10_11ins(10)", "unspecified inserted length"),
+        ] {
+            assert_eq!(
+                key(descriptor),
+                None,
+                "`{descriptor}` must have no key ({why}) — a key here is a silent collision"
+            );
+        }
+    }
+
+    /// The one documented exception to "unequal keys mean different bases": a
+    /// description that changes nothing keys at its own position, so two no-ops
+    /// at different positions do not group even though both denote the unchanged
+    /// reference.
+    ///
+    /// Pinned here because [`spdi_key`]'s contract is now stated with this as its
+    /// sole carve-out. If the residual is ever given one answer — which
+    /// [`canonical_spdi`]'s own docs say is a choice nobody has needed to make —
+    /// that sentence has to move with it, and a red test here is what says so.
+    #[test]
+    fn two_no_ops_at_different_positions_do_not_group() {
+        let here = key("NC_KEY.1:g.3A>A").expect("a no-op still keys");
+        let there = key("NC_KEY.1:g.5T>T").expect("a no-op still keys");
+        assert_ne!(here, there, "the residual is stated on `spdi_key`");
+        for no_op in [&here, &there] {
+            assert_eq!(no_op.as_spdi().deletion, "", "a no-op deletes nothing");
+            assert_eq!(no_op.as_spdi().insertion, "", "a no-op inserts nothing");
+        }
+    }
+
+    /// A member with a stated order in one payload does key, which is what makes
+    /// the coincident-insertion refusal a refusal to *guess* rather than a gap.
+    #[test]
+    fn a_stated_insertion_order_still_keys() {
+        assert!(key("NC_KEY.1:g.5_6insAC").is_some());
+    }
+
+    #[test]
+    fn grouping_separates_buckets_from_refusals() {
+        let provider = provider();
+        let variants: Vec<HgvsVariant> = [
+            "NC_KEY.1:g.3_7delinsGGCTA",
+            "NC_KEY.1:g.[3A>G;4T>G;5T>C;6A>T;7C>A]",
+            "NC_KEY.1:g.13_14insT",
+            "NC_KEY.1:g.[3_5del;4T>G]",
+        ]
+        .iter()
+        .map(|d| parse_hgvs(d).expect("fixture must parse"))
+        .collect();
+
+        let grouped = group_by_spdi_key(&variants, &provider);
+        assert_eq!(grouped.group_count(), 2);
+        assert_eq!(grouped.unkeyable().len(), 1);
+        assert!(!grouped.is_confluent());
+
+        let (largest, members) = grouped
+            .groups()
+            .max_by_key(|(_, members)| members.len())
+            .expect("two buckets");
+        assert_eq!(members.len(), 2, "the two partitions of one edit");
+        assert_eq!(grouped.get(largest).map(<[_]>::len), Some(2));
+    }
+
+    /// `into_parts` hands back exactly what went in, so a caller can own the
+    /// buckets without re-deriving them.
+    #[test]
+    fn into_parts_preserves_every_input() {
+        let provider = provider();
+        let variants: Vec<HgvsVariant> = ["NC_KEY.1:g.3A>G", "NC_ABSENT.1:g.3A>G"]
+            .iter()
+            .map(|d| parse_hgvs(d).expect("fixture must parse"))
+            .collect();
+        let (groups, unkeyable) = group_by_spdi_key(variants.clone(), &provider).into_parts();
+        let returned = groups.values().map(Vec::len).sum::<usize>() + unkeyable.len();
+        assert_eq!(returned, variants.len());
+    }
+
+    /// A soft-masked reference must key identically to the uppercase one.
+    ///
+    /// Real genomic FASTAs lowercase repeat regions, so the *same* accession can
+    /// be served soft-masked by one provider and uppercase by another. Case
+    /// carries no biological meaning, so the two denote the same bases and the
+    /// contract — "equal exactly when the denoted bases are" — requires one key.
+    ///
+    /// Asserted on `Eq`, `Hash` and `Ord` together rather than on `Eq` alone: a
+    /// `BTreeMap` bucket is found by `Ord` and a `HashMap` bucket by `Hash`, so a
+    /// key that compared equal while hashing or ordering differently would still
+    /// split a consumer's buckets, which is the failure the type exists to
+    /// prevent.
+    #[test]
+    fn a_soft_masked_reference_keys_the_same_as_an_uppercase_one() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        const UPPER: &str = "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT";
+
+        let hashed = |key: &SpdiKey| {
+            let mut hasher = DefaultHasher::new();
+            key.hash(&mut hasher);
+            hasher.finish()
+        };
+        let keyed = |sequence: &str, descriptor: &str| {
+            let mut provider = MockProvider::new();
+            provider.add_genomic_sequence("NC_KEY.1", sequence.to_string());
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            spdi_key(&variant, &provider)
+        };
+
+        // Every shape whose key can carry reference-derived bases: a stated
+        // deletion, a deletion the description does not spell, a duplication and
+        // an inversion (both of which read their inserted bases *out of* the
+        // reference), and a delins mixing both directions.
+        for descriptor in [
+            "NC_KEY.1:g.3_7delinsGGCTA",
+            "NC_KEY.1:g.3_5del",
+            "NC_KEY.1:g.3_5dup",
+            "NC_KEY.1:g.3_7inv",
+            "NC_KEY.1:g.3A>G",
+            "NC_KEY.1:g.5_6insAC",
+        ] {
+            let upper = keyed(UPPER, descriptor).expect("the uppercase reference keys");
+            let lower = keyed(&UPPER.to_ascii_lowercase(), descriptor)
+                .expect("the soft-masked reference keys");
+            assert_eq!(
+                upper, lower,
+                "`{descriptor}` keys differently on a soft-masked reference: \
+                 {upper} vs {lower}"
+            );
+            assert_eq!(
+                hashed(&upper),
+                hashed(&lower),
+                "`{descriptor}` hashes differently on a soft-masked reference, so a \
+                 `HashMap` would split the bucket even if `Eq` agreed"
+            );
+            assert_eq!(
+                upper.cmp(&lower),
+                std::cmp::Ordering::Equal,
+                "`{descriptor}` orders unequally on a soft-masked reference, so a \
+                 `BTreeMap` would split the bucket even if `Eq` agreed"
+            );
+        }
+    }
+
+    /// The delegated `Ord` really is the documented tuple order, and it really
+    /// does agree with `Eq`.
+    ///
+    /// `Ord` is delegated to [`SpdiVariant`]'s derive so a future field cannot
+    /// fall out of the comparison. That trades a hand-written `cmp` for a
+    /// declaration order, so the thing to pin is that the declaration order is
+    /// the documented one: each field is varied in isolation, from the least
+    /// significant up, and each must dominate every field below it. Ordering
+    /// consistency with `Eq` is asserted alongside, because an `Ord` returning
+    /// `Equal` for unequal keys would merge two variants into one `BTreeMap`
+    /// bucket — a silent collision, which is the one failure this type exists to
+    /// make impossible.
+    #[test]
+    fn ord_follows_the_documented_field_order_and_agrees_with_eq() {
+        use std::cmp::Ordering;
+
+        let of = |spdi: SpdiVariant| SpdiKey { spdi };
+        let base = SpdiVariant::new("NC_A.1", 10, "AC", "GG");
+
+        // Each entry raises exactly one field of `base`, most significant last.
+        // A greater value in a *less* significant field must never outrank one in
+        // a more significant field, which is what "lexicographic" buys.
+        let ascending = [
+            of(SpdiVariant::new("NC_A.1", 10, "AC", "GG")),
+            of(SpdiVariant::new("NC_A.1", 10, "AC", "GT")),
+            of(SpdiVariant::new("NC_A.1", 10, "AT", "GG")),
+            of(SpdiVariant::new("NC_A.1", 11, "AC", "GG")),
+            of(SpdiVariant::new("NC_B.1", 10, "AC", "GG")),
+        ];
+        for (index, lower) in ascending.iter().enumerate() {
+            for higher in &ascending[index + 1..] {
+                assert_eq!(
+                    lower.cmp(higher),
+                    Ordering::Less,
+                    "{lower} must sort before {higher}"
+                );
+            }
+        }
+
+        // Consistency with `Eq`, in both directions.
+        assert_eq!(of(base.clone()).cmp(&of(base.clone())), Ordering::Equal);
+        for other in &ascending[1..] {
+            assert_ne!(of(base.clone()), *other);
+            assert_ne!(
+                of(base.clone()).cmp(other),
+                Ordering::Equal,
+                "unequal keys must not compare equal — a `BTreeMap` would merge them"
+            );
+        }
+    }
+
+    /// Ordering exists so the key can index a `BTreeMap`; pin that it is
+    /// positional within an accession rather than an accident of the string.
+    #[test]
+    fn keys_order_positionally_within_an_accession() {
+        let mut keys = [
+            key("NC_KEY.1:g.7C>A").expect("keys"),
+            key("NC_KEY.1:g.3A>G").expect("keys"),
+        ];
+        keys.sort();
+        assert!(keys[0].as_spdi().position < keys[1].as_spdi().position);
+        assert_eq!(keys[0].clone().into_spdi().position, 2);
+    }
+}

--- a/src/equivalence/mod.rs
+++ b/src/equivalence/mod.rs
@@ -37,11 +37,32 @@
 //! recognizing a new class of equivalence adds a level without breaking
 //! downstream matches.
 //!
+//! # Pairwise levels, or a groupable key
+//!
+//! [`EquivalenceChecker`] answers a rich question about **two** variants, and
+//! its answer is a level rather than a value — `AccessionVersionDifference` is
+//! decided by comparing *two* accessions' versions, so there is no scalar a
+//! bucket could be keyed on. A consumer that wants to *count distinct changes*
+//! across a whole call set needs the other shape: one value per variant, equal
+//! exactly when the bases are. That is [`SpdiKey`]. Equal keys cover the
+//! `Identical`, `NormalizedMatch` and `SequenceMatch` rungs at once — including
+//! the case `SequenceMatch` exists for, where two partitions of one edit reach
+//! distinct canonical forms, as the spec's own `DNA/delins.md:44-47` pair does.
+//! The key does **not** carry `AccessionVersionDifference`, and it has one
+//! documented residual where equal bases key unequally; see [`spdi_key`].
+//!
+//! Note the implication runs one way. Equal keys imply one of those three rungs,
+//! but a pair *at* one of them need not key at all: two identical `p.`
+//! descriptions are `Identical` and have no key, because [`spdi_key`] refuses
+//! rather than guess. [`spdi_key`] enumerates every such class.
+//!
 //! # References
 //!
 //! - [HGVS Nomenclature](https://hgvs-nomenclature.org/)
 //! - [Variant Normalization](https://www.ncbi.nlm.nih.gov/variation/notation/)
 
 mod checker;
+mod key;
 
 pub use checker::{EquivalenceChecker, EquivalenceLevel, EquivalenceResult};
+pub use key::{group_by_spdi_key, spdi_key, SpdiKey, SpdiKeyGrouping};

--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -41,6 +41,14 @@
 //! Before the window was padded they did not, and that was the defect: the
 //! window was exactly the members' own span, leaving the trim no room to move.
 //!
+//! **Also guaranteed, as of the alphabet fold:** the key does not depend on the
+//! provider's spelling conventions. Its bases are emitted uppercase, and `U` is
+//! folded to `T` on the `r.` axis, so a soft-masked FASTA and an uppercase one
+//! key the same locus identically. Stated here because it is a guarantee a
+//! *caller* has, while the mechanism is a private helper (`key_alphabet`) that
+//! rustdoc does not publish — read that helper for the one boundary the fold
+//! does not reach, a provider serving a uracil-spelled transcript.
+//!
 //! **Still not claimed:** byte-compatibility with the SPDI specification's own
 //! canonical form. The form targeted here is **3'-maximal**, per `general.md:34`;
 //! NCBI's is extended in *both* directions over the repeat, so the two differ on
@@ -54,6 +62,7 @@
 use crate::error::FerroError;
 use crate::hgvs::variant::HgvsVariant;
 use crate::reference::ReferenceProvider;
+use crate::spdi::convert::{apply_alphabet, AlphabetMode};
 use crate::spdi::SpdiVariant;
 
 /// A variant applied to its reference.
@@ -253,6 +262,7 @@ pub fn canonical_spdi<P: ReferenceProvider + ?Sized>(
     /// covers every non-repeat case in one.
     const FIRST_PAD: u64 = 64;
 
+    let alphabet = key_alphabet(variant);
     let mut pad = 0u64;
     loop {
         let (applied, window_is_final) = apply_to_reference_padded(variant, provider, pad)?;
@@ -281,11 +291,14 @@ pub fn canonical_spdi<P: ReferenceProvider + ?Sized>(
         let reaches_edge = offset + deletion.len() == applied.reference.len();
 
         if is_no_op || !reaches_edge || !window_is_final {
+            // Folded through `apply_alphabet`, not emitted raw: see
+            // `key_alphabet` for why a raw window makes the key depend on the
+            // provider's case convention rather than on the bases.
             return Ok(SpdiVariant {
                 sequence: applied.accession,
                 position: applied.start + offset as u64,
-                deletion: String::from_utf8_lossy(deletion).into_owned(),
-                insertion: String::from_utf8_lossy(insertion).into_owned(),
+                deletion: apply_alphabet(&String::from_utf8_lossy(deletion), alphabet),
+                insertion: apply_alphabet(&String::from_utf8_lossy(insertion), alphabet),
             });
         }
 
@@ -307,6 +320,86 @@ pub fn canonical_spdi<P: ReferenceProvider + ?Sized>(
         } else {
             pad.saturating_mul(2)
         };
+    }
+}
+
+/// The alphabet convention [`canonical_spdi`] renders a key's bases in.
+///
+/// **A key must not depend on the provider's spelling conventions**, and without
+/// this fold it did. The two halves of a key come from two places: the inserted
+/// payload is carried in by the triples, which [`crate::spdi::hgvs_to_spdi`] has
+/// already run through [`apply_alphabet`] with the member's own axis, while the
+/// deleted bases — and any inserted bases a `dup` or `inv` reads *out of* the
+/// reference — come from the fetched window verbatim. So one key could hold two
+/// conventions at once, and two providers serving the same sequence could key it
+/// differently.
+///
+/// Measured before this fold, on a soft-masked copy of the module's own fixture
+/// contig: `g.3_7delinsGGCTA` keyed as `2:ATTAC:GGCTA` against the uppercase
+/// contig and as `2:attac:GGCTA` against the lowercase one. Real genomic FASTAs
+/// lowercase repeat tracts, so that is the common case rather than a corner:
+/// `SpdiKey`'s whole contract is that equal keys mean equal bases, and case
+/// carries no biological meaning. `trim_common_flanks` was already
+/// case-insensitive, so only the *emitted* strings were affected — the position
+/// and the block boundaries were right all along, which is what made this
+/// invisible to every test using an uppercase fixture.
+/// `a_soft_masked_reference_keys_the_same_as_an_uppercase_one` pins it.
+///
+/// [`AlphabetMode::Rna`] additionally rewrites `U` to `T`, the same convention
+/// the `r.` axis's triples already carry. **That reconciles a uracil-spelled
+/// provider only where the U-bearing reference bases reach the emitted block
+/// through [`trim_common_flanks`], and the boundary is worth stating rather than
+/// generalising from** — the fold runs *after* both comparisons that decide the
+/// block, and each is `eq_ignore_ascii_case` only, which does not relate `U` to
+/// `T`. Measured on one 40-base transcript served both ways:
+///
+/// ```text
+///                        T-spelled provider   U-spelled provider
+///   r.[3a>g;7c>a]        2:ATTAC:GTTAA        2:ATTAC:GTTAA   agrees — the fold
+///   r.3a>g               2:A:G                2:A:G           agrees
+///   r.14dup              14::T                14::T           agrees
+///   r.13_14insu          14::T                13::T           position shifts
+///   r.3_5del             3:TTA:               declined        apply_triples
+///   r.3_7delinsggcua     2:ATTAC:GGCTA        declined        apply_triples
+/// ```
+///
+/// The two failing shapes are bounded by named code, not by luck. A **stated**
+/// deletion is validated against the reference in [`apply_triples`] before any
+/// fold, so `T` against `U` reads as a ref-mismatch and the variant is declined
+/// outright. An insertion or `dup` rolling 3' has its common-prefix scan stopped
+/// at the first `U`/`T` disagreement, so the roll is cut short and the *position*
+/// moves. Neither is reachable from a RefSeq-spelled provider — `refseq.md` and
+/// [`apply_alphabet`] both record that transcript sequences are stored as DNA —
+/// which is why this is left stated rather than fixed here: making the two
+/// comparisons alphabet-aware is a change to the `n.`/`c.` paths as well.
+/// `the_alphabet_fold_reconciles_case_and_bounds_the_uracil_case` pins every row
+/// above.
+///
+/// Note this deliberately does **not** fold [`AppliedVariant`], whose whole
+/// point is to hand back the reference window as it was served; a caller
+/// inspecting soft-masking there is asking a legitimate question. Nothing
+/// compares a folded key against an unfolded window: [`EquivalenceChecker`]
+/// compares two [`apply_triples`] results with each other, and
+/// `examples/dump_normalized_corpus.rs` compares `reference` against the frame
+/// it generated — neither reads a [`SpdiVariant`] field.
+///
+/// [`EquivalenceChecker`]: crate::equivalence::EquivalenceChecker
+fn key_alphabet(variant: &HgvsVariant) -> AlphabetMode {
+    fn is_rna(variant: &HgvsVariant) -> bool {
+        matches!(variant, HgvsVariant::Rna(_))
+    }
+    match variant {
+        // `any` rather than `all`, and the distinction is **reachable** — not, as
+        // this comment once claimed, ruled out by the members sharing one
+        // accession. `[NR_X.1:r.3a>g;NR_X.1:n.7C>A]` parses, is one cis allele on
+        // one accession, and keys; measured on a U-spelled provider it keys
+        // `2:ATTAC:GTTAA` under `any` and `2:AUUAC:GUUAA` under `all`. So `any`
+        // is what stops one key from carrying two alphabets, which is the whole
+        // point of the fold. Pinned by
+        // `a_mixed_axis_cis_allele_folds_on_any_rna_member`.
+        HgvsVariant::Allele(allele) if allele.variants.iter().any(is_rna) => AlphabetMode::Rna,
+        single if is_rna(single) => AlphabetMode::Rna,
+        _ => AlphabetMode::Dna,
     }
 }
 
@@ -795,5 +888,183 @@ mod tests {
     fn an_unreadable_reference_declines() {
         let variant = parse_hgvs("NC_ABSENT.1:g.3A>G").unwrap();
         assert!(apply_to_reference(&variant, &provider()).is_err());
+    }
+
+    /// The 40-base fixture served as a transcript, so the `r.` axis is reachable;
+    /// `spell` chooses the DNA or the uracil spelling of the same molecule.
+    fn transcript_provider(spell_uracil: bool) -> MockProvider {
+        use crate::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+
+        const DNA: &str = "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT";
+        let sequence = if spell_uracil {
+            DNA.replace('T', "U")
+        } else {
+            DNA.to_string()
+        };
+        let length = sequence.len() as u64;
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript::new(
+            "NR_KEY.1".to_string(),
+            Some("SYNTH".to_string()),
+            Strand::Plus,
+            sequence.clone(),
+            None,
+            None,
+            vec![Exon::with_genomic(1, 1, length, 1, length)],
+            Some("chr_key".to_string()),
+            Some(1),
+            Some(length),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        ));
+        provider.add_genomic_sequence("chr_key", sequence);
+        provider
+    }
+
+    /// The alphabet fold, in both directions: what it reconciles, and the
+    /// boundary it does not reach.
+    ///
+    /// **Case is reconciled unconditionally.** Real genomic FASTAs lowercase
+    /// repeat tracts, so the same accession can be served soft-masked by one
+    /// provider and uppercase by another; case carries no biological meaning, so
+    /// the key must not move. Every shape whose key can carry reference-derived
+    /// bases is covered — a stated deletion, an unspelled one, a `dup` and an
+    /// `inv` (both of which read their inserted bases *out of* the reference),
+    /// and a `delins` mixing both directions.
+    ///
+    /// **`U`/`T` is reconciled only part of the way, and that is the point of
+    /// asserting it.** [`key_alphabet`] folds *after* the two comparisons that
+    /// decide the emitted block, and both are `eq_ignore_ascii_case`, which does
+    /// not relate `U` to `T`. So a uracil-spelled provider agrees with a
+    /// DNA-spelled one exactly when the U-bearing bases reach the block through
+    /// [`trim_common_flanks`]; where a `U` sits in a **stated** deletion
+    /// [`apply_triples`] reads a ref-mismatch and declines, and where it stops an
+    /// insertion's common-prefix scan the roll is cut short and the position
+    /// moves. Both rows are pinned as the current answer rather than left to be
+    /// rediscovered as a surprise — a uracil-spelled transcript provider is not a
+    /// RefSeq spelling, so neither is a defect on any supported path, but a doc
+    /// claiming blanket reconciliation would be wrong and this is what keeps it
+    /// honest.
+    #[test]
+    fn the_alphabet_fold_reconciles_case_and_bounds_the_uracil_case() {
+        for descriptor in [
+            "NC_KEY.1:g.3_7delinsGGCTA",
+            "NC_KEY.1:g.3_5del",
+            "NC_KEY.1:g.3_5dup",
+            "NC_KEY.1:g.3_7inv",
+            "NC_KEY.1:g.3A>G",
+            "NC_KEY.1:g.5_6insAC",
+        ] {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            let mut masked = MockProvider::new();
+            masked.add_genomic_sequence(
+                "NC_KEY.1",
+                "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT".to_ascii_lowercase(),
+            );
+            let upper =
+                canonical_spdi(&variant, &provider()).expect("the uppercase reference keys");
+            let lower = canonical_spdi(&variant, &masked).expect("the soft-masked reference keys");
+            assert_eq!(
+                upper, lower,
+                "`{descriptor}` must key identically on a soft-masked reference"
+            );
+            assert!(
+                upper.deletion.chars().all(|c| !c.is_ascii_lowercase())
+                    && upper.insertion.chars().all(|c| !c.is_ascii_lowercase()),
+                "`{descriptor}` emitted lowercase bases: {upper}"
+            );
+        }
+
+        let dna = transcript_provider(false);
+        let uracil = transcript_provider(true);
+        let keyed = |descriptor: &str, provider: &MockProvider| {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            canonical_spdi(&variant, provider)
+                .ok()
+                .map(|spdi| spdi.to_string())
+        };
+
+        // Reconciled: the U-bearing bases reach the block through the trim.
+        for descriptor in [
+            "NR_KEY.1:r.[3a>g;7c>a]",
+            "NR_KEY.1:r.3a>g",
+            "NR_KEY.1:r.14dup",
+        ] {
+            assert_eq!(
+                keyed(descriptor, &dna),
+                keyed(descriptor, &uracil),
+                "`{descriptor}` is a shape the fold does reconcile"
+            );
+        }
+        assert_eq!(
+            keyed("NR_KEY.1:r.[3a>g;7c>a]", &uracil).as_deref(),
+            Some("NR_KEY.1:2:ATTAC:GTTAA"),
+            "and it reconciles by folding, not by refusing both sides"
+        );
+
+        // Not reconciled: a stated deletion is validated before the fold.
+        for descriptor in [
+            "NR_KEY.1:r.3_5del",
+            "NR_KEY.1:r.3_7delinsggcua",
+            "NR_KEY.1:r.3_7inv",
+        ] {
+            assert!(
+                keyed(descriptor, &dna).is_some(),
+                "`{descriptor}` keys on the RefSeq spelling"
+            );
+            assert_eq!(
+                keyed(descriptor, &uracil),
+                None,
+                "`{descriptor}` is declined on a uracil provider — `apply_triples` \
+                 validates the stated deletion case-insensitively, not alphabet-insensitively"
+            );
+        }
+
+        // Not reconciled: the roll's common-prefix scan stops at the first U/T
+        // disagreement, so the position moves rather than the bases.
+        assert_eq!(
+            (
+                keyed("NR_KEY.1:r.13_14insu", &dna).as_deref(),
+                keyed("NR_KEY.1:r.13_14insu", &uracil).as_deref()
+            ),
+            (Some("NR_KEY.1:14::T"), Some("NR_KEY.1:13::T")),
+            "the 3' roll is cut short on a uracil provider"
+        );
+    }
+
+    /// A cis allele mixing an `r.` member with an `n.` one on a single accession
+    /// is reachable, so [`key_alphabet`]'s `any`-versus-`all` choice is a real
+    /// decision and not a formality.
+    ///
+    /// The comment on that arm used to say the members "must share one accession
+    /// to key at all, so in practice they share one axis". They need not: the
+    /// description below parses, is one cis allele on one accession, and keys.
+    /// With `any` the whole key is folded and agrees with the DNA-spelled
+    /// provider; with `all` it would emit `2:AUUAC:GUUAA`, one key carrying two
+    /// alphabets, which is exactly what the fold exists to prevent. The `n.`-only
+    /// spelling is asserted alongside as the control that the `r.` member is what
+    /// selects the fold.
+    #[test]
+    fn a_mixed_axis_cis_allele_folds_on_any_rna_member() {
+        let uracil = transcript_provider(true);
+        let keyed = |descriptor: &str| {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            canonical_spdi(&variant, &uracil)
+                .unwrap_or_else(|e| panic!("`{descriptor}` must key: {e}"))
+                .to_string()
+        };
+        assert_eq!(
+            keyed("[NR_KEY.1:r.3a>g;NR_KEY.1:n.7C>A]"),
+            "NR_KEY.1:2:ATTAC:GTTAA",
+            "one `r.` member folds the whole key"
+        );
+        assert_eq!(
+            keyed("NR_KEY.1:n.[3A>G;7C>A]"),
+            "NR_KEY.1:2:AUUAC:GUUAA",
+            "the same allele with no `r.` member is not folded — the control that \
+             the `r.` member is what selects `AlphabetMode::Rna`"
+        );
     }
 }

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -809,8 +809,12 @@ fn rna_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
 
 /// Whether to rewrite RNA bases (`u/U`) to DNA (`T`) in the emitted SPDI
 /// deletion/insertion strings.
+///
+/// `pub(crate)` for [`crate::spdi::apply`], which reads a key's bases back out
+/// of the reference window and so has to fold them in the same convention this
+/// module's triples already use.
 #[derive(Debug, Clone, Copy)]
-enum AlphabetMode {
+pub(crate) enum AlphabetMode {
     Dna,
     Rna,
 }
@@ -2100,7 +2104,7 @@ where
 /// sequences as DNA even on `NR_*` and `NM_*` accessions), so RNA `u`/`U`
 /// must become `T`. Other characters are returned unchanged. The output is
 /// always uppercase to match SPDI's standard form.
-fn apply_alphabet(s: &str, alphabet: AlphabetMode) -> String {
+pub(crate) fn apply_alphabet(s: &str, alphabet: AlphabetMode) -> String {
     match alphabet {
         AlphabetMode::Dna => s.to_ascii_uppercase(),
         AlphabetMode::Rna => s

--- a/src/spdi/mod.rs
+++ b/src/spdi/mod.rs
@@ -76,7 +76,17 @@ use std::str::FromStr;
 /// the fields stay `pub`, so they remain readable and individually assignable.
 /// Mirrors the attribute on [`crate::project::VariantProjection`], the
 /// analogous all-`pub`-field output type #1033 marked.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `Ord` is **derived**, so it is lexicographic over the fields in declaration
+/// order — `(sequence, position, deletion, insertion)`. That is the order
+/// [`crate::equivalence::SpdiKey`] documents and delegates to, and deriving it is
+/// what keeps a future field inside the comparison automatically: a hand-written
+/// `cmp` naming four fields silently stops being total the moment a fifth is
+/// added, while still type-checking and still agreeing with `Eq` on every value
+/// that predates it. Derived alongside the derived `Eq`, so the two cannot
+/// disagree — an `Ord` that called two unequal values equal would merge them into
+/// one `BTreeMap` bucket.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct SpdiVariant {
     /// Reference sequence identifier (e.g., "NC_000001.11").


### PR DESCRIPTION
Salvaged from #1565's stack and rebased onto `main`. #1565 makes the input's asserted partition the unit of normalization; that model was reversed on 2026-08-09 in favour of re-derivation, so #1565 is being closed and everything stacked on it goes with it. This piece never touched the partitioner — it was stranded only by its position.

Supersedes #1567.

**No longer a pure addition.** The body previously said nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` was touched and no existing behaviour changed. Review found a defect in the key's core contract that is only fixable in `src/spdi/`, so both halves of that sentence are now false and the correction is disclosed in the trailer. See [A correctness defect the first CLI review found](#a-correctness-defect-the-first-cli-review-found) below.

## The gap

`EquivalenceChecker` answers a rich question about **two** variants and returns a *level*, not a value — `AccessionVersionDifference` is decided by comparing two accessions' versions, so there is no scalar a bucket could be keyed on. A consumer that wants to count distinct changes across a whole call set needs the other shape: one value per variant, equal exactly when the denoted bases are.

Comparing normalized strings is not that. It answers a different question, and it couples the consumer's stored buckets to the normalizer.

## Why that coupling is a real cost, not a hypothetical

Two spellings that partition the same bases differently can reach different canonical forms, and that is by design rather than a gap to close. `canonical-form-choice-when-both-legal` is **decided**: derive from the resulting sequence, "subject to every explicit spec tie-break". Where two tie-breaks point opposite ways, neither is selected and both forms survive.

The spec supplies its own instance. `DNA/delins.md:44` gives a spanning `delins`, `:46` names a four-member split as an "alternative description" of the *same* variant, `:47` recommends the spanning form, and `general.md:34` requires members separated by unchanged nucleotides to stay individual. Two clauses, opposite directions, one variant, two legal forms.

And confluence work *moves* canonical forms — this project declares those moves as breaking rather than avoiding them. So buckets keyed on the normalized string re-bucket on every such release. `SpdiKey` is derived from `canonical_spdi` without consulting the normalizer, so it does not move when a canonical form does.

## The `None` contract is the load-bearing half

`spdi_key` returns `None` rather than a key that would silently collide. A key that answered for everything would bucket unrelated variants together, which is strictly worse than refusing — a consumer can see a refusal and cannot see a wrong bucket. The classes that have no key are enumerated on `spdi_key` itself.

`SpdiKeyGrouping` reports `unkeyable()` alongside the groups for the same reason: a grouping that quietly dropped what it could not key would report a smaller, cleaner-looking population than it was given.

## A correctness defect the first CLI review found

This PR had **eight** CodeRabbit CLI attempts; the first seven were rate-limited, so the eighth was the first time the CLI lens ever ran on it. It found a real defect in exactly the property the type exists for.

`canonical_spdi` read the key's deleted bases — and any inserted bases a `dup` or `inv` copies *out of* the reference — straight from the fetched window, while the inserted payload arrived through the triples, which `hgvs_to_spdi` has already folded with `apply_alphabet`. So one key could hold two alphabet conventions at once, and **a soft-masked reference keyed differently from the uppercase copy of the same sequence.** Measured on the module's own fixture contig, `g.3_7delinsGGCTA`:

```
uppercase contig   NC_KEY.1:2:ATTAC:GGCTA
lowercase contig   NC_KEY.1:2:attac:GGCTA
```

Real genomic FASTAs soft-mask repeat tracts in lowercase, so this is the ordinary case rather than a corner, and it breaks the one contract the whole type carries: equal keys mean equal bases. It was invisible because `trim_common_flanks` is already case-insensitive — the position and the block boundaries were right all along, only the emitted strings carried the provider's case — and because every fixture in the tree is uppercase.

Fixed by folding both emitted strings through the existing `apply_alphabet`, per its own doc at `convert.rs:1872` explaining why that is preferred to a bare `to_ascii_uppercase`: on the `r.` axis it also rewrites `U` to `T`, which is the convention the triples already carry. That reconciles a uracil-spelled transcript **only where the U-bearing reference bases reach the emitted block through `trim_common_flanks`** — the fold runs after the two comparisons that decide the block (`trim_common_flanks` and `apply_triples`' deletion validation) and both are `eq_ignore_ascii_case`, which does not relate `U` to `T`. Measured on one transcript served both ways: `r.[3a>g;7c>a]`, `r.3a>g` and `r.14dup` agree; `r.13_14insu` keys at `14::T` against `13::T` because the 3' roll's prefix scan stops at the first mismatch; and `r.3_5del`, `r.3_7delinsggcua` and `r.3_7inv` are **declined** on the uracil provider because a stated deletion of `T` fails validation against `U`. Every row is pinned by `the_alphabet_fold_reconciles_case_and_bounds_the_uracil_case`. None of it is reachable from a RefSeq-spelled provider, which stores transcripts as DNA, so the boundary is recorded rather than closed — making those two comparisons alphabet-aware would change the `n.`/`c.` paths too. `AppliedVariant` is deliberately **not** folded — handing back the window as served is its purpose, and a caller inspecting soft-masking there is asking a legitimate question.

`a_soft_masked_reference_keys_the_same_as_an_uppercase_one` pins it across six shapes (stated and unstated deletions, `dup`, `inv`, substitution, insertion) and asserts on `Eq`, `Hash` **and** `Ord` together, since a `BTreeMap` bucket is found by `Ord` and a `HashMap` bucket by `Hash` — a key that compared equal while hashing differently would still split a consumer's buckets.

## The measurement harness, and its vacuity denominator

`examples/measure_spdi_key_grouping.rs` asks the claim of the population that actually exhibits the divergence — every class `dump_confluence_divergences` reports — rather than of hand-written pairs. A hand-written pair proves the mechanism and says nothing about coverage.

Four verdicts, deliberately four rather than two: `grouped`, `split`, `undecided` (at least one output has no key, so the class cannot be answered either way) and `unmeasured` (at least one output could not be *asked*). `undecided` is `spdi_key` declining, which is evidence about the key; `unmeasured` is the harness failing, which is evidence about the corpus. Folding either into `split` would report a failure of one as a finding about the other. A run with any `unmeasured` exits non-zero.

**The vacuity check prints unconditionally.** A run whose input holds no class with two or more distinct outputs measures nothing about grouping, and a `0 split` from such a run reads exactly like success — the corpus-zero trap this repository has now hit three times (#1456, #1460, #1478). `multi_output` is that denominator, and when it is zero the report says so instead of printing a ratio.

Two further review findings landed on this harness, which has now had a counting defect corrected in three separate reviews — first an omitted `Verdict::Unmeasured` census row, now these:

- **The vacuity denominator counted JSON rows, not distinct output texts.** `dump_confluence_divergences` groups spellings into a map keyed on the output text and emits one row per key, so its own dumps cannot produce a duplicate and **no figure this harness has printed changes.** What the dedupe buys is that the single input shape able to defeat the vacuity check was the one it could not see: a class holding one output twice reads as `>1 distinct output`, suppressing the `VACUOUS` banner while measuring nothing. Only the count is deduped — two rows sharing a text carry *different* `from` spellings and the spelling pass needs both.
- **Spelling failures were conflated with output failures.** Both were pushed into one list, printed under a heading asserting "their classes are counted under the `unmeasured` verdict". That is true of an output row and **false of a spelling row**: the verdict is a statement about a class's normalized outputs and is fixed before the spelling pass runs, so a class can be `grouped` on its outputs while a spelling of it never reached the key. The reader was being sent to look for a census row that is not there. Now tracked independently and rendered under its own `UNMEASURED SPELLINGS` heading that says explicitly it changes no verdict; output-failure behaviour is unchanged, and both halves still fail the run, with the exit message naming which figure each shrank.

The target carries `test = true` so its `#[cfg(test)]` units actually run. It writes no artifact, so it takes on no `CaptureLedger` obligation.

## Two smaller review fixes

- **`SpdiKey`'s `Ord` was hand-written over all four fields.** Verified correct as written, but it silently stops being total the moment a fifth field is added, while still type-checking and still agreeing with `Eq` on every pre-existing value — two keys differing only in the new field would compare `Equal` and collapse into one `BTreeMap` bucket. `SpdiVariant` now derives `Ord`/`PartialOrd` and the key delegates to it. Its declaration order is `(sequence, position, deletion, insertion)`, which is exactly the order the key documents; derived alongside the derived `Eq`, so the two cannot disagree. `ord_follows_the_documented_field_order_and_agrees_with_eq` varies each field in isolation from least significant up and asserts consistency with `Eq` in both directions.
- **The `equivalence` module doc claimed `SpdiKey` "corresponds to the `SequenceMatch` rung".** Two independent review lenses raised this. Equal keys cover `Identical`, `NormalizedMatch` **and** `SequenceMatch` at once, so naming one understates it; rewritten to say so, with the implication's direction stated explicitly — a pair *at* one of those rungs need not key at all, since two identical `p.` descriptions are `Identical` and `spdi_key` refuses them. The section was also sitting after `# References`, separated by a blank non-doc line, which concatenates its heading onto the last list item; moved before the references.

## What was corrected in the salvage

Two claims in the inherited text were true on the stack and false on `main`, and both are load-bearing to the module's motivation rather than incidental:

- The module doc opened *"this project's normalizer preserves that partition rather than re-deriving a minimal one from the resulting sequence."* `main` re-derives. Restated from what actually holds — the derivation is subject to spec tie-breaks that sometimes conflict, which is why two forms survive. The motivation is stronger this way, and it no longer depends on which model ships.
- It quoted `canonical-form-choice-when-both-legal` as saying *"Sequence-level equivalence still needs an answer for consumers who dedupe; that is `EquivalenceLevel::SequenceMatch` and a groupable SPDI key, not the canonical string."* **That sentence is not in `main`'s copy of the record** — it was added by #1565's ledger change, which is being closed with it. Quoting it here would have left a citation pointing at text that does not exist. Removed, and the point argued from the record's actual decided text instead.

One smaller fix: the doctest's comment claimed the two descriptions "are two canonical forms by design" while the code compares two freshly *parsed* strings and never normalizes. Reworded to what it demonstrates, with a note that the key holds whether or not the normalizer converges the pair — which is the property that matters.

## A trap avoided, worth recording

Lifting the change as `git diff origin/main <stack-branch> -- Cargo.toml` **deletes** the `extract_inversion_sweep_windows` example target, which `main` gained from #1554 earlier the same day. A branch-to-branch diff reverts the newer side wherever the two have both moved. The `Cargo.toml` hunk here is the addition only; `extract_inversion_sweep_windows` is untouched.

## Verification

Every figure below is re-measured after the review fixes; the previous body's counts (127 targeted / 94 doctests) were taken before three tests were added and are superseded rather than carried forward.

- `cargo nextest run --features dev -E 'binary(measure_spdi_key_grouping) + test(equivalence::key) + test(equivalence)'` — **135 passed, 0 failed**.
- `cargo test --features dev --doc equivalence` — **6 passed, 0 failed**. Stated separately because `cargo nextest` does not run doctests, and this module's contract is carried by one.
- `cargo nextest run --features dev` (full suite, run because this now touches `src/spdi/`, which is widely depended on) — **10063 passed, 0 failed**.
- `cargo fmt --all -- --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean apart from the pre-existing third-party `proc-macro-error2` future-incompat line.

`RUSTDOCFLAGS="-D warnings" cargo doc` reports 106 errors repo-wide on `main` already; none is in a line this PR touches (the single hit under a touched file is `hgvs_to_spdi`'s pre-existing link at `convert.rs:371`). Recorded so the number is not read as introduced here.

Representation-Change: SPDI keys move on a soft-masked reference. `canonical_spdi`'s emitted `deletion` and `insertion` are now folded through `apply_alphabet`, so a lowercase repeat-masked contig keys `2:ATTAC:GGCTA` where it previously keyed `2:attac:GGCTA`, and an `r.`-axis provider serving uracil now folds to the RefSeq DNA spelling wherever the fold reaches (see above for the three shapes it does not, none reachable from a RefSeq-spelled provider). No normalized HGVS string changes, and no key derived from an uppercase reference changes. The affected consumer is any that keys off a soft-masked FASTA, for whom the previous keys split buckets that denote identical bases — so this is a fix to the type's contract, migrated by re-deriving keys once.

