### PR TITLE
fix(data): map cdot's CDS bounds out of gap-collapsed transcript space

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -50,15 +50,22 @@ mod rkyv_cache {
     use rustc_hash::FxHashMap;
     use std::collections::HashMap;
 
-    /// Bump whenever the layout below changes so a stale archive is rejected by
-    /// the version check (in addition to rkyv's own structural validation) and
-    /// regenerated rather than mis-read.
+    /// Bump whenever the layout below changes **or its coordinates change
+    /// meaning**, so a stale archive is rejected by the version check (in
+    /// addition to rkyv's own structural validation) and regenerated rather
+    /// than mis-read.
     // v2 (#742): exon coordinates are now stored in the HGVS convention
     // (genome 1-based, tx 0-based half-open); a v1 cache holds the old raw
     // cdot convention and must be regenerated.
     // v3 (#972): `RkyvTx` gained `cds_start_incomplete`; a v2 cache has no such
     // field and would silently rehydrate every transcript as "complete".
-    pub(super) const RKYV_FORMAT_VERSION: u32 = 3;
+    // v4 (#1619): `cds_start`/`cds_end` are now FLAT transcript offsets, mapped
+    // out of cdot's gap-collapsed `start_codon`/`stop_codon` space. The layout
+    // is unchanged, so rkyv's structural validation cannot see the difference —
+    // a v3 cache would rehydrate the 58 gapped GRCh38 builds with a CDS short by
+    // the enclosed gap, which is exactly the defect this bump exists to stop
+    // surviving in a cache.
+    pub(super) const RKYV_FORMAT_VERSION: u32 = 4;
 
     #[derive(Archive, Serialize, Deserialize)]
     pub(super) struct RkyvCigar {
@@ -399,7 +406,14 @@ const CDOT_BINCODE_MAGIC: [u8; 4] = *b"FCDT";
 // v3 (#972): `CdotTranscriptSnapshot` gained `cds_start_incomplete`; a v2
 // cache has no such field and bincode's positional layout would otherwise
 // misread the following bytes.
-const CDOT_BINCODE_VERSION: u32 = 3;
+// v4 (#1619): `cds_start`/`cds_end` are now FLAT transcript offsets, mapped out
+// of cdot's gap-collapsed `start_codon`/`stop_codon` space. The layout is
+// unchanged, so a v3 cache reads back cleanly and would serve the 58 gapped
+// GRCh38 builds a CDS short by the enclosed gap. This bump must move with
+// `RKYV_FORMAT_VERSION`, not after it: a *fresh* v3 bincode cache is loaded in
+// preference to the JSON and then PROMOTED to an rkyv archive, so leaving it at
+// 3 would launder the stale values into a current-version rkyv file.
+const CDOT_BINCODE_VERSION: u32 = 4;
 
 /// Parse the integer version suffix of an accession (`"NM_003002.4"` -> `Some(4)`),
 /// or `None` when there is no trailing numeric `.<n>`. Used to pick the highest
@@ -567,7 +581,23 @@ impl RawCdotTranscript {
             .exons
             .iter()
             .filter_map(|e| {
-                if e.len() >= 5 {
+                if e.len() < 5 {
+                    // Dropping a row is no longer free. Since #1619 the CDS
+                    // bounds are mapped THROUGH this exon table
+                    // (`collapsed_to_flat_tx_pos`), so a silently discarded exon
+                    // shortens `exon_bases_seen` and moves `cds_start`/`cds_end`
+                    // by that exon's span — where previously it only cost the
+                    // table one row. Account for the drop rather than let a
+                    // malformed record shift the CDS in silence.
+                    log::warn!(
+                        "cdot exon row for {} has {} fields (expected at least 5); \
+                         dropping it, which will shift this transcript's CDS bounds",
+                        self.gene_name.as_deref().unwrap_or("<unknown gene>"),
+                        e.len()
+                    );
+                    return None;
+                }
+                {
                     // cdot stores genomic bounds 0-based half-open (`alt_start`
                     // 0-based inclusive, `alt_end` 0-based exclusive) and cDNA
                     // bounds 1-based **inclusive** (`cds_start_i`/`cds_end_i`).
@@ -597,8 +627,6 @@ impl RawCdotTranscript {
                         None
                     };
                     Some((exon, cigar))
-                } else {
-                    None
                 }
             })
             .collect();
@@ -611,8 +639,36 @@ impl RawCdotTranscript {
         // Use transcript-level CDS coordinates (start_codon/stop_codon) if available
         // These are 0-indexed and more reliable than converting from genomic coords
         let (cds_start, cds_end) = if self.start_codon.is_some() || self.stop_codon.is_some() {
-            // Use transcript-level coordinates directly (0-indexed)
-            (self.start_codon, self.stop_codon)
+            // #1619: a cdot record carries TWO transcript coordinate spaces and
+            // labels neither. The exon table's `tx_start`/`tx_end` are absolute
+            // offsets into the transcript *sequence* (so a base unaligned to the
+            // genome still occupies a position), while `start_codon`/`stop_codon`
+            // are offsets into the gap-COLLAPSED transcript — exon bases only.
+            // The two agree for the 474,760 GRCh38 builds whose exon table is
+            // contiguous and disagree for the 58 that are not, where taking the
+            // codon bounds verbatim serves a CDS short by the enclosed gap.
+            //
+            // Measured over those 58 (50 have both a CDS and a sequence on the
+            // prepared reference): reading `start_codon`/`stop_codon` as
+            // collapsed offsets yields a valid ORF 50/50 and reading them as flat
+            // offsets 0/50. `NM_033517.1` is the worked case — cdot says 5157,
+            // RefSeq annotates `CDS 1..5196` and `NP_277052.1` is 1731 aa.
+            //
+            // Everything downstream — `cds_to_tx`, `tx_to_cds`, the exon walk in
+            // `TranscriptMetadata` — indexes the flat sequence, so map into that
+            // space here and let the rest of the crate keep one space. Note the
+            // end is mapped through its LAST CODING BASE rather than directly:
+            // a CDS flush with an exon boundary must not absorb the gap that
+            // follows it, which is what "add every preceding gap" would do.
+            (
+                self.start_codon
+                    .map(|start| collapsed_to_flat_tx_pos(&exons, start)),
+                self.stop_codon.map(|stop| match stop.checked_sub(1) {
+                    Some(last) => collapsed_to_flat_tx_pos(&exons, last).saturating_add(1),
+                    // An empty CDS carries no last coding base to map.
+                    None => 0,
+                }),
+            )
         } else {
             // Fall back to converting genomic CDS coordinates to transcript coordinates
             match (build.cds_start, build.cds_end) {
@@ -739,6 +795,46 @@ fn parse_strand(s: &str) -> Option<Strand> {
         "+" | "1" | "plus" => Some(Strand::Plus),
         "-" | "-1" | "minus" => Some(Strand::Minus),
         _ => None,
+    }
+}
+
+/// Map a 0-based **inclusive** offset in the gap-collapsed transcript onto the
+/// flat transcript sequence (#1619).
+///
+/// The gap-collapsed transcript is the concatenation of the exons' transcript
+/// spans, so it omits any base the exon table does not cover — the holes cdot
+/// leaves when part of a transcript does not align to the genome. The flat
+/// transcript is the sequence as the FASTA serves it, holes included. cdot's
+/// `start_codon`/`stop_codon` are stated in the former and every consumer in
+/// this crate indexes the latter.
+///
+/// # Arguments
+/// * `exons` - exons in the in-memory layout `[genome_start, genome_end,
+///   tx_start (0-based inclusive), tx_end (0-based exclusive)]`, sorted by
+///   `tx_start`.
+/// * `collapsed` - a 0-based inclusive offset into the gap-collapsed transcript.
+///
+/// # Returns
+/// The corresponding 0-based inclusive offset into the flat transcript. This is
+/// the identity whenever the exon table is contiguous and starts at 0, which is
+/// every build but the 58 gapped GRCh38 ones. An offset past the end of the
+/// collapsed transcript (and an empty exon table) degrades gracefully rather
+/// than declining: the overshoot is carried past the final exon, since a CDS
+/// bound that outruns its own exon table is annotation ferro reports on
+/// elsewhere, not something to silently drop here.
+fn collapsed_to_flat_tx_pos(exons: &[[u64; 4]], collapsed: u64) -> u64 {
+    let mut exon_bases_seen: u64 = 0;
+    for exon in exons {
+        let (tx_start, tx_end) = (exon[2], exon[3]);
+        let span = tx_end.saturating_sub(tx_start);
+        if collapsed < exon_bases_seen.saturating_add(span) {
+            return tx_start.saturating_add(collapsed - exon_bases_seen);
+        }
+        exon_bases_seen = exon_bases_seen.saturating_add(span);
+    }
+    match exons.last() {
+        Some(last) => last[3].saturating_add(collapsed - exon_bases_seen),
+        None => collapsed,
     }
 }
 
@@ -3734,6 +3830,207 @@ mod tests {
                  start_codon/stop_codon branch on the same record"
             );
         }
+    }
+
+    /// Two-exon raw cdot JSON with a 40-base transcript-coordinate hole between
+    /// the exons (exon 1 ends at cdna 100, exon 2 starts at cdna 141), carrying
+    /// the given `start_codon`/`stop_codon`. Genomic bounds are arbitrary but
+    /// well-formed; only the transcript axis is under test.
+    fn gapped_cdot_json(start_codon: u64, stop_codon: u64) -> String {
+        format!(
+            r#"
+            {{
+                "transcripts": {{
+                    "NM_GAPPED.1": {{
+                        "gene_name": "TEST",
+                        "genome_builds": {{
+                            "GRCh38": {{
+                                "contig": "NC_000001.11",
+                                "strand": "+",
+                                "exons": [
+                                    [1000, 1100, 0, 1, 100, "M100"],
+                                    [2000, 2100, 1, 141, 240, "M100"]
+                                ]
+                            }}
+                        }},
+                        "start_codon": {start_codon},
+                        "stop_codon": {stop_codon}
+                    }}
+                }}
+            }}
+            "#
+        )
+    }
+
+    fn load_gapped(start_codon: u64, stop_codon: u64) -> CdotTranscript {
+        let json = gapped_cdot_json(start_codon, stop_codon);
+        CdotMapper::from_reader_with_build(json.as_bytes(), "GRCh38")
+            .unwrap()
+            .get_transcript("NM_GAPPED.1")
+            .unwrap()
+            .clone()
+    }
+
+    /// A gap **between** the two codon bounds must widen the CDS: `stop_codon`
+    /// is an offset into the gap-collapsed transcript, so it lands 40 bases
+    /// short of the true flat end.
+    #[test]
+    fn cdot_cds_end_is_mapped_out_of_gap_collapsed_space() {
+        let tx = load_gapped(10, 180);
+        assert_eq!(tx.cds_start, Some(10), "no gap precedes the start codon");
+        // collapsed 179 (last coding base) sits at exon-2 offset 79 => flat 219.
+        assert_eq!(
+            tx.cds_end,
+            Some(220),
+            "cds_end must be a FLAT transcript offset"
+        );
+    }
+
+    /// A gap **before** the start codon must shift both bounds, not just the end.
+    #[test]
+    fn cdot_cds_start_is_mapped_out_of_gap_collapsed_space() {
+        let tx = load_gapped(120, 180);
+        assert_eq!(
+            tx.cds_start,
+            Some(160),
+            "collapsed 120 = exon-2 offset 20 => flat 160"
+        );
+        assert_eq!(tx.cds_end, Some(220));
+    }
+
+    /// The collapsed offset of the FIRST base after the gap must land on the
+    /// first base of exon 2, not inside the hole.
+    ///
+    /// This is the other side of the boundary
+    /// [`cdot_cds_end_flush_with_an_exon_boundary_excludes_the_following_gap`]
+    /// pins. That test fixes the last collapsed offset *before* the gap
+    /// (collapsed 99 -> flat 99); this one fixes the first offset *after* it
+    /// (collapsed 100 -> flat 140). An off-by-one in the loop's
+    /// `collapsed < exon_bases_seen + span` comparison moves exactly one of the
+    /// two, so neither test alone pins the boundary.
+    #[test]
+    fn cdot_cds_start_at_the_first_collapsed_base_after_the_gap() {
+        let tx = load_gapped(100, 180);
+        assert_eq!(
+            tx.cds_start,
+            Some(140),
+            "collapsed 100 is the first base of exon 2, which is flat 140 — not a \
+             position inside the 40-base hole"
+        );
+        assert_eq!(
+            tx.cds_end,
+            Some(220),
+            "collapsed 179 (the last coding base) is exon-2 offset 79 => flat 219"
+        );
+    }
+
+    /// A CDS ending exactly at an exon boundary must NOT absorb the gap that
+    /// follows it — the naive "add every preceding gap" mapping would return 140.
+    #[test]
+    fn cdot_cds_end_flush_with_an_exon_boundary_excludes_the_following_gap() {
+        let tx = load_gapped(10, 100);
+        assert_eq!(tx.cds_start, Some(10));
+        assert_eq!(
+            tx.cds_end,
+            Some(100),
+            "the CDS ends at the exon, before the gap"
+        );
+    }
+
+    /// The mapping is the identity on a gapless exon table, which is every
+    /// transcript but the 58 gapped GRCh38 builds.
+    #[test]
+    fn cdot_cds_bounds_are_unchanged_on_a_gapless_exon_table() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_FLAT.1": {
+                    "gene_name": "TEST",
+                    "genome_builds": {
+                        "GRCh38": {
+                            "contig": "NC_000001.11",
+                            "strand": "+",
+                            "exons": [
+                                [1000, 1100, 0, 1, 100, "M100"],
+                                [2000, 2100, 1, 101, 200, "M100"]
+                            ]
+                        }
+                    },
+                    "start_codon": 10,
+                    "stop_codon": 190
+                }
+            }
+        }
+        "#;
+        let cdot = CdotMapper::from_reader_with_build(json.as_bytes(), "GRCh38").unwrap();
+        let tx = cdot.get_transcript("NM_FLAT.1").unwrap();
+        assert_eq!(tx.cds_start, Some(10));
+        assert_eq!(tx.cds_end, Some(190));
+    }
+
+    /// #1619 real-geometry regression. `NM_033517.1` (SHANK3, GRCh38) is one of
+    /// the 58 gapped cdot builds: exon 10 ends at cdna 1302, exon 11 starts at
+    /// cdna 1342, a genuine 39-base transcript-coordinate hole. cdot's
+    /// `stop_codon` is 5157, which is 5196 - 39 — i.e. it counts exon bases only.
+    ///
+    /// RefSeq's own annotation for this accession is FLAT: GenBank annotates
+    /// `CDS 1..5196` with `/coded_by="NM_033517.1:1..5196"`, and `NP_277052.1`
+    /// is 1731 aa (5196 / 3 = 1732 codons = 1731 residues + stop). The repo's
+    /// own `tests/fixtures/sequences/normalization_transcripts.json` carries
+    /// `cds_end: 5196` for it, so the live provider and the fixture disagreed
+    /// until this mapping existed.
+    #[test]
+    fn cdot_nm_033517_cds_end_matches_refseq_issue_1619() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_033517.1": {
+                    "gene_name": "SHANK3",
+                    "protein": "NP_277052.1",
+                    "genome_builds": {
+                        "GRCh38": {
+                            "contig": "NC_000022.11",
+                            "strand": "+",
+                            "exons": [
+                                [50674641, 50674704, 0, 1, 63, null],
+                                [50675047, 50675251, 1, 64, 267, null],
+                                [50676621, 50676693, 2, 268, 339, null],
+                                [50678584, 50678693, 3, 340, 448, null],
+                                [50678768, 50678920, 4, 449, 600, null],
+                                [50679018, 50679186, 5, 601, 768, null],
+                                [50679311, 50679428, 6, 769, 885, null],
+                                [50683339, 50683417, 7, 886, 963, null],
+                                [50684584, 50684651, 8, 964, 1030, null],
+                                [50694774, 50695046, 9, 1031, 1302, null],
+                                [50697556, 50697715, 10, 1342, 1498, "M5 D2 M152"],
+                                [50698689, 50698803, 11, 1499, 1612, null],
+                                [50703859, 50703935, 12, 1613, 1688, null],
+                                [50704165, 50704248, 13, 1689, 1771, null],
+                                [50704737, 50704862, 14, 1772, 1896, null],
+                                [50704963, 50705096, 15, 1897, 2029, null],
+                                [50706071, 50706152, 16, 2030, 2110, null],
+                                [50711614, 50711638, 17, 2111, 2134, null],
+                                [50714916, 50715047, 18, 2135, 2265, null],
+                                [50715668, 50715753, 19, 2266, 2350, null],
+                                [50720183, 50722437, 20, 2351, 4604, null],
+                                [50730720, 50733212, 21, 4605, 7096, null]
+                            ]
+                        }
+                    },
+                    "start_codon": 0,
+                    "stop_codon": 5157
+                }
+            }
+        }
+        "#;
+        let cdot = CdotMapper::from_reader_with_build(json.as_bytes(), "GRCh38").unwrap();
+        let tx = cdot.get_transcript("NM_033517.1").unwrap();
+        assert_eq!(tx.cds_start, Some(0), "no gap precedes the start codon");
+        assert_eq!(
+            tx.cds_end,
+            Some(5196),
+            "cdot's stop_codon 5157 excludes the 39-base hole between exons 10 and 11"
+        );
     }
 
     /// Builds a minimal `RawGenomeBuild` carrying the given cdot `tag` string

--- a/src/reference/derived_tx_structure.rs
+++ b/src/reference/derived_tx_structure.rs
@@ -214,6 +214,36 @@ fn readback_mismatch_fraction(
     Some(mism as f64 / expected.len().max(1) as f64)
 }
 
+/// Whether `sibling`'s exon table lives in the same coordinate frame the
+/// reconstructed mRNA is measured in: each exon's transcript coordinates are the
+/// running sum of the exon *genome* spans, contiguous from zero.
+///
+/// [`reconstruct_spliced_mrna`] builds the mRNA by concatenating exon *genome*
+/// slices, so its length — and everything derived from it downstream in
+/// [`derive_transcript_structure`], namely `old_len` and the alignment offset
+/// `off` — lives in gap-collapsed space. The exon-clipping loop there, by
+/// contrast, maps each exon's *transcript* coordinates into old space with
+/// `te - off` and compares the result against `old_len`. Those two frames
+/// coincide only when every exon's transcript span equals its genome span and
+/// the table runs contiguously from zero. On any gapped / non-contiguous table
+/// the terminal exon's flat `o_te` overshoots the collapsed `old_len` by exactly
+/// the transcript-coordinate gap. See #1922.
+fn sibling_tx_frame_matches_collapsed_mrna(sibling: &CdotTranscript) -> bool {
+    let mut collapsed: u64 = 0;
+    for e in &sibling.exons {
+        let (gs, ge, ts, te) = (e[0], e[1], e[2], e[3]);
+        if ge < gs {
+            return false; // malformed genome span
+        }
+        let genome_span = ge - gs;
+        if ts != collapsed || te != collapsed + genome_span {
+            return false;
+        }
+        collapsed += genome_span;
+    }
+    true
+}
+
 /// Derive an old version's structure by anchoring to a sibling cdot record.
 ///
 /// Enforces the clean-terminal-trim invariant: `old_mrna` must equal the
@@ -233,6 +263,21 @@ pub fn derive_transcript_structure(
     genome: &dyn GenomeSlice,
 ) -> Option<DerivedTxStructure> {
     let sib_mrna = reconstruct_spliced_mrna(sibling, genome)?;
+
+    // #1922: the exon-clipping loop below maps the sibling's *transcript*
+    // coordinates into old space (`te - off`) and compares them against
+    // `old_len`, which is measured in the gap-collapsed frame of the
+    // reconstructed mRNA. Those frames coincide only when the sibling's tx table
+    // is the running sum of its genome spans (contiguous from zero). On a gapped
+    // table they diverge: the terminal exon over-clips and the readback below
+    // then declines by coming up short. Decline explicitly here instead of
+    // relying on that emergent shortfall — a flat `o_te` must never be compared
+    // against a collapsed `old_len`, and making the decline explicit keeps a
+    // future refactor of the clip test from silently promoting this latent
+    // mis-frame into an emitted (wrong) value.
+    if !sibling_tx_frame_matches_collapsed_mrna(sibling) {
+        return None;
+    }
 
     // Strip any poly-A tail from old_mrna before alignment: the tail is
     // post-transcriptional and has no genomic coordinate, so it must not be
@@ -519,6 +564,68 @@ mod derivation_tests {
         let mut old = sib_mrna.clone();
         old.remove(10); // delete a base at the exon0/exon1 junction interior
         assert!(derive_transcript_structure("NM_T.1", &old, "NM_T.2", &cdot, &genome,).is_none());
+    }
+
+    /// #1922: a sibling whose transcript coordinates are NOT the running sum of
+    /// its exon genome spans (a gapped / non-contiguous tx table) mixes two
+    /// coordinate frames — the reconstructed mRNA is gap-collapsed while the
+    /// exon-clip test works in the sibling's gapped tx space. Such a table MUST
+    /// decline, never emit: comparing a flat `o_te` against a collapsed
+    /// `old_len` over-clips the terminal exon and can only ever produce a wrong
+    /// value. The explicit guard in `derive_transcript_structure` pins that
+    /// decline so a future refactor of the clip test cannot silently promote the
+    /// latent mis-frame into an emitted result.
+    #[test]
+    fn declines_on_gapped_sibling_tx_table() {
+        // Start from the contiguous fixture, then open a 2-base gap in the
+        // terminal exon's transcript coordinates (10..20 -> 12..22) WITHOUT
+        // touching its genome slice. The reconstructed mRNA is unchanged (20 nt,
+        // built from genome slices), so `old_len == 20`, but the terminal exon's
+        // tx_end is now 22 — two bases beyond the collapsed frame.
+        let (mut cdot, genome, sib_mrna) = sibling_fixture();
+        cdot.exons = vec![[1, 11, 0, 10], [15, 25, 12, 22]];
+        // The old version is byte-identical to the sibling mRNA (no trim), so the
+        // only thing that could make derivation decline is the frame mix itself,
+        // not an alignment or CDS-bounds issue.
+        assert!(
+            derive_transcript_structure("NM_T.1", &sib_mrna, "NM_T.2", &cdot, &genome).is_none(),
+            "a gapped sibling tx table must decline, not emit a mis-framed structure"
+        );
+    }
+
+    /// Minus-strand mirror of [`declines_on_gapped_sibling_tx_table`] (#1922).
+    /// The frame guard is strand-agnostic, so a gapped tx table on the minus
+    /// strand must decline just the same — pinned here to match the module's
+    /// plus/minus test-pairing convention.
+    #[test]
+    fn declines_on_gapped_sibling_tx_table_minus_strand() {
+        // Contiguous minus fixture, then a 2-base gap in the terminal exon's tx
+        // coordinates (10..20 -> 12..22); the genome slices are untouched, so the
+        // reconstructed mRNA (and `old_len`) is unchanged.
+        let (mut cdot, genome) = minus_sibling_fixture();
+        let sib_mrna = reconstruct_spliced_mrna(&cdot, &genome).unwrap();
+        cdot.exons = vec![[15, 25, 0, 10], [1, 11, 12, 22]];
+        assert!(
+            derive_transcript_structure("NM_M.1", &sib_mrna, "NM_M.2", &cdot, &genome).is_none(),
+            "a gapped minus-strand sibling tx table must decline, not emit"
+        );
+    }
+
+    /// Control for [`declines_on_gapped_sibling_tx_table`]: the SAME derivation
+    /// on the contiguous-from-zero table (the gap closed) still emits, isolating
+    /// the decline above to the frame mismatch — nothing else about the fixture
+    /// or the derivation changed. Guards behaviour-preservation of the #1922
+    /// hardening: contiguous tables are untouched.
+    #[test]
+    fn contiguous_sibling_tx_table_still_emits() {
+        // Contiguous terminal exon (tx 10..20 == running sum of genome spans).
+        let (cdot, genome, sib_mrna) = sibling_fixture();
+        let d = derive_transcript_structure("NM_T.1", &sib_mrna, "NM_T.2", &cdot, &genome)
+            .expect("a contiguous-from-zero sibling table must still derive");
+        assert_eq!(d.exons, vec![[1, 11, 0, 10], [15, 25, 10, 20]]);
+        assert_eq!(d.cds_start, Some(2));
+        assert_eq!(d.cds_end, Some(18));
+        assert!(d.mismatch_fraction < 1e-9);
     }
 
     #[test]

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -2745,7 +2745,12 @@ impl MultiFastaProvider {
                             TranscriptMetadata {
                                 gene_symbol: tx.gene_name.clone(),
                                 strand: tx.strand,
-                                // CDS coordinates: cdot 0-based → transcript 1-based
+                                // CDS coordinates: cdot 0-based → transcript 1-based.
+                                // Both bounds are already FLAT transcript offsets
+                                // — `from_genome_build` maps cdot's gap-collapsed
+                                // `start_codon`/`stop_codon` onto the exon table's
+                                // own space (#1619) — so this is a pure basis
+                                // shift with no gap term left to apply here.
                                 cds_start: tx.cds_start.map(|s| s + 1), // 0-based → 1-based
                                 cds_end: tx.cds_end, // 0-based exclusive = 1-based inclusive
                                 chromosome: Some(tx.contig.clone()),

--- a/tests/it/normalization_transcripts_exon_contract.rs
+++ b/tests/it/normalization_transcripts_exon_contract.rs
@@ -139,11 +139,23 @@ const FLATTENED_RECORDS: &[(&str, &str)] = &[(
 /// module docs for what carrying it bought (#1619) and why it must stay.
 const CDOT_GAP_JUNCTIONS: &[(&str, u32, i64)] = &[("NM_033517.1", 10, 39)];
 
+/// cdot's own raw `stop_codon`, per accession, in the gap-COLLAPSED space cdot
+/// states its codon bounds in. The fixture's `cds_end` is the same bound in FLAT
+/// space, so the two differ by exactly that accession's enclosed gap — see
+/// [`the_gapped_records_cds_bounds_are_flat`]. Keyed by accession rather than
+/// assumed for every [`CDOT_GAP_JUNCTIONS`] row, since the raw number has to be
+/// read out of cdot for each one.
+const COLLAPSED_STOP_CODONS: &[(&str, u64)] = &[("NM_033517.1", 5157)];
+
 #[derive(Debug, Deserialize)]
 struct TranscriptRecord {
     id: String,
     sequence: String,
     exons: Vec<ExonRecord>,
+    #[serde(default)]
+    cds_start: Option<u64>,
+    #[serde(default)]
+    cds_end: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -230,6 +242,114 @@ fn every_pinned_gap_exemption_is_still_load_bearing() {
              the row — an exemption that matches nothing silently weakens this guard."
         );
     }
+}
+
+/// A gap-carrying record's CDS bounds are stated in FLAT transcript space, the
+/// same space as its exon table — which is what the live cdot provider now
+/// serves too (#1619).
+///
+/// This pins a disagreement that was real: cdot states `start_codon`/`stop_codon`
+/// in a gap-COLLAPSED space (exon bases only) while stating its exon `tx_start`/
+/// `tx_end` flat, and ferro copied the codon bounds through unadjusted. So the
+/// provider served `NM_033517.1` with `cds_end = 5157` while this fixture — built
+/// from RefSeq's own annotation, which is flat (`CDS 1..5196`,
+/// `/coded_by="NM_033517.1:1..5196"`, `NP_277052.1` = 1731 aa = 5196/3 - 1) —
+/// carried 5196. Two sources of truth for one accession, differing by exactly the
+/// gap, with nothing comparing them.
+///
+/// The assertions are deliberately structural rather than a bare `== 5196`: the
+/// gap must lie **inside** the CDS (otherwise flat and collapsed agree and the
+/// record proves nothing), the last coding base must land inside an exon (a
+/// collapsed bound would not), and subtracting the enclosed gap must reproduce
+/// cdot's own raw number — so this fails if either side is restated in the
+/// other's space.
+#[test]
+fn the_gapped_records_cds_bounds_are_flat() {
+    let records = load_records();
+    // The `continue` below is a legitimate skip (a non-coding record has no CDS
+    // bound to place in either space), but an unbounded skip makes this test pass
+    // having compared NOTHING — `CDOT_GAP_JUNCTIONS` holds one entry, so a single
+    // silent skip empties the whole test. That is reachable without anyone
+    // touching this file: `cds_start`/`cds_end` are `#[serde(default)]
+    // Option<u64>`, so renaming either key in the fixture yields `None` and a
+    // green run. Count what was actually compared and refuse a zero.
+    let mut compared = 0usize;
+    for &(accession, number, size) in CDOT_GAP_JUNCTIONS {
+        let record = records
+            .iter()
+            .find(|r| r.id == accession)
+            .unwrap_or_else(|| panic!("{accession} is pinned in CDOT_GAP_JUNCTIONS but absent"));
+        let (Some(cds_start), Some(cds_end)) = (record.cds_start, record.cds_end) else {
+            continue; // non-coding record: no CDS bound to place in either space
+        };
+        compared += 1;
+
+        // The gap's flat interval, 1-based inclusive: (prev.end, next.start).
+        let gap_start = record
+            .exons
+            .iter()
+            .find(|e| e.number == number)
+            .unwrap_or_else(|| panic!("{accession} has no exon {number}"))
+            .end;
+
+        // `size` is `i64`, and every arithmetic use below casts it to `u64`. A
+        // non-positive value would wrap to an enormous number and make the
+        // interval checks vacuously true rather than fail, so reject it by name
+        // first — the cast must not be where a bad pin turns into a green run.
+        assert!(
+            size > 0,
+            "{accession}: CDOT_GAP_JUNCTIONS pins a non-positive gap size {size} after exon \
+             {number}; a gap must have a positive width for this record to distinguish flat \
+             from collapsed space"
+        );
+        let size = size as u64;
+
+        assert!(
+            cds_start <= gap_start && gap_start + size < cds_end,
+            "{accession}: the {size}-base gap after exon {number} must lie INSIDE the CDS \
+             [{cds_start}, {cds_end}] for this record to distinguish flat from collapsed space"
+        );
+        assert!(
+            record
+                .exons
+                .iter()
+                .any(|e| e.start <= cds_end && cds_end <= e.end),
+            "{accession}: cds_end {cds_end} must land inside an exon — a gap-collapsed bound \
+             would not, which is how the defect presented"
+        );
+        // Require the entry rather than skipping when it is absent. This is the
+        // strongest assertion in the test — it is the only one that compares the
+        // two coordinate spaces against each other — so letting a missing row
+        // silently disable it would reintroduce, per accession, exactly the
+        // vacuity the `compared > 0` check below exists to prevent. Today every
+        // CDOT_GAP_JUNCTIONS accession has a matching entry, so this is a guard
+        // against a future row being added without its raw stop_codon, not a
+        // live gap.
+        let &(_, collapsed_stop) = COLLAPSED_STOP_CODONS
+            .iter()
+            .find(|(a, _)| *a == accession)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{accession} is pinned in CDOT_GAP_JUNCTIONS but has no COLLAPSED_STOP_CODONS \
+                     entry; add cdot's own raw stop_codon for it, or this record's flat-vs-\
+                     collapsed comparison silently does not run"
+                )
+            });
+        assert_eq!(
+            cds_end - size,
+            collapsed_stop,
+            "{accession}: cds_end minus the enclosed gap must reproduce cdot's own raw \
+             stop_codon, so neither side can drift into the other's coordinate space"
+        );
+    }
+
+    assert!(
+        compared > 0,
+        "no gapped record was actually compared: all {} CDOT_GAP_JUNCTIONS entries skipped for a \
+         missing CDS. This test would have passed while asserting nothing — check that the \
+         fixture still carries `cds_start`/`cds_end` for them",
+        CDOT_GAP_JUNCTIONS.len()
+    );
 }
 
 /// No record may be flattened to a single exon without saying so.


### PR DESCRIPTION
Closes #1736.
Closes #1922 (explicit-decline hardening folded in as `bf522fac`).

**Merge-order note (corrected):** this branch is *not* stacked on #1724 — it is rebased directly on `origin/main` (`git merge-base origin/main HEAD` == `e98fa77e`, one commit ahead) and `git merge-tree` is clean against both `main` and #1724's head, so the two are independent textually. The dependency runs the other way round semantically: **#1735 should land first** (it makes a `c.` number a flat transcript offset, which is the space this PR maps cdot's codon bounds into), and **#1724 should land last** (it stops discarding gapped cdot exon tables, so it enlarges the population both of the other two repair). Recommended order: #1735 -> #1737 -> #1724.

A cdot record states two transcript coordinate spaces and labels neither. The exon table's `tx_start`/`tx_end` are absolute offsets into the transcript sequence; `start_codon`/`stop_codon` are offsets into the gap-**collapsed** transcript. `from_genome_build` copied the codon bounds through verbatim, so on a transcript whose exon table has a hole the published CDS was short by the enclosed gap while the exons around it were not.

The provider served `NM_033517.1` with `cds_end = 5157`; RefSeq annotates `CDS 1..5196` (`/coded_by="NM_033517.1:1..5196"`), `NP_277052.1` is 1731 aa (5196/3 = 1732 codons = 1731 residues + stop), and this repo's `normalization_transcripts.json` already carried 5196. Two sources of truth for one accession, differing by exactly its 39-base gap, with nothing comparing them.

## Direction measured, not assumed

Over cdot-0.2.32.refseq.GRCh38's 58 gapped builds (50 have both a CDS and a sequence on the prepared reference), slicing the real transcript FASTA three ways:

| reading of cdot's `start_codon`/`stop_codon` | valid ORF |
|---|---|
| verbatim as flat offsets (what ferro did) | **0 / 50** |
| indexed into the exon-only sequence | 50 / 50 |
| collapsed → flat via the exon table (this fix) | **50 / 50** |

`NM_033517.1` is decisive: raw `[0, 5157)` → mapped `[0, 5196)`, 1732 codons, last codon `TGA`. The collapsed reading is *also* a valid ORF but only 1719 codons, so ORF validity alone does not discriminate — RefSeq's own flat annotation does, and the repo fixture already agreed with it.

Two internal confirmations that flat is the required space: `CdotTranscript::cds_to_tx`/`tx_to_cds` add `cds_start` directly to flat tx positions, and the genomic-CDS *fallback* branch already produces flat coordinates via `genomic_to_tx_pos`. Only the `start_codon`/`stop_codon` branch was in the wrong space.

## Both bounds are mapped

`collapsed_to_flat_tx_pos(exons, collapsed)` walks the exon table accumulating spans and returns the flat offset for a 0-based inclusive collapsed offset.

- `cds_start` = `map(start_codon)`. Shifts whenever a gap precedes the start codon — no build in this cdot does (measured 0/56), but the mapping does not assume it.
- `cds_end` = `map(stop_codon - 1) + 1` — mapped through its **last coding base**, not directly. This is what the naive "add every preceding gap" gets wrong: a CDS flush with an exon boundary would absorb the gap that *follows* it. Pinned by `cdot_cds_end_flush_with_an_exon_boundary_excludes_the_following_gap`, which passes both before and after — it guards against the wrong fix, not against the defect.

Nothing keys on gaps being multiples of 3. Identity on any contiguous exon table, so this is a no-op for 474,760 of 474,818 multi-exon GRCh38 builds; **56 records change, all on `cds_end`**.

## Two cache format versions bumped

`RKYV_FORMAT_VERSION` 3→4 and `CDOT_BINCODE_VERSION` 3→4. Both layouts are unchanged, so neither rkyv's structural validation nor bincode's positional read can see a purely semantic change, and a stale cache would keep serving collapsed bounds. The bincode bump is load-bearing in its own right: a fresh legacy `.bin` is preferred over the JSON and then **promoted to an rkyv archive**, so leaving it at 3 would launder stale values into a current-version cache. Precedent is #742/#972, which bumped both for the same class of change.

Existing prepared references reparse the cdot JSON once and self-heal (~10× slower first load). Neither cache file is listed in `manifest.json`, so the blessed reference identity is not at risk.

## What this does not fix

#1619's other half, where `hgvs_to_spdi` resolves a `c.` position by *walking* the exon list while the normalizer indexes the flat transcript — that is #1735. `NM_033517.1`'s `cds_start` is 0 and does not move, so the `c.4818dupC` denoted-sequence-oracle row is unchanged by this PR.

## Verification

`cargo fmt --all --check`, `cargo clippy --features dev --lib` and `--all-targets` all clean; `cargo t` 10,215 passed, 0 failed. Three tests failed first and are shown to fail on the previous behaviour.

`tests/it/normalization_transcripts_exon_contract.rs` gains `the_gapped_records_cds_bounds_are_flat`, pinning the fixture side — the gap must lie inside the CDS, `cds_end` must land inside an exon, and `cds_end − gap` must reproduce cdot's raw 5157. Sabotage-checked: flipping 5157→5158 fails it.

Representation-Change: 56 of 482,519 GRCh38 cdot builds move — all on cds_end, all widening by their transcript-coordinate gap; 0 cds_start moves. Every contiguous exon table is untouched. This changes what the live provider serves for those 56 accessions (a c. description near or past the CDS end resolves differently), so it is a real migration for a reference-backed consumer. Declared although src/data/ and src/reference/ are not watched directories — the check does not require this trailer for this PR.



## Upstream

cdot serves two coordinate spaces without distinguishing them, which is the condition this PR compensates for. That ambiguity is reported upstream as [SACGF/cdot#123](https://github.com/SACGF/cdot/issues/123) and tracked here by #1759.

The tracking issue matters because the compensation is direction-dependent: `collapsed_to_flat_tx_pos` becomes a *double*-correction if cdot ever changes its data to serve flat bounds, landing `cds_end` at 5235 instead of 5196. That would be invisible on a contiguous exon table, where the mapping is the identity. #1759 records what to re-measure if the upstream answer changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CDS and codon coordinate handling for transcripts containing gaps.
  * Prevented invalid or malformed exon data from producing incorrect transcript structures.
  * Added warnings when malformed exon records are discarded.
  * Improved fallback behavior for genomic CDS coordinates.

* **Compatibility**
  * Updated cached transcript data formats to ensure previously stored data is safely invalidated when coordinate semantics change.

* **Tests**
  * Expanded coverage for gapped transcripts, coordinate validation, both strand orientations, and CDS boundary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->