### PR TITLE
fix(ci): read the count, not the denominator, in a quantified-zero trailer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,9 +592,16 @@ as a repo-wide figure — for consumer impact, normalize a real corpus through b
 first word wins — so the disclosure would vanish silently, which is the worst direction this
 mechanism can fail in. The checker fails a declining trailer that also claims `<n> rows
 move|merge|split|respell` for non-zero `n`. Quantifying a *zero* is encouraged and passes
-(`none. 0 of 950 rows move`); the pattern requires the count to sit immediately before `rows`,
-which is what keeps #1547's `0 of 950 real cis-allele rows move` from tripping on the 950. It is a
-tripwire for the phrasing this repo actually uses, not a general contradiction detector.
+(`none. 0 of 950 rows move`). **The number that counts is the count, never the denominator** —
+`3 rows of 500,004 move`, `3 of 500,004 rows move` and `3 of 500,004 corpus rows move` all disclose
+three moved rows, and the rule reads three from each. It is a tripwire for the phrasing this repo
+actually uses, not a general contradiction detector — the enumerated forms live on
+`MOVEMENT_CLAIM_RE`, and that docstring is the one to extend when a new phrasing appears.
+
+This sentence used to say "the pattern requires the count to sit immediately before `rows`", and
+that was the #1647 defect rather than a description of it: in `0 of 950 rows move` the number
+immediately before `rows` is the **denominator**, so the very example offered here as passing was
+rejected, and the documented form was a merge blocker. Do not restate the rule positionally.
 
 **The section itself is audited, not just each PR's trailer.** `Changelog grouping audit` renders
 the changelog with the real `release-plz.toml` over `<latest tag>..HEAD` and checks the result

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -119,17 +119,48 @@ def declines(declaration: str) -> bool:
 #: good decline often quantifies its zero, and `0 rows move over 5,761,302 real
 #: expressions` (#1535) must not trip. Excluded by requiring a nonzero digit *somewhere in
 #: the count* rather than by rejecting a bare `0`, so `0,000` and `000` are zero here too —
-#: an anchored `(?!0\b)` read them as nonzero and failed the decline. **The count must sit
-#: immediately before `rows`**,
-#: which is what keeps `0 of 950 real cis-allele rows move their normalized string`
-#: (#1547) from tripping on the 950 -- a looser pattern fires on that exemplary decline,
-#: measured.
+#: an anchored `(?!0\b)` read them as nonzero and failed the decline.
 #:
-#: It catches the phrasing this repository actually uses -- every quantified disclosure in
-#: the corpus takes this shape -- and it is not a general contradiction detector. Spelled
-#: out numbers and unquantified claims pass. It is a tripwire, not a proof.
+#: **The number that matters is the COUNT, never the denominator** (#1647). Both orders
+#: occur in this repository's own trailers and both must be read the same way:
+#:
+#:     3 rows of 500,004 move          <- count first, denominator trailing
+#:     3 of 500,004 rows move          <- count first, denominator between count and `rows`
+#:     3 of 500,004 corpus rows move   <- and a noun phrase before `rows`
+#:
+#: This used to be written as "the count must sit immediately before `rows`", which reads
+#: the second form's *denominator* as the count. That made `none. 0 of 950 rows move` --
+#: the form `CONTRIBUTING.md` and `CLAUDE.md` both offer as the way to quantify a zero, and
+#: both state passes -- fire on the 950 and fail the build. The documented form was a merge
+#: blocker.
+#:
+#: Two lookbehinds carry the distinction, and the second is not redundant:
+#:
+#: * `(?<!of\s)` refuses to read a denominator as a count, which is what rescues
+#:   `0 of 950 rows move`.
+#: * `(?<![\d,])` stops the match restarting in the MIDDLE of a grouped number. Without it
+#:   `0 of 78,298 rows move` still fires -- the comma opens a word boundary, so the scan
+#:   resumes at `298`, which is nonzero, sits immediately before `rows`, and is not preceded
+#:   by `of `. Measured; the first lookbehind alone leaves that decline failing.
+#:
+#: The third form is here because a version of this comment claiming "every quantified
+#: disclosure in the corpus takes one of the two shapes above" was refuted by a trailer that
+#: was already on `main`: #1651's `1826 of 78298 corpus rows move`. One word between the
+#: denominator and `rows` and the tripwire went silent -- with the verdict flipped to a
+#: decline that is a real move hidden behind `none`, the one direction this mechanism must
+#: never fail in. Measured, not reasoned: the two-lookbehind pattern passed that string.
+#: So up to three intervening words are allowed. Punctuation still stops the run, which is
+#: what keeps `1 issue filed, 0 rows move` from reading `1` as the moving count.
+#:
+#: It catches the phrasing this repository actually uses -- and it is not a general
+#: contradiction detector. Spelled out numbers and unquantified claims pass, as does a
+#: nonzero count separated from `rows` by more than three words. It is a tripwire, not a
+#: proof, and the way to find the next gap is to run a real trailer through it rather than
+#: to read the pattern.
 MOVEMENT_CLAIM_RE = re.compile(
-    r"\b(?=[\d,]*[1-9])\d[\d,]*\s+rows?(?:\s+of\s+[\d,]+)?\s+"
+    r"\b(?<!of\s)(?<![\d,])(?=[\d,]*[1-9])\d[\d,]*\s+(?:of\s+[\d,]+\s+)?"
+    r"(?:[A-Za-z][\w-]*\s+){0,3}rows?"
+    r"(?:\s+of\s+[\d,]+)?\s+"
     r"(?:move|moves|moved|merge|merges|merged|split|splits|"
     r"respell|respells|respelled)\b",
     re.IGNORECASE,

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -431,6 +431,114 @@ def test_a_real_disclosure_is_not_a_contradiction() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# #1647: the count is the count, never the denominator
+#
+# The guard used to read "the number immediately before `rows`" as the moving
+# count. In `0 of 950 rows move` that number is the DENOMINATOR, so the form
+# both `CONTRIBUTING.md` and `CLAUDE.md` publish as the way to quantify a zero
+# — and both state passes — failed the build instead. The documented form was a
+# merge blocker.
+#
+# These are separated from the parametrized declines above because they pin a
+# specific past defect rather than the general "declines are numerate" rule.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # `CONTRIBUTING.md` and `CLAUDE.md`, verbatim. The whole of #1647.
+        "none. 0 of 950 rows move",
+        "none. 0 of 950 rows move.",
+        # A grouped denominator. `(?<!of\\s)` alone does NOT rescue this one: the
+        # comma opens a word boundary, so the scan restarts at `298` — nonzero,
+        # immediately before `rows`, not preceded by `of `. Measured; it is why
+        # the second `(?<![\\d,])` lookbehind exists.
+        "none. 0 of 78,298 rows move",
+        "none. 0 of 5,761,302 rows respell",
+        # Both orders of the same honest zero.
+        "none. 0 rows of 78,298 move",
+        # A noun phrase between the denominator and `rows`, which the repository
+        # uses freely -- #1547's own exemplary decline is this shape.
+        "none. 0 of 950 real cis-allele rows move",
+        "none. 0 of 78,298 corpus rows move",
+    ],
+)
+def test_a_quantified_zero_in_either_order_passes(value: str) -> None:
+    """The documented way to quantify a zero must not be a merge blocker."""
+    assert check_representation_change.contradicted_decline(value) is None, (
+        f"{value!r} is the documented quantified-zero form and must pass"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Count first, denominator between the count and `rows`. The tripwire has
+        # to reach this order too, or a real disclosure vanishes from the
+        # changelog behind a decline — the one direction this mechanism must
+        # never fail in.
+        "no. 3 of 500,004 rows move",
+        "none. 1,826 of 78,298 rows move",
+        # A noun phrase before `rows`. This is #1651's ACTUAL trailer wording with
+        # the verdict flipped to a decline, and the two-lookbehind pattern let it
+        # through -- a real 1826-row move hidden behind `none`, which is the one
+        # direction this mechanism must never fail in. Measured, then fixed.
+        "none. 1826 of 78298 corpus rows move",
+        "none. 3 of 500,004 real cis-allele rows move",
+        # The order the guard already caught, kept here as the control.
+        "no. 3 rows move",
+        "none. 2 rows of 500,004 respell",
+    ],
+)
+def test_a_nonzero_count_in_either_order_is_still_a_contradiction(value: str) -> None:
+    """Rescuing the zero must not blunt the tripwire for a real move."""
+    assert check_representation_change.contradicted_decline(value) is not None, (
+        f"{value!r} declines while disclosing a move and must be refused"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Punctuation must stop the intervening-word run, or the leading count of
+        # an unrelated clause gets read as the moving count. Without that, `1` here
+        # would pair with the `rows move` three words later and this honest decline
+        # would fail the build.
+        "none. 1 issue filed, 0 rows move",
+        "none. 12 clauses cited; 0 rows move",
+        "none. 4 tests added, no rows move",
+        # No number at all, and the ordinary shape of most declines.
+        "none. Tests only; no watched file is touched.",
+    ],
+)
+def test_allowing_words_before_rows_did_not_blunt_the_decline_path(value: str) -> None:
+    """The control on the widening: three words, not any distance.
+
+    Reaching a noun phrase before `rows` means a nonzero count elsewhere in the
+    sentence could pair with a *different* clause's `rows move`. Punctuation is
+    what prevents it, so these pin the boundary rather than the capability.
+    """
+    assert check_representation_change.contradicted_decline(value) is None, (
+        f"{value!r} is an honest decline and must not be read as a disclosure"
+    )
+
+
+def test_the_documented_zero_passes_the_whole_check_not_only_the_predicate() -> None:
+    """End-to-end, because #1647 was reported against the CLI's exit code.
+
+    `contradicted_decline` returning `None` is necessary but not sufficient —
+    the reported symptom was `check_representation_change.py` exiting 1 on a
+    watched change, which is what actually blocks the merge.
+    """
+    ok, _message = check(
+        ["src/normalize/merge.rs"],
+        "Representation-Change: none. 0 of 950 rows move.",
+    )
+    assert ok, "the documented quantified-zero trailer must pass the full check"
+
+
 def test_the_two_decline_rules_agree_value_by_value() -> None:
     """The vocabulary test above compares word lists; this one compares *verdicts*.
 


### PR DESCRIPTION
Representation-Change: none. No watched directory is touched — this changes `scripts/`, `tests/python/` and `CLAUDE.md` only.

Closes #1647

## The documented form was a merge blocker

`CONTRIBUTING.md:125` and `CLAUDE.md` both publish `none. 0 of 950 rows move` as the way to quantify a zero, and both state that it passes. It did not:

```console
$ printf 'Representation-Change: none. 0 of 950 rows move.\n' > /tmp/doc-example.md
$ echo "src/normalize/merge.rs" > /tmp/watched.txt
$ python3 scripts/check_representation_change.py --changed-files /tmp/watched.txt --declaration-file /tmp/doc-example.md
This trailer declines and then describes a move: ...
$ echo $?
1
```

The contradiction rule read the number sitting immediately before `rows` as the moving count. In that phrasing that number is the **denominator**, so the rule fired on the 950.

`CLAUDE.md` stated the positional rule and its own violating example one clause apart, which is why it read as a description of the behaviour rather than as the defect it was.

## The fix

Read the count as the count, in both orders this repository actually writes:

```
3 rows of 500,004 move      denominator trailing
3 of 500,004 rows move      denominator between the count and `rows`
```

Two lookbehinds carry it, and **the second is not redundant**:

- `(?<!of\s)` refuses to read a denominator as a count — this is what rescues `0 of 950 rows move`.
- `(?<![\d,])` stops the match restarting in the *middle* of a grouped number. Without it, `0 of 78,298 rows move` still fires: the comma opens a word boundary, so the scan resumes at `298`, which is nonzero, sits immediately before `rows`, and is not preceded by `of `. Measured — the first lookbehind alone leaves that decline failing.

## The tripwire is not blunted

A decline that discloses a nonzero move is still refused, in either order. That is the one direction this mechanism must never fail in. The count-first order is now caught **on the count** rather than incidentally on the denominator, which is why `no. 3 of 500,004 rows move` still exits 1.

## Verification

Checked against every trailer form the two documents publish plus the recorded declines of #1535, #1546, #1538 and #1547. The new rule agrees with intent on all 14; the old rule was wrong on two of them (`0 of 950 rows move` and `0 of 78,298 rows move`).

- `tests/python/test_representation_change_trailer.py` — 10 new cases across three tests, including one end-to-end through `check()` because the reported symptom was the CLI's **exit code**, not the predicate.
- `test_representation_change_trailer.py` + `test_changelog_grouping.py` green together, **115 passed** — so the checker and the changelog audit still agree, which `test_the_audit_and_the_checker_agree_on_every_documented_form` exists to enforce.
- `ruff check` and `ruff format --check` clean.

The remaining `tests/python/` modules fail to collect in a fresh worktree with `ModuleNotFoundError: No module named 'ferro_hgvs'` — the native extension is not built there. Pre-existing and unrelated; both files touched here load the script by path and need no extension module.