### PR TITLE
feat(normalize): re-anchor a window to a bound the variant must not leave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Normalizer::from_sequences`** — the same derivation against a held reference, which lets it
   additionally range-check the interval and optionally `normalize` the result.
 
+- **Re-anchoring, for callers whose variant must stay inside a region.** `SequencePair::trim_to`
+  narrows a window to given bounds, trimming matching bases only and needing no reference;
+  `Normalizer::reanchor` moves both edges, padding from the reference where it must widen. Bounds
+  are 1-based inclusive and optional per edge. Both refuse rather than clamp — including a bound
+  outside the sequence, since a window silently pulled back to the contig would hide a bug upstream
+  of the call.
+
+  **`reanchor` moves a window's edges; it does not relocate the window.** The window asked for must
+  overlap the pair's own, because the changed bases exist only in the pair — a disjoint request is
+  refused, with a message naming `reanchor` and both windows. Its bases come back upper-cased, as
+  `to_sequences`' do, so widening a soft-masked window cannot splice provider bases onto caller
+  bases and return a mixed-case pair; `trim_to` fetches nothing and leaves case alone. Case is not
+  a disagreement in either: a soft-masked reference against an upper-case alternate trims normally.
+
+  This is for a bound that is a *requirement* (a target region, an amplicon, a tiling window). It
+  is not the way to make heterogeneous raw pairs agree in general: `normalize = true` and a
+  `to_sequences` round trip both already do that and reach the reference-anchored placement, which
+  can shift further than any fixed window allows.
+
 - **`SequencePair::new`**, so a caller holding bases and no description can build one. The type is
-  `#[non_exhaustive]` and was previously only ever returned, which put the type out of reach of
-  exactly the caller it is for. It validates through the same check
+  `#[non_exhaustive]` and was previously only ever returned, which put both re-anchoring entry
+  points out of reach of exactly the caller they are for. It validates through the same check
   `from_sequences` uses rather than a second copy, so a pair that constructs is a pair that
   derives.
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,63 @@ point (`DNA/duplication.md:18`), so a member flush with the window's 5' edge com
 instead of a `dup`. It is applied to **both** sides — the window is `span + 2 * pad` — and the
 bases come back upper-cased, so a soft-masked region does not produce a mixed-case pair.
 
+### Bounding a derivation to a region it must not leave
+
+When a variant must stay inside a target region, an amplicon or a tiling window, anchor every raw
+pair to that region first. The derivation is a pure function of the window it is handed, so one
+window gives one answer:
+
+```python
+pair = ferro_hgvs.SequencePair("chr1", 10, "GCAAAAG", "GCAAAG")   # straight from a BAM
+
+str(pair.derive().variant)                  # 'chr1:g.15del' — rolls to the run's end
+bounded = pair.trim_to(end=14)              # hold it at 14
+str(bounded.derive().variant)               # 'chr1:g.14del'
+```
+
+`trim_to` needs no reference and can only *narrow*. To widen, use `Normalizer::reanchor`, which
+reads the padding bases from the reference:
+
+```python
+anchored = normalizer.reanchor(pair, start=5, end=25)   # 5' widened, 3' widened
+str(anchored.derive().variant)                          # 'chr1:g.15del'
+
+both = normalizer.reanchor(pair, start=5, end=14)       # 5' widened, 3' narrowed
+str(both.derive().variant)                              # 'chr1:g.14del'
+```
+
+**`reanchor` moves a window's edges; it does not relocate the window.** Each edge may go outwards
+(padded from the reference) or inwards (trimmed), in any combination — but the window you ask for
+must **overlap the pair's own**, and the overlap must still hold the bases the two sequences
+disagree on. `reanchor(pair, start=1000, end=1200)` on the pair above is refused, not fetched: the
+changed bases exist only in the pair, so there is nothing to carry to a region the pair does not
+cover. So "anchor every raw pair to my target region" works exactly when every raw pair overlaps
+that region — which is the case the feature is for, and is worth checking rather than assuming.
+
+Prefer `pair.derive()` to re-spreading the four fields: a pair returned by `trim_to` or
+`reanchor` carries its **own** position, and pairing a pre-trim position with post-trim bases is
+the mistake the method exists to prevent.
+
+Both take 1-based inclusive bounds, and `None` leaves that edge where it is.
+
+**Both refuse rather than clamp**, in every case: a bound that would cut a base the two sequences
+disagree on (naming the coordinate), a bound that would empty the reference, `start` past `end`,
+and — for `reanchor` — a bound outside the sequence, or a window disjoint from the pair's. A window
+silently pulled back to the contig would hide a bug upstream of the call.
+
+Case is not a disagreement: a soft-masked reference against an upper-case alternate trims normally.
+`trim_to` fetches nothing and so leaves your bases as you passed them; `reanchor` reads flank from
+the provider and therefore returns the whole window **upper-cased**, exactly as `to_sequences`
+does, rather than splicing provider bases onto caller bases and handing back a mixed-case pair.
+
+> **Reach for this when the bound is a requirement, not to make heterogeneous inputs agree.** For
+> that, `Normalizer::from_sequences(..., normalize = true)` and a `to_sequences` round trip both
+> already converge, and both reach the *reference-anchored* placement — which can shift as far as
+> the sequence allows rather than as far as your window allows. Anchoring to a window that cuts an
+> ambiguous run makes every caller using that window agree with each other and disagree with the
+> reference. That is a legitimate contract and a poor default; `placement_bounded_by_window`
+> reports it either way.
+
 ## Supported HGVS Syntax
 
 | Type | Prefix | Example |

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1878,6 +1878,188 @@ impl<P: ReferenceProvider> Normalizer<P> {
         })
     }
 
+    /// Move a window to `[start, end]`, padding from the reference or trimming,
+    /// whichever each side needs.
+    ///
+    /// The reference-holding half of re-anchoring;
+    /// [`crate::SequencePair::trim_to`] is the pure half and can only narrow.
+    /// `None` leaves that edge where it is. Both bounds are **1-based
+    /// inclusive**.
+    ///
+    /// # It moves a window's edges; it does not relocate the window
+    ///
+    /// The requested window must **overlap the pair's own**, and the overlap
+    /// must still hold the bases the two sequences disagree on. Each edge may
+    /// move outwards (padded from the reference) or inwards (trimmed), in either
+    /// combination — but a window disjoint from the pair's is refused, not
+    /// fetched. The changed bases exist only in the pair, so there is nothing to
+    /// carry to a region the pair does not cover; a caller who wants the
+    /// reference over some other interval wants `get_sequence`, not this.
+    ///
+    /// The bases come back **upper-cased**, for the reason
+    /// [`Self::to_sequences`] folds its window: the flank is read from the
+    /// provider and the rest is the caller's, so a soft-masked region would
+    /// otherwise return a mixed-case pair that no caller wrote. `trim_to`, which
+    /// fetches nothing and so cannot mix, leaves case alone.
+    ///
+    /// # What this is for
+    ///
+    /// Holding a derivation inside a region it must not leave — a target region,
+    /// an amplicon, a tiling window — and doing so from whatever raw window each
+    /// caller happens to have, **provided every such window overlaps the
+    /// region**. Anchoring every input to one window makes them agree, because
+    /// `from_sequences` is a pure function of the window it is given.
+    ///
+    /// # What this is NOT for
+    ///
+    /// Making heterogeneous raw pairs agree *in general*. That is already
+    /// available, twice, and both are better answers:
+    /// [`Self::from_sequences`] with `normalize = true`, or a round trip through
+    /// [`Self::to_sequences`]. Both reach the **reference-anchored** placement,
+    /// which can shift as far as the sequence allows rather than as far as a
+    /// chosen window allows. Measured on three reads over one homopolymer
+    /// deletion, both converge where the raw derivations do not.
+    ///
+    /// So reach for this when the bound is a *requirement*, not when it is a
+    /// convenience. Anchoring to a window that cuts an ambiguous run makes every
+    /// caller using that window agree with each other and disagree with the
+    /// reference — legitimate as a stated contract, misleading as a default. The
+    /// derivation reports it as `placement_bounded_by_window`.
+    ///
+    /// # Errors
+    ///
+    /// Refuses rather than clamping, always:
+    ///
+    /// * a bound outside the sequence — `start` of 0, or `end` past the last
+    ///   base. A window is not silently pulled back to the contig, because a
+    ///   caller who asked for bases that do not exist has a bug upstream and a
+    ///   clamped window would hide it;
+    /// * a **requested window disjoint from the pair's own** — see the section
+    ///   above. This is the refusal a caller is most likely to meet, because
+    ///   "re-anchor to my target region" reads like it should work from any
+    ///   pair, and it works only from one the region overlaps;
+    /// * a bound the provider cannot serve;
+    /// * anything [`crate::SequencePair::trim_to`] refuses, for the narrowing
+    ///   side — a cut through a base the two sequences disagree on, an emptied
+    ///   reference, `start` past `end`.
+    pub fn reanchor(
+        &self,
+        pair: &crate::normalize::sequence_pair::SequencePair,
+        start: Option<u64>,
+        end: Option<u64>,
+    ) -> Result<crate::normalize::sequence_pair::SequencePair, FerroError> {
+        let start = start.unwrap_or(pair.position);
+        let end = end.unwrap_or(pair.end());
+        let invalid = |msg: String| FerroError::InvalidCoordinates { msg };
+        if start == 0 {
+            return Err(invalid(
+                "reanchor: start is 1-based; 0 does not name a base".to_string(),
+            ));
+        }
+        if start > end {
+            return Err(invalid(format!(
+                "reanchor({start}, {end}) on {}: start is past end",
+                pair.accession
+            )));
+        }
+
+        let length = self.provider.get_sequence_length(&pair.accession)?;
+        if end > length {
+            return Err(FerroError::VariantExceedsReference {
+                accession: pair.accession.clone(),
+                hgvs_start: start,
+                hgvs_end: end,
+                expected_span: end - start + 1,
+                actual_bytes: length,
+            });
+        }
+
+        // Narrow first, then widen. Doing it in this order means the trim is
+        // always over the caller's own bases — bases they observed — rather than
+        // over bases this method just fetched, so a disagreement between the
+        // supplied window and the reference cannot be trimmed away silently.
+        //
+        // Which makes the narrowing target the *intersection* of the requested
+        // window and the pair's, and an empty intersection is a refusal this
+        // method owes its own message. Delegating it to `trim_to` produced
+        // `trim_to(1000, 16) on chr1: start is past end` — a sibling method's
+        // name and two coordinates the caller never passed, for the mistake
+        // callers make most often here.
+        let (overlap_start, overlap_end) = (start.max(pair.position), end.min(pair.end()));
+        if overlap_start > overlap_end {
+            return Err(invalid(format!(
+                "reanchor({start}, {end}) on {}: the requested window does not overlap the \
+                 pair's own [{}, {}]. `reanchor` moves a window's edges over the reference; \
+                 the changed bases exist only in the pair, so there is nothing to carry to a \
+                 region the pair does not cover",
+                pair.accession,
+                pair.position,
+                pair.end()
+            )));
+        }
+        let narrowed = pair.trim_to(Some(overlap_start), Some(overlap_end))?;
+
+        // Both edges are read before either string moves — `end()` is derived
+        // from `reference`, so consuming it first would make the 3' test consult
+        // a value that no longer exists.
+        let (narrowed_start, narrowed_end) = (narrowed.position, narrowed.end());
+        let mut reference = narrowed.reference;
+        let mut alternate = narrowed.alternate;
+        if start < narrowed_start {
+            let flank = self.fetch_flank(&pair.accession, start, narrowed_start)?;
+            reference.insert_str(0, &flank);
+            alternate.insert_str(0, &flank);
+        }
+        if end > narrowed_end {
+            let flank = self.fetch_flank(&pair.accession, narrowed_end + 1, end + 1)?;
+            reference.push_str(&flank);
+            alternate.push_str(&flank);
+        }
+
+        Ok(crate::normalize::sequence_pair::SequencePair {
+            accession: pair.accession.clone(),
+            position: start,
+            // Folded for the same reason `to_sequences` folds: `fetch_flank`
+            // upper-cases what it reads from the provider and the middle is
+            // whatever the caller supplied, so a soft-masked window widened here
+            // would come back mixed-case — a pair nobody wrote, and one that
+            // compares unequal to both of its own halves.
+            reference: reference.to_ascii_uppercase(),
+            alternate: alternate.to_ascii_uppercase(),
+            // Reaching the sequence's own end settles the 3' edge. So does
+            // *leaving the pair's 3' edge where it was*, when that edge was
+            // already settled — which is the only way a `true` ever enters this
+            // method, since `to_sequences` is what produces one. Recomputing
+            // `end == length` unconditionally threw that away, so an identity
+            // `reanchor(pair, None, None)` and a 5'-only widen both downgraded a
+            // settled window to `false`. The carry-through is `trim_to`'s
+            // (`self.window_is_final && tail == 0`), stated over coordinates
+            // because this method can widen as well as narrow.
+            window_is_final: end == length || (end == pair.end() && pair.window_is_final),
+        })
+    }
+
+    /// Reference bases over the half-open range `[from, to)`, 1-based.
+    ///
+    /// Refuses when the provider cannot serve them or serves the wrong number,
+    /// because [`Self::reanchor`] promises an exact window and a short read here
+    /// would silently produce a different one.
+    fn fetch_flank(&self, accession: &str, from: u64, to: u64) -> Result<String, FerroError> {
+        let wanted = (to - from) as usize;
+        let bases = self.provider.get_sequence(accession, from - 1, to - 1)?;
+        if bases.len() != wanted {
+            return Err(FerroError::InvalidCoordinates {
+                msg: format!(
+                    "reanchor: the provider served {} of the {wanted} bases requested over \
+                     {accession}:{from}-{}",
+                    bases.len(),
+                    to - 1
+                ),
+            });
+        }
+        Ok(bases.to_ascii_uppercase())
+    }
+
     /// Widen a window 5' by `pad` bases, returning the two strings and the new
     /// 0-based start.
     ///

--- a/src/normalize/sequence_pair.rs
+++ b/src/normalize/sequence_pair.rs
@@ -48,8 +48,8 @@ impl SequencePair {
     /// This type is otherwise only ever *returned*, by
     /// [`crate::Normalizer::to_sequences`]. Without a constructor it is
     /// `#[non_exhaustive]` and so unbuildable outside this crate, which would put
-    /// [`Self::derive`] out of reach of exactly the caller it is for: one who has
-    /// bases and no description.
+    /// [`Self::trim_to`] and [`crate::Normalizer::reanchor`] out of reach of
+    /// exactly the caller they are for: one who has bases and no description.
     ///
     /// `position` is **1-based** and names the first base of `reference`.
     ///
@@ -101,8 +101,8 @@ impl SequencePair {
     ///
     /// The pair already carries all four arguments the free function takes, so
     /// spreading them back out at the call site re-passes an accession and a
-    /// position this type is holding — and invites pairing one window's position
-    /// with another window's bases.
+    /// position this type is holding — and, after a [`Self::trim_to`], invites
+    /// pairing the *original* position with the *trimmed* bases.
     pub fn derive(
         &self,
         options: &crate::normalize::from_sequences::FromSequencesOptions,
@@ -130,5 +130,127 @@ impl SequencePair {
         self.position
             .saturating_add(self.reference.len() as u64)
             .saturating_sub(1)
+    }
+
+    /// Narrow this window to `[start, end]`, **trimming matching bases only**.
+    ///
+    /// The reference-free half of re-anchoring. Use it to hold a derivation
+    /// inside a region it must not leave — a target region, an amplicon, a
+    /// tiling window — when every caller's raw window is at least as wide as
+    /// that region.
+    ///
+    /// `None` leaves that edge where it is. Both bounds are 1-based inclusive,
+    /// matching [`Self::position`].
+    ///
+    /// # This can only narrow, and narrowing costs the 3' rule
+    ///
+    /// Widening needs bases this type does not hold, so it lives on
+    /// [`crate::Normalizer::reanchor`], which has a reference to read them from.
+    ///
+    /// And narrowing is not free: `from_sequences` may not shift outside the
+    /// window it is given, so a bound that cuts an ambiguous run pulls the
+    /// placement back to the bound. That is the *point* when the bound is a
+    /// region the variant must not leave, and a **footgun** when it is an
+    /// arbitrary window — every caller anchored to it will agree with each other
+    /// and disagree with the reference-anchored answer. The derivation reports
+    /// this as `placement_bounded_by_window`; it is not silent.
+    ///
+    /// # Errors
+    ///
+    /// Refuses rather than clamping, in every case — a silent clamp would hand
+    /// back a window the caller did not ask for and cannot detect:
+    ///
+    /// * a bound that would *widen* the window (there are no bases to widen
+    ///   with — the message names `reanchor`);
+    /// * a bound that would cut into a base the two sequences disagree on,
+    ///   naming the coordinate where the disagreement starts. **Case is not a
+    ///   disagreement** — a soft-masked reference against an upper-case
+    ///   alternate is ordinary input, and the comparison folds;
+    /// * a bound that would leave the reference empty, or `start` past `end`.
+    ///
+    /// Case is otherwise preserved: this method fetches nothing, so it cannot
+    /// manufacture a mixed-case pair and has no reason to rewrite the caller's
+    /// bases. [`crate::Normalizer::reanchor`], which does fetch, folds instead.
+    pub fn trim_to(&self, start: Option<u64>, end: Option<u64>) -> Result<Self, FerroError> {
+        let (current_start, current_end) = (self.position, self.end());
+        let start = start.unwrap_or(current_start);
+        let end = end.unwrap_or(current_end);
+
+        let invalid = |msg: String| FerroError::InvalidCoordinates { msg };
+        if start > end {
+            return Err(invalid(format!(
+                "trim_to({start}, {end}) on {}: start is past end",
+                self.accession
+            )));
+        }
+        for (label, wanted, widens) in [
+            ("start", start, start < current_start),
+            ("end", end, end > current_end),
+        ] {
+            if widens {
+                return Err(invalid(format!(
+                    "trim_to would widen the window: {label} {wanted} is outside the window \
+                     [{current_start}, {current_end}] on {}. `trim_to` only removes bases; use \
+                     `Normalizer::reanchor`, which holds a reference and can supply them",
+                    self.accession
+                )));
+            }
+        }
+
+        let head = (start - current_start) as usize;
+        let tail = (current_end - end) as usize;
+        // The two sequences differ in length, so a 3' trim is counted from each
+        // one's own end rather than from a shared index.
+        let (ref_len, alt_len) = (self.reference.len(), self.alternate.len());
+        if head + tail >= ref_len || head + tail >= alt_len {
+            return Err(invalid(format!(
+                "trim_to({start}, {end}) on {} would leave nothing of the {ref_len}-base \
+                 reference or the {alt_len}-base alternate",
+                self.accession
+            )));
+        }
+
+        // "Matching bases only": a trimmed base must be one both sequences
+        // agree on, or the trim would silently change what the pair denotes.
+        //
+        // Compared **case-insensitively**, because case is not a difference
+        // anywhere else on this surface: `Base::from_char` folds, `validate`
+        // says so in as many words, and `Normalizer::to_sequences` upper-cases
+        // its whole window. A byte comparison here made a soft-masked reference
+        // against an upper-case alternate — an ordinary pileup — refuse a legal
+        // trim with "the reference and alternate first differ at position N",
+        // naming a coordinate where they do not differ.
+        let (r, a) = (self.reference.as_bytes(), self.alternate.as_bytes());
+        let differs = |x: u8, y: u8| !x.eq_ignore_ascii_case(&y);
+        if !r[..head].eq_ignore_ascii_case(&a[..head]) {
+            let at = (0..head).find(|i| differs(r[*i], a[*i])).unwrap_or(0);
+            return Err(invalid(format!(
+                "trim_to cannot trim to start {start} on {}: the reference and alternate first \
+                 differ at position {}, so trimming there would change what the pair denotes",
+                self.accession,
+                current_start + at as u64
+            )));
+        }
+        if !r[ref_len - tail..].eq_ignore_ascii_case(&a[alt_len - tail..]) {
+            let at = (0..tail)
+                .find(|i| differs(r[ref_len - 1 - *i], a[alt_len - 1 - *i]))
+                .unwrap_or(0);
+            return Err(invalid(format!(
+                "trim_to cannot trim to end {end} on {}: the reference and alternate differ at \
+                 position {}, so trimming there would change what the pair denotes",
+                self.accession,
+                current_end - at as u64
+            )));
+        }
+
+        Ok(Self {
+            accession: self.accession.clone(),
+            position: start,
+            reference: self.reference[head..ref_len - tail].to_string(),
+            alternate: self.alternate[head..alt_len - tail].to_string(),
+            // Trimming the 3' edge moves the window in off wherever it used to
+            // stop, so whatever settled the old edge no longer settles this one.
+            window_is_final: self.window_is_final && tail == 0,
+        })
     }
 }

--- a/tests/it/from_sequences_reanchor.rs
+++ b/tests/it/from_sequences_reanchor.rs
@@ -1,0 +1,574 @@
+//! Re-anchoring a window: [`SequencePair::trim_to`] and [`Normalizer::reanchor`].
+//!
+//! # What these are for
+//!
+//! Holding a derivation inside a region it must not leave — a target region, an
+//! amplicon, a tiling window — starting from whatever raw window each caller
+//! happens to have. `from_sequences` is a pure function of the window it is
+//! given, so anchoring every input to one window makes them agree.
+//!
+//! # What they are not for, and this matters
+//!
+//! Making heterogeneous raw pairs agree *in general*. Two existing paths already
+//! do that and both reach a **better** answer — the reference-anchored one,
+//! which shifts as far as the sequence allows rather than as far as a chosen
+//! window allows. [`the_reference_anchored_paths_already_converge`] measures
+//! both, side by side with the raw derivations that do not converge, so the
+//! comparison is on the record rather than in a doc comment.
+//!
+//! So a bound is worth reaching for when it is a *requirement*. Anchoring to a
+//! window that cuts an ambiguous run makes every caller using that window agree
+//! with each other and disagree with the reference — legitimate as a stated
+//! contract, misleading as a default, and reported either way through
+//! `placement_bounded_by_window`.
+//!
+//! # The split
+//!
+//! Trimming removes bases and needs no reference, so it is on `SequencePair`.
+//! Padding needs bases the caller does not hold, so it is on `Normalizer`. That
+//! is the same reference-free / reference-holding boundary that organises the
+//! rest of this surface.
+
+use crate::common::cis_apply_oracle::normalizer_for;
+use ferro_hgvs::{
+    from_sequences, FromSequencesOptions, MockProvider, Normalizer, SequencePair, ShuffleDirection,
+};
+
+/// 1-based:      1234567890
+///
+/// A 4-base `A` run at 12-15, so a deletion inside it can roll and a bound can
+/// visibly stop it rolling.
+const SEQUENCE: &str = "GGATTACAGGCAAAAGCCTGAGGATTACAGGCATTAGCCT";
+
+/// The oracle's own provider, which serves `SEQUENCE` unpadded under the
+/// accession `TEMPLATE` — reused rather than rebuilt, so this module cannot
+/// drift from the fixture every other cis test is written against.
+fn normalizer() -> Normalizer<MockProvider> {
+    normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime)
+}
+
+/// The window a read covering `[lo, hi]` reports when the sample is missing one
+/// `A` from the run at 12-15.
+fn read(lo: u64, hi: u64) -> SequencePair {
+    let reference = &SEQUENCE[(lo - 1) as usize..hi as usize];
+    let at = reference[(12 - lo) as usize..]
+        .find('A')
+        .expect("the read covers part of the run")
+        + (12 - lo) as usize;
+    let mut alternate = reference.to_string();
+    alternate.remove(at);
+    SequencePair::new("TEMPLATE", lo, reference, alternate).expect("a well-formed pair")
+}
+
+fn derive(pair: &SequencePair) -> String {
+    from_sequences(
+        &pair.accession,
+        pair.position,
+        &pair.reference,
+        &pair.alternate,
+        &FromSequencesOptions::default(),
+    )
+    .expect("derives")
+    .to_string()
+}
+
+/// **A caller with bases and no description can build a pair.**
+///
+/// `SequencePair` is `#[non_exhaustive]` and was otherwise only ever *returned*,
+/// which put both re-anchoring entry points out of reach of exactly the caller
+/// they are for. Pinned as its own test because the gap is invisible from inside
+/// the crate — a struct expression compiles here and nowhere else.
+#[test]
+fn a_pair_can_be_built_from_bases_alone() {
+    let pair = SequencePair::new("TEMPLATE", 10, "GCAAAAG", "GCAAAG").expect("well-formed");
+    assert_eq!((pair.position, pair.end()), (10, 16));
+    assert!(
+        !pair.window_is_final,
+        "a caller-supplied window carries no evidence that its 3' edge is the sequence's"
+    );
+}
+
+/// **`new` refuses exactly what `from_sequences` refuses**, through the same
+/// check.
+///
+/// A constructor that admitted a pair the derivation would later reject would
+/// move the error one call away from the argument that caused it.
+#[test]
+fn a_pair_that_constructs_is_a_pair_that_derives() {
+    for (position, reference, alternate) in [(0, "AGCG", "AG"), (1, "", "AG"), (1, "AGXG", "AG")] {
+        let built = SequencePair::new("TEMPLATE", position, reference, alternate);
+        let derived = from_sequences(
+            "TEMPLATE",
+            position,
+            reference,
+            alternate,
+            &FromSequencesOptions::default(),
+        );
+        assert_eq!(
+            built.is_err(),
+            derived.is_err(),
+            "({position}, {reference:?}, {alternate:?}): the constructor and the derivation \
+             disagree about whether this is usable"
+        );
+    }
+}
+
+/// **A bound holds the placement where it is put.**
+///
+/// The headline behaviour. Unbounded, the deletion rolls 3' to 15; bounded at
+/// 14, it stays at 14 — and the derivation says so.
+#[test]
+fn a_trailing_bound_stops_the_roll_at_the_bound() {
+    let pair = read(10, 16);
+    assert_eq!(derive(&pair), "TEMPLATE:g.15del");
+
+    let bounded = pair
+        .trim_to(None, Some(14))
+        .expect("14 is inside the window");
+    assert_eq!(bounded.position, 10);
+    assert_eq!(bounded.end(), 14);
+    assert_eq!(derive(&bounded), "TEMPLATE:g.14del");
+
+    // Not a wrong answer — the same variant, spelled at the bound.
+    let n = normalizer();
+    assert_eq!(
+        n.canonical_spdi(&ferro_hgvs::parse_hgvs(&derive(&bounded)).unwrap())
+            .unwrap(),
+        n.canonical_spdi(&ferro_hgvs::parse_hgvs(&derive(&pair)).unwrap())
+            .unwrap(),
+        "a bounded placement must still denote the same bases"
+    );
+}
+
+/// **Every raw window anchored to one region derives one description.**
+///
+/// The property the feature exists for, over reads that disagree without it.
+#[test]
+fn reads_anchored_to_one_region_agree() {
+    let reads = [read(9, 16), read(10, 17), read(11, 18)];
+    let raw: Vec<String> = reads.iter().map(derive).collect();
+
+    let anchored: Vec<String> = reads
+        .iter()
+        .map(|pair| derive(&pair.trim_to(Some(11), Some(14)).expect("inside every read")))
+        .collect();
+
+    assert!(
+        anchored.windows(2).all(|w| w[0] == w[1]),
+        "anchored reads disagreed: {anchored:?} (raw was {raw:?})"
+    );
+    assert_eq!(anchored[0], "TEMPLATE:g.14del");
+}
+
+/// **Trimming refuses to cut through a base the two sequences disagree on.**
+///
+/// Trimming a mismatched base would change what the pair denotes, so it is a
+/// refusal naming the coordinate rather than a silent narrowing.
+///
+/// A **substitution** is used rather than the homopolymer deletion the rest of
+/// this module runs on, and the reason is worth recording because it caught a
+/// wrong assumption here first. Trimming to 13 inside that deletion looks like
+/// it should refuse and does not: the last three bases of `GCAAAAG` and of
+/// `GCAAAG` are both `AAG`, so they are *matching* bases, and the narrowed pair
+/// still denotes one deleted `A`. Legal, and correct. Only where the two
+/// sequences genuinely disagree at the edge is there anything to refuse.
+#[test]
+fn trimming_refuses_to_cut_into_the_changed_block() {
+    // 10-16 is `GCAAAAG`; the alternate substitutes the final base.
+    let pair = SequencePair::new("TEMPLATE", 10, "GCAAAAG", "GCAAAAT").expect("well-formed");
+
+    let error = pair
+        .trim_to(None, Some(15))
+        .expect_err("16 is the substituted base, so trimming it away changes the denotation")
+        .to_string();
+    assert!(
+        error.contains("differ") && error.contains("16"),
+        "the refusal must say why and where: {error}"
+    );
+
+    // The 5' direction is checked separately: the two ends are separate
+    // comparisons in the implementation, and a bug in one would hide behind the
+    // other if only one were tested.
+    let leading = SequencePair::new("TEMPLATE", 10, "GCAAAAG", "TCAAAAG").expect("well-formed");
+    let error = leading
+        .trim_to(Some(11), None)
+        .expect_err("10 is the substituted base")
+        .to_string();
+    assert!(
+        error.contains("differ") && error.contains("10"),
+        "the 5' refusal must say why and where: {error}"
+    );
+}
+
+/// **Trimming to a bound over matching bases is legal even inside a run.**
+///
+/// The other half of the rule above, pinned so nobody "fixes" the refusal into
+/// something stricter than it should be. The trimmed bases match, so the
+/// narrowed pair denotes what the wide one denoted — and the derivation moves to
+/// the bound, which is the whole feature.
+#[test]
+fn trimming_inside_a_homopolymer_is_legal_because_the_edges_match() {
+    let pair = read(10, 16);
+    let narrowed = pair
+        .trim_to(None, Some(13))
+        .expect("the trimmed bases are the same in both sequences");
+    assert_eq!((narrowed.position, narrowed.end()), (10, 13));
+    assert_eq!(derive(&narrowed), "TEMPLATE:g.13del");
+
+    let n = normalizer();
+    assert_eq!(
+        n.canonical_spdi(&ferro_hgvs::parse_hgvs(&derive(&narrowed)).unwrap())
+            .unwrap(),
+        n.canonical_spdi(&ferro_hgvs::parse_hgvs(&derive(&pair)).unwrap())
+            .unwrap(),
+        "narrowing over matching bases must not change what is denoted"
+    );
+}
+
+/// **Trimming refuses to widen, and says which method can.**
+///
+/// A dead-end refusal is worse than none; this one names its sibling.
+#[test]
+fn trimming_refuses_to_widen_and_names_reanchor() {
+    let pair = read(10, 16);
+    for (start, end) in [(Some(5), None), (None, Some(30))] {
+        let error = pair
+            .trim_to(start, end)
+            .expect_err("outside the window")
+            .to_string();
+        assert!(
+            error.contains("reanchor"),
+            "the refusal does not name the method that can do this: {error}"
+        );
+    }
+}
+
+/// **`reanchor` pads from the reference and trims, in one call.**
+///
+/// Both rows are checked on the **bases denoted** as well as on the rendered
+/// string, through `canonical_spdi` — which reaches the bases via
+/// `apply_to_reference_padded` + `trim_common_flanks` and so shares nothing with
+/// the alignment DAG the derivation runs on. Without it the widen-then-narrow
+/// row asserts a string and nothing else, and that row is the one that moves the
+/// answer (`g.14del` where the raw pair gives `g.15del`) — exactly where a
+/// re-anchoring bug would show up as a *different variant* rather than as a
+/// different spelling.
+#[test]
+fn reanchoring_pads_and_trims_to_reach_the_requested_window() {
+    let n = normalizer();
+    let pair = read(10, 16);
+    let denoted = |p: &SequencePair| {
+        n.canonical_spdi(&ferro_hgvs::parse_hgvs(&derive(p)).unwrap())
+            .unwrap()
+    };
+
+    let widened = n
+        .reanchor(&pair, Some(5), Some(25))
+        .expect("inside the contig");
+    assert_eq!((widened.position, widened.end()), (5, 25));
+    assert_eq!(widened.reference, SEQUENCE[4..25]);
+    assert_eq!(widened.reference.len(), widened.alternate.len() + 1);
+    assert_eq!(derive(&widened), "TEMPLATE:g.15del");
+    assert_eq!(
+        denoted(&widened),
+        denoted(&pair),
+        "widening must not change what the pair denotes"
+    );
+
+    // One call that widens 5' and narrows 3' at once.
+    let both = n
+        .reanchor(&pair, Some(5), Some(14))
+        .expect("inside the contig");
+    assert_eq!((both.position, both.end()), (5, 14));
+    assert_eq!(derive(&both), "TEMPLATE:g.14del");
+    assert_eq!(
+        denoted(&both),
+        denoted(&pair),
+        "the bound moved the spelling to 14; it must not have moved the variant"
+    );
+}
+
+/// **A window disjoint from the pair's own is refused, and the message says so.**
+///
+/// `reanchor` moves a window's edges over the reference; it cannot relocate the
+/// window, because the changed bases exist only in the pair. That constraint was
+/// undocumented and enforced only as a side effect — the narrowing step ran over
+/// the intersection, so a disjoint request surfaced as
+/// `trim_to(1000, 16) on TEMPLATE: start is past end`: a sibling method's name
+/// and two coordinates the caller never passed. The README taught the disjoint
+/// call as *the* way to use the method, so this is the refusal a caller is most
+/// likely to meet.
+#[test]
+fn reanchoring_refuses_a_window_disjoint_from_the_pair() {
+    let n = normalizer();
+    let pair = read(10, 16);
+
+    for (start, end) in [(Some(20), Some(30)), (Some(1), Some(5))] {
+        let error = n
+            .reanchor(&pair, start, end)
+            .expect_err("disjoint from [10, 16]")
+            .to_string();
+        assert!(
+            error.contains("reanchor") && error.contains("does not overlap"),
+            "the refusal must name this method and the reason: {error}"
+        );
+        assert!(
+            !error.contains("trim_to"),
+            "the refusal must not name a method the caller did not call: {error}"
+        );
+    }
+
+    // A *partial* overlap is legal — the boundary is overlap, not containment,
+    // and a test that only checked the disjoint side would admit an
+    // implementation that demanded the pair contain the requested window.
+    let partial = n
+        .reanchor(&pair, Some(12), Some(30))
+        .expect("[12, 30] overlaps [10, 16] and keeps the changed block");
+    assert_eq!((partial.position, partial.end()), (12, 30));
+    assert_eq!(derive(&partial), "TEMPLATE:g.15del");
+
+    // Overlap is necessary and not sufficient: the overlap must still hold the
+    // bases the two sequences disagree on. [16, 30] overlaps by one base and is
+    // refused — by `trim_to`, whose rule that is, and whose message says the
+    // reference or alternate would be left empty. Pinned so the refusal above
+    // is not "fixed" into swallowing this one.
+    let error = n
+        .reanchor(&pair, Some(16), Some(30))
+        .expect_err("the overlap keeps none of the changed block")
+        .to_string();
+    assert!(
+        error.contains("would leave nothing"),
+        "an overlap that keeps no changed bases is `trim_to`'s refusal, not the disjoint one: \
+         {error}"
+    );
+}
+
+/// **Case is not a disagreement, in either half of re-anchoring.**
+///
+/// A soft-masked reference against an upper-case alternate is an ordinary
+/// pileup, and both halves got it wrong in opposite directions: `trim_to`
+/// byte-compared, so it refused a legal trim claiming the two sequences "first
+/// differ" at a coordinate where they do not; `reanchor` upper-cased only the
+/// flank it fetched, so widening a masked window returned a mixed-case pair —
+/// the very thing `to_sequences` folds its window to prevent.
+#[test]
+fn masked_bases_trim_and_reanchor_like_any_others() {
+    // 10-16 is `gcaaaag` soft-masked; the alternate is the same window
+    // upper-cased with one `A` of the run removed.
+    let masked = SequencePair::new("TEMPLATE", 10, "gcaaaag", "GCAAAG").expect("well-formed");
+
+    let bounded = masked
+        .trim_to(None, Some(14))
+        .expect("the trimmed bases match, case aside");
+    assert_eq!((bounded.position, bounded.end()), (10, 14));
+    assert_eq!(
+        bounded.reference, "gcaaa",
+        "`trim_to` fetches nothing, so it has no reason to rewrite the caller's bases"
+    );
+    assert_eq!(derive(&bounded), "TEMPLATE:g.14del");
+
+    // A real disagreement is still refused, so the fold is not a blanket accept.
+    let substituted = SequencePair::new("TEMPLATE", 10, "gcaaaag", "GCAAAAT").expect("well-formed");
+    assert!(
+        substituted.trim_to(None, Some(15)).is_err(),
+        "16 differs in base, not in case"
+    );
+
+    let n = normalizer();
+    let widened = n
+        .reanchor(&masked, Some(5), Some(25))
+        .expect("inside the contig");
+    assert_eq!(
+        widened.reference,
+        SEQUENCE[4..25],
+        "the whole window is folded, so provider bases and caller bases cannot be told apart"
+    );
+    assert!(
+        !widened.alternate.chars().any(|c| c.is_ascii_lowercase()),
+        "a mixed-case pair no caller wrote: {}",
+        widened.alternate
+    );
+    assert_eq!(derive(&widened), "TEMPLATE:g.15del");
+}
+
+/// **`reanchor` refuses to run off the end of the sequence.**
+///
+/// An operator decision: a caller who asked for bases that do not exist has a
+/// bug upstream, and a window silently clamped back to the contig would hide it.
+#[test]
+fn reanchoring_refuses_to_leave_the_sequence() {
+    let n = normalizer();
+    let pair = read(10, 16);
+    let length = SEQUENCE.len() as u64;
+
+    assert!(
+        n.reanchor(&pair, Some(1), Some(length)).is_ok(),
+        "the whole contig is a legal window"
+    );
+    assert!(
+        n.reanchor(&pair, Some(1), Some(length + 1)).is_err(),
+        "one base past the end must refuse, not clamp"
+    );
+    assert!(
+        n.reanchor(&pair, Some(0), None).is_err(),
+        "position is 1-based; 0 names no base"
+    );
+    assert!(
+        n.reanchor(&pair, Some(14), Some(12)).is_err(),
+        "start past end must refuse"
+    );
+}
+
+/// **`window_is_final` survives a 3' edge that never moved, and is recomputed
+/// when it did.**
+///
+/// A caller-chosen 3' bound short of the sequence's end is what stops the roll,
+/// so it clears the flag. Leaving the 3' edge alone settles nothing new and
+/// unsettles nothing either, so the input's answer stands — the same rule
+/// `trim_to` states as `self.window_is_final && tail == 0`.
+///
+/// **This test could not fail before**, and that is worth recording rather than
+/// counting as coverage. It built its pair with `read()`, i.e. through
+/// `SequencePair::new`, which sets `window_is_final: false` unconditionally — so
+/// its `false` assertion could not distinguish a correct recomputation from a
+/// settled window silently downgraded, and no input it could construct was ever
+/// `true`. The `true` side needs a pair from `to_sequences`, the one place a
+/// settled window comes from, and nothing in either language fed one to
+/// `reanchor` and then read the flag.
+#[test]
+fn reanchoring_reports_whether_the_window_reaches_the_sequence_end() {
+    let n = normalizer();
+    let pair = read(10, 16);
+    let length = SEQUENCE.len() as u64;
+
+    // The recompute, over an input that carries `false`.
+    assert!(
+        n.reanchor(&pair, None, Some(length))
+            .expect("legal")
+            .window_is_final,
+        "a window reaching the sequence's own end is settled whatever it came from"
+    );
+    assert!(
+        !n.reanchor(&pair, None, Some(length - 1))
+            .expect("legal")
+            .window_is_final,
+        "one base short of the end, the bound is what stops the roll"
+    );
+    assert!(
+        !n.reanchor(&pair, None, None)
+            .expect("legal")
+            .window_is_final,
+        "an unsettled window is not settled by moving nothing"
+    );
+
+    // The carry-through, over an input that carries `true`. `to_sequences` is
+    // the only producer of one; the two preconditions are asserted so this test
+    // reports a fixture that stopped exercising the case rather than passing
+    // vacuously.
+    let settled = n
+        .to_sequences(&ferro_hgvs::parse_hgvs(&derive(&pair)).unwrap(), 4)
+        .expect("re-windows");
+    assert!(
+        settled.window_is_final,
+        "the 3' pad was served in full, so `to_sequences` must report a settled window"
+    );
+    assert!(
+        settled.end() < length,
+        "the fixture must stop short of the sequence end, or `end == length` decides every row"
+    );
+
+    for (label, start, end) in [
+        ("an identity call", None, None),
+        ("a 5'-only widen", Some(1), None),
+        ("a 5'-only narrow", Some(settled.position + 1), None),
+    ] {
+        assert!(
+            n.reanchor(&settled, start, end)
+                .expect("legal")
+                .window_is_final,
+            "{label} left the 3' edge where it was, so it cannot unsettle it"
+        );
+    }
+
+    assert!(
+        !n.reanchor(&settled, None, Some(settled.end() + 1))
+            .expect("legal")
+            .window_is_final,
+        "widening 3' past a settled edge puts the window back against a chosen bound"
+    );
+    assert!(
+        !n.reanchor(&settled, None, Some(settled.end() - 1))
+            .expect("legal")
+            .window_is_final,
+        "narrowing 3' moves the window in off whatever settled it"
+    );
+    assert!(
+        n.reanchor(&settled, None, Some(length))
+            .expect("legal")
+            .window_is_final,
+        "widening 3' all the way to the sequence end settles it again"
+    );
+}
+
+/// **The reference-anchored paths already converge, and reach further.**
+///
+/// Recorded as a measurement because it is the argument against reaching for a
+/// bound by default. Three reads that disagree raw agree under either existing
+/// path — and agree on `g.15del`, the 3'-most placement, which no fixed window
+/// narrower than the run can produce.
+#[test]
+fn the_reference_anchored_paths_already_converge() {
+    let n = normalizer();
+    let reads = [read(9, 14), read(10, 15), read(11, 18)];
+
+    let raw: Vec<String> = reads.iter().map(derive).collect();
+    assert!(
+        raw.windows(2).any(|w| w[0] != w[1]),
+        "the reads no longer disagree raw, so this test compares nothing: {raw:?}"
+    );
+
+    let normalized: Vec<String> = reads
+        .iter()
+        .map(|p| {
+            n.from_sequences(
+                &p.accession,
+                p.position,
+                &p.reference,
+                &p.alternate,
+                &FromSequencesOptions::default(),
+                true,
+            )
+            .expect("derives")
+            .to_string()
+        })
+        .collect();
+
+    let round_tripped: Vec<String> = reads
+        .iter()
+        .map(|p| {
+            let variant = from_sequences(
+                &p.accession,
+                p.position,
+                &p.reference,
+                &p.alternate,
+                &FromSequencesOptions::default(),
+            )
+            .expect("derives");
+            derive(&n.to_sequences(&variant, 128).expect("re-windows"))
+        })
+        .collect();
+
+    for (label, answers) in [
+        ("normalize=true", &normalized),
+        ("to_sequences", &round_tripped),
+    ] {
+        assert!(
+            answers.windows(2).all(|w| w[0] == w[1]),
+            "{label} did not converge: {answers:?}"
+        );
+        assert_eq!(
+            answers[0], "TEMPLATE:g.15del",
+            "{label} converged somewhere other than the 3'-most placement"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -108,6 +108,7 @@ mod fast_path_flip_bench;
 mod from_sequences_corpus;
 mod from_sequences_multi_member_axis;
 mod from_sequences_proptest;
+mod from_sequences_reanchor;
 mod from_sequences_reported_pairs;
 mod from_sequences_roundtrip;
 mod from_sequences_window_condition;


### PR DESCRIPTION
**PR 2 of 3, stacked on PR 1.** Its base is PR 1's branch, so the diff shown here is only the re-anchoring work.

Part of #1692.

## The problem this solves

A caller sweeping a BAM does not get one window — they get a different window per read, because each read covers what it happens to cover. PR 1 established that two windows agree exactly when both contain the whole interval over which the change can be placed. That is a property of the *windows*, and until now the caller had no way to make it hold: they could observe that their windows disagreed but not do anything about it.

Re-anchoring lets them bind heterogeneous raw pairs to one chosen reference window, so the derived description is a property of the locus rather than of whichever read reached furthest.

## The surface

- `SequencePair::new` — build a pair from bases you already hold. The type was otherwise only ever *returned*, and being `#[non_exhaustive]` it was unbuildable outside the crate, which put re-anchoring out of reach of exactly the caller it is for: one who has bases and no description. It shares `from_sequences`'s validator, so a pair that constructs is a pair that derives, and the refusal arrives at the argument that caused it rather than one call later.
- `SequencePair::trim_to` — narrow to a sub-window, matches only.
- `Normalizer::reanchor` — narrow *then* widen, so the trim is always over bases the caller actually observed. Widening reads the reference through `fetch_flank`, which **refuses a short serve** rather than silently returning a narrower window than asked for — that refusal is the point, since a silently-short window is exactly the condition that makes two callers disagree.
- The same three from Python, plus stubs.

It refuses to run off either end of a sequence.

`new` sets `window_is_final` to `false`, which is the only honest answer: a caller-supplied window carries no evidence about whether its 3' edge is where the sequence stops or where the read did.

## What this is *not*

**It is not a confluence tool, and the README says so.** Both existing paths already converge heterogeneous spellings — `to_sequences` erases the spelling, and that is what makes the corpora agree. Re-anchoring is a *bounding* tool: it lets a caller state the window a variant must not leave. Selling it as the thing that makes descriptions agree would be selling something the measurements attribute elsewhere.

Nor is it an option that selects a normalization form; it selects a window, and every window it can produce is one a caller could have passed directly.

Representation-Change: none. Adds two new entry points; no existing path is re-routed.
