### PR TITLE
fix(normalize): decline a protein delins whose affix trim lands on the initiation codon

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -6770,7 +6770,48 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ));
         }
         if residual_del.len() == 1 && residual_seq.0.len() == 1 {
-            // Sub > delins.
+            // Sub > delins — except at the translation initiation codon, where
+            // the substitution form does not exist.
+            //
+            // `validate_no_start_loss_substitution` (parser) refuses
+            // `p.Met1<Xaa>`: a variant that changes the initiation codon is
+            // described neither as a substitution nor as an extension
+            // (`protein/substitution.md:49`, `checklist.md:65`,
+            // `protein/extension.md:28`). A *range* delins is not refused —
+            // that guard keys on a single certain position — so an input like
+            // `p.Met1_Ala3delinsValAlaAla` parses, and it is the affix trim
+            // here that would manufacture the illegal `p.Met1Val`. The guard
+            // therefore belongs in the producer as well (#1607).
+            //
+            // Declining is the only move available. The spec offers `p.0`,
+            // `p.0?`, `p.(Met1?)` and — when an upstream initiation site is
+            // activated — the insertion form `p.Met1_Leu2ins…`; which one holds
+            // is a claim about the *consequence*, and the reference and payload
+            // residues do not settle it. So the input is left as authored
+            // rather than canonicalised into a choice ferro cannot make.
+            //
+            // The condition mirrors **`validate_no_start_loss_substitution`**
+            // — the parser's guard, and only that one — evaluated against the
+            // substitution this branch is about to build: residue 1, an
+            // initiator `Met` as the reference residue, and a different
+            // residue replacing it. So the producer cannot emit a
+            // substitution that entry point would refuse. A non-`Met` residue
+            // 1 and a `Met`→`Met` residual are both accepted there and so are
+            // left to canonicalise.
+            //
+            // It is deliberately **not** parity with the sibling producer
+            // guard in `try_protein_delins_split_unchanged_interior`
+            // (#1606), which declines on the broader
+            // `start_pos.number == 1 && ref_aas[0] != seq.0[0]` — any change
+            // at residue 1, `Met` or not. That path emits an allele of
+            // members and takes the wider berth; this one is scoped to the
+            // reparse hole, so it tracks the parser instead.
+            if new_start == 1
+                && residual_del[0] == AminoAcid::Met
+                && residual_seq.0[0] != AminoAcid::Met
+            {
+                return None;
+            }
             let pos = ProtPos::new(residual_del[0], new_start);
             return Some((
                 ProteinEdit::Substitution {

--- a/tests/it/issue_1607_protein_residue_one_guard.rs
+++ b/tests/it/issue_1607_protein_residue_one_guard.rs
@@ -1,0 +1,207 @@
+//! Issue #1607 — a protein `delins` whose affix trim lands on the initiation
+//! codon must not be canonicalized into a start-loss substitution.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/1607>.
+//!
+//! `parse_hgvs` refuses `p.Met1Val` (`validate_no_start_loss_substitution`): a
+//! variant that changes the translation initiation codon is described neither
+//! as a substitution nor as an extension (`protein/substitution.md:49`,
+//! `checklist.md:65`, `protein/extension.md:28`). The input
+//! `p.Met1_Ala3delinsValAlaAla` parses because that guard keys on a single
+//! certain position and the input is a range — so the illegality is *created*
+//! by `try_protein_delins_canonicalize`'s affix trim, and the guard belongs in
+//! the producer too.
+//!
+//! Ferro must not pick among `p.0`, `p.0?`, `p.(Met1?)` and the
+//! upstream-initiation insertion form: which is correct is a claim about the
+//! *consequence*, and two residue lists do not settle it. The only move
+//! available is to decline and leave the input as authored.
+//!
+//! **Scope.** This fix closes exactly the reparse hole: the producer refuses
+//! to emit what the parser refuses to accept. Residuals at residue 1 that are
+//! a smaller `delins` or a pure `del` are legal, reparseable descriptions, so
+//! they are *not* touched here — whether they too should be declined is a
+//! representation question for the operator, and the current answers are
+//! pinned below so a later decision is a visible edit rather than a drift.
+//!
+//! **Two entry arms, both covered.** `try_protein_delins_canonicalize` reaches
+//! `residual_del` either from the fetched protein window or — with no protein
+//! data for the accession — from the residues named in the input's endpoints
+//! (#1119/#1131). The guard is downstream of both, so each arm gets its own
+//! positive case and its own negative control.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// `MAAGGG…` — Met at residue 1, Ala at 2 and 3, then a run of Gly.
+fn reference_backed_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein("NP_003997.1", format!("MAA{}", "G".repeat(20)));
+    provider
+}
+
+/// A provider carrying **no** protein sequence at all, so
+/// `ReferenceProvider::has_protein_data` is false and
+/// `try_protein_delins_canonicalize` takes its named-endpoint fallback.
+fn reference_free_provider() -> MockProvider {
+    MockProvider::new()
+}
+
+/// Normalize `input` against `provider` and return the emitted string.
+///
+/// The provider is a parameter rather than a constant because the guard has two
+/// distinct entry arms — see
+/// [`a_reference_free_delins_trimming_to_a_residue_one_substitution_is_declined`].
+fn normalized_with(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let parsed = parse_hgvs(input).expect("input must parse");
+    normalizer
+        .normalize(&parsed)
+        .expect("normalization must succeed")
+        .to_string()
+}
+
+/// Normalize `input` against the reference-backed provider.
+fn normalized(input: &str) -> String {
+    normalized_with(reference_backed_provider(), input)
+}
+
+/// Every output this file produces must survive a round trip. That is the
+/// property the whole issue is about, so assert it by name rather than only
+/// asserting the exact string.
+fn assert_reparses(out: &str) {
+    assert!(
+        parse_hgvs(out).is_ok(),
+        "normalization emitted a description parse_hgvs refuses: {out:?}",
+    );
+}
+
+/// The reported case: the common suffix `AlaAla` trims away, the residual is
+/// `Met` → `Val` at residue 1, and the `1 -> 1` residual would take the
+/// `sub > delins` branch. Declining leaves the input as authored.
+#[test]
+fn a_delins_trimming_to_a_residue_one_substitution_is_declined() {
+    let out = normalized("NP_003997.1:p.Met1_Ala3delinsValAlaAla");
+    assert_eq!(out, "NP_003997.1:p.Met1_Ala3delinsValAlaAla");
+    assert_reparses(&out);
+    assert_ne!(
+        out, "NP_003997.1:p.Met1Val",
+        "the start-loss substitution is exactly what must not be emitted",
+    );
+}
+
+/// The same hole reached without any affix to trim. A single-residue `delins`
+/// at the initiator parses — the parser's guard inspects the *edit*, and this
+/// one is a `Delins`, not a `Substitution` — and the `1 -> 1` residual then
+/// takes the same branch. Pinned separately because it exercises the
+/// `lcp == 0 && lcs == 0` fall-through rather than the trim.
+#[test]
+fn a_bare_residue_one_delins_is_declined() {
+    let out = normalized("NP_003997.1:p.Met1delinsVal");
+    assert_eq!(out, "NP_003997.1:p.Met1delinsVal");
+    assert_reparses(&out);
+}
+
+/// A **distinct positive arm**, not a variation of the two cases above.
+///
+/// `try_protein_delins_canonicalize` sources `residual_del` from two places.
+/// When `has_protein_data()` holds it is the fetched protein window; otherwise
+/// it is the residues **named in the input's own endpoints**, a fallback that is
+/// valid precisely because a ≤ 2-residue range names every residue it deletes
+/// (#1119, widened to the per-accession case by #1131). The guard keys on
+/// `residual_del[0]`, so it sits downstream of both — and every other case in
+/// this file is reference-backed, which would leave the fallback arm carrying
+/// the fix untested.
+///
+/// The arm is reachable and the hole was real. Against a bare provider,
+/// `p.Met1_Ala2delinsValAla` trims its common `Ala` suffix to a `Met` → `Val`
+/// residual at residue 1, and before this fix that emitted `p.Met1Val` — which
+/// `parse_hgvs` refuses. Measured A/B, same input, same bare provider:
+///
+/// ```text
+/// origin/main:  NP_003997.1:p.Met1_Ala2delinsValAla -> NP_003997.1:p.Met1Val   reparses=false
+/// this branch:  NP_003997.1:p.Met1_Ala2delinsValAla -> (input unchanged)       reparses=true
+/// ```
+#[test]
+fn a_reference_free_delins_trimming_to_a_residue_one_substitution_is_declined() {
+    let out = normalized_with(
+        reference_free_provider(),
+        "NP_003997.1:p.Met1_Ala2delinsValAla",
+    );
+    assert_eq!(out, "NP_003997.1:p.Met1_Ala2delinsValAla");
+    assert_reparses(&out);
+    assert_ne!(
+        out, "NP_003997.1:p.Met1Val",
+        "the start-loss substitution is exactly what must not be emitted, and \
+         the reference-free arm reaches the same branch",
+    );
+}
+
+/// The reference-free arm's negative control: the same fallback, the same
+/// residue-1 span, but the initiator is retained — so the guard must stay out
+/// of the way and the trim must still happen.
+#[test]
+fn a_reference_free_residual_that_keeps_the_initiator_still_canonicalizes() {
+    // Met-Ala -> Met-Cys: common prefix `Met`, residual is Ala2 -> Cys.
+    let out = normalized_with(
+        reference_free_provider(),
+        "NP_003997.1:p.Met1_Ala2delinsMetCys",
+    );
+    assert_eq!(out, "NP_003997.1:p.Ala2Cys");
+    assert_reparses(&out);
+}
+
+/// The guard keys on the initiator *changing*, not merely on the span
+/// touching residue 1. A trim whose residual retains `Met` at residue 1 is
+/// not a start loss, so canonicalization proceeds.
+#[test]
+fn a_residual_that_keeps_the_initiator_still_canonicalizes() {
+    // Met-Ala-Ala -> Met-Cys-Ala: common prefix `Met`, common suffix `Ala`,
+    // residual is Ala2 -> Cys. Residue 1 is untouched.
+    let out = normalized("NP_003997.1:p.Met1_Ala3delinsMetCysAla");
+    assert_eq!(out, "NP_003997.1:p.Ala2Cys");
+    assert_reparses(&out);
+}
+
+/// A trim landing wholly downstream of the initiation codon is unaffected.
+#[test]
+fn a_delins_away_from_the_initiator_still_canonicalizes() {
+    // Ala3-Gly4-Gly5 -> Cys-Gly-Gly: common suffix `GlyGly`, residual
+    // Ala3 -> Cys.
+    let out = normalized("NP_003997.1:p.Ala3_Gly5delinsCysGlyGly");
+    assert_eq!(out, "NP_003997.1:p.Ala3Cys");
+    assert_reparses(&out);
+}
+
+/// Out of scope, pinned: a residual that is still a `delins` beginning at
+/// residue 1. `p.Met1_Ala2delinsValCys` is a legal, reparseable description —
+/// the parser's start-loss guard does not apply to a range — so the reparse
+/// hole this issue reports is not present here and nothing is changed. Whether
+/// the initiator being replaced should nonetheless decline the trim is a
+/// representation question left to the operator.
+#[test]
+fn a_residual_delins_at_residue_one_is_left_as_it_is_today() {
+    let out = normalized("NP_003997.1:p.Met1_Gly4delinsValCysAlaGly");
+    assert_eq!(out, "NP_003997.1:p.Met1_Ala2delinsValCys");
+    assert_reparses(&out);
+}
+
+/// Out of scope, pinned: a residual that is a pure deletion covering the
+/// initiator. `p.Met1_Ala2del` is legal and reparseable, so — as above — this
+/// fix leaves it alone.
+///
+/// Two reasons the parser does not refuse it, and only the second is the one
+/// to cite. `validate_no_start_loss_substitution` requires a **single certain
+/// position** (`s == e`), which a range is not; and its `is_residue_swap`
+/// matches only `Substitution`, `SubstitutionAlternatives` and an N-terminal
+/// `Extension`, so a `Deletion` edit falls to the `_ => false` arm whatever
+/// its span. Its doc comment's remark that "a downstream one is a deletion"
+/// is **not** that rule: it classifies the *consequence* of a start-codon
+/// variant that activates a downstream initiation site, and says nothing
+/// about a deletion description spanning residue 1.
+#[test]
+fn a_residual_deletion_at_residue_one_is_left_as_it_is_today() {
+    let out = normalized("NP_003997.1:p.Met1_Ala3delinsAla");
+    assert_eq!(out, "NP_003997.1:p.Met1_Ala2del");
+    assert_reparses(&out);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,6 +24,7 @@ mod issue_1524_adjacent_split_members;
 mod issue_1539_split_member_separation;
 mod issue_1592_reduced_member_junction_clamp;
 mod issue_1600_reduced_delins_tract_demotion;
+mod issue_1607_protein_residue_one_guard;
 mod issue_1632_parse_entry_applies_no_mode;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;


### PR DESCRIPTION
Representation-Change: a protein `delins` whose affix trim leaves a single-residue residual at residue 1 replacing the initiator `Met` is now left as authored instead of being rewritten to a start-loss substitution. The old output (`p.Met1_Ala3delinsValAlaAla` -> `p.Met1Val`) **does not parse**, so no consumer can be holding a legal string that changed. 0 rows move across the four committed corpora.

Closes #1607

## The defect

`try_protein_delins_canonicalize` trims the common prefix and suffix of a protein `delins`, then routes the residual through the Prioritization ladder. For `NP_003997.1:p.Met1_Ala3delinsValAlaAla` against `MAAGGG…` the common suffix is `AlaAla`, the residual is `Met` → `Val`, and the `1 → 1` case takes the `sub > delins` branch — emitting `p.Met1Val`, which `parse_hgvs` refuses.

**Normalization is what creates the illegal description.** The input parses because `validate_no_start_loss_substitution` keys on a single certain position and the input is a range. So the guard has to exist in the producer as well as the parser, and this mirrors that one parser guard's condition — evaluated against the substitution the branch is about to build: residue 1, an initiator `Met` as the reference residue, and a different residue replacing it. It is deliberately **not** parity with the sibling producer guard in `try_protein_delins_split_unchanged_interior`, which declines on the broader `start_pos.number == 1 && ref_aas[0] != seq.0[0]` — any change at residue 1, `Met` or not.

## Why declining, rather than emitting a start-loss form

`protein/substitution.md:49`, `checklist.md:65` and `protein/extension.md:28` between them offer `p.0`, `p.0?`, `p.(Met1?)` and the upstream-initiation insertion form `p.Met1_Leu2ins…`. Which one holds is a claim about the **consequence**, and a reference span plus a payload do not settle it. Picking one would be an adjudication this PR has no basis to make, so the input is left as authored.

## Scope is exactly the reparse hole

A residual that is a smaller `delins`, or a pure `del` beginning at residue 1, is a legal reparseable description, so those are unchanged. Both are pinned by test, so a later ruling that widens this is a visible edit rather than a drift.

Two things keep a deletion out of the parser's guard, and only the second is the one to cite: `validate_no_start_loss_substitution` requires a **single certain position** (`s == e`), which a range is not; and its `is_residue_swap` matches only `Substitution`, `SubstitutionAlternatives` and an N-terminal `Extension`, so a `Deletion` edit falls to the `_ => false` arm whatever its span. Its doc comment's remark that "a downstream one is a deletion" is **not** that rule — it classifies the *consequence* of a start-codon variant that activates a downstream initiation site, and says nothing about a deletion description spanning residue 1. An earlier revision of this description cited it as though it did.

## Blast radius

No committed corpus row exhibits the shape. The only residue-1 protein `delins` across ClinVar 500k, ClinVar unique, CMRG and Paraphase is `p.Met1_Pro2delinsIleSer` (3 occurrences), whose residual is 2 → 2 and never reaches the substitution branch.

**The corpus harness is structurally blind here too**, but not for the reason this description previously gave. It claimed `examples/dump_normalized_corpus.rs` "has no protein axis". That is false — #1606 added `PROTEIN_ACCESSION` (`:214`), `PROTEIN_FAMILIES` with five families (`:607`), the provider wiring (`:1356`) and the emit loop (`:1109`). The real reason is stronger, checkable, and already documented in that file citing #1607 by number: `RESIDUE_CODES` puts `Met` first and cores draw from `RESIDUE_CODES[1..]` (`:1198`), so `Met` never appears in a core body and no shift can arrive at residue 1. `protein_inputs_for` starts every span at residue 2 or later for the same reason, and a unit test asserts no generated input contains `Met1`. So the harness cannot construct this shape by design, and its zero is structural rather than reassuring.

The prepared reference carries `protein_fastas: []`, which is unchanged and verified. The zero quoted above comes from the four real corpora, not from that harness.

## Tests

`tests/it/issue_1607_protein_residue_one_guard.rs`, eight cases. **Every case asserts the output reparses.**

`try_protein_delins_canonicalize` sources `residual_del` from two places and the new guard sits downstream of both, so each arm gets its own positive case and its own negative control:

- **Reference-backed** (`has_protein_data()` holds, so the residues come from the fetched protein window): the reported trim, the bare `p.Met1delinsVal` that reaches the same branch with nothing to trim, a residual keeping `Met` at residue 1, and a trim landing downstream.
- **Reference-free** (no protein data, so the residues come from those *named in the input's endpoints* — valid for spans ≤ 2, per #1119/#1131): `p.Met1_Ala2delinsValAla` declines, and `p.Met1_Ala2delinsMetCys` still canonicalizes to `p.Ala2Cys`.

Plus the two out-of-scope shapes above.

The reference-free arm was added in review: the fix repaired a reparse hole none of the original tests exercised, because `provider()` called `add_protein` and was the only entry point. Measured A/B against `origin/main` with a bare `MockProvider::new()`:

```
origin/main:  NP_003997.1:p.Met1_Ala2delinsValAla -> NP_003997.1:p.Met1Val   reparses=false
this branch:  NP_003997.1:p.Met1_Ala2delinsValAla -> (input unchanged)       reparses=true
```

## Closed: the sibling path that was flagged as an open question

An earlier revision of this description left one question open — a *declined* protein split emitting the same non-reparseable `p.Met1Val`, found unreachable at the time because the code path lived in then-unmerged #1606, with a note to re-check the premise once that merged.

**Re-checked, and closed.** That path is live and it is **already guarded**. `src/normalize/mod.rs:6965` carries `if start_pos.number == 1 && ref_aas[0] != seq.0[0] { return None; }` inside `try_protein_delins_split_unchanged_interior`; it landed as part of #1606 itself (`4bcc8dd2`) and is present on `origin/main`. Nothing is left to fold in.

Worth noting the two guards are not the same predicate, deliberately. The sibling declines whenever residue 1 changes at all; this PR's guard is `Met`-specific, because it is scoped to the reparse hole and therefore tracks what the parser actually refuses.

## Verification

- Full suite on current `main`: **10,142 run, 10,142 passed, 152 skipped** (`FERRO_MANIFEST` set, so the conformance censuses ran rather than skipping green). Nothing re-blessed.
- `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean.
