### PR TITLE
test(normalize): pin that normalization is axis-preserving and frame-free axes ignore annotation

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -417,6 +417,7 @@ mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;
 mod network_benchmark_tests;
 mod normalization_transcripts_exon_contract;
+mod normalize_axis_preserving;
 mod normalize_config_disambiguation;
 mod normalize_idempotency_proptest;
 mod normalize_property_tests;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -419,6 +419,7 @@ mod network_benchmark_tests;
 mod normalization_transcripts_exon_contract;
 mod normalize_axis_preserving;
 mod normalize_config_disambiguation;
+mod normalize_frame_free_axis_independence;
 mod normalize_idempotency_proptest;
 mod normalize_property_tests;
 mod normalize_reparse_invariant;

--- a/tests/it/normalize_axis_preserving.rs
+++ b/tests/it/normalize_axis_preserving.rs
@@ -1,0 +1,470 @@
+//! Normalization does not move a description onto a different coordinate axis.
+//!
+//! # What this asserts
+//!
+//! For every description the normalizer accepts, the coordinate-system letter of
+//! the output equals that of the input: `g.` in gives `g.` out, and likewise for
+//! `c.`/`n.`/`r.`/`p.`/`m.`/`o.`. Re-expressing one axis on another is the
+//! *projector's* job (`src/project/`), and the dependency runs one way —
+//! `src/normalize/` names no projector — so today the property holds by
+//! construction. That is exactly why it is worth pinning: nothing in the type
+//! system stops a future normalization rule from reaching for a projection, and
+//! a consumer that stored `c.` strings would get `g.` ones back with no error.
+//!
+//! # The one sanctioned rewrite, and why it is not a counter-example
+//!
+//! A `g.` description on a mitochondrial reference (`NC_012920` / `NC_001807`)
+//! is re-labelled `m.` (#487, `Normalizer::normalize_dispatch`). The reference
+//! molecule is unchanged — only the coordinate-system letter HGVS requires for
+//! it is corrected — so this is a label repair rather than a change of axis.
+//! It is admitted here as an enumerated exception and each occurrence is
+//! re-checked against [`Accession::is_mitochondrial`], so the carve-out cannot
+//! launder a `g.` -> `m.` rewrite on any other accession.
+//!
+//! # The near-miss to keep in mind: the accession may change, the axis may not
+//!
+//! Legacy-selector resolution rewrites `NG_012337.1(NM_003002.2):c.274G>T` to
+//! `NM_003002.2:c.274G>T`. The *accession* changes; the axis letter does not.
+//! So the comparison here is on [`CoordinateAxis`] alone and never on the
+//! description's prefix — `the_check_reads_the_axis_letter_not_the_prefix`
+//! pins that distinction directly, because a prefix comparison would report
+//! that rewrite as a violation and the corpora (which run with no reference
+//! provider) cannot exhibit it.
+//!
+//! # Denominators are part of the result
+//!
+//! "0 violations" is meaningless without the population it was measured over, and
+//! a census that compared nothing looks identical to a clean one. Every test here
+//! prints its full accounting — rows, unparsed, unnormalizable, axis-less,
+//! compared, and the per-axis breakdown of what was compared — and asserts the
+//! compared count is non-zero before believing a zero. The first attempt at this
+//! measurement reported `compared: 0`, from a mis-guessed JSON field name; the
+//! denominator is what caught it.
+//!
+//! # What this does NOT claim
+//!
+//! Nothing about whether the normalized *description* is right — only about its
+//! axis. Nothing about descriptions the normalizer rejects, or that the parser
+//! rejects: both are counted and skipped, not judged. And nothing about the
+//! projector, whose whole purpose is to change axis.
+//!
+//! The bulk fixtures are git-lfs artifacts. Following the sibling corpus suites
+//! (`clinvar_hgvs_tests`, `cmrg_exhaustive_tests`, `paraphase_exhaustive_tests`),
+//! a missing fixture skips green rather than failing — so an absent corpus is
+//! reported as a skip, never as a pass.
+
+use ferro_hgvs::{parse_hgvs, CoordinateAxis, HgvsVariant, MockProvider, Normalizer};
+use flate2::read::GzDecoder;
+use rayon::prelude::*;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Read;
+use std::time::Instant;
+
+/// Slim deserialization shape shared by the four bulk fixtures: `input` is the
+/// only field this census reads. `&'a str` borrows into the decompressed buffer
+/// — see `cmrg_exhaustive_tests::load_fixture_bytes` for why that matters here.
+#[derive(Deserialize)]
+struct BulkFixture<'a> {
+    #[serde(borrow)]
+    test_cases: Vec<BulkCase<'a>>,
+}
+
+#[derive(Deserialize)]
+struct BulkCase<'a> {
+    #[serde(borrow)]
+    input: &'a str,
+}
+
+impl AsRef<str> for BulkCase<'_> {
+    fn as_ref(&self) -> &str {
+        self.input
+    }
+}
+
+/// The generated HGVS spec-normalization fixture. Read for the axes the bulk
+/// corpora barely reach — it is the only population here carrying an `o.` row,
+/// and it holds roughly nineteen times as many `r.` rows as all four bulk
+/// corpora combined (measured: 130 against 7).
+#[derive(Deserialize)]
+struct SpecFixture {
+    rows: Vec<SpecRow>,
+}
+
+#[derive(Deserialize)]
+struct SpecRow {
+    input: String,
+    /// Default-prefixed form for the bare illustrative fragments the spec states
+    /// without an accession (#84); `input` verbatim when there is none.
+    #[serde(default)]
+    input_prefixed: Option<String>,
+}
+
+fn load_gzipped(path: &str) -> Option<Vec<u8>> {
+    if !std::path::Path::new(path).exists() {
+        return None;
+    }
+    let file = File::open(path).unwrap_or_else(|e| panic!("failed to open {path}: {e}"));
+    let mut buf = Vec::new();
+    GzDecoder::new(file)
+        .read_to_end(&mut buf)
+        .unwrap_or_else(|e| panic!("failed to decompress {path}: {e}"));
+    Some(buf)
+}
+
+/// One corpus's accounting. Every input lands in exactly one of the four
+/// disposition counters, so `rows` is recoverable from the census and a silently
+/// dropped population is not representable.
+#[derive(Default)]
+struct AxisCensus {
+    /// Rows offered to the census.
+    rows: usize,
+    /// `parse_hgvs` declined — not this module's subject.
+    unparsed: usize,
+    /// `normalize` returned `Err` — likewise not this module's subject.
+    unnormalizable: usize,
+    /// One side has no single coordinate axis: an RNA fusion (`::`, which joins
+    /// two transcripts) or a bare `[0]`/`[?]` marker. There is no axis letter to
+    /// compare, so there is nothing to assert.
+    axis_less: usize,
+    /// Rows where both sides had an axis and the two were compared.
+    compared: usize,
+    /// Of `compared`, those whose axis letter is unchanged.
+    preserved: usize,
+    /// Of `compared`, the #487 `g.` -> `m.` label repair on a mitochondrial
+    /// reference, verified per occurrence.
+    mito_relabels: usize,
+    /// Input-axis breakdown of `compared`, so a zero can be read per axis.
+    per_axis: BTreeMap<&'static str, usize>,
+    /// Of `compared`, how many violations occurred — uncapped, unlike
+    /// [`Self::violations`], which holds only a printable sample. Reporting
+    /// `violations.len()` as the count would describe any regression wider than
+    /// [`MAX_REPORTED_VIOLATIONS`] as exactly that many rows, understating it at
+    /// precisely the moment the number matters most.
+    violations_seen: usize,
+    /// A readable sample of the axis changes that are not the sanctioned
+    /// relabel, capped so a broad regression prints a sample rather than
+    /// millions of lines.
+    violations: Vec<String>,
+}
+
+/// How the census classifies one `(input, output)` pair.
+///
+/// Extracted so `the_check_reads_the_axis_letter_not_the_prefix` can exercise
+/// the census's *own* decision instead of restating it. A test that re-derives
+/// the comparison it means to pin passes no matter what the census does — which
+/// is what that test did before this was factored out.
+#[derive(Debug, PartialEq, Eq)]
+enum Disposition {
+    /// The axis letter is unchanged.
+    Preserved,
+    /// The #487 `g.` -> `m.` label repair on a mitochondrial reference.
+    MitochondrialRelabel,
+    /// Any other axis change.
+    Violation,
+}
+
+/// Classify one pair, or `None` when either side has no single coordinate axis.
+///
+/// The comparison is on [`CoordinateAxis`] and on nothing else — in particular
+/// not on the accession or the rendered prefix, both of which normalization is
+/// allowed to move (legacy-selector resolution does exactly that).
+fn classify(variant: &HgvsVariant, normalized: &HgvsVariant) -> Option<Disposition> {
+    let (before, after) = (variant.coordinate_axis()?, normalized.coordinate_axis()?);
+    Some(if before == after {
+        Disposition::Preserved
+    } else if is_mitochondrial_relabel(variant, before, after) {
+        Disposition::MitochondrialRelabel
+    } else {
+        Disposition::Violation
+    })
+}
+
+const MAX_REPORTED_VIOLATIONS: usize = 20;
+
+impl AxisCensus {
+    fn of_one(input: &str) -> Self {
+        let mut census = Self {
+            rows: 1,
+            ..Self::default()
+        };
+        let Ok(variant) = parse_hgvs(input) else {
+            census.unparsed = 1;
+            return census;
+        };
+        // An empty provider, deliberately: the property is about the axis label,
+        // which no reference can inform. Normalization degrades leniently
+        // without one, so a large majority of every corpus still normalizes.
+        let normalizer = Normalizer::new(MockProvider::new());
+        let Ok(normalized) = normalizer.normalize(&variant) else {
+            census.unnormalizable = 1;
+            return census;
+        };
+        let (Some(before), Some(after)) = (variant.coordinate_axis(), normalized.coordinate_axis())
+        else {
+            census.axis_less = 1;
+            return census;
+        };
+        census.compared = 1;
+        *census.per_axis.entry(before.code()).or_default() += 1;
+        match classify(&variant, &normalized).expect("both sides carry an axis here") {
+            Disposition::Preserved => census.preserved = 1,
+            Disposition::MitochondrialRelabel => census.mito_relabels = 1,
+            Disposition::Violation => {
+                census.violations_seen = 1;
+                census.violations.push(format!(
+                    "`{input}` [{}] normalized to `{normalized}` [{}]",
+                    before.code(),
+                    after.code()
+                ));
+            }
+        }
+        census
+    }
+
+    fn merge(mut self, other: Self) -> Self {
+        self.rows += other.rows;
+        self.unparsed += other.unparsed;
+        self.unnormalizable += other.unnormalizable;
+        self.axis_less += other.axis_less;
+        self.compared += other.compared;
+        self.preserved += other.preserved;
+        self.mito_relabels += other.mito_relabels;
+        self.violations_seen += other.violations_seen;
+        for (axis, count) in other.per_axis {
+            *self.per_axis.entry(axis).or_default() += count;
+        }
+        for violation in other.violations {
+            if self.violations.len() < MAX_REPORTED_VIOLATIONS {
+                self.violations.push(violation);
+            }
+        }
+        self
+    }
+
+    /// Print the accounting, then assert on it.
+    ///
+    /// The print is unconditional and comes first: a run that asserts without
+    /// reporting its denominator cannot be told apart from one that compared
+    /// nothing, which is the failure this module is written against.
+    fn report_and_assert(&self, label: &str, elapsed_secs: f64) {
+        eprintln!("\n=== axis preservation: {label} ===");
+        eprintln!("  rows offered      : {}", self.rows);
+        eprintln!("  unparsed          : {}", self.unparsed);
+        eprintln!("  unnormalizable    : {}", self.unnormalizable);
+        eprintln!("  no single axis    : {}", self.axis_less);
+        eprintln!("  COMPARED          : {}", self.compared);
+        eprintln!("    axis preserved  : {}", self.preserved);
+        eprintln!("    #487 g. -> m.   : {}", self.mito_relabels);
+        eprintln!("    violations      : {}", self.violations_seen);
+        eprintln!("  compared by input axis:");
+        for (axis, count) in &self.per_axis {
+            eprintln!("    {axis}. : {count}");
+        }
+        eprintln!("  elapsed: {elapsed_secs:.2}s\n");
+
+        assert!(
+            self.compared > 0,
+            "{label}: compared 0 rows of {} offered — a structural zero, not a clean result",
+            self.rows
+        );
+        assert_eq!(
+            self.violations_seen,
+            0,
+            "{label}: normalization changed the coordinate axis on {} of {} compared rows \
+             ({} shown):\n  {}",
+            self.violations_seen,
+            self.compared,
+            self.violations.len(),
+            self.violations.join("\n  ")
+        );
+        assert_eq!(
+            self.preserved + self.mito_relabels + self.violations_seen,
+            self.compared,
+            "{label}: the dispositions do not account for every compared row"
+        );
+        // The doc on `AxisCensus` claims every input lands in exactly one of the
+        // four disposition counters. Check it rather than assert it in prose: a
+        // population that stopped being counted would otherwise shrink the
+        // denominator silently, which is the one failure this module is written
+        // against.
+        assert_eq!(
+            self.unparsed + self.unnormalizable + self.axis_less + self.compared,
+            self.rows,
+            "{label}: the dispositions do not account for every row offered"
+        );
+    }
+}
+
+/// Whether an axis change is the #487 mitochondrial label repair.
+///
+/// Checked per occurrence rather than by matching the letters alone: the
+/// accession must itself be mitochondrial, so the carve-out admits only the
+/// rewrite `normalize_dispatch` actually performs.
+fn is_mitochondrial_relabel(
+    variant: &HgvsVariant,
+    before: CoordinateAxis,
+    after: CoordinateAxis,
+) -> bool {
+    before == CoordinateAxis::Genomic
+        && after == CoordinateAxis::Mitochondrial
+        && variant
+            .accession()
+            .is_some_and(|accession| accession.is_mitochondrial())
+}
+
+fn census_of<I>(inputs: I) -> AxisCensus
+where
+    I: IntoParallelIterator,
+    I::Item: AsRef<str>,
+{
+    inputs
+        .into_par_iter()
+        .map(|input| AxisCensus::of_one(input.as_ref()))
+        .reduce(AxisCensus::default, AxisCensus::merge)
+}
+
+/// Run the census over one gzipped bulk fixture, skipping green when the git-lfs
+/// artifact is absent — the idiom the sibling corpus suites use.
+fn assert_axis_preserved_over_bulk_fixture(path: &str) {
+    let Some(buf) = load_gzipped(path) else {
+        eprintln!("Skipping axis-preservation census: {path} not found (git-lfs artifact)");
+        return;
+    };
+    let fixture: BulkFixture<'_> = serde_json::from_slice(&buf)
+        .unwrap_or_else(|e| panic!("failed to parse {path} (is Git LFS installed?): {e}"));
+    let start = Instant::now();
+    let census = census_of(&fixture.test_cases[..]);
+    census.report_and_assert(path, start.elapsed().as_secs_f64());
+}
+
+#[test]
+fn axis_is_preserved_over_the_clinvar_500k_corpus() {
+    assert_axis_preserved_over_bulk_fixture("tests/fixtures/bulk/clinvar_hgvs_500k.json.gz");
+}
+
+#[test]
+fn axis_is_preserved_over_the_clinvar_unique_corpus() {
+    assert_axis_preserved_over_bulk_fixture("tests/fixtures/bulk/clinvar_hgvs_unique.json.gz");
+}
+
+#[test]
+fn axis_is_preserved_over_the_cmrg_corpus() {
+    assert_axis_preserved_over_bulk_fixture(
+        "tests/fixtures/validation/cmrg_genes_exhaustive.json.gz",
+    );
+}
+
+#[test]
+fn axis_is_preserved_over_the_paraphase_corpus() {
+    assert_axis_preserved_over_bulk_fixture(
+        "tests/fixtures/validation/paraphase_genes_exhaustive.json.gz",
+    );
+}
+
+/// The spec fixture is small, and it is here for axis *breadth* rather than
+/// volume. Measured over the four bulk corpora: `o.` is reached **0** times and
+/// `r.` **7** times, against 1 and 130 in this fixture. A census over ten
+/// million observed variants that never reaches one of the seven axes at all,
+/// and reaches another seven times, is not a census over seven axes.
+///
+/// Those are the figures the per-axis breakdown prints, so they can be
+/// re-derived from any run rather than taken from this comment.
+#[test]
+fn axis_is_preserved_over_the_spec_normalization_corpus() {
+    crate::common::spec_fixture::ensure_spec_fixture();
+    let path = crate::common::spec_fixture::spec_fixture_path();
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let fixture: SpecFixture = serde_json::from_str(&content)
+        .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()));
+    let inputs: Vec<String> = fixture
+        .rows
+        .into_iter()
+        .map(|row| row.input_prefixed.unwrap_or(row.input))
+        .collect();
+    let start = Instant::now();
+    let census = census_of(inputs);
+    census.report_and_assert(
+        "hgvs_spec_normalization.json",
+        start.elapsed().as_secs_f64(),
+    );
+}
+
+/// The comparison is on the axis letter, never on the description's prefix.
+///
+/// Legacy-selector resolution replaces an `NG_`-anchored selector with the bare
+/// transcript, so the accession moves while the axis stays put. A check written
+/// on the prefix would call that a violation. This pins the distinction
+/// hermetically — the two spellings differ in accession and agree in axis —
+/// because the corpus censuses run with no reference provider and therefore
+/// never trigger the rewrite themselves (measured: 0 accession changes across
+/// all four bulk corpora, so those censuses cannot stand in for this test).
+///
+/// It asserts on [`classify`], the census's own decision, rather than
+/// re-deriving the comparison. That distinction is the whole test: an earlier
+/// version called only `parse_hgvs` and `coordinate_axis`, so it survived a
+/// mutation that made the census compare accessions as well as axes — exactly
+/// the check its name forbids. Routed through `classify`, that mutation now
+/// turns this red.
+#[test]
+fn the_check_reads_the_axis_letter_not_the_prefix() {
+    let selector_form = parse_hgvs("NG_012337.1(NM_003002.2):c.274G>T").expect("parses");
+    let resolved_form = parse_hgvs("NM_003002.2:c.274G>T").expect("parses");
+
+    assert_ne!(
+        selector_form.accession().map(|a| a.to_string()),
+        resolved_form.accession().map(|a| a.to_string()),
+        "the two spellings must differ in accession for this to be the near-miss it claims"
+    );
+    assert_eq!(
+        classify(&selector_form, &resolved_form),
+        Some(Disposition::Preserved),
+        "the census must read legacy-selector resolution as axis-preserving; a comparison \
+         that also looked at the accession or the rendered prefix would call it a violation"
+    );
+    assert_eq!(
+        selector_form.coordinate_axis().map(CoordinateAxis::code),
+        Some("c")
+    );
+}
+
+/// The sanctioned exception is scoped to the mitochondrial accessions, and
+/// nothing else can pass through it.
+///
+/// Without this, a regression that re-expressed arbitrary `g.` descriptions as
+/// `m.` would be absorbed by the carve-out and the corpus censuses would stay
+/// green.
+#[test]
+fn the_mitochondrial_carve_out_admits_only_mitochondrial_accessions() {
+    for accession in ["NC_012920.1", "NC_001807.4"] {
+        let variant = parse_hgvs(&format!("{accession}:g.7623C>T")).expect("parses");
+        assert!(
+            is_mitochondrial_relabel(
+                &variant,
+                CoordinateAxis::Genomic,
+                CoordinateAxis::Mitochondrial
+            ),
+            "{accession} is a mitochondrial reference, so #487's relabel applies to it"
+        );
+    }
+
+    let chromosomal = parse_hgvs("NC_000017.11:g.7623C>T").expect("parses");
+    assert!(
+        !is_mitochondrial_relabel(
+            &chromosomal,
+            CoordinateAxis::Genomic,
+            CoordinateAxis::Mitochondrial
+        ),
+        "a chromosomal accession must not be admitted by the mitochondrial carve-out"
+    );
+    // …and the carve-out is about `g.` -> `m.` specifically, not about any pair
+    // of axes on a mitochondrial accession.
+    let mito = parse_hgvs("NC_012920.1:g.7623C>T").expect("parses");
+    assert!(!is_mitochondrial_relabel(
+        &mito,
+        CoordinateAxis::Genomic,
+        CoordinateAxis::Coding
+    ));
+}

--- a/tests/it/normalize_frame_free_axis_independence.rs
+++ b/tests/it/normalize_frame_free_axis_independence.rs
@@ -1,0 +1,372 @@
+//! An axis with no reading frame normalizes without consulting transcript
+//! annotation.
+//!
+//! # What this asserts
+//!
+//! Normalize one `g.` (and one `m.`) description twice — once against a provider
+//! that can resolve the covering transcript *and* its CDS, once against a
+//! provider that cannot — and the two outputs are identical. A genomic string
+//! must be derivable from its own reference; if the answer moves when annotation
+//! appears, the normalizer is importing information the reference does not
+//! carry, and the same input would normalize differently for two callers holding
+//! different reference bundles.
+//!
+//! Two seams decide it, and each is `false` for the genomic axes by
+//! construction:
+//!
+//! - `Normalizer::apply_canonical_split`'s `codon_frame_aware` — `true` for
+//!   `HgvsVariant::Cds`, asked of the provider for `HgvsVariant::Rna` (#1241: an
+//!   `r.` on a non-coding transcript has no frame), `false` for everything else.
+//! - `merge::axis_frame`'s `reading_frame` — `false` for `CisKind::Genome` and
+//!   `CisKind::Mt` with no provider round-trip at all.
+//!
+//! Nothing enforces either, which is why this is worth a test: a rule that
+//! reached for a covering transcript on the genomic axis would compile.
+//!
+//! **The two seams cross-check each other, and that bounds what this module can
+//! catch.** Measured by mutating each in turn to consult the annotated provider:
+//! with only the first leaking, `sequence_first_pass` re-derives the merged
+//! delins back into the split and the output is unchanged; with only the second
+//! leaking, `apply_canonical_split` has already split and the codon exception
+//! does not re-merge. Under either single-seam leak all five tests here still
+//! pass. Only when **both** leak does the answer move.
+//!
+//! **Which tests then fire depends on whether the leak consults the provider,
+//! and that is the sharper bound.** Both figures below are measured, not
+//! reasoned:
+//!
+//! - A **provider-mediated** leak on both genomic seams — one that reaches the
+//!   annotated transcript's CDS — turns
+//!   `a_genomic_description_normalizes_the_same_…` red, together with
+//!   `the_genomic_case_is_one_a_leaked_reading_frame_would_have_changed`. This
+//!   is the shape the module is written against and the A/B design catches it.
+//! - A leak that simply hard-codes a reading frame for the genomic axis, without
+//!   consulting the provider at all, changes **both** arms of the A/B
+//!   identically, so every equality assertion here still passes. Only the exact
+//!   string pinned by `the_genomic_case_…` catches that shape.
+//!
+//! So the value pin is not redundant with the A/B — it is the only assertion
+//! covering a non-provider-mediated leak, and the A/B is the only one covering a
+//! leak whose *effect* depends on the reference bundle. The `m.` assertion
+//! answers to a leak on the `Mt` arm and to nothing else (measured: mutating
+//! `CisKind::Mt` and `HgvsVariant::Mt` fires it alone).
+//!
+//! Note also what no mutation here can reach: the `ReferenceProvider` trait
+//! exposes no genomic-region-to-transcript lookup, so a leak in `src/normalize/`
+//! cannot find the covering transcript of a `g.` description by position
+//! through the public trait at all. The provider-mediated mutation above had to
+//! name the transcript accession outright. That is a statement about today's
+//! trait surface, and it is exactly the thing that would change if such a lookup
+//! were ever added — which is when this module starts earning its keep.
+//!
+//! The seams are named because they are where a leak would come from, not because
+//! this module reaches into them. Every assertion below is on public behaviour:
+//! parse, normalize twice, compare the strings.
+//!
+//! # The case is chosen so that a leak would be visible
+//!
+//! The fixture places `CGC` at genomic positions that are exactly one codon of a
+//! transcript the annotated provider knows. Replacing them with `TGG` changes
+//! the first and third base and leaves the middle one, so:
+//!
+//! ```text
+//!   frame-free  g.265_267delinsTGG  ->  g.[265C>T;267C>G]     split
+//!   framed      c.[10C>T;12C>G]     ->  c.10_12delinsTGG      merged
+//! ```
+//!
+//! `general.md:34` splits two changes separated by an unchanged base; `:35`'s
+//! one-amino-acid exception is what licenses the merge, and it needs a reading
+//! frame. A genomic normalizer that leaked the frame would therefore emit the
+//! merged form, which is a *different string* — the assertion is not vacuous.
+//! The shape is `LRG_199:g.494841_494843delinsTGG`, whose bases are `c.145`-`c.147`
+//! of `LRG_199t1`, rebuilt hermetically at codon 4 of a synthetic transcript.
+//!
+//! # The negative control is load-bearing
+//!
+//! An "identical" result proves nothing unless the harness can detect
+//! annotation-dependence at all — two providers that differ in a way the
+//! normalizer never sees would produce identical outputs for every input,
+//! including ones that *should* differ. So the same provider pair is run against
+//! the `c.` axis, where the dependence is legitimate and expected, and the
+//! outputs must differ. Both sides return `Ok` there: the difference is the rule
+//! that fired, not a provider error, which is the strongest form the control can
+//! take.
+//!
+//! # What this does NOT claim
+//!
+//! **Nothing about the `n.` axis.** Whether `n.` on a *coding* transcript should
+//! carry that transcript's reading frame is an open question — normalization and
+//! projection disagree about it, and the disagreement is recorded but unruled.
+//! The omission is deliberate: asserting either side here would pre-empt an
+//! operator ruling by freezing it in a test. (`axis_frame` currently answers
+//! `reading_frame: false` for `CisKind::Tx`; that is the status quo, not a
+//! ruling, and this module does not pin it.)
+//!
+//! It also claims nothing about *which* output is correct. The property is
+//! stability of the answer across reference bundles, not the answer itself; the
+//! one exact string it does pin is the genomic split, and only to establish that
+//! a leak would have been visible.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer, ReferenceProvider};
+
+/// Transcript sequence, 10 codons. Bases 10-12 are `CGC` — codon 4 — and are the
+/// three the test edits. Their neighbours (`A` at 9, `T` at 13) stop the edit
+/// shuffling out of the codon, so the case stays where the fixture puts it.
+const TRANSCRIPT_SEQUENCE: &str = "ATGGCCTTACGCTAGGATCACTTGGACTAA";
+
+/// Bases of `ACGT` flanking the transcript on each side, so the normalizer's
+/// 100bp window stays in bounds. Same idea as `common::synthetic::padded`,
+/// spelled out here because this module needs the genomic accession and the
+/// transcript placement to be its own.
+///
+/// **255, not 256, and the value is load-bearing.** `merge::same_codon` asks
+/// `(pos - 1) / 3` of the *description's own* coordinates, so a leaked reading
+/// frame merges only when the two edited endpoints are codon-aligned in the frame
+/// the leak happens to use. A flank of 255 makes the edited bases codon-aligned
+/// on **both** frames at once — `c.10`/`c.12` on the transcript and `g.265`/
+/// `g.267` on the chromosome — so the case detects a leak that projects into the
+/// transcript *and* one that merely turns the coding flag on and reads genomic
+/// positions. With 256 the second is invisible: no codon of the transcript can
+/// land on a genomically codon-aligned position, and a mutation enabling the
+/// coding path for `HgvsVariant::Genome` passes this module unchanged (measured).
+const FLANK_LEN: u64 = 255;
+
+/// 1-based genomic position of transcript base 1.
+const TX_GENOMIC_START: u64 = FLANK_LEN + 1;
+
+/// 1-based genomic position of `c.10` (== transcript base 10, since the CDS
+/// starts at transcript base 1).
+const CODON_GENOMIC_START: u64 = FLANK_LEN + 10;
+
+const CHROMOSOME: &str = "NC_TEST.1";
+const MITOCHONDRION: &str = "NC_012920.1";
+const TRANSCRIPT: &str = "NM_TEST.1";
+
+fn genomic_sequence() -> String {
+    let mut flank = "ACGT".repeat(FLANK_LEN as usize / 4 + 1);
+    flank.truncate(FLANK_LEN as usize);
+    format!("{flank}{TRANSCRIPT_SEQUENCE}{flank}")
+}
+
+/// A provider holding the genomic sequence and nothing else: it cannot resolve
+/// any transcript, so it cannot know where a CDS is.
+fn without_annotation(contig: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(contig, genomic_sequence());
+    provider
+}
+
+/// The same genomic sequence, plus a transcript placed on `contig` that covers
+/// the edited bases and declares a CDS putting them on a codon boundary.
+///
+/// The *only* difference from [`without_annotation`] is the transcript. The
+/// genomic accession, its sequence and its coordinates are identical, so any
+/// difference in a `g.` result is attributable to the annotation and to nothing
+/// else.
+fn with_annotation(contig: &str) -> MockProvider {
+    let mut provider = without_annotation(contig);
+    let tx_len = TRANSCRIPT_SEQUENCE.len() as u64;
+    let tx_genomic_end = FLANK_LEN + tx_len;
+    provider.add_transcript(Transcript::new(
+        TRANSCRIPT.to_string(),
+        Some("SYNTH".to_string()),
+        Strand::Plus,
+        TRANSCRIPT_SEQUENCE.to_string(),
+        Some(1),
+        Some(tx_len),
+        vec![Exon::with_genomic(
+            1,
+            1,
+            tx_len,
+            TX_GENOMIC_START,
+            tx_genomic_end,
+        )],
+        Some(contig.to_string()),
+        Some(TX_GENOMIC_START),
+        Some(tx_genomic_end),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(provider: MockProvider, input: &str) -> Result<String, String> {
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("`{input}` must parse: {e}"));
+    Normalizer::new(provider)
+        .normalize(&variant)
+        .map(|normalized| normalized.to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// The fixture's own claims, checked rather than asserted in prose.
+///
+/// If the transcript stopped covering the edited bases, or the CDS stopped
+/// putting them on a codon boundary, every "identical output" below would still
+/// pass while measuring nothing — the annotated provider would simply have no
+/// frame to leak.
+#[test]
+fn the_fixture_puts_the_edited_bases_on_a_codon_of_the_annotated_transcript() {
+    let provider = with_annotation(CHROMOSOME);
+    let transcript = provider
+        .get_transcript(TRANSCRIPT)
+        .expect("the annotated provider resolves the transcript");
+    let cds_start = transcript.cds_start.expect("…and it declares a CDS");
+    assert_eq!(cds_start, 1, "c.<n> maps 1:1 onto transcript base <n>");
+
+    let exon = transcript.exons.first().expect("one exon");
+    let (exon_g_start, exon_g_end) = (
+        exon.genomic_start.expect("exon carries genomic coords"),
+        exon.genomic_end.expect("exon carries genomic coords"),
+    );
+    assert!(
+        exon_g_start <= CODON_GENOMIC_START && CODON_GENOMIC_START + 2 <= exon_g_end,
+        "the edited bases must lie inside the annotated exon"
+    );
+
+    // c.10 is the first base of codon 4: (10 - 1) % 3 == 0.
+    let cds_position = CODON_GENOMIC_START - TX_GENOMIC_START + 1;
+    assert_eq!(cds_position, 10);
+    assert_eq!(
+        (cds_position - cds_start) % 3,
+        0,
+        "the three edited bases must be a whole codon, or there is no frame to leak"
+    );
+
+    // The edited endpoints must ALSO be codon-aligned in the genomic frame, or a
+    // leak that turns the coding flag on without projecting is invisible here —
+    // `merge::same_codon` reads `(pos - 1) / 3` of whatever coordinates the
+    // description carries. See [`FLANK_LEN`].
+    assert_eq!(
+        (CODON_GENOMIC_START - 1) / 3,
+        (CODON_GENOMIC_START + 1) / 3,
+        "the genomic endpoints must share a codon under `same_codon`'s arithmetic too"
+    );
+
+    // And the bases really are `CGC`, so replacing them with `TGG` leaves the
+    // middle one unchanged — the shape whose split-vs-merge answer depends on
+    // whether a reading frame is in scope.
+    let genome = genomic_sequence();
+    let start = (CODON_GENOMIC_START - 1) as usize;
+    assert_eq!(&genome[start..start + 3], "CGC");
+
+    // The provider without annotation must genuinely lack it, or the A/B is
+    // between two identical inputs.
+    assert!(
+        without_annotation(CHROMOSOME)
+            .get_transcript(TRANSCRIPT)
+            .is_err(),
+        "the unannotated provider must not resolve the transcript"
+    );
+}
+
+/// The invariant, on `g.`.
+#[test]
+fn a_genomic_description_normalizes_the_same_with_and_without_transcript_annotation() {
+    for input in [
+        &format!(
+            "{CHROMOSOME}:g.{CODON_GENOMIC_START}_{}delinsTGG",
+            CODON_GENOMIC_START + 2
+        ),
+        // The split spelling of the same variant, so the invariant is checked in
+        // both directions rather than only on the input that happens to move.
+        &format!(
+            "{CHROMOSOME}:g.[{CODON_GENOMIC_START}C>T;{}C>G]",
+            CODON_GENOMIC_START + 2
+        ),
+        // A `g.` carrying a gene selector — the genomic shape that most plausibly
+        // hands the normalizer a route to the annotation.
+        &format!(
+            "{CHROMOSOME}(SYNTH):g.{CODON_GENOMIC_START}_{}delinsTGG",
+            CODON_GENOMIC_START + 2
+        ),
+    ] {
+        let bare = normalize(without_annotation(CHROMOSOME), input);
+        let annotated = normalize(with_annotation(CHROMOSOME), input);
+        assert_eq!(
+            bare, annotated,
+            "`{input}` normalized differently once the covering transcript and its CDS \
+             became resolvable — a genomic description must be derivable from its own reference"
+        );
+    }
+}
+
+/// The same, on `m.`. The mitochondrial axis is the other frame-free DNA axis
+/// `axis_frame` answers without a provider, and nothing else in this module
+/// reaches it.
+#[test]
+fn a_mitochondrial_description_normalizes_the_same_with_and_without_transcript_annotation() {
+    let input = format!(
+        "{MITOCHONDRION}:m.{CODON_GENOMIC_START}_{}delinsTGG",
+        CODON_GENOMIC_START + 2
+    );
+    assert_eq!(
+        normalize(without_annotation(MITOCHONDRION), &input),
+        normalize(with_annotation(MITOCHONDRION), &input),
+        "`{input}` normalized differently once transcript annotation became resolvable"
+    );
+}
+
+/// The genomic answer is the *split* form, which is what makes the equality
+/// above worth asserting: a leaked reading frame would have merged it, so the
+/// two providers would have disagreed.
+///
+/// It is also the only assertion in this module that survives a leak which
+/// never consults the provider — such a leak moves both arms of the A/B
+/// identically and every equality above stays green. See the module doc; do not
+/// delete this as a redundant value pin.
+#[test]
+fn the_genomic_case_is_one_a_leaked_reading_frame_would_have_changed() {
+    let input = format!(
+        "{CHROMOSOME}:g.{CODON_GENOMIC_START}_{}delinsTGG",
+        CODON_GENOMIC_START + 2
+    );
+    let expected = format!(
+        "{CHROMOSOME}:g.[{CODON_GENOMIC_START}C>T;{}C>G]",
+        CODON_GENOMIC_START + 2
+    );
+    assert_eq!(
+        normalize(with_annotation(CHROMOSOME), &input).expect("normalizes"),
+        expected,
+        "the frame-free split is the whole point of the case; if this becomes the merged \
+         delins, the equality assertions above stop distinguishing anything"
+    );
+}
+
+/// **Negative control.** The same provider pair, on the axis where dependence on
+/// the CDS is legitimate, must produce *different* answers — otherwise "the
+/// outputs are identical" above is indistinguishable from a harness that cannot
+/// see the provider difference at all.
+///
+/// Both sides return `Ok`, and both return a normalized description: with the
+/// CDS, `general.md:35`'s one-amino-acid exception merges the two substitutions
+/// into one `delins`; without it, there is no frame and `general.md:34` keeps
+/// them apart. So what the control demonstrates is that a difference in
+/// resolvable annotation reaches the *output* — not merely that one provider
+/// errors where the other does not, which would say nothing about whether the
+/// normalizer consults annotation at all.
+#[test]
+fn the_control_shows_the_harness_detects_annotation_dependence_on_the_coding_axis() {
+    let input = "NM_TEST.1:c.[10C>T;12C>G]";
+    let bare = normalize(without_annotation(CHROMOSOME), input);
+    let annotated = normalize(with_annotation(CHROMOSOME), input);
+
+    assert_ne!(
+        bare, annotated,
+        "the control did not fire: the coding axis answered identically with and without \
+         the CDS, so this harness cannot detect annotation-dependence and the genomic \
+         equality assertions prove nothing"
+    );
+    assert_eq!(
+        bare.as_deref(),
+        Ok("NM_TEST.1:c.[10C>T;12C>G]"),
+        "with no reading frame in scope the two substitutions stay separate"
+    );
+    assert_eq!(
+        annotated.as_deref(),
+        Ok("NM_TEST.1:c.10_12delinsTGG"),
+        "with the CDS resolvable the codon exception merges them"
+    );
+}


### PR DESCRIPTION
Two properties of normalization that were true by construction and untested. Neither changes behaviour; both are guards.

### Invariant A — normalization preserves the coordinate axis

A `g.` in gives a `g.` out, `c.`→`c.`, and so on. Structural evidence it already held: a search for the projector anywhere under `src/normalize/` returns nothing — the dependency is one-way, projector → normalizer.

Measured over the real corpora, with denominators, because a census that compared nothing looks identical to a clean one:

| corpus | rows offered | compared | axis preserved | #487 `g.`→`m.` | violations |
|---|---:|---:|---:|---:|---:|
| ClinVar 500k | 500,004 | 499,998 | 499,996 | 2 | **0** |
| ClinVar unique | 4,188,436 | 4,188,169 | 4,188,053 | 116 | **0** |
| CMRG | 4,826,063 | 4,826,001 | 4,826,001 | 0 | **0** |
| Paraphase | 435,235 | 435,219 | 435,219 | 0 | **0** |

**~9.95 million rows compared, zero violations.** An earlier attempt at this measurement reported `compared: 0` from a mis-guessed JSON field name — the denominator is what caught it, which is why every test here prints one and asserts it non-zero before believing a zero.

**The one sanctioned rewrite.** A `g.` description on a mitochondrial reference (`NC_012920` / `NC_001807`) is re-labelled `m.` (#487, `Normalizer::normalize_dispatch`). The reference molecule is unchanged — only the coordinate-system letter HGVS requires for it is corrected — so it is a label repair, not a change of axis. It is admitted as an enumerated exception and **each occurrence is re-checked against `Accession::is_mitochondrial`**, so the carve-out cannot launder a `g.`→`m.` rewrite on any other accession.

**The near-miss the test is built around.** Legacy-selector resolution rewrites `NG_012337.1(NM_003002.2):c.274G>T` to `NM_003002.2:c.274G>T` — the *accession* changes, the axis letter does not. The comparison is therefore on `CoordinateAxis` alone and never on the description's prefix, pinned by `the_check_reads_the_axis_letter_not_the_prefix`.

Corpora are git-lfs fixtures that skip green when absent, so the tests follow the existing skip idiom and report an absent corpus as a skip, never as a pass.

### Invariant B — an axis with no reading frame ignores transcript annotation

The stronger property, and the one that matters. Axis preservation alone would still permit a normalizer to consult a transcript for a `g.` input — same axis in, same axis out, frame-derived rule fired anyway.

So this is behavioural: normalize the same input twice, once against a provider that resolves the covering transcript and its CDS and once against one that cannot, and assert the outputs are identical. A genomic string must be derivable from its own reference; if the answer moves when annotation appears, it is importing information the reference does not carry.

**The negative control is load-bearing and it fires.** On the coding axis — where dependence is legitimate — the same provider pair produces *different* strings, and the difference is a merge that actually fired rather than a provider error. Without that, an "identical" result would be indistinguishable from a harness that cannot see anything. Two further guards keep the fixture honest: `the_fixture_puts_the_edited_bases_on_a_codon_of_the_annotated_transcript` asserts the premise, and `the_genomic_case_is_one_a_leaked_reading_frame_would_have_changed` proves the chosen case is one where a leak would have shown.

Covers `g.` and `m.`

### What is deliberately not asserted

**Nothing about the `n.` axis.** Whether `n.` on a coding transcript should carry the frame is open: normalizing `LRG_199t1:n.389_391delinsTGG` directly splits it, while a projection of the equivalent `c.` renders it merged, because that axis is derived by CDS-offset arithmetic rather than normalized on its own reference. Pinning either side would pre-empt a ruling, so the module doc says the omission is deliberate.

### Verification

Rebased onto `origin/main` at `6f22cde9`. Every figure in the table above was re-measured on that base and is unchanged; the `r.`/`o.` breadth figures quoted in the module docs were **not**, and have been corrected to the measured values (`r.` is 130 against 7 across the four bulk corpora — roughly 19x, not the two orders of magnitude previously claimed; `o.` is 1 against 0).

```
cargo nextest run --features dev --lib --test it -E 'test(normalize_axis_preserving) + test(normalize_frame_free_axis_independence)'
Summary [14.543s] 12 tests run: 12 passed, 10312 skipped

# full gate, mirroring CI's `test` job selection
cargo nextest run --features dev --lib --test it --test-threads=4 \
  -E 'not test(proptest) and not (<SWEEP_FILTER>)'
Summary [272.081s] 10105 tests run: 10105 passed, 214 skipped

cargo fmt --all                                  0
cargo clippy --all-features --all-targets -D warnings   0
```

These modules also land in `test-oracle`, which arms `FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS` over what is now the suite's first full-corpus normalization (~9.95M rows; the sibling ClinVar/CMRG/Paraphase suites only parse). Measured armed: 12 passed, no oracle fires, ~2x runtime, longest test 35.8s locally.

### What the guards were measured to catch

Each assertion was mutation-tested rather than assumed:

- Dropping the `is_mitochondrial()` guard in `normalize_dispatch` so every `g.` is relabelled `m.` turns **all five** corpus censuses red.
- Weakening the carve-out to match on the axis letters alone turns `the_mitochondrial_carve_out_admits_only_mitochondrial_accessions` red.
- `the_check_reads_the_axis_letter_not_the_prefix` **survived** a mutation that made the census compare accessions as well as axes — the check its own name forbids — because it re-derived the comparison instead of calling it. It now asserts on `classify`, the census's own decision, and that mutation turns it red.
- A reading-frame leak on **both** genomic seams moves the answer only when it is provider-mediated; a leak that hard-codes a frame changes both arms of the A/B identically and is caught only by the exact-string pin. Either seam alone moves nothing. The module doc previously claimed all three behavioural assertions fail; measured, that is not so, and it has been corrected to what was observed.

Neither invariant flags behaviour the ruling ledger has decided: `projection-codon-exception-is-decided-by-the-rendered-axis` governs the projector, which invariant A never invokes and whose split-on-`g.` outcome invariant B agrees with; `delins-payload-coincidence-carve-out-is-coding-dna-scoped` scopes `:47` to `c.`, which is the axis the negative control merges on.

Representation-Change: none

