### PR TITLE
docs: describe the citation-quote guard as the substring check it is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,8 +526,10 @@ one governs, which is deviated from, and why. `undecided` is a first-class state
 — either implies a side was chosen, and an unsettled question must not be able to smuggle in a
 ruling nobody made. It equally refuses an `undecided` record citing fewer than two clauses: such a
 record states no conflict, only a position it declines to name as one. Every citation carries a
-verbatim quote that the generator checks against the spec checkout, so a submodule bump that moves
-a clause fails the build instead of leaving the citation pointing at unrelated prose.
+quote that the generator checks against the spec checkout, so a submodule bump that moves a clause
+fails the build instead of leaving the citation pointing at unrelated prose. That check is a
+whitespace-collapsed substring match rather than a byte-for-byte one; what it does and does not
+guarantee is spelled out under **Cite the clause exactly, and quote it** below.
 
 Requires the `assets/hgvs-nomenclature` submodule (`git submodule update --init assets/hgvs-nomenclature`); without it the generator fails with `no HGVS strings harvested from …`, naming that command.
 
@@ -694,10 +696,23 @@ stale-local-artifact detectors). What makes a record an adjudication is the *aut
 "undecided, and here is why". Without one, you have frozen the current behaviour including
 whatever is wrong with it.
 
-**Cite the clause exactly, and quote it.** `rulings` citations carry a verbatim quote the
-generator checks against the spec checkout, so a submodule bump that moves a clause fails the
-build instead of leaving the citation pointing at unrelated prose. Do the same in prose comments:
-`general.md:34`, not "the separation rule".
+**Cite the clause exactly, and quote it.** `rulings` citations carry a quote the generator checks
+against the spec checkout, so a submodule bump that moves a clause fails the build instead of
+leaving the citation pointing at unrelated prose. Do the same in prose comments: `general.md:34`,
+not "the separation rule". A clause's directory is its jurisdiction: a claim about an `r.` axis
+needs a clause under `RNA/` because a `DNA/` one cannot scope `r.`, while `general.md` is not
+molecule-specific.
+
+**That check is a whitespace-collapsed substring match, not a byte-for-byte one.** The generator
+joins the cited line range with spaces and collapses runs of whitespace on both sides before
+testing containment. Two consequences follow, and only the first is usually noticed. A quote may
+**span** the cited lines — which is what makes a multi-line range work at all — and re-wrapping the
+spec's prose leaves a citation valid while the clause moving out from under it still fails the
+build. That much is the deliberate trade. What the guard does **not** buy is that a quote is
+reproduced byte-for-byte: one whose only difference from the spec is spacing or a line break
+passes, and citations in this ledger do exactly that. So do not offer the guard as evidence that a
+quote is exact — if a claim rests on exactness, measure it against the spec file rather than
+inferring it from a green build.
 
 **Record what was refuted, not only what was decided.** Measurements that killed a plausible
 belief are worth as much as the ruling itself, because the belief will recur. Existing examples


### PR DESCRIPTION
`CLAUDE.md` claimed in two places that a `rulings` citation carries a "verbatim quote that the generator checks against the spec checkout". The guard is real and worth keeping, but verbatimness is not what it checks, and the claim gets offered as if it were.

### What the guard actually does

`generate_spec_fixture` joins the cited line range with spaces and collapses runs of whitespace on **both** sides before testing containment:

```rust
// Join on a space so a quote may span the cited lines. Both sides are
// whitespace-collapsed, so re-wrapping the spec's prose does not
// invalidate a citation while moving it elsewhere still does.
let collapse = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
let haystack = collapse(&lines[first - 1..last].join(" "));
if !haystack.contains(&collapse(&citation.quote)) {
```

So it is a whitespace-collapsed **substring** match over the cited range. What it proves is that the clause has not moved out from under the citation — which is exactly the failure mode a submodule bump produces, and why the guard earns its keep. What it does not prove is that the quote reproduces the spec byte for byte.

Both properties are deliberate and the code comment says so. Only the description in `CLAUDE.md` was narrower than the mechanism.

### Also: a clause's directory is its jurisdiction

One sentence added to the same section. `assets/hgvs-nomenclature` organises recommendations by molecule — `docs/recommendations/DNA/` covers `g.`/`c.`/`n.`/`m.`, `RNA/` covers `r.`, `protein/` covers `p.` — so a `DNA/` clause cannot scope a claim about an `r.` axis, and `general.md` is not molecule-specific. This belongs next to "cite the clause exactly" because it is the same failure one step further out: a citation that resolves cleanly, quotes correctly, and still is not authority for what the ruling says. It is stated once, here, and not summarised elsewhere.

### Measurement

At spec pin `6f85311`, over every citation in `hgvs_spec_normalization_overrides.json`:

| | count |
|---|---:|
| citations | 74 |
| byte-exact in the spec file | 72 |
| pass only after the collapse | 2 |
| fail the guard | 0 |

The two are `DNA/inversion.md:33-34` and `consultation/open-issues.md:77-78`. Both are multi-line ranges whose quote spans the line break, so the space-join is precisely what makes them pass. They are working as designed — there is no guard gap here, and no citation to repair.

### Why no number went into the doc

The counts above are pinned to `6f85311` and would go stale the moment the spec pin moves (a pending re-point to `565b973` shifts citation line numbers by one). `CLAUDE.md` already warns that a count quoted in prose is stale by the next change, so the correction states the guarantee and leaves the measurement here, where it is a claim about a moment.

### Verification

```
cargo nextest run --features dev -E 'test(claude_md) + test(ruling_citation) + test(clause_ruling_index)'
Summary [2.626s] 17 tests run: 17 passed, 10302 skipped
```

Representation-Change: none
