### PR TITLE
test(rulings): refuse a ruling that speaks to a molecule it does not cite

### DIFF
--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -523,6 +523,14 @@
           "quote": "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\""
         },
         {
+          "clause": "docs/recommendations/RNA/delins.md:18",
+          "quote": "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\" (e.g., `r.142_144delinsugg` `p.(Arg48Trp)`)."
+        },
+        {
+          "clause": "docs/recommendations/RNA/substitution.md:18",
+          "quote": "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\" (e.g., `r.142_144delinsugg` (`p.Arg48Trp`))."
+        },
+        {
           "clause": "docs/recommendations/general.md:39",
           "quote": "The new recommendation will be: **two variants separated by less than two nucleotides should be described as a \"delins\"**."
         },

--- a/tests/it/clause_ruling_index.rs
+++ b/tests/it/clause_ruling_index.rs
@@ -103,7 +103,7 @@
 //! ```text
 //! CLAUSE -> RECORD INDEX
 //! 21 records, 18 decided / 3 undecided
-//! 79 clause lines, of which 19 are named by more than one record
+//! 81 clause lines, of which 19 are named by more than one record
 //!
 //! == every clause line ==
 //!
@@ -234,6 +234,8 @@
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (governing)
 //! docs/recommendations/DNA/substitution.md:95
 //!     `delins-adjacent-members-when-both-consume-reference` — decided (cited)
+//! docs/recommendations/RNA/delins.md:18
+//!     `delins-codon-carve-out-gap-one` — decided (cited)
 //! docs/recommendations/RNA/delins.md:41
 //!     `canonical-form-choice-when-both-legal` — decided (cited)
 //! docs/recommendations/RNA/delins.md:70
@@ -246,6 +248,8 @@
 //!     `rna-repeat-range-plus-unit-redundancy` — undecided (cited)
 //! docs/recommendations/RNA/repeated.md:27
 //!     `rna-repeat-range-plus-unit-redundancy` — undecided (cited)
+//! docs/recommendations/RNA/substitution.md:18
+//!     `delins-codon-carve-out-gap-one` — decided (cited)
 //! docs/recommendations/checklist.md:5
 //!     `absolute-prohibition-enforcement-stage` — decided (governing)
 //! docs/recommendations/checklist.md:16

--- a/tests/it/common/rulings.rs
+++ b/tests/it/common/rulings.rs
@@ -1,11 +1,14 @@
 //! Reads the adjudication ledger — the `rulings` section of
 //! `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`.
 //!
-//! Two integration tests need the same file for different reasons:
+//! Three integration tests need the same file for different reasons:
 //! `ruling_citation_currency.rs` wants `id -> status` so it can judge prose that
-//! makes a status claim, and `clause_ruling_index.rs` wants the citations so it
-//! can invert the ledger into a clause-to-record index. Parsing it twice would
-//! give two definitions of "a record", so both read it from here.
+//! makes a status claim, `clause_ruling_index.rs` wants the citations so it
+//! can invert the ledger into a clause-to-record index, and
+//! `ledger_clause_jurisdiction.rs` wants the citations, their quotes and
+//! `applies_to` so it can compare what a record rules on against the molecule
+//! directories it cites. Parsing it three times would give three definitions of
+//! "a record", so all three read it from here.
 //!
 //! Nothing in this module names a record id, deliberately: it is scanned by
 //! `ruling_citation_currency.rs` along with every other `.rs` file in the tree.
@@ -58,6 +61,13 @@ pub struct Citation {
     /// The clause as the record spells it — a repo-relative path into the spec
     /// checkout with a line or line range (`docs/…/delins.md:79-84`).
     pub clause: String,
+    /// The clause's quoted text, verbatim from the ledger.
+    ///
+    /// Required rather than optional, matching what `generate_spec_fixture`
+    /// already demands: a citation with no quote is a `file:line` nothing checks
+    /// against the spec checkout. `ledger_clause_jurisdiction.rs` also reads it,
+    /// so an absent quote would silently narrow the authority a clause supplies.
+    pub quote: String,
     /// How the record relates to this clause; see [`Role`].
     pub role: Role,
 }
@@ -77,9 +87,23 @@ pub struct Record {
     /// the source scan in `ruling_citation_currency.rs`, which reads `.rs` files
     /// only. See `every_record_to_record_citation_resolves` there.
     pub rationale: String,
+    /// The descriptions the record declares itself to apply to, verbatim, in the
+    /// ledger's own order. Absent or `null` reads as none.
+    ///
+    /// Exposed because it is the record's own statement of what it rules on, and
+    /// so the strongest available evidence of which axes it reaches;
+    /// `ledger_clause_jurisdiction.rs` reads the axis prefix of each entry.
+    pub applies_to: Vec<String>,
     /// Every clause the record names, in the ledger's own order, each tagged
     /// with the role the record's verdict fields give it.
     pub citations: Vec<Citation>,
+    /// The clause the record rules **under**, verbatim, when it names one.
+    ///
+    /// Derivable from `citations` by looking for [`Role::Governing`], but
+    /// exposed directly because "this record has no governing clause" and "this
+    /// record's governing clause is molecule-agnostic" are different states and
+    /// `ledger_clause_jurisdiction.rs` distinguishes them.
+    pub governing: Option<String>,
 }
 
 /// The only two `status` values a record may carry.
@@ -222,10 +246,20 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
                 .unwrap_or_else(|| panic!("record {id} has no `clauses` array"));
             let citations: Vec<Citation> = clauses
                 .iter()
-                .map(|clause| {
-                    let clause =
-                        required_str(clause, "clause", &format!("a clause of record {id}"))
+                .map(|entry| {
+                    let subject = format!("a clause of record {id}");
+                    let clause = required_str(entry, "clause", &subject).to_string();
+                    let quote =
+                        required_str(entry, "quote", &format!("clause {clause} of record {id}"))
                             .to_string();
+                    // A blank quote is the absent case wearing a string: it
+                    // checks against nothing in the spec checkout and supplies
+                    // no axis text, which is precisely what requiring the field
+                    // was meant to prevent.
+                    assert!(
+                        !quote.trim().is_empty(),
+                        "clause {clause} of record {id} has a blank `quote`"
+                    );
                     let role = if governing == Some(clause.as_str()) {
                         Role::Governing
                     } else if deviates_from.contains(&clause.as_str()) {
@@ -233,7 +267,11 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
                     } else {
                         Role::Cited
                     };
-                    Citation { clause, role }
+                    Citation {
+                        clause,
+                        quote,
+                        role,
+                    }
                 })
                 .collect();
 
@@ -254,11 +292,30 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
                 );
             }
 
+            let applies_to: Vec<String> = match record.get("applies_to") {
+                None | Some(serde_json::Value::Null) => Vec::new(),
+                Some(value) => value
+                    .as_array()
+                    .unwrap_or_else(|| panic!("record {id} has a non-array `applies_to`: {value}"))
+                    .iter()
+                    .map(|entry| {
+                        entry
+                            .as_str()
+                            .unwrap_or_else(|| {
+                                panic!("record {id} has a non-string `applies_to` entry: {entry}")
+                            })
+                            .to_string()
+                    })
+                    .collect(),
+            };
+
             Record {
                 id,
                 status,
                 rationale,
+                applies_to,
                 citations,
+                governing: governing.map(str::to_string),
             }
         })
         .collect();
@@ -308,7 +365,7 @@ fn one_valid_record() -> serde_json::Value {
             "status": "decided",
             "rationale": "A test record, with prose that cites no other record.",
             "governing": "docs/a.md:1",
-            "clauses": [{ "clause": "docs/a.md:1" }],
+            "clauses": [{ "clause": "docs/a.md:1", "quote": "a quoted clause" }],
         }],
     })
 }
@@ -406,11 +463,61 @@ fn a_non_array_deviates_from_is_rejected() {
 fn a_mixed_type_deviates_from_is_rejected() {
     let mut document = one_valid_record();
     document["rulings"][0]["clauses"] = serde_json::json!([
-        { "clause": "docs/a.md:1" },
-        { "clause": "docs/b.md:2" },
+        { "clause": "docs/a.md:1", "quote": "a quoted clause" },
+        { "clause": "docs/b.md:2", "quote": "another quoted clause" },
     ]);
     document["rulings"][0]["deviates_from"] = serde_json::json!(["docs/b.md:2", 17]);
     records_from_value(&document, "<test>");
+}
+
+/// A clause with no `quote` is rejected rather than read as an empty quote.
+///
+/// An empty quote is not a harmless absence: it is a `file:line` the spec-fixture
+/// generator has nothing to check against the spec checkout, and it supplies no
+/// axis text for `ledger_clause_jurisdiction.rs` to read. Both would go on
+/// passing.
+#[test]
+#[should_panic(expected = "has no `quote`")]
+fn a_clause_with_no_quote_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["clauses"] = serde_json::json!([{ "clause": "docs/a.md:1" }]);
+    records_from_value(&document, "<test>");
+}
+
+/// A present-but-blank `quote` is rejected too.
+///
+/// Requiring the key buys nothing on its own: `""` satisfies it, checks against
+/// no line of the spec checkout, and supplies `ledger_clause_jurisdiction.rs`
+/// with no axis text — the same silent narrowing the required field exists to
+/// stop, one step further in.
+#[test]
+#[should_panic(expected = "has a blank `quote`")]
+fn a_clause_with_a_blank_quote_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["clauses"] =
+        serde_json::json!([{ "clause": "docs/a.md:1", "quote": "   " }]);
+    records_from_value(&document, "<test>");
+}
+
+/// A non-array `applies_to` is rejected rather than read as absent — the same
+/// reasoning as `deviates_from` above, and it matters more here because
+/// `ledger_clause_jurisdiction.rs` reads that array to decide which axes a
+/// record rules on. Silently reading it as empty would narrow the record's
+/// declared reach to nothing and pass every jurisdiction check.
+#[test]
+#[should_panic(expected = "non-array `applies_to`")]
+fn a_non_array_applies_to_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["applies_to"] = serde_json::json!("c.235_237delinsTAT");
+    records_from_value(&document, "<test>");
+}
+
+/// An absent `applies_to` reads as none, which is what most records spell.
+#[test]
+fn an_absent_applies_to_reads_as_none() {
+    let records = records_from_value(&one_valid_record(), "<test>");
+    assert!(records[0].applies_to.is_empty());
+    assert_eq!(records[0].governing.as_deref(), Some("docs/a.md:1"));
 }
 
 /// An explicit `null` verdict field still means "not set" — that is a

--- a/tests/it/ledger_clause_jurisdiction.rs
+++ b/tests/it/ledger_clause_jurisdiction.rs
@@ -1,0 +1,804 @@
+//! A ruling may not speak to an axis whose molecule directory it does not cite.
+//!
+//! # The failure mode this exists for
+//!
+//! `assets/hgvs-nomenclature` organises the recommendations by **molecule**:
+//! `docs/recommendations/DNA/` covers the `g.`, `c.`, `n.` and `m.` axes,
+//! `RNA/` covers `r.`, `protein/` covers `p.`. That directory is the
+//! jurisdiction of every clause inside it — a `DNA/` clause is not authority for
+//! a claim about `r.`, however exactly it is quoted and however precisely its
+//! `file:line` resolves.
+//!
+//! The existing ledger guards all pass such a record. The spec-fixture
+//! generator checks that each citation's quote is really at that `file:line`;
+//! `clause_ruling_index.rs` checks that every cited clause is reachable from a
+//! clause string; `ruling_citation_currency.rs` checks that prose does not
+//! contradict a record's status. A citation can satisfy all three and still not
+//! be authority for what the record says, because none of them compares the
+//! **axes a record rules on** against the **molecules it cites**.
+//!
+//! Two instances were found on one day, which is what argued for a guard rather
+//! than a third correction:
+//!
+//! * `delins-codon-carve-out-gap-one` listed `r.142_144delinsugg` and
+//!   `r.[142c>u;144a>g]` in `applies_to` while its structured `clauses` were
+//!   `DNA/delins.md:18`, `general.md:39` and `consultation/SVD-WG010.md:5`. It
+//!   named `RNA/delins.md:18` and `RNA/substitution.md:18` in its rationale
+//!   prose and cited neither, so a ruling that is `decided` rested its RNA reach
+//!   on an uncited clause. The fix landed with this guard, and is a citation
+//!   promotion: the two clauses the rationale already named became structured
+//!   entries, and no verdict moved.
+//! * A record proposed on PR #1682 cited six clauses, all under `DNA/` or
+//!   `general.md`, and ruled in its rationale on `r.` over a coding transcript
+//!   and on a non-coding `r.`. `RNA/delins.md` has no counterpart to the
+//!   `DNA/delins.md:47` clause that record leans on. That PR is fixing its own
+//!   record; this guard is what stops the next one.
+//!
+//! # What "speaks to" means, and why the rationale is read
+//!
+//! An axis prefix in an `applies_to` entry is the record's own statement of what
+//! it rules on and is the strongest signal available. It is **not** sufficient:
+//! the second instance above has a single `applies_to` entry, a `c.` string, and
+//! its whole RNA problem lives in the rationale. So axis tokens in the rationale
+//! count too — read only inside backticked spans, because that is how this ledger
+//! writes an axis and because unbackticked prose is where the false positives
+//! are.
+//!
+//! # What "cites" means, and where `general.md` fits
+//!
+//! This is the part that was decided from measurement rather than from taste,
+//! because the two obvious readings both fail. Counting `general.md` as
+//! universal authority makes the guard **toothless**: both known defects cite
+//! `general.md`, so that rule flags neither. Counting it for nothing flags
+//! records that rule entirely under molecule-agnostic authority
+//! (`background/standards.md`, `recommendations/checklist.md`) and mention a
+//! `c.` example in passing. Neither is usable.
+//!
+//! **The counts that argument was made on are not restated here**, because they
+//! were measured on a 16-record ledger with both defects present and neither
+//! condition survives: this PR fixes the first defect and the second lives on a
+//! branch. A count quoted from a base nobody can rebuild is the failure mode
+//! `clause_ruling_index.rs` documents at length. What is enforceable is that
+//! **each half changes the verdict on the ledger as it stands**, and that is
+//! what [`the_scan_is_not_vacuous`] asserts — drop either half and it fails.
+//!
+//! The rule has two halves:
+//!
+//! 1. **Jurisdiction attaches to the clause a record rules under.** If the
+//!    `governing` clause is molecule-agnostic — `general.md`, `checklist.md`,
+//!    `style.md`, anything under `background/`, `consultation/` or `versions/` —
+//!    the record carries no molecule-scoped authority to exceed and is
+//!    unconstrained. That is where `general.md` gets to be universal, and it is
+//!    what keeps the records above out of the flag list — today
+//!    `alignment-only-symbol-in-a-description`,
+//!    `bare-transcript-intronic-position` and
+//!    `absolute-prohibition-enforcement-stage`. A record with no
+//!    `governing` clause at all is constrained only if it reaches into a
+//!    molecule directory anyway, so that an `undecided` record — which the
+//!    generator forbids from naming a governing clause — is not exempt by
+//!    construction.
+//! 2. **A molecule-agnostic clause carries the jurisdiction its own quoted text
+//!    enumerates, and no more.** `general.md:44` reads "**exception**:
+//!    deletions/duplications around exon/exon junctions using **c.**, **r.** or
+//!    **n.** reference sequences" — it names the RNA axis, so it *is* RNA
+//!    authority, and `exon-junction-dup-converge-from-the-far-side` scoping its
+//!    ruling onto `r.` is properly cited rather than a defect. `general.md:34`,
+//!    `:39` and `:43` name no axis at all, so they extend nothing. Without this
+//!    half the guard reports that record too, which measurement says is wrong.
+//!
+//! # What this does NOT claim
+//!
+//! * **Not that a cited clause supports the ruling.** It compares directories,
+//!   not arguments. A record can cite `RNA/repeated.md` for a delins question
+//!   and pass. Whether the clause says what the record needs is review's job.
+//! * **Not that the axes it reads are all the axes a record touches.** An axis
+//!   discussed in unbackticked prose, or implied ("on a coding transcript"), is
+//!   invisible here. This is a floor: it catches a record that *writes* an axis
+//!   token it has no directory for.
+//! * **Not that a quote is byte-exact.** The generator's citation check is a
+//!   whitespace-collapsed substring match over the cited line range, so a green
+//!   build is not evidence of exactness — check a quote against the spec file if
+//!   a claim rests on it. Half 2 above reads the quote as the ledger stores it,
+//!   which is the text a reader sees.
+//! * **Not that an axis token is a claim rather than a disclaimer.** A record
+//!   that writes `` `p.` `` only to say it does *not* rule on the protein axis
+//!   reads identically to one that does. One ledger record does exactly that and
+//!   is exempted by name in [`SCOPE_DISCLAIMERS`]; the exemption is
+//!   shrink-only, so it cannot grow into a way of silencing the guard.
+//! * **Not that `protein/` is exercised by the ledger.** No record cites a
+//!   clause under it, so that arm of the mapping is exercised only by the
+//!   synthetic cases at the bottom of this file. Said plainly rather than left
+//!   for someone to discover, since a rule with an unexercised arm reads as
+//!   coverage.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::common::rulings::{self, Record};
+
+/// A molecule, and the directory that is its jurisdiction.
+///
+/// Prefixes rather than exact paths: every file under `DNA/` is DNA authority,
+/// and the spec adds pages without asking.
+const MOLECULE_DIRECTORIES: &[(&str, &str)] = &[
+    ("DNA", "docs/recommendations/DNA/"),
+    ("RNA", "docs/recommendations/RNA/"),
+    ("protein", "docs/recommendations/protein/"),
+];
+
+/// Axis prefix -> the molecule whose recommendations govern it.
+///
+/// `o.` is the circular-genome axis and `m.` the mitochondrial one; both are DNA
+/// descriptions and both live under `DNA/`.
+const AXIS_MOLECULES: &[(char, &str)] = &[
+    ('g', "DNA"),
+    ('c', "DNA"),
+    ('n', "DNA"),
+    ('m', "DNA"),
+    ('o', "DNA"),
+    ('r', "RNA"),
+    ('p', "protein"),
+];
+
+/// The molecule an axis prefix belongs to, if the character is an axis at all.
+fn molecule_of_axis(prefix: char) -> Option<&'static str> {
+    AXIS_MOLECULES
+        .iter()
+        .find(|(axis, _)| *axis == prefix)
+        .map(|(_, molecule)| *molecule)
+}
+
+/// The molecule a clause's directory places it under, or `None` when the clause
+/// is molecule-agnostic.
+///
+/// Takes the citation as the ledger spells it, line locator and all, because
+/// only the leading path matters.
+fn molecule_of_clause(clause: &str) -> Option<&'static str> {
+    MOLECULE_DIRECTORIES
+        .iter()
+        .find(|(_, directory)| clause.starts_with(directory))
+        .map(|(molecule, _)| *molecule)
+}
+
+/// Every axis prefix appearing in `text`, as `<letter>.`.
+///
+/// The preceding character must not be alphanumeric, `_` or `.`, which is what
+/// keeps two classes of non-axis text out. **Spec filenames**: `inversion.md`
+/// and `substitution.md` both end in `n` before the dot, so without the check
+/// every citation of either would read as a claim about the `n.` axis.
+/// **Abbreviations**: `e.g.` ends in `g` before a dot, and the recommendations
+/// use it constantly. Measured over the ledger, six `<dot><axis>.` occurrences:
+/// five inside citation quotes, one in a rationale (outside backticks, so
+/// unread).
+///
+/// ```text
+/// python3 -c "import json,re;d=json.load(open('tests/fixtures/grammar/hgvs_spec_normalization_overrides.json'));\
+/// print(sum(len(re.findall(r'(?<=\.)[gcnmorp]\.',c['quote'])) for r in d['rulings'] for c in r['clauses']))"
+/// ```
+///
+/// The second class is the one that matters for correctness rather than noise,
+/// because it over-reads in the *unsafe* direction. `molecules_with_authority`
+/// reads the quote of a molecule-agnostic clause, so an `e.g.` in a
+/// `general.md` or `checklist.md` quote would hand the record DNA authority it
+/// was never granted and quietly stop the guard catching a DNA overreach. **No
+/// agnostic quote carries one today** — all five sit on clauses under a
+/// molecule directory, whose quotes are never read — so this moves no verdict
+/// and is a latent hazard closed rather than a defect fixed.
+///
+/// [`filenames_are_not_read_as_axes`] pins both classes.
+fn axes_in(text: &str) -> BTreeSet<char> {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut found = BTreeSet::new();
+    for (index, window) in bytes.windows(2).enumerate() {
+        let (candidate, dot) = (window[0], window[1]);
+        if dot != '.' || molecule_of_axis(candidate).is_none() {
+            continue;
+        }
+        let preceded_by_word = index
+            .checked_sub(1)
+            .map(|before| {
+                let previous = bytes[before];
+                previous.is_alphanumeric() || previous == '_' || previous == '.'
+            })
+            .unwrap_or(false);
+        if !preceded_by_word {
+            found.insert(candidate);
+        }
+    }
+    found
+}
+
+/// Every axis prefix appearing inside a backticked span of `text`.
+///
+/// Scoped to backticks because that is how this ledger spells an axis, and
+/// because unbackticked rationale prose is discursive enough that a bare
+/// `<letter>.` there is far more often a sentence ending than an axis.
+fn axes_in_backticks(text: &str) -> BTreeSet<char> {
+    let mut found = BTreeSet::new();
+    let mut inside = false;
+    for span in text.split('`') {
+        if inside {
+            found.extend(axes_in(span));
+        }
+        inside = !inside;
+    }
+    found
+}
+
+/// One reason a record was read as speaking to a molecule, for the diagnostic.
+type Evidence = BTreeMap<&'static str, Vec<String>>;
+
+/// The molecules a record speaks to, with why.
+fn molecules_spoken_to(record: &Record) -> Evidence {
+    let mut spoken: Evidence = BTreeMap::new();
+    for description in &record.applies_to {
+        for axis in axes_in(description) {
+            if let Some(molecule) = molecule_of_axis(axis) {
+                spoken
+                    .entry(molecule)
+                    .or_default()
+                    .push(format!("`applies_to` entry {description:?}"));
+            }
+        }
+    }
+    for axis in axes_in_backticks(&record.rationale) {
+        if let Some(molecule) = molecule_of_axis(axis) {
+            spoken
+                .entry(molecule)
+                .or_default()
+                .push(format!("a backticked `{axis}.` in the rationale"));
+        }
+    }
+    spoken
+}
+
+/// The molecules a record has authority for, with why.
+///
+/// Both halves of the rule's second point: a clause under a molecule directory
+/// supplies that molecule, and a molecule-agnostic clause supplies exactly the
+/// molecules its own quote names by axis token.
+fn molecules_with_authority(record: &Record) -> Evidence {
+    let mut authority: Evidence = BTreeMap::new();
+    for citation in &record.citations {
+        match molecule_of_clause(&citation.clause) {
+            Some(molecule) => authority
+                .entry(molecule)
+                .or_default()
+                .push(format!("cites {}", citation.clause)),
+            None => {
+                for axis in axes_in(&citation.quote) {
+                    if let Some(molecule) = molecule_of_axis(axis) {
+                        authority.entry(molecule).or_default().push(format!(
+                            "{} quotes the `{axis}.` axis by name",
+                            citation.clause
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    authority
+}
+
+/// Whether a record's authority is molecule-scoped at all.
+///
+/// A record ruling under a molecule-agnostic clause is unconstrained; so is one
+/// that names no governing clause and reaches into no molecule directory. See
+/// half 1 of the rule in this module's docs.
+fn is_molecule_scoped(record: &Record) -> bool {
+    match &record.governing {
+        Some(governing) => molecule_of_clause(governing).is_some(),
+        None => record
+            .citations
+            .iter()
+            .any(|c| molecule_of_clause(&c.clause).is_some()),
+    }
+}
+
+/// One molecule a record speaks to without authority for it.
+#[derive(Debug)]
+struct Overreach {
+    id: String,
+    molecule: &'static str,
+    spoken_because: Vec<String>,
+    authority_for: Vec<&'static str>,
+}
+
+/// Every overreach in `records`, in ledger order.
+fn overreaches(records: &[Record]) -> Vec<Overreach> {
+    let mut found = Vec::new();
+    for record in records {
+        if !is_molecule_scoped(record) {
+            continue;
+        }
+        let authority = molecules_with_authority(record);
+        for (molecule, why) in molecules_spoken_to(record) {
+            if !authority.contains_key(molecule) {
+                found.push(Overreach {
+                    id: record.id.clone(),
+                    molecule,
+                    spoken_because: why,
+                    authority_for: authority.keys().copied().collect(),
+                });
+            }
+        }
+    }
+    found
+}
+
+/// Records that name a molecule in prose **only to disclaim it**, by id,
+/// molecule, and the sentence that does the disclaiming.
+///
+/// The rule reads an axis token as a claim because prose cannot be parsed for
+/// intent, and a record that writes `` `p.` `` to say "not this axis" is
+/// indistinguishable from one that rules on it. Rather than weaken the
+/// tokenizer — which would silently drop the bare-label form across the whole
+/// ledger, and that form is how the known defects could recur — the exceptions
+/// are named here with their reason.
+///
+/// [`every_scope_disclaimer_is_still_needed`] makes the list **shrink-only**: a
+/// row that stops being needed fails the test and must be deleted, so this
+/// cannot become a way of silencing the guard. Adding a row is a legitimate
+/// answer; doing it without a quoted sentence is not.
+const SCOPE_DISCLAIMERS: &[(&str, &str, &str)] = &[(
+    "projection-codon-exception-is-decided-by-the-rendered-axis",
+    "protein",
+    "its `SCOPE, STATED NARROWLY` paragraph reads \"The `p.` axis is the protein consequence \
+     itself.\" — the record's only `p.`, and a statement that the protein axis is out of scope \
+     rather than a ruling on it. The same paragraph disclaims `r.` and `n.` in the same breath; \
+     `r.` needs no row only because `general.md:44`'s quote names that axis",
+)];
+
+/// The disclaiming sentence for `(id, molecule)`, when the pair is listed.
+fn scope_disclaimer(id: &str, molecule: &str) -> Option<&'static str> {
+    SCOPE_DISCLAIMERS
+        .iter()
+        .find(|(record, listed, _)| *record == id && *listed == molecule)
+        .map(|(_, _, why)| *why)
+}
+
+// --------------------------------------------------------------------------
+// The guard.
+// --------------------------------------------------------------------------
+
+/// **The assertion this file exists to make.**
+#[test]
+fn no_record_speaks_to_a_molecule_it_cannot_cite() {
+    let found: Vec<Overreach> = overreaches(&rulings::records())
+        .into_iter()
+        .filter(|o| scope_disclaimer(&o.id, o.molecule).is_none())
+        .collect();
+    let report: Vec<String> = found
+        .iter()
+        .map(|o| {
+            format!(
+                "\n  {} rules on the {} axes ({}) but its authority reaches only {:?}",
+                o.id,
+                o.molecule,
+                o.spoken_because.join("; "),
+                o.authority_for
+            )
+        })
+        .collect();
+    assert!(
+        found.is_empty(),
+        "a ruling names an axis whose molecule directory it does not cite:{}\n\n\
+         `assets/hgvs-nomenclature/docs/recommendations/` is organised by molecule, and that \
+         directory is the jurisdiction of every clause inside it — a `DNA/` clause cannot scope a \
+         claim about `r.`. Cite a clause under the molecule's own directory, or narrow what the \
+         record says. If the authority really is a molecule-agnostic clause that names the axis \
+         itself (as `general.md:44` does), cite that clause and quote the part that names it.",
+        report.join("")
+    );
+}
+
+/// The scan reads what it claims to, and both carve-outs are load-bearing.
+///
+/// Modelled on `clause_ruling_index.rs`'s `the_index_is_not_vacuous`. Each
+/// assertion below pins a population that a broken reader would empty: a ledger
+/// that failed to yield axes, a molecule map that matched no directory, or a
+/// carve-out that no record exercises. A rule whose exemptions are dead code
+/// reads as nuance and provides none.
+#[test]
+fn the_scan_is_not_vacuous() {
+    let records = rulings::records();
+    assert!(
+        records.len() >= 10,
+        "the ledger reader returned {} records",
+        records.len()
+    );
+
+    let speaking: Vec<&Record> = records
+        .iter()
+        .filter(|r| !molecules_spoken_to(r).is_empty())
+        .collect();
+    assert!(
+        speaking.len() >= 8,
+        "only {} records were read as speaking to any molecule — the axis tokenizer is broken, \
+         and every jurisdiction check below would pass vacuously",
+        speaking.len()
+    );
+
+    let molecules_reached: BTreeSet<&str> = records
+        .iter()
+        .flat_map(|r| molecules_with_authority(r).into_keys())
+        .collect();
+    assert!(
+        molecules_reached.len() >= 2,
+        "citations resolved to only {molecules_reached:?} — with one molecule in play the \
+         comparison cannot fail"
+    );
+
+    // The population the guard actually judges. Without this, an
+    // `is_molecule_scoped` that answered `false` for everything would make
+    // `no_record_speaks_to_a_molecule_it_cannot_cite` pass over an empty set
+    // while every other assertion here still held — including the half-1 pin
+    // below, which such a break would satisfy *harder*.
+    let constrained: Vec<&String> = records
+        .iter()
+        .filter(|r| is_molecule_scoped(r) && !molecules_spoken_to(r).is_empty())
+        .map(|r| &r.id)
+        .collect();
+    assert!(
+        constrained.len() >= 8,
+        "only {} records are both molecule-scoped and read as speaking to a molecule, so the \
+         guard is judging almost nothing: {constrained:?}",
+        constrained.len()
+    );
+
+    // Half 1: at least one record rules under molecule-agnostic authority.
+    let unscoped: Vec<&String> = records
+        .iter()
+        .filter(|r| !is_molecule_scoped(r))
+        .map(|r| &r.id)
+        .collect();
+    assert!(
+        !unscoped.is_empty(),
+        "no record is exempted by its governing clause, so half 1 of the rule is dead code. It \
+         exists because three records rule under `checklist.md` or `background/standards.md` and \
+         mention a `c.` example; if the ledger no longer has one, delete the carve-out rather \
+         than leaving it unexercised"
+    );
+
+    // Half 2: at least one molecule is supplied by an axis-naming agnostic quote.
+    let by_quote: Vec<(&String, &'static str)> = records
+        .iter()
+        .flat_map(|record| {
+            let direct: BTreeSet<&str> = record
+                .citations
+                .iter()
+                .filter_map(|c| molecule_of_clause(&c.clause))
+                .collect();
+            molecules_with_authority(record)
+                .into_keys()
+                .filter(move |m| !direct.contains(m))
+                .map(move |m| (&record.id, m))
+        })
+        .collect();
+    assert!(
+        !by_quote.is_empty(),
+        "no molecule-agnostic clause supplies a molecule through its own quote, so half 2 of the \
+         rule is dead code. `general.md:44` naming `**c.**, **r.** or **n.**` is the case it was \
+         written for"
+    );
+}
+
+/// Every [`SCOPE_DISCLAIMERS`] row still exempts something, so the list cannot
+/// outlive the records it was written for.
+///
+/// Shrink-only in the same sense as `LEDGER_EXEMPT` in
+/// `generator_completeness.rs`: a row whose record has been deleted, re-cited,
+/// or reworded so the token is gone fails here and must be removed. That is the
+/// only thing standing between a named exception and a general mute button.
+#[test]
+fn every_scope_disclaimer_is_still_needed() {
+    let raw = overreaches(&rulings::records());
+    for (id, molecule, why) in SCOPE_DISCLAIMERS {
+        assert!(
+            raw.iter().any(|o| o.id == *id && o.molecule == *molecule),
+            "`{id}` is no longer read as speaking to {molecule} without authority, so its \
+             disclaimer row is dead. Delete it rather than leaving an unexercised exemption. It \
+             was there because {why}"
+        );
+    }
+}
+
+/// The `r.` half of `delins-codon-carve-out-gap-one` is cited, not only narrated.
+///
+/// A named pin on top of the general guard, because this record is the reason
+/// the guard exists and a general assertion says nothing about which record it
+/// was passing for. The record is `decided`, so its RNA rows rest on structured
+/// authority or on nothing.
+#[test]
+fn the_codon_carve_out_record_cites_rna_for_its_rna_rows() {
+    let records = rulings::records();
+    let record = records
+        .iter()
+        .find(|r| r.id == "delins-codon-carve-out-gap-one")
+        .expect("the ledger still carries this ruling");
+
+    assert!(
+        record
+            .applies_to
+            .iter()
+            .any(|description| description.starts_with("r.")),
+        "this pin assumes the record still declares RNA descriptions; if that changed, the RNA \
+         citation requirement below may no longer be the right assertion"
+    );
+
+    let rna: Vec<&str> = record
+        .citations
+        .iter()
+        .map(|c| c.clause.as_str())
+        .filter(|clause| molecule_of_clause(clause) == Some("RNA"))
+        .collect();
+    assert!(
+        !rna.is_empty(),
+        "the ruling declares `r.` descriptions in `applies_to` and cites no clause under \
+         `docs/recommendations/RNA/`"
+    );
+}
+
+// --------------------------------------------------------------------------
+// The rule, on synthetic records.
+//
+// Plain `#[test]`, not a `#[cfg(test)] mod tests` — this tree is an integration
+// binary and compiles without `cfg(test)`, so a gated module would never run.
+//
+// The tests above read the committed ledger, so none of them can exercise a
+// record the ledger does not contain. These drive the rule directly, which is
+// the only way to pin that it *fires* and that each carve-out is doing what its
+// justification says.
+// --------------------------------------------------------------------------
+
+/// Build a record from its parts, so a case reads as the shape it is testing.
+fn record(
+    id: &str,
+    governing: Option<&str>,
+    clauses: &[(&str, &str)],
+    applies_to: &[&str],
+    rationale: &str,
+) -> Record {
+    Record {
+        id: id.to_string(),
+        status: "decided".to_string(),
+        rationale: rationale.to_string(),
+        applies_to: applies_to.iter().map(|s| s.to_string()).collect(),
+        citations: clauses
+            .iter()
+            .map(|(clause, quote)| rulings::Citation {
+                clause: clause.to_string(),
+                quote: quote.to_string(),
+                role: if Some(*clause) == governing {
+                    rulings::Role::Governing
+                } else {
+                    rulings::Role::Cited
+                },
+            })
+            .collect(),
+        governing: governing.map(str::to_string),
+    }
+}
+
+const DNA_DELINS: (&str, &str) = (
+    "docs/recommendations/DNA/delins.md:18",
+    "**exception**: two variants separated by one nucleotide",
+);
+const RNA_DELINS: (&str, &str) = (
+    "docs/recommendations/RNA/delins.md:18",
+    "**exception**: two variants separated by one nucleotide",
+);
+
+/// The shape of both defects: a DNA-governed ruling that rules on `r.`.
+#[test]
+fn a_dna_governed_ruling_may_not_rule_on_rna() {
+    let found = overreaches(&[record(
+        "a-dna-ruling-reaching-rna",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS],
+        &["r.142_144delinsugg"],
+        "It also settles the coding `r.` case.",
+    )]);
+    assert_eq!(
+        found.len(),
+        1,
+        "expected exactly one overreach, got {found:?}"
+    );
+    assert_eq!(found[0].molecule, "RNA");
+}
+
+/// The fix, and the negative control for the case above: citing the RNA clause
+/// clears it, with nothing else changed.
+#[test]
+fn citing_the_rna_clause_clears_it() {
+    let found = overreaches(&[record(
+        "a-dna-ruling-citing-rna",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS, RNA_DELINS],
+        &["r.142_144delinsugg"],
+        "It also settles the coding `r.` case.",
+    )]);
+    assert!(found.is_empty(), "{found:?}");
+}
+
+/// The rationale is read, not only `applies_to` — the second defect's whole
+/// problem lives there, its single `applies_to` entry being a `c.` string.
+#[test]
+fn an_rna_claim_made_only_in_the_rationale_is_caught() {
+    let found = overreaches(&[record(
+        "a-ruling-whose-rna-claim-is-prose",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS],
+        &["LRG_199t1:c.850_901delinsTTCCTCGATGCCTG"],
+        "On a coding transcript the same reasoning gives `r.850_901delinsuuccucg`.",
+    )]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].molecule, "RNA");
+}
+
+/// Half 1: a record ruling under a molecule-agnostic clause is unconstrained.
+///
+/// Without this the guard reports `alignment-only-symbol-in-a-description`,
+/// `bare-transcript-intronic-position` and `absolute-prohibition-enforcement-stage`,
+/// all three of which rule under `checklist.md` or `background/standards.md`
+/// and use a `c.` string only as an example.
+#[test]
+fn a_ruling_under_molecule_agnostic_authority_is_unconstrained() {
+    let checklist = (
+        "docs/recommendations/checklist.md:20",
+        "a description should be based on a reference sequence",
+    );
+    let found = overreaches(&[record(
+        "a-ruling-under-the-checklist",
+        Some(checklist.0),
+        &[checklist],
+        &[],
+        "Strict input hygiene refuses `NM_TEST.1:c.20+2del`.",
+    )]);
+    assert!(found.is_empty(), "{found:?}");
+}
+
+/// Half 2: a molecule-agnostic clause whose quote names an axis supplies that
+/// molecule. This is `general.md:44`, and it is why
+/// `exon-junction-dup-converge-from-the-far-side` scoping onto `r.` is cited
+/// rather than an overreach.
+#[test]
+fn an_agnostic_clause_that_names_an_axis_supplies_that_molecule() {
+    let general = (
+        "docs/recommendations/general.md:44",
+        "**exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** \
+         or **n.** reference sequences",
+    );
+    let duplication = (
+        "docs/recommendations/DNA/duplication.md:26",
+        "the variant is described as `LRG_199t1:c.3921dup`",
+    );
+    let found = overreaches(&[record(
+        "a-junction-ruling-scoped-onto-rna",
+        Some(duplication.0),
+        &[duplication, general],
+        &[],
+        "SCOPE. Deletions and duplications, on the `c.` and `n.` axes, and on `r.`.",
+    )]);
+    assert!(found.is_empty(), "{found:?}");
+}
+
+/// …and the control for it: an agnostic clause that names no axis extends
+/// nothing. `general.md:34` and `:43` are the two the second defect leaned on.
+#[test]
+fn an_agnostic_clause_that_names_no_axis_extends_nothing() {
+    let general = (
+        "docs/recommendations/general.md:34",
+        "two variants separated by one or more nucleotides should be described individually",
+    );
+    let found = overreaches(&[record(
+        "a-ruling-leaning-on-silent-general-prose",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS, general],
+        &[],
+        "And on a non-coding `r.` the same follows.",
+    )]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].molecule, "RNA");
+}
+
+/// An `undecided` record cannot name a governing clause, so it must not be
+/// exempt merely for having none.
+#[test]
+fn a_record_with_no_governing_clause_is_still_scoped_by_what_it_cites() {
+    let found = overreaches(&[record(
+        "an-undecided-record-reaching-rna",
+        None,
+        &[DNA_DELINS],
+        &["r.142_144delinsugg"],
+        "Unsettled.",
+    )]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].molecule, "RNA");
+}
+
+/// The `protein/` arm, which no ledger record currently exercises.
+#[test]
+fn the_protein_arm_behaves_like_the_others() {
+    let protein = (
+        "docs/recommendations/protein/delins.md:21",
+        "two variants affecting the same amino acid",
+    );
+    let reaching = overreaches(&[record(
+        "a-dna-ruling-reaching-protein",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS],
+        &["p.(Arg48Trp)"],
+        "",
+    )]);
+    assert_eq!(reaching.len(), 1, "{reaching:?}");
+    assert_eq!(reaching[0].molecule, "protein");
+
+    let cited = overreaches(&[record(
+        "a-dna-ruling-citing-protein",
+        Some(DNA_DELINS.0),
+        &[DNA_DELINS, protein],
+        &["p.(Arg48Trp)"],
+        "",
+    )]);
+    assert!(cited.is_empty(), "{cited:?}");
+}
+
+/// The tokenizer's own guard: neither a spec filename nor an abbreviation is an
+/// axis.
+///
+/// `inversion.md` and `substitution.md` end in `n` before the dot and
+/// `delins.md` in `s`; without the preceding-character check, every citation of
+/// the first two would read as a claim about the `n.` axis and the ledger would
+/// be one large false positive.
+///
+/// `e.g.` is the second class and the one that could weaken rather than merely
+/// noise up the guard — see [`axes_in`]. A quote is read for authority only
+/// when the clause it belongs to is molecule-agnostic, which is the case this
+/// must never get wrong, so the pinned string is a real ledger quote rather
+/// than a paraphrase of one.
+#[test]
+fn filenames_are_not_read_as_axes() {
+    assert!(axes_in("docs/recommendations/DNA/inversion.md:20").is_empty());
+    assert!(axes_in("docs/recommendations/DNA/substitution.md:32").is_empty());
+    assert!(axes_in("docs/recommendations/DNA/delins.md:47").is_empty());
+    assert!(axes_in("general.md:34").is_empty());
+
+    // Abbreviations. The dot before the axis letter is what disqualifies it.
+    // The first is `codon-carve-out-shape-restriction`'s quote of
+    // `DNA/duplication.md:18`, verbatim from the ledger.
+    assert!(axes_in(
+        "when a variant can be described as a duplication, it **must** be described as a \
+         duplication and not as, e.g., an insertion"
+    )
+    .is_empty());
+    assert!(axes_in("e.g. two variants").is_empty());
+
+    // And the positives it must still see, including one at the start of the
+    // string, one after a `:` accession separator, and one after a `/`, which
+    // is how the spec's own prose writes a pair of axes.
+    assert_eq!(axes_in("r.142_144delinsugg"), BTreeSet::from(['r']));
+    assert_eq!(axes_in("LRG_199t1:c.3921dup"), BTreeSet::from(['c']));
+    assert_eq!(
+        axes_in("the `c.` and `n.` axes"),
+        BTreeSet::from(['c', 'n'])
+    );
+    assert_eq!(axes_in("the c./r. pair"), BTreeSet::from(['c', 'r']));
+}
+
+/// Backtick scoping: an axis token outside backticks is not read.
+#[test]
+fn only_backticked_axes_are_read_from_a_rationale() {
+    assert!(axes_in_backticks("the RNA axis is r. throughout").is_empty());
+    assert_eq!(
+        axes_in_backticks("the RNA axis is `r.` throughout"),
+        BTreeSet::from(['r'])
+    );
+    // An unterminated backtick opens a span that runs to the end of the text;
+    // pinned so the split-based reader's behaviour is a decision, not a
+    // surprise. Over-reading here is the safe direction — it can only add a
+    // molecule the record must then cite.
+    assert_eq!(
+        axes_in_backticks("trailing `r.142del"),
+        BTreeSet::from(['r'])
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -398,6 +398,7 @@ mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;
 mod issue_999_shift_created_adjacency_collapse;
 mod issue_l2_w4001_swapped_positions;
+mod ledger_clause_jurisdiction;
 mod legacy_integration;
 mod lenient_overlap_and_projection_split;
 mod long_delins_splits_at_unchanged_bases;


### PR DESCRIPTION
A ruling in `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json` can cite a clause that resolves cleanly, quotes correctly, and still is not authority for what the record says — because `assets/hgvs-nomenclature/docs/recommendations/` is organised by **molecule** and the record rules on a different one. `DNA/` covers `g.`/`c.`/`n.`/`m.`, `RNA/` covers `r.`, `protein/` covers `p.`. That directory is the jurisdiction of every clause inside it.

Nothing checked it. The spec-fixture generator checks each quote is really at its `file:line`; `clause_ruling_index.rs` checks every cited clause is reachable from a clause string; `ruling_citation_currency.rs` checks prose does not contradict a record's status. A record can satisfy all three and still rest an RNA ruling on a DNA clause.

Two instances turned up on the same day, which is what argued for a guard rather than a third one-off correction.

### The ledger fix, which is a citation promotion and not a re-adjudication

`delins-codon-carve-out-gap-one` declares `r.142_144delinsugg` and `r.[142c>u;144a>g]` in `applies_to`, and its rationale rests the "not weakenable by edit type" argument on the identical sentence appearing in nine places — naming `RNA/delins.md:18` and `RNA/substitution.md:18` among them. Its structured `clauses` cited neither. So a settled ruling rested its RNA reach on clauses its own prose named and its citation list omitted.

This PR promotes those two clauses into the `clauses` array. **Nothing else about the record changes** — not `status`, not `governing` (still `DNA/delins.md:18`), not `deviates_from`, not `applies_to`, not `equivalence_classes`, not one word of the rationale, and not the outcome for any input. Please do not read it as re-adjudication; it makes the citation list match the argument the record already makes.

Both quotes were extracted programmatically from the spec checkout at pin `6f85311` rather than transcribed, and re-verified on this branch as byte-exact substrings of their cited lines (`quote in "\n".join(lines[a-1:b])`, both `True`). That check is worth stating because the generator's citation guard is a **whitespace-collapsed substring** match over the cited range, not a byte-for-byte one — a green build is not evidence a quote is exact.

`RNA/delins.md:18` is the stronger of the two for these rows: it states the exception with `r.142_144delinsugg` as its own worked example, which is verbatim one of the record's `applies_to` entries.

### The guard, and how its one open design question was decided

`tests/it/ledger_clause_jurisdiction.rs`. A record may not **speak to** a molecule it has no **authority** for.

- *speaks to* = axis prefixes in `applies_to` entries, plus axis tokens inside backticked spans of the `rationale`. The rationale half is not optional: the second instance's sole `applies_to` entry is a `c.` string and its entire RNA problem lives in prose.
- *authority* = a `clauses` entry under that molecule's directory.

The unresolved question was what to do with `general.md`, which is not molecule-specific. It was decided from the flag list rather than from taste, because both obvious answers fail. **Re-measured on this branch's base (`6f22cde9`, a 21-record ledger), against `origin/main`'s ledger** — i.e. before this PR's citation promotion, so the first defect is still present:

| candidate rule | flags | verdict |
|---|---:|---|
| naive — molecule directories cited, nothing else | 8 | 3 of them spurious: records ruling entirely under `checklist.md` / `background/standards.md` that mention a `c.` example in passing |
| `general.md` is universal authority | 0 | toothless — both known defects cite `general.md`, so neither is caught |
| jurisdiction keyed off the **governing** clause's directory | 4 | drops the 3 spurious rows and one more, but still reports two `r.` rows that half 2 clears |
| **chosen** — governing-keyed, plus an agnostic clause carries the jurisdiction its own quote names | **2** | the defect this PR fixes, and one prose disclaimer (below) |

The earlier revision of this table quoted 6 / 0 / 3 / 2 measured on a 16-record ledger. Those numbers are not restated in the module docs any more, and the docs say why: a count measured on a base nobody can rebuild is the failure `clause_ruling_index.rs` documents at length. What the module now carries instead is `the_scan_is_not_vacuous`, which fails if either half stops changing the verdict.

The chosen rule has two halves, and both are load-bearing:

1. **Jurisdiction attaches to the clause a record rules under.** If `governing` is molecule-agnostic — `general.md`, `checklist.md`, `style.md`, `background/`, `consultation/`, `versions/` — the record carries no molecule-scoped authority to exceed and is unconstrained. That is where `general.md` gets to be universal, and it is what drops the three spurious rows. A record with no `governing` clause at all is still constrained if it reaches into a molecule directory anyway, so a record the generator forbids from naming a governing clause is not exempt by construction.
2. **A molecule-agnostic clause carries the jurisdiction its own quoted text enumerates, and no more.** `exon-junction-dup-converge-from-the-far-side` scopes its ruling onto `r.` and cites `general.md:44`, whose quoted text reads "**exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** or **n.** reference sequences" — it names the RNA axis, so it *is* RNA authority and that record is properly cited. `general.md:34`, `:39` and `:43` name no axis, so they extend nothing. Without this half the guard reports a record that is not wrong.

Both carve-outs are pinned as non-vacuous by `the_scan_is_not_vacuous`: if the ledger ever stops exercising one, the test says to delete the carve-out rather than leave it as unexercised nuance.

### One decided record names an axis only to disclaim it

`projection-codon-exception-is-decided-by-the-rendered-axis` landed on `main` in #1672 after this branch was written, and the guard flags it: its `SCOPE, STATED NARROWLY` paragraph reads "The `p.` axis is the protein consequence itself." That is the record's only `p.`, and it is a statement that the protein axis is **out of scope** — the opposite of a ruling on it. The same paragraph disclaims `r.` and `n.` in the same breath; `r.` needs no handling only because `general.md:44`'s quote names that axis and the record cites it.

Prose cannot be parsed for intent, so the guard cannot tell a claim from a disclaimer. Two ways out were considered and one was rejected:

- **Rejected — weaken the tokenizer** so a bare `` `p.` `` label does not count and only a full description (`` `r.850_901delinsuuccucg` ``) does. That silently drops the bare-label form across the whole ledger, and the bare-label form is exactly how the known defect class recurs.
- **Chosen — name the exception.** `SCOPE_DISCLAIMERS` carries one row: record id, molecule, and the quoted sentence that does the disclaiming. `every_scope_disclaimer_is_still_needed` makes the list **shrink-only** in the same sense as `LEDGER_EXEMPT` — a row whose record has been deleted, re-cited or reworded fails the test and must be removed, so it cannot grow into a mute button.

Adding a citation to that record instead would have been worse: it is an operator ruling that explicitly declines to rule on `p.`, and manufacturing `protein/` authority for it to satisfy a test would assert reach the record disclaims. No verdict, citation, `applies_to` or word of that record is touched.

### What the guard deliberately does not claim

- **Not that a cited clause supports the ruling.** It compares directories, not arguments. Whether the clause says what the record needs is review's job.
- **Not that an axis token is a claim rather than a disclaimer.** See above; the one instance is named.
- **Not that it sees every axis a record touches.** An axis discussed in unbackticked prose, or implied ("on a coding transcript"), is invisible. It is a floor: it catches a record that *writes* an axis token it has no directory for.
- **Not that a quote is byte-exact**, for the reason given above.
- **Nothing about `protein/` from the ledger's citations.** No record cites a clause under it, so that arm is exercised only by synthetic cases in the file. Stated plainly, since a rule with an unexercised arm reads as coverage.

### The tokenizer reads `e.g.` as the `g.` axis — closed, latent, moves nothing

`axes_in` disqualified an axis letter preceded by an alphanumeric or `_`, which keeps spec filenames out (`inversion.md` ends in `n` before a dot). It did not disqualify a preceding `.`, so `e.g.` read as a claim about the `g.` axis. The ledger holds six such occurrences: five in citation quotes, one in a rationale outside backticks.

The direction matters. `molecules_with_authority` reads the quote of a **molecule-agnostic** clause, so an `e.g.` in a `general.md` or `checklist.md` quote hands the record DNA authority it was never granted and quietly stops the guard catching a DNA overreach — a weakening, not noise. **No agnostic quote carries one today**; all five sit on clauses under a molecule directory, whose quotes are never read. So this moves no verdict and is a latent hazard closed rather than a defect fixed. `filenames_are_not_read_as_axes` pins both classes and the positives (`c./r.`, `LRG_199t1:c.3921dup`, a leading `r.`).

### The vacuity pin missed the population the guard actually judges

`the_scan_is_not_vacuous` pinned the ledger size, the records read as speaking, the molecules reached, and each carve-out being exercised. It did **not** pin that any record is both molecule-scoped *and* speaking — the set the guard iterates. Measured: an `is_molecule_scoped` that answers `false` for everything made `no_record_speaks_to_a_molecule_it_cannot_cite` pass over an empty set **and left `the_scan_is_not_vacuous` green**, because such a break satisfies the half-1 pin harder. That assertion is added; the same mutation now fails.

Mutation results, all run against the ledger rather than synthetics (`-E 'test(ledger_clause_jurisdiction)'`, 14 tests):

| mutation | tests failed |
|---|---:|
| `overreaches` returns empty (never flags) | 6 |
| every spoken molecule flagged (always flags) | 5 |
| `is_molecule_scoped` always `false` | 7 (was 0 before the new assertion) |
| molecule-agnostic clause = universal authority | 2 |
| rationale half removed | 4 |

### Other changes

- `tests/it/common/rulings.rs` grows `quote`, `applies_to` and `governing` on its record model, so "what a record is" stays defined in one place. `quote` is **required** — the generator already demands it, and reading an absent quote as empty would silently narrow the authority a clause supplies. A present-but-**blank** quote is rejected too, for the same reason one step further in: `""` satisfies a required key, checks against no line of the spec checkout, and supplies no axis text. Each new field gets a `should_panic` case for the malformed shape, matching the existing ones.
- `tests/it/clause_ruling_index.rs`'s generated block moves from 79 to 81 clause lines, gaining the two RNA entries. It was **spliced programmatically** on its `BEGIN`/`END` markers from the block the failing test prints, never retyped — the file's own docs warn that hand-transcribing that block drops rows silently.

### Verification

Run from the worktree on `6f22cde9`, exit status captured into the log rather than inferred:

```
cargo run --features dev --bin generate_spec_fixture        EXIT_FIXTURE=0
cargo run --features dev --bin generate_spec_enumeration    EXIT_ENUM=0
cargo fmt --all --check                                     EXIT_FMT=0
cargo clippy --all-features --all-targets -- -D warnings    EXIT_CLIPPY=0
cargo nextest run --features dev --lib --test it            EXIT_NEXTEST=0   (10175 passed, 0 failed)
```

`FERRO_MANIFEST` was set throughout, so the reference-aware suites ran rather than skipped.

Ledger integrity was checked programmatically rather than by reading the diff: 21 records on `origin/main` and 21 on `HEAD`, none dropped relative to `origin/main` or to either pre-rebase tip, and no status change. The only difference in the whole `rulings` section is the two added `clauses` entries.

Representation-Change: none. Tests and the ruling ledger's citation list only; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, and no normalized output moves.
