### PR TITLE
test(conformance): pin what the output denotes, not only how it is spelled

### DIFF
--- a/tests/it/coding_frame_merge_axis_asymmetry.rs
+++ b/tests/it/coding_frame_merge_axis_asymmetry.rs
@@ -133,11 +133,50 @@
 //! defect than a confluence failure — both spellings of the variant do reach one
 //! answer on every axis. Fact 1 below is what stops that regressing.
 //!
+//! # Every pinned output is also checked against the bases it denotes
+//!
+//! The strings above are change detectors, and a string equality cannot tell a
+//! **re-spelling** from a **corruption**: an output describing different bases
+//! that happened to render as the pinned string would satisfy it. That is not a
+//! hypothetical class here — it is what #1615 exists for, and #1592 and #1600
+//! are live instances on `main` where a well-formed, in-bounds, idempotent,
+//! re-parseable output denotes different bases.
+//!
+//! It bites hardest on this table because the outputs are `dup`s and `ins`s. A
+//! `dup` names no bases in its rendering, so a composition that duplicated the
+//! *wrong* base still prints the identical string.
+//!
+//! So each of the 42 comparisons — 14 rows x 3 axes — now also asserts that the
+//! output and the input denote the same sequence, through `cis_apply_oracle` —
+//! `hgvs_to_spdi` plus an SPDI splice, with no normalization in the path, so it
+//! cannot agree with an output merely because normalization produced it (#1626).
+//! All 42 pass.
+//!
+//! **28 of the 42 can fail; the `c.` 14 cannot, and saying which is which is the
+//! point.** The `n.` and `g.` answers are genuine re-spellings — a lone `delins`
+//! in, an insertion pair out — so a corrupted composition moves the applied
+//! sequence and the comparison catches it. The `c.` answer is the lone input
+//! *unchanged* (that non-split is the finding; [`ROWS`] records that the `c.`
+//! output is `c.{position}delinsATC` at every one of the fourteen, which is
+//! exactly the string [`spellings`] feeds in), so there `actual == input` and the
+//! comparison is an identity. That leaves the `c.` column pinned but not freshly:
+//! `CDS_START == 1`, so `c.p` and `n.p` are one position and the two axes' inputs
+//! denote the same bases of [`CORE`] — the `n.` row's assertion therefore already
+//! fixes what the `c.` answer denotes, transitively. What carries the `c.` row on
+//! its own is the string equality.
+//!
+//! Note what this does **not** buy. It cannot say the `c.` merge is the right
+//! form — the whole point of the assert-then-flip note above is that nothing has
+//! ruled on that — only that today's answer and tomorrow's flipped one are
+//! answers about the same bases.
+//!
 //! Fully hermetic: a `MockProvider`, no `FERRO_MANIFEST`, no fixtures.
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::reference::MockProvider;
 use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
+
+use crate::common::cis_apply_oracle::apply_reason;
 
 /// Padding on each side of the core on the genomic contig, so that transcript
 /// position `p` is genomic position `PAD_OFFSET + p`.
@@ -264,6 +303,61 @@ fn normalize(provider: MockProvider, input: &str) -> String {
         .to_string()
 }
 
+/// The sequence `description` denotes, reached **without** the normalizer
+/// (#1626).
+///
+/// `cis_apply_oracle` converts each member through `hgvs_to_spdi` and splices
+/// the reference, so nothing in this path can agree with an output merely
+/// because normalization produced it. Reusing it rather than hand-rolling a
+/// second applier is the point: a per-file copy is a per-file way to drift.
+///
+/// It panics rather than returning an `Option`. Every description this file
+/// feeds it is a lone `delins` or a two-member insertion pair on a synthetic
+/// reference, so a decline is a defect and not a limit of the oracle — and a
+/// comparison that silently skips is the failure mode this check exists to
+/// remove.
+fn denotes(provider: &MockProvider, reference: &str, description: &str) -> String {
+    apply_reason(provider, reference, description)
+        .unwrap_or_else(|why| panic!("{description} denotes no single sequence: {why:?}"))
+}
+
+/// Assert that `input` normalizes to `expected` on `provider` **and** that the
+/// two denote the same bases of `reference`.
+///
+/// The second half is what is new (#1626). On `n.` and `g.` the answer is a
+/// **re-spelling** — a one-base span with a three-base payload comes back as an
+/// insertion pair — and a string equality cannot tell a re-spelling from a
+/// corruption. It is especially blind on those outputs, since a `dup` names no
+/// bases in its rendering: a composition that duplicated the *wrong* base still
+/// prints the identical string.
+///
+/// On `c.` the answer is the lone input *unchanged*, so `actual == input` and the
+/// second assertion is an identity there — it cannot fail. It is applied
+/// uniformly rather than special-cased: the row is carried by the string
+/// equality, and what the `c.` answer denotes is fixed transitively by the `n.`
+/// row, whose input denotes the same bases (`CDS_START == 1`). See the module
+/// docs.
+///
+/// Nor does the sibling [`every_axis_is_self_confluent_across_both_spellings`]
+/// close it. Agreement between two spellings cannot distinguish "both correct"
+/// from "both wrong" — the argument `cis_allele_confluence_proptest.rs` makes
+/// about itself.
+fn assert_normalizes_preserving(
+    provider: &MockProvider,
+    reference: &str,
+    input: &str,
+    expected: &str,
+    context: &str,
+) {
+    let actual = normalize(provider.clone(), input);
+    assert_eq!(actual, expected, "{context}");
+    assert_eq!(
+        denotes(provider, reference, &actual),
+        denotes(provider, reference, input),
+        "{input} -> {actual} is not a re-spelling: it denotes different bases"
+    );
+}
+
 /// The two spellings of "replace the `T` at `position` with `ATC`", on one axis.
 fn spellings(accession: &str, axis: char, position: u64) -> (String, String) {
     (
@@ -348,36 +442,40 @@ fn the_coding_axis_merges_what_the_other_axes_split() {
     for &(p, same_codon, noncoding, genomic) in ROWS {
         // `n.` and `g.` — the same two-member answer, 256 apart.
         let (n_lone, _) = spellings(NONCODING_TX, 'n', p);
-        assert_eq!(
-            normalize(transcript_provider(NONCODING_TX, None), &n_lone),
+        assert_normalizes_preserving(
+            &transcript_provider(NONCODING_TX, None),
+            CORE,
+            &n_lone,
             noncoding,
-            "n. axis at {p}"
+            &format!("n. axis at {p}"),
         );
         let (g_lone, _) = spellings(GENOMIC_CONTIG, 'g', p + PAD_OFFSET as u64);
-        assert_eq!(
-            normalize(genomic_provider(), &g_lone),
+        assert_normalizes_preserving(
+            &genomic_provider(),
+            &padded(),
+            &g_lone,
             genomic,
-            "g. axis at {p}"
+            &format!("g. axis at {p}"),
         );
 
         // `c.` — the lone `delins`, at every position, in and out of frame.
         let (c_lone, _) = spellings(CODING_TX, 'c', p);
         let coding_n_parity = noncoding.replace("NR_TEST.1:n.", "NM_TEST.1:c.");
-        assert_eq!(
-            normalize(
-                transcript_provider(CODING_TX, Some((CDS_START, CDS_END))),
-                &c_lone
-            ),
-            format!("NM_TEST.1:c.{p}delinsATC"),
-            "c. axis at {p} (same_codon={}): `coalesce_coding_frame_separation` re-merges the \
+        assert_normalizes_preserving(
+            &transcript_provider(CODING_TX, Some((CDS_START, CDS_END))),
+            CORE,
+            &c_lone,
+            &format!("NM_TEST.1:c.{p}delinsATC"),
+            &format!(
+            "c. axis at {p} (same_codon={same_codon}): `coalesce_coding_frame_separation` re-merges the \
              two pieces because `axis_frame` gives `CisKind::Cds` a reading frame, without \
              checking `general.md:35`'s \"together affecting one amino acid\" precondition — \
              which a net +2 frameshift cannot meet. The `n.`-parity form is {coding_n_parity}. \
              If this assertion just failed with that string, the pass has stopped firing on this \
              shape: that is the candidate flip in this file's docs, so check that the house-style \
              question it names has actually been settled, then flip the expectation and declare \
-             the representation change",
-            same_codon
+             the representation change"
+            ),
         );
 
         // Stated explicitly so the flip cannot be mistaken for a no-op.

--- a/tests/it/delins_equal_vs_unequal_length_hermetic.rs
+++ b/tests/it/delins_equal_vs_unequal_length_hermetic.rs
@@ -119,11 +119,31 @@
 //! The flip is an output-moving change and owes the release a
 //! `Representation-Change:` trailer.
 //!
+//! # Both arms are also checked against the bases they denote
+//!
+//! Each arm now asserts that the pinned output and its input denote the same
+//! contig sequence, through `cis_apply_oracle` — `hgvs_to_spdi` plus an SPDI
+//! splice, with no normalization in the path, so it cannot agree with an output
+//! merely because normalization produced it (#1626).
+//!
+//! Without it a string equality cannot tell a **re-spelling** from a
+//! **corruption**: an output describing different bases that happened to render
+//! as the pinned string would satisfy it. Both arms pass, so both of today's
+//! answers are genuine re-spellings.
+//!
+//! It matters most on the unequal arm precisely *because* that expectation is
+//! assert-then-flip. A pin whose purpose is to record an answer we mean to
+//! change should at least be able to say that today's wrong answer is wrong
+//! about the **partition** and not about the bases — which is the difference
+//! between a representation change and a defect.
+//!
 //! Fully hermetic: a `JsonProvider` (the type the sibling hermetic tests still
 //! name by its `MockProvider` alias), no `FERRO_MANIFEST`, no fixtures, no LFS.
 
 use ferro_hgvs::reference::JsonProvider;
 use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
+
+use crate::common::cis_apply_oracle::apply_reason;
 
 /// Padding on each side of [`CORE`], so the measured span sits far from either
 /// contig end and no boundary clamp is in play.
@@ -196,6 +216,49 @@ fn normalize(input: &str) -> String {
         .normalize(&parsed)
         .unwrap_or_else(|e| panic!("normalize {input}: {e}"))
         .to_string()
+}
+
+/// The contig sequence `description` denotes, reached **without** the
+/// normalizer (#1626).
+///
+/// `cis_apply_oracle` converts each member through `hgvs_to_spdi` and splices
+/// the reference, so nothing in this path can agree with an output merely
+/// because normalization produced it. A hand-rolled applier here would be a
+/// second thing to drift; this is the one the cis sweeps already rest on.
+///
+/// It panics rather than returning an `Option`. Every description this module
+/// feeds it is a two-member allele on disjoint columns of a synthetic contig,
+/// so a decline is a defect in the description and not a limit of the oracle —
+/// and a silently skipped comparison is the failure mode the whole check exists
+/// to remove.
+fn denotes(description: &str) -> String {
+    apply_reason(&provider(), &padded_contig(), description)
+        .unwrap_or_else(|why| panic!("{description} denotes no single sequence: {why:?}"))
+}
+
+/// Assert that `input` normalizes to `expected` **and** that the two denote the
+/// same contig sequence.
+///
+/// The second half is the one that is new. Both arms below are re-spellings —
+/// the pinned output is never the input — and a string equality cannot tell a
+/// re-spelling from a corruption: an output describing different bases that
+/// happened to render as the pinned string would satisfy it. That is not a
+/// hypothetical class in this repository; it is what #1615 exists for, and
+/// #1592 and #1600 are live instances where a well-formed, in-bounds,
+/// idempotent, re-parseable output denotes different bases.
+///
+/// It matters most on the unequal arm precisely *because* that expectation is
+/// assert-then-flip. A pin whose purpose is to record an answer we mean to
+/// change should at least be able to say that today's wrong answer is wrong
+/// about the partition and not about the bases.
+fn assert_normalizes_preserving(input: &str, expected: &str, whichever: &str) {
+    let actual = normalize(input);
+    assert_eq!(actual, expected, "{whichever}");
+    assert_eq!(
+        denotes(&actual),
+        denotes(input),
+        "{input} -> {actual} is not a re-spelling: it denotes different bases"
+    );
 }
 
 /// The payload of a `<accession>:g.<start>_<end>delins<payload>` input.
@@ -319,23 +382,27 @@ fn equal_and_unequal_length_delins_get_opposite_verdicts_hermetically() {
     // this shape meets: the equal-length span denotes an unchanged interior
     // column, and `delins.md:18`'s codon exception cannot reach a `g.`
     // description.
-    assert_eq!(
-        normalize(EQUAL_INPUT),
+    assert_normalizes_preserving(
+        EQUAL_INPUT,
         EQUAL_EXPECTED,
-        "equal-length {EQUAL_INPUT} is described individually, which is what `delins.md:17` \
-         recommends and the only clause of the three that reaches this shape"
+        &format!(
+            "equal-length {EQUAL_INPUT} is described individually, which is what \
+             `delins.md:17` recommends and the only clause of the three that reaches this shape"
+        ),
     );
 
     // UNEQUAL — WRONG, pinned deliberately. See "Assert-then-flip" above.
-    assert_eq!(
-        normalize(UNEQUAL_INPUT),
+    assert_normalizes_preserving(
+        UNEQUAL_INPUT,
         UNEQUAL_EXPECTED,
-        "unequal-length {UNEQUAL_INPUT} is currently split on a payload/reference coincidence at \
-         265, which is the alignment-driven split `delins.md:46` constructs and `delins.md:47` \
-         advises against. The decided ruling `delins-merge-vs-individual-gap-two-or-more` says \
-         the spanning form wins, i.e. {UNEQUAL_RULING_CONFORMANT}. If this assertion just failed \
-         with that string, the defect is FIXED — flip the expectation and declare the \
-         representation change"
+        &format!(
+            "unequal-length {UNEQUAL_INPUT} is currently split on a payload/reference \
+             coincidence at 265, which is the alignment-driven split `delins.md:46` constructs \
+             and `delins.md:47` advises against. The decided ruling \
+             `delins-merge-vs-individual-gap-two-or-more` says the spanning form wins, i.e. \
+             {UNEQUAL_RULING_CONFORMANT}. If this assertion just failed with that string, the \
+             defect is FIXED — flip the expectation and declare the representation change"
+        ),
     );
 
     // Guard the flip against being confused with a different move: state


### PR DESCRIPTION
Closes #1626.

Representation-Change: none. Tests only — `tests/it/` is the whole diff, no watched directory is touched. Verified rather than assumed: the diff changes no pinned string (the only edit to one is a borrow, `format!(…)` to `&format!(…)`), and 9,856 tests pass with **nothing re-blessed**.

## The gap

Two tests pinned a normalized output **string** and asserted nothing about the sequence that string denotes. Neither file mentioned `hgvs_to_spdi`, `apply_to_reference`, `cis_apply_oracle` or `canonical_spdi`.

| test | rows |
|---|---|
| `coding_frame_merge_axis_asymmetry::the_coding_axis_merges_what_the_other_axes_split` | 14 positions x 3 axes |
| `delins_equal_vs_unequal_length_hermetic::equal_and_unequal_length_delins_get_opposite_verdicts_hermetically` | 2 arms |

A string equality cannot tell a **re-spelling** from a **corruption**. An output describing different bases that happened to render as the pinned string satisfies it — and so does the more realistic version, where the normalizer starts corrupting, the string moves, and someone re-blesses the pin without noticing the bases moved too. That is the class #1615 exists for, and #1592 and #1600 are live instances on `main` today where a well-formed, in-bounds, idempotent, re-parseable output denotes different bases.

Both files are honest about being change detectors; `ROWS` says so in as many words. That is not what is being fixed. What is being fixed is that a change detector which cannot see a corruption is detecting less than it appears to.

**30 of the 44 comparisons are re-spellings** — the pinned output differs from the input on the `n.` and `g.` columns and on both delins arms, which is what makes this load-bearing rather than theoretical:

- The axis-asymmetry table's outputs are `dup`s and `ins`s. **A `dup` names no bases in its rendering**, so a composition that duplicated the wrong base prints the identical string.
- The unequal-length `delins` arm is **assert-then-flip**: it deliberately records an answer the project believes wrong and intends to change. A pin whose purpose is to be flipped should be able to say that today's wrong answer is wrong about the *partition* and not about the *bases* — which is the difference between a representation change and a defect.

Neither is closed by what was already there. `every_axis_is_self_confluent_across_both_spellings` asserts the two spellings **agree**, and agreement cannot distinguish "both correct" from "both wrong" — the argument `cis_allele_confluence_proptest.rs` makes about itself. The delins file's existing assertions (fixture bases, minimality, payload arithmetic) are all **input**-side.

## The fix

Each string assertion is now paired with: applying the input and applying the pinned output produce the same sequence.

The applier is `tests/it/common/cis_apply_oracle.rs`'s `apply_reason`, not a third hand-rolled copy. It reaches the bases through `hgvs_to_spdi` and an SPDI splice with **no normalization in the path**, so it cannot agree with an output merely because normalization produced it. It panics on a decline rather than returning `Option`: every description here is a lone `delins` or a two-member pair on disjoint columns of a synthetic reference, so a decline is a defect, and a silently skipped comparison is the exact failure mode this check exists to remove.

**All 44 comparisons pass, and 30 of them can fail.** The other 14 are the `c.` column, where the pinned output is byte-identical to the input — that non-split is the finding this file records — so `denotes(actual) == denotes(input)` is an identity there and cannot catch a corruption. Those 14 stay pinned *transitively*: `CDS_START == 1`, so the `n.` row's assertion fixes the same bases. The module doc of `tests/it/coding_frame_merge_axis_asymmetry.rs` says exactly this; the four demonstrated mutants below are all `n.`/delins, never `c.`, which is consistent with it.

One detail worth recording: the transcript axes apply against the **transcript sequence** and the genomic axis against the **padded contig**. Passing the padded contig for an `n.` row is rejected as `StatedBasesMismatch` rather than silently compared, which is itself evidence the oracle is reading the reference rather than rubber-stamping.

## Both new assertions were shown to bite

The mutant is the realistic failure, not an artificial one: corrupt the normalizer's output *and* re-bless the pin to match, so the string assertion passes and only the denotation assertion can object.

**`delins_equal_vs_unequal_length_hermetic`** — pin re-blessed to `g.[264del;266G>A]` and the normalizer stubbed to return it:

```
FAIL  equal_and_unequal_length_delins_get_opposite_verdicts_hermetically
```

**`coding_frame_merge_axis_asymmetry`** — the `p=9` `n.` row re-blessed to `n.[8dup;9_10insG]` and the normalizer stubbed to return it:

```
assertion `left == right` failed:
  NR_TEST.1:n.9delinsATC -> NR_TEST.1:n.[8dup;9_10insG] is not a re-spelling: it denotes different bases
  left:  ACGTACGAATGGCAAG…
  right: ACGTACGAATCGCAAG…
```

Both restored from a file copy afterwards, and the suite is green.

## Not in scope

`cis_confluence_adjudication::a_dup_flush_against_a_del_is_left_alone` has the same gap, and it is the more surprising instance: that file defines its own apply oracle and its module docs claim every case is checked through it — but the check is applied to the **inputs** only ("these spellings are one variant"), never to the normalized output. Three tests there re-spell with the output's denotation unasserted. Noted on #1626 for a follow-up rather than folded in here.

