### PR TITLE
feat(changelog): attach each Representation-Change trailer to its changelog entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,25 @@ jobs:
         with:
           python-version: "3.12"
       - uses: taiki-e/install-action@a8fb21b85430c7a58551cf7ea87b03f355b826d9  # git-cliff
+      - name: Require each Representation changes entry to carry its disclosure
+        # The audit below asks whether the right commits are in the section. This asks
+        # whether each entry in the *committed* changelog says what it moved (#1556): the
+        # bullet is the commit subject and nothing else, so the rejected-vs-accepted fact
+        # the release checklist asks for had to be read out of every linked PR.
+        #
+        # A no-op on an ordinary PR, because `CHANGELOG.md` holds only released sections
+        # and release-plz has not written a pending one. It becomes the gate on the
+        # release PR, where the fix is the one command it names.
+        #
+        # It runs BEFORE the synthesis step on purpose, and moving it after would be a
+        # latent red. `squash_commits()` resolves each linked PR by walking `git log`, and
+        # synthesis ends in `git reset --soft "$PR_BASE_SHA"` — which rewinds HEAD's
+        # ancestry to the base tip as of the last PR event while leaving the worktree on
+        # the merge ref. On a PR whose base has since moved, a changelog entry can then
+        # cite a PR whose commit is no longer reachable, the lookup fails, and the script
+        # exits 2 for a cause no author can fix. Same hazard the synthesis step already
+        # documents for `git describe`.
+        run: python scripts/inject_representation_disclosure.py --check
       - name: Synthesize the squash commit this PR will become
         # Without this the audit cannot see the commit it exists to judge. GitHub builds
         # the squash subject from the PR title and the body from the PR description, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,25 @@ violations.
 [#1537]: https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537
 
 - *(normalize)* never split a delins into members on consecutive nucleotides ([#1537](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1537))
+  > 3 rows of 500,004 move (0.0006%) — 2 respell, 1
+  > merge toward the submitted form. Confluence drops by 6 classes of
+  > 11,272, deliberately and by operator ruling: those classes agreed only
+  > through a spec-illegal intermediate, `sequence_changed` stays 0, and the
+  > surviving form is the better-formed one. 58 separation-0 violations of
+  > `delins.md:16` are fixed.
 - *(normalize)* type the whole-block inversion by what it competes with ([#1535](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1535))
+  > 0 rows move over 5,761,302 real expressions
+  > (ClinVar 500,004 / Paraphase 435,235 / CMRG 4,826,063), diffed row by
+  > row between this branch and its base on both binaries. That zero is
+  > structural for the direction that could move: a cis-allele of >=2
+  > `delins` members forming a whole-block reverse complement has **0**
+  > instances in those corpora, so the corpus cannot build the input this
+  > change converts. It is not vacuous either — 2,639 `inv` rows (897 of
+  > them genomic) and 38,190 multi-base spanning `delins` rows do reach the
+  > typing path and are byte-identical across the change, so the gate
+  > demonstrably does not over-fire. Where the shape does occur, the split
+  > spelling moves onto `inv`; the `inv` and spanning-`delins` spellings do
+  > not move on `c.`, and on a frameless axis all three converge on `inv`.
 
 ### Other
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,11 +561,38 @@ which is filed as a real change. This was the #1555 defect: the value used to be
 declining *with a reason* was read as a disclosure. It is not a corner case — in the v0.13.1
 cycle 8 of the 14 declines gave a reason, and the section listed 10 entries of which 2 were real.
 
-**Two limits of the section itself.** It carries the commit subject only — the trailer's text is
-unreachable from the changelog template (#1556), so the rejected-vs-accepted fact lives in the PR
-description. And a declining commit is filed under **Other** whatever its type, so a declining
-`fix:` is missing from **Fixed** (#1557); git-cliff evaluates a parser's fields as OR, not AND, so
-this cannot be repaired by adding `message` to the exclusion rule.
+**One limit of the section itself, and one that is now closed.** A declining commit is filed
+under **Other** whatever its type, so a declining `fix:` is missing from **Fixed** (#1557);
+git-cliff evaluates a parser's fields as OR, not AND, so this cannot be repaired by adding
+`message` to the exclusion rule.
+
+The other — the bullet carrying the commit subject and nothing else, so the
+rejected-vs-accepted fact had to be read out of every linked PR — is #1556, and it is closed by
+`scripts/inject_representation_disclosure.py`, which attaches each trailer's own text under its
+bullet. **It is deliberately not a git-cliff template**, and the three template routes measured
+dead in #1556 should not be re-walked: `commit.footers` is mis-parsed by git_conventional (any
+`word:` line is a footer token, so a prose body shreds it), `commit.body` has the trailer split
+out of it entirely (0 occurrences for both real v0.13.1 disclosures), and splitting on the
+unanchored literal finds only the prose *mentions* — which is worse than nothing, because it
+produces plausible output for some commits and quoted prose for others.
+
+The route that works is not through the template: read the trailer from the raw commit message
+with `git log`, and attach it to the rendered bullet afterwards — which is what
+`check_changelog_grouping.py` already does to attribute trailers, so the script imports its
+`trailer_value` rather than keeping a fourth copy of the column-0 rule.
+
+Two things it measured that contradict what `CONTRIBUTING.md` asks for, and that any future work
+here will hit again. **The trailer is not the last thing in the squash body**: GitHub appends
+CodeRabbit's auto-generated summary after it, so reading to end-of-message quotes three
+paragraphs of "Summary by CodeRabbit" as the author's disclosure. And **the trailers are not
+well-formed**, their continuation lines being unindented, so indentation cannot delimit the
+value — which is also why `git interpret-trailers --parse` reports *no* trailers at all for
+#1537, #1535 or #1547. The script stops at the next column-0 trailer token, Markdown heading or
+HTML comment instead.
+
+CI runs it as `--check` in the `Changelog grouping audit` job: a no-op on an ordinary PR, and the
+gate on the release PR, where the fix is the one command it names. It is idempotent, so re-run it
+after any push that makes release-plz regenerate the pending section.
 
 **It must be in the PR description, not only in a commit message.** GitHub builds the squash
 commit body from the description, and `release-plz.toml`'s parsers match the commit *footer*; a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,17 @@ whatever its type, so a `fix:` that correctly declined is not listed under
 
 That it is generated is also why a `Representation-Change:` trailer is the way to get such a note into the changelog *at release time*: release-plz regenerates the pending section of an open release PR on every run, so an entry hand-written there is lost the next time the PR updates. `release-plz.toml`'s `commit_parsers` route trailered commits into a **Representation changes** group ahead of the usual ones, and its `pr_body` template surfaces that group on the release PR itself. The parsers match the commit **footer**, so the trailer must survive squashing — put it in the PR description as well, since that is what GitHub uses for the squash commit body.
 
+**The bullet release-plz writes is the commit subject and nothing else, so the trailer's own text is attached afterwards** (#1556). `scripts/inject_representation_disclosure.py` reads each trailer out of the raw commit message with `git log` and quotes it under its bullet, which is what makes the release checklist's "previously rejected or previously accepted?" question answerable from the changelog rather than from every linked PR. Run it on the release PR:
+
+```bash
+python scripts/inject_representation_disclosure.py          # attach; idempotent
+python scripts/inject_representation_disclosure.py --check   # what CI asks
+```
+
+CI runs the `--check` form in the `Changelog grouping audit` job, so a release PR stays red until it has been run. Re-run it after any push that makes release-plz regenerate the pending section — a second run over an already-attached section changes nothing.
+
+Two consequences for how you write the trailer. Keep it **at column 0** — an indented `Representation-Change:` is a continuation of the line above it to git, to release-plz and to both checkers. And know that "put it last" is advice the tooling cannot rely on: GitHub appends CodeRabbit's summary after your description, so the script stops the value at the next column-0 trailer token, Markdown heading or HTML comment rather than at the end of the message. Do not put a heading inside the disclosure.
+
 A section that has already been released is a different matter: a release only prepends to `CHANGELOG.md`, leaving earlier sections untouched, and the GitHub release body is never revisited once its tag exists. So a retrospective note — a consolidated representation summary for a release whose commits predate this convention, say — can be added afterwards, by editing the released section and `gh release edit <tag>`. That is the escape hatch for a cycle that shipped without trailers; it is not a substitute for declaring changes as you make them, because nobody can reconstruct the rejected-vs-accepted distinction after the fact.
 
 ### Submitting a Pull Request

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,7 +34,8 @@ pr_body = """
 
 Any PR that moves a normalized output should carry a `Representation-Change:`
 trailer (see CONTRIBUTING.md). Those are collected into the **Representation
-changes** section of the changelog below.
+changes** section of the changelog below, and each entry's trailer text is
+attached under its bullet by `scripts/inject_representation_disclosure.py`.
 
 Reviewer checklist:
 
@@ -43,11 +44,13 @@ Reviewer checklist:
 - [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
       none`, optionally followed by a reason, and belongs under its own type —
       not here. Spot-check two entries against their PR descriptions.
-- [ ] For each entry, that PR's description says whether the affected inputs
-      were previously **rejected** (no stored string, so free) or previously
-      **accepted** (a real migration for the consumer). The bullet below carries
-      only the commit subject: the trailer's own text cannot reach the changelog
-      (fulcrumgenomics/ferro-hgvs#1556), so this one has to be read from the PRs.
+- [ ] Every entry carries its trailer's own text, quoted under the bullet, and
+      that text says whether the affected inputs were previously **rejected**
+      (no stored string, so free) or previously **accepted** (a real migration
+      for the consumer). release-plz writes the bullet from the commit subject
+      alone; `python scripts/inject_representation_disclosure.py` attaches the
+      rest, and CI's `Changelog grouping audit` fails until it has been run.
+      Re-run it after any push that regenerates this section — it is idempotent.
 
 A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` that
 moved output without declaring it means the trailer is missing. Fix that before

--- a/scripts/inject_representation_disclosure.py
+++ b/scripts/inject_representation_disclosure.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Attach each `Representation-Change:` trailer's own text to its changelog bullet.
+
+## The problem this closes
+
+`release-plz.toml` routes trailered commits into a **Representation changes** section, but
+a changelog bullet is the commit **subject** and nothing else:
+
+    - *(normalize)* never split a delins into members on consecutive nucleotides ([#1537](...))
+
+The trailer behind it -- `3 rows of 500,004 move (0.0006%) -- 2 respell, 1 merge toward the
+submitted form. Previously accepted, so a real migration.` -- reaches no reader. The release
+checklist asks whether each entry's inputs were previously **rejected** (free) or previously
+**accepted** (a migration), and no entry carries the answer, so a reviewer either ticks the
+box without checking or opens every linked PR (#1556).
+
+## Why this is not a git-cliff template
+
+Three routes through the template are measured dead in #1556, and none of them is what this
+script uses:
+
+1. **`commit.footers` is mis-parsed.** git_conventional treats any `word:` line as a footer
+   token, so a prose body shreds it -- for #1523 it produced seven "footers", the first with
+   a value containing the entire rest of the body.
+2. **`commit.body` does not contain the trailer.** git_conventional splits body from footers,
+   so splitting `commit.body` on `\\nRepresentation-Change:` finds **0** occurrences for both
+   real v0.13.1 disclosures.
+3. **Splitting on the unanchored literal finds only prose mentions**, which is worse than
+   nothing: it produces plausible-looking output for some commits and quoted prose for
+   others.
+
+The fourth route is not through the template at all. **Read the trailer from the raw commit
+message with git, and attach it to the rendered bullet afterwards.** That is exactly what
+`scripts/check_changelog_grouping.py` already does in CI to attribute trailers to commits,
+using the same column-anchored `trailer_value` this script imports rather than re-implements
+-- three copies of one rule drift silently, which is the lesson `CONTRIBUTING.md` records
+about the decline vocabulary.
+
+The bullet is matched to its commit by the **PR number** GitHub puts in the squash subject,
+which is the one token both sides are guaranteed to share.
+
+## Usage
+
+    python scripts/inject_representation_disclosure.py --check      # CI: is CHANGELOG.md current?
+    python scripts/inject_representation_disclosure.py              # rewrite CHANGELOG.md in place
+    python scripts/inject_representation_disclosure.py --stdout     # print, change nothing
+
+Idempotent: a bullet that already carries its disclosure is left alone, so re-running after
+release-plz regenerates the pending section is safe and is the intended workflow.
+
+Exits 0 when nothing needed changing, 1 under `--check` when something did, and 2 on a
+bullet whose commit or trailer cannot be found -- a silently-skipped bullet would reintroduce
+the exact failure this script exists to remove.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_changelog_grouping import (  # noqa: E402
+    REPRESENTATION_GROUP,
+    strip_ordering_prefix,
+    trailer_value,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The marker opening an injected disclosure. Both the idempotence check and `--check` key
+#: on it, so it must be something no hand-written section would begin a line with.
+DISCLOSURE_PREFIX = "  > "
+
+#: A changelog bullet: `- ...` at column 0, possibly wrapped over later lines.
+BULLET_RE = re.compile(r"^- (?P<text>.*\S)\s*$")
+
+#: A section heading. `##` is the version, `###` the group.
+HEADING_RE = re.compile(r"^(?P<hashes>#{2,})\s+(?P<title>.*\S)\s*$")
+
+#: The PR number GitHub writes into a squash subject, in the bullet's link or bare.
+PR_RE = re.compile(r"\(#(?P<number>\d+)\)|\[#(?P<linked>\d+)\]")
+
+
+def squash_commits(repo: Path) -> dict[str, str]:
+    """Return `{PR number: full commit message}` for every commit with a PR number.
+
+    Framed on NUL for the same reason `check_changelog_grouping.commit_bodies` is: a commit
+    message may contain any other byte, and mis-framing here would attribute a trailer to
+    the wrong entry in a script whose whole job is attribution.
+
+    A PR number seen twice keeps the **newest** commit, which is the one a reader following
+    the link lands on.
+    """
+    result = subprocess.run(
+        ["git", "log", "-z", "--format=%H%x00%B"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    fields = result.stdout.split("\x00")
+    if fields and fields[-1] == "":
+        fields.pop()
+    if len(fields) % 2 != 0:
+        raise RuntimeError(
+            f"git log -z returned {len(fields)} NUL-separated fields, which is not an "
+            "id/message pairing; refusing to guess the framing"
+        )
+
+    by_pr: dict[str, str] = {}
+    for index in range(0, len(fields), 2):
+        message = fields[index + 1]
+        subject = message.splitlines()[0] if message else ""
+        match = re.search(r"\(#(\d+)\)\s*$", subject)
+        if match and match.group(1) not in by_pr:
+            by_pr[match.group(1)] = message
+    return by_pr
+
+
+#: A line that ends the disclosure because it opens a block the trailer cannot own: another
+#: column-0 trailer token, a Markdown heading, or an HTML comment.
+#:
+#: **The HTML-comment arm is not defensive, it is load-bearing.** `CONTRIBUTING.md` requires
+#: the trailer to be the last thing in the PR description, and in the squash bodies on this
+#: repo it is *not*: GitHub appends CodeRabbit's auto-generated summary after it, opening
+#: with `<!-- This is an auto-generated comment: release notes by coderabbit.ai -->`. Taken
+#: literally to end-of-message, #1484's disclosure came out with three paragraphs of
+#: "Summary by CodeRabbit" quoted under it as though the author had written them.
+DISCLOSURE_END_RE = re.compile(r"^([A-Za-z][A-Za-z0-9-]*:[ \t]|#{1,6}\s|<!--)")
+
+
+def disclosure_value(message: str) -> str | None:
+    """Return the whole `Representation-Change:` value, continuations included.
+
+    **`trailer_value` alone is not enough here, and using it alone truncated every
+    multi-line disclosure to its first clause** -- `371 rows move of 5,629,002 swept; all
+    371 were` cut mid-sentence. It is still what decides *whether* there is a trailer and
+    where it starts, so the column-0 rule that `scripts/check_representation_change.py` and
+    `scripts/check_changelog_grouping.py` share stays in one place; this only extends the
+    value past its first line.
+
+    **The continuation rule has to be "to the end of the message", because this repo's
+    trailers are not well-formed** -- `git interpret-trailers --parse` reports *no* trailers
+    at all for #1537, #1535 or #1547, since their continuation lines are unindented (#1556).
+    So indentation cannot delimit the value.
+
+    **Do not rest this on "the trailer is last".** It is not, and `CONTRIBUTING.md` says so
+    as of #1556: GitHub appends CodeRabbit's auto-generated summary after the description,
+    so end-of-message would quote three paragraphs of "Summary by CodeRabbit" as the
+    author's disclosure -- which is exactly what happened to #1484 before the terminator
+    existed. Nothing enforces position either; the trailer checker is column-0-anchored and
+    `MULTILINE`, and polices *count*, not placement. What actually bounds the value is the
+    terminator: the next column-0 `Token: ` line, Markdown heading, or HTML comment.
+    """
+    first = trailer_value(message)
+    if first is None:
+        return None
+    lines = message.splitlines()
+    start = next(
+        index
+        for index, line in enumerate(lines)
+        if line.lower().startswith("representation-change:")
+    )
+    collected = [first]
+    for line in lines[start + 1 :]:
+        if DISCLOSURE_END_RE.match(line):
+            break
+        collected.append(line.rstrip())
+    while collected and not collected[-1].strip():
+        collected.pop()
+    return "\n".join(collected)
+
+
+def bullet_pr_number(text: str) -> str | None:
+    """Return the PR number a bullet cites, or None."""
+    numbers = [m.group("number") or m.group("linked") for m in PR_RE.finditer(text)]
+    return numbers[-1] if numbers else None
+
+
+def _is_disclosure_line(line: str) -> bool:
+    """Is this line part of an attached disclosure block?
+
+    Both forms count, and missing the second one is a real defect rather than a nicety: a
+    disclosure containing a blank line renders that line as a bare `  >`, because
+    `wrap_disclosure` rstrips and `DISCLOSURE_PREFIX` carries a trailing space. Matching
+    only the prefix therefore stops collecting at the first paragraph break, so a
+    multi-paragraph disclosure the script itself wrote reads back as a one-line block and
+    is reported as drift against its own trailer -- exit 2, red CI, on a file nothing had
+    touched. Measured on a two-paragraph value before this guard existed.
+    """
+    return line.startswith(DISCLOSURE_PREFIX) or line == DISCLOSURE_PREFIX.rstrip()
+
+
+def _flatten(block: list[str]) -> str:
+    """Render a `  > ` block as one line, for a side-by-side drift message.
+
+    The two sides differ in *wrapping* as often as in content, so a raw diff of the lists
+    reports a difference the reader cannot see. Stripping the quote prefix and joining makes
+    the actual disagreement visible in the first 160 characters.
+    """
+    return " ".join(line.strip("> ").strip() for line in block)
+
+
+def wrap_disclosure(value: str) -> list[str]:
+    """Render `value` as blockquote continuation lines under a bullet.
+
+    A blockquote rather than an indented paragraph because the value is frequently several
+    sentences and sometimes several lines: quoting it keeps it visibly the *trailer's own
+    words* rather than editorial summary, which is the distinction the checklist turns on.
+    """
+    return [f"{DISCLOSURE_PREFIX}{line}".rstrip() for line in value.splitlines()]
+
+
+def inject(changelog: str, by_pr: dict[str, str]) -> tuple[str, list[str], list[str]]:
+    """Return `(rewritten changelog, changed bullets, problems)`.
+
+    Only bullets inside a **Representation changes** group are touched. A group ends at the
+    next heading of any depth, so a hand-written released section -- which has prose and no
+    bullets -- passes through untouched.
+    """
+    lines = changelog.splitlines()
+    out: list[str] = []
+    changed: list[str] = []
+    problems: list[str] = []
+    in_section = False
+
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        heading = HEADING_RE.match(line)
+        if heading:
+            in_section = strip_ordering_prefix(heading.group("title")) == REPRESENTATION_GROUP
+            out.append(line)
+            index += 1
+            continue
+
+        bullet = BULLET_RE.match(line) if in_section else None
+        if bullet is None:
+            out.append(line)
+            index += 1
+            continue
+
+        out.append(line)
+        index += 1
+        # Consume any continuation the bullet already has, so a re-run does not duplicate a
+        # disclosure. What is consumed is KEPT for comparison rather than trusted: the
+        # bullet is supposed to carry the trailer's own words, so an existing block that no
+        # longer matches its trailer is drift, and drift is what this script exists to
+        # catch. An earlier revision `continue`d here the moment it saw a `  > ` line, which
+        # meant a stale, truncated or hand-rewritten block passed `--check` green forever —
+        # the script could only ever be right on the run that first wrote it.
+        existing: list[str] = []
+        while index < len(lines) and _is_disclosure_line(lines[index]):
+            existing.append(lines[index])
+            out.append(lines[index])
+            index += 1
+
+        number = bullet_pr_number(bullet.group("text"))
+        if number is None:
+            problems.append(
+                f"bullet cites no PR number, so its trailer cannot be found: "
+                f"{bullet.group('text')[:70]!r}"
+            )
+            continue
+
+        message = by_pr.get(number)
+        if message is None:
+            problems.append(f"#{number} is in the changelog but no commit in this history cites it")
+            continue
+        value = disclosure_value(message)
+        if value is None:
+            problems.append(
+                f"#{number} is filed under {REPRESENTATION_GROUP} with no "
+                "`Representation-Change:` trailer in its commit message"
+            )
+            continue
+
+        wanted = wrap_disclosure(value)
+        if existing:
+            # Already carried a block: judge it rather than trust it. The trailer in the
+            # commit message is the single source of truth — editing the changelog copy
+            # instead makes the two disagree with nothing to notice, which is the failure
+            # this whole script exists to remove. Fix by correcting the trailer and
+            # re-running, not by editing `CHANGELOG.md`.
+            if existing != wanted:
+                problems.append(
+                    f"#{number}'s disclosure in the changelog no longer matches its "
+                    "`Representation-Change:` trailer. The trailer is the source of "
+                    "truth; re-run `python scripts/inject_representation_disclosure.py` "
+                    "after correcting it.\n"
+                    f"  changelog says: {_flatten(existing)[:160]!r}\n"
+                    f"  trailer says:   {_flatten(wanted)[:160]!r}"
+                )
+            continue
+
+        out.extend(wanted)
+        changed.append(f"#{number}")
+
+    return "\n".join(out) + ("\n" if changelog.endswith("\n") else ""), changed, problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT, help="Repository root.")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        help="Changelog to rewrite. Defaults to `<repo>/CHANGELOG.md`.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report what would change and exit 1 if anything would, writing nothing.",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help=(
+            "Write the result to stdout instead of the file. Mutually exclusive with "
+            "`--check`, which reports drift through its exit code."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    # `--stdout` used to be tested first, so `--stdout --check` printed the rewritten file
+    # and returned 0 on a stale changelog — a silent false pass in the one mode whose entire
+    # job is to fail. They answer different questions and cannot be combined coherently.
+    if args.stdout and args.check:
+        parser.error("--stdout and --check are mutually exclusive")
+
+    path = args.changelog or (args.repo / "CHANGELOG.md")
+    original = path.read_text(encoding="utf-8")
+    try:
+        rewritten, changed, problems = inject(original, squash_commits(args.repo))
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as error:
+        # `squash_commits` runs `git log` with `check=True`. Unguarded, a git failure exits
+        # 1 with a traceback — colliding with the documented meaning of exit 1 ("--check
+        # found drift"), so a broken environment reads as a stale changelog.
+        print(f"git failed while reading this history: {error}", file=sys.stderr)
+        return 2
+
+    for problem in problems:
+        print(problem, file=sys.stderr)
+
+    # Refuse before writing anything. Previously the write happened first and the exit code
+    # came after, so a run with one resolvable and one unresolvable bullet left a PARTIALLY
+    # injected changelog on disk *and* exited 2 — the worst pairing available, because the
+    # file looks updated and the failure looks like a transient. A partial artifact is not
+    # a better outcome than no artifact.
+    if problems:
+        return 2
+
+    if args.stdout:
+        sys.stdout.write(rewritten)
+        return 0
+
+    if args.check:
+        if changed:
+            print(
+                f"{len(changed)} changelog entr{'y' if len(changed) == 1 else 'ies'} would gain "
+                f"a disclosure: {', '.join(changed)}. Run "
+                "`python scripts/inject_representation_disclosure.py`.",
+                file=sys.stderr,
+            )
+        # `problems` is already handled above by an early `return 2`, so drift is the only
+        # thing left to report here.
+        return 1 if changed else 0
+
+    if changed:
+        path.write_text(rewritten, encoding="utf-8")
+        print(f"attached {len(changed)} disclosure(s): {', '.join(changed)}")
+    else:
+        print("every Representation changes entry already carries its disclosure")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_inject_representation_disclosure.py
+++ b/tests/python/test_inject_representation_disclosure.py
@@ -1,0 +1,231 @@
+"""Unit tests for `scripts/inject_representation_disclosure.py` (#1556).
+
+The script's job is to put the `Representation-Change:` trailer's own text under its
+changelog bullet, which the changelog template cannot do. What is worth testing is not the
+happy path -- that is visible by running it -- but the three rules that decide *how much* of
+the message is the value, each of which was wrong at some point while the script was written
+and each of which fails silently:
+
+- where the value **ends** (a CodeRabbit block appended after the trailer is not the value);
+- that a bullet with **no** matching commit or **no** trailer is reported rather than skipped;
+- that a second run is a **no-op**, since release-plz regenerates the section on every push.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "inject_representation_disclosure.py"
+
+
+def _load():
+    """Import the script by path; `scripts/` is not a package."""
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    spec = importlib.util.spec_from_file_location("inject_representation_disclosure", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+module = _load()
+
+
+SECTION = """## [unreleased]
+
+### Representation changes
+
+- *(normalize)* Move a thing ([#1234](https://example.invalid/1234))
+
+### Other
+
+- *(ci)* Something else ([#1235](https://example.invalid/1235))
+"""
+
+
+def test_the_value_stops_at_an_appended_coderabbit_block():
+    """The trailer is documented as the last thing in the description and is not.
+
+    GitHub appends CodeRabbit's auto-generated summary to the PR body, so it lands in the
+    squash message *after* the trailer. Read to end-of-message, #1484's disclosure came out
+    with three paragraphs of "Summary by CodeRabbit" quoted under it as the author's words.
+    """
+    message = (
+        "fix(normalize): move a thing (#1234)\n\n"
+        "Body prose.\n\n"
+        "Representation-Change: 3 rows move of 500,004.\n"
+        "Previously accepted, so a real migration.\n\n"
+        "<!-- This is an auto-generated comment: release notes by coderabbit.ai -->\n"
+        "## Summary by CodeRabbit\n"
+        "- **Bug Fixes**\n"
+    )
+    value = module.disclosure_value(message)
+    assert value == "3 rows move of 500,004.\nPreviously accepted, so a real migration."
+
+
+def test_the_value_stops_at_the_next_trailer():
+    message = (
+        "fix: x (#1)\n\nRepresentation-Change: 2 rows move.\ncontinued.\nCloses: #99\ntrailing\n"
+    )
+    assert module.disclosure_value(message) == "2 rows move.\ncontinued."
+
+
+def test_a_single_line_value_is_unchanged():
+    assert module.disclosure_value("fix: x (#1)\n\nRepresentation-Change: none.\n") == "none."
+
+
+def test_no_trailer_is_none():
+    assert module.disclosure_value("fix: x (#1)\n\nJust a body.\n") is None
+
+
+def test_an_indented_trailer_is_not_a_trailer():
+    """Column 0, matching both existing checkers: an indented line is a continuation of the
+    value above it, and reading it as a trailer is what #1573 fixed in the sibling script."""
+    assert module.disclosure_value("fix: x (#1)\n\n  Representation-Change: none.\n") is None
+
+
+def test_the_disclosure_is_attached_under_its_bullet():
+    by_pr = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"}
+    rewritten, changed, problems = module.inject(SECTION, by_pr)
+    assert problems == []
+    assert changed == ["#1234"]
+    assert "  > 3 rows move." in rewritten
+    # And nothing outside the section is touched.
+    assert "- *(ci)* Something else ([#1235](https://example.invalid/1235))\n" in rewritten
+    assert rewritten.count("  > ") == 1
+
+
+def test_a_second_run_changes_nothing():
+    by_pr = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"}
+    once, _, _ = module.inject(SECTION, by_pr)
+    twice, changed, problems = module.inject(once, by_pr)
+    assert twice == once
+    assert changed == []
+    assert problems == []
+
+
+@pytest.mark.parametrize(
+    ("by_pr", "expected"),
+    [
+        ({}, "no commit in this history cites it"),
+        (
+            {"1234": "fix: move a thing (#1234)\n\nNo trailer here.\n"},
+            "no\n`Representation-Change:` trailer",
+        ),
+    ],
+)
+def test_a_bullet_that_cannot_be_resolved_is_reported_not_skipped(by_pr, expected):
+    """A silently-skipped bullet would reintroduce exactly the gap this script closes: a
+    Representation changes entry with no disclosure, indistinguishable from one that needed
+    none."""
+    _, changed, problems = module.inject(SECTION, by_pr)
+    assert changed == []
+    assert len(problems) == 1
+    assert expected.replace("\n", " ") in problems[0].replace("\n", " ")
+
+
+def test_an_edited_disclosure_is_reported_rather_than_trusted():
+    """The bullet is supposed to carry the trailer's own words, so a block that no longer
+    matches its trailer is drift.
+
+    This was silently green: the loop consuming the existing `  > ` lines then `continue`d
+    past both the commit lookup and the trailer comparison, so a stale, truncated or
+    hand-rewritten disclosure passed `--check` forever. The script could only ever be right
+    on the run that first wrote it, which is the failure mode it exists to remove.
+    """
+    by_pr = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"}
+    injected, _, _ = module.inject(SECTION, by_pr)
+    tampered = injected.replace("  > 3 rows move.", "  > 9000 rows move, actually.")
+
+    _, changed, problems = module.inject(tampered, by_pr)
+
+    assert changed == []
+    assert len(problems) == 1
+    assert "no longer matches its `Representation-Change:` trailer" in problems[0]
+    # The message must show both sides; "they differ" alone is not actionable.
+    assert "9000 rows move" in problems[0]
+    assert "3 rows move" in problems[0]
+
+
+def test_a_trailer_edited_upstream_is_caught_on_the_next_run():
+    """The same guard from the other direction: the changelog is untouched and the *trailer*
+    moved. Both are drift and both must be reported, because which side someone edited is
+    not knowable from the artifact."""
+    original = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"}
+    injected, _, _ = module.inject(SECTION, original)
+
+    corrected = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 4 rows move.\n"}
+    _, changed, problems = module.inject(injected, corrected)
+
+    assert changed == []
+    assert len(problems) == 1
+    assert "no longer matches" in problems[0]
+
+
+def test_stdout_and_check_are_refused_together():
+    """`--stdout` used to be tested first, so `--stdout --check` printed the rewritten file
+    and returned 0 on a stale changelog -- a silent false pass in the one mode whose entire
+    job is to fail."""
+    with pytest.raises(SystemExit) as excinfo:
+        module.main(["--stdout", "--check"])
+    assert excinfo.value.code != 0
+
+
+def test_write_mode_refuses_before_writing_when_a_bullet_is_unresolvable(tmp_path):
+    """A partial artifact is not a better outcome than no artifact.
+
+    The write used to happen before the exit code was computed, so a run with one resolvable
+    and one unresolvable bullet left a PARTIALLY injected changelog on disk *and* exited 2 --
+    the file looks updated and the failure looks transient.
+    """
+    two_bullets = SECTION.replace(
+        "- *(normalize)* Move a thing ([#1234](https://example.invalid/1234))",
+        "- *(normalize)* Move a thing ([#1234](https://example.invalid/1234))\n"
+        "- *(normalize)* Move another ([#4321](https://example.invalid/4321))",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(two_bullets, encoding="utf-8")
+    before = changelog.read_text(encoding="utf-8")
+
+    # #1234 resolves; #4321 does not.
+    module.squash_commits = lambda _repo: {
+        "1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"
+    }
+    code = module.main(["--changelog", str(changelog)])
+
+    assert code == 2
+    assert changelog.read_text(encoding="utf-8") == before, "wrote a partially injected file"
+
+
+def test_a_multi_paragraph_disclosure_is_not_reported_as_drift_against_itself():
+    """The blank line inside a disclosure renders as a bare `  >`, not `  > `.
+
+    `wrap_disclosure` rstrips and `DISCLOSURE_PREFIX` carries a trailing space, so a
+    collector keyed only on the prefix stops at the first paragraph break. The block then
+    reads back one line long and is reported as drift against the very trailer that
+    produced it -- a red CI on a file the script itself wrote, which is the same
+    unsatisfiable-check failure this module exists to prevent.
+    """
+    message = (
+        "fix: move a thing (#1234)\n\n"
+        "Representation-Change: 3 rows move.\n\n"
+        "Previously accepted, so a real migration.\n"
+    )
+    by_pr = {"1234": message}
+
+    once, changed, problems = module.inject(SECTION, by_pr)
+    assert changed == ["#1234"]
+    assert problems == []
+    # The blank line really is emitted bare -- if this stops holding, the guard above is
+    # solving a problem that no longer exists and should be re-derived, not kept.
+    assert "  >\n" in once
+
+    twice, changed_again, problems_again = module.inject(once, by_pr)
+    assert twice == once
+    assert changed_again == []
+    assert problems_again == [], f"re-run reported drift against its own output: {problems_again}"


### PR DESCRIPTION
Closes #1556

The release checklist asked reviewers to confirm each **Representation changes** entry says whether the affected inputs were previously **rejected** (no stored string, so free) or previously **accepted** (a real migration). No entry could: release-plz writes the bullet from the commit subject alone, so the trailer's own text reached no reader and the answer had to be read out of every linked PR.

## Route four, because routes one to three are dead

The issue measures three routes through the git-cliff template and none of them is used here — they were read, not re-walked:

1. **`commit.footers` is mis-parsed.** git_conventional treats any `word:` line as a footer token, so a prose body shreds it.
2. **`commit.body` does not contain the trailer**, git_conventional having split it out — 0 occurrences for both real v0.13.1 disclosures.
3. **Splitting on the unanchored literal finds only the prose mentions**, which is worse than nothing: plausible output for some commits, quoted prose for others.

The fourth route is not through the template at all: **read the trailer from the raw commit message with `git log`, and attach it to the rendered bullet afterwards.** That is what `scripts/check_changelog_grouping.py` already does in CI to attribute trailers to commits, so the new script imports its `trailer_value` rather than keeping a fourth copy of the column-0 rule. Bullets are matched to commits by the PR number GitHub puts in the squash subject, the one token both sides are guaranteed to share.

## Rendered, and seen there

Not claimed — run. Rendering the pending cycle (`v0.13.1..HEAD`) through the real `release-plz.toml` parsers and then through the script turns this:

```
- *(normalize)* Bound the junction of a member that reduces to an insertion (#1598)
```

into this:

```
- *(normalize)* Bound the junction of a member that reduces to an insertion (#1598)
  > 371 rows move of 5,629,002 swept; all 371 were
  > previously incorrect — 321 denoted the wrong bases outright and 50
  > denoted no sequence at all because their members overlapped. This is a
  > correctness repair, not a respelling: no row that already denoted its
  > input's bases changes.
```

All ten entries in that cycle gain their disclosure. Running it over the **committed** `CHANGELOG.md` attaches the two v0.13.1 disclosures, which is the diff in this PR.

## Two measurements that contradict what `CONTRIBUTING.md` asks for

Both are load-bearing and both will be hit again by anyone working here:

- **The trailer is not the last thing in the squash body.** GitHub appends CodeRabbit's auto-generated summary after the PR description, so reading to end-of-message came out with three paragraphs of "Summary by CodeRabbit" quoted under #1484 as the author's disclosure. The walk stops at the next column-0 trailer token, Markdown heading or HTML comment.
- **The trailers are not well-formed**, their continuation lines being unindented — which is also why `git interpret-trailers --parse` reports *no* trailers at all for #1537, #1535 or #1547 — so indentation cannot delimit the value.

Both are recorded on the constants that implement them and pinned by tests, rather than left as a comment.

## What the checklist now asks

It asked for something unsatisfiable and said so, pointing at this issue. It now asks whether every entry carries its trailer text, names the one command that attaches it, and says the command is idempotent so it can be re-run after release-plz regenerates the section. CI runs the `--check` form inside the existing `Changelog grouping audit` job: a no-op on an ordinary PR (`CHANGELOG.md` holds only released sections), the gate on the release PR.

## What it refuses rather than skips

A bullet whose commit cannot be found, or whose commit carries no trailer, exits 2 with the bullet named. A silently-skipped bullet would reintroduce exactly the gap this closes — an entry with no disclosure, indistinguishable from one that needed none.

## Verification

- `pytest tests/python/test_inject_representation_disclosure.py tests/python/test_changelog_grouping.py tests/python/test_representation_change_trailer.py` — **114 passed**. (The rest of `tests/python/` needs the built extension module and does not collect without `maturin develop`; that is unchanged by this PR.)
- `python scripts/check_changelog_grouping.py` — `43 commits in v0.13.1..HEAD; 10 listed as representation changes / Representation changes section is consistent with the trailers.`
- `python scripts/inject_representation_disclosure.py --check` — exit 0 after the change, exit 1 naming `#1537, #1535` before it.
- `ruff check` and `ruff format --check` clean; `actionlint .github/workflows/ci.yml` clean.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — this is a script, its tests, a CI step, and three documents. No ferro output moves.
