### PR TITLE
chore(adjudication): correct two stale claims and pin what two respell tests denote

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2756,12 +2756,13 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // which `crate::normalize::rules`' single-span typing renders as `inv` —
     // so there is nothing left for a veto to protect.
 
-    // There was a veto here, and it was the last gate in this pass that read the
-    // *input spelling* rather than the sequence: when the derivation produced
-    // fewer pieces than there were members, and any piece covered a base the
-    // input had left between two of them, the pass refused and returned the
-    // input verbatim. It cited `general.md:34` — two variants separated by one
-    // or more unchanged nucleotides are described individually.
+    // There was a veto here, and — at the time it was removed — it was the
+    // last gate in this pass that read the *input spelling* rather than the
+    // sequence: when the derivation produced fewer pieces than there were
+    // members, and any piece covered a base the input had left between two
+    // of them, the pass refused and returned the input verbatim. It cited
+    // `general.md:34` — two variants separated by one or more unchanged
+    // nucleotides are described individually.
     //
     // The citation is sound and the mechanism was not. `general.md:34` is about
     // what the *sequence* separates; the veto measured what the *input's
@@ -2784,6 +2785,17 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // it holds no live line and could not have been the net this argument leans
     // on. The two are twins by design (see its own doc comment); the live one is
     // the one worth naming here.
+    //
+    // "Last" no longer holds: #1480 added `crosses_exon_junction`, above, which
+    // declines on the members' own span (`c_lo`/`c_hi`, the union of the member
+    // edits as they arrive — already per-member clamped, as the note on that
+    // call site says) rather than on anything the derived sequence states —
+    // the same shape of dependence this veto was removed for. That one is
+    // deliberate rather than an oversight (`general.md:44`'s exon-junction
+    // exemption has no sequence-only substitute yet), and its own non-confluence
+    // is tracked rather than hidden: #1480 records it as "still owed to #1450" —
+    // two spellings of one cross-junction variant can still settle on different
+    // forms, because neither is re-derived.
 
     // A derivation collapsing to a single pure insertion used to be refused
     // here, on the grounds that the per-member pipeline owned two capabilities

--- a/tests/it/issue_1307_terminal_dup_respell.rs
+++ b/tests/it/issue_1307_terminal_dup_respell.rs
@@ -168,6 +168,45 @@ fn assert_within_contig(input: &str, output: &str) {
     }
 }
 
+/// The output must denote the same bases as the input.
+///
+/// A bounds check ([`assert_within_contig`]) and a pinned expected string both
+/// pass on a well-formed description of the *wrong* sequence: a merge composes
+/// two members into one edit, and if the composition is wrong the result is a
+/// well-formed description of the wrong bases, which no other check here would
+/// notice. Checked with an applier that is **not** the normalizer —
+/// `apply_with` converts each member to its SPDI triple and splices `sequence`
+/// directly — so a bug shared between the normalizer and this check cannot
+/// cancel out. Mirrors the same pattern in
+/// `issue_1327_mt_respell_past_contig_end` and `cis_apply_oracle` generally.
+///
+/// Extracted from [`the_merged_output_denotes_the_inputs_bases`], which held
+/// this body inline and now calls it, so the two cannot drift apart.
+///
+/// [`a_deletion_sibling_at_the_last_base_still_merges`],
+/// [`a_three_member_allele_stays_in_range_in_any_order`] and
+/// [`an_in_range_collision_is_still_repaired`] call it directly too. The
+/// module's three remaining merged/reordered pins do **not**, and that does not
+/// leave them unguarded: all five inputs of
+/// [`a_substitution_sibling_leaves_the_terminal_duplication_alone`],
+/// [`a_delins_sibling_leaves_the_terminal_duplication_alone`] and
+/// [`the_circular_axis_gets_the_same_answer`] are themselves rows of
+/// `the_merged_output_denotes_the_inputs_bases`, which is where their sequence
+/// check lives. Adding a newly pinned input to any of those three is the case to
+/// watch, because that overlap is a coincidence nothing enforces.
+fn assert_denotes_the_same_bases(accession: &str, sequence: &str, input: &str, output: &str) {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(accession, sequence.to_string());
+    let want = apply_with(&provider, sequence, input)
+        .unwrap_or_else(|| panic!("`{input}` must denote a sequence"));
+    let got = apply_with(&provider, sequence, output)
+        .unwrap_or_else(|| panic!("`{input}` -> `{output}`, which denotes no sequence at all"));
+    assert_eq!(
+        got, want,
+        "`{input}` -> `{output}` no longer denotes the input's bases"
+    );
+}
+
 /// The issue's reproducer, on both member orders.
 ///
 /// Pinned, not merely bounded. A bounds check alone is satisfied by a refusal,
@@ -239,9 +278,11 @@ fn the_circular_axis_gets_the_same_answer() {
 /// that only reordered would otherwise pass.
 #[test]
 fn a_deletion_sibling_at_the_last_base_still_merges() {
+    let sequence = run_terminated_sequence();
     for input in ["NC_TEST.1:g.[21del;22dup]", "NC_TEST.1:g.[22dup;21del]"] {
-        let output = normalize("NC_TEST.1", &run_terminated_sequence(), input);
+        let output = normalize("NC_TEST.1", &sequence, input);
         assert_within_contig(input, &output);
+        assert_denotes_the_same_bases("NC_TEST.1", &sequence, input, &output);
         // The pair cancels — one `A` removed from the terminal run and one added
         // back — so an identity is the right answer, and the merge that produces
         // it is only reachable through the junction spelling this fix must not
@@ -300,6 +341,7 @@ fn a_three_member_allele_stays_in_range_in_any_order() {
     ] {
         let output = normalize("NC_TEST.1", &sequence, input);
         assert_within_contig(input, &output);
+        assert_denotes_the_same_bases("NC_TEST.1", &sequence, input, &output);
         assert_eq!(
             output, expected,
             "`{input}` must stay in range and not depend on member order"
@@ -315,6 +357,7 @@ fn an_in_range_collision_is_still_repaired() {
     let input = "NC_TEST.1:g.[20dup;21A>G]";
     let output = normalize("NC_TEST.1", &sequence, input);
     assert_within_contig(input, &output);
+    assert_denotes_the_same_bases("NC_TEST.1", &sequence, input, &output);
     assert_eq!(
         output, "NC_TEST.1:g.21delinsGG",
         "`{input}` must still collapse as it did before"
@@ -388,16 +431,7 @@ fn the_merged_output_denotes_the_inputs_bases() {
         ("NC_012920.1", "NC_012920.1:m.[24dup;24C>G]"),
         ("NC_012920.1", "NC_012920.1:m.[24dup;24delinsGG]"),
     ] {
-        let mut provider = MockProvider::new();
-        provider.add_genomic_sequence(accession, SEQUENCE.to_string());
-        let want = apply_with(&provider, SEQUENCE, input)
-            .unwrap_or_else(|| panic!("`{input}` must denote a sequence"));
         let output = normalize("NC_TEST.1", SEQUENCE, input);
-        let got = apply_with(&provider, SEQUENCE, &output)
-            .unwrap_or_else(|| panic!("`{input}` -> `{output}`, which denotes no sequence at all"));
-        assert_eq!(
-            got, want,
-            "`{input}` -> `{output}` no longer denotes the input's bases"
-        );
+        assert_denotes_the_same_bases(accession, SEQUENCE, input, &output);
     }
 }

--- a/tests/it/reported_confluence_pairs.rs
+++ b/tests/it/reported_confluence_pairs.rs
@@ -34,11 +34,14 @@
 //! `reported_partition_verdicts` now pins what each of the eighteen spellings
 //! prints — under 3' *and* under 5' — together with the form its issue asks for
 //! and what backs that form under the project's precedence policy
-//! (**spec-explicit > Mutalyzer > our judgement**). Twelve of the eighteen rows
-//! have a spec line that answers them outright; #1419's six do not, because
-//! `delins.md:44-47` recommends the merged delins for the very alignment
-//! coincidence `general.md:56` is being used to split — so those stay recorded
-//! rather than targeted.
+//! (**spec-explicit > Mutalyzer > our judgement**). Six of those eighteen
+//! spellings — three pairs — have a spec line that answers them outright, which
+//! is the split `the_spec_authority_census_holds` pins next door as `(6, 12)`
+//! rows; #1419's six and #1421's six do not, because `delins.md:44-47`
+//! recommends the merged delins for the same alignment coincidence each pair's
+//! split relies on (`general.md:56` for #1419, the unchanged interior
+//! reappearing in the payload for #1421) — so those stay recorded rather than
+//! targeted.
 //!
 //! So this module keeps exactly one job: the **ratchet**.
 //! [`CONVERGING_PAIRS_THREE_PRIME`] and [`CONVERGING_PAIRS_FIVE_PRIME`] are the

--- a/tests/it/reported_confluence_pairs.rs
+++ b/tests/it/reported_confluence_pairs.rs
@@ -40,15 +40,19 @@
 //! coincidence `general.md:56` is being used to split — so those stay recorded
 //! rather than targeted.
 //!
-//! So this module keeps exactly one job: the **ratchet**. [`CONVERGING_PAIRS`]
-//! is the number that must only ever go up, and it is deliberately a count and
-//! not nine strings, because the goal is total convergence and partial progress
-//! should read as one number moving.
+//! So this module keeps exactly one job: the **ratchet**.
+//! [`CONVERGING_PAIRS_THREE_PRIME`] and [`CONVERGING_PAIRS_FIVE_PRIME`] are the
+//! numbers that must only ever go up, and each is deliberately a count and not
+//! nine strings, because the goal is total convergence and partial progress
+//! should read as one number moving. They are tracked separately per direction
+//! rather than as one shared constant, since the two directions are not
+//! guaranteed to converge the same rows.
 //!
 //! # Current status
 //!
-//! [`CONVERGING_PAIRS`] records how many converge today. Both spellings of every
-//! row are well-formed and sequence-preserving, so a split row is a pure
+//! [`CONVERGING_PAIRS_THREE_PRIME`] and [`CONVERGING_PAIRS_FIVE_PRIME`] record
+//! how many converge today (currently 0 under both directions). Both spellings
+//! of every row are well-formed and sequence-preserving, so a split row is a pure
 //! representation difference rather than a correctness bug — which is precisely
 //! why it is damaging downstream: key-based aggregation silently files one
 //! variant under two keys and halves its count.
@@ -123,11 +127,26 @@ pub(crate) const REPORTED_PAIRS: &[(&str, &str, &str)] = &[
     ),
 ];
 
-/// How many reported pairs converge today, in each shuffle direction.
+/// How many reported pairs converge today under `ShuffleDirection::ThreePrime`.
 ///
 /// **This may only ever go up.** A drop means a change has regressed a defect
 /// somebody outside the project reported, and must not be re-blessed silently.
-const CONVERGING_PAIRS: usize = 0;
+///
+/// Kept as a separate constant from [`CONVERGING_PAIRS_FIVE_PRIME`] — the two
+/// directions reach the same partitioner but are not guaranteed to converge the
+/// same rows, and one shared constant cannot state two different true counts:
+/// whichever direction differed would have to be re-blessed against the other's
+/// number. Not because sharing would *hide* a single-direction regression — it
+/// would not. [`the_reported_pair_census_is_unchanged`] asserts inside the
+/// per-direction loop, so each direction is already compared against the
+/// constant on its own and no sum is ever taken. Measured: both are currently 0.
+const CONVERGING_PAIRS_THREE_PRIME: usize = 0;
+
+/// How many reported pairs converge today under `ShuffleDirection::FivePrime`.
+///
+/// See [`CONVERGING_PAIRS_THREE_PRIME`] for why this is tracked separately
+/// rather than shared. Measured: currently 0, same as 3'.
+const CONVERGING_PAIRS_FIVE_PRIME: usize = 0;
 
 /// Both directions, because a rule that converges only under the default 3'
 /// direction has not solved the problem: 5' is a supported option and reaches
@@ -195,6 +214,21 @@ fn no_reported_pair_normalizes_to_a_different_sequence() {
 #[test]
 fn the_reported_pair_census_is_unchanged() {
     for direction in DIRECTIONS {
+        // The catch-all arm is required, not defensive padding, and deleting it
+        // for "compile-time exhaustiveness" does not compile: `ShuffleDirection`
+        // is `#[non_exhaustive]` (see its own doc comment), so from outside the
+        // defining crate — which `tests/it` is — a `match` on it must carry a
+        // wildcard however many variants it has today. A runtime panic is
+        // therefore the strongest check available here, and it is reachable only
+        // via `DIRECTIONS`, so a new variant must be added there too before this
+        // fires. Prefer widening both together over relying on the panic.
+        let expected = match direction {
+            ShuffleDirection::ThreePrime => CONVERGING_PAIRS_THREE_PRIME,
+            ShuffleDirection::FivePrime => CONVERGING_PAIRS_FIVE_PRIME,
+            _ => panic!(
+                "unhandled shuffle direction {direction:?} — add a per-direction census constant"
+            ),
+        };
         let mut converged: Vec<String> = Vec::new();
         let mut split: Vec<String> = Vec::new();
         for (label, a, b) in REPORTED_PAIRS {
@@ -210,12 +244,13 @@ fn the_reported_pair_census_is_unchanged() {
         }
         assert_eq!(
             converged.len(),
-            CONVERGING_PAIRS,
+            expected,
             "reported-pair convergence moved under {direction:?}.\n\n\
              converged ({}):\n    {}\n\nstill split ({}):\n    {}\n\n\
-             If this went UP, raise CONVERGING_PAIRS and say so in the PR — it is \
-             a representation change for anyone storing the losing spelling. If it \
-             went DOWN, a change has regressed an externally-reported defect.",
+             If this went UP, raise CONVERGING_PAIRS_THREE_PRIME/CONVERGING_PAIRS_FIVE_PRIME \
+             (whichever direction moved) and say so in the PR — it is a representation \
+             change for anyone storing the losing spelling. If it went DOWN, a change has \
+             regressed an externally-reported defect.",
             converged.len(),
             converged.join("\n    "),
             split.len(),

--- a/tests/it/reported_partition_verdicts.rs
+++ b/tests/it/reported_partition_verdicts.rs
@@ -731,10 +731,10 @@ fn every_canonical_row_already_prints_its_wanted_form() {
 ///
 /// Pinned because the authority is what decides whether a row's `wanted` is a
 /// *target* or merely a *record*, and that is the single most consequential
-/// judgement in this file. Six pairs rest on a spec line nothing contradicts;
-/// three (#1419's) rest on a spec that answers both ways, where the precedence
-/// policy hands the tie-break to Mutalyzer and Mutalyzer picks neither ferro's
-/// answer nor the issue's.
+/// judgement in this file. Three pairs (#1420's) rest on a spec line nothing
+/// contradicts; six (#1419's and #1421's) rest on a spec that answers both
+/// ways, where the precedence policy hands the tie-break to Mutalyzer and
+/// Mutalyzer picks neither ferro's answer nor the issue's.
 #[test]
 fn the_spec_authority_census_holds() {
     for (a, b) in reported_pairs() {


### PR DESCRIPTION
Four small bookkeeping fixes salvaged from an unpushed branch, rebased onto current `main`. Three are documentation corrections; one adds assertions that were missing.

## The commits

**`docs(normalize): correct a stale "last gate that reads input spelling" claim`** — a comment in `merge.rs` said a removed veto "was the last gate in this pass that read the *input spelling* rather than the sequence". That is no longer true; other spelling-readers remain in the pass. Reworded to *"at the time it was removed, it was the last gate…"*, which is a historical statement rather than a present-tense one that has since become false.

**`test(1307): assert sequence preservation on the remaining respell tests`** — the tests in `issue_1307_terminal_dup_respell.rs` pinned only the output string, so they could not distinguish a legitimate re-spelling from a corruption: a change that emitted a description denoting different bases would stay green as long as the string matched. Adds denoted-sequence assertions alongside the existing string ones. Same class of gap as #1626/#1633, on a file that PR did not cover.

**`docs(msto): fix a stale spec-authority split left over from #1421's reclassification`** — the doc split rows between two authorities in a way that no longer matched how #1421 classified them.

**`test(msto): split the reported-pair census constant per direction`** — the census pinned one constant across both shuffle directions, so a change in one direction could be masked by a compensating change in the other. Split into a 3′ and a 5′ constant.

## Verification

- Full suite: **10,013 passed, 0 failed, 150 skipped — nothing re-blessed.** For a branch rebased across 21 commits of `main`, an unchanged expectation set is the signal worth stating: the per-direction census constants introduced by the last commit still hold at the current tip.
- `cargo fmt --all --check` clean.
- One test failed before an unrelated fix: `ruling_records_are_intact` compared a 10-record pinned list against `main`'s 16. The test file on this branch is byte-identical to `main`'s — the cause was a stale gitignored generated fixture in the worktree (`tests/fixtures/grammar/hgvs_spec_normalization.json`, two days old). Regenerating resolved it. Recorded here because the failure reads like a real ledger regression and is not one.

Representation-Change: none. Three commits touch documentation or tests only; the `merge.rs` change is comment-only, verified by the unchanged expectation set above.
