### PR TITLE
fix(ci): let the failure reporter resolve the repository it files against

### DIFF
--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -71,6 +71,17 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
+          # `gh issue list|comment|create` are repo-scoped commands: with no
+          # `--repo`, `gh` resolves the target by shelling out to `git` in the
+          # working directory. This job has no `actions/checkout` — it only
+          # touches the API — so that lookup died on every invocation with
+          #
+          #     failed to run git: fatal: not a git repository
+          #
+          # and the reporter exited 1 without filing anything. `GH_REPO` supplies
+          # the target directly and skips the git lookup, which is cheaper than
+          # adding a checkout for a job that never reads the tree.
+          GH_REPO: ${{ github.repository }}
           TITLE: ${{ inputs.title }}
           SUMMARY: ${{ inputs.summary }}
           HINT: ${{ inputs.hint }}

--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -100,9 +100,26 @@ jobs:
           # interpolating it into the jq program: a title containing a quote
           # would otherwise produce a malformed filter, and the value is
           # workflow-supplied input.
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+          #
+          # The lookup must not be able to abort the step. It runs under
+          # `set -e` and is the FIRST thing this job does, so any transient
+          # failure — a rate limit, a search-API blip — kills the reporter
+          # before the `gh issue create` fallback below is ever reached, and
+          # the alerting path fails silently underneath the failure it exists
+          # to announce. That is the exact shape of the defect that left this
+          # job broken. Filing a duplicate is strictly better than filing
+          # nothing, so a failed lookup degrades to "no rolling issue found"
+          # and says so in the log.
+          #
+          # Only the LOOKUP is forgiving. If `gh issue comment` or `gh issue
+          # create` fails, nothing was recorded anywhere and the step must go
+          # red — that is the last remaining signal.
+          if ! EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
             --json number,title \
-            --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty')
+            --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty'); then
+            echo "::warning::rolling-issue lookup failed; filing a new issue instead of commenting"
+            EXISTING=""
+          fi
           BODY=$(printf '%s\n' \
             "$SUMMARY" \
             "" \

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -474,6 +474,7 @@ mod uta_loader_tests;
 mod variantvalidator_tests;
 mod web_service_tests;
 mod weight_bound_worked_examples;
+mod workflow_gh_repo_context;
 
 mod reported_confluence_pairs;
 mod ring_segment_wellformedness;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -476,5 +476,6 @@ mod web_service_tests;
 mod weight_bound_worked_examples;
 mod workflow_gh_repo_context;
 
+mod report_failure_degrades;
 mod reported_confluence_pairs;
 mod ring_segment_wellformedness;

--- a/tests/it/report_failure_degrades.rs
+++ b/tests/it/report_failure_degrades.rs
@@ -1,0 +1,183 @@
+//! The failure reporter must file something even when its lookup fails.
+//!
+//! `report-failure.yml` runs under `set -euo pipefail` and opens by searching
+//! for the rolling issue to comment on. That search is a network call to the
+//! GitHub search API, and it is the *first* thing the job does — so before this
+//! was guarded, any transient failure of it (rate limit, API blip, a title the
+//! search chokes on) aborted the step before the `gh issue create` fallback was
+//! ever reached. The alerting path would then fail silently underneath the very
+//! failure it exists to announce.
+//!
+//! That is the same shape as the defect this workflow was already carrying: a
+//! path nobody exercises, whose broken state is indistinguishable from its
+//! working state. Asserting the `GH_REPO` line is present does not touch it,
+//! because the question is not what the file says but what the script *does*.
+//!
+//! So this test runs the script. It extracts the `run:` block from the workflow
+//! and executes it under `bash` with a stub `gh` on `PATH`, then checks which
+//! command the script reached. Three scenarios, all of which must file
+//! something:
+//!
+//! | lookup | expected |
+//! |---|---|
+//! | fails outright | warn, then **create** — a duplicate beats silence |
+//! | succeeds, no match | **create** |
+//! | succeeds, match | **comment** on the issue it found |
+//!
+//! Deliberately NOT asserted: that `gh issue create` or `gh issue comment`
+//! failing still reddens the step. It does, and it should — at that point
+//! nothing was recorded anywhere and the step's own red X is the last remaining
+//! signal — but a test that pinned it would be pinning `set -e`, not this
+//! script.
+
+#![cfg(unix)]
+
+use serde_yaml::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The `run:` script of the reporter's only step, read out of the workflow.
+///
+/// Read from the workflow rather than duplicated here: a copy would keep
+/// passing after the real script changed, which is the failure mode this whole
+/// file is about.
+fn reporter_script() -> String {
+    let path = repo_root().join(".github/workflows/report-failure.yml");
+    let text = std::fs::read_to_string(&path).expect("report-failure.yml is readable");
+    let doc: Value = serde_yaml::from_str(&text).expect("report-failure.yml parses");
+    doc.get("jobs")
+        .and_then(|j| j.get("report"))
+        .and_then(|j| j.get("steps"))
+        .and_then(Value::as_sequence)
+        .and_then(|steps| steps.iter().find_map(|s| s.get("run")))
+        .and_then(Value::as_str)
+        .expect("the `report` job has a `run` step")
+        .to_string()
+}
+
+/// A `gh` that records which subcommand it was asked for instead of calling
+/// GitHub, and can be told to fail the lookup.
+fn write_stub_gh(dir: &Path) {
+    let stub = dir.join("gh");
+    std::fs::write(
+        &stub,
+        r#"#!/bin/bash
+case "$1 $2" in
+  "issue list")
+      if [ "${GH_STUB_LOOKUP:-ok}" = "fail" ]; then
+        echo "gh: API rate limit exceeded" >&2
+        exit 1
+      fi
+      echo "${GH_STUB_FOUND:-}"
+      ;;
+  "issue comment") echo "STUB_COMMENTED $3" ;;
+  "issue create")  echo "STUB_CREATED" ;;
+  *) echo "STUB: unexpected: $*" >&2; exit 99 ;;
+esac
+"#,
+    )
+    .expect("write stub gh");
+    let mut perms = std::fs::metadata(&stub).expect("stat stub").permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&stub, perms).expect("chmod stub");
+}
+
+struct Outcome {
+    status: Option<i32>,
+    output: String,
+}
+
+fn run_reporter(lookup: &str, found: &str) -> Outcome {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_stub_gh(dir.path());
+    let script = dir.path().join("step.sh");
+    std::fs::write(&script, reporter_script()).expect("write script");
+
+    let path = format!(
+        "{}:{}",
+        dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let out = Command::new("bash")
+        .arg(&script)
+        .env("PATH", path)
+        .env("GH_STUB_LOOKUP", lookup)
+        .env("GH_STUB_FOUND", found)
+        // The values the workflow would supply. `set -u` aborts on any unset
+        // one, so every variable the script reads has to be here.
+        .env("GH_TOKEN", "stub-token")
+        .env("GH_REPO", "example/repo")
+        .env("TITLE", "a stable failure-mode title")
+        .env("SUMMARY", "something failed")
+        .env("HINT", "reproduce with: cargo test")
+        .env("RUN_URL", "https://example.invalid/run/1")
+        .env("WORKFLOW", "Coverage")
+        .env("SHA", "0123456789abcdef")
+        .output()
+        .expect("run the reporter script under bash");
+
+    Outcome {
+        status: out.status.code(),
+        output: format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    }
+}
+
+#[test]
+fn a_failed_lookup_still_files_an_issue() {
+    let run = run_reporter("fail", "");
+    assert_eq!(
+        run.status,
+        Some(0),
+        "a failed rolling-issue lookup aborted the reporter instead of falling back. \
+         The step dies before it can file anything, so the failure it was reporting \
+         goes unrecorded — the defect this workflow exists to prevent.\n{}",
+        run.output
+    );
+    assert!(
+        run.output.contains("STUB_CREATED"),
+        "the reporter exited cleanly but filed nothing after a failed lookup\n{}",
+        run.output
+    );
+    assert!(
+        run.output.contains("::warning::"),
+        "the reporter degraded silently. A run that could not check for the rolling \
+         issue may have filed a duplicate, and the log has to say so\n{}",
+        run.output
+    );
+}
+
+#[test]
+fn no_existing_issue_is_created_fresh() {
+    let run = run_reporter("ok", "");
+    assert_eq!(run.status, Some(0), "{}", run.output);
+    assert!(
+        run.output.contains("STUB_CREATED"),
+        "with no rolling issue found, the reporter must create one\n{}",
+        run.output
+    );
+}
+
+#[test]
+fn an_existing_issue_is_commented_on_rather_than_duplicated() {
+    let run = run_reporter("ok", "4242");
+    assert_eq!(run.status, Some(0), "{}", run.output);
+    assert!(
+        run.output.contains("STUB_COMMENTED 4242"),
+        "the reporter must comment on the rolling issue it found, not open a second \
+         one — one issue per failure mode is the whole point of the lookup\n{}",
+        run.output
+    );
+    assert!(
+        !run.output.contains("STUB_CREATED"),
+        "the reporter both commented and created\n{}",
+        run.output
+    );
+}

--- a/tests/it/workflow_gh_repo_context.rs
+++ b/tests/it/workflow_gh_repo_context.rs
@@ -1,0 +1,370 @@
+//! Every repo-scoped `gh` call in a workflow must be able to name its repo.
+//!
+//! `gh issue`, `gh pr`, `gh run` and friends operate on "the current
+//! repository". With no `--repo` flag and no `GH_REPO` in the environment, `gh`
+//! works out which one that is by shelling out to `git` in the working
+//! directory — so a job that never runs `actions/checkout` has nothing to
+//! resolve against and the command dies before it does anything:
+//!
+//! ```text
+//! failed to run git: fatal: not a git repository (or any of the parent directories): .git
+//! ```
+//!
+//! **This is the guard for a defect that shipped and stayed invisible.**
+//! `report-failure.yml` is the reusable job six workflows call to open a
+//! tracking issue when they break after merge — the alerting that exists
+//! precisely because those workflows cannot fail a pull request. It had no
+//! checkout and no `GH_REPO`, so it exited 1 on every invocation without filing
+//! anything, and the only symptom was a second red X underneath the red X it was
+//! supposed to be reporting. A reporter that fails exactly when it is needed
+//! looks identical to one that is never needed.
+//!
+//! Note what a test of `report-failure.yml` alone would have been worth: nothing
+//! much, since a guard written against one known-broken file passes the moment
+//! that file is fixed and says nothing about the next one. The class is what is
+//! checked here — six other workflows shell out to `gh`, and two of them
+//! (`audit-pr-runs`, `prune-ci-caches`) are correct today only because they use
+//! `gh api` with the repo already interpolated into the path.
+//!
+//! Parsed rather than grepped, for the reason `generator_completeness.rs` gives
+//! about `Cargo.toml`: the question is a property of the workflow's structure —
+//! which steps sit in which job, and which `env` blocks are in scope for them —
+//! and a substring scan cannot answer it. It would also match `gh` commands
+//! quoted inside a `with:` input, which is real text in `audit-pr-runs.yml`'s
+//! reproduction hint and is documentation rather than a command anything runs.
+
+use serde_yaml::Value;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// `gh` subcommands that act on "the current repository" and therefore need one
+/// named.
+///
+/// Deliberately a list of the repo-scoped command *groups* rather than every
+/// leaf: `gh issue list` and `gh issue create` fail identically, and enumerating
+/// leaves would leave the next one added silently unguarded. `gh api` is not
+/// here because an absolute path (`/repos/OWNER/REPO/...`) needs no resolution —
+/// it is handled separately, since the placeholder form does.
+///
+/// The list is deliberately wider than what the workflows currently call —
+/// measured, they use `issue`, `api`, `pr`, `run` and `release` — because a name
+/// missing here fails in the silent direction: a future checkout-less step using
+/// it passes the scan and dies at runtime, which is the defect this file exists to
+/// catch. `secret`, `variable` and `ruleset` are the likeliest additions (a release
+/// or publish job setting one), so they are listed before anyone needs them.
+const REPO_SCOPED: &[&str] = &[
+    "issue", "pr", "release", "run", "workflow", "cache", "label", "browse", "secret", "variable",
+    "ruleset",
+];
+
+fn workflow_files() -> Vec<PathBuf> {
+    let dir = repo_root().join(".github/workflows");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .map(|entry| entry.expect("readable dir entry").path())
+        .filter(|path| {
+            matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("yml") | Some("yaml")
+            )
+        })
+        .collect();
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        ".github/workflows holds no workflow files; this guard would pass \
+         vacuously, which is the failure mode it exists to prevent"
+    );
+    files
+}
+
+/// A `run:` script reduced to the shell lines worth scanning.
+///
+/// Two normalisations, both load-bearing. Comment lines are dropped, because
+/// `report-failure.yml` explains its own `gh` usage in a comment directly above
+/// the call and that prose must not be read as a second invocation. Backslash
+/// continuations are joined, because `--repo` habitually lands on a later line
+/// than the subcommand — treating those as separate lines would report a
+/// correctly-flagged call as unflagged.
+fn shell_lines(run: &str) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut pending = String::new();
+    for raw in run.lines() {
+        let line = raw.trim();
+        if pending.is_empty() && line.starts_with('#') {
+            continue;
+        }
+        if let Some(head) = line.strip_suffix('\\') {
+            pending.push_str(head.trim_end());
+            pending.push(' ');
+            continue;
+        }
+        pending.push_str(line);
+        lines.push(std::mem::take(&mut pending));
+    }
+    if !pending.is_empty() {
+        lines.push(pending);
+    }
+    lines
+}
+
+/// One shell line split at the operators that end a command.
+///
+/// `--repo` is a property of an invocation, not of a line, so a line carrying two
+/// commands has to be judged in two pieces: `gh pr view --repo x/y && gh issue
+/// create` supplies a repository to the first and nothing to the second, and a
+/// whole-line `contains("--repo ")` clears both. Splitting on `&&`, `||`, `;` and
+/// `|` is coarse — it does not understand quoting — but it errs toward *more*
+/// scrutiny, which is the safe direction for a guard: a split inside a quoted
+/// string can only produce a piece that fails the check, never one that passes it
+/// wrongly.
+fn shell_segments(line: &str) -> Vec<&str> {
+    line.split("&&")
+        .flat_map(|piece| piece.split("||"))
+        .flat_map(|piece| piece.split(';'))
+        .flat_map(|piece| piece.split('|'))
+        .map(str::trim)
+        .filter(|piece| !piece.is_empty())
+        .collect()
+}
+
+/// The subcommand of each `gh` invocation on one shell line.
+///
+/// A line can carry more than one (`gh issue comment … && gh issue edit …`), so
+/// every occurrence is returned rather than the first. `gh` must start a command
+/// — preceded by nothing, whitespace, or a shell operator — so that a word
+/// merely *ending* in "gh" does not match.
+fn gh_subcommands(line: &str) -> Vec<&str> {
+    let bytes = line.as_bytes();
+    let mut found = Vec::new();
+    for (at, _) in line.match_indices("gh ") {
+        let starts_command = at == 0
+            || matches!(
+                bytes[at - 1],
+                b' ' | b'\t' | b'|' | b'(' | b'&' | b';' | b'$' | b'`'
+            );
+        if !starts_command {
+            continue;
+        }
+        if let Some(word) = line[at + 3..].split_whitespace().next() {
+            found.push(word);
+        }
+    }
+    found
+}
+
+/// Whether an invocation resolves its own repo, either by flag or by not needing
+/// one.
+fn names_its_repo(line: &str, subcommand: &str) -> bool {
+    if line.contains("--repo ") || line.contains("--repo=") || line.contains(" -R ") {
+        return true;
+    }
+    // `gh api` substitutes `{owner}`/`{repo}` from the resolved repository, so
+    // the placeholder form needs context exactly as much as `gh issue` does;
+    // a path with the repo already written into it needs none.
+    if subcommand == "api" {
+        return !line.contains("{owner}") && !line.contains("{repo}");
+    }
+    !REPO_SCOPED.contains(&subcommand)
+}
+
+/// Whether `GH_REPO` is set anywhere in scope for a step, to a value that could
+/// actually resolve a repository.
+///
+/// Presence alone is not enough: `GH_REPO: ""` sets the key and leaves `gh` with
+/// nothing to resolve, so a guard keyed on `contains_key` would call the very
+/// state it exists to catch a pass. An unexpanded expression (`${{ … }}`) is
+/// accepted — its value is not knowable from the YAML, and refusing it would
+/// reject the fix this file was written to pin.
+fn env_sets_gh_repo(scopes: &[Option<&Value>]) -> bool {
+    scopes.iter().flatten().any(|env| {
+        env.as_mapping()
+            .and_then(|m| m.get(Value::String("GH_REPO".into())))
+            .is_some_and(|value| match value {
+                Value::String(s) => !s.trim().is_empty(),
+                // A non-string scalar is odd here but is not empty.
+                other => !other.is_null(),
+            })
+    })
+}
+
+#[test]
+fn repo_scoped_gh_calls_can_resolve_their_repository() {
+    let mut checked = 0usize;
+    let mut offences: Vec<String> = Vec::new();
+
+    for path in workflow_files() {
+        let text = std::fs::read_to_string(&path).expect("workflow is readable");
+        let doc: Value =
+            serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+        let workflow_env = doc.get("env");
+
+        let Some(jobs) = doc.get("jobs").and_then(Value::as_mapping) else {
+            continue;
+        };
+        for (job_id, job) in jobs {
+            let job_id = job_id.as_str().unwrap_or("?");
+            let job_env = job.get("env");
+            // A job that delegates to a reusable workflow has no steps of its
+            // own; the callee is scanned as its own file.
+            let Some(steps) = job.get("steps").and_then(Value::as_sequence) else {
+                continue;
+            };
+            // Tracked in step ORDER, not as `steps.iter().any(...)`. A checkout
+            // later in the job has not run yet when an earlier step shells out to
+            // `gh`, so an aggregate would clear exactly the arrangement that
+            // fails: `gh` first, checkout after. Measured: no job is in that
+            // state today, so this closes it before it happens rather than after.
+            let mut checked_out = false;
+
+            for step in steps {
+                if step
+                    .get("uses")
+                    .and_then(Value::as_str)
+                    .is_some_and(|u| u.starts_with("actions/checkout"))
+                {
+                    checked_out = true;
+                    continue;
+                }
+                let Some(run) = step.get("run").and_then(Value::as_str) else {
+                    continue;
+                };
+                let scopes = [workflow_env, job_env, step.get("env")];
+                for line in shell_lines(run) {
+                    // Per INVOCATION, not per line: `gh pr view --repo x/y && gh
+                    // issue create` carries `--repo` on the line but not on the
+                    // second command, and judging the line would clear it.
+                    for segment in shell_segments(&line) {
+                        for subcommand in gh_subcommands(segment) {
+                            if names_its_repo(segment, subcommand) {
+                                continue;
+                            }
+                            checked += 1;
+                            if checked_out || env_sets_gh_repo(&scopes) {
+                                continue;
+                            }
+                            offences.push(format!(
+                                "{name} / job `{job_id}`: `gh {subcommand}` has no `--repo`, \
+                                 no `GH_REPO` in scope, and the repository is not checked out \
+                                 at that point in the job, so `gh` cannot resolve a target \
+                                 and the step exits 1"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // A guard that scanned nothing would pass, and would keep passing after a
+    // refactor moved every `gh` call out of reach of the scan.
+    assert!(
+        checked > 0,
+        "no repo-scoped `gh` invocations were found in any workflow. Either they \
+         are all flagged with `--repo` now — in which case relax this assertion \
+         deliberately — or the scan stopped matching the shape they are written in"
+    );
+    assert!(
+        offences.is_empty(),
+        "workflow `gh` calls cannot resolve their repository:\n  {}",
+        offences.join("\n  ")
+    );
+}
+
+/// The reporter is the case this guard was written for, so it is pinned by name.
+///
+/// The scan above is the general claim and would go green if `report-failure.yml`
+/// were deleted. It is the one workflow whose whole purpose is to be reachable
+/// when something else has already failed, and it is called by six others, so
+/// losing it silently is worth its own assertion.
+#[test]
+fn the_failure_reporter_names_its_repository() {
+    let path = repo_root().join(".github/workflows/report-failure.yml");
+    let text = std::fs::read_to_string(&path).expect("report-failure.yml is readable");
+    let doc: Value = serde_yaml::from_str(&text).expect("report-failure.yml parses");
+
+    let step = doc
+        .get("jobs")
+        .and_then(|j| j.get("report"))
+        .and_then(|j| j.get("steps"))
+        .and_then(Value::as_sequence)
+        .and_then(|steps| steps.iter().find(|s| s.get("run").is_some()))
+        .expect("the `report` job still has a `run` step");
+
+    let env = step.get("env").expect("the `run` step sets env");
+    for key in ["GH_TOKEN", "GH_REPO"] {
+        assert!(
+            env.get(key).is_some(),
+            "`report-failure.yml` must set `{key}`: without a token it cannot \
+             authenticate and without `GH_REPO` it cannot resolve the repository, \
+             and either way it fails exactly when a caller has already failed"
+        );
+    }
+}
+
+/// `GH_REPO` present but empty must not satisfy the scan.
+///
+/// Keyed on `contains_key`, the scan called `GH_REPO: ""` a pass — the exact
+/// state it exists to catch, since `gh` has nothing to resolve from it and the
+/// step dies the same way the unset case did. Pinned on synthetic YAML because
+/// the real workflow cannot hold the broken value and stay green.
+#[test]
+fn an_empty_gh_repo_does_not_satisfy_the_scan() {
+    let cases = [
+        ("GH_REPO: \"\"", false),
+        ("GH_REPO: \"   \"", false),
+        ("GH_REPO: fulcrumgenomics/ferro-hgvs", true),
+        ("GH_REPO: ${{ github.repository }}", true),
+    ];
+    for (yaml, want) in cases {
+        let doc: Value = serde_yaml::from_str(yaml).expect("case parses");
+        assert_eq!(
+            env_sets_gh_repo(&[Some(&doc)]),
+            want,
+            "`{yaml}` should {} a resolvable repository",
+            if want { "supply" } else { "NOT supply" }
+        );
+    }
+
+    // And the absent case, which is what the whole guard was written for.
+    let doc: Value = serde_yaml::from_str("GH_TOKEN: x").expect("case parses");
+    assert!(
+        !env_sets_gh_repo(&[Some(&doc)]),
+        "an env block with no GH_REPO must not satisfy the scan"
+    );
+}
+
+/// A line carrying two commands is judged per command, not per line.
+///
+/// Both of these were latent rather than live — measured, no workflow has a line
+/// with two `gh` calls in a `run:`, and no job runs `gh` before a later checkout
+/// — so they are pinned on synthetic input. A guard whose whole purpose is to
+/// catch the *next* occurrence must not be satisfied by there being none today.
+#[test]
+fn a_repo_flag_on_one_command_does_not_clear_its_neighbour() {
+    let line = "gh pr view 1 --repo owner/name && gh issue create --title x";
+    let segments = shell_segments(line);
+    assert_eq!(segments.len(), 2, "the line must split into two commands");
+
+    // First command: flagged, so it resolves.
+    assert!(
+        names_its_repo(segments[0], "pr"),
+        "`--repo` on the first command must count for the first command"
+    );
+    // Second command: not flagged, and must NOT inherit the first one's flag.
+    assert!(
+        !names_its_repo(segments[1], "issue"),
+        "`gh issue create` supplies no repository and must not be cleared by the \
+         `--repo` on the command before it"
+    );
+    // And the whole-line reading is the bug this replaces: it clears both.
+    assert!(
+        names_its_repo(line, "issue"),
+        "sanity: judged as one line, the unflagged command is wrongly cleared — \
+         which is why the scan works on segments"
+    );
+}


### PR DESCRIPTION
Found while triaging a flaked `Code Coverage` run on #1660: underneath the coverage failure sat a second red X, and it was the job whose whole purpose is to report the first one.

## The reporter has never worked

`report-failure.yml` is the reusable job **six** workflows call — `coverage`, `external-validation`, `fuzz`, `nightly-mutalyzer`, `nightly-perf`, `audit-pr-runs`. It exists because those workflows only run after a merge, so their red X cannot block anything; the tracking issue is the entire alerting path.

`gh issue list|comment|create` are repo-scoped commands. With no `--repo` and no `GH_REPO`, `gh` works out which repository it means by shelling out to `git` in the working directory. The job has no `actions/checkout` — it only touches the API — so the lookup has nothing to resolve against:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

Observed on [run 31517344115](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31517344115), where it fired correctly on a genuine `Coverage` failure and then died instead of filing.

The reason it went unnoticed is structural: **a reporter that fails exactly when it is needed is indistinguishable from one that is never needed.** It is only ever reached on someone else's failure, and its own red X reads as part of that failure.

## The fix

`GH_REPO: ${{ github.repository }}`. It supplies the target directly and skips the git lookup — cheaper than adding a checkout to a job that never reads the tree, and it covers all three `gh` calls at once rather than three `--repo` flags.

## The guard is for the class, not this file

A test asserting `report-failure.yml` sets `GH_REPO` would be worth almost nothing: it goes green the moment the line lands and says nothing about the next workflow that shells out to `gh`. Seven do today.

`tests/it/workflow_gh_repo_context.rs` walks every workflow and fails any job that issues a repo-scoped `gh` command with no `--repo`, no `GH_REPO` in scope (workflow, job or step `env`), and no `actions/checkout`.

Three things it does deliberately:

- **Parses rather than greps.** The question is structural — which steps sit in which job, which `env` blocks are in scope. A substring scan also matches the `gh pr close … --repo <owner>/<repo>` text inside `audit-pr-runs.yml`'s reproduction *hint*, which is documentation, not a command. Same reasoning `generator_completeness.rs` gives for parsing `Cargo.toml`.
- **Handles `gh api` separately.** An absolute path (`/repos/OWNER/REPO/...`) needs no resolution; the `{owner}`/`{repo}` placeholder form needs it exactly as much as `gh issue` does. `audit-pr-runs` and `prune-ci-caches` are correct today only because they interpolate the repo into the path — that is why they are not flagged, and the placeholder form is checked so it stays that way.
- **Joins backslash continuations and drops comment lines.** `--repo` habitually lands on a later line than the subcommand, and `report-failure.yml` explains its own `gh` usage in a comment directly above the call.

It also asserts it scanned something. A guard over zero invocations passes, and would keep passing after a refactor moved every call out of the shape it matches.

`the_failure_reporter_names_its_repository` pins the reporter by name on top of that, since it is the one workflow whose value is being reachable when something else has already broken.

## Verified in both directions

The scan claim is only worth what its negative control is worth:

| state | result |
|---|---|
| with the fix | both tests pass |
| fix reverted | both fail; the scan names all three `gh issue` calls as `report-failure.yml / job \`report\`` |

- `cargo nextest run --features dev -E 'test(report_failure_degrades) or test(workflow_gh_repo_context)'` — 5/5; with the lookup wrapping removed, only `a_failed_lookup_still_files_an_issue` fails, with exit 1 and nothing filed
- `cargo fmt --all --check` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `actionlint .github/workflows/report-failure.yml` — clean

## Second commit: the reporter had no failure mode of its own

Found while retro-ing the first commit, and the same shape as the bug it fixes. The step's *first* act is the rolling-issue search, under `set -e`, so any transient failure of it — rate limit, API blip — aborted before the `gh issue create` fallback. The alerting path would die underneath the failure it exists to announce.

Only the **lookup** is made forgiving: a failed search warns and degrades to "no rolling issue found", because a duplicate issue beats silence. `gh issue comment` / `gh issue create` failing still reddens the step — at that point nothing was recorded anywhere and the red X is the last signal.

**Guarded by running the script, not by reading it.** Asserting the shape of the file cannot answer what the script does. `tests/it/report_failure_degrades.rs` extracts the `run:` block from the workflow and executes it under bash with a stub `gh` on `PATH`:

| lookup | required behaviour |
|---|---|
| fails outright | warn, then **create** |
| succeeds, no match | **create** |
| succeeds, match `4242` | **comment** on 4242, and not also create |

Extracted rather than copied — a copied script keeps passing after the real one changes.

## Evidence the reporter has never once filed

Independent of the code: the footer every filed issue would carry — *"One rolling issue is used per failure mode; repeat occurrences are added as comments."* — appears in **zero** issues in this repo, open or closed. The `gh` mechanism itself was also checked directly from a non-git directory:

```
control   (no GH_REPO): exit=1, "failed to run git: fatal: not a git repository"   ← the shipped bug, verbatim
treatment (GH_REPO set): exit=0
```

## What this does not fix

Whether the six callers pass the right `title`/`summary`, and whether one rolling issue per failure mode is the right granularity. Untouched. Worth noting that because the job has never completed, **no caller's inputs have ever been exercised** — including the requirement that `title` be stable per failure mode, which is the rolling-issue lookup key.

Representation-Change: none. CI workflow and one integration test; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched.
