### PR TITLE
feat(python): expose from_sequences, to_sequences and re-anchoring

### DIFF
--- a/docs/python_reference_guide.md
+++ b/docs/python_reference_guide.md
@@ -14,6 +14,7 @@ harness) before trusting a genome-aware result.
 | A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro_hgvs.convert_gff(...)` / `ferro_hgvs.build_transcript(...)` in-process (or the `ferro convert-gff` / `ferro build-transcript` CLIs, all with `emit_genomic_sequences=True` / `--emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
 | Transcript-level normalization only (exonic SNV/indel shuffle; no introns, no `g.` axis) | a `transcripts.json` **without** `genomic_sequences` → `Normalizer(reference_json=...)` | ❌ by design (see the boundary below) |
 | Just trying the API | `Normalizer()` (built-in toy data) | ❌ toy data |
+| **Bases rather than a description** — a window out of a BAM, a VCF row, an aligner's output | `ferro_hgvs.from_sequences(...)` — no `Normalizer`, no reference, nothing to set up | n/a — reads no reference by design; see [below](#deriving-a-description-with-no-reference-at-all) |
 
 "Genome-aware rules" = intronic positions (`c.10+5del`), the cross-exon/intron
 3′-shift (#670), and the genomic (`g.`) axis / `project_to_genomic`. See
@@ -183,12 +184,89 @@ ferro check --reference construct.json
 #   Protein data: no
 ```
 
+## Deriving a description with no reference at all
+
+Everything above is about how much capability your reference buys you. There is
+one path where the question does not arise: if what you hold is **bases** rather
+than a description, `from_sequences` derives the description and reads no
+reference at all.
+
+```python
+import ferro_hgvs
+
+print(ferro_hgvs.from_sequences("NC_000001.11", 1000, "AGCG", "AG"))
+# NC_000001.11:g.1002_1003del
+```
+
+(`print`, or `str(...)`, rather than letting the REPL echo it — `HgvsVariant.__repr__` returns
+`HgvsVariant('NC_000001.11:g.1002_1003del')`, so the bare expression does not print the comment
+above.)
+
+No `Normalizer`, no `transcripts.json`, no manifest — so `has_genomic_data()`
+does not apply, and there is no reduced-capability mode to check for. The output
+is a pure function of the four arguments, which means the same bases give the
+same description on any machine and against any reference build.
+
+**What you get, and what you do not.** This delivers the two normalization rules
+that need nothing but your arguments — the output is conformant (rule 1) and
+deterministic (rule 4). It does **not** deliver the recommended form (rule 2) or
+agreement with a description derived from a different window (rule 3), because
+both of those are reference-anchored. If you want them, call `normalize`
+afterwards. The full statement, including how wide a window to supply and what
+each refusal means, is the
+[how-to in the README](../README.md#how-to-one-canonical-description-per-variant).
+
+`position` is 1-based, and `reference` is taken on trust: verifying it would need
+a provider, which would make the reference a hidden fifth input and cost exactly
+the determinism the function exists to provide. Pass bases that are not the
+reference and you get a faithful description of the pair you passed.
+
+### The three neighbours that *do* need a reference
+
+Same feature, opposite capability answer — these are `Normalizer` methods, so
+everything above about picking a reference applies to them normally:
+
+| Method | Needs | Why |
+|---|---|---|
+| `Normalizer.to_sequences(variant, pad=128)` | a reference | it reads the bases a description denotes, plus flank on both sides |
+| `Normalizer.from_sequences(..., normalize=True)` | a reference | the derivation itself does not, but range-checking the interval and the optional `normalize` pass do |
+| `Normalizer.reanchor(pair, start, end)` | a reference | widening a window means reading bases the caller never supplied |
+
+Note `normalize` defaults to **False**, and that is not the value most callers
+want. Prefer `normalize=True` unless you have a reason not to: over a
+6,000-shape sweep it moved 8.6% of derived descriptions. False is still a
+conformant, deterministic answer — the 8.6% is entirely rules 2 and 3, which the
+derivation never claimed — but if you are storing one canonical string per
+variant, that is the difference between the derived form and the recommended
+one.
+
+**That figure is a claim about that sweep, not about the world:** one synthetic
+contig, six shape generators, genomic axis only. It is a conformance-movement
+rate, not a benchmark, so no host or timing applies to it — but it is also a
+**one-off measurement with no committed harness that re-derives it**, so treat it
+as an order of magnitude rather than a number to quote. Your own rate depends
+entirely on which shapes your inputs are. The full statement of what was swept,
+and the three classes the movement falls into, is in the
+[README](../README.md#how-to-one-canonical-description-per-variant); this page
+does not restate it.
+
+`to_sequences` is the inverse direction, so a caller who already holds
+descriptions can reach the derivation without new plumbing:
+
+```python
+pair = normalizer.to_sequences(variant, pad=128)
+derived = normalizer.from_sequences(pair.accession, pair.position, pair.reference, pair.alternate)
+```
+
 ## The capability boundary in one line
 
+- **No reference needed at all:** `ferro_hgvs.from_sequences` — conformant and
+  deterministic output derived from the bases you supply.
 - **Any `transcripts.json`:** reference-allele checks, exonic 3′/5′ shuffle,
   dup/repeat canonicalization.
 - **Needs `genomic_sequences` (genome-capable) or a prepared manifest:** intronic
-  positions, cross-exon/intron 3′-shift, the `g.` axis / `project_to_genomic`.
+  positions, cross-exon/intron 3′-shift, the `g.` axis / `project_to_genomic`,
+  and the three reference-reading neighbours in the table above.
 
 Full details, the schema, and what the load-time validation does and does not
 guarantee are in [`transcripts_json_schema.md`](transcripts_json_schema.md).

--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -97,6 +97,9 @@ __all__ = [
     "parse",
     "normalize",
     "normalize_with_warnings",
+    # Sequence-pair functions
+    "from_sequences",
+    "from_sequences_detailed",
     # SPDI functions
     "parse_spdi",
     "hgvs_to_spdi",
@@ -128,6 +131,8 @@ __all__ = [
     # SPDI classes
     "SpdiVariant",
     "AppliedVariant",
+    "SequencePair",
+    "DerivedDescription",
     # Coordinate classes
     "ZeroBasedPos",
     "OneBasedPos",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -94,6 +94,93 @@ def normalize_with_warnings(
     ...
 
 # ============================================================================
+# Sequence-pair Functions
+# ============================================================================
+
+def from_sequences(
+    accession: str,
+    position: int,
+    reference: str,
+    alternate: str,
+    *,
+    max_grid_cells: int | None = None,
+    direction: str = "3prime",
+) -> HgvsVariant:
+    """Derive an HGVS description from a reference/alternate sequence pair.
+
+    The caller supplies the bases; this supplies the description. It reads **no
+    reference sequence**, so its output is a pure function of its arguments —
+    the same bases give the same description on any machine, against any
+    reference build, with no hidden input.
+
+    **Case is not a refusal.** Both sequences are upper-cased before anything
+    reads them, so a soft-masked (lower-case) window derives exactly what its
+    upper-case twin derives.
+
+    This delivers the two normalization rules that are always achievable —
+    conformant and deterministic — and deliberately not the two that need the
+    reference, recommended form and confluent. So an output may be 3'-shiftable
+    further than a window-local function could shift it, which is not a defect.
+    Run ``Normalizer.normalize`` afterwards if you want it, or
+    ``Normalizer.from_sequences(..., normalize=True)`` to do both in one call.
+
+    Args:
+        accession: The sequence the window is on. A transcript or protein
+            accession is refused — a ``g.`` description on an ``NM_`` denotes
+            nothing.
+        position: 1-based position of the window's first base.
+        reference: The reference bases over the window. Taken on trust and not
+            verified — verifying it would need the reference and would make the
+            provider a hidden input, costing exactly the determinism this
+            function exists to provide.
+        alternate: The observed bases over the same window.
+        max_grid_cells: Largest alignment grid, in cells, the partitioner will
+            build. Defaults to ``(4096 + 1) ** 2``, about 310 MB at roughly 18
+            bytes a cell. Exceeding it raises rather than answering with a
+            weaker rule.
+        direction: Which end of an ambiguous run a pure indel is placed at —
+            "3prime" (default) or "5prime".
+
+    Returns:
+        The derived HgvsVariant.
+
+    Raises:
+        ValueError: for an unrecognized ``direction``, or a ``max_grid_cells``
+            of 0. These two are checked at the binding, before any derivation.
+        NormalizationError: for everything the derivation itself refuses — a
+            zero position, an empty reference, a non-nucleotide symbol, a
+            transcript or protein accession, a grid over budget, or an inserted
+            payload resting against the window's 5' edge with no anchor inside
+            it. A subclass of ``FerroError`` and ``RuntimeError``.
+
+    The two classes are **not** one hierarchy, and no single class catches both:
+    the binding's ``ValueError``s are outside ``FerroError`` by design, which is
+    the repository-wide split between an argument-shape mistake and a
+    variant-processing failure. Catch ``(ValueError, ferro_hgvs.FerroError)`` —
+    or simply ``Exception`` — to handle everything this function can raise.
+
+    Example:
+        >>> str(from_sequences("NC_000001.11", 1000, "AGCG", "AG"))
+        'NC_000001.11:g.1002_1003del'
+    """
+    ...
+
+def from_sequences_detailed(
+    accession: str,
+    position: int,
+    reference: str,
+    alternate: str,
+    *,
+    max_grid_cells: int | None = None,
+    direction: str = "3prime",
+) -> DerivedDescription:
+    """:func:`from_sequences`, reporting also whether the derivation reached a window edge.
+
+    Same arguments and same refusals; see :func:`from_sequences`.
+    """
+    ...
+
+# ============================================================================
 # SPDI Functions
 # ============================================================================
 
@@ -794,6 +881,120 @@ class Normalizer:
         """Parse and normalize an HGVS string."""
         ...
 
+    def to_sequences(self, variant: HgvsVariant, pad: int = 128) -> SequencePair:
+        """Apply the variant and return the padded window as a sequence pair.
+
+        The inverse of :func:`from_sequences`, and what turns any HGVS
+        description into derivation input — so a caller that already has
+        descriptions needs no new plumbing to reach it. Differs from
+        `apply_to_reference` in three ways that all matter to that use: the
+        position is 1-based, both sides are padded, and it reports whether the
+        window's 3' edge is settled (``window_is_final``).
+
+        That flag is **not** "the full pad was served" — see its own doc. A
+        window clipped by the sequence end served less than the full pad and is
+        still settled, because there is nothing further to read.
+
+        The pad is not decoration. `dup` typing reads the reference bases
+        immediately 5' of an insertion point, so a member flush with the
+        window's 5' edge comes back as an `ins` rather than a `dup`.
+
+        Args:
+            variant: The variant to express as sequences.
+            pad: Flank in bases, on each side. Defaults to 128.
+
+        Raises:
+            ProjectionError: as `apply_to_reference`.
+        """
+        ...
+
+    def reanchor(
+        self,
+        pair: SequencePair,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> SequencePair:
+        """Move a window to [start, end], padding from the reference or trimming.
+
+        The reference-holding half of re-anchoring; ``SequencePair.trim_to`` is
+        the pure half and can only narrow. ``None`` leaves that edge where it
+        is; both bounds are 1-based inclusive.
+
+        Use it to hold a derivation inside a region it must not leave — a target
+        region, an amplicon, a tiling window — provided every raw window
+        overlaps that region.
+
+        **It moves a window's edges; it does not relocate the window.** Each
+        edge may go outwards (padded from the reference) or inwards (trimmed),
+        in any combination — but the requested window must overlap the pair's
+        own, and the overlap must still hold the bases the two sequences
+        disagree on. The bases come back upper-cased, as from
+        ``to_sequences``; ``SequencePair.trim_to`` fetches nothing and leaves
+        case alone.
+
+        **Not the tool for making heterogeneous inputs agree in general.** That
+        is already available and better: ``from_sequences(..., normalize=True)``
+        or a round trip through ``to_sequences``, both of which reach the
+        reference-anchored placement.
+
+        Raises:
+            NormalizationError: for every refusal — a bound outside the sequence
+                (refused rather than clamped back to the contig), a requested
+                window disjoint from the pair's own, and anything
+                ``SequencePair.trim_to`` refuses. This method raises one class;
+                it is not ``ReferenceDataError``, which this stub named until
+                2026-08-12 and which no input could produce.
+        """
+        ...
+
+    def from_sequences(
+        self,
+        accession: str,
+        position: int,
+        reference: str,
+        alternate: str,
+        *,
+        max_grid_cells: int | None = None,
+        normalize: bool = False,
+    ) -> HgvsVariant:
+        """:func:`from_sequences`, against this normalizer's reference.
+
+        The free function is a pure function of its arguments and so cannot
+        range-check ``position`` — doing that needs the reference, which would
+        make the provider a hidden input. This one holds a provider, so it does
+        check, and refuses an interval running past the end of the sequence. It
+        also offers ``normalize``, which the free function cannot.
+
+        The shuffle direction is this normalizer's own, set when it was
+        constructed, rather than a separate keyword.
+
+        Args:
+            accession: The sequence the window is on.
+            position: 1-based position of the window's first base.
+            reference: The reference bases over the window.
+            alternate: The observed bases over the same window.
+            max_grid_cells: As the free function.
+            normalize: Normalize the derived description before returning it.
+                Defaults to False, but prefer True unless you have a reason not
+                to: over a 6,000-shape sweep ``normalize`` moved 8.6% of derived
+                descriptions (repeat notation, reference-anchored member
+                re-derivation, and inversions spread across several members).
+                All three are the recommended-form and confluence rules this
+                design assigns to ``normalize``, so False still yields a
+                conformant, deterministic description.
+
+        Raises:
+            ValueError: for a ``max_grid_cells`` of 0. Checked at the binding
+                and outside the ``FerroError`` hierarchy.
+            NormalizationError: everything else, including the two refusals this
+                method adds over the free function — an unknown accession, and
+                an interval running past the end of the sequence — plus any
+                refusal from ``normalize`` when ``normalize=True``. Those two
+                were documented as ``ReferenceDataError`` until 2026-08-12 and
+                never raised it.
+        """
+        ...
+
 # ============================================================================
 # SPDI Classes
 # ============================================================================
@@ -1256,6 +1457,148 @@ class AppliedVariant:
     @property
     def resulting(self) -> str:
         """The same window after every member has been applied."""
+        ...
+
+    def __repr__(self) -> str: ...
+
+class SequencePair:
+    """A reference/alternate pair over one window.
+
+    The input `from_sequences` takes and the output `to_sequences` produces.
+    """
+
+    def __init__(self, accession: str, position: int, reference: str, alternate: str) -> None:
+        """Build a pair from bases you already hold.
+
+        A window out of a BAM, a VCF row, an aligner's output. ``position`` is
+        1-based and names the first base of ``reference``.
+
+        ``window_is_final`` is False on a pair built this way: caller-supplied
+        bases carry no evidence about whether their 3' edge is where the
+        sequence stops or where the read did.
+
+        Raises:
+            NormalizationError: for a zero position, an empty reference, or a
+                symbol outside the IUPAC-IUBMB nucleotide set (``general.md:48``),
+                which ``U`` is excluded from here because this surface's axis is
+                DNA — exactly what :func:`from_sequences` refuses, so a pair that
+                constructs is a pair that derives. The ambiguity codes (``Y``,
+                ``R``, ``S``, …) are admitted; real ClinVar rows carry them.
+                ``X`` and ``-`` are not, being alignment-only.
+        """
+        ...
+
+    def trim_to(self, start: int | None = None, end: int | None = None) -> SequencePair:
+        """Narrow this window to [start, end], trimming matching bases only.
+
+        The reference-free half of re-anchoring: use it to hold a derivation
+        inside a region it must not leave. ``None`` leaves that edge where it
+        is; both bounds are 1-based inclusive.
+
+        It can only narrow — widening needs bases this object does not hold, so
+        that is ``Normalizer.reanchor``. Narrowing is not free: a bound that
+        cuts an ambiguous run pulls the placement back to the bound, which is
+        the point when the bound is a requirement and a footgun when it is
+        arbitrary. The derivation reports it as ``placement_bounded_by_window``.
+
+        Raises:
+            NormalizationError: for a bound that would widen the window, cut
+                into a base the two sequences disagree on, empty the reference,
+                or put start past end. Refuses rather than clamping.
+        """
+        ...
+
+    def derive(
+        self, *, max_grid_cells: int | None = None, direction: str = "3prime"
+    ) -> DerivedDescription:
+        """Derive an HGVS description from this window.
+
+        :func:`from_sequences` over the four values this pair already carries,
+        so a caller holding a pair — especially one just returned by
+        ``trim_to`` or ``reanchor`` — does not re-spread them and cannot
+        accidentally pair a pre-trim position with post-trim bases.
+
+        Raises:
+            ValueError: for an unrecognized ``direction``, or a
+                ``max_grid_cells`` of 0.
+            NormalizationError: as the free :func:`from_sequences`.
+        """
+        ...
+
+    @property
+    def end(self) -> int:
+        """1-based position of the last base of ``reference``."""
+        ...
+
+    @property
+    def accession(self) -> str:
+        """The accession the window is on."""
+        ...
+
+    @property
+    def position(self) -> int:
+        """1-based position of the window's first base.
+
+        Note this differs from `AppliedVariant.start`, which is 0-based.
+        """
+        ...
+
+    @property
+    def reference(self) -> str:
+        """The reference bases over the window."""
+        ...
+
+    @property
+    def alternate(self) -> str:
+        """The same window after the variant has been applied."""
+        ...
+
+    @property
+    def window_is_final(self) -> bool:
+        """Whether the window is as wide 3' as it can usefully be.
+
+        True when it ends where the pad asked *or* where the sequence itself
+        ends — so True is the ordinary answer, including near a sequence end
+        where the pad was clipped. False means the provider stopped short of
+        both and the window may have cut an ambiguous run in half.
+
+        Not "the full pad was served", and 3'-only: the 5' flank is prepended
+        separately and is not reflected here.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool:
+        """Equality over all five fields, not by identity."""
+        ...
+
+    def __hash__(self) -> int:
+        """Hash consistent with :meth:`__eq__`."""
+        ...
+
+class DerivedDescription:
+    """A derived description, plus the one caveat a window-local derivation owes its caller."""
+
+    @property
+    def variant(self) -> HgvsVariant:
+        """The description."""
+        ...
+
+    @property
+    def placement_bounded_by_window(self) -> bool:
+        """Whether any member rests on an edge of the supplied window.
+
+        A "could move" flag, not an "is wrong" flag, and conservative in that
+        direction deliberately: the placement may lie against the edge of the
+        bases supplied, so a wider window — or a `Normalizer.normalize` pass,
+        which holds the reference — could move it.
+
+        It is *not* "exactly and only when the answer is read-dependent". That
+        wording was here and is measurably false: over a 4-base run a window
+        flush with the tract is flagged and still gives the same answer a
+        whole-sequence derivation gives. A flagged answer is never wrong — it
+        denotes the same bases and carries the same canonical SPDI.
+        """
         ...
 
     def __repr__(self) -> str: ...

--- a/src/python.rs
+++ b/src/python.rs
@@ -1314,6 +1314,406 @@ impl PyAppliedVariant {
     }
 }
 
+/// A reference/alternate pair over one window — the input `from_sequences`
+/// takes and the output `to_sequences` produces.
+#[pyclass(name = "SequencePair")]
+pub struct PySequencePair {
+    inner: crate::SequencePair,
+}
+
+#[pymethods]
+impl PySequencePair {
+    /// Build a pair from bases you already hold — a window out of a BAM, a VCF
+    /// row, an aligner's output.
+    ///
+    /// `position` is 1-based and names the first base of `reference`.
+    ///
+    /// `window_is_final` is False on a pair built this way, which is the only
+    /// honest answer: caller-supplied bases carry no evidence about whether
+    /// their 3' edge is where the sequence stops or where the read did.
+    ///
+    /// Args:
+    ///     accession: The sequence the window is on.
+    ///     position: 1-based position of the window's first base.
+    ///     reference: The reference bases over the window.
+    ///     alternate: The observed bases over the same window.
+    ///
+    /// Raises:
+    ///     NormalizationError: for a zero position, an empty reference, or a
+    ///         symbol outside the IUPAC-IUBMB nucleotide set (`general.md:48`),
+    ///         which `U` is excluded from here because this surface's axis is
+    ///         DNA — exactly what `from_sequences` refuses, so a pair that
+    ///         constructs is a pair that derives. The ambiguity codes (`Y`,
+    ///         `R`, `S`, …) are admitted; real ClinVar rows carry them.
+    ///         `X` and `-` are not, being alignment-only.
+    #[new]
+    #[pyo3(signature = (accession, position, reference, alternate))]
+    #[pyo3(text_signature = "(accession, position, reference, alternate)")]
+    fn new(
+        accession: String,
+        position: u64,
+        reference: String,
+        alternate: String,
+    ) -> PyResult<Self> {
+        crate::SequencePair::new(accession, position, reference, alternate)
+            .map(|inner| Self { inner })
+            .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+    }
+
+    /// Narrow this window to `[start, end]`, trimming matching bases only.
+    ///
+    /// The reference-free half of re-anchoring: use it to hold a derivation
+    /// inside a region it must not leave. `None` leaves that edge where it is;
+    /// both bounds are 1-based inclusive.
+    ///
+    /// It can only narrow — widening needs bases this object does not hold, so
+    /// that is `Normalizer.reanchor`. And narrowing is not free: a bound that
+    /// cuts an ambiguous run pulls the placement back to the bound, which is the
+    /// point when the bound is a requirement and a footgun when it is
+    /// arbitrary. The derivation reports it as `placement_bounded_by_window`.
+    ///
+    /// Raises:
+    ///     NormalizationError: for a bound that would widen the window, cut into
+    ///         a base the two sequences disagree on, empty the reference, or put
+    ///         start past end. Refuses rather than clamping in every case.
+    #[pyo3(signature = (start=None, end=None))]
+    #[pyo3(text_signature = "(start=None, end=None)")]
+    fn trim_to(&self, start: Option<u64>, end: Option<u64>) -> PyResult<Self> {
+        self.inner
+            .trim_to(start, end)
+            .map(|inner| Self { inner })
+            .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+    }
+
+    /// Derive an HGVS description from this window.
+    ///
+    /// `from_sequences` over the four values this pair already carries, so a
+    /// caller holding a pair — especially one just returned by `trim_to` or
+    /// `reanchor` — does not re-spread them and cannot accidentally pair a
+    /// pre-trim position with post-trim bases.
+    ///
+    /// Args:
+    ///     max_grid_cells: As the free `from_sequences`.
+    ///     direction: "3prime" (default) or "5prime".
+    ///
+    /// Returns:
+    ///     DerivedDescription
+    ///
+    /// Raises:
+    ///     ValueError: for an unrecognized direction, or a max_grid_cells of 0.
+    ///     NormalizationError: as the free `from_sequences`.
+    #[pyo3(signature = (*, max_grid_cells=None, direction="3prime"))]
+    #[pyo3(text_signature = "(*, max_grid_cells=None, direction='3prime')")]
+    fn derive(
+        &self,
+        py: Python<'_>,
+        max_grid_cells: Option<usize>,
+        direction: &str,
+    ) -> PyResult<PyDerivedDescription> {
+        let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+        let inner = self.inner.clone();
+        // Detached for the reason given on the free `from_sequences`: the grid
+        // is caller-tunable and unbounded by design.
+        py.detach(|| inner.derive(&options))
+            .map(|inner| PyDerivedDescription { inner })
+            .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+    }
+
+    /// 1-based position of the last base of `reference`.
+    #[getter]
+    fn end(&self) -> u64 {
+        self.inner.end()
+    }
+
+    /// The accession the window is on.
+    #[getter]
+    fn accession(&self) -> &str {
+        &self.inner.accession
+    }
+
+    /// **1-based** position of the window's first base.
+    ///
+    /// Note this differs from `AppliedVariant.start`, which is 0-based. HGVS and
+    /// VCF are both 1-based and this pair is what you hand `from_sequences`, so
+    /// it is 1-based too.
+    #[getter]
+    fn position(&self) -> u64 {
+        self.inner.position
+    }
+
+    /// The reference bases over the window.
+    #[getter]
+    fn reference(&self) -> &str {
+        &self.inner.reference
+    }
+
+    /// The same window after the variant has been applied.
+    #[getter]
+    fn alternate(&self) -> &str {
+        &self.inner.alternate
+    }
+
+    /// Whether the window is as wide 3' as it can usefully be — it ends where
+    /// the pad asked, **or** where the sequence itself ends.
+    ///
+    /// So `True` is the ordinary answer, including for a variant near a sequence
+    /// end where the pad was clipped: there was nothing further to read, so the
+    /// roll is settled either way. `False` means the provider stopped short of
+    /// both and the window may have cut an ambiguous run in half.
+    ///
+    /// Not "the full pad was served", despite what a pad-shaped name would
+    /// suggest, and 3'-only — the 5' flank is prepended separately and is not
+    /// reflected here.
+    #[getter]
+    fn window_is_final(&self) -> bool {
+        self.inner.window_is_final
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SequencePair(accession={:?}, position={}, reference={:?}, alternate={:?}, \
+             window_is_final={})",
+            self.inner.accession,
+            self.inner.position,
+            self.inner.reference,
+            self.inner.alternate,
+            if self.inner.window_is_final {
+                "True"
+            } else {
+                "False"
+            },
+        )
+    }
+
+    /// Equality over all five fields, matching the Rust type's derived
+    /// `PartialEq`.
+    ///
+    /// A `#[pyclass]` does not forward a derived `PartialEq`, so without this
+    /// two pairs holding the same window compared unequal — by identity, which
+    /// is the default and is never the answer a caller wants from a value
+    /// object. It is one an assertion silently passes over (`assert a != b`),
+    /// so it is pinned by a test rather than left to the `__repr__`.
+    fn __eq__(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+
+    /// Hash consistent with `__eq__`, making pairs usable as dict keys and set
+    /// members.
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.inner.accession.hash(&mut hasher);
+        self.inner.position.hash(&mut hasher);
+        self.inner.reference.hash(&mut hasher);
+        self.inner.alternate.hash(&mut hasher);
+        self.inner.window_is_final.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// A derived description, plus the one caveat a window-local derivation owes
+/// its caller.
+#[pyclass(name = "DerivedDescription")]
+pub struct PyDerivedDescription {
+    inner: crate::DerivedDescription,
+}
+
+#[pymethods]
+impl PyDerivedDescription {
+    /// The description.
+    #[getter]
+    fn variant(&self) -> PyHgvsVariant {
+        PyHgvsVariant {
+            inner: self.inner.variant.clone(),
+        }
+    }
+
+    /// Whether any member rests on an edge of the supplied window.
+    ///
+    /// **A "could move" flag, not an "is wrong" flag**, and conservative in that
+    /// direction deliberately: the placement may lie against the edge of the
+    /// bases supplied, so a wider window — or a `Normalizer.normalize` pass,
+    /// which holds the reference — could move it.
+    ///
+    /// It is **not** "exactly and only when the answer is read-dependent". That
+    /// wording was here and is measurably false: over a 4-base run a window
+    /// flush with the tract is flagged and still gives the same answer a
+    /// whole-sequence derivation gives. Telling the two apart needs the
+    /// reference, which this derivation does not read, so it reports the
+    /// uncertainty instead of resolving it. A flagged answer is never *wrong* —
+    /// it denotes the same bases and carries the same canonical SPDI.
+    #[getter]
+    fn placement_bounded_by_window(&self) -> bool {
+        self.inner.placement_bounded_by_window
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DerivedDescription(variant={:?}, placement_bounded_by_window={})",
+            self.inner.variant.to_string(),
+            if self.inner.placement_bounded_by_window {
+                "True"
+            } else {
+                "False"
+            },
+        )
+    }
+}
+
+/// Resolve the keyword arguments the two `from_sequences` entry points share.
+///
+/// Takes a resolved [`ShuffleDirection`] rather than the keyword string so that
+/// **both** callers can reach it: the free functions parse a string, while
+/// `Normalizer::from_sequences` takes the direction off its own config. Shaped
+/// around the first caller, the second forked it — and with it the refusal
+/// message, which two Python tests pin by text.
+///
+/// `max_grid_cells=None` means "the default", which is what an unset keyword
+/// should mean; `0` is rejected rather than silently admitting no grid at all,
+/// since every non-trivial pair needs at least one cell and a caller writing it
+/// has made a mistake this would otherwise hide behind an unrelated refusal.
+fn from_sequences_options(
+    max_grid_cells: Option<usize>,
+    direction: ShuffleDirection,
+) -> PyResult<crate::FromSequencesOptions> {
+    let mut options = crate::FromSequencesOptions::default().with_direction(direction);
+    if let Some(cells) = max_grid_cells {
+        if cells == 0 {
+            return Err(PyValueError::new_err(
+                "max_grid_cells must be positive; 0 admits no alignment grid at all",
+            ));
+        }
+        options = options.with_max_grid_cells(cells);
+    }
+    Ok(options)
+}
+
+/// Derive an HGVS description from a reference/alternate sequence pair.
+///
+/// The caller supplies the bases; this supplies the description. It reads **no
+/// reference sequence**, so its output is a pure function of its arguments —
+/// the same bases give the same description on any machine, against any
+/// reference build, with no hidden input.
+///
+/// **Case is not a refusal.** Both sequences are upper-cased before anything
+/// reads them, so a soft-masked (lower-case) window derives exactly what its
+/// upper-case twin derives, and a masked reference against an upper-case
+/// alternate is ordinary input rather than a mismatch.
+///
+/// This delivers the two normalization rules that are always achievable —
+/// **conformant** and **deterministic** — and deliberately not the two that
+/// need the reference, **recommended form** and **confluent**. So an output may
+/// be 3'-shiftable further than a window-local function could shift it, which
+/// is not a defect. Run `Normalizer.normalize` afterwards if you want it, or
+/// `Normalizer.from_sequences(..., normalize=True)` to do both in one call.
+///
+/// Args:
+///     accession: The sequence the window is on. A transcript or protein
+///         accession is refused — a `g.` description on an `NM_` denotes
+///         nothing.
+///     position: **1-based** position of the window's first base.
+///     reference: The reference bases over the window. Taken on trust and not
+///         verified — verifying it would need the reference and would make the
+///         provider a hidden input, costing exactly the determinism this
+///         function exists to provide. Pass bases that are not the reference
+///         and you get a faithful description of the pair you passed.
+///     alternate: The observed bases over the same window.
+///     max_grid_cells: Largest alignment grid, in cells, the partitioner will
+///         build. Defaults to (4096 + 1) ** 2, about 310 MB at roughly 18
+///         bytes a cell. Exceeding it raises rather than answering with a
+///         weaker rule.
+///     direction: Which end of an ambiguous run a pure indel is placed at —
+///         "3prime" (default) or "5prime".
+///
+/// Returns:
+///     HgvsVariant
+///
+/// Raises:
+///     ValueError: for an unrecognized `direction`, or a `max_grid_cells` of 0.
+///         These two are checked at the binding, before any derivation.
+///     NormalizationError: for everything the derivation itself refuses — a
+///         zero position, an empty reference, a non-nucleotide symbol, a
+///         transcript or protein accession, a grid over budget, or an inserted
+///         payload resting against the window's 5' edge with no anchor inside
+///         it. A subclass of `FerroError` and `RuntimeError`.
+///
+/// The two classes are **not** one hierarchy, and no single class catches
+/// both: the binding's `ValueError`s are raised by `PyValueError::new_err` and
+/// are deliberately outside `FerroError`, which is the repository-wide split
+/// between an argument-shape mistake and a variant-processing failure. To
+/// handle everything this function can raise in one clause, catch
+/// `(ValueError, ferro_hgvs.FerroError)` — or simply `Exception`. This doc said
+/// `ferro_hgvs.FerroError` alone covered both; it does not, and
+/// `test_the_two_refusal_classes_are_the_established_split` asserts it does
+/// not.
+///
+/// Example:
+///     >>> import ferro_hgvs
+///     >>> str(ferro_hgvs.from_sequences("NC_000001.11", 1000, "AGCG", "AG"))
+///     'NC_000001.11:g.1002_1003del'
+#[pyfunction]
+#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None, direction="3prime"))]
+#[pyo3(
+    text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None, direction='3prime')"
+)]
+fn from_sequences(
+    py: Python<'_>,
+    accession: &str,
+    position: u64,
+    reference: &str,
+    alternate: &str,
+    max_grid_cells: Option<usize>,
+    direction: &str,
+) -> PyResult<PyHgvsVariant> {
+    let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+    // Detached even though no provider is touched: the work behind this call is
+    // unbounded by design — the default budget admits a 4097x4097 grid, ~310 MB
+    // and 16.8 M cells, and the docs invite raising it — so holding the GIL
+    // would block every other Python thread for its duration. The sibling
+    // `Normalizer::from_sequences` already detaches around the same derivation.
+    // The `&str` arguments borrow Python-owned memory, so they are owned first.
+    let (accession, reference, alternate) = (
+        accession.to_string(),
+        reference.to_string(),
+        alternate.to_string(),
+    );
+    py.detach(|| crate::from_sequences(&accession, position, &reference, &alternate, &options))
+        .map(|inner| PyHgvsVariant { inner })
+        .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+}
+
+/// `from_sequences`, reporting also whether the derivation reached a window
+/// edge.
+///
+/// Returns:
+///     DerivedDescription with `variant` and `placement_bounded_by_window`.
+#[pyfunction]
+#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None, direction="3prime"))]
+#[pyo3(
+    text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None, direction='3prime')"
+)]
+fn from_sequences_detailed(
+    py: Python<'_>,
+    accession: &str,
+    position: u64,
+    reference: &str,
+    alternate: &str,
+    max_grid_cells: Option<usize>,
+    direction: &str,
+) -> PyResult<PyDerivedDescription> {
+    let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+    // Detached for the reason given on `from_sequences` above.
+    let (accession, reference, alternate) = (
+        accession.to_string(),
+        reference.to_string(),
+        alternate.to_string(),
+    );
+    py.detach(|| {
+        crate::from_sequences_detailed(&accession, position, &reference, &alternate, &options)
+    })
+    .map(|inner| PyDerivedDescription { inner })
+    .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+}
+
 #[pyclass(name = "Normalizer")]
 pub struct PyNormalizer {
     provider: PyProvider,
@@ -1547,6 +1947,217 @@ impl PyNormalizer {
         py.detach(|| normalizer.apply_to_reference(&inner_variant))
             .map(|inner| PyAppliedVariant { inner })
             .map_err(|e| ferro_typed("ProjectionError", format!("{e}"), &e))
+    }
+
+    /// Apply a variant to the reference and return the padded window as a
+    /// reference/alternate pair — the inverse of `from_sequences`.
+    ///
+    /// This is what turns any HGVS description into `from_sequences` input, so a
+    /// caller that already has descriptions needs no new plumbing to reach the
+    /// derivation. It differs from `apply_to_reference` in three ways that all
+    /// matter to that use: the position is **1-based**, both sides are padded,
+    /// and it reports whether the window's 3' edge is settled
+    /// (`window_is_final`).
+    ///
+    /// **That flag is not "the full pad was served"** — see its own doc. A
+    /// window clipped by the *sequence end* served less than the full pad and
+    /// is still settled, because there is nothing further to read. This
+    /// paragraph said "reports whether the full pad was served" while the
+    /// getter 500 lines below said it is not that, which is the literal reading
+    /// a Python test asserted and failed, and is what renamed the field off
+    /// `full_pad_served`.
+    ///
+    /// The pad is not decoration. `dup` typing reads the reference bases
+    /// immediately 5' of an insertion point, so a member flush with the window's
+    /// 5' edge comes back as an `ins` instead of a `dup` — measured over the cis
+    /// confluence corpus, ten classes reached both spellings purely from how
+    /// much flank their spans left them.
+    ///
+    /// Args:
+    ///     variant: The variant to express as sequences.
+    ///     pad: Flank in bases, on each side. Defaults to 128, matching the room
+    ///         the normalizer's own derivation gives its 3' placement.
+    ///
+    /// Returns:
+    ///     SequencePair with `accession`, `position` (1-based), `reference`,
+    ///     `alternate` and `window_is_final`.
+    ///
+    /// Raises:
+    ///     ProjectionError: as `apply_to_reference` — a variant with no single
+    ///         well-defined resulting sequence, or a span the provider cannot
+    ///         serve.
+    #[pyo3(signature = (variant, pad=128))]
+    #[pyo3(text_signature = "(variant, pad=128)")]
+    fn to_sequences(
+        &self,
+        py: Python<'_>,
+        variant: &PyHgvsVariant,
+        pad: u64,
+    ) -> PyResult<PySequencePair> {
+        let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
+        let inner_variant = variant.inner.clone();
+        py.detach(|| normalizer.to_sequences(&inner_variant, pad))
+            .map(|inner| PySequencePair { inner })
+            .map_err(|e| ferro_typed("ProjectionError", format!("{e}"), &e))
+    }
+
+    /// Move a window to `[start, end]`, padding from the reference or trimming,
+    /// whichever each side needs.
+    ///
+    /// The reference-holding half of re-anchoring; `SequencePair.trim_to` is the
+    /// pure half and can only narrow. `None` leaves that edge where it is; both
+    /// bounds are 1-based inclusive.
+    ///
+    /// Use it to hold a derivation inside a region it must not leave — a target
+    /// region, an amplicon, a tiling window — from whatever raw window each
+    /// caller happens to have, **provided every such window overlaps the
+    /// region**.
+    ///
+    /// **It moves a window's edges; it does not relocate the window.** Each edge
+    /// may go outwards (padded from the reference) or inwards (trimmed), in any
+    /// combination — but the requested window must overlap the pair's own, and
+    /// the overlap must still hold the bases the two sequences disagree on. The
+    /// changed bases exist only in the pair, so there is nothing to carry to a
+    /// region the pair does not cover.
+    ///
+    /// The bases come back **upper-cased**, as from `to_sequences`: the flank is
+    /// read from the provider and the rest is the caller's, so a soft-masked
+    /// region would otherwise return a mixed-case pair no caller wrote.
+    /// `SequencePair.trim_to`, which fetches nothing, leaves case alone.
+    ///
+    /// **Not the tool for making heterogeneous inputs agree in general.** That
+    /// is already available and better: `Normalizer.from_sequences(...,
+    /// normalize=True)`, or a round trip through `to_sequences`. Both reach the
+    /// reference-anchored placement, which shifts as far as the sequence allows
+    /// rather than as far as a chosen window allows. Anchoring to a window that
+    /// cuts an ambiguous run makes every caller using that window agree with
+    /// each other and disagree with the reference.
+    ///
+    /// Args:
+    ///     pair: The window to move.
+    ///     start: New 1-based first position, or None to leave it.
+    ///     end: New 1-based last position, or None to leave it.
+    ///
+    /// Raises:
+    ///     NormalizationError: for every refusal — a bound outside the sequence
+    ///         (a start of 0, or an end past the last base; refused rather than
+    ///         clamped back to the contig, because a caller who asked for bases
+    ///         that do not exist has a bug upstream a clamp would hide), a
+    ///         requested window disjoint from the pair's own, and anything
+    ///         `SequencePair.trim_to` refuses on the narrowing side.
+    ///
+    /// This method raises **one** class. It is not `ReferenceDataError`, which
+    /// this doc named until 2026-08-12 for the out-of-sequence bound: every
+    /// error here is mapped through one `ferro_typed("NormalizationError", …)`,
+    /// and `ferro_exception` resolves a class *name* rather than dispatching on
+    /// the `FerroError` variant, so no input could ever produce the documented
+    /// class. `ReferenceDataError` is this binding's class for failures loading
+    /// reference data (`Normalizer(...)`, `from_manifest`, `prepare`, `check`),
+    /// not for a per-call lookup — the sibling `normalize_variant` likewise
+    /// raises `NormalizationError` for an unknown accession. Documenting the
+    /// class that is raised keeps that convention; raising the documented one
+    /// would make these the only per-call sites in the file that vary their
+    /// class by error variant.
+    #[pyo3(signature = (pair, start=None, end=None))]
+    #[pyo3(text_signature = "(pair, start=None, end=None)")]
+    fn reanchor(
+        &self,
+        py: Python<'_>,
+        pair: &PySequencePair,
+        start: Option<u64>,
+        end: Option<u64>,
+    ) -> PyResult<PySequencePair> {
+        let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
+        let inner = pair.inner.clone();
+        py.detach(|| normalizer.reanchor(&inner, start, end))
+            .map(|inner| PySequencePair { inner })
+            .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+    }
+
+    /// `from_sequences`, against this normalizer's reference.
+    ///
+    /// The free `ferro_hgvs.from_sequences` is a pure function of its arguments
+    /// and so cannot range-check `position` — doing that needs the reference,
+    /// which would make the provider a hidden input. This one holds a provider,
+    /// so it does check, and refuses an interval running past the end of the
+    /// sequence. It also offers `normalize`, which the free function cannot.
+    ///
+    /// The shuffle direction is this normalizer's own, set when it was
+    /// constructed, rather than a separate keyword — one direction per
+    /// normalizer is the contract every other method here follows.
+    ///
+    /// Args:
+    ///     accession: The sequence the window is on.
+    ///     position: **1-based** position of the window's first base.
+    ///     reference: The reference bases over the window.
+    ///     alternate: The observed bases over the same window.
+    ///     max_grid_cells: As the free function.
+    ///     normalize: Normalize the derived description before returning it.
+    ///         Defaults to False, but prefer True unless you have a reason not
+    ///         to: over a 6,000-shape sweep `normalize` moved 8.6% of derived
+    ///         descriptions (repeat notation, reference-anchored member
+    ///         re-derivation, and inversions spread across several members).
+    ///         All three are the recommended-form and confluence rules this
+    ///         design assigns to `normalize`, so False still yields a
+    ///         conformant, deterministic description.
+    ///
+    /// Returns:
+    ///     HgvsVariant
+    ///
+    /// Raises:
+    ///     ValueError: for a `max_grid_cells` of 0. Checked at the binding,
+    ///         before any derivation, and outside the `FerroError` hierarchy —
+    ///         see the free function.
+    ///     NormalizationError: everything else, including the two refusals this
+    ///         method adds over the free function: an unknown accession, and an
+    ///         interval running past the end of the sequence. Plus any refusal
+    ///         from `normalize` when `normalize=True`.
+    ///
+    /// Those last two were documented as `ReferenceDataError` until 2026-08-12
+    /// and never raised it — see `reanchor` for why this file maps a per-call
+    /// failure to the method's own class rather than dispatching on the
+    /// `FerroError` variant.
+    #[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None, normalize=false))]
+    #[pyo3(
+        text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None, normalize=False)"
+    )]
+    // `wrong_self_convention`: the name is the point. It matches
+    // `ferro_hgvs.from_sequences`, the free function it is the reference-holding
+    // sibling of, and the repository's `from` convention for a constructor-like
+    // entry point. Renaming it to satisfy the lint would break the one
+    // correspondence a caller navigates by.
+    //
+    // `too_many_arguments`: four are the variant, two are options and one is the
+    // GIL token. The established handling in this file — three other bindings
+    // carry the same allow — since the argument list is fixed by the Python
+    // surface rather than chosen here.
+    #[allow(clippy::wrong_self_convention, clippy::too_many_arguments)]
+    fn from_sequences(
+        &self,
+        py: Python<'_>,
+        accession: &str,
+        position: u64,
+        reference: &str,
+        alternate: &str,
+        max_grid_cells: Option<usize>,
+        normalize: bool,
+    ) -> PyResult<PyHgvsVariant> {
+        let options = from_sequences_options(max_grid_cells, self.config.shuffle_direction)?;
+        let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
+        // Owned before detaching: `&str` borrows Python-owned memory and cannot
+        // cross into the closure. The same shape `VariantProjector` uses.
+        let (accession, reference, alternate) = (
+            accession.to_string(),
+            reference.to_string(),
+            alternate.to_string(),
+        );
+        py.detach(|| {
+            normalizer.from_sequences(
+                &accession, position, &reference, &alternate, &options, normalize,
+            )
+        })
+        .map(|inner| PyHgvsVariant { inner })
+        .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
     }
 
     /// Normalize an HGVS variant
@@ -6262,6 +6873,8 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(normalize, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_with_warnings, m)?)?;
+    m.add_function(wrap_pyfunction!(from_sequences, m)?)?;
+    m.add_function(wrap_pyfunction!(from_sequences_detailed, m)?)?;
 
     // SPDI functions
     m.add_function(wrap_pyfunction!(parse_spdi, m)?)?;
@@ -6326,6 +6939,8 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyBatchProgress>()?;
     m.add_class::<PyBatchResult>()?;
     m.add_class::<PyAppliedVariant>()?;
+    m.add_class::<PySequencePair>()?;
+    m.add_class::<PyDerivedDescription>()?;
     m.add_class::<PyBatchProcessor>()?;
     m.add_class::<PyBatchStream>()?;
     m.add_class::<PyBatchItem>()?;

--- a/tests/python/test_from_sequences.py
+++ b/tests/python/test_from_sequences.py
@@ -1,0 +1,625 @@
+"""Deriving an HGVS description from a reference/alternate sequence pair.
+
+The scenario this surface exists for: a pipeline aligns reads, post-processes a
+BAM, and wants one canonical, spec-conformant description per variant determined
+by the reference and observed bases alone. Today that pipeline has to choose an
+HGVS spelling itself and hand it to ``normalize`` — and that choice leaks into
+the output.
+
+``from_sequences`` takes the bases instead. It delivers the two normalization
+rules that are always achievable, **conformant** and **deterministic**, and
+deliberately not the two that need the reference, **recommended form** and
+**confluent**. ``Normalizer.to_sequences`` is the inverse, so a caller holding
+descriptions rather than bases needs no new plumbing to reach it.
+
+The tests below are the Python half of that contract. The properties themselves
+— confluence over the cis corpus's 5 636 **genomic** classes (its other 5 636 are
+``c.`` against ``NM_TEST.1``, which the ``g.``-only gate refuses, so they never
+enter the comparison; the exclusion is structural and is asserted as such in
+``tests/it/from_sequences_corpus.rs``), the nine externally-reported #1419/#1420/
+#1421 pairs, denotation preservation over 23 121 derivations — are judged in
+Rust, where the corpora live. What is checked here is what only the binding can
+get wrong: the keyword-only signature, the 1-based position, which exception
+comes out of which failure, and that the two directions actually reach the
+partitioner rather than being accepted and dropped.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+# 1-based:      1234567890
+#
+# A 4-base `A` homopolymer run at 12-15, and `GGATTACAGG` repeated at 1-10 and
+# 22-31 — so a derivation has something to shuffle and the two directions are
+# distinguishable.
+#
+# The run's coordinates read 11-14 here until 2026-08-12, which is where it sits
+# inside `test_the_direction_reaches_the_partitioner`'s *window* (that pair
+# starts at 10, not at 1) rather than in this sequence. #1694's Rust counterpart,
+# `tests/it/from_sequences_reanchor.rs`, says 12-15 and is right.
+SEQUENCE = "GGATTACAGGCAAAAGCCTGAGGATTACAGGCATTAGCCT"
+
+
+@pytest.fixture(scope="module")
+def normalizer():
+    """A provider whose bases are known, so expected strings can be written by
+    hand rather than read back out of the code under test."""
+    reference = {
+        "transcripts": [
+            {
+                "id": "TEMPLATE",
+                "gene_symbol": "T",
+                "strand": "+",
+                "sequence": SEQUENCE,
+                "exons": [{"number": 1, "start": 1, "end": len(SEQUENCE)}],
+            }
+        ]
+    }
+    path = Path(tempfile.mkdtemp()) / "reference.json"
+    path.write_text(json.dumps(reference))
+    return ferro_hgvs.Normalizer(reference_json=str(path))
+
+
+# ---------------------------------------------------------------------------
+# The free function: a pure function of its arguments
+# ---------------------------------------------------------------------------
+
+
+def test_derives_a_description_from_bases_alone():
+    """No reference, no provider, no Normalizer — just the four arguments."""
+    variant = ferro_hgvs.from_sequences("NC_000001.11", 1000, "AGCG", "AG")
+    assert str(variant) == "NC_000001.11:g.1002_1003del"
+
+
+def test_the_position_is_one_based():
+    """The single most likely thing for a caller to get wrong, and the reason
+    ``SequencePair`` exists rather than ``AppliedVariant`` being handed straight
+    across: ``AppliedVariant.start`` is 0-based and this is not.
+
+    Asserted against a coordinate computed by hand: the window starts at 1000,
+    the last two bases of ``AGCG`` are dropped, so the deletion is 1002_1003.
+    """
+    assert str(ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG")) == "NC_1:g.3_4del"
+    assert str(ferro_hgvs.from_sequences("NC_1", 2, "AGCG", "AG")) == "NC_1:g.4_5del"
+
+
+def test_the_same_bases_give_the_same_description():
+    """Rule 4, at the binding. Not a deep property — the Rust side proves it over
+    the corpora — but a binding that leaked a hash seed or an iteration order
+    into the output would fail here and nowhere else in this file."""
+    calls = [ferro_hgvs.from_sequences("NC_1", 5, "GGCATTAGC", "GGCTTAGC") for _ in range(8)]
+    assert len({str(v) for v in calls}) == 1
+
+
+def test_an_unchanged_pair_is_the_identity_description():
+    assert str(ferro_hgvs.from_sequences("NC_1", 5, "GGCA", "GGCA")) == "NC_1:g.="
+
+
+# ---------------------------------------------------------------------------
+# The signature
+# ---------------------------------------------------------------------------
+
+
+def test_the_options_are_keyword_only():
+    """``max_grid_cells`` and ``direction`` are keyword-only on purpose: they are
+    tuning knobs, and a positional fifth argument would read as part of the
+    variant rather than as configuration."""
+    with pytest.raises(TypeError):
+        ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", 1024)  # type: ignore[misc]
+
+
+def test_the_direction_reaches_the_partitioner():
+    """Both directions must be accepted *and act*. A binding that parsed the
+    keyword and then dropped it would pass a "does not raise" test, so this pins
+    a pair where the two answers differ — a single-base deletion inside the
+    ``AAAA`` run, which 3' places at 14 and 5' at 11. Those are coordinates in
+    *this pair's* frame (it starts at 10 and is written out below, not sliced
+    from ``SEQUENCE``); the run sits at 12-15 of ``SEQUENCE`` itself."""
+    three = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAG", "CAAAG", direction="3prime")
+    five = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAG", "CAAAG", direction="5prime")
+    assert str(three) == "NC_1:g.14del"
+    assert str(five) == "NC_1:g.11del"
+
+
+def test_an_unrecognized_direction_is_a_value_error():
+    with pytest.raises(ValueError, match="unrecognized direction"):
+        ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", direction="sideways")
+
+
+# ---------------------------------------------------------------------------
+# Refusals: which exception, and does it say what to do
+# ---------------------------------------------------------------------------
+
+
+def test_a_zero_grid_budget_is_a_value_error():
+    """Checked at the binding, before any derivation — so it is a ``ValueError``
+    rather than a ``NormalizationError``, and the docs say which is which."""
+    with pytest.raises(ValueError, match="max_grid_cells must be positive"):
+        ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", max_grid_cells=0)
+
+
+def test_a_grid_over_budget_refuses_and_names_the_knob():
+    """The operator's stated policy is to refuse above the window rather than
+    degrade to a weaker rule, so a refusal has to be actionable: it names the
+    knob and its per-cell cost."""
+    with pytest.raises(ferro_hgvs.NormalizationError) as excinfo:
+        ferro_hgvs.from_sequences("NC_1", 1, "ACGTACGTAC", "TGCATGCATG", max_grid_cells=4)
+    assert "max_grid_cells" in str(excinfo.value)
+
+
+def test_a_transcript_accession_is_refused():
+    """``NM_TEST.1:g.9_10del`` is well-formed and denotes nothing — a ``g.``
+    description on a transcript is not one the recommendations admit
+    (``checklist.md:20``). Found by running the corpus, not by a unit test."""
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        ferro_hgvs.from_sequences("NM_000088.3", 10, "AGCG", "AG")
+
+
+@pytest.mark.parametrize(
+    ("position", "reference", "alternate"),
+    [
+        (0, "AGCG", "AG"),  # 1-based; 0 names no base
+        (1, "", "AG"),  # no interval to describe
+        (1, "AGXG", "AG"),  # standards.md:39 — X is alignment-only
+    ],
+)
+def test_unusable_input_refuses(position, reference, alternate):
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        ferro_hgvs.from_sequences("NC_1", position, reference, alternate)
+
+
+def test_the_two_refusal_classes_are_the_established_split():
+    """Argument-shape errors are a plain ``ValueError``; everything the
+    derivation itself refuses is a ``NormalizationError``, which is a
+    ``FerroError``.
+
+    That split is the binding's existing convention, not a choice made here —
+    ``Normalizer(direction=...)`` has always raised a plain ``ValueError`` for an
+    unrecognized direction. Pinned because the obvious wrong guess is that
+    ``FerroError`` catches everything from one call, and it does not: a caller
+    wrapping ``from_sequences`` needs ``(ValueError, ferro_hgvs.FerroError)``, or
+    simply ``Exception``."""
+    binding_checks = (
+        lambda: ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", max_grid_cells=0),
+        lambda: ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", direction="sideways"),
+    )
+    for call in binding_checks:
+        with pytest.raises(ValueError) as excinfo:
+            call()
+        assert not isinstance(excinfo.value, ferro_hgvs.FerroError)
+
+    with pytest.raises(ferro_hgvs.FerroError):
+        ferro_hgvs.from_sequences("NC_1", 0, "AGCG", "AG")
+
+
+# ---------------------------------------------------------------------------
+# from_sequences_detailed
+# ---------------------------------------------------------------------------
+
+
+def test_a_derivation_reports_whether_it_reached_a_window_edge():
+    """The one caveat a window-local derivation owes its caller: on an edge, the
+    3' placement may lie outside the bases supplied, so a wider window could move
+    the answer. Reported rather than silently absorbed.
+
+    The pair is the same deletion twice, once with flank and once without."""
+    interior = ferro_hgvs.from_sequences_detailed("NC_1", 10, "CAAAAGCC", "CAAAGCC")
+    assert interior.placement_bounded_by_window is False
+
+    flush = ferro_hgvs.from_sequences_detailed("NC_1", 10, "AAAA", "AAA")
+    assert flush.placement_bounded_by_window is True
+    assert str(flush.variant) == "NC_1:g.13del"
+
+
+def test_the_detailed_variant_matches_the_plain_call():
+    plain = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAGCC", "CAAAGCC")
+    detailed = ferro_hgvs.from_sequences_detailed("NC_1", 10, "CAAAAGCC", "CAAAGCC")
+    assert str(detailed.variant) == str(plain)
+
+
+def test_derived_description_has_a_useful_repr():
+    rendered = repr(ferro_hgvs.from_sequences_detailed("NC_1", 10, "CAAAAGCC", "CAAAGCC"))
+    assert rendered.startswith("DerivedDescription(")
+    assert "placement_bounded_by_window" in rendered
+
+
+# ---------------------------------------------------------------------------
+# to_sequences: the inverse
+# ---------------------------------------------------------------------------
+
+
+def test_to_sequences_returns_a_one_based_window(normalizer):
+    variant = normalizer.parse("TEMPLATE:n.13del")
+    pair = normalizer.to_sequences(variant, pad=4)
+
+    assert pair.accession == "TEMPLATE"
+    # The window is the member's span padded on both sides, and `position` is
+    # 1-based, so `SEQUENCE[position - 1]` is its first base.
+    assert SEQUENCE[pair.position - 1 : pair.position - 1 + len(pair.reference)] == pair.reference
+    assert len(pair.alternate) == len(pair.reference) - 1
+    assert pair.window_is_final is True
+
+
+def test_to_sequences_pads_both_sides(normalizer):
+    """The 5' half of the pad is load-bearing and was missing at first: ``dup``
+    typing reads the reference bases immediately 5' of an insertion point
+    (``duplication.md:18``), so a member flush with the window's 5' edge comes
+    back as an ``ins`` instead of a ``dup``. Ten corpus classes reached both
+    spellings before this was fixed."""
+    variant = normalizer.parse("TEMPLATE:n.13del")
+    pair = normalizer.to_sequences(variant, pad=4)
+    assert pair.position < 13
+    assert pair.position - 1 + len(pair.reference) > 13
+
+
+def test_to_sequences_clamps_the_pad_to_the_sequence(normalizer):
+    """Near a sequence start there is less flank than asked for, so the window
+    is clamped rather than the request refused.
+
+    ``window_is_final`` stays True through that, and the distinction is the
+    point: a window clipped by the *sequence end* has nothing further to read,
+    so the roll is settled and a 3' placement against that edge is trustworthy.
+    Only a provider stopping short of both makes it False. This test asserted
+    the pad-shaped reading first and failed, which is what renamed the field
+    from ``full_pad_served``."""
+    variant = normalizer.parse("TEMPLATE:n.2del")
+    pair = normalizer.to_sequences(variant, pad=100)
+    assert pair.position == 1
+    assert pair.reference == SEQUENCE
+    assert pair.window_is_final is True
+
+
+def test_to_sequences_refuses_what_apply_to_reference_refuses(normalizer):
+    """``to_sequences`` promises ``ProjectionError`` and had no test at all, so
+    the promise was unchecked in the one direction it could be wrong — the
+    binding maps it through a *literal* class name, and nothing but a test on
+    that name notices when the name and the docstring drift apart."""
+    with pytest.raises(ferro_hgvs.ProjectionError):
+        normalizer.to_sequences(normalizer.parse("NOT_A_TEMPLATE:n.13del"), pad=4)
+
+
+def test_sequence_pair_has_a_useful_repr(normalizer):
+    rendered = repr(normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=4))
+    assert rendered.startswith("SequencePair(")
+    assert "position=" in rendered
+
+
+def test_sequence_pairs_compare_by_value(normalizer):
+    """The Rust type derives ``PartialEq``; a ``#[pyclass]`` does not forward it,
+    so without an explicit ``__eq__`` two pairs holding the same window compared
+    unequal by identity — the kind of default an ``assert a != b`` passes over in
+    silence."""
+    variant = normalizer.parse("TEMPLATE:n.13del")
+    one = normalizer.to_sequences(variant, pad=4)
+    same = normalizer.to_sequences(variant, pad=4)
+    wider = normalizer.to_sequences(variant, pad=6)
+
+    assert one == same
+    assert one is not same
+    assert one != wider
+    assert len({one, same, wider}) == 2
+
+
+# ---------------------------------------------------------------------------
+# The round trip, and the Normalizer method
+# ---------------------------------------------------------------------------
+
+
+def test_a_description_survives_the_round_trip(normalizer):
+    """description -> sequences -> description. The two functions check each
+    other, which is exactly how the Rust corpus tests turn every committed HGVS
+    corpus into a ``from_sequences`` corpus with no new fixtures."""
+    for spelling in ["TEMPLATE:n.13del", "TEMPLATE:n.3_5del", "TEMPLATE:n.13dup"]:
+        pair = normalizer.to_sequences(normalizer.parse(spelling), pad=16)
+        derived = normalizer.from_sequences(
+            pair.accession, pair.position, pair.reference, pair.alternate
+        )
+        # Compared on the bases denoted, not on the string: a derivation may
+        # legitimately narrow the span or choose another legal spelling, and
+        # `canonical_spdi` is independent of both.
+        assert normalizer.canonical_spdi(derived) == normalizer.canonical_spdi(
+            normalizer.parse(spelling)
+        )
+
+
+def test_the_method_refuses_an_interval_past_the_sequence_end(normalizer):
+    """The free function cannot range-check ``position`` — that needs the
+    reference, which would make the provider a hidden input and cost exactly the
+    determinism it exists to provide. The method holds a provider, so it does.
+
+    Asserted on the exact class, not on ``FerroError``. The binding promises one
+    per method, and a ``FerroError`` assertion passes for all four of them — so
+    it cannot catch a docstring that promises a class the code never raises,
+    which is exactly what this method's did (``ReferenceDataError`` for both of
+    the refusals it adds over the free function)."""
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        normalizer.from_sequences("TEMPLATE", len(SEQUENCE), "AGCG", "AG")
+
+
+def test_the_method_refuses_an_unknown_accession(normalizer):
+    """The other refusal the method adds over the free function, and the other
+    one its docstring promised as ``ReferenceDataError``. That class is this
+    binding's for failures *loading* reference data; a per-call lookup is the
+    method's own class, as ``normalize_variant`` has always been."""
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        normalizer.from_sequences("NOT_A_TEMPLATE", 10, "CAAAAG", "CAAAG")
+
+
+def test_the_method_uses_the_normalizers_own_direction():
+    """One direction per normalizer, set at construction — the contract every
+    other method here follows, rather than a second place to set it."""
+    reference = {
+        "transcripts": [
+            {
+                "id": "TEMPLATE",
+                "gene_symbol": "T",
+                "strand": "+",
+                "sequence": SEQUENCE,
+                "exons": [{"number": 1, "start": 1, "end": len(SEQUENCE)}],
+            }
+        ]
+    }
+    path = Path(tempfile.mkdtemp()) / "reference.json"
+    path.write_text(json.dumps(reference))
+
+    args = ("TEMPLATE", 10, "CAAAAG", "CAAAG")
+    three = ferro_hgvs.Normalizer(reference_json=str(path), direction="3prime")
+    five = ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
+    assert str(three.from_sequences(*args)) != str(five.from_sequences(*args))
+
+
+def test_post_normalizing_is_available_and_is_a_no_op_here(normalizer):
+    """``normalize=False`` is the ordinary posture. On measured material the flag
+    is a no-op **on these rows** — a 6,000-shape sweep found it moves 8.6% of
+    derived descriptions overall, so this is a property of the rows below and
+    never of the surface. On them a derived description is a fixed point of ``normalize``
+    on the genomic axis — so its value is the diagnostics ``normalize`` raises
+    and inheriting its improvements as they land. Pinned as a measurement on
+    these rows, never as a law."""
+    pair = normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=16)
+    plain = normalizer.from_sequences(pair.accession, pair.position, pair.reference, pair.alternate)
+    normalized = normalizer.from_sequences(
+        pair.accession, pair.position, pair.reference, pair.alternate, normalize=True
+    )
+    assert str(normalized) == str(plain)
+
+
+def test_the_method_rejects_a_zero_grid_budget(normalizer):
+    with pytest.raises(ValueError, match="max_grid_cells must be positive"):
+        normalizer.from_sequences("TEMPLATE", 10, "CAAAAG", "CAAAG", max_grid_cells=0)
+
+
+# ---------------------------------------------------------------------------
+# The exported surface
+# ---------------------------------------------------------------------------
+
+
+def test_the_surface_is_exported():
+    """Both classes and both functions must be reachable as ``ferro_hgvs.X`` and
+    named in ``__all__`` — a binding registered in the pymodule but missing from
+    ``__all__`` is importable and invisible to ``from ferro_hgvs import *``."""
+    for name in (
+        "from_sequences",
+        "from_sequences_detailed",
+        "SequencePair",
+        "DerivedDescription",
+    ):
+        assert hasattr(ferro_hgvs, name), f"{name} is not exported"
+        assert name in ferro_hgvs.__all__, f"{name} is missing from __all__"
+
+
+# ---------------------------------------------------------------------------
+# Re-anchoring: bounding a derivation to a window it must not leave
+# ---------------------------------------------------------------------------
+
+
+def test_a_pair_can_be_built_from_bases_alone():
+    """`SequencePair` was previously only ever *returned*, which put both
+    re-anchoring entry points out of reach of the caller they are for: one who
+    has bases out of a BAM and no description at all."""
+    pair = ferro_hgvs.SequencePair("T", 10, "GCAAAAG", "GCAAAG")
+    assert (pair.position, pair.end) == (10, 16)
+    assert pair.window_is_final is False
+
+
+def test_a_pair_that_constructs_is_a_pair_that_derives():
+    """The constructor shares `from_sequences`'s check rather than copying it,
+    so the refusal lands on the argument that caused it."""
+    for position, reference, alternate in [(0, "AGCG", "AG"), (1, "", "AG"), (1, "AGXG", "AG")]:
+        with pytest.raises(ferro_hgvs.NormalizationError):
+            ferro_hgvs.SequencePair("T", position, reference, alternate)
+
+
+def test_the_constructor_admits_the_iupac_ambiguity_codes():
+    """The alphabet is ``Base::from_char``'s — the IUPAC-IUBMB set of
+    ``general.md:48`` — not ``ACGTN``, which is what it was before #1693 widened
+    it and what both Python docstrings still claimed. Real ClinVar rows carry the
+    ambiguity codes (``NM_000518.4:c.[20A>T;249G>Y]`` among them), so a narrow
+    alphabet refuses submitted data.
+
+    ``U`` stays refused, and that exclusion is this surface's own rather than
+    ``from_char``'s: this surface emits ``g.``/``m.`` descriptions, which are
+    DNA."""
+    assert ferro_hgvs.SequencePair("T", 1, "AGYG", "AG").reference == "AGYG"
+
+    for bad in ("AGUG", "AGXG", "AG-G"):
+        with pytest.raises(ferro_hgvs.NormalizationError):
+            ferro_hgvs.SequencePair("T", 1, bad, "AG")
+
+
+def test_a_bound_stops_the_roll_at_the_bound():
+    """The headline behaviour. Unbounded the deletion rolls 3' to 15; bounded at
+    14 it stays at 14."""
+    pair = ferro_hgvs.SequencePair("NC_1", 10, "GCAAAAG", "GCAAAG")
+    assert str(
+        ferro_hgvs.from_sequences("NC_1", pair.position, pair.reference, pair.alternate)
+    ) == ("NC_1:g.15del")
+
+    bounded = pair.trim_to(end=14)
+    assert (bounded.position, bounded.end) == (10, 14)
+    derived = ferro_hgvs.from_sequences_detailed(
+        "NC_1", bounded.position, bounded.reference, bounded.alternate
+    )
+    assert str(derived.variant) == "NC_1:g.14del"
+    assert derived.placement_bounded_by_window is True
+
+
+def test_trim_to_refuses_rather_than_clamping():
+    pair = ferro_hgvs.SequencePair("NC_1", 10, "GCAAAAG", "GCAAAAT")
+    # Cuts the substituted base at 16.
+    with pytest.raises(ferro_hgvs.NormalizationError, match="differ"):
+        pair.trim_to(end=15)
+    # Widening is not something a reference-free object can do; the message says
+    # which method can.
+    with pytest.raises(ferro_hgvs.NormalizationError, match="reanchor"):
+        pair.trim_to(start=5)
+
+
+def test_trim_to_treats_case_as_agreement():
+    """A soft-masked reference against an upper-case alternate is an ordinary
+    pileup. The comparison folds — ``Base.from_char`` does, and the constructor's
+    own validation says case is not a reason to refuse — so a byte comparison
+    here refused a legal trim claiming the two sequences "first differ" at a
+    coordinate where they do not.
+
+    ``trim_to`` fetches nothing, so it cannot manufacture a mixed-case pair and
+    leaves the bases as passed. ``Normalizer.reanchor``, which does fetch, folds
+    the whole window instead."""
+    masked = ferro_hgvs.SequencePair("NC_1", 10, "gcaaaag", "GCAAAG")
+    bounded = masked.trim_to(end=14)
+    assert (bounded.position, bounded.end) == (10, 14)
+    assert bounded.reference == "gcaaa"
+    assert str(bounded.derive().variant) == "NC_1:g.14del"
+
+    # A real disagreement is still refused, so the fold is not a blanket accept.
+    with pytest.raises(ferro_hgvs.NormalizationError, match="differ"):
+        ferro_hgvs.SequencePair("NC_1", 10, "gcaaaag", "GCAAAAT").trim_to(end=15)
+
+
+def test_reanchor_pads_and_trims(normalizer):
+    """One call that widens one edge and narrows the other."""
+    pair = normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=2)
+    widened = normalizer.reanchor(pair, start=1, end=20)
+    assert (widened.position, widened.end) == (1, 20)
+    assert widened.reference == SEQUENCE[:20]
+    assert len(widened.alternate) == len(widened.reference) - 1
+
+
+def test_reanchor_keeps_window_is_final_when_the_three_prime_edge_never_moves(normalizer):
+    """``window_is_final`` was recomputed as ``end == length`` unconditionally, so
+    an *identity* re-anchor downgraded a settled window to False — and no test in
+    either language fed a ``to_sequences`` pair to ``reanchor`` and then read the
+    flag, which is the only way a True ever reaches it.
+
+    The rule is ``trim_to``'s, stated over coordinates because this method can
+    widen as well as narrow: reaching the sequence's own end settles the edge,
+    and so does leaving an already-settled edge alone."""
+    settled = normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=4)
+    assert settled.window_is_final is True
+    assert settled.end < len(SEQUENCE), "the fixture must stop short of the sequence end"
+
+    assert normalizer.reanchor(settled).window_is_final is True
+    assert normalizer.reanchor(settled, start=1).window_is_final is True
+    assert normalizer.reanchor(settled, end=settled.end + 1).window_is_final is False
+    assert normalizer.reanchor(settled, end=len(SEQUENCE)).window_is_final is True
+
+    # A caller-built pair carries False by construction, and moving nothing does
+    # not settle it.
+    raw = ferro_hgvs.SequencePair("TEMPLATE", 10, "GCAAAAG", "GCAAAG")
+    assert normalizer.reanchor(raw).window_is_final is False
+    assert normalizer.reanchor(raw, end=len(SEQUENCE)).window_is_final is True
+
+
+def test_reanchor_refuses_to_leave_the_sequence(normalizer):
+    """The operator's call: a caller who asked for bases that do not exist has a
+    bug upstream, and a silently clamped window would hide it.
+
+    On the exact class, not on ``FerroError``: the docstring promised
+    ``ReferenceDataError`` for precisely these two bounds and the binding maps
+    every error here through ``NormalizationError``, so a ``FerroError``
+    assertion is what let the promise sit green."""
+    pair = normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=2)
+    whole = normalizer.reanchor(pair, start=1, end=len(SEQUENCE))
+    assert (whole.position, whole.end) == (1, len(SEQUENCE))
+    assert whole.reference == SEQUENCE
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        normalizer.reanchor(pair, start=1, end=len(SEQUENCE) + 1)
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        normalizer.reanchor(pair, start=0)
+
+
+def test_reanchor_moves_a_windows_edges_and_does_not_relocate_it(normalizer):
+    """The constraint the README taught backwards. ``reanchor`` pads or trims
+    each edge, in any combination — but the window asked for must overlap the
+    pair's own, because the changed bases exist only in the pair. A disjoint
+    request is refused, not fetched, and the message says so rather than naming
+    ``trim_to`` and two coordinates the caller never passed."""
+    pair = normalizer.to_sequences(normalizer.parse("TEMPLATE:n.13del"), pad=2)
+
+    with pytest.raises(ferro_hgvs.NormalizationError, match="does not overlap") as excinfo:
+        normalizer.reanchor(pair, start=30, end=len(SEQUENCE))
+    assert "trim_to" not in str(excinfo.value)
+
+    # A partial overlap is legal — the boundary is overlap, not containment.
+    # [11, 15] narrowed to 13 and widened to 30; the deletion still rolls to the
+    # 3' end of the ``A`` run at 12-15, which the new window still contains.
+    partial = normalizer.reanchor(pair, start=13, end=30)
+    assert (partial.position, partial.end) == (13, 30)
+    assert str(partial.derive().variant) == "TEMPLATE:g.15del"
+
+
+def test_reanchor_upper_cases_the_window_it_returns(normalizer):
+    """``reanchor`` reads flank from the provider and keeps the caller's bases in
+    the middle, so a soft-masked window would otherwise come back mixed-case — a
+    pair no caller wrote. It folds the whole window, exactly as ``to_sequences``
+    does. ``trim_to``, which fetches nothing, does not."""
+    masked = ferro_hgvs.SequencePair("TEMPLATE", 10, "gcaaaag", "GCAAAG")
+    widened = normalizer.reanchor(masked, start=5, end=25)
+    assert widened.reference == SEQUENCE[4:25]
+    assert widened.alternate == widened.alternate.upper()
+
+
+def test_reads_anchored_to_one_region_agree():
+    """The property the feature exists for, over windows that disagree without
+    it."""
+    seq = "GGATTACAGGCAAAAGCCTGAGGATTACAGGCATTAGCCT"
+
+    def read(lo, hi):
+        reference = seq[lo - 1 : hi]
+        at = reference.index("A", 12 - lo)
+        return ferro_hgvs.SequencePair("NC_1", lo, reference, reference[:at] + reference[at + 1 :])
+
+    reads = [read(9, 16), read(10, 17), read(11, 18)]
+    anchored = {
+        str(ferro_hgvs.from_sequences("NC_1", p.position, p.reference, p.alternate))
+        for p in (r.trim_to(start=11, end=14) for r in reads)
+    }
+    assert anchored == {"NC_1:g.14del"}
+
+
+def test_a_pair_derives_from_itself():
+    """`derive` over the four values the pair already carries.
+
+    The point is that a pair returned by `trim_to` carries its **own**
+    position, so a caller never pairs a pre-trim position with post-trim bases
+    — the mistake the README example used to teach.
+    """
+    pair = ferro_hgvs.SequencePair("NC_1", 10, "GCAAAAG", "GCAAAG")
+    assert str(pair.derive().variant) == "NC_1:g.15del"
+
+    bounded = pair.trim_to(end=14)
+    derived = bounded.derive()
+    assert str(derived.variant) == "NC_1:g.14del"
+    assert derived.placement_bounded_by_window is True
+
+    # Same knobs as the free function, and the same refusals.
+    assert str(pair.derive(direction="5prime").variant) == "NC_1:g.12del"
+    with pytest.raises(ValueError, match="max_grid_cells must be positive"):
+        pair.derive(max_grid_cells=0)
+    with pytest.raises(ValueError, match="unrecognized direction"):
+        pair.derive(direction="sideways")


### PR DESCRIPTION
**PR 3 of 3, stacked on PR 2.** Its base is PR 2's branch, so the diff shown here is only the Python surface.

Closes #1692.

This is the last of the three, so it carries `Closes`; PRs 1 and 2 say `Part of` so that merging them does not close the issue while the stack is still open.

## What this adds

The Python bindings for the surface PRs 1 and 2 introduce — nothing new about the derivation itself, which is why it is a separate PR rather than 500 more lines on the first one.

- free functions `from_sequences` and `from_sequences_detailed`
- `Normalizer.to_sequences`, `Normalizer.from_sequences` and `Normalizer.reanchor`
- `SequencePair` and `DerivedDescription` as Python classes, with getters and a `__repr__`
- type stubs in `python/ferro_hgvs/__init__.pyi`

## Two things worth a reviewer's attention

**The GIL is released around the derivation.** Both free functions take `py: Python<'_>` and `detach`, following #1455. The derivation reads no reference and touches no Python object once its arguments are copied in, so there is nothing to hold the GIL for — and a caller sweeping a BAM is exactly the workload that would notice.

**`window_is_final` is named for what it means.** It was `full_pad_served` until a Python test asserted the literal reading of that name and failed: the flag is true when the window ends where the pad asked **or** where the sequence itself ends. So the ordinary answer near a contig end is `true` — there was nothing further to read, so the roll is settled either way — and `false` means the provider stopped short of both. It is also 3'-only; `to_sequences` prepends its 5' flank separately and that half is not reflected in the flag.

The Rust field was renamed to match, so the two cannot drift.

## Tests

`tests/python/test_from_sequences.py` — 35 tests covering the free functions, both `Normalizer` methods, the classes and their reprs, the refusals, and the flag semantics above. `ruff` and `mypy` are clean.


Representation-Change: none. Bindings only; no Rust normalization path changes.
