### PR TITLE
fix(normalize): test the span the codon-frame merge authorises, not one edge

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -173,13 +173,41 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
             //     share a codon-relative axis. `g.` / `n.` / UTR / intron
             //     are excluded.
             //   * `prev_a.end + 2 == next_start` (gap of exactly 1 nt).
-            //   * `same_codon(prev_a.end, next_start)` — both endpoints
-            //     fall in the same 1-indexed codon. The right edge of
-            //     `prev_a` is what matters, so a chain that has already
-            //     grown via earlier strict merges can still extend via
-            //     codon-frame (issue #275 item 2).
+            //   * `same_codon(prev_a.start, next_start)` — the two ends of
+            //     the span this merge authorises, `prev_a.start ..=
+            //     next_anchor.end`, fall in the same 1-indexed codon. That
+            //     is `general.md:35`'s **second** conjunct, "together
+            //     affecting one amino acid", and it has to be asked of the
+            //     whole merged span rather than of one endpoint: a codon is
+            //     three positions, so any span of four or more crosses a
+            //     boundary however its right edge lands.
+            //
+            //     It tested `prev_a.end` until #1716. Under #104's original
+            //     `prev_a.start == prev_a.end` the two were the same
+            //     position; #275/#292 relaxed that to `<=` for chain
+            //     extension and the endpoint choice stopped being
+            //     equivalent, so a left member wider than one base merged
+            //     across a codon boundary — `c.[18_19del;21A>C]` ->
+            //     `c.18_21delinsTC` on `NM_004006.2`, which no clause
+            //     licenses and `general.md:34` / `DNA/delins.md:17` then
+            //     govern. The two sibling passes always keyed on the span:
+            //     [`apply_coding_codon_exception`] tests the triplet from
+            //     the left piece's start, [`coalesce_coding_frame_separation`]
+            //     tests `pair[0].ref_start` against `pair[1].ref_end - 1`.
+            //
+            //     #275 item 2's chain extension is not lost by this. A chain
+            //     grown by strict adjacency is length-preserving, so the
+            //     sequence-first canonicalizer re-derives it and
+            //     `build_split_variants` puts it back on the codon boundary;
+            //     since #1524 re-blessed those outputs (`c.[3G>T;4C>G;6A>T]`
+            //     -> `c.[3_4delinsTG;6A>T]`) the merge and the decline emit
+            //     the same string. `issue_275_codon_frame_extensions` pins
+            //     both, unchanged.
             //   * `prev_a.start <= prev_a.end` — `prev_a` is not an
-            //     insertion anchor (those use `start == end + 1`).
+            //     insertion anchor (those use `start == end + 1`). Still
+            //     load-bearing after the change above: an insertion anchor
+            //     has `start == next_start - 1`, which lands in one codon
+            //     two thirds of the time.
             //   * `next_anchor` is a 1-position substitution OR deletion
             //     (checked below): `next_anchor.start == next_anchor.end`
             //     and `next_anchor.alt.len() <= 1`. Issue #275 item 3
@@ -189,7 +217,7 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
                 && (prev_a.region == Region::Cds || prev_a.region == Region::Rna)
                 && prev_a.end.checked_add(2) == Some(next_start)
                 && prev_a.start <= prev_a.end
-                && same_codon(prev_a.end, next_start);
+                && same_codon(prev_a.start, next_start);
 
             if !strict_adjacent && !codon_frame_eligible {
                 break 'try_merge false;
@@ -12319,6 +12347,152 @@ mod tests {
         );
         assert_eq!(out[0], v1);
         assert_eq!(out[1], v2);
+    }
+
+    // ------------------------------------------------------------------
+    // The codon-frame arm's two CALL-SITE conjuncts (#1716)
+    // ------------------------------------------------------------------
+
+    /// The first 36 nt of the real DMD CDS as a `cds_start = 1` transcript, so
+    /// `c.N` indexes byte `N`: `c.19=G`, `c.20=T`, `c.21=A`, `c.22=G`.
+    ///
+    /// Deliberately the same bases as the integration module
+    /// `it::issue_1716_codon_frame_merged_span`, so the two describe one
+    /// fixture rather than two — but the tests below cannot live there, for the
+    /// reason each of them states.
+    fn codon_frame_transcript_provider() -> MockProvider {
+        use crate::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+        let sequence = "ATGCTTTGGTGGGAAGAAGTAGAGGACTGTTATGAA".to_string();
+        let len = sequence.len() as u64;
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: Some("TEST".to_string()),
+            strand: Strand::Plus,
+            sequence: Some(sequence),
+            cds_start: Some(1),
+            cds_end: Some(len),
+            exons: vec![Exon::new(1, 1, len)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::Select,
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            cds_start_incomplete: false,
+            exon_cigars: Vec::new(),
+            cached_introns: std::sync::OnceLock::new(),
+        });
+        provider
+    }
+
+    fn merged_members(inputs: [&str; 2]) -> Vec<HgvsVariant> {
+        let provider = codon_frame_transcript_provider();
+        let variants: Vec<HgvsVariant> = inputs
+            .iter()
+            .map(|s| parse_hgvs(s).expect("fixture must parse"))
+            .collect();
+        merge_consecutive_edits(variants, AllelePhase::Cis, &provider)
+    }
+
+    /// `prev_a.start <= prev_a.end` — the conjunct that keeps an **insertion
+    /// anchor** out of the codon-frame arm — is load-bearing, and #1716 made it
+    /// twice as load-bearing.
+    ///
+    /// An insertion's anchor is the empty range `[end, start]` with
+    /// `start == end + 1` (see [`simple_range_for_loc_edit`]), so for
+    /// `c.19_20insG` it is `start = 20`, `end = 19`. The arm's gap test then
+    /// reads `19 + 2 == 21`, and the *span* test this change introduced reads
+    /// `same_codon(20, 21)` — both true. Before #1716 the span test was
+    /// `same_codon(prev_a.end, next_start)` = `same_codon(19, 21)`, which is
+    /// also true here; the change is that the new form holds for **two frames
+    /// in three** rather than one, so the population this conjunct is the only
+    /// thing excluding roughly doubles.
+    ///
+    /// # Why this is a unit test and not an end-to-end one
+    ///
+    /// **Measured, not assumed.** Deleting the conjunct and re-running the whole
+    /// `issue_1716` / `issue_275` / `codon` / `merge` / `spec_corpus_regressions`
+    /// selection — 582 tests — leaves every one of them **green**, and a probe
+    /// of eighteen insertion-anchored descriptions through `Normalizer::normalize`
+    /// returns byte-identical output with and without it. The reason is that the
+    /// sequence-first canonicalizer re-derives the same string from the resulting
+    /// sequence: `c.[19_20insG;21A>C]` normalizes to `c.20_21delinsGTC` whether
+    /// or not `merge_consecutive_edits` merged it. So the conjunct is invisible
+    /// downstream by construction, and only a test at this call site can hold it.
+    #[test]
+    fn an_insertion_anchor_is_refused_by_the_codon_frame_arm() {
+        let out = merged_members(["NM_TEST.1:c.19_20insG", "NM_TEST.1:c.21A>C"]);
+        assert_eq!(
+            out.len(),
+            2,
+            "an insertion anchor must not enter the codon-frame arm, however its \
+             `start` lands in the codon: got {}",
+            out.iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(";")
+        );
+        assert_eq!(out[0].to_string(), "NM_TEST.1:c.19_20insG");
+        assert_eq!(out[1].to_string(), "NM_TEST.1:c.21A>C");
+    }
+
+    /// The sibling conjunct: `next_anchor` must be a **1-position** substitution
+    /// or deletion, so a multi-position `next` and a multi-base payload are both
+    /// refused.
+    ///
+    /// Two cases because the check is a disjunction and each disjunct needs one:
+    /// `c.21_22del` fails `start == end`, `c.21delinsCC` fails `alt.len() <= 1`.
+    /// The first is the one that matters most — merging it would authorise the
+    /// span `c.19..c.22`, four positions, which cannot lie in one codon and so
+    /// fails `general.md:35`'s second conjunct outright.
+    ///
+    /// Same reason for being a unit test as
+    /// [`an_insertion_anchor_is_refused_by_the_codon_frame_arm`], measured the
+    /// same way: dropping the width check leaves all 582 selected tests green,
+    /// and `c.[19G>T;21delinsCC]` normalizes to `c.19_21delinsTTCC` either way.
+    #[test]
+    fn a_multi_position_next_anchor_is_refused_by_the_codon_frame_arm() {
+        for (next, why) in [
+            (
+                "NM_TEST.1:c.21_22del",
+                "a 2-position deletion (start != end)",
+            ),
+            ("NM_TEST.1:c.21delinsCC", "a 2-base payload (alt.len() > 1)"),
+        ] {
+            let out = merged_members(["NM_TEST.1:c.19G>T", next]);
+            assert_eq!(
+                out.len(),
+                2,
+                "{why} must not enter the codon-frame arm: got {}",
+                out.iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(";")
+            );
+            assert_eq!(out[0].to_string(), "NM_TEST.1:c.19G>T");
+            assert_eq!(out[1].to_string(), next);
+        }
+    }
+
+    /// The positive control for the two above: with a 1-position `next` and a
+    /// non-insertion `prev`, the very same arm **does** merge.
+    ///
+    /// Without this, both tests above are satisfied by a `merge_consecutive_edits`
+    /// that never merges anything — "refused for the documented reason" and
+    /// "refused because the arm is dead" are the same observation otherwise.
+    #[test]
+    fn the_codon_frame_arm_still_merges_the_shape_it_is_for() {
+        let out = merged_members(["NM_TEST.1:c.19G>T", "NM_TEST.1:c.21A>C"]);
+        assert_eq!(
+            out.len(),
+            1,
+            "two 1-position substitutions inside codon 7 are the exception's own \
+             shape and must still merge"
+        );
+        assert_eq!(out[0].to_string(), "NM_TEST.1:c.19_21delinsTTC");
     }
 
     /// `apply_edits_to_window` must not depend on the order its edits arrive in.

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -287,13 +287,40 @@ const CDS_END: u64 = 63;
 /// 10; the three sum to the 334 `converged` gains, so **every** moved class went
 /// straight to convergence and none merely dropped an arity. No divergence
 /// figure rises, so the ratchet is satisfied in the direction it was written for.
+///
+/// # Re-blessed by #1716, and this one costs a class rather than buying one
+///
+/// `merge_consecutive_edits`' per-member codon-frame predicate tested its left
+/// anchor's **right edge** for codon membership while authorising a `delins` over
+/// `prev_a.start ..= next.end`, so a left member wider than one base merged
+/// across a codon boundary — `general.md:35`'s "together affecting one amino
+/// acid" cannot hold over four or more positions. Testing the span instead
+/// declines those merges.
+///
+/// `converged` is **unchanged at 8 361 / 8 367**, and exactly one class moves, in
+/// both directions: `s03-c-m3-sep1-p8-rot2` goes from two outputs to three, so
+/// `split_two` falls by one and `split_three` rises by one. The full divergence
+/// list was dumped either side (the `worst` cap raised locally, then restored)
+/// and diffed by class id: **no class loses convergence, none gains it, and no
+/// other class changes arity** in either direction.
+///
+/// **`split_three` rising is a divergence figure going UP**, which this pin's
+/// ratchet forbids without a re-bless — hence this section. The price is the same
+/// one #1240 records two paragraphs above, and for the same reason: the
+/// newly-divergent third output is `c.[9_16delinsATGAGTAA;18delinsGTCCTGGCA]`,
+/// and what it stopped agreeing with is `c.9_18delinsATGAGTAAAGTCCTGGCA` — a
+/// merge across `c.9..c.18`, i.e. codons 3 to 6, which `general.md:34` says to
+/// describe individually. Agreement is lost; correctness is not. `declined`,
+/// `underdetermined` and `sequence_changed` are all still 0.
 const THREE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
     converged: 8_361,
-    split_two: 2_835,
-    split_three: 67,
+    // #1716: one class (`s03-c-m3-sep1-p8-rot2`) moved from two outputs to
+    // three — see the section above.
+    split_two: 2_834,
+    split_three: 68,
     split_more: 9,
     underdetermined: 0,
     sequence_changed: 0,
@@ -349,13 +376,20 @@ const THREE_PRIME: Census = Census {
 /// finer partition is chosen before the shift, so the two members are then
 /// shuffled independently and only some of those landings coincide with the
 /// other spelling's.
+///
+/// **Re-blessed by #1716 with `converged` unchanged at 8 367**, `split_two` down
+/// one and `split_three` up one — the same single class (`s03-c-m3-sep1-p8-rot2`)
+/// as at 3', and no asymmetry this time because the merge the fix declines is
+/// decided before either shuffle. See `THREE_PRIME` for the class's two forms and
+/// for why losing this agreement is not losing correctness.
 const FIVE_PRIME: Census = Census {
     classes: 11_272,
     spellings: 47_392,
     declined: 0,
     converged: 8_367,
-    split_two: 2_826,
-    split_three: 74,
+    // #1716: see `THREE_PRIME` — one class moved from two outputs to three.
+    split_two: 2_825,
+    split_three: 75,
     split_more: 5,
     underdetermined: 0,
     sequence_changed: 0,

--- a/tests/it/issue_1716_codon_frame_merged_span.rs
+++ b/tests/it/issue_1716_codon_frame_merged_span.rs
@@ -1,0 +1,208 @@
+//! Issue #1716: the codon-frame merge must test the span it authorises.
+//!
+//! `general.md:34` — "two variants separated by one or more nucleotides should
+//! be described individually and **not** as a 'delins'" (`DNA/delins.md:17`
+//! restates it verbatim) — is the governing clause at separation one. The only
+//! thing that lifts it is `general.md:35`'s exception, and that clause has
+//! **two** conjuncts:
+//!
+//! > **exception**: two variants separated by one nucleotide, together
+//! > affecting one amino acid, should be described as a "delins".
+//!
+//! `merge_consecutive_edits`' codon-frame predicate implemented the second
+//! conjunct as `same_codon(prev_a.end, next_start)` — the left member's *right*
+//! edge — while the `delins` it authorises spans `prev_a.start ..= next.end`.
+//! For a one-position left member the two are the same test, which is why the
+//! term was harmless when #104 wrote it under `prev_a.start == prev_a.end`.
+//! #292 relaxed that to `prev_a.start <= prev_a.end` to admit chain extension,
+//! and from then on a **wider** left member could satisfy the endpoint test
+//! while the merged span demonstrably covered four or more reference positions
+//! — which cannot lie in one codon, so the exception's second conjunct fails
+//! and nothing licenses the merge.
+//!
+//! # The fixture is the real reproducer, hermetically
+//!
+//! The transcript below is the first 210 nucleotides of the **real** DMD CDS
+//! (`NM_004006.2` / `LRG_199t1`, the transcript the spec itself uses for
+//! `c.145_147delinsTGG`), with the 5'UTR trimmed so `cds_start = 1` and every
+//! `c.` coordinate here is the coordinate on the real transcript. Each string
+//! below was first observed against the prepared reference through
+//! `ferro normalize --reference <dir>`; running them through this fixture
+//! reproduces those outputs byte for byte, which is what makes a `MockProvider`
+//! legitimate here — the guard needs no `FERRO_MANIFEST` and therefore cannot
+//! skip green.
+//!
+//! # What each case is for
+//!
+//! Two cases are the defect, and three are the surrounding population that a
+//! narrowed predicate must **not** disturb: the spec's own worked example, the
+//! chain extension #292 was written for, and a frameshift pair inside one
+//! codon. The ledger record `codon-carve-out-shape-restriction` is `decided`
+//! (WIDEN — the exception reaches every edit type), and it separately records
+//! that it does not implement the frameshift half of its own reasoning, leaving
+//! that question unanswered. This change does not answer it either.
+//!
+//! **All three of those are end-to-end pins on the emitted string, and none of
+//! them guards this predicate.** The PR that added them said so for the chain
+//! extension and not for the other two; it is true of all three, and measuring
+//! it is what found the gap. Forcing `codon_frame_eligible` to `false` — the
+//! codon-frame arm disabled outright — leaves every one of them **passing**,
+//! because the sequence-first canonicalizer re-derives those strings from the
+//! resulting sequence rather than from the members `merge_consecutive_edits` was
+//! handed. They are worth having as composite-output pins; they are not evidence
+//! about the arm.
+//!
+//! **The guards on the arm's two call-site conjuncts are therefore not in this
+//! file at all.** `prev_a.start <= prev_a.end` (which keeps an insertion anchor
+//! out) and the 1-position `next_anchor` width check are both invisible from
+//! here for the same measured reason — the canonicalizer re-derives the same
+//! string either way — so they are pinned as unit tests beside the predicate,
+//! in `normalize::merge`'s own `mod tests`:
+//! `an_insertion_anchor_is_refused_by_the_codon_frame_arm`,
+//! `a_multi_position_next_anchor_is_refused_by_the_codon_frame_arm`, and the
+//! positive control `the_codon_frame_arm_still_merges_the_shape_it_is_for`
+//! that stops the other two passing on a dead arm. Each states its own
+//! measurement.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// First 210 nt of the DMD coding sequence (`NM_004006.2` c.1..c.210).
+///
+/// Bases that matter below, 1-indexed on the `c.` axis: `c.18=A`, `c.19=G`,
+/// `c.20=T`, `c.21=A`; `c.22=G`, `c.23=A`, `c.24=G`; `c.30=T`, `c.31=T`,
+/// `c.32=A`, `c.33=T`; `c.145=C`, `c.146=G`, `c.147=C`.
+const DMD_CDS_PREFIX: &str = concat!(
+    "ATGCTTTGGTGGGAAGAAGTAGAGGACTGTTATGAAAGAGAAGATGTTCAAAAGAAAACA",
+    "TTCACAAAATGGGTAAATGCACAATTTTCTAAGTTTGGGAAGCAGCATATTGAGAACCTC",
+    "TTCAGTGACCTACAGGATGGGAGGCGCCTCCTAGACCTCCTCGAAGGCCTGACAGGGCAA",
+    "AAACTGCCAAAAGAAAAAGGATCCACAAGA",
+);
+
+/// The DMD CDS prefix as a single-exon coding transcript with `cds_start = 1`,
+/// so `c.N` indexes byte `N` of [`DMD_CDS_PREFIX`].
+fn provider_dmd_cds() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = DMD_CDS_PREFIX.to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_004006.2".to_string(),
+        Some("DMD".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(len),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize(input: &str) -> String {
+    let normalizer = Normalizer::new(provider_dmd_cds());
+    let variant = parse_hgvs(input).expect("parse failed");
+    format!(
+        "{}",
+        normalizer.normalize(&variant).expect("normalize failed")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The defect: a net-length-changing pair whose merged span crosses a codon
+// ---------------------------------------------------------------------------
+
+/// `c.[18_19del;21A>C]` merged into `c.18_21delinsTC` on the shipping arm.
+///
+/// The merged span is `c.18..c.21`: `c.18` is in **codon 6** (positions 16-18)
+/// and `c.19_21` is **codon 7**. Two codons, so the pair cannot "together
+/// affect one amino acid" and `general.md:35` does not reach it under any
+/// reading — the merge is unlicensed whatever force `general.md:34` carries.
+/// With the exception out, `general.md:34` / `DNA/delins.md:17` govern and the
+/// two variants are described individually.
+#[test]
+fn del_then_sub_across_a_codon_boundary_stays_individual() {
+    assert_eq!(
+        normalize("NM_004006.2:c.[18_19del;21A>C]"),
+        "NM_004006.2:c.[18_19del;21A>C]",
+    );
+}
+
+/// Second real reproducer, same shape one codon along: the merged span
+/// `c.30..c.33` covers **codon 10** (positions 28-30) and **codon 11**
+/// (31-33). Merged into `c.30_33delinsAG` on the shipping arm.
+#[test]
+fn del_then_sub_across_a_codon_boundary_stays_individual_second_row() {
+    assert_eq!(
+        normalize("NM_004006.2:c.[30_31del;33T>G]"),
+        "NM_004006.2:c.[30_31del;33T>G]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The population that must not move
+// ---------------------------------------------------------------------------
+
+/// The spec's own worked example (`DNA/delins.md:37` — `LRG_199t1:c.145_147delinsTGG`),
+/// on the transcript the spec quotes it against. Both changed positions and the
+/// unchanged one lie in **codon 49** (`c.145_147`), so the exception applies and
+/// it is the *split* that `DNA/delins.md:42` marks `class="invalid"`. Narrowing
+/// the predicate to the merged span must leave this merging.
+///
+/// **This is an end-to-end pin on the emitted string, not a guard on the
+/// predicate** — the same disclosure [`equal_length_chain_extension_is_unchanged`]
+/// carries, and for the same reason. Measured by mutation: with the codon-frame
+/// arm forced off entirely, this test still **passes**, because the
+/// sequence-first canonicalizer re-derives `c.145_147delinsTGG` from the
+/// resulting sequence without ever consulting `merge_consecutive_edits`. What it
+/// pins is that the composite output does not move; what it cannot detect is a
+/// change to the arm this PR narrows. The two guards that *are* sensitive to it
+/// are the two reproducers above (they fail when the pre-#1716 endpoint test is
+/// restored) and `merge_consecutive_edits_tests::test_codon_frame_then_strict_chain`.
+#[test]
+fn spec_worked_example_still_merges_within_one_codon() {
+    assert_eq!(
+        normalize("NM_004006.2:c.[145C>T;147C>G]"),
+        "NM_004006.2:c.145_147delinsTGG",
+    );
+}
+
+/// Chain extension, which is what #292 relaxed `prev_a.start == prev_a.end` to
+/// `prev_a.start <= prev_a.end` in order to admit. `c.18` and `c.19` merge by
+/// strict adjacency first, so the left anchor is already two positions wide
+/// when `c.21` is offered — the exact configuration the narrowed predicate
+/// refuses. This output must survive the narrowing, and it does, because the
+/// sequence-first canonicalizer re-derives the same grouping from the resulting
+/// sequence rather than from the members it was handed.
+#[test]
+fn equal_length_chain_extension_is_unchanged() {
+    assert_eq!(
+        normalize("NM_004006.2:c.[18A>C;19G>T;21A>C]"),
+        "NM_004006.2:c.[18_19inv;21A>C]",
+    );
+}
+
+/// A net-length-changing pair whose merged span *does* lie in one codon
+/// (`c.22_24` is **codon 8**). Whether `general.md:35`'s second conjunct can be
+/// satisfied by a pair that frameshifts every downstream residue is a question
+/// the ledger's `codon-carve-out-shape-restriction` states and then declines to
+/// implement — see the module doc. This fix answers only the span question, so
+/// the row must not move.
+///
+/// Same disclosure as [`spec_worked_example_still_merges_within_one_codon`]: an
+/// end-to-end pin on the string, measured to survive the codon-frame arm being
+/// forced off, so it is not a guard on the predicate either.
+#[test]
+fn frameshift_pair_inside_one_codon_is_left_open() {
+    assert_eq!(
+        normalize("NM_004006.2:c.[22del;24G>C]"),
+        "NM_004006.2:c.22_24delinsAC",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -271,6 +271,7 @@ mod issue_1631_repeat_label_repair;
 mod issue_163_rna_utr3_flag;
 mod issue_165_delins_sub_only_decompose;
 mod issue_1691_homopolymer_convergence;
+mod issue_1716_codon_frame_merged_span;
 mod issue_180_allele_3prime_shift;
 mod issue_182_postcanon_adjacency;
 mod issue_207_multi_repeat_compound_roundtrip;

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -46,9 +46,9 @@
 //! behaviour, not that PR's. The corpus is new; the defects it counts are not.
 //!
 //! **That paragraph is the CORPUS branch speaking, and it no longer holds.**
-//! Four changes have re-blessed figures here since, and there are four
+//! Five changes have re-blessed figures here since, and there are five
 //! RE-BLESSED sections below — one per change, in the order they landed. Read
-//! all four before quoting any figure as a `main` baseline:
+//! all five before quoting any figure as a `main` baseline:
 //!
 //! 1. the amino-acid precondition on `coalesce_coding_frame_separation` (#1599),
 //!    which moved five figures, one of them a net regression in `converged`;
@@ -57,7 +57,9 @@
 //! 3. the two-deletion alignment in the payload splitter (#1649), which moved
 //!    eight and regressed none — the largest confluence move recorded here;
 //! 4. the `standards.md:39` refusal (#1627), which moved two REFUSAL/validity
-//!    figures, both down, identically in both directions.
+//!    figures, both down, identically in both directions;
+//! 5. the codon-frame merge's own span (#1716), which moved six rank-2 figures,
+//!    left `converged` alone in both directions, and raised `split_three` at 3'.
 //!
 //! **The second was measured on the first, not composed with it.** The two
 //! changes' affected row sets are disjoint — verified by diffing the row ids, not
@@ -88,7 +90,7 @@
 //! fix intact — it is now carried by `outputs_intronic_under_a_genomic_wrapper`,
 //! and it is still a claim about the code rather than about the corpus.
 //!
-//! # RE-BLESSED (1 of 4) — #1599, the amino-acid precondition
+//! # RE-BLESSED (1 of 5) — #1599, the amino-acid precondition
 //!
 //! Everything above and in [`THREE_PRIME`]'s own doc was written on the corpus
 //! PR, which touched no normalizer file. **That is no longer the base.** #1599
@@ -127,7 +129,7 @@
 //! #1599, which was the pre-existing baseline and not a regression of its — it is
 //! #1704, three sections down, that finally moves it.
 //!
-//! # RE-BLESSED (2 of 4) — #1536, the cross-axis re-typing carve-out
+//! # RE-BLESSED (2 of 5) — #1536, the cross-axis re-typing carve-out
 //!
 //! This branch adds a third carve-out from the #350 cross-axis bail in
 //! `normalize_cds`, so a `delins`/`inv` whose span straddles a CDS boundary is
@@ -180,7 +182,7 @@
 //! measures **6** at 3', the two extra rows being
 //! `s00-c3{p,m}-cds-end-del-del-p2-sep1`. Every rank-1 counter is unchanged.
 //!
-//! # RE-BLESSED (3 of 4) — #1649, the two-deletion alignment
+//! # RE-BLESSED (3 of 5) — #1649, the two-deletion alignment
 //!
 //! `merge`'s payload splitter could express *insertion, retained reference,
 //! insertion* but not *deletion, retained reference, deletion*, so a payload
@@ -233,7 +235,7 @@
 //! converged. `s00-c3{p,m}-m4-all-del-p1-sep2` is untouched and stays pinned
 //! there — its spanning `delins` still stops where `general.md:34` puts it.
 //!
-//! # RE-BLESSED (4 of 4) — #1627, the alignment-only symbol
+//! # RE-BLESSED (4 of 5) — #1627, the alignment-only symbol
 //!
 //! `background/standards.md:39` footnotes the table's daggered `X` and `-` as
 //! "used in alignment only", and the decided
@@ -287,6 +289,58 @@
 //! `corpus_prohibited_inputs::an_alignment_only_symbol_is_refused_in_every_mode_for_both_x_and_dash`,
 //! which covers the embedded shapes (`delinsACGTX`, `delinsXACGT`,
 //! `delinsACXGT`) the corpus does not generate.
+//!
+//! # RE-BLESSED (5 of 5) — #1716, the codon-frame merge's own span
+//!
+//! `merge_consecutive_edits`' per-member codon-frame predicate asked
+//! `same_codon(prev_a.end, next_start)` — its left anchor's **right** edge —
+//! while authorising a `delins` over `prev_a.start ..= next.end`. A codon is
+//! three positions, so any anchor wider than one base makes that span four or
+//! more and `general.md:35`'s "together affecting one amino acid" cannot hold;
+//! `general.md:34` / `DNA/delins.md:17` then govern and the members stay
+//! individual. Asking the span instead is the fix. (Sibling passes always did:
+//! `apply_coding_codon_exception` and `coalesce_coding_frame_separation`.)
+//!
+//! **Six figures move, all rank 2, and `converged` is unchanged in BOTH
+//! directions:**
+//!
+//! | figure | was (post-#1627) | now | direction |
+//! |---|---|---|---|
+//! | 3' `converged` | 9,402 | **9,402** | unchanged |
+//! | 3' `split_two` | 2,225 | **2,223** | −2, both to `split_three` |
+//! | 3' `split_three` | 223 | **226** | **+3 — rises** |
+//! | 3' `split_more` | 32 | **31** | −1, to `split_three` |
+//! | 5' `converged` | 9,228 | **9,228** | unchanged |
+//! | 5' `split_two` | 2,461 | **2,462** | +1, from `split_more` |
+//! | 5' `split_three` | 167 | **168** | +1, from `split_more` |
+//! | 5' `split_more` | 26 | **24** | −2 |
+//!
+//! **Exactly three family instances move per direction, and they are named**,
+//! because the net counters cannot tell an arity rise from an arity fall when
+//! both happen. The full divergence row-id lists were dumped either side (the
+//! `divergences` cap in [`measure`] raised locally, then restored) and diffed:
+//!
+//! - **0 families lose convergence, 0 gain it, and 0 become divergent that were
+//!   not** — the divergent *set* is byte-identical in both directions (3': 2,480
+//!   families; 5': 2,654). Only three members of it change arity.
+//! - 3': `s00-c1-m4-all-del-p2-sep1` 4 -> 3 (improves);
+//!   `s00-c3p-m4-all-del-p1-sep2` and `s00-c3m-m4-all-del-p1-sep2` 2 -> 3.
+//! - 5': `s00-c1-m4-all-del-p2-sep1` 3 -> 2 and both `m4-all-del-p1-sep2` rows
+//!   4 -> 3 (all three improve).
+//!
+//! **The two rows that rise are already promoted**, which is why this section
+//! adds nothing to `spec_corpus_regressions.rs`:
+//! `the_codon_gate_splits_a_spanning_delins_its_own_members_do_not` has pinned
+//! `s00-c3{p,m}-m4-all-del-p1-sep2` since #1599. What changed there is its
+//! *members'* answer, and it changed toward that test's own clause — the old
+//! `c.[24del;30_33delinsA]` merged across `c.30..c.33`, codon 10 into codon 11.
+//! The pin is updated in this commit with the reason on the row.
+//!
+//! **Every rank-1 counter is unchanged**, in both directions — `outputs`,
+//! `declined`, `unparseable_outputs`, `outputs_denoting_no_sequence`,
+//! `outputs_leaving_the_transcript`, `prohibition_violating_outputs` — as are
+//! `non_idempotent_outputs` (4 / 4), `sequence_changed` (4 / 0), all three
+//! refusal counters and `guard_violations`.
 //!
 //! # CORRECTED — what the transcript-leaving class actually violates
 //!
@@ -494,10 +548,14 @@ pub(crate) const THREE_PRIME: Census = Census {
     // (which cannot tell net from gross). Every moved family goes straight to
     // `converged`, which is why the three deltas below sum exactly to
     // `converged`'s: 215 + 25 + 21 = 261.
+    //
+    // #1716 leaves `converged` alone and moves three family instances between
+    // the `split_*` buckets — see the module docs' fifth RE-BLESSED section for
+    // the three row ids and the diffed divergence sets.
     converged: 9_402,
-    split_two: 2_225,
-    split_three: 223,
-    split_more: 32,
+    split_two: 2_223,
+    split_three: 226,
+    split_more: 31,
     underdetermined: 0,
     // -- idempotency --
     //
@@ -527,7 +585,7 @@ pub(crate) const THREE_PRIME: Census = Census {
 /// partitioner.
 ///
 /// Measured on the same base as [`THREE_PRIME`], and re-blessed by the same
-/// four changes — see the module docs' four RE-BLESSED sections.
+/// five changes — see the module docs' five RE-BLESSED sections.
 ///
 /// The two directions agreeing on every rank-1 counter except
 /// `outputs_leaving_the_transcript` is itself the cross-check the two-direction
@@ -568,9 +626,13 @@ pub(crate) const FIVE_PRIME: Census = Census {
     // is decided the same way in both, but the *follow-on* shuffle it enables
     // runs 3' or 5'. Here 5' moves the larger set (284 against 261), the reverse
     // of #1536.
-    split_two: 2_461,
-    split_three: 167,
-    split_more: 26,
+    //
+    // #1716 moves the same three family instances as at 3', all three
+    // *improving* on this side; `converged` is unchanged. Fifth RE-BLESSED
+    // section.
+    split_two: 2_462,
+    split_three: 168,
+    split_more: 24,
     underdetermined: 0,
     non_idempotent_outputs: 4,
     sequence_changed: 0,

--- a/tests/it/spec_corpus_regressions.rs
+++ b/tests/it/spec_corpus_regressions.rs
@@ -862,6 +862,15 @@ fn a_repeat_typing_at_the_cds_end_overlaps_its_sibling_deletion() {
 /// Its spanning `delins` still stops where `general.md:34` puts it, so everything
 /// this test was promoted to say still holds for it.
 ///
+/// **The members' side moved once, in #1716, and it moved toward this test's own
+/// clause.** It used to read `c.[24del;30_33delinsA]`; that `delins` spans
+/// `c.30..c.33`, i.e. codon 10 (28-30) and codon 11 (31-33), so it was itself a
+/// merge `general.md:35` cannot license — the per-member codon-frame predicate in
+/// `merge::merge_consecutive_edits` was testing its left anchor's right edge
+/// rather than the span it authorised. With the span tested, the pair stays
+/// individual and the answer is `c.[24del;30_31del;33del]`. The two spellings
+/// still disagree, so the row stays; only the fifth column below changed.
+///
 /// What remains unanswered is whether the *members'* answer is reachable from the
 /// `delins` at all under the restored precondition. What is **not** unanswered is
 /// the neighbouring record: `codon-carve-out-shape-restriction` is `decided`, and
@@ -896,7 +905,8 @@ fn the_codon_gate_splits_a_spanning_delins_its_own_members_do_not() {
         "NM_TEST.1:c.24_33delinsAATTTA",
         "NM_TEST.1:c.[24T>A;26_29del;32_33delinsTA]",
         "NM_TEST.1:c.[24del;27del;30del;33del]",
-        "NM_TEST.1:c.[24del;30_33delinsA]",
+        // Was `c.[24del;30_33delinsA]` until #1716 — see the doc above.
+        "NM_TEST.1:c.[24del;30_31del;33del]",
     )];
 
     for strand in [Strand::Plus, Strand::Minus] {
@@ -907,9 +917,11 @@ fn the_codon_gate_splits_a_spanning_delins_its_own_members_do_not() {
             assert_eq!(
                 normalize_3prime(&frame, members),
                 members_output,
-                "{design} ({strand:?}): the authored member spelling's answer is unchanged by \
-                 the amino-acid precondition — if this moved, the divergence below has a \
-                 different cause than the one recorded here"
+                "{design} ({strand:?}): the authored member spelling's answer is the one #1716 \
+                 left it at, with every span the CODON-FRAME arm authorises inside one codon \
+                 — `c.30_31del` is a merged span and straddles codons 10/11, but it is the \
+                 strict-adjacency arm's, which `general.md:35` never gated — if this moved, \
+                 the divergence below has a different cause than the one recorded here"
             );
 
             let output = normalize_3prime(&frame, spanning);


### PR DESCRIPTION
Closes #1716

Representation-Change: 6 of the 1,221 coding separation-one corpus rows move, and 0 of the 592 real multi-member cis alleles harvested from 9,949,738 ClinVar/CMRG/Paraphase rows. Every moved row is a merge whose `delins` span crossed a codon boundary; the merge is withdrawn and the two variants are described individually per `general.md:34`. The real-corpus zero is a property of that corpus rather than of the change — the reproducers are real transcripts (`NM_004006.2` / `LRG_199t1`), the shape just does not occur in ClinVar.

## The defect

`merge_consecutive_edits`' per-member codon-frame predicate (`src/normalize/merge.rs`) asked

```rust
same_codon(prev_a.end, next_start)
```

— the **right** edge of the left member — while the `delins` it authorises spans `prev_a.start ..= next_anchor.end`. A codon is three positions, so whenever `prev_a.start < prev_a.end` the merged span is four or more and cannot lie in one codon. `general.md:35`'s exception has two conjuncts and its second one ("together affecting one amino acid") therefore fails under every reading, so nothing licenses the merge and `general.md:34` / `DNA/delins.md:17` govern.

On the shipping arm (`FERRO_PARTITION` unset), prepared reference:

```
LRG_199t1:c.[18_19del;21A>C]  ->  c.18_21delinsTC     codon 6 + codon 7
LRG_199t1:c.[30_31del;33T>G]  ->  c.30_33delinsAG     codon 10 + codon 11
```

The fix asks the span instead — `same_codon(prev_a.start, next_start)` — which is the idiom the two sibling passes already use (`apply_coding_codon_exception` keys off the left piece's start; `coalesce_coding_frame_separation` tests `pair[0].ref_start` against `pair[1].ref_end - 1`).

## Why this does not narrow #292's chain extension

The term was harmless when #104 wrote it under `prev_a.start == prev_a.end`; #292 (`8c3732ca`) relaxed that to `<=` to admit chain extension, and only then did the endpoint choice stop being equivalent. Given `prev_a.end + 2 == next_start`, `same_codon(prev_a.start, next_start)` can hold only when `prev_a.start == prev_a.end`, so on paper the change reverts #292's relaxation for this predicate.

It does not revert its **output**, and that is measured rather than argued. A chain grown by strict adjacency is length-preserving, so the sequence-first canonicalizer re-derives it and `build_split_variants` re-cuts it on the codon boundary — and #1524 already re-blessed those outputs to the un-merged form (`c.[3G>T;4C>G;6A>T]` -> `c.[3_4delinsTG;6A>T]`, `c.[3_4delinsCG;6A>T]` -> itself). So the merge and the decline emit the same string. **All 16 `issue_275_codon_frame_extensions` tests pass unchanged**, including both chain-extension cases, and on the real reference `LRG_199t1:c.[18A>C;19G>T;21A>C]` still gives `c.[18_19inv;21A>C]`.

`prev_a.start <= prev_a.end` is kept and is still load-bearing: an insertion anchor has `start == end + 1 == next_start - 1`, which would land in one codon two thirds of the time.

## Blast radius, measured

Base `origin/main` = `2f4e3bb9`, `FERRO_MANIFEST` set on every run, freshly built in this worktree.

**Corpus census** — coding-shape `RowKind::Family` rows at separation exactly one, counting rows whose normalized output has fewer members than the authored spelling:

| direction | before | after |
|---|---:|---:|
| 3' | 450 of 1,221 | **444** |
| 5' | 433 of 1,221 | **429** |

Six distinct rows drop and **nothing is added**. All six are the same shape — a left member wider than one base and a merged span crossing a codon boundary:

```
s01-c1-pair-del-sub-p2-sep1     c.[9_10del;12C>G]        -> c.9_12delinsAG     codons 3+4
s01-c1-pair-sub-del-p2-sep1     c.[9T>A;11_12del]        -> c.9_12delinsAG     codons 3+4
s01-c3m-pair-del-sub-p2-sep1    c.[24_25del;27T>A]       -> c.24_27delinsAA    codons 8+9
s01-c3p-pair-del-sub-p2-sep1    c.[24_25del;27T>A]       -> c.24_27delinsAA    codons 8+9
s00-c1-pair-delins-del-p2-sep1  c.[9_10delinsAC;12_13del] -> c.9_12delinsAC    codons 3+4
s00-c1-mid-cds-delins-del-p2-sep1  (same variant, second family)
```

**The licensed population is untouched**, verified row by row in the same census: the eight two-substitutions-in-one-codon rows (`c.[52G>T;54C>G]` -> `c.52_54delinsTAG`, `c.[52A>C;54T>A]` -> `c.52_54delinsCAA`) still merge, and so does the whole-block inversion `c.[9_12inv;14_17inv;19_22inv]` -> `c.9_22inv`. So does the frameshift-inside-one-codon class (`c.[52del;54del]` -> `c.52_54delinsA`, `c.[52delinsT;54del]` -> `c.52_54delinsTA`) — `codon-carve-out-shape-restriction` records that question as unimplemented and this change does not answer it.

**Census pins re-blessed, and `converged` moves in neither direction.** Both `spec_conformance_axis` censuses and both `cis_confluence_axis` censuses shift rank-2 figures only. The full divergence row-id lists were dumped either side (the `divergences` / `worst` caps raised locally, then restored) and diffed by class id:

- **0 families lose convergence, 0 gain it, 0 become divergent that were not**, in any of the four censuses. The divergent sets are identical (conformance 3': 2,480; 5': 2,654; confluence 3': 2,911; 5': 2,905).
- Only three family instances change arity per conformance direction: 3' `s00-c1-m4-all-del-p2-sep1` 4→3 (improves) and `s00-c3{p,m}-m4-all-del-p1-sep2` 2→3; 5' the same three, all improving (3→2 and 4→3).
- Confluence: exactly one class, `s03-c-m3-sep1-p8-rot2`, 2→3 in both directions. What it stopped agreeing with is `c.9_18delinsATGAGTAAAGTCCTGGCA` — a merge across codons 3 to 6. Agreement is lost, correctness is not.

Every rank-1 counter is unchanged in both directions, as are `non_idempotent_outputs`, `sequence_changed`, all three refusal counters and `guard_violations`.

The two rows that rise in arity at 3' are already promoted — `spec_corpus_regressions::the_codon_gate_splits_a_spanning_delins_its_own_members_do_not` has pinned `s00-c3{p,m}-m4-all-del-p1-sep2` since #1599. Its *members'* side moved, toward that test's own clause: the old `c.[24del;30_33delinsA]` spanned codon 10 into codon 11, and is now `c.[24del;30_31del;33del]`. The row and the reason are updated there.

**Real corpus.** All 592 multi-member cis alleles in `tests/fixtures/cis/multi_member_cis_alleles.json` — the complete set of real-world inputs that reach `merge_consecutive_edits`, harvested from 9,949,738 ClinVar/CMRG/Paraphase rows — normalized through `ferro normalize -i <inputs> --reference <dir> -f tsv` on both revisions: **0 rows move**, 111 pre-existing normalize errors either side. Single-member inputs cannot reach this pass at all (it is called only from `normalize_allele`).

## Tests

`tests/it/issue_1716_codon_frame_merged_span.rs` is hermetic — the fixture is the first 210 nt of the real DMD CDS with the 5'UTR trimmed, so every `c.` coordinate is the real one and the guard needs no `FERRO_MANIFEST` and cannot skip. It pins both reproducers by exact string, and three rows that must not move: the spec's own `c.145_147delinsTGG` worked example (`DNA/delins.md:37` — `:42` is the NOTE marking the *split* invalid, and the module cites each for its own half now), #292's chain extension, and the frameshift-in-one-codon shape.

**Those three are end-to-end pins on the emitted string and none of them guards the predicate**, which the module now says for all three rather than for the chain extension alone. Measured: with `codon_frame_eligible` forced `false` — the codon-frame arm disabled outright — all three still **pass**, because the sequence-first canonicalizer re-derives those strings from the resulting sequence. They are worth having as composite-output pins; they are not evidence about this arm.

### The arm's two call-site conjuncts now have guards, beside the predicate

Mutation found that `prev_a.start <= prev_a.end` (which keeps an insertion anchor out of the arm) and the 1-position `next_anchor` width check were detected by **nothing** — not by any of the 582 tests in the `issue_1716 + issue_275 + codon + merge + spec_corpus_regressions` selection. Both are documented at length in the comment this PR rewrites, and this change makes the first of them roughly twice as load-bearing (`same_codon(start, next_start)` holds for two frames in three where `same_codon(end, next_start)` held for one).

They could not be closed end to end, and that was measured rather than assumed: a probe of eighteen insertion-anchored and multi-position-`next` descriptions through `Normalizer::normalize` returns **byte-identical output with and without each conjunct** — `c.[19_20insG;21A>C]` normalizes to `c.20_21delinsGTC` either way, because the canonicalizer re-derives it. So the guards are unit tests over `merge_consecutive_edits` itself, in `normalize::merge`'s own `mod tests`:

| test | kills |
|---|---|
| `an_insertion_anchor_is_refused_by_the_codon_frame_arm` | dropping `&& prev_a.start <= prev_a.end` |
| `a_multi_position_next_anchor_is_refused_by_the_codon_frame_arm` | dropping the width check — two cases, one per disjunct (`start != end`, `alt.len() > 1`) |
| `the_codon_frame_arm_still_merges_the_shape_it_is_for` | the positive control: without it the two above are satisfied by an arm that never merges |

Re-run after adding them, each mutation applied to a `cp` backup and restored:

| mutation | before | after |
|---|---|---|
| drop `prev_a.start <= prev_a.end` | 0 of 582 fire | **FAIL** `an_insertion_anchor_is_refused_by_the_codon_frame_arm` (merged to `c.20_21delinsGTC`) |
| drop the whole width check | 0 of 582 fire | **FAIL** `a_multi_position_next_anchor_is_refused_by_the_codon_frame_arm` (merged to `c.19_22delinsTT`, a four-position span) |
| drop only `\|\| next_anchor.alt.len() > 1` | — | **FAIL** the same test's second case (merged to `c.19_21delinsTTCC`) |
| `codon_frame_eligible -> false` | 1 of 582 fires | **FAIL** `the_codon_frame_arm_still_merges_the_shape_it_is_for` — so the positive control is not vacuous |

Also corrected: the re-pinned message in `spec_corpus_regressions` claimed "every merged span inside one codon" while its own pinned value contains `c.30_31del`, which straddles codons 10/11. That span is the **strict-adjacency** arm's, which `general.md:35` never gated; the message now says so.

## Verification

- `cargo nextest run --features dev` — **10,403 passed, 0 failed, 152 skipped**, `FERRO_MANIFEST` set, no `not run due to signal` in the log.
- `cargo fmt --all --check` — clean.
- `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- Both spec artifacts regenerated (`--bin generate_spec_fixture`, `--bin generate_spec_enumeration`) before every test run.

