### PR TITLE
fix(normalize): make a partitioner decline observable, and stop the bake-off switch aborting a shipping process

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ This works on a **stock release build** — the switch is not behind a build fea
 
 ### Two traps worth knowing
 
-**A misspelled value is refused, loudly.** `FERRO_PARTITION=canonicl` aborts at the first variant ferro normalizes, naming the value you gave and the arms this build has:
+**A misspelled value is refused, loudly.** `FERRO_PARTITION=canonicl` makes `ferro` exit with an error before it reads any input, naming the value you gave and the arms this build has:
 
 ```
 FERRO_PARTITION="canonicl" is not a partitioner this build has. This build's arms
@@ -377,6 +377,8 @@ name reports that the candidate changes nothing.
 ```
 
 Naming *this build's* arms is the point: a value that exists on some other branch, or that used to exist, is reported as absent here rather than quietly answered as `live`.
+
+The refusal comes from the CLI, not from the normalizer. Up to and including v0.14.0 it was a panic raised deep inside normalization, which meant a development-only switch could abort any process — a long-running service, or a Python caller, across the FFI boundary — that merely happened to have the variable set. A release build of the *library* now falls safe to `live` for a value that names no arm and keeps the refusal for its caller to report. Every binary in this repository reports it — `ferro`, `ferro-web`, `ferro-benchmark`, both spec generators, and the `dump_normalized_corpus` bake-off harness — and that is pinned by a test rather than by this sentence, so a binary added later cannot quietly skip it. If you embed ferro as a library and run bake-offs through it, read `ferro_hgvs::normalize::partition_switch_startup_error()` at startup and do the same.
 
 Builds up to and including v0.13.1 fell back to `live` instead, and produced a clean, empty diff that read as "the candidate changes nothing". The fallback emitted a warning through the `log` facade, but the `ferro` CLI installs no logger, so that warning reached no stream and `RUST_LOG` could not surface it — there was no signal at all. If you are on an older build, treat every empty diff as unproven.
 

--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -288,6 +288,16 @@ fn verify_row(row: &Row) -> (SpdiVerdict, String, String) {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    // This is the harness a bake-off runs through, so it is the entry point that
+    // can least afford to serve `live` under a candidate's name. In a release
+    // build the library falls safe rather than aborting, and the two silences
+    // compound: the dump would come back identical to the `live` dump, and
+    // `report_partition_declines` would print nothing at all, because a `live`
+    // run attempts no sequence-first partition. Refuse here instead.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        eprintln!("error: {message}");
+        return ExitCode::FAILURE;
+    }
     if let (Some(before), Some(after)) = (&cli.compare, &cli.against) {
         return match compare(before, after) {
             Ok(report) => {

--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -302,6 +302,7 @@ fn main() -> ExitCode {
     }
 
     let rows = dump(cli.seeds);
+    report_partition_declines();
     let mut out = String::new();
     out.push_str(HEADER);
     for row in &rows {
@@ -363,6 +364,38 @@ fn main() -> ExitCode {
         None => print!("{out}"),
     }
     ExitCode::SUCCESS
+}
+
+/// Say, on stderr, how much of this dump a sequence-first arm actually answered.
+///
+/// A `FERRO_PARTITION=canonical` dump that comes back identical to the `live`
+/// dump reads as *"the candidate changes nothing"*. It can equally mean the
+/// candidate declined every block and `partition_block` produced both columns,
+/// and no output distinguishes those — which is what makes the line below part
+/// of the measurement rather than decoration.
+///
+/// Printed **unconditionally when the arm ran at all**, including the zero:
+/// `0 declined of N` is the reading that licenses quoting the diff, and it is
+/// only worth anything if the same line would have shown a non-zero.
+fn report_partition_declines() {
+    let counts = ferro_hgvs::normalize::partition_decline_counts();
+    if counts.attempted == 0 {
+        // The selected arm was `live`, which has no decline path, so there is no
+        // census to report and a "0 of 0" line would read as a clean bill of
+        // health for an arm that did not run.
+        //
+        // "Selected" is the load-bearing word: the separate
+        // `FERRO_SEQFIRST_SHADOW` audit asks a sequence-first partitioner on
+        // every block whatever `FERRO_PARTITION` says, and those attempts are
+        // deliberately outside this census — they cannot reach the emitted
+        // pieces, and the audit reports its own outcomes through `log::debug!`.
+        return;
+    }
+    eprintln!(
+        "partitioner: {} of {} blocks declined and were served by `partition_block` \
+         (the shipped rule) instead",
+        counts.declined, counts.attempted
+    );
 }
 
 /// One measured row. `was_fixed_point` records whether the *input* was already its

--- a/examples/generate_spec_enumeration.rs
+++ b/examples/generate_spec_enumeration.rs
@@ -96,6 +96,14 @@ struct Cli {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    // This enumeration replays recorded normalization behaviour, so a
+    // `FERRO_PARTITION` value naming no arm would record the shipped rule under
+    // a candidate's name. The library falls safe to `live` in a release build
+    // rather than aborting, and leaves the refusal to its entry point.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        eprintln!("error: {message}");
+        return ExitCode::FAILURE;
+    }
     match run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -57,6 +57,14 @@ struct Cli {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    // Every row in this fixture is a `Normalizer` output, so a `FERRO_PARTITION`
+    // value naming no arm would record the shipped rule under a candidate's
+    // name. The library falls safe to `live` in a release build rather than
+    // aborting, and leaves the refusal to its entry point.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        eprintln!("error: {message}");
+        return ExitCode::FAILURE;
+    }
     match run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -50,6 +50,15 @@ use ferro_hgvs::benchmark::{check_hgvs_rs_available, check_seqrepo_path, HgvsRsC
 fn main() {
     let cli = Cli::parse();
 
+    // This binary normalizes with ferro to compare it against other tools, so a
+    // `FERRO_PARTITION` value naming no arm would have it measure the shipped
+    // rule under a candidate's name. The library falls safe to `live` in a
+    // release build rather than aborting, and leaves the refusal here.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        eprintln!("Error: {message}");
+        std::process::exit(1);
+    }
+
     let result = match cli.command {
         // =========================================================================
         // GROUPED SUBCOMMAND HANDLERS (Phase 2)

--- a/src/bin/ferro-web.rs
+++ b/src/bin/ferro-web.rs
@@ -77,6 +77,17 @@ enum Commands {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
+    // `FERRO_PARTITION` naming an arm this build has not got is refused here,
+    // before a listener exists. The library cannot refuse it from
+    // `canonicalize_from_sequence` -- it is infallible -- and in a release build
+    // it falls safe to the shipped rule rather than aborting, so a service that
+    // never asked would serve `live` under a candidate's name. This service is
+    // also the reason the library stopped panicking: the panic fired inside a
+    // request handler, which takes the worker down.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        return Err(message.into());
+    }
+
     match cli.command {
         Commands::Serve {
             config,

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -235,12 +235,19 @@ UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
                canonical, plus the delins.md:44-47 merge -- a split whose
                payload realigns as one block becomes a single delins
 
-  An unrecognised value is REFUSED: the process aborts at the first variant it
-  normalizes, naming the value you gave and the arms this build has. It does not
-  fall back to `live`. It used to, which made a misspelling look exactly like
-  'the candidate changes nothing' -- and the warning that fallback logged went
-  through the `log` facade, which this CLI installs no logger for, so it reached
-  no stream and RUST_LOG could not surface it.
+  An unrecognised value is REFUSED: this command exits with an error BEFORE it
+  reads any input, naming the value you gave and the arms this build has. It
+  does not fall back to `live`. It used to, which made a misspelling look
+  exactly like 'the candidate changes nothing' -- and the warning that fallback
+  logged went through the `log` facade, which this CLI installs no logger for,
+  so it reached no stream and RUST_LOG could not surface it.
+
+  The refusal is delivered here, at the entry point, rather than by panicking
+  from inside the normalizer. A development-only switch must not be able to
+  abort a process that merely happens to have the variable set, so in a release
+  build the library itself falls safe to `live` and leaves the refusal for a
+  binary to report. Every arm is still honoured in every build -- it is only the
+  handling of a value that names NO arm that differs.
 
   It is read once per process and cached, so it cannot be changed after the
   first variant is normalized. That is also why this is an environment variable
@@ -731,6 +738,22 @@ UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    // Before any input is read or normalized: this build may have been asked for
+    // a partitioner it does not carry. A library cannot refuse that from
+    // `canonicalize_from_sequence` -- it is infallible -- and ignoring it would
+    // serve the shipped `live` rule under a candidate's name, which is a
+    // bake-off that reports the candidate changes nothing. A binary has
+    // somewhere to fail to, so it fails here.
+    //
+    // After `Cli::parse()` on purpose: clap answers `--help` and `--version` by
+    // exiting from inside `parse`, and those must keep working for somebody who
+    // has a stale `FERRO_PARTITION` exported -- reading the help is how they
+    // find out what the arms are. Nothing has been read or normalized yet
+    // either way, so the refusal still precedes any work.
+    if let Some(message) = ferro_hgvs::normalize::partition_switch_startup_error() {
+        return Err(message.into());
+    }
 
     match cli.command {
         Commands::AnnotateVcf {

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1960,24 +1960,65 @@ const MAX_TWO_GAP_PLACEMENTS: usize = 65_536;
 
 /// Largest alignment grid the sequence-first splitter will build, in cells.
 ///
-/// `AlignmentDag::build` is `Θ(n·m)` in **space** as well as time, and it
-/// allocates four grids of that size: two `u32` edit grids, the on-path flags,
-/// and the adjacency mask. Only the reference side is bounded upstream
-/// ([`MAX_CANONICAL_WINDOW`]); the alternate side is whatever the members
-/// produce, and a duplication over the whole window doubles it. A 4096 x 8192
-/// grid is 33.5 M cells, or roughly 340 MB across the four — enough to matter,
-/// and reachable from a single description rather than from a pathological
-/// corpus.
+/// Every pass over the DAG is `Θ(n·m)` in **space** as well as time. Only the
+/// reference side is bounded upstream ([`MAX_CANONICAL_WINDOW`]); the alternate
+/// side is whatever the members produce, and a duplication over the whole window
+/// doubles it.
 ///
-/// Derived from [`MAX_CANONICAL_WINDOW`] rather than picked: the budget is a
-/// *square* grid at that bound, so it admits any block whose alternate side is
-/// within the same limit already imposed on the reference side, and refuses one
-/// where the alternate side runs past it. The 4096 x 8192 duplication above is
-/// 33.5 M cells against this 16.8 M, so it is declined.
+/// # What the budget actually pays for
 ///
-/// The honest cost of stating it this way: at the very top of the reference range
-/// an alternate side even slightly longer than the reference is declined too.
-/// That is a cost bound, not a policy — above it
+/// An earlier revision of this comment counted only the four grids inside
+/// `AlignmentDag::build` and put the peak at "roughly 340 MB" for a 4096 x 8192
+/// grid. That understates it, because the sweep that runs over the built DAG
+/// allocates more than the DAG it walks, and both arms run one. Per cell:
+///
+/// | allocation | where | bytes/cell | survives `build`? |
+/// |---|---|---|---|
+/// | two `u32` edit grids | `AlignmentDag::build` | 8 | no |
+/// | `on_optimal_path` flags | `AlignmentDag::build` | 1 | yes |
+/// | `out` adjacency mask | `AlignmentDag::build` | 1 | yes |
+/// | `in_degree` (`u32`) | `AlignmentDag::dominators` (the `shadow` arm) | 4 | — |
+/// | `order: Vec<(u32, u32)>` | `AlignmentDag::dominators` | up to 8 | — |
+/// | `to_go` (two `u32` planes) | `CanonicalAlignment::of` (the `canonical` arms) | 8 | — |
+/// | `cells: Vec<(u32, u32)>` | `CanonicalAlignment::of` | up to 8 | — |
+///
+/// The last column is what makes this arithmetic addition rather than a sum:
+/// `prefix` and `suffix_grid` are locals of `build` and are dropped when it
+/// returns, so the 8 bytes/cell they cost never coexists with a sweep. The peak
+/// is therefore `max(build, retained + sweep)` — `max(10, 2 + 12)` = **~14
+/// bytes/cell** on the `shadow` arm and `max(10, 2 + 16)` = **~18** on the
+/// `canonical` arms — not the ~10 the old figure implied, and not the sum of the
+/// two columns either.
+///
+/// At the accepted boundary (a 4096 x 4096 block, `cells == MAX_SEQFIRST_GRID_CELLS`)
+/// ~18 bytes/cell over 16,785,409 cells is 302 MB, which is what the measured
+/// peak RSS of **~310 MB and 5–9 s** in a debug build says it is; adding the
+/// columns instead would predict 369 MB and disagree with the measurement. A
+/// release build cuts the time and not the memory.
+///
+/// # Is the bound itself defensible?
+///
+/// As a *cost* bound, yes, and it is deliberately conservative in the direction
+/// that matters: it is derived from [`MAX_CANONICAL_WINDOW`] rather than picked,
+/// being a *square* grid at that bound, so it admits any block whose alternate
+/// side stays within the limit already imposed on the reference side. The
+/// 4096 x 8192 duplication is 33.5 M cells against this 16.8 M and is declined.
+///
+/// What it is **not** is a bound anybody would choose for a per-description
+/// budget. 310 MB and seconds of CPU is reachable from a single equal-length
+/// 4 kb `delins`, and [`MAX_SPLIT_BLOCK`] deliberately does not bound that case
+/// (it is scoped to length-changing blocks). Lowering it is not free either:
+/// every block it newly refuses is one the sequence-first arm stops answering,
+/// and under a promoted arm that is a silent handover to [`partition_block`]
+/// (counted, since [`PartitionDeclineCounts`], but still a different rule). So
+/// the number is left where it is and the cost is written down instead — the
+/// decision worth making is whether a promoted arm should *refuse* past the cap
+/// rather than fall back, and that is a policy question this constant cannot
+/// answer.
+///
+/// The honest cost of stating it as a square: at the very top of the reference
+/// range an alternate side even slightly longer than the reference is declined
+/// too. That is a cost bound, not a policy — above it
 /// [`partition_block_sequence_first`] returns `None` and the caller keeps the
 /// per-member result, the same fallback every other bound here takes.
 const MAX_SEQFIRST_GRID_CELLS: usize =
@@ -2258,6 +2299,93 @@ fn partition_rule() -> PartitionRule {
     })
 }
 
+/// How often a sequence-first arm was asked to partition a block, and how often
+/// it declined and the caller served [`partition_block`] instead.
+///
+/// A decline is not an error and not a different answer to the same question: it
+/// is the **shipped** rule answering under the candidate rule's name. Over a
+/// bake-off that is indistinguishable from the candidate agreeing with `live` on
+/// every block it declined, so a run in which the candidate declined throughout
+/// reports that the candidate changes nothing — the same failure
+/// [`partition_rule_from_env`] refuses an unrecognised arm name to avoid,
+/// reached through a different door.
+///
+/// `attempted` counts only the sequence-first arms *the environment selected*.
+/// [`PartitionRule::Live`] cannot decline, so counting it would add a per-block
+/// atomic to the shipped path to record a number that is structurally zero — and
+/// the `FERRO_SEQFIRST_SHADOW` audit's own sequence-first call is out of scope
+/// too: it cannot reach the emitted pieces, so a decline there is not a handover
+/// to anything.
+///
+/// **Unstable, like the switch it measures.** `FERRO_PARTITION` sits outside
+/// semantic versioning and is expected to be removed once the normalization rule
+/// is settled; this census goes with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PartitionDeclineCounts {
+    /// Blocks handed to a sequence-first partitioner.
+    pub attempted: u64,
+    /// Of those, blocks it declined — answered by [`partition_block`] instead.
+    pub declined: u64,
+}
+
+/// Blocks handed to a sequence-first partitioner so far in this process.
+static SEQFIRST_ATTEMPTED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Of those, the ones it declined.
+static SEQFIRST_DECLINED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// This process's census of sequence-first partition attempts and declines.
+///
+/// Process-wide and monotone, like the arm selection itself: there is one
+/// `FERRO_PARTITION` per process, so a per-call return value would have nothing
+/// to attach to. Read it at the end of a bake-off and quote it beside the
+/// diff — a non-zero `declined` says how much of that diff was produced by
+/// [`partition_block`].
+///
+/// Relaxed ordering: the two counters are a census, never a happens-before
+/// edge, and no reader draws a conclusion from their relative order.
+pub fn partition_decline_counts() -> PartitionDeclineCounts {
+    use std::sync::atomic::Ordering;
+    PartitionDeclineCounts {
+        attempted: SEQFIRST_ATTEMPTED.load(Ordering::Relaxed),
+        declined: SEQFIRST_DECLINED.load(Ordering::Relaxed),
+    }
+}
+
+/// Cut a trimmed block with `rule`, falling back to [`partition_block`] when a
+/// sequence-first arm declines — and **counting** the fallback.
+///
+/// Split out of [`canonicalize_from_sequence`] so the decline path is reachable
+/// without a process-global environment variable: [`partition_rule`] caches its
+/// read in a `OnceLock`, so a test that wants a non-`Live` arm can only get one
+/// by passing it. See [`PartitionDeclineCounts`] for why the fallback has to be
+/// observable at all.
+fn partition_block_for_rule(
+    rule: PartitionRule,
+    reference: &[u8],
+    result: &[u8],
+    min_separation: u32,
+) -> Vec<Piece> {
+    use std::sync::atomic::Ordering;
+
+    let attempt = match rule {
+        // The shipped rule, and the only configuration that ships. It has no
+        // decline path, so it is not counted.
+        PartitionRule::Live => return partition_block(reference, result),
+        PartitionRule::Shadow => partition_block_sequence_first(reference, result, min_separation),
+        // `CanonicalCoalesced` is identical to `Canonical` here on purpose: the
+        // `delins.md:44-47` merge is applied *after* the downstream passes, not
+        // as part of partitioning — see `coalesce_payload_alignment_split`.
+        PartitionRule::Canonical | PartitionRule::CanonicalCoalesced => {
+            partition_block_canonical(reference, result)
+        }
+    };
+    SEQFIRST_ATTEMPTED.fetch_add(1, Ordering::Relaxed);
+    attempt.unwrap_or_else(|| {
+        SEQFIRST_DECLINED.fetch_add(1, Ordering::Relaxed);
+        partition_block(reference, result)
+    })
+}
+
 /// The unchanged-base separation threshold an axis merges runs below.
 ///
 /// A reading-frame axis gets `general.md:35`'s coding one-amino-acid exception
@@ -2481,29 +2609,17 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
 
     // Which rule cuts the block. `FERRO_PARTITION` unset — the only configuration
     // that ships — takes the `Live` arm, so this is `partition_block` and nothing
-    // else. The other two arms fall back to it when their splitter declines,
-    // rather than abandoning the canonicalization, so a bake-off run measures the
-    // partitioners and not their decline rates.
-    let mut pieces = match partition_rule() {
-        PartitionRule::Live => partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]),
-        PartitionRule::Shadow => partition_block_sequence_first(
-            &ref_bytes[lo..hi_ref],
-            &result[lo..hi_alt],
-            axis_min_separation(frame.reading_frame),
-        )
-        .unwrap_or_else(|| partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt])),
-        PartitionRule::Canonical => {
-            partition_block_canonical(&ref_bytes[lo..hi_ref], &result[lo..hi_alt])
-                .unwrap_or_else(|| partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]))
-        }
-        PartitionRule::CanonicalCoalesced => {
-            // Identical to `Canonical` here on purpose. The `delins.md:44-47`
-            // merge is applied *after* the downstream passes below, not as part
-            // of partitioning — see `coalesce_payload_alignment_split`.
-            partition_block_canonical(&ref_bytes[lo..hi_ref], &result[lo..hi_alt])
-                .unwrap_or_else(|| partition_block(&ref_bytes[lo..hi_ref], &result[lo..hi_alt]))
-        }
-    };
+    // else. The other arms fall back to it when their splitter declines, rather
+    // than abandoning the canonicalization, so a bake-off run measures the
+    // partitioners and not their decline rates — and every such fallback is
+    // counted, so the run can tell "the candidate agreed" from "the candidate
+    // was not asked" (see `PartitionDeclineCounts`).
+    let mut pieces = partition_block_for_rule(
+        partition_rule(),
+        &ref_bytes[lo..hi_ref],
+        &result[lo..hi_alt],
+        axis_min_separation(frame.reading_frame),
+    );
     // Shadow the sequence-first splitter on the very same trimmed block, before
     // any 3'-shift or coalescing, so a reported disagreement is a disagreement
     // about the *split* and not about a downstream pass. Never affects `pieces`.
@@ -11955,6 +12071,96 @@ mod tests {
             ),
             None,
             "a 4096 x 8192 grid is 33.5 M cells and must be declined, not allocated"
+        );
+    }
+
+    /// A declined sequence-first partition is **counted**, so a bake-off can
+    /// tell "the candidate agreed with `live`" from "the candidate was never
+    /// asked and `live` answered under its name".
+    ///
+    /// The block is the reachable one: a duplication of the whole canonical
+    /// window (`4096 -> 8192`) is 33.5 M cells against a 16.8 M budget, so both
+    /// sequence-first arms decline it and the caller serves `partition_block`.
+    /// The pieces that come back are byte-identical to `partition_block`'s,
+    /// which is exactly why nothing downstream can notice — the counter is the
+    /// only place the handover is visible.
+    ///
+    /// `partition_block_for_rule` is called with the rule rather than through
+    /// `partition_rule()` because that read is cached in a `OnceLock`: a test
+    /// cannot select a non-`Live` arm at all once any other test in the binary
+    /// has normalized something.
+    ///
+    /// Counters are process-global and monotone, so the assertions are on the
+    /// *delta* across the calls, never on an absolute value — another test in
+    /// this binary may legitimately have moved them first.
+    ///
+    /// A delta is only safe because this is the sole test that moves them: under
+    /// `cargo test` (as opposed to `cargo nextest`, which forks per test) the lib
+    /// tests share one process and run concurrently, so a second test calling
+    /// `partition_block_for_rule` on a non-`Live` arm would interleave and turn
+    /// these `== 1` deltas into a flake. Keep it that way, or take a mutex.
+    #[test]
+    fn a_declined_sequence_first_partition_is_counted() {
+        let reference = b"ACGT".repeat(1024);
+        let doubled = b"ACGT".repeat(2048);
+
+        let before = partition_decline_counts();
+        let pieces = partition_block_for_rule(
+            PartitionRule::Canonical,
+            &reference,
+            &doubled,
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        );
+        let after = partition_decline_counts();
+
+        assert_eq!(
+            pieces,
+            partition_block(&reference, &doubled),
+            "the declined block is served by `partition_block`, byte for byte"
+        );
+        assert_eq!(
+            after.attempted - before.attempted,
+            1,
+            "the attempt is the denominator; without it a zero decline count \
+             cannot be told from an arm that never ran"
+        );
+        assert_eq!(
+            after.declined - before.declined,
+            1,
+            "the fallback to `partition_block` must be visible somewhere"
+        );
+
+        // A block the arm *answers* moves the denominator and not the
+        // numerator, so the two counters cannot both be a running total of
+        // "blocks seen".
+        let answered = partition_block_for_rule(
+            PartitionRule::Canonical,
+            b"ACGTACGT",
+            b"ATGTTCGT",
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        );
+        let served = partition_decline_counts();
+        assert!(!answered.is_empty());
+        assert_eq!(served.attempted - after.attempted, 1);
+        assert_eq!(
+            served.declined - after.declined,
+            0,
+            "an arm that answered must not be recorded as having declined"
+        );
+
+        // `Live` has no decline path, so it is not counted at all — the shipped
+        // configuration pays no atomic per block.
+        let live = partition_block_for_rule(
+            PartitionRule::Live,
+            b"ACGTACGT",
+            b"ATGTTCGT",
+            crate::normalize::seqfirst::MIN_SEPARATION,
+        );
+        let unchanged = partition_decline_counts();
+        assert_eq!(live, partition_block(b"ACGTACGT", b"ATGTTCGT"));
+        assert_eq!(
+            unchanged, served,
+            "the `live` arm must not touch the census"
         );
     }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2273,6 +2273,91 @@ fn partition_rule_env_value(read: Result<String, std::env::VarError>) -> Option<
     }
 }
 
+/// Whether a refused `FERRO_PARTITION` value may abort the process where it is
+/// read, rather than being reported at a boundary that can return a failure.
+///
+/// `debug_assertions`, the same gate the three assertion oracles at this seam
+/// take. A debug build is one somebody is measuring in, and there aborting at
+/// the first normalized variant is the honest answer. A release build is one
+/// somebody is *shipping*, and a development-only switch must not be able to
+/// abort a production process from the environment — least of all from inside
+/// [`canonicalize_from_sequence`], which is infallible, sits under every public
+/// entry point, and is reached across the FFI boundary by the Python bindings.
+///
+/// # What this deliberately does **not** do
+///
+/// It does not compile the switch out of release builds. That was tried first
+/// and it is wrong here: `README.md` documents the A/B recipe as working on a
+/// **stock release build**, which is also the only way to normalize a real
+/// corpus at size, so compiling it out would delete the measurement this whole
+/// switch exists for. Release builds still honour every arm; what changes is
+/// only what happens to a value that names no arm.
+const PARTITION_SWITCH_MAY_ABORT: bool = cfg!(debug_assertions);
+
+/// The rule to cut with, given how `FERRO_PARTITION` parsed and whether this
+/// build may abort on a refusal.
+///
+/// Split out of [`partition_rule`] so both halves of the contract are testable:
+/// [`partition_rule`] caches its read in a `OnceLock` and consults a real
+/// process environment, so one test binary can never exercise two outcomes.
+///
+/// Falling safe to [`PartitionRule::Live`] is not the silent fallback
+/// [`partition_rule_from_env`] refuses — the refusal is not discarded, it is
+/// retained by [`partition_switch_startup_error`] for a caller with somewhere to
+/// return it. What would be silent is dropping it on the floor, and the two are
+/// only the same if nobody asks.
+fn partition_rule_from_outcome(
+    outcome: &Result<PartitionRule, String>,
+    may_abort: bool,
+) -> PartitionRule {
+    match outcome {
+        Ok(rule) => *rule,
+        Err(message) if may_abort => panic!("{message}"),
+        Err(_) => PartitionRule::Live,
+    }
+}
+
+/// How `FERRO_PARTITION` parsed in this process, computed once.
+///
+/// The `Result` is cached rather than the [`PartitionRule`], so the refusal
+/// survives to be reported by [`partition_switch_startup_error`] instead of
+/// being consumed by the first caller.
+fn partition_rule_outcome() -> &'static Result<PartitionRule, String> {
+    static OUTCOME: std::sync::OnceLock<Result<PartitionRule, String>> = std::sync::OnceLock::new();
+    OUTCOME.get_or_init(|| {
+        let value = partition_rule_env_value(std::env::var("FERRO_PARTITION"));
+        partition_rule_from_env(value.as_deref())
+    })
+}
+
+/// The refusal a binary should print and exit on before doing any work, if any.
+///
+/// `Some(message)` exactly when `FERRO_PARTITION` named an arm this build has
+/// not got. Call it once from an entry point — which, unlike
+/// [`canonicalize_from_sequence`], has somewhere to return a failure to — so
+/// that a release build refuses a misspelled bake-off *without* the library
+/// aborting the process to say so.
+///
+/// **Unstable, like the switch it serves.** `FERRO_PARTITION` is an evaluation
+/// switch outside semantic versioning and expected to be removed once the
+/// normalization rule is settled; this accessor goes with it. It is `pub` because
+/// a binary in another crate — or an embedder running its own bake-off — cannot
+/// otherwise ask, not because it is a supported API.
+///
+/// # The residual, stated rather than hidden
+///
+/// An embedder that neither calls this nor runs a debug build gets
+/// [`PartitionRule::Live`] for a refused value. That is the shipped rule under
+/// no name at all rather than under a candidate's, and it is strictly safer than
+/// the abort it replaces — but it is only *reported* if somebody asks. Every
+/// binary in this repository asks, and
+/// `it::partition_switch_wiring::every_binary_target_reports_a_refused_partition_switch`
+/// fails if a new one does not; a third-party embedder running a bake-off through
+/// a release library should too.
+pub fn partition_switch_startup_error() -> Option<String> {
+    partition_rule_outcome().as_ref().err().cloned()
+}
+
 /// Which partitioner this process cuts blocks with, from `FERRO_PARTITION`.
 ///
 /// A **development-only bake-off switch**. Read once and cached, like
@@ -2280,23 +2365,27 @@ fn partition_rule_env_value(read: Result<String, std::env::VarError>) -> Option<
 /// per canonicalized block and nothing else; with the variable unset the result
 /// is byte-identical to having no switch at all.
 ///
+/// Every arm is honoured in every build — see [`PARTITION_SWITCH_MAY_ABORT`] for
+/// why the gate is on the *refusal* and not on the switch.
+///
 /// # Panics
 ///
-/// If `FERRO_PARTITION` names an arm this build does not have. Both call sites
-/// are inside `canonicalize_from_sequence`, which is infallible and sits deep
-/// under every public normalization entry point, so there is no `Result` to
-/// return the rejection through without threading one the length of the
-/// pipeline. A panic here is the honest alternative: it fires once, at the first
-/// normalized variant, before any output exists to be mistaken for a
-/// measurement. See [`partition_rule_from_env`] for why silence was not an
-/// option, and [`partition_rule_env_value`] for why the raw read is matched
-/// rather than `.ok()`-ed.
+/// In a **debug** build, if `FERRO_PARTITION` names an arm this build does not
+/// have. Both call sites are inside [`canonicalize_from_sequence`], which is
+/// infallible and sits deep under every public normalization entry point, so
+/// there is no `Result` to return the rejection through without threading one
+/// the length of the pipeline. A panic there is the honest alternative for a
+/// build somebody is measuring in: it fires once, at the first normalized
+/// variant, before any output exists to be mistaken for a measurement. See
+/// [`partition_rule_from_env`] for why silence was not an option, and
+/// [`partition_rule_env_value`] for why the raw read is matched rather than
+/// `.ok()`-ed.
+///
+/// A **release** build cannot reach that panic. It falls safe to
+/// [`PartitionRule::Live`] and keeps the refusal for
+/// [`partition_switch_startup_error`] to deliver.
 fn partition_rule() -> PartitionRule {
-    static RULE: std::sync::OnceLock<PartitionRule> = std::sync::OnceLock::new();
-    *RULE.get_or_init(|| {
-        let value = partition_rule_env_value(std::env::var("FERRO_PARTITION"));
-        partition_rule_from_env(value.as_deref()).unwrap_or_else(|message| panic!("{message}"))
-    })
+    partition_rule_from_outcome(partition_rule_outcome(), PARTITION_SWITCH_MAY_ABORT)
 }
 
 /// How often a sequence-first arm was asked to partition a block, and how often
@@ -12860,6 +12949,70 @@ mod tests {
                 "the spec's own published inversion must survive the canonical \
                  partition as one piece, not five members"
             );
+        }
+
+        /// A release build **cannot** be aborted by this switch.
+        ///
+        /// Until #1636 `partition_rule()` panicked on an unrecognised value in
+        /// every build, from inside `canonicalize_from_sequence` — infallible,
+        /// under every public entry point, and reached across the FFI boundary
+        /// by the Python bindings. A development-only bake-off switch must not
+        /// be able to abort a production process from the environment.
+        ///
+        /// Exercised through `partition_rule_from_outcome` rather than
+        /// `partition_rule()`: the latter caches in a `OnceLock` and consults a
+        /// real environment, so one test binary can never see two outcomes.
+        #[test]
+        fn a_refused_value_does_not_abort_a_build_that_may_not_abort() {
+            let refused = partition_rule_from_env(Some("preserve"));
+            assert!(refused.is_err(), "`preserve` is not an arm on this build");
+            assert_eq!(
+                partition_rule_from_outcome(&refused, false),
+                PartitionRule::Live,
+                "a release build must fall safe to the shipped rule, not abort"
+            );
+            // …and a value that *is* an arm is still served, in either build.
+            let accepted = partition_rule_from_env(Some("canonical"));
+            for may_abort in [false, true] {
+                assert_eq!(
+                    partition_rule_from_outcome(&accepted, may_abort),
+                    PartitionRule::Canonical
+                );
+            }
+        }
+
+        /// …while a build that may abort still does, so falling safe above did
+        /// not quietly retire the refusal in the configuration that measures.
+        #[test]
+        #[should_panic(expected = "is not a partitioner this build has")]
+        fn a_refused_value_still_aborts_a_build_that_may_abort() {
+            let refused = partition_rule_from_env(Some("preserve"));
+            let _ = partition_rule_from_outcome(&refused, true);
+        }
+
+        /// Falling safe must not mean falling **silent**: the refusal survives
+        /// the read, so an entry point can deliver it.
+        ///
+        /// This is the difference between the fix and the fallback
+        /// `partition_rule_from_env`'s doc refuses. A discarded rejection and a
+        /// retained one produce the same `PartitionRule`; only one of them can
+        /// be reported.
+        #[test]
+        fn the_refusal_survives_the_read_so_an_entry_point_can_report_it() {
+            // The process this suite runs in has the variable unset — pinned by
+            // `the_suite_runs_on_the_live_rule` — so the accessor is `None`
+            // here, and that is the production reading it must give.
+            assert_eq!(
+                partition_switch_startup_error(),
+                None,
+                "an unset FERRO_PARTITION is not something to refuse at startup"
+            );
+            // The mapping the accessor reports is the parser's own `Err`, which
+            // is the half a test in this process can reach.
+            let message = partition_rule_from_env(Some("canonicl"))
+                .expect_err("a misspelling must be refused");
+            assert!(message.contains("canonicl"));
+            assert!(message.contains("live"));
         }
 
         /// This suite's expectations are the live rule's, and the cached read

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -50,6 +50,12 @@ pub mod validate;
 #[cfg(feature = "dev")]
 pub use merge::dev_partitioners;
 
+// How often a sequence-first partitioner declined and `partition_block` answered
+// under its name. Not gated on `dev`: a bake-off is run from whatever build the
+// measurement uses, and a census that exists only in some builds is one a run can
+// forget to read. See `PartitionDeclineCounts`.
+pub use merge::{partition_decline_counts, PartitionDeclineCounts};
+
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::hgvs::edit::{

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -56,6 +56,12 @@ pub use merge::dev_partitioners;
 // forget to read. See `PartitionDeclineCounts`.
 pub use merge::{partition_decline_counts, PartitionDeclineCounts};
 
+// The refusal a binary should print and exit on when `FERRO_PARTITION` named an
+// arm this build has not got. A library cannot refuse from
+// `canonicalize_from_sequence` -- it is infallible -- so the refusal is offered
+// to entry points that can return a failure.
+pub use merge::partition_switch_startup_error;
+
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::hgvs::edit::{

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -409,6 +409,7 @@ mod normalize_warning_seam;
 mod oracle_exclude_invariant;
 mod paraphase_exhaustive_tests;
 mod parser_tests;
+mod partition_switch_wiring;
 mod pastcds_star_canonicalization;
 mod perf_table;
 mod predicted_cis_allele;

--- a/tests/it/partition_switch_wiring.rs
+++ b/tests/it/partition_switch_wiring.rs
@@ -1,0 +1,197 @@
+//! The `FERRO_PARTITION` refusal must be delivered by every entry point.
+//!
+//! `partition_rule()` used to panic on a value naming no arm, in every build,
+//! from inside `canonicalize_from_sequence` — infallible, under every public
+//! normalization entry point, and reached across the FFI boundary by the Python
+//! bindings. A development-only bake-off switch must not be able to abort a
+//! process that merely happens to have the variable set, so a release build of
+//! the library now falls safe to the shipped `live` rule and retains the refusal
+//! in `partition_switch_startup_error()` for a caller to report.
+//!
+//! That trade only holds if the callers actually report it. Falling safe without
+//! reporting is the *original* defect this switch was given a refusal to prevent:
+//! a bake-off served the shipped rule under a candidate's name, coming back with
+//! a clean empty diff that reads as "the candidate changes nothing". So the
+//! wiring is the contract, and these two tests pin both halves of it:
+//!
+//! - the behaviour, end to end, through the `ferro` binary — a misspelling exits
+//!   non-zero with the message, a real arm still runs, and `--help` keeps working;
+//! - the completeness, over `Cargo.toml`'s own `[[bin]]` table — so a binary
+//!   added later cannot skip the call and leave `README.md`'s "every binary in
+//!   this repository reports it" quietly false.
+//!
+//! The second is a source scan, so it proves the call is *written*, not that it
+//! is reached. The first is what proves it is reached, and it is written against
+//! the binary a user actually runs.
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A value no build has an arm for. Deliberately the near-miss `README.md` uses,
+/// since a plausible misspelling is the input the refusal exists for.
+const MISSPELLED: &str = "canonicl";
+
+/// The repository root, from this test target's manifest directory.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// A deletion inside the `CCCC` homopolymer at c.16-19 of the mock `NM_000088.3`,
+/// so the normalizer 3'-shifts it and the positive control below exercises the
+/// partitioner rather than only the parser. Within the mock CDS (60 bases), which
+/// the more obvious `c.459A>G` is not — that one is rejected as past the CDS end
+/// under the default strict mode.
+const SHIFTED: &str = "NM_000088.3:c.16del";
+
+/// Run `ferro normalize` over one variant with `FERRO_PARTITION` set to `value`.
+///
+/// The mock provider serves `NM_000088.3`, so no `--reference` and no prepared
+/// reference directory is needed.
+fn normalize_one(value: &str) -> std::process::Output {
+    let mut input = tempfile::Builder::new()
+        .suffix(".txt")
+        .tempfile()
+        .expect("create input file");
+    writeln!(input, "{SHIFTED}").expect("write input");
+    input.flush().expect("flush input");
+
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+        .arg("normalize")
+        .arg("-i")
+        .arg(input.path())
+        .env("FERRO_PARTITION", value)
+        .output()
+        .expect("run ferro normalize")
+}
+
+/// A misspelled arm name stops the CLI before it reads input, and a real one does
+/// not.
+///
+/// Both directions are asserted in one test on purpose: a binary that refused
+/// *every* value would pass the first assertion while making the switch useless,
+/// and that failure would look identical in a log to the fix working.
+#[test]
+fn the_ferro_cli_refuses_a_misspelled_partition_switch_and_still_serves_a_real_arm() {
+    let refused = normalize_one(MISSPELLED);
+    assert!(
+        !refused.status.success(),
+        "a value naming no arm must fail the process; stdout was:\n{}",
+        String::from_utf8_lossy(&refused.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        stderr.contains(MISSPELLED) && stderr.contains("is not a partitioner this build has"),
+        "the refusal must name the value given and say what it is; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("canonical-coalesced"),
+        "the refusal must name THIS build's arms, so a value that exists on \
+         another branch is reported as absent here; stderr was:\n{stderr}"
+    );
+    assert!(
+        refused.stdout.is_empty(),
+        "the refusal must precede any output that could be mistaken for a \
+         measurement; stdout was:\n{}",
+        String::from_utf8_lossy(&refused.stdout)
+    );
+
+    let accepted = normalize_one("canonical");
+    assert!(
+        accepted.status.success(),
+        "a value that IS an arm must still run; stderr was:\n{}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+}
+
+/// `--help` still answers under a stale `FERRO_PARTITION`.
+///
+/// Reading the help is how somebody finds out what the arms are, so refusing it
+/// would leave them holding a rejected value and no way to look up the right one.
+/// This is why the check sits after `Cli::parse()` rather than before it — clap
+/// answers `--help` by exiting from inside `parse`, and nothing has been read or
+/// normalized at that point either way.
+#[test]
+fn help_still_works_when_the_partition_switch_names_no_arm() {
+    let out = Command::new(env!("CARGO_BIN_EXE_ferro"))
+        .arg("--help")
+        .env("FERRO_PARTITION", MISSPELLED)
+        .output()
+        .expect("run ferro --help");
+    assert!(
+        out.status.success(),
+        "`--help` must not be refused; stderr was:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "`--help` must still print the help text"
+    );
+}
+
+/// Every `[[bin]]` target's source calls `partition_switch_startup_error`.
+///
+/// Parsed as TOML rather than substring-matched, for the reason
+/// `generator_completeness.rs` gives: a `path` inside a comment, or under a
+/// `[[example]]` table, must not count.
+///
+/// The denominator is asserted non-zero, so "0 of 0 binaries are missing it"
+/// cannot pass as a result — the failure mode this repository has been bitten by
+/// often enough to make it a house rule.
+#[test]
+fn every_binary_target_reports_a_refused_partition_switch() {
+    let manifest_text =
+        std::fs::read_to_string(repo_root().join("Cargo.toml")).expect("read Cargo.toml");
+    let manifest: toml::Value = manifest_text.parse().expect("parse Cargo.toml as TOML");
+
+    let mut sources = BTreeSet::new();
+    for entry in manifest
+        .get("bin")
+        .and_then(toml::Value::as_array)
+        .expect("Cargo.toml declares at least one [[bin]] target")
+    {
+        let name = entry
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .expect("every [[bin]] has a name");
+        let path = entry
+            .get("path")
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("[[bin]] {name} declares no path"));
+        sources.insert((name.to_string(), path.to_string()));
+    }
+    assert!(
+        sources.len() >= 5,
+        "expected the five known binaries (ferro, ferro-web, ferro-benchmark and \
+         the two spec generators); found {sources:?}"
+    );
+
+    // The bake-off harness is not a `[[bin]]`, but it is the entry point a
+    // blast-radius measurement runs through, so it carries the same obligation:
+    // a refused value there yields an empty diff AND a silent decline census.
+    let mut expected: Vec<(String, String)> = sources.into_iter().collect();
+    expected.push((
+        "dump_normalized_corpus".to_string(),
+        "examples/dump_normalized_corpus.rs".to_string(),
+    ));
+
+    let missing: Vec<&str> = expected
+        .iter()
+        .filter(|(_, path)| {
+            let text = std::fs::read_to_string(repo_root().join(path))
+                .unwrap_or_else(|e| panic!("read {path}: {e}"));
+            !text.contains("partition_switch_startup_error()")
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these entry points normalize without reporting a refused \
+         FERRO_PARTITION, so they would serve the shipped rule under a \
+         candidate's name in a release build: {missing:?}. Call \
+         `ferro_hgvs::normalize::partition_switch_startup_error()` after \
+         argument parsing and fail on `Some`."
+    );
+}


### PR DESCRIPTION
Two fixes to the `FERRO_PARTITION` bake-off switch. They share the same twenty lines of `merge.rs`, so they are one PR with one commit each.

Closes #1635
Closes #1636

## 1. A declined sequence-first partition silently served `partition_block`

Both sequence-first arms decline when the alignment grid would exceed `MAX_SEQFIRST_GRID_CELLS`, and the caller then served `partition_block` — the shipped rule — under the candidate arm's name. Nothing counted it and nothing logged it, so a bake-off could not tell *"the candidate agreed with `live`"* from *"the candidate was never asked"*. A run in which the candidate declined throughout reported that the candidate changes nothing.

That is the failure `partition_rule_from_env` already refuses an unrecognised arm name to avoid — *"a measurement instrument that manufactures agreement"* — reached through a different door. The cap is reachable from one description: a duplication of the whole canonical window is `4096 x 8192`, or 33,559,521 cells against 16,785,409.

Adds `partition_decline_counts()`, a process-wide census incremented only on the sequence-first arms — `Live` has no decline path, so the shipped configuration pays no atomic per block — and reports it from `dump_normalized_corpus`, the harness a blast-radius measurement runs through.

Also corrects `MAX_SEQFIRST_GRID_CELLS`' own doc, which counted the four grids inside `AlignmentDag::build` and put the peak at "roughly 340 MB". The sweep that runs over the built DAG allocates more than the DAG it walks — `dominators`' `in_degree` and `order`, `CanonicalAlignment::of`'s `to_go` and `cells` — but it does not run *alongside* the build: `prefix` and `suffix_grid` are locals of `build` and are dropped when it returns, so only 2 of its 10 bytes/cell survive into the sweep. The peak is therefore `max(build, retained + sweep)` — **~14 bytes/cell** on `shadow` and **~18** on the `canonical` arms, not the sum of the two columns. ~18 bytes/cell over 16,785,409 cells is 302 MB, which is what the measured peak RSS of ~310 MB and 5–9 s in a debug build says it is; adding the columns would predict 369 MB and disagree with the measurement. The doc now tabulates every allocation and says plainly what the bound is and is not defensible as: fine as a cost bound derived from `MAX_CANONICAL_WINDOW`, not a number anybody would choose for a per-description budget, and lowering it is not free because every newly-refused block is a silent handover to `partition_block`.

**The failing test, observed before the fix.** With the two `fetch_add` calls neutralised, `a_declined_sequence_first_partition_is_counted` fails with `left: 0, right: 1` on the *denominator* — "without it a zero decline count cannot be told from an arm that never ran".

## 2. The switch could abort a shipping process

`partition_rule()` read `FERRO_PARTITION` in every build and **panicked** when the value named no arm — from inside `canonicalize_from_sequence`, which is infallible, sits under every public normalization entry point, and is reached across the FFI boundary by the Python bindings. The three assertion oracles at this same seam are all `#[cfg(debug_assertions)]` for exactly that reason.

The refusal itself is not the defect and is kept. What moves is *where it is delivered*: the parse outcome is cached as a `Result` rather than a `PartitionRule`, a debug build still aborts at the first normalized variant, and a release build falls safe to `live` and retains the refusal for `partition_switch_startup_error()`, which every binary in this repository calls after argument parsing and before reading any input — `ferro`, `ferro-web`, `ferro-benchmark`, both spec generators, and the `dump_normalized_corpus` bake-off harness.

Falling safe is only sound if the callers really do report it: falling safe *without* reporting is the original defect, a bake-off served the shipped rule under a candidate's name and coming back with a clean empty diff. So the wiring is the contract and `tests/it/partition_switch_wiring.rs` pins it from both sides — end to end through the `ferro` binary (a misspelling exits non-zero naming this build's arms and emits nothing on stdout, a real arm still runs, and `--help` keeps working under a stale value), and over `Cargo.toml`'s own `[[bin]]` table, so a binary added later cannot skip the call and leave the claim above quietly false. Verified to bite: with the call removed from `ferro-benchmark`, the completeness test fails naming it.

**Compiling the switch out of release builds was tried first and is wrong.** `README.md` documents the A/B recipe as working on a **stock release build**, and that is the only way to normalize a real corpus at size — so compiling it out would delete the measurement the switch exists for. Every arm is still honoured in every build; only a value naming *no* arm behaves differently.

**The failing test, observed before the fix.** With `may_abort` ignored, `a_refused_value_does_not_abort_a_build_that_may_not_abort` fails by panicking — which is the defect itself.

## Verification

- `cargo nextest run --features dev --no-fail-fast`: 9,991 tests, **0 failures**, nothing re-blessed.
- `cargo fmt --check`, `cargo clippy --all-features --all-targets` clean.
- `cargo build --release` then `FERRO_PARTITION=canonicl ./target/release/ferro normalize …` exits with the refusal before reading input.

Representation-Change: none. No partitioner rule changes; the arm selection for every recognised value is unchanged in every build, and the added census is read-only.

