### PR TITLE
docs(readme): state that rule 3 governs rule 2's evaluation basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,13 @@ ferro's normalizer follows four rules about its output, and three about how it h
 2. **Recommended form.** Where the spec prefers among conformant forms, ferro produces it.
    *Best effort.*
    Scope: "recommended", "preferred", lowercase "should", the 3' rule. A preference clause outranks
-   maintainer judgment.
+   maintainer judgment, but not rule 3: where it is not evaluable on what a normalizer holds, rule 3
+   governs.
 
 3. **Confluent.** Inputs denoting one variant produce one output. *Best effort.*
-   Every rule is evaluated over the **resulting sequence**, never over the input's spelling.
+   Every rule — rule 2 included — is evaluated over the **resulting sequence**, never over the
+   input's spelling. Reference context counts as sequence: transcript model, exon boundaries,
+   reading frame, strand and topology are functions of the accession, not of the description.
 
 4. **Deterministic.** Same input, same output. *Absolute.*
    Note that 4 does not imply 3 — a deterministic normalizer can be arbitrarily non-confluent.
@@ -223,10 +226,18 @@ Rules 2 and 3 depend on the spec **determining an answer**, and sometimes it doe
   correspondence is unique, so "two variants separated by N nucleotides" is a fact about the
   variant. For an unequal-length block there is no correspondence — recovering one means *choosing*
   an alignment, and the spec does not say which. There is no derivable form to converge on.
+- **The preference keys on information a normalizer does not hold.** A "frequently occurring
+  variant" (`RNA/delins.md`); a repeat "variable in the population" (`RNA/repeated.md`,
+  `protein/repeated.md`); two variants "reported (or might occur) individually" (`DNA/delins.md`).
+  The spec determines an answer; ferro cannot see what it keys on.
 
-**"Best effort" is bounded by the spec's determinacy, not by ferro's implementation quality.** A
-failure of rule 2 or 3 caused by ferro's code is a **bug** under rule 7. Only a failure caused by
-the spec not determining an answer falls under best effort — and that triggers rule 5.
+**"Best effort" is bounded by the spec's determinacy and by what a normalizer's inputs can decide —
+not by ferro's implementation quality.** A failure of rule 2 or 3 caused by ferro's code is a
+**bug** under rule 7; one caused by the spec not determining an answer triggers rule 5; one caused
+by a clause keying on provenance or population data is a **declared deviation** — permanent, and
+recorded in the ruling ledger's `deviates_from`. Where such a clause also contradicts one forbidding
+provenance — `general.md` says knowledge of the DNA-level change "should not be used" — that
+contradiction is a defect and rule 5 applies to it.
 
 ### A worked example of reading force from prose
 
@@ -235,6 +246,39 @@ the spec not determining an answer falls under best effort — and that triggers
 only when the additional copy is directly 3'-flanking the original. So the rule ranks the *label*
 for one span; it does not require that a partition be chosen so as to produce a duplication.
 Reading the force without the scope inverts the rule.
+
+### What rule 3 excludes
+
+"Never over the input's spelling" is narrower than it sounds. Most of a description is context.
+
+| Carried by the description | Treatment |
+|---|---|
+| Accession, axis (`g.`/`c.`/`n.`), version | **Used** — it *is* the reference context |
+| Which bases end up different | **Used** — this is the variant |
+| Cis against trans (`[a;b]` against `[a];[b]`) | **Used** — different variants, not two spellings of one |
+| Type label (`dup` against `ins`, `inv` against `delins`) | **Re-derived**, then ranked by `general.md` |
+| How the edit set is cut into members | **Excluded** — a property of who wrote the string |
+| Which copy in a run of identical residues a member names | **Excluded** — the 3' rule assigns this *"arbitrarily"* |
+| Repeat unit and phase, where several are equivalent | **Excluded** |
+
+So three rows read **Excluded**, and they are three spellings of the one thing the input does not
+get to decide: the **partition**, the run-position choice that feeds it, and — where several
+unit-and-phase pairs describe one tract equally well — which pair a repeat member names.
+
+`NC_000001.11:g.1001002_1001016` reads `ATGAGGGGCCACTGT`: a `GGGG` run at `1001006-1001009`, a `CC`
+run at `1001010-1001011`, a lone `C` at `1001013`. Two spellings, one denoted sequence
+(`ATGAGGGCATGT`), because `1001010` and `1001011` are both `C`:
+
+```
+g.[1001009del;1001010del;1001013del]     written gaps of 0 and 2
+g.[1001009del;1001011del;1001013del]     written gaps of 1 and 1
+```
+
+`general.md`'s "two variants separated by one or more nucleotides should be described individually"
+reads those gaps, so it answers twice for one variant. Rule 3 reads them off the partition ferro
+derives instead: both give `g.[1001009_1001010del;1001013del]`. Rule 2 then keeps that over the
+spanning `g.1001009_1001013delinsCA`, which merges across two unchanged nucleotides. Pinned in
+[`tests/it/cis_confluence_adjudication.rs`](tests/it/cis_confluence_adjudication.rs).
 
 ### Known limitation
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ ferro's normalizer follows four rules about its output, and three about how it h
       feature request, worth making but never a reason to hold a release.
 
 6. **Among multiple conformant forms:** the maintainers choose. **There are no user options for
-   normalization form.** Options remain available for orthogonal axes — error mode, 3'/5' direction.
+   normalization form.** Error mode is an orthogonal axis and stays available. The 3'/5' knob is
+   **not** orthogonal — it selects the frame every rule is evaluated in, so rules 2 and 3 are
+   claimed *per direction* rather than across the two.
 
 7. **Disclosure.** Any change to these rules, and any different choice made under 5 or 6, is
    disclosed: in the changelog before v1, by a major version bump after. Output that *violates*

--- a/README.md
+++ b/README.md
@@ -229,17 +229,36 @@ Rules 2 and 3 depend on the spec **determining an answer**, and sometimes it doe
   variant. For an unequal-length block there is no correspondence — recovering one means *choosing*
   an alignment, and the spec does not say which. There is no derivable form to converge on.
 - **The preference keys on information a normalizer does not hold.** A "frequently occurring
-  variant" (`RNA/delins.md`); a repeat "variable in the population" (`RNA/repeated.md`,
-  `protein/repeated.md`); two variants "reported (or might occur) individually" (`DNA/delins.md`).
+  variant" (`RNA/delins.md:41`); a repeat "variable in the population" (`RNA/repeated.md:33`,
+  `protein/repeated.md:22`); two variants "reported (or might occur) individually" (`DNA/delins.md:83`).
   The spec determines an answer; ferro cannot see what it keys on.
 
 **"Best effort" is bounded by the spec's determinacy and by what a normalizer's inputs can decide —
 not by ferro's implementation quality.** A failure of rule 2 or 3 caused by ferro's code is a
 **bug** under rule 7; one caused by the spec not determining an answer triggers rule 5; one caused
-by a clause keying on provenance or population data is a **declared deviation** — permanent, and
-recorded in the ruling ledger's `deviates_from`. Where such a clause also contradicts one forbidding
-provenance — `general.md` says knowledge of the DNA-level change "should not be used" — that
-contradiction is a defect and rule 5 applies to it.
+by a clause keying on provenance or population data is a **declared deviation**, and a permanent
+one — no upstream answer can put that information into a normalizer's hands.
+
+Permanent is the only thing the last case adds, and it does **not** exempt the question from rule
+5. The grain matters, because the two grains give opposite answers. Read **on its own**, such a
+clause is not silent, ambiguous or self-contradictory — it determines an answer perfectly well, and
+ferro is the one that cannot see what the answer keys on. Read **against the spec's own
+re-derivation mandate** — `general.md:157-160`, which has a protein description derived by
+comparing the variant and reference protein sequences and says knowledge of the underlying DNA
+change "should not be used", with `general.md:13` extending the method to RNA — it is one half of a
+pair that cannot both hold. That is rule 5's self-contradiction limb exactly, and the ruling ledger
+says so in those words. What the carve-out states is that rule 5's escalation cannot *end*
+the matter here: a choice made under rule 5 is provisional pending an upstream ruling, and no
+ruling upstream makes provenance visible, so the deviation outlives the filing.
+
+Where it is recorded is worth stating precisely, because the obvious pointer does not resolve.
+`canonical-form-choice-when-both-legal` has **no `deviates_from` field**: it carries all four
+clauses in its rationale as the recorded counter-evidence to re-derivation, opens that paragraph
+with "The spec contradicts itself here", and adopts re-derivation over them deliberately. The one
+of the four that is recorded *as* a deviation is `DNA/delins.md:83`, through the
+`deviates_from: ["docs/recommendations/DNA/delins.md:79-84"]` on
+`separation-is-a-property-of-the-spelling-not-of-the-variant` — the record whose ruling the rule 3
+example below turns on.
 
 ### A worked example of reading force from prose
 
@@ -260,7 +279,7 @@ Reading the force without the scope inverts the rule.
 | Cis against trans (`[a;b]` against `[a];[b]`) | **Used** — different variants, not two spellings of one |
 | Type label (`dup` against `ins`, `inv` against `delins`) | **Re-derived**, then ranked by `general.md` |
 | How the edit set is cut into members | **Excluded** — a property of who wrote the string |
-| Which copy in a run of identical residues a member names | **Excluded** — the 3' rule assigns this *"arbitrarily"* |
+| Which copy in a run of identical residues a member names | **Excluded** — the 3' rule assigns this *"arbitrarily"* (`general.md:41`) |
 | Repeat unit and phase, where several are equivalent | **Excluded** |
 
 So three rows read **Excluded**, and they are three spellings of the one thing the input does not
@@ -276,7 +295,7 @@ g.[1001009del;1001010del;1001013del]     written gaps of 0 and 2
 g.[1001009del;1001011del;1001013del]     written gaps of 1 and 1
 ```
 
-`general.md`'s "two variants separated by one or more nucleotides should be described individually"
+`general.md:34`'s "two variants separated by one or more nucleotides should be described individually"
 reads those gaps, so it answers twice for one variant. Rule 3 reads them off the partition ferro
 derives instead: both give `g.[1001009_1001010del;1001013del]`. Rule 2 then keeps that over the
 spanning `g.1001009_1001013delinsCA`, which merges across two unchanged nucleotides. Pinned in

--- a/tests/it/cis_confluence_adjudication.rs
+++ b/tests/it/cis_confluence_adjudication.rs
@@ -282,9 +282,9 @@ fn the_separation_two_members_present_is_not_a_property_of_the_variant() {
 
 /// The window the record's ruling is stated on, reproduced synthetically.
 ///
-/// **Provenance.** These fifteen bases are `NC_000001.11:g.1001002-1001016` on
-/// GRCh38 — a `GGGG` run at `g.1001006-1001009`, a `CC` run at
-/// `g.1001010-1001011`, and a lone `C` at `g.1001013`. They are laid down on a
+/// **Provenance.** These fifteen bases are `NC_000001.11:g.1001002_1001016` on
+/// GRCh38 — a `GGGG` run at `g.1001006_1001009`, a `CC` run at
+/// `g.1001010_1001011`, and a lone `C` at `g.1001013`. They are laid down on a
 /// contig of that name at those offsets so the descriptions below read exactly
 /// as the ruling states them, while everything outside the window is filler:
 /// the test is hermetic and needs no `FERRO_MANIFEST`.

--- a/tests/it/readme_normalization_rules.rs
+++ b/tests/it/readme_normalization_rules.rs
@@ -17,12 +17,17 @@
 //! that classifies it — enough that an edit to the ruleset has to be deliberate, and
 //! little enough that rewording the body of a rule does not fail the build.
 //!
-//! Every assertion is scoped to the section it is about ([`section`]) rather than
-//! to the whole file, and the two cross-links are matched as whole Markdown tokens
-//! rather than as bare `#anchor` fragments. Both are the difference between "this
-//! string exists in a long document" and "the ruleset states this" — a guard
-//! satisfiable from a code block or an unrelated section is one that passes while
-//! the thing it guards is broken.
+//! Every assertion is scoped to the section it is about rather than to the whole
+//! file — [`section`] for Markdown, [`banner_block`] for the `// Record N —`
+//! blocks of an adjudication test module — and the two cross-links are matched as
+//! whole Markdown tokens rather than as bare `#anchor` fragments. Both are the
+//! difference between "this string exists in a long document" and "the ruleset
+//! states this" — a guard satisfiable from a code block or an unrelated section is
+//! one that passes while the thing it guards is broken.
+//!
+//! That applies to the *pinned* side of a cross-claim as much as to the README
+//! side, which is why [`banner_block`] exists: a whole-file `contains` over a
+//! 500-line Rust module is the same weak question in a different language.
 //!
 //! Scoping is applied on **both** sides of each claim, which is a strictly stronger
 //! test than scoping one side. Pinning the rules' order without binding each rule to
@@ -87,6 +92,67 @@ fn section<'a>(text: &'a str, heading: &str) -> &'a str {
     &text[start..end]
 }
 
+/// The body of a `// Record N — …` banner block in an adjudication test module,
+/// up to the next banner rule (or end of input).
+///
+/// The Rust counterpart of [`section`], and it exists for the same reason: the
+/// pinned side of a cross-claim has to be scoped too, or the claim degrades to
+/// "this token appears somewhere in a 500-line file". `cis_confluence_adjudication.rs`
+/// carries four records separated by
+///
+/// ```text
+/// // ---------------------------------------------------------------------------
+/// // Record 1 — settled: separation is a property of the spelling
+/// // ---------------------------------------------------------------------------
+/// ```
+///
+/// so the banner is the structure to key on. `title` is matched line-anchored,
+/// exactly as `section` matches a heading, and the block ends at the next rule
+/// line — which is the *opening* rule of the following record, since a title's
+/// own closing rule is consumed first.
+///
+/// **What this does not buy**, stated because overclaiming a guard is worse than
+/// not having one: it scopes to the record, not to an executed assertion. A
+/// token sitting only in a doc comment inside the right record still passes.
+/// What it rules out is the failure that actually happens here — the case
+/// migrating to a different record, or surviving only as commented-out text
+/// elsewhere in the file — while the README goes on citing it.
+fn banner_block<'a>(text: &'a str, title: &str) -> &'a str {
+    /// The prefix a banner rule line starts with; long enough not to match an
+    /// ordinary `// --` comment.
+    const RULE: &str = "// -----";
+
+    // `(offset, line)` pairs, so a slice can be taken from any line boundary.
+    let lines: Vec<(usize, &str)> = {
+        let mut offset = 0usize;
+        text.split_inclusive('\n')
+            .map(|line| {
+                let at = offset;
+                offset += line.len();
+                (at, line)
+            })
+            .collect()
+    };
+
+    let title_index = lines
+        .iter()
+        .position(|(_, line)| line.trim_end() == title)
+        .unwrap_or_else(|| panic!("no `{title}` banner found"));
+
+    // The title's own closing rule is the first rule at or after it; the block
+    // is everything from just past that rule to the next rule line.
+    let is_rule = |index: usize| lines[index].1.trim_start().starts_with(RULE);
+    let closing = (title_index + 1..lines.len())
+        .find(|index| is_rule(*index))
+        .unwrap_or_else(|| panic!("the `{title}` banner has no closing rule line"));
+    let start = lines[closing].0 + lines[closing].1.len();
+    let end = (closing + 1..lines.len())
+        .find(|index| is_rule(*index))
+        .map_or(text.len(), |index| lines[index].0);
+
+    &text[start..end]
+}
+
 /// The section heading, and the subsection headings that organise it.
 ///
 /// Listed in the order they must appear: the two halves of the ruleset first
@@ -98,8 +164,29 @@ const HEADINGS: &[&str] = &[
     "### The procedure",
     "### Why 2 and 3 are best effort, and 1 and 4 are not",
     "### A worked example of reading force from prose",
+    "### What rule 3 excludes",
     "### Known limitation",
 ];
+
+/// The coordinates the README's rule 3 example is stated on.
+///
+/// The example exists in two places by necessity — the README states the rule and
+/// `cis_confluence_adjudication.rs` pins the behaviour — so it is exactly the shape
+/// this repository drifts on. Neither copy is the authority for the other's *prose*;
+/// what must not diverge is the case itself, since a README example on coordinates
+/// no test covers is a claim nothing checks.
+const RULE_3_EXAMPLE_TOKENS: &[&str] = &[
+    "NC_000001.11",
+    "ATGAGGGGCCACTGT",
+    "g.[1001009del;1001010del;1001013del]",
+    "g.[1001009del;1001011del;1001013del]",
+    "g.[1001009_1001010del;1001013del]",
+];
+
+/// The banner block of `cis_confluence_adjudication.rs` that owns the rule 3
+/// example, so the pinned side of the cross-claim is scoped like the README side.
+const RULE_3_PINNED_RECORD: &str =
+    "// Record 1 — settled: separation is a property of the spelling";
 
 /// The seven rules, by number and name, exactly as the README opens each one.
 ///
@@ -324,5 +411,60 @@ fn the_ledgers_pointer_at_the_readme_ruleset_resolves() {
         restated.is_empty(),
         "`adjudication-precedence-order` has started restating the ruleset it is supposed to \
          point at ({restated:?}). The ruling is that the rules are stated in exactly one place"
+    );
+}
+
+/// The README's rule 3 example must still be the case the adjudication test pins.
+///
+/// [`the_ruleset_and_its_disclosure_mechanism_point_at_each_other`] guards a
+/// cross-*link*; this guards a cross-*claim*, which is the weaker link of the two.
+/// A link breaks loudly when its anchor moves. An example does not: the README can
+/// go on quoting coordinates long after the test stopped covering them, or the test
+/// can be re-pinned onto a different run, and both documents still read as though
+/// they agree. That is the failure this repository has recorded against itself
+/// repeatedly — one fact in several places, drifting apart quietly.
+///
+/// Deliberately token-based rather than a diff. The two texts *should* differ: one
+/// states a rule to a reader, the other exercises a normalizer. Only the case they
+/// are both about — the reference window, the two spellings, and the decided output
+/// — has to stay shared.
+///
+/// **Both sides are scoped**, which is what the module doc above claims of every
+/// assertion here and what this test would otherwise have been the one exception
+/// to. The README side is bound to `### What rule 3 excludes` by [`section`]; the
+/// pinned side is bound to record 1's banner block by [`banner_block`], since a
+/// whole-file `contains` over a 500-line module answers the weaker question
+/// [`section`]'s own doc argues against — it would stay green with the case moved
+/// into an unrelated record, or left behind as commented-out text.
+#[test]
+fn the_rule_3_example_is_the_case_the_adjudication_test_pins() {
+    let readme = read("README.md");
+    let rules = section(&readme, "## Normalization rules");
+    let example = section(rules, "### What rule 3 excludes");
+    let pinned_file = read("tests/it/cis_confluence_adjudication.rs");
+    let pinned = banner_block(&pinned_file, RULE_3_PINNED_RECORD);
+
+    for token in RULE_3_EXAMPLE_TOKENS {
+        assert!(
+            example.contains(token),
+            "the README's rule 3 example no longer states `{token}`; if the example moved to \
+             different coordinates, move `RULE_3_EXAMPLE_TOKENS` and the pinned test with it"
+        );
+        assert!(
+            pinned.contains(token),
+            "the README's rule 3 example states `{token}`, which \
+             `tests/it/cis_confluence_adjudication.rs` no longer covers under \
+             `{RULE_3_PINNED_RECORD}`. The README would be quoting a case nothing checks — or \
+             the case moved to another record, in which case move `RULE_3_PINNED_RECORD` too"
+        );
+    }
+
+    // The link is what sends a reader from the claim to its evidence, so it is
+    // part of the claim rather than a courtesy.
+    assert!(
+        example.contains(
+            "[`tests/it/cis_confluence_adjudication.rs`](tests/it/cis_confluence_adjudication.rs)"
+        ),
+        "the rule 3 example must link to the test that pins it"
     );
 }


### PR DESCRIPTION
Follow-up to #1605, from review feedback on the ruleset it shipped: rules 2 and 3 can be read as demanding opposite things, and the section that classifies a miss puts this one in the wrong box.

## The conflict

Rule 2 says a preference clause outranks maintainer judgment. Rule 3 says every rule is evaluated over the resulting sequence, never over the input's spelling. Both are *Best effort*, and no precedence is stated between them — so where a preference clause keys on what rule 3 excludes, the ruleset does not say which gives way.

It is not hypothetical. Four clauses, all matching rule 2's own scope vocabulary, key on provenance or on population knowledge:

| clause | text | keys on |
|---|---|---|
| `RNA/delins.md:41` | "**preferred** when either of the two variants is known as a frequently occurring variant" | population frequency |
| `RNA/repeated.md:33-34` | "when the repeat is variable in the population … is **preferred** over" | population variability |
| `protein/repeated.md:22-23` | same shape | population variability |
| `DNA/delins.md:79-84` | "should **preferably** be described individually" — because "the two variants may have been reported (or might occur) individually" | the input's decomposition |

## The mislabelling, which is the part that is wrong rather than merely unstated

The subsection closed with:

> Only a failure caused by the spec not determining an answer falls under best effort — and that triggers rule 5.

The spec **is** determinate on all four. Ferro's code is not at fault either. So by the ruleset's own dichotomy a miss is a **bug under rule 7** — which contradicts two decided ledger records. `canonical-form-choice-when-both-legal` records these clauses under its counter-evidence and rules that ferro "cannot implement them and does not try … deliberately, not in ignorance of the other half". `separation-is-a-property-of-the-spelling-not-of-the-variant` carries `DNA/delins.md:79-84` in `deviates_from`.

So the position was already decided; the canonical statement of the rules just did not carry it.

## What changed

- **Rule 2** defers to rule 3 where the two meet.
- **Rule 3** says what "resulting sequence" includes. This was the second half of the feedback, and it corrects a real over-narrowing: ferro consults the transcript model, exon boundaries, reading frame, strand and topology, and must — `general.md:36` says so of the codon exception ("one needs to know whether the two variants are in a coding sequence"), and `exon-junction-dup-converge-from-the-far-side` turns on two spellings that denote one transcript sequence yet project 2,790 bp apart. Those are functions of the accession, not of the description, so they are context rather than spelling.
- **A fifth cause** of best-effort failure, and **a third outcome** beside bug and best effort: the *declared deviation*, permanent and recorded in `deviates_from`. Where such a clause also contradicts one forbidding the use of provenance (`general.md:157-160`), that contradiction stays a defect and rule 5 still applies to it.
- **One new subsection**, `### What rule 3 excludes`: a table of what a description carries and how each part is treated — the answer is one degree of freedom, the partition, plus the run-position choice that feeds it — and the worked example on the coordinates `separation-is-a-property-of-the-spelling-not-of-the-variant` was decided on.

The section adds 49 lines and is written to the register of the ones around it: the table replaces a paragraph, and the two written gaps are annotated in the code block rather than explained in prose. The example states the **decided target** only. It deliberately does not describe current behaviour on those two spellings — that is #1617's, and it would be false the day #1617 lands. `### Known limitation` sits immediately below it and already says the rules are enforced intent rather than a claim of completeness.

## Drift guard

`readme_normalization_rules.rs` gains `the_rule_3_example_is_the_case_the_adjudication_test_pins`: the README's window, both spellings and the decided output must all still appear in `tests/it/cis_confluence_adjudication.rs`, and the link between them must resolve.

The existing guards cover cross-*links*, which break loudly when an anchor moves. An example is the weaker case — the README can go on quoting coordinates long after the test stopped covering them and both documents still read as though they agree. Token-based rather than a diff, because the two texts *should* differ; only the case has to stay shared.

No rule was renumbered, reworded at its opener, or moved between the two halves, so every existing citation by number still resolves and the other five guards pass untouched.

## Second commit: rule 6 called the 3'/5' knob an orthogonal axis

Rule 6 says there are no user options for normalization form, then names 3'/5' direction as an orthogonal axis that stays available. It is the most form-determining option there is — the ledger quotes its own measurements per direction (`3': 2,697 to 1,710; 5': 2,669 to 1,682`) — so as written the rule permits exactly what its first half refuses: confluence as a property of *(input, direction)* rather than of an input.

Now says what is true: error mode is orthogonal, the direction knob is not, and rules 2 and 3 are claimed **per direction** rather than across the two.

**Deliberately not adjudicated:** whether 5' output is conformant at all under `general.md`'s 3' rule. That is a real and separate question, the CLI makes no claim either way today, and answering it here would be the same over-reach this section is being corrected for. Noted on #1669.

The other defect in that same sentence — rule 6 forbidding user options while an uncommitted ruling gave partition preservation a "declared opt-in mode" — is an operator decision and is filed as **#1669**, not folded in here.

## Verification

- `cargo nextest run --features dev -E 'test(readme_normalization_rules)'` — 6/6 pass, including the new guard
- `cargo fmt --all --check` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo run --features dev --example generate_tool_support_tables -- --check` — exit 0, generated README tables untouched
- Every clause quoted above verified against `assets/hgvs-nomenclature` @ `6f85311`

Representation-Change: none. Documentation plus one integration-test assertion; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched and no expectation was re-blessed.
