### PR TITLE
fix(normalize): coalesce protein cis adjacency created by the 3'-shift, and add the corpus axis that found it

### DIFF
--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -83,6 +83,32 @@
 //!    brings its own designed references because a random core cannot be asked to
 //!    have a coincidence pattern.
 //!
+//!    **Two corpus totals appear in this file and both are correct — do not
+//!    "reconcile" them.** `78,028` is the corpus *before* `separated_revcomp_runs`
+//!    existed, which is the only denominator a measurement taken before that
+//!    family was added can honestly carry; `78,298` is the corpus now, and
+//!    `78,298 - 78,028 = 270` is exactly that family's row count. They differ by a
+//!    digit transposition as well as by 270, which is a coincidence and has
+//!    already been read once as a typo in one of them. When you quote a figure,
+//!    quote the denominator it was measured against.
+//!
+//! 6. **…and only on the molecule types it builds** (#1606). Every family above is
+//!    spelled from nucleotides, so until the protein axis was added this corpus
+//!    could not emit one `p.` row and a protein-scoped change measured a structural
+//!    `0 of 78,298`. #1606 is the live instance: it moves an equal-length protein
+//!    `delins` onto its members and had to *report* the zero and name the generator
+//!    as its cause, because there was no measurement to quote. With the axis in
+//!    place the same change measures **1,584 of 85,642 rows, all in
+//!    `protein_equal_length_delins` and none anywhere else**.
+//!
+//!    Note what the four instances have in common and why the list keeps growing:
+//!    fixing one blindness does not reveal the next. Geometry (#1456) was only
+//!    findable once the conflict families existed, scale (#1460) once geometry was
+//!    fixed, transcript geometry (#1478) once scale was — and molecule type was
+//!    invisible behind all three, because a corpus with three axes looks well
+//!    covered. `compare` names the families it covered (#1459), which catches a
+//!    missing *family*; it cannot tell you the axis you never built.
+//!
 //! ## One family knows its own ground truth, and that buys three oracles
 //!
 //! Everything above measures **movement** — two dumps, one diff — and never
@@ -178,6 +204,40 @@ const EXON_SPANS: &[(usize, usize)] = &[(0, 7), (7, 14), (14, 20)];
 /// Long enough that an exon's genomic span cannot abut its neighbour's, so a shift
 /// that runs off an exon end lands in intron rather than silently in the next exon.
 const INTRON_LEN: usize = 10;
+
+/// The protein reference a `p.` row is drawn against (#1606).
+///
+/// A bare `NP_` accession with no nucleotide counterpart, which is deliberate: it
+/// takes `MockProvider::add_protein` and nothing else, so the protein axis needs
+/// neither a transcript nor a CDS and cannot be perturbed by the exon geometry the
+/// `c.`/`cx.` references carry.
+const PROTEIN_ACCESSION: &str = "NP_TEST.1";
+
+/// Residues protein cores are built from, as `(one-letter, three-letter)`.
+///
+/// `Met` leads the table because it is residue 1 of every core and is **never
+/// drawn** into the body — cores draw from `[1..]`. Two reasons, and the second is
+/// the one that would silently weaken the corpus. A protein starts at `Met`, so a
+/// core that did not would not be a protein; and an edit reaching residue 1 emits
+/// the illegal start-loss spelling filed as #1607, so a `Met` in the body would let
+/// a shift *arrive* at residue 1 and turn a representation measurement into a
+/// rediscovery of that bug. Keeping `Met` out of the body means the only residue-1
+/// interaction is one the families never construct.
+const RESIDUE_CODES: &[(char, &str)] = &[
+    ('M', "Met"),
+    ('A', "Ala"),
+    ('G', "Gly"),
+    ('S', "Ser"),
+    ('L', "Leu"),
+    ('K', "Lys"),
+    ('V', "Val"),
+];
+
+/// Residues in a protein core, `Met` included.
+///
+/// Twenty, matching the DNA cores, so the two halves of the corpus report row
+/// counts on the same scale and a per-core figure means the same thing on either.
+const PROTEIN_LEN: usize = 20;
 
 /// The dump header, written on emit and required verbatim on read.
 const HEADER: &str = "reference\taxis\tdirection\tfamily\tinput\toutput\twas_fixed_point\n";
@@ -525,6 +585,45 @@ const FAMILIES: &[(&str, &str)] = &[
     (
         "repeat_expansion",
         "a ranged repeat as an input — emitted on 1,558 rows, consumed on none",
+    ),
+];
+
+/// The shape families drawn against the **protein** cores (#1606).
+///
+/// Kept out of `FAMILIES` because they are not crossed with the DNA axes: a `p.`
+/// description is spelled from residues, so nothing above can be evaluated on a
+/// protein core and nothing here on a nucleotide one. The split is the same one
+/// `LONG_FAMILY` and `REVCOMP_FAMILY` make, and it has the same consequence — every
+/// existing row is byte-identical, because an added axis, like an added family,
+/// only appends.
+///
+/// **This is the fourth instance of the corpus-blindness class**, after member
+/// geometry (#1456), scale (#1460) and transcript geometry (#1478). The corpus
+/// built no protein row at all, so a change scoped to the protein axis measured a
+/// structural `0 of 78,298` — indistinguishable in the output from a change that
+/// genuinely moved nothing. #1606 is the live instance: it moves an equal-length
+/// `p.` delins onto its members, and had to report the zero and name the generator
+/// as the reason, because there was no measurement to quote.
+const PROTEIN_FAMILIES: &[(&str, &str)] = &[
+    (
+        "protein_shift_del",
+        "#91 — a deletion inside a residue run, which shifts to the C-terminal end",
+    ),
+    (
+        "protein_shift_dup",
+        "#91 / #92 — a duplication inside a residue run",
+    ),
+    (
+        "protein_ins_becomes_dup",
+        "#92 — an insertion whose payload copies its 5' neighbour, so it re-types as a dup",
+    ),
+    (
+        "protein_equal_length_delins",
+        "#1606 — an equal-length delins whose interior residues are unchanged",
+    ),
+    (
+        "protein_cis_separated",
+        "#1232 / #1401 on the protein axis — two members separated by unchanged residues",
     ),
 ];
 
@@ -990,6 +1089,43 @@ fn dump(seeds: u32) -> Vec<Row> {
             }
         }
     }
+    // The protein axis, appended last so every row above keeps its position in the
+    // dump (#1606).
+    //
+    // **One direction, not two, and that is measured rather than assumed.** Every
+    // loop above crosses its cores with `axes_and_directions`, which carries a 3'
+    // and a 5' cell. The protein normalization path never reads
+    // `NormalizeConfig::direction` — a `p.` row comes out identical under both — so
+    // dumping the second direction would double the protein half of the corpus with
+    // byte-identical rows and make a reader believe the axis had been measured under
+    // 5' shifting when nothing had. `the_protein_axis_is_direction_invariant` pins
+    // that, and it is a live guard rather than a comment: if the protein path ever
+    // starts honouring the direction, it fails and says to add the cell here.
+    for peptide in protein_sequences(seeds) {
+        let normalizer = Normalizer::with_config(
+            protein_provider(&peptide),
+            NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+        );
+        for (family, _) in PROTEIN_FAMILIES {
+            for input in protein_inputs_for(family, &peptide) {
+                let output = normalize_through(&normalizer, &input);
+                rows.push(Row {
+                    reference: peptide.clone(),
+                    // The protein axis brings no designed references, so the
+                    // `reference` column is the peptide itself rather than a
+                    // label — `core` is therefore equal to it, which is the
+                    // ordinary case the field documents (#1624/#1625).
+                    core: peptide.clone(),
+                    axis: "p",
+                    direction: "3prime",
+                    family,
+                    was_fixed_point: output == input,
+                    input,
+                    output,
+                });
+            }
+        }
+    }
     rows
 }
 
@@ -1042,6 +1178,183 @@ fn corpus_sequences(seeds: u32) -> Vec<String> {
         }
     }
     sequences
+}
+
+/// Deterministic 20-residue peptides, two per seed, each starting with `Met`.
+///
+/// Two per seed mirrors [`corpus_sequences`] — one drawn from a two-residue
+/// alphabet and one from the full table — so the protein half of the corpus scales
+/// with `--seeds` exactly as the DNA half does and stays prefix-stable.
+///
+/// **Runs are planted, not hoped for.** The residues are drawn in runs of one to
+/// three rather than one at a time, and that is the whole design. Every family
+/// below is about *shifting*, and a shift only has somewhere to go inside a tract
+/// of equal residues; drawing residue-by-residue from a 6-letter alphabet gives a
+/// run of 3 about once per 36 positions, so most cores would be fixed points for
+/// the two shift families and the corpus would report a near-zero it had generated
+/// rather than measured. This is the same lesson as `#1517` — a random core cannot
+/// be *asked* to have a structural property, so the property is built in.
+fn protein_sequences(seeds: u32) -> Vec<String> {
+    let drawn = &RESIDUE_CODES[1..];
+    let mut peptides = Vec::with_capacity(2 * seeds as usize);
+    for seed in 0..seeds {
+        for alphabet in [&drawn[..2], drawn] {
+            let mut state = u64::from(seed).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+            let mut peptide = String::with_capacity(PROTEIN_LEN);
+            peptide.push('M');
+            while peptide.len() < PROTEIN_LEN {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let residue = alphabet[(state % alphabet.len() as u64) as usize].0;
+                let run = 1 + (state >> 32) % 3;
+                for _ in 0..run {
+                    if peptide.len() == PROTEIN_LEN {
+                        break;
+                    }
+                    peptide.push(residue);
+                }
+            }
+            peptides.push(peptide);
+        }
+    }
+    peptides
+}
+
+/// Three-letter code of the residue at 1-based `position` of `peptide`.
+///
+/// Panics on a residue outside [`RESIDUE_CODES`] rather than rendering something
+/// unparseable: cores are generated from that table, so a miss means the generator
+/// and the table have drifted apart, and a description built from a wrong code
+/// would be recorded as a parse error — a corpus row that looks like a measurement
+/// and is really a bug in the corpus.
+fn residue_at(peptide: &str, position: usize) -> &'static str {
+    let one = peptide
+        .as_bytes()
+        .get(position - 1)
+        .map(|b| *b as char)
+        .unwrap_or_else(|| panic!("position {position} is past the end of a {PROTEIN_LEN}-mer"));
+    RESIDUE_CODES
+        .iter()
+        .find(|(letter, _)| *letter == one)
+        .map(|(_, three)| *three)
+        .unwrap_or_else(|| panic!("residue {one} is not in RESIDUE_CODES"))
+}
+
+/// A three-letter residue that is **not** the one at `position`, for building an
+/// edit whose payload genuinely changes the reference.
+///
+/// A payload equal to the reference residue would make the edit a no-op that
+/// normalizes to `=`, which is a different family's question. The table has seven
+/// entries, so a differing one always exists.
+fn residue_other_than(peptide: &str, position: usize) -> &'static str {
+    let same = residue_at(peptide, position);
+    RESIDUE_CODES
+        .iter()
+        .skip(1)
+        .map(|(_, three)| *three)
+        .find(|three| *three != same)
+        .expect("the residue table holds more than one entry")
+}
+
+/// The inputs one protein `family` contributes for one peptide core.
+///
+/// Every position is read **off the peptide** rather than assumed, because
+/// normalization checks the spelled residue against the reference and rejects a
+/// mismatch (`Amino acid mismatch at position N`). A hardcoded residue would turn
+/// the whole family into rejected rows that still look like a populated corpus.
+///
+/// All spans start at residue 2 or later. Residue 1 is `Met`, and an edit that
+/// reaches it emits the illegal start-loss spelling of #1607 — a defect worth its
+/// own guard, not worth silently seeding thousands of corpus rows with.
+fn protein_inputs_for(family: &str, peptide: &str) -> Vec<String> {
+    let prefix = format!("{PROTEIN_ACCESSION}:p.");
+    let at = |p: usize| format!("{}{}", residue_at(peptide, p), p);
+    let mut out = Vec::new();
+    match family {
+        "protein_shift_del" => {
+            for start in 2..PROTEIN_LEN {
+                out.push(format!("{prefix}{}del", at(start)));
+                out.push(format!("{prefix}{}_{}del", at(start), at(start + 1)));
+            }
+        }
+        "protein_shift_dup" => {
+            for start in 2..PROTEIN_LEN {
+                out.push(format!("{prefix}{}dup", at(start)));
+                out.push(format!("{prefix}{}_{}dup", at(start), at(start + 1)));
+            }
+        }
+        "protein_ins_becomes_dup" => {
+            // The payload copies the residue 5' of the junction, so the insertion
+            // denotes a duplication and the question is whether it is re-typed as
+            // one. `general.md:56` ranks duplication above insertion.
+            for start in 2..PROTEIN_LEN {
+                out.push(format!(
+                    "{prefix}{}_{}ins{}",
+                    at(start),
+                    at(start + 1),
+                    residue_at(peptide, start)
+                ));
+            }
+        }
+        "protein_equal_length_delins" => {
+            // Payload length equals span length and the interior residues repeat
+            // the reference, so the span is unchanged in the middle and changed at
+            // both ends — the shape #1606 splits. Widths 3 and 4 give one and two
+            // unchanged interior residues respectively.
+            // `start` is bounded per width rather than once for the widest, so a
+            // width-3 span reaches the C-terminal residue instead of stopping one
+            // short of it. Deriving the bound this way also means there is no
+            // unreachable `end > PROTEIN_LEN` guard to mislead a later reader about
+            // whether spans can run off the end — they cannot, by construction.
+            for width in [3usize, 4] {
+                for start in 2..=(PROTEIN_LEN - width + 1) {
+                    let end = start + width - 1;
+                    let mut payload = String::new();
+                    payload.push_str(residue_other_than(peptide, start));
+                    for interior in (start + 1)..end {
+                        payload.push_str(residue_at(peptide, interior));
+                    }
+                    payload.push_str(residue_other_than(peptide, end));
+                    out.push(format!("{prefix}{}_{}delins{payload}", at(start), at(end)));
+                }
+            }
+        }
+        "protein_cis_separated" => {
+            // Two members with two unchanged residues between them: the protein
+            // analogue of `split_vs_spanning_delins`, which is where the DNA axes
+            // see most of their churn.
+            for start in 2..(PROTEIN_LEN - 3) {
+                let far = start + 3;
+                out.push(format!(
+                    "{prefix}[{}{};{}{}]",
+                    at(start),
+                    residue_other_than(peptide, start),
+                    at(far),
+                    residue_other_than(peptide, far)
+                ));
+                out.push(format!(
+                    "{prefix}[{}del;{}{}]",
+                    at(start),
+                    at(far),
+                    residue_other_than(peptide, far)
+                ));
+            }
+        }
+        other => unreachable!("unknown protein family {other}"),
+    }
+    out
+}
+
+/// The provider a protein row is normalized through.
+///
+/// `add_protein` and nothing else — no transcript, no CDS, no contig. That is why
+/// the protein axis costs so much less per row than the coding axes, which rebuild
+/// a `Transcript` per cell (see [`normalizer_for`]).
+fn protein_provider(peptide: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein(PROTEIN_ACCESSION, peptide);
+    provider
 }
 
 /// 1-based position of core offset `i` on the axis in question. A `g.` row sits in
@@ -1711,7 +2024,7 @@ mod tests {
     ///
     /// The one that earns the test is `Unverifiable`. `canonical_spdi` declines an
     /// allele whose members overlap, and this corpus is deliberately full of those
-    /// — 20,526 of 78,028 rows. Classifying a decline as `Different` would report
+    /// — 20,516 of 78,298 rows. Classifying a decline as `Different` would report
     /// twenty thousand findings and bury the eighty real ones, which is exactly
     /// what the first hand-written cut of this check did.
     #[test]
@@ -1793,7 +2106,7 @@ mod tests {
     /// The two views agree on thirteen of the fifteen families, and that is
     /// precisely what made the verify pass's confusion of them survive review —
     /// a bug that only manifests on `long_block_inversion` and
-    /// `separated_revcomp_runs` is a bug in 286 rows out of 78,028. So this pins
+    /// `separated_revcomp_runs` is a bug in 286 rows out of 78,298. So this pins
     /// the distinction itself, on both sides: where the column is a label the
     /// sequence must be the design's, and where it is not the two must be equal.
     #[test]
@@ -1807,11 +2120,30 @@ mod tests {
             // A label is not over `ACGT` — `revcomp_sep0_at0` and
             // `nearpalindrome_1024` both fail this — so it is the one predicate
             // that separates the two kinds of string without consulting the map.
+            //
+            // The alphabet is per-axis, and that is load-bearing rather than a
+            // widening: a `p.` row is drawn against a **peptide**, so testing it
+            // for `ACGT` would fail every protein row on the strength of the
+            // corpus having grown a molecule type. Exempting them instead would
+            // be worse — it would leave the protein half of the corpus with no
+            // check that `core` holds a sequence at all — so each axis is
+            // checked against the alphabet it is actually drawn from.
+            let (alphabet_ok, alphabet) = if row.axis == "p" {
+                (
+                    row.core
+                        .chars()
+                        .all(|c| RESIDUE_CODES.iter().any(|(one, _)| *one == c)),
+                    "one-letter residue codes",
+                )
+            } else {
+                (row.core.bytes().all(|b| b"ACGT".contains(&b)), "ACGT")
+            };
             assert!(
-                !row.core.is_empty() && row.core.bytes().all(|b| b"ACGT".contains(&b)),
-                "[{}] {} carries something that is not a sequence: {}",
+                !row.core.is_empty() && alphabet_ok,
+                "[{}] {} carries something that is not a {} sequence: {}",
                 row.family,
                 row.reference,
+                alphabet,
                 row.core
             );
             match labelled.get(&row.reference) {
@@ -2131,6 +2463,191 @@ mod tests {
                     !inputs_for(family, axis, core).is_empty(),
                     "family {family} emitted no {axis}. rows"
                 );
+            }
+        }
+    }
+
+    /// Every protein family emits something, so none can contribute a silent zero.
+    ///
+    /// The sibling of `every_family_emits_rows_on_both_axes`, and the reason it is
+    /// separate is that the protein families are not crossed with the DNA axes —
+    /// there is one axis here, so there is one loop.
+    #[test]
+    fn every_protein_family_emits_rows() {
+        let peptide = &protein_sequences(1)[0];
+        for (family, _) in PROTEIN_FAMILIES {
+            assert!(
+                !protein_inputs_for(family, peptide).is_empty(),
+                "protein family {family} emitted no rows"
+            );
+        }
+    }
+
+    /// The protein corpus scales and truncates like the DNA one.
+    #[test]
+    fn the_protein_corpus_is_prefix_stable() {
+        let few = protein_sequences(3);
+        let many = protein_sequences(9);
+        assert_eq!(few, many[..few.len()]);
+        assert_eq!(few.len(), 6, "two peptides per seed");
+        assert!(
+            few.iter()
+                .all(|p| p.len() == PROTEIN_LEN && p.starts_with('M')),
+            "every core is a {PROTEIN_LEN}-mer starting at Met"
+        );
+    }
+
+    /// **The pin that justifies dumping the protein axis at one direction.**
+    ///
+    /// Every other loop in [`dump`] crosses its cores with `axes_and_directions`,
+    /// which carries a 3' and a 5' cell. The protein path does not read
+    /// `NormalizeConfig::direction` at all, so the second cell would be a
+    /// byte-identical copy of the first — 7,344 more rows asserting nothing, and
+    /// worse, a dump that *looks* like it measured the axis under 5' shifting.
+    ///
+    /// This is a live guard, not a comment restating an assumption. If protein
+    /// normalization ever starts honouring the direction, this fails, and the fix
+    /// is to add the 5' cell to the protein loop rather than to relax the test.
+    ///
+    /// Measured over every family on two cores rather than argued from the source,
+    /// because "the code does not mention `direction`" is exactly the kind of claim
+    /// that stops being true without anyone noticing.
+    #[test]
+    fn the_protein_axis_is_direction_invariant() {
+        let mut compared = 0;
+        for peptide in protein_sequences(2) {
+            let provider = protein_provider(&peptide);
+            let three = Normalizer::with_config(
+                provider.clone(),
+                NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+            );
+            let five = Normalizer::with_config(
+                provider,
+                NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+            );
+            for (family, _) in PROTEIN_FAMILIES {
+                for input in protein_inputs_for(family, &peptide) {
+                    let a = normalize_through(&three, &input);
+                    let b = normalize_through(&five, &input);
+                    assert_eq!(
+                        a, b,
+                        "{input} differs by shuffle direction on the protein axis — \
+                         the protein loop in `dump` must now carry both directions"
+                    );
+                    compared += 1;
+                }
+            }
+        }
+        assert!(
+            compared > 500,
+            "only {compared} rows compared — the families stopped emitting"
+        );
+    }
+
+    /// No protein row is a parse error, a decline or a panic.
+    ///
+    /// This is the guard on the thing most likely to go quietly wrong here.
+    /// Normalization checks each spelled residue against the reference and rejects
+    /// a mismatch, so one wrong three-letter code turns a whole family into
+    /// `<declined>` rows — a populated-looking corpus measuring nothing. It would
+    /// not fail any other test: the rows exist, the key is unique, and the family
+    /// is non-vacuous.
+    #[test]
+    fn no_protein_input_is_rejected() {
+        for peptide in protein_sequences(2) {
+            let normalizer = Normalizer::with_config(
+                protein_provider(&peptide),
+                NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+            );
+            for (family, _) in PROTEIN_FAMILIES {
+                for input in protein_inputs_for(family, &peptide) {
+                    let output = normalize_through(&normalizer, &input);
+                    assert!(
+                        !output.starts_with('<'),
+                        "{family}: {input} on {peptide} gave {output}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The cores carry residue runs long enough for a shift to move through.
+    ///
+    /// The generator plants runs rather than drawing residue-by-residue, and this
+    /// is what pins that. Without it a later "simplification" of
+    /// [`protein_sequences`] to a per-residue draw would leave the two shift
+    /// families almost entirely fixed points, and the corpus would report a
+    /// near-zero it had generated rather than measured — the corpus-blindness class
+    /// one level down.
+    #[test]
+    fn protein_cores_carry_runs_a_shift_can_move_through() {
+        for peptide in protein_sequences(4) {
+            let bytes = peptide.as_bytes();
+            let longest = bytes
+                .iter()
+                .enumerate()
+                .map(|(i, b)| bytes[i..].iter().take_while(|other| *other == b).count())
+                .max()
+                .unwrap_or(0);
+            assert!(
+                longest >= 3,
+                "{peptide}'s longest residue run is {longest}, so the shift families \
+                 have almost nowhere to move on it"
+            );
+        }
+    }
+
+    /// The measured floor behind the bound above, so the bound is not folklore.
+    ///
+    /// Over the whole 48-core default corpus the shortest longest-run is **3** and
+    /// the longest is 16. The `>= 3` bound is therefore the real floor rather than a
+    /// round number picked to pass: a first cut asserted `>= 2`, which every core
+    /// clears by a margin and which a regression to per-residue drawing would very
+    /// likely clear too, since a two-residue alphabet throws adjacent pairs by
+    /// chance. Asserting the distribution here keeps the two numbers honest — if
+    /// the generator changes, this fails with what it actually produced.
+    #[test]
+    fn the_planted_runs_are_longer_than_chance_would_give() {
+        let longest_run = |peptide: &str| -> usize {
+            let bytes = peptide.as_bytes();
+            bytes
+                .iter()
+                .enumerate()
+                .map(|(i, b)| bytes[i..].iter().take_while(|other| *other == b).count())
+                .max()
+                .unwrap_or(0)
+        };
+        let cores = protein_sequences(24);
+        assert_eq!(cores.len(), 48, "the default corpus is 24 seeds");
+        let floor = cores
+            .iter()
+            .map(|p| longest_run(p))
+            .min()
+            .expect("non-empty");
+        let ceiling = cores
+            .iter()
+            .map(|p| longest_run(p))
+            .max()
+            .expect("non-empty");
+        assert_eq!(floor, 3, "measured floor moved");
+        assert_eq!(ceiling, 16, "measured ceiling moved");
+    }
+
+    /// No protein family constructs an edit reaching residue 1.
+    ///
+    /// Residue 1 is `Met`, and an edit that reaches it emits the illegal start-loss
+    /// spelling filed as #1607. Seeding the corpus with that would mean thousands
+    /// of rows whose movement is a known bug rather than a representation choice.
+    #[test]
+    fn no_protein_family_touches_residue_one() {
+        for peptide in protein_sequences(2) {
+            for (family, _) in PROTEIN_FAMILIES {
+                for input in protein_inputs_for(family, &peptide) {
+                    assert!(
+                        !input.contains("Met1"),
+                        "{family} built {input}, which reaches residue 1"
+                    );
+                }
             }
         }
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3634,6 +3634,66 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 &self.provider,
             );
 
+            // And last for the protein axis specifically: the coalesce above
+            // this loop runs on the *authored* members, so it only ever sees
+            // adjacency the input already had. The per-member 3' shift can
+            // *create* it — `p.[Gly13del;Gly16Ala]` shifts the deletion down
+            // its Gly run to `Gly17del`, which lands flush against `Gly16Ala`
+            // — and the nucleotide `merge_consecutive_edits` at the top of the
+            // pass never fires on protein members, so nothing closed that gap.
+            // The result was that pass one emitted `p.[Gly16Ala;Gly17del]` and
+            // pass two merged it to `p.Gly16_Gly17delinsAla`, i.e. `normalize`
+            // was not idempotent (found by #1614's protein corpus axis under
+            // `FERRO_ASSERT_IDEMPOTENT`).
+            //
+            // `substitution.md:32` is why the merged form is the right answer
+            // rather than a matter of taste: at separation zero the split
+            // spelling is marked `class="invalid"`, which the decided
+            // `rulings[delins-adjacent-members-when-both-consume-reference]`
+            // record scopes to members that both consume reference bases — a
+            // substitution and a single-residue deletion both do.
+            //
+            // `general.md:157-160` is the authority for the other half — the
+            // shift that *creates* the adjacency — and it is easy to miss
+            // because it is stated as a Q&A rather than as a rule: "protein
+            // variant descriptions should be derived from comparing the variant
+            // protein sequence with the reference protein sequence. Knowledge on
+            // the underlying change on the DNA level should not be used." Its
+            // worked example is a 3'-rule application at the protein level: a
+            // `Ser` lost from a `SerSer` run is `p.Ser5del`, and the passage
+            // says in as many words that placing it at the deleted *codon* —
+            // `p.Ser4del` — "is not correct". So carrying `Gly13del` down its
+            // Gly run to `Gly17del` is required rather than incidental, and
+            // `substitution.md:32` governs what is then made of the result. Both
+            // halves are published clauses; neither rests on judgement.
+            //
+            // Inside the loop for the same reason `respell_colliding_duplications`
+            // is: the coalesced allele is a new variant that must go back through
+            // the per-member pipeline. Termination is unchanged — a coalesce
+            // strictly reduces the member count, and the helper is a no-op once
+            // no adjacent run remains.
+            // Gated on the helper's *own* preconditions rather than on `is_cis`
+            // alone. It declines an allele with fewer than two members or with
+            // any non-protein member, so building the candidate under a bare
+            // `is_cis` clones the member vector on every pass of every
+            // nucleotide cis allele only to have the helper return `None`.
+            let coalescible = is_cis
+                && result.len() >= 2
+                && result.iter().all(|v| matches!(v, HgvsVariant::Protein(_)));
+            if coalescible {
+                let mut candidate = crate::hgvs::variant::AlleleVariant::new(
+                    result.clone(),
+                    crate::hgvs::variant::AllelePhase::Cis,
+                );
+                candidate.uncertain = allele.uncertain;
+                if let Some(coalesced) = merge::coalesce_protein_adjacent_changes(&candidate) {
+                    result = match coalesced {
+                        HgvsVariant::Allele(inner) => inner.variants,
+                        single => vec![single],
+                    };
+                }
+            }
+
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.
             // `max_passes == 1` (non-cis) forces the original single-pass

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -425,6 +425,7 @@ mod protein_insertion_special;
 mod protein_no_protein_roundtrip;
 mod protein_predicted_trans;
 mod protein_render_policy;
+mod protein_shift_created_adjacency;
 mod protein_silent_eq;
 mod protein_stop_codon_canonicalization;
 mod protein_substitution_alternatives;

--- a/tests/it/protein_shift_created_adjacency.rs
+++ b/tests/it/protein_shift_created_adjacency.rs
@@ -1,0 +1,147 @@
+//! A protein cis allele whose adjacency is *created* by the 3' shift must
+//! coalesce in the same pass that created it.
+//!
+//! Found by #1614's protein corpus axis under `FERRO_ASSERT_IDEMPOTENT=1`, which
+//! is the point of adding that axis: the shape is unreachable from any
+//! hand-written protein test in the suite, because it needs a reference peptide
+//! with a residue run long enough for a member to shift *into* its sibling.
+//!
+//! The defect. `coalesce_protein_adjacent_changes` runs once, on the **authored**
+//! members, before the collapse/merge/shift loop — so it only ever saw adjacency
+//! the input already had. The per-member 3' shift then created more of it, and
+//! the nucleotide `merge_consecutive_edits` inside the loop never fires on
+//! protein members, so nothing closed the gap:
+//!
+//! ```text
+//! input   NP_TEST.1:p.[Gly13del;Gly16Ala]
+//! pass 1  NP_TEST.1:p.[Gly16Ala;Gly17del]     <- the deletion shifted 13 -> 17
+//! pass 2  NP_TEST.1:p.Gly16_Gly17delinsAla    <- and only now merged
+//! ```
+//!
+//! Two passes disagreeing is exactly what `FERRO_ASSERT_IDEMPOTENT` exists to
+//! catch, and pass 2 is the correct answer rather than pass 1:
+//! `protein/substitution.md:32` marks the split spelling of two adjacent members
+//! `class="invalid"`, and the decided
+//! `rulings[delins-adjacent-members-when-both-consume-reference]` record scopes
+//! that ruling to members which both consume reference bases — a substitution and
+//! a single-residue deletion both do. So the fix is to coalesce inside the loop,
+//! not to accept the bracket form.
+//!
+//! The *shift* half — what makes `Gly13del` -> `Gly17del` obligatory rather than
+//! merely something ferro happens to do — is `general.md:157-160`. The argument
+//! and its verbatim quote live at the coalesce site in `src/normalize/mod.rs`,
+//! beside the code they justify, deliberately not restated here: one rule written
+//! in two places and then drifting apart is this project's named recurring
+//! failure mode (`rulings[adjudication-precedence-order]`). The control test
+//! below exercises that clause directly.
+//!
+//! **The `Gly13del` control below is what keeps these assertions honest.** The
+//! merge can only be observed if the deletion really travels from 13 to 17; were
+//! the shift to stop happening, the two members would never become adjacent and a
+//! bare "the output is the merged form" assertion would be satisfied by the
+//! absence of the shift rather than by the presence of the merge. Assert the
+//! movement separately, so a regression in either half is named.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+const ACCESSION: &str = "NP_TEST.1";
+
+/// Positions 13..=17 are a five-residue glycine run, so a deletion authored at
+/// 13 shifts to 17 and lands flush against a substitution at 16. Residue 18 is
+/// not glycine, which is what bounds the run.
+///
+/// ```text
+/// 1  2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22
+/// M  A C D E F H I K L  M  N  G  G  G  G  G  A  C  D  E  F
+/// ```
+const PEPTIDE: &str = "MACDEFHIKLMNGGGGGACDEF";
+
+fn normalizer() -> Normalizer<MockProvider> {
+    let mut provider = MockProvider::new();
+    provider.add_protein(ACCESSION, PEPTIDE);
+    Normalizer::new(provider)
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer()
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// The control: the deletion really does travel the glycine run.
+///
+/// Without this, the merge assertions below could pass because the shift stopped
+/// happening rather than because the coalesce started.
+#[test]
+fn the_deletion_shifts_to_the_end_of_the_glycine_run() {
+    assert_eq!(
+        normalize_to_string(&format!("{ACCESSION}:p.Gly13del")),
+        format!("{ACCESSION}:p.Gly17del"),
+        "the 3' rule must carry a deletion to the last position of its run — if it \
+         does not, `p.[Gly13del;Gly16Ala]` never becomes adjacent and the merge \
+         assertions in this file are vacuous"
+    );
+}
+
+/// The defect itself: one pass, not two.
+#[test]
+fn shift_created_adjacency_coalesces_in_the_pass_that_created_it() {
+    let once = normalize_to_string(&format!("{ACCESSION}:p.[Gly13del;Gly16Ala]"));
+    assert_eq!(
+        once,
+        format!("{ACCESSION}:p.Gly16_Gly17delinsAla"),
+        "the shifted deletion is flush against the substitution, so \
+         `protein/substitution.md:32` makes the merged delins the correct form; \
+         emitting the bracket spelling here is the #1614 defect"
+    );
+    let twice = normalize_to_string(&once);
+    assert_eq!(
+        once, twice,
+        "and the merged form must be its own fixed point, or the pass merely moved \
+         the non-idempotency one step later"
+    );
+}
+
+/// The bracket form the defect used to emit must itself normalize to the merged
+/// form, so a consumer holding the old string converges rather than sitting on a
+/// second fixed point.
+#[test]
+fn the_previously_emitted_bracket_form_converges_on_the_merged_form() {
+    assert_eq!(
+        normalize_to_string(&format!("{ACCESSION}:p.[Gly16Ala;Gly17del]")),
+        format!("{ACCESSION}:p.Gly16_Gly17delinsAla"),
+        "the string the defect shipped must converge, not persist as a rival form"
+    );
+}
+
+/// Authored adjacency still reaches the merged form — by whichever pass reaches
+/// it first.
+///
+/// This deliberately does **not** attribute the merge to the pre-loop coalesce.
+/// The in-loop coalesce this change adds runs on every cis pass and would merge
+/// authored adjacency on its own, so no assertion here can tell the two routes
+/// apart; what is pinned is the outcome. (An earlier version of this comment
+/// claimed the test guarded the pre-loop coalesce specifically. It never could.)
+///
+/// **Pinned against the merged literal, not against the sibling spelling's
+/// output.** Comparing the two orders to each other proves only
+/// order-independence, and order-independence is satisfied by the coalesce *not
+/// firing at all*: cis members are sorted by `cis_member_order_key` before
+/// rendering, so both spellings converge on one bracket string either way and the
+/// assertion could not fail for the reason its name gives. Pinning the literal
+/// here, with the forward spelling pinned in
+/// `the_previously_emitted_bracket_form_converges_on_the_merged_form`, keeps
+/// #1116's order-independence — two literals that agree — while making each
+/// direction falsifiable on its own.
+#[test]
+fn authored_adjacency_still_coalesces() {
+    assert_eq!(
+        normalize_to_string(&format!("{ACCESSION}:p.[Gly17del;Gly16Ala]")),
+        format!("{ACCESSION}:p.Gly16_Gly17delinsAla"),
+        "authored adjacency must reach the merged form from either member order \
+         (#1116) — and reaching it is what this asserts, not merely agreeing with \
+         the other order, which the coordinate-order render guarantees anyway"
+    );
+}


### PR DESCRIPTION
`examples/dump_normalized_corpus.rs` is the harness a representation-moving PR is required to measure with. It could not emit a single protein row, so **any protein-scoped change measured a structural `0 of 78,298`** — which is byte-identical, in the output, to a change that genuinely moved nothing.

This is the **fourth instance of the corpus-blindness class**, after member geometry (#1456), scale (#1460) and transcript geometry (#1478). The corpus had three axes (`g`, `c`, `cx`), which is enough to look well covered.

## The cost is live, not hypothetical

#1606 moves an equal-length protein `delins` onto its members. It could not quote this harness, and said so honestly in its own body:

> `examples/dump_normalized_corpus.rs` generates **no protein rows at all** — a structural zero, reported rather than quoted.

That is the right way to handle a blind corpus, and it is still a measurement nobody has. With the axis in place, #1606 measures:

| | rows |
|---|---|
| total | 85,642 |
| **moved** | **1,584 (1.8%)** |
| of which previously **accepted** (a migration) | 1,584 |

| family | rows | moved |
|---|---|---|
| `protein_equal_length_delins` | 1,584 | **1,584** |
| `protein_shift_del` | 1,728 | 0 |
| `protein_shift_dup` | 1,728 | 0 |
| `protein_ins_becomes_dup` | 864 | 0 |
| `protein_cis_separated` | 1,440 | 0 |
| *(all 16 nucleotide families)* | 78,298 | 0 |

Every moved row is in the one family that describes #1606's shape, and no row moves anywhere else. That is the measurement, and it is the shape of answer the corpus exists to give.

## Five families, each grounded in a defect

| family | rows/core | shape |
|---|---|---|
| `protein_shift_del` | 36 | #91 — a deletion inside a residue run |
| `protein_shift_dup` | 36 | #91 / #92 — a duplication inside a run |
| `protein_ins_becomes_dup` | 18 | #92 — an insertion whose payload copies its 5' neighbour |
| `protein_equal_length_delins` | 33 | #1606 — equal-length `delins`, interior unchanged |
| `protein_cis_separated` | 30 | #1232 / #1401 on the protein axis — two members, unchanged residues between |

7,344 rows over 48 peptide cores. **Every pre-existing row is byte-identical** — verified with `cmp` against a baseline dump, not asserted — because an added axis only appends, exactly as `LONG_FAMILY` and `REVCOMP_FAMILY` do. Old dumps stay comparable for every nucleotide family.

## Three design decisions worth review

**One shuffle direction, and it is measured rather than assumed.** Every other loop crosses its cores with a 3' and a 5' cell. The protein path never reads `NormalizeConfig::direction`, so a 5' cell would be 7,344 byte-identical rows — and worse, a dump that *looks* like the axis was measured under 5' shifting. `the_protein_axis_is_direction_invariant` compares both directions across every family on two cores (>500 rows) and fails if that ever stops holding, naming the fix: add the cell.

**Runs are planted, not hoped for.** Every family is about shifting, and a shift needs a tract of equal residues to move through. Drawing residue-by-residue from a 6-letter alphabet gives a run of 3 about once per 36 positions, so most cores would be fixed points and the corpus would report a near-zero it had *generated* rather than measured — the same class one level down. Residues are drawn in runs of 1–3 instead. Measured floor across the 48-core default corpus: longest-run **3**, ceiling **16**, both pinned. A first cut asserted `>= 2`, which every core clears by a margin and which a regression to per-residue drawing would likely clear too; `the_planted_runs_are_longer_than_chance_would_give` pins the real distribution so the bound is not folklore.

**No family reaches residue 1.** Residue 1 is `Met`, and an edit reaching it emits the illegal start-loss spelling filed as **#1607**. `Met` is therefore never drawn into a core body, so a shift cannot arrive there either — otherwise thousands of rows would be measuring a known bug rather than a representation choice. Pinned by `no_protein_family_touches_residue_one`.

## Guards

Seven new tests, all in the example's own module (`test = true` is already set on the target):

- `the_protein_axis_is_direction_invariant` — the pin that justifies one direction
- `no_protein_input_is_rejected` — **the one most likely to matter.** Normalization checks each spelled residue against the reference, so one wrong three-letter code turns a family into `<declined>` rows: a populated-looking corpus measuring nothing, which no other test would catch — the rows exist, the key is unique, the family is non-vacuous
- `every_protein_family_emits_rows` — no silent zero
- `the_protein_corpus_is_prefix_stable` — `--seeds` truncates to a strict prefix, as the DNA half does
- `protein_cores_carry_runs_a_shift_can_move_through` / `the_planted_runs_are_longer_than_chance_would_give`
- `no_protein_family_touches_residue_one`

The existing `the_corpus_key_is_unique` covers the protein rows too, which is what rules out two families emitting the same input for one core.

## Verification

`cargo fmt --all --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean. Full suite green with nothing re-blessed. Baseline/candidate dumps diffed with `cmp` to prove the first 78,298 rows are unchanged. Zero protein rows are parse errors, declines or panics.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protein-level variant normalization support.
  * Expanded coverage across multiple protein sequence shapes and 3′-direction inputs.
  * Added deterministic peptide and residue generation for broader validation.

* **Bug Fixes**
  * Improved handling of adjacent protein changes created by 3′ shifting.
  * Ensured normalization remains stable and repeatable.
  * Added safeguards against invalid inputs and edits affecting the first residue.

* **Documentation**
  * Updated documentation with protein-axis coverage and measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Scope grew: this PR now also fixes the defect its own axis found

The protein axis was added to make protein-scoped changes measurable. Armed with
`FERRO_ASSERT_IDEMPOTENT=1` it immediately failed on its own corpus, which is the axis doing its
job:

```text
input   NP_TEST.1:p.[Gly13del;Gly16Ala]
pass 1  NP_TEST.1:p.[Gly16Ala;Gly17del]     <- the deletion shifted 13 -> 17
pass 2  NP_TEST.1:p.Gly16_Gly17delinsAla    <- and only now merged
```

`coalesce_protein_adjacent_changes` ran once, on the **authored** members, before the
collapse/merge/shift loop — so it only ever saw adjacency the input already had. The per-member 3'
shift then *created* more of it, and the nucleotide `merge_consecutive_edits` inside the loop never
fires on protein members, so nothing closed the gap.

Pass 2 is the correct answer rather than a matter of taste: `protein/substitution.md:32` marks the
split spelling of two adjacent members `class="invalid"`, and the decided
`rulings[delins-adjacent-members-when-both-consume-reference]` record scopes that ruling to members
which both consume reference bases — a substitution and a single-residue deletion both do. So the
fix coalesces **inside** the loop, where `respell_colliding_duplications` already sits for the
identical documented reason.

`tests/it/protein_shift_created_adjacency.rs` pins it, including a control asserting the deletion
really travels 13 -> 17 — without which the merge assertion could pass because the *shift* stopped
rather than the merge starting. Mutation-tested: disabling the fix reddens exactly that guard.

Two corpus-figure corrections came out of measuring, and one reviewer finding is rejected:

* `78,028` and `78,298` are **both correct** and are not a transposition of each other.
  `separated_revcomp_runs` is exactly 270 rows and `78,298 - 270 = 78,028`, so the smaller figure is
  the corpus *before* that family existed — the only honest denominator for a measurement taken
  then. A note now says so, since the file used two totals without ever explaining it.
* Genuinely stale, now re-measured: `20,526 of 78,028` -> **`20,516 of 78,298`**, and `286 rows out
  of 78,028` -> `78,298` (the `286` numerator is current: 270 + 16).
* `every_row_carries_the_sequence_it_was_drawn_against` asserted `core` is over `ACGT`; a protein
  row carries a peptide. The alphabet is now per-axis rather than protein rows being exempted, so
  the protein half of the corpus keeps a real check.

Validated as CI runs it, not with oracles armed globally: plain `test` **10147/10147**, and
`test-oracle` (armed, `ORACLE_EXCLUDE` negated) **10085/10085**.

Representation-Change: 171 of 85642 corpus rows move (0.2%), all in `protein_cis_separated`. The forms: a two-member protein bracket allele whose members became adjacent under the 3'-shift, `p.[Gly16Ala;Gly17del]`, becomes the merged delins `p.Gly16_Gly17delinsAla`. Direction: TOWARD the already-shipped form, not away from it — those 171 rows were not fixed points, so a second normalization pass already produced the merged form; the change moves pass one onto the answer pass two was giving, and toward the spec's stated form, since `protein/substitution.md:32` marks the split spelling `class="invalid"` (the decided `delins-adjacent-members-when-both-consume-reference` record scopes that to members which both consume reference bases, as a substitution and a single-residue deletion do). 0 of the moved rows were previously accepted forms: all 171 were not fixed points, so nothing downstream holds them and the move is free. Measured by dumping this branch before and after the fix over the identical 85,642-row corpus.
