### PR TITLE
docs(parser): say what parse_hgvs actually applies — the grammar, and no ErrorConfig

### DIFF
--- a/src/hgvs/parser/mod.rs
+++ b/src/hgvs/parser/mod.rs
@@ -6,11 +6,14 @@
 //!
 //! The parser supports three error handling modes:
 //!
-//! - **Strict** (default): Reject all non-standard input
+//! - **Strict**: Reject all non-standard input
 //! - **Lenient**: Auto-correct common errors with warnings
 //! - **Silent**: Auto-correct common errors without warnings
 //!
-//! Use [`parse_hgvs_with_config`] to specify the error handling mode.
+//! A mode is applied only by [`parse_hgvs_with_config`]; strict is
+//! [`ErrorConfig::default`], so `parse_hgvs_with_config(input,
+//! ErrorConfig::default())` is the strict entry. [`parse_hgvs`] applies **no**
+//! mode at all — see its own documentation (#1632).
 
 pub mod accession;
 pub mod edit;
@@ -27,8 +30,41 @@ use crate::hgvs::HgvsVariant;
 
 /// Parse an HGVS string into a variant
 ///
-/// Uses strict error handling mode by default. For configurable error handling,
-/// use [`parse_hgvs_with_config`] instead.
+/// # Error handling: this entry applies the grammar only
+///
+/// `parse_hgvs` applies **no [`ErrorConfig`]**. It trims surrounding
+/// whitespace, runs the fast path, and falls back to the grammar; the
+/// input-hygiene ladder — both the repairs
+/// lenient mode performs and the parse-stage refusals that make strict strict —
+/// runs only in [`parse_hgvs_with_config`]. So this is not "strict mode": it is
+/// a third behaviour that is neither mode, and it accepts inputs strict rejects.
+/// For example `NM_024312.4:r.-6_-3g[6]` states a base label the range already
+/// determines; `parse_hgvs` returns it unchanged, while
+/// `parse_hgvs_with_config(_, ErrorConfig::strict())` refuses it by name.
+///
+/// Note the scope of that claim: it is the ladder that runs at the *parse*
+/// stage. Strict mode also refuses at **normalize** — a bare-transcript
+/// intronic position (`W4007`) is one, and no parse-stage entry rejects it in
+/// any mode — so switching to [`parse_hgvs_with_config`] buys the parse-stage
+/// half only.
+///
+/// Call [`parse_hgvs_with_config`] when the mode matters — validating untrusted
+/// input, or matching what the CLI does with the same string. `ferro normalize`,
+/// `ferro parse` and `ferro project` each take `--error-mode`, and all three
+/// default to `strict`.
+///
+/// Do not generalise that default to the whole crate: it runs the other way one
+/// layer down. [`ErrorConfig::default`] is strict, but `NormalizeConfig::default`
+/// sets `ErrorConfig::lenient` for backwards compatibility, so a
+/// `Normalizer::new(provider)` normalizes in **lenient** mode. Two `default()`s
+/// pointing opposite ways is the reason to name the mode you want rather than
+/// infer it.
+///
+/// This doc previously claimed strict handling "by default" (#1632). Whether
+/// the function should be routed through `ErrorConfig::strict()` to make that
+/// claim true is open; it would newly refuse inputs the crate's headline entry
+/// point accepts today. `tests/it/issue_1632_parse_entry_applies_no_mode.rs`
+/// pins the current behaviour so the two cannot drift apart again.
 ///
 /// # Performance
 ///

--- a/tests/it/issue_1632_parse_entry_applies_no_mode.rs
+++ b/tests/it/issue_1632_parse_entry_applies_no_mode.rs
@@ -1,0 +1,217 @@
+//! Issue #1632 — `parse_hgvs` documents itself as strict but applies no
+//! `ErrorConfig`, so it accepts what strict rejects.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/1632>.
+//!
+//! `parse_hgvs` runs the fast path and then the grammar. It never constructs an
+//! `InputPreprocessor`, so none of the input-hygiene ladder runs on it — not the
+//! repairs lenient performs, and not the refusals that make strict strict. Only
+//! `parse_hgvs_with_config` applies a mode.
+//!
+//! This file pins that as *measured behaviour* so the doc comment and the code
+//! cannot drift apart again. It deliberately does **not** change what
+//! `parse_hgvs` accepts: routing it through `ErrorConfig::strict()` is the
+//! crate's headline entry point newly refusing inputs it accepts today, which is
+//! a behaviour change for callers to weigh.
+//!
+//! It also sits directly downstream of `absolute-prohibition-enforcement-stage`,
+//! which #1634 decided as **mode-dependent** — an absolute prohibition is refused
+//! at strict-mode normalize rather than unconditionally at parse. A mode-less
+//! entry point therefore has no defined enforcement stage under that ruling,
+//! which is an argument for giving `parse_hgvs` a mode rather than against it;
+//! what stage that mode should enforce at is the part the ruling settles and this
+//! PR does not touch.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+/// Parse under an explicit mode, flattening to `Ok(rendered)` / `Err(message)`
+/// so the two entries can be compared on equal terms.
+fn with_config(input: &str, config: ErrorConfig) -> Result<String, String> {
+    parse_hgvs_with_config(input, config)
+        .map(|r| r.result.to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// The bare entry, flattened the same way.
+fn bare(input: &str) -> Result<String, String> {
+    parse_hgvs(input)
+        .map(|v| v.to_string())
+        .map_err(|e| e.to_string())
+}
+
+// Every refusal below is asserted on its **message**, not on `ErrorCode`, and
+// that choice is measured rather than stylistic. `ErrorCode` does not
+// discriminate these rungs: the redundant-base-label refusal and the
+// size-count-suffix refusal both report `ErrorCode::InvalidEdit`, and the bare
+// entry's whitespace refusal carries `code: None` at all. Pinning the code
+// would therefore be barely stronger than `is_err()` — it would pass on an
+// unrelated `InvalidEdit` from anywhere in the grammar, which is the exact
+// weakness these assertions exist to remove. The messages name the rung, so
+// they are what the stated contract is pinned on.
+
+/// Guards the comment above. Those `ErrorCode` values are the whole reason the
+/// assertions in this file key on messages, and an unpinned claim about
+/// behaviour is what #1632 is — so pin it here rather than let it rot into a
+/// second wrong comment about the same parser.
+///
+/// If this test fails because a rung gained its own code, that is good news:
+/// re-point the assertions in this file at the code and delete the comment.
+#[test]
+fn the_error_codes_do_not_discriminate_these_rungs() {
+    use ferro_hgvs::error::{ErrorCode, FerroError};
+
+    // Generic over the `Ok` type: the two entries succeed with different types
+    // (`ParseResultWithWarnings<HgvsVariant>` vs `HgvsVariant`), and only the
+    // error side is under test here.
+    fn code_of<T>(r: Result<T, FerroError>) -> Option<String> {
+        match r {
+            Err(FerroError::Parse { diagnostic, .. }) => {
+                diagnostic.and_then(|d| d.code).map(|c| format!("{c:?}"))
+            }
+            _ => panic!("expected a parse error"),
+        }
+    }
+
+    let invalid_edit = Some(format!("{:?}", ErrorCode::InvalidEdit));
+
+    assert_eq!(
+        code_of(parse_hgvs_with_config(
+            "NM_024312.4:r.-6_-3g[6]",
+            ErrorConfig::strict()
+        )),
+        invalid_edit,
+        "the redundant-base-label rung reports the generic InvalidEdit"
+    );
+    assert_eq!(
+        code_of(parse_hgvs_with_config(
+            "NC_TEST.1:g.266del3",
+            ErrorConfig::strict()
+        )),
+        invalid_edit,
+        "so does the size-count-suffix rung — one code, two rungs, which is why \
+         a code assertion would not discriminate them"
+    );
+    assert_eq!(
+        code_of(parse_hgvs("NM_TEST.1:c.10_12 del")),
+        None,
+        "and the bare entry's whitespace refusal carries no code at all"
+    );
+}
+
+/// The plain finding: two inputs the *actual* strict config refuses are
+/// accepted, unchanged, by the entry point whose doc comment claims strict.
+///
+/// `r.-6_-3g[6]` and `r.-125_-123cug[4]` state a base label that the range
+/// already determines — the `RedundantRepeatLabel` rung (`W3013`) of the
+/// hygiene ladder. The ladder never runs on `parse_hgvs`, so it has no opinion.
+#[test]
+fn the_bare_entry_accepts_two_inputs_strict_refuses() {
+    for input in ["NM_024312.4:r.-6_-3g[6]", "NM_024312.4:r.-125_-123cug[4]"] {
+        assert_eq!(
+            bare(input).as_deref(),
+            Ok(input),
+            "parse_hgvs accepts the input unchanged"
+        );
+        let refusal = with_config(input, ErrorConfig::strict())
+            .expect_err("strict must refuse a redundant repeat base label");
+        assert!(
+            refusal.contains("Repeat description has redundant base label"),
+            "the refusal must name this rung, not merely fail; got: {refusal}"
+        );
+    }
+}
+
+/// The same seam viewed from the other side: inputs the grammar refuses for its
+/// own reasons. `parse_hgvs` reports a grammar error; the mode-aware entry
+/// reports the *mode-appropriate* answer — a named refusal under strict, and a
+/// repair under lenient. So the bare entry is not merely "strict without the
+/// repairs"; it is a third behaviour that is neither mode.
+#[test]
+fn the_bare_entry_gives_a_grammar_error_where_a_mode_gives_a_mode_answer() {
+    // `del3` — a size-count suffix (`checklist.md:49`). Both entries refuse,
+    // and the two refusals are not the same refusal: the grammar cites the
+    // clause and offers the rewrite, strict names its hygiene rung.
+    let bare_del3 =
+        bare("NC_TEST.1:g.266del3").expect_err("the grammar refuses a size-count suffix");
+    assert!(
+        bare_del3.contains("checklist.md:49"),
+        "the bare entry refuses in the grammar, citing the clause; got: {bare_del3}"
+    );
+    let strict_del3 = with_config("NC_TEST.1:g.266del3", ErrorConfig::strict())
+        .expect_err("strict refuses a size-count suffix");
+    assert!(
+        strict_del3.contains("uses size-count suffix"),
+        "strict refuses at its own hygiene rung; got: {strict_del3}"
+    );
+    assert_ne!(
+        bare_del3, strict_del3,
+        "the two entries must refuse for different stated reasons — that is what \
+         makes the bare entry a third behaviour rather than strict-without-repairs"
+    );
+    assert_eq!(
+        with_config("NC_TEST.1:g.266del3", ErrorConfig::lenient()).as_deref(),
+        Ok("NC_TEST.1:g.266_268del"),
+        "lenient repairs the size-count suffix into the range it denotes"
+    );
+
+    // An internal space (`general.md:96`).
+    let bare_space =
+        bare("NM_TEST.1:c.10_12 del").expect_err("the grammar refuses an internal space");
+    assert!(
+        bare_space.contains("Unexpected trailing characters"),
+        "the bare entry sees only unparsed trailing input; got: {bare_space}"
+    );
+    let strict_space = with_config("NM_TEST.1:c.10_12 del", ErrorConfig::strict())
+        .expect_err("strict refuses an internal space");
+    assert!(
+        strict_space.contains("Extra whitespace"),
+        "strict names the whitespace rung; got: {strict_space}"
+    );
+    assert_eq!(
+        with_config("NM_TEST.1:c.10_12 del", ErrorConfig::lenient()).as_deref(),
+        Ok("NM_TEST.1:c.10_12del"),
+        "lenient strips the internal whitespace"
+    );
+}
+
+/// Leading and trailing whitespace is the one hygiene concern `parse_hgvs`
+/// handles on its own, via `trim_hgvs`. Pinned so the doc's "grammar only"
+/// wording is not read as "nothing at all".
+#[test]
+fn the_bare_entry_still_trims_surrounding_whitespace() {
+    assert_eq!(
+        bare("  NM_000088.3:c.459del  ").as_deref(),
+        Ok("NM_000088.3:c.459del"),
+    );
+}
+
+/// **Negative control for the intronic question, and the reason it is here.**
+///
+/// A bare-transcript intronic position (`checklist.md:20`) is accepted by
+/// `parse_hgvs` — but it is *equally* accepted by
+/// `parse_hgvs_with_config(_, strict())`. So the missing `ErrorConfig` is not
+/// what lets that shape through: there is no parse-stage rung for it in any
+/// mode. Its refusal lives at strict-mode **normalize**
+/// (`IntronicOnBareTranscript` / `W4007`), which is where the
+/// `bare-transcript-intronic-position` ruling put it — see
+/// `corpus_prohibited_inputs.rs::a_bare_transcript_intronic_position_is_refused_in_strict_only`.
+///
+/// This pin exists so that closing #1632 by routing `parse_hgvs` through a mode
+/// is not mistaken for a fix to the intronic shape, in either direction.
+#[test]
+fn the_missing_config_is_not_what_admits_a_bare_transcript_intronic_position() {
+    let input = "NM_TEST.1:c.20+2del";
+    assert_eq!(bare(input).as_deref(), Ok(input));
+    assert_eq!(
+        with_config(input, ErrorConfig::strict()).as_deref(),
+        Ok(input),
+        "strict input hygiene has no rung for checklist.md:20 either — the \
+         refusal is a normalize-stage one"
+    );
+    assert_eq!(
+        with_config(input, ErrorConfig::lenient()).as_deref(),
+        Ok(input)
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,6 +24,7 @@ mod issue_1524_adjacent_split_members;
 mod issue_1539_split_member_separation;
 mod issue_1592_reduced_member_junction_clamp;
 mod issue_1600_reduced_delins_tract_demotion;
+mod issue_1632_parse_entry_applies_no_mode;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Representation-Change: none. A doc comment and a test; no parsing, normalization or output behaviour changes.

Refs #1632

## Deliberately `Refs`, not `Closes`

#1632 lists two options. This takes the **second** — make the documentation honest — which the issue itself calls free and says should not wait on the first. The issue stays open for the first.

## What was wrong

`parse_hgvs`'s doc comment claimed "strict error handling mode by default". It applies **no `ErrorConfig` at all**: it trims surrounding whitespace, runs the fast path, and falls back to the grammar. The input-hygiene ladder — both the repairs `lenient` performs and the refusals that make `strict` strict — lives in `InputPreprocessor` and is reached only from `parse_hgvs_with_config`.

So the entry point is not "strict". It is a third behaviour that is neither mode, and it accepts inputs `strict` refuses:

```
NM_024312.4:r.-6_-3g[6]
  parse_hgvs(..)                            -> accepted, unchanged
  parse_hgvs_with_config(.., strict())      -> refused: "redundant base label 'g'"
```

That is the gap the doc was hiding, and the test pins it in both directions so the claim cannot rot back.

## Why the other half is left alone

Routing `parse_hgvs` through `ErrorConfig::strict()` means the crate's headline entry point starts refusing inputs it accepts today — a real behaviour change for every caller — and it sits downstream of `absolute-prohibition-enforcement-stage`, which #1634 decided as **mode-dependent** — refusal at strict-mode normalize rather than unconditionally at parse. A mode-less entry point has no defined enforcement stage under that ruling, which argues for giving `parse_hgvs` a mode rather than against it; either way it is not a doc fix and should not ride along with one.

## Correcting the issue's premise

#1632's framing is that `parse_hgvs` is documented strict and silently is not. That much holds. What does **not** hold is the related claim carried in our own notes that intronic-position-on-a-bare-accession is "refused in no mode" — `bare-transcript-intronic-position` is a **decided** record with a passing test: strict refuses a bare `NM_…:c.20+2del` with `W4007`, lenient accepts. Making that absolute would re-open a decided ruling, not fix a bug. Recorded here so the wrong version does not get acted on.

Also drops "(default)" from the module-level mode list, where it read as a property of the parser rather than of `ErrorConfig::default()`.

## Verification

- Full suite on current `main`: **10,140 run, 10,140 passed, 152 skipped** (`FERRO_MANIFEST` set, so the conformance censuses ran rather than skipping green). That figure was measured at `68694272`; the branch has since taken three review fixes and a fifth test, so the count is now five higher.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `issue_1632_parse_entry_applies_no_mode` 5/5 pass
- `cargo fmt --all --check` clean

