### PR TITLE
docs(ci): correct the soak archive's two stale selection counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,7 +859,16 @@ jobs:
         # gates only 2 of its ~360 modules on the feature and neither the soak
         # nor the sweeps selects one, so the selections are unchanged: verified
         # by listing both under each feature set, `test(proptest)` resolves to
-        # 10 tests either way and the sweep filter to 29.
+        # 15 tests either way and the sweep filter to 44.
+        #
+        # Both counts were stale (10 and 29) and both are re-measured above.
+        # The claim this comment exists to make is the *feature-independence* —
+        # "either way" — which held and still holds; the totals are incidental
+        # to it and drift whenever a matching module is added. Re-measure rather
+        # than trust them:
+        #
+        #   cargo nextest list --test it -E 'test(proptest)' | wc -l
+        #   cargo nextest list --test it -E "$SWEEP_FILTER" | wc -l
         run: |
           cargo nextest archive --cargo-profile soak --test it \
             --archive-file nextest-soak.tar.zst


### PR DESCRIPTION
One comment, two numbers, no behaviour change.

## What's wrong

`test-build-soak` builds its archive without `--features dev`, and the comment justifying that decision certifies the selections are unaffected:

> `tests/it` gates only 2 of its ~360 modules on the feature and neither the soak nor the sweeps selects one, so the selections are unchanged: verified by listing both under each feature set, `test(proptest)` resolves to **10** tests either way and the sweep filter to **29**.

Both totals have drifted. Measured against this tree:

```
$ cargo nextest list --test it -E 'test(proptest)' | wc -l
15
$ cargo nextest list --test it -E 'test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap) + test(issue_1254_sibling_crossing_shift)' | wc -l
44
```

## What is *not* wrong

The claim the comment exists to make — **feature-independence**, the "either way" — held when it was written and still holds. Both filters resolve identically with and without `--features dev`. So this corrects the evidence, not the conclusion, and the build decision it supports is unchanged.

## Why bother

The totals are incidental to that claim and move whenever a matching module is added, which is exactly how they went stale. But a number sitting in a comment whose stated purpose is "verified by listing both under each feature set" reads as a measured fact, and the next person to touch that job has no way to tell a current figure from a stale one.

So the re-measurement commands are now recorded beside the numbers, and the comment says plainly that the totals drift and the feature-independence is the durable part.

## Note for reviewers

#1693 edits this same sentence (it adds five `*proptest*` tests, taking 15 → 20), so whichever of the two lands second will need a one-line conflict resolution. The merged value is `20 tests either way and the sweep filter to 44`.

Representation-Change: none. A workflow comment; no code, no test, no output.
