### PR TITLE
test(protein): assert the reference stop decodes to `AminoAcid::Ter`

### DIFF
--- a/tests/it/protein_axis_split_move.rs
+++ b/tests/it/protein_axis_split_move.rs
@@ -53,7 +53,8 @@
 //!   would emit a description ferro cannot read back. Unlike the three above,
 //!   this illegality is *created* by the split — the range input parses fine.
 
-use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use ferro_hgvs::hgvs::location::AminoAcid;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer, ReferenceProvider};
 
 /// The accession every case is written against.
 const NP: &str = "NP_003997.1";
@@ -236,8 +237,24 @@ fn a_provider_with_no_protein_data_declines_rather_than_guessing() {
 /// `has_protein_data()` is a **provider-wide** flag (#1131), so a provider that
 /// carries some other protein still cannot answer for this accession. The fetch,
 /// not the flag, is what decides.
+///
+/// That last sentence is the whole content of this case, and `must_not_split`
+/// cannot see it: the decline one gate earlier — `!has_protein_data()` — renders
+/// the input unchanged too, which is what the test two above already asserts on
+/// the *same* input and the *same* forbidden string. So the two assertions below
+/// pin which gate fires: the flag is true, and `NP` itself is unservable.
 #[test]
 fn a_provider_missing_this_accession_declines_rather_than_guessing() {
+    let probe = provider_without_the_accession();
+    assert!(
+        probe.has_protein_data(),
+        "the flag must be true, or this is the no-protein-data case again rather than \
+         a fetch that fails for this accession"
+    );
+    assert!(
+        probe.get_protein_sequence(NP, 43, 46).is_err(),
+        "residues 44..=46 of {NP} must be unservable, so the decline is the fetch"
+    );
     must_not_split(
         provider_without_the_accession(),
         &format!("{NP}:p.Ser44_Trp46delinsArgLeuArg"),
@@ -298,6 +315,9 @@ fn an_interior_stop_is_refused_by_the_parser() {
 /// wrong consequence: it spells a stop-loss as an ordinary substitution and
 /// silently drops the extension. The payload guard cannot catch it — the payload
 /// here carries no `Ter` at all — which is why the reference span needs its own.
+///
+/// The control that makes this test measure the stop-loss guard rather than any
+/// decline is `residue_forty_six_is_a_stop_the_reference_decodes_as_ter` below.
 #[test]
 fn a_reference_stop_is_not_split_into_a_substitution() {
     must_not_split(
@@ -305,6 +325,63 @@ fn a_reference_stop_is_not_split_into_a_substitution() {
         &format!("{NP}:p.Ser44_Ter46delinsAlaLeuHis"),
         &format!("{NP}:p.[Ser44Ala;Ter46His]"),
         "protein/extension.md:18 — a stop-loss is an extension, not a substitution",
+    );
+}
+
+/// The control the reference-stop decline rests on: the span really does carry a
+/// `Ter` at residue 46, decoded the way the split move itself decodes it.
+///
+/// `must_not_split` inspects only the rendered output, and **every** reason the
+/// split declines renders identically — the input, preserved. So on its own it
+/// cannot tell the stop-loss guard from a reference the normalizer never managed
+/// to read. Concretely: `Normalizer::fetch_protein_window` decodes each byte with
+/// `AminoAcid::from_one_letter` and returns `None` on the first byte that is not a
+/// one-letter code, and `try_protein_delins_split` propagates that `None` as a
+/// decline via `?` — one line *above* the `ref_aas.contains(&AminoAcid::Ter)`
+/// guard. If `'*'` ever stopped decoding to `AminoAcid::Ter` the window would
+/// fail to decode, the split would decline for that reason instead, and the test
+/// above would still pass while the guard it names went untested.
+///
+/// The decoded window is the assertion that carries the coverage: it pins that the
+/// provider serves that span *and* that `'*'` reaches `AminoAcid::Ter`, i.e. that
+/// what the guard inspects is `[Ser, Leu, Ter]` rather than an unread `None`.
+///
+/// The two assertions on the fixture itself are not independent of it in the same
+/// way, and it would overstate them to say so. `[45] == b'*'` is *implied* by the
+/// decoded window — bytes 43..46 must be `S`, `L`, `*` for it to hold — and earns
+/// its place by localising a failure instead: asserted on the fixture string, it
+/// separates a fixture whose stop moved from a `MockProvider` slicing the wrong
+/// window. The length is genuinely independent, and pins that residue 46 is the
+/// *last* residue rather than a stop with residues listed after it.
+#[test]
+fn residue_forty_six_is_a_stop_the_reference_decodes_as_ter() {
+    let seq = stop_at_46_protein();
+    assert_eq!(
+        seq.len(),
+        46,
+        "the span the decline names ends at residue 46"
+    );
+    assert_eq!(
+        seq.as_bytes()[45],
+        b'*',
+        "residue 46 of the reference-stop fixture must be the stop codon"
+    );
+
+    // The decode `Normalizer::fetch_protein_window` performs, byte for byte, over
+    // the same window the split move fetches: residues 44..=46, 0-based [43, 46).
+    let window = provider_with_a_reference_stop()
+        .get_protein_sequence(NP, 43, 46)
+        .expect("the provider must serve the span the split move fetches");
+    let decoded: Option<Vec<AminoAcid>> = window
+        .as_bytes()
+        .iter()
+        .map(|&b| AminoAcid::from_one_letter(b as char))
+        .collect();
+    assert_eq!(
+        decoded,
+        Some(vec![AminoAcid::Ser, AminoAcid::Leu, AminoAcid::Ter]),
+        "the window must decode, and residue 46 must decode to `AminoAcid::Ter` — \
+         otherwise the decline above is a failed fetch, not the stop-loss guard"
     );
 }
 


### PR DESCRIPTION
Closes a CodeRabbit finding that was merged **unaddressed** on #1606 (squashed to `main` as `4bcc8dd2`). The bot-check query was batched into the same shell command as `gh pr merge`, so its result printed after the merge had already run — the thread was unresolved at merge time and nobody saw it until afterwards. The finding is legitimate, so it is fixed forward here rather than reverted.

## The finding

> **Assert that the reference stop decodes to `AminoAcid::Ter`.** `AminoAcid::from_one_letter('*')` maps to `Some(AminoAcid::Ter)`, so the current fixture reaches `ref_aas.contains(&AminoAcid::Ter)`. However, `must_not_split` only checks the rendered result. If `*` decoding regresses, `fetch_protein_window` returns `None` and the test still passes. Add a direct assertion for residue 46; otherwise remove the claim that this test covers the reference-stop guard.

Verified before fixing, all three halves:

- `src/hgvs/location.rs:683` — `'*' => Some(Self::Ter)`, so the fixture does reach the guard today.
- `tests/it/protein_axis_split_move.rs` `must_not_split` reads only `normalize_with(..)`'s rendered `String`, then asserts `actual != forbidden` and `actual == input`. Every decline in `try_protein_delins_split` renders identically — the input, preserved — so the helper cannot distinguish which gate fired.
- `src/normalize/mod.rs` — `fetch_protein_window` returns `None` on the first byte `from_one_letter` rejects, and `try_protein_delins_split` propagates it with `?` **one line above** the `ref_aas.contains(&AminoAcid::Ter)` check. A decoding regression therefore declines earlier, for the wrong reason, and the test stays green.

## Remedy chosen

The **first** remedy — a direct assertion — because it is reachable: `AminoAcid` and `from_one_letter` are public (`ferro_hgvs::hgvs::location::AminoAcid`, already imported by seven other `tests/it/` modules), and `ReferenceProvider::get_protein_sequence` is public too, so the test can perform byte-for-byte the same fetch-and-decode the split move performs. The second remedy — narrowing the test's doc comment so it no longer claims to cover the stop-loss guard — was the fallback for the case where the decode is unobservable from `tests/it/`. It is observable, so narrowing the claim would have given up coverage that is available for four lines of test code.

The coverage is carried by one assertion, and the other two are not independent of it in the same way — an earlier draft of this description claimed all three were, which was wrong in one direction and is corrected here:

- the decoded window — residues 44..=46 (0-based `[43, 46)`) fetched through the provider and decoded with `from_one_letter` must equal `[Ser, Leu, Ter]`. This pins that the provider serves the span *and* that `'*'` reaches `AminoAcid::Ter`, i.e. that what the guard inspects is a real window rather than an unread `None`. It is the assertion the mutation below kills;
- byte 46 of the fixture is `b'*'` — *implied* by the assertion above, since bytes 43..46 must be `S`, `L`, `*` for it to hold. It earns its place by localising a failure rather than by adding coverage: asserted on the fixture string, it separates a fixture whose stop moved from a `MockProvider` slicing the wrong window;
- `stop_at_46_protein()` is 46 residues — genuinely independent, and pins that residue 46 is the *last* residue rather than a stop with residues listed after it.

## Verification that it bites

Mutation: deleted the `'*' => Some(Self::Ter)` arm from `AminoAcid::from_one_letter` so `'*'` falls through to `_ => None`. Restored afterwards from a file copy.

`cargo nextest run --features dev -E 'test(protein_axis_split_move)'` → **rc=100**, `20 tests run: 19 passed, 1 failed`:

```
FAIL residue_forty_six_is_a_stop_the_reference_decodes_as_ter
panicked at tests/it/protein_axis_split_move.rs:358:5:
assertion `left == right` failed: the window must decode, and residue 46 must decode to
`AminoAcid::Ter` — otherwise the decline above is a failed fetch, not the stop-loss guard
  left: None
 right: Some([Ser, Leu, Ter])
```

The new control is the **only** failure — `a_reference_stop_is_not_split_into_a_substitution` still `PASS`es under the mutation, which is precisely the vacuity the finding described and the control now closes.

That transcript is verbatim from the run that measured it, so its `:358` is the line number **as measured**; the review pass below shifted the assertion to `:380`. The mutation was not re-run afterwards, because it exercises `AminoAcid::from_one_letter` and neither change below touches the assertion it kills.

## A second site of the same shape, found by review

A `coderabbitai-review` pass over this diff swept the class rather than the instance, and found that `a_provider_missing_this_accession_declines_rather_than_guessing` has the identical vacuity — one gate earlier.

Its doc comment's whole content is "The fetch, not the flag, is what decides", and `must_not_split` cannot see that: `try_protein_delins_split` tests `!self.provider.has_protein_data()` (`src/normalize/mod.rs:6467`) *before* it reaches `fetch_protein_window` (`:6472`), and a decline at either renders the input unchanged. The claim holds today only because `MockProvider::has_protein_data` is `!self.proteins.is_empty()` (`src/reference/mock.rs:948-950`); were it ever to become accession-aware, the test would keep passing while silently becoming a duplicate of `a_provider_with_no_protein_data_declines_rather_than_guessing`, which asserts the same forbidden string on the same input two tests above.

Two assertions now pin which gate fires — `has_protein_data()` is true, and `get_protein_sequence(NP, 43, 46)` is `Err` for this accession.

The sweep covered all seven `must_not_split` sites in the file against the gate ladder at `src/normalize/mod.rs:6440-6489`. The other four are each already discriminated, by a positive twin on the same provider or by the parse control at `:281-286`: `an_unequal_length_delins_is_not_split` (`span != seq.0.len()`), `a_payload_carrying_a_stop_is_declined`, `a_fully_changed_run_stays_one_delins` (`runs.len() < 2`) and `an_adjacent_pair_has_no_interior_to_split` (`span < 3`). So this was the last site of the shape, not the second of many.

## Local gate

| command | rc | result |
|---|---|---|
| `cargo nextest run --features dev -E 'test(protein_axis_split_move)'` | 0 | 20 tests run, 20 passed (19 pre-existing + 1 new; a filter matching nothing would have reported 0 tests) |
| `cargo fmt --all -- --check` | 0 | no output |
| `cargo clippy --all-features --all-targets -- -D warnings` | 0 | one pre-existing third-party line only (`proc-macro-error2 v2.0.1` future-rejection notice) |

Re-run after the review edits above:

| command | rc | result |
|---|---|---|
| `cargo nextest run --features dev --lib --test it -E 'test(protein_axis_split_move)'` | 0 | `20 tests run: 20 passed, 10051 skipped` — the skip count is what shows the filter matched rather than selecting nothing |
| `cargo fmt --all --check` | 0 | no output |
| `cargo clippy --features dev --tests -- -D warnings` | 0 | no warnings |

No `FERRO_ASSERT_*` variables were set.

`git diff --name-only` is `tests/it/protein_axis_split_move.rs` and nothing else — no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, so no output can move.

Representation-Change: none. Tests only; no watched directory is in the diff.

