### PR TITLE
fix(normalize): scope the compensating-gap coalesce to the coding DNA axis

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3062,7 +3062,14 @@ pub(crate) fn canonicalize_from_sequence<P: ReferenceProvider>(
     // partitioner produced the pieces. Shipped output is unaffected either way —
     // `FERRO_PARTITION` unset is `Live` — but a bake-off column can carry a
     // widening the arm it is labelled with did not cause.
-    if partition_rule().cuts_with_canonical() {
+    // Scoped to the coding DNA axis as well as to the arms, per the decided
+    // `delins-payload-coincidence-carve-out-is-coding-dna-scoped` (#1711): the
+    // pass can only merge *across unchanged reference bases*, which is exactly
+    // the population `general.md:34` keeps individual, and `DNA/delins.md:47` —
+    // the only clause that overrides it here — reaches `c.` and nothing else.
+    // See `compensating_gap_coalesce_applies` for the argument and for the
+    // competing reading it decides against.
+    if compensating_gap_coalesce_applies(partition_rule(), kind) {
         coalesce_compensating_gap_split(&mut pieces, &ref_bytes);
     }
     coalesce_whole_block_inversion(&mut pieces, &ref_bytes);
@@ -5185,6 +5192,42 @@ const MIN_MANUFACTURED_SPLIT_MEMBERS: usize = 3;
 /// `general.md:34` keeps them individual. **There are no counterexamples in the
 /// 65 rows.**
 ///
+/// # …but there ARE counterexamples in the 11,272-class conformance corpus
+///
+/// **Corrected 2026-08-12 (#1711).** The sentence directly above is true of the
+/// corpus it names and was read as a property of the rule. It is not. Six rows
+/// of `conformance::spec_corpus` fire this pass and are merged wrongly, and the
+/// spec corpus counts them itself, through the negative guard it carries for the
+/// **rejected** SVD-WG010 proposal — `spec_conformance_axis`'s `guard_violations`,
+/// pinned at 0, read 6 in both directions on both canonical arms:
+/// `s01-n3{m,p}-pair-del-inv-p4-sep1`, `scale-g-block{128,1032}-inv-del` and
+/// `scale-g-block{248,1032}-delins-del`.
+///
+/// **None of the three conditions is about the axis, and two of them are
+/// satisfied by construction on that shape.** An `inv` or a payload-bearing
+/// `delins` member presents to an edit-distance aligner as inserted somewhere
+/// and deleted somewhere else, so condition 2 holds; and the big `del` beside it
+/// makes condition 3 hold, since [`changed_columns_of_pieces`] counts a
+/// deletion's full reference width. Worked, on the `n3m`/`n3p` row — the derived
+/// pieces over `CGATTTCTG` are `[3,8)/"" · gap 2 · [10,11)/"A" · gap 1 ·
+/// [12,12)/"A"`, so 7 claimed columns against 3 unchanged and `inserted &&
+/// deleted` both true. Note the pass swallowed a **two**-base run as well as a
+/// one-base one: there is no per-gap notion of separation in here at all, and
+/// none of the arithmetic implements "one unchanged base".
+///
+/// So the fix is not in the conditions. The caller now gates the pass on the
+/// **coding DNA axis** ([`compensating_gap_coalesce_applies`]), which is where
+/// `DNA/delins.md:47` — the only clause that can license merging across
+/// unchanged bases at all — was decided to reach. Read that gate's doc before
+/// changing anything here: it also records the competing reading, under which
+/// this rule is partitioner parity rather than a `:47` re-spelling and would
+/// apply on every axis.
+///
+/// **Nothing downstream re-audits the merge.** `split_concealed_separations`
+/// runs *before* this pass and is gated on `pieces.len() >= 2`, so once one
+/// spanning piece is written it is final. That is why the gate is at the call
+/// site and not a later repair.
+///
 /// So this takes no threshold and no constant, which is deliberate: the live
 /// path's [`MAX_SINGLE_BASE_SEPARATION_CHANGE`] records that its own value is
 /// "under-determined", constrained only to `[2, 15)`, and that "no threshold at
@@ -6273,6 +6316,117 @@ fn payload_coalesce_applies(rule: PartitionRule, kind: CisKind) -> bool {
     // be given *different* arms — and would compile, so the drift would be
     // silent. One rule, written once.
     rule == PartitionRule::CanonicalCoalesced && AxisFrame::is_coding_dna(kind)
+}
+
+/// Whether [`coalesce_compensating_gap_split`] applies, given the arm and the
+/// axis the description is written on.
+///
+/// The **same** clause and the **same** axis scope as [`payload_coalesce_applies`],
+/// differing only in the arm half, and that difference is the whole reason the
+/// two gates are separate functions rather than one. `delins.md:47`'s carve-out
+/// is a [`PartitionRule::CanonicalCoalesced`] behaviour when it is undoing a
+/// *payload* coincidence, because the live partitioner produces that split too;
+/// the compensating-gap shape is produced only by `partition_block_canonical`,
+/// so its pass is scoped to both canonical arms
+/// ([`PartitionRule::cuts_with_canonical`]) and the reasoning for that scoping is
+/// at the call site in [`canonicalize_from_sequence`].
+///
+/// # Why the axis half is here at all (#1711)
+///
+/// Because the two passes re-spell the same clause and were given different
+/// scopes. [`coalesce_compensating_gap_split`] merges a run of derived members
+/// into one spanning `delins`, and it can only ever do so **across unchanged
+/// reference bases** — a piece list with no gaps between its members is one
+/// piece, so the pass would have nothing to join. Every firing is therefore
+/// inside the population `general.md:34` governs: "two variants separated by one
+/// or more nucleotides should be described individually and **not** as a
+/// 'delins'". The only clause that overrides it for this shape is
+/// `DNA/delins.md:47`, and the decided operator ruling
+/// `delins-payload-coincidence-carve-out-is-coding-dna-scoped` (2026-08-11)
+/// scopes `:47` to the coding DNA axis "and nothing else"; its sibling
+/// `delins-merge-vs-individual-gap-two-or-more` says the same thing from the
+/// other side — "rows on an axis with no reading frame … remain violations and
+/// are untouched by this ruling".
+///
+/// So the merge had no licence off `c.`, and six rows of the spec conformance
+/// corpus were counted by that corpus's own negative guard for the **rejected**
+/// SVD-WG010 proposal: two variants one unchanged base apart, on `g.` and `n.`,
+/// merged into one spanning `delins`. See #1711.
+///
+/// # It is the AXIS KIND, not `AxisFrame::reading_frame`
+///
+/// The same trap [`payload_coalesce_applies`] documents, for the same reason:
+/// `reading_frame` is true for a coding `r.` too, and a `DNA/` clause has no
+/// jurisdiction over the RNA axis (`RNA/delins.md` states no `:47` counterpart).
+/// Keying on the frame flag would extend a DNA-only carve-out onto an axis the
+/// ruling deliberately does not reach.
+///
+/// # What this does NOT claim
+///
+/// [`coalesce_compensating_gap_split`]'s own doc argues its rule from the
+/// *partitioner*: `partition_block` forbids compensating gaps in its search, and
+/// this pass states that restriction on the derived pieces instead. That
+/// argument is about why the split exists; it is not a licence for the
+/// **output**, which is a spanning `delins` across unchanged bases and needs one.
+/// Both readings are real and they disagree off `c.` — the parity reading would
+/// apply the pass on every axis — so the cost of choosing the clause is stated
+/// where it is paid, below, rather than hidden here.
+///
+/// # MEASURED, and the cost is not small
+///
+/// Instrumented over the 11,272-class spec conformance corpus with the arm set
+/// to `canonical`. The gate suppresses **exactly** the non-coding-DNA firings
+/// and no others — 2,101 of 4,204 at 3' (995 `g.`, 1,106 `n.`) and 1,892 of
+/// 3,722 at 5' (916 `g.`, 976 `n.`) — leaving all 2,103 / 1,830 `c.` firings
+/// untouched. That partition is arithmetic, not a threshold: there is no
+/// tunable here and no row in between.
+///
+/// Of those suppressed firings, **1,471 output strings move at 3' and 1,304 at
+/// 5'**, over 58,412 outputs and 260 / 230 distinct corpus rows, **0 of them on
+/// `c.`**. At 3' the direction is 1,387 splits, 65 re-spellings and 19 merges;
+/// at 5' it is 1,237 / 48 / 19. So the price is real and is paid in split
+/// genomic and non-coding descriptions, which is precisely the price
+/// `delins-payload-coincidence-carve-out-is-coding-dna-scoped` already accepted
+/// for the sibling pass when it kept a stored 723-base `g.` `delins` as a
+/// 193-member re-derivation.
+///
+/// **Nothing else moves.** Every other figure of `spec_conformance_axis`'s
+/// census is byte-identical in both directions on both canonical arms — only
+/// `guard_violations` moves, 6 -> 0 — and so are all six `cis_confluence_axis` /
+/// `cis_confluence_nr_axis` censuses on the `canonical` arm, down to the
+/// divergent class ids (`s02-r-m3-sep1-p1-rot3`, `s02-r-m4-sep1-p1-rot3`,
+/// `s06-{g,n,r}-m4-sep1-p1-all-dup`). A census counts *classes*, and a class
+/// whose every spelling moves together stays converged, so those zeros are a
+/// statement about confluence and emphatically not about representation
+/// stability — the 1,471 / 1,304 figure above is the one that measures that.
+/// Shipped output does not move at all: `FERRO_PARTITION` unset is
+/// [`PartitionRule::Live`], which never reached this pass.
+///
+/// # A narrower cut was looked for, and the search FAILED
+///
+/// Recorded so it is not re-run. The obvious repair is a per-gap test inside the
+/// pass, since its three conditions are aggregates over the whole hull and none
+/// of them is about separation. Every candidate was evaluated over the full 5'
+/// firing dump, asking it to refuse all 12 guarded-row firings and few others:
+///
+/// | candidate condition | refuses of the 12 | refuses of the other 3,710 |
+/// |---|---|---|
+/// | some gap sits at cumulative offset 0 | 2 | 1,646 |
+/// | some gap is exactly one base | 12 | 3,124 |
+/// | claimed columns < twice the unchanged bases | 8 | 3,077 |
+/// | three or more unchanged bases in the hull | 12 | 3,608 |
+/// | hull of nine bases or more | 12 | 2,981 |
+///
+/// The zero-offset test is the one with a principled story — an unchanged run at
+/// zero shift is unchanged *in place* rather than by coincidence — and it is
+/// refuted outright: on all six rows **every** gap sits at a non-zero cumulative
+/// offset (the `n3m` row's two gaps are both at −5). Nothing else separates the
+/// populations at all; each predicate that catches all 12 also catches 80–97% of
+/// the rest. The axis is the only clean separator in the data, and it is also
+/// the one a decided ruling names.
+fn compensating_gap_coalesce_applies(rule: PartitionRule, kind: CisKind) -> bool {
+    // As above: one spelling of the axis scope, shared with the sibling gate.
+    rule.cuts_with_canonical() && AxisFrame::is_coding_dna(kind)
 }
 
 /// Re-spell a multi-member allele as the single `delins` the spec recommends,
@@ -13673,6 +13827,82 @@ mod tests {
                         "{rule:?} must not run the `delins.md:44-47` re-spelling"
                     );
                 }
+            }
+        }
+
+        /// The compensating-gap re-spelling carries the **same** axis scope, and
+        /// a **wider** arm scope. #1711.
+        ///
+        /// Both halves are asserted because getting either wrong is a defect
+        /// that has already happened here. Dropping the axis half is #1711
+        /// itself: the pass merged two variants one unchanged base apart on `g.`
+        /// and `n.` into one spanning `delins`, which is the **rejected**
+        /// SVD-WG010 proposal and what `spec_conformance_axis`'s
+        /// `guard_violations` counts. Narrowing the arm half to
+        /// [`PartitionRule::CanonicalCoalesced`] — the obvious way to "make it
+        /// match its sibling" — would silently stop auditing
+        /// [`PartitionRule::Canonical`], whose partitioner is the one that
+        /// manufactures the split in the first place.
+        ///
+        /// The pure predicate rather than the call site, for the reason the test
+        /// directly above states: `partition_rule()` caches in a `OnceLock`.
+        #[test]
+        fn the_compensating_gap_coalesce_needs_both_a_canonical_arm_and_the_coding_dna_axis() {
+            for rule in [PartitionRule::Canonical, PartitionRule::CanonicalCoalesced] {
+                assert!(
+                    compensating_gap_coalesce_applies(rule, CisKind::Cds),
+                    "{rule:?} cuts with `partition_block_canonical`, so it is the \
+                     partitioner whose compensating gaps this pass exists to undo"
+                );
+                for kind in [CisKind::Genome, CisKind::Mt, CisKind::Tx, CisKind::Rna] {
+                    assert!(
+                        !compensating_gap_coalesce_applies(rule, kind),
+                        "{kind:?} is outside `DNA/delins.md:47`'s scope; `general.md:34` \
+                         governs and the members stay individual (#1711)"
+                    );
+                }
+            }
+            for rule in [PartitionRule::Live, PartitionRule::Shadow] {
+                for kind in [
+                    CisKind::Genome,
+                    CisKind::Mt,
+                    CisKind::Cds,
+                    CisKind::Tx,
+                    CisKind::Rna,
+                ] {
+                    assert!(
+                        !compensating_gap_coalesce_applies(rule, kind),
+                        "{rule:?} does not cut with the canonical partitioner, so its \
+                         boundaries are not the ones this pass argues about"
+                    );
+                }
+            }
+        }
+
+        /// The two gates agree on the axis, and disagree on the arm, **by
+        /// construction rather than by coincidence**.
+        ///
+        /// One clause, one axis scope: if a future change moves
+        /// `delins.md:47`'s jurisdiction, both passes must move together or one
+        /// of them is re-spelling a merge the ruling withdrew. Written as a
+        /// cross-product equality rather than as two independent expectations,
+        /// because two hand-written matrices are exactly how the scopes drifted
+        /// apart in the first place (#1711).
+        #[test]
+        fn the_two_delins_47_gates_share_one_axis_scope() {
+            for kind in [
+                CisKind::Genome,
+                CisKind::Mt,
+                CisKind::Cds,
+                CisKind::Tx,
+                CisKind::Rna,
+            ] {
+                assert_eq!(
+                    payload_coalesce_applies(PartitionRule::CanonicalCoalesced, kind),
+                    compensating_gap_coalesce_applies(PartitionRule::CanonicalCoalesced, kind),
+                    "the two `delins.md:47` re-spellings disagree about {kind:?}; \
+                     they answer to one ruling and must carry one axis scope"
+                );
             }
         }
 

--- a/tests/it/partition_switch_wiring.rs
+++ b/tests/it/partition_switch_wiring.rs
@@ -12,7 +12,7 @@
 //! reporting is the *original* defect this switch was given a refusal to prevent:
 //! a bake-off served the shipped rule under a candidate's name, coming back with
 //! a clean empty diff that reads as "the candidate changes nothing". So the
-//! wiring is the contract, and these two tests pin both halves of it:
+//! wiring is the contract, and the first two tests pin both halves of it:
 //!
 //! - the behaviour, end to end, through the `ferro` binary — a misspelling exits
 //!   non-zero with the message, a real arm still runs, and `--help` keeps working;
@@ -23,8 +23,30 @@
 //! The second is a source scan, so it proves the call is *written*, not that it
 //! is reached. The first is what proves it is reached, and it is written against
 //! the binary a user actually runs.
+//!
+//! # A third test, about a different call site the arms are the only way to reach
+//!
+//! `canonicalize_from_sequence` calls `coalesce_compensating_gap_split` behind
+//! `compensating_gap_coalesce_applies(partition_rule(), kind)` — the arm **and**
+//! the axis (#1711). `merge.rs`'s own unit tests pin that predicate exhaustively,
+//! and they can only pin the predicate: `partition_rule()` caches into a
+//! process-global `OnceLock`, so an in-process test cannot select the `canonical`
+//! / `canonical-coalesced` arms the pass runs on. That reads as "the call site
+//! cannot be tested", and it is not — a **subprocess** gets its own `OnceLock`,
+//! which is exactly what the two tests above already exploit, against the mock
+//! provider and so with no prepared reference.
+//!
+//! Measured before this test existed, and the reason it now does: replacing
+//! that call site's axis argument with a hardcoded `CisKind::Cds` — #1711
+//! restored verbatim — left the whole suite passing and clippy exiting 0. A
+//! well-guarded predicate wired to nothing is indistinguishable from a fix.
+//!
+//! It lives here rather than beside the predicate because what it asks is
+//! whether the call site consults the axis at all. That is a wiring question,
+//! and the answer to it survives either reading of what `DNA/delins.md:47`
+//! reaches.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
@@ -45,16 +67,20 @@ fn repo_root() -> PathBuf {
 /// under the default strict mode.
 const SHIFTED: &str = "NM_000088.3:c.16del";
 
-/// Run `ferro normalize` over one variant with `FERRO_PARTITION` set to `value`.
+/// Run `ferro normalize` over `inputs` with `FERRO_PARTITION` set to `value`.
 ///
-/// The mock provider serves `NM_000088.3`, so no `--reference` and no prepared
-/// reference directory is needed.
-fn normalize_one(value: &str) -> std::process::Output {
+/// The mock provider serves every accession used here, so no `--reference` and
+/// no prepared reference directory is needed — which is what makes driving the
+/// real binary cheap enough to be the default answer whenever a `OnceLock` puts
+/// a switch out of an in-process test's reach.
+fn normalize(inputs: &[&str], value: &str) -> std::process::Output {
     let mut input = tempfile::Builder::new()
         .suffix(".txt")
         .tempfile()
         .expect("create input file");
-    writeln!(input, "{SHIFTED}").expect("write input");
+    for line in inputs {
+        writeln!(input, "{line}").expect("write input");
+    }
     input.flush().expect("flush input");
 
     Command::new(env!("CARGO_BIN_EXE_ferro"))
@@ -64,6 +90,11 @@ fn normalize_one(value: &str) -> std::process::Output {
         .env("FERRO_PARTITION", value)
         .output()
         .expect("run ferro normalize")
+}
+
+/// Run `ferro normalize` over one variant with `FERRO_PARTITION` set to `value`.
+fn normalize_one(value: &str) -> std::process::Output {
+    normalize(&[SHIFTED], value)
 }
 
 /// A misspelled arm name stops the CLI before it reads input, and a real one does
@@ -194,4 +225,121 @@ fn every_binary_target_reports_a_refused_partition_switch() {
          `ferro_hgvs::normalize::partition_switch_startup_error()` after \
          argument parsing and fail on `Some`."
     );
+}
+
+/// The two `partition_block_canonical` arms — the ones
+/// `PartitionRule::cuts_with_canonical` names, and the only ones on which
+/// `coalesce_compensating_gap_split` runs at all.
+const CANONICAL_ARMS: [&str; 2] = ["canonical", "canonical-coalesced"];
+
+/// A cis allele on the **non-coding** `n.` axis whose re-derivation carries a
+/// compensating gap, so the pass fires on it once the axis test is bypassed.
+///
+/// The mock `NR_000123.1` is `ACGTACGTACGT` with no CDS, so `n.` is
+/// transcript-relative and the axis is `CisKind::Tx` — `false` under both
+/// `AxisFrame::is_coding_dna` and `AxisFrame::carries_translated_frame`, which
+/// is what makes it a test of the *kind* rather than of the frame flag.
+///
+/// The shape is the one #1711 was found on: an `inv` and a `del` one unchanged
+/// base apart, the same family as the spec conformance corpus rows
+/// (`s01-n3{m,p}-pair-del-inv-p4-sep1`) whose merge that corpus's own negative
+/// guard for the **rejected** SVD-WG010 proposal counts.
+const NONCODING_COMPENSATING_GAP: &str = "NR_000123.1:n.[2_4inv;6del]";
+
+/// What the pass makes of [`NONCODING_COMPENSATING_GAP`] when the axis test is
+/// bypassed: one `delins` spanning the members *and the unchanged bases between
+/// them* — two variants merged across a gap `general.md:34` keeps individual.
+///
+/// Measured on the mutated builds rather than reasoned about, on both arms of
+/// [`CANONICAL_ARMS`].
+const NONCODING_MERGED: &str = "NR_000123.1:n.2_6delinsACGA";
+
+/// The coding-axis control, in the same shape, on the mock `NM_000088.3`.
+///
+/// It is here so this test cannot pass in a build where the pass is simply never
+/// called — which is the one mutation the negative half above is blind to, and
+/// which would look exactly like the fix. Removing the call site entirely splits
+/// this row into `c.[2dup;4_5inv;8_9del]` instead (measured), so the assertion
+/// below fails.
+const CODING_COMPENSATING_GAP: &str = "NM_000088.3:c.[3_7inv;9del]";
+
+/// The single spanning `delins` [`CODING_COMPENSATING_GAP`] must still reach on
+/// the coding axis, where `DNA/delins.md:47`'s carve-out does apply.
+const CODING_MERGED: &str = "NM_000088.3:c.3_9delinsTGGGCA";
+
+/// Each input's normalized output, read out of `ferro normalize`'s stdout.
+///
+/// A row the normalizer left alone is printed as the input alone, with no arrow,
+/// so it maps to itself; anything else would silently drop exactly the rows a
+/// caller most wants to see unchanged.
+fn normalized_outputs(inputs: &[&str], arm: &str) -> BTreeMap<String, String> {
+    let out = normalize(inputs, arm);
+    assert!(
+        out.status.success(),
+        "`ferro normalize` failed under FERRO_PARTITION={arm}; stderr was:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let mut parsed = BTreeMap::new();
+    for line in stdout.lines() {
+        let (input, output) = line.split_once(" -> ").unwrap_or((line, line));
+        if inputs.contains(&input) {
+            parsed.insert(input.to_string(), output.to_string());
+        }
+    }
+    for input in inputs {
+        assert!(
+            parsed.contains_key(*input),
+            "no output for {input} under FERRO_PARTITION={arm}; stdout was:\n{stdout}"
+        );
+    }
+    parsed
+}
+
+/// The compensating-gap coalesce consults the **axis** at its call site, not
+/// only in its predicate. #1711.
+///
+/// Both directions in one test, for the reason the misspelling test above gives:
+/// a build that declined the pass on *every* axis would satisfy the negative
+/// half while making the pass dead, and in a log that is indistinguishable from
+/// the fix working.
+///
+/// The negative half deliberately does **not** pin the split spelling. What
+/// `general.md:34` governs is that the members stay individual; which individual
+/// members the re-derivation lands on is a separate question, and pinning it
+/// here would redden this guard for changes that leave its subject untouched.
+#[test]
+fn the_cli_declines_the_compensating_gap_coalesce_off_the_coding_dna_axis() {
+    for arm in CANONICAL_ARMS {
+        let outputs =
+            normalized_outputs(&[NONCODING_COMPENSATING_GAP, CODING_COMPENSATING_GAP], arm);
+
+        let noncoding = &outputs[NONCODING_COMPENSATING_GAP];
+        assert_ne!(
+            noncoding, NONCODING_MERGED,
+            "on FERRO_PARTITION={arm} the `n.` row merged across the unchanged \
+             base between its members. That is the **rejected** SVD-WG010 \
+             proposal, and `DNA/delins.md:47` — the only clause that licenses \
+             merging across unchanged bases — reaches `c.` and nothing else \
+             (`delins-payload-coincidence-carve-out-is-coding-dna-scoped`). The \
+             call site must pass the description's own axis to \
+             `compensating_gap_coalesce_applies`, not a constant (#1711)."
+        );
+        assert!(
+            noncoding.contains(';'),
+            "on FERRO_PARTITION={arm} the `n.` row collapsed to one member \
+             ({noncoding}); off the coding DNA axis `general.md:34` governs and \
+             the members stay individual (#1711)"
+        );
+
+        let coding = &outputs[CODING_COMPENSATING_GAP];
+        assert_eq!(
+            coding, CODING_MERGED,
+            "on FERRO_PARTITION={arm} the `c.` row did not reach the spanning \
+             `delins`, so this test is no longer measuring anything: the pass is \
+             not running on the arm it is scoped to, and the assertion above \
+             would hold in a build that had simply deleted the call. Check the \
+             call site before re-blessing this string."
+        );
+    }
 }


### PR DESCRIPTION
Closes #1711.

## What was wrong

`coalesce_compensating_gap_split` (`src/normalize/merge.rs`) re-spells a canonical-arm split as the single spanning `delins` of `DNA/delins.md:44-47`. It runs only on the two `partition_block_canonical` arms, which is why the defect is flip-specific — with `FERRO_PARTITION` unset the shipped `live` arm never reaches it.

The pass can only ever join pieces **across unchanged reference bases**: a piece list with no gaps between its members is one piece, so there would be nothing to join. Every firing therefore sits inside the population `general.md:34` governs — "two variants separated by one or more nucleotides should be described individually and **not** as a 'delins'" — and the only clause that can override it for this shape is `DNA/delins.md:47`.

`:47`'s reach is already settled. The decided `rulings[delins-payload-coincidence-carve-out-is-coding-dna-scoped]` (2026-08-11) scopes it to the coding DNA axis "and nothing else"; its sibling `rulings[delins-merge-vs-individual-gap-two-or-more]` says the same from the other side — rows on an axis with no reading frame "remain violations and are untouched by this ruling". The sibling pass `coalesce_payload_alignment_split` was gated on that ruling and this one was not, so **one clause had two answers on one arm**: on `CanonicalCoalesced`, a `g.` payload coincidence is refused a merge by one pass and granted it by the other, two statements earlier in the same function.

Off `c.` the ungated pass merged two variants one unchanged nucleotide apart into one spanning `delins` — the answer of the **rejected** proposal SVD-WG010 — on six rows of the spec conformance corpus, which that corpus's own negative guard counts.

These are a **rule 2** miss (Recommended form, best effort): `general.md:34` grades as a preference, per `rulings[separation-rule-force-modal-or-negation]` (ruled 2026-08-12, landing separately — it is not in this branch's ledger), and `DNA/delins.md:81` restates the same rule with "preferably". Rule 2 still binds — a preference clause outranks maintainer judgement — which is why the fix is worth making.

## The fix

A sibling gate to `payload_coalesce_applies`:

```rust
fn compensating_gap_coalesce_applies(rule: PartitionRule, kind: CisKind) -> bool {
    rule.cuts_with_canonical() && AxisFrame::is_coding_dna(kind)
}
```

Same clause, same axis scope, wider arm scope (the compensating-gap shape is produced only by `partition_block_canonical`, so both canonical arms are audited, not just `CanonicalCoalesced`). The gate is the axis **kind** and deliberately not `AxisFrame::reading_frame`, which is true for a coding `r.` and would extend a DNA-only carve-out onto an axis the ruling does not reach — the trap that ruling's own implementation note names.

No new constant, and no condition inside the pass was touched.

## `guard_violations`, both directions, both canonical arms

`spec_conformance_axis`, 210 guarded rows of 11,272 classes / 58,552 outputs, `FERRO_MANIFEST` set, both spec artifacts regenerated with `--bin`.

| arm | direction | before | after |
|---|---|---:|---:|
| `canonical` | 3' | 6 | **0** |
| `canonical` | 5' | 6 | **0** |
| `canonical-coalesced` | 3' | 6 | **0** |
| `canonical-coalesced` | 5' | 6 | **0** |

The six rows are `s01-n3m-pair-del-inv-p4-sep1`, `s01-n3p-pair-del-inv-p4-sep1`, `scale-g-block128-inv-del`, `scale-g-block248-delins-del`, `scale-g-block1032-delins-del`, `scale-g-block1032-inv-del`.

**Every other census figure is byte-identical** in both directions on both arms:

| figure | 3' | 5' |
|---|---:|---:|
| outputs / declined / unparseable | 58552 / 0 / 0 | 58552 / 0 / 0 |
| denoting no sequence | 10 | 18 |
| leaving the transcript | 389 | 0 |
| prohibition-violating outputs | 8 | 8 |
| converged | 11016 | 10753 |
| split 2 / 3 / 4+ | 673 / 164 / 29 | 981 / 124 / 24 |
| non-idempotent | 4 | 4 |
| sequence changed | 4 | 0 |
| refusal (conflicts / absolute / conditional) | 72 / 32 / 16 | 72 / 32 / 16 |

At 3' the `outputs_leaving_the_transcript` assertion aborts the loop before the guard assertion, so the guard figure is read out of the census printed in the failure message, not out of a green run. That counter reads **389** on the canonical arms against the `live` pin of 371; it is unmoved by this change and is #1704's, not this PR's.

## What happened to the other firings

Instrumented at the collapse, `FERRO_PARTITION=canonical`, over the same corpus. The gate suppresses **exactly** the non-coding-DNA firings and nothing else — that partition is arithmetic, not a threshold:

| direction | firings before | suppressed | `c.` firings after |
|---|---:|---:|---:|
| 3' | 4,204 | 2,101 (995 `g.`, 1,106 `n.`) | 2,103 |
| 5' | 3,722 | 1,892 (916 `g.`, 976 `n.`) | 1,830 |

The brief for this work quoted **6,290** firings across the 5' corpus (3,094 `c.` / 1,518 `g.` / 1,678 `n.`). Measured here it is **3,722** (1,830 / 916 / 976). The shape of the claim survives — most firings are on `c.`, only 6 land on guarded rows — but the figure does not; quote the one above with the command that produced it.

The census cannot see representation movement, because a class whose every spelling moves together stays converged. Diffing every `(row, spelling) -> output` pair either side:

| direction | outputs compared | moved | `g.` | `n.` | `c.` | distinct rows |
|---|---:|---:|---:|---:|---:|---:|
| 3' | 58,412 | 1,471 | 675 | 796 | **0** | 260 |
| 5' | 58,412 | 1,304 | 602 | 702 | **0** | 230 |

By direction of the move: 3' is 1,387 splits / 65 re-spellings / 19 merges; 5' is 1,237 / 48 / 19. So the price is real, it is paid entirely in split `g.` and `n.` descriptions, and it is the same price `delins-payload-coincidence-carve-out-is-coding-dna-scoped` already accepted for the sibling pass when it kept a stored 723-base `g.` `delins` as a 193-member re-derivation. That record explicitly leaves "whether the coalesce should acquire some other licence for spans of that size" open; this PR does not answer it, it stops the two passes answering it differently.

Identical figures on `canonical-coalesced`.

## `cis_confluence_axis` / `cis_confluence_nr_axis`

Both corpora, `FERRO_PARTITION=canonical`, both directions, before and after. All six censuses are **byte-identical**, `sequence_changed: 0` and `declined: 0` throughout:

| census | classes | converged | split 2 | split 3 | split 4+ |
|---|---:|---:|---:|---:|---:|
| `g,c` 3' | 11,272 | 11,271 | 1 | 0 | 0 |
| `g,c` 5' | 11,272 | 11,272 | 0 | 0 | 0 |
| `n.` 3' | 5,636 | 5,635 | 1 | 0 | 0 |
| `n.` 5' | 5,636 | 5,636 | 0 | 0 | 0 |
| `r.` 3' | 5,636 | 5,633 | 3 | 0 | 0 |
| `r.` 5' | 5,636 | 5,634 | 2 | 0 | 0 |

The divergent class **ids** were dumped and diffed rather than the totals compared, because a class entering `split_two` from `split_three` and one leaving `converged` look identical in a total. The sets are equal either side: `s02-r-m3-sep1-p1-rot3`, `s02-r-m4-sep1-p1-rot3`, `s06-g-m4-sep1-p1-all-dup`, `s06-n-m4-sep1-p1-all-dup`, `s06-r-m4-sep1-p1-all-dup`. `examples/dump_confluence_divergences --out` agrees on the `g,c` corpus (one divergent class, `s06-g-m4-sep1-p1-all-dup`, both sides, both arms); on the `n,r` corpus that dumper excludes 10,536 classes as "unresolved member spans", so the `n.`/`r.` ids above come from the axis tests themselves and not from it.

## A narrower cut was looked for and the search failed

The pass's three conditions are aggregates over the whole hull and **none** of them is about separation, the axis, or the input — on the `n3m`/`n3p` rows it swallowed a two-base run as well as a one-base one. The obvious repair is therefore a per-gap test, and every candidate was evaluated over the full 5' firing dump, asking it to refuse all 12 guarded-row firings and few others:

| candidate | refuses of the 12 | refuses of the other 3,710 |
|---|---:|---:|
| some gap sits at cumulative offset 0 | 2 | 1,646 |
| some gap is exactly one base | 12 | 3,124 |
| claimed columns < twice the unchanged bases | 8 | 3,077 |
| three or more unchanged bases in the hull | 12 | 3,608 |
| hull of nine bases or more | 12 | 2,981 |

The zero-offset test is the one with a principled story — an unchanged run at zero shift is unchanged *in place* rather than by coincidence — and it is refuted outright: on all six rows **every** gap sits at a non-zero cumulative offset. The `n3m` row's derived pieces over `CGATTTCTG` are `[3,8)/"" · gap 2 @ −5 · [10,11)/"A" · gap 1 @ −5 · [12,12)/"A"`. Nothing else separates the populations; each predicate that catches all 12 also catches 80–97% of the rest. The axis is the only clean separator in the data, and it is also the one a decided ruling names. The table is on the new gate so the search is not re-run.

The dominator / "forced separation" family was not revisited; it is annotated WITHDRAWN.

## Doc correction

`coalesce_compensating_gap_split`'s own doc justified its rule from a 65-row reproducer corpus and closed with "**There are no counterexamples in the 65 rows.**" That sentence is true of the corpus it names and was being read as a property of the rule. These six rows are counterexamples in the 11,272-class conformance corpus, and the doc now says so, with the worked `n3m` piece list and with why conditions 2 and 3 are satisfied by construction on that shape (an `inv` or payload-bearing `delins` presents to an edit-distance aligner as inserted somewhere and deleted somewhere else; the big `del` beside it makes `changed_columns_of_pieces` trivially clear the density bar). It also records that nothing downstream re-audits the merge — `split_concealed_separations` runs *before* this pass and is gated on `pieces.len() >= 2` — which is why the gate is at the call site.

## Tests

- `the_compensating_gap_coalesce_needs_both_a_canonical_arm_and_the_coding_dna_axis` — the full arm × kind matrix. Pins the axis half (dropping it is #1711) and the arm half (narrowing it to `CanonicalCoalesced` would silently stop auditing `Canonical`, whose partitioner manufactures the split).
- `the_two_delins_47_gates_share_one_axis_scope` — a cross-product equality against `payload_coalesce_applies`, so the two re-spellings of one clause cannot drift apart again. Two hand-written matrices are how they drifted apart the first time.
- `the_cli_declines_the_compensating_gap_coalesce_off_the_coding_dna_axis` (`tests/it/partition_switch_wiring.rs`) — the **call site**, end to end through the `ferro` binary.

### The call site was unguarded, and this description said it could not be guarded

An earlier revision of this section said the two tests above were "pure-predicate tests rather than call-site tests" because `partition_rule()` caches in a `OnceLock`, so one test binary cannot drive two arms through `canonicalize_from_sequence`. **The premise is true and the conclusion was wrong**, and the cost of it was measured: with the call site's axis argument replaced by a hardcoded `CisKind::Cds` — #1711 restored verbatim — the whole suite passed (10,233/10,233) and `clippy` exited 0. Reverting the call site to the pre-#1711 form passed too. The predicate was guarded four ways over and the thing it was wired to was guarded not at all.

`tests/it/partition_switch_wiring.rs` already sidesteps the `OnceLock`: it drives the real `ferro` binary in a **subprocess**, which gets its own, against the `MockProvider` — so no `--reference` and no prepared reference directory. The new test lives there rather than beside the predicate because what it asks is whether the call site consults the axis at all, which is a wiring question and survives either reading of what `delins.md:47` reaches.

**Input, and the check that it is not vacuous.** `NR_000123.1:n.[2_4inv;6del]` — the mock non-coding transcript (`ACGTACGTACGT`, no CDS, so `CisKind::Tx`, `false` under both `is_coding_dna` and `carries_translated_frame`), in the same `inv`+`del`-at-separation-1 shape as the `s01-n3{m,p}-pair-del-inv-p4-sep1` rows this PR is about. No fixture change was needed; the accession as committed hosts the shape. A guard built on an input that cannot reach the pass would pass under the mutation and prove nothing, so that was measured first, on the unmutated build:

- remove the call entirely (`if false`) — the row's output is **unchanged**, so nothing else is producing this answer;
- remove only the axis argument — the row merges to `n.2_6delinsACGA`, one `delins` spanning the members *and the unchanged base between them*.

So the pass is reached on this row and the axis test is what declines it. Over a 35,264-row sweep of `n.` cis alleles on that transcript, 1,207 rows move when the axis argument is removed — 926 of them onto a single spanning `delins`.

A coding control rides in the same subprocess, `NM_000088.3:c.[3_7inv;9del]` → `c.3_9delinsTGGGCA`, because the negative half alone cannot tell the fix from a build that deleted the call: with the call removed that row splits into `c.[2dup;4_5inv;8_9del]`.

**Mutation table.** One test, run on both canonical arms:

| call site | new guard |
|---|---|
| `compensating_gap_coalesce_applies(partition_rule(), kind)` — this branch | passes |
| `partition_rule().cuts_with_canonical()` — the pre-#1711 defect | **FAILS**, on the `n.` half |
| `compensating_gap_coalesce_applies(partition_rule(), CisKind::Cds)` | **FAILS**, on the `n.` half |
| `false` — the call removed | **FAILS**, on the `c.` control |

The negative half deliberately does not pin the split spelling. `general.md:34` governs that the members stay individual; which individual members the re-derivation lands on is a separate question, and pinning it would redden this guard for changes that leave its subject untouched.

Local gate, `FERRO_MANIFEST` set and both spec artifacts regenerated with `--bin`: `cargo nextest run --features dev --lib --test it --test-threads=4` — **10,237 passed, 150 skipped, 0 failed**. `cargo fmt --all` and `cargo clippy --all-features --all-targets -- -D warnings` clean. No pin re-blessed.

## Not in scope

Coding-axis merges (`general.md:35`'s exception is live there and `:47` reaches `c.`); merges at separation ≥ 2; `outputs_leaving_the_transcript`, which is #1704; and whether the coalesce should acquire a separate licence for very large spans, which `delins-payload-coincidence-carve-out-is-coding-dna-scoped` leaves open by name.

Representation-Change: none. The gated pass is reachable only under FERRO_PARTITION=canonical / canonical-coalesced; with the variable unset the shipped `live` arm never reached it, the full local suite is green and no pin is re-blessed. The canonical-arm figures are tabulated above.

