### PR TITLE
feat(normalize): a fourth seam oracle that compares the denoted sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ env:
   # NOTE: that partition is over `test` + `sweeps`. `test-oracle` additionally
   # negates `ORACLE_EXCLUDE` below, so it runs a strict SUBSET of `test` rather
   # than the same selection. Every test still runs somewhere unarmed.
+  #
+  # NOTE also: `sweeps` selects on this filter PLUS one module it deliberately
+  # re-runs — `issue_1615_denoted_sequence_oracle`, the only test that reads the
+  # denoted-sequence oracle's counters, which are meaningless unless
+  # `FERRO_ASSERT_SEQUENCE` is set and `sweeps` is the only job that sets it. So
+  # "nothing is run twice" holds of this filter and is one module short of
+  # holding of that job's `-E`; the reason it is appended there rather than added
+  # here is on the job itself.
   SWEEP_FILTER: >-
     test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap)
     + test(issue_1254_sibling_crossing_shift)
@@ -980,7 +988,27 @@ jobs:
         # perturbs idempotency it need not. The class had been found by hand three
         # times (#1274, #1343, #1307) before it was asserted here.
         #
-        # All three sit at the same seam, `normalize_core_checked`'s single exit.
+        # `FERRO_ASSERT_SEQUENCE` — the fourth oracle at this same seam (#1615) —
+        # is deliberately **not** set here, and this job is the one place the set
+        # is incomplete. It fires on two rows of this job's own selection, and
+        # both are real disagreements rather than noise to be suppressed:
+        #
+        #   * #1618 — `NC_TEST.1:g.262TG[6]` -> `g.259_262GT[6]`
+        #     (`repeat_tract_maximization`). `hgvs_to_spdi` reads the anchored
+        #     spelling as 6 copies replacing a 1-copy tract and the normalizer's
+        #     output as 6 copies replacing a 2-copy tract — 14 bases against 12.
+        #   * #1619 — `NM_000492.4:c.1520_1522del` -> `c.1521_1523del`
+        #     (`normalize_tests`). The two forms are genuinely equivalent on the
+        #     flat transcript; `hgvs_to_spdi` resolves the c. position by walking
+        #     the fixture's exon list, whose 1-base synthetic introns put it 10
+        #     bases 3' of where the normalizer reads.
+        #
+        # Turning the flag on here before those are settled would make the job
+        # red for a reason that is not the PR's; suppressing them would hollow out
+        # the oracle. So it runs in `sweeps` below — the cis-allele space every
+        # one of the eight defects it was built for came from, and where it is
+        # measured green — and non-gating in the nightly. Move it here once both
+        # rows are closed.
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
@@ -1142,13 +1170,45 @@ jobs:
           # class so far has come from. See the note on the pair in the `test`
           # job above.
           FERRO_ASSERT_IN_BOUNDS: "1"
+          # The denoted-sequence oracle (#1615): does the normalized description
+          # denote the same bases the input does? This job is its gating home
+          # rather than `test-oracle` — see the note there for the two rows that
+          # keep it out of the wider selection for now. The sweeps are also where
+          # it has the most to say: every one of the eight defects it was built
+          # for is a cis member crossing a sibling, which is exactly the space
+          # these three modules enumerate. They already assert sequence
+          # preservation case by case through `common::cis_apply_oracle`; this
+          # extends the same question to every intermediate normalization the
+          # sweeps perform rather than only the ones a test asserts on. Measured
+          # green over the full corpus before it was set here.
+          FERRO_ASSERT_SEQUENCE: "1"
         # `--no-tests=fail` for the reason spelled out on `soak`, and it matters
         # more here: `SWEEP_FILTER` names three modules explicitly, so renaming
         # one is exactly the edit that would drop a sweep from CI silently.
+        #
+        # `issue_1615_denoted_sequence_oracle` is appended to the selection
+        # because this job is the only one that sets `FERRO_ASSERT_SEQUENCE`, and
+        # that module holds the one test which reads the oracle's counters —
+        # `the_seam_compares_when_the_flag_is_set`, the guard that a green run
+        # actually compared something rather than the seam call having been
+        # deleted. Without it here that guard would run only in jobs where the
+        # flag is unset, where it skips by design, so the wiring would be
+        # unverified everywhere.
+        #
+        # Appended here rather than added to `SWEEP_FILTER` for two reasons.
+        # `tests/it/sweep_filter_invariant.rs`'s
+        # `every_module_named_in_the_sweep_filter_consumes_the_seed_knob` fails
+        # on a module in that filter which does not draw through `sweep_seeds(`,
+        # and this one does not — the filter is a claim about the seed knob, not
+        # a list of what this job runs. And `SWEEP_FILTER` is negated by `test`
+        # and `test-oracle`, so naming it there would REMOVE the module from both
+        # — trading the armed run for the unarmed one instead of adding it. The
+        # module is therefore run twice on purpose: unarmed in `test`, armed
+        # here. It is ~10 cheap unit tests, no sweep and no provider corpus.
         run: |
           cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
-            -E "$SWEEP_FILTER"
+            -E "$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)"
 
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -176,6 +176,13 @@ jobs:
           # ci.yml's `test-oracle` and `sweeps` jobs, which set the same flag and
           # carry no `continue-on-error`.
           FERRO_ASSERT_IN_BOUNDS: "1"
+          # And that the normalized description denotes the same bases the input
+          # does (#1615). Worth setting here for the same reason as the one above
+          # it: the conformance corpora are real transcripts and contigs, so this
+          # is the only place the comparison runs over reference geometry a
+          # fixture cannot build — real exon structure, real 5'UTRs, real
+          # soft-masked bases. Non-gating here like the other three.
+          FERRO_ASSERT_SEQUENCE: "1"
         run: |
           cargo nextest run --features dev \
             -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/) | test(/hgvs_rs_projection_tests::/)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ into a `OnceLock`, so a disabled run pays only one atomic load. CI runs the suit
 a second time with it set; the nightly reference-aware job sets it too, which is
 where the manifest-backed conformance corpora are actually covered.
 
-The check runs from `Normalizer::assert_seam_oracles`, which all three oracles
+The check runs from `Normalizer::assert_seam_oracles`, which all four oracles
 share, at the single exit of `normalize_core_checked`. That covers every public
 normalization: `normalize()`, `normalize_with_diagnostics()`, and every
 `VariantProjector` path (the projection-driven genomic/coding/protein axes).
@@ -166,7 +166,7 @@ It is one call site again as of #1382. `normalize_with_diagnostics` used to reac
 actual defect — the strict-mode rejection ladder, so #1366 had to call
 `assert_seam_oracles` from it separately. Routing it through
 `normalize_core_checked` fixes both at once, and the extra call would now just
-re-run all three oracles on that path.
+re-run all four oracles on that path.
 
 The idempotency oracle's verification pass re-enters normalization, so a
 thread-local `IN_IDEMPOTENCY_CHECK` guard breaks the recursion — the inner call
@@ -207,7 +207,10 @@ Kept separate from `FERRO_ASSERT_IDEMPOTENT` because neither subsumes the other,
 and the idempotency oracle has a blind spot this one covers: it verifies by
 *re-normalizing* its own output, which it cannot do for an output that fails to
 parse, so an unparseable result is invisible to it. Both run from
-`assert_seam_oracles` alongside the in-bounds check, and CI sets all three together.
+`assert_seam_oracles` alongside the in-bounds and denoted-sequence checks, and CI
+sets these two and the in-bounds check together. The **denoted-sequence** flag is
+the exception and is not set everywhere they are — see
+[Where it runs, and the one place it deliberately does not](#normalization-denoted-sequence-oracle).
 
 #### Normalization in-bounds oracle
 
@@ -249,10 +252,121 @@ on `merge::first_out_of_bounds_coordinate`. In brief:
   (`g.10_11ins[20_30]`).
 
 Like the two above it, compiled out in release (`#[cfg(debug_assertions)]`) and
-read once into a `OnceLock`. CI sets all three together, in the sharded
+read once into a `OnceLock`. CI sets **these three** together, in the sharded
 `test-oracle` job and the `sweeps` job (those two and nowhere else — the plain
 `test` and `soak` jobs run without the flags); the nightly sets it too, where it
 is the only place the check runs against true transcript and contig lengths.
+
+**The fourth flag is not set in all of those places, so do not read "all four"
+off this paragraph.** `FERRO_ASSERT_SEQUENCE` runs in `sweeps` and in the
+nightly, and deliberately not in `test-oracle` — the reason, and the two rows
+that keep it out, are under
+[Where it runs, and the one place it deliberately does not](#normalization-denoted-sequence-oracle)
+below and in `ci.yml`'s comment on the `test-oracle` job.
+
+#### Normalization denoted-sequence oracle
+
+`FERRO_ASSERT_SEQUENCE=1` is the fourth at the same seam, and the only one that
+asks what the output **means** rather than how it is written: apply the input to
+the reference, apply the output, and assert the bases agree.
+
+```bash
+FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev
+```
+
+**The other three are all form questions, and a wrong sequence passes all of
+them.** It is a fixed point, so `FERRO_ASSERT_IDEMPOTENT` is satisfied; it
+parses, and `parse_hgvs` holds no provider so it could not know either way; and
+its coordinates exist, so `FERRO_ASSERT_IN_BOUNDS` is satisfied. #1592 and #1600
+each record all three passing on their own reproducer. The class had been found
+by hand six times before those two — **#1254** (`g.[3_4del;9del]` → `g.12_14del`),
+**#1281** (→ `g.[1del;1del]`), **#1290**, **#1304**, **#1308**, **#1312** — each
+filed, fixed and regression-tested separately. Eight instances is the same
+argument #1353 made for the in-bounds oracle after three.
+
+**The applier is not the normalizer.** `spdi::compare_denoted_sequences` reaches
+the bases through `hgvs_to_spdi` and an SPDI splice — the same walk
+`apply_to_reference` and `tests/it/common/cis_apply_oracle.rs` use — so nothing
+here can agree with the output merely because normalization produced it.
+`EquivalenceChecker` is **not** usable for this: it normalizes both sides, which
+is circular (`tests/it/issue_1234_sibling_clamped_shift.rs:198`).
+
+Both descriptions are applied over the **union** of their spans, in one fetch. A
+per-description window would give each its own frame and report every 3'-shift as
+a difference; over a window containing both, `g.3_4del` and `g.7_8del` in a tract
+denote the same bases, which is what makes shifting sequence-preserving in the
+first place.
+
+**A side that cannot be applied is counted, not silently passed** — a skip that
+reads as a pass is the exact failure mode this oracle exists to remove:
+
+| case | verdict |
+|---|---|
+| both apply, bases agree | pass, counted in `compared` |
+| both apply, bases differ | **fire** |
+| the **output** denotes no sequence while the input does | **fire** — #1281's `g.[1del;1del]`, two members claiming one base. Worse than a wrong sequence, so it must not be filed under the skip exemption |
+| the **input** denotes no sequence (trans allele, `REFSEQ_MISMATCH`, an edit SPDI cannot carry) | skip, counted in `skipped` — there is no baseline, the same discipline the other two apply to already-broken inputs |
+| the two name different accessions (#785 version substitution) | skip, counted |
+| the union window exceeds `MAX_APPLY_WINDOW`, or the provider cannot serve it | skip, counted |
+
+`normalize::denoted_sequence_oracle_counts()` returns `(compared, skipped)`
+process-wide, so a run can say how much it actually compared. **Read it before
+trusting a green oracle run**: zero comparisons and zero faults look identical
+from the outside.
+
+`tests/it/issue_1615_denoted_sequence_oracle.rs` is the oracle's own regression
+guard. It pins the recorded `(reference, input, wrong output)` triple from each
+of the eight issues and asserts the predicate fires — deliberately *not* by
+re-normalizing, since a test that ran the normalizer would go green as each
+defect is fixed and stop saying anything about the oracle. Its other half is the
+negative control: legitimate re-spellings (a 3'-shift, a merge, a decomposition,
+a dup/ins equivalence) must stay silent.
+
+Compiled out in release like the three beside it, and the most expensive of the
+four when on — one provider fetch and two splices per normalization — so it runs
+last in `assert_seam_oracles`, after the cheaper and more specific checks have
+had their chance to name the fault more precisely.
+
+**Where it runs, and the one place it deliberately does not.** `sweeps` sets it
+(gating, measured green over the full corpus) and the nightly sets it
+(non-gating). `test-oracle` does **not**, which makes it the only job where the
+set of four is incomplete. Two rows in that job's selection fire, and both are
+real disagreements inside ferro rather than noise:
+
+| row | what disagrees |
+|---|---|
+| #1618 — `NC_TEST.1:g.262TG[6]` → `g.259_262GT[6]` | `hgvs_to_spdi` reads the anchored spelling as 6 copies replacing a **1**-copy tract, the normalizer's output as 6 copies replacing a **2**-copy tract — 14 bases against 12 |
+| #1619 — `NM_000492.4:c.1520_1522del` → `c.1521_1523del` | the two forms are equivalent on the flat transcript; `hgvs_to_spdi` resolves the `c.` position by walking `normalization_transcripts.json`'s exon list, whose 1-base synthetic introns land it **10 bases** 3' of where the normalizer reads |
+
+Suppressing either would hollow out the oracle, and turning the flag on before
+they are settled would redden the job for a reason no PR caused. Move it into
+`test-oracle` once both are closed.
+
+**Measured false-positive classes, and what closed each.** The first run of this
+oracle over the suite raised **344** fires, all but 16 of them false. Each fix
+below is a class, not a case, and the reasoning is on the code.
+
+**Do not sum the `fires` column, and do not read it as a partition of the 344.**
+Only the 344 and the 16 come from one run. Each row's count was measured on the
+run that isolated *that* class, after the rows above it had been closed — closing
+one class changes which normalizations reach the comparison at all, so the same
+normalization can be counted in more than one row and the column adds up to well
+over 344. Read each figure as the size of the class at the point it was diagnosed,
+which is what makes it an argument for the fix beside it:
+
+| class | fires | why it was not a defect |
+|---|---|---|
+| output cannot be transliterated | 328 | the input states its own deleted bases (`g.1000delC`) and converts with no provider; the output (`g.1000del`) must read the reference, which the fixture does not hold |
+| insertion flush against a deletion | 233 | `triples_are_disjoint` calls it an overlap; `cis_apply_oracle`'s tie-break does not, and it is well defined |
+| overlap-conflicting input | ~12 | an insertion *interior* to a deletion — the input denotes nothing, so there is no baseline |
+| `pter`/`qter` | 6 | carry no numeric coordinate (`base: 0`); `hgvs_to_spdi` reads `base` and silently resolves `c.pterdel` to the sequence's **last** base |
+| corrected `REFSEQ_MISMATCH` | 5 | `c.10dupA` where the reference reads `C`: normalization is *supposed* to change the denoted sequence here |
+| `r.` payload vs DNA reference | 1 | `UGC` against `TGC` — the same bases in two alphabets |
+| uncertain allele `[(…)]` | 1 | the normalizer deliberately does not clamp those |
+
+The lesson generalizes past this oracle: **the two sides of a comparison do not
+need the reference equally**, and any check that treats "I could not derive it"
+as "it is wrong" will fire hardest on the shapes where that asymmetry is largest.
 
 **An oracle failure is visible in PR CI and silent in the nightly.** In PR CI,
 `test-oracle` and `sweeps` carry no `continue-on-error`, so a fire turns the job
@@ -260,7 +374,7 @@ red. The nightly reference-aware job does carry it, deliberately — its purpose
 to surface drift in the xfail report rather than to gate, and the corpus runner
 wraps normalization in `catch_panics`, so an oracle panic there lands in the
 uploaded xfail artifact as a FAILing case instead of failing the workflow. That
-applies equally to all three flags, and it is why a red oracle in the nightly must
+applies equally to all four flags, and it is why a red oracle in the nightly must
 be read out of the xfail report rather than from the workflow conclusion.
 
 **An oracle fire DOES block the merge — corrected 2026-08-09.** This section used

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1648,14 +1648,86 @@ fn in_bounds_self_check_enabled() -> bool {
     })
 }
 
+/// Whether the opt-in denoted-sequence self-check is active.
+///
+/// Enabled when `FERRO_ASSERT_SEQUENCE` is set to anything other than
+/// `0`/empty. Read once and cached, like the three gates above it.
+///
+/// The fourth at the same seam (#1615), and the only one that asks what the
+/// output *means* rather than how it is written. The three before it are all
+/// well-formedness questions — is it a fixed point, does it parse, is it in
+/// bounds — and a description denoting entirely different bases can satisfy all
+/// three at once. That is not hypothetical: #1592 and #1600 were both live on
+/// `main`, both emitted different bases than their input, and both issues record
+/// all three oracles passing on the reproducer.
+///
+/// The most expensive of the four when enabled — a provider fetch of the union
+/// window plus two splices per normalization — which is why it runs last in
+/// [`Normalizer::assert_seam_oracles`] and why it is its own flag rather than
+/// being folded into one of the others.
+#[cfg(debug_assertions)]
+fn denoted_sequence_self_check_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("FERRO_ASSERT_SEQUENCE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+/// Normalizations the denoted-sequence oracle looked at but could not compare.
+///
+/// A skip that reads as a pass is the exact failure mode a sequence oracle
+/// exists to remove, so the skips are *counted* rather than being silent. A run
+/// that reports zero comparisons made is a run that checked nothing, however
+/// green it looks. See [`denoted_sequence_oracle_counts`].
+#[cfg(debug_assertions)]
+static DENOTED_SEQUENCE_SKIPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Normalizations the denoted-sequence oracle compared and found to agree.
+#[cfg(debug_assertions)]
+static DENOTED_SEQUENCE_COMPARED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// `(compared, skipped)` for the denoted-sequence oracle, process-wide.
+///
+/// `compared` counts the normalizations whose input and output sequences were
+/// actually derived and found equal; `skipped` counts those the comparison
+/// declined, for any of the [`crate::spdi::NotComparable`] reasons. A mismatch
+/// panics rather than being counted, so there is no third figure.
+///
+/// Exposed so a caller can assert its run made comparisons at all. Both counters
+/// stay at zero when `FERRO_ASSERT_SEQUENCE` is unset — the oracle returns before
+/// touching them — so a nonzero `compared` also witnesses that the flag is on.
+///
+/// Compiled out in release, like the oracle itself.
+#[cfg(debug_assertions)]
+pub fn denoted_sequence_oracle_counts() -> (u64, u64) {
+    use std::sync::atomic::Ordering;
+    (
+        DENOTED_SEQUENCE_COMPARED.load(Ordering::Relaxed),
+        DENOTED_SEQUENCE_SKIPPED.load(Ordering::Relaxed),
+    )
+}
+
 #[cfg(debug_assertions)]
 thread_local! {
-    /// Re-entrancy guard for the idempotency self-check.
+    /// Re-entrancy guard for the idempotency self-check's verification pass.
     ///
     /// The check lives in `normalize_core_checked` so it covers the projector
     /// too, but its verification pass re-enters that very method — without this
     /// flag each check would recurse forever. Thread-local (not a global) so
     /// concurrent normalizations on other threads stay checked.
+    ///
+    /// Read by **two** oracles, for different reasons. `assert_idempotent` must
+    /// honour it or it recurses; `assert_denoted_sequence` honours it because the
+    /// re-entrant pass asks a question the outer call already asked, at the price
+    /// of a second provider fetch and a counter the outer call did not ask for.
+    /// `assert_reparseable` and `assert_in_bounds` deliberately do not: they are
+    /// pure predicates over one description, hold no counters, and re-running
+    /// them on the verification pass costs nothing worth naming.
     static IN_IDEMPOTENCY_CHECK: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
@@ -1989,6 +2061,144 @@ impl<P: ReferenceProvider> Normalizer<P> {
              have\n  input:  {variant}\n  output: {normalized}\n  member: {member}\n  names \
              position {position} on {accession}, which has {length} bases",
         );
+    }
+
+    /// Assert that a normalized description denotes the same bases its input
+    /// does.
+    ///
+    /// The fourth seam oracle (#1615), and the first that asks about *meaning*
+    /// rather than form. Normalization may re-spell a variant however the
+    /// canonical form requires; what it may never do is change the sequence the
+    /// description resolves to. Nothing else at this seam checks that:
+    ///
+    /// * `FERRO_ASSERT_IDEMPOTENT` asks whether the output is a fixed point. A
+    ///   wrong sequence normalizes to itself perfectly well — #1592, #1600,
+    ///   #1304, #1308 and #1312 are all fixed points.
+    /// * `FERRO_ASSERT_REPARSE` asks whether it parses. `parse_hgvs` holds no
+    ///   provider, so it cannot know what any description denotes.
+    /// * `FERRO_ASSERT_IN_BOUNDS` asks whether its coordinates exist. Every one
+    ///   of the eight defects below names positions that do exist.
+    ///
+    /// The class had been found by hand six times — #1254, #1281, #1290, #1304,
+    /// #1308, #1312 — each filed, fixed and regression-tested separately, before
+    /// #1592 and #1600 made it eight. That is the same argument #1353 made for
+    /// the in-bounds oracle after three.
+    ///
+    /// # The applier is not the normalizer
+    ///
+    /// [`crate::spdi::compare_denoted_sequences`] reaches the bases through
+    /// `hgvs_to_spdi` and an SPDI splice, with no normalization anywhere in the
+    /// path — otherwise the check would agree with the output merely because
+    /// normalization produced it. `EquivalenceChecker` is *not* usable here for
+    /// exactly that reason.
+    ///
+    /// # Skipping is counted, and an inapplicable output is not a skip
+    ///
+    /// Whenever the input itself denotes no single sequence — a trans allele, a
+    /// `REFSEQ_MISMATCH` whose stated base is wrong, an edit SPDI cannot carry —
+    /// there is no baseline, and the comparison declines. That is the same
+    /// discipline `assert_reparseable` and `assert_in_bounds` apply, and it is
+    /// deliberately *counted* ([`denoted_sequence_oracle_counts`]) rather than
+    /// silent: a run that compared nothing looks identical to a run that
+    /// compared everything and found no fault.
+    ///
+    /// An output that is **self-contradictory** while its input denotes a
+    /// sequence is the opposite case and fires. #1281's `g.[1del;9_10delinsA]`
+    /// normalized to `g.[1del;1del]`, two members claiming one base: the
+    /// description has no resulting sequence at all, which is worse than having
+    /// the wrong one. Treating it as a skip would file the more severe defect
+    /// under the milder one's exemption.
+    ///
+    /// That fire is deliberately narrower than "the output produced no triples".
+    /// An output the applier merely cannot *transliterate* is a skip, because
+    /// the two sides do not need the reference equally: `g.1000delC` states its
+    /// deleted base and converts with no provider at all, while the `g.1000del`
+    /// normalization emits for it must read one. Reading that asymmetry as a
+    /// fault raised 328 false alarms across the suite in a single measured run,
+    /// against 16 genuine ones.
+    ///
+    /// # It does not run on the idempotency oracle's verification pass
+    ///
+    /// `assert_idempotent` re-enters `normalize_core_checked`, so this seam is
+    /// reached a second time with `(normalized, again)` — a pair the outer call
+    /// has already asked about, since the outer comparison covers
+    /// `(input, normalized)` and the idempotency assertion covers
+    /// `normalized == again`. Honouring `IN_IDEMPOTENCY_CHECK` therefore costs no
+    /// coverage and buys three things: it halves the provider fetches when both
+    /// flags are set (`sweeps` sets both), it keeps
+    /// [`denoted_sequence_oracle_counts`] a count of *normalizations the caller
+    /// asked for* rather than a mixture of those and re-entrant verification
+    /// passes, and it stops a non-idempotent output being reported as a sequence
+    /// fault by the inner call before `assert_idempotent` can name it as the
+    /// non-idempotency it is.
+    ///
+    /// The return is before either counter, like the flag-off path: a re-entrant
+    /// pass is not a skip the oracle declined, so counting it as one would put
+    /// the same inflation into `skipped` that it removes from `compared`.
+    ///
+    /// Compiled out in release, like the three beside it, and the most expensive
+    /// of the four when on — one provider fetch and two splices per
+    /// normalization — so it runs last.
+    #[cfg(debug_assertions)]
+    fn assert_denoted_sequence(
+        &self,
+        variant: &HgvsVariant,
+        normalized: &HgvsVariant,
+        warnings: &[NormalizationWarning],
+    ) {
+        use crate::spdi::DenotedSequenceComparison as Outcome;
+        use std::sync::atomic::Ordering;
+
+        if !denoted_sequence_self_check_enabled() || IN_IDEMPOTENCY_CHECK.with(|f| f.get()) {
+            return;
+        }
+        // A corrected `REFSEQ_MISMATCH` is a sequence change the normalizer is
+        // *supposed* to make, and the only one there is. The input stated a base
+        // the reference does not have — `c.10dupA` where the reference reads `C`
+        // — and canonicalization drops the wrong bases, so the two descriptions
+        // legitimately denote different sequences. Counted as a skip rather than
+        // exempted silently, and kept narrow: only the `corrected` half, since a
+        // mismatch the normalizer declines to rewrite leaves both sides denoting
+        // whatever the input said.
+        if warnings.iter().any(|w| {
+            matches!(
+                w,
+                NormalizationWarning::RefSeqMismatch {
+                    corrected: true,
+                    ..
+                }
+            )
+        }) {
+            DENOTED_SEQUENCE_SKIPPED.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        match crate::spdi::compare_denoted_sequences(variant, normalized, &self.provider) {
+            Outcome::Agree => {
+                DENOTED_SEQUENCE_COMPARED.fetch_add(1, Ordering::Relaxed);
+            }
+            Outcome::NotComparable(_) => {
+                DENOTED_SEQUENCE_SKIPPED.fetch_add(1, Ordering::Relaxed);
+            }
+            Outcome::OutputContradictsItself => panic!(
+                "FERRO_ASSERT_SEQUENCE: normalization produced a description that denotes no \
+                 sequence at all, from an input that denotes one\n  input:  {variant}\n  output: \
+                 {normalized}\n  its members claim the same base, or two of its insertions share \
+                 one interbase with no stated order",
+            ),
+            Outcome::Differ {
+                accession,
+                start,
+                reference,
+                from_input,
+                from_output,
+            } => panic!(
+                "FERRO_ASSERT_SEQUENCE: normalization changed the sequence the description \
+                 denotes\n  input:  {variant}\n  output: {normalized}\n  over {accession} \
+                 [{start}, {}):\n    reference       {reference}\n    input applies   \
+                 {from_input}\n    output applies  {from_output}",
+                start + reference.len() as u64,
+            ),
+        }
     }
 
     /// Whether a lone (non-allele) member is a shape the sequence-first pass
@@ -2591,7 +2801,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
-        self.assert_seam_oracles(variant, &result.result);
+        self.assert_seam_oracles(variant, &result.result, &result.warnings);
 
         // Provenance (#1235, `DNA/delins.md:79-84`). If the input described more
         // cis members than the normalized form does, two or more separately
@@ -2627,7 +2837,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Ok((result.result, result.warnings))
     }
 
-    /// The three seam oracles, run on a normalized result before it is returned.
+    /// The four seam oracles, run on a normalized result before it is returned.
     ///
     /// Ordered cheapest-and-most-specific first, so the failure a run reports is
     /// the most precise one available: a bad coordinate is a bad coordinate
@@ -2635,6 +2845,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// `assert_idempotent` would otherwise report an out-of-range output as a
     /// non-idempotency, which is the symptom rather than the fault. See
     /// `assert_idempotent` for the re-entrancy guard.
+    ///
+    /// `assert_denoted_sequence` (#1615) is last for the same reason: it is the
+    /// only one that reads the reference, and an output that is out of bounds or
+    /// unparseable should be reported as *that* rather than as a sequence it
+    /// could not be applied to. It is also the most expensive.
     ///
     /// A method rather than an inline block because there is more than one public
     /// exit to cover. `normalize_core_checked` is the seam for `normalize()` and
@@ -2646,17 +2861,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///
     /// Each call stays individually `#[cfg(debug_assertions)]`-gated, so the whole
     /// body compiles away in release exactly as the inline block did.
-    fn assert_seam_oracles(&self, variant: &HgvsVariant, normalized: &HgvsVariant) {
+    fn assert_seam_oracles(
+        &self,
+        variant: &HgvsVariant,
+        normalized: &HgvsVariant,
+        warnings: &[NormalizationWarning],
+    ) {
         #[cfg(debug_assertions)]
         self.assert_in_bounds(variant, normalized);
         #[cfg(debug_assertions)]
         self.assert_reparseable(variant, normalized);
         #[cfg(debug_assertions)]
         self.assert_idempotent(variant, normalized);
-        // Release builds read neither parameter once the three calls above are
-        // compiled out.
+        #[cfg(debug_assertions)]
+        self.assert_denoted_sequence(variant, normalized, warnings);
+        // Release builds read none of the parameters once the four calls above
+        // are compiled out.
         #[cfg(not(debug_assertions))]
-        let _ = (variant, normalized);
+        let _ = (variant, normalized, warnings);
     }
 
     /// Normalize a variant with detailed warnings

--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -428,11 +428,49 @@ fn triples_are_disjoint(ordered: &[&SpdiVariant]) -> bool {
 /// accession they act on.
 ///
 /// `None` when a single resulting sequence is undefined or cannot be derived —
-/// see [`apply_to_reference`]'s error list, which this decides.
+/// see [`apply_to_reference`]'s error list, which this decides. Use
+/// [`variant_edit_triples_reason`] when the *cause* matters.
 pub(crate) fn variant_edit_triples<P: ReferenceProvider + ?Sized>(
     variant: &HgvsVariant,
     provider: &P,
 ) -> Option<(String, Vec<SpdiVariant>)> {
+    variant_edit_triples_reason(variant, provider).ok()
+}
+
+/// Why a description yields no SPDI triple set.
+///
+/// The split exists because the two are **not equally severe**, and a caller
+/// that cannot tell them apart draws the wrong conclusion from a decline. See
+/// [`compare_denoted_sequences`], where reading every decline as
+/// [`Self::SelfContradictory`] produced 328 false alarms across the test suite
+/// in a single run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NoTriples {
+    /// The applier could not transliterate it: a shape with no single resulting
+    /// sequence by construction (a trans allele, a null allele, members on
+    /// different accessions), an edit SPDI cannot carry, a position it cannot
+    /// resolve, or reference data the provider does not hold.
+    ///
+    /// **A limit of the applier or of the shape, never a verdict on the
+    /// description.** The last cause is the common one and the one that misleads:
+    /// `g.1000delC` states its deleted base and so converts with no provider at
+    /// all, while the `g.1000del` a normalizer emits for it must read the
+    /// reference — so on a provider holding no bases the input converts and the
+    /// output does not, through no fault of the normalization.
+    Untransliterable,
+    /// The description states an edit set with no defined result **whatever the
+    /// reference says** — members claiming the same base, or two insertions at
+    /// one interbase with no stated order.
+    ///
+    /// A real fault in a description that claims to denote one sequence.
+    SelfContradictory,
+}
+
+/// [`variant_edit_triples`], reporting why it declined.
+pub(crate) fn variant_edit_triples_reason<P: ReferenceProvider + ?Sized>(
+    variant: &HgvsVariant,
+    provider: &P,
+) -> Result<(String, Vec<SpdiVariant>), NoTriples> {
     use crate::hgvs::variant::AllelePhase;
 
     let members: Vec<&HgvsVariant> = match variant {
@@ -440,24 +478,27 @@ pub(crate) fn variant_edit_triples<P: ReferenceProvider + ?Sized>(
             // A single resulting sequence is only well-defined for a cis allele —
             // every edit applied to the same molecule.
             if allele.phase != AllelePhase::Cis {
-                return None;
+                return Err(NoTriples::Untransliterable);
             }
             allele.variants.iter().collect()
         }
-        HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => return None,
+        HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
+            return Err(NoTriples::Untransliterable)
+        }
         single => vec![single],
     };
     if members.is_empty() {
-        return None;
+        return Err(NoTriples::Untransliterable);
     }
 
     let mut accession: Option<String> = None;
     let mut triples = Vec::with_capacity(members.len());
     for member in members {
-        let spdi = crate::spdi::hgvs_to_spdi(member, provider).ok()?;
+        let spdi =
+            crate::spdi::hgvs_to_spdi(member, provider).map_err(|_| NoTriples::Untransliterable)?;
         match &accession {
             None => accession = Some(spdi.sequence.clone()),
-            Some(acc) if *acc != spdi.sequence => return None,
+            Some(acc) if *acc != spdi.sequence => return Err(NoTriples::Untransliterable),
             Some(_) => {}
         }
         triples.push(spdi);
@@ -488,10 +529,402 @@ pub(crate) fn variant_edit_triples<P: ReferenceProvider + ?Sized>(
         .collect();
     zero_width.sort_unstable();
     if zero_width.windows(2).any(|pair| pair[0] == pair[1]) {
-        return None;
+        return Err(NoTriples::SelfContradictory);
     }
 
-    accession.map(|acc| (acc, triples))
+    accession
+        .map(|acc| (acc, triples))
+        .ok_or(NoTriples::Untransliterable)
+}
+
+/// Why two descriptions' denoted sequences could not be compared (#1615).
+///
+/// Every variant here is a limit of the *comparison*, not a verdict on either
+/// description. They are enumerated rather than collapsed to one "skip" because
+/// a skip that reads as a pass is the failure mode the denoted-sequence oracle
+/// exists to remove: a caller that cannot say which of these it hit cannot tell
+/// a clean run from a run that compared nothing.
+///
+/// Marked `#[non_exhaustive]` so a new decline reason is additive rather than a
+/// breaking change, matching `SpdiParseError` and `ConversionError` in this
+/// module. The set is demonstrably still growing:
+/// [`Self::UnresolvableSpecialPosition`] exists only until `hgvs_to_spdi` stops
+/// resolving `pter` silently, and #1618/#1619 are two more disagreements in
+/// flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NotComparable {
+    /// The **input** denotes no single sequence, so there is no baseline to
+    /// compare the output against.
+    ///
+    /// A multi-molecule or null allele, members on different accessions, an edit
+    /// SPDI cannot represent, a self-contradictory member set, or a stated
+    /// reference base that disagrees with the reference (the `REFSEQ_MISMATCH`
+    /// inputs normalization exists to correct). Blaming normalization for any of
+    /// those would make a fire mean two different things — the discipline
+    /// `assert_reparseable` and `assert_in_bounds` already apply.
+    InputDenotesNoSequence,
+    /// The **output** cannot be transliterated, though it is not
+    /// self-contradictory. A limit of the applier or of the provider, not of the
+    /// description — see [`NoTriples::Untransliterable`], which is exactly the
+    /// asymmetry that makes this its own verdict rather than a fire.
+    OutputUntransliterable,
+    /// One side is an allele wrapped in the predicted marker `[(…)]`, whose
+    /// members are uncertain by construction.
+    UncertainAllele,
+    /// One side names `pter`/`qter`/`cen`.
+    ///
+    /// Those carry no numeric coordinate — `GenomePos::pter()` and
+    /// `CdsPos::pter()` both set `base: 0` — and `hgvs_to_spdi` reads the `base`
+    /// field, so it resolves them *silently* to a position that is not the one
+    /// meant. Measured: `NM_003002.2:c.pterdel` transliterates to a deletion of
+    /// the sequence's LAST base. Comparing against that would report every
+    /// correct `pter` normalization as a corruption, so the pair is declined
+    /// until the transliteration is fixed.
+    UnresolvableSpecialPosition,
+    /// The two descriptions name different accessions, so their sequences are
+    /// not comparable at all. Normalization can do this legitimately (the #785
+    /// transcript-version substitution).
+    AccessionChanged,
+    /// The union of the two descriptions' spans is wider than
+    /// [`MAX_APPLY_WINDOW`].
+    WindowTooWide,
+    /// The provider could not serve the union window.
+    ReferenceUnreadable,
+}
+
+impl std::fmt::Display for NotComparable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            Self::InputDenotesNoSequence => "the input denotes no single sequence",
+            Self::OutputUntransliterable => "the output cannot be transliterated to SPDI",
+            Self::UncertainAllele => "one side is a predicted `[(…)]` allele",
+            Self::UnresolvableSpecialPosition => "one side names pter/qter/cen",
+            Self::AccessionChanged => "the two descriptions name different accessions",
+            Self::WindowTooWide => "their union spans more than MAX_APPLY_WINDOW bases",
+            Self::ReferenceUnreadable => "the provider could not serve the union window",
+        };
+        f.write_str(reason)
+    }
+}
+
+/// The outcome of comparing the sequences two descriptions denote (#1615).
+///
+/// Deliberately **not** `#[non_exhaustive]`, unlike its
+/// [`NotComparable`] payload: `issue_1615_denoted_sequence_oracle::
+/// the_oracle_fires_on_every_recorded_defect` matches this enum exhaustively
+/// from outside the crate, which is what makes a new verdict fail to compile
+/// rather than be swallowed by a wildcard arm. A new *decline reason* is
+/// additive and belongs in `NotComparable`; a new *verdict* is a change to what
+/// the oracle can say, and every caller should have to answer for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenotedSequenceComparison {
+    /// Both descriptions apply, and to the same bases.
+    Agree,
+    /// Both apply, and to **different** bases.
+    Differ {
+        /// The accession both descriptions act on.
+        accession: String,
+        /// 0-based start of the window both strings cover.
+        start: u64,
+        /// The reference bases over that window.
+        reference: String,
+        /// The window after applying the first description.
+        from_input: String,
+        /// The window after applying the second.
+        from_output: String,
+    },
+    /// The **output** is self-contradictory although the input denotes a
+    /// sequence: its members claim the same base, or two of its insertions share
+    /// one interbase with no stated order.
+    ///
+    /// Deliberately *not* a [`NotComparable`] variant. #1281's `g.[1del;1del]`
+    /// denotes nothing at all, which is strictly worse than denoting the wrong
+    /// thing, so folding it in with the skips would hide the more severe defect
+    /// behind the milder one. Equally deliberately, it is **narrower** than "the
+    /// output produced no triples" — see [`NotComparable::OutputUntransliterable`].
+    OutputContradictsItself,
+    /// Neither verdict is available, for a stated reason.
+    NotComparable(NotComparable),
+}
+
+/// Whether `variant` is an allele wrapped in the predicted marker `[(…)]`.
+fn is_uncertain_allele(variant: &HgvsVariant) -> bool {
+    matches!(variant, HgvsVariant::Allele(allele) if allele.uncertain)
+}
+
+/// Whether `variant` names a chromosome-arm or centromere special position.
+///
+/// Only [`crate::hgvs::location::GenomePos`] and
+/// [`crate::hgvs::location::CdsPos`] carry the marker, so only the axes built on
+/// those are walked; the rest cannot express one. See
+/// [`NotComparable::UnresolvableSpecialPosition`] for why the answer matters.
+fn names_a_special_position(variant: &HgvsVariant) -> bool {
+    use crate::hgvs::interval::{Interval, UncertainBoundary};
+    use crate::hgvs::location::{CdsPos, GenomePos};
+
+    fn boundary_is_special<T>(boundary: &UncertainBoundary<T>, special: fn(&T) -> bool) -> bool {
+        match boundary {
+            UncertainBoundary::Single(mu) => mu.inner().is_some_and(special),
+            UncertainBoundary::Range { start, end } => {
+                start.inner().is_some_and(special) || end.inner().is_some_and(special)
+            }
+        }
+    }
+    fn interval_is_special<T>(interval: &Interval<T>, special: fn(&T) -> bool) -> bool {
+        boundary_is_special(&interval.start, special) || boundary_is_special(&interval.end, special)
+    }
+    fn genomic(interval: &Interval<GenomePos>) -> bool {
+        interval_is_special(interval, |p| p.special.is_some())
+    }
+
+    match variant {
+        HgvsVariant::Allele(allele) => allele.variants.iter().any(names_a_special_position),
+        HgvsVariant::Genome(v) => genomic(&v.loc_edit.location),
+        HgvsVariant::Mt(v) => genomic(&v.loc_edit.location),
+        HgvsVariant::Circular(v) => genomic(&v.loc_edit.location),
+        HgvsVariant::Cds(v) => {
+            interval_is_special(&v.loc_edit.location, |p: &CdsPos| p.special.is_some())
+        }
+        _ => false,
+    }
+}
+
+/// Compare the sequences `input` and `output` denote against one reference
+/// window (#1615).
+///
+/// This is the primitive behind the denoted-sequence seam oracle, and it is
+/// **independent of the normalizer**: it reaches the bases through
+/// [`variant_edit_triples_reason`] and [`apply_triples`], the same SPDI-splicing
+/// walk [`apply_to_reference`] uses, so nothing here can agree with
+/// normalization merely because normalization produced it. (`EquivalenceChecker`
+/// cannot serve this role — it normalizes both sides, which is circular.)
+///
+/// Both descriptions are applied over the **union** of their two spans, one
+/// fetch, so a 3'-shift is compared where it belongs: `g.3_4del` and `g.7_8del`
+/// in a tract denote the same bases over any window containing both, and a
+/// per-description window would give each its own frame and make them look
+/// different. The comparison is ASCII-case-insensitive for the reason
+/// [`trim_common_flanks`] gives — reference FASTAs are often soft-masked and
+/// case carries no biological meaning, while one side's payload may be
+/// reference-derived (a `dup`) and the other's a literal.
+///
+/// # Declining is the default; only two outcomes are faults
+///
+/// [`DenotedSequenceComparison::Differ`] and
+/// [`DenotedSequenceComparison::OutputContradictsItself`] are the faults.
+/// Everything else the applier cannot do is a [`NotComparable`] with a stated
+/// reason, and that asymmetry is load-bearing rather than cautious: an earlier
+/// revision reported *any* untranslatable output as a fault and raised **328**
+/// false alarms over the test suite, essentially all of them one shape — an
+/// input that states its own deleted bases (`g.1000delC`, `g.[1000G>A;1001A>C]`)
+/// against an output that does not (`g.1000del`, `g.1000_1001delinsAC`), on a
+/// provider holding no reference at that locus. The input converted with no
+/// provider and the output could not, and nothing was wrong with either.
+pub fn compare_denoted_sequences<P: ReferenceProvider + ?Sized>(
+    input: &HgvsVariant,
+    output: &HgvsVariant,
+    provider: &P,
+) -> DenotedSequenceComparison {
+    use DenotedSequenceComparison as Outcome;
+
+    if names_a_special_position(input) || names_a_special_position(output) {
+        return Outcome::NotComparable(NotComparable::UnresolvableSpecialPosition);
+    }
+    // An allele wrapped in the predicted marker `[(…)]` states that its members
+    // are *uncertain*, so "which bases does it denote" is not a question it
+    // answers. `normalize` agrees and leaves such members where the caller put
+    // them — `sort_cis_members_by_genomic_order` and the sibling clamps all gate
+    // on cis-and-not-uncertain — so its output may legitimately still overlap.
+    //
+    // Checked here rather than in `variant_edit_triples_reason` on purpose: that
+    // function also backs the public `apply_to_reference` and `canonical_spdi`,
+    // and narrowing what *they* accept is a separate decision from what this
+    // comparison is willing to adjudicate.
+    if is_uncertain_allele(input) || is_uncertain_allele(output) {
+        return Outcome::NotComparable(NotComparable::UncertainAllele);
+    }
+
+    let Ok((accession, input_triples)) = variant_edit_triples_reason(input, provider) else {
+        return Outcome::NotComparable(NotComparable::InputDenotesNoSequence);
+    };
+    let (output_accession, output_triples) = match variant_edit_triples_reason(output, provider) {
+        Ok(pair) => pair,
+        Err(NoTriples::SelfContradictory) => return Outcome::OutputContradictsItself,
+        Err(NoTriples::Untransliterable) => {
+            return Outcome::NotComparable(NotComparable::OutputUntransliterable)
+        }
+    };
+    if accession != output_accession {
+        return Outcome::NotComparable(NotComparable::AccessionChanged);
+    }
+
+    let (mut start, mut end) = (u64::MAX, u64::MIN);
+    for triple in input_triples.iter().chain(&output_triples) {
+        start = start.min(triple.position);
+        // Checked for the same reason `apply_to_reference_padded` checks it: a
+        // wrap would silently shrink the window and compare the wrong bases.
+        let Some(triple_end) = triple.position.checked_add(triple.deletion.len() as u64) else {
+            return Outcome::NotComparable(NotComparable::WindowTooWide);
+        };
+        end = end.max(triple_end);
+    }
+    if start > end || end - start > MAX_APPLY_WINDOW {
+        return Outcome::NotComparable(NotComparable::WindowTooWide);
+    }
+
+    let Some(reference) = fetch_window(provider, &accession, start, end) else {
+        return Outcome::NotComparable(NotComparable::ReferenceUnreadable);
+    };
+    let from_input = match splice_denoted_sequence(&reference, start, &input_triples) {
+        Ok(bases) => bases,
+        Err(_) => return Outcome::NotComparable(NotComparable::InputDenotesNoSequence),
+    };
+    let from_output = match splice_denoted_sequence(&reference, start, &output_triples) {
+        Ok(bases) => bases,
+        // Only one of the two refusals is the description's own fault.
+        // Overlapping members claim the same base whatever the reference holds;
+        // a stated base that disagrees with the reference is a claim this
+        // comparison cannot adjudicate — and is exactly what an input carrying a
+        // `REFSEQ_MISMATCH` looks like.
+        Err(SpliceFailure::Overlapping) => return Outcome::OutputContradictsItself,
+        Err(SpliceFailure::StatedBasesMismatch) => {
+            return Outcome::NotComparable(NotComparable::OutputUntransliterable)
+        }
+    };
+
+    if same_bases(&from_input, &from_output) {
+        Outcome::Agree
+    } else {
+        Outcome::Differ {
+            accession,
+            start,
+            reference,
+            from_input,
+            from_output,
+        }
+    }
+}
+
+/// Why [`splice_denoted_sequence`] refused a triple set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpliceFailure {
+    /// Two members claim the same reference base, so the result depends on an
+    /// order the description does not state. A fault in the description itself.
+    Overlapping,
+    /// A member's stated deleted bases disagree with the reference.
+    StatedBasesMismatch,
+}
+
+/// Splice `triples` into `reference` — the bases beginning at interbase
+/// `win_start` — and return the resulting sequence.
+///
+/// Deliberately **not** [`apply_triples`], which is shared with
+/// `EquivalenceChecker` and whose [`triples_are_disjoint`] guard reports a pure
+/// insertion flush against the 5' end of a deletion as an overlap. That
+/// combination is well defined — the payload lands at the junction, then the
+/// span is removed — and it is a shape cis alleles reach constantly: measured
+/// over one suite run, reading it as an overlap produced **233** false alarms,
+/// nearly all of them `g.[…;261_262insA;262_264A[5]]`-shaped. (Its verdict there
+/// is also input-order dependent, since the sort breaks position ties by input
+/// order.) Changing that predicate is out of scope — two pinned tests depend on
+/// its permissiveness in the other direction — so this walk is the one used for
+/// the comparison.
+///
+/// The walk is `tests/it/common/cis_apply_oracle.rs`'s, the applier every
+/// sibling-crossing test already rests on: 3'→5' so an applied splice never
+/// moves a later one's coordinates, with **longer deletions first** among
+/// members at one position so a span-claiming member is always applied before
+/// the zero-length one flush against it. Coincident insertions are refused
+/// upstream, by [`variant_edit_triples_reason`].
+fn splice_denoted_sequence(
+    reference: &str,
+    win_start: u64,
+    triples: &[SpdiVariant],
+) -> Result<String, SpliceFailure> {
+    let reference = reference.as_bytes();
+    let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
+    ordered.sort_by_key(|t| {
+        (
+            std::cmp::Reverse(t.position),
+            std::cmp::Reverse(t.deletion.len()),
+        )
+    });
+
+    let mut edited = reference.to_vec();
+    let mut claimed_from = reference.len();
+    for triple in ordered {
+        // The caller builds the window from these very triples, so an
+        // out-of-window position is unreachable; treat it defensively as a
+        // stated-bases problem rather than panicking on the slice.
+        let Some(start) = triple
+            .position
+            .checked_sub(win_start)
+            .and_then(|offset| usize::try_from(offset).ok())
+        else {
+            return Err(SpliceFailure::StatedBasesMismatch);
+        };
+        let Some(end) = start.checked_add(triple.deletion.len()) else {
+            return Err(SpliceFailure::StatedBasesMismatch);
+        };
+        if end > reference.len() {
+            return Err(SpliceFailure::StatedBasesMismatch);
+        }
+        if end > claimed_from {
+            return Err(SpliceFailure::Overlapping);
+        }
+        if !same_bases_bytes(&reference[start..end], triple.deletion.as_bytes()) {
+            return Err(SpliceFailure::StatedBasesMismatch);
+        }
+        // The splice targets the mutated buffer, whose length no longer matches
+        // the reference once a length-changing edit has been applied. The
+        // descending walk and the overlap check above already make
+        // `end <= edited.len()` hold — every applied splice sits at or past
+        // `claimed_from`, so the prefix this indexes into is untouched — but bound
+        // it explicitly anyway, so a future change cannot turn a logic slip back
+        // into the out-of-bounds panic of #1244.
+        if end > edited.len() {
+            return Err(SpliceFailure::StatedBasesMismatch);
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+        // Unconditionally, including for a pure insertion — an insertion
+        // *interior* to a member 5' of it is an overlap even though it claims no
+        // base of its own, and that is precisely the overlap-conflicting allele
+        // (`g.[2_3del;2_3insAA]`) this repository declines to canonicalize. The
+        // flush case the tie-break above exists for is already safe: the
+        // span-claiming member is applied first, so the zero-length one sits
+        // exactly *at* `claimed_from` rather than past it.
+        claimed_from = start;
+    }
+    String::from_utf8(edited).map_err(|_| SpliceFailure::StatedBasesMismatch)
+}
+
+/// The base `b` is compared as, folding case and the RNA alphabet.
+///
+/// Case, for the reason [`trim_common_flanks`] gives: reference FASTAs are often
+/// soft-masked and case carries no biological meaning. `U` to `T` because the
+/// two sides of a comparison need not agree on the alphabet — an `r.` payload is
+/// transliterated to RNA by `hgvs_to_spdi` while the reference window it is
+/// spliced into is served as DNA, so `r.6_8dupugc` and `r.6_8dup` denote one
+/// sequence and would otherwise read as `UGC` against `TGC`.
+fn canonical_base(b: u8) -> u8 {
+    match b.to_ascii_uppercase() {
+        b'U' => b'T',
+        other => other,
+    }
+}
+
+/// Whether two base strings denote the same sequence under [`canonical_base`].
+fn same_bases(left: &str, right: &str) -> bool {
+    same_bases_bytes(left.as_bytes(), right.as_bytes())
+}
+
+fn same_bases_bytes(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(l, r)| canonical_base(*l) == canonical_base(*r))
 }
 
 /// Read `[start, end)` from `accession`, or `None` if the provider cannot serve

--- a/src/spdi/mod.rs
+++ b/src/spdi/mod.rs
@@ -39,7 +39,8 @@ pub mod convert;
 mod parser;
 
 pub use apply::{
-    apply_to_reference, canonical_spdi, AppliedVariant, MAX_APPLY_WINDOW, MAX_SHIFT_TRACT,
+    apply_to_reference, canonical_spdi, compare_denoted_sequences, AppliedVariant,
+    DenotedSequenceComparison, NotComparable, MAX_APPLY_WINDOW, MAX_SHIFT_TRACT,
 };
 pub use convert::{
     hgvs_to_spdi, hgvs_to_spdi_simple, spdi_to_hgvs, spdi_to_hgvs_with_ref, ConversionError,

--- a/tests/it/issue_1615_denoted_sequence_oracle.rs
+++ b/tests/it/issue_1615_denoted_sequence_oracle.rs
@@ -1,0 +1,529 @@
+//! The denoted-sequence seam oracle, checked against the defects it exists for.
+//!
+//! `FERRO_ASSERT_SEQUENCE` is the fourth oracle at `normalize_core_checked`'s
+//! exit (#1615). The three before it — `FERRO_ASSERT_IDEMPOTENT`,
+//! `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` — are all *form* questions,
+//! and a description denoting entirely different bases can satisfy every one of
+//! them at once. Eight defects did exactly that.
+//!
+//! This file is the oracle's own regression guard. It does **not** normalize:
+//! every row pins a `(reference, input, wrong output)` triple recorded on the
+//! issue that reported it, and asserts that
+//! [`compare_denoted_sequences`](ferro_hgvs::spdi::compare_denoted_sequences) —
+//! the predicate `Normalizer::assert_denoted_sequence` wraps — reports the pair
+//! as a fault. Pinning the recorded strings rather than re-normalizing is what
+//! keeps the guard meaningful after each defect is fixed: a test that ran the
+//! normalizer would go green on the fix and stop saying anything about the
+//! oracle.
+//!
+//! The two halves matter equally. The rows below must **fire**; the rows in
+//! `respellings_that_denote_the_same_bases` must **not**, because an oracle that
+//! fires on ordinary correct normalization is one nobody can leave enabled.
+
+use crate::common::cis_apply_oracle::provider as template_provider;
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::spdi::{compare_denoted_sequences, DenotedSequenceComparison, NotComparable};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Which reference a recorded defect was found on.
+enum Reference {
+    /// A bare contig under the accession `TEMPLATE`, as the cis-allele tests
+    /// build it.
+    Template(&'static str),
+    /// A core wrapped in 256 bases of `ACGT` padding under `NC_TEST.1`, so core
+    /// base 1 sits at `g.257`. The shape every `SyntheticBuilder`-backed issue
+    /// reproducer uses.
+    PaddedCore(&'static str),
+}
+
+impl Reference {
+    fn build(&self) -> MockProvider {
+        match self {
+            Self::Template(sequence) => template_provider(sequence),
+            Self::PaddedCore(core) => SyntheticBuilder::genomic(core).build(),
+        }
+    }
+}
+
+/// A defect this oracle is answerable for: the reference it was found on, the
+/// input, and the description the normalizer emitted for it at the time.
+struct Recorded {
+    issue: &'static str,
+    reference: Reference,
+    input: &'static str,
+    /// The output as recorded on the issue. **Not** what `main` emits today for
+    /// the six that are fixed — see the module docs for why that is the point.
+    wrong_output: &'static str,
+}
+
+/// The eight defects named on #1615, each with the wrong output its own issue
+/// records.
+///
+/// Six were found by hand, one shape at a time, and fixed and regression-tested
+/// separately (#1254, #1281, #1290, #1304, #1308, #1312). #1592 and #1600 were
+/// found by a proptest run past its default case budget and are open at the time
+/// of writing. All eight are the same class, and none of the three older oracles
+/// sees any of them.
+const RECORDED_DEFECTS: &[Recorded] = &[
+    Recorded {
+        issue: "#1254",
+        reference: Reference::Template("TAATATATATAATATATATT"),
+        input: "TEMPLATE:g.[3_4del;9del]",
+        // The deletion 3'-shifted straight past its sibling, the two merged,
+        // and the merged member shifted again.
+        wrong_output: "TEMPLATE:g.12_14del",
+    },
+    Recorded {
+        issue: "#1281",
+        reference: Reference::Template("TTTTTTTTTAATATATTTTAATAT"),
+        input: "TEMPLATE:g.[1del;9_10delinsA]",
+        // Two members claiming base 1. This one denotes no sequence at all,
+        // which is a *different* and more severe verdict — see
+        // `an_output_that_contradicts_itself_is_not_a_skip`.
+        wrong_output: "TEMPLATE:g.[1del;1del]",
+    },
+    Recorded {
+        issue: "#1290",
+        reference: Reference::PaddedCore("ATACAGAAAATCAGGGCATA"),
+        input: "NC_TEST.1:g.[263_264insA;265_266insC]",
+        wrong_output: "NC_TEST.1:g.[265_266insC;266dup]",
+    },
+    Recorded {
+        issue: "#1304",
+        reference: Reference::PaddedCore("GCATGAAAAT"),
+        input: "NC_TEST.1:g.[260_261insGA;261_262insA;264del]",
+        wrong_output: "NC_TEST.1:g.[261_262insA;261_262dup;265del]",
+    },
+    Recorded {
+        issue: "#1308",
+        reference: Reference::PaddedCore("CAGAAGATGAATAA"),
+        input: "NC_TEST.1:g.[263_264insTG;264_265insTG]",
+        wrong_output: "NC_TEST.1:g.[264_265insTG;264_265dup]",
+    },
+    Recorded {
+        issue: "#1312",
+        reference: Reference::PaddedCore("TAAAACCA"),
+        input: "NC_TEST.1:g.[260_261insAC;261_262insAC]",
+        wrong_output: "NC_TEST.1:g.261_262insACCA",
+    },
+    Recorded {
+        issue: "#1592",
+        reference: Reference::PaddedCore("TCCAGCAGATAT"),
+        input: "NC_TEST.1:g.[262_263insAG;264G>T;266T>A]",
+        // The repeat names the lone `A` at 265 rather than the one at 267.
+        wrong_output: "NC_TEST.1:g.265A[3]",
+    },
+    Recorded {
+        issue: "#1600",
+        reference: Reference::PaddedCore("GAACAGCAGAAGCGA"),
+        input: "NC_TEST.1:g.261_267delinsGCAGAAAC",
+        wrong_output: "NC_TEST.1:g.[261del;266_267insCA]",
+    },
+];
+
+/// The oracle's acceptance criterion: it fires on every defect #1615 names.
+///
+/// "Fires" is either verdict the seam panics on — a changed sequence, or an
+/// output that denotes none while the input does. A `NotComparable` or an
+/// `Agree` here would be a miss, and the message says which so a regression
+/// reads as itself rather than as a generic failure.
+#[test]
+fn the_oracle_fires_on_every_recorded_defect() {
+    let mut missed = Vec::new();
+    for defect in RECORDED_DEFECTS {
+        let provider = defect.reference.build();
+        let input = parse_hgvs(defect.input).expect("input must parse");
+        let output = parse_hgvs(defect.wrong_output).expect("recorded output must parse");
+        match compare_denoted_sequences(&input, &output, &provider) {
+            DenotedSequenceComparison::Differ { .. }
+            | DenotedSequenceComparison::OutputContradictsItself => {}
+            DenotedSequenceComparison::Agree => missed.push(format!(
+                "{}: the oracle sees no difference between `{}` and `{}`",
+                defect.issue, defect.input, defect.wrong_output
+            )),
+            DenotedSequenceComparison::NotComparable(reason) => missed.push(format!(
+                "{}: the oracle declined to compare `{}` against `{}` — {reason}",
+                defect.issue, defect.input, defect.wrong_output
+            )),
+        }
+    }
+    assert!(
+        missed.is_empty(),
+        "the denoted-sequence oracle must fire on every defect #1615 names, but missed \
+         {}/{}:\n  {}",
+        missed.len(),
+        RECORDED_DEFECTS.len(),
+        missed.join("\n  "),
+    );
+}
+
+/// #1281's verdict is specifically the severe one, not merely "different".
+///
+/// `g.[1del;1del]` has no resulting sequence — two members claim base 1, so
+/// applying them depends on an order the description does not state. Reporting
+/// that as a skip would file the worse defect under the milder one's exemption,
+/// which is the failure mode a sequence oracle exists to remove.
+#[test]
+fn an_output_that_contradicts_itself_is_not_a_skip() {
+    let provider = template_provider("TTTTTTTTTAATATATTTTAATAT");
+    let input = parse_hgvs("TEMPLATE:g.[1del;9_10delinsA]").expect("parse");
+    let output = parse_hgvs("TEMPLATE:g.[1del;1del]").expect("parse");
+    assert_eq!(
+        compare_denoted_sequences(&input, &output, &provider),
+        DenotedSequenceComparison::OutputContradictsItself,
+    );
+}
+
+/// The negative control at unit scale: legitimate re-spellings must not fire.
+///
+/// Every row here is a pair the normalizer is *allowed* to move between — a
+/// 3'-shift through a tract, a merge of adjacent members, a decomposition, a
+/// repeat spelling of a duplication. The union window is what makes the first
+/// kind work: `g.3_4del` and `g.7_8del` denote the same bases over any window
+/// containing both, and a per-description window would give each its own frame
+/// and report a difference that is not there.
+#[test]
+fn respellings_that_denote_the_same_bases_do_not_fire() {
+    let rows: &[(Reference, &str, &str)] = &[
+        // #1254's correct answer, against its own input: a clamped 3'-shift plus
+        // a merge of the two now-adjacent deletions.
+        (
+            Reference::Template("TAATATATATAATATATATT"),
+            "TEMPLATE:g.[3_4del;9del]",
+            "TEMPLATE:g.7_9del",
+        ),
+        // A pure 3'-shift with no merge, across a window neither description
+        // covers alone.
+        (
+            Reference::Template("TAATATATATAATATATATT"),
+            "TEMPLATE:g.3_4del",
+            "TEMPLATE:g.7_8del",
+        ),
+        // A spanning delins and its full decomposition — #1159's shape.
+        (
+            Reference::PaddedCore("GCATGAAAAT"),
+            "NC_TEST.1:g.257_258delinsAA",
+            "NC_TEST.1:g.[257G>A;258C>A]",
+        ),
+        // A duplication and the insertion that denotes it.
+        (
+            Reference::PaddedCore("GCATGAAAAT"),
+            "NC_TEST.1:g.261_262insA",
+            "NC_TEST.1:g.262dup",
+        ),
+        // #1290's correct answer: two insertions that merge into one.
+        (
+            Reference::PaddedCore("ATACAGAAAATCAGGGCATA"),
+            "NC_TEST.1:g.[263_264insA;265_266insC]",
+            "NC_TEST.1:g.266_267insCA",
+        ),
+        // #1600's correct answer, which the bracketed spelling already reaches.
+        (
+            Reference::PaddedCore("GAACAGCAGAAGCGA"),
+            "NC_TEST.1:g.261_267delinsGCAGAAAC",
+            "NC_TEST.1:g.[261del;267_268insAC]",
+        ),
+    ];
+    for (reference, input, output) in rows {
+        let provider = reference.build();
+        let input_variant = parse_hgvs(input).expect("parse");
+        let output_variant = parse_hgvs(output).expect("parse");
+        assert_eq!(
+            compare_denoted_sequences(&input_variant, &output_variant, &provider),
+            DenotedSequenceComparison::Agree,
+            "`{input}` and `{output}` denote the same bases; the oracle must stay silent",
+        );
+    }
+}
+
+/// An input that denotes no single sequence is a *counted skip*, not a pass.
+///
+/// There is no baseline to compare an output against, so the comparison
+/// declines — the same discipline `assert_reparseable` and `assert_in_bounds`
+/// apply to inputs that were already broken. What matters is that the reason is
+/// reported rather than collapsed into silence, so a run can say how much it
+/// actually compared.
+#[test]
+fn an_input_that_denotes_no_sequence_is_reported_as_such() {
+    let provider = template_provider("TAATATATATAATATATATT");
+    // A trans allele describes two molecules, so there is no one resulting
+    // sequence for either side.
+    let input = parse_hgvs("TEMPLATE:g.[3_4del];[9del]").expect("parse");
+    let output = parse_hgvs("TEMPLATE:g.[7_8del];[9del]").expect("parse");
+    assert_eq!(
+        compare_denoted_sequences(&input, &output, &provider),
+        DenotedSequenceComparison::NotComparable(NotComparable::InputDenotesNoSequence),
+    );
+}
+
+/// Two descriptions on different accessions are not comparable at all.
+///
+/// Normalization can legitimately substitute an accession (#785's transcript
+/// version selection), and comparing bases across two sequences would report a
+/// difference that says nothing about the normalization.
+#[test]
+fn a_changed_accession_is_reported_rather_than_compared() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_ONE.1", "GGATTACAGGCATTAGCCTGA");
+    provider.add_genomic_sequence("NC_TWO.1", "TTTTTTTTTTTTTTTTTTTTT");
+    let input = parse_hgvs("NC_ONE.1:g.5del").expect("parse");
+    let output = parse_hgvs("NC_TWO.1:g.5del").expect("parse");
+    assert_eq!(
+        compare_denoted_sequences(&input, &output, &provider),
+        DenotedSequenceComparison::NotComparable(NotComparable::AccessionChanged),
+    );
+}
+
+/// The comparison reports the bases, not just a verdict.
+///
+/// The seam's panic message quotes all three strings, because "the sequence
+/// changed" is not actionable on its own — #1592 and #1600 were both diagnosed
+/// from the reference/input/output triple, and a bare boolean would have made
+/// each of them a fresh investigation.
+#[test]
+fn a_difference_carries_the_three_sequences() {
+    let provider = template_provider("TAATATATATAATATATATT");
+    let input = parse_hgvs("TEMPLATE:g.[3_4del;9del]").expect("parse");
+    let output = parse_hgvs("TEMPLATE:g.12_14del").expect("parse");
+    let DenotedSequenceComparison::Differ {
+        accession,
+        start,
+        reference,
+        from_input,
+        from_output,
+    } = compare_denoted_sequences(&input, &output, &provider)
+    else {
+        panic!("#1254's recorded pair must differ");
+    };
+    assert_eq!(accession, "TEMPLATE");
+    // The window is the union of both descriptions' spans: interbase 2 (the
+    // input's `3_4del`) through 14 (the output's `12_14del`).
+    assert_eq!(start, 2);
+    assert_eq!(reference, "ATATATATAATA");
+    assert_eq!(from_input, "ATATTAATA");
+    assert_eq!(from_output, "ATATATATA");
+    assert_ne!(from_input, from_output);
+}
+
+/// The measured false-positive classes, each pinned to the verdict that closed
+/// it.
+///
+/// This is the half of the oracle that took the work. Its first run over the
+/// suite raised **344** fires, of which 16 were real: an oracle that cannot tell
+/// "the applier could not derive this" from "the normalizer got this wrong" is
+/// not usable, and every row below is a class — not a case — that was
+/// misclassified until the verdict beside it existed.
+///
+/// The parenthesised counts below are each measured on the run that isolated that
+/// class, after the earlier ones were closed — they overlap and sum well above
+/// 344, so they are not a partition of it. `CLAUDE.md`'s table carries the full
+/// caveat; it is not restated here.
+///
+/// **Which of the seven measured classes are here, and which are not** — the
+/// name says "the measured false-positive classes", so say where each one
+/// actually lives rather than letting the name imply all seven:
+///
+/// | class | covered by |
+/// |---|---|
+/// | untransliterable output (328) | two rows below |
+/// | insertion flush against a deletion (233) | `an_insertion_flush_against_a_deletion_is_not_an_overlap` |
+/// | overlap-conflicting input (~12) | a row below |
+/// | `pter`/`qter` (6) | a row below |
+/// | uncertain `[(…)]` allele (1) | a row below |
+/// | `r.` payload vs a DNA reference (1) | `an_rna_description_over_a_dna_reference_does_not_fire` |
+/// | corrected `REFSEQ_MISMATCH` (5) | **not covered here, and not coverable here** — it is skipped in `Normalizer::assert_denoted_sequence`, which reads the warning list, not in this predicate, so no input to `compare_denoted_sequences` can reach it |
+///
+/// The unifying mistake was reading a *derivation failure* as a *fault*. The two
+/// sides of the comparison do not need the reference equally: a description that
+/// states its own bases converts with no provider, and the canonical form of the
+/// same variant usually does not.
+#[test]
+fn the_measured_false_positive_classes_stay_silent() {
+    // A provider holding no bases at all, which is what most of the suite
+    // normalizes against.
+    let bare = MockProvider::new();
+    let tract = template_provider("TAATATATATAATATATATT");
+
+    let rows: &[(&MockProvider, &str, &str, NotComparable)] = &[
+        // 328 fires. The input states its deleted bases and needs no reference;
+        // the output does not state them and cannot be derived without one.
+        (
+            &bare,
+            "NC_000001.11:g.[1000G>A;1001A>C]",
+            "NC_000001.11:g.1000_1001delinsAC",
+            NotComparable::OutputUntransliterable,
+        ),
+        (
+            &bare,
+            "NC_000007.13:g.21641025delT",
+            "NC_000007.13:g.21641025del",
+            NotComparable::OutputUntransliterable,
+        ),
+        // 6 fires. `pter` carries no numeric coordinate, and `hgvs_to_spdi`
+        // reads the `base` field it leaves at 0.
+        (
+            &tract,
+            "TEMPLATE:g.pter_5del",
+            "TEMPLATE:g.1_5del",
+            NotComparable::UnresolvableSpecialPosition,
+        ),
+        // 1 fire. The members of a predicted allele are uncertain by
+        // construction, so the normalizer does not clamp them and the output may
+        // legitimately still overlap.
+        (
+            &tract,
+            "TEMPLATE:g.[(3_4del;9del)]",
+            "TEMPLATE:g.[(7_9del;9del)]",
+            NotComparable::UncertainAllele,
+        ),
+        // ~12 fires. An insertion *interior* to a deletion: the input itself
+        // denotes nothing, so there is no baseline. This is the
+        // overlap-conflicting allele the repository declines to canonicalize.
+        (
+            &tract,
+            "TEMPLATE:g.[2_4del;2_3insAA]",
+            "TEMPLATE:g.2_4delinsAA",
+            NotComparable::InputDenotesNoSequence,
+        ),
+    ];
+
+    for (provider, input, output, expected) in rows {
+        let input_variant = parse_hgvs(input).expect("parse");
+        let output_variant = parse_hgvs(output).expect("parse");
+        assert_eq!(
+            compare_denoted_sequences(&input_variant, &output_variant, *provider),
+            DenotedSequenceComparison::NotComparable(*expected),
+            "`{input}` -> `{output}` must decline as {expected}",
+        );
+    }
+}
+
+/// A pure insertion flush against the 5' end of a deletion is **not** an
+/// overlap, and the pair denotes one well-defined sequence.
+///
+/// 233 of the first run's fires were this shape, `g.[…;insA;A[5]]`-flavoured, and
+/// they came from `apply_triples`' disjointness guard rather than from anything
+/// the descriptions did. `splice_denoted_sequence` uses `cis_apply_oracle`'s
+/// walk instead: longer deletions first among members at one position, so the
+/// span-claiming member is applied before the zero-length one flush against it.
+///
+/// The companion case — an insertion *interior* to a deletion — is a genuine
+/// overlap and is covered above; keeping both pinned is what stops a fix to
+/// either from quietly becoming a fix to the other.
+/// Two assertions, because they fail for different reasons and only the second
+/// can see the walk order. Against itself the pair only has to *apply at all* —
+/// that is the 233-fire regression, since a disjointness refusal makes both sides
+/// denote nothing and the verdict becomes `InputDenotesNoSequence` rather than
+/// `Agree`. But identical strings cannot distinguish "the members were applied in
+/// the right order" from "both sides made the same mistake": a walk that dropped
+/// the insertion, or applied it after the deletion had consumed base 4, would
+/// still agree with itself. The re-spelling closes that — `g.4_5delinsCC` states
+/// the resulting bases in one member, with no ordering left to get wrong, so it
+/// agrees with the two-member form only if the walk really produced `TAA` + `CC` +
+/// base 6 onwards.
+#[test]
+fn an_insertion_flush_against_a_deletion_is_not_an_overlap() {
+    let provider = template_provider("TAATATATATAATATATATT");
+    // `3_4insCC` sits at the interbase 5' of `4_5del`'s first base.
+    let flush_pair = parse_hgvs("TEMPLATE:g.[3_4insCC;4_5del]").expect("parse");
+    assert_eq!(
+        compare_denoted_sequences(&flush_pair, &flush_pair, &provider),
+        DenotedSequenceComparison::Agree,
+        "the flush pair must apply at all; a disjointness refusal reports it as \
+         denoting no sequence, which is the 233-fire class",
+    );
+
+    // Bases 1-5 are `TAATA`, so deleting `4_5` and inserting `CC` leaves
+    // `TAA` + `CC` + base 6 onwards — the same bases the two-member spelling
+    // denotes, in a single member that fixes no order.
+    let respelled = parse_hgvs("TEMPLATE:g.4_5delinsCC").expect("parse");
+    assert_eq!(
+        compare_denoted_sequences(&flush_pair, &respelled, &provider),
+        DenotedSequenceComparison::Agree,
+        "`g.[3_4insCC;4_5del]` and `g.4_5delinsCC` denote the same bases; a walk \
+         that mis-orders the flush members disagrees with the single-member form",
+    );
+}
+
+/// The seventh measured class: an `r.` description against a DNA reference.
+///
+/// One fire, and the only thing that closes it is the `U`-to-`T` fold in
+/// `canonical_base`. `hgvs_to_spdi` transliterates the `r.` axis to RNA while the
+/// window it is spliced into is served as DNA, so every `r.` comparison rests on
+/// that fold — without it these pairs read as `UGC` against `TGC` and the
+/// comparison declines rather than agreeing.
+///
+/// `SyntheticBuilder::noncoding` is what creates the asymmetry: it stores the
+/// transcript's bases as **DNA** under `NR_TEST.1`, which is what a real prepared
+/// reference does too.
+#[test]
+fn an_rna_description_over_a_dna_reference_does_not_fire() {
+    // Transcript positions 1..20; `r.6_8` is `TGC` in the served DNA, `ugc` on
+    // the RNA axis. Positions 6..12 carry no tract, so neither spelling shifts.
+    let provider = SyntheticBuilder::noncoding("ACGTGTGCAAGTACGTTTTT", Strand::Plus).build();
+    let rows: &[(&str, &str)] = &[
+        // The pair `canonical_base`'s doc comment names: a stated RNA payload
+        // against the same duplication read off the DNA reference.
+        ("NR_TEST.1:r.6_8dupugc", "NR_TEST.1:r.6_8dup"),
+        // And the same question with no stated payload at all, so the fold is
+        // reached through the deleted-bases check rather than the final compare.
+        ("NR_TEST.1:r.6_8delugc", "NR_TEST.1:r.6_8del"),
+    ];
+    for (input, output) in rows {
+        let input_variant = parse_hgvs(input).expect("parse");
+        let output_variant = parse_hgvs(output).expect("parse");
+        assert_eq!(
+            compare_denoted_sequences(&input_variant, &output_variant, &provider),
+            DenotedSequenceComparison::Agree,
+            "`{input}` and `{output}` denote the same bases in two alphabets; the oracle \
+             must stay silent",
+        );
+    }
+}
+
+/// The seam is wired, and a run with the flag on really compares something.
+///
+/// Everything else in this file exercises `compare_denoted_sequences` directly,
+/// so **deleting the `assert_denoted_sequence` call from
+/// `Normalizer::assert_seam_oracles` would leave this whole suite green** — and
+/// `sweeps`, the flag's only gating home, green with zero comparisons made. That
+/// is the failure mode the counters exist for; this is the assertion that reads
+/// them, rather than leaving it to a human to remember to.
+///
+/// `compared` is monotonic and this test contributes to it itself, so a `> 0`
+/// assertion is safe under `cargo test`'s shared process as well as under
+/// nextest's process-per-test — no ordering between tests is assumed.
+///
+/// Gated on the flag because the oracle is: with `FERRO_ASSERT_SEQUENCE` unset,
+/// `assert_denoted_sequence` returns before touching either counter, so there is
+/// nothing to assert. The skip says so out loud rather than passing quietly.
+#[cfg(debug_assertions)]
+#[test]
+fn the_seam_compares_when_the_flag_is_set() {
+    let enabled = std::env::var("FERRO_ASSERT_SEQUENCE")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    if !enabled {
+        eprintln!(
+            "skipping: FERRO_ASSERT_SEQUENCE is unset, so the seam oracle is off and its \
+             counters stay at zero by design. CI's `sweeps` job sets it."
+        );
+        return;
+    }
+
+    let provider = template_provider("TAATATATATAATATATATT");
+    let variant = parse_hgvs("TEMPLATE:g.3_4del").expect("parse");
+    Normalizer::new(provider)
+        .normalize(&variant)
+        .expect("normalize");
+
+    let (compared, skipped) = ferro_hgvs::normalize::denoted_sequence_oracle_counts();
+    assert!(
+        compared > 0,
+        "FERRO_ASSERT_SEQUENCE is set and a normalization just ran, but the denoted-sequence \
+         oracle reports {compared} comparisons ({skipped} skipped). Either the call to \
+         `assert_denoted_sequence` is no longer on `assert_seam_oracles`' path, or every \
+         normalization is declining — both make a green run meaningless."
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -249,6 +249,7 @@ mod issue_1578_followup_equivalence_rungs;
 mod issue_1578_followup_ring_declines;
 mod issue_1578_followup_self_cancelling_rings;
 mod issue_1578_ring_validator_escapes;
+mod issue_1615_denoted_sequence_oracle;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1615.


## What this adds

A fourth seam oracle at `normalize_core_checked`'s exit, `FERRO_ASSERT_SEQUENCE=1`: apply the input description to the reference, apply the output, assert the bases agree.

The three already there are all *form* questions — is it a fixed point, does it parse, are its coordinates in range — and a description denoting entirely different bases satisfies every one of them at once.

The applier is `spdi::compare_denoted_sequences`, new in the first commit. It reaches the bases through `hgvs_to_spdi` and an SPDI splice with no normalization in the path, so it cannot agree with an output merely because normalization produced it. (`EquivalenceChecker` normalizes both sides and is documented as circular at `tests/it/issue_1234_sibling_clamped_shift.rs:198`.) Both descriptions are applied over the **union** of their spans, one fetch, which is what makes a 3'-shift compare as the identity it is rather than as a difference of frames.

## The catch table

Every defect #1615 names, against the wrong output its own issue records. `tests/it/issue_1615_denoted_sequence_oracle.rs` pins all eight.

| issue | verdict | input applies | output applies |
|---|---|---|---|
| #1254 | changed sequence | `ATATTAATA` | `ATATATATA` |
| #1281 | **output denotes nothing** | — | `g.[1del;1del]`, two members claiming base 1 |
| #1290 | changed sequence | `AAACA` | `AACAA` |
| #1304 | changed sequence | `GAGAAAA` | `GAAGAAA` |
| #1308 | changed sequence | `TGTTGG` | `TTGGTG` |
| #1312 | changed sequence | `ACAAC` | `AACCA` |
| #1592 | changed sequence | `AGATAA` | `AGAAAT` |
| #1600 | changed sequence | `GCAGAAAC` | `GCAGACAA` |

**8 of 8, no misses.** Each pair of applied strings reproduces its own issue's hand-written "intended vs emitted" line exactly, which is the cross-check that the oracle is reading the same defect the reporter saw.

The test deliberately does **not** re-normalize. A test that ran the normalizer would go green as each defect is fixed and stop saying anything about the oracle; pinning the recorded strings keeps it a guard on the oracle rather than on the six fixes.

## Skip vs fail — the design decision, and why it was not free

A skip that reads as a pass is the exact failure mode a sequence oracle exists to remove, so:

- **fires** when both sides apply and the bases differ;
- **fires** when the output is *self-contradictory* while the input denotes a sequence — #1281's shape, which is worse than a wrong sequence, not milder;
- **skips, counted**, otherwise. `normalize::denoted_sequence_oracle_counts()` returns `(compared, skipped)` process-wide, because zero comparisons and zero faults look identical from outside.

The load-bearing part is that the second bullet is narrower than "the output produced no triples". Reading any underivable output as a fault is the obvious implementation and it is wrong, because **the two sides of the comparison do not need the reference equally**: `g.1000delC` states its own deleted base and converts with no provider, while the `g.1000del` normalization emits for it must read one.

Measured over the full suite, first run to last:

| round | fires | class closed |
|---|---|---|
| 1 | 344 | — |
| 2 | 246 | 328 × untranslatable output → counted skip |
| 3 | 21 | 233 × insertion flush against a deletion (`triples_are_disjoint` calls it an overlap; `cis_apply_oracle`'s tie-break does not, and its verdict there is input-order dependent); 6 × `pter`/`qter`; 5 × corrected `REFSEQ_MISMATCH`; 1 × `r.` `U` against DNA `T` |
| 4–5 | **6** | ~12 × insertion *interior* to a deletion (a genuine overlap — the input denotes nothing, so there is no baseline); 1 × predicted `[(…)]` allele |

Every one of those is pinned as a *class* in `the_measured_false_positive_classes_stay_silent`, not patched as a case.

## Negative control

`FERRO_SWEEP_SEEDS=full cargo nextest run --features dev`, with the flag on: **6 fires in 2 rows**, and both are real disagreements inside ferro rather than noise — filed as **#1618** and **#1619**:

- **#1618** — `g.262TG[6]` → `g.259_262GT[6]`. `hgvs_to_spdi` reads the anchored spelling as 6 copies replacing a 1-copy tract, the normalizer's output as 6 copies replacing a 2-copy tract: 14 bases against 12. An unmade decision about what a single-anchor copy count is counted against, made twice, differently.
- **#1619** — `NM_000492.4:c.1520_1522del` → `c.1521_1523del`. The normalization is *correct* on the flat transcript (both spell `TATCATTGGT`); `hgvs_to_spdi` resolves the `c.` position by walking `normalization_transcripts.json`'s 27 exons with their 1-base synthetic introns and lands 10 bases 3'. A false positive **for this oracle**, and a real applier bug.

With the flag off, the suite is **9,853/9,853 green**.

## Where it runs, and the one place it deliberately does not

`sweeps` (gating — the cis-allele space all eight defects came from, and measured green there over the full corpus) and the nightly (non-gating, per that job's existing contract).

`sweeps` selects `$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`. The appended term is not cosmetic: `sweeps` is the only job that sets `FERRO_ASSERT_SEQUENCE`, and it selected on `SWEEP_FILTER` alone, which names three sweep modules and not this PR's own test module — so `the_seam_compares_when_the_flag_is_set`, the guard that a green run really compared something, would have run only in jobs where the flag is unset and it skips by design. **That is a behaviour change for CI**: ten unit tests now also run in `sweeps`, armed, and the wiring guard is live there. It is appended to that job's `-E` rather than added to `SWEEP_FILTER` because `SWEEP_FILTER` is negated by `test` and `test-oracle` (naming it there would *remove* the module from both rather than add it anywhere), and because `sweep_filter_invariant.rs` fails on a module in that filter which does not draw through `sweep_seeds(`. The module is therefore run twice on purpose — unarmed in `test`, armed in `sweeps` — which is the one deliberate exception to that filter's partition claim, recorded in its comment. Locally, the exact composed selection with all four flags set is 53/53 green.

**Not** `test-oracle`, whose selection contains exactly the two rows above. This is the one job where the set of four is now incomplete, and the comment there says so and names both issues. Suppressing them would hollow out the oracle; enabling the flag before they are settled would redden the job for a reason no PR caused. Move it once both are closed.

## Reviewing

`src/spdi/apply.rs` first (the primitive and, more to the point, what it declines to answer), then `src/normalize/mod.rs` (the seam), then the test file. The two CI hunks and `CLAUDE.md` are the same argument written for a reader who hits a fire later.

## Not done

- The oracle's *seam wiring* is only exercised when the flag is set. `the_seam_compares_when_the_flag_is_set` now closes the half that matters — with `FERRO_ASSERT_SEQUENCE` on it normalizes, then asserts `denoted_sequence_oracle_counts().0 > 0`, so removing the `assert_denoted_sequence` call from `assert_seam_oracles` reddens `sweeps` instead of leaving it green with zero comparisons. Unarmed it skips and says so. The `cargo test` race the earlier revision of this section worried about does not arise: the assertion is `> 0` on a monotonic counter the test increments itself, so it assumes no ordering between tests.
- The re-entrant pass is no longer compared. `assert_denoted_sequence` now honours `IN_IDEMPOTENCY_CHECK`, like `assert_idempotent` does: the idempotency oracle's verification pass re-enters `normalize_core_checked`, so with both flags set the seam was comparing `(normalized, again)` — a question the outer call already answers between its own comparison and the idempotency assertion. Measured on one normalization with `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_SEQUENCE=1`: `compared` was **2**, is now **1**, `skipped` **0** either way. It halves the provider fetches in `sweeps` (which sets both), keeps the counters a count of normalizations a caller asked for, and stops a non-idempotent output being reported as a sequence fault by the inner call before `assert_idempotent` can name it as the non-idempotency it is. The return is before either counter, like the flag-off path, so nothing moves into `skipped`.
- The corrected-`REFSEQ_MISMATCH` false-positive class is still untested. It is skipped in `Normalizer::assert_denoted_sequence` from the warning list rather than inside `compare_denoted_sequences`, so no input to the predicate can reach it; `the_measured_false_positive_classes_stay_silent` now says which of the seven measured classes it covers and which it cannot.

Representation-Change: none. Every one of the four asserts is `#[cfg(debug_assertions)]` and env-gated, so nothing runs unless `FERRO_ASSERT_SEQUENCE` is set; the only unconditional edit is a mechanical `Option` → `Result` refactor of `variant_edit_triples`, whose `.ok()` wrapper preserves its old signature and semantics exactly. Verified by the suite rather than asserted: 9,853 tests pass with **nothing re-blessed** — no fixture, ledger, census or snapshot in this diff.

