### PR TITLE
docs: enforce the adjudication tables against the ledger, and correct three records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,6 +625,22 @@ Contributor-facing guidance is in `CONTRIBUTING.md`. The checker is
 `tests/python/test_representation_change_trailer.py`, because three copies of one list drift
 silently.
 
+### Never hand-edit `tests/it/clause_ruling_index.rs` — it embeds a GENERATED block
+
+The file is committed, so it looks hand-maintainable. It is not: it carries a rendered index of
+every clause the ruling records cite, and `the_rendered_index_is_current` compares that block
+against what the code generates. Editing it by hand is transcription, and transcription of a
+~100-row block is lossy in a way that reads as a small diff — two attempts at it were made here
+and both dropped rows silently.
+
+Capture what the test prints **programmatically** instead. The pattern that works: add a throwaway
+test that writes `render_index()` to a file, run it, restore the source byte-for-byte from a
+pre-edit copy, then splice the generated text in on its `BEGIN`/`END` markers. Nothing is retyped.
+
+Note this is a *different* trap from the gitignored spec artifacts above. Those regenerate on
+demand and a stale one fails loudly. This one is committed, so a lossy edit survives review as an
+ordinary diff and only fails on the one assertion that re-renders it.
+
 ### Record every adjudication as a committed test or ruling record, in the same change
 
 **Policy.** When you decide what the *correct* normalization behaviour is — not how to
@@ -1004,6 +1020,20 @@ The `rulings` section of `tests/fixtures/grammar/hgvs_spec_normalization_overrid
 decision log, pinned by `ruling_records_are_intact` (ids **and** statuses; keep `RULING_STATUSES`
 in sync).
 
+**Read the ledger before adjudicating anything from spec text.** The records answer most of what
+gets re-argued, and re-deriving a settled decision is this project's most repeated failure. Two
+traps make it worse than simply forgetting to look:
+
+- **A record's id states its QUESTION, not its ruling, and the two can be opposites.**
+  `separation-is-a-property-of-the-spelling-not-of-the-variant` rules that separation is read off
+  the partition **re-derived from the resulting sequence** — the negation of its own name. Reading
+  the id and stopping gets the answer exactly backwards.
+- **A record's own instructions can be stale.** `delins-merge-vs-individual-gap-two-or-more` says
+  "Re-run the census before citing it" and then publishes a grep whose alternation omits
+  `REQUIRES`, so following it reproduces the wrong count — one uppercase RFC 2119 keyword outside
+  `style.md` when there are two (`RNA/adjoined_transcript.md:20` and `:21`, at spec checkout
+  `6f85311`). Re-run the command *and* sanity-check the command.
+
 **Do not trust a count of decided/undecided records written down here, and do not trust which
 side of the line a record is on either.** Both failures have happened: the sentence this replaces
 said "five of its eight records are `undecided`" long after the ledger had grown and four of those
@@ -1021,18 +1051,23 @@ python3 -c "import json;d=json.load(open('tests/fixtures/grammar/hgvs_spec_norma
 [print(f\"{r['status']:<10} {r['id']}\") for r in d['rulings']]"
 ```
 
-The table below lists the records that are **open**, with what each leaves unsettled. It is a
-description of the open questions, not a census — when a record is ruled on it moves out of this
-table, and the authority for which rows belong here is the ledger, not this list. Read them before
-re-deriving the same argument; the first is an operator decision that blocks other work:
+**Both tables below are now enforced against the ledger**, by
+`claude_md_adjudication_tables::the_two_tables_partition_the_ledger_by_status`. Moving a record
+between them is part of deciding it, and the build fails otherwise. That guard exists because this
+section had drifted three records deep and the existing currency scan could not see it: that scan is
+line-based over `.rs` files under `src/` and `tests/`, so a Markdown table at the repository root was
+outside it twice over, and the word "open" sits in this paragraph while the ids sit in table rows —
+so no line carries both. Widening the scan would not have caught it; the check had to be
+section-aware.
+
+The table below lists the records that are **open**, with what each leaves unsettled. Read them
+before re-deriving the same argument:
 
 | record | what is open |
 |---|---|
-| `codon-carve-out-shape-restriction` | `delins.md:18` names no edit type; ferro applies it only to sub/unchanged/sub |
-| `exon-junction-dup-converge-from-the-far-side` | `LRG_199t1:c.3921dup` and `c.3922dup` denote one transcript sequence but are two fixed points, projecting 2,790 bp apart. `duplication.md:26` argues for converging them, `general.md:44` does not prescribe the 5' shift that would |
 | `rna-repeat-range-plus-unit-redundancy` | `RNA/repeated.md:22` calls range-plus-unit invalid, `:27` publishes exactly that shape as valid. Upstream's conflict (#466); ferro answers both ways depending on input-hygiene mode |
-| `separation-is-a-property-of-the-spelling-not-of-the-variant` | `general.md:34` is stated over "two variants", so the separation it keys on is read off a decomposition a normalizer never sees. Which spelling the rule is evaluated on is unanswered; the spec's own discriminator (`delins.md:79-84`) is provenance, which makes it unfixable as stated |
 | `absolute-prohibition-enforcement-stage` | Whether an absolute prohibition is refused at PARSE (unconditional) or at strict-mode normalize (opt-outable). Recorded because ferro answers it three ways for clauses of identical strength — within `checklist.md:16` alone, `g.*10del` is refused at parse while `g.266+2del` is refused nowhere |
+| `ring-telomere-anchoring` | Must a ring's first `::` segment start at `pter` and its last end at `qter`, so a ring naming only interior coordinates is refused? Ferro currently **accepts** an unanchored ring (pinned by `a_ring_with_no_telomere_anchor_is_still_accepted`) — that is the status quo, not a ruling. Enforcing is not simply "is the first endpoint `pter`": `:28`'s `(pter)_#` / `#_(qter)` forms and `cen` complicate the predicate, and `cen`-anchored segments do not parse at all today |
 
 The `decided` records, and the scope each was decided **at** — read the record before citing it,
 because several of these rulings are narrower than their one-line summary:
@@ -1049,6 +1084,9 @@ because several of these rulings are narrower than their one-line summary:
 | `conflicting-member-geometry-refusal-scope` | `DNA/alleles.md:5` governs — the *definition*, not `general.md:58`, is what reaches nested and coincident-insertion geometries; `:58`'s stated ground literally describes only its own `del`+`dup` example. `general.md:56` is cited to record that it does **not** reach a multi-member allele |
 | `delins-merge-vs-individual-gap-two-or-more` | `DNA/delins.md:44-47` governs `:17`, **scoped** to the alignment-coincidence shape `:44-47` describes. Where a separation of two or more arises from anything else, `general.md:34` still governs; unscoped the reading reaches roughly fifteen times the row set the argument was made on |
 | `inversion-vs-two-delins-76-83` | `inversion.md:5` governs: a whole-block reverse complement is one `inv` when the members it competes with are `delins`, since `general.md:56` ranks substitution but not `delins`. #1230's substitution case is untouched and still splits |
+| `separation-is-a-property-of-the-spelling-not-of-the-variant` | **Read the ruling, not the id** — the title states the *question*, and the answer is the opposite of it. The separation `general.md:34` keys on is read off the partition **re-derived from the resulting sequence**, never off the input's spelling. On its own case both spellings converge on `g.[1001009_1001010del;1001013del]`. Deviates from `delins.md:79-84`, whose provenance rationale ferro cannot honour |
+| `codon-carve-out-shape-restriction` | **WIDEN.** The `delins.md:18` / `general.md:35` exception applies wherever its stated precondition holds — two variants separated by one nucleotide, together affecting one amino acid — **regardless of edit type**. Ferro's restriction to a sub/unchanged/sub shape is dropped, on the ground that edit type is a property of the spelling while "together affecting one amino acid" is a property of the resulting sequence |
+| `exon-junction-dup-converge-from-the-far-side` | **CONVERGE.** `LRG_199t1:c.3922dup` normalizes to `c.3921dup`. The canonical position is the most 3' position that does **not** cross an exon/exon junction, reached from **either** side — a description approaching the junction stops at it, one already spelled past it is pulled back. Grounded three times in `DNA/duplication.md` (`:26`, `:60`, `:148`), which is what carries it past the RFC 2119 census's lesson about single lowercase-prose clauses |
 
 Two things follow for representation-stability work specifically. The repository's doctrine once
 read as "do not move a normalized output", while the downstream filer has said instability is

--- a/tests/it/claude_md_adjudication_tables.rs
+++ b/tests/it/claude_md_adjudication_tables.rs
@@ -1,0 +1,245 @@
+//! `CLAUDE.md`'s two adjudication tables must partition the ledger by status.
+//!
+//! # Why this exists
+//!
+//! `CLAUDE.md` lists the ruling records in two tables — one for the open
+//! questions, one for the decided rulings and the scope each was decided at.
+//! Which table a record sits in is a **status claim**, and it was hand-maintained.
+//!
+//! It drifted three records deep (#1584): `codon-carve-out-shape-restriction`,
+//! `exon-junction-dup-converge-from-the-far-side` and
+//! `separation-is-a-property-of-the-spelling-not-of-the-variant` had all been
+//! ruled on while the table still carried them as live questions. A fourth,
+//! `ring-telomere-anchoring`, appeared in neither table at all.
+//!
+//! (The wording above is deliberately status-word-free next to each id.
+//! `ruling_citation_currency` scans this file and reads an id sitting on a line
+//! with contradicting status words as a false claim — which it did, on the first
+//! draft of this comment. Describing historical drift and asserting a current
+//! status look identical to a line-based scan, so keep the two apart rather than
+//! adding an exclusion, which would blind the scan to this file for good.)
+//!
+//! That is the more expensive direction of the two. A stale *count* reads as a
+//! claim about coverage; a stale *status* reads as an open question that is in
+//! fact settled, and the next reader re-derives a decision that has already been
+//! made. It came within one step of doing exactly that: the
+//! `separation-is-a-property-of-the-spelling-not-of-the-variant` record's **id
+//! states its question, and its ruling is the opposite of it**, so a reader who
+//! trusts the stale table and reads no further gets the answer backwards.
+//!
+//! # Why the existing currency scan could not catch it
+//!
+//! `ruling_citation_currency` already compares status claims against the ledger,
+//! and it would not have helped here for two independent reasons:
+//!
+//! 1. It scans `.rs` files under `SCAN_ROOTS = ["src", "tests"]`. `CLAUDE.md` is
+//!    Markdown, at the repository root — outside that twice over.
+//! 2. It is **line-based**. In these tables the status word ("open") sits in the
+//!    introducing paragraph while the record ids sit in table rows, so no single
+//!    line carries both an id and a status word. Widening the scan's roots or
+//!    extensions would still have found nothing.
+//!
+//! So the check has to be *section-aware*, which is what this file adds. The two
+//! guards are complements, not duplicates: that one judges prose anywhere, this
+//! one judges membership of two specific tables.
+//!
+//! # What it does not claim
+//!
+//! Only membership. Nothing here reads the prose in the second column, so a row
+//! can sit in the right table and still describe the ruling wrongly — that is
+//! what review is for. What it does buy is that a record cannot be *silently* on
+//! the wrong side of the line, and that a newly added record cannot be omitted.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use crate::common::rulings;
+
+/// The header row that opens the open-questions table.
+const OPEN_TABLE_HEADER: &str = "| record | what is open |";
+
+/// The header row that opens the decided-rulings table.
+const DECIDED_TABLE_HEADER: &str = "| record | ruling |";
+
+fn claude_md() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("CLAUDE.md");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// The backticked ids in the first column of the table opened by `header`, in
+/// document order and **with duplicates kept**.
+///
+/// Reads from the header to the first line that is not a table row, so adding
+/// prose after a table cannot silently extend it.
+///
+/// Returning a `Vec` rather than a set is deliberate. Collecting straight into a
+/// `BTreeSet` discards a repeated row, so one record listed twice in the same
+/// table compared equal to the ledger and passed — under a test named
+/// `every_ledger_record_appears_exactly_once`. `unique_ids` is what makes the
+/// name true.
+fn ids_in_table(markdown: &str, header: &str) -> Vec<String> {
+    let mut lines = markdown.lines().skip_while(|line| line.trim() != header);
+    assert!(
+        lines.next().is_some(),
+        "CLAUDE.md has no table opened by {header:?} — the guard would be vacuous. If the table \
+         was renamed, rename it here too rather than deleting this assertion"
+    );
+
+    let mut ids = Vec::new();
+    for line in lines {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            break;
+        }
+        if line.starts_with("|---") {
+            continue;
+        }
+        // First cell, between the leading `|` and the next one.
+        let first_cell = line
+            .trim_start_matches('|')
+            .split('|')
+            .next()
+            .unwrap_or_default();
+        if let Some(id) = first_cell.split('`').nth(1) {
+            ids.push(id.to_string());
+        }
+    }
+    ids
+}
+
+/// The ids of `rows` as a set, refusing a table that lists one record twice.
+///
+/// A repeated row is a documentation defect on its own — two rows for one record
+/// can carry two different descriptions of the ruling, and nothing says which is
+/// current — and it is invisible to any set-versus-set comparison.
+fn unique_ids(rows: Vec<String>, table: &str) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut repeated = Vec::new();
+    for id in rows {
+        if !seen.insert(id.clone()) {
+            repeated.push(id);
+        }
+    }
+    assert!(
+        repeated.is_empty(),
+        "the {table} table lists these records more than once, so one row of each pair is \
+         unreachable prose that no comparison here can check: {repeated:?}"
+    );
+    seen
+}
+
+#[test]
+fn the_two_tables_partition_the_ledger_by_status() {
+    let markdown = claude_md();
+    let open = unique_ids(ids_in_table(&markdown, OPEN_TABLE_HEADER), "open-questions");
+    let decided = unique_ids(
+        ids_in_table(&markdown, DECIDED_TABLE_HEADER),
+        "decided-rulings",
+    );
+
+    let ledger = rulings::records();
+    let mut want_open = BTreeSet::new();
+    let mut want_decided = BTreeSet::new();
+    for record in &ledger {
+        match record.status.as_str() {
+            "undecided" => want_open.insert(record.id.clone()),
+            "decided" => want_decided.insert(record.id.clone()),
+            other => panic!("record {} has unknown status {other:?}", record.id),
+        };
+    }
+
+    // Non-vacuous in both directions: `0 of 0` must not pass as a result, and a
+    // ledger that had become all-decided would silently empty one table.
+    assert!(
+        !want_open.is_empty() && !want_decided.is_empty(),
+        "the ledger has no record on one side of the line, so this guard measures nothing"
+    );
+
+    assert_eq!(
+        open,
+        want_open,
+        // `want_open` is built from the `undecided` records, so the second list is
+        // records the ledger leaves OPEN. Calling them "decided" here would state
+        // the opposite of the ledger — the precise failure this guard exists to
+        // catch, reproduced in its own diagnostic, and it would send the reader to
+        // move the row into the wrong table.
+        "CLAUDE.md's open-questions table disagrees with the ledger.\n  \
+         listed as open but decided in the ledger: {:?}\n  \
+         undecided in the ledger but missing from the open table: {:?}\n\
+         Moving a record between the two tables is part of deciding it.",
+        open.difference(&want_open).collect::<Vec<_>>(),
+        want_open.difference(&open).collect::<Vec<_>>(),
+    );
+
+    assert_eq!(
+        decided,
+        want_decided,
+        "CLAUDE.md's decided-rulings table disagrees with the ledger.\n  \
+         listed as decided but still open: {:?}\n  \
+         decided in the ledger but missing from the table: {:?}",
+        decided.difference(&want_decided).collect::<Vec<_>>(),
+        want_decided.difference(&decided).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn every_ledger_record_appears_exactly_once() {
+    let markdown = claude_md();
+    let open = unique_ids(ids_in_table(&markdown, OPEN_TABLE_HEADER), "open-questions");
+    let decided = unique_ids(
+        ids_in_table(&markdown, DECIDED_TABLE_HEADER),
+        "decided-rulings",
+    );
+
+    let overlap: Vec<_> = open.intersection(&decided).collect();
+    assert!(
+        overlap.is_empty(),
+        "these records are in BOTH tables, so one of the two is a false status claim: {overlap:?}"
+    );
+
+    // The union check is what would have caught `ring-telomere-anchoring`, which
+    // was in neither table — an omission that no per-table comparison sees if
+    // you only look at the table you happen to be reading.
+    let listed: BTreeSet<_> = open.union(&decided).cloned().collect();
+    let ledger: BTreeSet<_> = rulings::records().iter().map(|r| r.id.clone()).collect();
+    assert_eq!(
+        listed,
+        ledger,
+        "CLAUDE.md and the ledger name different record sets.\n  \
+         in CLAUDE.md but not the ledger: {:?}\n  \
+         in the ledger but documented nowhere: {:?}",
+        listed.difference(&ledger).collect::<Vec<_>>(),
+        ledger.difference(&listed).collect::<Vec<_>>(),
+    );
+}
+
+/// The parser's own guard, on synthetic input.
+///
+/// The two tests above read the real `CLAUDE.md`, so neither can exercise a
+/// malformed table without editing a committed file. This one hands `ids_in_table`
+/// a table it controls, which is the only way to pin that a repeated row is
+/// *rejected* rather than quietly deduped — the defect the `BTreeSet` collect
+/// hid, under a test whose name promised otherwise.
+#[test]
+#[should_panic(expected = "lists these records more than once")]
+fn a_record_listed_twice_in_one_table_is_rejected() {
+    let markdown = format!(
+        "{OPEN_TABLE_HEADER}\n|---|---|\n| `alpha` | first |\n| `beta` | second |\n| `alpha` | \
+         a second row for alpha, saying something else |\n"
+    );
+    let _ = unique_ids(ids_in_table(&markdown, OPEN_TABLE_HEADER), "open-questions");
+}
+
+/// And the negative control: a well-formed table of the same shape passes, so the
+/// guard above cannot be satisfied by `ids_in_table` failing for some other reason.
+#[test]
+fn a_table_with_no_repeats_is_accepted() {
+    let markdown =
+        format!("{OPEN_TABLE_HEADER}\n|---|---|\n| `alpha` | first |\n| `beta` | second |\n");
+    let ids = unique_ids(ids_in_table(&markdown, OPEN_TABLE_HEADER), "open-questions");
+    assert_eq!(
+        ids,
+        ["alpha", "beta"].iter().map(|s| s.to_string()).collect(),
+        "the parser must read both rows of a well-formed table"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -53,6 +53,7 @@ mod cis_confluence_nr_axis;
 mod cis_junction_crossing_shift;
 mod cis_spelling_confluence_gap;
 mod civic_validation;
+mod claude_md_adjudication_tables;
 mod clause_ruling_index;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;


### PR DESCRIPTION
Representation-Change: none. Documentation plus one new integration test; nothing under `src/` is touched and no expectation was re-blessed.

Closes #1584

## The drift

`CLAUDE.md`'s two adjudication tables encode a **status claim** — which table a record sits in — and that split was hand-maintained. Measured against `origin/main`'s ledger:

| | |
|---|---|
| listed as open, actually `decided` | `codon-carve-out-shape-restriction`, `exon-junction-dup-converge-from-the-far-side`, `separation-is-a-property-of-the-spelling-not-of-the-variant` |
| in **neither** table | `ring-telomere-anchoring` |
| ledger truth | 16 records, 13 decided, 3 undecided |

A stale status is the expensive direction. A stale *count* reads as a claim about coverage; a stale *status* reads as an open question that is in fact settled, and the next reader re-derives a decision already made.

**This came within one step of doing exactly that today.** The `separation-is-a-property-of-the-spelling-not-of-the-variant` record's id states its **question**, and its ruling is the **opposite** of it — separation is read off the partition re-derived from the resulting sequence, never off the input's spelling. A reader who trusts the stale table and stops at the id gets the answer backwards.

## Why the existing currency scan could not catch it

`ruling_citation_currency` already compares status claims against the ledger. It would not have helped, for two independent reasons:

1. It scans `.rs` files under `SCAN_ROOTS = ["src", "tests"]`. `CLAUDE.md` is Markdown at the repository root — outside that twice over.
2. It is **line-based**. Here the status word ("open") sits in the introducing paragraph while the ids sit in table rows, so **no single line carries both**.

Widening its roots or its extension filter would still have found nothing. The check has to be section-aware, which is what this adds.

## The guard

`claude_md_adjudication_tables`, two tests:

- the two tables must **partition** the ledger by status
- their **union** must be the ledger exactly, with no record in both

Both were exercised against the real drift rather than assumed to work — reinstating a decided record in the open table, and deleting a record from both tables. Each fails with the specific record named, and passes once restored.

The failure messages name which records are on the wrong side and in which direction, so the fix is mechanical.

## Also recorded

- **A record's id states its question, not its ruling** — with the example above, since that is not derivable from the ledger.
- **`delins-merge-vs-individual-gap-two-or-more` says "re-run the census before citing it" and then publishes a grep that omits `REQUIRES`.** Following it reproduces the wrong count: one uppercase RFC 2119 keyword outside `style.md` where there are two (`RNA/adjoined_transcript.md:20` and `:21`, at spec checkout `6f85311`). Verified both ways.
- **The `clause_ruling_index` trap** — the file is committed but embeds a *generated* block, so a hand edit is lossy transcription that survives review as an ordinary diff and fails only on the one assertion that re-renders it. Capture what the test prints programmatically.

## One claim dropped rather than fixed, because it is false

Our notes carried "CLAUDE.md says a decline reason may follow the marker — the shipped regex says no". The regex **does** admit it: `none. Tests only; no watched file is touched.` passes, and `DECLINE_RE` explicitly allows a terminator followed by prose. Nothing to correct.

## Verification

- Full suite: **10,138 run, 10,138 passed, 152 skipped** (`FERRO_MANIFEST` set, so the conformance censuses ran rather than skipping green)
- `cargo fmt --all --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean
- The new guard's first draft **tripped `ruling_citation_currency`** — describing historical drift put a record id on a line with contradicting status words. Fixed by rewording rather than by adding a scan exclusion, which would have blinded the scan to this file permanently.