### PR TITLE
fix(ci): derive the reporter's provenance sentence from the triggering event

### DIFF
--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -1,4 +1,5 @@
-# Reusable failure reporter for workflows that cannot fail on a pull request.
+# Reusable failure reporter for workflows whose red X would otherwise be
+# decoration.
 #
 # A workflow that only ever runs after a merge — on a schedule, or on push to
 # `main` — has no way to stop the break it detects. Its red X is decoration
@@ -7,6 +8,14 @@
 # demonstrated the consequence: it stayed red for 15 commits (`92da6d0` ..
 # `e90dff2`) while every pull request in that window reported a full green
 # board (#1225, #1226).
+#
+# NOT every caller is post-merge-only, and assuming so is what this file got
+# wrong. `coverage.yml` runs on `pull_request` as well as on `main` — added by
+# #1225, the same change that motivated this reporter — so one of the six
+# callers CAN fail before a merge. The issue body therefore derives its
+# provenance sentence from `github.event_name` rather than stating a fixed
+# claim; see the comment on that branch below. Adding a `pull_request` trigger
+# to another caller needs no change here, which is the point.
 #
 # `nightly-soak` already had the right pattern and this is a straight
 # generalisation of it: ONE rolling issue per workflow, updated rather than
@@ -88,6 +97,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW: ${{ github.workflow }}
           SHA: ${{ github.sha }}
+          # The provenance sentence below is derived from THIS RUN rather than
+          # asserted about the workflow, because the assertion went stale the
+          # moment one caller gained a `pull_request` trigger. In a
+          # `workflow_call`, both of these describe the caller's own triggering
+          # event, which is exactly the fact a reader needs.
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           # `--search "<title> in:title"` is a fuzzy full-text match, so an
@@ -120,6 +136,34 @@ jobs:
             echo "::warning::rolling-issue lookup failed; filing a new issue instead of commenting"
             EXISTING=""
           fi
+          # Provenance, derived rather than asserted. The previous text was the
+          # fixed sentence "This workflow does not run on pull requests, so this
+          # failure could not have been caught before merge" — true of five of
+          # the six callers and FALSE of `coverage.yml`, which gained a
+          # `pull_request` trigger in the very change that created this reporter
+          # (#1225). It failed in the misleading direction: it excused a failure
+          # that WAS visible on the pull request, and told the reader not to look
+          # where the answer was.
+          #
+          # Keying on `github.event_name` states a fact about this run, which
+          # cannot go stale when a caller's triggers change.
+          # Both reads are `${VAR:-}`, not `$VAR`, and that is load-bearing rather
+          # than defensive habit. The step runs under `set -u`, so a bare `$EVENT`
+          # aborts it when the variable is absent — and aborting here means the
+          # reporter files NOTHING, which is the exact failure
+          # `report_failure_degrades` exists to prevent. That test caught this by
+          # executing the block standalone; it is not reachable from real CI,
+          # where `env:` always supplies both, so nothing but the test would have
+          # said so.
+          if [ "${EVENT:-}" = "pull_request" ]; then
+            WHERE="pull request"
+            if [ -n "${PR_NUMBER:-}" ]; then
+              WHERE="pull request #${PR_NUMBER}"
+            fi
+            PROVENANCE="_This run was triggered by a ${WHERE}, so the failure is visible there and can be fixed before merge — check that pull request before treating this as a post-merge break._"
+          else
+            PROVENANCE="_This run was triggered by \`${EVENT:-unknown}\`, not by a pull request, so this failure was not visible on a pull request before the commit landed._"
+          fi
           BODY=$(printf '%s\n' \
             "$SUMMARY" \
             "" \
@@ -129,7 +173,7 @@ jobs:
             "" \
             "$HINT" \
             "" \
-            "_This workflow does not run on pull requests, so this failure could not have been caught before merge. One rolling issue is used per failure mode; repeat occurrences are added as comments._")
+            "$PROVENANCE One rolling issue is used per failure mode; repeat occurrences are added as comments.")
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "$BODY"
           else

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -488,5 +488,6 @@ mod workflow_gh_repo_context;
 
 mod issue_1618_anchored_repeat_semantics;
 mod report_failure_degrades;
+mod report_failure_provenance;
 mod reported_confluence_pairs;
 mod ring_segment_wellformedness;

--- a/tests/it/report_failure_provenance.rs
+++ b/tests/it/report_failure_provenance.rs
@@ -1,0 +1,193 @@
+//! The failure reporter must not assert that its callers cannot fail on a pull
+//! request.
+//!
+//! `report-failure.yml` appends a provenance sentence to every tracking issue it
+//! opens. That sentence used to be the fixed text *"This workflow does not run on
+//! pull requests, so this failure could not have been caught before merge"* — a
+//! claim about the CALLER, hardcoded in the CALLEE, and therefore unable to
+//! notice when a caller's triggers change.
+//!
+//! It went stale immediately. #1225 both created this reporter (because
+//! `Coverage` stayed red for 15 commits while every PR showed a green board) and
+//! gave `coverage.yml` a `pull_request` trigger. From that commit the sentence
+//! was false for `Coverage` and true for the other five callers, and five of the
+//! recurrences filed on the rolling coverage issue carried it.
+//!
+//! **The direction of the error is what makes it worth a guard.** It excused a
+//! failure that *was* visible on the pull request, and pointed the reader away
+//! from the one place the answer was sitting. A wrong claim that discourages
+//! checking is worse than no claim.
+//!
+//! The fix is to derive the sentence from `github.event_name`, which in a
+//! `workflow_call` describes the caller's own triggering event. This test pins
+//! that: the reporter must key on the event, and must not carry a blanket claim
+//! about pull-request coverage while any caller runs on `pull_request`.
+//!
+//! Modelled on `sweep_filter_invariant.rs` and `coderabbit_config_paths.rs`,
+//! which make the same class of silent config rot loud.
+
+use std::path::{Path, PathBuf};
+
+/// The reusable reporter under test.
+const REPORTER: &str = "report-failure.yml";
+
+/// Phrases that assert, as a fixed fact, that the failure could not have been
+/// seen before a merge. Any of these in the reporter is the defect this file
+/// exists to catch — they can only be true of *some* callers.
+///
+/// Kept as fragments rather than the whole sentence so a light rewording cannot
+/// slip past: the defect is the CLAIM, not its exact punctuation.
+const BLANKET_CLAIMS: &[&str] = &[
+    "does not run on pull requests",
+    "could not have been caught before merge",
+    "cannot fail on a pull request",
+];
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(".github")
+        .join("workflows")
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// The reporter with comment lines removed.
+///
+/// The guard below asks what the workflow **emits**, and a comment emits
+/// nothing. Scanning the raw file conflates the two, and not in a theoretical
+/// way: the fix for this very defect quotes the offending sentence in a comment
+/// to explain why it was removed, so a raw scan would fail the file for
+/// documenting its own correction. That is the `SELF`-exclusion problem
+/// `sweep_filter_invariant.rs` records, in a different costume.
+///
+/// One rule covers both layers: a line whose first non-whitespace character is
+/// `#` is a comment in YAML and in the `run:` block's bash alike.
+fn emitted_text(path: &Path) -> String {
+    read(path)
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Every workflow that calls the reporter, paired with whether it can run on a
+/// pull request.
+///
+/// The `on:` scan is deliberately crude — it reads the block between `on:` and
+/// the next top-level key — because the alternative is a YAML dependency for one
+/// boolean. It is a floor: a caller whose trigger it cannot parse counts as
+/// non-PR, which biases toward *not* firing this test. That is the safe
+/// direction for a guard whose failure message accuses the reporter.
+fn callers() -> Vec<(String, bool)> {
+    let dir = workflows_dir();
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("read .github/workflows") {
+        let path = entry.expect("dir entry").path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if name == REPORTER || !name.ends_with(".yml") {
+            continue;
+        }
+        let body = read(&path);
+        if !body.contains(REPORTER) {
+            continue;
+        }
+        let mut in_on = false;
+        let mut runs_on_pr = false;
+        for line in body.lines() {
+            if line.starts_with("on:") {
+                in_on = true;
+                continue;
+            }
+            // A new top-level key ends the `on:` block.
+            if in_on
+                && !line.starts_with(char::is_whitespace)
+                && !line.trim().is_empty()
+                && !line.trim_start().starts_with('#')
+            {
+                in_on = false;
+            }
+            if in_on && line.contains("pull_request") {
+                runs_on_pr = true;
+            }
+        }
+        out.push((name, runs_on_pr));
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn the_reporter_has_callers_to_speak_for() {
+    let callers = callers();
+    assert!(
+        !callers.is_empty(),
+        "no workflow calls {REPORTER}. Either the reporter is dead — delete it and this \
+         test — or the scan stopped matching, in which case every assertion below is \
+         vacuous and this test is proving nothing."
+    );
+}
+
+#[test]
+fn at_least_one_caller_can_fail_on_a_pull_request() {
+    let callers = callers();
+    let pr_callers: Vec<&String> = callers
+        .iter()
+        .filter(|(_, pr)| *pr)
+        .map(|(name, _)| name)
+        .collect();
+    assert!(
+        !pr_callers.is_empty(),
+        "no caller of {REPORTER} runs on `pull_request`, so the blanket claim this test \
+         forbids would now be TRUE. That is a legitimate state — but it means the guard \
+         below has nothing to guard, so decide deliberately rather than leaving a test \
+         that passes for the wrong reason. Callers: {callers:?}"
+    );
+}
+
+#[test]
+fn the_reporter_does_not_assert_that_failures_were_uncatchable() {
+    let body = emitted_text(&workflows_dir().join(REPORTER));
+    let callers = callers();
+    let pr_callers: Vec<&str> = callers
+        .iter()
+        .filter(|(_, pr)| *pr)
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    for claim in BLANKET_CLAIMS {
+        assert!(
+            !body.contains(claim),
+            "{REPORTER} contains the blanket claim {claim:?}, but {n} of its callers run \
+             on `pull_request` ({pr_callers:?}). For those, a failure IS visible before \
+             merge, and the sentence sends the reader away from the pull request that \
+             carries the answer.\n\n\
+             Derive the sentence from `github.event_name` instead — in a `workflow_call` \
+             that is the caller's own triggering event, so it cannot go stale when a \
+             caller gains or loses a trigger.",
+            n = pr_callers.len(),
+        );
+    }
+}
+
+#[test]
+fn the_reporter_derives_provenance_from_the_triggering_event() {
+    let body = read(&workflows_dir().join(REPORTER));
+    assert!(
+        body.contains("github.event_name"),
+        "{REPORTER} no longer reads `github.event_name`. The provenance sentence in the \
+         issue body must be derived from this run's triggering event rather than asserted \
+         about the workflow — that is the whole correction, and without it the text can \
+         silently become false again the next time a caller changes its triggers."
+    );
+    assert!(
+        body.contains("pull_request"),
+        "{REPORTER} reads `github.event_name` but never compares it against \
+         `pull_request`, so both branches of the provenance sentence cannot be reachable."
+    );
+}


### PR DESCRIPTION
`report-failure.yml` ended every tracking issue it files with a fixed sentence: that the workflow does not run on pull requests, and that the failure therefore could not have been caught before merge. That is a claim about the **caller**, hardcoded in the **callee**, so it cannot notice when a caller's triggers change.

It went stale on arrival. #1225 both created this reporter — because `Coverage` stayed red for 15 commits while every PR reported a green board — and gave `coverage.yml` a `pull_request` trigger. From that commit the sentence was false for one of the six callers.

## Measured

Six workflows call the reporter. Exactly one runs on pull requests:

| caller | `pull_request` trigger |
|---|---|
| `coverage.yml` | **yes** |
| `audit-pr-runs.yml`, `external-validation.yml`, `fuzz.yml`, `nightly-perf.yml`, `nightly-mutalyzer.yml` | no |

So the sentence was true of five callers and false of one — and `coverage.yml`'s own header says why it should be: *"Runs on pull requests as well as on `main`. Until #1225 this workflow was push-only, which made it structurally incapable of failing before a merge."*

All five recurrences on the rolling coverage issue carried the false sentence, most recently against a superseded head of an open PR — where the failure was not merely catchable but already visible on the PR.

## The direction of the error is why this is a fix rather than a deletion

It excused a failure that *was* visible on the pull request, and pointed the reader away from the one place the answer was sitting. A wrong claim that discourages checking is worse than no claim.

## The change

The sentence is derived from `github.event_name`, which in a `workflow_call` is the caller's own triggering event. On a pull request it names the PR and says to look there; otherwise it names the actual event. That is a fact about *this run*, so adding a `pull_request` trigger to another caller needs no change here.

Both new reads are `${VAR:-}` rather than bare, and that is load-bearing rather than defensive habit. The step runs under `set -u`, so an unset `EVENT` aborts it — and aborting here files **nothing**, which is the exact failure `report_failure_degrades` exists to prevent. That test caught it, by executing the `run:` block standalone with a stubbed `gh`; it is unreachable from real CI, where `env:` always supplies both, so nothing else would have said so.

## The guard

`tests/it/report_failure_provenance.rs`, in the idiom of `sweep_filter_invariant.rs` and `coderabbit_config_paths.rs`. Four tests, two of which exist to stop the other two passing vacuously:

- the reporter has callers at all — otherwise every assertion below is empty
- at least one caller runs on `pull_request` — because if none did, the old sentence would be **true**, and this guard should be reconsidered deliberately rather than left green for the wrong reason
- the emitted text carries no blanket uncatchable-before-merge claim
- the reporter keys on `github.event_name`, and compares it against `pull_request`, so both branches are reachable

**The scan reads the file with comment lines removed.** The question is what the workflow *emits*, and a comment emits nothing — which also lets the fix quote the offending sentence to explain why it was removed, without failing itself. That is the `SELF`-exclusion problem `sweep_filter_invariant.rs` records, in a different costume.

**Proven to discriminate.** With the blanket claim restored to the emitted body, `the_reporter_does_not_assert_that_failures_were_uncatchable` fails; restored via `cp` and verified byte-identical.

## Verification

`FMT=0`, `CLIPPY=0` (`--all-features --all-targets -D warnings`), `actionlint` clean, YAML parses. 7/7 in the two `report_failure` modules — my 4 new plus the 3 existing, which were red until the `${VAR:-}` fix.

Representation-Change: none. CI and tests only; no file under `src/` is touched.
