### PR TITLE
test: Add more test coverage based on mutatino testing

### DIFF
--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -146,36 +146,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_cds_pos_normal() {
-        let tx = make_test_transcript();
-        assert!(validate_cds_pos(&CdsPos::new(1), &tx).is_ok());
-        assert!(validate_cds_pos(&CdsPos::new(15), &tx).is_ok());
-    }
-
-    #[test]
-    fn test_validate_cds_pos_out_of_range() {
-        let tx = make_test_transcript();
-        // CDS is 15bp (positions 1-15)
-        assert!(validate_cds_pos(&CdsPos::new(20), &tx).is_err());
-    }
-
-    #[test]
-    fn test_validate_cds_pos_5utr() {
-        let tx = make_test_transcript();
-        // 5' UTR is 5bp (positions -1 to -5)
-        assert!(validate_cds_pos(&CdsPos::new(-3), &tx).is_ok());
-        assert!(validate_cds_pos(&CdsPos::new(-10), &tx).is_err());
-    }
-
-    #[test]
-    fn test_validate_cds_pos_3utr() {
-        let tx = make_test_transcript();
-        // 3' UTR is 6bp (positions *1 to *6)
-        assert!(validate_cds_pos(&CdsPos::utr3(3), &tx).is_ok());
-        assert!(validate_cds_pos(&CdsPos::utr3(10), &tx).is_err());
-    }
-
-    #[test]
     fn test_cds_to_transcript_pos_5utr_and_legacy_c0() {
         // Pin the issue #97 fix and the legacy c.0 mapping in the public
         // helper, mirroring Normalizer::cds_to_tx_pos.
@@ -218,5 +188,179 @@ mod tests {
         let result = cds_to_transcript_pos(&CdsPos::new(0), &tx_zero_cds).unwrap();
         assert_eq!(result, tx_zero_cds.cds_start.unwrap().saturating_sub(1));
         assert_eq!(result, 0);
+    }
+
+    /// Boundaries of `validate_cds_pos`, one assertion per edge: both sides
+    /// of the 3'UTR guard (`*0` err, `*1` ok, `*6` ok, `*7` err), both sides
+    /// of the 5'UTR guard (`-5` ok, `-6` err), both sides of the CDS guard
+    /// (`15` ok, `16` err), and the offset sanity limit on both signs — the
+    /// guard is `offset.unsigned_abs() > 1_000_000`, pinned here at the
+    /// ±1_000_000 (ok) and ±1_000_001 (err) pairs, so dropping the
+    /// magnitude check would otherwise sail through unpinned on the
+    /// negative side.
+    ///
+    /// One offset class is deliberately NOT pinned here: the uncertain-offset
+    /// sentinels `-?` / `+?` (`OFFSET_UNKNOWN_NEGATIVE` /
+    /// `OFFSET_UNKNOWN_POSITIVE` = `i64::MIN` / `i64::MAX`, declared in
+    /// `src/hgvs/parser/position.rs`).
+    ///
+    /// This paragraph previously recorded that class as an OPEN production
+    /// gap — that `i64::MIN.abs()` overflows, so `validate_cds_pos` panicked
+    /// in debug on `c.100-?` instead of returning an error (issue #1087).
+    /// That is no longer true: `validate_cds_pos` declines the sentinels up
+    /// front via `pos.has_unknown_offset()`, and its magnitude checks use
+    /// `unsigned_abs()` throughout, so `c.100-?` and `c.100+?` both return
+    /// `Err` and neither overflows. That class is pinned by
+    /// `unknown_offset_sentinels_are_rejected` below.
+    #[test]
+    fn validate_cds_pos_boundaries() {
+        let tx = make_test_transcript();
+
+        assert!(
+            validate_cds_pos(&CdsPos::new(1), &tx).is_ok(),
+            "1 is the first CDS base"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::new(20), &tx).is_err(),
+            "20 is out of CDS range"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::new(-3), &tx).is_ok(),
+            "-3 is within the 5'UTR"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::new(-10), &tx).is_err(),
+            "-10 is out of 5'UTR range"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(3), &tx).is_ok(),
+            "*3 is within the 3'UTR"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(10), &tx).is_err(),
+            "*10 is out of 3'UTR range"
+        );
+
+        // 3'UTR runs *1..*6 inclusive.
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(0), &tx).is_err(),
+            "*0 is not a valid 3'UTR position"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(1), &tx).is_ok(),
+            "*1 is the first 3'UTR base"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(6), &tx).is_ok(),
+            "*6 is the last 3'UTR base"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::utr3(7), &tx).is_err(),
+            "*7 is past the 3'UTR"
+        );
+
+        // 5'UTR runs -1..-5 inclusive.
+        assert!(
+            validate_cds_pos(&CdsPos::new(-5), &tx).is_ok(),
+            "-5 is the last 5'UTR base"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::new(-6), &tx).is_err(),
+            "-6 is past the 5'UTR"
+        );
+
+        // CDS runs 1..15 inclusive.
+        assert!(
+            validate_cds_pos(&CdsPos::new(15), &tx).is_ok(),
+            "15 is the last CDS base"
+        );
+        assert!(
+            validate_cds_pos(&CdsPos::new(16), &tx).is_err(),
+            "16 is past the CDS"
+        );
+
+        // The offset sanity limit is `offset.unsigned_abs() > 1_000_000`, so
+        // 1_000_000 is legal on both the positive and negative side.
+        let at_limit = CdsPos::with_offset(1, 1_000_000);
+        assert!(
+            validate_cds_pos(&at_limit, &tx).is_ok(),
+            "offset 1_000_000 is at the limit"
+        );
+
+        let past_limit = CdsPos::with_offset(1, 1_000_001);
+        assert!(
+            validate_cds_pos(&past_limit, &tx).is_err(),
+            "offset 1_000_001 is past it"
+        );
+
+        let at_negative_limit = CdsPos::with_offset(1, -1_000_000);
+        assert!(
+            validate_cds_pos(&at_negative_limit, &tx).is_ok(),
+            "offset -1_000_000 is at the limit"
+        );
+
+        let past_negative_limit = CdsPos::with_offset(1, -1_000_001);
+        assert!(
+            validate_cds_pos(&past_negative_limit, &tx).is_err(),
+            "offset -1_000_001 is past it"
+        );
+    }
+
+    /// Exact tx positions for each branch of `cds_to_transcript_pos`.
+    #[test]
+    fn cds_to_transcript_pos_arithmetic() {
+        let tx = make_test_transcript();
+
+        // CDS: cds_start + base - 1.
+        assert_eq!(cds_to_transcript_pos(&CdsPos::new(1), &tx).unwrap(), 6);
+        assert_eq!(cds_to_transcript_pos(&CdsPos::new(2), &tx).unwrap(), 7);
+        assert_eq!(cds_to_transcript_pos(&CdsPos::new(15), &tx).unwrap(), 20);
+
+        // 3'UTR: cds_end + base.
+        assert_eq!(cds_to_transcript_pos(&CdsPos::utr3(1), &tx).unwrap(), 21);
+        assert_eq!(cds_to_transcript_pos(&CdsPos::utr3(3), &tx).unwrap(), 23);
+    }
+
+    /// The uncertain-offset sentinels `-?` / `+?` (`OFFSET_UNKNOWN_NEGATIVE` /
+    /// `OFFSET_UNKNOWN_POSITIVE` = `i64::MIN` / `i64::MAX`) are not distances,
+    /// so `validate_cds_pos` must decline them rather than measure them.
+    ///
+    /// Two failure modes are pinned at once:
+    ///
+    /// 1. **Panic.** `i64::MIN.abs()` overflows, so reaching this with a plain
+    ///    `.abs()` panics in debug on `c.1-?`. Reaching the assertion at all
+    ///    proves the magnitude check uses `unsigned_abs()`.
+    /// 2. **Refusal for the wrong reason.** This is the one that makes the
+    ///    assertion below check the MESSAGE rather than just `is_err()`.
+    ///    Both sentinels have enormous magnitudes, so the
+    ///    `unsigned_abs() > 1_000_000` check rejects them on its own — which
+    ///    means deleting the `has_unknown_offset()` decline entirely leaves
+    ///    an `is_err()`-only assertion **green**. Verified by sabotage: with
+    ///    the guard removed, an `is_err()` version of this test still passed.
+    ///    A sentinel refused as "unreasonably large" has been silently
+    ///    reclassified as a measured distance that happens to be too big,
+    ///    which is the opposite of what #1767 decided.
+    #[test]
+    fn unknown_offset_sentinels_are_rejected() {
+        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+
+        let tx = make_test_transcript();
+
+        for (label, offset) in [
+            ("c.1-?", OFFSET_UNKNOWN_NEGATIVE),
+            ("c.1+?", OFFSET_UNKNOWN_POSITIVE),
+        ] {
+            let err = validate_cds_pos(&CdsPos::with_offset(1, offset), &tx)
+                .expect_err("must be declined, not measured");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("denotes no transcript coordinate"),
+                "{label} must be refused AS A SENTINEL; got: {msg}"
+            );
+            assert!(
+                !msg.contains("unreasonably large"),
+                "{label} must not be refused as a mere magnitude; got: {msg}"
+            );
+        }
     }
 }

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -227,7 +227,14 @@ impl<'a> CoordinateMapper<'a> {
         Self::translate_codon(codon)
     }
 
-    /// Translate a codon to an amino acid
+    /// Translate a codon to an amino acid.
+    ///
+    /// Total: every one of the 22 match arms (21 named plus the `_`
+    /// fall-through) returns `Some`, so this never returns `None` despite
+    /// the `Option` signature. The `_` arm is what makes it total: it
+    /// coerces *every* unrecognised codon — including `N`-containing ones
+    /// from real reference sequences — to `Some(Xaa)`, indistinguishable
+    /// from a genuine unknown residue.
     fn translate_codon(codon: &str) -> Option<AminoAcid> {
         match codon.to_uppercase().as_str() {
             "TTT" | "TTC" => Some(AminoAcid::Phe),
@@ -625,7 +632,10 @@ mod tests {
             id: "NM_TEST.1".to_string(),
             gene_symbol: Some("TEST".to_string()),
             strand: Strand::Plus,
-            // 5' UTR (5bp) + CDS (30bp) + 3' UTR (5bp) = 40bp
+            // 5'UTR (5bp) + CDS (30bp) + 3'UTR (3bp) = 38bp.
+            // NOTE: cds_start = 6 is the `T` of the visible `ATG` (whose `A` is at
+            // 0-based 4), so the first codon is seq[5..8] == "TGC" and p.1 is Cys,
+            // not Met. Use `make_codon_sweep_transcript` for amino-acid assertions.
             sequence: Some("AAAAATGCCCAAAGGGTTTAGGCCCAAAGGGTTATAAA".to_string()),
             cds_start: Some(6),
             cds_end: Some(35),
@@ -643,10 +653,234 @@ mod tests {
         }
     }
 
+    /// One codon per `translate_codon` match arm, 21 codons, all 21 amino acids
+    /// distinct. Three properties are load-bearing — do not "tidy" them:
+    ///
+    /// 1. All 21 amino acids differ, so a mutated `codon_start` reads a codon
+    ///    that translates differently rather than coinciding.
+    /// 2. The 5'UTR's first codon is `CCC` (Pro), never `ATG`. In
+    ///    `get_amino_acid_at`'s `codon_start` arithmetic
+    ///    (`cds_start as usize - 1 + (position as usize - 1) * 3`), a
+    ///    `+ -> *` mutant degenerates `codon_start` to 0 at p.1 and reads
+    ///    seq[0..3]; a Met-translating 5'UTR would let it survive.
+    /// 3. The 3'UTR translates (`GGG` -> Gly). In `get_amino_acid_at`'s
+    ///    past-CDS guard (`codon_end > cds_end as usize || codon_end >
+    ///    seq.len()`), a `|| -> &&` mutant stops it firing at p.22 and reads
+    ///    seq[68..71]; Gly there is what distinguishes it from the `Xaa` the
+    ///    original returns.
+    ///
+    /// Layout: 5'UTR 5bp (cds_start = 6), CDS 63bp (cds_end = 68), 3'UTR 6bp,
+    /// total 74bp.
+    fn make_codon_sweep_transcript() -> Transcript {
+        Transcript {
+            id: "NM_CODONS.1".to_string(),
+            gene_symbol: Some("TEST".to_string()),
+            sequence: Some(
+                "CCCCC".to_string()
+                    + "ATGTTTCTGATTGTGTCACCCACAGCCTAT"
+                    + "CATCAAAATAAAGATGAATGTTGGCGCGGA"
+                    + "TAA"
+                    + "GGGTTT",
+            ),
+            cds_start: Some(6),
+            cds_end: Some(68),
+            exons: vec![Exon::new(1, 1, 74)],
+            ..Default::default()
+        }
+    }
+
+    /// A deliberately malformed transcript whose `cds_end` exceeds its sequence
+    /// length. This is the ONLY way to reach `get_amino_acid_at`'s second guard
+    /// clause: under `||`, `codon_end > seq.len()` is unreachable whenever
+    /// `codon_end > cds_end` has already fired.
+    ///
+    /// Sequence is 12bp, cds_start = 1, cds_end = 100.
+    ///
+    /// Do not reuse this fixture with `validate_cds_pos`: its
+    /// `transcript.sequence_length() - cds_end` is unchecked `u64`
+    /// subtraction, and `12 - 100` here underflows and panics in debug.
+    fn make_cds_end_past_sequence_transcript() -> Transcript {
+        Transcript {
+            id: "NM_SHORTSEQ.1".to_string(),
+            gene_symbol: Some("TEST".to_string()),
+            sequence: Some("ATGTTTCTGATT".to_string()),
+            cds_start: Some(1),
+            cds_end: Some(100),
+            exons: vec![Exon::new(1, 1, 12)],
+            ..Default::default()
+        }
+    }
+
+    /// Pins the amino acid at every codon of a 21-arm sweep.
+    ///
+    /// `test_cds_to_protein` asserts only `.number`, leaving the amino acid
+    /// itself unchecked: `get_amino_acid_at` returning `None` is invisible
+    /// there because `cds_to_protein` swallows it with `.unwrap_or(Xaa)`,
+    /// and every `translate_codon` arm falls through to `_ => Some(Xaa)`
+    /// when deleted, so a mutated arm and a correct one are indistinguishable
+    /// by number alone. This test checks `.aa` directly so both are caught.
+    #[test]
+    fn cds_to_protein_pins_every_codon_arm() {
+        let tx = make_codon_sweep_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+
+        let expected = [
+            AminoAcid::Met,
+            AminoAcid::Phe,
+            AminoAcid::Leu,
+            AminoAcid::Ile,
+            AminoAcid::Val,
+            AminoAcid::Ser,
+            AminoAcid::Pro,
+            AminoAcid::Thr,
+            AminoAcid::Ala,
+            AminoAcid::Tyr,
+            AminoAcid::His,
+            AminoAcid::Gln,
+            AminoAcid::Asn,
+            AminoAcid::Lys,
+            AminoAcid::Asp,
+            AminoAcid::Glu,
+            AminoAcid::Cys,
+            AminoAcid::Trp,
+            AminoAcid::Arg,
+            AminoAcid::Gly,
+            AminoAcid::Ter,
+        ];
+
+        for (index, aa) in expected.iter().enumerate() {
+            let protein_number = (index + 1) as u64;
+            let cds_base = (index as i64) * 3 + 1;
+            let got = mapper.cds_to_protein(&CdsPos::new(cds_base)).unwrap();
+            assert_eq!(got.number, protein_number, "p.{} number", protein_number);
+            assert_eq!(
+                got.aa, *aa,
+                "p.{} amino acid (c.{})",
+                protein_number, cds_base
+            );
+        }
+    }
+
+    /// p.21 is the last codon (`codon_end == cds_end`, 68) and must translate;
+    /// p.22 runs past the CDS and must yield `Xaa`.
+    ///
+    /// The p.22 case is what kills a `|| -> &&` mutant of `get_amino_acid_at`'s
+    /// guard (the `codon_end > cds_end as usize || codon_end > seq.len()`
+    /// early return in `get_amino_acid_at`): with `&&` the guard does
+    /// not fire, the function reads the 3'UTR's `GGG`, and `cds_to_protein`
+    /// returns Gly instead of Xaa.
+    ///
+    /// The two indirect assertions above observe the guard only through
+    /// `cds_to_protein`'s `.unwrap_or(AminoAcid::Xaa)`, which — exactly as
+    /// `get_amino_acid_at_guards_a_cds_end_past_the_sequence`'s doc comment
+    /// diagnoses for its own case — collapses five distinct causes of
+    /// `None` into one `Xaa` value: a missing `cds_start`, a missing
+    /// `cds_end`, a missing cached `sequence`, `codon_end > cds_end` (the
+    /// primary guard clause), and `codon_end > seq.len()` (the secondary
+    /// one). `translate_codon` is not a sixth cause — it is total (every
+    /// match arm, including `_`, yields `Some`, coercing any unrecognised
+    /// codon to `Xaa` rather than `None`), so it can never contribute a
+    /// `None` here. That test unmasks the *secondary*,
+    /// malformed-transcript-only guard clause (`codon_end > seq.len()`) by
+    /// calling `get_amino_acid_at` directly; this test exercises the
+    /// *primary* clause (`codon_end > cds_end as usize`), the one that fires
+    /// on a well-formed transcript, so it gets the same direct treatment
+    /// here.
+    #[test]
+    fn cds_to_protein_stops_at_the_cds_end() {
+        let tx = make_codon_sweep_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+
+        assert_eq!(
+            mapper.cds_to_protein(&CdsPos::new(61)).unwrap().aa,
+            AminoAcid::Ter,
+            "c.61 is the last codon and must still translate"
+        );
+        assert_eq!(
+            mapper.cds_to_protein(&CdsPos::new(64)).unwrap().aa,
+            AminoAcid::Xaa,
+            "c.64 is past cds_end and must not read into the 3'UTR"
+        );
+
+        // Direct, unmasked: `get_amino_acid_at` itself must draw the p.21/p.22
+        // line at `codon_end > cds_end`, not just leave `cds_to_protein` to
+        // paper over it with `Xaa`.
+        assert_eq!(
+            mapper.get_amino_acid_at(21),
+            Some(AminoAcid::Ter),
+            "get_amino_acid_at(21) must translate unmasked, codon_end 68 == cds_end 68"
+        );
+        assert_eq!(
+            mapper.get_amino_acid_at(22),
+            None,
+            "get_amino_acid_at(22) must return None unmasked, codon_end 71 > cds_end 68"
+        );
+    }
+
+    /// Exercises `get_amino_acid_at`'s SECOND guard clause
+    /// (`codon_end > seq.len()`), which is unreachable on a well-formed
+    /// transcript because the first clause fires first.
+    ///
+    /// cds_end = 100 but the sequence is 12bp, so:
+    ///   p.1 codon_end = 3  (< 12)  -> translates
+    ///   p.4 codon_end = 12 (== 12) -> translates, the boundary
+    ///   p.5 codon_end = 15 (> 12)  -> Xaa
+    ///
+    /// The assertions below observe the guard only through `cds_to_protein`,
+    /// which coerces every `None` from `get_amino_acid_at` — regardless of
+    /// which of at least five distinct causes produced it — into `Xaa` via
+    /// `cds_to_protein`'s `.unwrap_or(AminoAcid::Xaa)` fallback. That masks
+    /// the guard: the assertion cannot fail for the *right* reason. The
+    /// direct call below observes `get_amino_acid_at` unmasked, alongside
+    /// the existing indirect ones.
+    #[test]
+    fn get_amino_acid_at_guards_a_cds_end_past_the_sequence() {
+        let tx = make_cds_end_past_sequence_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+
+        assert_eq!(
+            mapper.cds_to_protein(&CdsPos::new(1)).unwrap().aa,
+            AminoAcid::Met,
+            "codon_end 3 is well inside a 12bp sequence"
+        );
+        assert_eq!(
+            mapper.cds_to_protein(&CdsPos::new(10)).unwrap().aa,
+            AminoAcid::Ile,
+            "codon_end 12 == seq.len() is the last readable codon"
+        );
+        assert_eq!(
+            mapper.cds_to_protein(&CdsPos::new(13)).unwrap().aa,
+            AminoAcid::Xaa,
+            "codon_end 15 > seq.len() must not read out of bounds"
+        );
+
+        // Direct, unmasked: `get_amino_acid_at` itself must return `None`
+        // past the end (p.5, codon_end 15 > seq.len() 12), not just leave
+        // `cds_to_protein` to paper over it with `Xaa`.
+        assert_eq!(
+            mapper.get_amino_acid_at(5),
+            None,
+            "get_amino_acid_at(5) must return None unmasked, codon_end 15 > seq.len() 12"
+        );
+    }
+
     #[test]
     fn test_cds_to_tx_normal() {
         let tx = make_test_transcript();
         let mapper = CoordinateMapper::new(&tx);
+
+        // Pins `make_test_transcript`'s length (5'UTR 5bp + CDS 30bp + 3'UTR
+        // 3bp = 38bp) against the hardcoded `38` literal below — that catches
+        // the sequence literal changing size, not the comment drifting from
+        // it (both copies once said `= 40bp` while the sequence stayed 38bp,
+        // and this assertion would not have caught that). The fixture is
+        // duplicated with the same data but different code in
+        // `tests/it/convert_tests.rs` (a `Transcript { .. }` literal here vs.
+        // `Transcript::new(..)` there). It is also not sequence-specific:
+        // `sequence_length()` falls back to summing exon lengths when
+        // `sequence` is `None`, and this fixture's `Exon::new(1, 1, 38)`
+        // sums to 38 too, so dropping the sequence would still pass.
+        assert_eq!(tx.sequence_length(), 38, "make_test_transcript is 38bp");
 
         // c.1 should be tx position 6
         let result = mapper.cds_to_tx(&CdsPos::new(1)).unwrap();
@@ -848,6 +1082,11 @@ mod tests {
         assert_eq!(
             CoordinateMapper::translate_codon("GGG"),
             Some(AminoAcid::Gly)
+        );
+        // An unrecognised codon falls through to the `_ => Some(Xaa)` arm.
+        assert_eq!(
+            CoordinateMapper::translate_codon("NNN"),
+            Some(AminoAcid::Xaa)
         );
     }
 
@@ -1176,6 +1415,102 @@ mod tests {
         assert_eq!(mapper.tx_to_cds(&tx_pos).unwrap().base, 10);
         // Direct n->c: tx 10 -> c.10 (bug produced c.7).
         assert_eq!(mapper.tx_to_cds(&TxPos::new(10)).unwrap().base, 10);
+    }
+
+    /// `chromosome()` had no assertion anywhere, so `-> None`, `-> Some("")`
+    /// and `-> Some("xyzzy")` all survived.
+    #[test]
+    fn chromosome_reports_the_transcript_contig() {
+        let tx = make_genomic_transcript_plus();
+        let mapper = CoordinateMapper::new(&tx);
+        assert_eq!(mapper.chromosome(), Some("chr1"));
+    }
+
+    /// `get_intron_position` has one production caller (in `src/vcf/to_hgvs.rs`)
+    /// and no test reached it, so the whole-function `-> None` survived.
+    ///
+    /// Exon 1 ends at genomic 1009 (tx 10); genomic 1012 is 3 bases into
+    /// intron 1.
+    #[test]
+    fn get_intron_position_reports_an_intronic_offset() {
+        let tx = make_genomic_transcript_plus();
+        let mapper = CoordinateMapper::new(&tx);
+
+        let intron = mapper
+            .get_intron_position(1012)
+            .expect("genomic 1012 lies in intron 1");
+        assert_eq!(intron.intron_number, 1, "genomic 1012 lies in intron 1");
+        assert_eq!(intron.offset, 3, "3 bases past the exon 1 boundary");
+        assert_eq!(intron.tx_boundary_pos, 10, "exon 1 ends at tx 10");
+
+        // An exonic position is not intronic.
+        assert!(mapper.get_intron_position(1005).is_none());
+    }
+
+    /// `fold_non_intronic_utr_offset` folds only 3'UTR and negative-base
+    /// (5'UTR) positions. `base == 0` is neither of those — it is
+    /// `CDS_BASE_UNKNOWN` (in `src/hgvs/location.rs`), the `c.?`
+    /// unknown-position sentinel, not an arithmetic edge of the UTR check.
+    /// It must still decline to fold, and doing so also happens to pin
+    /// `pos.base < 0` against a `<= 0` mutant, since 0 is where the two
+    /// diverge. Base 0 is the interesting input precisely because the two
+    /// functions disagree about it: this gate classifies 5'UTR as
+    /// `pos.base < 0`, while `cds_to_tx` (above) uses `pos.base < 1`,
+    /// so base 0 is 5'UTR to `cds_to_tx` but not to this gate — that
+    /// divergence is the whole reason this test exists.
+    #[test]
+    fn fold_offset_declines_unknown_position() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+
+        let pos = CdsPos::unknown(Some(5));
+
+        // The decline happens at the `in_utr` gate, three lines before
+        // `cds_to_tx` is even called: `pos.utr3 || pos.base < 0` is
+        // `false || (0 < 0)` = `false` for base 0 (`CDS_BASE_UNKNOWN`), so
+        // `fold_non_intronic_utr_offset` returns `None` right there and the
+        // `c.?` sentinel never reaches the conversion at all.
+        // (`cds_to_tx`'s own handling of this sentinel — it coerces rather
+        // than declines — is pinned separately by
+        // `cds_to_tx_coerces_the_unknown_sentinel` below.)
+        assert!(mapper.fold_non_intronic_utr_offset(&pos).is_none());
+    }
+
+    /// `cds_to_tx` does not honour the `c.?` sentinel the way
+    /// `merge::simple_cds_pos` (in `src/normalize/merge.rs`) and
+    /// `VariantProjector::project_to_genomic` (in `src/project/projector.rs`)
+    /// do — both decline it explicitly. Here it silently coerces
+    /// `CdsPos::unknown(Some(5))` (base `CDS_BASE_UNKNOWN` = 0) into
+    /// `TxPos { base: 6, offset: Some(5) }`, bit-identical to what `c.1+5`
+    /// produces (`cds_start` is 6 on `make_test_transcript`).
+    ///
+    /// The quirk is not contained by those declining callers:
+    /// `spdi::convert::resolve_cds_to_tx` (in `src/spdi/convert.rs`) guards
+    /// only `is_intronic()`, which is `false` for `c.?` (offset is `None`),
+    /// so the sentinel passes straight through and is emitted as a concrete
+    /// SPDI position for what is, by definition, an unknown coordinate.
+    /// This pins today's behaviour, not a requirement — if `cds_to_tx`
+    /// later grows an `is_unknown()` guard and declines this input, update
+    /// this assertion to match; do not revert the guard to keep it green.
+    #[test]
+    fn cds_to_tx_coerces_the_unknown_sentinel() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+
+        let pos = CdsPos::unknown(Some(5));
+
+        let result = mapper
+            .cds_to_tx(&pos)
+            .expect("cds_to_tx coerces the c.? sentinel rather than declining it");
+        assert_eq!(
+            result,
+            TxPos {
+                base: 6,
+                offset: Some(5),
+                downstream: false,
+            },
+            "cds_to_tx coerces the c.? sentinel rather than declining it (today's observed behaviour, not a requirement)"
+        );
     }
 }
 

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -444,61 +444,6 @@ mod tests {
     }
 
     #[test]
-    fn test_intronic_consequence_from_cds_pos() {
-        // Splice donor +1
-        let pos = CdsPos::with_offset(100, 1);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceDonorVariant));
-
-        // Splice donor +5
-        let pos = CdsPos::with_offset(100, 5);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceDonorRegionVariant)
-        );
-
-        // Splice acceptor -2
-        let pos = CdsPos::with_offset(100, -2);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceAcceptorVariant)
-        );
-
-        // Splice acceptor region -10
-        let pos = CdsPos::with_offset(100, -10);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceAcceptorRegionVariant)
-        );
-
-        // Splice region +15
-        let pos = CdsPos::with_offset(100, 15);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceRegionVariant));
-
-        // Near splice site +30
-        let pos = CdsPos::with_offset(100, 30);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::NearSpliceSiteVariant)
-        );
-
-        // Deep intronic +100
-        let pos = CdsPos::with_offset(100, 100);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::IntronVariant));
-
-        // Non-intronic position
-        let pos = CdsPos::new(100);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, None);
-    }
-
-    #[test]
     fn test_intronic_consequence_so_terms() {
         assert_eq!(
             IntronicConsequence::SpliceDonorVariant.so_term(),
@@ -540,34 +485,6 @@ mod tests {
         assert!(IntronicConsequence::SpliceDonorVariant.may_affect_splicing());
         assert!(IntronicConsequence::SpliceRegionVariant.may_affect_splicing());
         assert!(!IntronicConsequence::IntronVariant.may_affect_splicing());
-    }
-
-    #[test]
-    fn test_intronic_region_from_offset() {
-        assert_eq!(
-            IntronicRegion::from_offset(1),
-            Some(IntronicRegion::CanonicalSpliceSite)
-        );
-        assert_eq!(
-            IntronicRegion::from_offset(-2),
-            Some(IntronicRegion::CanonicalSpliceSite)
-        );
-        assert_eq!(
-            IntronicRegion::from_offset(10),
-            Some(IntronicRegion::ExtendedSpliceRegion)
-        );
-        assert_eq!(
-            IntronicRegion::from_offset(-15),
-            Some(IntronicRegion::ExtendedSpliceRegion)
-        );
-        assert_eq!(
-            IntronicRegion::from_offset(35),
-            Some(IntronicRegion::NearSpliceSite)
-        );
-        assert_eq!(
-            IntronicRegion::from_offset(100),
-            Some(IntronicRegion::DeepIntronic)
-        );
     }
 
     /// The #1841 break: the sentinels are out of the enum's domain, and the
@@ -614,96 +531,6 @@ mod tests {
         assert!(!is_clinically_significant_splice_position(&CdsPos::new(
             100
         )));
-    }
-
-    #[test]
-    fn test_validate_tx_pos_with_large_offset() {
-        let tx = make_test_transcript();
-
-        // Large offset should fail
-        let pos = TxPos::with_offset(50, 100001);
-        assert!(validate_tx_pos(&pos, &tx).is_err());
-
-        // Reasonable offset should pass
-        let pos = TxPos::with_offset(50, 1000);
-        assert!(validate_tx_pos(&pos, &tx).is_ok());
-
-        // Negative offset should work too
-        let pos = TxPos::with_offset(50, -1000);
-        assert!(validate_tx_pos(&pos, &tx).is_ok());
-    }
-
-    #[test]
-    fn test_intronic_consequence_from_tx_pos() {
-        // Splice donor +1
-        let pos = TxPos::with_offset(50, 1);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceDonorVariant));
-
-        // Splice donor +2
-        let pos = TxPos::with_offset(50, 2);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceDonorVariant));
-
-        // Splice donor region +5
-        let pos = TxPos::with_offset(50, 5);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceDonorRegionVariant)
-        );
-
-        // Splice region +15
-        let pos = TxPos::with_offset(50, 15);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceRegionVariant));
-
-        // Near splice site +35
-        let pos = TxPos::with_offset(50, 35);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::NearSpliceSiteVariant)
-        );
-
-        // Deep intronic +100
-        let pos = TxPos::with_offset(50, 100);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::IntronVariant));
-
-        // Splice acceptor -1
-        let pos = TxPos::with_offset(50, -1);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceAcceptorVariant)
-        );
-
-        // Splice acceptor region -10
-        let pos = TxPos::with_offset(50, -10);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceAcceptorRegionVariant)
-        );
-
-        // Splice region -15
-        let pos = TxPos::with_offset(50, -15);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceRegionVariant));
-
-        // Near splice site -35
-        let pos = TxPos::with_offset(50, -35);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::NearSpliceSiteVariant)
-        );
-
-        // Non-intronic
-        let pos = TxPos::new(50);
-        let consequence = IntronicConsequence::from_tx_pos(&pos);
-        assert!(consequence.is_none());
     }
 
     #[test]
@@ -893,51 +720,249 @@ mod tests {
         assert_eq!(intron_num, None);
     }
 
+    /// The offset sanity limit is `offset.unsigned_abs() > 100_000`, so
+    /// 100_000 is legal on both the positive and negative side. The negative
+    /// side is the routine acceptor-side case, and it needs its own
+    /// assertion: the existing positive-only pins leave the magnitude check
+    /// free to be dropped without failing the suite, since a large negative
+    /// offset would then sail through unchecked.
+    ///
+    /// The uncertain-offset sentinels `-?` / `+?` (`i64::MIN` / `i64::MAX`,
+    /// declared in `src/hgvs/parser/position.rs`) are NOT pinned here or in
+    /// `splice_ladder_boundaries`.
+    ///
+    /// This paragraph previously recorded that as an OPEN production gap —
+    /// that `i64::MIN.abs()` overflows, so `validate_tx_pos`,
+    /// `IntronicConsequence::from_{cds,tx}_pos` and
+    /// `IntronicRegion::from_offset` all panicked in debug on `-?` and filed
+    /// `+?` as deep-intronic, none of them calling `has_unknown_offset`
+    /// (issue #1087). That is no longer true: `validate_tx_pos` and both
+    /// `IntronicConsequence` constructors decline the sentinels via
+    /// `pos.has_unknown_offset()`, `IntronicRegion::from_offset` declines via
+    /// `is_unknown_offset` and returns `None`, and every magnitude check uses
+    /// `unsigned_abs()`. The class is pinned by
+    /// `unknown_offset_sentinels_are_declined_not_classified` below.
     #[test]
-    fn test_intronic_consequence_acceptor_extended_boundary() {
-        // Test boundary at -12 (acceptor extended)
-        let pos = CdsPos::with_offset(100, -12);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceAcceptorRegionVariant)
+    fn validate_tx_pos_offset_limit_boundary() {
+        let tx = make_test_transcript();
+
+        // Carried over from the deleted `test_validate_tx_pos_with_large_offset`
+        // (a routine offset on each side of zero, well inside the limit), so no
+        // assertion from that test is lost.
+        assert!(
+            validate_tx_pos(&TxPos::with_offset(50, 1000), &tx).is_ok(),
+            "offset 1000 is well within the limit"
+        );
+        assert!(
+            validate_tx_pos(&TxPos::with_offset(50, -1000), &tx).is_ok(),
+            "offset -1000 is well within the limit"
         );
 
-        // Test -13 (splice region)
-        let pos = CdsPos::with_offset(100, -13);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceRegionVariant));
+        let at_limit = TxPos::with_offset(50, 100_000);
+        assert!(
+            validate_tx_pos(&at_limit, &tx).is_ok(),
+            "offset 100_000 is at the limit"
+        );
+
+        let past_limit = TxPos::with_offset(50, 100_001);
+        assert!(
+            validate_tx_pos(&past_limit, &tx).is_err(),
+            "offset 100_001 is past it"
+        );
+
+        let at_negative_limit = TxPos::with_offset(50, -100_000);
+        assert!(
+            validate_tx_pos(&at_negative_limit, &tx).is_ok(),
+            "offset -100_000 is at the limit"
+        );
+
+        let past_negative_limit = TxPos::with_offset(50, -100_001);
+        assert!(
+            validate_tx_pos(&past_negative_limit, &tx).is_err(),
+            "offset -100_001 is past it"
+        );
     }
 
+    /// Every rung of all three splice ladders, at its exact boundary and
+    /// boundary+1, on both the donor (positive offset) and acceptor
+    /// (negative offset) side.
+    ///
+    /// `IntronicConsequence::from_cds_pos`'s donor chain (`abs_offset <= 2`
+    /// / `<= 6` / `<= 20` / `<= 50`) and its acceptor chain (`<= 2` / `<= 12`
+    /// / `<= 20` / `<= 50`), together with `::from_tx_pos`'s byte-identical
+    /// donor and acceptor chains, are copies of one donor/acceptor ladder:
+    /// donor breaks at 2 / 6 / 20 / 50, acceptor at 2 / 12 / 20 / 50 — the
+    /// donor and acceptor thresholds differ (6 vs 12), so they are not
+    /// mirror images of each other. `IntronicRegion::from_offset`'s
+    /// `abs_offset <= 2` / `<= 20` / `<= 50` chain is a third, shorter
+    /// ladder that is symmetric in the offset's sign (2 / 20 / 50 on both
+    /// sides) and has no 6 or 12 break.
+    /// A hand-unrolled `#[test]` per rung would be the fourth near-verbatim
+    /// copy of this shape in this file; this table drives all three
+    /// functions from one set of rows instead.
     #[test]
-    fn test_intronic_consequence_donor_extended_boundary() {
-        // Test +6 (donor extended)
-        let pos = CdsPos::with_offset(100, 6);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(
-            consequence,
-            Some(IntronicConsequence::SpliceDonorRegionVariant)
-        );
+    fn splice_ladder_boundaries() {
+        use IntronicConsequence::{
+            IntronVariant, NearSpliceSiteVariant, SpliceAcceptorRegionVariant,
+            SpliceAcceptorVariant, SpliceDonorRegionVariant, SpliceDonorVariant,
+            SpliceRegionVariant,
+        };
+        use IntronicRegion::{
+            CanonicalSpliceSite, DeepIntronic, ExtendedSpliceRegion, NearSpliceSite,
+        };
 
-        // Test +7 (splice region)
-        let pos = CdsPos::with_offset(100, 7);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::SpliceRegionVariant));
+        // (offset, expected IntronicConsequence, expected IntronicRegion)
+        let rows: &[(i64, IntronicConsequence, IntronicRegion)] = &[
+            // Donor side (offset > 0): consequence ladder breaks at 2/6/20/50.
+            (1, SpliceDonorVariant, CanonicalSpliceSite),
+            (2, SpliceDonorVariant, CanonicalSpliceSite),
+            (3, SpliceDonorRegionVariant, ExtendedSpliceRegion),
+            (6, SpliceDonorRegionVariant, ExtendedSpliceRegion),
+            (7, SpliceRegionVariant, ExtendedSpliceRegion),
+            (20, SpliceRegionVariant, ExtendedSpliceRegion),
+            (21, NearSpliceSiteVariant, NearSpliceSite),
+            (50, NearSpliceSiteVariant, NearSpliceSite),
+            (51, IntronVariant, DeepIntronic),
+            // Acceptor side (offset < 0): consequence ladder breaks at 2/12/20/50.
+            (-1, SpliceAcceptorVariant, CanonicalSpliceSite),
+            (-2, SpliceAcceptorVariant, CanonicalSpliceSite),
+            (-3, SpliceAcceptorRegionVariant, ExtendedSpliceRegion),
+            (-12, SpliceAcceptorRegionVariant, ExtendedSpliceRegion),
+            (-13, SpliceRegionVariant, ExtendedSpliceRegion),
+            (-20, SpliceRegionVariant, ExtendedSpliceRegion),
+            (-21, NearSpliceSiteVariant, NearSpliceSite),
+            (-50, NearSpliceSiteVariant, NearSpliceSite),
+            (-51, IntronVariant, DeepIntronic),
+        ];
+
+        for &(offset, expected_consequence, expected_region) in rows {
+            let cds_pos = CdsPos::with_offset(100, offset);
+            assert_eq!(
+                IntronicConsequence::from_cds_pos(&cds_pos),
+                Some(expected_consequence),
+                "from_cds_pos at offset {offset}"
+            );
+
+            let tx_pos = TxPos::with_offset(50, offset);
+            assert_eq!(
+                IntronicConsequence::from_tx_pos(&tx_pos),
+                Some(expected_consequence),
+                "from_tx_pos at offset {offset}"
+            );
+
+            // #1841 made `from_offset` total by returning `Option`: the unknown-offset
+            // sentinels are outside the enum's domain. Every row here is an ordinary
+            // offset, so each still classifies.
+            assert_eq!(
+                IntronicRegion::from_offset(offset),
+                Some(expected_region),
+                "from_offset at offset {offset}"
+            );
+        }
     }
 
+    /// `from_cds_pos` and `from_tx_pos` return `None` for a non-intronic
+    /// position (no offset); `splice_ladder_boundaries` never exercises this
+    /// branch, since every row there carries an offset.
+    ///
+    /// `offset: Some(0)` is the second, distinct shape reaching that guard —
+    /// both `c.100+0` and `n.50+0` parse — and what it pins is the guard
+    /// itself, not the ladder behind it. `is_intronic` is
+    /// `offset.is_some() && offset != Some(0)` (defined in
+    /// `src/hgvs/location.rs`, once for `CdsPos` and once for `TxPos`), so a
+    /// zero offset is not intronic
+    /// and both functions decline at `!pos.is_intronic()` before any rung
+    /// runs; deleting the `!= Some(0)` clause turns these two rows into
+    /// `SpliceAcceptorVariant`.
+    ///
+    /// It deliberately does NOT pin the donor/acceptor split (`offset > 0`)
+    /// against an `>= 0` mutant: a zero offset never reaches that branch, so
+    /// `> 0` and `>= 0` are observationally identical and no input can
+    /// distinguish them.
     #[test]
-    fn test_intronic_consequence_near_boundary() {
-        // Test +50 (near splice)
-        let pos = CdsPos::with_offset(100, 50);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
+    fn intronic_consequence_declines_a_non_intronic_position() {
         assert_eq!(
-            consequence,
-            Some(IntronicConsequence::NearSpliceSiteVariant)
+            IntronicConsequence::from_cds_pos(&CdsPos::new(100)),
+            None,
+            "a CdsPos with no offset is not intronic"
         );
+        assert_eq!(
+            IntronicConsequence::from_tx_pos(&TxPos::new(50)),
+            None,
+            "a TxPos with no offset is not intronic"
+        );
+        assert_eq!(
+            IntronicConsequence::from_cds_pos(&CdsPos::with_offset(100, 0)),
+            None,
+            "a CdsPos with an explicit zero offset is not intronic"
+        );
+        assert_eq!(
+            IntronicConsequence::from_tx_pos(&TxPos::with_offset(50, 0)),
+            None,
+            "a TxPos with an explicit zero offset is not intronic"
+        );
+    }
 
-        // Test +51 (deep intronic)
-        let pos = CdsPos::with_offset(100, 51);
-        let consequence = IntronicConsequence::from_cds_pos(&pos);
-        assert_eq!(consequence, Some(IntronicConsequence::IntronVariant));
+    /// The uncertain-offset sentinels `-?` / `+?` (`OFFSET_UNKNOWN_NEGATIVE` /
+    /// `OFFSET_UNKNOWN_POSITIVE` = `i64::MIN` / `i64::MAX`) are out of the
+    /// domain of every intronic classifier on this axis, and each must say so
+    /// rather than measure them.
+    ///
+    /// Two failure modes are pinned at once, both of which this code has
+    /// carried historically:
+    ///
+    /// 1. **Panic.** `i64::MIN.abs()` overflows, so any of these reached with
+    ///    a plain `.abs()` panics in debug on `-?`. Reaching the assertion at
+    ///    all proves the magnitude checks use `unsigned_abs()`.
+    /// 2. **Silent misclassification.** `+?` is `i64::MAX`, which compares
+    ///    greater than every ladder rung, so an unguarded classifier files it
+    ///    as ordinary deep-intronic — a measured distance where there is no
+    ///    distance to measure.
+    ///
+    /// `IntronicRegion::from_offset` is the #1841 half (it declines via
+    /// `is_unknown_offset` and returns `None`); the other three decline via
+    /// `pos.has_unknown_offset()` (#1767).
+    #[test]
+    fn unknown_offset_sentinels_are_declined_not_classified() {
+        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+
+        let tx = make_test_transcript();
+
+        for (label, offset) in [
+            ("-?", OFFSET_UNKNOWN_NEGATIVE),
+            ("+?", OFFSET_UNKNOWN_POSITIVE),
+        ] {
+            // Checks the MESSAGE, not just `is_err()`: both sentinels exceed
+            // the `unsigned_abs() > 100_000` limit on their own, so an
+            // `is_err()`-only assertion stays green with the
+            // `has_unknown_offset()` decline deleted — it would merely have
+            // been reclassified as a distance that is too large.
+            let err = validate_tx_pos(&TxPos::with_offset(50, offset), &tx)
+                .expect_err("must be declined, not measured");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("denotes no transcript coordinate"),
+                "validate_tx_pos must decline the {label} sentinel AS A SENTINEL; got: {msg}"
+            );
+            assert!(
+                !msg.contains("unreasonably large"),
+                "validate_tx_pos must not refuse {label} as a mere magnitude; got: {msg}"
+            );
+            assert_eq!(
+                IntronicConsequence::from_cds_pos(&CdsPos::with_offset(100, offset)),
+                None,
+                "from_cds_pos must decline the {label} sentinel, not classify it"
+            );
+            assert_eq!(
+                IntronicConsequence::from_tx_pos(&TxPos::with_offset(50, offset)),
+                None,
+                "from_tx_pos must decline the {label} sentinel, not classify it"
+            );
+            assert_eq!(
+                IntronicRegion::from_offset(offset),
+                None,
+                "from_offset must decline the {label} sentinel, not classify it"
+            );
+        }
     }
 }

--- a/tests/it/convert_tests.rs
+++ b/tests/it/convert_tests.rs
@@ -5,7 +5,9 @@ use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
 
 fn make_test_transcript() -> Transcript {
-    // Structure: 5bp 5'UTR + 30bp CDS + 5bp 3'UTR = 40bp
+    // Structure: 5bp 5'UTR + 30bp CDS + 3bp 3'UTR = 38bp.
+    // (cds_start 6, cds_end 35, exon tx 1..38 — the 38 is pinned by the
+    // `sequence_length()` assertion in `test_cds_to_tx_basic` below.)
     Transcript::new(
         "NM_TEST.1".to_string(),
         Some("TEST".to_string()),
@@ -28,6 +30,19 @@ fn make_test_transcript() -> Transcript {
 fn test_cds_to_tx_basic() {
     let tx = make_test_transcript();
     let mapper = CoordinateMapper::new(&tx);
+
+    // Pins `make_test_transcript`'s length (5bp 5'UTR + 30bp CDS + 3bp
+    // 3'UTR = 38bp) against the hardcoded `38` literal below — that catches
+    // the sequence literal changing size, not the comment drifting from it
+    // (both copies once said `= 40bp` while the sequence stayed 38bp, and
+    // this assertion would not have caught that). The fixture is duplicated
+    // with the same data but different code in `src/convert/mapper.rs` (a
+    // `Transcript::new(..)` call here vs. a `Transcript { .. }` literal
+    // there). It is also not sequence-specific: `sequence_length()` falls
+    // back to summing exon lengths when `sequence` is `None`, and this
+    // fixture's `Exon::new(1, 1, 38)` sums to 38 too, so dropping the
+    // sequence would still pass.
+    assert_eq!(tx.sequence_length(), 38, "make_test_transcript is 38bp");
 
     // c.1 should map to tx position 6 (first CDS base)
     let result = mapper.cds_to_tx(&CdsPos::new(1)).unwrap();


### PR DESCRIPTION
There was a bunch of concrete stuff that got flagged along the way. We dabbled with clearing some of it out but wound up shifting back to a pure test-only PR. I'll look through the concrete items separately. I'm pretty sure there's still some detritus whining about some of these in the comments, so If a code review scanner flags things referencing pre-existing behavior, there ya go.

**NB** re the test deletions:

 **The two kinds of removal**

1.   Exact duplicates — _acceptor_extended_boundary (−12/−13), _donor_extended_boundary (+6/+7), _near_boundary (+50/+51). Each asserted values that are now literally rows of the table, same function, same expected variant.
2. Strictly weaker interior probes — the rest. test_intronic_consequence_from_cds_pos probed +1, +5, +15, +30, −10; test_validate_cds_pos_normal/_out_of_range/_5utr/_3utr probed new(20), new(-3), utr3(3) and friends. Every one sits inside a region the new boundary pair straddles. A boundary-plus-one pair kills every threshold mutant an interior probe would, and more — an interior value can't distinguish <= 50 from < 50, but 50/51 can.