### PR TITLE
fix(spdi): refuse a genomic pter/qter/cen instead of flattening it to base 0

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -405,6 +405,64 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     /// refuse pairs the checker answers today on no evidence that any of those
     /// answers is wrong. Add it when a wrong answer is measured, with the pair
     /// that measures it.
+    ///
+    /// **A third shape now shares the SPDI blindness and is deliberately not
+    /// listed either: a genomic `pter`/`qter`/`cen` description (#1643).**
+    /// `hgvs_to_spdi` used to flatten those onto `base: 0` and convert; it now
+    /// refuses, so [`Self::edit_triples`]'s `.ok()?` swallows the new error and
+    /// the `SequenceMatch` rung stops firing for them. The reach is narrower
+    /// than it looks, and the reason is worth writing down because it is not
+    /// visible from this file: both rungs run on the **normalized** forms, and
+    /// normalization *resolves* a marker against the provider
+    /// (`g.10_qterdelACGTACGTAC` -> `g.10_28del` on a 28-base contig), so most
+    /// of the class never reaches the sequence rung carrying one at all.
+    ///
+    /// **Which markers survive normalization is a property of the PROVIDER, not
+    /// of the marker.** `cen` always does — `resolve_special_genome_pos` returns
+    /// `Ok(None)` for it unconditionally, there being no centromere annotation
+    /// on a sequence accession to resolve against. But `pter` and `qter` survive
+    /// too whenever the length lookup fails: that arm falls through to
+    /// `canonicalize_genome_variant`, which rewrites only the edit body and
+    /// clones the location, so the marker is echoed. Measured, on a provider
+    /// holding no sequence for the accession: `g.10_qterdelACGTACGTAC` ->
+    /// `g.10_qterdel` and `g.pter_10delACGTACGTAC` -> `g.pter_10del`. So this is
+    /// "`cen` plus any marker whose reference is unservable", not "`cen`".
+    ///
+    /// **One verdict class moved, and the old answer was wrong.** Both figures
+    /// below come from disabling the guard in place and re-running, and they are
+    /// **two separate corpora** — do not read either denominator onto the other:
+    ///
+    /// | corpus | pairs | verdicts that moved |
+    /// |---|---|---|
+    /// | 22 mixed `cen`/`qter`/`pter` descriptors, on a serving and a non-serving provider | 231 x 2 | **0** |
+    /// | 10 descriptors whose 3' anchor is `cen`, serving provider | 45 | **3** |
+    ///
+    /// The three are what the first corpus could not reach, and they say why: a
+    /// `cen` on the END of a *duplication* is what zeroes the triple, because
+    /// the `Duplication` arm emits `end_one_based` as the SPDI position. So
+    /// `g.10_cendupACGTACGTAC`, `g.12_cendupACGTACGTAC` and
+    /// `g.4_cendupACGTACGTAC` all converted to `NC_000001.11:0::ACGTACGTAC`, and
+    /// each of the three pairs among them answered `SequenceMatch` — **wrong**,
+    /// since they duplicate different spans. All three now answer
+    /// `NotEquivalent`. The `del`/`inv` spellings of the same shape never
+    /// collided: those arms emit `start_one_based - 1`, which the `cen` does not
+    /// touch.
+    ///
+    /// So the sibling in such a pair has to be another special position, and an
+    /// earlier revision of this note gave `g.10_19dupACGTACGTAC` instead. That
+    /// is not a case: on a fully numeric anchor the same arm emits
+    /// `end_one_based` as a real coordinate, so it converts at **19**, and two
+    /// triples at different positions cannot match however blind the rung is.
+    ///
+    /// **No genuinely-equivalent pair lost an answer**, which is why nothing
+    /// here changed. Every equivalent `cen` pair tried (cis decompositions,
+    /// member reorderings, delins/substitution respellings) is decided one rung
+    /// earlier by `NormalizedMatch`, because normalization's own cis merge
+    /// collapses them, and no pair moved in the `NotEquivalent` -> equivalent
+    /// direction in either corpus. The residual hazard is the honesty one this
+    /// predicate exists for — a `NotEquivalent` reached with the sequence rung
+    /// blind — not a wrong answer left standing, so per the standard above it
+    /// earns this note rather than a decline.
     fn undecidable_reason(&self, variant: &HgvsVariant) -> Option<String> {
         // SPDI first, at every level: if `edit_triples` succeeds the `SequenceMatch`
         // rung can decide, so there is nothing undecidable to report. Keeping this

--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -642,8 +642,9 @@ pub(crate) fn variant_edit_triples_reason<P: ReferenceProvider + ?Sized>(
 /// breaking change, matching `SpdiParseError` and `ConversionError` in this
 /// module. The set is demonstrably still growing:
 /// [`Self::UnresolvableSpecialPosition`] exists only until `hgvs_to_spdi` stops
-/// resolving `pter` silently, and #1618/#1619 are two more disagreements in
-/// flight.
+/// resolving `pter` silently — which as of #1643 is true of the **transcript**
+/// axis only, the genomic half now being refused outright — and #1618/#1619 are
+/// two more disagreements in flight.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum NotComparable {
@@ -668,12 +669,21 @@ pub enum NotComparable {
     /// One side names `pter`/`qter`/`cen`.
     ///
     /// Those carry no numeric coordinate — `GenomePos::pter()` and
-    /// `CdsPos::pter()` both set `base: 0` — and `hgvs_to_spdi` reads the `base`
-    /// field, so it resolves them *silently* to a position that is not the one
-    /// meant. Measured: `NM_003002.2:c.pterdel` transliterates to a deletion of
-    /// the sequence's LAST base. Comparing against that would report every
-    /// correct `pter` normalization as a corruption, so the pair is declined
-    /// until the transliteration is fixed.
+    /// `CdsPos::pter()` both set `base: 0` — and comparing against a position
+    /// that is not the one meant would report every correct `pter`
+    /// normalization as a corruption. So `names_a_special_position` declines
+    /// the pair on **both** axes, before either side is transliterated.
+    ///
+    /// **Only the transcript half is still resolved silently.** #1643 closed
+    /// the genomic one: `hgvs_to_spdi` now refuses a `g.`/`m.`/`o.` special
+    /// position with `ConversionError::InvalidPosition` (see
+    /// `convert::reject_unresolvable_genomic_position`), so on that axis this
+    /// decline has become belt-and-braces rather than the only thing standing
+    /// between the oracle and a false fault. On the transcript axis `CdsPos`
+    /// still flattens onto `base: 0` and `hgvs_to_spdi` still reads it as a
+    /// coordinate — measured: `NM_003002.2:c.pterdel` transliterates to a
+    /// deletion of the sequence's LAST base — which is the half this variant
+    /// now exists for, and it retires when that half is fixed.
     UnresolvableSpecialPosition,
     /// The two descriptions name different accessions, so their sequences are
     /// not comparable at all. Normalization can do this legitimately (the #785

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -20,8 +20,8 @@
 //! | Deletion `g.100_102delATG` | `seq:99:ATG:` | not required (explicit form) |
 //! | Insertion `g.100_101insATG` | `seq:100::ATG` | not required |
 //! | Delins `g.100_102delinsATG` | `seq:99:ATG:ATG` | required |
-//! | Duplication `g.100_102dup` | `seq:101::ATG` | required (short form) |
-//! | Duplication `g.100_102dupATG` | `seq:101::ATG` | not required (explicit form) |
+//! | Duplication `g.100_102dup` | `seq:102::ATG` | required (short form) |
+//! | Duplication `g.100_102dupATG` | `seq:102::ATG` | not required (explicit form) |
 //! | Inversion `g.100_102inv` | `seq:99:ATG:CAT` | required (short form) |
 //! | Inversion `g.100_102invATG` | `seq:99:ATG:CAT` | not required (explicit form) |
 //! | Repeat `g.100_105AT[5]` | `seq:99:ATATAT:ATATATATAT` | required |
@@ -224,28 +224,49 @@ fn get_end_pos(interval: &Interval<GenomePos>) -> Option<u64> {
     interval.end.inner().map(|p| p.base)
 }
 
-/// Refuse a genomic interval whose start or end carries a `+`/`-` offset (#1628).
+/// Refuse a genomic interval whose start or end holds something SPDI cannot be
+/// given a coordinate for: a `+`/`-` offset (#1628) or a `pter`/`qter`/`cen`
+/// special position (#1643).
 ///
-/// `GenomePos` can hold an offset because the parser accepts one, but neither
-/// half of the conversion can honour it: a genomic accession has no exon
-/// structure to measure an offset against — `checklist.md:16` prohibits an
-/// offset on a genomic position outright — and SPDI is purely positional, with
-/// no offset notation.
+/// The two are the same defect in two fields of one struct. `GenomePos` can
+/// hold either because the parser accepts both, and neither half of the
+/// conversion can honour them:
 ///
-/// What the conversion did instead was drop it, which is the one answer that is
-/// worse than either honest option. `g.266+2del`, `g.266-268del` and `g.266del`
-/// all flattened onto the same triple while `normalize` keeps them as three
-/// distinct descriptions, so ferro's two halves disagreed about what a variant
-/// is: descriptions the SPDI path called identical normalized to three
-/// different strings.
+/// - an **offset** has nothing on a genomic accession to be measured against —
+///   there is no exon structure, and `checklist.md:16` prohibits an offset on a
+///   genomic position outright — and SPDI has no offset notation;
+/// - a **special position** names a landmark of the assembled chromosome
+///   (`pter`, `qter`) or of its centromere annotation (`cen`), none of which a
+///   sequence accession carries. `GenomePos` stores `base: 0` beside the
+///   `special` marker precisely because there is no coordinate to store.
+///
+/// What the conversion did instead was drop both, which is the one answer worse
+/// than either honest option, and it produced the same confluence failure
+/// twice. `g.266+2del`, `g.266-268del` and `g.266del` flattened onto one triple
+/// while `normalize` keeps them as three distinct descriptions. So did
+/// `g.10_qterdelACGTACGTAC`, `g.10_cendelACGTACGTAC` and
+/// `g.10_19delACGTACGTAC` — a deletion to the q-arm telomere, one to the
+/// centromere and a literal ten-base deletion, all `NC_000001.11:9:ACGTACGTAC:`.
+///
+/// **The special-position half was reachable only when the description spells
+/// its own bases**, which is why it survived #1641 and why the guard is what
+/// closes it rather than the checks that appear to. Every other shape happened
+/// to be refused *incidentally*, by a check asking a different question:
+/// `g.pter_10del` by the 1-based position check ("position 0 is not valid in
+/// HGVS"), `g.10_qterdel` by the reference fetch (`invalid 1-based interval
+/// [10, 0]`), and the `m.`/`o.` forms by the circular-wraparound check, which
+/// reads `start > end` and reports a wraparound that is not there. Those
+/// messages diagnose the wrong thing and none of them is a guarantee — a
+/// description carrying its own bases needs no fetch and no position check, and
+/// so converted.
 ///
 /// Refusing is also what the other axes already do with the offsets that *are*
 /// legitimate there — see [`resolve_cds_to_tx`], [`resolve_tx_pos`] and
 /// [`require_simple_tx_pos`], each of which declines an intronic `c.`/`n.`/`r.`
 /// position for want of an SPDI representation. Those decline because the
-/// offset cannot be projected onto the transcript accession; this one declines
+/// position cannot be projected onto the transcript accession; this one declines
 /// because there is nothing on a genomic accession to project it against.
-fn reject_genomic_offset(
+fn reject_unresolvable_genomic_position(
     interval: &Interval<GenomePos>,
     coord: &str,
 ) -> Result<(), ConversionError> {
@@ -260,6 +281,16 @@ fn reject_genomic_offset(
                      cannot have one and SPDI has no offset notation to express it. Drop the \
                      offset, or describe the variant on a transcript accession where an offset \
                      is meaningful"
+                ),
+            });
+        }
+        if let Some(special) = endpoint.special {
+            return Err(ConversionError::InvalidPosition {
+                description: format!(
+                    "{coord}. position `{special}` names no numeric coordinate: `pter`, `qter` \
+                     and `cen` are landmarks of the assembled chromosome, not positions on the \
+                     sequence, and SPDI has no notation for them. Give the position a number, \
+                     or keep the description in HGVS"
                 ),
             });
         }
@@ -290,10 +321,11 @@ fn reject_genomic_offset(
 /// by either entry point — SPDI has no offset notation, and genomic
 /// projection is future work; both functions return
 /// [`ConversionError::MissingReferenceData`]. A `g.`/`m.`/`o.` position
-/// carrying an offset is refused outright by both entry points with
-/// [`ConversionError::InvalidPosition`]: there is no exon structure on a
-/// genomic accession to resolve it against, and dropping it made distinct
-/// descriptions share one triple (#1628).
+/// carrying an offset (#1628) or a `pter`/`qter`/`cen` special position
+/// (#1643) is refused outright by both entry points with
+/// [`ConversionError::InvalidPosition`]: neither has anything on a genomic
+/// accession to resolve it against, and dropping either made distinct
+/// descriptions share one triple.
 ///
 /// # Arguments
 ///
@@ -366,9 +398,10 @@ pub fn hgvs_to_spdi_simple(variant: &HgvsVariant) -> Result<SpdiVariant, Convers
 /// `g.100_102dupATG`, `g.100A=`, etc.) emits the user-supplied bases as-is
 /// and does not consult the provider. Intronic `n.`/`r.` positions remain
 /// unsupported (SPDI has no offset notation) and return
-/// [`ConversionError::MissingReferenceData`]. An offset on a `g.`/`m.`/`o.`
-/// position is refused with [`ConversionError::InvalidPosition`] — see
-/// [`reject_genomic_offset`].
+/// [`ConversionError::MissingReferenceData`]. An offset or a `pter`/`qter`/`cen`
+/// special position on a `g.`/`m.`/`o.` position is refused with
+/// [`ConversionError::InvalidPosition`] — see
+/// [`reject_unresolvable_genomic_position`].
 ///
 /// An **unspelled identity** (`g.100=`, `g.100_102=`) therefore needs a
 /// provider: on [`hgvs_to_spdi_simple`] it returns
@@ -442,7 +475,7 @@ pub fn hgvs_to_spdi<P: ReferenceProvider + ?Sized>(
 
 /// Convert a genomic variant to SPDI (simple conversion).
 fn genome_to_spdi_simple(variant: &GenomeVariant) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "g")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "g")?;
     let edit = unwrap_edit(&variant.loc_edit.edit)?;
     let start_pos = get_start_pos(&variant.loc_edit.location).ok_or_else(|| {
         ConversionError::InvalidPosition {
@@ -470,7 +503,7 @@ fn genome_to_spdi_simple(variant: &GenomeVariant) -> Result<SpdiVariant, Convers
 /// single-edit format with no native representation for circular-contig
 /// wraparound.
 fn mt_to_spdi_simple(variant: &MtVariant) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "m")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "m")?;
     if let (Some(s), Some(e)) = (
         get_start_pos(&variant.loc_edit.location),
         get_end_pos(&variant.loc_edit.location),
@@ -551,7 +584,7 @@ fn genome_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
     variant: &GenomeVariant,
     provider: &P,
 ) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "g")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "g")?;
     let edit = unwrap_edit(&variant.loc_edit.edit)?;
     let start_pos = get_start_pos(&variant.loc_edit.location).ok_or_else(|| {
         ConversionError::InvalidPosition {
@@ -581,7 +614,7 @@ fn mt_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
     variant: &MtVariant,
     provider: &P,
 ) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "m")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "m")?;
     if let (Some(s), Some(e)) = (
         get_start_pos(&variant.loc_edit.location),
         get_end_pos(&variant.loc_edit.location),
@@ -622,7 +655,7 @@ fn mt_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
 /// single-edit format with no native representation for circular-contig
 /// wraparound.
 fn circular_to_spdi_simple(variant: &CircularVariant) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "o")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "o")?;
     if let (Some(s), Some(e)) = (
         get_start_pos(&variant.loc_edit.location),
         get_end_pos(&variant.loc_edit.location),
@@ -666,7 +699,7 @@ fn circular_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
     variant: &CircularVariant,
     provider: &P,
 ) -> Result<SpdiVariant, ConversionError> {
-    reject_genomic_offset(&variant.loc_edit.location, "o")?;
+    reject_unresolvable_genomic_position(&variant.loc_edit.location, "o")?;
     if let (Some(s), Some(e)) = (
         get_start_pos(&variant.loc_edit.location),
         get_end_pos(&variant.loc_edit.location),
@@ -5303,6 +5336,143 @@ mod tests {
                  only its intronic positions are unrepresentable"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Genomic special positions (#1643)
+    // ------------------------------------------------------------------
+
+    /// `pter`, `qter` and `cen` name no numeric coordinate, and `GenomePos`
+    /// stores `base: 0` for all three. `hgvs_to_spdi` read `base` and never
+    /// looked at `special`, so every special position resolved to base 0 — the
+    /// sibling of the dropped `offset` of #1628, in the same helper and with
+    /// the same consequence: descriptions of different variants collapse onto
+    /// one triple.
+    ///
+    /// **Every descriptor here spells its own bases, and that is the whole
+    /// reason the class survived #1641.** A description carrying its bases
+    /// needs no provider fetch and no position resolution, so none of the
+    /// checks that appear to cover this ever runs. The shapes that do not spell
+    /// their bases were refused *incidentally* and for the wrong reason —
+    /// `g.pter_10del` by the 1-based check ("position 0 is not valid in HGVS"),
+    /// `g.10_qterdel` by the fetch (`invalid 1-based interval [10, 0]`), the
+    /// `m.`/`o.` forms by the circular-wraparound check reporting a wraparound
+    /// that is not there — which is exactly why reading those refusals as
+    /// coverage was wrong.
+    ///
+    /// The verdict is `InvalidPosition` for the reason #1641 established for
+    /// the offset case: a special position cannot be *resolved* on a bare
+    /// genomic accession — `pter` and `qter` are landmarks of the assembled
+    /// chromosome, and `cen` of its centromere annotation, neither of which a
+    /// sequence accession carries — so refusing is the only honest answer, and
+    /// it differs from the transcript axes' `MissingReferenceData` because
+    /// those decline a *well-formed* position SPDI cannot carry.
+    ///
+    /// Both entry points and every genomic axis, so all six guard call sites
+    /// are covered, and the message is asserted rather than a bare `is_err()`:
+    /// "failed somehow" is what every one of those incidental refusals already
+    /// satisfied.
+    #[test]
+    fn a_genomic_special_position_is_refused_rather_than_flattened() {
+        let provider = identity_provider();
+        for (descriptor, coord) in [
+            ("NC_000001.11:g.10_qterdelACGTACGTAC", "g"),
+            ("NC_000001.11:g.10_cendelACGTACGTAC", "g"),
+            ("NC_000001.11:g.10_qterdupACGTACGTAC", "g"),
+            ("NC_000001.11:g.10_qterinvACGTACGTAC", "g"),
+            ("NC_000001.11:g.pter_10delACGTACGTAC", "g"),
+            ("NC_012920.1:m.10_qterdelACGTACGTAC", "m"),
+            ("NC_012920.1:m.pter_10delACGTACGTAC", "m"),
+            ("NC_001416.1:o.10_qterdelACGTACGTAC", "o"),
+            ("NC_001416.1:o.pter_10delACGTACGTAC", "o"),
+        ] {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            for (path, converted) in [
+                ("without a provider", hgvs_to_spdi_simple(&variant)),
+                ("with a provider", hgvs_to_spdi(&variant, &provider)),
+            ] {
+                let err = match converted {
+                    Err(err) => err,
+                    Ok(spdi) => panic!(
+                        "`{descriptor}` converted {path} to `{spdi}`; the special position \
+                         was flattened onto base 0"
+                    ),
+                };
+                assert!(
+                    matches!(err, ConversionError::InvalidPosition { .. }),
+                    "`{descriptor}` {path} must be refused as InvalidPosition, got {err:?}"
+                );
+                let message = err.to_string();
+                assert!(
+                    message.contains("names no numeric coordinate"),
+                    "`{descriptor}` {path} was refused for some other reason: {message}"
+                );
+                assert!(
+                    message.contains(&format!("{coord}. position")),
+                    "`{descriptor}` {path} named the wrong coordinate axis: {message}"
+                );
+            }
+        }
+    }
+
+    /// The confluence failure the flattening produced, measured on `main`
+    /// before the guard: a deletion running to the q-arm telomere, one running
+    /// to the centromere, and a literal ten-base deletion all converted to
+    /// `NC_000001.11:9:ACGTACGTAC:`. Three descriptions of three different
+    /// things, one triple.
+    ///
+    /// Stated as the invariant rather than as three pinned errors, so it keeps
+    /// meaning something if a future change makes any of these resolvable: what
+    /// must never happen is two of them sharing an answer.
+    ///
+    /// **The denominator is asserted, because with the guard in place the
+    /// `panic!` above is unreachable.** Two of the three descriptors are now
+    /// refused and skipped by the `if let Ok`, so `seen` holds one triple and
+    /// there is no pair left to collide — exactly the `0 of 0` shape this
+    /// repository asserts denominators against. The census below is therefore
+    /// what carries the meaning today, and it is written to fail the moment a
+    /// special position becomes convertible again: that is precisely when the
+    /// collision check goes live and has to be re-read rather than trusted.
+    #[test]
+    fn special_positions_do_not_collapse_onto_one_another() {
+        /// Refused by the #1643 guard today, so they never reach `seen`.
+        const CONVERTIBLE_TODAY: usize = 1;
+
+        let provider = identity_provider();
+        let descriptors = [
+            "NC_000001.11:g.10_qterdelACGTACGTAC",
+            "NC_000001.11:g.10_cendelACGTACGTAC",
+            "NC_000001.11:g.10_19delACGTACGTAC",
+        ];
+        let mut seen: Vec<(String, String)> = Vec::new();
+        for descriptor in descriptors {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            if let Ok(spdi) = hgvs_to_spdi(&variant, &provider) {
+                let triple = spdi.to_string();
+                if let Some((other, _)) = seen.iter().find(|(_, t)| *t == triple) {
+                    panic!(
+                        "`{descriptor}` and `{other}` are different variants but share the \
+                         triple `{triple}`"
+                    );
+                }
+                seen.push((descriptor.to_string(), triple));
+            }
+        }
+
+        assert_eq!(
+            seen.len(),
+            CONVERTIBLE_TODAY,
+            "{} of {} descriptors converted, expected {CONVERTIBLE_TODAY}: {seen:?}. \
+             If this grew, a special position is convertible again and the collision check \
+             above has just become live — read what it now compares before re-pinning this \
+             number. If it shrank, the loop is comparing nothing at all",
+            seen.len(),
+            descriptors.len()
+        );
+        assert!(
+            seen.len() < descriptors.len(),
+            "every descriptor converted, so the #1643 guard is refusing nothing"
+        );
     }
 
     /// The invariant the drop breaks, stated directly: two descriptions that


### PR DESCRIPTION
Closes #1643

`GenomePos` stores `base: 0` beside a `special` marker because `pter`, `qter` and `cen` name landmarks of the assembled chromosome — and `cen` of its centromere annotation — not positions on the sequence. `hgvs_to_spdi` read `base` and never looked at `special`, so every special position resolved to base 0. Same helper as #1628, same shape: a field the AST carries that the conversion discards.

## What reproduces, and one correction to the issue

Measured on `main` at `b9f6cecb`, on `NC_000001.11`:

```
g.10_qterdelACGTACGTAC  -> NC_000001.11:9:ACGTACGTAC:
g.10_cendelACGTACGTAC   -> NC_000001.11:9:ACGTACGTAC:
g.10_19delACGTACGTAC    -> NC_000001.11:9:ACGTACGTAC:
```

A deletion running to the q-arm telomere, one running to the centromere, and a literal ten-base deletion — three descriptions of three different things, one triple. `g.10_qterdupACGTACGTAC` is worse still: it converts to `NC_000001.11:0::ACGTACGTAC`, anchoring the duplication at position 0.

**The issue's reproducer as written does not reproduce, and the reason matters.** `g.pter_10del` and `g.10_qterdel` are already refused today — but *incidentally*, by checks asking a different question, each of which diagnoses the wrong thing:

| shape | refused by | message |
|---|---|---|
| `g.pter_10del` | the 1-based position check | `position 0 is not valid in HGVS` |
| `g.10_qterdel` | the reference fetch | `invalid 1-based interval [10, 0] for reference fetch` |
| `m.10_qterdel`, `o.10_qterdel` | the circular-wraparound check | `Cannot convert wraparound m. variant to SPDI` — a wraparound that is not there |

None of them is a guard, and the one shape that reaches none of them is the one that converts: **a description that spells its own bases** needs no provider fetch and no position resolution. That is why the class outlived #1641, and why "it already errors" was not coverage. Every descriptor in the new test spells its bases for exactly this reason.

## The fix

`reject_genomic_offset` becomes `reject_unresolvable_genomic_position` and refuses both fields at the same six genomic call sites. They are one defect in two fields of one struct and they decline for the same reason — there is nothing on a genomic accession to resolve either against — so a sibling guard would have been two functions with one docstring.

The verdict is `InvalidPosition`, following what #1641 established: it differs from the transcript axes' `MissingReferenceData` because those decline a *well-formed* position SPDI cannot carry, while `g.qter` is not a resolvable position at all. `a_transcript_axis_offset_declines_for_its_own_reason` still passes unchanged, which is the control that the genomic guard has not reached the axes where these fields are legitimate.

## Verification

- `cargo nextest run --features dev` — **`Summary [134.888s] 10138 tests run: 10138 passed, 152 skipped`**. Nothing re-blessed: for a change to what `to_spdi` answers, an untouched expectation set is the strong signal.
- Reproduction control: with the four added lines of guard deleted and nothing else changed, both new tests fail — `converted without a provider to NC_000001.11:9:ACGTACGTAC:; the special position was flattened onto base 0`, and `g.10_cendelACGTACGTAC and g.10_qterdelACGTACGTAC are different variants but share the triple`.
- All four seam oracles on, full suite, against `origin/main` at `b9f6cecb`: **25 failures on each side, failing test-name sets byte-identical**. This closes none of the two rows keeping `FERRO_ASSERT_SEQUENCE` out of `test-oracle` (#1618 and #1619) and adds none.

Representation-Change: none. Four paths under `src/normalize/` DO reach `hgvs_to_spdi` — `Normalizer::to_spdi` calls it directly, `apply_to_reference` and `canonical_spdi` reach it through `spdi::apply::variant_edit_triples`, and the debug-only `assert_denoted_sequence` reaches it through `compare_denoted_sequences` — so an earlier "nothing calls it" premise is withdrawn. None of the four produces a normalized description: the first three are separate public entry points returning an SPDI triple or an `AppliedVariant`, reached only from `src/python.rs` and `src/equivalence/key.rs`, and the fourth is compiled out of release. The normalization pipeline itself makes no `spdi::` call. The only producer of a `special` position is the parser — projection builds every genomic position with `GenomePos::new`. What changes is `to_spdi`'s answer for descriptions whose position has no coordinate to convert, from a triple that answers for a different variant to an error. Verified rather than asserted: 10,138 tests pass with nothing re-blessed. `examples/dump_normalized_corpus.rs` was not used as evidence — it dumps *normalized* output and no family builds a `pter`/`qter`/`cen` position, so a `0 moved` from it would be a fact about the corpus rather than about this change; the suite is the evidence.

Previously **accepted**, and measured empty. The rejected-vs-accepted fact belongs in this trailer and was missing: a genomic `pter`/`qter`/`cen` description that spells its own deleted bases *did* convert before this change and now errors — `NC_000001.11:g.10_qterdelACGTACGTAC` returned `NC_000001.11:9:ACGTACGTAC:` at `b9f6cecb` and returns the landmark error here. So the class is real, not hypothetical. Its measured size is **0 of 4,188,436** ClinVar expressions (`clinvar_hgvs_unique`): the only **2** rows carrying a genomic `qter` — `NC_000009.12:g.12891379_qterdelins[T;NC_000020.11:g.47204889_qterinv]` and `NC_000013.10:g.114819939_qterdelins[96729864_114814234inv;96735632_104289803]` — already failed conversion at `b9f6cecb` on their non-literal insert payload, so for those the only change is which error is returned. Measured by swapping `src/spdi/convert.rs` for its merge-base version and re-running the same five inputs, rather than by reasoning about reachability.


