### PR TITLE
refactor: label the coordinate-basis docs by layer, one splice ladder per question

### DIFF
--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -6,10 +6,18 @@
 //!
 //! | System | Basis | Notes |
 //! |--------|-------|-------|
-//! | Genomic | 0-based | Half-open intervals for exons |
+//! | Genomic | 1-based | Closed `[start, end]` exon intervals ([`crate::reference::transcript::Exon`]); `GenomicLocation.position` is an HGVS `g.` number |
 //! | Transcript (tx) | 1-based | `TxPos.base` is 1-based |
 //! | CDS (c.) | 1-based | `CdsPos.base` is 1-based, negative for 5'UTR |
 //! | Protein (p.) | 1-based | `ProtPos.number` is 1-based |
+//!
+//! The genomic row is 1-based **inclusive on both ends** because this mapper only
+//! ever reads a materialised [`crate::reference::transcript::Transcript`], never raw
+//! cdot JSON: `genomic_to_tx` tests `g_start <= pos <= g_end` against
+//! `Exon::genomic_start`/`genomic_end`, which are 1-based inclusive by construction
+//! (whichever loader built them has already converted). Raw cdot's 0-based half-open
+//! genomic bounds are a different layer entirely and never reach this module — see
+//! [`crate::coords`] for that layer and [`crate::data::cdot`] for the in-memory one.
 //!
 //! ## Key conversions:
 //! - CDS → Tx: `cds_to_tx()` - accounts for CDS start/end and UTR regions

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -117,9 +117,14 @@ pub enum IntronicConsequence {
 }
 
 impl IntronicConsequence {
-    /// Create from an IntronPosition
-    pub fn from_intron_position(pos: &IntronPosition) -> Self {
-        match pos.splice_site_type() {
+    /// Create from a [`SpliceSiteType`] bin.
+    ///
+    /// The distance thresholds are **not** restated here — they live in one
+    /// place, [`SpliceSiteType::from_distance_on_side`]. This is only the
+    /// projection of that bin onto this enum, which is coarser: the two
+    /// `*Region` bins collapse into [`Self::SpliceRegionVariant`].
+    pub fn from_splice_site_type(site: SpliceSiteType) -> Self {
+        match site {
             SpliceSiteType::DonorCanonical => Self::SpliceDonorVariant,
             SpliceSiteType::AcceptorCanonical => Self::SpliceAcceptorVariant,
             SpliceSiteType::DonorExtended => Self::SpliceDonorRegionVariant,
@@ -132,85 +137,47 @@ impl IntronicConsequence {
         }
     }
 
+    /// Create from an IntronPosition
+    pub fn from_intron_position(pos: &IntronPosition) -> Self {
+        Self::from_splice_site_type(pos.splice_site_type())
+    }
+
     /// Create from a CDS position with intronic offset.
     ///
-    /// Returns `None` for an unknown offset (`c.100+?` / `c.100-?`): every
-    /// variant of this enum states a distance from the exon boundary, and the
-    /// sentinels denote a position unbounded in one direction, so there is no
-    /// distance to state (#1767). `is_intronic` is satisfied by a sentinel, so
-    /// this guard is what keeps it out — not the check above.
+    /// Returns `None` for a non-intronic position, and for an unknown offset
+    /// (`c.100+?` / `c.100-?`): every variant of this enum states a distance
+    /// from the exon boundary, and the sentinels denote a position unbounded in
+    /// one direction, so there is no distance to state (#1767). `is_intronic`
+    /// is satisfied by a sentinel, so the `has_unknown_offset` guard is what
+    /// keeps it out — not the `is_intronic` check beside it.
+    ///
+    /// Positive offsets are the donor side, zero and negative the acceptor
+    /// side — see [`SpliceSiteType::from_signed_offset`], which selects the side
+    /// and hands off to [`SpliceSiteType::from_distance_on_side`], where the
+    /// thresholds live. (`is_intronic` already excludes `Some(0)`, so the sign
+    /// rule's zero case is unreachable from here.)
     pub fn from_cds_pos(pos: &CdsPos) -> Option<Self> {
         if !pos.is_intronic() || pos.has_unknown_offset() {
             return None;
         }
-
-        let offset = pos.offset?;
-        let abs_offset = offset.unsigned_abs();
-
-        Some(if offset > 0 {
-            // 5' end of intron (splice donor side)
-            if abs_offset <= 2 {
-                Self::SpliceDonorVariant
-            } else if abs_offset <= 6 {
-                Self::SpliceDonorRegionVariant
-            } else if abs_offset <= 20 {
-                Self::SpliceRegionVariant
-            } else if abs_offset <= 50 {
-                Self::NearSpliceSiteVariant
-            } else {
-                Self::IntronVariant
-            }
-        } else {
-            // 3' end of intron (splice acceptor side)
-            if abs_offset <= 2 {
-                Self::SpliceAcceptorVariant
-            } else if abs_offset <= 12 {
-                Self::SpliceAcceptorRegionVariant
-            } else if abs_offset <= 20 {
-                Self::SpliceRegionVariant
-            } else if abs_offset <= 50 {
-                Self::NearSpliceSiteVariant
-            } else {
-                Self::IntronVariant
-            }
-        })
+        Some(Self::from_splice_site_type(
+            SpliceSiteType::from_signed_offset(pos.offset?),
+        ))
     }
 
     /// Create from a transcript position with intronic offset.
     ///
-    /// Declines an unknown offset (`n.100+?` / `n.100-?`) for the same reason
-    /// as [`IntronicConsequence::from_cds_pos`] (#1767).
+    /// Returns `None` for a non-intronic position, and declines an unknown
+    /// offset (`n.100+?` / `n.100-?`) for the same reason as
+    /// [`IntronicConsequence::from_cds_pos`] (#1767). Same ladder and same sign
+    /// convention as that method.
     pub fn from_tx_pos(pos: &TxPos) -> Option<Self> {
         if !pos.is_intronic() || pos.has_unknown_offset() {
             return None;
         }
-
-        let offset = pos.offset?;
-        let abs_offset = offset.unsigned_abs();
-
-        Some(if offset > 0 {
-            if abs_offset <= 2 {
-                Self::SpliceDonorVariant
-            } else if abs_offset <= 6 {
-                Self::SpliceDonorRegionVariant
-            } else if abs_offset <= 20 {
-                Self::SpliceRegionVariant
-            } else if abs_offset <= 50 {
-                Self::NearSpliceSiteVariant
-            } else {
-                Self::IntronVariant
-            }
-        } else if abs_offset <= 2 {
-            Self::SpliceAcceptorVariant
-        } else if abs_offset <= 12 {
-            Self::SpliceAcceptorRegionVariant
-        } else if abs_offset <= 20 {
-            Self::SpliceRegionVariant
-        } else if abs_offset <= 50 {
-            Self::NearSpliceSiteVariant
-        } else {
-            Self::IntronVariant
-        })
+        Some(Self::from_splice_site_type(
+            SpliceSiteType::from_signed_offset(pos.offset?),
+        ))
     }
 
     /// Get the SO (Sequence Ontology) term for this consequence
@@ -281,21 +248,31 @@ impl IntronicRegion {
     /// took that break. The precondition used to be documented ("screen with
     /// `has_unknown_offset` before calling"); it is now in the type.
     ///
+    /// The bands are the side-agnostic collapse of the same ladder
+    /// [`SpliceSiteType::from_distance_on_side`] owns, reached through
+    /// [`SpliceSiteType::from_signed_offset`]: the donor/acceptor distinction is
+    /// dropped and the extended + region bins merge into
+    /// [`Self::ExtendedSpliceRegion`]. It used to restate a partial copy of the
+    /// thresholds (2/20/50, with the 6- and 12-rungs missing), which is why it
+    /// derives rather than repeats them — the rungs it drops must be dropped by
+    /// the mapping, not by a second and independently-editable ladder.
+    ///
     /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
     /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
     pub fn from_offset(offset: i64) -> Option<Self> {
         if crate::hgvs::parser::position::is_unknown_offset(offset) {
             return None;
         }
-        let abs_offset = offset.unsigned_abs();
-        Some(if abs_offset <= 2 {
-            Self::CanonicalSpliceSite
-        } else if abs_offset <= 20 {
-            Self::ExtendedSpliceRegion
-        } else if abs_offset <= 50 {
-            Self::NearSpliceSite
-        } else {
-            Self::DeepIntronic
+        Some(match SpliceSiteType::from_signed_offset(offset) {
+            SpliceSiteType::DonorCanonical | SpliceSiteType::AcceptorCanonical => {
+                Self::CanonicalSpliceSite
+            }
+            SpliceSiteType::DonorExtended
+            | SpliceSiteType::AcceptorExtended
+            | SpliceSiteType::DonorRegion
+            | SpliceSiteType::AcceptorRegion => Self::ExtendedSpliceRegion,
+            SpliceSiteType::NearSplice => Self::NearSpliceSite,
+            SpliceSiteType::DeepIntronic => Self::DeepIntronic,
         })
     }
 

--- a/src/coords/mod.rs
+++ b/src/coords/mod.rs
@@ -8,8 +8,23 @@
 //!
 //! | Type | Basis | Use Cases |
 //! |------|-------|-----------|
-//! | [`ZeroBasedPos`] | 0-based | Array indexing, SPDI, cdot genomic, BED |
-//! | [`OneBasedPos`] | 1-based | HGVS, VCF, cdot transcript, GFF/GTF, SAM |
+//! | [`ZeroBasedPos`] | 0-based | Array indexing, SPDI, **raw** cdot genomic, BED |
+//! | [`OneBasedPos`] | 1-based | HGVS, VCF, **raw** cdot transcript, GFF/GTF, SAM |
+//!
+//! # Which cdot layer does this module describe?
+//!
+//! Every `cdot_*` helper in this module describes the **raw cdot JSON** as it
+//! arrives on disk — genomic bounds 0-based half-open, transcript bounds
+//! 1-based inclusive. That is *not* the layout ferro holds in memory: on load,
+//! `RawCdotTranscript::from_genome_build` (private, in [`crate::data::cdot`])
+//! converts both axes (#742), so
+//! [`crate::data::cdot::CdotTranscript`] carries genome 1-based `[incl, excl)`
+//! and transcript **0-based** half-open. The table at the top of
+//! [`crate::data::cdot`] describes that *internal* layout, using the same field
+//! names (`tx_start`/`tx_end`) as the raw format.
+//!
+//! Two tables, two layers, same names: always check which one a statement is
+//! about before acting on it.
 //!
 //! # Design Principles
 //!
@@ -503,9 +518,18 @@ pub const fn index_to_hgvs_pos(idx: usize) -> u64 {
     idx as u64 + 1
 }
 
-/// Convert cdot genomic coordinates (0-based half-open) to 1-based closed
+/// Convert **raw cdot JSON** genomic coordinates (0-based half-open) to 1-based closed
 ///
-/// cdot uses 0-based half-open for genomic coordinates.
+/// # Layer
+///
+/// This describes the **raw cdot JSON on disk**, where genomic bounds are
+/// 0-based half-open. It does **not** describe ferro's in-memory
+/// [`crate::data::cdot::CdotTranscript`], whose `exons[i][0..2]` were already
+/// converted on load to genome 1-based `[incl, excl)` (#742) — feeding those
+/// through this helper would convert twice.
+///
+/// Note the *target* here is 1-based **inclusive** on both ends, which differs
+/// from the ingestion path's target of 1-based `[incl, excl)`.
 ///
 /// # Arguments
 ///
@@ -533,15 +557,28 @@ pub const fn cdot_genomic_to_closed(start: u64, end: u64) -> (u64, u64) {
     (start + 1, end)
 }
 
-/// Document that cdot transcript coordinates are already 1-based
+/// Document that **raw cdot JSON** transcript coordinates are already 1-based
 ///
-/// This function exists as documentation - cdot tx_start/tx_end are 1-based,
-/// NOT 0-based like cdot genomic coordinates. This was the source of bug 944a4e9.
+/// # Layer
+///
+/// This is a statement about the **raw cdot JSON on disk**: there, `tx_start` /
+/// `tx_end` are 1-based **inclusive**, unlike the same record's genomic bounds,
+/// which are 0-based half-open. Mixing the two up is the mistake this
+/// no-op helper exists to make visible at the call site.
+///
+/// It is **not** a statement about ferro's in-memory
+/// [`crate::data::cdot::CdotTranscript`]. `RawCdotTranscript::from_genome_build`
+/// (private, in [`crate::data::cdot`])
+/// converts the raw 1-based-inclusive tx bounds to **0-based half-open** on
+/// load (#742), so `CdotTranscript.exons[i][2..4]` are 0-based and must not be
+/// passed here. The basis table at the top of [`crate::data::cdot`] describes
+/// that internal layout — with the same field names — so read the layer, not
+/// just the name.
 ///
 /// # Arguments
 ///
-/// * `tx_start` - 1-based transcript start (NOT 0-based!)
-/// * `tx_end` - 1-based transcript end (NOT 0-based!)
+/// * `tx_start` - raw-cdot 1-based inclusive transcript start (NOT 0-based!)
+/// * `tx_end` - raw-cdot 1-based inclusive transcript end (NOT 0-based!)
 ///
 /// # Returns
 ///

--- a/src/effect/mod.rs
+++ b/src/effect/mod.rs
@@ -25,6 +25,73 @@
 use crate::backtranslate::{Codon, CodonTable};
 use crate::hgvs::location::AminoAcid;
 
+/// Where an intronic offset falls on the **SO-term consequence** ladder.
+///
+/// # Which question this answers
+///
+/// This is the VEP-style call — "which Sequence Ontology term applies?" — on
+/// the ladder VEP uses: canonical site within 2 bases of the exon, splice
+/// region out to 8, plain intron beyond that. It is the single definition of
+/// that ladder; both [`EffectPredictor::classify_splice_variant`] and the
+/// web service's CDS effect handler derive from it.
+///
+/// # Why it is NOT
+/// [`crate::reference::transcript::SpliceSiteType`]
+///
+/// That type answers a different question — ferro's own fine-grained
+/// splice-distance bins, donor 2/6/20/50 and acceptor 2/12/20/50 — and the two
+/// ladders **disagree by construction**, which is correct rather than a defect:
+///
+/// The offsets are **signed**, as [`SpliceSiteType::from_signed_offset`] reads
+/// them: positive is the donor side, negative the acceptor side. Spelling the
+/// third row `12` rather than `-12` would make it false — `from_signed_offset(12)`
+/// is `DonorRegion`, not `AcceptorExtended`.
+///
+/// | offset | `SpliceSiteType` | `SpliceRegionBin` |
+/// |---|---|---|
+/// | `+6` | `DonorExtended` | `Region` |
+/// | `+10` | `DonorRegion` | `Intron` |
+/// | `-12` | `AcceptorExtended` | `Intron` |
+///
+/// A consumer that needs one must not silently receive the other. The
+/// relationship is pinned at every boundary offset in
+/// `tests/it/splice_ladder_shapes.rs`, so an edit to either ladder that moves
+/// them relative to each other fails there rather than quietly changing what
+/// one of ferro's two surfaces reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpliceRegionBin {
+    /// Within 2 bases of the exon — the canonical donor (GT) / acceptor (AG)
+    /// dinucleotide.
+    Canonical,
+    /// 3 to 8 bases from the exon — `splice_region_variant`.
+    Region,
+    /// More than 8 bases from the exon — `intron_variant`.
+    Intron,
+}
+
+impl SpliceRegionBin {
+    /// Classify a signed intronic offset. The sign selects donor (positive) vs
+    /// acceptor (negative) at the call site; this ladder itself is symmetric,
+    /// so only the magnitude is read.
+    ///
+    /// The magnitude is taken with `unsigned_abs` for the same reason
+    /// [`crate::reference::transcript::SpliceSiteType::from_distance_on_side`]
+    /// does: `c.<base>-?` parses to `offset == Some(i64::MIN)`, whose `abs()`
+    /// panics in debug and wraps to a *negative* value in release — which would
+    /// satisfy `<= 2` and report a HIGH-impact canonical splice site for a
+    /// position whose distance is unknown. It lands in [`Self::Intron`] instead.
+    pub fn from_offset(offset: i64) -> Self {
+        let abs_offset = offset.unsigned_abs();
+        if abs_offset <= 2 {
+            Self::Canonical
+        } else if abs_offset <= 8 {
+            Self::Region
+        } else {
+            Self::Intron
+        }
+    }
+}
+
 /// Sequence Ontology consequence term.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Consequence {
@@ -389,6 +456,10 @@ impl EffectPredictor {
 
     /// Classify a splice site variant by distance, or decline.
     ///
+    /// Uses the SO-term ladder ([`SpliceRegionBin`]), not ferro's fine-grained
+    /// [`crate::reference::transcript::SpliceSiteType`] bins — see
+    /// `SpliceRegionBin`'s docs for why the two differ and must stay separate.
+    ///
     /// Returns `None` for an unknown offset (`+?` / `-?`, carried as
     /// `i64::MAX` / `i64::MIN`). This function's whole input is a distance, so
     /// a description that declines to state one leaves it nothing to classify.
@@ -425,21 +496,16 @@ impl EffectPredictor {
         if crate::hgvs::parser::position::is_unknown_offset(offset) {
             return None;
         }
-        // `unsigned_abs` rather than `abs`: total for every `i64`, so the
-        // ladder cannot overflow even on a magnitude that is not a sentinel
-        // (`i64::MIN` is the only such value, and it is reachable here).
-        let abs_offset = offset.unsigned_abs();
-
-        let consequence = if abs_offset <= 2 {
-            if offset > 0 {
-                Consequence::SpliceDonorVariant
-            } else {
-                Consequence::SpliceAcceptorVariant
+        let consequence = match SpliceRegionBin::from_offset(offset) {
+            SpliceRegionBin::Canonical => {
+                if offset > 0 {
+                    Consequence::SpliceDonorVariant
+                } else {
+                    Consequence::SpliceAcceptorVariant
+                }
             }
-        } else if abs_offset <= 8 {
-            Consequence::SpliceRegionVariant
-        } else {
-            Consequence::IntronVariant
+            SpliceRegionBin::Region => Consequence::SpliceRegionVariant,
+            SpliceRegionBin::Intron => Consequence::IntronVariant,
         };
 
         Some(ProteinEffect {

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -135,7 +135,13 @@ impl fmt::Display for GenomePos {
 /// Positions with * prefix are downstream of stop codon.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CdsPos {
-    /// Base position in CDS (can be negative for 5' UTR)
+    /// Base position in CDS, **1-based** (`c.1` is the A of the start codon).
+    ///
+    /// Negative for 5' UTR, counting back from `c.1` with no zero in between, so
+    /// `c.-1` is the base immediately before the start codon. With `utr3`, counts
+    /// forward from the stop codon (`c.*1`). The value `0` is not a position: it is
+    /// [`CDS_BASE_UNKNOWN`], the sentinel for `c.?`, and also the placeholder `base`
+    /// carried by a `special` position.
     pub base: i64,
     /// Intronic offset (+ for downstream, - for upstream of exon)
     pub offset: Option<i64>,
@@ -306,7 +312,11 @@ impl fmt::Display for CdsPos {
 /// (e.g., n.*5 is 5 bases after the transcript end).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TxPos {
-    /// Position on transcript (can be negative for upstream positions)
+    /// Position on transcript, **1-based** (`n.1` is the first transcribed base).
+    ///
+    /// Negative for positions upstream of the transcript start, counting back from
+    /// `n.1` with no zero in between, so `n.-1` is the base immediately before it.
+    /// With `downstream`, counts forward from the transcript end (`n.*1`).
     pub base: i64,
     /// Intronic offset
     pub offset: Option<i64>,

--- a/src/reference/derived_tx_structure.rs
+++ b/src/reference/derived_tx_structure.rs
@@ -322,6 +322,11 @@ pub fn derive_transcript_structure(
         exon_cigars: vec![None; exons.len()],
         gene_id: None,
         protein: sibling.protein.clone(),
+        // Inert here, and deliberately not threaded from `sibling`: this probe
+        // is local and reaches only `reconstruct_spliced_mrna`, which reads
+        // `exons`/`contig`/`strand` and nothing else. The #972 flag is carried
+        // on the value that actually escapes — see the `DerivedTxStructure`
+        // built below, which takes `sibling.cds_start_incomplete`.
         cds_start_incomplete: false,
     };
     let frac = readback_mismatch_fraction(&probe, old_core, genome)?;

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -5,14 +5,26 @@
 //!
 //! # Coordinate Systems
 //!
-//! This module handles coordinate conversions when loading sequences:
+//! This module handles coordinate conversions when loading sequences.
+//!
+//! **Which cdot layer do the `cdot *` rows describe? The internal one.** Every
+//! `cdot *` row below describes
+//! [`crate::data::cdot::CdotTranscript`] as this module actually receives it —
+//! i.e. *after* `RawCdotTranscript::from_genome_build` (private, in
+//! [`crate::data::cdot`]) has converted both axes (#742) —
+//! because that is the value the conversion code beneath reads. It is **not** the
+//! raw cdot JSON on disk, whose genomic bounds are 0-based half-open and whose
+//! transcript bounds are 1-based inclusive; the raw layer is what the `cdot_*`
+//! helpers in [`crate::coords`] describe. The two layers share one set of field
+//! names (`genome_start`, `tx_start`, …), so always check which layer a statement
+//! is about before acting on it.
 //!
 //! | Source | Basis | Target | Notes |
 //! |--------|-------|--------|-------|
 //! | FASTA/FAI index | 0-based | Internal | Half-open `[start, end)` |
-//! | cdot genomic | 0-based | Transcript | `genome_start` is 0-based, converted to 1-based |
-//! | cdot tx | 1-based | Transcript | `tx_start`/`tx_end` used directly (already 1-based) |
-//! | cdot CDS | 0-based | Transcript | `cds_start` converted via `+ 1` to 1-based |
+//! | cdot genomic (internal) | 1-based | Transcript | `[incl, excl)`: `genome_start` used as-is, `genome_end` converted via `- 1` to 1-based inclusive |
+//! | cdot tx (internal) | 0-based | Transcript | Half-open: `tx_start` converted via `+ 1` to 1-based inclusive; the exclusive `tx_end` already equals the 1-based inclusive end |
+//! | cdot CDS (internal) | 0-based | Transcript | Half-open: `cds_start` converted via `+ 1` to 1-based inclusive; the exclusive `cds_end` already equals the 1-based inclusive end |
 //!
 //! **Important**: The `get_sequence()` method uses 0-based half-open coordinates
 //! consistent with FASTA index conventions.

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -953,6 +953,13 @@ pub struct IntronPosition {
 // Neither is reachable from a string entry point today; both are reachable by a
 // library caller, because every field of this struct is `pub`.
 impl IntronPosition {
+    // These four predicates spell their thresholds inline rather than deriving
+    // from [`SpliceSiteType::from_distance_on_side`], because three of the four
+    // do not correspond to a single rung of it — `is_near_splice_site`'s 10 is
+    // on neither ladder at all. They take the magnitude with `unsigned_abs` for
+    // the reason recorded on `from_distance_on_side`: `abs()` panics on
+    // `i64::MIN`, the `-?` unknown-offset sentinel.
+
     /// Check if this is a deep intronic position (>50bp from nearest exon)
     pub fn is_deep_intronic(&self) -> bool {
         self.offset.unsigned_abs() > 50
@@ -974,39 +981,13 @@ impl IntronPosition {
     }
 
     /// Get the splice site type based on position
+    ///
+    /// The ladder itself lives on [`SpliceSiteType::from_distance_on_side`];
+    /// this only supplies the side, which is taken from `boundary` rather than
+    /// from the sign of `offset` because the two are independent fields and
+    /// `boundary` is the authoritative one.
     pub fn splice_site_type(&self) -> SpliceSiteType {
-        let abs_offset = self.offset.unsigned_abs();
-        match self.boundary {
-            IntronBoundary::FivePrime => {
-                // 5' end of intron = splice donor site
-                if abs_offset <= 2 {
-                    SpliceSiteType::DonorCanonical
-                } else if abs_offset <= 6 {
-                    SpliceSiteType::DonorExtended
-                } else if abs_offset <= 20 {
-                    SpliceSiteType::DonorRegion
-                } else if abs_offset <= 50 {
-                    SpliceSiteType::NearSplice
-                } else {
-                    SpliceSiteType::DeepIntronic
-                }
-            }
-            IntronBoundary::ThreePrime => {
-                // 3' end of intron = splice acceptor site
-                if abs_offset <= 2 {
-                    SpliceSiteType::AcceptorCanonical
-                } else if abs_offset <= 12 {
-                    // Branch point region is typically -18 to -35
-                    SpliceSiteType::AcceptorExtended
-                } else if abs_offset <= 20 {
-                    SpliceSiteType::AcceptorRegion
-                } else if abs_offset <= 50 {
-                    SpliceSiteType::NearSplice
-                } else {
-                    SpliceSiteType::DeepIntronic
-                }
-            }
-        }
+        SpliceSiteType::from_distance_on_side(self.offset, self.boundary)
     }
 
     /// Get distance from splice donor (5' end of intron)
@@ -1060,6 +1041,117 @@ pub enum SpliceSiteType {
     NearSplice,
     /// Deep intronic (>50bp from nearest exon)
     DeepIntronic,
+}
+
+impl SpliceSiteType {
+    /// Classify a signed intronic offset into ferro's fine-grained splice bins.
+    ///
+    /// # Which question this answers
+    ///
+    /// This is **ferro's own splice-distance granularity**: donor 2/6/20/50,
+    /// acceptor 2/12/20/50, with the donor and acceptor sides distinguished at
+    /// every rung. The rungs themselves live in exactly one body,
+    /// [`SpliceSiteType::from_distance_on_side`], which this delegates to;
+    /// [`IntronPosition::splice_site_type`],
+    /// [`crate::convert::noncoding::IntronicConsequence`] and
+    /// [`crate::convert::noncoding::IntronicRegion`] all derive from that same
+    /// body rather than restating the thresholds.
+    ///
+    /// The exception, named so it is not mistaken for coverage: `IntronPosition`
+    /// also carries four standalone predicates — `is_canonical_splice_site`
+    /// (2), `is_extended_splice_region` (20), `is_deep_intronic` (50) and
+    /// `is_near_splice_site` (10, a threshold on **neither** ladder) — which
+    /// still spell their thresholds inline and are not derived from here.
+    ///
+    /// It is deliberately **not** the SO-term consequence call. That question —
+    /// "which Sequence Ontology term does VEP assign?" — is answered by
+    /// [`crate::effect::SpliceRegionBin`], on a coarser ladder (2/8) that
+    /// disagrees with this one by construction: offset `+10` is a `DonorRegion`
+    /// here (and `-10` an `AcceptorExtended`, the acceptor side reaching to 12)
+    /// while both are a plain intron variant there. The two are cross-tested at
+    /// their boundary offsets in `tests/it/splice_ladder_shapes.rs`; neither is
+    /// wrong, and they must not be merged.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - signed intronic offset. Positive is the 5' end of the
+    ///   intron (splice **donor** side, HGVS `+n`); zero or negative is the 3'
+    ///   end (splice **acceptor** side, HGVS `-n`).
+    pub fn from_signed_offset(offset: i64) -> Self {
+        let side = if offset > 0 {
+            IntronBoundary::FivePrime
+        } else {
+            IntronBoundary::ThreePrime
+        };
+        // Not `offset.abs()`: the callee takes the magnitude with
+        // `unsigned_abs`, and `i64::MIN.abs()` panics. See the note on
+        // `from_distance_on_side`.
+        Self::from_distance_on_side(offset, side)
+    }
+
+    /// Classify a distance from an exon boundary against an explicit intron side.
+    ///
+    /// This is where the rungs live. [`SpliceSiteType::from_signed_offset`] is
+    /// the thin wrapper that *derives* the side from the offset's sign and then
+    /// calls this; the split exists because [`IntronPosition`] carries its side
+    /// as a field rather than as the sign of its offset — and an
+    /// `IntronPosition` with `offset == 0` on the 5' boundary must still
+    /// classify as a donor, which reading the sign alone would get wrong.
+    ///
+    /// # Arguments
+    ///
+    /// # The magnitude is taken with `unsigned_abs`, deliberately
+    ///
+    /// `i64::MIN.abs()` **panics** in a debug build and wraps back to
+    /// `i64::MIN` in a release one, where every `abs_offset <= n` test below
+    /// would then read *true* and report a canonical splice site. That is not
+    /// hypothetical input: `c.<base>-?` parses to `offset == Some(i64::MIN)`
+    /// (`parser::position::OFFSET_UNKNOWN_NEGATIVE`), and this ladder is
+    /// reachable from the web service's untrusted-input handler. `unsigned_abs`
+    /// is total, so the sentinel lands in [`Self::DeepIntronic`] instead — still
+    /// not a *meaningful* answer for an unknown offset, but a conservative one
+    /// rather than a panic or a HIGH-impact claim. Declining outright for an
+    /// unknown offset is a separate behaviour question, not settled here.
+    ///
+    /// # Arguments
+    ///
+    /// * `distance` - distance from the exon boundary; its sign is ignored.
+    /// * `side` - which end of the intron the distance is measured from.
+    pub fn from_distance_on_side(distance: i64, side: IntronBoundary) -> Self {
+        let abs_offset = distance.unsigned_abs();
+        if side == IntronBoundary::FivePrime {
+            // 5' end of intron = splice donor site
+            if abs_offset <= 2 {
+                Self::DonorCanonical
+            } else if abs_offset <= 6 {
+                Self::DonorExtended
+            } else if abs_offset <= 20 {
+                Self::DonorRegion
+            } else if abs_offset <= 50 {
+                Self::NearSplice
+            } else {
+                Self::DeepIntronic
+            }
+        } else {
+            // 3' end of intron = splice acceptor site
+            if abs_offset <= 2 {
+                Self::AcceptorCanonical
+            } else if abs_offset <= 12 {
+                // The 12-rung is the POLYPYRIMIDINE TRACT, which abuts the
+                // acceptor (roughly -5 to -15) — not the branch point, which
+                // sits further out at roughly -18 to -35 and therefore falls in
+                // `AcceptorRegion`/`NearSplice`. This comment used to cite the
+                // branch point, a region the threshold it annotated excludes.
+                Self::AcceptorExtended
+            } else if abs_offset <= 20 {
+                Self::AcceptorRegion
+            } else if abs_offset <= 50 {
+                Self::NearSplice
+            } else {
+                Self::DeepIntronic
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -158,12 +158,26 @@ pub fn validate_transcript_record(tx: &Transcript) -> Vec<TranscriptAnomaly> {
     let seq_len = bytes.len() as u64;
 
     // --- Length consistency: served bases vs exon-alignment extent ----------
-    // The exon alignment tiles transcript coordinates [1, max_end]
-    // contiguously (gaps are rejected upstream during ingestion). A served
-    // sequence *shorter* than that extent means the alignment references bases
-    // the sequence lacks — unambiguous corruption. A *longer* sequence is the
-    // normal poly-A / unaligned-3' case and is intentionally NOT flagged here
-    // (see the module docs).
+    // `max_end` is the highest transcript coordinate the exon alignment names,
+    // so a served sequence *shorter* than that extent means the alignment
+    // references bases the sequence lacks — unambiguous corruption. A *longer*
+    // sequence is the normal poly-A / unaligned-3' case and is intentionally
+    // NOT flagged here (see the module docs).
+    //
+    // Deliberately phrased as an extent, NOT as contiguous tiling of
+    // [1, max_end]: the alignment may legitimately carry a transcript-
+    // coordinate gap, and this check is sound either way because it compares
+    // against the maximum rather than against a summed exon length.
+    //
+    // Gaps are NOT rejected upstream, contrary to what this comment used to
+    // claim. `data::cdot`'s `RawCdotTranscript::from_genome_build` silently
+    // drops any exon row with fewer than five fields, which can itself open a
+    // gap, and `MultiFastaProvider` diverts a gapped cdot table to supplemental
+    // CDS data only when a supplemental record exists for that accession —
+    // otherwise the gapped table is served as-is. Real annotation has such
+    // gaps: over cdot-0.2.32.refseq.GRCh38, 58 of 474,818 multi-exon builds
+    // carry one (23–2718 bases; the census is recorded on
+    // `convert::mapper`'s `cdot_tx_basis_cross_checked_against_real_cdot`).
     let exon_extent = tx.exons.iter().map(|e| e.end).max();
     if let Some(extent) = exon_extent {
         if seq_len < extent {

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -3,6 +3,7 @@
 use axum::{extract::State, http::StatusCode, response::Json};
 use std::time::Instant;
 
+use crate::effect::SpliceRegionBin;
 use crate::hgvs::location::CdsPos;
 use crate::service::{
     server::AppState,
@@ -565,39 +566,30 @@ fn predict_cds_effect(
     cds_pos: &CdsPos,
 ) -> SequenceEffect {
     if is_intronic {
-        // Check for splice site impact.
-        //
-        // An unknown offset (`c.100-?`) reaches here straight from a parsed
-        // request field: `CdsPos::is_intronic` is satisfied by the `i64::MAX` /
-        // `i64::MIN` sentinels. Taking a magnitude from one is meaningless, and
-        // `.abs()` on `i64::MIN` panicked the worker under `overflow-checks`
-        // while wrapping to a *negative* value in release, where it passed the
-        // `<= 2` test and was answered `splice_site_variant` / HIGH (#1767).
-        // Skip the distance ladder entirely and fall through to
-        // `intron_variant`, which is what is actually known about the position.
-        let measured_offset = if cds_pos.has_unknown_offset() {
-            None
-        } else {
-            cds_pos.offset
-        };
-        if let Some(offset) = measured_offset {
-            // `unsigned_abs` so the ladder is total for every `i64`, not only
-            // for the two values spelled `?`.
-            let abs_offset = offset.unsigned_abs();
-            if abs_offset <= 2 {
-                return SequenceEffect {
-                    so_term: "SO:0001629".to_string(),
-                    name: "splice_site_variant".to_string(),
-                    description: "A sequence variant that changes the first two or last two bases of an intron".to_string(),
-                    impact: "HIGH".to_string(),
-                };
-            } else if abs_offset <= 8 {
-                return SequenceEffect {
-                    so_term: "SO:0001630".to_string(),
-                    name: "splice_region_variant".to_string(),
-                    description: "A sequence variant in which a change has occurred within the region of the splice site".to_string(),
-                    impact: "LOW".to_string(),
-                };
+        // Check for splice site impact. The distance thresholds live on
+        // `SpliceRegionBin`, shared with `EffectPredictor::classify_splice_variant`
+        // so this surface and the library one cannot drift apart; only the
+        // rendering into an SO term is local. Note this is deliberately the
+        // SO-term ladder, not `SpliceSiteType`'s finer bins.
+        if let Some(offset) = cds_pos.offset {
+            match SpliceRegionBin::from_offset(offset) {
+                SpliceRegionBin::Canonical => {
+                    return SequenceEffect {
+                        so_term: "SO:0001629".to_string(),
+                        name: "splice_site_variant".to_string(),
+                        description: "A sequence variant that changes the first two or last two bases of an intron".to_string(),
+                        impact: "HIGH".to_string(),
+                    };
+                }
+                SpliceRegionBin::Region => {
+                    return SequenceEffect {
+                        so_term: "SO:0001630".to_string(),
+                        name: "splice_region_variant".to_string(),
+                        description: "A sequence variant in which a change has occurred within the region of the splice site".to_string(),
+                        impact: "LOW".to_string(),
+                    };
+                }
+                SpliceRegionBin::Intron => {}
             }
         }
         return SequenceEffect {

--- a/tests/it/cdot_coordinate_basis_layers.rs
+++ b/tests/it/cdot_coordinate_basis_layers.rs
@@ -1,0 +1,227 @@
+//! Hermetic pin on the **two** cdot coordinate layers, and on which is which.
+//!
+//! # Why this exists
+//!
+//! `cdot` coordinates appear in two layers with the *same field names*, and the
+//! two disagree:
+//!
+//! | layer | genomic | transcript |
+//! |---|---|---|
+//! | raw cdot JSON, on disk | 0-based half-open | **1-based inclusive** |
+//! | ferro's in-memory `CdotTranscript` (post-#742) | 1-based `[incl, excl)` | **0-based half-open** |
+//!
+//! `coords::cdot_tx_coords` documents the *raw* layer; the basis table at the
+//! top of `data::cdot` documents the *internal* one. Two tables, two layers, one
+//! set of names — which is how two independent audits of that ambiguity each
+//! resolved it the wrong way.
+//!
+//! # Why it is here rather than beside the code
+//!
+//! The test that is cited as *the* pin on the internal transcript basis —
+//! `ferro_hgvs::convert::mapper`'s `test_cdot_tx_coordinates_are_0_based` —
+//! opens by looking for `benchmark-output/cdot/cdot-0.2.32.refseq.GRCh38.json`
+//! and `return`ing if it is absent. That file is a multi-gigabyte download
+//! present on approximately no default checkout, so on almost every machine and
+//! almost every CI job that test asserts **nothing** and reports green. A skip
+//! that reads as a pass is the failure mode `tests/fixtures/CORPUS_LAYOUT.md`
+//! exists to remove, and the convention this repo uses elsewhere is to pair any
+//! skipping tier with a hermetic tier that never skips.
+//!
+//! **This module is that hermetic tier.** Its fixture is a synthetic cdot
+//! payload in this file, so it downloads nothing, reads no LFS object, consults
+//! no environment variable, and therefore has no way to skip. Fixing the
+//! skipping sibling in place is a separate change to `src/convert/mapper.rs`;
+//! this guard is what makes the invariant asserted on every run in the meantime.
+
+use ferro_hgvs::coords::{cdot_genomic_to_closed, cdot_tx_coords};
+use ferro_hgvs::data::cdot::CdotMapper;
+
+/// Raw cdot JSON: one plus-strand transcript, two exons.
+///
+/// Exon rows are `[genome_start, genome_end, exon_number, tx_start, tx_end, cigar]`
+/// in cdot's own conventions — genome 0-based half-open, transcript **1-based
+/// inclusive**. So exon 1 covers 100 genomic bases at 0-based `[1000, 1100)` and
+/// transcript bases 1..=100; exon 2 covers 50 at `[2000, 2050)` and 101..=150.
+const RAW_CDOT_JSON: &str = r#"
+{
+    "transcripts": {
+        "NM_LAYER.1": {
+            "gene_name": "LAYERTEST",
+            "genome_builds": {
+                "GRCh38": {
+                    "contig": "NC_000001.11",
+                    "strand": "+",
+                    "exons": [
+                        [1000, 1100, 0, 1, 100, "M100"],
+                        [2000, 2050, 1, 101, 150, "M50"]
+                    ]
+                }
+            },
+            "start_codon": 30,
+            "stop_codon": 120
+        }
+    }
+}
+"#;
+
+/// The raw values written into [`RAW_CDOT_JSON`], named so the assertions below
+/// can state the before/after rather than restating literals.
+mod raw {
+    /// Exon 1: 0-based inclusive genomic start / 0-based exclusive genomic end.
+    pub const EXON1_GENOME: (u64, u64) = (1000, 1100);
+    /// Exon 1: 1-based **inclusive** transcript start / end.
+    pub const EXON1_TX: (u64, u64) = (1, 100);
+    /// Exon 2, same conventions.
+    pub const EXON2_GENOME: (u64, u64) = (2000, 2050);
+    /// Exon 2, same conventions.
+    pub const EXON2_TX: (u64, u64) = (101, 150);
+}
+
+fn load() -> ferro_hgvs::data::cdot::CdotTranscript {
+    let mapper = CdotMapper::from_reader_with_build(RAW_CDOT_JSON.as_bytes(), "GRCh38")
+        .expect("the synthetic cdot fixture must parse");
+    mapper
+        .get_transcript("NM_LAYER.1")
+        .expect("the synthetic cdot fixture must contain NM_LAYER.1")
+        .clone()
+}
+
+/// The fixture is real, so nothing downstream can be vacuously green.
+///
+/// Asserted before the basis checks, in the house style, so an empty or
+/// silently-dropped exon table cannot make them pass over zero rows.
+#[test]
+fn the_synthetic_fixture_loads_and_is_not_empty() {
+    let tx = load();
+    assert_eq!(
+        tx.exons.len(),
+        2,
+        "the fixture must load both exon rows; the ingestion path silently \
+         drops rows with fewer than five fields, so a shortfall here would make \
+         every basis assertion below a claim about a corpus that is not there"
+    );
+}
+
+/// The claim `test_cdot_tx_coordinates_are_0_based` makes, asserted hermetically.
+///
+/// Raw cdot spells the first exon's transcript bounds `1..=100`; after loading,
+/// the first exon must start at transcript **0**, not 1.
+#[test]
+fn raw_one_based_transcript_bounds_load_as_zero_based_half_open() {
+    let tx = load();
+
+    assert_eq!(
+        raw::EXON1_TX.0,
+        1,
+        "precondition: the fixture must spell the first exon's transcript start \
+         as raw cdot does (1-based), or this test proves nothing about the \
+         conversion"
+    );
+
+    assert_eq!(
+        tx.exons[0][2], 0,
+        "first exon tx_start must be 0 (0-based half-open) after loading, not \
+         the raw JSON's 1"
+    );
+    assert_eq!(
+        (tx.exons[0][2], tx.exons[0][3]),
+        (raw::EXON1_TX.0 - 1, raw::EXON1_TX.1),
+        "tx bounds convert 1-based inclusive -> 0-based half-open: start -1, \
+         end unchanged"
+    );
+    assert_eq!(
+        (tx.exons[1][2], tx.exons[1][3]),
+        (raw::EXON2_TX.0 - 1, raw::EXON2_TX.1),
+    );
+
+    // Both exons are exactly as long on the transcript axis as their genomic
+    // spans, so the conversion cannot have shifted one end without the other.
+    assert_eq!(tx.exons[0][3] - tx.exons[0][2], 100);
+    assert_eq!(tx.exons[1][3] - tx.exons[1][2], 50);
+}
+
+/// The genomic axis converts in the opposite direction on the same rows, which
+/// is the mixed-basis trap the two tables exist to warn about.
+#[test]
+fn raw_zero_based_genomic_bounds_load_as_one_based() {
+    let tx = load();
+    assert_eq!(
+        (tx.exons[0][0], tx.exons[0][1]),
+        (raw::EXON1_GENOME.0 + 1, raw::EXON1_GENOME.1 + 1),
+        "genome bounds convert 0-based half-open -> 1-based [incl, excl)"
+    );
+    assert_eq!(
+        (tx.exons[1][0], tx.exons[1][1]),
+        (raw::EXON2_GENOME.0 + 1, raw::EXON2_GENOME.1 + 1),
+    );
+}
+
+/// The CDS bounds ride through untouched **on a contiguous exon table**, so a
+/// reader cannot infer that *everything* on the record was shifted.
+///
+/// The qualifier is load-bearing rather than a hedge, and it is a third
+/// coordinate space rather than a third layer of the two above. cdot's
+/// `start_codon`/`stop_codon` are offsets into the gap-COLLAPSED transcript —
+/// exon bases only — while the exon table's own `tx_start`/`tx_end` are offsets
+/// into the flat sequence. `data::cdot::collapsed_to_flat_tx_pos` maps the
+/// former onto the latter (#1619), and that mapping is the **identity** exactly
+/// when the exon table is contiguous and starts at 0.
+///
+/// [`RAW_CDOT_JSON`] is both: exon 1 covers tx `1..=100` and exon 2 `101..=150`,
+/// so the internal rows abut at 100 with no hole between them. That is why
+/// `start_codon` 30 and `stop_codon` 120 arrive here unchanged — not because the
+/// loader leaves the CDS alone.
+///
+/// Give the fixture a transcript-coordinate gap and the identity stops holding:
+/// the bounds would then be shifted by the enclosed hole while the exon rows
+/// around them are not, which is this module's mixed-basis trap in its third
+/// space. So do not read this test as "the loader never touches the CDS" — read
+/// it as "on this geometry, the mapping has nothing to do".
+#[test]
+fn cds_bounds_survive_loading_unchanged_on_a_contiguous_exon_table() {
+    let tx = load();
+    assert_eq!(tx.cds_start, Some(30));
+    assert_eq!(tx.cds_end, Some(120));
+}
+
+/// `coords::cdot_tx_coords` describes the RAW layer, and this pins that the raw
+/// and internal layers genuinely differ — so pointing the helper at an
+/// in-memory `CdotTranscript` is a real error, not a harmless no-op.
+#[test]
+fn the_coords_helpers_describe_the_raw_layer_not_the_internal_one() {
+    let tx = load();
+
+    // On the raw layer the helper is correctly a no-op: raw tx bounds are
+    // already 1-based.
+    assert_eq!(
+        cdot_tx_coords(raw::EXON1_TX.0, raw::EXON1_TX.1),
+        raw::EXON1_TX
+    );
+
+    // On the internal layer it is wrong, because the internal values are no
+    // longer 1-based. Stated as an inequality rather than as an expected
+    // wrong answer: the point is that the two layers are distinguishable.
+    assert_ne!(
+        cdot_tx_coords(tx.exons[0][2], tx.exons[0][3]),
+        raw::EXON1_TX,
+        "if these were equal the two layers would be indistinguishable and the \
+         helper's 'already 1-based' claim would be safe to apply to either — it \
+         is not"
+    );
+
+    // Same asymmetry on the genomic axis, in the other direction: the raw
+    // helper's input is the raw value, and the loaded value has already moved.
+    let (raw_g_start, _raw_g_end) =
+        cdot_genomic_to_closed(raw::EXON1_GENOME.0, raw::EXON1_GENOME.1);
+    assert_eq!(
+        raw_g_start, tx.exons[0][0],
+        "the genomic start agrees across layers (both 1-based inclusive) — it is \
+         the END that differs: the helper returns 1-based inclusive, ingestion \
+         stores 1-based exclusive"
+    );
+    assert_ne!(
+        cdot_genomic_to_closed(raw::EXON1_GENOME.0, raw::EXON1_GENOME.1).1,
+        tx.exons[0][1],
+        "1-based inclusive end vs 1-based exclusive end must not coincide"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -503,6 +503,7 @@ mod spec_enumeration_tests;
 mod spec_generator_preconditions;
 mod spec_worked_example_rules;
 mod spec_worked_examples;
+mod splice_ladder_shapes;
 mod strict_del_size_suffix_mode;
 mod strict_explicit_seq_size_modes;
 mod strict_rejection_survives_normalization;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -57,6 +57,7 @@ mod breakpoint_insertion;
 mod build_transcript_library_parity;
 mod bulk_fixture_tests;
 mod case_harvest;
+mod cdot_coordinate_basis_layers;
 mod cds_utr3_crossing_shift_idempotency;
 mod cis_adjudication_enumeration;
 mod cis_allele_confluence_proptest;

--- a/tests/it/splice_ladder_shapes.rs
+++ b/tests/it/splice_ladder_shapes.rs
@@ -1,0 +1,482 @@
+//! Cross-test for ferro's two splice-distance ladders.
+//!
+//! ferro classifies intronic offsets on **two** ladders that disagree, and both
+//! are correct because they answer different questions:
+//!
+//! | shape | type | ladder | question |
+//! |---|---|---|---|
+//! | A | [`SpliceSiteType`] | donor 2/6/20/50, acceptor 2/12/20/50 | ferro's fine-grained splice-distance bin |
+//! | B | [`SpliceRegionBin`] | 2/8 | which Sequence Ontology term does VEP assign? |
+//!
+//! Shape A previously existed as **three** full copies (`reference/transcript.rs`,
+//! and twice in `convert/noncoding.rs`) plus a fourth partial one
+//! (`IntronicRegion::from_offset`, 2/20/50 — missing the 6- and 12-rungs), and
+//! shape B as **two** (`effect/mod.rs` and the web service's CDS effect
+//! handler). Each shape now has one definition and the rest derive from it.
+//!
+//! This module pins two things a future edit could silently break:
+//!
+//! 1. Every shape-A consumer still agrees with the one shape-A ladder, and
+//!    every shape-B consumer with the one shape-B ladder — i.e. the
+//!    de-duplication stayed de-duplicated.
+//! 2. The **relationship between the two shapes** at their boundary offsets. The
+//!    ladders are meant to disagree; what must not happen is one of them moving
+//!    relative to the other without anyone noticing, since two surfaces of one
+//!    product would then classify one variant differently for a new reason.
+//!
+//! The web service's `predict_cds_effect` is private and feature-gated, so it is
+//! not called here; it shares `SpliceRegionBin`, which is what makes it unable
+//! to drift.
+
+use ferro_hgvs::convert::noncoding::{IntronicConsequence, IntronicRegion};
+use ferro_hgvs::effect::{Consequence, EffectPredictor, SpliceRegionBin};
+use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
+use ferro_hgvs::reference::transcript::{IntronBoundary, IntronPosition, SpliceSiteType};
+
+/// The offsets worth pinning: every rung of both ladders, and the base either
+/// side of each rung. Signed — positive is the donor side.
+const BOUNDARY_OFFSETS: &[i64] = &[
+    1, 2, 3, 6, 7, 8, 9, 10, 12, 13, 20, 21, 50, 51, //
+    -1, -2, -3, -6, -7, -8, -9, -10, -12, -13, -20, -21, -50, -51,
+];
+
+fn cds_at(offset: i64) -> CdsPos {
+    CdsPos {
+        base: 100,
+        offset: Some(offset),
+        utr3: false,
+        special: None,
+    }
+}
+
+fn tx_at(offset: i64) -> TxPos {
+    TxPos {
+        base: 100,
+        offset: Some(offset),
+        downstream: false,
+    }
+}
+
+fn intron_position_at(offset: i64) -> IntronPosition {
+    IntronPosition {
+        intron_number: 1,
+        boundary: if offset > 0 {
+            IntronBoundary::FivePrime
+        } else {
+            IntronBoundary::ThreePrime
+        },
+        offset,
+        tx_boundary_pos: 100,
+        intron_length: 1000,
+    }
+}
+
+// --- Shape A: one ladder, several consumers ---------------------------------
+
+/// The fine-grained ladder itself, rung by rung, in both directions.
+#[test]
+fn shape_a_bins_every_boundary_offset_as_specified() {
+    use SpliceSiteType::*;
+    let expected: &[(i64, SpliceSiteType)] = &[
+        (1, DonorCanonical),
+        (2, DonorCanonical),
+        (3, DonorExtended),
+        (6, DonorExtended),
+        (7, DonorRegion),
+        (20, DonorRegion),
+        (21, NearSplice),
+        (50, NearSplice),
+        (51, DeepIntronic),
+        (-1, AcceptorCanonical),
+        (-2, AcceptorCanonical),
+        (-3, AcceptorExtended),
+        (-12, AcceptorExtended),
+        (-13, AcceptorRegion),
+        (-20, AcceptorRegion),
+        (-21, NearSplice),
+        (-50, NearSplice),
+        (-51, DeepIntronic),
+    ];
+    assert!(
+        !expected.is_empty(),
+        "the ladder table must be non-empty, or this test passes vacuously"
+    );
+    for (offset, want) in expected {
+        assert_eq!(
+            SpliceSiteType::from_signed_offset(*offset),
+            *want,
+            "SpliceSiteType::from_signed_offset({offset})"
+        );
+    }
+}
+
+/// `IntronPosition` carries its side as a field, not as the sign of its offset,
+/// so an offset of 0 on the 5' boundary must still classify as a **donor**.
+///
+/// This is the one case where reading the side off the sign would change
+/// behaviour, which is why the shared ladder is reachable both ways
+/// (`from_signed_offset` for offsets, `from_distance_on_side` for the field).
+#[test]
+fn shape_a_reads_its_side_from_the_boundary_field_not_the_sign() {
+    let five_prime_zero = IntronPosition {
+        intron_number: 1,
+        boundary: IntronBoundary::FivePrime,
+        offset: 0,
+        tx_boundary_pos: 100,
+        intron_length: 1000,
+    };
+    assert_eq!(
+        five_prime_zero.splice_site_type(),
+        SpliceSiteType::DonorCanonical,
+        "a 5'-boundary position must classify as a donor even at offset 0, where \
+         the sign alone would say acceptor"
+    );
+
+    // And a negatively-spelled offset on the 5' boundary is still a donor: the
+    // field wins over the sign in both directions.
+    let five_prime_negative = IntronPosition {
+        offset: -6,
+        ..five_prime_zero
+    };
+    assert_eq!(
+        five_prime_negative.splice_site_type(),
+        SpliceSiteType::DonorExtended
+    );
+
+    // The mirror: a positively-spelled offset on the 3' boundary is still an
+    // acceptor, and lands on the acceptor's own 12-rung — which the donor
+    // ladder does not have, so this could not pass if the side were read off
+    // the sign.
+    let three_prime_positive = IntronPosition {
+        boundary: IntronBoundary::ThreePrime,
+        offset: 12,
+        ..five_prime_zero
+    };
+    assert_eq!(
+        three_prime_positive.splice_site_type(),
+        SpliceSiteType::AcceptorExtended,
+        "offset +12 on the 3' boundary must be AcceptorExtended; reading the \
+         side off the sign would give DonorRegion"
+    );
+}
+
+/// The `+?` / `-?` unknown-offset sentinels must not panic and must not be
+/// reported as a canonical splice site.
+///
+/// `c.<base>-?` parses to `offset == Some(i64::MIN)`
+/// (`parser::position::OFFSET_UNKNOWN_NEGATIVE`), and every ladder here takes
+/// the offset's magnitude. Taken with `abs()` that is a debug panic, and in
+/// release it wraps back to `i64::MIN`, which satisfies every `<= n` rung and
+/// reports the *closest* possible bin — a HIGH-impact canonical splice site —
+/// for a position whose distance is by definition unknown. Both ladders take
+/// the magnitude with `unsigned_abs`, so the sentinel lands in the farthest bin
+/// instead.
+///
+/// This pins "does not panic, is not canonical". Whether to decline outright
+/// was left open here, and #1841 settled it: the two ladders that answer *for a
+/// position* — `IntronicRegion::from_offset` and the two `IntronicConsequence`
+/// constructors — now return `None`, because every variant of those enums names
+/// a distance band and a sentinel states that the distance is unknown. The two
+/// raw bin ladders below still answer, and still answer with the farthest bin;
+/// they classify a magnitude, not a position.
+#[test]
+fn the_unknown_offset_sentinels_do_not_panic_or_read_as_canonical() {
+    for sentinel in [i64::MIN, i64::MAX] {
+        assert_eq!(
+            SpliceSiteType::from_signed_offset(sentinel),
+            SpliceSiteType::DeepIntronic,
+            "SpliceSiteType::from_signed_offset({sentinel})"
+        );
+        assert_eq!(
+            SpliceRegionBin::from_offset(sentinel),
+            SpliceRegionBin::Intron,
+            "SpliceRegionBin::from_offset({sentinel})"
+        );
+        assert_eq!(
+            IntronicRegion::from_offset(sentinel),
+            None,
+            "IntronicRegion::from_offset({sentinel})"
+        );
+        assert_eq!(
+            IntronicConsequence::from_cds_pos(&cds_at(sentinel)),
+            None,
+            "IntronicConsequence::from_cds_pos({sentinel})"
+        );
+        assert_eq!(
+            IntronicConsequence::from_tx_pos(&tx_at(sentinel)),
+            None,
+            "IntronicConsequence::from_tx_pos({sentinel})"
+        );
+        assert!(
+            EffectPredictor::new()
+                .classify_splice_variant(sentinel)
+                .is_none(),
+            "EffectPredictor::classify_splice_variant({sentinel})"
+        );
+
+        // `IntronPosition`'s four standalone predicates take the same magnitude
+        // and had the same `abs()` hazard.
+        let pos = intron_position_at(sentinel);
+        assert!(pos.is_deep_intronic());
+        assert!(!pos.is_canonical_splice_site());
+        assert!(!pos.is_near_splice_site());
+        assert!(!pos.is_extended_splice_region());
+    }
+}
+
+/// `IntronicConsequence` has three entry points; all three must land on the one
+/// shape-A ladder rather than on a private copy of its thresholds.
+#[test]
+fn every_shape_a_consumer_agrees_with_the_one_shape_a_ladder() {
+    let mut checked = 0usize;
+    for &offset in BOUNDARY_OFFSETS {
+        let site = SpliceSiteType::from_signed_offset(offset);
+        let want = IntronicConsequence::from_splice_site_type(site);
+
+        assert_eq!(
+            IntronicConsequence::from_cds_pos(&cds_at(offset)),
+            Some(want),
+            "IntronicConsequence::from_cds_pos at offset {offset}"
+        );
+        assert_eq!(
+            IntronicConsequence::from_tx_pos(&tx_at(offset)),
+            Some(want),
+            "IntronicConsequence::from_tx_pos at offset {offset}"
+        );
+        assert_eq!(
+            IntronicConsequence::from_intron_position(&intron_position_at(offset)),
+            want,
+            "IntronicConsequence::from_intron_position at offset {offset}"
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 0,
+        "VACUOUS: no offset was checked against the shape-A ladder"
+    );
+}
+
+/// The projection `IntronicConsequence::from_splice_site_type` performs, pinned
+/// against literals rather than against itself.
+///
+/// The test above derives its expectation *from* this projection, so it pins
+/// that the three entry points agree with each other and says nothing about
+/// whether the projection is right. Since de-duplicating those three onto it is
+/// this change's only functional edit, the mapping needs its own outright pin —
+/// the same treatment `IntronicRegion`'s historical 2/20/50 spelling gets below.
+#[test]
+fn the_consequence_projection_maps_every_bin_as_specified() {
+    use IntronicConsequence::*;
+    use SpliceSiteType::*;
+    let expected: &[(SpliceSiteType, IntronicConsequence)] = &[
+        (DonorCanonical, SpliceDonorVariant),
+        (AcceptorCanonical, SpliceAcceptorVariant),
+        (DonorExtended, SpliceDonorRegionVariant),
+        (AcceptorExtended, SpliceAcceptorRegionVariant),
+        (DonorRegion, SpliceRegionVariant),
+        (AcceptorRegion, SpliceRegionVariant),
+        (NearSplice, NearSpliceSiteVariant),
+        (DeepIntronic, IntronVariant),
+    ];
+    assert!(
+        !expected.is_empty(),
+        "the projection table must be non-empty, or this test passes vacuously"
+    );
+    for (site, want) in expected {
+        assert_eq!(
+            IntronicConsequence::from_splice_site_type(*site),
+            *want,
+            "IntronicConsequence::from_splice_site_type({site:?})"
+        );
+    }
+}
+
+/// `IntronicRegion` is the side-agnostic collapse of shape A. It used to restate
+/// a *partial* copy of the ladder (2/20/50), so this pins that the rungs it
+/// drops are dropped by the mapping and not by a second editable ladder.
+#[test]
+fn the_coarse_region_view_is_a_collapse_of_the_same_ladder() {
+    use IntronicRegion::*;
+    let mut checked = 0usize;
+    for &offset in BOUNDARY_OFFSETS {
+        let want = match SpliceSiteType::from_signed_offset(offset) {
+            SpliceSiteType::DonorCanonical | SpliceSiteType::AcceptorCanonical => {
+                CanonicalSpliceSite
+            }
+            SpliceSiteType::DonorExtended
+            | SpliceSiteType::AcceptorExtended
+            | SpliceSiteType::DonorRegion
+            | SpliceSiteType::AcceptorRegion => ExtendedSpliceRegion,
+            SpliceSiteType::NearSplice => NearSpliceSite,
+            SpliceSiteType::DeepIntronic => DeepIntronic,
+        };
+        assert_eq!(
+            IntronicRegion::from_offset(offset),
+            Some(want),
+            "IntronicRegion::from_offset({offset})"
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "VACUOUS: no offset was checked");
+
+    // The historical 2/20/50 spelling, pinned outright so the collapse cannot
+    // quietly change what this view reports.
+    assert_eq!(IntronicRegion::from_offset(2), Some(CanonicalSpliceSite));
+    assert_eq!(IntronicRegion::from_offset(3), Some(ExtendedSpliceRegion));
+    assert_eq!(IntronicRegion::from_offset(20), Some(ExtendedSpliceRegion));
+    assert_eq!(IntronicRegion::from_offset(21), Some(NearSpliceSite));
+    assert_eq!(IntronicRegion::from_offset(50), Some(NearSpliceSite));
+    assert_eq!(IntronicRegion::from_offset(51), Some(DeepIntronic));
+}
+
+// --- Shape B: one ladder, several consumers ---------------------------------
+
+#[test]
+fn shape_b_bins_every_boundary_offset_as_specified() {
+    use SpliceRegionBin::*;
+    let expected: &[(i64, SpliceRegionBin)] = &[
+        (1, Canonical),
+        (2, Canonical),
+        (3, Region),
+        (8, Region),
+        (9, Intron),
+        (51, Intron),
+        (-2, Canonical),
+        (-8, Region),
+        (-9, Intron),
+    ];
+    assert!(
+        !expected.is_empty(),
+        "the ladder table must be non-empty, or this test passes vacuously"
+    );
+    for (offset, want) in expected {
+        assert_eq!(
+            SpliceRegionBin::from_offset(*offset),
+            *want,
+            "SpliceRegionBin::from_offset({offset})"
+        );
+    }
+}
+
+#[test]
+fn the_effect_predictor_agrees_with_the_one_shape_b_ladder() {
+    let predictor = EffectPredictor::new();
+    let mut checked = 0usize;
+    for &offset in BOUNDARY_OFFSETS {
+        let want = match SpliceRegionBin::from_offset(offset) {
+            SpliceRegionBin::Canonical => {
+                if offset > 0 {
+                    Consequence::SpliceDonorVariant
+                } else {
+                    Consequence::SpliceAcceptorVariant
+                }
+            }
+            SpliceRegionBin::Region => Consequence::SpliceRegionVariant,
+            SpliceRegionBin::Intron => Consequence::IntronVariant,
+        };
+        let effect = predictor
+            .classify_splice_variant(offset)
+            .expect("a measured offset is not a sentinel, so it classifies");
+        assert_eq!(
+            effect.consequences,
+            vec![want],
+            "EffectPredictor::classify_splice_variant({offset})"
+        );
+        assert_eq!(effect.intronic_offset, Some(offset));
+        checked += 1;
+    }
+    assert!(
+        checked > 0,
+        "VACUOUS: no offset was checked against the shape-B ladder"
+    );
+}
+
+// --- The relationship between the two shapes --------------------------------
+
+/// The two ladders disagree **by design**, and this pins a representative
+/// sample of where.
+///
+/// Deliberately a sample and not an exhaustive set — the two disagree over
+/// roughly `3..=50` in both directions, and pinning every one of those offsets
+/// would restate a ladder rather than pin a relationship. What is pinned is one
+/// offset per *kind* of disagreement, which is what an edit to either ladder
+/// would move.
+///
+/// If a future edit makes this test fail, the question to answer is not "which
+/// ladder is wrong" — it is "did I mean to change what one of ferro's two
+/// surfaces reports for this offset?". Neither shape is a bug.
+#[test]
+fn the_two_shapes_disagree_at_the_documented_offsets() {
+    // (offset, shape A, shape B) at representative offsets where the two
+    // ladders put the position in bins of different coarseness. Offsets are
+    // signed: positive is the donor side.
+    let disagreements: &[(i64, SpliceSiteType, SpliceRegionBin)] = &[
+        // +3..=+6 donor: A says "extended donor consensus", B says "splice region".
+        (6, SpliceSiteType::DonorExtended, SpliceRegionBin::Region),
+        // Beyond +8/-8, B has already dropped to a plain intron variant while A
+        // is still inside a splice bin out to 20. This is the widest gap between
+        // the two. Note A's bin differs by side here: +10 is `DonorRegion`
+        // (donor's 6-rung is behind it), while -10 is still `AcceptorExtended`
+        // (the acceptor's extended rung reaches 12).
+        (10, SpliceSiteType::DonorRegion, SpliceRegionBin::Intron),
+        (
+            -10,
+            SpliceSiteType::AcceptorExtended,
+            SpliceRegionBin::Intron,
+        ),
+        (
+            -12,
+            SpliceSiteType::AcceptorExtended,
+            SpliceRegionBin::Intron,
+        ),
+        (-20, SpliceSiteType::AcceptorRegion, SpliceRegionBin::Intron),
+    ];
+    assert!(
+        !disagreements.is_empty(),
+        "VACUOUS: the two shapes must be pinned as disagreeing somewhere, or \
+         this guard would pass if they were silently merged"
+    );
+    for (offset, want_a, want_b) in disagreements {
+        assert_eq!(
+            SpliceSiteType::from_signed_offset(*offset),
+            *want_a,
+            "shape A at offset {offset}"
+        );
+        assert_eq!(
+            SpliceRegionBin::from_offset(*offset),
+            *want_b,
+            "shape B at offset {offset}"
+        );
+    }
+}
+
+/// The converse half: the two shapes must still agree at the canonical site and
+/// deep in the intron. A change that made them disagree *there* would be a real
+/// defect rather than the designed difference above.
+#[test]
+fn the_two_shapes_agree_at_the_canonical_site_and_deep_intronic() {
+    for offset in [1i64, 2, -1, -2] {
+        assert!(
+            matches!(
+                SpliceSiteType::from_signed_offset(offset),
+                SpliceSiteType::DonorCanonical | SpliceSiteType::AcceptorCanonical
+            ),
+            "shape A must call offset {offset} canonical"
+        );
+        assert_eq!(
+            SpliceRegionBin::from_offset(offset),
+            SpliceRegionBin::Canonical
+        );
+    }
+    for offset in [51i64, 200, -51, -200] {
+        assert_eq!(
+            SpliceSiteType::from_signed_offset(offset),
+            SpliceSiteType::DeepIntronic,
+            "shape A must call offset {offset} deep intronic"
+        );
+        assert_eq!(
+            SpliceRegionBin::from_offset(offset),
+            SpliceRegionBin::Intron
+        );
+    }
+}


### PR DESCRIPTION
Closes the MINOR/NIT cluster of the coordinate-seam audit: m1, m2, m3, m4, n1, n2, m6, n3, plus a corrected diagnosis on m5. **Net behaviour change: none.** When this was first written the PR also carried the `i64::MIN` ladder fix — `c.<base>-?` parses to `offset = Some(i64::MIN)`, and a plain `.abs()` panics under `overflow-checks` and wraps negative in a release build, so every `<= n` rung read true and an unknown-distance intronic position was reported as a canonical splice site at HIGH impact. **That fix has since landed on `main` in #1767**, so what remains here is the de-duplication, which is behaviour-preserving: the consolidated ladder takes its magnitude with `unsigned_abs()` exactly as each former copy already did. The earlier claim that `c.100-?` moves from `splice_site_variant`/HIGH to `intron_variant`/MODIFIER is withdrawn — it describes a transition that has already happened on `main`.

`IvsPos` keeps its own copy of the ladder and is deliberately **not** touched here — that file is in a watched directory and outside this PR's scope. Both that and the larger question — whether an unknown offset should be classified at all rather than assigned a fabricated distance — are tracked in #1826.

`Representation-Change: none` is unaffected: no normalized description moves.

## The through-line: two cdot layers, one set of field names

Raw cdot JSON is genomic 0-based half-open / transcript 1-based inclusive. Ferro's in-memory `CdotTranscript` is genomic 1-based `[incl, excl)` / transcript **0-based** half-open, because `RawCdotTranscript::from_genome_build` (`src/data/cdot.rs:551`) converts both axes on load (#742) — note `CdotMapper` is a real type but has no such method; its constructor is `from_transcripts`. The two layers use the same field names — `genome_start`, `tx_start`, `cds_start` — so a sentence naming a field names a basis only if it also names a layer, and almost none of them did.

That single ambiguity is what every documentation defect in this PR turned out to be. Each table was written by someone reading a real, correct piece of code; the tables disagree because they were each describing a different layer while claiming to describe "cdot". Two independent audits of that ambiguity each resolved it the wrong way, which is the strongest available argument that the fix is to label the layer rather than to correct the basis. Every table below now names its layer in its first line and cross-links the other.

The code was correct at all six sites. Only comments changed.

## The six sites

**m3 — `coords/mod.rs` (raw layer).** Every `cdot_*` helper here describes raw on-disk cdot, and nothing said so; a caller who reached for `cdot_tx_coords` holding an in-memory `CdotTranscript` would have been silently one off on both axes. The module now opens with which layer it is about and points at `data::cdot` for the other. It also cited "bug 944a4e9", which is not an object in this repository (`git cat-file -t` → `fatal: Not a valid object name`); citation dropped.

**m1 — `reference/multi_fasta.rs` (internal layer).** The basis table claimed cdot transcript coordinates are "used directly (already 1-based)" and that `genome_start` "is 0-based, converted to 1-based". Both are exactly backwards relative to the code beneath them, which converts `tx_start` via `+ 1` and uses `genome_start` as-is — and the code is right. The table was describing raw cdot while the loader beneath it reads internal cdot; the conversion comment three lines into that loader already said `#742` and `already 1-based incl`, so the file contradicted itself within one screen. Rows now read `cdot genomic (internal)` / `cdot tx (internal)` / `cdot CDS (internal)` and state the conversion each one actually performs.

**m2 — `convert/mapper.rs`.** The table said `| Genomic | 0-based | Half-open intervals for exons |`. Both halves are wrong: `genomic_to_tx` tests `g_start <= pos <= g_end`, a *closed* interval, against `Exon::genomic_start`/`genomic_end`, which `reference/transcript.rs` documents as 1-based inclusive — and `GenomicLocation.position` in this same file is already documented as an HGVS `g.` number. This is the layer confusion at one remove: the mapper never sees cdot at all, only a materialised `Transcript` whose loader has already converted, so it inherited raw cdot's basis in its docs without ever handling raw cdot's values. The row is corrected and a note says why this module is the 1-based end of that seam.

**n2 — `hgvs/location.rs`.** `CdsPos.base` and `TxPos.base` — the two fields the `mapper.rs` table points at as its authority for "1-based" — stated no basis at all, only "can be negative". The basis was therefore documented in exactly one place, a table that was wrong about a different row. Both now state 1-based, that the negative range counts back with no zero in between, what the `utr3`/`downstream` flags change, and (for `CdsPos`) that `0` is not a position but the `CDS_BASE_UNKNOWN` sentinel.

**m4 — `reference/validate.rs` claimed exon-alignment gaps are rejected upstream.** They are not: `from_genome_build` silently drops exon rows with fewer than five fields, and `MultiFastaProvider` diverts a gapped table only when a supplemental CDS record exists. 58 of 474,818 multi-exon cdot builds carry a gap. The check itself is sound either way because it compares against the maximum exon end rather than a summed length, so only the justification changes.

**m5 — a correction to the audit, not a fix.** `reference/derived_tx_structure.rs:325` was reported as silently dropping `cds_start_incomplete`. It is not a construction path — it is a throwaway readback probe reaching only `reconstruct_spliced_mrna`, which reads `exons`/`contig`/`strand`, so the flag is inert there. `:346` already propagates it (landed with #972/#994) and has a test. A comment now records this so it is not re-filed. The two genuine sites are in `data/cdot.rs` and are left to a change that owns that file.

## Six splice ladders in two shapes → one per shape, with each shape's question named

The two shapes are deliberately **not** merged: shape A is ferro's fine-grained distance bin (donor 2/6/20/50, acceptor 2/12/20/50), shape B is the SO/VEP consequence call (2/8), and they disagree by construction — offset 10 is a donor region under A and a plain intron variant under B. Neither is wrong. What was missing is that nothing named the question each answers and nothing cross-tested them.

Each shape now has one implementation whose doc states its question and points at the other as deliberately different; every former copy delegates. Shape A had three full copies plus one partial (`IntronicRegion::from_offset`, missing the 6- and 12-rungs), which now derives its coarser bins by *mapping* the shared ones, so its missing rungs are dropped by the mapping rather than by a second editable ladder. `from_distance_on_side` exists for a real edge: `IntronPosition` carries its side as a field rather than as the offset's sign, so a 5'-boundary position at offset 0 must still classify as a donor — reading the side off the sign alone would silently change that one case, and there is a test for it.

`tests/it/splice_ladder_shapes.rs` pins both the within-shape agreement and the between-shape relationship at offsets 2, 6, 8, 10, 12, 20, 50, including where they must agree. Sabotage-verified: moving the shared acceptor rung 12 → 11 reddens three of the ten tests in that file.

Also corrects the acceptor 12-rung's comment, which cited a branch-point region (−18 to −35) that its own threshold excludes; the 12-rung is the polypyrimidine tract, as the bin's enum doc and its `splice_polypyrimidine_tract_variant` SO term already said.

## n3 — a hermetic pin on the cdot basis

`convert::mapper`'s `test_cdot_tx_coordinates_are_0_based` — the test both audits cite as *the* pin on the internal transcript basis — returns early when a multi-gigabyte download is absent, i.e. on every default checkout, so it asserts nothing and reports green. `tests/it/cdot_coordinate_basis_layers.rs` adds the tier that cannot skip: a synthetic cdot payload written inline, asserting the conversion on both axes, that CDS bounds ride through, and that the raw-layer helper gives a *different* answer from the loaded values — so pointing it at an in-memory `CdotTranscript` is a real error rather than a harmless no-op. The exon-row count is asserted before the basis checks so a dropped row cannot make them vacuous. Repairing the skipping sibling in place is left to a change that owns `src/convert/mapper.rs`.

## Overlap with in-flight branches

m1, m2 and n2 were deferred on an earlier revision of this PR because other open branches touch those files; they are included now, scoped so they cannot collide. #1762 also edits `src/hgvs/location.rs` and `src/convert/mapper.rs`, but only the `Display` impls, a new `unknown_offset_marker` helper, and `CoordinateMapper` method bodies — the n2 edit touches only the `base` field doc comments inside the `CdsPos`/`TxPos` struct definitions, and the m2 edit only the module header table, so neither lands in a region #1762 restructures. `multi_fasta.rs` is not touched by #1762.

Still out of scope: m5's two genuine `cds_start_incomplete` sites in `data/cdot.rs`, left to a change that owns that file.

## Gate

`cargo fmt --all --check`, `cargo clippy --features dev --lib -- -D warnings` and `cargo clippy --features python --lib -- -D warnings` all clean; `cargo ta` green.

Representation-Change: none. The check genuinely applies to this revision — the n2 edit puts `src/hgvs/location.rs` in the diff — and the answer is still none: that edit is two field doc comments inside the `CdsPos`/`TxPos` struct definitions, adding no code and changing no `Display` arm, so no description renders differently. `src/reference/` **is** touched (four files) and **is** a watched directory as of #1876, and the answer there is none too: those edits are comments and doc tables only. Nothing under `src/normalize/`, `src/spdi/`, `src/project/` or `src/error_handling/` is touched at all.


