### PR TITLE
fix(normalize): settle whole-span inversion typing before the block is cut

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2107,6 +2107,18 @@ impl Piece {
         (self.alt.is_empty() && ref_len > 0) || (ref_len == 0 && !self.alt.is_empty())
     }
 
+    /// Whether this piece spells a substitution: exactly one reference
+    /// nucleotide replaced by exactly one other.
+    ///
+    /// `delins.md:15` — "when **one** nucleotide is replaced by **one** other
+    /// nucleotide, the change is a substitution". Both halves are load-bearing
+    /// and a width test alone gets the second one wrong: a 1-base *deletion* is
+    /// also one column wide and is not a substitution. See
+    /// [`no_piece_is_a_lone_substitution`], which is the reason this exists.
+    fn is_substitution(&self) -> bool {
+        self.ref_end.saturating_sub(self.ref_start) == 1 && self.alt.len() == 1
+    }
+
     /// Whether this piece is a pure insertion sitting immediately outside one
     /// end of the fetched window.
     ///
@@ -2878,6 +2890,37 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
         w_lo,
         &ref_bytes,
     );
+    // Whether this block is one `inv`, decided **here** — while the pieces still
+    // partition the trimmed block — and applied far below, after the weight
+    // bound. Two orderings are in tension and this is what reconciles them.
+    //
+    // `inversion.md:5` defines an inversion by the content of the **whole** span,
+    // so the typing is a predicate over the block; where to cut is a decision
+    // about how to divide it. The typing has to settle first. It does not survive
+    // `shift_pieces`: that pass moves a pure indel 3' as far as the reference
+    // allows, and a derived insertion sitting on the hull's right edge moves
+    // *past* it whenever the next reference base repeats the payload. The pieces
+    // then no longer span the block, and the reconstruction
+    // `whole_block_inversion` builds from their hull is a different, longer
+    // string. On `NC_000017.11:g.43044327_43044331` (`GTTAA -> TTAAC`) the hull
+    // becomes 6 bases and the reconstruction `TTAACC` against `GTTAAC`, which is
+    // not a reverse complement — so the answer computed after the shift is `None`
+    // for a block that is an exact reverse complement (#1703).
+    //
+    // The *application* must nevertheless stay after the changed-columns weight
+    // bound, for the reason `coalesce_whole_block_inversion`'s own doc works
+    // through in full: this rule **widens**, and the bound compares the derived
+    // weight against the *input's*, which differs between two spellings of one
+    // variant. `GTTAA -> TTAAC` weighs 3 spelled as three substitutions and 5
+    // spelled as one spanning `delins`, so a pre-bound widening to 5 columns is
+    // accepted for the second and refused for the first. Deciding here and
+    // applying below is what lets both constraints hold at once; collapsing them
+    // either way reintroduces one of the two defects.
+    //
+    // Nothing between here and the application can make this stale. It is a
+    // function of the trimmed block alone — `ref_bytes[lo..hi_ref]` against the
+    // denoted sequence — and neither is touched again.
+    let block_inversion = whole_block_inversion(&pieces, &ref_bytes);
     shift_pieces(&mut pieces, &ref_bytes, direction);
     coalesce_adjacent_pieces(&mut pieces);
     // Partitioning decides where the members are; this decides how wide each
@@ -3065,7 +3108,22 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     if partition_rule().cuts_with_canonical() {
         coalesce_compensating_gap_split(&mut pieces, &ref_bytes);
     }
-    coalesce_whole_block_inversion(&mut pieces, &ref_bytes);
+    // The typing decided on the trimmed block wins, and the post-shift pieces are
+    // consulted only when it declined. See the `block_inversion` binding above
+    // for why the decision and its application sit either side of the weight
+    // bound.
+    //
+    // Both directions are kept rather than the earlier one replacing the later:
+    // the pre-shift answer is stronger where a member has since left the hull,
+    // and the post-shift answer is the one that reaches a block whose pieces the
+    // passes between the two calls have merged (`coalesce_payload_alignment_split`
+    // and `coalesce_compensating_gap_split` both re-partition). Neither
+    // subsumes the other, and each is a whole-span reverse complement over the
+    // pieces it is asked about, so preferring the earlier one costs nothing.
+    match block_inversion {
+        Some(whole) => pieces = vec![whole],
+        None => coalesce_whole_block_inversion(&mut pieces, &ref_bytes),
+    }
 
     // Applied *after* the weight bound, deliberately. The bound is a statement
     // about the re-derived partition — it may not describe more change than the
@@ -5465,13 +5523,22 @@ fn changed_columns_dominate_the_span(pieces: &[Piece]) -> bool {
 ///   partition_block_canonical 0:0/A | 2:3/     an insertion and a deletion
 /// ```
 ///
-/// Both denote `AGC` and both are distance-minimal. On the second, all three
-/// earlier routes refuse: the gap is `2 - 0 = 2` so it is not a single base; the
-/// reference widths total `0 + 1 = 1` against a span of `3`; and the insertion's
-/// reference width is `0`, so it reads as narrower than a lone substitution. The
-/// block is an inversion and the gate says nothing about it — which is the
-/// defect, since the pass exists precisely to keep `inversion.md:5`'s
-/// whole-span reverse complement from being shredded into its columns.
+/// Both denote `AGC` and both are distance-minimal. When #1637 was filed all
+/// three earlier routes refused the second: the gap is `2 - 0 = 2` so it is not
+/// a single base; the reference widths total `0 + 1 = 1` against a span of `3`;
+/// and [`no_piece_is_a_lone_substitution`] then measured reference **width**, so
+/// the insertion read as narrower than a lone substitution. The block is an
+/// inversion and the gate said nothing about it — which is the defect, since the
+/// pass exists precisely to keep `inversion.md:5`'s whole-span reverse
+/// complement from being shredded into its columns.
+///
+/// The third route no longer refuses **this** block: #1703 corrected it to ask
+/// whether a piece *is* a substitution (`delins.md:15`) rather than how wide it
+/// is, and neither an insertion nor a deletion is one. That does not make this
+/// route redundant — it is still the only one that reaches a partition
+/// containing a genuine substitution, which is the shape the spec's own
+/// published 16 nt example takes (`8:9/A`, pinned by
+/// [`the_inversion_coalesce_reaches_the_spec_published_sixteen_nt_example`]).
 ///
 /// The density argument in [`changed_columns_dominate_the_span`]'s own doc is
 /// about **columns**, not reference width, so counting `max(ref_width, payload)`
@@ -5576,7 +5643,8 @@ fn every_separation_is_a_single_base(pieces: &[Piece]) -> bool {
         .all(|pair| pair[1].ref_start.saturating_sub(pair[0].ref_end) <= 1)
 }
 
-/// No piece spells a lone substitution — every one covers two or more columns.
+/// No piece spells a lone substitution — no piece replaces exactly one
+/// nucleotide by exactly one other.
 ///
 /// The third alternative admitting [`coalesce_whole_block_inversion`], and the
 /// one that closes #1517. It exists because the other two are geometric — they
@@ -5620,10 +5688,67 @@ fn every_separation_is_a_single_base(pieces: &[Piece]) -> bool {
 /// member type is an implementer's reading of `:56`, not something its text
 /// compels. `tests/it/issue_1517_inv_priority_over_delins.rs` records the
 /// question, both readings, and the choice.
+///
+/// # It asks about substitution-hood, not about width — corrected by #1703
+///
+/// This used to read `ref_end - ref_start >= 2`, i.e. "every piece covers two or
+/// more reference columns". That is the right verdict for a `sub`/`delins`
+/// partition and the wrong one for any piece that does not consume and replace
+/// reference in equal measure, because **a narrow piece is not the same thing as
+/// a substitution**:
+///
+/// | piece | reference width | payload | is it a substitution? | width test said |
+/// |---|---|---|---|---|
+/// | `0:1/T` | 1 | 1 | yes | refuse — correct |
+/// | `0:1/` (a deletion) | 1 | 0 | **no** | refuse — wrong |
+/// | `5:5/C` (an insertion) | 0 | 1 | **no** | refuse — wrong |
+/// | `0:2/TT` | 2 | 2 | no | admit — correct |
+///
+/// `delins.md:15` states the distinction the name has always claimed: "when
+/// **one** nucleotide is replaced by **one** other nucleotide, the change is a
+/// substitution". A deletion replaces one nucleotide by none and an insertion
+/// replaces none by one, so `general.md:56`'s ranking of substitution above
+/// inversion — which is the entire content of this route — reaches neither, and
+/// nothing withdraws `inversion.md:5` from the block they partition.
+///
+/// The correction is **additive**: a piece two or more columns wide can never be
+/// a one-for-one replacement, so every partition the width test admitted is
+/// still admitted, and only a currently-refused one can change. What it newly
+/// admits is a partition made entirely of indels and multi-column runs, and such
+/// a partition still has to survive [`is_inversion`] on the reconstruction — an
+/// exact, equal-length reverse complement — so the widening is bounded by the
+/// sequence rather than by this predicate.
+///
+/// #1703 is the case it was refusing: `GTTAA -> TTAAC`, the real
+/// `NC_000017.11:g.43044327_43044331`, whose canonical partition is a 1-base
+/// deletion plus a 1-base insertion because Levenshtein reads that pair (2) as
+/// cheaper than the three substitutions its columns present (3). All four routes
+/// refused it and the whole-span reverse complement came back as
+/// `g.[43044327del;43044332dup]`, which `delins.md:5` and `inversion.md:5`
+/// between them do not admit.
+///
+/// # Jurisdiction, because this gate is axis-blind and the citations are not
+///
+/// Everything above cites the `DNA/` directory, and a `DNA/` clause cannot scope
+/// the `r.` axis — that misreading is what
+/// `delins-payload-coincidence-carve-out-is-coding-dna-scoped` was opened on. It
+/// is not a problem here only because the RNA recommendations state the **same**
+/// three clauses in their own directory, which was checked rather than assumed
+/// (spec checkout `6f85311`):
+///
+/// | claim | DNA | RNA |
+/// |---|---|---|
+/// | an inversion is a whole-span reverse complement of more than one nucleotide | `DNA/inversion.md:5` | `RNA/inversion.md:5` |
+/// | a delins is a replacement "and which is not a substitution or inversion" | `DNA/delins.md:5` | `RNA/delins.md:5` |
+/// | one nucleotide replaced by one other is a substitution | `DNA/delins.md:15` | `RNA/delins.md:16` |
+///
+/// The RNA texts of the first two are word-for-word identical to their DNA
+/// twins. `general.md:56`'s prioritisation is not molecule-specific. So each
+/// axis this gate decides is decided under a clause with jurisdiction over it,
+/// and an `r.` row moving with a `g.` row is a coincidence of wording rather
+/// than one directory reaching across.
 fn no_piece_is_a_lone_substitution(pieces: &[Piece]) -> bool {
-    pieces
-        .iter()
-        .all(|piece| piece.ref_end.saturating_sub(piece.ref_start) >= 2)
+    pieces.iter().all(|piece| !piece.is_substitution())
 }
 
 /// Partition a changed block by deriving member boundaries from the **denoted
@@ -13002,7 +13127,8 @@ mod tests {
         /// reconstruction is a valid inversion — `is_inversion` accepts it — so
         /// nothing is wrong with what the pass would produce. What refused was
         /// the admission gate, and each of the three routes that predate #1637
-        /// is asserted below to be the reason.
+        /// is asserted below — two of them still refusing, and the third only
+        /// because #1703 corrected it (see the note on that assertion).
         #[test]
         fn the_inversion_coalesce_reaches_a_canonical_partition() {
             let reference = b"GCT";
@@ -13046,9 +13172,24 @@ mod tests {
                 "the insertion consumes no reference, so reference width \
                  under-reads this partition's density"
             );
+            // RE-BLESSED by #1703, from `!no_piece_is_a_lone_substitution` to the
+            // positive. The verdict moved because the *predicate* was corrected,
+            // not because this block changed: it used to measure reference width
+            // (`>= 2`) and so called this insertion and this deletion lone
+            // substitutions, which `delins.md:15` says they are not. Nothing
+            // about `GCT -> AGC` moved — the pass reached the same `inv` before
+            // and after, by route 4 then and by two routes now.
+            //
+            // The test's subject is unaffected: what it pins is that the gate
+            // refused this partition and that the reconstruction was sound, and
+            // #1637's route is still the one that uniquely decides a partition
+            // containing a genuine substitution — see
+            // `the_inversion_coalesce_reaches_the_spec_published_sixteen_nt_example`,
+            // whose `8:9/A` keeps this route refusing there.
             assert!(
-                !no_piece_is_a_lone_substitution(&pieces),
-                "the insertion's reference width is 0, narrower than a lone substitution"
+                no_piece_is_a_lone_substitution(&pieces),
+                "an insertion replaces no reference base and a deletion replaces \
+                 it with none, so neither is a substitution (`delins.md:15`)"
             );
             assert!(
                 payload_columns_dominate_the_span(&pieces),
@@ -13060,6 +13201,174 @@ mod tests {
                 pieces,
                 vec![reconstructed],
                 "a whole-block inversion must survive the canonical partition as one piece"
+            );
+        }
+
+        /// A compensating deletion/insertion pair is not two lone substitutions,
+        /// and the gate must not read it as one (#1703).
+        ///
+        /// The canonical partition of `GTTAA -> TTAAC` — the real
+        /// `NC_000017.11:g.43044327_43044331`, whose 2nd and 4th columns are
+        /// self-complementary — is a 1-base deletion at the hull start plus a
+        /// 1-base insertion at the hull end. Levenshtein reads that pair as
+        /// cheaper (2) than the three substitutions the columns present (3), so
+        /// it is what a minimal alignment produces.
+        ///
+        /// Neither member is a substitution. `delins.md:15` is explicit about
+        /// what one is — "when **one** nucleotide is replaced by **one** other
+        /// nucleotide, the change is a substitution" — and a deletion replaces
+        /// one nucleotide by none while an insertion replaces none by one. So
+        /// `general.md:56`'s ranking of substitution (1) above inversion (3),
+        /// which is the whole content of this route, does not reach either of
+        /// them, and nothing withdraws `inversion.md:5`.
+        ///
+        /// This is the assertion the predicate failed before #1703: it measured
+        /// reference **width** (`>= 2`) while its name and its reasoning are
+        /// about substitution-hood, so it called a pure indel a lone
+        /// substitution and refused the block.
+        #[test]
+        fn a_deletion_and_an_insertion_are_not_lone_substitutions() {
+            let reference = b"GTTAA";
+            let pieces =
+                partition_block_canonical(reference, b"TTAAC").expect("grid far below the bound");
+            assert_eq!(
+                pieces,
+                vec![
+                    Piece {
+                        ref_start: 0,
+                        ref_end: 1,
+                        alt: Vec::new(),
+                    },
+                    Piece {
+                        ref_start: 5,
+                        ref_end: 5,
+                        alt: b"C".to_vec(),
+                    },
+                ],
+                "if the canonical partition of this block ever changes, the rest \
+                 of this test is measuring something else"
+            );
+            assert!(
+                no_piece_is_a_lone_substitution(&pieces),
+                "a 1-base deletion and a pure insertion are a deletion and an \
+                 insertion, not substitutions (`delins.md:15`)"
+            );
+
+            // The three routes that cannot see this block, each for its own
+            // reason — so a later widening of any of them cannot silently become
+            // the thing this test is measuring.
+            assert!(
+                !every_separation_is_a_single_base(&pieces),
+                "the gap is 4, so the single-base route cannot admit it"
+            );
+            assert!(
+                !changed_columns_dominate_the_span(&pieces),
+                "reference widths total 1 + 0 against a span of 5"
+            );
+            assert!(
+                !payload_columns_dominate_the_span(&pieces),
+                "counting the payload lifts the total only to 2, still under half \
+                 of 5 — density cannot reach a block this sparse, which is why \
+                 #1637's route is not the answer here"
+            );
+
+            // And the block really is the inversion the gate was refusing.
+            assert_eq!(
+                whole_block_inversion(&pieces, reference),
+                Some(Piece {
+                    ref_start: 0,
+                    ref_end: 5,
+                    alt: b"TTAAC".to_vec(),
+                }),
+                "`inversion.md:5` defines an inversion by the content of the \
+                 whole span, and this span is an exact reverse complement"
+            );
+        }
+
+        /// A lone substitution is still refused, and the corrected predicate is
+        /// what says so (#1703).
+        ///
+        /// The negative half of the test above, and the one that keeps
+        /// `general.md:56` doing work. `AAGCTA -> TAGCTT` is also a whole-span
+        /// reverse complement, but its members are two genuine substitutions —
+        /// one nucleotide replaced by one other — so the split outranks the
+        /// spanning `inv` and the gate must refuse.
+        #[test]
+        fn two_lone_substitutions_are_still_refused_by_the_corrected_predicate() {
+            let reference = b"AAGCTA";
+            let pieces = vec![
+                Piece {
+                    ref_start: 0,
+                    ref_end: 1,
+                    alt: b"T".to_vec(),
+                },
+                Piece {
+                    ref_start: 5,
+                    ref_end: 6,
+                    alt: b"T".to_vec(),
+                },
+            ];
+            assert!(
+                !no_piece_is_a_lone_substitution(&pieces),
+                "both members replace one nucleotide by one other, which is a \
+                 substitution by `delins.md:15`"
+            );
+            let mut refused = pieces.clone();
+            coalesce_whole_block_inversion(&mut refused, reference);
+            assert_eq!(
+                refused, pieces,
+                "the #1040 control must survive the pass untouched"
+            );
+        }
+
+        /// Inversion typing is settled on the trimmed block, **before** the
+        /// 3'-shift moves a member out of it (#1703).
+        ///
+        /// The second, independent half of #1703, and the one a fix to the gate
+        /// alone does not reach. `shift_pieces` runs before
+        /// `coalesce_whole_block_inversion` in `canonicalize_from_sequence`, and
+        /// it moves the derived insertion from the hull's right edge to one past
+        /// it whenever the next reference base repeats the payload — which is
+        /// exactly the case here, and is what renders the wrong answer's second
+        /// member as a `dup`.
+        ///
+        /// After that move the pieces no longer span the block: the hull is 6
+        /// bases and the reconstruction is `TTAACC` against `GTTAAC`, which is
+        /// not a reverse complement. So the pass must consult the answer computed
+        /// before the shift, and this test pins the two verdicts *differing* —
+        /// which is the whole reason the answer has to be carried forward rather
+        /// than recomputed.
+        #[test]
+        fn the_whole_block_inversion_is_settled_before_the_three_prime_shift() {
+            // The trailing `C` is the base the insertion shifts onto, mirroring
+            // `NC_000017.11:g.43044332`.
+            let reference = b"GTTAACG";
+            let mut pieces = partition_block_canonical(&reference[..5], b"TTAAC")
+                .expect("grid far below the bound");
+
+            let before = whole_block_inversion(&pieces, reference);
+            assert_eq!(
+                before,
+                Some(Piece {
+                    ref_start: 0,
+                    ref_end: 5,
+                    alt: b"TTAAC".to_vec(),
+                }),
+                "on the trimmed block the pieces span exactly the inversion"
+            );
+
+            shift_pieces(&mut pieces, reference, ShuffleDirection::ThreePrime);
+            assert_eq!(
+                pieces.last().map(|piece| piece.ref_start),
+                Some(6),
+                "the 3'-shift must move the insertion past the block's right edge, \
+                 or this test is not exercising the ordering at all"
+            );
+            assert_eq!(
+                whole_block_inversion(&pieces, reference),
+                None,
+                "once a member is outside the block hull the reconstruction spans \
+                 6 bases against a 6-base payload that is not a reverse complement"
             );
         }
 

--- a/tests/it/issue_1703_whole_span_inversion_before_the_cut.rs
+++ b/tests/it/issue_1703_whole_span_inversion_before_the_cut.rs
@@ -1,0 +1,309 @@
+//! Issue #1703: a whole-span reverse complement must be **typed** before the
+//! block is **cut**.
+//!
+//! The defect
+//! ----------
+//! On every sequence-first partition arm (`FERRO_PARTITION=shadow`, `canonical`,
+//! `canonical-coalesced`) a 5 nt span whose replacement is its own reverse
+//! complement came back as a `[del;dup]` pair rather than an `inv`. Every
+//! spelling reached the same wrong string, so the arm was self-consistent and
+//! wrong together and no confluence check could see it.
+//!
+//! Real GRCh38 reproducer, which the synthetic core below mirrors base for base:
+//! `NC_000017.11:g.43044327_43044331` is `GTTAA`, `revcomp(GTTAA) = TTAAC`, and
+//! columns `43044328`/`43044330` are self-complementary — so the substitution
+//! spelling is three *separated* substitutions.
+//!
+//! ```text
+//! g.        43044327  43044328  43044329  43044330  43044331
+//! ref          G         T         T         A         A
+//!              X         |         X         |         X
+//! alt          T         T         A         A         C
+//! ```
+//!
+//! `FERRO_PARTITION=live` emitted `g.43044327_43044331inv` for all three
+//! spellings; the sequence-first arms emitted `g.[43044327del;43044332dup]`.
+//! Mutalyzer converges all three on the `inv`.
+//!
+//! Why the wrong form is not admissible
+//! ------------------------------------
+//! `DNA/inversion.md:5` defines an inversion by the content of the **whole**
+//! span — "**more than one nucleotide** replacing the original sequence is the
+//! reverse complement of the original sequence" — and this span is an exact
+//! reverse complement. `DNA/delins.md:5` independently excludes the spanning
+//! `delins` spelling by definition, "**and which is not** a substitution or
+//! inversion". Both are prohibitions read from prose force, which is rule 1's
+//! scope in `README.md`, so this is a bug and not a disclosure.
+//!
+//! What the guards below are for
+//! -----------------------------
+//! `issue_1040_inv_overrecognition_probes` already pins the same 5 nt core on
+//! the **`live`** arm, in process, through `assert_padded_preserving`. It cannot
+//! reach an arm: `partition_rule()` caches its read of `FERRO_PARTITION` in a
+//! `OnceLock`, and `tests/it/common/cis_apply_oracle.rs` records why a test must
+//! not `set_var` to get around that (sound under nextest, false under `cargo
+//! test`, which runs tests as threads in one process). So the arm is reached the
+//! way `partition_switch_wiring.rs` reaches it — through the `ferro` binary, with
+//! the variable in the child's environment.
+//!
+//! The two negative controls are the point of the file as much as the positive
+//! case is, because the fix widens an admission gate:
+//!
+//! * `AAGCTA -> TAGCTT` is **also** a whole-span reverse complement, but its
+//!   members are two lone substitutions, and `general.md:56` ranks substitution
+//!   (1) above inversion (3). It must stay split — this is the #1040 control.
+//! * `GTTAT -> TTATC` has the **identical geometry** to the positive case (a
+//!   1-base deletion at the hull start plus a 1-base insertion at the hull end,
+//!   four unchanged bases between them) and is *not* a reverse complement. It
+//!   must stay split, which is what makes the positive case a statement about
+//!   the sequence rather than about the shape.
+
+use crate::common::cis_apply_oracle::apply;
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+/// The contig every fixture below serves, and the accession
+/// [`crate::common::cis_apply_oracle`] builds its own provider under — so the
+/// same descriptor can be applied in process to cross-check what the child
+/// process printed.
+const CONTIG: &str = "TEMPLATE";
+
+/// 0-based offset of the core inside a fixture sequence, i.e. the core's first
+/// 1-based HGVS position is `PREFIX_LEN + 1` = 81.
+const PREFIX_LEN: usize = 80;
+
+/// Every arm `FERRO_PARTITION` accepts. The defect was present on the three
+/// sequence-first arms and absent from `live`; the fix has to leave `live` where
+/// it is, so it is asserted here rather than merely believed.
+const ARMS: [&str; 4] = ["live", "shadow", "canonical", "canonical-coalesced"];
+
+/// The reference a fixture serves: `ACGT…` padding, the core, a single `C`, then
+/// more padding.
+///
+/// The trailing `C` is not decoration. It is what makes the 3'-shift render the
+/// derived insertion as `86dup` rather than `85_86insC`, so the synthetic output
+/// is the same *shape* as the real locus's `g.[43044327del;43044332dup]` — where
+/// `NC_000017.11:g.43044332` is likewise a `C`.
+fn fixture_sequence(core: &str) -> String {
+    format!("{pad}{core}C{pad}", pad = "ACGT".repeat(PREFIX_LEN / 4))
+}
+
+/// Write `core`'s fixture into `dir` as an indexed single-contig FASTA.
+///
+/// `MultiFastaProvider::from_directory` — which `ferro normalize --reference`
+/// takes when the directory holds no `manifest.json` — requires a `.fai`, so one
+/// is written alongside. The index is exact rather than approximate: a
+/// single-record FASTA wrapped at a fixed width has a closed-form index, and
+/// getting it wrong would surface as a wrong base rather than as an error.
+fn write_fixture(dir: &Path, core: &str) -> String {
+    const LINE_BASES: usize = 60;
+    let sequence = fixture_sequence(core);
+    let header = format!(">{CONTIG}\n");
+
+    let mut fasta = std::fs::File::create(dir.join("t.fa")).expect("create fasta");
+    fasta.write_all(header.as_bytes()).expect("write header");
+    for line in sequence.as_bytes().chunks(LINE_BASES) {
+        fasta.write_all(line).expect("write bases");
+        fasta.write_all(b"\n").expect("write newline");
+    }
+    fasta.flush().expect("flush fasta");
+
+    std::fs::write(
+        dir.join("t.fa.fai"),
+        format!(
+            "{CONTIG}\t{}\t{}\t{LINE_BASES}\t{}\n",
+            sequence.len(),
+            header.len(),
+            LINE_BASES + 1,
+        ),
+    )
+    .expect("write fai");
+
+    sequence
+}
+
+/// Normalize `variant` against `core`'s fixture with `FERRO_PARTITION=arm`, and
+/// return the normalized description.
+///
+/// `ferro normalize` prints either the description (when nothing changed) or
+/// `<input> -> <output>`, so the output is whatever follows the last arrow.
+fn normalize_on_arm(core: &str, arm: &str, variant: &str) -> String {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_fixture(dir.path(), core);
+
+    let run = Command::new(env!("CARGO_BIN_EXE_ferro"))
+        .arg("normalize")
+        .arg(variant)
+        .arg("--reference")
+        .arg(dir.path())
+        .env("FERRO_PARTITION", arm)
+        .output()
+        .expect("run ferro normalize");
+    assert!(
+        run.status.success(),
+        "`{variant}` on arm `{arm}` failed; stderr was:\n{}",
+        String::from_utf8_lossy(&run.stderr),
+    );
+
+    let stdout = String::from_utf8(run.stdout).expect("utf-8 stdout");
+    let last = stdout
+        .lines()
+        .next_back()
+        .unwrap_or_else(|| panic!("`{variant}` on arm `{arm}` printed nothing"))
+        .trim();
+    last.rsplit(" -> ")
+        .next()
+        .expect("a description")
+        .to_string()
+}
+
+/// Assert that every `spelling` of one variant reaches `expected` on every arm,
+/// and that each output still denotes the bases its input did.
+///
+/// Convergence is a property of the *set* of outputs, so the set is built and
+/// its cardinality asserted rather than each spelling being compared against a
+/// constant in isolation — a single-input assertion cannot observe convergence,
+/// and three of them agreeing with a constant is not the same statement as the
+/// three agreeing with each other.
+///
+/// The denoted-sequence half goes through
+/// [`crate::common::cis_apply_oracle::apply`], which reaches the bases through
+/// `hgvs_to_spdi` and an SPDI splice rather than through the normalizer — so a
+/// re-typing that quietly changed the sequence fails here loudly instead of
+/// merely disagreeing with a pinned string. This is the same discipline
+/// `assert_padded_preserving` applies on the in-process `live` path, expressed
+/// against a child process's output.
+fn assert_converges(core: &str, spellings: &[String], expected: &str) {
+    let reference = fixture_sequence(core);
+    for arm in ARMS {
+        let mut outputs = BTreeSet::new();
+        for spelling in spellings {
+            let output = normalize_on_arm(core, arm, spelling);
+            let denoted_in = apply(&reference, spelling)
+                .unwrap_or_else(|| panic!("`{spelling}` denotes no sequence"));
+            let denoted_out = apply(&reference, &output).unwrap_or_else(|| {
+                panic!("`{spelling}` -> `{output}` on arm `{arm}` denotes no sequence")
+            });
+            assert_eq!(
+                denoted_out, denoted_in,
+                "`{spelling}` -> `{output}` on arm `{arm}` changed the sequence",
+            );
+            outputs.insert(output);
+        }
+        assert_eq!(
+            outputs.len(),
+            1,
+            "arm `{arm}` gave {} answers for one variant: {outputs:?}",
+            outputs.len(),
+        );
+        assert_eq!(
+            outputs.iter().next().map(String::as_str),
+            Some(expected),
+            "arm `{arm}` converged on the wrong form",
+        );
+    }
+}
+
+/// The core the real locus carries, and the one
+/// `issue_1040_inv_overrecognition_probes::
+/// every_spelling_of_a_derived_whole_block_inversion_converges_on_inv` already
+/// pins on `live`.
+const INVERSION_CORE: &str = "GTTAA";
+
+#[test]
+fn every_spelling_of_a_whole_span_reverse_complement_converges_on_inv_on_every_arm() {
+    // `NC_000017.11:g.43044327_43044331inv`, its three-substitution spelling and
+    // its spanning `delins` spelling, re-sited at position 81 of the fixture.
+    //
+    // The `delins` spelling is included even though `DNA/delins.md:5` makes it an
+    // incorrect *output*: ferro accepts it as input, and must land on the same
+    // normal form as the spellings that are correct.
+    assert_converges(
+        INVERSION_CORE,
+        &[
+            format!("{CONTIG}:g.81_85inv"),
+            format!("{CONTIG}:g.[81G>T;83T>A;85A>C]"),
+            format!("{CONTIG}:g.81_85delinsTTAAC"),
+        ],
+        &format!("{CONTIG}:g.81_85inv"),
+    );
+}
+
+#[test]
+fn a_reverse_complement_whose_members_are_substitutions_still_splits_on_every_arm() {
+    // The #1040 control, and the assertion that stops the fix from becoming "merge
+    // any whole-span reverse complement". `AAGCTA -> TAGCTT` is an exact reverse
+    // complement whose only changed columns are its first and last, four unchanged
+    // bases apart, and whose members are therefore two **lone substitutions**.
+    //
+    // `general.md:56` ranks substitution (1) above inversion (3), so the split
+    // wins here and the spanning `inv` must not be reached. That ranking is what
+    // `whole_block_inversion`'s `no_piece_is_a_lone_substitution` route encodes,
+    // and widening that route is exactly what this issue's fix does — so this
+    // control is load-bearing rather than decorative.
+    assert_converges(
+        "AAGCTA",
+        &[
+            format!("{CONTIG}:g.81_86inv"),
+            format!("{CONTIG}:g.[81A>T;86A>T]"),
+            format!("{CONTIG}:g.81_86delinsTAGCTT"),
+        ],
+        &format!("{CONTIG}:g.[81A>T;86A>T]"),
+    );
+}
+
+#[test]
+fn a_del_ins_block_that_is_not_a_reverse_complement_still_splits_on_the_arms() {
+    // The geometric control. `GTTAT -> TTATC` partitions on the canonical arms
+    // into precisely the same shape as the positive case — a 1-base deletion at
+    // the hull start and a 1-base insertion at the hull end, four unchanged bases
+    // between them, rendering as `g.[81del;86dup]` — and it is **not** a reverse
+    // complement (`revcomp(GTTAT) = ATAAC`, not `TTATC`).
+    //
+    // So the two cases are separated by the sequence relation and by nothing else.
+    // Without this, the positive test above would pass just as well against a rule
+    // that merged every compensating deletion/insertion pair.
+    //
+    // Asserted per arm rather than through `assert_converges`, because the answer
+    // legitimately differs between the arms: `live`'s single-gap search never
+    // proposes the compensating pair at all.
+    let spelling = format!("{CONTIG}:g.81_85delinsTTATC");
+    assert_eq!(
+        normalize_on_arm("GTTAT", "live", &spelling),
+        format!("{CONTIG}:g.[81G>T;83_85delinsATC]"),
+    );
+    for arm in ["shadow", "canonical", "canonical-coalesced"] {
+        assert_eq!(
+            normalize_on_arm("GTTAT", arm, &spelling),
+            format!("{CONTIG}:g.[81del;86dup]"),
+            "arm `{arm}` merged a block that is not a reverse complement",
+        );
+    }
+}
+
+#[test]
+fn the_wrong_form_denoted_the_right_bases_which_is_why_no_oracle_reached_it() {
+    // Why this needed an issue rather than being caught by CI. The form the arms
+    // emitted is a *mis-typing*, not a mis-application: it denotes exactly the
+    // bases the `inv` does, it re-parses, its coordinates are in bounds, and it is
+    // a fixed point. So all four seam oracles — `FERRO_ASSERT_IDEMPOTENT`,
+    // `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and the strongest of them,
+    // `FERRO_ASSERT_SEQUENCE` — pass on it, and every spelling reached it, so the
+    // confluence checks passed too.
+    //
+    // Pinned by applying both descriptions independently of the normalizer, so
+    // this assertion stays true (and stays the explanation) whatever the
+    // normalizer later does.
+    let reference = fixture_sequence(INVERSION_CORE);
+    let inversion = apply(&reference, &format!("{CONTIG}:g.81_85inv")).expect("the inv applies");
+    let del_dup =
+        apply(&reference, &format!("{CONTIG}:g.[81del;86dup]")).expect("the pair applies");
+    assert_eq!(
+        inversion, del_dup,
+        "the two forms must denote one sequence — otherwise this was never a \
+         typing question",
+    );
+    assert_ne!(inversion, reference, "the fixture must actually change");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -26,6 +26,7 @@ mod issue_1592_reduced_member_junction_clamp;
 mod issue_1600_reduced_delins_tract_demotion;
 mod issue_1607_protein_residue_one_guard;
 mod issue_1632_parse_entry_applies_no_mode;
+mod issue_1703_whole_span_inversion_before_the_cut;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Closes #1703.

On every sequence-first partition arm (`FERRO_PARTITION=shadow`, `canonical`, `canonical-coalesced`) a whole-span reverse complement was re-derived as a `[del;dup]` pair instead of an `inv`. Every spelling reached the same wrong string, so the arm was self-consistent and wrong together and no confluence check could see it. `NC_000017.11:g.43044327_43044331` is `GTTAA`, `revcomp(GTTAA) = TTAAC`, and columns `43044328`/`43044330` are self-complementary.

`DNA/inversion.md:5` defines an inversion by the content of the whole span, and `DNA/delins.md:5` excludes the spanning `delins` spelling by definition. Both are prohibitions read from prose force, so this is a rule 1 bug rather than a disclosure, and it blocks #148.

## The mechanism is not the one the issue diagnosed

The issue attributes the decline to `shift_pieces` moving the trailing insertion outside the block hull, after which `coalesce_whole_block_inversion` "computes a 6-base hull against a 5-base payload and declines". Instrumented before changing anything, the pass never reaches that reconstruction — it declines at the **admission gate**, identically before and after the shift:

```
partition_block_canonical(GTTAA, TTAAC) = [0..1>""] , [5..5>"C"]
  PRE-shift  gate: sep1=false chg=false nolone=false pay=false  -> None
  shift_pieces moves the insertion 5..5 -> 6..6
  POST-shift gate: sep1=false chg=false nolone=false pay=false  -> None
```

So there are **two independent defects**, and neither change reaches the case on its own.

**The gate.** `no_piece_is_a_lone_substitution` measured reference *width* (`>= 2`) while its name and its `general.md:56` reasoning are about substitution-hood. `DNA/delins.md:15` is explicit — a substitution is one nucleotide replaced by one other — so a 1-base deletion (one replaced by none) and a pure insertion (none replaced by one) are not substitutions, and `:56`'s ranking of substitution above inversion reaches neither. The predicate now tests substitution-hood. This is additive: a piece two or more columns wide can never be a one-for-one replacement, so every partition the width test admitted is still admitted, and an admission still has to survive `is_inversion` on the reconstruction.

**The ordering.** `shift_pieces` runs before `coalesce_whole_block_inversion`, and moves a derived insertion off the hull's right edge whenever the next reference base repeats the payload — which is what renders the wrong answer's second member as a `dup`. The verdict is now taken while the pieces still partition the trimmed block, and applied at the existing call site, which keeps the widening **after** the changed-columns weight bound. That placement is load-bearing in both directions: the bound compares the derived weight against the input's, and `GTTAA -> TTAAC` weighs 3 spelled as three substitutions against 5 spelled as one `delins`, so a pre-bound widening is accepted for one spelling of the variant and refused for the other.

## Which function owns the whole-block predicate

`rules::decompose_delins` does not and must not. Its unit is the **maximal contiguous mismatch run**, bounded by identity positions — and a whole-span reverse complement with self-complementary interior columns has identity positions by construction (coincidences come in mirror pairs). On this block it sees three length-1 runs and types three substitutions. The per-member path answers correctly for a different reason: `rules::canonicalize_delins`'s step-4d full-span check runs first and tests the shared-affix-trimmed span as a whole. The cis re-derivation's counterpart is `merge::whole_block_inversion`, and that is where the predicate belongs — one function per path, each testing the whole span.

## Blast radius

**`live` does not move.** Verified byte-for-byte, not sampled: 819,396 descriptions drawn from the committed ClinVar 500k, CMRG and Paraphase fixtures (every `del`/`ins`/`dup`/`delins`/`inv`/multi-member row, 619,396 of them, plus a 200,000-row random sample of the remainder), normalized against the prepared GRCh38 reference through the merge base and this branch. The whole TSV — including the status and detail columns — is byte-identical in **strict** and in **lenient** mode (lenient leaves only 51 rows unnormalized, so the effective denominator is 819,345). The committed `dump_normalized_corpus` harness likewise reports `0 (0.0%)` moved over 85,642 rows across its 21 shape families, with byte-identical dumps.

That zero is structural rather than lucky: `is_inversion` requires an equal-length reverse complement, so the trimmed block is length-preserving, and `partition_block`'s single-gap search cannot express a length-preserving block with any gap at all — so it never produces the compensating deletion/insertion pair this fix admits.

**The arms move by one row.** Over the same 819,396-row corpus, `FERRO_PARTITION=canonical-coalesced` re-types exactly one row: `NM_001410759.1:c.[854del;857dup]` becomes `NM_001410759.1:c.854_856inv`. So the defect is real-corpus reachable, and the fix is narrow.

## Axes and strand

Probed rather than inferred, on the prepared reference, against a minus-strand gene (BRCA1 `NM_007294.4`, CDS `c.571_575` = `GTTAA`) and a plus-strand gene (CFTR `NM_000492.4`, CDS `c.814_818` = `GTTAA`), three spellings each:

| axis | strand | before (`canonical-coalesced`) | after |
|---|---|---|---|
| `g.` | + | `g.[43044327del;43044332dup]` | `g.43044327_43044331inv` |
| `c.` | − | `c.[571del;575_576insC]` | `c.571_575inv` |
| `n.` | − | `n.[684del;688_689insC]` | `n.684_688inv` |
| `r.` | − | `r.[571del;575_576insc]` | `r.571_575inv` |
| `c.` | + | `c.[814del;818_819insC]` | `c.814_818inv` |
| `n.` | + | `n.[884del;888_889insC]` | `n.884_888inv` |
| `r.` | + | `r.[814del;818_819insc]` | `r.814_818inv` |

All 21 rows were wrong before and all 21 converge on the `inv` after, on all three sequence-first arms; `live` gave the `inv` throughout. The defect was axis-blind and strand-blind, which follows from the pipeline — the partition and the gate read only the trimmed block.

Because the `r.` axis moves too, jurisdiction was checked rather than assumed: a `DNA/` clause cannot scope `r.`, and the RNA recommendations state the same three clauses in their own directory — `RNA/inversion.md:5` and `RNA/delins.md:5` word-for-word identical to their DNA twins, and `RNA/delins.md:16` for the substitution definition. `general.md:56` is not molecule-specific. The table is on `no_piece_is_a_lone_substitution`.

## Tests, written first and watched fail

The end-to-end guard has to reach an arm, and `partition_rule()` caches its `FERRO_PARTITION` read in a `OnceLock`. `tests/it/common/cis_apply_oracle.rs` records why a test must not `set_var` to get around that (sound under nextest, false under `cargo test`), so the arm is reached the way `partition_switch_wiring.rs` reaches it — through the `ferro` binary, with the variable in the child's environment and a temporary indexed FASTA as the reference.

* `tests/it/issue_1703_whole_span_inversion_before_the_cut.rs` — all three spellings converging on the `inv` across all four arms, asserted as the cardinality of the output *set* so convergence is observed rather than three constants agreeing; each output cross-checked through `hgvs_to_spdi` so a re-typing that changed the sequence fails loudly; plus two negative controls and a note recording why all four seam oracles passed on the wrong form.
* `merge.rs` units for each defect: the deletion/insertion pair is not two lone substitutions, two genuine substitutions still are, and the whole-block verdict differs either side of the 3'-shift.

Both negative controls are load-bearing, because the fix widens an admission gate. `AAGCTA -> TAGCTT` is also an exact reverse complement but its members are two lone substitutions, which `general.md:56` ranks above inversion, so it must stay split. `GTTAT -> TTATC` has the *identical geometry* to the positive case — a 1-base deletion at the hull start, a 1-base insertion at the hull end, four unchanged bases between, rendering as `g.[81del;86dup]` — and is not a reverse complement, so it must stay split too. Both were green before the fix and stayed green after; only the three intended assertions were red.

## One assertion re-blessed, deliberately

`the_inversion_coalesce_reaches_a_canonical_partition` asserted `!no_piece_is_a_lone_substitution` for `GCT -> AGC`'s insertion-plus-deletion partition. That verdict moved because the **predicate** was corrected, not because the block changed: the pass reached the same `inv` before and after, by route 4 then and by two routes now. The test's subject is untouched, and `the_inversion_coalesce_reaches_the_spec_published_sixteen_nt_example` still pins route 4 as the one that uniquely decides a partition containing a genuine substitution. The re-bless carries that reasoning inline.

Full suite green: 10,267 passed, 0 failed, with both spec artifacts regenerated. `cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean.

Representation-Change: none. 0 of 819,396 corpus rows move on the shipped `live` arm — the strict and lenient TSVs are byte-identical against the merge base, as is the committed `dump_normalized_corpus` dump at 85,642 rows. `FERRO_PARTITION` unset is `live`, and the partition shape this fix admits cannot arise there. The development-only `shadow`, `canonical` and `canonical-coalesced` arms do change: a whole-span reverse complement is now typed `inv` rather than as a `[del;dup]` pair, which over that same corpus re-types exactly one row (`NM_001410759.1:c.[854del;857dup]` becoming `c.854_856inv`).
