### PR TITLE
refactor!: remove unused convert API (cds_to_transcript_pos, strand, …

### DIFF
--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -6,7 +6,6 @@
 //! |---------------|-------|-------|
 //! | `CdsPos.base` | 1-based | Positive for CDS, negative for 5'UTR |
 //! | `cds_start`, `cds_end` | 1-based | From transcript metadata |
-//! | Return values | 0-based | For array indexing |
 //!
 //! For type-safe coordinate handling, see [`crate::coords`].
 
@@ -91,31 +90,6 @@ pub fn validate_cds_pos(pos: &CdsPos, transcript: &Transcript) -> Result<(), Fer
     Ok(())
 }
 
-/// Convert a CDS position to a 0-based transcript position
-pub fn cds_to_transcript_pos(pos: &CdsPos, transcript: &Transcript) -> Result<u64, FerroError> {
-    validate_cds_pos(pos, transcript)?;
-
-    let cds_start = transcript.cds_start.unwrap(); // Already validated
-    let cds_end = transcript.cds_end.unwrap();
-
-    let tx_pos = if pos.utr3 {
-        cds_end + pos.base as u64
-    } else if pos.base < 0 {
-        // 5'UTR: HGVS numbering skips c.0 (c.-1 is the base immediately
-        // upstream of c.1), so c.-N maps to tx position cds_start - N.
-        // Issue #97.
-        (cds_start as i64 + pos.base) as u64
-    } else if pos.base == 0 {
-        // c.0 is not a valid HGVS position; preserve the legacy mapping
-        // (last 5'UTR base, equivalent to c.-1) rather than failing.
-        cds_start.saturating_sub(1)
-    } else {
-        cds_start + pos.base as u64 - 1
-    };
-
-    Ok(tx_pos)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,51 +117,6 @@ mod tests {
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
-    }
-
-    #[test]
-    fn test_cds_to_transcript_pos_5utr_and_legacy_c0() {
-        // Pin the issue #97 fix and the legacy c.0 mapping in the public
-        // helper, mirroring Normalizer::cds_to_tx_pos.
-        //
-        // 5'UTR (issue #97): HGVS skips c.0, so c.-N maps to tx position
-        // cds_start - N — i.e. (cds_start as i64 + pos.base) as u64.
-        let tx = make_test_transcript();
-        let cds_start = tx.cds_start.unwrap(); // 6
-
-        let result = cds_to_transcript_pos(&CdsPos::new(-1), &tx).unwrap();
-        assert_eq!(result, (cds_start as i64 + (-1)) as u64);
-
-        // Legacy c.0 mapping: treat as the last 5'UTR base (== c.-1) via
-        // cds_start.saturating_sub(1) rather than failing.
-        let result = cds_to_transcript_pos(&CdsPos::new(0), &tx).unwrap();
-        assert_eq!(result, cds_start.saturating_sub(1));
-
-        // Defensive: cds_start == 0 must not underflow. saturating_sub
-        // pins the result at 0 instead of wrapping to u64::MAX.
-        let tx_zero_cds = Transcript {
-            cds_start_incomplete: false,
-            id: "NM_TEST_ZERO.1".to_string(),
-            gene_symbol: None,
-            strand: Strand::Plus,
-            sequence: Some("ATGCCCAAAGGG".to_string()),
-            cds_start: Some(0),
-            cds_end: Some(5),
-            exons: vec![Exon::new(1, 1, 12)],
-            chromosome: None,
-            genomic_start: None,
-            genomic_end: None,
-            genome_build: Default::default(),
-            mane_status: ManeStatus::default(),
-            refseq_match: None,
-            ensembl_match: None,
-            protein_id: None,
-            exon_cigars: Vec::new(),
-            cached_introns: OnceLock::new(),
-        };
-        let result = cds_to_transcript_pos(&CdsPos::new(0), &tx_zero_cds).unwrap();
-        assert_eq!(result, tx_zero_cds.cds_start.unwrap().saturating_sub(1));
-        assert_eq!(result, 0);
     }
 
     /// Boundaries of `validate_cds_pos`, one assertion per edge: both sides
@@ -304,21 +233,6 @@ mod tests {
             validate_cds_pos(&past_negative_limit, &tx).is_err(),
             "offset -1_000_001 is past it"
         );
-    }
-
-    /// Exact tx positions for each branch of `cds_to_transcript_pos`.
-    #[test]
-    fn cds_to_transcript_pos_arithmetic() {
-        let tx = make_test_transcript();
-
-        // CDS: cds_start + base - 1.
-        assert_eq!(cds_to_transcript_pos(&CdsPos::new(1), &tx).unwrap(), 6);
-        assert_eq!(cds_to_transcript_pos(&CdsPos::new(2), &tx).unwrap(), 7);
-        assert_eq!(cds_to_transcript_pos(&CdsPos::new(15), &tx).unwrap(), 20);
-
-        // 3'UTR: cds_end + base.
-        assert_eq!(cds_to_transcript_pos(&CdsPos::utr3(1), &tx).unwrap(), 21);
-        assert_eq!(cds_to_transcript_pos(&CdsPos::utr3(3), &tx).unwrap(), 23);
     }
 
     /// The uncertain-offset sentinels `-?` / `+?` (`OFFSET_UNKNOWN_NEGATIVE` /

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -517,13 +517,6 @@ impl<'a> CoordinateMapper<'a> {
             .map(|(_, pos)| pos)
     }
 
-    /// Check if a genomic position is intronic
-    pub fn is_intronic_at_genomic(&self, genomic_pos: u64) -> bool {
-        self.transcript
-            .find_intron_at_genomic(genomic_pos)
-            .is_some()
-    }
-
     /// Convert transcript position to genomic position
     ///
     /// Returns None if the transcript position is not covered by exons with genomic coords.
@@ -621,11 +614,6 @@ impl<'a> CoordinateMapper<'a> {
     /// Get the chromosome name for this transcript
     pub fn chromosome(&self) -> Option<&str> {
         self.transcript.chromosome.as_deref()
-    }
-
-    /// Get the strand for this transcript
-    pub fn strand(&self) -> Strand {
-        self.transcript.strand
     }
 
     /// Convert CDS position with intronic offset to genomic position

--- a/tests/it/issue_283_convert_c_to_r_audit.rs
+++ b/tests/it/issue_283_convert_c_to_r_audit.rs
@@ -10,8 +10,7 @@
 //! `src/convert/` does **not** expose a dedicated `c. → r. variant-level
 //! conversion function**. The module contains:
 //!
-//! - `convert::coding`  — `validate_cds_pos` / `cds_to_transcript_pos`
-//!   (CDS → 0-based tx index helpers).
+//! - `convert::coding`  — `validate_cds_pos`.
 //! - `convert::genomic` — `validate_genome_pos` and basis conversions.
 //! - `convert::mapper::CoordinateMapper` — `cds_to_tx`, `tx_to_cds`,
 //!   `cds_to_protein`, `genomic_to_tx`, `tx_to_genomic`, plus intronic


### PR DESCRIPTION
…is_intronic_at_genomic)

These functions have been confirmed to not be called in existing clients.

BREAKING CHANGE: ferro_hgvs::convert::coding::cds_to_transcript_pos, CoordinateMapper::strand, and CoordinateMapper::is_intronic_at_genomic are removed.