### PR TITLE
fix(convert): resolve a c./n. position on the flat transcript, not through exon gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,17 +330,30 @@ had their chance to name the fault more precisely.
 **Where it runs, and the one place it deliberately does not.** `sweeps` sets it
 (gating, measured green over the full corpus) and the nightly sets it
 (non-gating). `test-oracle` does **not**, which makes it the only job where the
-set of four is incomplete. Two rows in that job's selection fire, and both are
-real disagreements inside ferro rather than noise:
+set of four is incomplete. **One** row in that job's selection fires, and it is a
+real disagreement inside ferro rather than noise:
 
 | row | what disagrees |
 |---|---|
 | #1618 — `NC_TEST.1:g.262TG[6]` → `g.259_262GT[6]` | `hgvs_to_spdi` reads the anchored spelling as 6 copies replacing a **1**-copy tract, the normalizer's output as 6 copies replacing a **2**-copy tract — 14 bases against 12 |
-| #1619 — `NM_000492.4:c.1520_1522del` → `c.1521_1523del` | the two forms are equivalent on the flat transcript; `hgvs_to_spdi` resolves the `c.` position by walking `normalization_transcripts.json`'s exon list, whose 1-base synthetic introns land it **10 bases** 3' of where the normalizer reads |
 
-Suppressing either would hollow out the oracle, and turning the flag on before
-they are settled would redden the job for a reason no PR caused. Move it into
-`test-oracle` once both are closed.
+**This was two rows until #1619 landed**, and the second is worth keeping on
+record because it is the only one of the pair that had an answer:
+`NM_000492.4:c.1520_1522del` → `c.1521_1523del` fired because `hgvs_to_spdi`
+resolved the `c.` position by walking `normalization_transcripts.json`'s exon
+list, whose one-base gaps in *transcript* coordinates landed it ten bases 3' of
+where the normalizer reads. Those gaps are malformed fixture data — measured
+over 20 real prepared-reference transcripts, none has one — so the walk was
+removed rather than the fixture patched. Measured with all four flags on: **25
+failing tests before, 22 after, the three fewer being exactly that row and its
+two siblings, and nothing added.**
+
+What is left is #1618, and it is *not* the same kind of thing: it needs a ruling
+on what a single-anchor repeat's copy count is counted against, which is why no
+PR has closed it. Suppressing it would hollow out the oracle, and turning the
+flag on before it is settled would redden the job for a reason no PR caused.
+Move `FERRO_ASSERT_SEQUENCE` into `test-oracle` once #1618 is closed — it is now
+the only thing in the way.
 
 **Measured false-positive classes, and what closed each.** The first run of this
 oracle over the suite raised **344** fires, all but 16 of them false. Each fix

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -64,15 +64,15 @@ impl<'a> CoordinateMapper<'a> {
         let tx_base = if pos.utr3 {
             // 3' UTR: *N = CDS_end + N
             // For UTR, use exon-aware mapping from CDS end
-            self.cds_to_tx_exon_aware(cds_end as i64, pos.base)?
+            self.offset_tx_position(cds_end as i64, pos.base)?
         } else if pos.base < 1 {
             // 5' UTR: -N = CDS_start - N (where N is positive in HGVS but stored as negative)
             // e.g., c.-3 means 3 bases before CDS start, so offset is -3
-            self.cds_to_tx_exon_aware(cds_start as i64, pos.base)?
+            self.offset_tx_position(cds_start as i64, pos.base)?
         } else {
             // Normal CDS position - use exon-aware mapping
             // c.1 = cds_start (offset 0), c.2 = cds_start + 1 (offset 1), etc.
-            self.cds_to_tx_exon_aware(cds_start as i64, pos.base - 1)?
+            self.offset_tx_position(cds_start as i64, pos.base - 1)?
         };
 
         Ok(TxPos {
@@ -82,103 +82,44 @@ impl<'a> CoordinateMapper<'a> {
         })
     }
 
-    /// Convert CDS position to tx position using exon-aware mapping
+    /// Offset a transcript position by a number of transcript bases.
     ///
-    /// This walks through exons, counting bases in the CDS to properly
-    /// handle gaps in cdot's coordinate system.
+    /// **There is nothing exon-aware to do on this axis, and doing it was
+    /// #1619.** `Exon::start`/`end` are documented as *transcript* coordinates,
+    /// and a transcript sequence is the concatenation of its exons: it has no
+    /// holes, so `c.`/`n.` numbering and the served sequence both count every
+    /// base and the mapping is `start_tx + offset`. That is also true across an
+    /// intra-exon insertion (a CIGAR `I`), which is why no CIGAR adjustment
+    /// belongs here either — adjusting was a genome-centric error that shifted
+    /// every position 3' of such an insertion (#944; `NM_015120.4` `c.87` ->
+    /// `n.198`, not `n.201`).
+    ///
+    /// This used to walk the exon list whenever the exons showed a gap *in
+    /// transcript coordinates*, skipping each gap as though it were an intron.
+    /// A transcript-coordinate gap is not an intron; it is malformed exon data,
+    /// because introns are absent from the transcript by construction. The walk
+    /// therefore made `hgvs_to_spdi` index a base the normalizer never reads:
+    /// on `tests/fixtures/sequences/normalization_transcripts.json`, whose
+    /// `NM_000492.4` record spells 27 exons with a one-base gap between each
+    /// pair, `c.1520` resolved to flat offset **1599** instead of **1589** —
+    /// exactly the ten gaps the walk crossed — so the correct 3'-shift
+    /// `c.1520_1522del` -> `c.1521_1523del` read as a corruption to the
+    /// denoted-sequence oracle. 22 of that fixture's 29 records carry the same
+    /// synthetic gaps; no cdot-derived transcript does, because
+    /// `MultiFastaProvider` builds each exon's tx interval from cdot's own
+    /// tiling.
     ///
     /// # Arguments
     /// * `start_tx` - Starting transcript position (e.g., cds_start)
     /// * `offset` - Number of bases to offset from start (can be negative for 5' UTR)
-    fn cds_to_tx_exon_aware(&self, start_tx: i64, offset: i64) -> Result<i64, FerroError> {
-        // If no exon data or offset is 0, use simple calculation
-        if self.transcript.exons.is_empty() || offset == 0 {
-            return Ok(start_tx + offset);
-        }
-
-        // Sort exons by transcript position
-        let mut sorted_exons: Vec<_> = self.transcript.exons.iter().collect();
-        sorted_exons.sort_by_key(|e| e.start);
-
-        // Check if exons are contiguous (no gaps in tx coordinates)
-        // Most real transcripts from cdot are contiguous
-        let has_gaps = sorted_exons.windows(2).any(|w| w[0].end + 1 != w[1].start);
-        if !has_gaps {
-            // No tx-coordinate gaps: c./n. numbering and the transcript sequence
-            // both count every base — including bases inserted relative to the
-            // genome via a CIGAR `I` — so CDS<->tx on this pure-transcript axis is
-            // naive `start_tx + offset`, with NO CIGAR adjustment. Adjusting here
-            // was a genome-centric error that shifted every position 3' of an
-            // intra-exon insertion (#944; NM_015120.4 c.87 -> n.198, not n.201).
-            return Ok(start_tx + offset);
-        }
-
-        // Exons have gaps - use exon-aware mapping
-        if offset > 0 {
-            // Moving forward through exons
-            let mut remaining = offset;
-            let mut current_tx = start_tx as u64;
-
-            // Find which exon contains start_tx
-            let mut found_start = false;
-            for exon in &sorted_exons {
-                if current_tx >= exon.start && current_tx <= exon.end {
-                    // Start is in this exon
-                    found_start = true;
-                    let bases_in_exon = exon.end - current_tx;
-                    if remaining <= bases_in_exon as i64 {
-                        // Target is in this exon
-                        return Ok((current_tx + remaining as u64) as i64);
-                    }
-                    remaining -= bases_in_exon as i64;
-                    // Move to next exon's start (skip gap)
-                    current_tx = exon.end + 1;
-                } else if found_start && current_tx < exon.start {
-                    // We're in a gap, jump to this exon's start
-                    let bases_in_exon = exon.end - exon.start + 1;
-                    if remaining <= bases_in_exon as i64 {
-                        return Ok((exon.start + remaining as u64 - 1) as i64);
-                    }
-                    remaining -= bases_in_exon as i64;
-                    current_tx = exon.end + 1;
-                }
-            }
-            // If we get here, position is beyond all exons
-            Ok(current_tx as i64 + remaining - 1)
-        } else {
-            // Moving backward through exons (for 5' UTR)
-            let mut remaining = -offset;
-            let mut current_tx = start_tx as u64;
-
-            // Find which exon contains start_tx and go backward
-            let mut found_start = false;
-            for exon in sorted_exons.iter().rev() {
-                if current_tx >= exon.start && current_tx <= exon.end {
-                    found_start = true;
-                    let bases_before = current_tx - exon.start;
-                    if remaining <= bases_before as i64 {
-                        return Ok((current_tx - remaining as u64) as i64);
-                    }
-                    remaining -= bases_before as i64;
-                    current_tx = exon.start - 1;
-                } else if found_start && current_tx > exon.end {
-                    // We're in a gap, jump to this exon's end
-                    let bases_in_exon = exon.end - exon.start + 1;
-                    if remaining <= bases_in_exon as i64 {
-                        return Ok((exon.end - remaining as u64 + 1) as i64);
-                    }
-                    remaining -= bases_in_exon as i64;
-                    current_tx = exon.start - 1;
-                }
-            }
-            Ok(current_tx as i64 - remaining + 1)
-        }
+    fn offset_tx_position(&self, start_tx: i64, offset: i64) -> Result<i64, FerroError> {
+        Ok(start_tx + offset)
     }
 
-    /// Convert transcript position to CDS position
+    /// Convert transcript position to CDS position.
     ///
-    /// This method is exon-aware: it properly maps tx positions to CDS positions
-    /// accounting for gaps in cdot's coordinate system.
+    /// Flat on the transcript axis — see [`Self::tx_offset_in_cds_numbering`]
+    /// for why there is no exon gap here to be aware of.
     pub fn tx_to_cds(&self, pos: &TxPos) -> Result<CdsPos, FerroError> {
         let cds_start = self
             .transcript
@@ -196,8 +137,9 @@ impl<'a> CoordinateMapper<'a> {
         let base = pos.base;
 
         if base < cds_start {
-            // 5' UTR - count bases backward from CDS start through exons
-            let cds_offset = self.tx_to_cds_exon_aware(base, cds_start)?;
+            // 5' UTR: `c.-1` is `cds_start - 1`, so the difference is used
+            // unshifted.
+            let cds_offset = self.tx_offset_in_cds_numbering(base, cds_start)?;
             Ok(CdsPos {
                 base: cds_offset, // Will be negative for 5' UTR
                 offset: pos.offset,
@@ -205,8 +147,8 @@ impl<'a> CoordinateMapper<'a> {
                 special: None,
             })
         } else if base > cds_end {
-            // 3' UTR - count bases forward from CDS end through exons
-            let cds_offset = self.tx_to_cds_exon_aware(base, cds_end)?;
+            // 3' UTR: `*1` is `cds_end + 1`, hence the `- 1` below.
+            let cds_offset = self.tx_offset_in_cds_numbering(base, cds_end)?;
             Ok(CdsPos {
                 base: cds_offset - 1, // Adjust for 3' UTR notation (*1, *2, etc.)
                 offset: pos.offset,
@@ -214,8 +156,8 @@ impl<'a> CoordinateMapper<'a> {
                 special: None,
             })
         } else {
-            // Within CDS - use exon-aware mapping
-            let cds_pos = self.tx_to_cds_exon_aware(base, cds_start)?;
+            // Within the CDS: 1-based, so `c.1` is `cds_start`.
+            let cds_pos = self.tx_offset_in_cds_numbering(base, cds_start)?;
             Ok(CdsPos {
                 base: cds_pos,
                 offset: pos.offset,
@@ -225,109 +167,19 @@ impl<'a> CoordinateMapper<'a> {
         }
     }
 
-    /// Convert tx position to CDS position using exon-aware mapping
+    /// Distance from `start_tx` to `target_tx` in CDS numbering.
     ///
-    /// This counts actual exonic bases between start_tx and target_tx,
-    /// skipping any gaps in cdot's coordinate system.
-    ///
-    /// Returns the number of CDS bases from start to target (can be negative).
-    fn tx_to_cds_exon_aware(&self, target_tx: i64, start_tx: i64) -> Result<i64, FerroError> {
-        // If no exon data, use simple calculation
-        if self.transcript.exons.is_empty() {
-            // For 5' UTR (target < start), formula is target - start
-            // For CDS (target >= start), formula is target - start + 1
-            if target_tx >= start_tx {
-                return Ok(target_tx - start_tx + 1);
-            } else {
-                return Ok(target_tx - start_tx);
-            }
-        }
-
-        // Sort exons by transcript position
-        let mut sorted_exons: Vec<_> = self.transcript.exons.iter().collect();
-        sorted_exons.sort_by_key(|e| e.start);
-
-        // Check if exons are contiguous (no gaps in tx coordinates)
-        // Most real transcripts from cdot are contiguous
-        let has_gaps = sorted_exons.windows(2).any(|w| w[0].end + 1 != w[1].start);
-        if !has_gaps {
-            // Inverse of cds_to_tx_exon_aware on the pure-transcript axis: no CIGAR
-            // adjustment (#944 — CDS positions do NOT "follow genome alignment").
-            // target >= start => CDS; target < start => 5' UTR.
-            if target_tx >= start_tx {
-                return Ok(target_tx - start_tx + 1);
-            } else {
-                return Ok(target_tx - start_tx);
-            }
-        }
-
-        // Exons have gaps - use exon-aware counting
+    /// The exact inverse of [`Self::offset_tx_position`], and flat for the same
+    /// reason: `Exon::start`/`end` are transcript coordinates, so there is no
+    /// gap on this axis to skip (#1619), and there is no CIGAR adjustment
+    /// either (#944). `target >= start` is the CDS (1-based, so `+ 1`);
+    /// `target < start` is the 5'UTR, where `c.-1` is `cds_start - 1` and the
+    /// difference is used unshifted.
+    fn tx_offset_in_cds_numbering(&self, target_tx: i64, start_tx: i64) -> Result<i64, FerroError> {
         if target_tx >= start_tx {
-            // Counting forward
-            let mut cds_count: i64 = 0;
-            let mut counting = false;
-
-            for exon in &sorted_exons {
-                let exon_start = exon.start as i64;
-                let exon_end = exon.end as i64;
-
-                if !counting && exon_end >= start_tx && exon_start <= start_tx {
-                    // Start counting from here
-                    counting = true;
-                    let count_start = start_tx.max(exon_start);
-                    let count_end = target_tx.min(exon_end);
-                    if count_end >= count_start {
-                        cds_count += count_end - count_start + 1;
-                    }
-                    if target_tx <= exon_end {
-                        return Ok(cds_count);
-                    }
-                } else if counting {
-                    // Continue counting in subsequent exons
-                    if target_tx < exon_start {
-                        // Target is in a gap before this exon
-                        return Ok(cds_count);
-                    }
-                    let count_end = target_tx.min(exon_end);
-                    cds_count += count_end - exon_start + 1;
-                    if target_tx <= exon_end {
-                        return Ok(cds_count);
-                    }
-                }
-            }
-            Ok(cds_count)
+            Ok(target_tx - start_tx + 1)
         } else {
-            // Counting backward (for 5' UTR)
-            let mut cds_count: i64 = 0;
-            let mut counting = false;
-
-            for exon in sorted_exons.iter().rev() {
-                let exon_start = exon.start as i64;
-                let exon_end = exon.end as i64;
-
-                if !counting && exon_start <= start_tx && exon_end >= start_tx {
-                    // Start counting backward from here
-                    counting = true;
-                    let count_end = start_tx.min(exon_end);
-                    let count_start = target_tx.max(exon_start);
-                    if count_end >= count_start {
-                        cds_count -= count_end - count_start + 1;
-                    }
-                    if target_tx >= exon_start {
-                        return Ok(cds_count + 1); // Adjust for 1-based
-                    }
-                } else if counting {
-                    if target_tx > exon_end {
-                        return Ok(cds_count);
-                    }
-                    let count_start = target_tx.max(exon_start);
-                    cds_count -= exon_end - count_start + 1;
-                    if target_tx >= exon_start {
-                        return Ok(cds_count + 1);
-                    }
-                }
-            }
-            Ok(cds_count)
+            Ok(target_tx - start_tx)
         }
     }
 
@@ -1129,8 +981,21 @@ mod tests {
         assert!(mapper.tx_to_genomic(&TxPos::new(1)).is_err());
     }
 
-    /// Create a transcript with gaps between exons (like cdot format)
-    /// This simulates how cdot encodes transcripts with virtual intron positions
+    /// A transcript whose exon list claims gaps **in transcript coordinates**.
+    ///
+    /// The comment this replaces said the shape simulated "how cdot encodes
+    /// transcripts with virtual intron positions", and that premise is false
+    /// (#1619). `Exon::start`/`end` are transcript coordinates, and cdot's tx
+    /// intervals tile the transcript: measured over 20 transcripts served from
+    /// a real prepared reference — `NM_000492.4`, `NM_000088.3`, `NM_004006.2`,
+    /// `NM_000051.3` among them — **all 20 have zero transcript-coordinate
+    /// gaps**, every one starting at tx 1 and tiling contiguously, because
+    /// `MultiFastaProvider` builds each exon's tx interval straight from cdot's
+    /// own tiling.
+    ///
+    /// So the fixture is kept, with its purpose inverted: it now pins that a
+    /// claimed gap **changes nothing**. That is the invariant #1619 needs, and
+    /// the one the tests below assert.
     fn make_transcript_with_gaps() -> Transcript {
         // Transcript with 3 exons and gaps between them
         // Exon 1: tx 2-94 (93 bases)
@@ -1178,35 +1043,41 @@ mod tests {
         assert_eq!(result.base, 123);
     }
 
+    /// A claimed transcript-coordinate gap does not move a `c.`->tx mapping
+    /// (#1619).
+    ///
+    /// These three used to pin the opposite — `c.81` -> tx 195, skipping the
+    /// gap at tx 194 — which is what put `hgvs_to_spdi` on a different base
+    /// from the one the normalizer reads. `region_sequence_delta` maps `c.N`
+    /// to `cds_start + N - 1` flat, and the served sequence has a base at every
+    /// one of those offsets, so there is nothing to skip.
     #[test]
     fn test_cds_to_tx_with_gaps_at_exon_boundary() {
         let tx = make_transcript_with_gaps();
         let mapper = CoordinateMapper::new(&tx);
 
-        // CDS 80 = tx 193 (last base of exon 2)
-        // 114 + 79 = 193
-        let result = mapper.cds_to_tx(&CdsPos::new(80)).unwrap();
-        assert_eq!(result.base, 193);
-
-        // CDS 81 = tx 195 (first base of exon 3, skipping gap at tx 194)
-        let result = mapper.cds_to_tx(&CdsPos::new(81)).unwrap();
-        assert_eq!(result.base, 195);
-
-        // CDS 82 = tx 196 (second base of exon 3)
-        let result = mapper.cds_to_tx(&CdsPos::new(82)).unwrap();
-        assert_eq!(result.base, 196);
+        // cds_start = 114, so c.N is tx 113 + N throughout — the claimed gap at
+        // tx 194 sits between c.80 and c.82 and is simply another base.
+        for (cds, expected_tx) in [(80, 193), (81, 194), (82, 195)] {
+            let result = mapper.cds_to_tx(&CdsPos::new(cds)).unwrap();
+            assert_eq!(
+                result.base, expected_tx,
+                "c.{cds} must map flat; the exon list's claimed gap is not an intron"
+            );
+        }
     }
 
+    /// The same across several claimed gaps, where the old walk's error grew by
+    /// one per gap crossed — the mechanism behind #1619's ten-base displacement.
     #[test]
     fn test_cds_to_tx_with_gaps_crossing_multiple_exons() {
         let tx = make_transcript_with_gaps();
         let mapper = CoordinateMapper::new(&tx);
 
-        // CDS 133 = tx 247 (last base of exon 3)
-        // CDS 81-133 is in exon 3 (53 bases)
-        // tx 195 + 52 = tx 247
+        // 113 + 133 = 246. The walk answered 247, one base further for the one
+        // gap it crossed.
         let result = mapper.cds_to_tx(&CdsPos::new(133)).unwrap();
-        assert_eq!(result.base, 247);
+        assert_eq!(result.base, 246);
     }
 
     #[test]
@@ -1223,22 +1094,20 @@ mod tests {
         assert_eq!(result.base, 10);
     }
 
+    /// The inverse direction, pinned the same way (#1619): tx -> `c.` is flat
+    /// across a claimed gap.
     #[test]
     fn test_tx_to_cds_with_gaps_at_exon_boundary() {
         let tx = make_transcript_with_gaps();
         let mapper = CoordinateMapper::new(&tx);
 
-        // tx 193 = CDS 80 (last base of exon 2)
-        let result = mapper.tx_to_cds(&TxPos::new(193)).unwrap();
-        assert_eq!(result.base, 80);
-
-        // tx 195 = CDS 81 (first base of exon 3)
-        let result = mapper.tx_to_cds(&TxPos::new(195)).unwrap();
-        assert_eq!(result.base, 81);
-
-        // tx 196 = CDS 82
-        let result = mapper.tx_to_cds(&TxPos::new(196)).unwrap();
-        assert_eq!(result.base, 82);
+        for (tx_pos, expected_cds) in [(193, 80), (194, 81), (195, 82)] {
+            let result = mapper.tx_to_cds(&TxPos::new(tx_pos)).unwrap();
+            assert_eq!(
+                result.base, expected_cds,
+                "tx {tx_pos} must map flat back to c.{expected_cds}"
+            );
+        }
     }
 
     #[test]
@@ -1246,9 +1115,10 @@ mod tests {
         let tx = make_transcript_with_gaps();
         let mapper = CoordinateMapper::new(&tx);
 
-        // tx 247 = CDS 133 (last base of exon 3)
+        // tx 247 - 113 = c.134. The walk answered c.133, having skipped a base
+        // that the transcript sequence in fact contains.
         let result = mapper.tx_to_cds(&TxPos::new(247)).unwrap();
-        assert_eq!(result.base, 133);
+        assert_eq!(result.base, 134);
     }
 
     #[test]

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -3863,22 +3863,22 @@ mod tests {
         assert_eq!(c_spdi.position, 35);
     }
 
-    /// Build a transcript whose 3'UTR lives in a *separate exon across a
-    /// tx-coordinate gap*, so the exon-aware mapper and the old
-    /// `cds_end + base` short-circuit DISAGREE:
+    /// Build a transcript whose 3'UTR sits in a second exon behind a *claimed*
+    /// tx-coordinate gap:
     ///
     /// - Exon 1: tx 1..35 (5'UTR tx 1-5, CDS tx 6-35; `cds_end` = 35 is the
     ///   last base of exon 1).
-    /// - Gap in tx coordinates: tx 36..39 do not exist (cdot-style alignment
-    ///   gap — `exon1.end + 1 (36) != exon2.start (40)`).
-    /// - Exon 2: tx 40..44 — the entire 3'UTR.
+    /// - A gap the exon list claims at tx 36..39 (`exon1.end + 1 (36) !=
+    ///   exon2.start (40)`).
+    /// - Exon 2: tx 40..44 — the 3'UTR.
     ///
-    /// For `*1`, `CoordinateMapper::cds_to_tx` walks forward from `cds_end`
-    /// (35), finds it is the last base of exon 1, skips the tx 36-39 gap, and
-    /// lands on `exon2.start` = tx 40. The reverted `cds_end + base` path would
-    /// instead land on tx 36 (a nonexistent coordinate inside the gap). Thus
-    /// r.*1 and c.*1 only agree here if r.*N routes through the exon-aware
-    /// mapper — this is the fixture that makes the #944 test non-vacuous.
+    /// The doc this replaces called that "a cdot-style alignment gap". It is
+    /// not one: `Exon::start`/`end` are transcript coordinates, cdot's tx
+    /// intervals tile the transcript, and measured over 20 real prepared-
+    /// reference transcripts **none** has a transcript-coordinate gap (#1619).
+    /// The sequence here is 44 bases with a base at every one of tx 36..39, so
+    /// the "nonexistent coordinates" the old doc named are the ones
+    /// `get_sequence` actually serves.
     fn make_gapped_utr3_provider() -> MockProvider {
         let tx = Transcript::new(
             "NM_GAP.1".to_string(),
@@ -3901,18 +3901,17 @@ mod tests {
         provider
     }
 
-    /// #944 (non-vacuous): on a transcript whose 3'UTR sits in a separate exon
-    /// across a tx-coordinate gap, r.*1 and c.*1 must STILL resolve to the same
-    /// SPDI position. The only way they agree is if r.*N is mapped through the
-    /// exon-aware `CoordinateMapper::cds_to_tx` (tx 40 → SPDI 39). The reverted
-    /// `cds_end + base` short-circuit would put r.*1 at tx 36 → SPDI 35, so this
-    /// test fails if the fix is reverted (unlike the single-exon sibling test,
-    /// where old and new code coincide).
+    /// #944: `r.*1` and `c.*1` must resolve to the same SPDI position; #1619:
+    /// that position is the flat one, `cds_end + 1` = tx 36 → SPDI 35.
+    ///
+    /// The pinned value used to be 39 — exon 2's first base, reached by
+    /// skipping the claimed gap — and the doc argued the two axes could only
+    /// agree that way. They agree either way, because both route through the
+    /// same helper; #944's point is that `r.*N` must not get its own
+    /// short-circuit, and that still holds.
     #[test]
     fn r_star_c_star_agree_across_exon_gap() {
         let provider = make_gapped_utr3_provider();
-        // cds_end = tx 35 is the last base of exon 1; the 3'UTR resumes at
-        // exon 2 (tx 40) across the tx 36-39 gap. So *1 = tx 40 → SPDI 0-based 39.
         let c = parse_hgvs("NM_GAP.1:c.*1A>G").unwrap();
         let r = parse_hgvs("NM_GAP.1:r.*1a>g").unwrap();
         let c_spdi = hgvs_to_spdi(&c, &provider).unwrap();
@@ -3922,9 +3921,9 @@ mod tests {
             "c.*1 and r.*1 must resolve to the same SPDI position across the exon gap"
         );
         assert_eq!(
-            c_spdi.position, 39,
-            "*1 must map through the tx 36-39 gap to exon 2 (tx 40) → SPDI 39, \
-             not the reverted cds_end+base tx 36 → SPDI 35"
+            c_spdi.position, 35,
+            "*1 must map flat from cds_end (tx 35) to tx 36 → SPDI 35, which is \
+             the base the served sequence holds there"
         );
     }
 
@@ -3976,20 +3975,23 @@ mod tests {
         assert_eq!(c_spdi.position, 2);
     }
 
-    /// Build a transcript whose 5'UTR straddles a *tx-coordinate gap*, so the
-    /// exon-aware mapper and a plain `cds_start - base` short-circuit DISAGREE:
+    /// Build a transcript whose 5'UTR spans a *claimed* tx-coordinate gap:
     ///
     /// - Exon 1: tx 1..5 — the upstream part of the 5'UTR.
-    /// - Gap in tx coordinates: tx 6..9 do not exist (`exon1.end + 1 (6) !=
+    /// - A gap the exon list claims at tx 6..9 (`exon1.end + 1 (6) !=
     ///   exon2.start (10)`).
     /// - Exon 2: tx 10..44 — 5'UTR tx 10-11 then CDS from `cds_start` = tx 12.
     ///
-    /// For `c.-3`, `CoordinateMapper::cds_to_tx` walks backward from `cds_start`
-    /// (12): c.-1 = tx 11, c.-2 = tx 10 (start of exon 2), then skips the tx 6-9
-    /// gap and lands on `exon1.end` = tx 5. A plain `cds_start - 3` = tx 9 would
-    /// instead land inside the nonexistent gap. So r.-3 and c.-3 only agree here
-    /// if r.-N routes through the exon-aware mapper — the fixture that makes the
-    /// #960 test non-vacuous against a naive re-implementation.
+    /// **The gap is a claim the sequence contradicts, and #1619 is what that
+    /// cost.** The transcript is 44 bases with a base at every one of tx 6..9,
+    /// which is what `get_sequence` serves and what the normalizer reads. The
+    /// mapper used to walk the exon list and skip those four, so `c.-3` landed
+    /// on tx 5 instead of tx 9 — a base neither the normalizer nor any other
+    /// consumer of the sequence would have picked.
+    ///
+    /// The fixture is kept because the invariant it now pins is the one that
+    /// matters: `r.-N` and `c.-N` must agree, and both must agree with the flat
+    /// transcript, whatever the exon list claims.
     fn make_gapped_utr5_provider() -> MockProvider {
         let tx = Transcript::new(
             "NM_GAP5.1".to_string(),
@@ -4012,18 +4014,17 @@ mod tests {
         provider
     }
 
-    /// #960 (non-vacuous): on a transcript whose 5'UTR straddles a tx-coordinate
-    /// gap, r.-3 and c.-3 must STILL resolve to the same SPDI position. The only
-    /// way they agree is if r.-N is mapped through the exon-aware
-    /// `CoordinateMapper::cds_to_tx` (tx 5 → SPDI 4). A naive `cds_start - base`
-    /// would put r.-3 at tx 9 → SPDI 8, so this test fails against such a
-    /// re-implementation (unlike the single-exon sibling test, where the two
-    /// coincide).
+    /// #960: `r.-3` and `c.-3` must resolve to the same SPDI position; #1619:
+    /// that position is the flat one, `cds_start - 3` = tx 9 → SPDI 8.
+    ///
+    /// The pinned value used to be 4 — the base the exon walk reached after
+    /// skipping tx 6..9 — on the reasoning that only walking made the two axes
+    /// agree. They agree either way, because both route through the same
+    /// helper; what the walk did was make them agree on a base the rest of ferro
+    /// does not read.
     #[test]
     fn r_minus_c_minus_agree_across_exon_gap() {
         let provider = make_gapped_utr5_provider();
-        // cds_start = tx 12 (exon 2); counting 3 bases upstream skips the tx 6-9
-        // gap to exon 1's last base (tx 5). So c.-3 / r.-3 = tx 5 → SPDI 4.
         let c = parse_hgvs("NM_GAP5.1:c.-3A>G").unwrap();
         let r = parse_hgvs("NM_GAP5.1:r.-3a>g").unwrap();
         let c_spdi = hgvs_to_spdi(&c, &provider).unwrap();
@@ -4033,9 +4034,9 @@ mod tests {
             "c.-3 and r.-3 must resolve to the same SPDI position across the exon gap"
         );
         assert_eq!(
-            c_spdi.position, 4,
-            "-3 must map through the tx 6-9 gap to exon 1 (tx 5) → SPDI 4, \
-             not the naive cds_start-base tx 9 → SPDI 8"
+            c_spdi.position, 8,
+            "-3 must map flat from cds_start (tx 12) to tx 9 → SPDI 8, which is \
+             the base the served sequence holds there"
         );
     }
 

--- a/tests/it/issue_1619_spdi_exon_gap_frame.rs
+++ b/tests/it/issue_1619_spdi_exon_gap_frame.rs
@@ -1,0 +1,174 @@
+//! #1619 — `hgvs_to_spdi` must index the same base the normalizer reads.
+//!
+//! `Exon::start`/`end` are documented as **transcript** coordinates, and a
+//! transcript sequence is the concatenation of its exons, so it has no holes.
+//! `CoordinateMapper` nonetheless walked the exon list whenever those
+//! coordinates showed a gap, skipping each gap as though it were an intron —
+//! and the normalizer does no such thing: `region_sequence_delta` maps `c.N` to
+//! the flat offset `cds_start + N - 1`. So the two halves of ferro named
+//! different bases of one accession, and the gap grew by one per "intron"
+//! crossed.
+//!
+//! Measured on `main`, on the committed
+//! `tests/fixtures/sequences/normalization_transcripts.json`, whose
+//! `NM_000492.4` record carries the real 6,070-base CFTR transcript,
+//! `cds_start: 71`, and 27 exons spelled with a one-base gap between each pair:
+//! `c.1520` is flat offset 1589 and `hgvs_to_spdi` placed it at **1599**, the
+//! ten gaps its walk crossed.
+//!
+//! The visible symptom was a correct normalization reading as a corruption.
+//! `NM_000492.4:c.1520_1522del` -> `c.1521_1523del` is the documented CFTR
+//! 3'-shift — `c.1515..1530` reads `TATCATCTTTGGTGTT`, so deleting either `TCT`
+//! or `CTT` leaves `TATCATTGGTGTT` over that window — but read through the walk the pair landed on
+//! `[1599, 1603) = TTCC`, where the two deletions leave `C` and `T`. That is
+//! the row the denoted-sequence oracle (#1615) fires on, and one of the two
+//! keeping `FERRO_ASSERT_SEQUENCE` out of CI's `test-oracle` job.
+//!
+//! The gaps are a property of that hand-written fixture, not of real data: no
+//! cdot-derived transcript has them, because `MultiFastaProvider` builds each
+//! exon's transcript interval from cdot's own tiling. 22 of the fixture's 29
+//! records carry them.
+
+use std::path::Path;
+
+use ferro_hgvs::reference::mock::JsonProvider;
+use ferro_hgvs::reference::provider::ReferenceProvider;
+use ferro_hgvs::spdi::convert::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+const FIXTURE: &str = "tests/fixtures/sequences/normalization_transcripts.json";
+
+/// The fixture's records all carry their sequence; a missing one is a fixture
+/// problem, not a case to skip.
+fn sequence_of(transcript: &ferro_hgvs::reference::transcript::Transcript) -> &str {
+    transcript
+        .sequence
+        .as_deref()
+        .expect("the fixture record carries its sequence")
+}
+
+fn provider() -> JsonProvider {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE);
+    JsonProvider::from_json(&path).expect("load normalization_transcripts.json")
+}
+
+/// The fixture really does carry transcript-coordinate gaps, so the test below
+/// is exercising the shape it claims to. Asserted rather than assumed: if the
+/// fixture is ever regenerated contiguously, this test stops proving anything
+/// and should say so loudly rather than pass for the wrong reason.
+#[test]
+fn the_fixture_still_carries_the_gaps_that_made_the_two_halves_disagree() {
+    let transcript = provider()
+        .get_transcript("NM_000492.4")
+        .expect("the fixture serves NM_000492.4");
+    let mut exons: Vec<_> = transcript.exons.iter().collect();
+    exons.sort_by_key(|e| e.start);
+    let gaps = exons
+        .windows(2)
+        .filter(|w| w[0].end + 1 != w[1].start)
+        .count();
+    assert_eq!(
+        gaps, 26,
+        "NM_000492.4's 27 exons no longer show 26 transcript-coordinate gaps; \
+         this test's premise has moved"
+    );
+    let spanned: u64 = exons.iter().map(|e| e.end - e.start + 1).sum();
+    assert_eq!(
+        (spanned, sequence_of(&transcript).len()),
+        (6043, 6070),
+        "the fixture's internal inconsistency — exon spans that do not sum to \
+         the sequence length — has moved"
+    );
+}
+
+/// `c.1520` must resolve to the base the normalizer reads, flat offset 1589.
+///
+/// Asserted through the SPDI position rather than through an internal helper,
+/// because the position `to_spdi` publishes is what every caller downstream of
+/// it — `apply_to_reference`, `canonical_spdi`, `compare_denoted_sequences` —
+/// actually indexes with.
+#[test]
+fn a_cds_position_resolves_onto_the_flat_transcript() {
+    let provider = provider();
+    let variant = parse_hgvs("NM_000492.4:c.1520_1522del").expect("fixture must parse");
+    let spdi = hgvs_to_spdi(&variant, &provider).expect("converts against the fixture");
+
+    // cds_start - 1 + 1520 - 1 = 70 + 1519 = 1589, 0-based.
+    assert_eq!(
+        spdi.position, 1589,
+        "c.1520 must land on the flat transcript offset the normalizer reads; \
+         1599 is the exon walk crossing ten synthetic gaps"
+    );
+
+    let transcript = provider
+        .get_transcript("NM_000492.4")
+        .expect("the fixture serves NM_000492.4");
+    assert_eq!(
+        &sequence_of(&transcript)[1589..1592],
+        "TCT",
+        "the deleted bases the description names"
+    );
+    assert_eq!(spdi.deletion, "TCT");
+}
+
+/// The invariant behind the row, and the reason this is filed as a defect in
+/// the applier rather than in the normalizer: the two halves of ferro must
+/// agree on which bases a description denotes.
+///
+/// `c.1520_1522del` 3'-shifts to `c.1521_1523del`, and both spellings delete
+/// one base from the same `TCTTT` run. Applied over a window containing both,
+/// they must leave the same sequence — which is exactly what the walk broke,
+/// and it broke it while the normalization itself was right.
+#[test]
+fn the_shifted_pair_denotes_one_sequence_to_the_applier() {
+    let provider = provider();
+    let input = parse_hgvs("NM_000492.4:c.1520_1522del").expect("fixture must parse");
+    let normalized = Normalizer::new(provider.clone())
+        .normalize(&input)
+        .expect("normalizes against the fixture");
+    assert_eq!(
+        normalized.to_string(),
+        "NM_000492.4:c.1521_1523del",
+        "the documented CFTR 3'-shift"
+    );
+
+    let before = hgvs_to_spdi(&input, &provider).expect("input converts");
+    let after = hgvs_to_spdi(&normalized, &provider).expect("output converts");
+
+    let transcript = provider
+        .get_transcript("NM_000492.4")
+        .expect("the fixture serves NM_000492.4");
+    let sequence = sequence_of(&transcript);
+    // The window is `c.1515`..`c.1530` on the flat transcript
+    // (`cds_start - 1 + N - 1`), wide enough to contain both spellings — a
+    // per-description window would give each its own frame and report every
+    // 3'-shift as a difference.
+    const WINDOW_START: usize = 1584;
+    const WINDOW_END: usize = 1600;
+    assert_eq!(
+        &sequence[WINDOW_START..WINDOW_END],
+        "TATCATCTTTGGTGTT",
+        "the CFTR homopolymer the 3'-shift runs in"
+    );
+    let applied = |spdi: &ferro_hgvs::spdi::SpdiVariant| {
+        let start = spdi.position as usize;
+        let end = start + spdi.deletion.len();
+        format!(
+            "{}{}{}",
+            &sequence[WINDOW_START..start],
+            spdi.insertion,
+            &sequence[end..WINDOW_END]
+        )
+    };
+    assert_eq!(
+        applied(&before),
+        applied(&after),
+        "the input and its 3'-shifted normalization denote different bases to \
+         the applier; the normalization is correct, so the applier is wrong"
+    );
+    assert_eq!(
+        applied(&before),
+        "TATCATTGGTGTT",
+        "and both leave one base short of the `TTT` run, over the window above"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -253,6 +253,7 @@ mod issue_1578_followup_ring_declines;
 mod issue_1578_followup_self_cancelling_rings;
 mod issue_1578_ring_validator_escapes;
 mod issue_1615_denoted_sequence_oracle;
+mod issue_1619_spdi_exon_gap_frame;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_180_allele_3prime_shift;


### PR DESCRIPTION
Closes #1619

`Exon::start`/`end` are documented as **transcript** coordinates, and a transcript sequence is the concatenation of its exons — it has no holes. `CoordinateMapper` nonetheless walked the exon list whenever those coordinates showed a gap and skipped each gap as though it were an intron. The normalizer does no such thing: `region_sequence_delta` maps `c.N` to the flat offset `cds_start + N - 1`. So the two halves of ferro named different bases of one accession, and the error grew by one per gap crossed.

Reproduced by a test written to fail first, on the committed `tests/fixtures/sequences/normalization_transcripts.json`:

```
a_cds_position_resolves_onto_the_flat_transcript
  left: 1599      (hgvs_to_spdi, walking ten one-base gaps)
 right: 1589      (cds_start - 1 + 1520 - 1, what the normalizer reads)
```

The visible symptom was a correct normalization reading as a corruption. `c.1520_1522del` -> `c.1521_1523del` is the documented CFTR 3'-shift, and `the_shifted_pair_denotes_one_sequence_to_the_applier` pins that both spellings leave `TATCATTGGTGTT` over a window containing both. Read through the walk they landed on `[1599, 1603)` and left different sequences.

## Which side was wrong — settled by measurement, not by argument

The issue offered both readings, and said so: "either the resolution should not consult exons when the target sequence is the transcript itself, or the exon coordinates in that fixture are not the frame the resolver assumes them to be in." Both turn out to be true, and the second decides the first.

**The gaps are malformed fixture data, not a real shape.** Measured over 20 transcripts served from a real prepared reference — `NM_000492.4`, `NM_000088.3`, `NM_004006.2`, `NM_000051.3`, `NM_002111.8` among them — **all 20 have zero transcript-coordinate gaps**, every one starting at tx 1 and tiling contiguously, because `MultiFastaProvider` builds each exon's transcript interval straight from cdot's own tiling (`start: e[2] + 1, end: e[3]`). The fixture is worse than the issue reports: **22 of its 29 records** carry the same one-base-per-junction pattern, and it came in with the initial commit with no generator behind it.

So the walk is removed rather than the fixture patched. Patching the fixture would leave the resolver able to mis-resolve the next malformed record, and there is no faithful exon structure to patch it *to* — the spans sum to `seq_len − (n_exons − 1)` however they are re-tiled.

**The premise the walk was built on is written down and is false.** `make_transcript_with_gaps` says it "simulates how cdot encodes transcripts with virtual intron positions". cdot encodes nothing of the sort on the transcript axis; that comment is now replaced with the measurement.

## The six tests that pinned the walk

Their fixtures are kept and their invariant inverted: **a claimed transcript-coordinate gap must change nothing**, which is exactly what #1619 establishes. The two in `src/spdi/convert.rs` keep their real point — #944 and #960 are about `r.*N` / `r.-N` not getting their own short-circuit, so the two axes agree — and move only the value they agree *on*, onto the base the served sequence actually holds (`SPDI 39 -> 35`, `4 -> 8`). Their doc comments called those bases "nonexistent coordinates inside the gap"; the fixtures are 44-base sequences with a base at every one of them.

## Verification

- `cargo nextest run --features dev` — **`Summary [154.504s] 10139 tests run: 10139 passed (1 slow), 152 skipped`**.
- Reproduction control: with `origin/main`'s `src/convert/mapper.rs` restored and nothing else changed, 2 of the 3 new tests fail, `left: 1599 / right: 1589`.
- **All four seam oracles on, full suite, against `origin/main` at `b9f6cecb`: 25 failing tests before, 22 after.** The three fewer are exactly this row and its two siblings — `normalize_tests::…::test_deletion_shifts_in_real_homopolymer`, `…::test_3prime_shifting::case_1` and `idempotency_tests::test_normalization_idempotency` — and **nothing is added**.
- `cargo fmt --all --check` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean.

## `FERRO_ASSERT_SEQUENCE` in `test-oracle` — not yet, and now for one reason

This closes one of the two rows keeping the flag out of CI's `test-oracle` job. **#1618 still fires**, and it is not the same kind of thing: it needs a ruling on what a single-anchor repeat's copy count is counted against, which is why no PR has closed it. The flag is deliberately not moved here. `CLAUDE.md`'s table is updated to say one row rather than two, to record what closed the other, and to name #1618 as the only remaining blocker.

Representation-Change: none. The normalizer's own `c.`->sequence mapping is `region_sequence_delta` and was already flat — this change makes `hgvs_to_spdi` agree with it, so what moves is the SPDI triple for a `c.`/`n.`/`r.` variant on a transcript whose exon list is malformed, from a triple naming bases the normalizer never reads to the one it does. No normalized HGVS string moves: the full suite passes with nothing re-blessed except the six pins that encoded the walk, and under the denoted-sequence oracle three previously-firing rows go green with none added. `examples/dump_normalized_corpus.rs` was not used as evidence, and the reason is worth stating correctly because an earlier draft of this trailer got it backwards. That generator does **not** build only a single exon: alongside the flat axis (`CDS_START = 1`) it carries a three-exon `cx` axis — `EXON_SPANS = [(0,7),(7,14),(14,20)]`, `CDS_START_MULTI = 4`, `INTRON_LEN = 10`, two junctions, both shuffle directions — which is what #1478 *added* rather than removed. The zero is still structural, for a different reason: those exons tile **contiguously in transcript coordinates** (tx 1-7 / 8-14 / 15-20), so no corpus row can carry a *gapped* exon list, and a gap is the only thing the removed walk keyed on. So a `0 moved` from it remains a fact about the corpus — just not the fact first claimed.

Previously **accepted**, with a wrong answer — the fact this trailer was missing. On the `NM_000492.4` fixture, `c.1520` is flat offset **1589** and `hgvs_to_spdi` published position **1599**, ten bases 3' of the base the normalizer reads (the fixture's exon list carries 1-base synthetic introns). So the conversion succeeded and named the wrong base; it did not error. Pinned in `tests/it/issue_1619_spdi_exon_gap_frame.rs`, which asserts `spdi.position == 1589`.

One surface this understates: the trailer says "what moves is the SPDI triple", but `CoordinateMapper::cds_to_tx`/`tx_to_cds` also back the public Python `CoordinateMapper` (`src/python.rs`), so that API's answers move too on a transcript whose exon list is gapped.

