### PR TITLE
fix(fixtures): restore transcript exon ends and guard the Exon contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1016,11 +1016,27 @@ jobs:
         #     (`repeat_tract_maximization`). `hgvs_to_spdi` reads the anchored
         #     spelling as 6 copies replacing a 1-copy tract and the normalizer's
         #     output as 6 copies replacing a 2-copy tract — 14 bases against 12.
-        #   * #1619 — `NM_000492.4:c.1520_1522del` -> `c.1521_1523del`
-        #     (`normalize_tests`). The two forms are genuinely equivalent on the
-        #     flat transcript; `hgvs_to_spdi` resolves the c. position by walking
-        #     the fixture's exon list, whose 1-base synthetic introns put it 10
-        #     bases 3' of where the normalizer reads.
+        #   * #1619 — `NM_033517.1:c.4818dupC` -> `c.4818dup`
+        #     (`normalize_tests`). `hgvs_to_spdi` resolves the c. position by
+        #     WALKING the exon list while the normalizer indexes the FLAT
+        #     transcript, so the two disagree across any transcript-coordinate
+        #     gap: here the input applies `C` and the output applies `T` at
+        #     transcript position 4877.
+        #
+        #     This row replaced an earlier one on the same issue
+        #     (`NM_000492.4:c.1520_1522del` -> `c.1521_1523del`), and the swap is
+        #     the point rather than a detail. That one rode on a FIXTURE DEFECT —
+        #     `normalization_transcripts.json` held cdot's exon table with every
+        #     `end` decremented by one, giving a 1-base hole at every junction, a
+        #     shape that occurs nowhere in 474,818 real builds. Repairing the
+        #     fixture removed it. This row rides on cdot's own annotation:
+        #     `NM_033517.1` genuinely has a 39-base hole between exon 10 and exon
+        #     11, one of the 58 gapped builds in cdot-0.2.32.refseq.GRCh38. So
+        #     #1619 is now demonstrated on real geometry rather than on an
+        #     artifact, which makes it a STRONGER reason to keep the flag out of
+        #     this job, not a weaker one — and it is the reproducer the issue had
+        #     otherwise lost. See `CDOT_GAP_JUNCTIONS` in
+        #     `tests/it/normalization_transcripts_exon_contract.rs`.
         #
         # Turning the flag on here before those are settled would make the job
         # red for a reason that is not the PR's; suppressing them would hollow out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,11 +336,88 @@ real disagreements inside ferro rather than noise:
 | row | what disagrees |
 |---|---|
 | #1618 — `NC_TEST.1:g.262TG[6]` → `g.259_262GT[6]` | `hgvs_to_spdi` reads the anchored spelling as 6 copies replacing a **1**-copy tract, the normalizer's output as 6 copies replacing a **2**-copy tract — 14 bases against 12 |
-| #1619 — `NM_000492.4:c.1520_1522del` → `c.1521_1523del` | the two forms are equivalent on the flat transcript; `hgvs_to_spdi` resolves the `c.` position by walking `normalization_transcripts.json`'s exon list, whose 1-base synthetic introns land it **10 bases** 3' of where the normalizer reads |
+| #1619 — `NM_033517.1:c.4818dupC` → `c.4818dup` | `hgvs_to_spdi` resolves the `c.` position by **walking** the exon list while the normalizer indexes the **flat** transcript, so the two disagree across any transcript-coordinate gap: the input applies `C`, the output applies `T`, at transcript position 4877. `NM_033517.1` carries a real 39-base cdot hole between exons 10 and 11 — see below, because this row **replaced** an earlier one on the same issue |
 
 Suppressing either would hollow out the oracle, and turning the flag on before
 they are settled would redden the job for a reason no PR caused. Move it into
 `test-oracle` once both are closed.
+
+**#1619's row was replaced, not closed, and the swap is the whole point.** The
+old row (`NM_000492.4:c.1520_1522del` → `c.1521_1523del`) rode on a **fixture
+defect**, not on annotation: `normalization_transcripts.json` was the real cdot
+exon table with every exon's `end` decremented by one, so all 22 of its
+multi-exon records carried a one-base hole at every junction — a shape that
+occurs nowhere in 474,818 real builds. Repairing the fixture removed that row.
+
+The row that stands in its place rides on **cdot's own annotation**.
+`NM_033517.1` is one of the 58 gapped builds, with a genuine 39-base hole
+between exon 10 (ends 1302) and exon 11 (starts 1342), and the fixture now
+carries its real table. So #1619 is demonstrated on real transcript geometry
+rather than on an artifact — which is a *stronger* reason to keep
+`FERRO_ASSERT_SEQUENCE` out of `test-oracle`, and it hands the issue the
+reproducer the repair would otherwise have destroyed. The gap is exempted by
+name in `CDOT_GAP_JUNCTIONS`
+(`tests/it/normalization_transcripts_exon_contract.rs`), never by loosening the
+contiguity rule.
+
+**No CI job arms the oracle where it fires** — checked, not assumed.
+`FERRO_ASSERT_SEQUENCE` is set in exactly two places: `ci.yml`'s `sweeps`, which
+selects `SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`, and
+`nightly-mutalyzer.yml`, which selects the three reference-aware modules and is
+`continue-on-error`. `normalize_tests` is in neither selection, so the fire is
+reachable only by setting the flag by hand.
+
+**Here is the command the before/after comes from**, because a figure with no
+command is one nobody can re-derive. Swap only the fixture, and exclude the guard
+this change adds — that guard is *about* the fixture, so it cannot be a term in a
+before/after on it:
+
+```bash
+# "before" = the fixture as it stands on the PR's base; "after" = the fixed one
+git show <base>:tests/fixtures/sequences/normalization_transcripts.json \
+  > tests/fixtures/sequences/normalization_transcripts.json
+FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
+FERRO_ASSERT_SEQUENCE=1 \
+  cargo nextest run --features dev --lib --test it \
+  -E 'not test(normalization_transcripts_exon_contract)'
+```
+
+Against `origin/main` at `d5f26fcb`: **25 failures before, 22 after, zero new.**
+The three that went green are `idempotency_tests::test_normalization_idempotency`,
+`normalize_tests::normalization_transformations::test_3prime_shifting::case_1` and
+`normalize_tests::normalization_transformations::test_deletion_shifts_in_real_homopolymer::case_1`.
+
+**That is two files, not three.** Three files read the fixture —
+`normalize_property_tests`, `normalize_tests` and `idempotency_tests` — and the
+three green tests come from the latter two; `normalize_property_tests` reads it
+and contributes none. This paragraph used to call them "exactly the three suites
+that read that fixture", which is the claim being corrected.
+
+**Quote the command, not the pair.** The *difference* is stable — three tests,
+always the same three — but the totals are a property of `main` on the day: the
+same measurement read **20 before, 17 after** against `5f22abed` and 25/22
+against `d5f26fcb` a few hours later, because unrelated PRs were landing into the
+pre-existing oracle residue the whole time. A bare "25 / 22" quoted without its
+base is not reproducible, which is what this paragraph originally shipped.
+`tests/it/normalization_transcripts_exon_contract.rs` now guards the shape.
+
+**The defect the issue names is still live**, and losing the only corpus that
+exercised it is the hazard here. `hgvs_to_spdi` resolves a `c.` position by
+*walking* the exon list while the normalizer indexes the *flat* transcript, and
+those two readings disagree whenever the exon table has a transcript-coordinate
+gap. Real cdot has such gaps — measured over cdot-0.2.32.refseq.GRCh38,
+**58** of 474,818 multi-exon builds, sizes 23–2718 bases (none of them one base,
+which is why the fixture's shape was diagnostic of a generator bug rather than of
+real annotation).
+
+**And the suite does exercise it, on real geometry.** `NM_033517.1`'s restored
+cdot table is that corpus: one record, one genuine gap, one existing case
+(`c.4818dupC`) that fires the denoted-sequence oracle. So closing #1619 does not
+need a corpus built from scratch — it needs the walk and the flat read to be
+reconciled, and this row is the regression guard for whichever way that is
+settled. Do **not** "fix" it by re-flattening the record or by widening
+`CDOT_GAP_JUNCTIONS`: the first destroys the reproducer, the second re-admits
+the synthetic one-base holes the contract guard exists to keep out.
 
 **Measured false-positive classes, and what closed each.** The first run of this
 oracle over the suite raised **344** fires, all but 16 of them false. Each fix

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -1129,8 +1129,32 @@ mod tests {
         assert!(mapper.tx_to_genomic(&TxPos::new(1)).is_err());
     }
 
-    /// Create a transcript with gaps between exons (like cdot format)
-    /// This simulates how cdot encodes transcripts with virtual intron positions
+    /// A deliberately **malformed** transcript whose exons do not tile transcript
+    /// space: transcript positions 1, 95 and 194 fall in no exon.
+    ///
+    /// This is a synthetic stress case for `CoordinateMapper`'s exon-walking
+    /// arithmetic, not a model of any real annotation. The mapper must resolve
+    /// `c.`/`n.` positions by stepping through exonic bases rather than assuming
+    /// the flat `tx = cds_start + cds - 1`, and the holes below are what makes
+    /// the two answers differ — so the tests using it pin the walk, not the
+    /// shortcut.
+    ///
+    /// It does **not** describe cdot. This helper previously claimed to
+    /// "simulate how cdot encodes transcripts with virtual intron positions";
+    /// cdot has no such encoding. Its `cds_start_i`/`cds_end_i` are 1-based
+    /// inclusive coordinates on the *spliced* transcript, so consecutive exons
+    /// abut and introns occupy no transcript coordinate at all. Measured over
+    /// cdot-0.2.32.refseq.GRCh38, 474,818 multi-exon builds yield 58 with any
+    /// transcript-coordinate gap (0.012%), the smallest of them 23 bases, and
+    /// **none** with a one-base gap.
+    ///
+    /// The false claim was load-bearing: it was the stated justification for the
+    /// one-base-per-junction holes that
+    /// `tests/fixtures/sequences/normalization_transcripts.json` carried in every
+    /// multi-exon record, which drifted `NM_000492.4:c.1520` ten bases 3' (#1619).
+    /// `tests/it/normalization_transcripts_exon_contract.rs` now guards that
+    /// fixture; this helper stays malformed on purpose, and is scoped to the
+    /// seven tests below.
     fn make_transcript_with_gaps() -> Transcript {
         // Transcript with 3 exons and gaps between them
         // Exon 1: tx 2-94 (93 bases)

--- a/tests/fixtures/sequences/normalization_transcripts.json
+++ b/tests/fixtures/sequences/normalization_transcripts.json
@@ -10,257 +10,257 @@
       {
         "number": 1,
         "start": 1,
-        "end": 220
+        "end": 221
       },
       {
         "number": 2,
         "start": 222,
-        "end": 415
+        "end": 416
       },
       {
         "number": 3,
         "start": 417,
-        "end": 450
+        "end": 451
       },
       {
         "number": 4,
         "start": 452,
-        "end": 486
+        "end": 487
       },
       {
         "number": 5,
         "start": 488,
-        "end": 588
+        "end": 589
       },
       {
         "number": 6,
         "start": 590,
-        "end": 660
+        "end": 661
       },
       {
         "number": 7,
         "start": 662,
-        "end": 705
+        "end": 706
       },
       {
         "number": 8,
         "start": 707,
-        "end": 759
+        "end": 760
       },
       {
         "number": 9,
         "start": 761,
-        "end": 813
+        "end": 814
       },
       {
         "number": 10,
         "start": 815,
-        "end": 867
+        "end": 868
       },
       {
         "number": 11,
         "start": 869,
-        "end": 921
+        "end": 922
       },
       {
         "number": 12,
         "start": 923,
-        "end": 975
+        "end": 976
       },
       {
         "number": 13,
         "start": 977,
-        "end": 1020
+        "end": 1021
       },
       {
         "number": 14,
         "start": 1022,
-        "end": 1074
+        "end": 1075
       },
       {
         "number": 15,
         "start": 1076,
-        "end": 1119
+        "end": 1120
       },
       {
         "number": 16,
         "start": 1121,
-        "end": 1173
+        "end": 1174
       },
       {
         "number": 17,
         "start": 1175,
-        "end": 1272
+        "end": 1273
       },
       {
         "number": 18,
         "start": 1274,
-        "end": 1317
+        "end": 1318
       },
       {
         "number": 19,
         "start": 1319,
-        "end": 1416
+        "end": 1417
       },
       {
         "number": 20,
         "start": 1418,
-        "end": 1470
+        "end": 1471
       },
       {
         "number": 21,
         "start": 1472,
-        "end": 1578
+        "end": 1579
       },
       {
         "number": 22,
         "start": 1580,
-        "end": 1632
+        "end": 1633
       },
       {
         "number": 23,
         "start": 1634,
-        "end": 1731
+        "end": 1732
       },
       {
         "number": 24,
         "start": 1733,
-        "end": 1785
+        "end": 1786
       },
       {
         "number": 25,
         "start": 1787,
-        "end": 1884
+        "end": 1885
       },
       {
         "number": 26,
         "start": 1886,
-        "end": 1938
+        "end": 1939
       },
       {
         "number": 27,
         "start": 1940,
-        "end": 1992
+        "end": 1993
       },
       {
         "number": 28,
         "start": 1994,
-        "end": 2046
+        "end": 2047
       },
       {
         "number": 29,
         "start": 2048,
-        "end": 2100
+        "end": 2101
       },
       {
         "number": 30,
         "start": 2102,
-        "end": 2145
+        "end": 2146
       },
       {
         "number": 31,
         "start": 2147,
-        "end": 2244
+        "end": 2245
       },
       {
         "number": 32,
         "start": 2246,
-        "end": 2352
+        "end": 2353
       },
       {
         "number": 33,
         "start": 2354,
-        "end": 2460
+        "end": 2461
       },
       {
         "number": 34,
         "start": 2462,
-        "end": 2514
+        "end": 2515
       },
       {
         "number": 35,
         "start": 2516,
-        "end": 2568
+        "end": 2569
       },
       {
         "number": 36,
         "start": 2570,
-        "end": 2676
+        "end": 2677
       },
       {
         "number": 37,
         "start": 2678,
-        "end": 2730
+        "end": 2731
       },
       {
         "number": 38,
         "start": 2732,
-        "end": 2784
+        "end": 2785
       },
       {
         "number": 39,
         "start": 2786,
-        "end": 2946
+        "end": 2947
       },
       {
         "number": 40,
         "start": 2948,
-        "end": 3054
+        "end": 3055
       },
       {
         "number": 41,
         "start": 3056,
-        "end": 3162
+        "end": 3163
       },
       {
         "number": 42,
         "start": 3164,
-        "end": 3216
+        "end": 3217
       },
       {
         "number": 43,
         "start": 3218,
-        "end": 3324
+        "end": 3325
       },
       {
         "number": 44,
         "start": 3326,
-        "end": 3378
+        "end": 3379
       },
       {
         "number": 45,
         "start": 3380,
-        "end": 3486
+        "end": 3487
       },
       {
         "number": 46,
         "start": 3488,
-        "end": 3540
+        "end": 3541
       },
       {
         "number": 47,
         "start": 3542,
-        "end": 3648
+        "end": 3649
       },
       {
         "number": 48,
         "start": 3650,
-        "end": 3931
+        "end": 3932
       },
       {
         "number": 49,
         "start": 3933,
-        "end": 4122
+        "end": 4123
       },
       {
         "number": 50,
         "start": 4124,
-        "end": 4365
+        "end": 4366
       },
       {
         "number": 51,
         "start": 4367,
-        "end": 5913
+        "end": 5914
       }
     ]
   },
@@ -275,137 +275,137 @@
       {
         "number": 1,
         "start": 1,
-        "end": 122
+        "end": 123
       },
       {
         "number": 2,
         "start": 124,
-        "end": 233
+        "end": 234
       },
       {
         "number": 3,
         "start": 235,
-        "end": 342
+        "end": 343
       },
       {
         "number": 4,
         "start": 344,
-        "end": 558
+        "end": 559
       },
       {
         "number": 5,
         "start": 560,
-        "end": 648
+        "end": 649
       },
       {
         "number": 6,
         "start": 650,
-        "end": 812
+        "end": 813
       },
       {
         "number": 7,
         "start": 814,
-        "end": 938
+        "end": 939
       },
       {
         "number": 8,
         "start": 940,
-        "end": 1185
+        "end": 1186
       },
       {
         "number": 9,
         "start": 1187,
-        "end": 1278
+        "end": 1279
       },
       {
         "number": 10,
         "start": 1280,
-        "end": 1461
+        "end": 1462
       },
       {
         "number": 11,
         "start": 1463,
-        "end": 1653
+        "end": 1654
       },
       {
         "number": 12,
         "start": 1655,
-        "end": 1748
+        "end": 1749
       },
       {
         "number": 13,
         "start": 1750,
-        "end": 1835
+        "end": 1836
       },
       {
         "number": 14,
         "start": 1837,
-        "end": 2559
+        "end": 2560
       },
       {
         "number": 15,
         "start": 2561,
-        "end": 2688
+        "end": 2689
       },
       {
         "number": 16,
         "start": 2690,
-        "end": 2726
+        "end": 2727
       },
       {
         "number": 17,
         "start": 2728,
-        "end": 2977
+        "end": 2978
       },
       {
         "number": 18,
         "start": 2979,
-        "end": 3057
+        "end": 3058
       },
       {
         "number": 19,
         "start": 3059,
-        "end": 3208
+        "end": 3209
       },
       {
         "number": 20,
         "start": 3210,
-        "end": 3436
+        "end": 3437
       },
       {
         "number": 21,
         "start": 3438,
-        "end": 3537
+        "end": 3538
       },
       {
         "number": 22,
         "start": 3539,
-        "end": 3786
+        "end": 3787
       },
       {
         "number": 23,
         "start": 3788,
-        "end": 3942
+        "end": 3943
       },
       {
         "number": 24,
         "start": 3944,
-        "end": 4032
+        "end": 4033
       },
       {
         "number": 25,
         "start": 4034,
-        "end": 4205
+        "end": 4206
       },
       {
         "number": 26,
         "start": 4207,
-        "end": 4311
+        "end": 4312
       },
       {
         "number": 27,
         "start": 4313,
-        "end": 6069
+        "end": 6070
       }
     ]
   },
@@ -420,117 +420,117 @@
       {
         "number": 1,
         "start": 1,
-        "end": 93
+        "end": 94
       },
       {
         "number": 2,
         "start": 95,
-        "end": 192
+        "end": 193
       },
       {
         "number": 3,
         "start": 194,
-        "end": 246
+        "end": 247
       },
       {
         "number": 4,
         "start": 248,
-        "end": 324
+        "end": 325
       },
       {
         "number": 5,
         "start": 326,
-        "end": 413
+        "end": 414
       },
       {
         "number": 6,
         "start": 415,
-        "end": 553
+        "end": 554
       },
       {
         "number": 7,
         "start": 555,
-        "end": 659
+        "end": 660
       },
       {
         "number": 8,
         "start": 661,
-        "end": 705
+        "end": 706
       },
       {
         "number": 9,
         "start": 707,
-        "end": 782
+        "end": 783
       },
       {
         "number": 10,
         "start": 784,
-        "end": 4208
+        "end": 4209
       },
       {
         "number": 11,
         "start": 4210,
-        "end": 4297
+        "end": 4298
       },
       {
         "number": 12,
         "start": 4299,
-        "end": 4469
+        "end": 4470
       },
       {
         "number": 13,
         "start": 4471,
-        "end": 4596
+        "end": 4597
       },
       {
         "number": 14,
         "start": 4598,
-        "end": 4787
+        "end": 4788
       },
       {
         "number": 15,
         "start": 4789,
-        "end": 5098
+        "end": 5099
       },
       {
         "number": 16,
         "start": 5100,
-        "end": 5186
+        "end": 5187
       },
       {
         "number": 17,
         "start": 5188,
-        "end": 5264
+        "end": 5265
       },
       {
         "number": 18,
         "start": 5266,
-        "end": 5305
+        "end": 5306
       },
       {
         "number": 19,
         "start": 5307,
-        "end": 5389
+        "end": 5390
       },
       {
         "number": 20,
         "start": 5391,
-        "end": 5444
+        "end": 5445
       },
       {
         "number": 21,
         "start": 5446,
-        "end": 5518
+        "end": 5519
       },
       {
         "number": 22,
         "start": 5520,
-        "end": 5579
+        "end": 5580
       },
       {
         "number": 23,
         "start": 5581,
-        "end": 7087
+        "end": 7088
       }
     ]
   },
@@ -545,137 +545,137 @@
       {
         "number": 1,
         "start": 1,
-        "end": 159
+        "end": 160
       },
       {
         "number": 2,
         "start": 161,
-        "end": 265
+        "end": 266
       },
       {
         "number": 3,
         "start": 267,
-        "end": 514
+        "end": 515
       },
       {
         "number": 4,
         "start": 516,
-        "end": 623
+        "end": 624
       },
       {
         "number": 5,
         "start": 625,
-        "end": 673
+        "end": 674
       },
       {
         "number": 6,
         "start": 675,
-        "end": 714
+        "end": 715
       },
       {
         "number": 7,
         "start": 716,
-        "end": 829
+        "end": 830
       },
       {
         "number": 8,
         "start": 831,
-        "end": 879
+        "end": 880
       },
       {
         "number": 9,
         "start": 881,
-        "end": 991
+        "end": 992
       },
       {
         "number": 10,
         "start": 993,
-        "end": 2107
+        "end": 2108
       },
       {
         "number": 11,
         "start": 2109,
-        "end": 7039
+        "end": 7040
       },
       {
         "number": 12,
         "start": 7041,
-        "end": 7135
+        "end": 7136
       },
       {
         "number": 13,
         "start": 7137,
-        "end": 7205
+        "end": 7206
       },
       {
         "number": 14,
         "start": 7207,
-        "end": 7633
+        "end": 7634
       },
       {
         "number": 15,
         "start": 7635,
-        "end": 7815
+        "end": 7816
       },
       {
         "number": 16,
         "start": 7817,
-        "end": 8003
+        "end": 8004
       },
       {
         "number": 17,
         "start": 8005,
-        "end": 8174
+        "end": 8175
       },
       {
         "number": 18,
         "start": 8176,
-        "end": 8529
+        "end": 8530
       },
       {
         "number": 19,
         "start": 8531,
-        "end": 8685
+        "end": 8686
       },
       {
         "number": 20,
         "start": 8687,
-        "end": 8830
+        "end": 8831
       },
       {
         "number": 21,
         "start": 8832,
-        "end": 8952
+        "end": 8953
       },
       {
         "number": 22,
         "start": 8954,
-        "end": 9151
+        "end": 9152
       },
       {
         "number": 23,
         "start": 9153,
-        "end": 9315
+        "end": 9316
       },
       {
         "number": 24,
         "start": 9317,
-        "end": 9454
+        "end": 9455
       },
       {
         "number": 25,
         "start": 9456,
-        "end": 9699
+        "end": 9700
       },
       {
         "number": 26,
         "start": 9701,
-        "end": 9846
+        "end": 9847
       },
       {
         "number": 27,
         "start": 9848,
-        "end": 11953
+        "end": 11954
       }
     ]
   },
@@ -690,57 +690,57 @@
       {
         "number": 1,
         "start": 1,
-        "end": 113
+        "end": 114
       },
       {
         "number": 2,
         "start": 115,
-        "end": 215
+        "end": 216
       },
       {
         "number": 3,
         "start": 217,
-        "end": 237
+        "end": 238
       },
       {
         "number": 4,
         "start": 239,
-        "end": 516
+        "end": 517
       },
       {
         "number": 5,
         "start": 518,
-        "end": 700
+        "end": 701
       },
       {
         "number": 6,
         "start": 702,
-        "end": 813
+        "end": 814
       },
       {
         "number": 7,
         "start": 815,
-        "end": 923
+        "end": 924
       },
       {
         "number": 8,
         "start": 925,
-        "end": 1060
+        "end": 1061
       },
       {
         "number": 9,
         "start": 1062,
-        "end": 1134
+        "end": 1135
       },
       {
         "number": 10,
         "start": 1136,
-        "end": 1241
+        "end": 1242
       },
       {
         "number": 11,
         "start": 1243,
-        "end": 2511
+        "end": 2512
       }
     ]
   },
@@ -755,67 +755,67 @@
       {
         "number": 1,
         "start": 1,
-        "end": 348
+        "end": 349
       },
       {
         "number": 2,
         "start": 350,
-        "end": 492
+        "end": 493
       },
       {
         "number": 3,
         "start": 494,
-        "end": 648
+        "end": 649
       },
       {
         "number": 4,
         "start": 650,
-        "end": 1168
+        "end": 1169
       },
       {
         "number": 5,
         "start": 1170,
-        "end": 1250
+        "end": 1251
       },
       {
         "number": 6,
         "start": 1252,
-        "end": 1383
+        "end": 1384
       },
       {
         "number": 7,
         "start": 1385,
-        "end": 1595
+        "end": 1596
       },
       {
         "number": 8,
         "start": 1597,
-        "end": 1650
+        "end": 1651
       },
       {
         "number": 9,
         "start": 1652,
-        "end": 1811
+        "end": 1812
       },
       {
         "number": 10,
         "start": 1813,
-        "end": 1895
+        "end": 1896
       },
       {
         "number": 11,
         "start": 1897,
-        "end": 2070
+        "end": 2071
       },
       {
         "number": 12,
         "start": 2072,
-        "end": 2270
+        "end": 2271
       },
       {
         "number": 13,
         "start": 2272,
-        "end": 2568
+        "end": 2569
       }
     ]
   },
@@ -830,72 +830,72 @@
       {
         "number": 1,
         "start": 1,
-        "end": 66
+        "end": 67
       },
       {
         "number": 2,
         "start": 68,
-        "end": 102
+        "end": 103
       },
       {
         "number": 3,
         "start": 104,
-        "end": 246
+        "end": 247
       },
       {
         "number": 4,
         "start": 248,
-        "end": 402
+        "end": 403
       },
       {
         "number": 5,
         "start": 404,
-        "end": 922
+        "end": 923
       },
       {
         "number": 6,
         "start": 924,
-        "end": 1004
+        "end": 1005
       },
       {
         "number": 7,
         "start": 1006,
-        "end": 1137
+        "end": 1138
       },
       {
         "number": 8,
         "start": 1139,
-        "end": 1349
+        "end": 1350
       },
       {
         "number": 9,
         "start": 1351,
-        "end": 1404
+        "end": 1405
       },
       {
         "number": 10,
         "start": 1406,
-        "end": 1565
+        "end": 1566
       },
       {
         "number": 11,
         "start": 1567,
-        "end": 1649
+        "end": 1650
       },
       {
         "number": 12,
         "start": 1651,
-        "end": 1824
+        "end": 1825
       },
       {
         "number": 13,
         "start": 1826,
-        "end": 2024
+        "end": 2025
       },
       {
         "number": 14,
         "start": 2026,
-        "end": 2322
+        "end": 2323
       }
     ]
   },
@@ -910,87 +910,87 @@
       {
         "number": 1,
         "start": 1,
-        "end": 168
+        "end": 169
       },
       {
         "number": 2,
         "start": 170,
-        "end": 233
+        "end": 234
       },
       {
         "number": 3,
         "start": 235,
-        "end": 387
+        "end": 388
       },
       {
         "number": 4,
         "start": 389,
-        "end": 488
+        "end": 489
       },
       {
         "number": 5,
         "start": 490,
-        "end": 570
+        "end": 571
       },
       {
         "number": 6,
         "start": 572,
-        "end": 603
+        "end": 604
       },
       {
         "number": 7,
         "start": 605,
-        "end": 664
+        "end": 665
       },
       {
         "number": 8,
         "start": 666,
-        "end": 722
+        "end": 723
       },
       {
         "number": 9,
         "start": 724,
-        "end": 816
+        "end": 817
       },
       {
         "number": 10,
         "start": 818,
-        "end": 849
+        "end": 850
       },
       {
         "number": 11,
         "start": 851,
-        "end": 972
+        "end": 973
       },
       {
         "number": 12,
         "start": 974,
-        "end": 1113
+        "end": 1114
       },
       {
         "number": 13,
         "start": 1115,
-        "end": 1266
+        "end": 1267
       },
       {
         "number": 14,
         "start": 1268,
-        "end": 1417
+        "end": 1418
       },
       {
         "number": 15,
         "start": 1419,
-        "end": 1504
+        "end": 1505
       },
       {
         "number": 16,
         "start": 1506,
-        "end": 1669
+        "end": 1670
       },
       {
         "number": 17,
         "start": 1671,
-        "end": 9269
+        "end": 9270
       }
     ]
   },
@@ -1005,17 +1005,17 @@
       {
         "number": 1,
         "start": 1,
-        "end": 114
+        "end": 115
       },
       {
         "number": 2,
         "start": 116,
-        "end": 345
+        "end": 346
       },
       {
         "number": 3,
         "start": 347,
-        "end": 569
+        "end": 570
       }
     ]
   },
@@ -1030,117 +1030,117 @@
       {
         "number": 1,
         "start": 1,
-        "end": 47
+        "end": 48
       },
       {
         "number": 2,
         "start": 49,
-        "end": 106
+        "end": 107
       },
       {
         "number": 3,
         "start": 108,
-        "end": 254
+        "end": 255
       },
       {
         "number": 4,
         "start": 256,
-        "end": 404
+        "end": 405
       },
       {
         "number": 5,
         "start": 406,
-        "end": 491
+        "end": 492
       },
       {
         "number": 6,
         "start": 493,
-        "end": 620
+        "end": 621
       },
       {
         "number": 7,
         "start": 622,
-        "end": 741
+        "end": 742
       },
       {
         "number": 8,
         "start": 743,
-        "end": 818
+        "end": 819
       },
       {
         "number": 9,
         "start": 820,
-        "end": 908
+        "end": 909
       },
       {
         "number": 10,
         "start": 910,
-        "end": 1095
+        "end": 1096
       },
       {
         "number": 11,
         "start": 1097,
-        "end": 1175
+        "end": 1176
       },
       {
         "number": 12,
         "start": 1177,
-        "end": 1436
+        "end": 1437
       },
       {
         "number": 13,
         "start": 1438,
-        "end": 1482
+        "end": 1483
       },
       {
         "number": 14,
         "start": 1484,
-        "end": 1608
+        "end": 1609
       },
       {
         "number": 15,
         "start": 1610,
-        "end": 1768
+        "end": 1769
       },
       {
         "number": 16,
         "start": 1770,
-        "end": 1858
+        "end": 1859
       },
       {
         "number": 17,
         "start": 1860,
-        "end": 1908
+        "end": 1909
       },
       {
         "number": 18,
         "start": 1910,
-        "end": 2039
+        "end": 2040
       },
       {
         "number": 19,
         "start": 2041,
-        "end": 2112
+        "end": 2113
       },
       {
         "number": 20,
         "start": 2114,
-        "end": 2211
+        "end": 2212
       },
       {
         "number": 21,
         "start": 2213,
-        "end": 2314
+        "end": 2315
       },
       {
         "number": 22,
         "start": 2316,
-        "end": 2462
+        "end": 2463
       },
       {
         "number": 23,
         "start": 2464,
-        "end": 5645
+        "end": 5646
       }
     ]
   },
@@ -1155,77 +1155,77 @@
       {
         "number": 1,
         "start": 1,
-        "end": 313
+        "end": 314
       },
       {
         "number": 2,
         "start": 315,
-        "end": 447
+        "end": 448
       },
       {
         "number": 3,
         "start": 449,
-        "end": 618
+        "end": 619
       },
       {
         "number": 4,
         "start": 620,
-        "end": 737
+        "end": 738
       },
       {
         "number": 5,
         "start": 739,
-        "end": 895
+        "end": 896
       },
       {
         "number": 6,
         "start": 897,
-        "end": 991
+        "end": 992
       },
       {
         "number": 7,
         "start": 993,
-        "end": 1121
+        "end": 1122
       },
       {
         "number": 8,
         "start": 1123,
-        "end": 1811
+        "end": 1812
       },
       {
         "number": 9,
         "start": 1813,
-        "end": 1896
+        "end": 1897
       },
       {
         "number": 10,
         "start": 1898,
-        "end": 2033
+        "end": 2034
       },
       {
         "number": 11,
         "start": 2035,
-        "end": 2125
+        "end": 2126
       },
       {
         "number": 12,
         "start": 2127,
-        "end": 2206
+        "end": 2207
       },
       {
         "number": 13,
         "start": 2208,
-        "end": 2459
+        "end": 2460
       },
       {
         "number": 14,
         "start": 2461,
-        "end": 3282
+        "end": 3283
       },
       {
         "number": 15,
         "start": 3284,
-        "end": 4298
+        "end": 4299
       }
     ]
   },
@@ -1240,12 +1240,12 @@
       {
         "number": 1,
         "start": 1,
-        "end": 2490
+        "end": 2491
       },
       {
         "number": 2,
         "start": 2492,
-        "end": 2598
+        "end": 2599
       }
     ]
   },
@@ -1260,32 +1260,32 @@
       {
         "number": 1,
         "start": 1,
-        "end": 162
+        "end": 163
       },
       {
         "number": 2,
         "start": 164,
-        "end": 235
+        "end": 236
       },
       {
         "number": 3,
         "start": 237,
-        "end": 368
+        "end": 369
       },
       {
         "number": 4,
         "start": 370,
-        "end": 627
+        "end": 628
       },
       {
         "number": 5,
         "start": 629,
-        "end": 791
+        "end": 792
       },
       {
         "number": 6,
         "start": 793,
-        "end": 1212
+        "end": 1213
       }
     ]
   },
@@ -1300,22 +1300,22 @@
       {
         "number": 1,
         "start": 1,
-        "end": 188
+        "end": 189
       },
       {
         "number": 2,
         "start": 190,
-        "end": 480
+        "end": 481
       },
       {
         "number": 3,
         "start": 482,
-        "end": 595
+        "end": 596
       },
       {
         "number": 4,
         "start": 597,
-        "end": 1956
+        "end": 1957
       }
     ]
   },
@@ -1330,82 +1330,82 @@
       {
         "number": 1,
         "start": 1,
-        "end": 40
+        "end": 41
       },
       {
         "number": 2,
         "start": 42,
-        "end": 193
+        "end": 194
       },
       {
         "number": 3,
         "start": 195,
-        "end": 278
+        "end": 279
       },
       {
         "number": 4,
         "start": 280,
-        "end": 480
+        "end": 481
       },
       {
         "number": 5,
         "start": 482,
-        "end": 589
+        "end": 590
       },
       {
         "number": 6,
         "start": 591,
-        "end": 703
+        "end": 704
       },
       {
         "number": 7,
         "start": 705,
-        "end": 787
+        "end": 788
       },
       {
         "number": 8,
         "start": 789,
-        "end": 892
+        "end": 893
       },
       {
         "number": 9,
         "start": 894,
-        "end": 991
+        "end": 992
       },
       {
         "number": 10,
         "start": 993,
-        "end": 1370
+        "end": 1371
       },
       {
         "number": 11,
         "start": 1372,
-        "end": 1466
+        "end": 1467
       },
       {
         "number": 12,
         "start": 1468,
-        "end": 1606
+        "end": 1607
       },
       {
         "number": 13,
         "start": 1608,
-        "end": 1684
+        "end": 1685
       },
       {
         "number": 14,
         "start": 1686,
-        "end": 1801
+        "end": 1802
       },
       {
         "number": 15,
         "start": 1803,
-        "end": 2016
+        "end": 2017
       },
       {
         "number": 16,
         "start": 2018,
-        "end": 10703
+        "end": 10704
       }
     ]
   },
@@ -1420,317 +1420,317 @@
       {
         "number": 1,
         "start": 1,
-        "end": 119
+        "end": 120
       },
       {
         "number": 2,
         "start": 121,
-        "end": 221
+        "end": 222
       },
       {
         "number": 3,
         "start": 223,
-        "end": 334
+        "end": 335
       },
       {
         "number": 4,
         "start": 336,
-        "end": 480
+        "end": 481
       },
       {
         "number": 5,
         "start": 482,
-        "end": 645
+        "end": 646
       },
       {
         "number": 6,
         "start": 647,
-        "end": 811
+        "end": 812
       },
       {
         "number": 7,
         "start": 813,
-        "end": 1050
+        "end": 1051
       },
       {
         "number": 8,
         "start": 1052,
-        "end": 1214
+        "end": 1215
       },
       {
         "number": 9,
         "start": 1216,
-        "end": 1384
+        "end": 1385
       },
       {
         "number": 10,
         "start": 1386,
-        "end": 1756
+        "end": 1757
       },
       {
         "number": 11,
         "start": 1758,
-        "end": 1951
+        "end": 1952
       },
       {
         "number": 12,
         "start": 1953,
-        "end": 2047
+        "end": 2048
       },
       {
         "number": 13,
         "start": 2049,
-        "end": 2273
+        "end": 2274
       },
       {
         "number": 14,
         "start": 2275,
-        "end": 2399
+        "end": 2400
       },
       {
         "number": 15,
         "start": 2401,
-        "end": 2525
+        "end": 2526
       },
       {
         "number": 16,
         "start": 2527,
-        "end": 2615
+        "end": 2616
       },
       {
         "number": 17,
         "start": 2617,
-        "end": 2787
+        "end": 2788
       },
       {
         "number": 18,
         "start": 2789,
-        "end": 2987
+        "end": 2988
       },
       {
         "number": 19,
         "start": 2989,
-        "end": 3070
+        "end": 3071
       },
       {
         "number": 20,
         "start": 3072,
-        "end": 3226
+        "end": 3227
       },
       {
         "number": 21,
         "start": 3228,
-        "end": 3302
+        "end": 3303
       },
       {
         "number": 22,
         "start": 3304,
-        "end": 3433
+        "end": 3434
       },
       {
         "number": 23,
         "start": 3435,
-        "end": 3551
+        "end": 3552
       },
       {
         "number": 24,
         "start": 3553,
-        "end": 3725
+        "end": 3726
       },
       {
         "number": 25,
         "start": 3727,
-        "end": 3895
+        "end": 3896
       },
       {
         "number": 26,
         "start": 3897,
-        "end": 4142
+        "end": 4143
       },
       {
         "number": 27,
         "start": 4144,
-        "end": 4258
+        "end": 4259
       },
       {
         "number": 28,
         "start": 4260,
-        "end": 4385
+        "end": 4386
       },
       {
         "number": 29,
         "start": 4387,
-        "end": 4585
+        "end": 4586
       },
       {
         "number": 30,
         "start": 4587,
-        "end": 4760
+        "end": 4761
       },
       {
         "number": 31,
         "start": 4762,
-        "end": 4925
+        "end": 4926
       },
       {
         "number": 32,
         "start": 4927,
-        "end": 5058
+        "end": 5059
       },
       {
         "number": 33,
         "start": 5060,
-        "end": 5154
+        "end": 5155
       },
       {
         "number": 34,
         "start": 5156,
-        "end": 5326
+        "end": 5327
       },
       {
         "number": 35,
         "start": 5328,
-        "end": 5468
+        "end": 5469
       },
       {
         "number": 36,
         "start": 5470,
-        "end": 5645
+        "end": 5646
       },
       {
         "number": 37,
         "start": 5647,
-        "end": 5823
+        "end": 5824
       },
       {
         "number": 38,
         "start": 5825,
-        "end": 5911
+        "end": 5912
       },
       {
         "number": 39,
         "start": 5913,
-        "end": 6067
+        "end": 6068
       },
       {
         "number": 40,
         "start": 6069,
-        "end": 6155
+        "end": 6156
       },
       {
         "number": 41,
         "start": 6157,
-        "end": 6244
+        "end": 6245
       },
       {
         "number": 42,
         "start": 6246,
-        "end": 6347
+        "end": 6348
       },
       {
         "number": 43,
         "start": 6349,
-        "end": 6496
+        "end": 6497
       },
       {
         "number": 44,
         "start": 6498,
-        "end": 6601
+        "end": 6602
       },
       {
         "number": 45,
         "start": 6603,
-        "end": 6721
+        "end": 6722
       },
       {
         "number": 46,
         "start": 6723,
-        "end": 6956
+        "end": 6957
       },
       {
         "number": 47,
         "start": 6958,
-        "end": 7124
+        "end": 7125
       },
       {
         "number": 48,
         "start": 7126,
-        "end": 7238
+        "end": 7239
       },
       {
         "number": 49,
         "start": 7240,
-        "end": 7456
+        "end": 7457
       },
       {
         "number": 50,
         "start": 7458,
-        "end": 7664
+        "end": 7665
       },
       {
         "number": 51,
         "start": 7666,
-        "end": 7778
+        "end": 7779
       },
       {
         "number": 52,
         "start": 7780,
-        "end": 7937
+        "end": 7938
       },
       {
         "number": 53,
         "start": 7939,
-        "end": 8076
+        "end": 8077
       },
       {
         "number": 54,
         "start": 8078,
-        "end": 8159
+        "end": 8160
       },
       {
         "number": 55,
         "start": 8161,
-        "end": 8300
+        "end": 8301
       },
       {
         "number": 56,
         "start": 8302,
-        "end": 8417
+        "end": 8418
       },
       {
         "number": 57,
         "start": 8419,
-        "end": 8567
+        "end": 8568
       },
       {
         "number": 58,
         "start": 8569,
-        "end": 8733
+        "end": 8734
       },
       {
         "number": 59,
         "start": 8735,
-        "end": 8820
+        "end": 8821
       },
       {
         "number": 60,
         "start": 8822,
-        "end": 8935
+        "end": 8936
       },
       {
         "number": 61,
         "start": 8937,
-        "end": 8999
+        "end": 9000
       },
       {
         "number": 62,
         "start": 9001,
-        "end": 9136
+        "end": 9137
       },
       {
         "number": 63,
         "start": 9138,
-        "end": 12914
+        "end": 12915
       }
     ]
   },
@@ -1745,6 +1745,86 @@
       {
         "number": 1,
         "start": 1,
+        "end": 59
+      },
+      {
+        "number": 2,
+        "start": 60,
+        "end": 136
+      },
+      {
+        "number": 3,
+        "start": 137,
+        "end": 171
+      },
+      {
+        "number": 4,
+        "start": 172,
+        "end": 444
+      },
+      {
+        "number": 5,
+        "start": 445,
+        "end": 491
+      },
+      {
+        "number": 6,
+        "start": 492,
+        "end": 530
+      },
+      {
+        "number": 7,
+        "start": 531,
+        "end": 603
+      },
+      {
+        "number": 8,
+        "start": 604,
+        "end": 735
+      },
+      {
+        "number": 9,
+        "start": 736,
+        "end": 842
+      },
+      {
+        "number": 10,
+        "start": 843,
+        "end": 963
+      },
+      {
+        "number": 11,
+        "start": 964,
+        "end": 1122
+      },
+      {
+        "number": 12,
+        "start": 1123,
+        "end": 1192
+      },
+      {
+        "number": 13,
+        "start": 1193,
+        "end": 1351
+      },
+      {
+        "number": 14,
+        "start": 1352,
+        "end": 1485
+      },
+      {
+        "number": 15,
+        "start": 1486,
+        "end": 1620
+      },
+      {
+        "number": 16,
+        "start": 1621,
+        "end": 1707
+      },
+      {
+        "number": 17,
+        "start": 1708,
         "end": 3370
       }
     ]
@@ -1760,57 +1840,57 @@
       {
         "number": 1,
         "start": 1,
-        "end": 158
+        "end": 159
       },
       {
         "number": 2,
         "start": 160,
-        "end": 394
+        "end": 395
       },
       {
         "number": 3,
         "start": 396,
-        "end": 542
+        "end": 543
       },
       {
         "number": 4,
         "start": 544,
-        "end": 611
+        "end": 612
       },
       {
         "number": 5,
         "start": 613,
-        "end": 777
+        "end": 778
       },
       {
         "number": 6,
         "start": 779,
-        "end": 887
+        "end": 888
       },
       {
         "number": 7,
         "start": 889,
-        "end": 1054
+        "end": 1055
       },
       {
         "number": 8,
         "start": 1056,
-        "end": 1074
+        "end": 1075
       },
       {
         "number": 9,
         "start": 1076,
-        "end": 1211
+        "end": 1212
       },
       {
         "number": 10,
         "start": 1213,
-        "end": 1408
+        "end": 1409
       },
       {
         "number": 11,
         "start": 1410,
-        "end": 5717
+        "end": 5718
       }
     ]
   },
@@ -1825,117 +1905,117 @@
       {
         "number": 1,
         "start": 1,
-        "end": 437
+        "end": 438
       },
       {
         "number": 2,
         "start": 439,
-        "end": 563
+        "end": 564
       },
       {
         "number": 3,
         "start": 565,
-        "end": 759
+        "end": 760
       },
       {
         "number": 4,
         "start": 761,
-        "end": 877
+        "end": 878
       },
       {
         "number": 5,
         "start": 879,
-        "end": 1350
+        "end": 1351
       },
       {
         "number": 6,
         "start": 1352,
-        "end": 1451
+        "end": 1452
       },
       {
         "number": 7,
         "start": 1453,
-        "end": 1545
+        "end": 1546
       },
       {
         "number": 8,
         "start": 1547,
-        "end": 7653
+        "end": 7654
       },
       {
         "number": 9,
         "start": 7655,
-        "end": 7787
+        "end": 7788
       },
       {
         "number": 10,
         "start": 7789,
-        "end": 9652
+        "end": 9653
       },
       {
         "number": 11,
         "start": 9654,
-        "end": 9894
+        "end": 9895
       },
       {
         "number": 12,
         "start": 9896,
-        "end": 10020
+        "end": 10021
       },
       {
         "number": 13,
         "start": 10022,
-        "end": 10191
+        "end": 10192
       },
       {
         "number": 14,
         "start": 10193,
-        "end": 10326
+        "end": 10327
       },
       {
         "number": 15,
         "start": 10328,
-        "end": 10497
+        "end": 10498
       },
       {
         "number": 16,
         "start": 10499,
-        "end": 11660
+        "end": 11661
       },
       {
         "number": 17,
         "start": 11662,
-        "end": 11781
+        "end": 11782
       },
       {
         "number": 18,
         "start": 11783,
-        "end": 11985
+        "end": 11986
       },
       {
         "number": 19,
         "start": 11987,
-        "end": 12227
+        "end": 12228
       },
       {
         "number": 20,
         "start": 12229,
-        "end": 12411
+        "end": 12412
       },
       {
         "number": 21,
         "start": 12413,
-        "end": 12475
+        "end": 12476
       },
       {
         "number": 22,
         "start": 12477,
-        "end": 12575
+        "end": 12576
       },
       {
         "number": 23,
         "start": 12577,
-        "end": 12927
+        "end": 12928
       }
     ]
   },
@@ -1950,252 +2030,252 @@
       {
         "number": 1,
         "start": 1,
-        "end": 168
+        "end": 169
       },
       {
         "number": 2,
         "start": 170,
-        "end": 262
+        "end": 263
       },
       {
         "number": 3,
         "start": 264,
-        "end": 404
+        "end": 405
       },
       {
         "number": 4,
         "start": 406,
-        "end": 544
+        "end": 545
       },
       {
         "number": 5,
         "start": 546,
-        "end": 672
+        "end": 673
       },
       {
         "number": 6,
         "start": 674,
-        "end": 870
+        "end": 871
       },
       {
         "number": 7,
         "start": 872,
-        "end": 960
+        "end": 961
       },
       {
         "number": 8,
         "start": 962,
-        "end": 1201
+        "end": 1202
       },
       {
         "number": 9,
         "start": 1203,
-        "end": 1341
+        "end": 1342
       },
       {
         "number": 10,
         "start": 1343,
-        "end": 1458
+        "end": 1459
       },
       {
         "number": 11,
         "start": 1460,
-        "end": 1656
+        "end": 1657
       },
       {
         "number": 12,
         "start": 1658,
-        "end": 1862
+        "end": 1863
       },
       {
         "number": 13,
         "start": 1864,
-        "end": 2039
+        "end": 2040
       },
       {
         "number": 14,
         "start": 2041,
-        "end": 2262
+        "end": 2263
       },
       {
         "number": 15,
         "start": 2264,
-        "end": 2484
+        "end": 2485
       },
       {
         "number": 16,
         "start": 2486,
-        "end": 2689
+        "end": 2690
       },
       {
         "number": 17,
         "start": 2691,
-        "end": 2755
+        "end": 2756
       },
       {
         "number": 18,
         "start": 2757,
-        "end": 2845
+        "end": 2846
       },
       {
         "number": 19,
         "start": 2847,
-        "end": 3020
+        "end": 3021
       },
       {
         "number": 20,
         "start": 3022,
-        "end": 3152
+        "end": 3153
       },
       {
         "number": 21,
         "start": 3154,
-        "end": 3292
+        "end": 3293
       },
       {
         "number": 22,
         "start": 3294,
-        "end": 3430
+        "end": 3431
       },
       {
         "number": 23,
         "start": 3432,
-        "end": 3624
+        "end": 3625
       },
       {
         "number": 24,
         "start": 3626,
-        "end": 3709
+        "end": 3710
       },
       {
         "number": 25,
         "start": 3711,
-        "end": 3915
+        "end": 3916
       },
       {
         "number": 26,
         "start": 3917,
-        "end": 3964
+        "end": 3965
       },
       {
         "number": 27,
         "start": 3966,
-        "end": 4230
+        "end": 4231
       },
       {
         "number": 28,
         "start": 4232,
-        "end": 4355
+        "end": 4356
       },
       {
         "number": 29,
         "start": 4357,
-        "end": 4454
+        "end": 4455
       },
       {
         "number": 30,
         "start": 4456,
-        "end": 4641
+        "end": 4642
       },
       {
         "number": 31,
         "start": 4643,
-        "end": 4736
+        "end": 4737
       },
       {
         "number": 32,
         "start": 4738,
-        "end": 4769
+        "end": 4770
       },
       {
         "number": 33,
         "start": 4771,
-        "end": 4875
+        "end": 4876
       },
       {
         "number": 34,
         "start": 4877,
-        "end": 4950
+        "end": 4951
       },
       {
         "number": 35,
         "start": 4952,
-        "end": 5120
+        "end": 5121
       },
       {
         "number": 36,
         "start": 5122,
-        "end": 5298
+        "end": 5299
       },
       {
         "number": 37,
         "start": 5300,
-        "end": 5414
+        "end": 5415
       },
       {
         "number": 38,
         "start": 5416,
-        "end": 5562
+        "end": 5563
       },
       {
         "number": 39,
         "start": 5564,
-        "end": 5686
+        "end": 5687
       },
       {
         "number": 40,
         "start": 5688,
-        "end": 5816
+        "end": 5817
       },
       {
         "number": 41,
         "start": 5818,
-        "end": 5937
+        "end": 5938
       },
       {
         "number": 42,
         "start": 5939,
-        "end": 6000
+        "end": 6001
       },
       {
         "number": 43,
         "start": 6002,
-        "end": 6107
+        "end": 6108
       },
       {
         "number": 44,
         "start": 6109,
-        "end": 6249
+        "end": 6250
       },
       {
         "number": 45,
         "start": 6251,
-        "end": 6384
+        "end": 6385
       },
       {
         "number": 46,
         "start": 6386,
-        "end": 6488
+        "end": 6489
       },
       {
         "number": 47,
         "start": 6490,
-        "end": 6581
+        "end": 6582
       },
       {
         "number": 48,
         "start": 6583,
-        "end": 6831
+        "end": 6832
       },
       {
         "number": 49,
         "start": 6833,
-        "end": 6918
+        "end": 6919
       },
       {
         "number": 50,
         "start": 6920,
-        "end": 7327
+        "end": 7328
       }
     ]
   },
@@ -2210,57 +2290,57 @@
       {
         "number": 1,
         "start": 1,
-        "end": 271
+        "end": 272
       },
       {
         "number": 2,
         "start": 273,
-        "end": 445
+        "end": 446
       },
       {
         "number": 3,
         "start": 447,
-        "end": 741
+        "end": 742
       },
       {
         "number": 4,
         "start": 743,
-        "end": 1014
+        "end": 1015
       },
       {
         "number": 5,
         "start": 1016,
-        "end": 1099
+        "end": 1100
       },
       {
         "number": 6,
         "start": 1101,
-        "end": 1277
+        "end": 1278
       },
       {
         "number": 7,
         "start": 1279,
-        "end": 1462
+        "end": 1463
       },
       {
         "number": 8,
         "start": 1464,
-        "end": 1615
+        "end": 1616
       },
       {
         "number": 9,
         "start": 1617,
-        "end": 1705
+        "end": 1706
       },
       {
         "number": 10,
         "start": 1707,
-        "end": 1870
+        "end": 1871
       },
       {
         "number": 11,
         "start": 1872,
-        "end": 5577
+        "end": 5578
       }
     ]
   },
@@ -2275,17 +2355,17 @@
       {
         "number": 1,
         "start": 1,
-        "end": 50
+        "end": 51
       },
       {
         "number": 2,
         "start": 52,
-        "end": 209
+        "end": 210
       },
       {
         "number": 3,
         "start": 211,
-        "end": 12792
+        "end": 12793
       }
     ]
   },
@@ -2300,7 +2380,47 @@
       {
         "number": 1,
         "start": 1,
-        "end": 3097
+        "end": 527
+      },
+      {
+        "number": 2,
+        "start": 528,
+        "end": 588
+      },
+      {
+        "number": 3,
+        "start": 589,
+        "end": 684
+      },
+      {
+        "number": 4,
+        "start": 685,
+        "end": 846
+      },
+      {
+        "number": 5,
+        "start": 847,
+        "end": 972
+      },
+      {
+        "number": 6,
+        "start": 973,
+        "end": 1193
+      },
+      {
+        "number": 7,
+        "start": 1194,
+        "end": 1237
+      },
+      {
+        "number": 8,
+        "start": 1238,
+        "end": 1323
+      },
+      {
+        "number": 9,
+        "start": 1324,
+        "end": 3086
       }
     ]
   },
@@ -2315,107 +2435,107 @@
       {
         "number": 1,
         "start": 1,
-        "end": 274
+        "end": 275
       },
       {
         "number": 2,
         "start": 276,
-        "end": 337
+        "end": 338
       },
       {
         "number": 3,
         "start": 339,
-        "end": 394
+        "end": 395
       },
       {
         "number": 4,
         "start": 396,
-        "end": 474
+        "end": 475
       },
       {
         "number": 5,
         "start": 476,
-        "end": 583
+        "end": 584
       },
       {
         "number": 6,
         "start": 585,
-        "end": 667
+        "end": 668
       },
       {
         "number": 7,
         "start": 669,
-        "end": 725
+        "end": 726
       },
       {
         "number": 8,
         "start": 727,
-        "end": 865
+        "end": 866
       },
       {
         "number": 9,
         "start": 867,
-        "end": 1067
+        "end": 1068
       },
       {
         "number": 10,
         "start": 1069,
-        "end": 1223
+        "end": 1224
       },
       {
         "number": 11,
         "start": 1225,
-        "end": 1334
+        "end": 1335
       },
       {
         "number": 12,
         "start": 1336,
-        "end": 1427
+        "end": 1428
       },
       {
         "number": 13,
         "start": 1429,
-        "end": 1523
+        "end": 1524
       },
       {
         "number": 14,
         "start": 1525,
-        "end": 1689
+        "end": 1690
       },
       {
         "number": 15,
         "start": 1691,
-        "end": 1859
+        "end": 1860
       },
       {
         "number": 16,
         "start": 1861,
-        "end": 2016
+        "end": 2017
       },
       {
         "number": 17,
         "start": 2018,
-        "end": 2143
+        "end": 2144
       },
       {
         "number": 18,
         "start": 2145,
-        "end": 2293
+        "end": 2294
       },
       {
         "number": 19,
         "start": 2295,
-        "end": 2399
+        "end": 2400
       },
       {
         "number": 20,
         "start": 2401,
-        "end": 2480
+        "end": 2481
       },
       {
         "number": 21,
         "start": 2482,
-        "end": 4281
+        "end": 4282
       }
     ]
   },
@@ -2430,6 +2550,166 @@
       {
         "number": 1,
         "start": 1,
+        "end": 174
+      },
+      {
+        "number": 2,
+        "start": 175,
+        "end": 381
+      },
+      {
+        "number": 3,
+        "start": 382,
+        "end": 686
+      },
+      {
+        "number": 4,
+        "start": 687,
+        "end": 766
+      },
+      {
+        "number": 5,
+        "start": 767,
+        "end": 1031
+      },
+      {
+        "number": 6,
+        "start": 1032,
+        "end": 1159
+      },
+      {
+        "number": 7,
+        "start": 1160,
+        "end": 1325
+      },
+      {
+        "number": 8,
+        "start": 1326,
+        "end": 1585
+      },
+      {
+        "number": 9,
+        "start": 1586,
+        "end": 1702
+      },
+      {
+        "number": 10,
+        "start": 1703,
+        "end": 1823
+      },
+      {
+        "number": 11,
+        "start": 1824,
+        "end": 1997
+      },
+      {
+        "number": 12,
+        "start": 1998,
+        "end": 2179
+      },
+      {
+        "number": 13,
+        "start": 2180,
+        "end": 2323
+      },
+      {
+        "number": 14,
+        "start": 2324,
+        "end": 2453
+      },
+      {
+        "number": 15,
+        "start": 2454,
+        "end": 2608
+      },
+      {
+        "number": 16,
+        "start": 2609,
+        "end": 2764
+      },
+      {
+        "number": 17,
+        "start": 2765,
+        "end": 2975
+      },
+      {
+        "number": 18,
+        "start": 2976,
+        "end": 3126
+      },
+      {
+        "number": 19,
+        "start": 3127,
+        "end": 3225
+      },
+      {
+        "number": 20,
+        "start": 3226,
+        "end": 3412
+      },
+      {
+        "number": 21,
+        "start": 3413,
+        "end": 3716
+      },
+      {
+        "number": 22,
+        "start": 3717,
+        "end": 3990
+      },
+      {
+        "number": 23,
+        "start": 3991,
+        "end": 4195
+      },
+      {
+        "number": 24,
+        "start": 4196,
+        "end": 4415
+      },
+      {
+        "number": 25,
+        "start": 4416,
+        "end": 4574
+      },
+      {
+        "number": 26,
+        "start": 4575,
+        "end": 4747
+      },
+      {
+        "number": 27,
+        "start": 4748,
+        "end": 4876
+      },
+      {
+        "number": 28,
+        "start": 4877,
+        "end": 5071
+      },
+      {
+        "number": 29,
+        "start": 5072,
+        "end": 5259
+      },
+      {
+        "number": 30,
+        "start": 5260,
+        "end": 5430
+      },
+      {
+        "number": 31,
+        "start": 5431,
+        "end": 5621
+      },
+      {
+        "number": 32,
+        "start": 5622,
+        "end": 5695
+      },
+      {
+        "number": 33,
+        "start": 5696,
         "end": 6623
       }
     ]
@@ -2460,7 +2740,102 @@
       {
         "number": 1,
         "start": 1,
-        "end": 9648
+        "end": 1542
+      },
+      {
+        "number": 2,
+        "start": 1543,
+        "end": 1737
+      },
+      {
+        "number": 3,
+        "start": 1738,
+        "end": 1776
+      },
+      {
+        "number": 4,
+        "start": 1777,
+        "end": 1926
+      },
+      {
+        "number": 5,
+        "start": 1927,
+        "end": 2037
+      },
+      {
+        "number": 6,
+        "start": 2038,
+        "end": 2281
+      },
+      {
+        "number": 7,
+        "start": 2282,
+        "end": 2371
+      },
+      {
+        "number": 8,
+        "start": 2372,
+        "end": 2551
+      },
+      {
+        "number": 9,
+        "start": 2552,
+        "end": 2879
+      },
+      {
+        "number": 10,
+        "start": 2880,
+        "end": 3025
+      },
+      {
+        "number": 11,
+        "start": 3026,
+        "end": 3135
+      },
+      {
+        "number": 12,
+        "start": 3136,
+        "end": 3345
+      },
+      {
+        "number": 13,
+        "start": 3346,
+        "end": 3550
+      },
+      {
+        "number": 14,
+        "start": 3551,
+        "end": 3689
+      },
+      {
+        "number": 15,
+        "start": 3690,
+        "end": 3862
+      },
+      {
+        "number": 16,
+        "start": 3863,
+        "end": 4013
+      },
+      {
+        "number": 17,
+        "start": 4014,
+        "end": 4110
+      },
+      {
+        "number": 18,
+        "start": 4111,
+        "end": 4894
+      },
+      {
+        "number": 19,
+        "start": 4895,
+        "end": 5025
+      },
+      {
+        "number": 20,
+        "start": 5026,
+        "end": 9638
       }
     ]
   },
@@ -2475,6 +2850,51 @@
       {
         "number": 1,
         "start": 1,
+        "end": 374
+      },
+      {
+        "number": 2,
+        "start": 375,
+        "end": 606
+      },
+      {
+        "number": 3,
+        "start": 607,
+        "end": 692
+      },
+      {
+        "number": 4,
+        "start": 693,
+        "end": 901
+      },
+      {
+        "number": 5,
+        "start": 902,
+        "end": 1019
+      },
+      {
+        "number": 6,
+        "start": 1020,
+        "end": 1161
+      },
+      {
+        "number": 7,
+        "start": 1162,
+        "end": 1328
+      },
+      {
+        "number": 8,
+        "start": 1329,
+        "end": 1428
+      },
+      {
+        "number": 9,
+        "start": 1429,
+        "end": 1664
+      },
+      {
+        "number": 10,
+        "start": 1665,
         "end": 3703
       }
     ]
@@ -2490,7 +2910,112 @@
       {
         "number": 1,
         "start": 1,
-        "end": 7113
+        "end": 63
+      },
+      {
+        "number": 2,
+        "start": 64,
+        "end": 267
+      },
+      {
+        "number": 3,
+        "start": 268,
+        "end": 339
+      },
+      {
+        "number": 4,
+        "start": 340,
+        "end": 448
+      },
+      {
+        "number": 5,
+        "start": 449,
+        "end": 600
+      },
+      {
+        "number": 6,
+        "start": 601,
+        "end": 768
+      },
+      {
+        "number": 7,
+        "start": 769,
+        "end": 885
+      },
+      {
+        "number": 8,
+        "start": 886,
+        "end": 963
+      },
+      {
+        "number": 9,
+        "start": 964,
+        "end": 1030
+      },
+      {
+        "number": 10,
+        "start": 1031,
+        "end": 1302
+      },
+      {
+        "number": 11,
+        "start": 1342,
+        "end": 1498
+      },
+      {
+        "number": 12,
+        "start": 1499,
+        "end": 1612
+      },
+      {
+        "number": 13,
+        "start": 1613,
+        "end": 1688
+      },
+      {
+        "number": 14,
+        "start": 1689,
+        "end": 1771
+      },
+      {
+        "number": 15,
+        "start": 1772,
+        "end": 1896
+      },
+      {
+        "number": 16,
+        "start": 1897,
+        "end": 2029
+      },
+      {
+        "number": 17,
+        "start": 2030,
+        "end": 2110
+      },
+      {
+        "number": 18,
+        "start": 2111,
+        "end": 2134
+      },
+      {
+        "number": 19,
+        "start": 2135,
+        "end": 2265
+      },
+      {
+        "number": 20,
+        "start": 2266,
+        "end": 2350
+      },
+      {
+        "number": 21,
+        "start": 2351,
+        "end": 4604
+      },
+      {
+        "number": 22,
+        "start": 4605,
+        "end": 7096
       }
     ]
   }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -405,6 +405,7 @@ mod mutalyzer_grammar_tests;
 mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;
 mod network_benchmark_tests;
+mod normalization_transcripts_exon_contract;
 mod normalize_config_disambiguation;
 mod normalize_idempotency_proptest;
 mod normalize_property_tests;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -433,6 +433,7 @@ mod protein_predicted_trans;
 mod protein_render_policy;
 mod protein_shift_created_adjacency;
 mod protein_silent_eq;
+mod protein_split_decline_reparse;
 mod protein_stop_codon_canonicalization;
 mod protein_substitution_alternatives;
 mod protein_unknown_roundtrip;

--- a/tests/it/normalization_transcripts_exon_contract.rs
+++ b/tests/it/normalization_transcripts_exon_contract.rs
@@ -1,0 +1,359 @@
+//! Structural guard for `tests/fixtures/sequences/normalization_transcripts.json`.
+//!
+//! That fixture is the transcript table behind `normalize_property_tests`,
+//! `normalize_tests` and `idempotency_tests`: each record is loaded into a
+//! `MockProvider` as a [`Transcript`], and its `exons` list is what every
+//! `c.`/`n.` position in those suites is resolved through. Nothing checked that
+//! the exon list was well formed, and it was not — see the contract below.
+//!
+//! # The `Exon` contract
+//!
+//! `src/reference/transcript.rs` documents `Exon.start`/`Exon.end` as
+//! "position in **transcript** coordinates (1-based, inclusive)". Transcript
+//! coordinates address the *spliced* transcript — introns have already been
+//! removed — so the exons must **tile a contiguous run** of transcript space
+//! with no holes and no overlaps: consecutive exons abut. A transcript
+//! coordinate that falls between two exons is not an intronic position, it is
+//! an unaddressable one.
+//!
+//! What the contract does **not** say is where that run begins or ends. Neither
+//! endpoint is anchored — `1` at the 5' end and `sequence.len()` at the 3' end
+//! are both left free, each for its own measured reason, in the two sections
+//! below. The invariant is the junctions.
+//!
+//! That is also **almost** exactly what cdot, the upstream producer, emits: its
+//! `cds_start_i`/`cds_end_i` are 1-based inclusive transcript bounds, and
+//! `CdotTranscript` consumes them as such (`src/data/cdot.rs`, `from_genome_build`).
+//! "Almost", because 58 of its 474,818 multi-exon builds do carry a real gap —
+//! so the contract above is what cdot means, not a property every cdot record
+//! has. One such record is in this fixture, exempted by name in
+//! [`CDOT_GAP_JUNCTIONS`]; see the section on it below.
+//!
+//! # Why this file exists
+//!
+//! Measured against cdot-0.2.32.refseq.GRCh38 (482,519 exon-bearing builds,
+//! 474,818 of them multi-exon): **58** builds carry any transcript-coordinate
+//! gap at all (0.012%), the smallest such gap is **23** bases, and **zero**
+//! builds have a one-base gap. The fixture used to carry a one-base gap at
+//! *every* junction of *every* multi-exon record — a shape that does not occur
+//! in the upstream data even once.
+//!
+//! The effect was not cosmetic. On `NM_000492.4` (27 exons, 26 synthetic holes)
+//! a consumer that resolved `c.` positions by walking the exon list landed
+//! **10 bases** 3' of the flat-transcript answer by `c.1520`, which is the
+//! `hgvs_to_spdi`-vs-normalizer disagreement recorded against #1619.
+//!
+//! # Coverage is deliberately a bound, not an equality
+//!
+//! `exons.last().end == sequence.len()` is **not** asserted. Two records
+//! (`NR_046285.1`, `NR_153405.1`) have real cdot exon tables that stop short of
+//! the true RefSeq transcript length (2599/2619 and 4299/4337) because their 3'
+//! bases do not align to the genome. That is genuine upstream data, so the
+//! assertion here is the one-sided `<=`: the exon list may under-span the stored
+//! sequence, but it may never address a base the sequence does not have.
+//!
+//! # The 5' anchor is not asserted either, and for a measured reason
+//!
+//! `exons[0].start == 1` looks like the natural companion to the bound above and
+//! is **not** checked. An earlier revision of this file asserted it, on no
+//! measurement: over cdot-0.2.32.refseq.GRCh38, **109** builds start their first
+//! exon past transcript coordinate 1 — `NM_000280.5` at 8, `NM_000910.2` at 7,
+//! `NM_001100631.1` at 870 — which is **1.9×** the 58-build gapped population
+//! this module's whole argument rests on. A hard 5' anchor would therefore
+//! reject genuine upstream data almost twice as often as the synthetic shape it
+//! was meant to catch, and it is the same under-span at the other end.
+//!
+//! No consumer asks for it. `CoordinateMapper` chooses between its flat and its
+//! exon-walking arithmetic on `w[0].end + 1 != w[1].start` (`src/convert/mapper.rs`,
+//! `cds_to_tx_exon_aware` and `tx_to_cds_exon_aware`) — a junction predicate —
+//! and nothing under `src/` reads `exons[0].start` at all. Every record in this
+//! fixture does begin at 1; that is an observation about the fixture, not a
+//! contract the data owes.
+//!
+//! # Where the exon tables come from, and the one that is not cdot's
+//!
+//! 28 of the 29 records carry their accession's cdot-0.2.32.refseq.GRCh38 exon
+//! table exactly, in transcript order. The one exception is `NM_001127687.1`,
+//! which cdot does not carry at all; it is named in [`FLATTENED_RECORDS`] and
+//! [`no_unnamed_record_is_flattened`] fails if a second single-exon record ever
+//! appears. That guard exists because a single-exon record satisfies every
+//! junction assertion below **for free**, so a flattening is invisible here —
+//! six of them were, until they were restored.
+//!
+//! # One record has a REAL gap, and it is exempted by name
+//!
+//! `NM_033517.1` is one of the 58: cdot gives it a genuine 39-base
+//! transcript-coordinate hole between exon 10 (ends 1302) and exon 11 (starts
+//! 1342). That is upstream annotation, not a fixture defect, so it is pinned in
+//! [`CDOT_GAP_JUNCTIONS`] — **by accession, junction and exact size** — rather
+//! than accommodated by loosening the contiguity rule. A general relaxation
+//! would re-admit the one-base synthetic holes this whole file exists to keep
+//! out; an exemption that names its one instance and its measurement cannot.
+//!
+//! Carrying it has a consequence worth stating plainly, because it is the
+//! reason this record was nearly left flattened. It re-arms #1619 inside the
+//! shared normalization corpus: `hgvs_to_spdi` walks the exon list across the
+//! hole while the normalizer indexes the flat transcript, so with
+//! `FERRO_ASSERT_SEQUENCE=1` the existing case `NM_033517.1:c.4818dupC` ->
+//! `c.4818dup` fires — the input applies `C`, the output applies `T`, at
+//! transcript position 4877. That is deliberate. It is the reproducer #1619 has
+//! not otherwise had, and no CI job arms the oracle where it fires: the flag is
+//! set only by `ci.yml`'s `sweeps` job, which selects `SWEEP_FILTER +
+//! test(issue_1615_denoted_sequence_oracle)`, and by the non-gating nightly,
+//! which selects the three reference-aware modules — `normalize_tests` is in
+//! neither. It is recorded as a deferred row on `test-oracle` in `ci.yml` and in
+//! `CLAUDE.md`.
+
+use serde::Deserialize;
+use std::collections::BTreeSet;
+
+/// Records whose `exons` list is deliberately **not** the cdot table for that
+/// accession, with the reason.
+///
+/// A single-exon record has no junction, so it satisfies [`check_exon_contract`]
+/// vacuously — which is the whole hazard, and why the one that remains is
+/// written down rather than left to be rediscovered.
+const FLATTENED_RECORDS: &[(&str, &str)] = &[(
+    "NM_001127687.1",
+    "absent from cdot-0.2.32.refseq.GRCh38 entirely — there is no upstream exon \
+     table to restore, so its single exon is a placeholder rather than a \
+     flattening of anything",
+)];
+
+/// Junctions permitted to carry a transcript-coordinate gap, because cdot
+/// itself puts one there.
+///
+/// Each entry is `(accession, exon number on the 5' side of the junction, exact
+/// gap in bases)` and every field is checked, so this cannot drift into a
+/// blanket: a different junction, a different size, or a gap on any accession
+/// not listed is still a violation. Measured against
+/// cdot-0.2.32.refseq.GRCh38, where 58 of 474,818 multi-exon builds carry a
+/// gap, the smallest is 23 bases and **none** is one base.
+///
+/// `NM_033517.1` is this fixture's only member of that population. See the
+/// module docs for what carrying it costs (#1619) and why that is deliberate.
+const CDOT_GAP_JUNCTIONS: &[(&str, u32, i64)] = &[("NM_033517.1", 10, 39)];
+
+#[derive(Debug, Deserialize)]
+struct TranscriptRecord {
+    id: String,
+    sequence: String,
+    exons: Vec<ExonRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExonRecord {
+    number: u32,
+    start: u64,
+    end: u64,
+}
+
+fn load_records() -> Vec<TranscriptRecord> {
+    let path = format!(
+        "{}/tests/fixtures/sequences/normalization_transcripts.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let json =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("failed to parse {path}: {e}"))
+}
+
+/// The fixture must actually be able to *fail* the contiguity assertion below.
+///
+/// This is the non-vacuity guard, and it is not ceremony. Contiguity is a
+/// property of exon **junctions**, so a single-exon record has nothing to get
+/// wrong and passes for free. When this fixture was first audited, the seven
+/// records that satisfied contiguity were precisely its seven single-exon ones —
+/// every record with a junction violated it, so "7 records pass" was a
+/// structural artifact rather than evidence of anything. Six of those seven
+/// have since had their real cdot tables restored; the seventh is named in
+/// [`FLATTENED_RECORDS`] because cdot has no table for it.
+///
+/// Asserting on the junction count keeps that from recurring silently: if the
+/// fixture is ever emptied, truncated, or flattened to one exon per record,
+/// this fails loudly instead of letting `check_exon_contract` sail through with
+/// nothing to check.
+#[test]
+fn fixture_exercises_the_contiguity_property() {
+    let records = load_records();
+    assert!(
+        records.len() >= 29,
+        "fixture shrank to {} records; it had 29 when this guard was written",
+        records.len()
+    );
+
+    let junctions: usize = records
+        .iter()
+        .map(|r| r.exons.len().saturating_sub(1))
+        .sum();
+    let multi_exon = records.iter().filter(|r| r.exons.len() > 1).count();
+    assert!(
+        multi_exon >= 28 && junctions >= 517,
+        "contiguity is a property of exon junctions, so it is only checkable on \
+         multi-exon records: found {multi_exon} multi-exon record(s) spanning \
+         {junctions} junction(s), expected at least 28 and 517. A pass from \
+         `check_exon_contract` with fewer than this is a structural zero, not a \
+         clean fixture."
+    );
+}
+
+/// Every pinned gap exemption must still describe a gap the fixture has.
+///
+/// [`CDOT_GAP_JUNCTIONS`] suppresses a violation, so a stale entry is the one
+/// kind of error [`check_exon_contract`] cannot report: if the gap it names were
+/// edited away, the exemption would go quietly dead and the guard would still
+/// pass. Requiring each entry to match a junction that is really there keeps the
+/// list **shrink-only** — restoring contiguity means deleting the row, and
+/// deleting the row is a visible diff.
+#[test]
+fn every_pinned_gap_exemption_is_still_load_bearing() {
+    let records = load_records();
+    for &(accession, number, size) in CDOT_GAP_JUNCTIONS {
+        let record = records
+            .iter()
+            .find(|r| r.id == accession)
+            .unwrap_or_else(|| panic!("{accession} is pinned in CDOT_GAP_JUNCTIONS but absent"));
+        let found = record.exons.windows(2).any(|pair| {
+            pair[0].number == number
+                && pair[1].start as i64 - pair[0].end as i64 - 1 == size
+                && size != 0
+        });
+        assert!(
+            found,
+            "CDOT_GAP_JUNCTIONS pins a {size}-base gap after exon {number} of {accession}, but \
+             the fixture has no such junction. If the table was restored to contiguity, delete \
+             the row — an exemption that matches nothing silently weakens this guard."
+        );
+    }
+}
+
+/// No record may be flattened to a single exon without saying so.
+///
+/// [`check_exon_contract`] cannot see a flattening — a single-exon record has no
+/// junction to violate — so a real multi-exon transcript rewritten as one exon
+/// passes it silently, and 111 exons across six records did exactly that before
+/// [`FLATTENED_RECORDS`] existed. This test makes the set of single-exon records
+/// an exact match against that list, so adding one costs a line and a stated
+/// reason, and restoring one costs deleting its line.
+#[test]
+fn no_unnamed_record_is_flattened() {
+    let records = load_records();
+    let single_exon: BTreeSet<&str> = records
+        .iter()
+        .filter(|r| r.exons.len() == 1)
+        .map(|r| r.id.as_str())
+        .collect();
+    let named: BTreeSet<&str> = FLATTENED_RECORDS.iter().map(|(id, _)| *id).collect();
+
+    let roster = FLATTENED_RECORDS
+        .iter()
+        .map(|(id, reason)| format!("  {id}: {reason}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_eq!(
+        single_exon,
+        named,
+        "the fixture's single-exon records must be exactly those named in \
+         FLATTENED_RECORDS. Unnamed and single-exon: {:?}. Named but no longer \
+         single-exon: {:?}. A single-exon record passes `check_exon_contract` \
+         vacuously, so an unnamed one is coverage this file does not have.\n\
+         FLATTENED_RECORDS is:\n{roster}",
+        single_exon.difference(&named).collect::<Vec<_>>(),
+        named.difference(&single_exon).collect::<Vec<_>>(),
+    );
+}
+
+/// Every record must satisfy the `Exon` contract stated in the module docs.
+#[test]
+fn check_exon_contract() {
+    let records = load_records();
+    assert!(!records.is_empty(), "fixture is empty");
+
+    let mut violations: Vec<String> = Vec::new();
+    for record in &records {
+        let id = &record.id;
+        let exons = &record.exons;
+
+        if exons.is_empty() {
+            violations.push(format!("{id}: has no exons"));
+            continue;
+        }
+
+        // Exon numbers are 1-based and consecutive in transcript order.
+        for (index, exon) in exons.iter().enumerate() {
+            let expected = index as u32 + 1;
+            if exon.number != expected {
+                violations.push(format!(
+                    "{id}: exon at index {index} is numbered {}, expected {expected}",
+                    exon.number
+                ));
+            }
+            // 1-based inclusive bounds describing at least one base.
+            if exon.start == 0 {
+                violations.push(format!("{id}: exon {expected} starts at 0 (1-based)"));
+            }
+            if exon.end < exon.start {
+                violations.push(format!(
+                    "{id}: exon {expected} is inverted ({}..={})",
+                    exon.start, exon.end
+                ));
+            }
+        }
+
+        // Deliberately NOT asserted here: `exons[0].start == 1`. 109 real cdot
+        // GRCh38 builds begin past transcript coordinate 1 and no consumer reads
+        // the field — see "The 5' anchor is not asserted either" in the module
+        // docs for the measurement and the reasoning.
+
+        // The load-bearing invariant: exons tile transcript space with no holes
+        // and no overlaps, because transcript coordinates address the spliced
+        // sequence.
+        for pair in exons.windows(2) {
+            let (left, right) = (&pair[0], &pair[1]);
+            if right.start != left.end + 1 {
+                let gap = right.start as i64 - left.end as i64 - 1;
+                // A gap cdot itself publishes here, of exactly this size, is
+                // upstream annotation rather than a defect. Every field must
+                // match — see `CDOT_GAP_JUNCTIONS`.
+                if CDOT_GAP_JUNCTIONS
+                    .iter()
+                    .any(|&(acc, number, size)| acc == id && number == left.number && size == gap)
+                {
+                    continue;
+                }
+                violations.push(format!(
+                    "{id}: exon {} ends at {} but exon {} starts at {} ({} of {} transcript \
+                     base(s)) — transcript coordinates must tile the spliced sequence",
+                    left.number,
+                    left.end,
+                    right.number,
+                    right.start,
+                    if gap > 0 { "hole" } else { "overlap" },
+                    gap.abs(),
+                ));
+            }
+        }
+
+        // The exon list may under-span the stored sequence (see module docs) but
+        // must never address a base beyond it.
+        let last_end = exons[exons.len() - 1].end;
+        if last_end > record.sequence.len() as u64 {
+            violations.push(format!(
+                "{id}: last exon ends at transcript position {last_end}, past the {}-base sequence",
+                record.sequence.len()
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "{} record(s) of {} violate the Exon contract:\n  {}",
+        violations
+            .iter()
+            .filter_map(|v| v.split(':').next())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        records.len(),
+        violations.join("\n  ")
+    );
+}

--- a/tests/it/protein_split_decline_reparse.rs
+++ b/tests/it/protein_split_decline_reparse.rs
@@ -1,0 +1,260 @@
+//! Every decline of the protein-axis split move leaves a description
+//! `parse_hgvs` accepts.
+//!
+//! # Why this guard exists
+//!
+//! `Normalizer::try_protein_split_delins` (added by #1606) turns an
+//! equal-length `p.` delins whose interior is unchanged into its members, and
+//! declines on seven distinct conditions. One of those declines — **residue 1
+//! is the changed one** — exists *only* to stop normalization emitting
+//! `p.Met1Xxx`, which `protein/substitution.md:49` forbids and `parse_hgvs`
+//! refuses. So that guard's whole value is a re-parse property, and nothing was
+//! asserting the property directly: #1606's own suite pins the exact output
+//! string for each decline, which goes green just as happily on a string that
+//! cannot be read back.
+//!
+//! The other six declines are covered here for the same reason, cheaply: a
+//! future decline that starts emitting a rewritten form rather than the input
+//! as authored would otherwise have nothing checking that the rewrite is
+//! legal.
+//!
+//! # What this file deliberately does NOT cover
+//!
+//! Ferro *does* emit an unparseable `p.Met1Gly` for a protein delins whose
+//! common-affix trimming leaves residue 1 as the residual — `p.Met1_Ser3delins`
+//! `GlyAlaSer` is the smallest case. That is **#1607**, it lives in
+//! `try_protein_delins_canonicalize`, and it is not the split: measured over a
+//! 4,336-input sweep, every such output enters `try_protein_split_delins`
+//! already collapsed to a `Substitution` and is turned away on the
+//! "not a delins" gate, and disabling the split entirely reproduces the same 16
+//! unparseable outputs byte for byte. Pinning it belongs to whatever closes
+//! #1607, not here — a guard that failed today would make this file a
+//! duplicate bug report rather than a regression guard for the split.
+//!
+//! Hermetic: no `FERRO_MANIFEST`, no network, no environment variable.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The accession every case is written against.
+const NP: &str = "NP_003997.1";
+
+/// Residues 1..=20. Residue 1 is `Met`; 2, 3, 4 are `Ala`, `Ser`, `Leu`, which
+/// is the span the splittable and declined cases below both name.
+const PROTEIN: &str = "MASLWEKTRNDQHIPFYCAA";
+
+/// The same protein with a stop **inserted** at position 4, for the
+/// reference-side `Ter` decline. It is 21 residues to [`PROTEIN`]'s 20 —
+/// nothing was replaced, so `Leu` and everything after it shift one position 3'
+/// (`Leu` is residue 5 here, not 4).
+const PROTEIN_WITH_STOP_AT_4: &str = "MAS*LWEKTRNDQHIPFYCAA";
+
+/// The same protein with an unknown residue **inserted** at position 4, for the
+/// reference-side `Xaa` decline. Same shape and same caveat as
+/// [`PROTEIN_WITH_STOP_AT_4`]: 21 residues, and `Leu` is residue 5.
+const PROTEIN_WITH_UNKNOWN_AT_4: &str = "MASXLWEKTRNDQHIPFYCAA";
+
+fn normalizer_over(sequences: &[(&str, &str)]) -> Normalizer<MockProvider> {
+    let mut provider = MockProvider::new();
+    for (accession, sequence) in sequences {
+        provider.add_protein(*accession, *sequence);
+    }
+    Normalizer::new(provider)
+}
+
+fn normalizer() -> Normalizer<MockProvider> {
+    normalizer_over(&[(NP, PROTEIN)])
+}
+
+/// Normalize `input`, assert the result is exactly `expected`, and assert the
+/// result **round-trips** through `parse_hgvs`.
+///
+/// The two assertions answer different questions and the second is the one this
+/// file is about: an exact-string assertion alone cannot tell a legal output
+/// from an illegal one.
+///
+/// The round-trip is a re-render comparison, not an `is_ok()`. `is_ok()` only
+/// says the parser did not refuse the string — it would pass on an output the
+/// parser silently read as some *other* description, which for the `p.` axis is
+/// a live shape (a member list flattened into the wrong bracket parses fine and
+/// means something else). Comparing `parse_hgvs(&output)?.to_string()` against
+/// `output` asks whether the parser and the renderer agree on what was written.
+fn assert_normalizes_and_reparses(
+    normalizer: &Normalizer<MockProvider>,
+    input: &str,
+    expected: &str,
+) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("input {input} must parse: {e}"));
+    let output = normalizer
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalizing {input}: {e}"))
+        .to_string();
+    assert_eq!(output, expected, "normalized form of {input}");
+    let reparsed = parse_hgvs(&output).unwrap_or_else(|e| {
+        panic!("normalization of {input} emitted {output}, which parse_hgvs refuses: {e}")
+    });
+    assert_eq!(
+        reparsed.to_string(),
+        output,
+        "normalization of {input} emitted {output}, which parse_hgvs reads back as a \
+         different description"
+    );
+}
+
+/// The positive control, and it is load-bearing: without it every assertion
+/// below could pass on a build where the split move never runs at all, and this
+/// file would report a structural zero as a clean bill of health.
+///
+/// Residues 2..=4 are `Ala-Ser-Leu`; the payload `Gly-Ser-Gly` leaves `Ser`
+/// unchanged between two changed residues, which is the separation
+/// `protein/delins.md:21` is about.
+#[test]
+fn the_split_move_is_reached_and_fires() {
+    assert_normalizes_and_reparses(
+        &normalizer(),
+        &format!("{NP}:p.Ala2_Leu4delinsGlySerGly"),
+        &format!("{NP}:p.[Ala2Gly;Leu4Gly]"),
+    );
+}
+
+/// The predicted form of the same input, so the `( )` marker's placement on the
+/// split's output is checked for legality too — it moves from the edit onto the
+/// whole allele, which is a different string than any decline can produce.
+#[test]
+fn the_split_move_fires_on_a_predicted_description() {
+    assert_normalizes_and_reparses(
+        &normalizer(),
+        &format!("{NP}:p.(Ala2_Leu4delinsGlySerGly)"),
+        &format!("{NP}:p.[(Ala2Gly;Leu4Gly)]"),
+    );
+}
+
+/// **Residue 1 changed.** The decline whose entire purpose is this property:
+/// splitting would emit `p.[Met1Gly;Ser3Gly]`, and `p.Met1Gly` is a description
+/// `parse_hgvs` refuses (`protein/substitution.md:49`).
+#[test]
+fn a_changed_residue_one_declines_to_a_description_that_reparses() {
+    let normalizer = normalizer();
+    for (input, expected) in [
+        (
+            format!("{NP}:p.Met1_Ser3delinsGlyAlaGly"),
+            format!("{NP}:p.Met1_Ser3delinsGlyAlaGly"),
+        ),
+        (
+            format!("{NP}:p.Met1_Trp5delinsGlyAlaGlyLeuGly"),
+            format!("{NP}:p.Met1_Trp5delinsGlyAlaGlyLeuGly"),
+        ),
+    ] {
+        assert_normalizes_and_reparses(&normalizer, &input, &expected);
+    }
+}
+
+/// **A `Ter` or an `Xaa` in the payload** (`delins.md:45`) and **a `Ter` or an
+/// `Xaa` in the reference span** (`extension.md:18`, the stop-loss ranking).
+///
+/// All four arms are exercised because the production guard is one predicate
+/// per side — `seq.0.contains(Ter) || seq.0.contains(Xaa)` and the matching
+/// `ref_aas` test in `try_protein_split_delins` — so covering only `Ter` would
+/// leave half of each disjunction unasserted, and dropping `Xaa` from either
+/// would go unnoticed.
+///
+/// The two reference-side arms use their own providers, because the residue
+/// they turn on is *inserted* into the protein rather than substituted in: the
+/// span named is `Ala2_Ter4` / `Ala2_Xaa4`, whose third residue is the one the
+/// guard rejects.
+#[test]
+fn a_ter_or_xaa_on_either_side_declines_to_a_description_that_reparses() {
+    // Payload side: the last residue of an otherwise splittable payload.
+    for payload in ["GlySerTer", "GlySerXaa"] {
+        let description = format!("{NP}:p.Ala2_Leu4delins{payload}");
+        assert_normalizes_and_reparses(&normalizer(), &description, &description);
+    }
+
+    // Reference side: the span's own residues carry the `Ter`/`Xaa`.
+    for (protein, span) in [
+        (PROTEIN_WITH_STOP_AT_4, "Ala2_Ter4"),
+        (PROTEIN_WITH_UNKNOWN_AT_4, "Ala2_Xaa4"),
+    ] {
+        let description = format!("{NP}:p.{span}delinsGlySerGly");
+        assert_normalizes_and_reparses(
+            &normalizer_over(&[(NP, protein)]),
+            &description,
+            &description,
+        );
+    }
+}
+
+/// **Unequal length** (no residue-wise correspondence) and **a span under
+/// three** (no interior to be unchanged).
+#[test]
+fn an_ineligible_geometry_declines_to_a_description_that_reparses() {
+    let normalizer = normalizer();
+    for (input, expected) in [
+        (
+            format!("{NP}:p.Ala2_Leu4delinsGlySer"),
+            format!("{NP}:p.Ala2_Leu4delinsGlySer"),
+        ),
+        (
+            format!("{NP}:p.Ala2_Ser3delinsGlyGly"),
+            format!("{NP}:p.Ala2_Ser3delinsGlyGly"),
+        ),
+    ] {
+        assert_normalizes_and_reparses(&normalizer, &input, &expected);
+    }
+}
+
+/// **Fewer than two changed runs** — the change really is one contiguous
+/// `delins`, and here the affix trimming that precedes the split has already
+/// reduced it to a substitution away from residue 1.
+#[test]
+fn one_changed_run_declines_to_a_description_that_reparses() {
+    assert_normalizes_and_reparses(
+        &normalizer(),
+        &format!("{NP}:p.Ala2_Leu4delinsGlySerLeu"),
+        &format!("{NP}:p.Ala2Gly"),
+    );
+}
+
+/// **No protein reference.** Both shapes of it: a provider carrying no protein
+/// data at all (`has_protein_data()` false) and one carrying a *different*
+/// accession, where the fetch is what declines (#1131).
+#[test]
+fn an_unavailable_protein_reference_declines_to_a_description_that_reparses() {
+    let input = format!("{NP}:p.Ala2_Leu4delinsGlySerGly");
+    for normalizer in [
+        normalizer_over(&[]),
+        normalizer_over(&[("NP_999999.9", PROTEIN)]),
+    ] {
+        assert_normalizes_and_reparses(&normalizer, &input, &input);
+    }
+}
+
+/// **Endpoints that are not certain single positions**, and a span whose window
+/// runs off the end of the protein.
+#[test]
+fn an_unreadable_span_declines_to_a_description_that_reparses() {
+    let normalizer = normalizer();
+    for input in [
+        format!("{NP}:p.Ala2_?delinsGlySerGly"),
+        format!("{NP}:p.(Ala2_Leu4)delinsGlySerGly"),
+        format!("{NP}:p.Ala19_Ala25delinsGlyAlaGlyAlaGlyAlaGly"),
+    ] {
+        assert_normalizes_and_reparses(&normalizer, &input, &input);
+    }
+}
+
+/// A splittable delins **inside** an allele is left alone — #1606 declines
+/// there rather than emit `p.[A;B];[C]`, which ferro's protein allele grammar
+/// cannot read back. Asserting the re-parse is the point: this decline is the
+/// one that is *about* an unparseable string, so a future change that flattened
+/// the members into the outer bracket would fail here rather than only on an
+/// exact-string comparison.
+#[test]
+fn a_delins_inside_an_allele_declines_to_a_description_that_reparses() {
+    let normalizer = normalizer();
+    for input in [
+        format!("{NP}:p.[Ala2_Leu4delinsGlySerGly;Ala19Gly]"),
+        format!("{NP}:p.[Ala2_Leu4delinsGlySerGly];[Ala19Gly]"),
+    ] {
+        assert_normalizes_and_reparses(&normalizer, &input, &input);
+    }
+}


### PR DESCRIPTION
`tests/fixtures/sequences/normalization_transcripts.json` violated the `Exon` contract in every multi-exon record, and nothing checked it. This restores the data, adds the guard, and corrects two doc claims that were keeping the defect plausible.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched — the only `src/` change is a doc comment in `src/convert/mapper.rs`. Ferro's behaviour on any real reference is byte-identical; what moves is the coordinates the test fixture feeds it, and real cdot transcripts never had the shape being removed.

## The contract

`src/reference/transcript.rs` documents `Exon.start`/`Exon.end` as "position in **transcript** coordinates (1-based, inclusive)". Transcript coordinates address the *spliced* transcript, so consecutive exons must **abut**: the list tiles a contiguous run of transcript space with no holes and no overlaps, and a coordinate falling between two exons is not an intronic position, it is an unaddressable one. Neither *endpoint* of that run is anchored — 5' start and 3' end are both left free, each for its own measured reason (below). The invariant is the junctions. That is also what the upstream producer emits: cdot's `cds_start_i`/`cds_end_i` are 1-based inclusive transcript bounds, consumed as such in `src/data/cdot.rs`.

## Measured, not taken on trust

**22 of 29 records violated it** — confirmed, and all on the single contiguity invariant, every gap exactly one base. Numbering, ordering, non-emptiness and `start == 1` were all clean.

**The 7 that passed are a structural zero.** All seven are single-exon. Contiguity is a property of junctions, so they had nothing to get wrong: *every* record with a junction violated it, and "7 pass" was an artifact rather than evidence. The guard's non-vacuity half now asserts the junction count so this cannot recur silently.

**Six of those seven were not real single-exon transcripts** — they were flattenings, and the first revision of this PR left that unmentioned, so the new guard passed them vacuously while nothing said the tables were wrong. Re-derived from `cdot-0.2.32.refseq.GRCh38`: `NM_001089.2` has **33** exons, `NM_033517.1` **22**, `NM_020732.3` **20**, `NM_024649.4` **17**, `NM_000382.3` **10**, `NM_002055.4` **9** — 111 exons and 105 junctions erased, while each record's `sequence` was the real transcript.

**All six are now restored** to cdot's table exactly. The fixture goes 22 -> 28 multi-exon records and 412 -> 517 junctions, and every record in it now carries its real cdot exon structure except `NM_001127687.1`, which cdot does not carry at all — that one is named in `FLATTENED_RECORDS` with its reason, and the new `no_unnamed_record_is_flattened` makes the single-exon set an exact match against that list, so a second flattening costs a line and a stated reason.

### `NM_033517.1` has a real cdot gap, and it is exempted by name

Five of the six restore to contiguous tables, which is behaviourally inert: a contiguous table makes the mapper's walk and its flat arithmetic agree. `NM_033517.1` is different and worth reading carefully. cdot gives it a **genuine** 39-base transcript-coordinate hole between exon 10 (ends 1302) and exon 11 (starts 1342) — it is one of the 58 gapped builds this PR counts.

That gap is pinned in `CDOT_GAP_JUNCTIONS` **by accession, junction and exact size**, never by loosening the contiguity rule — a general relaxation would re-admit the one-base synthetic holes this file exists to keep out. The pin is verified exact: changing the pinned size from 39 to 40 turns both `check_exon_contract` and `every_pinned_gap_exemption_is_still_load_bearing` red. That second test also keeps the list **shrink-only** — an exemption matching nothing fails, so restoring contiguity means deleting the row rather than leaving dead cover behind.

**Carrying it re-arms #1619 in the corpus, deliberately.** With `FERRO_ASSERT_SEQUENCE=1` the existing case `NM_033517.1:c.4818dupC` -> `c.4818dup` fires: the input applies `C`, the output applies `T`, at transcript position 4877, because `hgvs_to_spdi` walks the exon list across the hole while the normalizer indexes the flat transcript. This is the reproducer #1619 would otherwise have lost when the fixture was repaired, now demonstrated on **real annotation** rather than on an artifact.

**No CI job arms the oracle where it fires** — verified, not assumed. `FERRO_ASSERT_SEQUENCE` is set in exactly two places: `ci.yml`'s `sweeps`, which selects `SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`, and `nightly-mutalyzer.yml`, which selects the three reference-aware modules and carries `continue-on-error`. `normalize_tests` is in neither selection. The row is recorded as a deferred entry on `test-oracle` in both `ci.yml`'s comment and `CLAUDE.md`, replacing the old `NM_000492.4` row on the same issue.

**The fixture is real cdot with every exon `end` decremented by one.** Checked exon-by-exon against `cdot-0.2.32.refseq.GRCh38`: all 434 exons of the 22 records have a `start` matching cdot exactly and an `end` exactly one less. That identifies it as an inclusive/exclusive off-by-one on `cds_end_i`, and makes the repair exact rather than a guess. The diff is 434 lines, all `"end"` fields.

**The "20 of 20 real transcripts have zero gaps" claim is directionally right but not absolute** — I measured 27 of the 28 fixture accessions present in cdot, and across the full file, **58 of 474,818 multi-exon builds** do carry a transcript-coordinate gap. Not a structural zero: the property varies, and all 28 fixture accessions are multi-exon (16–62 junctions). What cdot never produces is the fixture's shape — smallest real gap **23 bases**, **zero** one-base gaps, and only one build gapped at every junction.

## Fixture or contract?

**The fixture.** The contract is stated correctly and matches the upstream producer; the fixture's shape does not occur in 474,818 real transcripts; the starts already agreed with cdot, so this is one systematic off-by-one, not a different exon model.

It was doing real damage. On `NM_000492.4`, resolving `c.` by walking the exon list lands 10 bases 3' of the flat-transcript answer by `c.1520` — the denoted-sequence oracle row recorded against #1619.

**The before/after, with the command it comes from.** The first revision quoted "25 before, 22 after" with no way to re-derive it, and called the three tests that went green "exactly the three suites that read this fixture" — which is wrong: three *files* read it, and the green tests come from **two** of them (`normalize_property_tests` reads it and contributes none). Re-measured against `origin/main` at `d5f26fcb`, swapping only the fixture and excluding the guard this PR adds, since that guard is *about* the fixture and cannot be a term in a before/after on it:

```bash
git show <base>:tests/fixtures/sequences/normalization_transcripts.json \
  > tests/fixtures/sequences/normalization_transcripts.json
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 \
FERRO_ASSERT_SEQUENCE=1 \
  cargo nextest run --features dev --lib --test it \
  -E 'not test(normalization_transcripts_exon_contract)'
```

**25 failures before, 22 after, zero new**, the three green ones being `idempotency_tests::test_normalization_idempotency`, `normalize_tests::…::test_3prime_shifting::case_1` and `normalize_tests::…::test_deletion_shifts_in_real_homopolymer::case_1`. The totals move with the base — the same measurement read 20/17 against `5f22abed` a few hours earlier — so quote the command, not the pair. (Measured before `NM_033517.1` was restored; restoring it adds back the one #1619 row described above, by design.)

**This does not close #1619, and the PR is careful not to claim it does.** The `hgvs_to_spdi`-vs-normalizer asymmetry the issue names is still reachable on the 58 real transcripts above; what the repair removes is the fixture artifact that was standing in for it — which also means nothing in the suite exercises it any more. `CLAUDE.md` records that, so the row is not read as fixed.

## The guard

`tests/it/normalization_transcripts_exon_contract.rs` checks every record: consecutive 1-based numbering, non-empty well-ordered bounds, junction contiguity, and last exon within the stored sequence. It reports all violations at once rather than the first.

Coverage is deliberately a one-sided bound, not an equality: `NR_046285.1` and `NR_153405.1` have genuine cdot exon tables that stop short of the true RefSeq length (2599/2619, 4299/4337) because their 3' bases do not align to the genome.

**The 5' anchor was dropped for the same reason, after measuring it.** The first revision asserted `exons[0].start == 1` — a two-sided claim with no measurement behind it, where the 3' bound had one. Over cdot-0.2.32.refseq.GRCh38, **109** builds begin past transcript coordinate 1 (`NM_000280.5` at 8, `NM_000910.2` at 7, `NM_001100631.1` at 870), **1.9x** the 58-build gapped population the argument rests on — so the anchor would reject genuine upstream data almost twice as often as the synthetic shape it was meant to catch. No consumer wants it either: `CoordinateMapper` switches between flat and exon-walking arithmetic on `w[0].end + 1 != w[1].start`, a junction predicate, and nothing under `src/` reads `exons[0].start`. Every fixture record still starts at 1; that is now recorded as an observation, not a contract.

**Verified non-vacuous by running it against the pre-fix fixture** — it fails, naming 22 of 29 records, independently reproducing the measurement through the test itself.

## Doc corrections

`make_transcript_with_gaps` claimed to "simulate how cdot encodes transcripts with virtual intron positions". cdot has no such encoding, and that false claim was the stated justification for the fixture's shape. Its doc now says what it actually builds — a deliberately malformed transcript stressing the mapper's exon-walking arithmetic — and why it stays that way.

## Second commit: declined protein splits re-parse

Separately, `try_protein_split_delins` (#1606) declines on seven conditions, one of which exists *only* to stop normalization emitting the unparseable `p.Met1Xxx`. That guard's whole value is a re-parse property and nothing asserted it — the existing suite pins exact output strings, which pass just as happily on a string that cannot be read back.

Investigated whether #1606 re-opened a retired "declined protein split reparse hole": **it did not.** The decline arm is `None => variant`, which returns the input value and produces no string, so a decline has no re-parse property to violate. Measured over a 4,347-input sweep with all nine decline sites instrumented — every branch fires (no structural zero), the split fires 320 times, and the 16 unparseable outputs found all enter already collapsed to a substitution and leave on the "not a delins" gate. Disabling the split reproduces all 16 byte for byte while moving 154 other outputs, which is the decisive A/B. Those 16 are #1607 and are deliberately not pinned here.

## Verification

`cargo fmt --all` and `cargo clippy --all-features --all-targets -- -D warnings` are clean, `actionlint` is clean on the `ci.yml` edit, and both spec generators were regenerated first.

The oracle-armed suite reports `10034 tests run: 10027 passed, 7 failed, 151 skipped`. **Every one of those failures is pre-existing on `origin/main` and none is attributable to this PR** — verified by building a throwaway detached worktree at pristine `origin/main` and running the same tests with the same three flags, where the identical set fails. This PR's only `src/` change is a doc comment, so it cannot move normalization behaviour; `git diff origin/main...HEAD -- src/` has no non-comment line.



## Review round: what changed after review

Four verified findings plus two nits, all fixed. In order of seriousness:

1. **The seven single-exon records were fabricated flattenings** and nothing said so — all six that cdot carries are restored, `NM_001127687.1` is named in `FLATTENED_RECORDS`, and `no_unnamed_record_is_flattened` + `every_pinned_gap_exemption_is_still_load_bearing` are the new guards. See *Measured, not taken on trust* above.
2. **`exons[0].start == 1` was a two-sided assertion with no measurement behind it** — dropped, with the 109-build measurement recorded. See *The guard*.
3. **The before/after figure shipped without a command**, and the "three suites" claim was wrong — both fixed here and in `CLAUDE.md`.
4. **`try_protein_split_delins`'s `Ter || Xaa` guard was only exercised on `Ter`.** The `Xaa` arm is added on both sides, and each is verified discriminating by deleting the corresponding `contains(&AminoAcid::Xaa)` from the production guard and confirming the test goes red (payload side emits `p.[Ala2Gly;Leu4Xaa]`, reference side `p.[Ala2Gly;Xaa4Gly]`).
5. Nits: `PROTEIN_WITH_STOP_AT_4`'s doc said residue 4 was "replaced" when the stop is **inserted** (21 residues to `PROTEIN`'s 20, so `Leu` is residue 5) — corrected, with the same caveat on the new `PROTEIN_WITH_UNKNOWN_AT_4`. And `parse_hgvs(&output).is_ok()` was not a round-trip; it now compares `parse_hgvs(&output)?.to_string()` against `output`, so an output the parser reads back as a *different* description fails.

**Reported, not fixed:** eight sibling fixtures carrying exon tables (`*/reference-windows.json`, `grammar/spec_enumeration_windows.json`, `transcripts/mock_transcripts.json`, `mutalyzer-normalize/genomic-windows.json`) hold **2,306** junctions this guard does not cover. All measured clean — zero contiguity violations — so it is a coverage gap, not a live defect. The 58/474,818 cdot census is also restated in three files (`CLAUDE.md`, `src/convert/mapper.rs`, the guard) with no committed derivation; it re-derives from the prepared cdot on request.
