### PR TITLE
ci: give the failure-reporting job a repository to talk to

### DIFF
--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -71,6 +71,15 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
+          # `gh issue` resolves the repository from the git remotes of the
+          # working directory, and this job deliberately does not check out the
+          # repository — it only calls the API. Without a repository the very
+          # first `gh` call dies with `failed to run git: fatal: not a git
+          # repository`, which is what every run of this reusable workflow has
+          # done since it was added. `GH_REPO` supplies the repository directly,
+          # so `gh` never shells out to git; a checkout would also work but
+          # clones the tree solely to let `gh` read a remote URL.
+          GH_REPO: ${{ github.repository }}
           TITLE: ${{ inputs.title }}
           SUMMARY: ${{ inputs.summary }}
           HINT: ${{ inputs.hint }}


### PR DESCRIPTION
The `report` job in the reusable `report-failure.yml` has **never succeeded**. Every run of it — via `audit-pr-runs.yml` and five other callers — fails at the step `report / Open or update the tracking issue` with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

## Cause

The job calls `gh issue list`, `gh issue comment` and `gh issue create` and deliberately does not check out the repository — it only touches the API. But `gh` resolves the target repository from the git remotes of the working directory, so with no checkout the first `gh` call shells out to `git`, finds no repository, and exits 1.

Confirmed by reading the workflow and by the failing step log of run [31513225466](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31513225466); the last ten scheduled `Audit PR runs` runs are all `failure` at that same step.

## Why this is worth more than one broken workflow

`report-failure.yml` is a reusable workflow, and six workflows call it:

`audit-pr-runs.yml`, `coverage.yml`, `external-validation.yml`, `fuzz.yml`, `nightly-mutalyzer.yml`, `nightly-perf.yml`

So no tracking issue has ever been opened or updated by any of them. The job whose entire purpose is to make a silent failure visible was itself failing silently — which is the same failure mode `audit-pr-runs.yml` exists to catch, one level up.

## Fix

Set `GH_REPO` from `github.repository` in the step `env`, rather than adding an `actions/checkout` step.

Both work. `GH_REPO` is the smaller and more robust of the two: the job makes only API calls, so a checkout would clone the whole tree solely to let `gh` read a remote URL, and it would leave the job depending on git state it has no other use for. `GH_REPO` removes the git lookup entirely and leaves the job's `contents: read` permission unused.

No new action is introduced, so there is nothing new to pin.

## Verification

- `actionlint .github/workflows/report-failure.yml` — clean
- `zizmor .github/workflows/report-failure.yml` — `No findings to report` (1 pre-existing suppression)
- `github.repository` is a trusted context, not attacker-controlled, so this adds no template-injection surface.

The end-to-end proof is the next scheduled `Audit PR runs` after merge: the step should reach the `gh issue list` lookup and either open or comment on the rolling issue instead of dying at the git call.

Representation-Change: none. CI workflow only; no file under `src/` is touched.