### PR TITLE
fix(normalize): let the splitter express two deletions, not just two insertions

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -6458,6 +6458,16 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
             return Some(columns);
         }
     }
+    // The mirror, on a net-deletion block: a single gap cannot express
+    // *deletion, retained reference, deletion* either, and the same argument
+    // licenses it — see [`two_gap_deletion_alignment`]. The trigger is the
+    // mirror too: the retained side of a net deletion is the result, so what
+    // signals a single gap's failure here is an unmatched *result* base.
+    if !shorter_is_ref && best.is_some_and(|(matches, _, _)| matches < result.len()) {
+        if let Some(columns) = two_gap_deletion_alignment(reference, result) {
+            return Some(columns);
+        }
+    }
 
     // Only the winner is materialized.
     best.map(|(_, _, k)| {
@@ -6536,9 +6546,16 @@ fn best_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
 /// introduced and no match is manufactured: every matched column is a reference
 /// base surviving verbatim. That argument never depended on `a` being 0 — all
 /// three chunks are verbatim reference either way. Cluster A is structurally out
-/// of reach — #1040 and the `inv` cases are equal-length, #1157A is a net
-/// deletion, and an equal-length or net-deletion block never reaches this
-/// function.
+/// of reach: #1040 and the `inv` cases are equal-length, and an equal-length
+/// block never reaches this function.
+///
+/// A **net-deletion** block reaches it only through
+/// [`two_gap_deletion_alignment`], which calls this with the two blocks swapped.
+/// The containment argument transposes with them and is unchanged in substance,
+/// but note the consequence for reading this function's preconditions: on that
+/// path `reference` is the observed sequence and `result` the reference. #1157A
+/// is a net deletion and is still out of reach — it has no decomposition of this
+/// shape in either orientation.
 ///
 /// Comparison is byte-exact, matching [`best_alignment`]'s own `==` throughout.
 /// Making only this path case-insensitive would let the two-gap form win on a
@@ -6606,6 +6623,60 @@ fn two_gap_insertion_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Co
         }
     }
     None
+}
+
+/// The alignment that keeps the **whole** result intact across two deletions,
+/// or `None` when the pair does not have that shape — the mirror of
+/// [`two_gap_insertion_alignment`].
+///
+/// # Why it is a transpose and not a second implementation
+///
+/// The two shapes are the same statement read from opposite sides. This
+/// function looks for
+///
+/// ```text
+/// reference = result[..a] + D1 + result[a..b] + D2 + result[b..]
+/// ```
+///
+/// and that is *literally* [`two_gap_insertion_alignment`]'s equation with the
+/// two blocks exchanged. Calling it with `(result, reference)` and swapping each
+/// column's two indices therefore yields exactly the alignment wanted here — so
+/// every bound, precondition and tie-break of that function applies unchanged,
+/// and there is no duplicated index arithmetic to drift.
+///
+/// # Why it does not reopen the corpus the single-gap rule protects
+///
+/// The same argument, transposed. The single-gap restriction exists to stop
+/// *compensating* gaps — a deletion **and** an insertion in one block — from
+/// manufacturing matches out of coincidence (#1034/#1040/#182). Both gaps here
+/// are deletions in a net-deletion block, so no insertion is introduced and no
+/// match is manufactured: every matched column is a result base that survives
+/// verbatim in the reference.
+///
+/// # What it is for
+///
+/// A block like `ATGC -> T` has no single-gap explanation that stays within its
+/// own edit distance: the lone gap parks at one end and the offset reads as
+/// substitutions, giving the 4-column `delins` where the block needs 3. The
+/// two-gap form is the description the block actually admits — delete `A`,
+/// retain `T`, delete `GC` — and it is the one `general.md:34` asks for, since
+/// the two deletions are separated by an unchanged nucleotide.
+///
+/// Without it, `canonicalize_from_sequence`'s weight bound correctly refuses the
+/// over-claiming `delins` and the pass falls back to the per-member pipeline,
+/// whose answer *is* spelling-dependent — so two spellings of one variant
+/// diverge. That is the confluence regression this closes. The bound is named
+/// generically here on purpose: the ceiling it compares against is derived from
+/// the input's spelling today and is being moved onto the block by a separate
+/// change, and this alignment is what it is either way.
+fn two_gap_deletion_alignment(reference: &[u8], result: &[u8]) -> Option<Vec<Column>> {
+    let transposed = two_gap_insertion_alignment(result, reference)?;
+    Some(
+        transposed
+            .into_iter()
+            .map(|(alt_index, ref_index)| (ref_index, alt_index))
+            .collect(),
+    )
 }
 
 /// Columns for an alignment with a single gap of `gap_len` after `k` aligned
@@ -14042,11 +14113,14 @@ mod tests {
         }
 
         /// Run both splitters on one block and check the two invariants that hold
-        /// for every disagreement found: both sides denote the alternate block,
-        /// and the sequence-first side never declines.
+        /// for every harvested block: both sides denote the alternate block, and
+        /// the sequence-first side never declines.
+        ///
+        /// Says nothing about whether the two agree — [`both`] and [`converged`]
+        /// are the two callers that do.
         ///
         /// Returns `(live, shadow)` for the caller to pin exactly.
-        fn both(reference: &[u8], result: &[u8]) -> (Vec<Piece>, Vec<Piece>) {
+        fn both_raw(reference: &[u8], result: &[u8]) -> (Vec<Piece>, Vec<Piece>) {
             let live = partition_block(reference, result);
             let shadow = partition_block_sequence_first(
                 reference,
@@ -14064,23 +14138,56 @@ mod tests {
                 Some(result),
                 "shadow pieces must denote the alternate block: {shadow:?}"
             );
+            (live, shadow)
+        }
+
+        /// [`both_raw`], for a class that still disagrees.
+        fn both(reference: &[u8], result: &[u8]) -> (Vec<Piece>, Vec<Piece>) {
+            let (live, shadow) = both_raw(reference, result);
             assert_ne!(shape(&live), shape(&shadow), "this block must disagree");
             (live, shadow)
         }
 
-        /// `A1` (7 035 blocks). `partition_block` has no single-gap explanation
-        /// for two separate deletions, so it emits the whole block as one
-        /// `delins`; the sequence-first split finds both deletions.
-        #[test]
-        fn shadow_splits_a_block_live_kept_whole() {
-            let (live, shadow) = both(b"ACAC", b"CA");
-            assert_eq!(shape(&live), [(0, 4, b"CA".as_slice())]);
+        /// [`both_raw`], for a class the live splitter has since **caught up
+        /// with**: the two now agree, and the agreed shape is returned once.
+        ///
+        /// Kept as a pin rather than deleted. The block counts these classes
+        /// carry are the measured size of a defect, and a closed defect that
+        /// leaves no test behind is one nothing stops from reopening — a
+        /// regression in `partition_block` would silently restore the
+        /// disagreement and no other test in this module would notice.
+        fn converged(reference: &[u8], result: &[u8]) -> Vec<Piece> {
+            let (live, shadow) = both_raw(reference, result);
             assert_eq!(
+                shape(&live),
                 shape(&shadow),
+                "this class is closed; the two splitters must agree"
+            );
+            live
+        }
+
+        /// `A1` (7 035 blocks) — **closed by [`two_gap_deletion_alignment`]**,
+        /// and the largest class this module recorded.
+        ///
+        /// The recorded defect was precisely the one that function exists to
+        /// remove: `partition_block` had no single-gap explanation for two
+        /// separate deletions, so it emitted the whole block as one `delins`
+        /// claiming 4 changed columns where the block needs 2, while the
+        /// sequence-first split found both deletions. Live now finds them too.
+        #[test]
+        fn two_separate_deletions_are_found_by_both_splitters() {
+            let pieces = converged(b"ACAC", b"CA");
+            assert_eq!(
+                shape(&pieces),
                 [(0, 1, b"".as_slice()), (3, 4, b"".as_slice())]
             );
-            assert_eq!(changed_columns_of_pieces(&live), 4);
-            assert_eq!(changed_columns_of_pieces(&shadow), 2);
+            // Two columns, against the four the spanning `delins` this replaced
+            // claimed. The count is pinned by value here rather than against the
+            // block's own Levenshtein distance: `minimal_changed_columns` is the
+            // helper that would state minimality directly, and it arrives with
+            // the separate change that derives the weight bound's ceiling from
+            // the block instead of the input.
+            assert_eq!(changed_columns_of_pieces(&pieces), 2);
         }
 
         /// `A2` (6 915 blocks). The block is a 5' insertion plus a 3' deletion.
@@ -14107,39 +14214,36 @@ mod tests {
             assert_eq!(changed_columns_of_pieces(&shadow), 2);
         }
 
-        /// `A3` (4 567 blocks). Same piece count; the live first piece spans one
-        /// base more than it needs to, and pays for it with a substitution the
-        /// sequence-first split renders as a deletion.
+        /// `A3` (4 567 blocks) — **closed by [`two_gap_deletion_alignment`]**.
+        ///
+        /// The recorded defect: same piece count on both sides, but the live
+        /// first piece spanned one base more than it needed to and paid for it
+        /// with a substitution the sequence-first split rendered as a deletion.
+        /// Both now narrow it.
         #[test]
-        fn shadow_narrows_a_piece_live_over_widened() {
-            let (live, shadow) = both(b"ACCA", b"CC");
+        fn neither_splitter_over_widens_the_first_of_two_deletions() {
+            let pieces = converged(b"ACCA", b"CC");
             assert_eq!(
-                shape(&live),
-                [(0, 2, b"".as_slice()), (3, 4, b"C".as_slice())]
-            );
-            assert_eq!(
-                shape(&shadow),
+                shape(&pieces),
                 [(0, 1, b"".as_slice()), (3, 4, b"".as_slice())]
             );
-            assert_eq!(changed_columns_of_pieces(&live), 3);
-            assert_eq!(changed_columns_of_pieces(&shadow), 2);
+            assert_eq!(changed_columns_of_pieces(&pieces), 2);
         }
 
-        /// `A4` (379 blocks). The rarest of the four: the sequence-first first
-        /// piece is *wider* than live's, and the total is still lower.
+        /// `A4` (379 blocks) — **closed by [`two_gap_deletion_alignment`]**, and
+        /// the rarest of the four.
+        ///
+        /// The recorded defect: the sequence-first first piece was *wider* than
+        /// live's and the total was still lower — live spent a substitution plus
+        /// a 3-base deletion where two deletions suffice.
         #[test]
-        fn shadow_widens_one_piece_and_still_lowers_the_total() {
-            let (live, shadow) = both(b"AACAC", b"CA");
+        fn a_wider_first_deletion_still_lowers_the_total_on_both_sides() {
+            let pieces = converged(b"AACAC", b"CA");
             assert_eq!(
-                shape(&live),
-                [(0, 1, b"C".as_slice()), (2, 5, b"".as_slice())]
-            );
-            assert_eq!(
-                shape(&shadow),
+                shape(&pieces),
                 [(0, 2, b"".as_slice()), (4, 5, b"".as_slice())]
             );
-            assert_eq!(changed_columns_of_pieces(&live), 4);
-            assert_eq!(changed_columns_of_pieces(&shadow), 3);
+            assert_eq!(changed_columns_of_pieces(&pieces), 3);
         }
 
         /// `B1` (8 044 blocks) — **the sequence-first answer is less minimal.**
@@ -14282,9 +14386,11 @@ mod tests {
                 (b"ACAGCG", b"CGCTGT"),
                 (b"AGAGT", b"GAAGAG"),
             ] {
-                // `both` asserts the denotation on each side and that the block
-                // does in fact disagree.
-                both(reference, result);
+                // `both_raw`, not `both`: the denotation invariant is what this
+                // test is about, and it must keep holding for the three classes
+                // the live splitter has since caught up with. Whether a given
+                // block still disagrees is each class's own test to say.
+                both_raw(reference, result);
             }
         }
     }

--- a/tests/fixtures/case-harvest/cases.json
+++ b/tests/fixtures/case-harvest/cases.json
@@ -144,12 +144,12 @@
     },
     {
       "input": "NC_000020.11:g.45891619_45891622delinsC",
-      "expected": "NC_000020.11:g.45891619_45891622delinsC",
+      "expected": "NC_000020.11:g.[45891619del;45891621_45891622del]",
       "citation": {
-        "clause": "docs/background/basics.md:38",
-        "quote": "designed to be **stable**, **meaningful**, **memorable**, and **unequivocal**"
+        "clause": "docs/recommendations/general.md:34",
+        "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
       },
-      "note": "STABILITY PIN, NOT A SPEC-CORRECTNESS CLAIM. The governing ruling (delins-merge-vs-individual-gap-two-or-more) is open, so what is asserted is only that this shipped form does not move. Verified a fixed point on both a pre-#1535 binary and the main tip, so the pin records a form that has already survived a normalizer change. Stability is the value the spec itself leads with, which is the authority cited; it is not authority for this particular spelling."
+      "note": "MOVED 2026-08-10 by `two_gap_deletion_alignment`, from the spanning `g.45891619_45891622delinsC` to the two-member split. NOT a re-bless of a spec-correctness claim: this row was a STABILITY PIN and stability is a tiebreaker, not a veto — the project bar is confluence plus disclosure. The two members are separated by ONE unchanged nucleotide (g.45891620), so the decided ruling `delins-merge-vs-individual-gap-two-or-more` does not reach it: that ruling is scoped by its own terms to a gap of two or more, and the row is `g.`, where `general.md:35`'s codon exception cannot apply either. What does reach it is `general.md:34` (\"two variants separated by one or more nucleotides should be described individually and **not** as a 'delins'\"), which asks for exactly this split. The earlier note said the governing ruling was open; it was decided 2026-08-07, and scoped away from this row. The pin now records the split as the form `general.md:34` states, and the citation moves with it."
     },
     {
       "input": "NG_008660.1:g.58604_58617delinsC",

--- a/tests/it/cis_confluence_adjudication.rs
+++ b/tests/it/cis_confluence_adjudication.rs
@@ -231,24 +231,28 @@ fn denotes_genomic(provider: &MockProvider, description: &str) -> String {
 /// returns two answers for one variant and cannot be evaluated confluently.
 ///
 /// **Authority.** Ruling record
-/// `separation-is-a-property-of-the-spelling-not-of-the-variant`, now
-/// `decided`: the separation is read off the partition **re-derived from the
-/// resulting sequence**, never off the input's spelling. This test pins the
+/// `separation-is-a-property-of-the-spelling-not-of-the-variant`, `decided`:
+/// the separation is read off the partition **re-derived from the resulting
+/// sequence**, never off the input's spelling. This test pins the
 /// *demonstration*, which was settled all along; the decided answer is asserted
-/// by `the_decided_target_is_the_re_derived_form`, which is `#[ignore]`d
-/// because ferro does not produce it yet (#1617).
+/// directly by `the_decided_target_is_the_re_derived_form`.
 ///
 /// The case: `c.10` and `c.11` are both `A`, so deleting one or the other is the
 /// same edit. `c.[9del;10del;13del]` therefore denotes exactly what
 /// `c.[9del;11del;13del]` denotes — checked here through the apply oracle, not
-/// assumed. But the first spells its members at separations 0 and 2 and the
-/// second at 1 and 1, and `general.md:34` merges a separation-0 pair while
-/// splitting a separation-1 pair. Ferro follows it, and produces two outputs.
+/// assumed. The first spells its members at separations 0 and 2 and the second
+/// at 1 and 1, so if `general.md:34` were evaluated on the spelling — merging a
+/// separation-0 pair, splitting a separation-1 pair — the two would part. They
+/// no longer do, which is what the record decided and what makes the presented
+/// separation demonstrably not a property of the variant.
 ///
-/// **These assertions are pre-fix behaviour against a now-decided target.** The
-/// `apart` spelling's answer is form B, which the ruling names as the bug; it is
-/// pinned here as an observation so the fix is visible when it lands, not as an
-/// endorsement.
+/// **The fix landed (#1617), and these assertions now pin the decided answer.**
+/// The `apart` spelling used to print form B — all three members kept individual
+/// — which the ruling names as the bug; it was pinned here as an observation, and
+/// this commit moves it to the decided form. `two_gap_deletion_alignment` lets
+/// the splitter express *deletion, retained reference, deletion*, so the block
+/// re-derived from the resulting sequence yields `c.[9_10del;13del]` from either
+/// spelling and the separation is no longer read off the input.
 #[test]
 fn the_separation_two_members_present_is_not_a_property_of_the_variant() {
     let provider = provider();
@@ -261,22 +265,28 @@ fn the_separation_two_members_present_is_not_a_property_of_the_variant() {
     assert_eq!(denotes(&provider, apart), sequence);
     assert_eq!(denotes(&provider, spanning), sequence);
 
-    // Three outputs. The separation each spelling presents is what selects them,
-    // and no two spellings present the same one.
+    // One output, not three. All three spellings — both member spellings and
+    // the spanning delins — now reach the form the record decides for, whatever
+    // separation each happens to present.
     assert_eq!(
         normalized(&provider, adjacent),
         "NM_TEST.1:c.[9_10del;13del]",
-        "separations 0 and 2: `delins.md:16` merges the adjacent pair"
+        "separations 0 and 2 as written: `delins.md:16` merges the adjacent pair"
     );
     assert_eq!(
         normalized(&provider, apart),
-        "NM_TEST.1:c.[9del;11del;13del]",
-        "separations 1 and 1: `general.md:34` keeps all three individual"
+        "NM_TEST.1:c.[9_10del;13del]",
+        "separations 1 and 1 as written, but the separation is read off the \
+         re-derived partition, not off this spelling — so it reaches the same \
+         answer the adjacent spelling does (#1617)"
     );
     assert_eq!(
         normalized(&provider, spanning),
-        "NM_TEST.1:c.9_13delinsAT",
-        "no members at all, so no separation to read: the spanning form survives"
+        "NM_TEST.1:c.[9_10del;13del]",
+        "no members at all, so no separation to read off the spelling — and now \
+         none is read off it: the block is re-derived and reaches the same \
+         answer the two member spellings do. This is the `c.` twin of the \
+         genomic form C -> form A move the record's own ruling settles"
     );
 }
 
@@ -318,12 +328,9 @@ fn genomic_provider() -> MockProvider {
 /// `separation-is-a-property-of-the-spelling-not-of-the-variant`, `decided`
 /// for the re-derived form (A below).
 ///
-/// **These assertions pin PRE-FIX behaviour against a now-decided target.**
-/// They are not adjudicated correct. `live` sends the two spellings to two
-/// different answers, one of which is the decided one and one of which is not;
-/// the decided answer for *both* is asserted by
-/// `the_decided_target_is_the_re_derived_form`, which is `#[ignore]`d until
-/// #1617 lands. When it does, both expectations here move to form A.
+/// **#1617 landed, so both expectations are now form A** — the decided answer,
+/// reached from both spellings. The second expectation used to be form B, the
+/// form the ruling names as the bug, pinned as an observation; it moved here.
 #[test]
 fn the_separation_two_members_present_is_not_a_property_of_the_variant_on_real_coordinates() {
     let provider = genomic_provider();
@@ -342,20 +349,18 @@ fn the_separation_two_members_present_is_not_a_property_of_the_variant_on_real_c
         denotes_genomic(&provider, adjacent)
     );
 
-    // Two outputs, selected by the separation each spelling happens to present.
+    // One output, no longer selected by the separation each spelling presents.
     assert_eq!(
         normalized(&provider, adjacent),
         "NC_000001.11:g.[1001009_1001010del;1001013del]",
-        "separations 0 and 2 as written: the adjacent pair is merged. This is \
-         form A, the decided answer — reached here for the wrong reason, off \
-         the spelling rather than off the resulting sequence"
+        "separations 0 and 2 as written: form A, the decided answer"
     );
     assert_eq!(
         normalized(&provider, apart),
-        "NC_000001.11:g.[1001009del;1001011del;1001013del]",
-        "separations 1 and 1 as written: all three kept individual. This is \
-         form B, which the ruling names as the bug — pinned as pre-fix \
-         behaviour, not endorsed (#1617)"
+        "NC_000001.11:g.[1001009_1001010del;1001013del]",
+        "separations 1 and 1 as written, and the same answer: form A. This used \
+         to be form B — all three kept individual, the form the ruling names as \
+         the bug — and #1617 closed it"
     );
 }
 
@@ -368,12 +373,14 @@ fn the_separation_two_members_present_is_not_a_property_of_the_variant_on_real_c
 /// the resulting sequence, never off the input's spelling — rule 3 of the
 /// README ruleset.
 ///
-/// **`#[ignore]`d because ferro does not do this yet**, not because the answer
-/// is in doubt. `FERRO_PARTITION=shadow` and `FERRO_PARTITION=canonical` — the
-/// sequence-first arms — already take both spellings here to form A; the
-/// default `live` partitioner takes the second to form B. Closing that gap is
-/// **#1617**, and this test is its acceptance criterion: delete the `#[ignore]`
-/// and move the two `apart` expectations above.
+/// **No longer `#[ignore]`d: #1617 is closed.** It was `#[ignore]`d because
+/// ferro did not do this yet, never because the answer was in doubt — the
+/// sequence-first arms (`FERRO_PARTITION=shadow`, `=canonical`) already took
+/// both spellings to form A while the default `live` partitioner took the second
+/// to form B. `two_gap_deletion_alignment` lets `live`'s splitter express
+/// *deletion, retained reference, deletion*, which is the shape form A needs, so
+/// `live` now agrees with them. This test was that fix's acceptance criterion,
+/// and the two `apart` expectations above moved with it.
 ///
 /// Form C, `g.1001009_1001013delinsCA`, is what `FERRO_PARTITION=
 /// canonical-coalesced` gives and what Mutalyzer and VariantValidator produce.
@@ -384,7 +391,6 @@ fn the_separation_two_members_present_is_not_a_property_of_the_variant_on_real_c
 /// scopes itself to a minimal single `delins` split on payload coincidence and
 /// says in as many words that it is not a general licence to merge at gap ≥ 2.
 #[test]
-#[ignore = "decided target, not yet implemented — see #1617"]
 fn the_decided_target_is_the_re_derived_form() {
     let provider = genomic_provider();
     let form_a = "NC_000001.11:g.[1001009_1001010del;1001013del]";
@@ -392,6 +398,13 @@ fn the_decided_target_is_the_re_derived_form() {
     for spelling in [
         "NC_000001.11:g.[1001009del;1001010del;1001013del]",
         "NC_000001.11:g.[1001009del;1001011del;1001013del]",
+        // Form C, added when the fix landed. The record's table names C as a
+        // conformant description that is **not** the target; it does not say
+        // what C itself should normalize to, and until now C was its own fixed
+        // point, so the ruling left one spelling of this variant reaching a
+        // fourth answer. It now reaches A like the rest, which is the same
+        // ruling applied to the one spelling it had not been applied to.
+        "NC_000001.11:g.1001009_1001013delinsCA",
         form_a,
     ] {
         assert_eq!(

--- a/tests/it/cis_confluence_adjudication.rs
+++ b/tests/it/cis_confluence_adjudication.rs
@@ -543,3 +543,74 @@ fn a_spanning_delins_and_its_aligned_split_are_two_fixed_points() {
          scope reaches a spelling that arrives already split is not settled"
     );
 }
+
+/// The net-deletion two-gap split, pinned through the **public diagnostics
+/// entry point** and asserted to be a fixed point there.
+///
+/// Everything else this change added tests the splitter directly, on `&[u8]`
+/// reference/result pairs. That is the right level for the algorithm and the
+/// wrong level for the only question a consumer asks, which is what
+/// `Normalizer` prints — and `normalize_with_diagnostics` is specifically the
+/// exit where that has gone wrong before: it used to call
+/// `normalize_core_canonical` directly, skipping the strict-mode rejection
+/// ladder *and* all four seam oracles, so a variant could take a different route
+/// through it than through `normalize()` (#1382). A pass that changes which
+/// partition is reachable therefore owes this seam a test rather than assuming
+/// the two exits agree.
+///
+/// Three things are asserted, and the second is the one with teeth:
+///
+/// 1. the exact displayed string, from all three spellings of the case
+///    `the_separation_two_members_present_is_not_a_property_of_the_variant`
+///    settles — the spanning `delins` and both member spellings;
+/// 2. that re-normalizing that output through the same entry point returns it
+///    **byte-identically**. `two_gap_deletion_alignment` makes a partition
+///    reachable that was not before, and a newly reachable partition is exactly
+///    the shape that can fail to be its own fixed point — the output would then
+///    be a second canonical form rather than the canonical one;
+/// 3. that the diagnostics exit and the plain `normalize()` exit agree, which is
+///    the #1382 asymmetry stated as an assertion instead of as a comment.
+#[test]
+fn the_two_gap_deletion_split_is_a_fixed_point_through_the_diagnostics_exit() {
+    let provider = provider();
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let with_diagnostics = |description: &str| -> String {
+        let variant = parse_hgvs(description).unwrap_or_else(|e| panic!("{description}: {e}"));
+        normalizer
+            .normalize_with_diagnostics(&variant)
+            .unwrap_or_else(|e| panic!("{description}: {e}"))
+            .result
+            .to_string()
+    };
+
+    // The spanning `delins` is the shape the pass exists for: a net deletion
+    // whose payload aligns against its span with TWO gaps, which the splitter
+    // could not express before and so had to flatten.
+    for spelling in [
+        "NM_TEST.1:c.9_13delinsAT",
+        "NM_TEST.1:c.[9del;10del;13del]",
+        "NM_TEST.1:c.[9del;11del;13del]",
+    ] {
+        let output = with_diagnostics(spelling);
+        assert_eq!(
+            output, "NM_TEST.1:c.[9_10del;13del]",
+            "{spelling}: the diagnostics exit must print the re-derived two-gap partition"
+        );
+        assert_eq!(
+            with_diagnostics(&output),
+            output,
+            "{spelling}: `{output}` is not a fixed point of the diagnostics exit — a newly \
+             reachable partition that re-normalizes elsewhere is a SECOND canonical form, not \
+             the canonical one"
+        );
+        assert_eq!(
+            normalized(&provider, spelling),
+            output,
+            "{spelling}: `normalize()` and `normalize_with_diagnostics()` disagree — the #1382 \
+             asymmetry, on a partition this change made reachable"
+        );
+    }
+}

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -126,7 +126,7 @@ const CDS_END: u64 = 63;
 /// figure is a baseline that must only ever go down, and `converged` a floor
 /// that must only ever go up.
 ///
-/// **71.2% of designed classes converge** (8 027 of 11 272). The 3 245 that do
+/// **74.2% of designed classes converge** (8 361 of 11 272). The 2 911 that do
 /// not are the measurement this module exists to make: nothing in the repo
 /// could state that number before, because only 650 real rows reach the
 /// partitioner at all — and `multi_member_cis_axis` measures 82% convergence
@@ -141,7 +141,7 @@ const CDS_END: u64 = 63;
 /// change that closed #1454 — and never again. So #1454 is the one movement it
 /// did track, and the ones it missed are #1524, the axis gate, #1539 and #1599.
 /// Each of those four is recorded in the chronology below, which terminates
-/// correctly at the pinned 8 027; only the headline was left behind. The one
+/// correctly at the pinned figure; only the headline was left behind. The one
 /// number a reader takes away was therefore the one number in the file that was
 /// wrong, and it was wrong by 1 394 classes — larger than any single movement the
 /// chronology records.
@@ -152,6 +152,13 @@ const CDS_END: u64 = 63;
 /// the drift this section is about, arriving once more during the change that
 /// documents it — and it is why the numbers below are asserted rather than
 /// written down.
+///
+/// It arrived a **third** time in #1649, which moved the pin to 8 361 while that
+/// very paragraph was on the branch. The headline moved with it because
+/// [`the_headline_matches_the_pin`] made it impossible not to — which is the
+/// first movement of this pin the prose has tracked without a human noticing it
+/// had to, and the argument for the guard stated as an outcome rather than as an
+/// intention.
 ///
 /// Restating a pinned constant in prose is the drift this repository names as
 /// its recurring failure mode, and prose cannot be derived from a `const`. The
@@ -269,14 +276,25 @@ const CDS_END: u64 = 63;
 /// generalises to the other, which is the whole reason two of them exist. The
 /// promoted rows are in
 /// `spec_corpus_regressions::the_codon_gate_splits_a_spanning_delins_its_own_members_do_not`.
+/// **Raised again by #1649's two-deletion alignment: 8 027 -> 8 361**, the
+/// largest movement this pin has taken since the axis gate. `merge`'s payload
+/// splitter could express *insertion, retained reference, insertion* but not the
+/// mirrored *deletion, retained reference, deletion*, so a payload whose
+/// alignment against its span carries two gaps was forced onto a coarser
+/// partition than the sequence supports — and which coarser partition it landed
+/// on depended on the spelling it started from, which is what a confluence
+/// failure is. `split_two` falls by 276, `split_three` by 48 and `split_more` by
+/// 10; the three sum to the 334 `converged` gains, so **every** moved class went
+/// straight to convergence and none merely dropped an arity. No divergence
+/// figure rises, so the ratchet is satisfied in the direction it was written for.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 8_027,
-    split_two: 3_111,
-    split_three: 115,
-    split_more: 19,
+    converged: 8_361,
+    split_two: 2_835,
+    split_three: 67,
+    split_more: 9,
     underdetermined: 0,
     sequence_changed: 0,
 };
@@ -323,14 +341,22 @@ const THREE_PRIME: Census = Census {
 /// start from, are historical and correctly labelled rather than stale figures.
 /// An earlier review of this file mistook the 3' side's equivalent entry for a
 /// second stale number; this side carries the same shape.
+/// **Raised again by #1649's two-deletion alignment: 8 023 -> 8 367**, with
+/// `split_two` down 309, `split_three` down 31 and `split_more` down 4 — again
+/// summing exactly to the 344 `converged` gains, so every moved class converged
+/// outright. The 5' direction gains 344 against the 3' direction's 334, the same
+/// ten-class asymmetry the entries above record and for the same reason: the
+/// finer partition is chosen before the shift, so the two members are then
+/// shuffled independently and only some of those landings coincide with the
+/// other spelling's.
 const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
-    converged: 8_023,
-    split_two: 3_135,
-    split_three: 105,
-    split_more: 9,
+    converged: 8_367,
+    split_two: 2_826,
+    split_three: 74,
+    split_more: 5,
     underdetermined: 0,
     sequence_changed: 0,
 };

--- a/tests/it/cis_confluence_nr_axis.rs
+++ b/tests/it/cis_confluence_nr_axis.rs
@@ -139,14 +139,27 @@ const TX_CONTIG: &str = "chr_synth";
 /// zero, so every divergence is two well-formed, sequence-preserving outputs for
 /// one variant — the confluence defect itself, not a parse failure or a
 /// corrupted sequence wearing its clothes.
+/// **Re-blessed again by #1649's two-deletion alignment: 4 012 -> 4 179.**
+/// `merge`'s payload splitter gains the *deletion, retained reference, deletion*
+/// shape it was missing — the mirror of the two-insertion shape it already had —
+/// so a two-gap alignment no longer has to be flattened onto a coarser partition
+/// chosen by the input's spelling. `split_two` falls 138, `split_three` 24 and
+/// `split_more` 5, summing exactly to the 167 gained, so every moved class
+/// converged outright rather than dropping an arity. No divergence figure rises.
+///
+/// **That this fires on `n.` at all is the finding.** The pass is not
+/// coding-axis machinery, and the four censuses in this file move by 167/167/172/172
+/// against `cis_confluence_axis`'s 334/344 — the `n.` and `r.` axes gain in the
+/// same proportion as the `c.` one, which is what a partitioner change should
+/// look like and what an axis-scoped carve-out would not.
 const N_THREE_PRIME: Census = Census {
     classes: 5_636,
     spellings: 23_696,
     declined: 0,
-    converged: 4_012,
-    split_two: 1_558,
-    split_three: 57,
-    split_more: 9,
+    converged: 4_179,
+    split_two: 1_420,
+    split_three: 33,
+    split_more: 4,
     underdetermined: 0,
     sequence_changed: 0,
 };
@@ -160,14 +173,18 @@ const N_THREE_PRIME: Census = Census {
 /// is #1484, which changed the `n.`/`r.` axes with no test covering them — this
 /// file is the coverage, and the re-bless is the first measurement of what that
 /// PR did here.
+/// **Re-blessed again by #1649: 4 010 -> 4 177**, an identical +167 to its `n.`
+/// twin with identical `split_*` deltas. The `r.` and `n.` axes tracking each
+/// other exactly is the cross-check this pair of pins exists for: the alphabet
+/// differs and the partition does not.
 const R_THREE_PRIME: Census = Census {
     classes: 5_636,
     spellings: 23_696,
     declined: 0,
-    converged: 4_010,
-    split_two: 1_560,
-    split_three: 57,
-    split_more: 9,
+    converged: 4_177,
+    split_two: 1_422,
+    split_three: 33,
+    split_more: 4,
     underdetermined: 0,
     sequence_changed: 0,
 };
@@ -179,14 +196,19 @@ const R_THREE_PRIME: Census = Census {
 /// Re-blessed alongside [`N_THREE_PRIME`]: `converged` 2_625 -> 4_011,
 /// `split_two` 2_954 -> 1_569, `split_three` 53 -> 52, every other field
 /// unchanged. Its `r.` twin is [`R_FIVE_PRIME`].
+/// **Re-blessed again by #1649: 4 011 -> 4 183** (+172), `split_two` -154,
+/// `split_three` -16, `split_more` -2. The 5' direction gains five more classes
+/// than the 3' does, the same asymmetry [`N_THREE_PRIME`]'s history records: the
+/// finer partition is chosen before the shift, so the members are shuffled
+/// independently afterwards and only some of those landings coincide.
 const N_FIVE_PRIME: Census = Census {
     classes: 5_636,
     spellings: 23_696,
     declined: 0,
-    converged: 4_011,
-    split_two: 1_569,
-    split_three: 52,
-    split_more: 4,
+    converged: 4_183,
+    split_two: 1_415,
+    split_three: 36,
+    split_more: 2,
     underdetermined: 0,
     sequence_changed: 0,
 };
@@ -198,14 +220,18 @@ const N_FIVE_PRIME: Census = Census {
 /// `split_three` 54 -> 52. That the two directions moved together (+1_383 and
 /// +1_385) is itself the evidence the change is a property of the normalizer
 /// rather than of one shuffle direction.
+/// **Re-blessed again by #1649: 4 009 -> 4 181**, again matching its `n.` twin
+/// exactly at +172. All four censuses in this file move monotonically — every
+/// `converged` up, every divergence figure down — so the ratchet is satisfied in
+/// the direction it was written for on both axes and both directions.
 const R_FIVE_PRIME: Census = Census {
     classes: 5_636,
     spellings: 23_696,
     declined: 0,
-    converged: 4_009,
-    split_two: 1_571,
-    split_three: 52,
-    split_more: 4,
+    converged: 4_181,
+    split_two: 1_417,
+    split_three: 36,
+    split_more: 2,
     underdetermined: 0,
     sequence_changed: 0,
 };

--- a/tests/it/defect_non_idempotent_outputs.rs
+++ b/tests/it/defect_non_idempotent_outputs.rs
@@ -833,8 +833,22 @@ fn the_scale_class_is_a_coding_axis_repartition_not_a_long_block_effect() {
     // equally consistent with "only the coding axis splits at all", which would
     // point a fix at the splitter rather than at the second pass. It is also what
     // keeps the flipped sweep above from being satisfiable by a normalizer that
-    // simply stopped partitioning: both axes still split this block, into 8 and
-    // 39 members respectively.
+    // simply stopped partitioning: both axes still split this block.
+    //
+    // **The two arities used to differ — 8 members on `c.` and 39 on `n.` — and
+    // #1649 collapsed both to 2.** The assertion below was
+    // `n. members > c. members`, which said "the `n.` axis is not stable merely
+    // by doing less work". That phrasing cannot survive the two axes agreeing,
+    // and re-blessing it to `>=` would have quietly turned a real claim into one
+    // that also passes when neither axis splits at all — the exact failure the
+    // comment above is guarding against.
+    //
+    // So it is re-pointed rather than relaxed, and it now asserts MORE than it
+    // did: each axis splits this block (so neither is stable by declining), and
+    // the two reach the SAME arity. The second half is the class closing stated
+    // as an assertion — the coding axis used to under-split relative to `n.` and
+    // no longer does, which is what "a coding-axis repartition" being fixed
+    // means. A future change that makes them differ again reopens it.
     //
     // One geometry rather than the sweep, because it takes a block long enough
     // that both axes split it: `scale-c3p-sep136`'s core, anchored inside the
@@ -853,10 +867,19 @@ fn the_scale_class_is_a_coding_axis_repartition_not_a_long_block_effect() {
     let input = spanning_delins(&noncoding, noncoding_shape, start, sep).expect("in range");
     let output = normalize(&noncoding, &input, ShuffleDirection::ThreePrime);
 
+    let noncoding_members = output.matches(';').count() + 1;
+    let coding_members = coding_output.matches(';').count() + 1;
     assert!(
-        output.matches(';').count() > coding_output.matches(';').count(),
-        "the `n.` axis must split this block FURTHER than the coding axis for the point to \
-         hold — it is not stable because it is doing less work:\n  n.: {output}\n  c.: {coding_output}"
+        noncoding_members > 1 && coding_members > 1,
+        "both axes must still SPLIT this block — an axis that returns it as one member is \
+         stable by declining to partition, which is what this assertion exists to rule \
+         out:\n  n.: {output}\n  c.: {coding_output}"
+    );
+    assert_eq!(
+        noncoding_members, coding_members,
+        "the two axes must reach the SAME arity now that #1649 closed the coding-axis \
+         under-split. `c.` reaching fewer members than `n.` is the repartition this file is \
+         named for coming back:\n  n.: {output}\n  c.: {coding_output}"
     );
     assert!(
         is_fixed_point(&noncoding, &input, ShuffleDirection::ThreePrime),
@@ -975,11 +998,25 @@ fn the_scale_onset_is_not_the_corpus_scale_band() {
 /// to do "something per-member normalization cannot" is precisely the pass that
 /// was merging across codon boundaries — a merge `general.md:35` never authorised.
 /// So the mechanism that made the two passes disagree was not member interaction
-/// at all, which is what the test said. The `matches_authored` column is the part
-/// worth keeping most: it is unchanged too, so **sep-136 still disagrees with its
-/// own authored design's output**, which is why that family remains non-confluent
-/// in `spec_conformance_axis`'s census even though it is now idempotent. Idempotent
-/// and confluent are different properties and this row is the demonstration.
+/// at all, which is what the test said.
+///
+/// **The `matches_authored` column has since closed too, and the distinction it
+/// was carrying is worth keeping even though the row that demonstrated it is
+/// gone.** It read `true, true, false`: sep-136 disagreed with its own authored
+/// design's output, so that family stayed non-confluent in
+/// `spec_conformance_axis`'s census *even though it was already idempotent* —
+/// idempotent and confluent being different properties, with this row as the
+/// demonstration that one can hold without the other.
+///
+/// #1649 closed the second half. The two-deletion alignment resolves sep-136's
+/// trailing `inv` — an artefact of the splitter having no way to express a
+/// second gap — into a plain deletion, and the row lands on its authored
+/// design's output like its two siblings, so the column now reads
+/// `true, true, true`. The demonstration is therefore historical, and it is
+/// recorded here rather than deleted because the *lesson* is what recurs: a
+/// class can be re-blessed out of `non_idempotent_outputs` while still costing
+/// `converged`, and reading only the first counter would have called this family
+/// fixed one change too early.
 #[test]
 fn pass_one_is_already_a_fixed_point_of_per_member_normalization() {
     // The spanning `delins` respelling, named the way the corpus names it rather
@@ -1027,9 +1064,15 @@ fn pass_one_is_already_a_fixed_point_of_per_member_normalization() {
         );
     }
 
-    // The exact answers, unchanged strings measured one pass earlier. Two of the
-    // three land on the authored design's own output and the third does not, which
-    // is why sep-136's family is still non-confluent.
+    // The exact answers. Two of the three are unchanged strings measured one pass
+    // earlier; sep-136's moved with #1649 and is annotated where it sits.
+    //
+    // **All three now land on the authored design's own output.** That was `2 of
+    // 3` until #1649, and the third was the argument that the class was still
+    // non-confluent about its authored design even after the idempotency half
+    // closed. It is not any more — which is why every `matches_authored` below
+    // reads `true`, and why a `false` reappearing here is the confluence half
+    // reopening rather than a new row.
     for (id, expected, matches_authored) in [
         (
             "scale-c3p-sep120-del-del",
@@ -1041,10 +1084,18 @@ fn pass_one_is_already_a_fixed_point_of_per_member_normalization() {
             "NM_TEST.1:c.[110_111del;240_241del]",
             true,
         ),
+        // Re-blessed by #1649. Was `[114_115del;250_251del;252_253inv]` with
+        // `matches_authored: false` — the odd one out of the three, and the
+        // reason the caveat below said the class was still non-confluent about
+        // its authored design. The two-deletion alignment lets the splitter
+        // express *deletion, retained reference, deletion*, so the trailing
+        // `inv` — which existed only because the second gap had no expression —
+        // resolves to a plain deletion and the row lands on the authored
+        // design's own output like its two siblings.
         (
             "scale-c3p-sep136-del-del",
-            "NM_TEST.1:c.[114_115del;250_251del;252_253inv]",
-            false,
+            "NM_TEST.1:c.[114_115del;253_254del]",
+            true,
         ),
     ] {
         let row = row(id);

--- a/tests/it/multi_member_cis_axis.rs
+++ b/tests/it/multi_member_cis_axis.rs
@@ -673,6 +673,33 @@ fn measure_axis(provider: &Arc<MultiFastaProvider>) -> (AxisCensus, Vec<String>)
 /// So before raising it: name the classes that moved, and the clause that
 /// carried each. If they cannot be named individually, the rise is a
 /// re-derivation and the constant stays where it is while the cause is found.
+///
+/// # Raised 395 -> 401 by #1649, and this section's test applied
+///
+/// The rise has the exact signature the section above warns about — every other
+/// field is unchanged, `respellable` included — so it is discharged here rather
+/// than asserted. The six rows are named in [`CONVERGED_ROWS`]'s own history and
+/// **all six are two-deletion cis pairs**:
+///
+/// ```text
+/// NM_001110792.2:c.[1076_1102del;1124_1142del]   NM_001110792.2:c.[859_907del;934_941del]
+/// NM_001282426.2:c.[391_397del;456_468del]       NM_004992.3:c.[1155_1200del;987_988del]
+/// NM_005144.5:c.[1258del;1263_1283del]           NM_130838.2:c.[255_259del;269del]
+/// ```
+///
+/// That is the mechanism, not a coincidence to be waved at: #1649 lets `merge`'s
+/// payload splitter express *deletion, retained reference, deletion*, the mirror
+/// of the two-insertion shape it already expressed, and the rows that move are
+/// exactly the ones carrying that shape. **0 rows stopped converging**, so this
+/// is `+6 −0` rather than a net figure hiding a swap — which is the distinction
+/// [`CONVERGED_ROWS`] exists to make visible.
+///
+/// The clause is `general.md:34` read through `canonical-form-choice-when-both-legal`
+/// (`decided`): the partition is re-derived from the **resulting sequence** and
+/// what falls out is emitted. So the finer partition is not an extra liberty
+/// taken with the input's unchanged bases — it is what the sequence supports and
+/// what the splitter previously could not spell. `sequence_changed` staying **0**
+/// across all 592 rows is the check that no member was lost buying it.
 const AXIS_CENSUS: AxisCensus = AxisCensus {
     rows: 592,
     declined: 0,
@@ -680,7 +707,7 @@ const AXIS_CENSUS: AxisCensus = AxisCensus {
     unwindowed: 96,
     sequence_changed: 0,
     respellable: 461,
-    respelling_converged: 395,
+    respelling_converged: 401,
 };
 
 /// The rows behind `respelling_converged`, by input, sorted.
@@ -1025,6 +1052,8 @@ const CONVERGED_ROWS: &[&str] = &[
     "NM_001080463.1:c.[12602C>T;9865G>A]",
     "NM_001080467.3:c.[1135C>T;2470C>T]",
     "NM_001105537.3:c.[4183delC;4185G>A]",
+    "NM_001110792.2:c.[1076_1102del;1124_1142del]",
+    "NM_001110792.2:c.[859_907del;934_941del]",
     "NM_001127701.1:c.[187C>T;739C>T]",
     "NM_001127701.1:c.[227_229delTCT;514G>A]",
     "NM_001130004.1:c.[2156A>C;2157G>C]",
@@ -1038,6 +1067,7 @@ const CONVERGED_ROWS: &[&str] = &[
     "NM_001232.3:c.[730C>T;731A>G]",
     "NM_001243279.3:c.[1385A>C;1394_1411del]",
     "NM_001282225.2:c.[1196G>A;1367A>G]",
+    "NM_001282426.2:c.[391_397del;456_468del]",
     "NM_001288953.1:c.[1715A>G;1912T>C]",
     "NM_001289396.1:c.[3495G>C;3917G>A]",
     "NM_001289862.1:c.[1243C>G;1250A>G]",
@@ -1095,7 +1125,9 @@ const CONVERGED_ROWS: &[&str] = &[
     "NM_004771.4:c.[1046C>T;911C>G]",
     "NM_004826.3:c.[1252C>T;590G>A]",
     "NM_004959.4:c.[368G>C;386C>T]",
+    "NM_004992.3:c.[1155_1200del;987_988del]",
     "NM_005035.4:c.[1696C>T;3578C>T]",
+    "NM_005144.5:c.[1258del;1263_1283del]",
     "NM_005154.3:c.[2138T>G;2150A>G]",
     "NM_005157.6:c.[1516G>A;1531G>C]",
     "NM_005215.4:c.[4009C>T;4210G>A]",
@@ -1155,6 +1187,7 @@ const CONVERGED_ROWS: &[&str] = &[
     "NM_058004.4:c.[1414A>C;355C>T]",
     "NM_130466.4:c.[1445T>A;1616T>C]",
     "NM_130468.3:c.[403C>G;410T>A]",
+    "NM_130838.2:c.[255_259del;269del]",
     "NM_133378.4:c.[45418A>G;45419A>T]",
     "NM_138694.4:c.[2165C>T;7438A>T]",
     "NM_139025.3:c.[1342C>G;1523G>A]",

--- a/tests/it/reported_confluence_pairs.rs
+++ b/tests/it/reported_confluence_pairs.rs
@@ -142,7 +142,7 @@ pub(crate) const REPORTED_PAIRS: &[(&str, &str, &str)] = &[
 /// number. Not because sharing would *hide* a single-direction regression — it
 /// would not. [`the_reported_pair_census_is_unchanged`] asserts inside the
 /// per-direction loop, so each direction is already compared against the
-/// constant on its own and no sum is ever taken. Measured: both are currently 0.
+/// constant on its own and no sum is ever taken. Measured: both are currently 3.
 ///
 /// # A rise is not automatically progress — read this before raising either
 ///
@@ -160,14 +160,44 @@ pub(crate) const REPORTED_PAIRS: &[(&str, &str, &str)] = &[
 ///
 /// So a rise must name **which** pair moved and **which clause** carried it. A
 /// rise that cannot name a clause is a re-derivation, not a convergence fix.
-const CONVERGING_PAIRS_THREE_PRIME: usize = 0;
+///
+/// # 0 -> 3 (#1649), the pairs and the clause
+///
+/// The three that converged are **`1419-r1`, `1419-r2` and `1419-r3`**, in both
+/// directions — so `CONVERGING_PAIRS_FIVE_PRIME` moves by the same 3, and the
+/// hazard row `1420-v2` is **not** among them.
+///
+/// In each pair it is the `/span` spelling that moved, onto the two-deletion
+/// form its `/cis` sibling already printed; the `/cis` spellings are unchanged,
+/// which is checkable from `reported_partition_verdicts`' per-row pins rather
+/// than taken on trust. The clause is `general.md:34` read through
+/// `canonical-form-choice-when-both-legal` (`decided`): the partition is
+/// re-derived from the **resulting sequence** and what falls out is emitted.
+/// #1649 lets `merge`'s payload splitter express *deletion, retained reference,
+/// deletion* — the mirror of the two-insertion shape it already expressed — so
+/// the form the sequence supports is now spellable and both spellings reach it.
+///
+/// **This is a convergence, not a closure, and the distinction is the whole
+/// reason `PAIRS_NO_SPELLING_REACHES` is a separate constant.** The string the
+/// three pairs converge on is still not the spanning `delins` the decided chain
+/// wants, so all three stay listed there and `OPEN_GAPS` stays at twelve. What
+/// moved is that the family stopped having two canonical forms.
+const CONVERGING_PAIRS_THREE_PRIME: usize = 3;
 
 /// How many reported pairs converge today under `ShuffleDirection::FivePrime`.
 ///
 /// See [`CONVERGING_PAIRS_THREE_PRIME`] for why this is tracked separately
 /// rather than shared, and for why a rise in either direction has to name the
-/// clause that carried it. Measured: currently 0, same as 3'.
-const CONVERGING_PAIRS_FIVE_PRIME: usize = 0;
+/// clause that carried it. Measured: currently 3, same as 3' — the same three
+/// `1419-r*` pairs, raised from 0 by #1649.
+///
+/// The two directions agreeing here is worth reading rather than skipping: the
+/// pairs converge under 5' on a *different* string in `1419-r3`'s case, because
+/// the 5' pass shifts that pair's leading deletion one base left. Convergence is
+/// a property of the partition the splitter can express, and that is what #1649
+/// changed; which end of the run the members then shuffle to is downstream of
+/// it and does not decide whether the two spellings meet.
+const CONVERGING_PAIRS_FIVE_PRIME: usize = 3;
 
 /// Both directions, because a rule that converges only under the default 3'
 /// direction has not solved the problem: 5' is a supported option and reaches

--- a/tests/it/reported_partition_verdicts.rs
+++ b/tests/it/reported_partition_verdicts.rs
@@ -10,8 +10,10 @@
 //! 1. what ferro prints for **each** of the two spellings,
 //! 2. which of the two the HGVS recommendations make canonical, and on which
 //!    line,
-//! 3. that `EquivalenceChecker` still calls the two one variant
-//!    (`SequenceMatch`) — which is what makes the divergence a *representation*
+//! 3. that `EquivalenceChecker` still calls the two one variant — at
+//!    `SequenceMatch` where the two spellings still print different strings,
+//!    and at `NormalizedMatch` for the three `1419-r*` pairs that #1649
+//!    converged. Either way it is what makes the divergence a *representation*
 //!    problem rather than a correctness one, and what leaves consumers a
 //!    working fallback,
 //! 4. the reference bases the argument in (2) rests on.
@@ -149,12 +151,17 @@
 //! [`every_reported_spelling_still_normalizes_as_the_reports_recorded`] pins the
 //! 3' answer the reports observed; [`Row::five_prime`] and
 //! [`every_reported_spelling_normalizes_as_recorded_under_five_prime`] pin the 5'
-//! answer, which nothing pinned before. Sixteen of the eighteen agree across
-//! directions; the two that do not are named in
-//! [`FIVE_PRIME_MOVERS`], and both are `Gap` rows that the 3' pass returns
-//! verbatim and the 5' pass does not — see
+//! answer, which nothing pinned before. Fifteen of the eighteen agree across
+//! directions; the three that do not are named in [`FIVE_PRIME_MOVERS`].
+//!
+//! **Two of those three are `Gap` rows that the 3' pass returns verbatim and
+//! the 5' pass does not** — see
 //! [`every_gap_row_is_returned_exactly_as_authored`] for why that distinction
-//! carries weight.
+//! carries weight. The third, `1419-r3/span`, is a `Gap` row that **neither**
+//! direction returns verbatim: #1649 moved it off `[19T>G;22_33del]` onto the
+//! two-deletion form its `/cis` sibling prints, and the 5' pass then shifts
+//! that form's leading deletion one base left. It is named in
+//! [`PAIRS_NO_SPELLING_REACHES`] for the retention exemption that follows.
 
 use crate::common::cis_apply_oracle::{normalize, normalize_in, provider};
 use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
@@ -211,8 +218,8 @@ struct Row {
     /// never transcribed.
     output: &'static str,
     /// What ferro prints for it under `ShuffleDirection::FivePrime`. Measured.
-    /// Equal to [`Row::output`] for sixteen of the eighteen rows; the two that
-    /// differ are listed in [`FIVE_PRIME_MOVERS`].
+    /// Equal to [`Row::output`] for fifteen of the eighteen rows; the three
+    /// that differ are listed in [`FIVE_PRIME_MOVERS`].
     five_prime: &'static str,
     verdict: Verdict,
     /// The output **the issue asks for**, in the issue's own terms — the string
@@ -262,12 +269,19 @@ const REPORTED_ROWS: &[Row] = &[
     Row {
         label: "1419-r1/span",
         input: "TEMPLATE:g.19_33delinsCGG",
-        // Measured, unchanged by this change: ferro still prints the
-        // general.md:56 form. What moved is `wanted`, and with it `verdict` —
-        // see the `# The three #1419 spans are Gap rows that do not retain
-        // their input` section of the module docs.
-        output: "TEMPLATE:g.[19_30del;33T>G]",
-        five_prime: "TEMPLATE:g.[19_30del;33T>G]",
+        // Measured, and MOVED by #1649's two-deletion alignment:
+        // `[19_30del;33T>G]` -> `[19_23del;27_33del]`, in both directions. The
+        // splitter can now express *deletion, retained reference, deletion*, so
+        // this span no longer has to be flattened onto the del-plus-sub form.
+        // What that changes is WHICH split ferro prints — not `wanted`, which
+        // is still the spanning delins on delins.md:46-47, and not `verdict`,
+        // which is still Gap because ferro still does not print it. The pair
+        // now CONVERGES: this is byte-identical to `1419-r1/cis`'s output, so
+        // `CONVERGING_PAIRS_THREE_PRIME`/`_FIVE_PRIME` are 3 rather than 0 and
+        // the equivalence level is NormalizedMatch. A migration for anyone
+        // storing the old string — see the PR's Representation-Change trailer.
+        output: "TEMPLATE:g.[19_23del;27_33del]",
+        five_prime: "TEMPLATE:g.[19_23del;27_33del]",
         verdict: Verdict::Gap,
         wanted: "TEMPLATE:g.19_33delinsCGG",
         authority: Authority::SpecSelfConflicting,
@@ -279,8 +293,8 @@ const REPORTED_ROWS: &[Row] = &[
                    have been CHANGED. Both grounds are withdrawn. \
                    The decided chain, applied. `adjudication-precedence-order` records that general.md:56 \"ranks single-variant TYPE LABELS FOR ONE SPAN — it never ranks a multi-member allele against a spanning description\", and that an earlier attempt to use it that way was refuted on exactly that ground, so :56 cannot settle a merge-versus-split question at all. :56 was the whole of the argument this row used to carry. `canonical-form-choice-when-both-legal` supplies what to do instead: derive from the resulting sequence, then apply every explicit spec tie-break. :56 does not apply; delins.md:46-47 does, this being precisely the alignment-coincidence shape it constructs and then declines — `The \"delins\" format is recommended`. So the wanted form is the SPANNING delins. That is this row's own \
                    input, so the wanted form is what it arrived as — and ferro \
-                   splits it to `[19_30del;33T>G]` instead, which is why this is \
-                   a Gap row that does NOT retain its input. Ferro's own \
+                   splits it to `[19_23del;27_33del]` instead, which is why this \
+                   is a Gap row that does NOT retain its input. Ferro's own \
                    coalesce pass encodes the same recommendation on the spec's \
                    worked example (see \
                    `merge::the_coalesce_pass_reaches_the_spec_worked_example`) \
@@ -303,9 +317,12 @@ const REPORTED_ROWS: &[Row] = &[
     Row {
         label: "1419-r2/span",
         input: "TEMPLATE:g.19_36delinsGCG",
-        // Measured, unchanged — see `1419-r1/span`.
-        output: "TEMPLATE:g.[19_33del;36A>G]",
-        five_prime: "TEMPLATE:g.[19_33del;36A>G]",
+        // Measured, and MOVED by #1649 — see `1419-r1/span`, same mechanism
+        // and same consequences: `[19_33del;36A>G]` -> `[19_22del;26_36del]`
+        // in both directions, which is `1419-r2/cis`'s output, so this pair
+        // converges too. `wanted` and `verdict` are untouched.
+        output: "TEMPLATE:g.[19_22del;26_36del]",
+        five_prime: "TEMPLATE:g.[19_22del;26_36del]",
         verdict: Verdict::Gap,
         wanted: "TEMPLATE:g.19_36delinsGCG",
         authority: Authority::SpecSelfConflicting,
@@ -345,17 +362,25 @@ const REPORTED_ROWS: &[Row] = &[
     Row {
         label: "1419-r3/span",
         input: "TEMPLATE:g.19_33delinsGGA",
-        // Measured, unchanged — see `1419-r1/span`.
-        output: "TEMPLATE:g.[19T>G;22_33del]",
-        five_prime: "TEMPLATE:g.[19T>G;22_33del]",
+        // Measured, and MOVED by #1649 — see `1419-r1/span`. Two differences
+        // from its two siblings, both measured. It lands on
+        // `[19_24del;28_33del]` rather than keeping the `[19T>G;22_33del]`
+        // substitution-plus-deletion form, which is `1419-r3/cis`'s output, so
+        // this pair converges as well. And it is now a FIVE_PRIME_MOVER: the 5'
+        // pass shifts the leading deletion one base left exactly as it does for
+        // `1419-r3/cis`, so the two directions no longer agree here. The
+        // argument below still says ferro splits this row rather than printing
+        // its `wanted` spanning delins, which remains true of both directions.
+        output: "TEMPLATE:g.[19_24del;28_33del]",
+        five_prime: "TEMPLATE:g.[18_23del;28_33del]",
         verdict: Verdict::Gap,
         wanted: "TEMPLATE:g.19_33delinsGGA",
         authority: Authority::SpecSelfConflicting,
         argument: "CORRECTED, verdict flipped Canonical -> Gap, for the same \
                    reason as `1419-r1/span`. The wanted form is this row's own \
-                   input; ferro splits it to `[19T>G;22_33del]` instead, in both \
-                   directions — unlike its `1419-r3/cis` sibling, which is a 5' \
-                   mover.",
+                   input; ferro splits it to `[19_24del;28_33del]` instead, and \
+                   to `[18_23del;28_33del]` under 5' — it is a FIVE_PRIME_MOVER \
+                   too now, alongside its `1419-r3/cis` sibling.",
     },
     // -- #1420 -- one row per member type. v2/v3 must reduce, v4 must coalesce:
     // the corrections point in opposite directions, which is the issue's
@@ -550,14 +575,20 @@ const REPORTED_ROWS: &[Row] = &[
     },
 ];
 
-/// The two rows whose 5' answer differs from their 3' answer.
+/// The three rows whose 5' answer differs from their 3' answer.
 ///
-/// Named rather than left implicit because both are `Gap` rows, and
+/// Named rather than left implicit because all three are `Gap` rows, and
 /// [`every_gap_row_is_returned_exactly_as_authored`] rests on a gap row being
 /// returned *untouched* — which is what makes it a second canonical form rather
 /// than an under-applied pass. That argument is a 3'-direction argument, and
-/// these two are where it stops holding.
-const FIVE_PRIME_MOVERS: &[&str] = &["1419-r3/cis", "1420-v2/cis"];
+/// these are where it stops holding.
+///
+/// **`1419-r3/span` was added by #1649**, which moved that row off
+/// `[19T>G;22_33del]` onto the same two-deletion form its `/cis` sibling
+/// prints — and the 5' pass shifts that form's leading deletion one base left,
+/// which the substitution-plus-deletion form gave it no way to do. So the row
+/// joins its own `/cis` sibling here rather than arriving for a new reason.
+const FIVE_PRIME_MOVERS: &[&str] = &["1419-r3/cis", "1419-r3/span", "1420-v2/cis"];
 
 /// How many of [`REPORTED_ROWS`] print something their issue argues against.
 ///
@@ -576,13 +607,20 @@ const FIVE_PRIME_MOVERS: &[&str] = &["1419-r3/cis", "1420-v2/cis"];
 /// the new one, so three rows that were `Canonical` against the withdrawn
 /// target are `Gap` against the standing one.
 ///
-/// **No output moved in this change, and that is checkable rather than
-/// asserted in prose**: every `output` and `five_prime` field in
-/// [`REPORTED_ROWS`] is byte-identical to what it was before, and
-/// [`every_reported_spelling_still_normalizes_as_the_reports_recorded`] plus
-/// [`every_reported_spelling_normalizes_as_recorded_under_five_prime`] measure
-/// them. The rise is entirely in `wanted`, which is an adjudication, and in
-/// `verdict`, which is derived from the two.
+/// **When this rose to twelve, no output moved** — the rise was entirely in
+/// `wanted`, which is an adjudication, and in `verdict`, which is derived from
+/// the two.
+///
+/// **That is no longer true of the file as a whole, and the paragraph above is
+/// scoped to the rise rather than describing the current state.** #1649 moved
+/// six fields: `output` and `five_prime` on all three `1419-r*/span` rows. The
+/// count did not move with them and that is the point — `wanted`, `verdict`
+/// and `authority` are untouched on every row, so all three remain `Gap`
+/// against the same standing target for the same reason, and `OPEN_GAPS` stays
+/// twelve. A moved output with a still-unreached target is a representation
+/// change, not a closure. Both directions are measured by
+/// [`every_reported_spelling_still_normalizes_as_the_reports_recorded`] and
+/// [`every_reported_spelling_normalizes_as_recorded_under_five_prime`].
 ///
 /// # Going down is not automatically progress either
 ///
@@ -633,12 +671,21 @@ const OPEN_GAPS: usize = 12;
 /// could not express, since it read "a pair is one canonical spelling and one
 /// gap" as a structural fact rather than as a consequence of what `wanted` was.
 ///
-/// Note this is a statement about `wanted`, **not** about convergence. These
-/// pairs have not converged: `reported_confluence_pairs`'
-/// `CONVERGING_PAIRS_THREE_PRIME`/`_FIVE_PRIME` are both still 0, and
-/// [`every_reported_pair_is_still_one_variant_by_equivalence`] still pins
-/// `SequenceMatch` for all nine pairs. A pair that genuinely converged would be
-/// a different event and would move that ratchet, which is where it belongs.
+/// Note this is a statement about `wanted`, **not** about convergence — and
+/// the two have now come apart, which is exactly why they were kept separate.
+///
+/// **All three of these pairs HAVE converged, as of #1649**, and they are still
+/// listed here. `reported_confluence_pairs`' `CONVERGING_PAIRS_THREE_PRIME` and
+/// `_FIVE_PRIME` are both **3** rather than 0, and
+/// [`every_reported_pair_is_still_one_variant_by_equivalence`] now pins
+/// `NormalizedMatch` for these three and `SequenceMatch` for the other six. That
+/// moved the ratchet where it belongs, in the module that owns it.
+///
+/// Convergence is not what this constant tracks. Both spellings of each pair now
+/// print **one** string, and it is still not the spanning `delins` the decided
+/// chain requires — so neither spelling reaches `wanted` and every entry stays.
+/// Removing one still means a spelling started reaching the wanted form; a pair
+/// merely agreeing with itself is not that.
 ///
 /// Listed explicitly rather than inferred, so the honestly-unfixed set is
 /// census-pinned and cannot grow in silence. Removing an entry means a spelling
@@ -1005,11 +1052,10 @@ fn each_pair_reaches_its_canonical_form_from_exactly_one_spelling() {
 /// returned untouched is a second canonical form, and a second canonical form is
 /// what splits a consumer's counts across two keys.
 ///
-/// **This is a 3'-direction claim and does not generalize.** Two gap rows do
+/// **This is a 3'-direction claim and does not generalize.** Three gap rows do
 /// move under 5' ([`FIVE_PRIME_MOVERS`]), so under that option the argument
-/// above holds for seven of the nine rows it reaches, not nine of nine — which
-/// is exactly why the 5' answers are now pinned per row rather than left to a
-/// convergence count.
+/// above reaches fewer rows than it does under 3' — which is exactly why the 5'
+/// answers are now pinned per row rather than left to a convergence count.
 ///
 /// **And it does not reach every gap row even under 3'.** There are twelve gap
 /// rows now ([`OPEN_GAPS`]), and the three `1419-r*/span` rows are gap rows that
@@ -1064,19 +1110,31 @@ fn every_gap_row_is_returned_exactly_as_authored() {
 /// reports' "use `EquivalenceChecker` instead" advice would quietly stop
 /// working — and nothing else in the suite covers these shapes.
 ///
-/// `SequenceMatch` exactly, not merely `is_equivalent()`: the two spellings
-/// normalize to different strings here, so anything stronger would mean the
-/// pair had converged and the rows above are stale.
+/// The exact level, not merely `is_equivalent()`, and it is **not one level for
+/// every pair**: a pair whose two spellings normalize to one string is
+/// `NormalizedMatch`, and a pair whose spellings still differ is
+/// `SequenceMatch`. Pinning the stronger level where it holds is what stops a
+/// convergence from being lost, and pinning the weaker one where it holds is
+/// what stops a convergence from being claimed.
 #[test]
 fn every_reported_pair_is_still_one_variant_by_equivalence() {
     let checker = EquivalenceChecker::new(provider(TEMPLATE));
     for (a, b) in reported_pairs() {
-        // Every pair, including the `PAIRS_NO_SPELLING_REACHES` ones: that
-        // constant says neither spelling reaches `wanted`, which is a claim
-        // about the target and not about convergence. The two spellings still
-        // normalize to different strings, so `SequenceMatch` is still the level
-        // and there is no exemption to take here.
-        let expected = EquivalenceLevel::SequenceMatch;
+        // Derived from the rows' own measured outputs rather than from a second
+        // list: the level IS whether the two spellings print one string, so a
+        // hand-maintained set of pair names could disagree with the pins above
+        // and would then be measuring itself.
+        //
+        // The three `1419-r*` pairs are `NormalizedMatch` as of #1649, which
+        // gave the splitter the two-deletion shape that lets each span spelling
+        // reach its `/cis` sibling's form. They stay in
+        // `PAIRS_NO_SPELLING_REACHES`: converging on one string is not reaching
+        // `wanted`, and that constant tracks the target.
+        let expected = if a.output == b.output {
+            EquivalenceLevel::NormalizedMatch
+        } else {
+            EquivalenceLevel::SequenceMatch
+        };
         let left = parse_hgvs(a.input).unwrap_or_else(|e| panic!("{}: {e}", a.label));
         let right = parse_hgvs(b.input).unwrap_or_else(|e| panic!("{}: {e}", b.label));
         let result = checker

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -45,15 +45,17 @@
 //! `src/normalize/` change of its own — so the census records `main`'s
 //! behaviour, not that PR's. The corpus is new; the defects it counts are not.
 //!
-//! **That paragraph is the CORPUS branch speaking, and it no longer holds.** Two
-//! normalizer changes have re-blessed figures here since, and there are two
-//! RE-BLESSED sections below — one per change, in the order they landed. Read
-//! both before quoting any figure as a `main` baseline:
+//! **That paragraph is the CORPUS branch speaking, and it no longer holds.**
+//! Three normalizer changes have re-blessed figures here since, and there are
+//! three RE-BLESSED sections below — one per change, in the order they landed.
+//! Read all three before quoting any figure as a `main` baseline:
 //!
 //! 1. the amino-acid precondition on `coalesce_coding_frame_separation` (#1599),
 //!    which moved five figures, one of them a net regression in `converged`;
 //! 2. the span-preserving re-typing carve-out for a member that straddles a CDS
-//!    boundary (#1536), which moved seven and regressed none.
+//!    boundary (#1536), which moved seven and regressed none;
+//! 3. the two-deletion alignment in the payload splitter (#1649), which moved
+//!    eight and regressed none — the largest confluence move recorded here.
 //!
 //! **The second was measured on the first, not composed with it.** The two
 //! changes' affected row sets are disjoint — verified by diffing the row ids, not
@@ -80,7 +82,7 @@
 //! The 3'/5' asymmetry is itself a finding: the transcript-leaving class is
 //! **371 to 0**, and 3' is the default direction.
 //!
-//! # RE-BLESSED (1 of 2) — #1599, the amino-acid precondition
+//! # RE-BLESSED (1 of 3) — #1599, the amino-acid precondition
 //!
 //! Everything above and in [`THREE_PRIME`]'s own doc was written on the corpus
 //! PR, which touched no normalizer file. **That is no longer the base.** #1599
@@ -118,7 +120,7 @@
 //! either met or it is not. `outputs_leaving_the_transcript` stays **371**, which
 //! is the pre-existing baseline and not a regression of #1599's.
 //!
-//! # RE-BLESSED (2 of 2) — #1536, the cross-axis re-typing carve-out
+//! # RE-BLESSED (2 of 3) — #1536, the cross-axis re-typing carve-out
 //!
 //! This branch adds a third carve-out from the #350 cross-axis bail in
 //! `normalize_cds`, so a `delins`/`inv` whose span straddles a CDS boundary is
@@ -170,6 +172,59 @@
 //! recursion step in `normalize_cds` is what keeps it there; without that step it
 //! measures **6** at 3', the two extra rows being
 //! `s00-c3{p,m}-cds-end-del-del-p2-sep1`. Every rank-1 counter is unchanged.
+//!
+//! # RE-BLESSED (3 of 3) — #1649, the two-deletion alignment
+//!
+//! `merge`'s payload splitter could express *insertion, retained reference,
+//! insertion* but not *deletion, retained reference, deletion*, so a payload
+//! whose alignment against its span carries two gaps was forced onto a coarser
+//! partition than the sequence supports. Letting it express the second shape
+//! moves eight figures, all rank 2, and **none regresses**:
+//!
+//! | figure | was (post-#1536) | now | direction |
+//! |---|---|---|---|
+//! | 3' `converged` | 9,141 | **9,402** | improves by 261 |
+//! | 3' `split_two` | 2,440 | **2,225** | improves by 215 |
+//! | 3' `split_three` | 248 | **223** | improves by 25 |
+//! | 3' `split_more` | 53 | **32** | improves by 21 |
+//! | 5' `converged` | 8,944 | **9,228** | improves by 284 |
+//! | 5' `split_two` | 2,706 | **2,461** | improves by 245 |
+//! | 5' `split_three` | 200 | **167** | improves by 33 |
+//! | 5' `split_more` | 32 | **26** | improves by 6 |
+//!
+//! This is the largest confluence move recorded in this module, which is exactly
+//! why the net counters are not allowed to carry it. **A family entering
+//! `split_two` from `split_three` and a family leaving `converged` for
+//! `split_two` look identical in the totals** — so the full divergence row-id
+//! lists were dumped on `origin/main` and on this branch (the `divergences` cap
+//! in [`measure`] raised locally for the measurement, then restored) and the sets
+//! diffed:
+//!
+//! - **0 families lose convergence**, at 3' or at 5'.
+//! - **0 families rise in arity**, and **0** families become divergent that were
+//!   not divergent on `main` — the branch's divergent set is a strict *subset* of
+//!   `main`'s in both directions (3': 2,741 -> 2,480; 5': 2,938 -> 2,654).
+//! - **0 still-divergent families change arity at all.** Every one of the 261 /
+//!   284 moved families goes straight to `converged`, which is why the three
+//!   `split_*` deltas sum exactly to the `converged` delta in each direction
+//!   (215 + 25 + 21 = 261; 245 + 33 + 6 = 284). They come from arity 2 / 3 / 4 / 5
+//!   in the counts 215 / 25 / 16 / 5 at 3' and 245 / 33 / 6 / 0 at 5'.
+//!
+//! The moved set is broad rather than local — 16 corpus shapes at each direction,
+//! led by `pair-del-*` (134 at 3', 150 at 5'), `m3-all-*`, `m4-all-*` and
+//! `mid-cds-*` — which is what a partitioner change looks like as against
+//! #1536's, whose every moved row was `s00-c3{p,m}-cds-end-*`.
+//!
+//! **Every rank-1 counter is unchanged**, in both directions, as are
+//! `non_idempotent_outputs` (4 / 4), `sequence_changed` (4 / 0), all three
+//! refusal counters and `guard_violations`.
+//!
+//! **Two of the six rows #1599 promoted come back**, and they are removed from
+//! `spec_corpus_regressions::the_codon_gate_splits_a_spanning_delins_its_own_members_do_not`
+//! per that test's own instruction: `s00-c3{p,m}-m3-all-del-p1-sep3` (arity 2 at
+//! 3', 3 at 5') and `s00-c3{p,m}-pair-del-del-p1-sep8` (arity 2 at both) are now
+//! converged. `s00-c3{p,m}-m4-all-del-p1-sep2` is untouched and stays pinned
+//! there — its spanning `delins` still stops where `general.md:34` puts it.
 //!
 //! # CORRECTED — what the transcript-leaving class actually violates
 //!
@@ -287,11 +342,11 @@ const SHAPE: CorpusShape = CorpusShape {
 /// fixed. Read the three asserted-zero counters before the headline, per the
 /// module docs.
 ///
-/// **The "measures `main`" heading above is now historical** — two normalizer
-/// changes have re-blessed figures here, #1599 and then #1536, and seven of these
-/// are measured against the second rather than against the corpus PR's `main`. The
-/// module docs carry a RE-BLESSED section per change, naming each figure, which way
-/// it moved, and the row ids behind it.
+/// **The "measures `main`" heading above is now historical** — three normalizer
+/// changes have re-blessed figures here (#1599, then #1536, then #1649), and the
+/// four confluence figures below are measured against the third rather than
+/// against the corpus PR's `main`. The module docs carry a RE-BLESSED section per
+/// change, naming each figure, which way it moved, and the row ids behind it.
 pub(crate) const THREE_PRIME: Census = Census {
     // -- validity (rank 1) --
     outputs: 58_552,
@@ -302,20 +357,21 @@ pub(crate) const THREE_PRIME: Census = Census {
     prohibition_violating_outputs: 32,
     // -- confluence (rank 2) --
     //
-    // Re-blessed by #1536, on top of the amino-acid precondition's re-bless
-    // directly above in history — **measured on this branch rebased onto that**,
-    // not composed from the two changes' deltas. `converged` goes UP and no
-    // counter regresses; the row-level diff is in the module docs' second
-    // RE-BLESSED section.
+    // Re-blessed by #1649's two-deletion alignment, on top of #1536's re-bless
+    // and #1599's before it — **measured on this branch rebased onto both**, not
+    // composed from the three changes' deltas. The row-level diff is in the
+    // module docs' third RE-BLESSED section.
     //
-    // 2 families newly converge and 10 more drop to a lower split arity. Zero
-    // families lose convergence and zero rise in arity — that is a measured
-    // statement, from diffing the full divergence lists either side, not an
-    // inference from the net counters (which cannot tell net from gross).
-    converged: 9_141,
-    split_two: 2_440,
-    split_three: 248,
-    split_more: 53,
+    // 261 families newly converge and **zero** lose convergence, rise in arity,
+    // or become divergent that were not — measured by diffing the full
+    // divergence row-id lists either side, not inferred from the net counters
+    // (which cannot tell net from gross). Every moved family goes straight to
+    // `converged`, which is why the three deltas below sum exactly to
+    // `converged`'s: 215 + 25 + 21 = 261.
+    converged: 9_402,
+    split_two: 2_225,
+    split_three: 223,
+    split_more: 32,
     underdetermined: 0,
     // -- idempotency --
     //
@@ -340,8 +396,8 @@ pub(crate) const THREE_PRIME: Census = Census {
 /// would mean a fix was treating a symptom of the shuffle rather than the
 /// partitioner.
 ///
-/// Measured on the same base as [`THREE_PRIME`], and re-blessed by the same two
-/// changes — see the module docs' two RE-BLESSED sections.
+/// Measured on the same base as [`THREE_PRIME`], and re-blessed by the same
+/// three changes — see the module docs' three RE-BLESSED sections.
 ///
 /// The two directions agreeing on every rank-1 counter except
 /// `outputs_leaving_the_transcript` is itself the cross-check the two-direction
@@ -355,21 +411,24 @@ pub(crate) const FIVE_PRIME: Census = Census {
     outputs_denoting_no_sequence: 18,
     outputs_leaving_the_transcript: 0,
     prohibition_violating_outputs: 32,
-    // Unmoved by either re-bless: no 5' family changes which side of the
-    // converged/split line it sits on, in #1599 or in #1536.
-    converged: 8_944,
-    // Re-blessed by #1536, rank-2 only, same as [`THREE_PRIME`] — and measured on
-    // the rebased branch rather than composed. 14 families drop to a lower split
-    // arity; **none** newly converges and none regresses, so `converged` is
-    // untouched here while it rose by 2 at 3'.
+    // Unmoved by #1599 or by #1536 — no 5' family changed which side of the
+    // converged/split line it sat on in either. **#1649 moves it for the first
+    // time**, by 284, and the same three measured zeros hold as at 3': no family
+    // loses convergence, rises in arity, or becomes divergent that was not.
+    converged: 9_228,
+    // Re-blessed by #1649, rank-2 only, same as [`THREE_PRIME`] — and measured on
+    // the rebased branch rather than composed. Every moved family goes straight
+    // to `converged`, so these three deltas sum exactly to `converged`'s:
+    // 245 + 33 + 6 = 284.
     //
     // The two directions moving by different amounts is expected rather than
-    // suspicious: the re-typed member is pinned to its own span in both, but the
-    // *follow-on* shuffle the re-typing enables runs 3' or 5'. Measured: 10 of the
-    // 3' rows and 14 of the 5' rows moved, 10 of them the same row ids in both.
-    split_two: 2_706,
-    split_three: 200,
-    split_more: 32,
+    // suspicious, for the reason #1536's re-bless already recorded: the partition
+    // is decided the same way in both, but the *follow-on* shuffle it enables
+    // runs 3' or 5'. Here 5' moves the larger set (284 against 261), the reverse
+    // of #1536.
+    split_two: 2_461,
+    split_three: 167,
+    split_more: 26,
     underdetermined: 0,
     non_idempotent_outputs: 4,
     sequence_changed: 0,

--- a/tests/it/spec_corpus_regressions.rs
+++ b/tests/it/spec_corpus_regressions.rs
@@ -806,7 +806,7 @@ fn a_repeat_typing_at_the_cds_end_overlaps_its_sibling_deletion() {
 /// named test. Six is the gross figure; five other families *gained*
 /// convergence in the same change, which is where the net -1 comes from.
 ///
-/// The six are three designs on each of the plus and minus coding multi-exon
+/// The six were three designs on each of the plus and minus coding multi-exon
 /// shapes, all on the `AT` core (`s00`):
 ///
 /// ```text
@@ -821,13 +821,30 @@ fn a_repeat_typing_at_the_cds_end_overlaps_its_sibling_deletion() {
 /// on the merits: the exception simply does not reach the pair, and
 /// `general.md:34`'s plain rule governs it.
 ///
+/// **Four of those six have since re-converged and are no longer pinned here.**
+/// #1649 lets `merge`'s payload splitter express *deletion, retained reference,
+/// deletion* — the mirror of the two-insertion shape it already expressed — and
+/// with the finer partition available the spanning `delins` reaches its members'
+/// answer again on `m3-all-del-p1-sep3` and `pair-del-del-p1-sep8`, on both
+/// strands. That is a re-convergence rather than a competing answer: the two
+/// spellings now denote one sequence *and* produce one string, and
+/// `general.md:35` still does not reach either row — nothing was narrowed back to
+/// a shape test to get there. This test's own `assert_ne!` prescribed the
+/// remedy (lower `split_two`, raise `converged`, delete the row), and the
+/// `spec_conformance_axis` re-bless is in the same commit; see that module's
+/// third RE-BLESSED section for the row-id diff behind it.
+///
+/// **`s00-c3{p,m}-m4-all-del-p1-sep2` is untouched and is what remains below.**
+/// Its spanning `delins` still stops where `general.md:34` puts it, so everything
+/// this test was promoted to say still holds for it.
+///
 /// What remains unanswered is whether the *members'* answer is reachable from the
 /// `delins` at all under the restored precondition. What is **not** unanswered is
 /// the neighbouring record: `codon-carve-out-shape-restriction` is `decided`, and
 /// it runs the same way — WIDEN, the exception applies wherever its precondition
 /// holds, regardless of edit type, because edit type is a property of the
 /// spelling. So the predicate may not be narrowed back to a shape test in order
-/// to recover these six rows.
+/// to recover the rows it still costs.
 ///
 /// **This is churn, not a rank-1 defect**, and that is asserted rather than
 /// claimed: both outputs are checked through `denotation_of` to denote the row's
@@ -837,39 +854,26 @@ fn a_repeat_typing_at_the_cds_end_overlaps_its_sibling_deletion() {
 /// either previously-shipped string.
 ///
 /// Named rather than left in the corpus for the usual reason: a later generator
-/// edit could stop emitting `sep3`/`sep8` separations, or stop respelling a
-/// design as a spanning `delins` at all, and the regression would vanish with the
-/// rows (#1456/#1460/#1478).
+/// edit could stop emitting the `sep2` separation, or stop respelling a design as
+/// a spanning `delins` at all, and the regression would vanish with the rows
+/// (#1456/#1460/#1478).
 #[test]
 fn the_codon_gate_splits_a_spanning_delins_its_own_members_do_not() {
     let core = at_core();
     // `(row id, the spanning-delins respelling, its output, the authored member
-    // spelling, the answer every member spelling reaches)`. On `main` the third
-    // column equalled the fifth in all three rows, which is what made them
+    // spelling, the answer every member spelling reaches)`. Before #1599 the
+    // third column equalled the fifth here, which is what made the family
     // converge.
-    let rows = [
-        (
-            "m3-all-del-p1-sep3",
-            "NM_TEST.1:c.24_32delinsAATTTT",
-            "NM_TEST.1:c.[24T>A;26_28del;32A>T]",
-            "NM_TEST.1:c.[24del;28del;32del]",
-            "NM_TEST.1:c.[24del;33_34del]",
-        ),
-        (
-            "m4-all-del-p1-sep2",
-            "NM_TEST.1:c.24_33delinsAATTTA",
-            "NM_TEST.1:c.[24T>A;26_29del;32_33delinsTA]",
-            "NM_TEST.1:c.[24del;27del;30del;33del]",
-            "NM_TEST.1:c.[24del;30_33delinsA]",
-        ),
-        (
-            "pair-del-del-p1-sep8",
-            "NM_TEST.1:c.24_33delinsAATTTTTA",
-            "NM_TEST.1:c.[24_27delinsAA;32_33delinsTA]",
-            "NM_TEST.1:c.[24del;33del]",
-            "NM_TEST.1:c.[24del;33del]",
-        ),
-    ];
+    //
+    // `m3-all-del-p1-sep3` and `pair-del-del-p1-sep8` used to sit alongside this
+    // row and were removed by #1649, which re-converged them — see the doc above.
+    let rows = [(
+        "m4-all-del-p1-sep2",
+        "NM_TEST.1:c.24_33delinsAATTTA",
+        "NM_TEST.1:c.[24T>A;26_29del;32_33delinsTA]",
+        "NM_TEST.1:c.[24del;27del;30del;33del]",
+        "NM_TEST.1:c.[24del;30_33delinsA]",
+    )];
 
     for strand in [Strand::Plus, Strand::Minus] {
         let frame = Frame::build(RefShape::CodingMultiExon(strand), &core);

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -385,7 +385,43 @@ const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // its job — `NM_000797.3:c.812_829delins908_925` over four axes and
     // `c.235_238delinsTAGT` over three, whose members end up two or more bases
     // apart, where `general.md:34` asks for the split.
-    (Status::ProjectionSplitsSingleMember, 9),
+    //
+    // # 9 -> 12 (#1649), and why the paragraph directly above does not forbid it
+    //
+    // The warning above is one-directional: it forbids going **below** 9, on the
+    // ground that a row leaving this status has been merged where
+    // `DNA/delins.md:17` wanted it split. This move is the other way. Three rows
+    // enter, and they are three projections of **one input**:
+    //
+    // ```text
+    // project-c/NM_004006.3:r.123_127delinsag
+    // project-n/NM_004006.3:r.123_127delinsag
+    // project-r/NM_004006.3:r.123_127delinsag
+    // ```
+    //
+    // `PASSING_CENSUS`'s `ProjectionPinned` falls by the same three (1168 ->
+    // 1165), so the pair still moves in equal and opposite steps and no row left
+    // the enumeration — which is the check that paragraph asks for, applied.
+    //
+    // **OPERATOR RULING, 2026-08-11 — the three rows are accepted, and they are
+    // not one thing.** They were measured through `spdi::compare_denoted_sequences`
+    // against the real reference and denote the input's own bases, so this is a
+    // representation move and not a correctness regression.
+    //
+    // - The `n.` row is a **fix**. #1682's payload-coincidence carve-out is
+    //   `c.`-scoped by `rulings[delins-payload-coincidence-carve-out-is-coding-dna-scoped]`,
+    //   so `general.md:34` governs the `n.` axis unopposed and the split is what
+    //   it asks for. This row was previously merged and should not have been.
+    // - The `r.` row is **unruled**. The same record puts `r.` out of the
+    //   carve-out in both directions — a DNA document has no jurisdiction over
+    //   the RNA axis — but `RNA/delins.md` states no counterpart clause either
+    //   way, so nothing selects between the two legal forms here.
+    // - The `c.` row is the **residue**, and the only one. Its real question is
+    //   whether `coalesce_payload_alignment_split` should be promoted onto the
+    //   shipping path: the pass is gated on `PartitionRule::CanonicalCoalesced`
+    //   while the shipped rule is `Live`. That is a separate change which #1649
+    //   neither makes nor blocks, and it is deliberately not made here.
+    (Status::ProjectionSplitsSingleMember, 12),
 ];
 
 /// Census of the **conformant** statuses — the counting half of
@@ -465,7 +501,12 @@ const PASSING_CENSUS: &[(Status, usize)] = &[
     // to 1170 and `ProjectionSplitsSingleMember` to 7; the ruling declines it,
     // so both constants stand. See that status's note in `DIVERGENCE_BUDGET`
     // for why, and read the two as a pair either way.
-    (Status::ProjectionPinned, 1168),
+    // 1168 -> 1165 (#1649). The three rows are the `project-{c,n,r}` axes of
+    // `NM_004006.3:r.123_127delinsag`, moving to `ProjectionSplitsSingleMember`
+    // — equal and opposite, as this pair must always be read. The adjudication
+    // is recorded with that status in `DIVERGENCE_BUDGET`: sequence-preserving
+    // in all three, a fix on `n.`, unruled on `r.`, and one residue on `c.`.
+    (Status::ProjectionPinned, 1165),
     (Status::ProjectionUnavailablePinned, 487),
     (Status::ProjectionErrorPinned, 210),
     // 132 -> 120 (#1498). The 12 rows are all LRG — `LRG_199:c.357+1G>A`,


### PR DESCRIPTION
Closes #1617.

`best_alignment` already had an escape from its single-gap restriction for *insertion, retained reference, insertion* — `two_gap_insertion_alignment`, added for #1260. The mirror shape was missing: *deletion, retained reference, deletion* had no expression, so a block like `ATGC -> T` got the single gap parked at one end and produced a 4-column spanning `delins` for what the block describes in 3. The weight bound then correctly refused that `delins` and the pass fell back to the per-member pipeline, whose answer **is** a function of how the input was spelled — which is the whole mechanism behind the non-confluence this repository has been chasing.

`two_gap_deletion_alignment` supplies the missing expression. It is a transpose, not a second implementation: it calls `two_gap_insertion_alignment` with `(result, reference)` and swaps each column's indices, so every bound, precondition and tie-break carries over and there is no duplicated index arithmetic to drift.

## Status: green, and the earlier "four tests are RED on purpose" section is withdrawn

That section described the pre-rebase branch and no longer applies. It said four `reported_partition_verdicts` tests were left failing because this PR re-blessed `output` while deliberately not touching `verdict`/`wanted`, and that repairing them needed an adjudication stacked on top.

**That adjudication landed on `main` independently**, in the `1419-r*` rows' own `argument` fields (`CORRECTED, and the verdict flipped Canonical -> Gap`). So on this base `wanted` is already the spanning `delins`, `verdict` is already `Gap`, and re-blessing the measured fields no longer creates an inconsistency — it resolves one. The rebase dropped the branch's own copy of that re-bless (`main` had moved the same file), and it is re-applied here on top: `output` and `five_prime` only, on the three `1419-r*/span` rows. `wanted`, `verdict`, `authority` and `argument` are untouched — zero changed lines among them, checkable with `git diff | grep -E 'wanted:|verdict:|authority:|argument:'`.

Full gate on this base: `cargo fmt --check` clean, `cargo clippy --all-features --all-targets -- -D warnings` clean, and the test suite green in both configurations CI runs it — armed with `FERRO_ASSERT_{IDEMPOTENT,REPARSE,IN_BOUNDS}` minus `ORACLE_EXCLUDE`, and plain over everything.

## It closes #1617, against a target `main` decided one commit ago

#1620 flipped `separation-is-a-property-of-the-spelling-not-of-the-variant` from `undecided` to `decided`, naming form **A** as the answer:

| | form | |
|---|---|---|
| A | `g.[1001009_1001010del;1001013del]` | **decided** |
| B | `g.[1001009del;1001011del;1001013del]` | "the defect #1419 and #1420 name in their own titles" |
| C | `g.1001009_1001013delinsCA` | outside the scope `delins-merge-vs-individual-gap-two-or-more` set for itself |

and shipped `the_decided_target_is_the_re_derived_form` `#[ignore]`d, describing it in its own commit message as **#1617's acceptance criterion**, with the follow-up spelled out in the test: *"delete the `#[ignore]` and move the two `apart` expectations above."* That test passes on this branch. The `#[ignore]` is deleted and the two pre-fix expectations move, exactly as instructed.

Form C is added to that test's loop as well. The record's table names C as conformant and **not** the target but says nothing about what C itself normalizes to, and C was its own fixed point until now — so one spelling of the variant was still reaching a fourth answer. It no longer is: all four spellings of that variant reach form A.

## What moved, measured

Nine confluence censuses move. **Every one improves monotonically** — `converged` up, every split arity down — and in each the three split deltas sum *exactly* to the `converged` delta, so every moved family went straight to convergence rather than merely dropping an arity.

```
                             converged        split_two      split_three   split_more
cis_confluence_axis    3'  8027 -> 8361   3111 -> 2835    115 ->  67    19 ->  9
                       5'  8023 -> 8367   3135 -> 2826    105 ->  74     9 ->  5
spec_conformance_axis  3'  9141 -> 9402   2440 -> 2225    248 -> 223    53 -> 32
                       5'  8944 -> 9228   2706 -> 2461    200 -> 167    32 -> 26
cis_confluence_nr_axis n3' 4012 -> 4179   1558 -> 1420     57 ->  33     9 ->  4
                       r3' 4010 -> 4177   1560 -> 1422     57 ->  33     9 ->  4
                       n5' 4011 -> 4183   1569 -> 1415     52 ->  36     4 ->  2
                       r5' 4009 -> 4181   1571 -> 1417     52 ->  36     4 ->  2
multi_member_cis_axis      respelling_converged 395 -> 401, 0 rows lost
```

**`multi_member_cis_axis` is manifest-gated, so that last row is NOT pre-merge coverage.** `axis_normalized` returns early with a `println!` when neither `FERRO_MANIFEST` nor `benchmark-output/manifest.json` is present, which is the case on PR CI — it skips silently there and only the nightly reference-aware job actually runs it. So `respelling_converged: 395 -> 401` and the six `CONVERGED_ROWS` additions are **nightly-only coverage**, and they are measured here against the local prepared reference rather than by any gating job. The one guard that does run on PR CI, `the_pinned_convergence_list_agrees_with_the_pinned_count`, checks the two constants against **each other** (401 names, 401 pinned) — not against reality, which is exactly the part a reader would otherwise mistake for verification. The other eight censuses in the table are hermetic and are gated normally.

**The nets are not what carries this.** A family entering `split_two` from `split_three` and a family leaving `converged` for `split_two` look identical in the totals. So the full divergence **row-id lists** were dumped on `origin/main` and on this branch — the `divergences` cap in `spec_conformance_axis::measure` raised locally for the measurement, then restored — and the sets diffed:

- **0 families lose convergence**, in any direction on any corpus.
- **0 families rise in arity**, and **0** become divergent that were not: the branch's divergent set is a strict *subset* of `main`'s (3': 2741 -> 2480; 5': 2938 -> 2654 on the spec corpus).
- **0 still-divergent families change arity at all** — which is why the sums are exact (215+25+21 = 261; 245+33+6 = 284).

`multi_member_cis_axis` is `+6 −0`, and all six rows are two-deletion cis pairs — the exact shape this change adds an expression for, which is the mechanism rather than a coincidence. Every rank-1 counter is unchanged everywhere: `sequence_changed`, `outputs_denoting_no_sequence`, `outputs_leaving_the_transcript`, the three refusal counters and `guard_violations`.

The `scale-*` non-idempotency family's second half closes too: `scale-c3p-sep136-del-del` loses the trailing `inv` that existed only because the splitter had no second gap to spend, so it lands on its authored design's output and `defect_non_idempotent_outputs`' `matches_authored` column reads `true, true, true` where it read `true, true, false`.

## Three enumeration rows move the other way, and the operator ruled on them

`spec_enumeration_tests`' `projection-splits-single-member` goes 9 -> 12 and `projection-pinned` 1168 -> 1165 — equal and opposite, so no row left the enumeration. The three are three projections of **one input**:

```
project-c/NM_004006.3:r.123_127delinsag
project-n/NM_004006.3:r.123_127delinsag
project-r/NM_004006.3:r.123_127delinsag
```

Measured through `spdi::compare_denoted_sequences` against the real reference: all three denote the input's own bases, so this is a representation move and not a correctness regression. The operator's ruling, recorded in full beside the constant:

- the **`n.`** row is a **fix** — #1682's payload-coincidence carve-out is `c.`-scoped by `rulings[delins-payload-coincidence-carve-out-is-coding-dna-scoped]`, so `general.md:34` governs unopposed and the split is required. This row was merged before and should not have been;
- the **`r.`** row is **unruled** — the same record puts `r.` out of the carve-out in both directions, and `RNA/delins.md` states no counterpart either way;
- the **`c.`** row is the only residue. Its real question is whether `coalesce_payload_alignment_split` should be promoted onto the shipping path (it is gated on `PartitionRule::CanonicalCoalesced` while the shipped rule is `Live`). That is a separate change which this PR neither makes nor blocks, and is deliberately not made here.

## #1419's three pairs converge

Each pair now reaches one string, from both spellings — the defect the issue reports:

```
1419-r1/span  g.19_33delinsCGG  [19_30del;33T>G] -> [19_23del;27_33del]
1419-r2/span  g.19_36delinsGCG  [19_33del;36A>G] -> [19_22del;26_36del]
1419-r3/span  g.19_33delinsGGA  [19T>G;22_33del] -> [19_24del;28_33del]
                            and at 5'            -> [18_23del;28_33del]
```

`CONVERGING_PAIRS_THREE_PRIME` and `_FIVE_PRIME` go 0 -> 3, and `FIVE_PRIME_MOVERS` gains `1419-r3/span`, both following from the measured fields. The clause is `general.md:34` read through `canonical-form-choice-when-both-legal` (`decided`): the partition is re-derived from the resulting sequence and what falls out is emitted.

**This is a convergence, not a closure.** The string the three pairs converge on is still not the spanning `delins` the decided chain wants, so all three stay in `PAIRS_NO_SPELLING_REACHES` and `OPEN_GAPS` stays at twelve. What changed is that the family stopped having two canonical forms.

## One real-world stability pin moves, at a gap of ONE

```
NC_000020.11:g.45891619_45891622delinsC
  was  g.45891619_45891622delinsC
  now  g.[45891619del;45891621_45891622del]
```

1 of 29 pinned `case_harvest` rows. It is self-described as a **stability pin, not a spec-correctness claim**, citing `basics.md:38` for stability as a value rather than for this spelling — and stability is a tiebreaker here, not a veto, since the project bar is confluence plus disclosure. The note named `delins-merge-vs-individual-gap-two-or-more` as governing and open; it was decided 2026-08-07 and scoped away from this row, which separates its two members by ONE unchanged nucleotide (`g.45891620`). The row is `g.`, so `general.md:35`'s codon exception cannot reach it either. `general.md:34` does, and asks for exactly this split.

## Review

Both CodeRabbit findings from the run against `6218f5e7` are addressed:

- **`reported_partition_verdicts` — "do not merge with four known failing tests."** Valid and fixed. All four pass; see the status section above for why the inconsistency it named no longer exists.
- **`merge.rs` — no coverage through `normalize_with_diagnostics()`.** Valid and fixed by `the_two_gap_deletion_split_is_a_fixed_point_through_the_diagnostics_exit`, which pins the exact displayed string from all three spellings, asserts the output is a fixed point of that same entry point, and asserts the diagnostics exit agrees with `normalize()` — the #1382 asymmetry as an assertion. Verified to fail on `origin/main`'s `merge.rs` and pass here, so it guards the change rather than restating it.

## What did NOT move

`long_delins_splits_at_unchanged_bases::a_long_net_deletion_stays_one_spanning_delins` passes, as does `a_delins_longer_than_the_old_cap_still_splits`. That 52 nt → 14 nt block is protected one layer downstream of the aligner by `separations_are_meaningful`, which refuses any proposed split whose inter-piece gaps are one base wide against `RAISED_PIECE_SEPARATION`. This change only widens what the aligner may *propose*; the separation floor still refuses it.

Rebased onto `62c83ec1` after the first push, which brought in #1673 — the wholesale replacement of `tests/fixtures/sequences/normalization_transcripts.json`'s exon tables (111 exons and 105 junctions restored; 22 -> 28 multi-exon records, 412 -> 517 junctions). Because this branch pins confluence census counts, that fixture could have moved them without a line of this diff changing. It did not: both spec artifacts were regenerated on the new base and all 85 census/adjudication tests re-run green with **no pin moved**, which is consistent with the mechanism — none of the census modules read that fixture (they build synthetic corpora, `NM_TEST.1` and `TEMPLATE`, or resolve the manifest). Its three readers are `idempotency_tests`, `normalize_tests` and `normalize_property_tests`, none of which pins a census here.

The corpus-level figure quoted in an earlier revision of this description (282 of 78298 rows, measured with `examples/dump_normalized_corpus.rs` against `main` at `ec8ebd66`) was measured before the rebase and has **not** been re-measured on this base; do not read it as current. The census figures above are the measurement of record.

Representation-Change: 9 confluence censuses move and none regresses; `converged` rises 8027->8361 (3') and 8023->8367 (5') in cis_confluence_axis, 9141->9402 and 8944->9228 in spec_conformance_axis, and by 167/167/172/172 across cis_confluence_nr_axis's n./r. x 3'/5' pins, while multi_member_cis_axis's respelling_converged goes 395->401 with 0 rows lost - that last one measured against a local prepared reference and NOT pre-merge coverage, since multi_member_cis_axis is manifest-gated and skips silently on PR CI; only the nightly runs it.
  In every one of those censuses the three split-arity deltas sum EXACTLY to the converged delta, so each moved family converged outright rather than dropping an arity.
  Measured by dumping the full divergence row-id lists on origin/main and on this branch and diffing the sets, not by reading the nets: 0 families lose convergence, 0 rise in arity, and 0 become divergent that were not, on any corpus in either direction.
  Moving the other way, 3 spec-enumeration rows go from projection-pinned to projection-splits-single-member (1168->1165 and 9->12) - the three projections project-{c,n,r} of NM_004006.3:r.123_127delinsag, sequence-preserving via spdi::compare_denoted_sequences, ruled a fix on n., unruled on r., and one deferred residue on c.
  Six previously-accepted pinned strings also move: the 3' and 5' outputs of 1419-r1/span, 1419-r2/span and 1419-r3/span in reported_partition_verdicts, which converge each pair onto its /cis sibling's form - a real migration for any consumer storing those.
