### PR TITLE
test(conformance): count coding-axis merges across two or more unchanged nucleotides

### DIFF
--- a/src/conformance/spec_corpus.rs
+++ b/src/conformance/spec_corpus.rs
@@ -523,6 +523,37 @@ pub struct Row {
     /// emitted SVD-WG010's own worked example. So the shape is generated with the
     /// guard attached rather than left to be re-discovered.
     pub negative_guards: Vec<&'static str>,
+    /// Whether this row is in the population a **coding-axis** merge across
+    /// **two or more** unchanged nucleotides could be observed on. See
+    /// [`is_coding_axis_separation_two_or_more_shape`], which carries the
+    /// reasoning — including why the floor is two rather than one.
+    ///
+    /// # An instrument's denominator, not a guard and not a ruling
+    ///
+    /// [`Self::negative_guards`] marks a row whose merge would implement a
+    /// **rejected** proposal, so a violation there is a verdict. This flag marks
+    /// a row where a merge is merely *interesting*, and its counter reports how
+    /// many such merges happen. It asserts nothing about whether they are right:
+    /// the adjudication is the operator's and is open.
+    ///
+    /// What makes the population worth counting is that `general.md:34` and
+    /// `DNA/delins.md:17` speak to it in as many words — "two variants separated
+    /// by one or more nucleotides should be described individually and **not**
+    /// as a 'delins'".
+    ///
+    /// # Why it exists as a separate flag
+    ///
+    /// [`is_svd_wg010_shape`]'s domain and this one's are **disjoint by
+    /// construction**: that guard admits only the two frameless shapes
+    /// ([`RefShape::Genomic`], [`RefShape::NonCodingMultiExon`]) at a separation
+    /// of exactly one with exactly two members, so it cannot count a coding-axis
+    /// merge at any separation, for any member count. Widening it would silently
+    /// re-scope a guard for a rejected proposal into something else, so this is a
+    /// second marker beside it rather than a change to it.
+    ///
+    /// Set by [`build_family`] alone, so it is a property of family rows;
+    /// single, conflicting and prohibited rows carry `false`.
+    pub coding_axis_separation_two_or_more: bool,
     /// Member layout (#1456).
     pub geometry: Geometry,
     /// Transcript placement (#1478).
@@ -1483,6 +1514,20 @@ impl SpecCorpus {
         self.rows.iter().map(|row| row.spellings.len()).sum()
     }
 
+    /// Rows in the coding-axis merge instrument's population — the denominator
+    /// its count is `n of` (see [`Row::coding_axis_separation_two_or_more`]).
+    ///
+    /// Reported so a consumer can fail as VACUOUS rather than read `0` as a
+    /// result: a corpus that stopped generating coding-axis separated designs
+    /// would otherwise report no merges and look like a clean bill of health.
+    #[must_use]
+    pub fn coding_axis_separation_two_or_more_rows(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|row| row.coding_axis_separation_two_or_more)
+            .count()
+    }
+
     /// Rows of each kind.
     #[must_use]
     pub fn by_kind(&self) -> BTreeMap<RowKind, usize> {
@@ -2118,18 +2163,36 @@ fn build_family(design: Design<'_>) -> Attempt {
         return Err((design.id, DropReason::Singleton));
     }
 
+    // Both the negative guard and the coding-axis merge instrument want the same
+    // property of the design: that the unchanged bases between the members
+    // cannot be shifted away. Two members separated by one `T` inside a `T`-tract
+    // are the *same variant* as two adjacent members, so a merge there is the 3'
+    // rule rather than a merge across a separation. Computed once and read twice;
+    // see `is_svd_wg010_shape`'s "This is only half the test".
+    let irreducible = triples
+        .iter()
+        .all(|t| equivalent_placements(served, t.0, &t.1, &t.2).is_empty());
+
     // The negative guard survives only when the intervening base is
     // irreducible: see `is_svd_wg010_shape`.
-    let negative_guards = if design.negative_guard_candidate
-        && triples.len() == 2
-        && triples
-            .iter()
-            .all(|t| equivalent_placements(served, t.0, &t.1, &t.2).is_empty())
-    {
+    let negative_guards = if design.negative_guard_candidate && triples.len() == 2 && irreducible {
         vec![SVD_WG010_GUARD]
     } else {
         Vec::new()
     };
+
+    // The coding-axis merge instrument's population. `triples.len()` must equal
+    // the member count for `irreducible` to be a statement about every member —
+    // a design whose members collapsed into fewer triples has already been
+    // re-read by the applier, so its separations are not the authored ones.
+    let coding_axis_separation_two_or_more = triples.len() == design.members.len()
+        && irreducible
+        && is_coding_axis_separation_two_or_more_shape(
+            frame.shape,
+            &design.members,
+            design.separation,
+            design.mechanism,
+        );
 
     let window = hi - lo + 2 * 128;
     Ok(Row {
@@ -2146,6 +2209,7 @@ fn build_family(design: Design<'_>) -> Attempt {
         mechanism: design.mechanism,
         prohibition: None,
         negative_guards,
+        coding_axis_separation_two_or_more,
         geometry: design.geometry,
         region: design.region,
         scale_bands: scale_bands(hi - lo, window),
@@ -2392,6 +2456,85 @@ fn is_svd_wg010_shape(shape: RefShape, kinds: &[Kind], separation: usize) -> boo
 
 /// The guard label a design earns once irreducibility is confirmed.
 const SVD_WG010_GUARD: &str = "svd-wg010-frameless-separation-floor-of-two";
+
+/// The coding-axis merge instrument's population: a **coding** multi-member cis
+/// design whose members each consume reference and sit **two or more** unchanged
+/// nucleotides apart.
+///
+/// # This is an instrument, not a holding
+///
+/// It says which rows are worth *counting a merge on*. It does not say a merge
+/// there is wrong — that adjudication is the operator's and is open. What makes
+/// the population interesting is that a clause speaks to it in as many words:
+/// `general.md:34` and `DNA/delins.md:17`, "two variants separated by one or
+/// more nucleotides should be described individually and **not** as a
+/// 'delins'". The counter's job is to make the size of the merged set readable
+/// at corpus scale, rather than argued from a hand-listed set of tests.
+///
+/// # Why the floor is TWO, which is the conjunct that keeps this honest
+///
+/// `general.md:35` and `DNA/delins.md:18` carve out an exception on this very
+/// axis — two variants "separated by **one** nucleotide, together affecting one
+/// amino acid", which needs a reading frame and so can be met **only** here.
+/// Ferro implements it, and it fires: measured on the shipping rule, **16** rows
+/// of this corpus merge at a separation of exactly one and **none** at two or
+/// more.
+///
+/// A floor of one would therefore count that exception as though it were the
+/// phenomenon, and the counter would have to open at a non-zero pin — leaving a
+/// licensed merge and an unlicensed one summed into one figure that no later
+/// reader could take apart. The floor of two is read straight off the
+/// exception's own stated conjunct ("separated by one nucleotide"), which is a
+/// textual scope rather than a ruling: at two or more the exception cannot
+/// reach, whatever anyone decides about how it applies at one.
+///
+/// The cost is stated rather than hidden: a coding-axis merge at separation
+/// **one** is invisible to this counter, and `is_svd_wg010_shape` does not cover
+/// it either (that guard is frameless-only). That gap is real and is left open
+/// deliberately, because closing it means deciding when `general.md:35` licenses
+/// a merge, which is exactly the adjudication an instrument must not make.
+///
+/// # Why the domain is stated positively rather than as "not frameless"
+///
+/// [`is_svd_wg010_shape`] admits `Genomic | NonCodingMultiExon` only, at a
+/// separation of exactly one, with exactly two members. This admits
+/// `CodingSingleExon | CodingMultiExon` only, at two or more, with two or more
+/// members. The two are disjoint twice over and are meant to stay that way — the
+/// guard is a negative result about a **rejected** proposal, and relaxing its
+/// `frameless` conjunct to make it count coding rows would silently turn it into
+/// a different instrument carrying the guard's name and its published zero.
+///
+/// # The conjuncts
+///
+/// - **Coding shape.** The `c.` axis.
+/// - **`separation >= 2`.** See above. A separation of zero is adjacency, ruled
+///   on separately (`delins-adjacent-members-when-both-consume-reference`),
+///   where merging is required rather than interesting.
+/// - **Two or more members**, combined as allele members — a composite payload
+///   or a repeat count is one member however it is spelled.
+/// - **Every member consumes reference.** A pure insertion has no footprint of
+///   its own, so "the unchanged bases between the members" is not well defined
+///   for it; the same conjunct, for the same reason, scopes the sibling guard.
+///
+/// Irreducibility is the fifth conjunct and is checked in [`build_family`],
+/// which is the only place the served sequence is available.
+fn is_coding_axis_separation_two_or_more_shape(
+    shape: RefShape,
+    members: &[Member],
+    separation: usize,
+    mechanism: Mechanism,
+) -> bool {
+    let coding = matches!(
+        shape,
+        RefShape::CodingSingleExon | RefShape::CodingMultiExon(_)
+    );
+    let all_consume_reference = members.iter().all(|member| member.kind != Kind::Ins);
+    coding
+        && separation >= 2
+        && members.len() >= 2
+        && mechanism.combines_members()
+        && all_consume_reference
+}
 
 /// Stratum 2: transcript geometry (#1478) — the placements a single-exon
 /// `CDS_START = 1` transcript makes structurally impossible.
@@ -2735,6 +2878,8 @@ fn enumerate_conflicts(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                             Strength::Absolute,
                         )),
                         negative_guards: Vec::new(),
+                        // Set by `build_family` alone; this row is not a family.
+                        coding_axis_separation_two_or_more: false,
                         geometry,
                         region: Region::MidCds,
                         scale_bands: Vec::new(),
@@ -2900,6 +3045,8 @@ fn enumerate_intronic(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                             },
                             prohibition: None,
                             negative_guards: Vec::new(),
+                            // Set by `build_family` alone; this row is not a family.
+                            coding_axis_separation_two_or_more: false,
                             geometry: Geometry::Disjoint,
                             region: Region::Intronic,
                             scale_bands: Vec::new(),
@@ -2989,6 +3136,8 @@ fn enumerate_mechanisms(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                                 Strength::Conditional,
                             )),
                             negative_guards: Vec::new(),
+                            // Set by `build_family` alone; this row is not a family.
+                            coding_axis_separation_two_or_more: false,
                             geometry: Geometry::Disjoint,
                             region: Region::MidCds,
                             scale_bands: Vec::new(),
@@ -3031,6 +3180,8 @@ fn enumerate_mechanisms(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                         mechanism,
                         prohibition: None,
                         negative_guards: Vec::new(),
+                        // Set by `build_family` alone; this row is not a family.
+                        coding_axis_separation_two_or_more: false,
                         geometry: Geometry::Disjoint,
                         region: Region::MidCds,
                         scale_bands: Vec::new(),
@@ -3227,6 +3378,8 @@ fn enumerate_prohibited(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                         mechanism,
                         prohibition: Some((prohibition.rule, prohibition.strength)),
                         negative_guards: Vec::new(),
+                        // Set by `build_family` alone; this row is not a family.
+                        coding_axis_separation_two_or_more: false,
                         geometry: Geometry::Disjoint,
                         region: Region::Anywhere,
                         scale_bands: Vec::new(),
@@ -3297,6 +3450,8 @@ fn enumerate_ambiguity(bounds: &CorpusBounds, out: &mut Vec<Attempt>) {
                     mechanism: Mechanism::Cis,
                     prohibition: None,
                     negative_guards: Vec::new(),
+                    // Set by `build_family` alone; this row is not a family.
+                    coding_axis_separation_two_or_more: false,
                     geometry: Geometry::Disjoint,
                     region: Region::MidCds,
                     scale_bands: Vec::new(),
@@ -3448,6 +3603,68 @@ mod tests {
         assert_eq!(
             apply_triples(reference, &[(4, "GGGG".to_string(), String::new())]),
             None
+        );
+    }
+
+    /// Every row the coding-axis merge instrument counts over really is in the
+    /// population it claims, and the population is not empty.
+    ///
+    /// Without this the counter's denominator is a number nobody checked: a
+    /// predicate that silently admitted a `g.` row, or a separation of one,
+    /// would make the census's zero mean something other than what its docs say
+    /// — and `spec_conformance_axis` asserts only that the denominator is
+    /// non-zero, never what is in it.
+    ///
+    /// It also pins the disjointness the instrument is built on: no row may
+    /// carry both this flag and the SVD-WG010 negative guard. That is what makes
+    /// "the guard cannot count these merges" a property of the corpus rather
+    /// than a claim in a doc comment.
+    #[test]
+    fn the_coding_axis_merge_population_is_what_it_says_it_is() {
+        let built = corpus(&CorpusBounds::default());
+        let mut checked = 0usize;
+        for row in &built.rows {
+            if !row.coding_axis_separation_two_or_more {
+                continue;
+            }
+            assert_eq!(
+                row.kind,
+                RowKind::Family,
+                "{}: only family rows carry the flag",
+                row.id
+            );
+            assert!(
+                matches!(
+                    row.shape,
+                    RefShape::CodingSingleExon | RefShape::CodingMultiExon(_)
+                ),
+                "{}: {:?} is not a coding axis",
+                row.id,
+                row.shape
+            );
+            assert!(
+                row.separation >= 2,
+                "{}: separation {} is below the floor the instrument documents",
+                row.id,
+                row.separation
+            );
+            assert!(row.is_multi_member(), "{}: not multi-member", row.id);
+            assert!(
+                row.negative_guards.is_empty(),
+                "{}: carries the SVD-WG010 guard as well, so the two domains overlap",
+                row.id
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "VACUOUS: the corpus builds no coding-axis row separated by two or more unchanged \
+             nucleotides, so the merge counter measures nothing"
+        );
+        assert_eq!(
+            checked,
+            built.coding_axis_separation_two_or_more_rows(),
+            "the accessor and a direct scan disagree"
         );
     }
 

--- a/src/conformance/spec_corpus.rs
+++ b/src/conformance/spec_corpus.rs
@@ -533,13 +533,14 @@ pub struct Row {
     /// [`Self::negative_guards`] marks a row whose merge would implement a
     /// **rejected** proposal, so a violation there is a verdict. This flag marks
     /// a row where a merge is merely *interesting*, and its counter reports how
-    /// many such merges happen. It asserts nothing about whether they are right:
-    /// the adjudication is the operator's and is open.
+    /// many such merges happen. It asserts nothing about whether they are right.
     ///
     /// What makes the population worth counting is that `general.md:34` and
     /// `DNA/delins.md:17` speak to it in as many words — "two variants separated
     /// by one or more nucleotides should be described individually and **not**
-    /// as a 'delins'".
+    /// as a "delins"" — and that three ruling records govern parts of it. Both
+    /// halves are on [`is_coding_axis_separation_two_or_more_shape`]; do not
+    /// argue from the two clauses without the records.
     ///
     /// # Why it exists as a separate flag
     ///
@@ -2461,38 +2462,181 @@ const SVD_WG010_GUARD: &str = "svd-wg010-frameless-separation-floor-of-two";
 /// design whose members each consume reference and sit **two or more** unchanged
 /// nucleotides apart.
 ///
-/// # This is an instrument, not a holding
+/// # This doc comment is the single authoritative statement of the argument
+///
+/// `Census::coding_axis_separation_two_or_more_merges` and
+/// `spec_conformance_axis`'s module docs point **here** rather than restating
+/// any of what follows. An earlier revision of this change carried the
+/// floor-of-two rationale in seven places and the sub-floor figure in three, and
+/// two of those copies had already drifted into contradicting each other 406
+/// lines apart inside one file — the repository `CLAUDE.md` names that as this
+/// project's recurring failure mode, and it had happened within a single change.
+///
+/// # This is an instrument, not a holding — and read the ledger before it
 ///
 /// It says which rows are worth *counting a merge on*. It does not say a merge
-/// there is wrong — that adjudication is the operator's and is open. What makes
-/// the population interesting is that a clause speaks to it in as many words:
-/// `general.md:34` and `DNA/delins.md:17`, "two variants separated by one or
-/// more nucleotides should be described individually and **not** as a
-/// 'delins'". The counter's job is to make the size of the merged set readable
-/// at corpus scale, rather than argued from a hand-listed set of tests.
+/// there is wrong. What makes the population interesting is that a clause speaks
+/// to it in as many words: `general.md:34` and `DNA/delins.md:17`, "two variants
+/// separated by one or more nucleotides should be described individually and
+/// **not** as a "delins"".
+///
+/// **Those two clauses are not the whole authority over this population**, and
+/// citing them alone is the mistake the repository `CLAUDE.md` warns about
+/// first: do not adjudicate from spec text before reading the ruling ledger.
+/// `tests/it/clause_ruling_index.rs` marks both clauses `[MULTI]`, and three
+/// records in `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`
+/// govern parts of exactly these rows:
+///
+/// - the `delins-payload-coincidence-carve-out-is-coding-dna-scoped` ruling is
+///   **decided**: `delins.md:47`'s payload-coincidence carve-out is scoped to the
+///   **coding DNA axis** — this population's axis, and the one axis on which
+///   `general.md:34` is overridden for that shape.
+/// - the `delins-merge-vs-individual-gap-two-or-more` ruling is **decided** and
+///   scoped twice: to the alignment-coincidence shape `:44-47` describes, and
+///   (2026-08-11) to the **net-deletion** direction. Outside that shape
+///   `general.md:34` still governs.
+/// - the `delins-recommendation-reach-when-the-input-arrives-split` ruling is
+///   the genuinely unsettled residue — which clause a *re-derivation* lands on.
+///   It is narrower than "may ferro merge an authored split", which
+///   `canonical-form-choice-when-both-legal` already answers.
+///
+/// **So neither a rise nor the zero means one thing.** Within the
+/// payload-coincidence subclass the first record *ratifies* the merge on this
+/// axis, so a rise there is a decided ruling arriving on the shipped rule, and
+/// the shipping arm's `0` is that ruling **not yet implemented** rather than a
+/// clean bill. Outside that shape `general.md:34` governs and a rise is a
+/// population that needs explaining. The counter cannot separate them, which is
+/// precisely why it counts and does not adjudicate. The sharpest illustration is
+/// that the pass producing every merge this counter sees on the
+/// `canonical-coalesced` arm, `merge::coalesce_payload_alignment_split`, cites
+/// the first of those records in its own doc comment.
 ///
 /// # Why the floor is TWO, which is the conjunct that keeps this honest
 ///
 /// `general.md:35` and `DNA/delins.md:18` carve out an exception on this very
 /// axis — two variants "separated by **one** nucleotide, together affecting one
 /// amino acid", which needs a reading frame and so can be met **only** here.
-/// Ferro implements it, and it fires: measured on the shipping rule, **16** rows
-/// of this corpus merge at a separation of exactly one and **none** at two or
-/// more.
+/// Measured on the shipping rule at `origin/main` `e98fa77e`: **41 of 340** rows
+/// separated by exactly one merge, and **0 of 997** at two or more. (Both were
+/// first derived at `1ea75334` and re-derived unchanged after the rebase;
+/// `git diff 1ea75334 origin/main -- src/` is empty, so no figure on this axis
+/// could have moved between the two.)
 ///
-/// A floor of one would therefore count that exception as though it were the
-/// phenomenon, and the counter would have to open at a non-zero pin — leaving a
-/// licensed merge and an unlicensed one summed into one figure that no later
-/// reader could take apart. The floor of two is read straight off the
-/// exception's own stated conjunct ("separated by one nucleotide"), which is a
-/// textual scope rather than a ruling: at two or more the exception cannot
-/// reach, whatever anyone decides about how it applies at one.
+/// A floor of one would therefore have to open at a non-zero pin, summing rows
+/// with three different verdicts into one figure no later reader could take
+/// apart. The floor of two is read straight off the exception's own stated
+/// conjunct ("separated by one nucleotide"), which is a textual scope rather
+/// than a ruling: at two or more the exception cannot reach, whatever anyone
+/// decides about how it applies at one.
 ///
-/// The cost is stated rather than hidden: a coding-axis merge at separation
+/// ## What the sub-floor 41 are, and why the number moved from 16
+///
+/// The 41 decompose by how far each row collapsed, measured directly rather than
+/// argued — the finding line reports `<authored> members -> <observed>`:
+///
+/// | shape | rows | seen by the old `< 2` numerator? |
+/// |---|---:|---|
+/// | 2 authored members -> 1 | 15 | yes |
+/// | 3 authored members -> 1 (a whole-span `inv`, `s00-c1-m3-all-inv-p4-sep1`) | 1 | yes |
+/// | 4 authored members -> 3 (a **partial** merge) | 25 | **no** |
+///
+/// So the earlier figure of **16** is the first two rows of that table and is
+/// **unchanged** — #1698 moved it not at all. The other 25 are merges the
+/// instrument's original numerator could not represent; see
+/// `spec_conformance_axis::coding_axis_merge_observed`, which is why it now tests
+/// `< row.members` rather than `< 2`. Read "16 -> 41" as an instrument that got
+/// less blind, not as behaviour that changed.
+///
+/// ## The 16 are not the codon exception firing — an earlier revision said so
+///
+/// This comment used to read "Ferro implements it, and it fires", which treated
+/// all 16 as the licensed shape. Knocking out each merge pass singly shows
+/// `apply_coding_codon_exception` produces **none** of them: they come from the
+/// per-member codon-frame merge in `merge_consecutive_edits` (`merge.rs:188`,
+/// from #79/#275) and one from `coalesce_whole_block_inversion` — which is the
+/// 15 / 1 split the table above measures independently. The verdicts are
+/// **9 licensed / 5 unlicensed / 2 filed as #1716**:
+///
+/// | verdict | rows | what they are |
+/// |---|---:|---|
+/// | licensed | 9 | two lone substitutions in one codon, net length 0 — the exception's own shape; plus one whole-span `inv` |
+/// | **unlicensed** | **5** | a frameshift *inside* one codon; filed as **#1744**, see below |
+/// | **unlicensed, filed** | **2** | the merged span crosses two codons, so the exception's second conjunct fails under every reading of it — issue **#1716**, reproducing on the prepared reference as `LRG_199t1:c.[18_19del;21A>C]` -> `c.18_21delinsTC` |
+///
+/// ### None of the 7 is a rule 1 violation — corrected on the rebase
+///
+/// The last row read "**rule 1 violation**" until this change was rebased onto
+/// `origin/main` `e98fa77e`, which carries #1725's
+/// `separation-rule-force-modal-or-negation`. That record is **decided**
+/// (operator ruling 2026-08-12) and grades `general.md:34` — the clause these
+/// rows fall back to once `general.md:35`'s exception declines — as README
+/// **rule 2** in its entirety: "'and not Y' names the excluded alternative; it
+/// does not grade the clause. The modal grades the clause." So an output
+/// merging across unchanged nucleotides where the exception cannot reach is a
+/// deviation to **disclose and pin with a tripwire**, not the rule-7 bug a rule
+/// 1 violation would be, and it does not by itself block a release.
+///
+/// What the record does *not* license is re-pinning such a counter to zero for
+/// a green build — in its own words, "the one move this record forbids". This
+/// counter's zero is pinned at its measured value on a population that sits
+/// **above** these rows, so nothing here is being pinned away; the 7 are named
+/// precisely because they are below its floor and it cannot see them.
+///
+/// ## The 5 were filed under a status word, and the record answers them
+///
+/// A previous revision filed those 5 as unresolved, on the strength of the
+/// `codon-carve-out-shape-restriction` ruling — which is **decided** (WIDEN,
+/// operator ruling 2026-08-10), and which settles this very sub-case rather than
+/// leaving it. Two different claims were being run together: what is *not yet
+/// implemented* is the widening's effect on `apply_coding_codon_exception`; what
+/// is *not* unsettled is whether the exception reaches a frameshift pair. It does
+/// not. The record's own words are that "together affecting one amino acid"
+/// cannot cover a frameshift pair, "so the widened rule declines there for the
+/// reason the spec gives rather than by a shape test".
+///
+/// Ferro merges those 5 anyway. They are therefore in the same category as the 2
+/// filed as #1716 — output no cited clause licenses — and on this corpus the
+/// **sub-floor count of unlicensed merges is 7, not 2**. Under
+/// `separation-rule-force-modal-or-negation` all 7 are rule-2 deviations to
+/// disclose rather than rule-7 bugs. That changes what they cost a release; it
+/// does **not** settle whether they should be accepted-and-disclosed or closed,
+/// which is a rule-2 trade nobody has made and which #1744 holds open. Do not
+/// read the word "unlicensed" here as that verdict — it says only that no cited
+/// clause licenses the merge. Note the 9 / 5 / 2 decomposition is over the 16
+/// full collapses only; the 25 partial merges are unclassified, so 7 is a floor
+/// on that floor.
+///
+/// ### What of that is RECORDED, and what is only written here
+///
+/// The repository policy is that an adjudication lands in a committed test or
+/// ruling record in the same change, so be exact about which this is. The
+/// *authority* is already committed and decided — `codon-carve-out-shape-restriction`
+/// for the reach of the exception and `separation-rule-force-modal-or-negation`
+/// for the force of the clause it falls back to, each with its own clauses and
+/// quotes — and the 2 cross-codon rows already have their artifact in **#1716**.
+/// What is written here and **nowhere else** is the application of those
+/// records to the 5 frameshift rows.
+///
+/// That is deliberately not turned into a new ruling record: no clause conflict
+/// is being adjudicated, the governing record already exists, and a second
+/// record restating a decided one is how this ledger has drifted before. It is
+/// also not turned into a pinned regression test, because this instrument does
+/// not identify those rows individually — they sit **below its floor** by
+/// construction, so it can count them only by moving the floor, which is the one
+/// thing the floor exists to prevent. **The artifact for the 5 is an issue,
+/// filed the way #1716 was for the 2: #1744.** That is what carries the rows,
+/// the measurement and the open classification question out of this comment;
+/// read it rather than this paragraph for their current status, because a
+/// comment is the one place a status cannot be updated from.
+///
+/// The cost, stated rather than hidden: a coding-axis merge at separation
 /// **one** is invisible to this counter, and `is_svd_wg010_shape` does not cover
-/// it either (that guard is frameless-only). That gap is real and is left open
-/// deliberately, because closing it means deciding when `general.md:35` licenses
-/// a merge, which is exactly the adjudication an instrument must not make.
+/// it either (that guard is frameless-only). **That gap conceals known defects**,
+/// not merely an unsettled question. Closing it properly means fixing #1716,
+/// implementing the widening the ruling above decided, and only then deciding
+/// what remains — the last of which is an adjudication an instrument must not
+/// make, which is why the gap is disclosed here rather than papered over with a
+/// wider predicate.
 ///
 /// # Why the domain is stated positively rather than as "not frameless"
 ///
@@ -2512,11 +2656,19 @@ const SVD_WG010_GUARD: &str = "svd-wg010-frameless-separation-floor-of-two";
 ///   where merging is required rather than interesting.
 /// - **Two or more members**, combined as allele members — a composite payload
 ///   or a repeat count is one member however it is spelled.
+/// - **[`Mechanism::Cis`] exactly**, not the wider `combines_members()` set. Both
+///   are true of every row the generator builds today (probe:
+///   `by_mechanism = {cis: 997}`), so this is future-proofing rather than a
+///   filter that currently removes anything — but `combines_members()` also
+///   admits `Trans` and `UnknownPhase`, and a merged *trans* allele has its
+///   members on different chromosomes. That is an unambiguous defect, not a
+///   population worth counting under prose calling the adjudication unsettled,
+///   so it must not arrive silently through this predicate.
 /// - **Every member consumes reference.** A pure insertion has no footprint of
 ///   its own, so "the unchanged bases between the members" is not well defined
 ///   for it; the same conjunct, for the same reason, scopes the sibling guard.
 ///
-/// Irreducibility is the fifth conjunct and is checked in [`build_family`],
+/// Irreducibility is the sixth conjunct and is checked in [`build_family`],
 /// which is the only place the served sequence is available.
 fn is_coding_axis_separation_two_or_more_shape(
     shape: RefShape,
@@ -2532,7 +2684,7 @@ fn is_coding_axis_separation_two_or_more_shape(
     coding
         && separation >= 2
         && members.len() >= 2
-        && mechanism.combines_members()
+        && matches!(mechanism, Mechanism::Cis)
         && all_consume_reference
 }
 
@@ -3619,6 +3771,16 @@ mod tests {
     /// carry both this flag and the SVD-WG010 negative guard. That is what makes
     /// "the guard cannot count these merges" a property of the corpus rather
     /// than a claim in a doc comment.
+    ///
+    /// # What it does NOT check, stated because a mutation showed it
+    ///
+    /// **Irreducibility.** [`is_coding_axis_separation_two_or_more_shape`] names
+    /// it as a conjunct and [`build_family`] computes it, but a `Row` does not
+    /// carry the triples the check needs, so this test cannot re-derive it.
+    /// Dropping that conjunct leaves this test **green** while moving the
+    /// denominator 997 -> 2,527 and the census numerator 0 -> 74 — so the
+    /// property is real and load-bearing, and it is defended by the two census
+    /// pins rather than here. Do not read this test as covering it.
     #[test]
     fn the_coding_axis_merge_population_is_what_it_says_it_is() {
         let built = corpus(&CorpusBounds::default());
@@ -3650,7 +3812,17 @@ mod tests {
             );
             assert!(row.is_multi_member(), "{}: not multi-member", row.id);
             assert!(
-                row.negative_guards.is_empty(),
+                matches!(row.mechanism, Mechanism::Cis),
+                "{}: mechanism {:?} — a merged trans or unknown-phase allele is a defect, not a \
+                 population this instrument may count",
+                row.id,
+                row.mechanism
+            );
+            // Named, not `is_empty()`. The property is disjointness from THIS
+            // guard; a second, unrelated guard label added to a coding row later
+            // would otherwise fail here with a message about SVD-WG010.
+            assert!(
+                !row.negative_guards.contains(&SVD_WG010_GUARD),
                 "{}: carries the SVD-WG010 guard as well, so the two domains overlap",
                 row.id
             );

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -364,6 +364,66 @@
 //! coalesced partitioner's own divergence and is unmoved by #1704 — verified by
 //! re-running that arm with `src/normalize/` reverted.
 //!
+//! # The coding-axis merge counter — an INSTRUMENT, and the guard beside it is not one
+//!
+//! `guard_violations` above is a **negative guard**: its rows are the shape
+//! rejected SVD-WG010 would have merged, so a violation there is a verdict.
+//! `coding_axis_separation_two_or_more_merges` is not that. It counts a
+//! population — coding-axis multi-member alleles whose members sit **two or
+//! more** unchanged nucleotides apart and which normalization merged into a
+//! single member — and makes no claim that merging them is wrong. `general.md:34`
+//! and `DNA/delins.md:17` are what make the population interesting ("two
+//! variants separated by one or more nucleotides should be described
+//! individually and **not** as a 'delins'"); which clause governs any particular
+//! merged row is an **open adjudication for the operator**, and nothing here
+//! settles it.
+//!
+//! **It exists because `guard_violations` provably cannot count these rows.**
+//! `is_svd_wg010_shape` admits `Genomic | NonCodingMultiExon` at a separation of
+//! exactly one with exactly two members; this counter's rows are
+//! `CodingSingleExon | CodingMultiExon` at two or more, with two or more
+//! members. The two domains are disjoint twice over, so a merge on the coding
+//! axis leaves `guard_violations` at zero however many rows it moves — which is
+//! why the guard is left exactly as it is and this is a second counter beside
+//! it, not a widening of it.
+//!
+//! **Pinned at 0 / 0, measured over 997 rows in each direction.** The zero is a
+//! real negative result, not an absence: the same corpus reads
+//!
+//! | evaluation arm (`FERRO_PARTITION`) | 3' | 5' |
+//! |---|---|---|
+//! | unset — the shipped rule | **0** of 997 | **0** of 997 |
+//! | `shadow` | 0 | 0 |
+//! | `canonical` | 1 | 1 |
+//! | `canonical-coalesced` | **122** | **122** |
+//!
+//! The 122 decompose by separation as 31 / 30 / 30 / 31 at gaps of 2 / 3 / 5 /
+//! 8, across both two- and three-member designs — every one of them a row
+//! `guard_violations` cannot see. The `canonical` arm's single residual is
+//! `s01-c1-pair-inv-del-p4-sep3`, which is not the coalesce pass (it survives
+//! with that pass stubbed out).
+//!
+//! **The counter was watched moving, in both directions, before being trusted.**
+//! Stubbing `merge::coalesce_payload_alignment_split` to decline unconditionally
+//! takes the `canonical-coalesced` arm from 122 to 1 — the `canonical` figure,
+//! exactly. Removing the arm gate so the pass runs on the shipped rule takes the
+//! shipping arm from 0 to 110 (3') / 113 (5'); making the pass merge
+//! unconditionally on top of that takes it to 190. So the shipping zero is the
+//! pass not running, not the instrument failing to look.
+//!
+//! **Why the floor is two and not one.** `general.md:35` / `DNA/delins.md:18`
+//! carve out an exception on this same axis for two variants "separated by
+//! **one** nucleotide, together affecting one amino acid", and ferro implements
+//! it: measured, **16** rows of this corpus merge at a separation of exactly one
+//! on the shipping rule. A floor of one would sum that licensed merge with an
+//! unlicensed one into a single figure and would have to open at a non-zero pin.
+//! The floor is read off the exception's own stated conjunct, so it is a textual
+//! scope rather than a ruling. The cost is stated rather than hidden: a
+//! coding-axis merge at separation **one** is counted by neither this counter
+//! nor `guard_violations`, and closing that gap means deciding when
+//! `general.md:35` licenses a merge — the adjudication an instrument must not
+//! make.
+//!
 //! # The honest-zero discipline is enforced, not described
 //!
 //! Every property whose denominator is zero fails loudly as **VACUOUS** rather
@@ -422,6 +482,7 @@ const SHAPE: CorpusShape = CorpusShape {
     prohibited_rows: 164,
     multi_member_rows: 12_496,
     guarded_rows: 210,
+    coding_axis_separation_two_or_more_rows: 997,
 };
 
 /// The 3'-direction census, pinned. See the module docs for which way each
@@ -516,6 +577,9 @@ pub(crate) const THREE_PRIME: Census = Census {
     prohibited_conditional_accepted: 16,
     // -- negative guards --
     guard_violations: 0,
+    // -- instruments --
+    coding_axis_separation_two_or_more_rows: 997,
+    coding_axis_separation_two_or_more_merges: 0,
 };
 
 /// The 5'-direction census, pinned.
@@ -579,6 +643,8 @@ pub(crate) const FIVE_PRIME: Census = Census {
     // Re-blessed DOWN by #1627, by the same 24 rows as at 3'.
     prohibited_conditional_accepted: 16,
     guard_violations: 0,
+    coding_axis_separation_two_or_more_rows: 997,
+    coding_axis_separation_two_or_more_merges: 0,
 };
 
 /// The corpus's shape, independent of any property measured over it.
@@ -593,6 +659,12 @@ struct CorpusShape {
     prohibited_rows: usize,
     multi_member_rows: usize,
     guarded_rows: usize,
+    /// The coding-axis merge instrument's population — see
+    /// [`Census::coding_axis_separation_two_or_more_merges`]. Pinned here as well as in the census
+    /// because the two answer different questions: this is how many rows the
+    /// *generator* built, and the census figure is how many the *measurement*
+    /// reached.
+    coding_axis_separation_two_or_more_rows: usize,
 }
 
 impl CorpusShape {
@@ -608,6 +680,8 @@ impl CorpusShape {
             prohibited_rows: by_kind.get(&RowKind::Prohibited).copied().unwrap_or(0),
             multi_member_rows: built.multi_member_rows(),
             guarded_rows: built.by_negative_guard().values().sum(),
+            coding_axis_separation_two_or_more_rows: built
+                .coding_axis_separation_two_or_more_rows(),
         }
     }
 }
@@ -759,6 +833,68 @@ pub(crate) struct Census {
     /// separation floor of two on a frameless axis, which is SVD-WG010
     /// (`consultation/SVD-WG010.md:8`, "The proposal has been **rejected**").
     pub(crate) guard_violations: usize,
+    /// The denominator [`Self::coding_axis_separation_two_or_more_merges`] is
+    /// `n of` — coding-axis rows separated by two or more unchanged nucleotides
+    /// that the measurement actually reached and evaluated.
+    ///
+    /// Pinned, and asserted non-zero. A separate figure from
+    /// `SHAPE.coding_axis_separation_two_or_more_rows` on purpose: that one says the
+    /// generator built the rows, this one says the run *normalized* them. A
+    /// measurement whose every eligible row declined would report `0` merges
+    /// with the generator-side denominator still healthy, which is the shape
+    /// of vacuity this axis exists to refuse.
+    pub(crate) coding_axis_separation_two_or_more_rows: usize,
+    /// Coding-axis multi-member alleles whose authored spelling normalized to a
+    /// **single member**, i.e. the members were merged across the two or more
+    /// unchanged nucleotides between them.
+    ///
+    /// # An instrument. It counts a population; it does not judge it
+    ///
+    /// This counter reports how often a merge of this shape happens. It does
+    /// **not** assert the merge is wrong — that adjudication is the operator's
+    /// and is open. What makes the population worth measuring is that
+    /// `general.md:34` / `DNA/delins.md:17` speak to it in as many words: "two
+    /// variants separated by one or more nucleotides should be described
+    /// individually and **not** as a 'delins'".
+    ///
+    /// So a count of `n` here is a measurement of how large the merged
+    /// population is, not a claim that `n` rows are defective. Contrast
+    /// [`Self::guard_violations`], which counts a shape whose merge implements
+    /// a **rejected** proposal and is therefore a verdict.
+    ///
+    /// # The floor of two is what keeps the zero readable
+    ///
+    /// `general.md:35` / `DNA/delins.md:18` carve out an exception on this same
+    /// axis, for two variants "separated by **one** nucleotide, together
+    /// affecting one amino acid". Ferro implements it and it fires: on the
+    /// shipping rule **16** rows of this corpus merge at a separation of
+    /// exactly one, and none at two or more. Counting from a floor of one would
+    /// sum a licensed merge and an unlicensed one into a figure no later reader
+    /// could take apart, and would open at a non-zero pin. The floor is read
+    /// off the exception's own stated conjunct, so it is a textual scope rather
+    /// than a ruling — see `spec_corpus::is_coding_axis_separation_two_or_more_shape`,
+    /// which also states what the choice costs.
+    ///
+    /// # Why it is a second counter rather than a widened guard
+    ///
+    /// [`Self::guard_violations`]'s rows are chosen by `is_svd_wg010_shape`,
+    /// which admits only the two **frameless** shapes, at a separation of
+    /// exactly one, with exactly two members. That domain and this one are
+    /// disjoint twice over, so `guard_violations` cannot count a coding-axis
+    /// merge at any separation for any member count, and a zero there says
+    /// nothing about this population. Relaxing that guard to cover
+    /// coding rows would re-scope a negative result about a rejected proposal
+    /// into a different instrument wearing its name, so this is a new counter
+    /// beside it.
+    ///
+    /// # Pinned at zero in both directions, and that zero is a measurement
+    ///
+    /// The pass that merges this population under the canonical-coalesced
+    /// evaluation arm — `merge::coalesce_payload_alignment_split`, reached only
+    /// when `payload_coalesce_applies` sees `PartitionRule::CanonicalCoalesced`
+    /// — does not run on the shipped rule, so the shipping arm merges none of
+    /// these rows. Measured rather than assumed: see the module docs.
+    pub(crate) coding_axis_separation_two_or_more_merges: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -1131,6 +1267,36 @@ fn measure(direction: ShuffleDirection) -> Measured {
                 }
             }
 
+            // --- the coding-axis merge instrument -----------------------------
+            // Read on the AUTHORED spelling only, for the same reason the guard
+            // above is: the corpus offers a spanning-`delins` respelling of its
+            // own designs, and that respelling is a single member before
+            // normalization ever runs.
+            //
+            // Not a verdict — see `Census::coding_axis_separation_two_or_more_merges`.
+            // The denominator is counted here rather than off the corpus so
+            // `0 of 0` cannot pass as a result even if every eligible row
+            // stopped normalizing.
+            if row.coding_axis_separation_two_or_more && spelling == row.authored_spelling() {
+                census.coding_axis_separation_two_or_more_rows += 1;
+                if let Ok(parsed_output) = parse_hgvs(&output) {
+                    if members_of(&parsed_output).len() < 2 {
+                        census.coding_axis_separation_two_or_more_merges += 1;
+                        findings.push(Finding {
+                            id: row.id.clone(),
+                            what: format!(
+                                "coding-axis allele merged across {} unchanged nucleotide(s) \
+                                 into one member (`general.md:34` / `DNA/delins.md:17` speak to \
+                                 this population; whether they govern each row is an OPEN \
+                                 adjudication — counted, not adjudicated): \
+                                 {spelling} -> {output}",
+                                row.separation
+                            ),
+                        });
+                    }
+                }
+            }
+
             outputs.insert(output);
         }
 
@@ -1177,7 +1343,9 @@ fn report(label: &str, measured: &Measured) -> String {
          SEQUENCE PRESERVATION: {} outputs denote different bases\n  \
          REFUSAL: {} conflicting alleles accepted, {} absolute prohibitions accepted, \
          {} conditional prohibitions accepted\n  \
-         NEGATIVE GUARDS: {} outputs implement rejected SVD-WG010\n",
+         NEGATIVE GUARDS: {} outputs implement rejected SVD-WG010\n  \
+         CODING-AXIS MERGE (an instrument, not a verdict): {} of {} coding-axis alleles \
+         separated by two or more unchanged nucleotides merged into a single member\n",
         census.measured_under,
         census.outputs,
         census.declined,
@@ -1197,6 +1365,8 @@ fn report(label: &str, measured: &Measured) -> String {
         census.prohibited_absolute_accepted,
         census.prohibited_conditional_accepted,
         census.guard_violations,
+        census.coding_axis_separation_two_or_more_merges,
+        census.coding_axis_separation_two_or_more_rows,
     );
     for divergence in &measured.divergences {
         out.push_str(&format!(
@@ -1235,6 +1405,14 @@ fn assert_census(direction: ShuffleDirection, label: &str, pinned: &Census) {
     assert!(
         census.outputs > 0,
         "{label}: VACUOUS — the corpus produced no outputs at all"
+    );
+    assert!(
+        census.coding_axis_separation_two_or_more_rows > 0,
+        "{label}: VACUOUS — no coding-axis allele separated by two or more unchanged \
+         nucleotides was evaluated, so `coding_axis_separation_two_or_more_merges` measures \
+         nothing and its zero is a claim about the corpus rather than about the \
+         implementation.\n{}",
+        report(label, &measured)
     );
 
     // The rank-1 counters are pinned rather than asserted at zero, because they
@@ -1306,6 +1484,26 @@ fn assert_census(direction: ShuffleDirection, label: &str, pinned: &Census) {
         );
     }
 
+    // The instrument is checked apart from the loop above, because that loop's
+    // message calls a rise a rank-1 conformance regression and this counter
+    // makes no such claim. A rise here is a population getting bigger — a
+    // finding to explain and, if it is the right behaviour, to re-pin.
+    assert!(
+        census.coding_axis_separation_two_or_more_merges
+            <= pinned.coding_axis_separation_two_or_more_merges,
+        "{label}: coding-axis alleles merged across two or more unchanged nucleotides rose \
+         from {} to {} (of {} evaluated). This counter is an INSTRUMENT, not a ruling: \
+         `general.md:34` / `DNA/delins.md:17` say such members are described individually, and \
+         `general.md:35`'s one-amino-acid exception cannot reach a separation of two by its own \
+         stated conjunct — but whether some other clause licenses these merges is an OPEN \
+         adjudication for the operator. So this is a population that grew, and it needs \
+         explaining and re-pinning rather than assuming either verdict.\n{}",
+        pinned.coding_axis_separation_two_or_more_merges,
+        census.coding_axis_separation_two_or_more_merges,
+        census.coding_axis_separation_two_or_more_rows,
+        report(label, &measured)
+    );
+
     assert_eq!(
         census,
         pinned,
@@ -1352,6 +1550,11 @@ fn the_corpus_has_the_shape_its_censuses_are_measured_over() {
         measured.single_rows > 0,
         "VACUOUS: no single-spelling rows, so intronic and trans/unknown-phase idempotency \
          measures nothing"
+    );
+    assert!(
+        measured.coding_axis_separation_two_or_more_rows > 0,
+        "VACUOUS: no coding-axis rows separated by two or more unchanged nucleotides, so the \
+         coding-axis merge counter measures nothing"
     );
 
     // Multi-member is the priority axis. Real corpora are 592 of 9,949,738.

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -370,13 +370,15 @@
 //! rejected SVD-WG010 would have merged, so a violation there is a verdict.
 //! `coding_axis_separation_two_or_more_merges` is not that. It counts a
 //! population — coding-axis multi-member alleles whose members sit **two or
-//! more** unchanged nucleotides apart and which normalization merged into a
-//! single member — and makes no claim that merging them is wrong. `general.md:34`
-//! and `DNA/delins.md:17` are what make the population interesting ("two
-//! variants separated by one or more nucleotides should be described
-//! individually and **not** as a 'delins'"); which clause governs any particular
-//! merged row is an **open adjudication for the operator**, and nothing here
-//! settles it.
+//! more** unchanged nucleotides apart and which normalization merged into fewer
+//! members than were authored — and makes no claim that merging them is wrong.
+//!
+//! **Why that population is worth counting, and which records govern it, are
+//! stated once**, on `spec_corpus::is_coding_axis_separation_two_or_more_shape`,
+//! and are not repeated here. In short: `general.md:34` / `DNA/delins.md:17` are
+//! what make it interesting, and three ruling records — two `decided`, one not —
+//! govern different parts of it, so a rise is not one thing and neither is the
+//! zero. Do not argue from the two clauses without reading those records.
 //!
 //! **It exists because `guard_violations` provably cannot count these rows.**
 //! `is_svd_wg010_shape` admits `Genomic | NonCodingMultiExon` at a separation of
@@ -385,44 +387,58 @@
 //! members. The two domains are disjoint twice over, so a merge on the coding
 //! axis leaves `guard_violations` at zero however many rows it moves — which is
 //! why the guard is left exactly as it is and this is a second counter beside
-//! it, not a widening of it.
+//! it, not a widening of it. That disjointness is pinned as a property of the
+//! corpus by `the_coding_axis_merge_population_is_what_it_says_it_is`.
 //!
 //! **Pinned at 0 / 0, measured over 997 rows in each direction.** The zero is a
-//! real negative result, not an absence: the same corpus reads
+//! real negative result, not an absence. Re-measured on `origin/main`
+//! `e98fa77e`, which is **after #1698** — see the paragraph below. (The table
+//! was first derived at `1ea75334` and reproduced cell-for-cell after the
+//! rebase; `git diff 1ea75334 origin/main -- src/` is empty, so the arms could
+//! not have moved.)
 //!
 //! | evaluation arm (`FERRO_PARTITION`) | 3' | 5' |
 //! |---|---|---|
 //! | unset — the shipped rule | **0** of 997 | **0** of 997 |
 //! | `shadow` | 0 | 0 |
 //! | `canonical` | 1 | 1 |
-//! | `canonical-coalesced` | **122** | **122** |
+//! | `canonical-coalesced` | **3** | **3** |
 //!
-//! The 122 decompose by separation as 31 / 30 / 30 / 31 at gaps of 2 / 3 / 5 /
-//! 8, across both two- and three-member designs — every one of them a row
+//! The 3 are one row at a separation of 3 and two at a separation of 2, all of
+//! them two-member designs collapsing to one member — every one a row
 //! `guard_violations` cannot see. The `canonical` arm's single residual is
-//! `s01-c1-pair-inv-del-p4-sep3`, which is not the coalesce pass (it survives
-//! with that pass stubbed out).
+//! `s01-c1-pair-inv-del-p4-sep3` (`c.[9_12inv;16_19del]` -> `c.9_19delinsGTCAGTA`),
+//! which is not the coalesce pass and is also one of the coalesced arm's 3.
+//!
+//! **That table read 122 in the `canonical-coalesced` arm when this change was
+//! written, and #1698 took it to 3.** `fix(normalize): require a gap-bearing
+//! insert before the delins.md:44-47 merge` landed on `merge.rs` between the
+//! branch point and the rebase, removing 119 of the 122 — a 97.5% collapse in
+//! the figure this change was originally motivated by, with **no test failing**,
+//! because the figures live in prose. That is the hazard this module is supposed
+//! to be about, realised on the module itself; it is recorded here rather than
+//! quietly restated. Attribution was measured, not assumed: re-running all four
+//! arms with the corrected numerator (below) reproduces 0 / 0 / 1 / 3, so the
+//! movement is #1698's and none of it is the numerator's.
+//!
+//! **The scale argument this counter was introduced with does not survive that,
+//! and the disjointness argument does.** At 122 rows the case was "the canonical
+//! arm's largest blocking family is invisible to this axis". At 3 it is not a
+//! large family. What is unchanged is that `guard_violations` *cannot* count
+//! them at any size — a structural fact about `is_svd_wg010_shape`'s domain, not
+//! a claim about how many rows there happen to be — and that a counter is how
+//! that stays true after the next change to `merge.rs`, which is exactly what
+//! #1698 demonstrated.
 //!
 //! **The counter was watched moving, in both directions, before being trusted.**
 //! Stubbing `merge::coalesce_payload_alignment_split` to decline unconditionally
-//! takes the `canonical-coalesced` arm from 122 to 1 — the `canonical` figure,
-//! exactly. Removing the arm gate so the pass runs on the shipped rule takes the
-//! shipping arm from 0 to 110 (3') / 113 (5'); making the pass merge
-//! unconditionally on top of that takes it to 190. So the shipping zero is the
-//! pass not running, not the instrument failing to look.
-//!
-//! **Why the floor is two and not one.** `general.md:35` / `DNA/delins.md:18`
-//! carve out an exception on this same axis for two variants "separated by
-//! **one** nucleotide, together affecting one amino acid", and ferro implements
-//! it: measured, **16** rows of this corpus merge at a separation of exactly one
-//! on the shipping rule. A floor of one would sum that licensed merge with an
-//! unlicensed one into a single figure and would have to open at a non-zero pin.
-//! The floor is read off the exception's own stated conjunct, so it is a textual
-//! scope rather than a ruling. The cost is stated rather than hidden: a
-//! coding-axis merge at separation **one** is counted by neither this counter
-//! nor `guard_violations`, and closing that gap means deciding when
-//! `general.md:35` licenses a merge — the adjudication an instrument must not
-//! make.
+//! takes the `canonical-coalesced` arm to the `canonical` figure exactly.
+//! Removing the arm gate so the pass runs on the shipped rule takes the shipping
+//! arm off zero. (Both figures were measured pre-#1698 — 122 -> 1, and 0 -> 110
+//! (3') / 113 (5') — so quote the direction, not the numbers.) The shipped
+//! zero is the pass not running, not the instrument failing to look. Since
+//! neither mutation ships, `the_coding_axis_merge_counter_can_observe_a_merge`
+//! is the positive control that keeps a blinded numerator from passing CI.
 //!
 //! # The honest-zero discipline is enforced, not described
 //!
@@ -844,48 +860,43 @@ pub(crate) struct Census {
     /// with the generator-side denominator still healthy, which is the shape
     /// of vacuity this axis exists to refuse.
     pub(crate) coding_axis_separation_two_or_more_rows: usize,
-    /// Coding-axis multi-member alleles whose authored spelling normalized to a
-    /// **single member**, i.e. the members were merged across the two or more
-    /// unchanged nucleotides between them.
+    /// Coding-axis multi-member alleles whose authored spelling normalized to
+    /// **fewer members than were authored** — i.e. the members were merged
+    /// across the two or more unchanged nucleotides between them.
     ///
     /// # An instrument. It counts a population; it does not judge it
     ///
     /// This counter reports how often a merge of this shape happens. It does
-    /// **not** assert the merge is wrong — that adjudication is the operator's
-    /// and is open. What makes the population worth measuring is that
-    /// `general.md:34` / `DNA/delins.md:17` speak to it in as many words: "two
-    /// variants separated by one or more nucleotides should be described
-    /// individually and **not** as a 'delins'".
+    /// **not** assert the merge is wrong. Contrast [`Self::guard_violations`],
+    /// which counts a shape whose merge implements a **rejected** proposal and
+    /// is therefore a verdict. A count of `n` here is a measurement of how large
+    /// the merged population is, not a claim that `n` rows are defective.
     ///
-    /// So a count of `n` here is a measurement of how large the merged
-    /// population is, not a claim that `n` rows are defective. Contrast
-    /// [`Self::guard_violations`], which counts a shape whose merge implements
-    /// a **rejected** proposal and is therefore a verdict.
+    /// # Everything else about this population is stated ONCE, and not here
     ///
-    /// # The floor of two is what keeps the zero readable
+    /// Why the floor is two; what the sub-floor population contains and which
+    /// part of it is a known defect; which three ruling records govern which
+    /// part of it, and therefore what a rise and a zero each mean; and why this
+    /// is a second counter rather than a widened guard — all of that is on
+    /// `spec_corpus::is_coding_axis_separation_two_or_more_shape`.
     ///
-    /// `general.md:35` / `DNA/delins.md:18` carve out an exception on this same
-    /// axis, for two variants "separated by **one** nucleotide, together
-    /// affecting one amino acid". Ferro implements it and it fires: on the
-    /// shipping rule **16** rows of this corpus merge at a separation of
-    /// exactly one, and none at two or more. Counting from a floor of one would
-    /// sum a licensed merge and an unlicensed one into a figure no later reader
-    /// could take apart, and would open at a non-zero pin. The floor is read
-    /// off the exception's own stated conjunct, so it is a textual scope rather
-    /// than a ruling — see `spec_corpus::is_coding_axis_separation_two_or_more_shape`,
-    /// which also states what the choice costs.
+    /// It is deliberately not restated here. The first revision of this change
+    /// carried that argument in seven places, and two of the copies ended up
+    /// contradicting each other 406 lines apart in this file — one saying ferro
+    /// implements the codon exception and it accounts for the sub-floor merges,
+    /// the other retracting exactly that. A pointer cannot drift.
     ///
-    /// # Why it is a second counter rather than a widened guard
+    /// # The numerator, and what it can and cannot see
     ///
-    /// [`Self::guard_violations`]'s rows are chosen by `is_svd_wg010_shape`,
-    /// which admits only the two **frameless** shapes, at a separation of
-    /// exactly one, with exactly two members. That domain and this one are
-    /// disjoint twice over, so `guard_violations` cannot count a coding-axis
-    /// merge at any separation for any member count, and a zero there says
-    /// nothing about this population. Relaxing that guard to cover
-    /// coding rows would re-scope a negative result about a rejected proposal
-    /// into a different instrument wearing its name, so this is a new counter
-    /// beside it.
+    /// [`coding_axis_merge_observed`] is the test: `members_of(output).len() <
+    /// row.members`. It was `< 2`, which on the 313 of 997 flagged rows carrying
+    /// three or four members could only ever see a collapse **all the way** to
+    /// one member — a 4-member row merged to 2 counted as zero. Below the floor
+    /// that blindness is 25 of 41 merges.
+    ///
+    /// It still cannot see a merge whose output is unparseable, since the count
+    /// is taken on a parsed output; `unparseable_outputs` is the counter for
+    /// that and is pinned at 0.
     ///
     /// # Pinned at zero in both directions, and that zero is a measurement
     ///
@@ -893,7 +904,10 @@ pub(crate) struct Census {
     /// evaluation arm — `merge::coalesce_payload_alignment_split`, reached only
     /// when `payload_coalesce_applies` sees `PartitionRule::CanonicalCoalesced`
     /// — does not run on the shipped rule, so the shipping arm merges none of
-    /// these rows. Measured rather than assumed: see the module docs.
+    /// these rows. That is a mechanical reason rather than an empirical
+    /// coincidence, and the counter is separately shown able to move: see the
+    /// module docs' arm table and
+    /// [`the_coding_axis_merge_counter_can_observe_a_merge`].
     pub(crate) coding_axis_separation_two_or_more_merges: usize,
 }
 
@@ -937,6 +951,31 @@ fn members_of(variant: &HgvsVariant) -> Vec<HgvsVariant> {
         HgvsVariant::Allele(allele) => allele.variants.clone(),
         single => vec![single.clone()],
     }
+}
+
+/// The coding-axis merge instrument's **numerator**: did normalization collapse
+/// `row`'s authored members into fewer members?
+///
+/// # It is `< row.members`, not `< 2`, and the difference is 31.4% of the corpus
+///
+/// The sibling `guard_violations` test may write `< 2` because
+/// `is_svd_wg010_shape` pins `kinds.len() == 2`, so for its rows "fewer than two
+/// members" and "merged" are the same statement. This population is wider —
+/// `MEMBER_COUNTS = [2, 3, 4]` — and there `< 2` means "collapsed **all the way**
+/// to one member". A 4-member row merged to 2 is two merges across two or more
+/// unchanged nucleotides and would have been counted as **zero**. Measured over
+/// the flagged rows: `{2: 684, 3: 159, 4: 154}`, so **313 of 997 (31.4%)** were
+/// blind to a partial merge under the narrower test.
+///
+/// That is the property the doc comments claim ("the members were merged across
+/// the two or more unchanged nucleotides between them"), so measuring anything
+/// narrower would be an assertion weaker than the stated contract.
+///
+/// Extracted as a named function rather than inlined so
+/// `the_coding_axis_merge_counter_can_observe_a_merge` can exercise it directly
+/// — see that test for why a zero pin needs a positive control.
+fn coding_axis_merge_observed(row: &Row, output: &HgvsVariant) -> bool {
+    members_of(output).len() < row.members
 }
 
 /// Whether either endpoint of `interval` names an intronic offset.
@@ -1280,17 +1319,21 @@ fn measure(direction: ShuffleDirection) -> Measured {
             if row.coding_axis_separation_two_or_more && spelling == row.authored_spelling() {
                 census.coding_axis_separation_two_or_more_rows += 1;
                 if let Ok(parsed_output) = parse_hgvs(&output) {
-                    if members_of(&parsed_output).len() < 2 {
+                    if coding_axis_merge_observed(row, &parsed_output) {
                         census.coding_axis_separation_two_or_more_merges += 1;
                         findings.push(Finding {
                             id: row.id.clone(),
                             what: format!(
-                                "coding-axis allele merged across {} unchanged nucleotide(s) \
-                                 into one member (`general.md:34` / `DNA/delins.md:17` speak to \
-                                 this population; whether they govern each row is an OPEN \
-                                 adjudication — counted, not adjudicated): \
+                                "coding-axis allele merged across {} unchanged nucleotide(s), \
+                                 {} authored members -> {} (`general.md:34` / \
+                                 `DNA/delins.md:17` speak to this population, and the three \
+                                 ruling records named on \
+                                 `spec_corpus::is_coding_axis_separation_two_or_more_shape` \
+                                 govern parts of it — counted, not adjudicated): \
                                  {spelling} -> {output}",
-                                row.separation
+                                row.separation,
+                                row.members,
+                                members_of(&parsed_output).len()
                             ),
                         });
                     }
@@ -1345,7 +1388,8 @@ fn report(label: &str, measured: &Measured) -> String {
          {} conditional prohibitions accepted\n  \
          NEGATIVE GUARDS: {} outputs implement rejected SVD-WG010\n  \
          CODING-AXIS MERGE (an instrument, not a verdict): {} of {} coding-axis alleles \
-         separated by two or more unchanged nucleotides merged into a single member\n",
+         separated by two or more unchanged nucleotides normalized to fewer members than \
+         were authored (a full or a partial merge)\n",
         census.measured_under,
         census.outputs,
         census.declined,
@@ -1495,9 +1539,12 @@ fn assert_census(direction: ShuffleDirection, label: &str, pinned: &Census) {
          from {} to {} (of {} evaluated). This counter is an INSTRUMENT, not a ruling: \
          `general.md:34` / `DNA/delins.md:17` say such members are described individually, and \
          `general.md:35`'s one-amino-acid exception cannot reach a separation of two by its own \
-         stated conjunct — but whether some other clause licenses these merges is an OPEN \
-         adjudication for the operator. So this is a population that grew, and it needs \
-         explaining and re-pinning rather than assuming either verdict.\n{}",
+         stated conjunct — but the ruling ledger governs part of this population and a rise is \
+         not automatically a defect. Read the three records named on \
+         `spec_corpus::is_coding_axis_separation_two_or_more_shape` BEFORE deciding what this \
+         means: within the payload-coincidence shape on this axis a rise is a decided ruling \
+         arriving, and outside it `general.md:34` still governs. So this is a population that \
+         grew, and it needs explaining and re-pinning rather than assuming either verdict.\n{}",
         pinned.coding_axis_separation_two_or_more_merges,
         census.coding_axis_separation_two_or_more_merges,
         census.coding_axis_separation_two_or_more_rows,
@@ -1562,6 +1609,102 @@ fn the_corpus_has_the_shape_its_censuses_are_measured_over() {
     assert!(
         share > 0.9,
         "multi-member share is {share:.4}; this corpus exists to invert the natural 0.00006"
+    );
+}
+
+/// A **positive control** for the coding-axis merge counter: it must be able to
+/// observe a merge.
+///
+/// # Why a zero pin needs one, and why nothing else supplies it
+///
+/// `coding_axis_separation_two_or_more_merges` is pinned at **0**, so every
+/// other test that mentions it is satisfied by a numerator that can never
+/// increment. Measured as a mutation matrix over the four tests that claim to
+/// cover the counter — the two censuses, the corpus-shape test and
+/// `spec_corpus`'s population test — hard-wiring
+/// [`coding_axis_merge_observed`] to `false` leaves **all four green**. "Pinned
+/// at 0" and "wired to 0" were the same observation, which is exactly what this
+/// module's own thesis says an instrument must not be: *a counter nobody has
+/// seen move is not an instrument*.
+///
+/// The other five mutations in that matrix are caught: predicate always-true,
+/// predicate always-false (as VACUOUS), the separation floor weakened to one,
+/// dropping the irreducibility conjunct, and the numerator forced always-true.
+/// Only the always-**false** direction was blind, because it is the direction a
+/// zero cannot distinguish.
+///
+/// # What it asserts
+///
+/// The predicate is exercised directly against real corpus rows and parsed
+/// outputs, so it covers `members_of`, the parse path and the member-count
+/// comparison — everything between normalization and the counter:
+///
+/// - an authored multi-member spelling is **not** a merge (no false positive);
+/// - a single-member output **is** (the plain merge);
+/// - a 3-or-more-member row collapsed to two members **is** — the partial merge
+///   the old `< 2` test could not see on 313 of the 997 flagged rows.
+#[test]
+fn the_coding_axis_merge_counter_can_observe_a_merge() {
+    let built = built();
+    let pair = built
+        .rows
+        .iter()
+        .find(|row| row.coding_axis_separation_two_or_more && row.members == 2)
+        .expect(
+            "VACUOUS: the corpus builds no two-member coding-axis row separated by two or more \
+             unchanged nucleotides, so this control controls nothing",
+        );
+
+    let authored = parse_hgvs(pair.authored_spelling()).expect("the authored spelling parses");
+    assert!(
+        !coding_axis_merge_observed(pair, &authored),
+        "{}: its own authored spelling ({}) counted as a merge, so the counter has a false \
+         positive and its zero would be unreadable in the other direction",
+        pair.id,
+        pair.authored_spelling()
+    );
+
+    // The merged form is the row's OWN spanning-`delins` respelling, not a
+    // hand-written literal: the corpus offers one for every family it builds,
+    // and it is a single member before normalization ever runs (which is why
+    // `measure` reads this counter on the authored spelling only). Deriving it
+    // from the row keeps the control anchored to the population it controls.
+    let (merged_spelling, merged) = pair
+        .spellings
+        .iter()
+        .filter_map(|spelling| Some((spelling, parse_hgvs(spelling).ok()?)))
+        .find(|(_, parsed)| members_of(parsed).len() == 1)
+        .expect("VACUOUS: the row offers no single-member respelling to merge INTO");
+    assert!(
+        coding_axis_merge_observed(pair, &merged),
+        "{}: its own single-member respelling ({merged_spelling}) was NOT counted as a merge. \
+         The counter is blind, and its pinned 0 is a property of this predicate rather than of \
+         the normalizer",
+        pair.id
+    );
+
+    // The partial half. `pair`'s two-member authored spelling stands in for a
+    // partial merge of `wide`, which authored three or more — 2 < wide.members
+    // is exactly the property, and both sides are corpus rows rather than
+    // literals. Re-spelling `wide` itself with a member dropped would mean
+    // reassembling an allele out of `Display` output, which is string surgery
+    // with its own failure mode and would not test anything further: the
+    // predicate reads member counts and nothing else.
+    let wide = built
+        .rows
+        .iter()
+        .find(|row| row.coding_axis_separation_two_or_more && row.members >= 3)
+        .expect(
+            "VACUOUS: the corpus builds no 3-or-more-member coding-axis row, so the partial-merge \
+             half of this control controls nothing",
+        );
+    assert!(
+        coding_axis_merge_observed(wide, &authored),
+        "{}: {} authored members collapsing to {} was NOT counted. That is the 313 of 997 rows \
+         (31.4%) `coding_axis_merge_observed` exists to stop losing",
+        wide.id,
+        wide.members,
+        members_of(&authored).len()
     );
 }
 


### PR DESCRIPTION
Representation-Change: none. Test and conformance-corpus instrumentation only; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, and the full suite is green on the shipping rule with every pre-existing pin unmoved.

**Rebased onto `origin/main` `57f71d31`** (from `e98fa77e`) while applying review findings. The branch's own delta is byte-identical across the rebase apart from the three edits described under "the 5 are not unresolved" — verified by diffing `git diff <old-base>..<old-tip>` against `git diff <new-base>..HEAD`, which differ only in those hunks and in hunk offsets. `57f71d31` carries #1718, which touches the same conformance-axis files, so the local gate was re-run on the rebased tree rather than inherited.

## Read this first — the motivating figure moved by 40x while this PR was open, and nothing went red

This PR was written against a `canonical-coalesced` figure of **122 of 997**. **#1698** (`fix(normalize): require a gap-bearing insert before the delins.md:44-47 merge`) landed on `src/normalize/merge.rs` between the branch point and this rebase and took that figure to **3 of 997** — 119 of the 122 removed. **No test failed**, because the figure lived only in prose. That is the exact hazard this module exists to remove, realised on the module itself, so it is recorded here rather than quietly restated.

Every figure below has been re-derived on `origin/main` at `1ea75334`, with attribution measured rather than assumed. The four arms were re-run twice — once with the original numerator and once with the widened one — so movement is attributed to #1698 rather than to this branch's own changes.

| figure | as originally written | re-derived at `1ea75334` | why it moved |
|---|---|---|---|
| `canonical-coalesced` arm | **122** of 997 (3' and 5') | **3** of 997 (3' and 5') | #1698 |
| its decomposition | 31 / 30 / 30 / 31 at gaps 2 / 3 / 5 / 8, two- and three-member designs | 1 row at separation 3, 2 rows at separation 2 — all two-member, all collapsing to one member | #1698 |
| shipped rule, `shadow` | 0 / 0 | 0 / 0 | unchanged |
| `canonical` | 1 (`s01-c1-pair-inv-del-p4-sep3`) | 1, the same row | unchanged |
| sub-floor merges (separation exactly one) | 16 | **41 of 340** | the numerator was widened; see below |
| …of which collapse all the way to one member | 16 | **16** | **unchanged by #1698** |
| pass attribution of those 16 | "14 from `merge.rs:188` + 1 from `coalesce_whole_block_inversion`" | 15 two-member pairs + 1 three-member whole-span `inv` (`s00-c1-m3-all-inv-p4-sep1`) | the original 14 + 1 sums to 15 against a stated total of 16 |
| sub-floor verdicts | 9 licensed / 5 **unresolved** / 2 rule 1 violations | 9 licensed / 5 **unlicensed** (#1744) / 2 **unlicensed, filed** (#1716) | see "the 5 are not unresolved"; and #1725 makes none of the 7 a rule-1 violation |
| suite | "10,163 passed, 0 failed" | 10,162 passed / **1 failed** at that head | the claim predated the commit that broke it; green now |

**What survives that, and what does not.** The scale argument does not: at 3 rows this is not "the canonical arm's largest blocking family", and saying so would be reframing around a number instead of reporting it. The **disjointness** argument does, and it is the one the counter rests on — `guard_violations` *cannot* count these rows at any size, which is a structural fact about `is_svd_wg010_shape`'s domain rather than a claim about how many rows there happen to be. #1698 is itself the argument for keeping the counter: it moved this population by 97.5% and every test stayed green.

## The gap this closes

`spec_conformance_axis`'s `guard_violations` is a **negative guard for rejected SVD-WG010**, and its rows are chosen by `spec_corpus::is_svd_wg010_shape`: the two **frameless** shapes (`Genomic`, `NonCodingMultiExon`), a separation of **exactly one**, and **exactly two** members. The coding axis is outside that domain twice over.

So when a coding-axis multi-member allele is merged, **no counter in the conformance axis can rise** — not "does not today", but cannot, at any separation and for any member count. That disjointness is now pinned as a property of the corpus by `the_coding_axis_merge_population_is_what_it_says_it_is`, not asserted in a doc comment.

## What this adds

A second counter **beside** the guard, never a widening of it — `is_svd_wg010_shape` is untouched, because relaxing its `frameless` conjunct would silently re-scope a negative result about a *rejected* proposal into a different instrument carrying that guard's name and its published zero.

- `Row::coding_axis_separation_two_or_more` marks the population: a **coding**, `Mechanism::Cis`, multi-member design whose members each consume reference and sit **two or more** unchanged nucleotides apart, with an **irreducible** separation.
- `Census::coding_axis_separation_two_or_more_merges` counts how many of those normalize to **fewer members than were authored**, on the authored spelling only.
- `Census::coding_axis_separation_two_or_more_rows` and `CorpusShape::coding_axis_separation_two_or_more_rows` are the denominator, pinned on both sides and asserted non-zero, so `0 of 0` fails as VACUOUS rather than passing as a result.
- `the_coding_axis_merge_counter_can_observe_a_merge` is a **positive control** — see below.

## Read the ledger, not only the clauses

`general.md:34` / `DNA/delins.md:17` are what make the population interesting. They are **not** the whole authority over it, and an earlier revision of this PR cited only them. `tests/it/clause_ruling_index.rs` marks both `[MULTI]`, and three records govern parts of these rows:

| record | status | what it does to this population |
|---|---|---|
| `delins-payload-coincidence-carve-out-is-coding-dna-scoped` | decided | scopes `delins.md:47`'s payload-coincidence carve-out to the **coding DNA axis** — this population's axis, and the one axis where `general.md:34` is overridden for that shape |
| `delins-merge-vs-individual-gap-two-or-more` | decided | `:44-47` governs `:17`, scoped to the alignment-coincidence shape and to the net-deletion direction; outside that, `general.md:34` still governs |
| `delins-recommendation-reach-when-the-input-arrives-split` | not settled | the genuine residue: which clause a *re-derivation* lands on. Narrower than "may ferro merge an authored split", which `canonical-form-choice-when-both-legal` already answers |

**So neither a rise nor the zero means one thing.** Within the payload-coincidence shape the first record *ratifies* the merge on this axis, so a rise there is a decided ruling arriving on the shipped rule and the shipping arm's `0` is that ruling **not yet implemented** — not a clean bill. Outside that shape `general.md:34` governs and a rise needs explaining. The counter cannot separate them, which is why it counts and does not adjudicate. The pass producing every merge the counter sees on the coalesced arm, `coalesce_payload_alignment_split`, cites the first record in its own doc comment.

## The numerator was blind to a partial merge

It tested `members_of(output).len() < 2`, copied from `guard_violations` — where `is_svd_wg010_shape` pins exactly two members, so "fewer than two" and "merged" are the same statement. This population admits 2, 3 and 4 members, and **313 of the 997 flagged rows carry three or four**, so a 4-member row merged to 2 counted as **zero**.

It now tests `< row.members`, which is the property the doc comments already claimed. Above the floor this moves nothing — all four arms re-measured either way read 0 / 0 / 1 / 3. Below the floor, **25 of the 41 merges were uncounted**.

## A positive control, because a zero pin cannot detect a blinded counter

Hard-wiring the numerator so it can never increment **passed** both censuses, the corpus-shape test and the population test. "Pinned at 0" and "wired to 0" were the same observation — in a module whose thesis is that a counter nobody has seen move is not an instrument.

`the_coding_axis_merge_counter_can_observe_a_merge` exercises the predicate directly against real corpus rows: an authored multi-member spelling must not count, a single-member output must, and a 3-or-more-member row collapsed to two must. Verified against the mutation: with the numerator wired to `false`, it is the **only** one of the five tests that fails.

The rest of the matrix was already sound and is unchanged: predicate always-true, predicate always-false (as VACUOUS, in the exact words the docs promise), the floor weakened to one, and the numerator forced always-true are each caught; dropping the `irreducible` conjunct moves the denominator 997 -> 2,527 and the numerator 0 -> 74, so that conjunct is load-bearing.

## Measured, in both directions

Pinned at **0 of 997** in `THREE_PRIME` and `FIVE_PRIME`. The zero is a real negative result: `coalesce_payload_alignment_split` is reached only when `payload_coalesce_applies` sees `PartitionRule::CanonicalCoalesced`, so it never runs on the shipped rule. That is a mechanical reason, not an empirical coincidence — which is also why the shipping zero is invariant under #1698 while the coalesced arm collapsed.

| `FERRO_PARTITION` | 3' | 5' |
|---|---|---|
| unset — the shipped rule | **0** of 997 | **0** of 997 |
| `shadow` | 0 | 0 |
| `canonical` | 1 | 1 |
| `canonical-coalesced` | **3** | **3** |

## Why the floor is two, and what that costs

`general.md:35` / `DNA/delins.md:18` carve out an exception on this same axis for two variants "separated by **one** nucleotide, together affecting one amino acid". Measured on the shipping rule at `1ea75334`: **41 of 340** rows merge at a separation of exactly one, and **0 of 997** at two or more.

The 41 decompose by how far each row collapsed — the finding line now reports `<authored> members -> <observed>`:

| shape | rows | visible to the old `< 2` numerator? |
|---|---:|---|
| 2 authored members -> 1 | 15 | yes |
| 3 authored members -> 1 (a whole-span `inv`) | 1 | yes |
| 4 authored members -> 3 (a **partial** merge) | 25 | no |

So the earlier figure of **16** is the first two rows and is unchanged; read "16 -> 41" as an instrument that got less blind, not as behaviour that changed.

**Those 16 are not the codon exception firing.** Knocking out each merge pass singly shows `apply_coding_codon_exception` produces none of them.

**And the 5 are not unresolved.** An earlier revision filed them as unresolved on the strength of `codon-carve-out-shape-restriction`, which is a **decided** record (WIDEN, operator ruling 2026-08-10) and which answers this sub-case rather than leaving it. Two claims were being run together: what is *not yet implemented* is the widening's effect on `apply_coding_codon_exception`; what is *not* unsettled is whether the exception reaches a frameshift pair. It does not — the record's own words are that "together affecting one amino acid" cannot cover a frameshift pair, "so the widened rule declines there for the reason the spec gives rather than by a shape test".

Ferro merges those 5 anyway, which puts them in the same category as the 2 filed as **#1716**: output no cited clause licenses. **On this corpus the sub-floor count of unlicensed merges is 7, not 2** — and since the 9 / 5 / 2 decomposition is over the 16 full collapses only, with the 25 partial merges unclassified, 7 is a floor.

**The 5 are filed as #1744, and that is now named in the code rather than described as a gap.** The comment used to read "the missing artifact is an issue for the 5, filed the way #1716 was for the 2, and until that exists this comment is the only record"; the issue exists, so the comment points at it. Read #1744 rather than the comment for their status: under `separation-rule-force-modal-or-negation` (**decided**, 2026-08-12) all 7 are rule-**2** departures to disclose rather than rule-7 bugs, and whether they are *accepted and disclosed* or *closed* is a trade nobody has made. The comment previously said the classification changed "what they cost a release and not whether they are wrong", which pre-empted that open question; it now says so explicitly and defers to #1744.

| verdict | rows | what they are |
|---|---:|---|
| licensed | 9 | two lone substitutions in one codon, net length 0 — the exception's own shape; plus one whole-span `inv` |
| **unlicensed** | **5** | a frameshift *inside* one codon; the decided record above declines them |
| **unlicensed, filed** | **2** | the merged span crosses two codons — #1716, reproducing on the prepared reference as `LRG_199t1:c.[18_19del;21A>C]` -> `c.18_21delinsTC`. **Not a rule-1 violation**: #1725's `separation-rule-force-modal-or-negation` grades `general.md:34` as README rule 2 in its entirety, so this is a deviation to disclose and pin, not a rule-7 bug |

A floor of one would therefore open at a non-zero pin summing rows with three different verdicts. The floor is read off the exception's own stated conjunct, so it is a textual scope rather than a ruling. The cost is stated rather than hidden, and it is worse than the first revision of this PR said: the sub-floor gap conceals **known defects**, not merely an unsettled question.

## One argument, one place

The floor-of-two rationale was written out seven times across the two files and the sub-floor figure three times, and two of those copies had drifted into contradicting each other **406 lines apart in one file** — one asserting ferro implements the codon exception and it accounts for the sub-floor merges, the other retracting exactly that. It is now stated once, on `spec_corpus::is_coding_axis_separation_two_or_more_shape`; every other site points at it.

## Also

- The population predicate requires `Mechanism::Cis` rather than `combines_members()`, which also admits `Trans` and `UnknownPhase`. No row changes today (probe: `by_mechanism = {cis: 997}`), but a merged *trans* allele is an unambiguous defect and must not arrive silently under prose describing an unsettled adjudication.
- The disjointness assertion names the SVD-WG010 guard rather than asserting the row carries no guards at all, so a later unrelated guard label cannot fail it with a message about SVD-WG010.
- The population test now discloses that it does **not** check irreducibility — a `Row` does not carry the triples the check needs, and dropping that conjunct leaves the test green while moving the census figures. It is defended by the two census pins, not by that test.

## Verification

Re-run after the rebase, not before — the previous claim of "10,163 passed, 0 failed" was taken before the commit that broke it, and that head in fact ran 10,162 passed / 1 failed on `ruling_citation_currency::no_ruling_citation_contradicts_the_ledger_status`, which was this branch's only CI failure and is fixed here.

- `cargo run --features dev --bin generate_spec_fixture` and `generate_spec_enumeration`, then `cargo nextest run --features dev --lib --test it`, with `FERRO_MANIFEST` set so the reference-aware suites run rather than skip. Exit status captured into the log and read back out of it.
- `scripts/run_oracle_suite.sh`, which mirrors `test-oracle`'s flags and selection.
- `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` both clean.
- Every pre-existing pin is unmoved in both directions, including the counters #1708 re-blessed.

