### PR TITLE
fix(python): validate the numeric conversion entry points at the boundary

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -220,6 +220,213 @@ fn projection_error_at(i: usize, e: &crate::error::FerroError) -> PyErr {
     )
 }
 
+// ============================================================================
+// Numeric coordinate entry points: boundary validation
+// ============================================================================
+//
+// `CoordinateMapper`'s `c_to_g` / `g_to_c` / `c_to_p` / `c_to_n` / `n_to_c`
+// take coordinates as raw integers rather than as a description, so nothing
+// the parser checks is on their path — they build a `CdsPos` / `TxPos` from
+// whatever Python passed. Everything a description would have been checked for
+// has to be checked here instead, or ferro answers questions it has already
+// refused to answer at its other entry point.
+//
+// These helpers are deliberately *pure*: they take and return plain values and
+// never touch the interpreter, so the unit tests at the bottom of this file can
+// exercise them without a Python runtime. Only `BoundaryRejection::into_pyerr`
+// crosses into PyO3.
+
+/// A refused argument at a numeric coordinate entry point.
+///
+/// Carries the library error the refusal corresponds to as well as the message,
+/// so the Python exception reports the same `E####` code and mutalyzer
+/// equivalents the rest of ferro reports for the same refusal — a caller
+/// discriminating on `err.code` sees one vocabulary, not one per entry point.
+struct BoundaryRejection {
+    /// The `ferro_hgvs` exception class to raise (see `ferro_exception`).
+    class: &'static str,
+    /// The message, phrased for a caller who passed integers: it names the
+    /// coordinate rather than an offset into a source string, because at these
+    /// entry points there is no source string.
+    message: String,
+    /// The equivalent library error, read only for its code and mutalyzer map.
+    error: crate::error::FerroError,
+}
+
+impl BoundaryRejection {
+    fn into_pyerr(self) -> PyErr {
+        ferro_typed(self.class, self.message, &self.error)
+    }
+}
+
+/// Spell the coordinate a numeric entry point was handed, for a diagnostic.
+fn render_boundary_position(axis: char, base: i64, utr3: bool) -> String {
+    if utr3 {
+        format!("{axis}.*{base}")
+    } else {
+        format!("{axis}.{base}")
+    }
+}
+
+/// Whether `offset` is one of the parser's unknown-offset sentinels rather than
+/// a measured intronic distance.
+///
+/// Mirrors [`CdsPos::has_unknown_offset`] but takes the bare `Option<i64>`, so
+/// it can be applied to an argument before any position struct is built — which
+/// is the whole point at these entry points.
+fn is_unknown_offset(offset: Option<i64>) -> bool {
+    use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+    matches!(
+        offset,
+        Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE)
+    )
+}
+
+/// Refuse a base coordinate of zero.
+///
+/// `parse_hgvs` refuses `c.0` / `n.0` as `E1003 InvalidPosition` ("Position 0
+/// is not valid in HGVS notation", `src/error_handling/preprocessor.rs`), on
+/// the spec's authority: `background/numbering.md:31` states there is no
+/// nucleotide `c.0`. That sits *inside* the definition of the numbering axis,
+/// so it is a claim about what the axis contains rather than input hygiene —
+/// and it therefore holds however the coordinate arrives, as an integer just as
+/// much as as text. Every other implementation agrees: biocommons/hgvs raises
+/// "BaseOffsetPosition base may not be 0" from the type itself, Mutalyzer
+/// rejects it, and `mutalyzer-crossmapper`'s documentation opens with "There is
+/// no zero (0) in any of the HGVS numbering systems".
+///
+/// Without this the numeric entry points answered `c.0` **identically to
+/// `c.1`** — `CoordinateMapper::cds_to_tx` routes a zero base through its
+/// `base < 1` arm, which adds nothing, landing on the CDS start.
+///
+/// No ruling record has been committed for `c.0` yet, so the authorities are
+/// recorded here rather than in the ledger. Two sites inside ferro still
+/// disagree with this and with each other (`src/convert/mapper.rs` reads `c.0`
+/// as `c.1`, `src/normalize/mod.rs` reads it as `c.-1`); reconciling those is
+/// separate work, and this refusal is correct whichever way it goes, because a
+/// coordinate that does not exist cannot be converted to one that does.
+fn reject_zero_base(axis: char, base: i64, utr3: bool) -> Result<(), BoundaryRejection> {
+    if base != 0 {
+        return Ok(());
+    }
+    let position = render_boundary_position(axis, base, utr3);
+    let message = format!("Position 0 is not valid in HGVS notation ({position})");
+    Err(BoundaryRejection {
+        class: "ParseError",
+        message: message.clone(),
+        error: crate::error::FerroError::parse_with_diagnostic(
+            0,
+            message,
+            crate::error::Diagnostic::new()
+                .with_code(crate::error::ErrorCode::InvalidPosition)
+                .with_hint("HGVS positions start at 1, not 0"),
+        ),
+    })
+}
+
+/// Refuse an unknown-offset sentinel where a measured distance is required.
+///
+/// `c.N+?` / `c.N-?` parse to `i64::MAX` / `i64::MIN`. Per the spec they denote
+/// an unknown position 3'/5' of the base, unbounded in that direction, so no
+/// coordinate can be derived from them at all — see
+/// [`CdsPos::has_unknown_offset`] and issue #1087.
+///
+/// The `#1087` / PR `#1088` guard lives in `src/data/mapping.rs` and is not on
+/// this path. This is the same refusal, at the entry point that reaches the
+/// conversion without it — the wording and the `UnsupportedProjection` code are
+/// deliberately kept identical to that guard's.
+///
+/// # What this guard does NOT do — read before widening it
+///
+/// It is keyed on sentinel **identity**, and that is all it can be keyed on: it
+/// runs before the transcript is fetched, so it holds no intron to measure a
+/// magnitude against. It is therefore **not** what protects
+/// `Transcript::intronic_to_genomic` from an oversized offset, and an earlier
+/// version of this comment claimed otherwise — describing the `i64::MIN`
+/// negation overflow as if refusing the sentinel closed it. It did not:
+/// `i64::MIN + 1` is one step away, is not a sentinel, and reproduced the whole
+/// class (panic under `debug_assertions`, silent wrap in a `--release` wheel),
+/// while `i64::MAX - 1` returned a coordinate-shaped number ~9.2e18 bases
+/// outside its intron. That is #1765.
+///
+/// The magnitude class is closed where the magnitude can actually be judged —
+/// in `intronic_to_genomic`, whose arithmetic is now total (`unsigned_abs` plus
+/// checked add/sub) and whose result must land inside the intron the offset was
+/// measured into, else it declines. Every caller gets that, not only this one.
+///
+/// So what survives here is the **diagnostic**: `+?` / `-?` deserve to be named
+/// as unknown-offset markers rather than reported as an unmappable distance.
+fn reject_sentinel_offset(
+    axis: char,
+    base: i64,
+    utr3: bool,
+    offset: Option<i64>,
+) -> Result<(), BoundaryRejection> {
+    use crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE;
+    if !is_unknown_offset(offset) {
+        return Ok(());
+    }
+    let sign = if offset == Some(OFFSET_UNKNOWN_NEGATIVE) {
+        '-'
+    } else {
+        '+'
+    };
+    let position = render_boundary_position(axis, base, utr3);
+    Err(unsupported_boundary_projection(format!(
+        "cannot resolve unknown intronic offset (`{sign}?`) at {position}"
+    )))
+}
+
+/// Refuse to *return* an unknown-offset sentinel to Python.
+///
+/// The sibling of [`reject_sentinel_offset`], on the way out. An `i64` sentinel
+/// crosses into Python as `9223372036854775807`, which a caller cannot tell
+/// from a measured distance — there is no `None`, no marker, nothing. Stated
+/// over the produced value rather than over the argument so it still holds if a
+/// conversion ever yields a sentinel it was not handed.
+fn reject_sentinel_result(
+    axis: char,
+    base: i64,
+    offset: Option<i64>,
+) -> Result<(), BoundaryRejection> {
+    if !is_unknown_offset(offset) {
+        return Ok(());
+    }
+    Err(unsupported_boundary_projection(format!(
+        "conversion produced an unknown intronic offset at {axis}.{base}, which has no \
+         representation as a distance"
+    )))
+}
+
+/// Refuse a `downstream` flag the conversion behind this entry point discards.
+///
+/// `n.*N` names a position past the end of the transcript. `tx_to_cds` drops
+/// the flag, so `downstream=True` and `downstream=False` returned the same
+/// triple and a caller asking about `n.*195` was answered about `n.195` — with
+/// no indication the question had been changed. Honouring the flag is a change
+/// to the conversion and is tracked separately; until that lands the honest
+/// answer at the boundary is a refusal, because a confidently wrong coordinate
+/// is worse than an error. Lift this once `tx_to_cds` honours the flag.
+fn reject_unhonoured_downstream(downstream: bool) -> Result<(), BoundaryRejection> {
+    if !downstream {
+        return Ok(());
+    }
+    Err(unsupported_boundary_projection(
+        "the transcript-to-CDS conversion does not honour `downstream` (n.*N), so it cannot be \
+         answered rather than silently answered as `downstream=False`"
+            .to_string(),
+    ))
+}
+
+/// Build the `UnsupportedProjection` rejection the three refusals above share.
+fn unsupported_boundary_projection(reason: String) -> BoundaryRejection {
+    BoundaryRejection {
+        class: "ProjectionError",
+        message: reason.clone(),
+        error: crate::error::FerroError::UnsupportedProjection { reason },
+    }
+}
+
 /// Convert a list of per-input projection lists into the Python return value —
 /// a `list[list[VariantProjection]]`.
 fn projections_to_pylist(
@@ -6610,15 +6817,24 @@ impl PyCoordinateMapper {
     ///
     /// Args:
     ///     transcript_id: Transcript accession (e.g., "NM_000088.3")
-    ///     cds_position: CDS position (e.g., 100 for c.100)
-    ///     offset: Optional intronic offset (e.g., 5 for c.100+5)
+    ///     cds_position: CDS position in the transcript's c. numbering, 1-based
+    ///         (e.g., 100 for c.100). Negative values are 5' UTR positions
+    ///         (-1 for c.-1); 0 is not a position on this axis and is refused.
+    ///     offset: Optional intronic offset in bases from the nearest exon
+    ///         boundary (e.g., 5 for c.100+5). Must be a measured distance:
+    ///         the unknown-offset sentinels that `c.100+?` / `c.100-?` parse to
+    ///         (2**63 - 1 and -2**63) denote no distance and are refused.
     ///
     /// Returns:
-    ///     Tuple of (chromosome, genomic_position) or None if position is intronic
-    ///     without offset support
+    ///     Tuple of (chromosome, genomic_position), where genomic_position is
+    ///     a 1-based coordinate on that chromosome; or None if the position is
+    ///     intronic without offset support.
     ///
     /// Raises:
-    ///     ValueError: If transcript not found or has no genomic coordinates
+    ///     ParseError: If cds_position is 0 (E1003; HGVS has no c.0).
+    ///     ProjectionError: If offset is an unknown-offset sentinel (E4003), or
+    ///         the conversion fails.
+    ///     ReferenceDataError: If the transcript is not found.
     #[pyo3(signature = (transcript_id, cds_position, offset=None))]
     fn c_to_g(
         &self,
@@ -6626,6 +6842,10 @@ impl PyCoordinateMapper {
         cds_position: i64,
         offset: Option<i64>,
     ) -> PyResult<Option<(String, u64)>> {
+        reject_zero_base('c', cds_position, false).map_err(BoundaryRejection::into_pyerr)?;
+        reject_sentinel_offset('c', cds_position, false, offset)
+            .map_err(BoundaryRejection::into_pyerr)?;
+
         let transcript = self.provider.get_transcript(transcript_id).map_err(|e| {
             ferro_typed(
                 "ReferenceDataError",
@@ -6700,16 +6920,21 @@ impl PyCoordinateMapper {
     ///
     /// Args:
     ///     transcript_id: Transcript accession (e.g., "NM_000088.3")
-    ///     genomic_position: Genomic position (1-based)
+    ///     genomic_position: Genomic position on the transcript's chromosome,
+    ///         1-based.
     ///
     /// Returns:
-    ///     Tuple of (cds_position, offset, is_utr3). For exonic positions,
-    ///     offset will be None. For intronic positions, offset will contain
-    ///     the distance from the nearest exon boundary.
+    ///     Tuple of (cds_position, offset, is_utr3), where cds_position is
+    ///     1-based in the transcript's c. numbering (negative in the 5' UTR,
+    ///     and counted from the CDS end when is_utr3 is True, i.e. c.*N). For
+    ///     exonic positions, offset will be None. For intronic positions,
+    ///     offset is the signed distance in bases from the nearest exon
+    ///     boundary.
     ///
     /// Raises:
-    ///     ValueError: If transcript not found, position is outside transcript bounds,
-    ///         or conversion fails
+    ///     ProjectionError: If the position is outside transcript bounds or the
+    ///         conversion fails.
+    ///     ReferenceDataError: If the transcript is not found.
     fn g_to_c(
         &self,
         transcript_id: &str,
@@ -6755,14 +6980,22 @@ impl PyCoordinateMapper {
     ///
     /// Args:
     ///     transcript_id: Transcript accession (e.g., "NM_000088.3")
-    ///     cds_position: CDS position (e.g., 100 for c.100)
+    ///     cds_position: CDS position in the transcript's c. numbering, 1-based
+    ///         (e.g., 100 for c.100). Negative values are 5' UTR positions and
+    ///         have no protein position; 0 is not a position on this axis and
+    ///         is refused.
     ///
     /// Returns:
-    ///     Protein position (1-based codon number)
+    ///     Protein position in the encoded protein's p. numbering, 1-based
+    ///     (the codon number).
     ///
     /// Raises:
-    ///     ValueError: If transcript not found or position is in UTR/intronic
+    ///     ParseError: If cds_position is 0 (E1003; HGVS has no c.0).
+    ///     ProjectionError: If the position is in a UTR or intronic.
+    ///     ReferenceDataError: If the transcript is not found.
     fn c_to_p(&self, transcript_id: &str, cds_position: i64) -> PyResult<u64> {
+        reject_zero_base('c', cds_position, false).map_err(BoundaryRejection::into_pyerr)?;
+
         let transcript = self.provider.get_transcript(transcript_id).map_err(|e| {
             ferro_typed(
                 "ReferenceDataError",
@@ -6785,15 +7018,26 @@ impl PyCoordinateMapper {
     ///
     /// Args:
     ///     transcript_id: Transcript accession (e.g., "NM_000088.3")
-    ///     cds_position: CDS position (e.g., 100 for c.100)
-    ///     offset: Optional intronic offset
+    ///     cds_position: CDS position in the transcript's c. numbering, 1-based
+    ///         (e.g., 100 for c.100). Negative values are 5' UTR positions; when
+    ///         utr3 is True the value counts from the CDS end (c.*N). 0 is not a
+    ///         position on this axis and is refused.
+    ///     offset: Optional intronic offset in bases from the nearest exon
+    ///         boundary. Must be a measured distance: the unknown-offset
+    ///         sentinels that `c.100+?` / `c.100-?` parse to (2**63 - 1 and
+    ///         -2**63) denote no distance and are refused.
     ///     utr3: Whether this is a 3' UTR position (c.*N notation)
     ///
     /// Returns:
-    ///     Tuple of (transcript_position, offset)
+    ///     Tuple of (transcript_position, offset), where transcript_position is
+    ///     1-based in the transcript's n. numbering and offset is the same
+    ///     signed intronic distance in bases, or None for an exonic position.
     ///
     /// Raises:
-    ///     ValueError: If transcript not found
+    ///     ParseError: If cds_position is 0 (E1003; HGVS has no c.0).
+    ///     ProjectionError: If offset is an unknown-offset sentinel (E4003), or
+    ///         the conversion fails.
+    ///     ReferenceDataError: If the transcript is not found.
     #[pyo3(signature = (transcript_id, cds_position, offset=None, utr3=false))]
     fn c_to_n(
         &self,
@@ -6802,6 +7046,10 @@ impl PyCoordinateMapper {
         offset: Option<i64>,
         utr3: bool,
     ) -> PyResult<(i64, Option<i64>)> {
+        reject_zero_base('c', cds_position, utr3).map_err(BoundaryRejection::into_pyerr)?;
+        reject_sentinel_offset('c', cds_position, utr3, offset)
+            .map_err(BoundaryRejection::into_pyerr)?;
+
         let transcript = self.provider.get_transcript(transcript_id).map_err(|e| {
             ferro_typed(
                 "ReferenceDataError",
@@ -6819,26 +7067,47 @@ impl PyCoordinateMapper {
             special: None,
         };
 
-        mapper
+        let tx_pos = mapper
             .cds_to_tx(&cds_pos)
-            .map(|tx_pos| (tx_pos.base, tx_pos.offset))
-            .map_err(|e| ferro_typed("ProjectionError", format!("Conversion error: {e}"), &e))
+            .map_err(|e| ferro_typed("ProjectionError", format!("Conversion error: {e}"), &e))?;
+
+        // `cds_to_tx` copies the offset through without arithmetic, so a
+        // sentinel that got past the entry check would leave here as a plain
+        // integer. Refusing on the way out too costs nothing and keeps the
+        // guarantee a property of the return value.
+        reject_sentinel_result('n', tx_pos.base, tx_pos.offset)
+            .map_err(BoundaryRejection::into_pyerr)?;
+
+        Ok((tx_pos.base, tx_pos.offset))
     }
 
     /// Convert a transcript position to CDS position
     ///
     /// Args:
     ///     transcript_id: Transcript accession (e.g., "NM_000088.3")
-    ///     tx_position: Transcript position (1-based)
-    ///     offset: Optional intronic offset
+    ///     tx_position: Transcript position in the transcript's n. numbering,
+    ///         1-based. 0 is not a position on this axis and is refused.
+    ///     offset: Optional intronic offset in bases from the nearest exon
+    ///         boundary. Must be a measured distance: the unknown-offset
+    ///         sentinels that `n.100+?` / `n.100-?` parse to (2**63 - 1 and
+    ///         -2**63) denote no distance and are refused.
     ///     downstream: Whether this is a downstream position (n.*100 notation for
     ///         positions past the end of the transcript). Defaults to False.
+    ///         Currently refused when True — the conversion does not honour it.
     ///
     /// Returns:
-    ///     Tuple of (cds_position, offset, is_utr3)
+    ///     Tuple of (cds_position, offset, is_utr3), where cds_position is
+    ///     1-based in the transcript's c. numbering (negative in the 5' UTR,
+    ///     and counted from the CDS end when is_utr3 is True, i.e. c.*N) and
+    ///     offset is the same signed intronic distance in bases, or None for an
+    ///     exonic position.
     ///
     /// Raises:
-    ///     ValueError: If transcript not found or has no CDS
+    ///     ParseError: If tx_position is 0 (E1003; HGVS has no n.0).
+    ///     ProjectionError: If offset is an unknown-offset sentinel, if
+    ///         downstream is True (both E4003), if the transcript resolves but
+    ///         has no CDS (E5001), or the conversion otherwise fails.
+    ///     ReferenceDataError: If the transcript is not found (E2001).
     #[pyo3(signature = (transcript_id, tx_position, offset=None, downstream=false))]
     fn n_to_c(
         &self,
@@ -6847,6 +7116,11 @@ impl PyCoordinateMapper {
         offset: Option<i64>,
         downstream: bool,
     ) -> PyResult<(i64, Option<i64>, bool)> {
+        reject_zero_base('n', tx_position, false).map_err(BoundaryRejection::into_pyerr)?;
+        reject_sentinel_offset('n', tx_position, false, offset)
+            .map_err(BoundaryRejection::into_pyerr)?;
+        reject_unhonoured_downstream(downstream).map_err(BoundaryRejection::into_pyerr)?;
+
         let transcript = self.provider.get_transcript(transcript_id).map_err(|e| {
             ferro_typed(
                 "ReferenceDataError",
@@ -7069,6 +7343,181 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The numeric coordinate entry points' boundary validators.
+    ///
+    /// These are asserted here rather than only through `tests/python/` because
+    /// they are pure — they never touch the interpreter — so they can be
+    /// exercised by `cargo test --features python --lib` with no Python
+    /// runtime. The end-to-end half, which proves the guards are actually wired
+    /// into the five methods and that the refusals cross into Python as the
+    /// right exception classes, is
+    /// `tests/python/test_numeric_entry_point_validation.py`.
+    mod numeric_entry_point_validation {
+        use super::*;
+        use crate::error::ErrorCode;
+        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+
+        #[test]
+        fn a_zero_base_is_refused_with_the_parsers_code() {
+            for (axis, utr3, rendered) in [
+                ('c', false, "c.0"),
+                ('c', true, "c.*0"),
+                ('n', false, "n.0"),
+            ] {
+                let rejection =
+                    reject_zero_base(axis, 0, utr3).expect_err("a base of zero must be refused");
+
+                assert_eq!(rejection.class, "ParseError");
+                assert_eq!(rejection.error.code(), Some(ErrorCode::InvalidPosition));
+                assert!(
+                    rejection
+                        .message
+                        .contains("Position 0 is not valid in HGVS notation"),
+                    "message must reuse the parser's wording, got {:?}",
+                    rejection.message
+                );
+                assert!(
+                    rejection.message.contains(rendered),
+                    "message must name the coordinate {rendered}, got {:?}",
+                    rejection.message
+                );
+            }
+        }
+
+        /// The guard fires at zero and nowhere else — in particular not on the
+        /// negative 5'UTR coordinates a "positions must be positive" check
+        /// would wrongly reject.
+        #[test]
+        fn every_other_base_is_admitted() {
+            for base in [-1000, -1, 1, 2, i64::MAX] {
+                assert!(reject_zero_base('c', base, false).is_ok(), "c.{base}");
+                assert!(reject_zero_base('c', base, true).is_ok(), "c.*{base}");
+                assert!(reject_zero_base('n', base, false).is_ok(), "n.{base}");
+            }
+        }
+
+        #[test]
+        fn a_sentinel_offset_is_refused_in_both_directions() {
+            for (offset, sign) in [
+                (OFFSET_UNKNOWN_POSITIVE, '+'),
+                (OFFSET_UNKNOWN_NEGATIVE, '-'),
+            ] {
+                let rejection = reject_sentinel_offset('c', 100, false, Some(offset))
+                    .expect_err("an unknown-offset sentinel must be refused");
+
+                assert_eq!(rejection.class, "ProjectionError");
+                assert_eq!(
+                    rejection.error.code(),
+                    Some(ErrorCode::UnsupportedProjection),
+                    "must reuse the #1088 guard's code, not invent one",
+                );
+                assert!(
+                    rejection
+                        .message
+                        .contains(&format!("unknown intronic offset (`{sign}?`)")),
+                    "message must name the direction, got {:?}",
+                    rejection.message
+                );
+                assert!(
+                    rejection.message.contains("c.100"),
+                    "{:?}",
+                    rejection.message
+                );
+            }
+        }
+
+        /// A measured distance — including one large enough to be implausible —
+        /// is not a sentinel and must pass *this* guard. Only the two exact
+        /// sentinel values are markers; everything else is a number the
+        /// conversion judges for itself.
+        ///
+        /// That last clause used to be an assumption and is now true: #1765
+        /// measured that the conversion did **not** judge them — it overflowed
+        /// on `i64::MIN + 1` and returned a coordinate-shaped number for
+        /// `i64::MAX - 1` — so this test was pinning the gap open rather than
+        /// stating a property. `intronic_to_genomic` is now total and bounded by
+        /// the intron the offset is measured into, which is what makes admitting
+        /// them here safe; see
+        /// `reference::transcript::tests::intronic_to_genomic_declines_an_offset_that_leaves_its_own_intron`
+        /// and its sibling, which pin the other side of that contract.
+        #[test]
+        fn a_measured_offset_is_admitted() {
+            for offset in [
+                None,
+                Some(-1_000_000),
+                Some(-5),
+                Some(0),
+                Some(5),
+                Some(i64::MAX - 1),
+            ] {
+                assert!(
+                    reject_sentinel_offset('c', 100, false, offset).is_ok(),
+                    "offset {offset:?}",
+                );
+                assert!(
+                    reject_sentinel_result('n', 100, offset).is_ok(),
+                    "offset {offset:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn a_sentinel_result_is_refused_on_the_way_out() {
+            for offset in [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE] {
+                let rejection = reject_sentinel_result('n', 100, Some(offset))
+                    .expect_err("a sentinel must not be returned to Python");
+
+                assert_eq!(rejection.class, "ProjectionError");
+                assert_eq!(
+                    rejection.error.code(),
+                    Some(ErrorCode::UnsupportedProjection)
+                );
+                assert!(
+                    rejection.message.contains("n.100"),
+                    "{:?}",
+                    rejection.message
+                );
+            }
+        }
+
+        #[test]
+        fn the_downstream_flag_is_refused_only_when_set() {
+            assert!(reject_unhonoured_downstream(false).is_ok());
+
+            let rejection = reject_unhonoured_downstream(true)
+                .expect_err("a flag the conversion discards must not be accepted");
+            assert_eq!(rejection.class, "ProjectionError");
+            assert_eq!(
+                rejection.error.code(),
+                Some(ErrorCode::UnsupportedProjection)
+            );
+            assert!(
+                rejection.message.contains("downstream"),
+                "{:?}",
+                rejection.message
+            );
+        }
+
+        /// The sentinel predicate must key on the two exact values, so that a
+        /// neighbouring magnitude is still treated as a distance. Pinned
+        /// separately because both guards above are built on it.
+        ///
+        /// "Treated as a distance" is the right answer to a question about
+        /// *sentinel identity* and was the wrong answer to the question #1765
+        /// actually asked, which is about magnitude. Keying this predicate wider
+        /// would have been the wrong repair — a sentinel is a sentinel, and
+        /// `i64::MIN + 1` is a number — so the magnitude condition is enforced in
+        /// `intronic_to_genomic` instead, where the intron is in hand.
+        #[test]
+        fn only_the_two_exact_sentinels_are_sentinels() {
+            assert!(is_unknown_offset(Some(OFFSET_UNKNOWN_POSITIVE)));
+            assert!(is_unknown_offset(Some(OFFSET_UNKNOWN_NEGATIVE)));
+            assert!(!is_unknown_offset(None));
+            assert!(!is_unknown_offset(Some(OFFSET_UNKNOWN_POSITIVE - 1)));
+            assert!(!is_unknown_offset(Some(OFFSET_UNKNOWN_NEGATIVE + 1)));
+        }
+    }
 
     /// Closes #395 item 5 — verifies the `From<&NormalizationWarning>
     /// for PyNormalizationWarning` converter at the Rust level.

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -802,32 +802,37 @@ impl Transcript {
         // Get the genomic coordinates of the intron
         let (g_start, g_end) = (intron.genomic_start?, intron.genomic_end?);
 
-        match self.strand {
-            Strand::Plus => {
-                if offset > 0 {
-                    // c.N+offset: offset bases after the 5' exon boundary
-                    // genomic = intron start + offset - 1 (offset is 1-based)
-                    Some(g_start + offset as u64 - 1)
-                } else {
-                    // c.N-offset: |offset| bases before the 3' exon boundary
-                    // genomic = intron end - |offset| + 1
-                    Some(g_end - (-offset) as u64 + 1)
-                }
-            }
-            Strand::Minus => {
-                // On minus strand, genomic coordinates are reversed relative to transcript
-                if offset > 0 {
-                    // c.N+offset: offset bases after the 5' exon boundary
-                    // For minus strand: intron end - offset + 1
-                    Some(g_end - offset as u64 + 1)
-                } else {
-                    // c.N-offset: |offset| bases before the 3' exon boundary
-                    // For minus strand: intron start + |offset| - 1
-                    Some(g_start + (-offset) as u64 - 1)
-                }
-            }
-            Strand::Unknown => None,
-        }
+        // An offset is a *distance into this intron*, so it is judged on its
+        // magnitude — never on whether it happens to equal one of the parser's
+        // unknown-offset sentinels. #1765.
+        //
+        // `unsigned_abs` is total where `-offset` is not: `i64::MIN` has no
+        // positive twin, so the old `(-offset) as u64` aborted with "attempt to
+        // negate with overflow" under `debug_assertions` and wrapped silently in
+        // a `--release` wheel. The checked add/sub then keep an oversized
+        // magnitude from wrapping the genomic coordinate.
+        let distance = offset.unsigned_abs();
+
+        let genomic = match (self.strand, offset > 0) {
+            // c.N+offset: `offset` bases 3' of the upstream exon boundary,
+            // counted from the intron's first base (the offset is 1-based).
+            (Strand::Plus, true) => g_start.checked_add(distance)?.checked_sub(1)?,
+            // c.N-offset: `|offset|` bases 5' of the downstream exon boundary,
+            // counted back from the intron's last base.
+            (Strand::Plus, false) => g_end.checked_sub(distance)?.checked_add(1)?,
+            // On the minus strand genomic coordinates run against transcript
+            // ones, so the two arms swap which intron edge they anchor on.
+            (Strand::Minus, true) => g_end.checked_sub(distance)?.checked_add(1)?,
+            (Strand::Minus, false) => g_start.checked_add(distance)?.checked_sub(1)?,
+            (Strand::Unknown, _) => return None,
+        };
+
+        // An offset larger than the intron it is measured into names no
+        // intronic base, so it names no genomic coordinate either. Without this
+        // the arithmetic stays in range for any magnitude `u64` can hold, and
+        // `i64::MAX - 1` returned a coordinate-shaped number ~9.2e18 bases
+        // outside the intron rather than declining. #1765.
+        (g_start..=g_end).contains(&genomic).then_some(genomic)
     }
 
     /// Map an offset that points *past a transcript terminus* to a genomic
@@ -1713,5 +1718,103 @@ mod tests {
         let tx = make_test_transcript_with_genomic();
         // tx 12 is interior to exon 2 (tx 8..14), not an exon boundary.
         assert_eq!(tx.intronic_to_genomic(12, 3), None);
+    }
+
+    /// A two-exon plus-strand transcript with a genuine *interior* intron, so
+    /// the intron arms of [`Transcript::intronic_to_genomic`] are exercised
+    /// rather than the beyond-terminus fallback. The geometry matches the
+    /// fixture in `tests/python/test_numeric_entry_point_validation.py`, so the
+    /// numbers here and the ones measured across FFI are the same numbers:
+    ///
+    /// ```text
+    ///   exon 1: tx   1..100, genomic 1001..1100
+    ///   intron:               genomic 1101..2000   (900 bases)
+    ///   exon 2: tx 101..200, genomic 2001..2100
+    /// ```
+    fn make_interior_intron_transcript() -> Transcript {
+        Transcript {
+            id: "NM_TEST.1".to_string(),
+            strand: Strand::Plus,
+            cds_start: Some(11),
+            cds_end: Some(190),
+            exons: vec![
+                Exon::with_genomic(1, 1, 100, 1001, 1100),
+                Exon::with_genomic(2, 101, 200, 2001, 2100),
+            ],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1001),
+            genomic_end: Some(2100),
+            ..Default::default()
+        }
+    }
+
+    /// #1765: the hazard is the offset's **magnitude**, not whether it happens
+    /// to equal an unknown-offset sentinel.
+    ///
+    /// The arms used to be unchecked mixed-width arithmetic, so `i64::MIN + 1`
+    /// — one step away from the sentinel a boundary guard refuses by identity —
+    /// still reached `g_end - (-offset) as u64 + 1` and aborted with "attempt
+    /// to subtract with overflow" under `debug_assertions`, wrapping silently
+    /// in a `--release` wheel. Measured across FFI in #1765 as
+    /// `pyo3_runtime.PanicException`.
+    #[test]
+    fn intronic_to_genomic_declines_an_offset_whose_arithmetic_would_overflow() {
+        let tx = make_interior_intron_transcript();
+
+        // Controls: an ordinary measured distance still resolves, from either
+        // side of the intron.
+        assert_eq!(tx.intronic_to_genomic(100, 5), Some(1105));
+        assert_eq!(tx.intronic_to_genomic(101, -5), Some(1996));
+
+        // `i64::MIN` has no positive twin, so negating it overflows before the
+        // cast; `i64::MIN + 1` negates fine and then underflows the subtract.
+        assert_eq!(tx.intronic_to_genomic(100, i64::MIN), None);
+        assert_eq!(tx.intronic_to_genomic(100, i64::MIN + 1), None);
+        assert_eq!(tx.intronic_to_genomic(101, i64::MIN + 1), None);
+    }
+
+    /// The other half of #1765, and the half that never panicked: an offset
+    /// larger than the intron it is measured into names no intronic base, so it
+    /// must name no genomic coordinate either.
+    ///
+    /// `i64::MAX - 1` needed no overflow to do damage — `u64` has room for it,
+    /// so the old code returned `9223372036854776906`, a coordinate-shaped
+    /// number ~9.2e18 bases outside a 900-base intron. In a `--release` wheel
+    /// that is what the caller gets, with no error and no marker.
+    #[test]
+    fn intronic_to_genomic_declines_an_offset_that_leaves_its_own_intron() {
+        let tx = make_interior_intron_transcript();
+
+        // The intron spans g 1101..2000, so 900 is the largest offset either
+        // arm can honour and 901 is one past it.
+        assert_eq!(tx.intronic_to_genomic(100, 900), Some(2000));
+        assert_eq!(tx.intronic_to_genomic(100, 901), None);
+        assert_eq!(tx.intronic_to_genomic(101, -900), Some(1101));
+        assert_eq!(tx.intronic_to_genomic(101, -901), None);
+
+        assert_eq!(tx.intronic_to_genomic(100, i64::MAX - 1), None);
+        assert_eq!(tx.intronic_to_genomic(100, i64::MAX), None);
+    }
+
+    /// The same two properties on the minus strand, where the arms walk the
+    /// other way: `intronic_to_genomic(5, +n)` counts *down* from the intron's
+    /// high edge and `(6, -n)` counts *up* from its low edge.
+    #[test]
+    fn intronic_to_genomic_bounds_the_offset_on_the_minus_strand_too() {
+        let tx = make_minus_test_transcript();
+
+        // exon 1 is g 200..204 and exon 2 is g 100..104, so the intron spans
+        // g 105..199 — 95 bases.
+        assert_eq!(tx.intronic_to_genomic(5, 1), Some(199));
+        assert_eq!(tx.intronic_to_genomic(5, 95), Some(105));
+        assert_eq!(tx.intronic_to_genomic(5, 96), None);
+        assert_eq!(tx.intronic_to_genomic(6, -1), Some(105));
+        assert_eq!(tx.intronic_to_genomic(6, -95), Some(199));
+        assert_eq!(tx.intronic_to_genomic(6, -96), None);
+
+        assert_eq!(tx.intronic_to_genomic(5, i64::MAX), None);
+        assert_eq!(tx.intronic_to_genomic(5, i64::MAX - 1), None);
+        assert_eq!(tx.intronic_to_genomic(6, i64::MIN), None);
+        assert_eq!(tx.intronic_to_genomic(6, i64::MIN + 1), None);
     }
 }

--- a/tests/python/test_issue_1018_typed_exceptions.py
+++ b/tests/python/test_issue_1018_typed_exceptions.py
@@ -148,19 +148,30 @@ class TestNormalizationError:
 class TestProjectionError:
     """Coordinate conversions raise a typed ``ProjectionError`` end-to-end."""
 
+    # Both tests below used ``c_to_p("NM_000088.3", 0)`` as their vehicle. That
+    # stopped being a projection failure: ``c.0`` is not a coordinate on the c.
+    # axis at all, and the numeric entry points now refuse it as ``ParseError``
+    # / ``E1003`` the way ``parse`` does. It only ever *reached* the converter
+    # because a zero base fell into the 5'UTR arm, where it failed with "Cannot
+    # convert UTR position to protein" — the right exception class for the wrong
+    # reason. ``c.-10`` is a genuine 5'UTR position and fails there honestly, so
+    # it exercises the same raise site while the tests keep their own subject,
+    # which is the exception *typing* and not what ``c.0`` means.
+
     def test_raises_projection_error(self) -> None:
         mapper = ferro_hgvs.CoordinateMapper()
-        # The transcript resolves, but CDS position 0 is not a valid coordinate,
-        # so the conversion (not the reference lookup) fails.
+        # The transcript resolves and c.-10 is a real coordinate, but it is in
+        # the 5' UTR and so has no protein position: the conversion (not the
+        # reference lookup, and not argument validation) is what fails.
         with pytest.raises(ferro_hgvs.ProjectionError):
-            mapper.c_to_p("NM_000088.3", 0)
+            mapper.c_to_p("NM_000088.3", -10)
 
     def test_backcompat_both_bases(self) -> None:
         # Conversion sites historically spanned ValueError and RuntimeError, so
         # ProjectionError must satisfy either ``except`` clause.
         mapper = ferro_hgvs.CoordinateMapper()
         with pytest.raises(ferro_hgvs.ProjectionError) as info:
-            mapper.c_to_p("NM_000088.3", 0)
+            mapper.c_to_p("NM_000088.3", -10)
         assert isinstance(info.value, ValueError)
         assert isinstance(info.value, RuntimeError)
 

--- a/tests/python/test_numeric_entry_point_validation.py
+++ b/tests/python/test_numeric_entry_point_validation.py
@@ -1,0 +1,403 @@
+"""``CoordinateMapper``'s numeric entry points must validate what they are handed.
+
+Five methods take raw integers from Python and build position structs directly,
+so none of the checks ``parse_hgvs`` applies to a written description reach
+them. Three escapes follow, and all three are only observable from here — the
+Rust API is reached through the parser, which refuses these values before a
+position struct exists.
+
+**Escape 1 — a base of zero.** ``parse_hgvs`` refuses ``c.0`` / ``n.0`` as
+``E1003 InvalidPosition`` ("Position 0 is not valid in HGVS notation"), on the
+spec's authority: ``background/numbering.md:31`` states there is no nucleotide
+``c.0``. That is a claim about what the numbering axis contains, so it holds
+however the coordinate arrives. Measured on the unfixed build, over the
+two-exon transcript below::
+
+    c_to_g("NM_TEST.1", 0) -> ('chr1', 1011)
+    c_to_g("NM_TEST.1", 1) -> ('chr1', 1011)
+
+— one entry point refusing and the other answering ``c.0`` *identically to*
+``c.1``.
+
+**Escape 2 — an unknown-offset sentinel used as a distance.** ``c.N+?`` / ``c.N-?``
+parse to ``i64::MAX`` / ``i64::MIN``, which are markers for "unknown, unbounded
+in this direction", not measured distances. Passed as ``offset`` they reach
+``Transcript::intronic_to_genomic``'s unchecked arithmetic — the ``#1087`` /
+PR ``#1088`` guard sits in ``src/data/mapping.rs`` and is not on this path.
+Measured on the unfixed build::
+
+    c_to_g("NM_TEST.1", 90, 2**63 - 1) -> ('chr1', 9223372036854776907)
+    c_to_g("NM_TEST.1", 91, -2**63)    !! pyo3_runtime.PanicException:
+                                          attempt to negate with overflow
+
+The negative sentinel overflows in ``-offset`` *before* the cast, so it panics
+under ``debug_assertions`` and wraps silently in the ``--release`` wheel CI
+ships. The positive sentinel needs no overflow to do damage: it returns a
+number that looks exactly like a coordinate.
+
+**Escape 2b — the same class, one step away from the sentinel (#1765).** The
+guard for escape 2 keys on sentinel *identity*, which is the right key for a
+marker and the wrong one for the arithmetic. ``i64::MIN + 1`` and
+``i64::MAX - 1`` are plain numbers, so no widening of the sentinel predicate
+reaches them, and both reproduced escape 2 in full. The magnitude condition is
+enforced where the magnitude can be judged — ``intronic_to_genomic`` is now
+total (``unsigned_abs`` plus checked add/sub) and refuses a result outside the
+intron the offset was measured into. See ``TestOversizedOffsetIsRefused``.
+
+**Escape 3 — a value handed back that the caller cannot read.** ``c_to_n``
+returns ``tx_pos.offset`` verbatim, so a sentinel comes back as
+``9223372036854775807``, indistinguishable from a measured distance; and
+``n_to_c`` forwards ``downstream``, which ``cds_to_tx``/``tx_to_cds`` discard,
+so ``downstream=True`` and ``downstream=False`` returned the same triple.
+
+The fix is at the boundary in every case: refuse the argument, or refuse to
+return the value. Repairing the conversions themselves is separate work on
+other branches, and a boundary that accepts a value it cannot mean is a defect
+whichever way those land.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+# The parser's own sentinels, spelled as Python ints. ``c.N+?`` -> ``i64::MAX``,
+# ``c.N-?`` -> ``i64::MIN`` (``src/hgvs/parser/position.rs``).
+OFFSET_UNKNOWN_POSITIVE = 2**63 - 1
+OFFSET_UNKNOWN_NEGATIVE = -(2**63)
+
+# A two-exon plus-strand transcript with genomic coordinates, so ``c_to_g``
+# resolves rather than declining for want of a genome. Built programmatically;
+# nothing here is committed as data.
+#
+#   exon 1: tx   1..100, genomic 1001..1100
+#   intron:               genomic 1101..2000
+#   exon 2: tx 101..200, genomic 2001..2100
+#   CDS:    tx  11..190  ->  c.1 = tx 11 = g.1011, c.90 = tx 100 = g.1100
+#
+# So ``c.90`` is the last exonic base before the intron and ``c.91`` the first
+# after it: ``c.90+n`` and ``c.91-n`` are the two intronic arms whose arithmetic
+# escape 2 is about.
+TRANSCRIPT_ID = "NM_TEST.1"
+REFERENCE = {
+    "transcripts": [
+        {
+            "id": TRANSCRIPT_ID,
+            "gene_symbol": "TEST",
+            "strand": "+",
+            "chromosome": "chr1",
+            "genomic_start": 1001,
+            "genomic_end": 2100,
+            "cds_start": 11,
+            "cds_end": 190,
+            "exons": [
+                {
+                    "number": 1,
+                    "start": 1,
+                    "end": 100,
+                    "genomic_start": 1001,
+                    "genomic_end": 1100,
+                },
+                {
+                    "number": 2,
+                    "start": 101,
+                    "end": 200,
+                    "genomic_start": 2001,
+                    "genomic_end": 2100,
+                },
+            ],
+        }
+    ]
+}
+
+
+@pytest.fixture
+def mapper(tmp_path: Path) -> ferro_hgvs.CoordinateMapper:
+    """A mapper over the two-exon transcript above.
+
+    Construction may emit the reduced-capability ``UserWarning`` (the reference
+    carries transcript geometry but no genome FASTA), which is expected and
+    unrelated to anything under test. It is suppressed rather than asserted:
+    the warn-once flag is process-global and shared across every surface, so
+    only the first mapper built in a given interpreter emits it and a
+    ``pytest.warns`` here would fail on every test after the first.
+    """
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(REFERENCE))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return ferro_hgvs.CoordinateMapper(reference_json=str(path))
+
+
+# ---------------------------------------------------------------------------
+# Escape 1: a base of zero
+# ---------------------------------------------------------------------------
+
+
+class TestBaseZeroIsRefused:
+    """``c.0`` / ``n.0`` get the parser's answer, not a coordinate."""
+
+    @pytest.mark.parametrize(
+        ("method", "args"),
+        [
+            ("c_to_g", ()),
+            ("c_to_p", ()),
+            ("c_to_n", ()),
+            ("n_to_c", ()),
+        ],
+    )
+    def test_zero_base_raises_e1003(
+        self, mapper: ferro_hgvs.CoordinateMapper, method: str, args: tuple[object, ...]
+    ) -> None:
+        """Every numeric entry point refuses a base of zero, with the parser's code.
+
+        The code is asserted, not just the exception type: ``c_to_p(0)`` already
+        failed before this change, but with "Cannot convert UTR position to
+        protein" — a wrong diagnosis that a bare ``pytest.raises`` would accept.
+        """
+        with pytest.raises(ferro_hgvs.ParseError) as excinfo:
+            getattr(mapper, method)(TRANSCRIPT_ID, 0, *args)
+
+        assert excinfo.value.code == "E1003"
+        assert "Position 0 is not valid in HGVS notation" in str(excinfo.value)
+
+    def test_the_written_and_the_numeric_entry_points_agree(
+        self, mapper: ferro_hgvs.CoordinateMapper
+    ) -> None:
+        """One coordinate, one answer, whichever door it arrives through.
+
+        This is the defect stated as a property: ``parse`` refuses ``c.0`` and
+        the numeric entry point answered it, so ferro had two entry points and
+        two answers. Only the *refusal* is compared, because the two doors
+        genuinely differ in how much they know: ``parse`` reports
+        ``ParseError`` with ``code is None`` (the nom parser bails before the
+        preprocessor's position-zero phase, which is what attaches ``E1003``
+        and what ``ferro parse`` prints on the CLI), while the numeric entry
+        point can name the code exactly because it has the integer in hand.
+        Pinning ``parse``'s missing code here would be pinning an unrelated
+        inconsistency.
+        """
+        with pytest.raises(ferro_hgvs.ParseError):
+            ferro_hgvs.parse(f"{TRANSCRIPT_ID}:c.0A>G")
+
+        with pytest.raises(ferro_hgvs.ParseError):
+            mapper.c_to_g(TRANSCRIPT_ID, 0)
+
+    def test_nonzero_neighbours_still_convert(self, mapper: ferro_hgvs.CoordinateMapper) -> None:
+        """The guard fires at zero and nowhere else.
+
+        Without this, refusing every base would satisfy the assertions above.
+        ``c.-1`` is the 5'UTR base immediately before ``c.1`` and must survive:
+        it is a legal coordinate whose sign a naive "must be positive" check
+        would reject.
+        """
+        assert mapper.c_to_g(TRANSCRIPT_ID, 1) == ("chr1", 1011)
+        assert mapper.c_to_g(TRANSCRIPT_ID, -1) == ("chr1", 1010)
+        assert mapper.c_to_p(TRANSCRIPT_ID, 1) == 1
+        assert mapper.c_to_n(TRANSCRIPT_ID, 1) == (11, None)
+        assert mapper.n_to_c(TRANSCRIPT_ID, 1) == (-10, None, False)
+
+
+# ---------------------------------------------------------------------------
+# Escape 2: an unknown-offset sentinel used as a distance
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelOffsetIsRefused:
+    """A sentinel is not a distance, so no coordinate may be derived from it."""
+
+    @pytest.mark.parametrize("offset", [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE])
+    @pytest.mark.parametrize(("method", "base"), [("c_to_g", 90), ("c_to_g", 91)])
+    def test_c_to_g_declines_a_sentinel_offset(
+        self,
+        mapper: ferro_hgvs.CoordinateMapper,
+        method: str,
+        base: int,
+        offset: int,
+    ) -> None:
+        """Refused before the arithmetic, in both directions and both arms.
+
+        Reaching the assertion at all is half the test on the negative
+        sentinel: a ``PanicException`` subclasses ``BaseException``, so it
+        aborts the call rather than raising something ``pytest.raises`` sees.
+        """
+        with pytest.raises(ferro_hgvs.ProjectionError) as excinfo:
+            getattr(mapper, method)(TRANSCRIPT_ID, base, offset)
+
+        assert excinfo.value.code == "E4003"
+        assert "unknown intronic offset" in str(excinfo.value)
+
+    @pytest.mark.parametrize("offset", [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE])
+    def test_c_to_n_declines_a_sentinel_offset(
+        self, mapper: ferro_hgvs.CoordinateMapper, offset: int
+    ) -> None:
+        """The value must not come back either — see escape 3."""
+        with pytest.raises(ferro_hgvs.ProjectionError) as excinfo:
+            mapper.c_to_n(TRANSCRIPT_ID, 90, offset)
+
+        assert excinfo.value.code == "E4003"
+
+    @pytest.mark.parametrize("offset", [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE])
+    def test_n_to_c_declines_a_sentinel_offset(
+        self, mapper: ferro_hgvs.CoordinateMapper, offset: int
+    ) -> None:
+        with pytest.raises(ferro_hgvs.ProjectionError) as excinfo:
+            mapper.n_to_c(TRANSCRIPT_ID, 100, offset)
+
+        assert excinfo.value.code == "E4003"
+
+    def test_measured_offsets_still_convert(self, mapper: ferro_hgvs.CoordinateMapper) -> None:
+        """A real intronic distance is untouched on both arms.
+
+        The intron is genomic 1101..2000, so ``c.90+5`` is 1105 and ``c.91-5``
+        is 1996. A guard that rejected every non-``None`` offset would pass
+        every assertion above and fail these.
+        """
+        assert mapper.c_to_g(TRANSCRIPT_ID, 90, 5) == ("chr1", 1105)
+        assert mapper.c_to_g(TRANSCRIPT_ID, 91, -5) == ("chr1", 1996)
+        assert mapper.c_to_n(TRANSCRIPT_ID, 90, 5) == (100, 5)
+        assert mapper.n_to_c(TRANSCRIPT_ID, 100, 5) == (90, 5, False)
+
+
+class TestOversizedOffsetIsRefused:
+    """The hazard is the offset's magnitude, not its sentinel identity (#1765).
+
+    The guard above keys on the two exact sentinel values, which is the right
+    key for a *marker* and the wrong one for the arithmetic downstream. Stepping
+    one away from each sentinel reproduced the whole class, measured on this
+    fixture on the unfixed build::
+
+        c_to_g(90, 2**63 - 2)   -> ('chr1', 9223372036854776906)
+        c_to_g(90, -(2**63) + 1) !! pyo3_runtime.PanicException:
+                                    attempt to subtract with overflow
+                                    (src/reference/transcript.rs:814)
+
+    Neither value is a sentinel, so no widening of the sentinel predicate could
+    reach them. ``Transcript::intronic_to_genomic`` is total and intron-bounded
+    instead, so both now decline.
+    """
+
+    #: One step in from each sentinel — a plain number, refused on magnitude.
+    NEIGHBOURS = [OFFSET_UNKNOWN_POSITIVE - 1, OFFSET_UNKNOWN_NEGATIVE + 1]
+
+    @pytest.mark.parametrize("offset", NEIGHBOURS)
+    @pytest.mark.parametrize("base", [90, 91])
+    def test_a_sentinel_neighbour_declines_rather_than_panicking(
+        self, mapper: ferro_hgvs.CoordinateMapper, base: int, offset: int
+    ) -> None:
+        """No panic, and no coordinate-shaped number either.
+
+        Reaching the assertion at all is half the test: a ``PanicException``
+        subclasses ``BaseException``, so ``pytest.raises(ProjectionError)``
+        does not catch it and the pre-fix run errors out here rather than
+        failing an assertion.
+        """
+        with pytest.raises(ferro_hgvs.ProjectionError):
+            mapper.c_to_g(TRANSCRIPT_ID, base, offset)
+
+    @pytest.mark.parametrize("offset", [901, -901, 10**6, -(10**6)])
+    def test_an_offset_larger_than_its_intron_declines(
+        self, mapper: ferro_hgvs.CoordinateMapper, offset: int
+    ) -> None:
+        """The intron spans genomic 1101..2000, so 900 is the largest honourable
+        distance on either arm. An offset past it names no intronic base."""
+        with pytest.raises(ferro_hgvs.ProjectionError):
+            mapper.c_to_g(TRANSCRIPT_ID, 90 if offset > 0 else 91, offset)
+
+    def test_the_intron_is_still_reachable_end_to_end(
+        self, mapper: ferro_hgvs.CoordinateMapper
+    ) -> None:
+        """The negative control for the bound above: a guard that refused every
+        large offset would pass both tests above and fail this one."""
+        assert mapper.c_to_g(TRANSCRIPT_ID, 90, 900) == ("chr1", 2000)
+        assert mapper.c_to_g(TRANSCRIPT_ID, 91, -900) == ("chr1", 1101)
+
+
+# ---------------------------------------------------------------------------
+# Escape 3: a value handed back that the caller cannot read
+# ---------------------------------------------------------------------------
+
+
+class TestNoUnreadableValueIsReturned:
+    """What comes back must mean what a caller would take it to mean."""
+
+    @pytest.mark.parametrize("offset", [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE])
+    def test_c_to_n_never_returns_a_sentinel(
+        self, mapper: ferro_hgvs.CoordinateMapper, offset: int
+    ) -> None:
+        """A sentinel returned as an ``int`` is indistinguishable from a distance.
+
+        Stated as a property of the *return value* rather than of the argument,
+        so it still holds if some future conversion path produces a sentinel it
+        was not handed.
+        """
+        try:
+            _, returned = mapper.c_to_n(TRANSCRIPT_ID, 90, offset)
+        except ferro_hgvs.ProjectionError:
+            return  # refused at entry, which is the stronger outcome
+
+        assert returned not in (OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE)
+
+    def test_n_to_c_refuses_the_downstream_flag_it_cannot_honour(
+        self, mapper: ferro_hgvs.CoordinateMapper
+    ) -> None:
+        """``downstream=True`` must not be answered as if it were ``False``.
+
+        ``tx_to_cds`` discards the flag, so before this change the two calls
+        returned the same triple and a caller asking about ``n.*195`` was told
+        about ``n.195``. Repairing the conversion is separate work; until it
+        lands, the honest answer at the boundary is a refusal rather than a
+        confidently wrong coordinate.
+        """
+        with pytest.raises(ferro_hgvs.ProjectionError) as excinfo:
+            mapper.n_to_c(TRANSCRIPT_ID, 195, None, True)
+
+        assert excinfo.value.code == "E4003"
+        assert "downstream" in str(excinfo.value)
+
+    def test_downstream_false_is_unaffected(self, mapper: ferro_hgvs.CoordinateMapper) -> None:
+        """The default path keeps working, positionally and by keyword."""
+        assert mapper.n_to_c(TRANSCRIPT_ID, 195) == (5, None, True)
+        assert mapper.n_to_c(TRANSCRIPT_ID, 195, None, False) == (5, None, True)
+        assert mapper.n_to_c(TRANSCRIPT_ID, 195, downstream=False) == (5, None, True)
+
+
+# ---------------------------------------------------------------------------
+# The docstring defect riding along
+# ---------------------------------------------------------------------------
+
+
+class TestDocstringsStateBothBases:
+    """Every numeric entry point names the basis of both sides.
+
+    All five previously left at least one side undocumented: ``c_to_g`` and
+    ``c_to_n`` documented neither, and ``c_to_p`` / ``g_to_c`` / ``n_to_c``
+    documented the input's basis and not the output's. A caller cannot use an
+    integer coordinate whose basis is not stated, and the ambiguity is exactly
+    what let these arguments go unvalidated.
+    """
+
+    @pytest.mark.parametrize("method", ["c_to_g", "g_to_c", "c_to_p", "c_to_n", "n_to_c"])
+    def test_docstring_states_one_based(self, method: str) -> None:
+        doc = getattr(ferro_hgvs.CoordinateMapper, method).__doc__
+        assert doc is not None, f"{method} has no docstring"
+        # Both the Args and the Returns section must say which basis they are
+        # on; "1-based" is the vocabulary the rest of this class already uses.
+        # Assert the delimiters exist before slicing on them. Without this a
+        # missing ``Returns:`` raises a bare ``IndexError: list index out of
+        # range`` naming neither the method nor the heading, and — the quieter
+        # half — a missing ``Raises:`` does not fail at all: the second split
+        # returns a one-element list, so ``returns_section`` silently widens to
+        # the whole docstring tail and can be satisfied by text from a section
+        # this test is not looking at.
+        for heading in ("Returns:", "Raises:"):
+            assert heading in doc, f"{method}: docstring has no {heading!r} section"
+        args_section = doc.split("Returns:")[0]
+        returns_section = doc.split("Returns:")[1].split("Raises:")[0]
+        assert "1-based" in args_section, f"{method}: input basis undocumented"
+        assert "1-based" in returns_section, f"{method}: output basis undocumented"


### PR DESCRIPTION
Closes #1739. Closes #1765.

Five `CoordinateMapper` methods exposed to Python took raw integers and built position structs directly, bypassing every check the parser applies. Three escapes, all measured on a programmatically-built two-exon transcript before any guard existed:

```
c_to_g(0)                -> ('chr1', 1011)      # identical to c.1
c_to_g(90, i64::MAX)     -> ('chr1', 9223372036854776907)
c_to_g(91, i64::MIN)     !! PanicException: attempt to negate with overflow
c_to_n(90, i64::MAX)     -> (100, 9223372036854775807)
n_to_c(195, ds=True)     -> (5, None, True)
n_to_c(0)                -> (-11, None, False)
```

**Base zero.** `reject_zero_base` refuses on all four `c.`/`n.` entry points as `ParseError` / **E1003**, reusing the preprocessor's exact wording ("Position 0 is not valid in HGVS notation") and hint, on the spec's authority (`background/numbering.md:31`, "there is no nucleotide `c.0`"). Negative 5'UTR bases are explicitly admitted. Every other implementation agrees: biocommons/hgvs raises "BaseOffsetPosition base may not be 0" in the type itself, Mutalyzer rejects it, and `mutalyzer-crossmapper`'s docs open with "There is no zero (0) in any of the HGVS numbering systems". `c.0` occurs 0 times in 346 Mutalyzer and 88 biocommons corpus cases.

**Sentinel offset.** `reject_sentinel_offset` refuses `i64::MAX`/`i64::MIN` before any arithmetic, reusing #1088's message and `UnsupportedProjection` (E4003) so there is one vocabulary.

**Unreadable return value.** `reject_sentinel_result` refuses on the way *out* of `c_to_n`, stated over the produced value, so a sentinel cannot come back to Python as `9223372036854775807`. `reject_unhonoured_downstream` refuses `downstream=True` rather than answering it as though the flag were false.

All five docstrings now state both sides' coordinate basis and the exception each refusal raises.

## A defect this PR's own review found in this PR, now fixed — #1765

Reviewing this branch, against an actually-imported `maturin develop --features python` module, found that the sentinel guard closes the **entry** to a hazard whose real key is **magnitude**, leaving the remaining hole easy to mistake for closed. `Transcript::intronic_to_genomic` did unchecked mixed-width arithmetic on any offset it was handed, so stepping one value away from each sentinel reproduced the whole class:

```
c_to_g(90, +5)             -> ('chr1', 1105)                       # control
c_to_g(90, i64::MAX)       !! ProjectionError   (this PR's guard)
c_to_g(90, i64::MIN)       !! ProjectionError   (this PR's guard)
c_to_g(90, i64::MAX - 1)   -> ('chr1', 9223372036854776906)        # still reachable
c_to_g(90, i64::MIN + 1)   !! PanicException: attempt to subtract with overflow
                              (src/reference/transcript.rs:814)
```

Those are the same two outcomes the description above lists as the things being fixed, one base away. In a `--release` wheel the panic becomes a silent wrap, which is the worse half. Neither value is a sentinel, so **no widening of the sentinel predicate could reach them**.

**The fix is #1765's option 1, plus its option 2 where option 2 is free.** `intronic_to_genomic` is now total and bounded by the intron the offset is measured into:

- `offset.unsigned_abs()` replaces `(-offset) as u64`, which is what `i64::MIN` needs — it has no positive twin, so the negation aborted before the cast. The four arms then use `checked_add`/`checked_sub`.
- Totality alone does **not** close `i64::MAX - 1`: `u64` has room for it, so the arithmetic never overflows and the old code simply returned a coordinate-shaped number ~9.2e18 bases outside a 900-base intron. The result must therefore land inside `[genomic_start, genomic_end]` of the intron it was measured into, else the function declines — an offset larger than its own intron names no intronic base, so it names no genomic coordinate either.

That fixes every caller rather than the Python one, which is why it lives in `src/reference/transcript.rs`. `cds_to_genomic_with_intron` already turns `None` into a `ConversionError`, so the entry point reports `ProjectionError` with no new plumbing.

**The two tests that pinned the gap open are corrected, and both keep their assertions.** `a_measured_offset_is_admitted` still admits `i64::MAX - 1` at this guard — that is the guard's contract — but its comment claimed "everything else is a number the conversion is entitled to judge for itself", which was an assumption and is now a fact; it points at the transcript-level tests that hold the other side. `only_the_two_exact_sentinels_are_sentinels` is unchanged in substance: a sentinel is a sentinel and `i64::MIN + 1` is a number, so widening *that* predicate would have been the wrong repair. `reject_sentinel_offset`'s own doc no longer claims to be what protects the arithmetic — it runs before the transcript is fetched and holds no intron to measure against, so what survives there is the diagnostic that names `+?` / `-?` as unknown-offset markers.

**Tests, and their pre-fix failures.** Three new Rust cases in `reference::transcript::tests`, over an interior-intron transcript with the same geometry as the Python fixture, so the two sets of numbers are the same numbers:

```
FAIL intronic_to_genomic_declines_an_offset_whose_arithmetic_would_overflow
       panicked at src/reference/transcript.rs:814: attempt to negate with overflow
FAIL intronic_to_genomic_declines_an_offset_that_leaves_its_own_intron
       left: Some(2001)   right: None
FAIL intronic_to_genomic_bounds_the_offset_on_the_minus_strand_too
       left: Some(104)    right: None
```

Each carries its own negative control, so a guard that refused every large offset would fail them: the intron spans g 1101..2000, and `+900` → 2000 and `-900` → 1101 must still resolve.

`TestOversizedOffsetIsRefused` states the same properties across FFI, against a real `maturin develop --features python` module. Rebuilt with the pre-fix arithmetic restored in place: **8 failed, 1 passed**, the one pass being the end-to-end negative control, which must pass on both.

```
FAILED test_a_sentinel_neighbour_declines_rather_than_panicking[90-9223372036854775806]
         Failed: DID NOT RAISE ProjectionError
FAILED test_a_sentinel_neighbour_declines_rather_than_panicking[90--9223372036854775807]
         pyo3_runtime.PanicException: attempt to subtract with overflow
FAILED test_a_sentinel_neighbour_declines_rather_than_panicking[91-9223372036854775806]
FAILED test_a_sentinel_neighbour_declines_rather_than_panicking[91--9223372036854775807]
FAILED test_an_offset_larger_than_its_intron_declines[901]
FAILED test_an_offset_larger_than_its_intron_declines[-901]
FAILED test_an_offset_larger_than_its_intron_declines[1000000]
FAILED test_an_offset_larger_than_its_intron_declines[-1000000]
```

## Two collateral items, reported rather than smoothed over

`test_issue_1018_typed_exceptions.py::TestProjectionError` used `c_to_p(id, 0)` as its vehicle for `ProjectionError` typing — it only reached the converter because a zero base fell into the 5'UTR arm, i.e. the right exception class for the wrong reason. Moved to `c.-10`, a genuine 5'UTR position failing at the same raise site, with a comment recording why. The test's own subject (exception typing and `ValueError`/`RuntimeError` back-compat) is unchanged.

`python/ferro_hgvs/__init__.pyi` carries duplicate copies of these five docstrings and now drifts from the runtime ones. Left deliberately: no test enforces stub/runtime parity, and that file is edited by another in-flight branch. Real follow-up.

## Verification

The two build profiles genuinely differ here and a first attempt hid it: `maturin develop` makes an *editable* install, so both venvs silently loaded the same `.so`. Rebuilt as two non-editable wheels in separate venvs, as CI does — only then does `c_to_g(91, i64::MIN)` show as `PanicException` in debug and a silent wrap to `chr1:9223372036854777809` in release.

New suite against the unfixed build: **21 failed, 3 passed** in each profile — the 3 passing are the negative controls (`c.-1`, measured offsets `c.90+5`→1105 / `c.91-5`→1996, `downstream=False`), which confirms the expected values are right before the guard exists.

With the #1765 fix in: full Rust gate `cargo nextest run --features dev --lib --test it` **10237/10237 passed**, exit 0 — the intron bound moves nothing. `pytest tests/python/` **930 passed, 8 skipped**. `cargo fmt --all --check`, `cargo clippy --features dev --lib --all-targets -- -D warnings` and `cargo clippy --features python --lib -- -D warnings` all exit 0.

Representation-Change: none. The diff is `src/python.rs` and `src/reference/transcript.rs` plus two files under `tests/python/`; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched.
