### PR TITLE
fix(normalize): grow the fetch window so a long homopolymer converges

### DIFF
--- a/src/normalize/boundary.rs
+++ b/src/normalize/boundary.rs
@@ -31,6 +31,28 @@ impl Boundaries {
         Self { left, right }
     }
 
+    /// Bounds that permit no shuffle travel at all, in either direction.
+    ///
+    /// [`crate::normalize::shuffle::shuffle`] walks 3' while
+    /// `new_end < right` and 5' while `new_start > left`, so a pair that is
+    /// empty in *both* senses — `left` above every position, `right` below every
+    /// one — makes each loop fall through on its first test whatever coordinates
+    /// the edit has. That is the point: the alternative is to derive a pinned
+    /// pair from the edit's own indices, which would have to reproduce
+    /// `normalize_na_edit`'s per-edit-type index adjustment (an insertion's
+    /// shuffle start and end are both shifted by one) and could only ever be
+    /// wrong in the same way twice.
+    ///
+    /// Used by `Normalizer::canonicalize_without_shifting` to re-type an edit
+    /// against the reference while refusing to move it — see that method for why
+    /// the two halves are separable.
+    pub fn pinned() -> Self {
+        Self {
+            left: u64::MAX,
+            right: 0,
+        }
+    }
+
     /// Check if a position is within the half-open bounds `[left, right)`.
     /// `right` itself is **not** contained — it's one past the last
     /// reachable position by the half-open convention documented on

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4124,6 +4124,94 @@ fn resolve_special_genome_pos<P: ReferenceProvider>(
     }
 }
 
+/// Widest **half**-width [`Normalizer::normalize_in_grown_window`] will grow the
+/// fetch to before refusing to shift any further.
+///
+/// **This bounds `window`, not the span read.** `normalize_in_grown_window`
+/// fetches `[start - window, end + window]`, so the widest reference span is
+/// roughly *twice* this plus the variant's own length — measured, a 60,000-base
+/// tract at contig offset 100,000 converges to `g.160000del` off a window
+/// covering `[34,465 .. 165,537]`, 131,073 bases. The *travel* bound is the
+/// half-width itself: a 65,000-base tract converges and a 66,000-base one is
+/// refused. [`MAX_INTRONIC_SHUFFLE_WINDOW`] at its own definition is tested as a
+/// **full** span, so the two constants are numerically equal and semantically a
+/// factor of two apart; do not read one off the other.
+///
+/// The value is **reused from** [`MAX_INTRONIC_SHUFFLE_WINDOW`] rather than
+/// independently sourced — that constant is this module's existing answer to the
+/// same question (how far a shuffle may fetch before the cost stops being worth
+/// the answer) and is itself unsourced. What justifies the reuse is that a run
+/// long enough to exhaust it is a structural feature (an assembly `N` gap, a
+/// synthetic contig) rather than a repeat tract: the pathogenic expansions that
+/// do run long — FMR1 `CGG`, RFC1 `AAGGG` — reach thousands of bases, which is
+/// still an order of magnitude inside 64 KiB. It is a cost bound picked to sit
+/// clear of the biology, not a bound derived from it.
+const MAX_SHUFFLE_FETCH_WINDOW: u64 = MAX_INTRONIC_SHUFFLE_WINDOW;
+
+/// Next window to try, or `None` once [`MAX_SHUFFLE_FETCH_WINDOW`] has been
+/// tried. Doubling keeps the number of re-fetches logarithmic in the distance
+/// the shuffle actually travels, so the overwhelmingly common case — a result
+/// that rests well inside the configured window — costs exactly one fetch and
+/// never consults this function at all.
+///
+/// `max(1)` guards a `window_size` of 0, which would otherwise double to itself
+/// forever.
+fn grow_shuffle_fetch_window(window: u64) -> Option<u64> {
+    if window >= MAX_SHUFFLE_FETCH_WINDOW {
+        return None;
+    }
+    Some(
+        window
+            .max(1)
+            .saturating_mul(2)
+            .min(MAX_SHUFFLE_FETCH_WINDOW),
+    )
+}
+
+/// Bases of reference kept either side of an edit's own span by
+/// [`Normalizer::canonicalize_without_shifting`].
+///
+/// Every type rule that survives the growth cap is decided within one payload
+/// length of the edit: `duplication.md:5` defines a duplication as a copy
+/// inserted "**directly 3'** of the original copy", so seeing the original costs
+/// exactly `|payload|` bases of 5' flank, and the mirror check on the 3' side
+/// costs the same. Delins trimming, the delins type ladder and the inversion
+/// shortening all read inside the span itself.
+///
+/// **The value must depend on the edit and on nothing else.** It is what bounds
+/// how far the capped answer can look, so a flank derived from the reference —
+/// a tract length, a window width — would make the answer depend on the very
+/// distance the cap declined to travel, and the walk would come straight back.
+/// The `max(1)` floor keeps a zero-payload edit (`del`, `inv`) from being handed
+/// a slice with no context at all.
+fn capped_typing_flank(edit: &NaEdit) -> u64 {
+    let payload = match edit {
+        NaEdit::Insertion { sequence } | NaEdit::Delins { sequence, .. } => {
+            sequence.bases().map_or(0, <[Base]>::len)
+        }
+        _ => 0,
+    };
+    (payload as u64).max(1)
+}
+
+/// One settled attempt at normalizing an edit against a fetched reference
+/// window. See [`Normalizer::normalize_in_grown_window`].
+struct WindowedNormalization {
+    /// 0-based offset of the window's first base within the contig. Positions
+    /// convert back with `contig = window_relative + window_start`.
+    window_start: u64,
+    /// The fetched bases.
+    ref_seq: String,
+    /// Window-relative 1-based start of the normalized edit.
+    new_rel_start: u64,
+    /// Window-relative 1-based end of the normalized edit.
+    new_rel_end: u64,
+    /// The normalized edit.
+    new_edit: NaEdit,
+    /// Warnings raised while normalizing it.
+    warnings: Vec<NormalizationWarning>,
+}
+
 impl<P: ReferenceProvider> Normalizer<P> {
     /// Clamp a window-fetch upper bound to the contig length.
     ///
@@ -4150,6 +4238,232 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Ok(len) if end <= len => raw_end.min(len),
             _ => raw_end,
         }
+    }
+
+    /// Normalize an edit against a reference window sized so the shuffle can
+    /// actually reach its fixed point (#1691).
+    ///
+    /// The `±window_size` fetch is a *cost* bound, but `normalize_na_edit` is
+    /// handed `Boundaries::new(0, ref_seq.len())` and so treats the window's far
+    /// edges as hard limits on the shuffle. Those edges are where the fetch
+    /// stopped, not properties of the contig, so inside a repeat tract longer
+    /// than the window the shuffle reports the edge it reached rather than the
+    /// tract's end. Re-normalizing that answer re-centres the window on it and
+    /// advances another `window_size` bases — `g.100del -> g.200del ->
+    /// g.300del -> …`, which never terminates and trips
+    /// `FERRO_ASSERT_IDEMPOTENT`.
+    ///
+    /// So the window is grown geometrically until the result rests strictly
+    /// inside it, and the caller gets whichever attempt settled. Growth is only
+    /// attempted when the edge is *provably* artificial — the contig is known to
+    /// continue past the window's 3' end, or the window's 5' end is not the
+    /// contig's first base. Where flushness cannot be established (no length
+    /// from the provider) the window is left alone, which is the same
+    /// conservative choice [`Self::clamp_fetch_end_to_contig`] makes.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(None)` when the caller should fall back to minimal notation: **any**
+    /// fetch failed — the first one or a grown one (a grown failure is not
+    /// allowed to fall back to the truncated attempt that preceded it, which
+    /// would reinstate the walk) — or the growth cap was reached by an edit
+    /// [`Self::canonicalize_without_shifting`] declines to re-type.
+    ///
+    /// **Refusing to shift is the only capped answer that is still a fixed
+    /// point.** Capping the *shift* instead — returning the far edge of the
+    /// largest window we were willing to fetch — just changes the walk's step
+    /// size from `window_size` to the cap; the second call re-centres on the new
+    /// position and walks again.
+    ///
+    /// **What is refused at the cap is the travel, and only the travel.** The
+    /// edit is still re-typed against the reference by
+    /// [`Self::canonicalize_without_shifting`], because the type rules —
+    /// `ins -> dup`, `delins -> sub/inv/dup/del`, the inversion shortening — are
+    /// decided by the bases flanking the edit rather than by how far a tract
+    /// runs, so they are answerable at the cap and `DNA/duplication.md:18` says
+    /// they must be answered ("when a variant can be described as a duplication,
+    /// it **must** be described as a duplication and not as, e.g., an
+    /// insertion"). Refusing them alongside the shift bought idempotency with
+    /// conformance, which is the one thing the README ruleset never trades.
+    ///
+    /// `fetch_end_of` maps a raw `end + window` upper bound to the one the
+    /// caller wants read (each axis clamps differently), and is re-consulted on
+    /// every attempt because the raw bound changes as the window grows.
+    fn normalize_in_grown_window(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+        edit: &NaEdit,
+        fetch_end_of: impl Fn(u64) -> u64,
+    ) -> Result<Option<WindowedNormalization>, FerroError> {
+        // Whether the contig continues past a window is a question about the
+        // contig, so the length is read once rather than per attempt.
+        let contig_len = self.provider.get_sequence_length(accession).ok();
+        let mut window = self.config.window_size;
+
+        loop {
+            let window_start = start.saturating_sub(window);
+            let fetch_end = fetch_end_of(end.saturating_add(window));
+            let Ok(ref_seq) = self
+                .provider
+                .get_sequence(accession, window_start, fetch_end)
+            else {
+                // A *grown* fetch that fails is reported the same as a failed
+                // first fetch rather than falling back to the truncated attempt,
+                // which would reinstate the walk this method exists to stop.
+                return Ok(None);
+            };
+
+            // Window-relative 1-based positions; `hgvs_pos_to_index` inside
+            // `normalize_na_edit` takes them the rest of the way.
+            let (new_rel_start, new_rel_end, new_edit, warnings) = self.normalize_na_edit(
+                ref_seq.as_bytes(),
+                edit,
+                start - window_start,
+                end - window_start,
+                &Boundaries::new(0, ref_seq.len() as u64),
+                // Neither the genomic nor the mitochondrial axis carries a
+                // reading frame; both callers passed this before the growth
+                // loop was factored out of them.
+                CodonGate::NotApplicable,
+            )?;
+
+            let seq_len = ref_seq.len() as u64;
+            // The 3' edge is artificial only where the contig is known to
+            // continue past it; the 5' edge only where the window did not start
+            // at the contig's first base.
+            let ran_to_three_prime_edge = new_rel_end >= seq_len
+                && contig_len.is_some_and(|len| window_start.saturating_add(seq_len) < len);
+            let ran_to_five_prime_edge = new_rel_start <= 1 && window_start > 0;
+
+            if !ran_to_three_prime_edge && !ran_to_five_prime_edge {
+                return Ok(Some(WindowedNormalization {
+                    window_start,
+                    ref_seq,
+                    new_rel_start,
+                    new_rel_end,
+                    new_edit,
+                    warnings,
+                }));
+            }
+
+            match grow_shuffle_fetch_window(window) {
+                Some(next) => window = next,
+                // Cap reached. Refuse the travel, not the typing: the sequence
+                // for the latter is already in hand, so it is re-derived from
+                // this last window rather than re-fetched.
+                None => {
+                    return self.canonicalize_without_shifting(
+                        &ref_seq,
+                        window_start,
+                        start,
+                        end,
+                        edit,
+                    )
+                }
+            }
+        }
+    }
+
+    /// Re-type an edit against the reference **without letting it travel**, for
+    /// the growth cap in [`Self::normalize_in_grown_window`].
+    ///
+    /// A normalized description answers three separable questions, and running
+    /// out of window costs it only two of them:
+    ///
+    /// - **Travel** — the 3' rule's resting place. Unanswerable past the cap by
+    ///   construction, and refusing it is what makes the capped answer a fixed
+    ///   point.
+    /// - **Extent** — repeat notation's `<first>_<last>unit[N]`, which states
+    ///   where the reference tract begins and ends. Equally unanswerable, and a
+    ///   *truncated* extent is worse than none: it is a false claim about the
+    ///   reference rather than a merely unshifted one. Declined below.
+    /// - **Type** — `ins -> dup`, `delins -> sub/inv/dup/del`, the inversion
+    ///   shortening. These read the bases flanking the edit and nothing else, so
+    ///   the cap does not touch them and `DNA/duplication.md:18` requires them.
+    ///
+    /// So the edit is re-normalized against a **slice** of the window whose
+    /// width is derived from the edit alone — never from the tract — with the
+    /// shuffle pinned by [`Boundaries::pinned`]. Both halves are load-bearing
+    /// for idempotency. Pinning alone is not enough: `insertion_to_duplication`
+    /// consults no boundaries, so on the full window it anchors the `dup` at the
+    /// far end of whatever tract it can see, which is the walk again wearing a
+    /// different edit type. Slicing alone is not enough either, for the same
+    /// reason the cap exists at all. Together, every base the answer reads sits
+    /// at a fixed offset from the edit the caller handed in, so re-normalizing
+    /// that answer reads the same relative bases and returns it unchanged.
+    ///
+    /// The result is returned as an ordinary [`WindowedNormalization`] over the
+    /// slice, so the callers' coordinate reconstruction, boundary clamp and
+    /// canonical split all apply to it unchanged — the capped answer is a
+    /// normalization like any other, not a second output path to keep in sync.
+    ///
+    /// `Ok(None)` means "no re-typing was available", and the caller falls back
+    /// to the syntactic minimal-notation cleanup exactly as it does for a failed
+    /// fetch.
+    fn canonicalize_without_shifting(
+        &self,
+        ref_seq: &str,
+        window_start: u64,
+        start: u64,
+        end: u64,
+        edit: &NaEdit,
+    ) -> Result<Option<WindowedNormalization>, FerroError> {
+        // A repeat's canonical form IS an extent claim, so there is no
+        // travel-free part of it to salvage: `normalize_repeat` would report the
+        // slice's own edges as the tract's. Hand it back untouched.
+        if matches!(edit, NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. }) {
+            return Ok(None);
+        }
+
+        let flank = capped_typing_flank(edit);
+        // Window-relative, 0-based: `p` sits at index `p - window_start - 1`.
+        let span_start_idx = (start - window_start).saturating_sub(1);
+        let span_end_idx = end - window_start;
+        let window_len = ref_seq.len() as u64;
+        // The slice has to hold the whole span, or the type rules would read a
+        // truncated edit and answer about a variant nobody described. The growth
+        // loop normalized this same span against this same window a moment ago,
+        // so a span that does not fit is a contradiction rather than a case —
+        // decline instead of clamping into a wrong answer.
+        if span_end_idx > window_len || span_start_idx >= span_end_idx {
+            return Ok(None);
+        }
+        let lo = span_start_idx.saturating_sub(flank);
+        let hi = span_end_idx.saturating_add(flank).min(window_len);
+        let slice = &ref_seq[lo as usize..hi as usize];
+        // The slice's own 0-based offset within the contig, which is what the
+        // caller adds back to the returned relative positions.
+        let slice_start = window_start + lo;
+
+        let (new_rel_start, new_rel_end, new_edit, warnings) = self.normalize_na_edit(
+            slice.as_bytes(),
+            edit,
+            start - slice_start,
+            end - slice_start,
+            &Boundaries::pinned(),
+            // Same reasoning as the growth loop's own call: neither axis
+            // reaching here carries a reading frame.
+            CodonGate::NotApplicable,
+        )?;
+
+        // Extent claim, arrived at from the other direction — an `ins` or `dup`
+        // the type rules promoted into repeat notation. The promotion itself is
+        // right; the tract it would name is the slice's, so decline it here
+        // rather than publish a span the reference does not have.
+        if matches!(new_edit, NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. }) {
+            return Ok(None);
+        }
+
+        Ok(Some(WindowedNormalization {
+            window_start: slice_start,
+            ref_seq: slice.to_string(),
+            new_rel_start,
+            new_rel_end,
+            new_edit,
+            warnings,
+        }))
     }
 
     /// Normalize a genomic variant
@@ -4321,42 +4635,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `g.pter_<past-end>del` fetches the whole contig and relies on
         // `shuffle`'s per-index bounds guard to echo the input verbatim
         // (see `genome_mixed_special_plain_past_end_matches_plain_path`).
-        let window_start = start.saturating_sub(self.config.window_size);
-        let raw_end = end.saturating_add(self.config.window_size);
-        let fetch_end = if had_special {
-            raw_end.min(resolved_len)
-        } else {
-            self.clamp_fetch_end_to_contig(&accession, end, raw_end)
-        };
-        let seq_result = self
-            .provider
-            .get_sequence(&accession, window_start, fetch_end);
-
-        let ref_seq = match seq_result {
-            Ok(s) => s,
-            // Can't do full normalization without sequence, but apply minimal notation
-            Err(_) => {
-                return Ok((
-                    HV::Genome(self.canonicalize_genome_variant(variant)),
-                    vec![],
-                ))
+        //
+        // #1691: the window also bounds the SHUFFLE, and its far edges are not
+        // contig properties, so a tract longer than the window walks instead of
+        // converging. `normalize_in_grown_window` re-fetches until the result
+        // settles strictly inside; `None` means either no sequence or a shuffle
+        // still running at the growth cap, and both take the minimal-notation
+        // fallback that a failed fetch always took.
+        let attempt = self.normalize_in_grown_window(&accession, start, end, edit, |raw_end| {
+            if had_special {
+                raw_end.min(resolved_len)
+            } else {
+                self.clamp_fetch_end_to_contig(&accession, end, raw_end)
             }
+        })?;
+        let Some(WindowedNormalization {
+            window_start,
+            ref_seq,
+            mut new_rel_start,
+            mut new_rel_end,
+            mut new_edit,
+            mut warnings,
+        }) = attempt
+        else {
+            return Ok((
+                HV::Genome(self.canonicalize_genome_variant(variant)),
+                vec![],
+            ));
         };
-
-        // Adjust coordinates to be relative to the window
-        let rel_start = start - window_start;
-        let rel_end = end - window_start;
-
-        // Perform normalization
-        let (mut new_rel_start, mut new_rel_end, mut new_edit, mut warnings) = self
-            .normalize_na_edit(
-                ref_seq.as_bytes(),
-                edit,
-                rel_start,
-                rel_end,
-                &Boundaries::new(0, ref_seq.len() as u64),
-                CodonGate::NotApplicable, // genomic context: no reading frame
-            )?;
 
         // #1205: an insertion driven to rest against a contig end has no valid
         // pair of adjacent anchors there, exactly as on the transcript axes
@@ -8266,36 +8572,38 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // the raw window and errors into the safe fallback. Wraparound
         // (`start > end`) already returned above, so `end` here is the
         // linear span end.
-        let window_start = start.saturating_sub(self.config.window_size);
-        let raw_end = end.saturating_add(self.config.window_size);
-        let fetch_end = self.clamp_fetch_end_to_contig(&accession, end, raw_end);
-        let seq_result = self
-            .provider
-            .get_sequence(&accession, window_start, fetch_end);
-
-        let ref_seq = match seq_result {
-            Ok(s) => s,
-            // No reference data → fall back to minimal-notation cleanup.
-            Err(_) => return Ok(mt_fallback(variant)),
-        };
-
-        let rel_start = start - window_start;
-        let rel_end = end - window_start;
-
+        //
+        // #1691: shared with `normalize_genome` for the same reason
+        // `clamp_fetch_end_to_contig` is — the window bounds the shuffle as well
+        // as the read, so a repeat tract longer than it walks instead of
+        // converging, and two copies of the growth loop would drift exactly as
+        // the two copies of the clamp did. The mitochondrial genome carries no
+        // homopolymer near that long, so this is a structural guarantee rather
+        // than a behaviour change for any real `m.` input; it is here so a
+        // synthetic contig cannot reach the defect through this door.
+        //
         // Mitochondrial reference is plus-strand and not subject to the
         // codon-frame `unit_len % 3 == 0` restriction (the mito genome
         // has no canonical "CDS" exemption boundary in the same sense as
         // nuclear `c.`; the spec's mito chapter doesn't carry the
-        // codon-frame clause), so the gate is `NotApplicable`.
-        let (mut new_rel_start, mut new_rel_end, mut new_edit, mut warnings) = self
-            .normalize_na_edit(
-                ref_seq.as_bytes(),
-                edit,
-                rel_start,
-                rel_end,
-                &Boundaries::new(0, ref_seq.len() as u64),
-                CodonGate::NotApplicable,
-            )?;
+        // codon-frame clause), so the gate `normalize_in_grown_window` passes
+        // (`NotApplicable`) is the one this path wants.
+        let attempt = self.normalize_in_grown_window(&accession, start, end, edit, |raw_end| {
+            self.clamp_fetch_end_to_contig(&accession, end, raw_end)
+        })?;
+        let Some(WindowedNormalization {
+            window_start,
+            ref_seq,
+            mut new_rel_start,
+            mut new_rel_end,
+            mut new_edit,
+            mut warnings,
+        }) = attempt
+        else {
+            // No reference data, or a shuffle still running at the growth cap →
+            // minimal-notation cleanup.
+            return Ok(mt_fallback(variant));
+        };
 
         // #1217: an insertion driven to rest against either mitochondrial
         // terminus has no valid pair of adjacent anchors there, exactly as on
@@ -12285,6 +12593,38 @@ mod tests {
     use super::*;
     use crate::hgvs::parser::parse_hgvs;
     use crate::reference::MockProvider;
+
+    /// The growth ladder must reach the cap and then stop, from any starting
+    /// window. #1691's fix depends on both halves: never terminating would spin
+    /// the fetch loop, and stopping early would leave a shorter, position-
+    /// relative bound in place — which is the defect itself.
+    #[test]
+    fn shuffle_fetch_window_growth_reaches_the_cap_and_then_stops() {
+        for start in [1_u64, 100, 1000, MAX_SHUFFLE_FETCH_WINDOW - 1] {
+            let mut window = start;
+            let mut steps = 0;
+            while let Some(next) = grow_shuffle_fetch_window(window) {
+                assert!(next > window, "growth from {window} did not advance");
+                assert!(next <= MAX_SHUFFLE_FETCH_WINDOW, "growth overshot the cap");
+                window = next;
+                steps += 1;
+                assert!(steps < 64, "growth from {start} did not terminate");
+            }
+            assert_eq!(
+                window, MAX_SHUFFLE_FETCH_WINDOW,
+                "growth from {start} stopped short of the cap",
+            );
+        }
+        assert_eq!(grow_shuffle_fetch_window(MAX_SHUFFLE_FETCH_WINDOW), None);
+    }
+
+    /// A configured `window_size` of 0 must still advance. Doubling alone leaves
+    /// it at 0 forever, and the fetch loop would never terminate — the one input
+    /// that turns a bounded retry into a hang.
+    #[test]
+    fn shuffle_fetch_window_growth_escapes_a_zero_window() {
+        assert_eq!(grow_shuffle_fetch_window(0), Some(2));
+    }
 
     /// `Normalizer` has exactly two public normalizing methods — `normalize` and
     /// `normalize_with_diagnostics` — and only the first went through

--- a/tests/it/issue_1691_homopolymer_convergence.rs
+++ b/tests/it/issue_1691_homopolymer_convergence.rs
@@ -1,0 +1,262 @@
+//! Issue #1691 — `Normalizer::normalize` never reaches a fixed point inside a
+//! homopolymer longer than the reference fetch window.
+//!
+//! Root cause: `normalize_genome` fetches a `±window_size` (default 100 bp)
+//! window around the variant and hands `normalize_na_edit` a
+//! `Boundaries::new(0, ref_seq.len())`. That right bound is *where the fetch
+//! stopped*, not a property of the contig, so inside a long homopolymer the 3'
+//! shuffle runs to the window edge and reports the position it happened to
+//! reach. Re-normalizing re-centres the window on that position and the shuffle
+//! advances another `window_size` bases:
+//!
+//! ```text
+//! c:g.65del -> c:g.165del -> c:g.265del -> c:g.365del -> ...   (step == 100)
+//! ```
+//!
+//! **`MAX_SEQUENCE_COMPARE_WINDOW` (100_000) is a red herring**, named in the
+//! issue only because the PR that surfaced this built a homopolymer that long.
+//! The bound that truncates the shuffle is `NormalizeConfig::window_size`, three
+//! orders of magnitude smaller — and the step size in the walk above is exactly
+//! that constant, which is the measurement that identifies it.
+//!
+//! **A short tract does not reproduce it, and that near-miss is worth pinning.**
+//! `canonicalize_from_sequence` alternates the sequence-first pass (which fetches
+//! its own `±CANONICAL_PAD = 128` window) with `normalize_core` up to
+//! `MAX_PASSES = 4` times, so a tract the alternation can cross end-to-end is
+//! rescued: a 200-base and a 600-base run both converge on unfixed code. The
+//! defect starts at the first tract the four alternations cannot span, which is
+//! **between 700 and 800 bases** — measured on `origin/main` by counting calls to
+//! a fixed point from `c:g.65del`:
+//!
+//! ```text
+//! run=600  1 call    run=800  2 calls    run=1000  4 calls
+//! run=700  1 call    run=900  3 calls    run=2000 12 calls
+//! ```
+//!
+//! `TRACT` below is 2000 rather than 800 so it sits comfortably past that
+//! boundary rather than on it, and rather than the 100_000-plus the issue
+//! reports. (This module previously bracketed the onset at "between 600 and
+//! 2000", which is true but loose; the 600 in
+//! `issue_1691_short_tracts_are_unaffected` is still correctly chosen — it is
+//! inside the converging range, not on its edge.)
+//!
+//! The fix grows the fetch window geometrically until the result rests strictly
+//! inside it, capped by `MAX_SHUFFLE_FETCH_WINDOW` (64 KiB). Past the cap the
+//! **shift** is refused outright rather than truncated, because a truncated shift
+//! only changes the walk's step size — see `normalize_in_grown_window`. The
+//! **edit type** is not refused with it: `canonicalize_without_shifting` still
+//! re-types the edit against the reference, because that verdict is decided by
+//! the bases flanking the edit and so survives the cap.
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// Long enough that `canonicalize_from_sequence`'s four alternations cannot span
+/// it, so the walk is visible. See the module comment for the measurement.
+const TRACT: usize = 2000;
+
+/// Flanking bases either side of the tract. A multiple of 4 so the cyclic
+/// `ACGT` lead ends on `T` — never on the tract's own base, which would extend
+/// the run and move its 3' end.
+const FLANK: usize = 64;
+
+/// Genome-capable provider serving one contig: `flank` bases of cyclic `ACGT`,
+/// then a run of `run` `A`s, then `flank` bases of cyclic `CGTA`.
+///
+/// The trailing flank starts at `C` rather than `A` for the same reason the
+/// leading one ends at `T`: the tract's 3' end must be exactly `flank + run`.
+fn homopolymer_provider(contig: &str, flank: usize, run: usize) -> JsonProvider {
+    let lead: String = "ACGT".chars().cycle().take(flank).collect();
+    let tract: String = std::iter::repeat_n('A', run).collect();
+    let trail: String = "CGTA".chars().cycle().take(flank).collect();
+    genomic_provider(contig, &format!("{lead}{tract}{trail}"))
+}
+
+fn genomic_provider(contig: &str, sequence: &str) -> JsonProvider {
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: sequence },
+    });
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(file.path()).unwrap()
+}
+
+fn norm(provider: &JsonProvider, input: &str) -> String {
+    let variant = parse_hgvs(input).unwrap();
+    Normalizer::new(provider.clone())
+        .normalize(&variant)
+        .unwrap()
+        .to_string()
+}
+
+/// The defect as the issue states it: repeated normalization must reach a fixed
+/// point instead of advancing one window per call.
+///
+/// Stated as the *chain* rather than as a single equality, so a failure prints
+/// the walk and its step size — which is the evidence that identifies the bound
+/// being hit.
+#[test]
+fn issue_1691_normalize_reaches_a_fixed_point_inside_a_long_homopolymer() {
+    let provider = homopolymer_provider("c", FLANK, TRACT);
+
+    let mut chain = vec![format!("c:g.{}del", FLANK + 1)];
+    for _ in 0..8 {
+        let next = norm(&provider, chain.last().unwrap());
+        if &next == chain.last().unwrap() {
+            break;
+        }
+        chain.push(next);
+    }
+
+    assert!(
+        chain.len() <= 2,
+        "normalize did not converge; it walked {chain:?}",
+    );
+}
+
+/// …and the fixed point it reaches is the 3'-most position in the tract, which
+/// is what the 3' rule asks for. A test that only asserted convergence would
+/// pass on a fix that simply stopped shifting.
+#[test]
+fn issue_1691_the_fixed_point_is_the_three_prime_end_of_the_tract() {
+    let provider = homopolymer_provider("c", FLANK, TRACT);
+    let three_prime_most = format!("c:g.{}del", FLANK + TRACT);
+
+    for authored in [FLANK + 1, FLANK + 2, FLANK + TRACT / 2, FLANK + TRACT] {
+        assert_eq!(
+            norm(&provider, &format!("c:g.{authored}del")),
+            three_prime_most,
+            "c:g.{authored}del did not reach the 3' end of the tract",
+        );
+    }
+}
+
+/// The insertion and duplication shuffles are driven by the same window bound
+/// and walk the same way; both must land on a fixed point too.
+#[test]
+fn issue_1691_insertions_and_duplications_converge_too() {
+    let provider = homopolymer_provider("c", FLANK, TRACT);
+
+    for input in [
+        format!("c:g.{}_{}insA", FLANK + 1, FLANK + 2),
+        format!("c:g.{}dup", FLANK + 1),
+    ] {
+        let once = norm(&provider, &input);
+        let twice = norm(&provider, &once);
+        assert_eq!(once, twice, "{input} did not converge ({once} -> {twice})");
+    }
+}
+
+/// The 3' growth must stop at the contig end rather than reading past it — the
+/// #1041 failure mode, which a naive "just fetch more" fix would reintroduce.
+#[test]
+fn issue_1691_growth_stops_at_the_contig_end() {
+    // No trailing flank: the tract is the last thing on the contig.
+    let lead: String = "ACGT".chars().cycle().take(FLANK).collect();
+    let tract: String = std::iter::repeat_n('A', TRACT).collect();
+    let provider = genomic_provider("c", &format!("{lead}{tract}"));
+
+    let last = FLANK + TRACT;
+    assert_eq!(
+        norm(&provider, &format!("c:g.{}del", FLANK + 1)),
+        format!("c:g.{last}del"),
+    );
+    assert_eq!(
+        norm(&provider, &format!("c:g.{last}del")),
+        format!("c:g.{last}del"),
+    );
+}
+
+/// A tract past `MAX_SHUFFLE_FETCH_WINDOW` (64 KiB) exhausts the growth cap.
+/// The answer there is a **refusal to shift**, not a shift truncated at the cap
+/// — a truncated shift would merely change the walk's step size from 100 to
+/// 65_536 and the description would still never settle.
+///
+/// This is the case the issue's own 200_000-base reproducer falls into, so it is
+/// the one that decides whether `FERRO_ASSERT_IDEMPOTENT` stays quiet on it.
+#[test]
+fn issue_1691_a_tract_past_the_growth_cap_refuses_to_shift_and_is_stable() {
+    // 70_000 > 64 KiB, so the cap is reached with contig left to read.
+    let provider = homopolymer_provider("c", FLANK, 70_000);
+
+    let authored = format!("c:g.{}del", FLANK + 1);
+    let once = norm(&provider, &authored);
+    assert_eq!(
+        once, authored,
+        "past the growth cap the shift must be refused, not truncated",
+    );
+    assert_eq!(norm(&provider, &once), once, "the refusal must be stable");
+}
+
+/// **Refusing the shift must not also refuse the re-typing.** `c:g.65_66insA`
+/// inserts an `A` directly 3' of an `A`, which is a tandem duplication:
+/// `DNA/duplication.md:18` — "when a variant can be described as a duplication,
+/// it **must** be described as a duplication and not as, e.g., an insertion" —
+/// and `DNA/insertion.md:17` renders the insertion spelling as
+/// `<code class="invalid">`. That verdict is decided by the bases immediately
+/// flanking the insertion point, not by how far the tract runs, so it is
+/// available at the growth cap and must still be given there.
+///
+/// Refusing it traded rule 1 (conformant output, README:176-179, "absolute —
+/// never traded") for idempotency, which is not one of the four output rules at
+/// all. The capped answer has to be **both**: a `dup`, and a fixed point.
+///
+/// Both axes, because the growth loop is shared and a per-axis fix would be the
+/// drift `clamp_fetch_end_to_contig` already exists to prevent.
+#[test]
+fn issue_1691_past_the_growth_cap_an_insertion_is_still_typed_as_a_duplication() {
+    // 70_000 > 64 KiB, so the cap is reached with contig left to read.
+    for (accession, axis) in [("c", "g"), ("NC_012920.1", "m")] {
+        let provider = homopolymer_provider(accession, FLANK, 70_000);
+        let authored = format!("{accession}:{axis}.{}_{}insA", FLANK + 1, FLANK + 2);
+
+        let once = norm(&provider, &authored);
+        assert!(
+            once.ends_with("dup"),
+            "{authored} is a tandem duplication; past the growth cap it was \
+             emitted as {once}, the spelling `DNA/insertion.md:17` marks invalid",
+        );
+        assert_eq!(
+            norm(&provider, &once),
+            once,
+            "the re-typed answer must still be a fixed point ({authored} -> {once})",
+        );
+    }
+}
+
+/// The rescue path this defect hid behind must keep working: a tract the
+/// sequence-first alternation can span end-to-end converged before the fix and
+/// must still converge after it.
+#[test]
+fn issue_1691_short_tracts_are_unaffected() {
+    for run in [8_usize, 60, 200, 600] {
+        let provider = homopolymer_provider("c", FLANK, run);
+        let three_prime_most = format!("c:g.{}del", FLANK + run);
+        assert_eq!(
+            norm(&provider, &format!("c:g.{}del", FLANK + 1)),
+            three_prime_most,
+            "a {run}-base tract regressed",
+        );
+    }
+}
+
+/// The same bound sits on the mitochondrial path, which shares the fetch with
+/// `normalize_genome`. mtDNA carries no run anywhere near this long, so this
+/// pins the shared helper rather than a real `m.` input.
+#[test]
+fn issue_1691_the_mitochondrial_path_converges_too() {
+    let lead: String = "ACGT".chars().cycle().take(FLANK).collect();
+    let tract: String = std::iter::repeat_n('A', TRACT).collect();
+    let trail: String = "CGTA".chars().cycle().take(FLANK).collect();
+    let provider = genomic_provider("NC_012920.1", &format!("{lead}{tract}{trail}"));
+
+    let once = norm(&provider, &format!("NC_012920.1:m.{}del", FLANK + 1));
+    assert_eq!(
+        norm(&provider, &once),
+        once,
+        "the mitochondrial path did not converge",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -260,6 +260,7 @@ mod issue_1629_error_mode_is_not_a_warning_gate;
 mod issue_1631_repeat_label_repair;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
+mod issue_1691_homopolymer_convergence;
 mod issue_180_allele_3prime_shift;
 mod issue_182_postcanon_adjacency;
 mod issue_207_multi_repeat_compound_roundtrip;


### PR DESCRIPTION
Closes #1691

## The defect

`Normalizer::normalize` never reaches a fixed point inside a homopolymer longer than the reference fetch window. On a poly-A tract it walks:

```
c:g.65del -> c:g.165del -> c:g.265del -> c:g.365del -> ...
```

**The step is exactly 100, which is `NormalizeConfig::window_size` — that constant is the bound, not `MAX_SEQUENCE_COMPARE_WINDOW`.** The issue names the latter because PR #1652's new test happens to build a 200,000-base tract, but the compare window is three orders of magnitude larger than the bound actually being hit and is byte-identical on both sides. The defect reproduces on a **2,000**-base tract, not a 200,000-base one.

`normalize_genome` (and its mitochondrial mirror) fetch `±window_size` around the variant as a *cost* bound, then hand `normalize_na_edit` a `Boundaries::new(0, ref_seq.len())`. The shuffle therefore treats the window's far edges as hard limits — but those edges are *where the fetch stopped*, not properties of the contig. Inside a tract longer than the window the shuffle reports the edge it reached; re-normalizing that answer re-centres the window on it and advances another `window_size` bases, forever.

### Why nobody hit it sooner

`canonicalize_from_sequence` alternates the sequence-first pass (its own `±CANONICAL_PAD = 128` window) with `normalize_core`, up to `MAX_PASSES = 4`. A tract those four alternations can span end-to-end is silently rescued, so a 200-base and a 600-base run both converge on unfixed code. The defect starts at the first tract the alternation cannot span, and that onset is **between 700 and 800 bases** — measured on `origin/main` by counting calls from `c:g.65del` to a fixed point:

```
run=600  1 call     run=800  2 calls     run=1000  4 calls
run=700  1 call     run=900  3 calls     run=2000 12 calls
```

An earlier revision of this description bracketed the onset as "between 600 and 2,000", which is true but loose. The 600 in `issue_1691_short_tracts_are_unaffected` is still the right choice — it sits inside the converging range rather than on its edge — and that test pins the rescue path so the fix cannot regress it.

## The fix

`Normalizer::normalize_in_grown_window` re-fetches geometrically until the normalized result rests **strictly inside** the window, and both axes that used a variant-relative window now go through it. Growth is attempted only where the edge is *provably* artificial — the contig is known to continue past the window's 3' end, or the window's 5' end is not the contig's first base — so where flushness cannot be established the window is left exactly as it was, the same conservative choice `clamp_fetch_end_to_contig` already makes.

Shared between the genomic and mitochondrial paths for the reason `clamp_fetch_end_to_contig` is: two copies of this logic already drifted once (#1042 vs. #1044). mtDNA carries no run remotely this long, so that half is a structural guarantee rather than a behaviour change for any real `m.` input.

The common case still costs exactly one fetch: a result resting well inside the configured window never consults the growth ladder.

### The cap: what it bounds, and where its value comes from

`MAX_SHUFFLE_FETCH_WINDOW` is 64 KiB, **reused from** `MAX_INTRONIC_SHUFFLE_WINDOW` rather than independently sourced — that constant is itself unsourced. What justifies the reuse is that the pathogenic expansions that do run long (FMR1 `CGG`, RFC1 `AAGGG`) reach thousands of bases, still an order of magnitude inside 64 KiB, so a run that exhausts the cap is a structural feature rather than a repeat tract. It is a cost bound picked to sit clear of the biology, not one derived from it.

**It bounds the half-width, not the span read.** `normalize_in_grown_window` fetches `[start - window, end + window]`, so the two constants are numerically equal and semantically a factor of two apart — `MAX_INTRONIC_SHUFFLE_WINDOW` is tested as a **full** span. Measured: a 60,000-base tract at contig offset 100,000 converges to `g.160000del` off a window covering `[34,465 .. 165,537]`, i.e. 131,073 bases. The *travel* bound is the half-width itself — a 65,000-base tract converges and a 66,000-base one is refused.

### Past the cap: the travel is refused, the typing is not

Past the cap the **shift** is refused outright rather than truncated. That is the load-bearing choice and it is not a corner case: a truncated shift is not a fix at all, it merely changes the walk's step size from 100 to 65,536 and the description still never settles.

**Refusing the travel must not also refuse the re-typing, and a first cut of this PR did exactly that.** The capped branch returned `canonicalize_genome_variant(variant)` / `mt_fallback(variant)`, neither of which reads the reference, so the reference-aware edit-type canonicalization went with the shift. Measured at that revision on a 70,000-base poly-A contig:

```
input               was              now              (200-base control)
c:g.65_66insA    -> c:g.65_66insA -> c:g.67dup     |  c:g.264dup
c:g.65delinsG    -> c:g.65delinsG -> c:g.65A>G     |  c:g.65A>G
m.65_66insA      -> m.65_66insA   -> m.67dup       |  (same shape)
```

`c:g.65_66insA` inserts an `A` directly 3' of an `A`, which is a tandem duplication. `DNA/duplication.md:18` — "when a variant can be described as a duplication, it **must** be described as a duplication and not as, e.g., an insertion"; `DNA/insertion.md:17` renders that spelling as `<code class="invalid">`; `general.md:57` puts duplication above insertion. That is rule 1 of the README ruleset, which is the one rule declared absolute and never traded — and idempotency is not one of the four output rules at all (rule 4 is determinism, which a refusal does not affect). So the branch was trading the absolute rule for a property that is not on the list.

The verdict is available at the cap, which is why the trade was avoidable: it is decided by the bases flanking the edit, not by how far the tract runs. `Normalizer::canonicalize_without_shifting` re-normalizes the edit against a **slice** of the window it already holds — width derived from the edit alone, never from the tract — with the shuffle pinned by the new `Boundaries::pinned()`. Both halves are load-bearing. Pinning alone is not enough, because `insertion_to_duplication` consults no boundaries and would anchor the `dup` at the far end of whatever tract it can see, which is the walk again wearing a different edit type. Slicing alone is not enough for the reason the cap exists. Together, every base the answer reads sits at a fixed offset from the edit the caller handed in, so re-normalizing the answer reads the same relative bases and returns it unchanged.

The one thing that stays refused besides travel is **extent**: repeat notation's `<first>_<last>unit[N]` states where the reference tract begins and ends, which is exactly the unanswerable question, and a *truncated* extent is worse than none — a false claim about the reference rather than a merely unshifted description. So a `Repeat` input, and any promotion into repeat notation, is declined and falls back to the syntactic cleanup. `c:g.65_66insAAA` past the cap therefore stays `c:g.65_66insAAA` rather than acquiring the truncated `c:g.65_166A[105]` that unfixed `origin/main` emits for it.

Every capped shape measured is a fixed point, on both axes:

```
c:g.65_66insA     -> c:g.67dup         -> c:g.67dup
c:g.65_66insAAA   -> c:g.65_66insAAA   -> c:g.65_66insAAA
c:g.65del         -> c:g.65del         -> c:g.65del
c:g.65delA        -> c:g.65del         -> c:g.65del
c:g.65dup         -> c:g.65dup         -> c:g.65dup
c:g.65_66dup      -> c:g.65_66dup      -> c:g.65_66dup
c:g.65delinsG     -> c:g.65A>G         -> c:g.65A>G
c:g.65_66delinsAA -> c:g.65_66=        -> c:g.65_66=
c:g.65_67inv      -> c:g.65_67inv      -> c:g.65_67inv
m.65_66insA       -> m.67dup           -> m.67dup
```

A note on wording, because it is what made the defect invisible: the capped branch does **not** "return the caller's own input". It never did — `canonicalize_genome_variant` strips a stated reference (`c:g.65delA` -> `c:g.65del`) and the mito side additionally runs `apply_canonical_split`. It was a *partial* canonicalization with the reference-aware half missing, and describing it as a no-op is what let the missing half go unnoticed.

## Tests

Eight tests in `tests/it/issue_1691_homopolymer_convergence.rs`. Six were confirmed RED on unfixed `origin/main`, one is the negative control that must stay green on both sides, and the eighth is the guard for the section above, confirmed RED against this PR's own previous revision:

```
c:g.65_66insA is a tandem duplication; past the growth cap it was emitted as
c:g.65_66insA, the spelling `DNA/insertion.md:17` marks invalid
```

It runs both the genomic and the mitochondrial axis, asserts the output is a `dup` rather than an `ins`, and asserts it is a fixed point. **No pre-existing test discriminated it**, which is why CI was green: `issue_1691_a_tract_past_the_growth_cap_refuses_to_shift_and_is_stable` uses a plain `del`, whose canonical form *is* its input, so `once == authored` cannot separate "refused the shift" from "refused all reference-aware work"; and `issue_1691_insertions_and_duplications_converge_too` runs at `TRACT = 2000`, below the cap.

The convergence test asserts on the *chain* rather than a single equality, so a failure prints the walk and its step size — which is the evidence identifying the bound:

```
normalize did not converge; it walked ["c:g.65del", "c:g.165del", "c:g.265del",
  "c:g.365del", "c:g.465del", "c:g.565del", "c:g.665del", "c:g.765del", "c:g.865del"]
```

Plus two unit tests on the growth ladder itself: that it terminates at the cap from any start, and that a configured `window_size` of 0 still advances (doubling alone leaves it at 0 forever, turning a bounded retry into a hang).

## Measurement

`examples/dump_normalized_corpus.rs`, 85,642 rows, both revisions: the two dumps are **byte-identical**.

**That zero is structural and must not be read as safety.** The property this change keys on is *a repeat tract longer than `window_size` (100 bases) that the shuffle can roll through*, and the corpus cannot build one. Measured directly rather than argued: **the largest first-position shift anywhere in the 85,642-row corpus is 14 bases.** The changed code path needs a shuffle to travel at least 100. The corpus misses the trigger by a factor of seven, so it could not have moved a row whatever this change did. The cap-refusal path is further out of reach still — it needs a tract past 64 KiB, and no corpus member's whole sequence is that long.

Real consumer impact is therefore *not* zero, and is not quantified here: any `g.` or `m.` description sitting in a repeat tract longer than 100 bases moves — to the tract's 3' end, which is the position the 3' rule asked for all along, and which the previous output was only an arbitrary way-point toward. Past 64 KiB, a description that was stored as an `ins` or a `delins` may now be stored as the `dup`/`sub`/`inv` the spec requires.

Representation-Change: two classes move. (1) A `g.` or `m.` description whose 3' shuffle runs past `window_size` (100 bases) now converges on the tract's 3' end instead of advancing 100 bases per normalize call. (2) Past the 64 KiB growth cap the shift is refused but the reference-aware edit type is no longer refused with it, so a description that is really a duplication, substitution or inversion is now spelled as one — `g.65_66insA` -> `g.67dup`, `g.65delinsG` -> `g.65A>G` — where before it was echoed in the authored edit type. Repeat notation stays refused past the cap, because its `<first>_<last>unit[N]` extent is unreadable there. Measured 0 of 85,642 corpus rows moved, but that zero is STRUCTURAL and is not evidence of safety — the corpus's largest shift is 14 bases and no member is 64 KiB long, so it cannot reach either changed path.
