### PR TITLE
test(ci): make the local seam-oracle run reproduce CI's selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,21 +63,48 @@ env:
   # in the plain `test` job; this is not a coverage exemption, it is a statement
   # about which instrument may be armed while another is measuring.
   #
-  # WHY: the corpus COUNTS non-idempotent outputs (7 at 3', 4 at 5' as pinned in
-  # `spec_conformance_axis.rs`) as a burn-down figure. `FERRO_ASSERT_IDEMPOTENT` PANICS
+  # WHY, REASON 1: the corpus COUNTS non-idempotent outputs (4 at 3', 4 at 5' as
+  # pinned in `spec_conformance_axis.rs`) as a burn-down figure.
+  # `FERRO_ASSERT_IDEMPOTENT` PANICS
   # on exactly that condition. The two agree perfectly about ferro — the oracle
   # fires on precisely the rows the corpus classifies — but a panic returns no
   # value, so the harness's `catch_unwind` files the row under `declined` and its
   # output never reaches the family's output set.
   #
   # That does not merely re-bucket a counter, it DESTROYS EVIDENCE, and in the
-  # flattering direction. Measured directly on `main` @ 35de96c8, where the
-  # figures were 7 at 3' and 4 at 5': in all 11 cases the non-idempotent output
-  # is the one that disagreed with its siblings, so removing it makes the family
-  # look unanimous. Confluence read 9147 converged / 2428 split-2 under the
-  # oracle against a true 9140 / 2435 — CI would have reported seven more
-  # converged families than actually converge. Those are still the pinned
-  # figures, re-measured unchanged on `main` @ 5b54b2b6.
+  # flattering direction: the non-idempotent output is the one that disagreed
+  # with its siblings, so removing it makes the family look unanimous.
+  #
+  # RE-MEASURED on `main` @ 1dd8148d, armed against the committed pins, both
+  # directions. The previous figures here were taken at `main` @ 35de96c8 and
+  # were stale in three places — #1599 re-blessed 3' `non_idempotent_outputs`
+  # 7 -> 4 and #1536 re-blessed `converged`/`split_two`, both recorded in
+  # `spec_conformance_axis.rs`'s own doc, so "still the pinned figures" had
+  # stopped being true:
+  #
+  #   3': declined 0 -> 4, non_idempotent_outputs 4 -> 0,
+  #       converged 9141 -> 9145, split_two 2440 -> 2436
+  #   5': declined 0 -> 4, non_idempotent_outputs 4 -> 0,
+  #       converged 8944 -> 8948, split_two 2706 -> 2702
+  #
+  # So CI would report FOUR more converged families than converge, in each
+  # direction — not the seven this comment used to claim, which was the figure
+  # before #1599 lowered the count it is derived from.
+  #
+  # WHY, REASON 2 — simpler, and not covered by the paragraphs above. Five tests
+  # in these modules do not merely count the defect, they ASSERT it: the four in
+  # `defect_non_idempotent_outputs` and
+  # `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`
+  # pin `c.*1delinsCTT` -> `c.72_*1insCT` -> `c.72delinsCCT` as a known
+  # non-fixed point. A test that pins a defect and an oracle that aborts on it
+  # cannot both run, whatever the census does. Together the two reasons account
+  # for all 7 tests a bare armed run fails, and `FERRO_ASSERT_IDEMPOTENT` alone
+  # accounts for all 7 — `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS`
+  # each contribute 0, and a prepared reference changes nothing (these modules
+  # are `MockProvider`-backed).
+  #
+  # Locally, `scripts/run_oracle_suite.sh` applies this same exclusion, reading
+  # it from here rather than copying it.
   #
   # The corpus loses nothing by running un-armed: it measures idempotency itself,
   # and more precisely than the oracle does (a count and a classification, versus

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -47,6 +47,19 @@ jobs:
     name: Reference-aware mutalyzer / biocommons tests
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      # The three reference-aware modules this job exists to run, defined ONCE
+      # because two steps need them: the run itself, and the reproduction recipe
+      # the summary step prints when that run fails. A second copy would drift —
+      # and it would drift in the direction that matters least visibly, since a
+      # stale recipe still looks like a working command to whoever pastes it.
+      #
+      # This is the same rule `scripts/run_oracle_suite.sh` applies to
+      # `test-oracle`'s selection: read it from one place, never copy it.
+      REFERENCE_AWARE_SELECTION: >-
+        test(/mutalyzer_normalize_tests::/) |
+        test(/biocommons_normalize_tests::/) |
+        test(/hgvs_rs_projection_tests::/)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -141,6 +154,7 @@ jobs:
           echo "manifest size: $(stat -c%s benchmark-output/manifest.json) bytes"
 
       - name: Run reference-aware tests
+        id: reference-aware-tests
         # Failures are NOT propagated to the workflow conclusion — the
         # purpose of the nightly is to surface drift in the xfail report,
         # not to gate PRs. (PR CI's strict-mode test job already covers
@@ -184,8 +198,58 @@ jobs:
           # soft-masked bases. Non-gating here like the other three.
           FERRO_ASSERT_SEQUENCE: "1"
         run: |
-          cargo nextest run --features dev \
-            -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/) | test(/hgvs_rs_projection_tests::/)'
+          cargo nextest run --features dev -E "$REFERENCE_AWARE_SELECTION"
+
+      # The reproduction recipe for the failure this job actually produces.
+      #
+      # It lives HERE, and not in `report-failure`'s `hint:` below, because
+      # `report-failure` is `if: failure()` and the step above is
+      # `continue-on-error: true` — so the job concludes `success` whenever the
+      # ONLY thing that failed is the test run, and that hint is never rendered
+      # for a fired oracle or a moved baseline. Every failure that does reach
+      # `report-failure` is an infrastructure one (checkout, `ferro prepare`, a
+      # missing manifest), for which an armed re-run is the wrong advice.
+      #
+      # Keyed on `outcome`, not `conclusion`: `continue-on-error` rewrites the
+      # latter to `success` while the former stays `failure`, which is exactly
+      # the distinction the step above documents.
+      #
+      # Non-gating like the run itself — it only writes to the job summary, so
+      # it cannot turn the nightly red.
+      - name: Explain how to reproduce a failed run
+        if: always() && steps.reference-aware-tests.outcome == 'failure'
+        env:
+          # Through `env:` rather than interpolated into `run:` — a `${{ }}`
+          # expansion is spliced in as text before the shell parses the script,
+          # which is the template-injection shape `zizmor` flags. Harmless for a
+          # run id, but the habit is what the rule is protecting.
+          XFAIL_ARTIFACT: ferro-xfail-${{ github.run_id }}
+        run: |
+          {
+            echo "## Reference-aware tests failed"
+            echo
+            echo "These axes only run with a prepared reference (\`FERRO_MANIFEST\`), so they"
+            echo "cannot run on a pull request. Reproduce on a box with the reference, with the"
+            echo "same four oracles armed and over the same three modules:"
+            echo
+            echo '```'
+            echo "FERRO_MANIFEST=<ref>/manifest.json \\"
+            echo "  FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 \\"
+            echo "  FERRO_ASSERT_IN_BOUNDS=1 FERRO_ASSERT_SEQUENCE=1 \\"
+            echo "  cargo nextest run --features dev -E '${REFERENCE_AWARE_SELECTION}'"
+            echo '```'
+            echo
+            echo "Keep the \`-E\` selection. Dropping it while keeping the flags widens the run"
+            echo "onto the modules \`ci.yml\`'s \`ORACLE_EXCLUDE\` withholds from an armed job,"
+            echo "which fail on \`main\` for reasons no nightly caused — see that variable's"
+            echo "comment, and \`scripts/run_oracle_suite.sh\` for the local runner that applies"
+            echo "the same exclusion."
+            echo
+            echo "A moved conformance baseline is re-blessable; a new live divergence is not."
+            echo "Read which it is out of the \`${XFAIL_ARTIFACT}\` artifact"
+            echo "attached to this run — an oracle fire lands there as a FAILing case rather"
+            echo "than as a failed workflow."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload xfail reports
         if: always()
@@ -207,8 +271,6 @@ jobs:
       summary: >-
         The nightly manifest-backed conformance run failed.
       hint: |
-          These axes only run with a prepared reference (`FERRO_MANIFEST`), so they cannot run on a pull request. Reproduce on a box with the reference:
-          ```
-          FERRO_MANIFEST=<ref>/manifest.json cargo nextest run --features dev
-          ```
-          A moved conformance baseline is re-blessable; a new live divergence is not.
+          **This is an infrastructure failure, not a conformance one.** The test step carries `continue-on-error: true`, so a fired oracle or a moved baseline leaves this job concluding `success` and never opens an issue — it lands in the run's `ferro-xfail-*` artifact instead, and the run's job summary carries the armed reproduction command. Reaching this issue therefore means something before or around the tests broke: the checkout, the `ferro` build, `ferro prepare`, a manifest that never appeared, or the artifact upload.
+          Start from the failing step's own log rather than from a re-run of the axes. These axes only run with a prepared reference (`FERRO_MANIFEST`), so they cannot run on a pull request, and re-running them proves nothing about a step that failed before they started.
+          `ferro prepare` runs on every night's run — the prepared reference is deliberately not cached (see the comment above that step) — so it fetches from NCBI and Ensembl each time, and an upstream fetch is the most likely thing to have broken.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,15 +141,73 @@ full suite) before pushing.
   139 k-line crate. A split would add a second full link for every change to
   `tests/it/common/`.
 
+#### Running the oracles locally — a bare armed run CANNOT pass
+
+Read this before running any of the four flags below over the whole suite. The
+obvious command is documented nowhere else in this file any more, because it is
+a trap:
+
+```bash
+FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev   # ALWAYS RED on main
+```
+
+It fails **7** tests on a clean `origin/main`, and has for as long as the spec
+corpus has existed. Use the local runner instead, which mirrors `ci.yml`'s
+`test-oracle` job — its flags, and its selection:
+
+```bash
+scripts/run_oracle_suite.sh                     # as test-oracle runs it
+scripts/run_oracle_suite.sh --print-selection   # what it would run, without running it
+scripts/run_oracle_suite.sh -E 'test(my_test)'  # extra args reach nextest
+```
+
+**Why the bare form is red, and why that is not a coverage gap to close.** All 7
+failures come from `FERRO_ASSERT_IDEMPOTENT` alone — measured: `FERRO_ASSERT_REPARSE`
+and `FERRO_ASSERT_IN_BOUNDS` each contribute **0**, and a prepared reference
+changes nothing (the same 7 fail with and without `FERRO_MANIFEST`; every one of
+these modules is `MockProvider`-backed). All 7 live in modules `ORACLE_EXCLUDE`
+already names, for two reasons that are worth keeping apart:
+
+- **5 of them ASSERT the defect the oracle PANICS on.** The four
+  `defect_non_idempotent_outputs` tests and
+  `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`
+  pin `c.*1delinsCTT` → `c.72_*1insCT` → `c.72delinsCCT` as a known non-fixed
+  point. A test that pins a defect and an oracle that aborts on it cannot both
+  run; there is no version of this the flag could pass.
+- **2 of them COUNT it**, and arming the oracle makes the count read *better*
+  than the truth. `spec_conformance_axis`'s censuses wrap normalization in
+  `catch_unwind`, so a panicking row is filed `declined` and never reaches its
+  family's output set. See `ORACLE_EXCLUDE`'s comment in `ci.yml` for the
+  measured figures.
+
+So the answer is not "run it in CI anyway" — that is the one thing that would
+destroy the evidence. The answer is that CI already excludes it, and the local
+path now excludes it the same way, from the same source of truth.
+
+**The runner reads the whole `-E` selection and the flag set out of `ci.yml`**,
+so neither can drift into a second copy. "Whole" is load-bearing: `test-oracle`
+negates `test(proptest)` and `SWEEP_FILTER` as well as `ORACLE_EXCLUDE`, and a
+runner that negated only the last of them would run the proptest modules and the
+three exhaustive sweeps while reporting itself as mirroring that job. So the
+shape of the expression is read too, and only its variable references are
+expanded — rebuilding it here from a hardcoded `not test(proptest) and not (…)`
+would trade today's drift for tomorrow's.
+
+`tests/it/oracle_exclude_invariant.rs` re-derives all of it in Rust — different
+anchors, deliberately — and compares; separately asserts that the agreed
+selection actually negates all three (a spelling-independent check, since both
+sides otherwise read the same line of `ci.yml` and a matching pair of wrong ones
+would satisfy the equality); and separately forbids the script from hardcoding a
+module name. Each of those guards is checked against a deliberate sabotage
+rather than assumed.
+
 #### Normalization idempotency oracle
 
 `FERRO_ASSERT_IDEMPOTENT=1` turns every `Normalizer::normalize` call into an
 assertion that `norm(norm(x)) == norm(x)`, so any test that normalizes becomes an
-idempotency check:
-
-```bash
-FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
-```
+idempotency check. Run it through `scripts/run_oracle_suite.sh` — see
+[Running the oracles locally](#running-the-oracles-locally--a-bare-armed-run-cannot-pass)
+for why the bare full-suite form cannot pass.
 
 It is compiled out in release builds (`#[cfg(debug_assertions)]`) and read once
 into a `OnceLock`, so a disabled run pays only one atomic load. CI runs the suite
@@ -199,9 +257,10 @@ Like the idempotency oracle it is compiled out in release builds
 (`#[cfg(debug_assertions)]`) and read once into a `OnceLock`, so it adds no
 release-build cost and a disabled debug run pays only one atomic load.
 
-```bash
-FERRO_ASSERT_REPARSE=1 cargo nextest run --features dev
-```
+`scripts/run_oracle_suite.sh` arms it, alongside the two flags beside it — the
+bare full-suite form is red for a reason this oracle has no part in, so it tells
+you nothing about re-parsing. Measured: `FERRO_ASSERT_REPARSE` on its own fails
+**0** tests over `ORACLE_EXCLUDE`'s modules.
 
 Kept separate from `FERRO_ASSERT_IDEMPOTENT` because neither subsumes the other,
 and the idempotency oracle has a blind spot this one covers: it verifies by
@@ -217,9 +276,10 @@ the exception and is not set everywhere they are — see
 `FERRO_ASSERT_IN_BOUNDS=1` is the third at the same seam: no coordinate a
 normalized description names may be past the end of its own sequence.
 
-```bash
-FERRO_ASSERT_IN_BOUNDS=1 cargo nextest run --features dev
-```
+`scripts/run_oracle_suite.sh` arms it too. As with the re-parse oracle,
+`FERRO_ASSERT_IN_BOUNDS` on its own fails **0** tests over `ORACLE_EXCLUDE`'s
+modules — the 7 failures a bare armed run shows are the idempotency oracle's,
+and reading them as this one's would send you after the wrong invariant.
 
 It exists because the class kept being found by hand, one shape at a time —
 **#1274** (`T:g.[8_9insA;10del]` -> `g.10_11=` on a 10-base contig), **#1343**
@@ -271,8 +331,16 @@ asks what the output **means** rather than how it is written: apply the input to
 the reference, apply the output, and assert the bases agree.
 
 ```bash
-FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev
+FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev -E "$SWEEP_SELECTION"
 ```
+
+**`scripts/run_oracle_suite.sh` deliberately does NOT arm this one**, because
+`test-oracle` does not — the runner mirrors that job, and mirroring it faithfully
+means inheriting the gap. The job where this flag is green is `sweeps`, so scope
+a local run to that job's selection rather than to the whole suite. Added to
+`ORACLE_EXCLUDE`'s modules it raises **5** further failures beyond the
+idempotency oracle's 7, all in `spec_corpus_regressions` and all the same shape
+as those: a test pinning the CDS-end defect that this oracle aborts on.
 
 **The other three are all form questions, and a wrong sequence passes all of
 them.** It is a fixed point, so `FERRO_ASSERT_IDEMPOTENT` is satisfied; it
@@ -453,6 +521,14 @@ wraps normalization in `catch_panics`, so an oracle panic there lands in the
 uploaded xfail artifact as a FAILing case instead of failing the workflow. That
 applies equally to all four flags, and it is why a red oracle in the nightly must
 be read out of the xfail report rather than from the workflow conclusion.
+
+**So the nightly's `report-failure` issue is never about an oracle.** `if:
+failure()` cannot fire on a step whose failure `continue-on-error` has already
+absorbed, so every issue that job opens is an infrastructure one — checkout, the
+`ferro` build, `ferro prepare`, a missing manifest, the artifact upload — and its
+`hint:` says so. The armed reproduction command lives where the oracle failure
+actually surfaces instead: an `outcome == 'failure'` step writes it to the run's
+**job summary**, alongside the pointer to the `ferro-xfail-*` artifact.
 
 **An oracle fire DOES block the merge — corrected 2026-08-09.** This section used
 to say the opposite: that the ruleset requires only a subset of the jobs CI runs,

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Runs the seam-oracle suite locally the way `ci.yml`'s `test-oracle` job runs
+# it: the oracle flags that job sets, over that job's selection.
+#
+# WHY THIS EXISTS. The obvious local command --
+#
+#     FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
+#
+# -- CANNOT PASS on `main`, and has not been able to for as long as the spec
+# corpus has existed. It fails 7 tests, and all 7 are in modules `ci.yml` names
+# in `ORACLE_EXCLUDE` precisely so that the armed job never runs them:
+#
+#   * defect_non_idempotent_outputs (4 tests) and
+#     spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point
+#     ASSERT the non-idempotency the oracle PANICS on. `c.*1delinsCTT` ->
+#     `c.72_*1insCT` -> `c.72delinsCCT` is a pinned defect; a test that pins it
+#     and an oracle that aborts on it cannot both run.
+#   * spec_conformance_axis's two censuses COUNT it. The corpus wraps
+#     normalization in `catch_unwind`, so a panicking row is filed `declined`
+#     and its output never reaches the family's output set -- which does not
+#     redden the census, it FLATTERS it. Measured on `main` @ 1dd8148d, both
+#     directions, armed against the committed pins:
+#
+#       3': declined 0 -> 4, non_idempotent_outputs 4 -> 0,
+#           converged 9141 -> 9145, split_two 2440 -> 2436
+#       5': declined 0 -> 4, non_idempotent_outputs 4 -> 0,
+#           converged 8944 -> 8948, split_two 2706 -> 2702
+#
+#     Four families read as converged in each direction that do not converge.
+#
+# So a bare armed run is not a coverage gap to be closed by running it anyway;
+# it is a measurement taken with two instruments that destroy each other. This
+# script applies the same exclusion CI does, so a local armed run is a signal
+# rather than a known-red wall.
+#
+# THE SELECTION AND THE FLAGS ARE READ FROM `ci.yml`, NEVER COPIED. That means
+# the WHOLE `-E` expression, not just `ORACLE_EXCLUDE`: `test-oracle` also
+# negates `test(proptest)` and `SWEEP_FILTER`, so a run that dropped either
+# would execute tests that job does not while claiming to mirror it. A second
+# copy of any of it would drift, and a drifted exclusion here fails in the
+# flattering direction -- it would exclude a module CI runs, so a local run
+# would go green on a defect CI is red on.
+# `tests/it/oracle_exclude_invariant.rs` invokes `--print-selection` below and
+# compares this extraction against one derived independently in Rust, so a
+# `ci.yml` restructure that breaks the awk fails loudly instead of yielding an
+# empty filter.
+#
+# Usage:
+#   scripts/run_oracle_suite.sh                    # run it
+#   scripts/run_oracle_suite.sh --print-selection  # print what it would run, and stop
+#   scripts/run_oracle_suite.sh -E 'test(foo)'     # extra args go through to nextest
+#
+# The denoted-sequence oracle (`FERRO_ASSERT_SEQUENCE`) is deliberately NOT
+# among the flags this mirrors, because `test-oracle` does not set it -- see
+# that job's comment for the two rows (#1618, #1619) that keep it out. Setting
+# it on this selection adds 5 further failures on `main`, all in
+# `spec_corpus_regressions` and all the same shape: a test pinning a defect the
+# oracle aborts on.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+
+if [[ ! -f "$CI_YML" ]]; then
+    echo "error: cannot find .github/workflows/ci.yml at '$CI_YML'" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+# A `KEY: >-` folded scalar from `ci.yml`'s top-level `env:`, folded back onto
+# one line.
+#
+# Reading only the first line would silently exempt whichever module happens to
+# sit on a continuation line, which is the same blind spot
+# `oracle_exclude_invariant.rs` exists to close -- and for `ORACLE_EXCLUDE` it
+# fails flatteringly, since an unexcluded module there is one this script would
+# run armed.
+#
+# Parameterised by key rather than written twice: `test-oracle`'s selection
+# negates `SWEEP_FILTER` as well as `ORACLE_EXCLUDE`, and two copies of one
+# folding rule is the drift this script exists to avoid.
+#
+# `$1` is interpolated into an awk regex, so it must be a bare YAML key with no
+# regex metacharacters. Both callers pass a literal; a key containing `.` or `[`
+# would need escaping first.
+folded_scalar() {
+    awk -v key="$1" '
+        $0 ~ "^[[:space:]]*" key ":[[:space:]]*[>|]" { found = 1; next }
+        found {
+            if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) { exit }
+            # A line at or left of the key indent ends the block scalar.
+            if ($0 !~ /^[[:space:]][[:space:]][[:space:]]/) { exit }
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            printf "%s%s", (n++ ? " " : ""), $0
+        }
+    ' "$CI_YML"
+}
+
+# The `-E` expression `test-oracle`'s own step hands to nextest, verbatim and
+# still holding its `$SWEEP_FILTER` / `$ORACLE_EXCLUDE` references.
+#
+# Read whole rather than reassembled from its parts. An earlier revision of this
+# script negated only `ORACLE_EXCLUDE`, so a local run also executed the proptest
+# modules and the three exhaustive sweeps -- tests `test-oracle` does not run --
+# while claiming to mirror that job. Rebuilding the expression here from a
+# hardcoded `not test(proptest) and not (...) and not (...)` would fix today's
+# drift by introducing tomorrow's: the shape of CI's filter would then live in
+# two files. So the shape is read too, and only the variable references are
+# expanded.
+oracle_selection_template() {
+    awk '
+        /^  test-oracle:/ { in_job = 1; next }
+        # A non-indented, non-comment line at job-key indent ends the job.
+        in_job && /^  [^ #]/ { exit }
+        in_job {
+            if (match($0, /-E "[^"]*"/)) {
+                print substr($0, RSTART + 4, RLENGTH - 5)
+                exit
+            }
+        }
+    ' "$CI_YML"
+}
+
+# The `FERRO_ASSERT_*` keys the `test-oracle` job's own step sets, in file
+# order.
+#
+# Scoped to the window between that step's `name:` and its `run:`, because the
+# comment block inside that window MENTIONS `FERRO_ASSERT_SEQUENCE` in prose to
+# explain why it is absent. Comment lines are skipped, so the prose mention is
+# not mistaken for a setting -- if it were, this script would arm an oracle CI
+# does not and go red on the two rows that comment is about.
+oracle_flags() {
+    awk '
+        /^[[:space:]]*-[[:space:]]*name:[[:space:]]*Run Rust tests with the normalization self-checks/ {
+            found = 1; next
+        }
+        found && /^[[:space:]]*run:/ { exit }
+        found && /^[[:space:]]*#/ { next }
+        found && /^[[:space:]]*FERRO_ASSERT_[A-Z_]+:/ {
+            sub(/:.*/, "")
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            print
+        }
+    ' "$CI_YML"
+}
+
+EXCLUDE="$(folded_scalar ORACLE_EXCLUDE)"
+SWEEPS="$(folded_scalar SWEEP_FILTER)"
+TEMPLATE="$(oracle_selection_template)"
+# A read loop rather than `mapfile`, which is bash 4+: stock macOS still ships
+# bash 3.2 as /bin/bash, and a script that dies on `mapfile: command not found`
+# would send the reader looking at their shell instead of at the oracle.
+FLAGS=()
+while IFS= read -r flag; do
+    [[ -n "$flag" ]] && FLAGS+=("$flag")
+done < <(oracle_flags)
+
+# Refuse a vacuous extraction rather than running something weaker than CI.
+# An empty exclusion would run the 7 known-red tests; an empty flag list would
+# run the whole suite with no oracle armed at all and report it as an oracle
+# pass, which is the worse of the two.
+if [[ -z "$EXCLUDE" ]]; then
+    echo "error: could not read ORACLE_EXCLUDE from $CI_YML." >&2
+    echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
+    exit 1
+fi
+if [[ "${#FLAGS[@]}" -eq 0 ]]; then
+    echo "error: could not read any FERRO_ASSERT_* flag from test-oracle's step in $CI_YML." >&2
+    echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
+    exit 1
+fi
+if [[ -z "$SWEEPS" ]]; then
+    echo "error: could not read SWEEP_FILTER from $CI_YML." >&2
+    echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
+    exit 1
+fi
+if [[ -z "$TEMPLATE" ]]; then
+    echo "error: could not read test-oracle's -E selection from $CI_YML." >&2
+    echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
+    exit 1
+fi
+
+# Expand the two references CI's expression carries. Substitution rather than
+# `eval`, so nothing in `ci.yml` can execute here.
+SELECTION="${TEMPLATE//\$SWEEP_FILTER/$SWEEPS}"
+SELECTION="${SELECTION//\$ORACLE_EXCLUDE/$EXCLUDE}"
+
+# Refuse a selection still naming a variable. A new `$FOO` in that expression
+# would otherwise reach nextest literally -- which either errors obscurely or,
+# worse, parses as a test-name substring and quietly narrows the run.
+if [[ "$SELECTION" == *'$'* ]]; then
+    echo "error: test-oracle's -E selection references a variable this script does not expand:" >&2
+    echo "  $SELECTION" >&2
+    echo "  Teach this script to read it from $CI_YML rather than inlining its value." >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--print-selection" ]]; then
+    printf 'ORACLE_EXCLUDE=%s\n' "$EXCLUDE"
+    printf 'SWEEP_FILTER=%s\n' "$SWEEPS"
+    printf 'SELECTION=%s\n' "$SELECTION"
+    for flag in "${FLAGS[@]}"; do printf 'FLAG=%s\n' "$flag"; done
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+for flag in "${FLAGS[@]}"; do export "$flag=1"; done
+
+echo "Running the seam-oracle suite with: ${FLAGS[*]}"
+echo "Selecting (as ci.yml's test-oracle job does): $SELECTION"
+
+OUTPUT="$(mktemp)"
+trap 'rm -f "$OUTPUT"' EXIT
+
+set +e
+cargo nextest run --features dev -E "$SELECTION" "$@" 2>&1 | tee "$OUTPUT"
+STATUS="${PIPESTATUS[0]}"
+set -e
+
+# nextest writes "1 test run" (singular) and "N tests run" (plural), so the
+# optional `s` is load-bearing -- without it a legitimate single-test run parses
+# as no run at all. Same rule as `run_conformance_axis.sh`.
+RAN="$(grep -Eo '[0-9]+ tests? run' "$OUTPUT" | tail -1 | grep -Eo '^[0-9]+' || true)"
+
+if [[ "$STATUS" -ne 0 ]]; then
+    echo "error: the seam-oracle suite FAILED (nextest exit ${STATUS})." >&2
+    exit "$STATUS"
+fi
+
+# A green run over zero tests is the failure this repo keeps meeting, so the
+# denominator is asserted rather than assumed.
+if [[ -z "$RAN" || "$RAN" -eq 0 ]]; then
+    echo "error: no tests ran -- this would be a vacuous oracle run." >&2
+    exit 1
+fi
+
+echo "Seam-oracle suite: ${RAN} test(s) ran armed with ${FLAGS[*]}."

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -290,6 +290,293 @@ fn no_shared_helper_hides_a_corpus_consumer_from_the_scan() {
     );
 }
 
+/// The local oracle runner, which mirrors `test-oracle` outside CI.
+const LOCAL_RUNNER: &str = "scripts/run_oracle_suite.sh";
+
+/// The `FERRO_ASSERT_*` keys the `test-oracle` job sets, derived in Rust.
+///
+/// Deliberately anchored **differently** from the awk in [`LOCAL_RUNNER`],
+/// which scopes to the window between that job's step `name:` and its `run:`.
+/// This one bounds the whole `test-oracle:` job by indentation and keys on the
+/// quoted `: "1"` value. A second opinion that shares the other's derivation is
+/// not a second opinion — it is the same reading written twice, and this repo
+/// has already shipped a defect that way (`check_changelog_grouping.py`'s
+/// rationale).
+///
+/// Comment lines are skipped for the reason the awk skips them: the job's
+/// comment block *mentions* `FERRO_ASSERT_SEQUENCE` in prose, to explain why it
+/// is absent. A scan that read the prose as a setting would demand the runner
+/// arm an oracle CI does not — and the two rows that comment names (#1618,
+/// #1619) would then be red locally and green in CI.
+fn test_oracle_job_flags() -> Vec<String> {
+    test_oracle_job_lines()
+        .into_iter()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') {
+                return None;
+            }
+            trimmed
+                .strip_suffix(": \"1\"")
+                .filter(|key| key.starts_with("FERRO_ASSERT_"))
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// The lines of `ci.yml`'s `test-oracle:` job, bounded by indentation.
+fn test_oracle_job_lines() -> Vec<String> {
+    let ci = std::fs::read_to_string(repo_root().join(".github/workflows/ci.yml"))
+        .expect("ci.yml is readable");
+    let mut in_job = false;
+    let mut lines = Vec::new();
+    for line in ci.lines() {
+        if line.starts_with("  test-oracle:") {
+            in_job = true;
+            continue;
+        }
+        if in_job {
+            // A non-blank, non-comment line at job-key indent ends the job.
+            let indent = line.len() - line.trim_start().len();
+            if !line.trim().is_empty() && !line.trim_start().starts_with('#') && indent <= 2 {
+                break;
+            }
+            lines.push(line.to_string());
+        }
+    }
+    lines
+}
+
+/// The complete `-E` expression `test-oracle` hands to nextest, with `ci.yml`'s
+/// two variable references expanded.
+///
+/// The job negates three things — the proptest modules, `SWEEP_FILTER` and
+/// `ORACLE_EXCLUDE` — and the runner first shipped negating only the last of
+/// them, so a local "as CI runs it" also executed the proptest modules and the
+/// three exhaustive sweeps. Comparing only the exclusion could not see that,
+/// which is why the whole expression is compared here.
+fn ci_oracle_selection() -> String {
+    let template = test_oracle_job_lines()
+        .iter()
+        .find_map(|line| {
+            let at = line.find("-E \"")? + "-E \"".len();
+            let rest = &line[at..];
+            rest.find('"').map(|end| rest[..end].to_string())
+        })
+        .expect("ci.yml's test-oracle job passes a -E selection to nextest");
+
+    let expanded = template
+        .replace("$SWEEP_FILTER", ci_filter("SWEEP_FILTER").trim())
+        .replace("$ORACLE_EXCLUDE", ci_filter("ORACLE_EXCLUDE").trim());
+    assert!(
+        !expanded.contains('$'),
+        "test-oracle's -E selection references a variable this test does not expand: {expanded}"
+    );
+    expanded
+}
+
+/// What [`LOCAL_RUNNER`] says it would run.
+struct RunnerSelection {
+    /// The `ORACLE_EXCLUDE` value it extracted from `ci.yml`.
+    exclude: String,
+    /// The complete `-E` expression it would hand to nextest.
+    selection: String,
+    /// The `FERRO_ASSERT_*` flags it would arm.
+    flags: Vec<String>,
+}
+
+/// What [`LOCAL_RUNNER`] says it would run, read from its own `--print-selection`.
+fn local_runner_selection() -> RunnerSelection {
+    let script = repo_root().join(LOCAL_RUNNER);
+    assert!(
+        script.is_file(),
+        "{LOCAL_RUNNER} is missing. It is the only local command that runs the seam \
+         oracles over the same selection CI does; without it the documented bare \
+         `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run` is the only recipe, and that \
+         one cannot pass."
+    );
+    let output = std::process::Command::new("bash")
+        .arg(&script)
+        .arg("--print-selection")
+        .current_dir(repo_root())
+        .output()
+        .expect("bash can run the local oracle runner");
+    assert!(
+        output.status.success(),
+        "{LOCAL_RUNNER} --print-selection failed ({}):\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("the runner prints UTF-8");
+
+    let mut exclude = String::new();
+    let mut selection = String::new();
+    let mut flags = Vec::new();
+    for line in stdout.lines() {
+        if let Some(value) = line.strip_prefix("ORACLE_EXCLUDE=") {
+            exclude = value.trim().to_string();
+        } else if let Some(value) = line.strip_prefix("SELECTION=") {
+            selection = value.trim().to_string();
+        } else if let Some(value) = line.strip_prefix("FLAG=") {
+            flags.push(value.trim().to_string());
+        }
+    }
+    assert!(
+        !selection.is_empty(),
+        "{LOCAL_RUNNER} --print-selection printed no SELECTION= line; \
+         its output shape changed and the comparison below would go vacuous"
+    );
+    RunnerSelection {
+        exclude,
+        selection,
+        flags,
+    }
+}
+
+/// The local runner must exclude exactly what `test-oracle` excludes.
+///
+/// A drift here fails in the **flattering** direction, which is why it is worth
+/// a test rather than a comment: a runner excluding more than CI goes green
+/// locally on a defect CI is red on, and the operator's evidence for "my change
+/// is clean" is then a run that never touched the modules in question.
+#[test]
+fn the_local_oracle_runner_excludes_exactly_what_ci_excludes() {
+    assert_eq!(
+        local_runner_selection().exclude,
+        ci_filter("ORACLE_EXCLUDE").trim(),
+        "{LOCAL_RUNNER} and ci.yml disagree about ORACLE_EXCLUDE. The runner reads it \
+         from ci.yml with awk; if that extraction broke, fix the awk — do not inline a \
+         copy of the list, which is the drift this test exists to catch."
+    );
+}
+
+/// The local runner must run the **whole** selection `test-oracle` runs, not
+/// just its exclusion.
+///
+/// `the_local_oracle_runner_excludes_exactly_what_ci_excludes` compares one of
+/// the expression's three negated terms, so it passed throughout the period the
+/// runner also executed the proptest modules and the three exhaustive sweeps —
+/// tests `test-oracle` does not run. A guard over a subset of the contract reads
+/// as a guard over the contract, which is the failure this file is otherwise
+/// about.
+#[test]
+fn the_local_oracle_runner_selects_exactly_what_ci_selects() {
+    assert_eq!(
+        local_runner_selection().selection,
+        ci_oracle_selection(),
+        "{LOCAL_RUNNER} and ci.yml's test-oracle job disagree about the nextest selection. \
+         The runner reads the whole `-E` expression out of ci.yml and expands its variable \
+         references; if that extraction broke, fix the awk — do not inline a copy of the \
+         expression, which is the drift this test exists to catch."
+    );
+}
+
+/// …and the agreed selection must actually **negate** all three things CI
+/// negates.
+///
+/// The equality test above cannot tell a correct expression from a matching
+/// pair of wrong ones: both sides read the same line of `ci.yml`, so a `-E`
+/// that stopped negating the sweeps would satisfy it. This one keys on the
+/// `not (…)` wrapper instead.
+///
+/// **Asserting that each module is merely NAMED in the selection would be
+/// vacuous**, and that was this test's first form. The selection is built *by
+/// substituting those two filters' values into* the template, so every module
+/// they name is guaranteed to appear as a `test(<module>)` substring however
+/// the template is spelled — including a template that had dropped the `not`.
+/// Dropping it is not hypothetical: `and ($SWEEP_FILTER)` in place of
+/// `and not ($SWEEP_FILTER)` inverts the job from "the suite minus the three
+/// sweeps" to "only the three sweeps", i.e. ~8,900 tests down to ~30, which is
+/// the quiet-narrowing failure the runner's own header warns about.
+#[test]
+fn the_ci_oracle_selection_negates_proptest_the_sweeps_and_the_corpus_modules() {
+    let selection = ci_oracle_selection();
+    assert!(
+        selection.contains("not test(proptest)"),
+        "test-oracle's selection no longer negates the proptest modules, which the `soak` \
+         job owns at 125k cases per shard: {selection}"
+    );
+
+    for key in ["SWEEP_FILTER", "ORACLE_EXCLUDE"] {
+        let value = ci_filter(key);
+        let value = value.trim();
+        assert!(
+            !modules_named_in(value).is_empty(),
+            "ci.yml's {key} names no module; its formatting changed and this guard has \
+             gone vacuous"
+        );
+        assert!(
+            selection.contains(&format!("not ({value})")),
+            "test-oracle's -E selection does not negate {key}, so the armed job RUNS those \
+             modules instead of withholding them. Note a bare `and (${key})` would still \
+             mention every one of them, which is why this asserts the `not (…)` wrapper \
+             rather than the module names.\nSelection is: {selection}"
+        );
+    }
+}
+
+/// …and arm exactly the oracles `test-oracle` arms.
+///
+/// Both directions matter and neither is symmetric with the other. Arming
+/// **fewer** makes a local run weaker than CI while reading as an oracle pass.
+/// Arming **more** — `FERRO_ASSERT_SEQUENCE` is the live candidate, since
+/// `test-oracle` deliberately withholds it — makes the runner red on rows no PR
+/// caused, which teaches the operator to ignore it.
+#[test]
+fn the_local_oracle_runner_arms_exactly_the_flags_test_oracle_arms() {
+    let runner_flags = local_runner_selection().flags;
+    let ci_flags = test_oracle_job_flags();
+    assert!(
+        !ci_flags.is_empty(),
+        "no FERRO_ASSERT_* flag was found in ci.yml's test-oracle job; its formatting \
+         changed and this guard has gone vacuous"
+    );
+    assert_eq!(
+        runner_flags, ci_flags,
+        "{LOCAL_RUNNER} and ci.yml's test-oracle job disagree about which oracles to arm"
+    );
+}
+
+/// The runner may not carry its own copy of the exclusion list.
+///
+/// The equality tests above compare *values*, so they would still pass against a
+/// hardcoded copy that happens to be current today. This one forbids the copy
+/// itself, because the value only has to be right at the moment someone runs the
+/// test — and the failure mode of a stale copy is silent and flattering.
+#[test]
+fn the_local_oracle_runner_does_not_hardcode_the_exclusion() {
+    let text = std::fs::read_to_string(repo_root().join(LOCAL_RUNNER))
+        .expect("the local oracle runner is readable");
+    // Strip comments before scanning: the script's header explains the failure
+    // by NAMING the modules, which is exactly what makes the header useful and
+    // must not be mistaken for a hardcoded filter.
+    let code: String = text
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let named = modules_named_in(&ci_filter("ORACLE_EXCLUDE"));
+    // The same non-vacuity guard its siblings carry: with no module names to
+    // look for, the filter below is trivially empty and this test passes
+    // without having checked anything.
+    assert!(
+        !named.is_empty(),
+        "ORACLE_EXCLUDE names no modules; its formatting changed and this guard has gone \
+         vacuous"
+    );
+    let hardcoded: Vec<String> = named
+        .into_iter()
+        .filter(|module| code.contains(&format!("test({module})")))
+        .collect();
+    assert!(
+        hardcoded.is_empty(),
+        "{LOCAL_RUNNER} hardcodes these modules instead of reading ORACLE_EXCLUDE from \
+         ci.yml: {hardcoded:#?}\n\
+         Two copies of one list drift, and this one drifts flatteringly — a stale copy \
+         excludes a module CI still runs armed."
+    );
+}
+
 /// The two filters must stay disjoint.
 ///
 /// They are negated together in one expression, so an overlap is harmless today


### PR DESCRIPTION
## The documented local oracle command cannot pass

`CLAUDE.md` tells you four times to run an oracle like this:

```bash
FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
```

On a clean `origin/main` @ `1dd8148d` that is **10,174 tests run, 7 failed**. It has been red for as long as the spec corpus has existed, and nothing in the repo said so. An operator following the documentation gets a wall of red that is indistinguishable from a regression their change caused.

This PR does not make those 7 pass. It makes the local path reproduce what CI actually runs, from the same source of truth, and corrects the figures that had gone stale underneath the explanation.

Nothing under `src/` is touched. No output moves.

## The 7 failures are one cause, and the reference has nothing to do with it

Measured over the three modules that hold them (30 tests selected, so the denominator is stated):

| run | environment | result |
|---|---|---|
| A | 3 flags + `FERRO_MANIFEST` | 30 run, **7 failed** |
| B | 3 flags, no manifest | 30 run, **7 failed** — the same 7 |
| C | `FERRO_MANIFEST` only | 30 run, 0 failed |
| D | neither | 30 run, 0 failed |
| E | `FERRO_ASSERT_IDEMPOTENT` only | 30 run, **7 failed** |
| F | `FERRO_ASSERT_REPARSE` only | 30 run, **0 failed** |
| G | `FERRO_ASSERT_IN_BOUNDS` only | 30 run, **0 failed** |
| H | all four + manifest | 30 run, 12 failed |

So: `FERRO_ASSERT_IDEMPOTENT` alone is necessary and sufficient for all 7. The other two contribute nothing. A prepared reference contributes nothing either — every one of these modules is `MockProvider`-backed, and B is byte-for-byte the same failure set as A. Every one of the 7 panics at the same site, `src/normalize/mod.rs:1924`.

They split into two shapes, and `ci.yml`'s comment only stated the second:

- **Five ASSERT the defect the oracle aborts on.** The four `defect_non_idempotent_outputs` tests and `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point` pin `c.*1delinsCTT` → `c.72_*1insCT` → `c.72delinsCCT` as a known non-fixed point. A test that pins a defect and an oracle that aborts on it cannot both run. There is no version of this the flag could pass.
- **Two COUNT it**, and arming the oracle makes the count read *better* than the truth, because `catch_unwind` files a panicking row as `declined` and its output never reaches its family's output set.

## The census figures in `ci.yml` were stale in three places

That comment was measured at `main` @ `35de96c8` and asserted "still the pinned figures, re-measured unchanged on `main` @ `5b54b2b6`". Two re-blessings have landed since — #1599 lowered 3' `non_idempotent_outputs` 7 → 4, #1536 moved `converged`/`split_two` — both recorded in `spec_conformance_axis.rs`'s own doc. Re-measured here at `1dd8148d`, armed against the committed pins:

```
3': declined 0 -> 4, non_idempotent_outputs 4 -> 0, converged 9141 -> 9145, split_two 2440 -> 2436
5': declined 0 -> 4, non_idempotent_outputs 4 -> 0, converged 8944 -> 8948, split_two 2706 -> 2702
```

Four families read as converged in each direction that do not converge — not the seven the comment claimed, which was the figure before #1599 lowered the count it derives from. The mechanism the comment describes is exactly right; only its numbers had drifted.

## What this adds

**`scripts/run_oracle_suite.sh`** — runs the suite the way `test-oracle` runs it. It reads *both* the exclusion and the flag set out of `ci.yml`; neither is copied, because a stale copy here fails in the flattering direction (it would exclude a module CI still runs armed, so a local run would go green on a defect CI is red on). It refuses a vacuous extraction and a zero-test run, in the same discipline as the existing `run_conformance_axis.sh`.

**Three guards in `tests/it/oracle_exclude_invariant.rs`** — the runner must exclude exactly what CI excludes, arm exactly what CI arms, and hardcode neither. The Rust side re-derives both from `ci.yml` using deliberately *different* anchors from the script's awk (job-block-and-quoted-value versus step-name-and-`run:` window), because a second opinion sharing the first's derivation is not a second opinion.

Each of the three was checked against a deliberate sabotage rather than assumed:

| sabotage | guard that fired |
|---|---|
| hardcode the exclusion list in the script | `does_not_hardcode_the_exclusion` + `excludes_exactly_what_ci_excludes` |
| add `FERRO_ASSERT_SEQUENCE` to the runner | `arms_exactly_the_flags_test_oracle_arms` |
| break the awk so `ci.yml` no longer parses | script exits 1; `excludes_exactly_what_ci_excludes` |

**Documentation.** The four always-red commands in `CLAUDE.md` are replaced by one section that states the trap once and points at the runner, per the repo's own rule against restating a rule in four places. The `FERRO_ASSERT_SEQUENCE` section keeps a bare command because `test-oracle` deliberately does not arm that oracle and the runner faithfully inherits that gap — its home is `sweeps`, and the section now says so and quantifies the 5 extra failures it raises here.

**The nightly's reproduce hint** named neither the four flags that job sets nor the three-module selection it sets them over, so it could not reproduce an oracle fire — which is that job's usual failure. It now carries both, and says why dropping the `-E` is what walks into the 7.

## What I deliberately did NOT change

- **`src/normalize/`.** The non-idempotency at the CDS/3'UTR boundary is a real, already-pinned defect. Fixing it is a representation change and the operator's call, not a test PR's.
- **`ORACLE_EXCLUDE` itself.** The exclusion is correct. Running these modules armed is the one action that would destroy the evidence, so "close the hole by running it in CI" is the wrong answer here; the honest answer is that CI already excludes it deliberately and the local path now excludes it identically.
- **The census pins.** Nothing re-blessed. The armed figures above are reported as a measurement of the collision, not as a new baseline.

## Verification

All from `/oracle-matrix` at `1dd8148d`, real exit status captured into each log rather than inferred from a pipeline:

```
scripts/run_oracle_suite.sh          -> 10,112 tests run, 10,112 passed, exit 0
bare armed full suite (3 flags)      -> 10,174 tests run, 7 failed,      exit 100
cargo fmt --all --check              -> exit 0
actionlint (both workflows)          -> clean
shellcheck scripts/run_oracle_suite.sh -> clean
oracle_exclude_invariant             -> 8 tests run, 8 passed (was 5)
```

The runner's 10,112 is 62 fewer than the bare run's 10,174 — the excluded modules — and the 7 failures sit inside those 62.

Representation-Change: none. Tests, a shell script, CI comments and documentation only; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, and no normalized output moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local oracle test runner that mirrors CI settings, exclusions, and enabled checks.
  * Added validation to detect configuration drift and reject failed or empty test selections.

* **Documentation**
  * Expanded guidance for running oracle tests locally, including expected failure counts and supported options.
  * Updated nightly failure instructions and clarified excluded test behavior.
  * Revised oracle exclusion details with current corpus counts and exclusion rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->