### PR TITLE
fix(normalize): canonicalize a member whose span crosses a CDS boundary

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4864,6 +4864,54 @@ impl<P: ReferenceProvider> Normalizer<P> {
             && matches!(edit, NaEdit::Deletion { .. } | NaEdit::Duplication { .. })
             && matches!(start_axis, boundary::AxisRegion::FiveUtr)
             && matches!(end_axis, boundary::AxisRegion::ThreeUtr);
+        // **Span-preserving re-typing exception (#1536).** The bail's stated
+        // ground is that *the shuffle* has no defined semantics across an axis
+        // boundary — and it then throws away the whole per-member pipeline,
+        // canonicalization included. Re-typing a `delins` against the bases it
+        // denotes (`canonicalize_delins`: `inv`, `del`, `ins`, `dup`, `sub`,
+        // plus the shared-affix trim) is not a shuffle. It reads the reference
+        // under the member's own span and moves nothing, and the `c.` reference
+        // is a single contiguous string (`refseq.md`) whose axis labels change
+        // at `cds_start`/`cds_end` while the sequence does not — the argument
+        // #918 already makes verbatim for a whole-CDS del/dup.
+        //
+        // Discarding it is what made `c.9_*1delinsTGTGCATT` and `c.9_*1inv` two
+        // fixed points for one variant, discriminated by nothing but where the
+        // stop codon falls (#1536). Measured on a 40-mer with a real UTR at both
+        // ends: over the 33 placements of one 8-base whole-block reverse
+        // complement, the 14 that cross a CDS boundary all diverged and the 19
+        // that do not all converged — including the three that sit wholly in a
+        // UTR and the one that runs to the transcript end, so the discriminator
+        // is the boundary and not the sequence end.
+        //
+        // `Delins` and `Inversion` together, not `Delins` alone. Confluence is a
+        // property of the *pair*: the `delins` spelling reaches `inv` only if the
+        // `inv` spelling reaches the same string, and the `inv` spelling is
+        // subject to the same shared-affix trim (`c.3_10inv` -> `c.4_9inv`).
+        // Letting one through and not the other trades one non-confluence for
+        // another.
+        //
+        // Every other edit kind keeps the bail. For a `del`/`dup` the
+        // canonicalization *is* the shuffle, so admitting them would be the
+        // cross-axis shift #350 refuses and #918 carves out only for a
+        // whole-CDS span; a `sub` cannot straddle a boundary; an `ins` is
+        // already carved out by #402.
+        let is_span_preserving_retype =
+            matches!(edit, NaEdit::Delins { .. } | NaEdit::Inversion { .. });
+        // Warnings raised before `normalize_na_edit` runs, so they survive the
+        // carve-out below rather than being dropped with the early return.
+        let mut pre_warnings: Vec<NormalizationWarning> = Vec::new();
+        // Whether the span-preserving re-type carve-out below was actually
+        // taken. Recorded explicitly rather than inferred from
+        // `!pre_warnings.is_empty()`, even though the two agree today: the
+        // recursion gate near the end of this function is a control-flow
+        // decision about *this* path, and keying it on whether some vector
+        // happens to be non-empty makes it fire for any future warning pushed
+        // before `normalize_na_edit` — which the name `pre_warnings` positively
+        // invites. That is the same mistake, one level up, as deciding which
+        // warnings to drop by what the vector happened to hold; see the note on
+        // the gate itself.
+        let mut took_span_preserving_retype = false;
         if start_axis != end_axis
             && !matches!(start_axis, boundary::AxisRegion::None)
             && !matches!(end_axis, boundary::AxisRegion::None)
@@ -4876,10 +4924,23 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 start_axis: start_axis.label().to_string(),
                 end_axis: end_axis.label().to_string(),
             };
-            return Ok((
-                HV::Cds(self.canonicalize_cds_variant(variant)),
-                vec![warning],
-            ));
+            if !is_span_preserving_retype {
+                return Ok((
+                    HV::Cds(self.canonicalize_cds_variant(variant)),
+                    vec![warning],
+                ));
+            }
+            // The warning still stands, and is still true: nothing below may
+            // move this member off the footprint it arrived on. Pinning the
+            // shuffle bound to the input span is what enforces that — the
+            // re-typing runs, and a derived piece may settle anywhere inside the
+            // member's own hull, but no shift can carry it into a region the
+            // input did not already occupy. `axis_info.clamped` cannot serve
+            // here: it is clamped to the *start* endpoint's region, which for a
+            // straddling member is narrower than the member itself.
+            pre_warnings.push(warning);
+            took_span_preserving_retype = true;
+            boundaries = Boundaries::new(tx_start.saturating_sub(1), tx_end);
         }
 
         // #918: relax the CDS↔3'UTR axis clamp for a CDS-resident del/dup so
@@ -5456,6 +5517,99 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 variant.loc_edit.edit.with_same_certainty(new_edit),
             ),
         };
+
+        // #1536: the span-preserving carve-out above pinned the shuffle to the
+        // input's own span, because a straddling member has no defined 3'-most
+        // position. Re-typing can *resolve* that — the shared-affix trim moves
+        // both endpoints inward, so `c.72_*3delins…` comes back as `c.*1_*4del`,
+        // which straddles nothing. At that point the pin has no ground left and
+        // the ordinary 3' rule applies again.
+        //
+        // Not cosmetic. Without this the pass emits an output that is not its
+        // own fixed point: `c.*1_*4del` sits wholly in the 3'UTR, so normalizing
+        // it a second time shuffles it on to `c.*2_*5del`. Measured by forcing the
+        // gate below closed and re-running, on the branch as rebased:
+        // `spec_conformance_axis`'s 3' `non_idempotent_outputs` reads **6** instead
+        // of **4** — the two extra rows being exactly
+        // `s00-c3{m,p}-cds-end-del-del-p2-sep1` — and confluence degrades with it,
+        // 3' `split_three`/`split_more` reading 246/55 instead of 248/53. That is a
+        // rank-1 conformance regression rather than a representation choice.
+        //
+        // (An earlier form of this comment quoted "rose from 7 to 9". That was
+        // measured against the pre-#1599 baseline of 7; the baseline is now 4, and
+        // 4 -> 6 is re-measured rather than the old figure rebased by arithmetic.)
+        //
+        // Recursion depth is one. The re-entry is gated on the new span sitting
+        // in a single axis region, and a single-region member cannot reach the
+        // carve-out; it is gated on the variant having actually changed, so a
+        // fixed point cannot re-enter either.
+        //
+        // Only the warnings the recursion *invalidates* are dropped. Which ones
+        // those are is decided by what each warning asserts, not by what happens
+        // to be in the vector:
+        //
+        // - `pre_warnings` holds exactly one warning, pushed at exactly one site
+        //   above — `CrossAxisVariantNotShuffled`. Invalidated: the member *is*
+        //   shuffled, by the recursive call.
+        // - `AxisClampApplied` is invalidated too. Its contract is to say *why
+        //   the position did not shift further*, and on this path it did shift
+        //   further (`c.*1_*4del` -> `c.*2_*5del`), so keeping it would misreport
+        //   the result.
+        // - **Everything else is carried forward**, because nothing about
+        //   re-typing the span makes it untrue. `warnings` comes from
+        //   `normalize_na_edit`, which validates the reference and pushes
+        //   `RefSeqMismatch`; `NormalizeResult::has_ref_mismatch` is what strict
+        //   mode rejects on. Dropping that one would silently stop strict
+        //   `normalize()` refusing a straddling delins whose stated deleted bases
+        //   do not match the reference. `ReducedCapabilityNoGenome` is the same
+        //   shape — a statement about the *provider*, which a re-type cannot fix.
+        //
+        // **This is a correction, and the measurement that preceded it is why the
+        // correction was needed.** An assertion at this line over the whole
+        // `--lib --test it` suite fired on exactly one of 9 956 tests, carrying
+        // only `AxisClampApplied` — and that was read as licence to drop the lot.
+        // It is a claim about the corpus, not about the code: no corpus row builds
+        // a straddling retype whose explicit deleted bases mismatch, so
+        // `RefSeqMismatch` never reached the line and its loss was invisible.
+        // Filter on the predicate, never on what the corpus happened to produce.
+        //
+        // Carried warnings are prepended without de-duplication. The re-typed edit
+        // usually no longer states its deleted bases, so the recursive call cannot
+        // re-derive the mismatch — which is exactly why carrying is necessary; and
+        // `NormalizationWarning` is not `PartialEq`, while de-duplicating on
+        // `code()` would conflate two `RefSeqMismatch` warnings at different
+        // positions (position is the whole key — see the merge-time comment that
+        // says so). A duplicated warning is strictly preferable to a lost one.
+        // The gate reads the explicit `took_span_preserving_retype` flag rather
+        // than `!pre_warnings.is_empty()`. The two are equivalent today, since
+        // that vector has exactly one push site and it is the carve-out — but
+        // equivalent-today is what this whole comment is about: the flag says
+        // *the carve-out ran*, which is the fact the recursion depends on, while
+        // emptiness is an observable that a second push site would silently
+        // decouple from it.
+        if took_span_preserving_retype && new_variant != *variant {
+            let new_start_axis = boundary::axis_region_of(&transcript, new_tx_start);
+            let new_end_axis = boundary::axis_region_of(&transcript, new_tx_end);
+            if new_start_axis == new_end_axis
+                && !matches!(new_start_axis, boundary::AxisRegion::None)
+            {
+                let mut carried: Vec<NormalizationWarning> = warnings
+                    .into_iter()
+                    .filter(|w| !matches!(w, NormalizationWarning::AxisClampApplied { .. }))
+                    .collect();
+                let (inner, inner_warnings) = self.normalize_cds(&new_variant)?;
+                carried.extend(inner_warnings);
+                return Ok((inner, carried));
+            }
+        }
+        // Prepended, not appended: `pre_warnings` describes a decision taken
+        // before the edit was touched, so it reads first — and on the
+        // early-return path above it was the only warning, which keeps the two
+        // paths' ordering comparable.
+        if !pre_warnings.is_empty() {
+            pre_warnings.append(&mut warnings);
+            warnings = pre_warnings;
+        }
 
         // Issue #160 + #165 post-canonicalization split. The codon-frame
         // exception applies only to CDS-proper positions, which the

--- a/tests/it/issue_1536_cds_boundary_delins.rs
+++ b/tests/it/issue_1536_cds_boundary_delins.rs
@@ -1,59 +1,73 @@
-//! #1536 — a lone `delins` whose span crosses a CDS boundary is never
+//! #1536 — a lone `delins` whose span crosses a CDS boundary was never
 //! re-derived from the sequence it denotes, so two spellings of one variant
-//! reach two different fixed points.
+//! reached two different fixed points.
 //!
-//! The identical block placed entirely inside the CDS converges correctly. The
-//! discriminator is nothing but where the start or stop codon happens to fall.
+//! The identical block placed entirely inside the CDS converged correctly. The
+//! discriminator was nothing but where the start or stop codon happens to fall.
 //!
-//! # Mechanism
+//! # Mechanism — CORRECTED, and the correction is the point
 //!
-//! `join_pos` (`src/normalize/merge.rs:1085-1087`) refuses any interval whose
-//! two ends are in different regions:
+//! This module's first form, and #1536 itself, named `merge::join_pos`
+//! (`src/normalize/merge.rs`) as the cause: it refuses any interval whose two
+//! ends are in different regions, so `collect_canonical_edits` returns `None`
+//! and the sequence-first pass is skipped. **That refusal is real and it is not
+//! what this issue was.** Measured with `normalize_with_diagnostics`:
 //!
 //! ```text
-//! if rs != re {
-//!     return None;
-//! }
+//! c.-4_4delinsCCTGATCG   -> unchanged    [CrossAxisVariantNotShuffled{5utr,cds}]
+//! c.17_*4delinsTAAGCTAC  -> unchanged    [CrossAxisVariantNotShuffled{cds,3utr}]
+//! c.*1_*8delinsACCGTAAG  -> c.*1_*8inv   []
+//! c.-10_-3delinsCGGACAGC -> c.-10_-3inv  []
 //! ```
 //!
-//! `simple_cds_pos` classifies a position as `Cds`, `FivePrimeUtr` or
-//! `ThreePrimeUtr` and returns the axis coordinate *within that region* — `*1`
-//! is `1`, `-3` is `-3`, `9` is `9`. Those numbers are not on one line, so
-//! `edit_span_union` and the `w_lo`/`w_hi` window arithmetic cannot be done in
-//! axis coordinates across a boundary. `join_pos` therefore declines,
-//! `collect_canonical_edits` returns `None`, and the whole sequence-first pass
-//! is skipped for the variant.
+//! The last two rows are the disproof. A lone `delins` sitting **entirely** in
+//! either UTR is refused by `collect_canonical_edits` just as hard — its region
+//! is not `body_region(Cds)` — and it comes back typed as `inv` anyway. The
+//! `delins -> inv` re-typing for a lone member belongs to the *per-member*
+//! pipeline (`rules`' single-span typing); `merge::anchor_for_piece` states
+//! outright that it does not type an inversion, and a whole-block reverse
+//! complement partitions to a single piece identical to the input, so
+//! `canonicalize_from_sequence` returns `None` on `rebuilt == variants` whatever
+//! `join_pos` decides.
 //!
-//! Unlike the exon-junction clamp a few lines further down — which carries an
-//! explicit rationale and states its confluence cost — this refusal is an
-//! unannotated consequence of doing window arithmetic in axis space. A fix
-//! converts the span to transcript coordinates for the window computation and
-//! back afterwards, the way the projector already does; the region split is a
-//! rendering concern, not a geometric one.
+//! What actually produced the two fixed points is the **#350 cross-axis bail**
+//! in `normalize_cds` (`src/normalize/mod.rs`): when the two endpoints fall in
+//! different axis regions it returns `canonicalize_cds_variant(variant)` — no
+//! shuffle, and no canonicalization either — plus
+//! `CrossAxisVariantNotShuffled`. Its stated ground is that *the shuffle* has no
+//! defined semantics across an axis boundary, which is a claim about moving a
+//! member, not about re-typing one against the bases under its own span.
+//!
+//! # The fix
+//!
+//! A third carve-out from that bail, beside #402's zero-width insertion and
+//! #918's whole-CDS del/dup: a cross-axis `Delins`/`Inversion` runs the ordinary
+//! per-member pipeline with the shuffle bound pinned to its own input span, so
+//! it is re-typed and affix-trimmed but cannot be carried off the footprint it
+//! arrived on. If the trim leaves it inside a single region, `normalize_cds`
+//! recurses once and the ordinary 3' rule resumes — without that step the pass
+//! emits `c.*1_*4del`, which is not its own fixed point.
 //!
 //! # What is measured here
 //!
-//! One 20-base transcript, one 8-base block at transcript positions 5..=12
-//! (`AATGCACA`), one payload (`TGTGCATT`, its exact reverse complement). Only
-//! the CDS annotation moves, so the block, the bases and the edit are held
-//! constant and the boundary is the sole variable:
+//! Two fixtures. [`PLACEMENTS`] is the original 20-base one, which holds the
+//! block, the bases and the edit constant and moves only the CDS annotation.
+//! [`walk`] is the wider one this fix was developed against: a 40-mer with
+//! **ten real 5'UTR bases and ten real 3'UTR bases**, so "crosses a CDS
+//! boundary" and "reaches the transcript end" are no longer the same statement —
+//! the confound the 20-base fixture and `cis_confluence_adjudication`'s
+//! `CDS_START = 1` / `CDS_END = 63` fixture both carry.
 //!
-//! | CDS | the same block reads | lone `delins` re-derives to `inv` |
-//! |---|---|---|
-//! | `1..=20` | `c.5_12`  | yes |
-//! | `1..=8`  | `c.5_*4`  | **no** |
-//! | `8..=20` | `c.-3_5`  | **no** |
-//!
-//! # Status
-//!
-//! **Unfixed.** [`a_delins_crossing_a_cds_boundary_converges_with_its_inv_spelling`]
-//! is `#[ignore]`d and RED against #1536 — an ignored red guard is a recorded
-//! defect; a weakened green one is a lie. Run it with
-//! `cargo nextest run --features dev -E 'test(issue_1536)' --run-ignored all`.
-//!
-//! The control — the same block entirely inside the CDS — is **not** ignored,
-//! so the half that works today is gated.
+//! Walking one 8-base whole-block reverse complement across all 33 placements on
+//! that transcript partitions perfectly on the boundary and on nothing else:
+//! before the fix, all 14 crossing placements diverged and all 19 non-crossing
+//! ones converged — **including the three that sit wholly in a UTR and the one
+//! that runs to the last base of the transcript**. Re-annotating the same
+//! transcript with `CDS 11..=40`, so that `cds_end` *is* the transcript end,
+//! makes the tx 27..34 placement converge where `CDS 11..=30` made it diverge.
+//! Same bases, same payload, only the stop codon moved.
 
+use ferro_hgvs::error_handling::ErrorMode;
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
 
@@ -63,14 +77,23 @@ use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleD
 /// depends on where the CDS is.
 const CORE: &str = "GCTGAATGCACATCCGTAGC";
 
+/// 40 bases, the wide fixture. Long enough to carry ten 5'UTR bases and ten
+/// 3'UTR bases either side of a 20-base CDS, which is what separates the two
+/// competing explanations — see the module docs.
+const WIDE_CORE: &str = "GCTGTCCGATCAGGTAATGCACATCCGTAGCTTACGGTAC";
+
 fn provider(cds_start: u64, cds_end: u64) -> MockProvider {
+    transcript_provider(CORE, cds_start, cds_end)
+}
+
+fn transcript_provider(core: &str, cds_start: u64, cds_end: u64) -> MockProvider {
     let mut provider = MockProvider::new();
-    let length = CORE.len() as u64;
+    let length = core.len() as u64;
     provider.add_transcript(Transcript::new(
         "NM_TEST.1".to_string(),
         Some("TESTGENE".to_string()),
         Strand::Plus,
-        CORE.to_string(),
+        core.to_string(),
         Some(cds_start),
         Some(cds_end),
         vec![Exon::new(1, 1, length)],
@@ -99,10 +122,10 @@ fn normalize(provider: &MockProvider, input: &str, direction: ShuffleDirection) 
 /// The three placements of one block: `(cds_start, cds_end, delins, inv)`.
 ///
 /// The `inv` spelling is the same variant written the other way. Confluence
-/// means the two reach one output; the defect is that across a boundary they
-/// do not.
+/// means the two reach one output; the defect was that across a boundary they
+/// did not.
 const PLACEMENTS: [(u64, u64, &str, &str); 3] = [
-    // Entirely inside the CDS — the control, which converges today.
+    // Entirely inside the CDS — the control, which converged even before the fix.
     (
         1,
         20,
@@ -125,12 +148,12 @@ const PLACEMENTS: [(u64, u64, &str, &str); 3] = [
     ),
 ];
 
-/// The half that works: inside the CDS, the two spellings converge.
+/// The half that always worked: inside the CDS, the two spellings converge.
 ///
-/// Not ignored. It is the control the whole issue rests on — "the identical
-/// block placed entirely inside the CDS converges correctly" — so if it ever
-/// stops holding, the defect below has been mis-stated and the record needs
-/// rewriting rather than the fix landing.
+/// It is the control the whole issue rests on — "the identical block placed
+/// entirely inside the CDS converges correctly" — so if it ever stops holding,
+/// the defect below has been mis-stated and the record needs rewriting rather
+/// than the fix landing.
 #[test]
 fn a_delins_inside_the_cds_converges_with_its_inv_spelling() {
     let (cds_start, cds_end, delins, inv) = PLACEMENTS[0];
@@ -153,25 +176,22 @@ fn a_delins_inside_the_cds_converges_with_its_inv_spelling() {
     }
 }
 
-/// #1536: across a CDS boundary they do not.
+/// #1536: across a CDS boundary they now converge too.
 ///
-/// Measured on `320e98dc` with the geometry in the module docs — the same
-/// block, the same payload, only the CDS annotation moved:
+/// Measured on `320e98dc`, before the fix, with the geometry in the module docs
+/// — the same block, the same payload, only the CDS annotation moved:
 ///
 /// ```text
-/// CDS 1..=20   c.5_12delinsTGTGCATT   -> c.5_12inv     (converges)
-/// CDS 1..=8    c.5_*4delinsTGTGCATT   -> unchanged     (does not)
-/// CDS 8..=20   c.-3_5delinsTGTGCATT   -> unchanged     (does not)
+/// CDS 1..=20   c.5_12delinsTGTGCATT   -> c.5_12inv     (converged)
+/// CDS 1..=8    c.5_*4delinsTGTGCATT   -> unchanged     (did not)
+/// CDS 8..=20   c.-3_5delinsTGTGCATT   -> unchanged     (did not)
 /// ```
 ///
-/// So `c.5_*4inv` and `c.5_*4delinsTGTGCATT` are both fixed points: two
+/// So `c.5_*4inv` and `c.5_*4delinsTGTGCATT` were both fixed points: two
 /// answers for one variant, discriminated by nothing but where the stop codon
-/// falls.
-///
-/// Ignored because #1536 is unfixed, not because the assertion is wrong.
-/// Un-ignore it with the fix, in the same change.
+/// falls. This was `#[ignore]`d and RED against #1536 until the #350 carve-out
+/// landed; it is un-ignored in the same change that closes it.
 #[test]
-#[ignore = "#1536: a delins crossing a CDS boundary is never re-derived — unfixed, this guard is red"]
 fn a_delins_crossing_a_cds_boundary_converges_with_its_inv_spelling() {
     let mut divergent = Vec::new();
     for (cds_start, cds_end, delins, inv) in PLACEMENTS.iter().skip(1) {
@@ -205,7 +225,17 @@ fn a_delins_crossing_a_cds_boundary_converges_with_its_inv_spelling() {
 #[test]
 fn the_payload_is_the_exact_reverse_complement_of_the_block() {
     let block = &CORE[4..12];
-    let revcomp: String = block
+    assert_eq!(block, "AATGCACA");
+    assert_eq!(reverse_complement(block), "TGTGCATT");
+}
+
+// ---------------------------------------------------------------------------
+// The wide fixture: a real UTR at both ends, so the boundary and the sequence
+// end are separable.
+// ---------------------------------------------------------------------------
+
+fn reverse_complement(block: &str) -> String {
+    block
         .chars()
         .rev()
         .map(|b| match b {
@@ -215,7 +245,395 @@ fn the_payload_is_the_exact_reverse_complement_of_the_block() {
             'T' => 'A',
             other => panic!("unexpected base {other}"),
         })
-        .collect();
-    assert_eq!(block, "AATGCACA");
-    assert_eq!(revcomp, "TGTGCATT");
+        .collect()
+}
+
+/// The `c.` spelling of a 1-based transcript position under the given CDS.
+fn cds_spelling(tx: i64, cds_start: i64, cds_end: i64) -> String {
+    if tx < cds_start {
+        format!("{}", tx - cds_start)
+    } else if tx <= cds_end {
+        format!("{}", tx - cds_start + 1)
+    } else {
+        format!("*{}", tx - cds_end)
+    }
+}
+
+/// Normalize both spellings of the 8-base whole-block reverse complement at
+/// transcript `start..=start + 7`, returning `(delins_output, inv_output)`.
+fn walk(cds_start: i64, cds_end: i64, start: i64) -> (String, String) {
+    let end = start + 7;
+    let block = &WIDE_CORE[(start - 1) as usize..end as usize];
+    let payload = reverse_complement(block);
+    let s = cds_spelling(start, cds_start, cds_end);
+    let e = cds_spelling(end, cds_start, cds_end);
+    let provider = transcript_provider(WIDE_CORE, cds_start as u64, cds_end as u64);
+    (
+        normalize(
+            &provider,
+            &format!("NM_TEST.1:c.{s}_{e}delins{payload}"),
+            ShuffleDirection::ThreePrime,
+        ),
+        normalize(
+            &provider,
+            &format!("NM_TEST.1:c.{s}_{e}inv"),
+            ShuffleDirection::ThreePrime,
+        ),
+    )
+}
+
+/// Every placement of one block on a transcript with a real UTR at both ends
+/// converges, crossing or not.
+///
+/// 33 placements — the 8-base block at every transcript start from 1 to 33 on a
+/// 40-mer with `CDS 11..=30`. Before the fix this was 14 divergent and 19
+/// converged, partitioning exactly on whether the block crossed `cds_start` or
+/// `cds_end`.
+///
+/// The three placements wholly inside the 5'UTR and the three wholly inside the
+/// 3'UTR are the load-bearing rows: they converged *before* the fix, which is
+/// what rules out "outside the CDS" as the explanation and forces the answer to
+/// be the boundary itself.
+#[test]
+fn every_placement_of_one_block_converges_on_a_transcript_with_two_real_utrs() {
+    let (cds_start, cds_end) = (11i64, 30i64);
+    let mut divergent = Vec::new();
+    for start in 1..=33i64 {
+        let (from_delins, from_inv) = walk(cds_start, cds_end, start);
+        if from_delins != from_inv {
+            divergent.push(format!(
+                "  tx {start}..={}: delins -> {from_delins}, but inv -> {from_inv}",
+                start + 7
+            ));
+        }
+    }
+    assert!(
+        divergent.is_empty(),
+        "#1536: {} of 33 placements reached two fixed points for one variant:\n{}",
+        divergent.len(),
+        divergent.join("\n")
+    );
+}
+
+/// The confound, resolved: the discriminator is the CDS boundary, not the end
+/// of the transcript.
+///
+/// The 20-base fixture above cannot tell the two apart — with `CDS 1..=8` on a
+/// 20-mer the block's far end is in the 3'UTR but nowhere near the sequence end,
+/// which is suggestive and not conclusive. `cis_confluence_adjudication`'s
+/// fixture is worse: `CDS_END = 63` on a 64-base core makes `c.64` simultaneously
+/// the last base of the transcript and the first base of the 3'UTR, so the two
+/// hypotheses are literally the same row.
+///
+/// Here they are separated in both directions on one transcript:
+///
+/// * tx 33..=40 ends on the transcript's **last base** and converged even before
+///   the fix, because it lies wholly inside the 3'UTR — so reaching the sequence
+///   end is not sufficient to break it;
+/// * tx 27..=34 crosses `cds_end` under `CDS 11..=30` and diverged, and sits
+///   wholly inside the CDS under `CDS 11..=40` — where `cds_end` *is* the
+///   transcript end — and converged. Same bases, same payload, only the
+///   annotation moved.
+#[test]
+fn the_discriminator_is_the_cds_boundary_and_not_the_transcript_end() {
+    // Reaching the transcript's last base, wholly inside the 3'UTR.
+    let (from_delins, from_inv) = walk(11, 30, 33);
+    assert_eq!(
+        from_delins, from_inv,
+        "a block running to the transcript end but not crossing a boundary must converge"
+    );
+    assert_eq!(
+        from_delins, "NM_TEST.1:c.*3_*10inv",
+        "and must be re-derived as an inversion"
+    );
+
+    // The same block, once crossing `cds_end` and once not, distinguished only
+    // by where `cds_end` is annotated.
+    let (crossing_delins, crossing_inv) = walk(11, 30, 27);
+    assert_eq!(crossing_delins, crossing_inv);
+    assert_eq!(crossing_delins, "NM_TEST.1:c.17_*4inv");
+
+    let (interior_delins, interior_inv) = walk(11, 40, 27);
+    assert_eq!(interior_delins, interior_inv);
+    assert_eq!(
+        interior_delins, "NM_TEST.1:c.17_24inv",
+        "with `cds_end` at the transcript end the same block is CDS-interior"
+    );
+}
+
+/// The re-typed member is shuffled once it stops straddling, and the output is
+/// its own fixed point.
+///
+/// The carve-out pins the shuffle to the input's own span, because a straddling
+/// member has no defined most-3' position. The shared-affix trim can dissolve
+/// the straddle, and at that point the pin has no ground left: `normalize_cds`
+/// recurses once and the ordinary 3' rule resumes.
+///
+/// Without the recursion this shape emits `c.*1_*4del`, which sits wholly in
+/// the 3'UTR and therefore shuffles again on the next pass — an output that is
+/// not its own fixed point, which `spec_conformance_axis` counts as a rank-1
+/// conformance regression rather than a representation choice. It caught exactly
+/// two rows (`s00-c3m-cds-end-del-del-p2-sep1`, `s00-c3p-cds-end-del-del-p2-sep1`).
+///
+/// # The input matters, and the first one chosen here did not reach the recursion
+///
+/// This test asserted `once == twice` on `c.20_*7delinsCC`, and **passed with the
+/// recursion block disabled** — so it was pinning nothing. Measured: that input's
+/// `ref` (`GCTTACGG`) and payload (`CC`) share neither a prefix nor a suffix, so
+/// the trim removes nothing, the member is returned on the footprint it arrived on,
+/// and the recursion's `new_variant != *variant` gate never opens. The mechanism
+/// above was right; the demonstration was of a different shape.
+/// [`the_input_that_taught_us_this_test_can_be_vacuous`] pins that input as the
+/// decline it is, so it cannot be reached for again.
+///
+/// `c.20_*4delinsG` does reach it. `ref` is `GCTTA` and the payload `G`, so the
+/// trim eats the one CDS-side base and leaves `c.*1_*4del` — wholly in the 3'UTR,
+/// and one base short of 3'-most, because transcript 35 repeats transcript 31:
+///
+/// ```text
+/// with the recursion:     c.20_*4delinsG -> c.*2_*5del    (a fixed point)
+/// without the recursion:  c.20_*4delinsG -> c.*1_*4del    (NOT a fixed point)
+/// ```
+///
+/// Both halves are asserted, so neither a lost shuffle nor a lost fixed point can
+/// pass, and the un-recursed form is asserted *not* to be a fixed point so the
+/// pair cannot go vacuous the way it did before. Verified by forcing the
+/// recursion's gate closed and re-running: this test fails, and 3'
+/// `non_idempotent_outputs` in `spec_conformance_axis` reads 6 rather than 4.
+#[test]
+fn a_retyped_member_that_stops_straddling_is_shuffled_and_is_a_fixed_point() {
+    // `CDS 11..=30` on the 40-mer, so `c.*1` is transcript 31.
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    // The form the trim produces, before anything shuffles it.
+    let untrimmed = "NM_TEST.1:c.*1_*4del";
+
+    let once = normalize(
+        &provider,
+        "NM_TEST.1:c.20_*4delinsG",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_ne!(
+        once, untrimmed,
+        "the trim dissolved the straddle and nothing shuffled the result — the \
+         recursion in `normalize_cds` did not run"
+    );
+    assert_eq!(
+        once, "NM_TEST.1:c.*2_*5del",
+        "the re-typed member must be shuffled to its 3'-most position once it stops \
+         straddling"
+    );
+    let twice = normalize(&provider, &once, ShuffleDirection::ThreePrime);
+    assert_eq!(
+        once, twice,
+        "the re-typed output must be its own fixed point, or the next pass moves it again"
+    );
+
+    // The control that makes the `assert_ne!` above measure the recursion rather
+    // than a coincidence: `c.*1_*4del` really is the un-shuffled form of the same
+    // answer, and really is not a fixed point — so emitting it would be the
+    // rank-1 regression, not a representation choice.
+    let from_untrimmed = normalize(&provider, untrimmed, ShuffleDirection::ThreePrime);
+    assert_eq!(
+        from_untrimmed, once,
+        "{untrimmed} must reach the same answer, or it is not the un-recursed form of it"
+    );
+    assert_ne!(
+        from_untrimmed, untrimmed,
+        "{untrimmed} must NOT be a fixed point — were it one, the recursion would be \
+         unobservable on this input and the assertions above would be vacuous again"
+    );
+}
+
+/// The recursion returns what the intermediate's own normalization returns —
+/// warnings included — so it cannot leak a warning that the direct route does not.
+///
+/// **Written as an equivalence, not as an absence, and that is the whole point.**
+/// A bare `assert!(no AXIS_CLAMP_APPLIED)` here would be satisfied by a build that
+/// never emits the warning at all, which is the vacuity the test directly above
+/// exists to remember. Comparing the two routes is falsifiable instead: the
+/// straddling input reaches its answer *through* the recursion in `normalize_cds`,
+/// the intermediate reaches it without recursing, and if the recursion kept the
+/// `AxisClampApplied` it accumulates before re-entering, these two warning lists
+/// would differ and this test would fail.
+///
+/// The warning is genuinely live on the recursing path — an assertion at the
+/// re-entry line fires on `a_retyped_member_that_stops_straddling_is_shuffled_and_is_a_fixed_point`
+/// carrying `AxisClampApplied { direction: "3prime", clamp_kind: "cds_end" }`.
+/// Dropping it is correct rather than lossy: its contract is to explain why a
+/// position did *not* shift further, and here it did (`c.*1_*4del` ->
+/// `c.*2_*5del`). See the comment at that line in `normalize_cds`.
+#[test]
+fn the_recursion_emits_no_stale_clamp_warning() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    let normalize_with_warnings = |input: &str| {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} must parse: {e}"));
+        let result = Normalizer::with_config(
+            provider.clone(),
+            NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+        )
+        .normalize_with_diagnostics(&variant)
+        .unwrap_or_else(|e| panic!("{input} must normalize: {e}"));
+        let mut codes: Vec<&'static str> = result.warnings.iter().map(|w| w.code()).collect();
+        codes.sort_unstable();
+        (result.result.to_string(), codes)
+    };
+
+    // Straddles the CDS/3'UTR boundary, so the carve-out re-types it and the
+    // re-entry runs.
+    let (recursed, recursed_codes) = normalize_with_warnings("NM_TEST.1:c.20_*4delinsG");
+    // The form the trim produces; single-axis, so it never reaches the carve-out.
+    let (direct, direct_codes) = normalize_with_warnings("NM_TEST.1:c.*1_*4del");
+
+    assert_eq!(
+        recursed, direct,
+        "the recursion must reach the same answer as normalizing the intermediate, \
+         or the two routes are not comparable and the warning check below is moot"
+    );
+    assert_ne!(
+        recursed, "NM_TEST.1:c.*1_*4del",
+        "the answer must have shifted past the intermediate — that is what makes a \
+         retained `AxisClampApplied` a false statement rather than a true one"
+    );
+    assert_eq!(
+        recursed_codes, direct_codes,
+        "the recursing route must not carry warnings the direct route does not: \
+         recursed={recursed_codes:?} direct={direct_codes:?}"
+    );
+}
+
+/// The input the test above used to run on, pinned as the decline it actually is.
+///
+/// Not a curiosity: it is the reason that test read as coverage for two review
+/// rounds while guarding nothing. `c.20_*7delinsCC` shares no affix between `ref`
+/// and payload, so the carve-out re-types nothing, the member comes back exactly as
+/// authored, and any `once == twice` assertion on it is satisfied by the decline
+/// rather than by the recursion. If this ever starts moving, the note on the test
+/// above needs rewriting rather than this pin loosening.
+#[test]
+fn the_input_that_taught_us_this_test_can_be_vacuous() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    let declined = "NM_TEST.1:c.20_*7delinsCC";
+    assert_eq!(
+        normalize(&provider, declined, ShuffleDirection::ThreePrime),
+        declined,
+        "an untrimmable straddling delins must be preserved, which is why it cannot \
+         demonstrate the recursion"
+    );
+}
+
+/// STILL OPEN, and deliberately recorded as such: the multi-member spelling of
+/// one variant does not converge with its `inv` spelling once the members
+/// straddle the boundary.
+///
+/// This is the `merge::join_pos` / `collect_canonical_edits` refusal the module
+/// docs above disentangle from #1536 — a real capability gap, and a genuine
+/// second pair of fixed points, but a different symptom with a different cause.
+/// Fixing it means doing the sequence-first window arithmetic in transcript
+/// coordinates and rendering each endpoint back onto its own region, which also
+/// reaches `apply_canonical_split`'s own `simple_cds_pos` (it refuses `*N` and
+/// `-N` outright). Out of scope here; tracked as #1650.
+///
+/// Measured on the 40-mer, `CDS 11..=26`, with the block at transcript 23..=30 —
+/// the placement whose CDS-interior twin *is* split into three members:
+///
+/// ```text
+/// CDS 11..=30  c.[13_15delinsCTA;18T>G;20G>T] -> itself
+///              c.13_20inv                     -> c.[13_15delinsCTA;18T>G;20G>T]   converges
+/// CDS 11..=26  c.[13_15delinsCTA;*2T>G;*4G>T] -> itself
+///              c.13_*4inv                     -> c.13_*4inv                       does NOT
+/// ```
+///
+/// Ignored because it is unfixed, not because the assertion is wrong. An ignored
+/// red guard is a recorded defect; a weakened green one is a lie.
+///
+/// **Tracked as #1650**, which is what says when it comes back: un-ignore it in the
+/// change that makes `collect_canonical_edits` do its window arithmetic in
+/// transcript coordinates. "Tracked separately" without a number is what this line
+/// used to say, and an unnumbered deferral is indistinguishable from a forgotten
+/// one.
+#[test]
+#[ignore = "unfixed, tracked as #1650: a cis allele whose members straddle a CDS boundary is \
+            refused by merge::collect_canonical_edits, so it does not converge with its inv \
+            spelling"]
+fn a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary() {
+    let provider = transcript_provider(WIDE_CORE, 11, 26);
+    let allele = "NM_TEST.1:c.[13_15delinsCTA;*2T>G;*4G>T]";
+    let inv = "NM_TEST.1:c.13_*4inv";
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize(&provider, allele, direction),
+            normalize(&provider, inv, direction),
+            "{allele} and {inv} denote one variant and must converge"
+        );
+    }
+}
+
+/// The control for the guard above, so its `#[ignore]` cannot quietly become
+/// vacuous: the identical design converges when the members sit inside the CDS.
+///
+/// If this ever goes red, the multi-member guard is no longer measuring the
+/// boundary and its record needs rewriting rather than un-ignoring.
+#[test]
+fn the_multi_member_spelling_converges_inside_the_cds() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    let allele = "NM_TEST.1:c.[13_15delinsCTA;18T>G;20G>T]";
+    let inv = "NM_TEST.1:c.13_20inv";
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize(&provider, allele, direction),
+            normalize(&provider, inv, direction),
+            "{allele} and {inv} denote one variant inside the CDS and must converge"
+        );
+    }
+}
+
+/// A reference mismatch must survive the recursion, or strict mode stops refusing.
+///
+/// The recursion in `normalize_cds` re-enters on the re-typed variant and returns its
+/// result. It used to `return` that result outright, discarding **every** warning the
+/// outer pass had accumulated — and `warnings` there comes from `normalize_na_edit`,
+/// which validates the reference and pushes `RefSeqMismatch`. Since
+/// `NormalizeResult::has_ref_mismatch` is what strict mode refuses on, a straddling
+/// delins whose stated deleted bases are wrong was silently accepted.
+///
+/// **The measurement that preceded this test is why it exists.** An assertion at the
+/// re-entry line fired on exactly one of 9 956 tests, carrying only
+/// `AxisClampApplied` — and that was read as licence to drop both vectors. It was a
+/// claim about the corpus: no row builds a straddling retype with mismatched explicit
+/// bases, so this class never reached the line and its loss was invisible. Filter on
+/// what a warning *asserts*, not on what the corpus happens to produce.
+///
+/// Reference at the straddling span (tx 30..=34 under `CDS 11..=30`) is `GCTTA`, so
+/// `delAAAAA` is a genuine mismatch rather than a coincidence of this fixture.
+#[test]
+fn a_reference_mismatch_survives_the_recursion_and_strict_mode_still_refuses() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    let input = "NM_TEST.1:c.20_*4delAAAAAinsG";
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} must parse: {e}"));
+
+    let lenient = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let result = lenient
+        .normalize_with_diagnostics(&variant)
+        .unwrap_or_else(|e| panic!("{input} must normalize in the default mode: {e}"));
+    assert!(
+        result.has_ref_mismatch(),
+        "the reference mismatch must survive the re-typing recursion — without it \
+         strict mode has nothing to refuse on. warnings={:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>()
+    );
+
+    let strict = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default()
+            .with_direction(ShuffleDirection::ThreePrime)
+            .with_error_mode(ErrorMode::Strict),
+    );
+    assert!(
+        strict.normalize(&variant).is_err(),
+        "strict mode must refuse a straddling delins whose stated deleted bases do \
+         not match the reference"
+    );
 }

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -41,14 +41,26 @@
 //! baseline unmeasurable).
 //!
 //! **The base they are measured against is `main`.** Every figure below was
-//! measured on this branch, which adds no `src/normalize/` change of its own —
-//! so the census records `main`'s behaviour, not this PR's. The corpus is new;
-//! the defects it counts are not.
+//! measured on the branch that introduced this module, which added no
+//! `src/normalize/` change of its own — so the census records `main`'s
+//! behaviour, not that PR's. The corpus is new; the defects it counts are not.
 //!
-//! **That paragraph is the CORPUS branch speaking, and it no longer holds.** The
-//! branch you are reading changes `coalesce_coding_frame_separation`, so three of
-//! the figures below are re-blessed against it rather than measured on `main`.
-//! See "RE-BLESSED" below before quoting any of them as a `main` baseline.
+//! **That paragraph is the CORPUS branch speaking, and it no longer holds.** Two
+//! normalizer changes have re-blessed figures here since, and there are two
+//! RE-BLESSED sections below — one per change, in the order they landed. Read
+//! both before quoting any figure as a `main` baseline:
+//!
+//! 1. the amino-acid precondition on `coalesce_coding_frame_separation` (#1599),
+//!    which moved five figures, one of them a net regression in `converged`;
+//! 2. the span-preserving re-typing carve-out for a member that straddles a CDS
+//!    boundary (#1536), which moved seven and regressed none.
+//!
+//! **The second was measured on the first, not composed with it.** The two
+//! changes' affected row sets are disjoint — verified by diffing the row ids, not
+//! assumed — so the deltas happen to be additive here, but a census counts
+//! *classes* rather than row-deltas and a composed figure would not have been a
+//! measurement. Every figure in the second section came from running the corpus
+//! on this branch rebased onto #1599.
 //!
 //! | counter | 3' | 5' | what it is |
 //! |---|---|---|---|
@@ -68,11 +80,11 @@
 //! The 3'/5' asymmetry is itself a finding: the transcript-leaving class is
 //! **371 to 0**, and 3' is the default direction.
 //!
-//! # RE-BLESSED — this branch DOES change `src/normalize/`, so the pins moved
+//! # RE-BLESSED (1 of 2) — #1599, the amino-acid precondition
 //!
 //! Everything above and in [`THREE_PRIME`]'s own doc was written on the corpus
-//! PR, which touched no normalizer file. **That is no longer the base.** This
-//! branch adds `general.md:35`'s amino-acid conjunct to
+//! PR, which touched no normalizer file. **That is no longer the base.** #1599
+//! adds `general.md:35`'s amino-acid conjunct to
 //! `coalesce_coding_frame_separation`, so the pass now declines a merge whose
 //! span crosses a codon boundary, and five figures moved:
 //!
@@ -104,7 +116,60 @@
 //! across a codon boundary — and neither direction of the move is a
 //! representation *choice* left open: `general.md:35`'s second conjunct is
 //! either met or it is not. `outputs_leaving_the_transcript` stays **371**, which
-//! is the pre-existing baseline and not a regression of this branch's.
+//! is the pre-existing baseline and not a regression of #1599's.
+//!
+//! # RE-BLESSED (2 of 2) — #1536, the cross-axis re-typing carve-out
+//!
+//! This branch adds a third carve-out from the #350 cross-axis bail in
+//! `normalize_cds`, so a `delins`/`inv` whose span straddles a CDS boundary is
+//! re-typed against the bases it denotes instead of being returned unprocessed.
+//! Seven figures moved and **none regressed**:
+//!
+//! | figure | was (post-#1599) | now | direction |
+//! |---|---|---|---|
+//! | 3' `converged` | 9,139 | **9,141** | improves by 2 |
+//! | 3' `split_two` | 2,436 | **2,440** | net +4, from higher arities |
+//! | 3' `split_three` | 250 | **248** | improves |
+//! | 3' `split_more` | 57 | **53** | improves |
+//! | 5' `split_two` | 2,698 | **2,706** | net +8, from higher arities |
+//! | 5' `split_three` | 202 | **200** | improves |
+//! | 5' `split_more` | 38 | **32** | improves |
+//!
+//! **The `was` column is measured, not carried over.** It was re-derived by
+//! running this branch's corpus against `main`'s `src/normalize/mod.rs` — which
+//! reproduced the committed post-#1599 pins exactly, `rc=0` — so the two sides of
+//! the table come from one corpus and one machine.
+//!
+//! **`split_two` rising is not a regression here**, and the net counters cannot
+//! settle that on their own: a family entering `split_two` from `split_three` and
+//! a family leaving `converged` for `split_two` look identical in the totals. So
+//! the full divergence lists were dumped on both sides and the row ids diffed:
+//!
+//! - **2 families newly converge** (3' only): `s00-c3{p,m}-cds-end-del-ins-p1-sep2`,
+//!   each from arity 2. At 5' the same two rows only drop 3 -> 2.
+//! - **10 families drop arity at 3'** and **14 at 5'**, 10 of them the same row
+//!   ids in both directions: `s00-c3{p,m}-cds-end-` `del-del-p1-sep2` (3 -> 2),
+//!   `del-del-p2-sep1` (4 -> 3), `del-ins-p2-sep1` (4 -> 3), `sub-sub-p1-sep0`
+//!   (3 -> 2) and `sub-sub-p2-sep0` (3 -> 2). The 5'-only four are
+//!   `s00-c3{p,m}-cds-end-del-ins-p1-sep2` (3 -> 2) and
+//!   `s00-c3{p,m}-cds-end-del-ins-p2-sep2` (4 -> 3).
+//! - **0 families lose convergence, and 0 rise in arity, in either direction.**
+//!
+//! So there is **nothing to promote** to `spec_corpus_regressions.rs` for this
+//! change — which is a measured claim about a diffed row set, not the absence of
+//! a search. Contrast #1599 directly above, which did have six rows to promote.
+//!
+//! **Every moved row is `s00-c3{p,m}-cds-end-*`.** That is the corpus speaking
+//! about itself, not a statement that the fix only reaches the CDS-end boundary:
+//! this corpus builds boundary designs at `cds_end` and none at `cds_start`, so
+//! the 5'UTR/CDS half of the carve-out is **unmeasured here**. It is covered
+//! instead by `issue_1536_cds_boundary_delins`, whose `PLACEMENTS` table crosses
+//! `cds_start` (`c.-3_5`) and whose 33-placement walk crosses both.
+//!
+//! `non_idempotent_outputs` stays **4** at 3' and **4** at 5' — measured, and the
+//! recursion step in `normalize_cds` is what keeps it there; without that step it
+//! measures **6** at 3', the two extra rows being
+//! `s00-c3{p,m}-cds-end-del-del-p2-sep1`. Every rank-1 counter is unchanged.
 //!
 //! # CORRECTED — what the transcript-leaving class actually violates
 //!
@@ -222,10 +287,11 @@ const SHAPE: CorpusShape = CorpusShape {
 /// fixed. Read the three asserted-zero counters before the headline, per the
 /// module docs.
 ///
-/// **The "measures `main`" heading above is now historical** — this branch does
-/// change `src/normalize/`, and three of these figures are re-blessed against it.
-/// The module docs' "RE-BLESSED" section names each one, which way it moved and
-/// the six-against-five row diff behind the net `converged` figure.
+/// **The "measures `main`" heading above is now historical** — two normalizer
+/// changes have re-blessed figures here, #1599 and then #1536, and seven of these
+/// are measured against the second rather than against the corpus PR's `main`. The
+/// module docs carry a RE-BLESSED section per change, naming each figure, which way
+/// it moved, and the row ids behind it.
 pub(crate) const THREE_PRIME: Census = Census {
     // -- validity (rank 1) --
     outputs: 58_552,
@@ -236,13 +302,20 @@ pub(crate) const THREE_PRIME: Census = Census {
     prohibition_violating_outputs: 32,
     // -- confluence (rank 2) --
     //
-    // Re-blessed by the amino-acid precondition: 6 classes lost convergence and
-    // 5 gained it, for a net -1 here and +1 in `split_two`. See the module docs'
-    // RE-BLESSED section for the row ids and the promoted regression test.
-    converged: 9_139,
-    split_two: 2_436,
-    split_three: 250,
-    split_more: 57,
+    // Re-blessed by #1536, on top of the amino-acid precondition's re-bless
+    // directly above in history — **measured on this branch rebased onto that**,
+    // not composed from the two changes' deltas. `converged` goes UP and no
+    // counter regresses; the row-level diff is in the module docs' second
+    // RE-BLESSED section.
+    //
+    // 2 families newly converge and 10 more drop to a lower split arity. Zero
+    // families lose convergence and zero rise in arity — that is a measured
+    // statement, from diffing the full divergence lists either side, not an
+    // inference from the net counters (which cannot tell net from gross).
+    converged: 9_141,
+    split_two: 2_440,
+    split_three: 248,
+    split_more: 53,
     underdetermined: 0,
     // -- idempotency --
     //
@@ -267,8 +340,8 @@ pub(crate) const THREE_PRIME: Census = Census {
 /// would mean a fix was treating a symptom of the shuffle rather than the
 /// partitioner.
 ///
-/// Measured on the same base as [`THREE_PRIME`] — `main`, which this branch
-/// does not modify.
+/// Measured on the same base as [`THREE_PRIME`], and re-blessed by the same two
+/// changes — see the module docs' two RE-BLESSED sections.
 ///
 /// The two directions agreeing on every rank-1 counter except
 /// `outputs_leaving_the_transcript` is itself the cross-check the two-direction
@@ -282,13 +355,21 @@ pub(crate) const FIVE_PRIME: Census = Census {
     outputs_denoting_no_sequence: 18,
     outputs_leaving_the_transcript: 0,
     prohibition_violating_outputs: 32,
+    // Unmoved by either re-bless: no 5' family changes which side of the
+    // converged/split line it sits on, in #1599 or in #1536.
     converged: 8_944,
-    // Re-blessed: the two `s01-c3{p,m}-m3-all-del-p1-sep2` classes fell from
-    // three outputs to two. `converged` is untouched, so no 5' class changed
-    // side; only the multiplicity of two that were already split moved.
-    split_two: 2_698,
-    split_three: 202,
-    split_more: 38,
+    // Re-blessed by #1536, rank-2 only, same as [`THREE_PRIME`] — and measured on
+    // the rebased branch rather than composed. 14 families drop to a lower split
+    // arity; **none** newly converges and none regresses, so `converged` is
+    // untouched here while it rose by 2 at 3'.
+    //
+    // The two directions moving by different amounts is expected rather than
+    // suspicious: the re-typed member is pinned to its own span in both, but the
+    // *follow-on* shuffle the re-typing enables runs 3' or 5'. Measured: 10 of the
+    // 3' rows and 14 of the 5' rows moved, 10 of them the same row ids in both.
+    split_two: 2_706,
+    split_three: 200,
+    split_more: 32,
     underdetermined: 0,
     non_idempotent_outputs: 4,
     sequence_changed: 0,


### PR DESCRIPTION
Closes #1536

## What was wrong

A `delins` whose span crosses a CDS/UTR boundary was never re-derived from the sequence it denotes, so two spellings of one variant reached two different fixed points. The identical block placed wholly inside the CDS converges correctly — the discriminator was nothing but where the start or stop codon happens to fall:

```
c.9_*1delinsTGTGCATT   ->  c.9_*1delinsTGTGCATT     (unchanged)
c.9_*1inv              ->  c.9_*1inv                (unchanged)
```

Two fixed points, one variant.

## Root cause

The cross-axis bail's stated ground is that **the shuffle** has no defined semantics across an axis boundary. It then discarded the whole per-member pipeline, canonicalization included.

Re-typing a `delins` against the bases it denotes — `canonicalize_delins`: `inv`, `del`, `ins`, `dup`, `sub`, plus the shared-affix trim — is not a shuffle. It reads the reference under the member's own span and moves nothing. The `c.` reference is a single contiguous string (`refseq.md`) whose axis *labels* change at `cds_start`/`cds_end` while the sequence does not; that is the argument #918 already makes verbatim for a whole-CDS del/dup.

## The boundary is the discriminator, not the transcript end

The obvious confound — that these spans also reach the end of the transcript — was ruled out by measuring on a 40-mer with a real UTR at **both** ends. Over the 33 placements of one 8-base whole-block reverse complement:

- the **14** that cross a CDS boundary all diverged
- the **19** that do not all converged — including the three sitting wholly in a UTR, and the one running to the transcript end

So the trigger is the boundary, not the sequence end.

## Scope: `Delins` and `Inversion` together, everything else keeps the bail

Confluence is a property of the **pair**. The `delins` spelling reaches `inv` only if the `inv` spelling reaches the same string, and the `inv` spelling is subject to the same shared-affix trim (`c.3_10inv` → `c.4_9inv`). Admitting one and not the other trades one non-confluence for another.

Every other edit kind keeps the bail:
- for a `del`/`dup` the canonicalization **is** the shuffle, so admitting them would be the cross-axis shift #350 refuses and #918 carves out only for a whole-CDS span
- a `sub` cannot straddle a boundary
- an `ins` is already carved out by #402

## A second, independent refusal — named, not fixed here

`merge::join_pos` / `collect_canonical_edits` refuse any interval whose ends are in different regions (`region != body`), and `apply_canonical_split`'s `simple_cds_pos` refuses `*N`/`-N` outright. Those block cross-region **splits**, which is a real capability gap but a different one:

```
CDS 11..=30   c.13_20delinsCTACGGAT  ->  c.[13_15delinsCTA;18T>G;20G>T]   (split)
CDS 11..=26   c.13_*4delinsCTACGGAT  ->  c.13_*4inv                        (converged, not split)
```

Fixing only `merge.rs` would **not** have fixed the reported symptom — the #350 bail is its root cause. The remaining gap is stated here rather than silently left as an unexplained asymmetry.

## Correcting a claim in the issue

The issue notes that the corpus is structurally blind here because "every pre-existing family is single-exon with `CDS_START = 1`". **That is stale.** `CDS_END = 15` on a 20-mer `c.` reference already yields a 3'UTR, and #1478's `cx.` axis added `CDS_START_MULTI = 4` / `CDS_END_MULTI = 15`, so both boundaries are reachable. The corpus does see this property — hence a real 1826-row blast radius rather than a structural zero.

## Rebased, and every figure below re-measured on the new base

This branch was opened against `822eb5d5`. Since then **#1599, #1606, #1609, #1622, #1639, #1640, #1644, #1645 and #1646** landed, and #1599 re-blessed the very constants this PR re-blesses — `tests/it/spec_conformance_axis.rs` was a real merge conflict, not a lagging `mergeStateStatus` (`git merge-tree` returned that file with rc=1; GitHub agreed at `CONFLICTING`/`DIRTY`). It is now rebased onto `bfcc1802` and clean.

**Nothing below is composed from the two changes' deltas.** A census counts *classes*, not row-deltas, and the two changes touch overlapping regions of the corpus, so a composed number would not be a measurement. Every figure was taken by running the corpus on the rebased branch, and every `before` figure by running the same corpus against `main`'s `src/normalize/mod.rs` in the same tree — which reproduced the committed post-#1599 pins exactly (`rc=0`), so both sides come from one corpus on one machine.

For the record, the deltas *did* turn out to be additive, because the two changes' affected row sets are disjoint — verified by diffing row ids, not assumed. That is a result, not the method.

## Confluence census

`before` = `main` @ `bfcc1802`; `after` = this branch.

| | converged | split 2 | split 3 | split 4+ | non-idempotent |
|---|---|---|---|---|---|
| 3' before | 9139 | 2436 | 250 | 57 | 4 |
| 3' after | **9141** | 2440 | 248 | 53 | 4 |
| 5' before | 8944 | 2698 | 202 | 38 | 4 |
| 5' after | 8944 | 2706 | 200 | 32 | 4 |

Every rank-1 counter is unchanged in both directions.

**The net counters cannot tell net from gross** — a family entering `split_two` from `split_three` and a family leaving `converged` for `split_two` look identical in the totals — so the full divergence lists were dumped on both sides and the row ids diffed:

- **2 families newly converge** (3' only): `s00-c3{p,m}-cds-end-del-ins-p1-sep2`. At 5' the same two rows only drop 3 -> 2.
- **10 families drop arity at 3'** and **14 at 5'**, 10 of them the same row ids in both: `s00-c3{p,m}-cds-end-` `del-del-p1-sep2` (3 -> 2), `del-del-p2-sep1` (4 -> 3), `del-ins-p2-sep1` (4 -> 3), `sub-sub-p1-sep0` (3 -> 2), `sub-sub-p2-sep0` (3 -> 2). The 5'-only four are `del-ins-p1-sep2` (3 -> 2) and `del-ins-p2-sep2` (4 -> 3), both strands.
- **0 families lose convergence and 0 rise in arity, in either direction.**

So the census assertion's instruction to "promote any newly-failing row to a named test in `spec_corpus_regressions.rs`" has **nothing to promote here** — which is a measured claim about a diffed row set, not the absence of a search. (#1599, directly below in history, did have six rows to promote and promoted them.)

**Every moved row is `s00-c3{p,m}-cds-end-*`, and that is the corpus speaking about itself.** This corpus builds boundary designs at `cds_end` and none at `cds_start`, so the 5'UTR/CDS half of the carve-out is *unmeasured by this census*. It is covered instead by `issue_1536_cds_boundary_delins`, whose `PLACEMENTS` table crosses `cds_start` (`c.-3_5`) and whose 33-placement walk crosses both. Recorded rather than left to read as "the fix only affects the CDS end".

## A test that read as coverage and guarded nothing

`a_retyped_member_that_stops_straddling_is_shuffled_and_is_a_fixed_point` asserted only `once == twice` on `c.20_*7delinsCC`, with a doc comment claiming that input emitted `c.*1_*4del` without the recursion step. **Measured: it passes with the recursion block's gate forced closed.**

Both halves of the claim were wrong for that input. Its `ref` (`GCTTACGG`) and payload (`CC`) share neither a prefix nor a suffix, so the trim removes nothing, the member never stops straddling, and the recursion's `new_variant != *variant` gate never opens — the assertion was satisfied by an input the carve-out *declines* to change. The mechanism the comment described is real; the demonstration was of a different shape.

Found by grid-probing every straddling `delins` on the fixture under both builds and diffing: **27** inputs produce a different output with and without the recursion, 9 of them on `WIDE_CORE`, so no new fixture was needed. The test now runs on `c.20_*4delinsG`:

```text
with the recursion:     c.20_*4delinsG -> c.*2_*5del    (a fixed point)
without the recursion:  c.20_*4delinsG -> c.*1_*4del    (NOT a fixed point)
```

and asserts both the shuffled value and the fixed point, plus that `c.*1_*4del` is *not* itself a fixed point so the pair cannot go vacuous the same way again. **Verified: with the gate forced closed the test now FAILS**, and 3' `non_idempotent_outputs` reads 6 rather than 4 (the two extra rows being `s00-c3{m,p}-cds-end-del-del-p2-sep1`). `the_input_that_taught_us_this_test_can_be_vacuous` pins the old input as the decline it is.

The same measurement corrected a stale figure in `normalize_cds`'s own comment, which quoted the recursion as holding `non_idempotent_outputs` down "from 7 to 9". 7 was the pre-#1599 baseline; on this base it is 4 -> 6, re-measured rather than rebased by arithmetic.

The `#[ignore]` on the multi-member guard also said "tracked separately" with no number. It is **#1650**; both the attribute and the doc comment now say so.

## Verification

All on the rebased branch, with **no** `FERRO_ASSERT_*` variable set (the plain `test` job runs un-armed, and arming them changes what fails).

| command | rc | result |
|---|---|---|
| `cargo nextest run --features dev --lib --test it` | 0 | `9949 tests run: 9949 passed, 150 skipped` |
| `... -E 'test(spec_conformance_axis) + test(spec_corpus_regressions) + test(defect_non_idempotent_outputs) + test(issue_1536)'` | 0 | `38 tests run: 38 passed` (the skip count is what shows the filter selected rather than matched nothing) |
| `... -E 'test(issue_1536)' --run-ignored all` | 100 | 8 passed, 1 failed — the #1650 guard, red by design |
| `cargo fmt --all --check` | 0 | no output |
| `cargo clippy --all-features --all-targets -- -D warnings` | 0 | clean (one pre-existing third-party future-incompat notice for `proc-macro-error2 v2.0.1`) |
| `dump_normalized_corpus --out` x2 + `--compare` | 0 | 78,298 rows each side, 1,826 moved |

**One figure is not fully re-verified, and is flagged rather than restated.** The earlier trailer's parenthetical that the *canonical* partitioner arm gives the identical moved-row set at `29/56/1741` was measured on `822eb5d5`; #1639 has since changed the partitioner-switch behaviour, and that A/B was not re-run. Treat it as unverified on this base. The shipped-arm figures below were re-measured.

The merge-vs-split partition of the 79 non-respell rows is `20/59` by member count over the two dumps. The declared `25/54` came from a derivation `--compare` does not emit, so the two cannot be reconciled from the artifacts; the **total** (79) and every other figure agree exactly.

## Review round 2: a dropped warning let strict mode stop refusing

The re-typing recursion returned the inner result outright, discarding **every** warning the outer
pass had accumulated. `warnings` there comes from `normalize_na_edit`, which validates the reference
and pushes `RefSeqMismatch` — and `NormalizeResult::has_ref_mismatch` is what strict mode refuses
on. So strict `normalize()` silently **accepted** a straddling delins whose stated deleted bases do
not match the reference.

It now filters on what each warning asserts rather than dropping the set:

* **Invalidated, so dropped** — `CrossAxisVariantNotShuffled` (the member *is* shuffled, by the
  recursive call) and `AxisClampApplied` (its contract is to say why a position did *not* shift
  further, and here it did: `c.*1_*4del` -> `c.*2_*5del`).
* **Carried** — everything else. `RefSeqMismatch` is not made untrue by re-typing a span, and
  `ReducedCapabilityNoGenome` is a statement about the *provider*, which a re-type cannot fix.

No de-duplication: `NormalizationWarning` is not `PartialEq`, and keying on `code()` would conflate
two `RefSeqMismatch` warnings at different positions — position is the whole key, as the merge-time
comment says. A duplicated warning is strictly preferable to a lost one.

**How this was missed the first time, recorded because the reasoning was the failure.** An assertion
at the re-entry line over the whole `--lib --test it` suite fired on exactly **one of 9 956** tests,
carrying only `AxisClampApplied`, and that was read as licence to drop both vectors. It is a claim
about the corpus, not the code: no corpus row builds a straddling retype with mismatched explicit
bases, so this class never reached the line. A `1 of 9 956` carries the same epistemic weight as a
`0 of 9 956` — state the population the probe could not build before concluding.

`a_reference_mismatch_survives_the_recursion_and_strict_mode_still_refuses` pins both halves
(warning present in the default mode, `Err` under `ErrorMode::Strict`). Mutation-tested: restoring
the blanket drop yields `warnings=[]` and reddens it.

**Behaviour note that is not a representation change.** No normalized output string moves — the
trailer's figures are unchanged and were re-measured on this base. What changes is that strict mode
now refuses a class of input it previously accepted, which is the point of the fix.

Validated as CI runs it, not with oracles armed globally: plain `test` **10142/10142**, and
`test-oracle` (armed, `ORACLE_EXCLUDE` negated) **10080/10080**. `clippy --all-features
--all-targets -D warnings` clean.

Representation-Change: 1826 of 78298 corpus rows move (2.3%) — 1747 respell and 79 change member count. Re-measured on this branch rebased onto bfcc1802, not carried over from the base it was opened against. 1460 of the moved rows were previously accepted forms; the other 366 were not fixed points, so moving those is free. Every move is a straddling member being re-typed or affix-trimmed against the bases it already denoted; no move changes what a description denotes.
