### PR TITLE
fix(hgvs): stop dropping and leaking in-band position markers

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -2467,13 +2467,19 @@ class CoordinateMapper:
             offset: Optional intronic offset
             downstream: Whether this is a downstream position (n.*100 notation for
                 positions past the end of the transcript). Defaults to False.
+                A downstream position is REFUSED: it names a nucleotide beyond
+                the transcript's last base, which the n. axis cannot number and
+                which has no CDS position (HGVS background/numbering.md:52, :54).
+                It previously returned a position derived from `tx_position`
+                alone, i.e. a different nucleotide, with no error.
 
         Returns:
             Tuple of (cds_position, offset, is_utr3)
 
         Raises:
             ReferenceDataError: If the transcript is not found.
-            ProjectionError: If it has no CDS (both subclass ValueError).
+            ProjectionError: If it has no CDS, or if `downstream` is True
+                (both subclass ValueError).
         """
         ...
 

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -125,6 +125,14 @@ impl<'a> CoordinateMapper<'a> {
             cds_start as i64 + pos.base - 1
         };
 
+        // `downstream: false` is a decision, not a default. `CdsPos.utr3`
+        // (`c.*N`) is the 3'UTR of a *coding* transcript, which lies **inside**
+        // the transcript — `c.*1` is the base after the stop codon, still
+        // transcribed — whereas `TxPos.downstream` (`n.*N`) marks a nucleotide
+        // past the transcript's last base. The two `*` markers are not the same
+        // marker, so carrying `utr3` across into `downstream` would be wrong;
+        // the arms above have already resolved `c.*N` to its plain `n.` base.
+        // Pinned by `cds_to_tx_keeps_a_coding_three_prime_utr_position_in_transcript`.
         Ok(TxPos {
             base: tx_base,
             offset: pos.offset,
@@ -138,7 +146,41 @@ impl<'a> CoordinateMapper<'a> {
     /// no exon walk, no CIGAR adjustment. The one input on which the round trip
     /// does not close is `c.0` — it converts to `cds_start` and comes back as
     /// `c.1`, because HGVS has no `c.0` for it to come back as.
+    ///
+    /// # Refuses `n.*N`
+    ///
+    /// [`TxPos::downstream`] marks the `n.*N` notation, which names a nucleotide
+    /// **past the transcript's last base**. There is no CDS position to convert
+    /// it to, so this refuses rather than answering:
+    ///
+    /// - `background/numbering.md:52` gives the whole of `n.` numbering as
+    ///   "`n.1`, `n.2`, `n.3`, ..., etc., from the first to the last nucleotide
+    ///   of the reference sequence" — no `*` zone exists on this axis;
+    /// - `:54` states that "it is **not** allowed to describe variants in
+    ///   nucleotides beyond the boundaries of a transcript reference sequence,
+    ///   using that transcript reference sequence".
+    ///
+    /// Before this refusal existed the flag was simply unread: classification
+    /// compared `base` against the CDS bounds, so `n.*5` on a transcript with a
+    /// 5-base 5'UTR was answered as `c.-1` — a different nucleotide, on the
+    /// wrong side of the CDS, with no diagnostic. That was already known and
+    /// worked around one layer up, where `project_*_direct` rejects `*N` inputs
+    /// "because `tx_to_cds` ... never reads this flag"; the check now lives with
+    /// the contract it belongs to, and that caller's earlier, better-worded
+    /// refusal still runs first.
     pub fn tx_to_cds(&self, pos: &TxPos) -> Result<CdsPos, FerroError> {
+        if pos.downstream {
+            return Err(FerroError::ConversionError {
+                msg: format!(
+                    "n.*{} lies beyond the transcript's last base and has no CDS position: \
+                     the n. axis numbers only n.1..n.<length> (background/numbering.md:52) \
+                     and a variant outside a transcript's boundaries may not be described \
+                     against that transcript (background/numbering.md:54)",
+                    pos.base
+                ),
+            });
+        }
+
         let cds_start = self
             .transcript
             .cds_start

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -45,7 +45,15 @@ pub struct GenomePos {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub special: Option<SpecialPosition>,
     /// Optional offset from the base position (e.g., -? for uncertain upstream, +? for uncertain downstream)
-    /// Uses i64::MIN for uncertain negative offset (-?) and i64::MAX for uncertain positive offset (+?)
+    ///
+    /// The uncertain forms are stored in band, as
+    /// [`OFFSET_UNKNOWN_POSITIVE`] (`+?`) and [`OFFSET_UNKNOWN_NEGATIVE`]
+    /// (`-?`). Name the constants rather than their current values: they are
+    /// defined in exactly one place, and a doc that respells them as literals
+    /// is a second declaration in prose.
+    ///
+    /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+    /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
 }
@@ -100,10 +108,25 @@ impl GenomePos {
     }
 }
 
-/// Sentinel value for unknown positive offset (+?)
-pub const GENOME_OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
-/// Sentinel value for unknown negative offset (-?)
-pub const GENOME_OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
+/// The unknown-offset sentinels, under their historical genome-axis names.
+///
+/// These are **re-exports**, not a second definition. The pair is defined once,
+/// by the parser that produces it
+/// ([`crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE`] and its negative
+/// twin), because the values enter the AST there and every axis — `g.`, `c.`,
+/// `n.`, `r.` — stores the same two.
+///
+/// They were previously declared here as their own `pub const`s, spelled as
+/// bare `i64::MAX` / `i64::MIN` literals. That is the same failure mode
+/// `unknown_offset_marker` was extracted to remove, one level up: two
+/// independent definitions of one value pair, where changing either leaves the
+/// other silently behind and the rendering stops matching the parser. Kept as
+/// aliases rather than deleted because they are public API of a published
+/// crate.
+pub use crate::hgvs::parser::position::{
+    OFFSET_UNKNOWN_NEGATIVE as GENOME_OFFSET_UNKNOWN_NEGATIVE,
+    OFFSET_UNKNOWN_POSITIVE as GENOME_OFFSET_UNKNOWN_POSITIVE,
+};
 
 /// The rendered form of an unknown-offset sentinel (`+?` / `-?`), or `None`
 /// when `offset` is a measured intronic distance.

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -105,6 +105,29 @@ pub const GENOME_OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
 /// Sentinel value for unknown negative offset (-?)
 pub const GENOME_OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
 
+/// The rendered form of an unknown-offset sentinel (`+?` / `-?`), or `None`
+/// when `offset` is a measured intronic distance.
+///
+/// The sentinels are stored **in band** (`i64::MAX` / `i64::MIN`, see
+/// [`crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE`]), so every
+/// `Display` that prints an offset has to ask this question first or the raw
+/// 19-digit integer escapes into a description as if it were a real distance.
+///
+/// It exists as one function, keyed off the named constants, because the
+/// alternative had already failed: `GenomePos::Display` compared against
+/// `GENOME_OFFSET_UNKNOWN_*`, `CdsPos::Display` re-spelled the same pair as
+/// bare `i64::MAX` / `i64::MIN` literals, and `TxPos`/`RnaPos` — added later —
+/// had no arm at all, so a parsed `n.5+?` printed as `5+9223372036854775807`.
+/// Three spellings of one pair is how the fourth axis came to have none.
+fn unknown_offset_marker(offset: i64) -> Option<&'static str> {
+    use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+    match offset {
+        OFFSET_UNKNOWN_POSITIVE => Some("+?"),
+        OFFSET_UNKNOWN_NEGATIVE => Some("-?"),
+        _ => None,
+    }
+}
+
 impl fmt::Display for GenomePos {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(special) = &self.special {
@@ -112,10 +135,10 @@ impl fmt::Display for GenomePos {
         } else {
             write!(f, "{}", self.base)?;
             if let Some(offset) = self.offset {
-                if offset == GENOME_OFFSET_UNKNOWN_POSITIVE {
-                    write!(f, "+?")?;
-                } else if offset == GENOME_OFFSET_UNKNOWN_NEGATIVE {
-                    write!(f, "-?")?;
+                // NOTE: unlike the transcript-relative axes below, a zero offset
+                // renders as nothing here rather than as `+0`. Unchanged.
+                if let Some(marker) = unknown_offset_marker(offset) {
+                    write!(f, "{}", marker)?;
                 } else if offset > 0 {
                     write!(f, "+{}", offset)?;
                 } else if offset < 0 {
@@ -283,11 +306,8 @@ impl fmt::Display for CdsPos {
             write!(f, "{}", self.base)?;
         }
         if let Some(offset) = self.offset {
-            // Handle sentinel values for uncertain offsets
-            if offset == i64::MAX {
-                write!(f, "+?")?;
-            } else if offset == i64::MIN {
-                write!(f, "-?")?;
+            if let Some(marker) = unknown_offset_marker(offset) {
+                write!(f, "{}", marker)?;
             } else if offset >= 0 {
                 write!(f, "+{}", offset)?;
             } else {
@@ -390,7 +410,9 @@ impl fmt::Display for TxPos {
             write!(f, "{}", self.base)?;
         }
         if let Some(offset) = self.offset {
-            if offset >= 0 {
+            if let Some(marker) = unknown_offset_marker(offset) {
+                write!(f, "{}", marker)?;
+            } else if offset >= 0 {
                 write!(f, "+{}", offset)?;
             } else {
                 write!(f, "{}", offset)?;
@@ -466,7 +488,9 @@ impl fmt::Display for RnaPos {
             write!(f, "{}", self.base)?;
         }
         if let Some(offset) = self.offset {
-            if offset >= 0 {
+            if let Some(marker) = unknown_offset_marker(offset) {
+                write!(f, "{}", marker)?;
+            } else if offset >= 0 {
                 write!(f, "+{}", offset)?;
             } else {
                 write!(f, "{}", offset)?;
@@ -826,7 +850,18 @@ impl IvsPos {
 
 impl fmt::Display for IvsPos {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.offset >= 0 {
+        // The fifth `Display` that has to ask this question, and the one the
+        // `GenomePos`/`CdsPos`/`TxPos`/`RnaPos` sweep missed. `IvsNotation::to_ivs`
+        // maps a `CdsPos`/`TxPos` offset straight in, so a parsed `c.100+?`
+        // reaches here and rendered as `IVS3+9223372036854775807`.
+        //
+        // The sign is taken from the marker rather than from the number, which
+        // is why this cannot be written as a prefix to the arms below: the
+        // negative sentinel is `i64::MIN`, whose `Display` already carries a
+        // `-`, while the positive one needs a `+` this arm would have to add.
+        if let Some(marker) = unknown_offset_marker(self.offset) {
+            write!(f, "IVS{}{}", self.intron, marker)
+        } else if self.offset >= 0 {
             write!(f, "IVS{}+{}", self.intron, self.offset)
         } else {
             write!(f, "IVS{}{}", self.intron, self.offset)

--- a/src/hgvs/parser/position.rs
+++ b/src/hgvs/parser/position.rs
@@ -74,7 +74,7 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
     }
 }
 
-/// Parse an intronic offset (+5, -10, etc.)
+/// Sentinel value for unknown positive offset (`+?` in HGVS notation)
 ///
 /// # Sentinel Values for Unknown Offsets
 ///
@@ -89,6 +89,9 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
 /// 2. Using the type's extreme values avoids the need for an Option wrapper
 /// 3. Callers can check for unknown offsets by comparing against these constants
 ///
+/// This pair is the crate's single definition of the two values;
+/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}` re-exports it.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -96,9 +99,10 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
 ///     // Handle unknown positive offset (+?)
 /// }
 /// ```
-/// Sentinel value for unknown positive offset (`+?` in HGVS notation)
 pub const OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
 /// Sentinel value for unknown negative offset (`-?` in HGVS notation)
+///
+/// See [`OFFSET_UNKNOWN_POSITIVE`] for why these values were chosen.
 pub const OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
 
 /// Whether a raw offset is one of the unknown-offset sentinels rather than a
@@ -122,6 +126,10 @@ pub fn is_unknown_offset(offset: i64) -> bool {
     offset == OFFSET_UNKNOWN_POSITIVE || offset == OFFSET_UNKNOWN_NEGATIVE
 }
 
+/// Parse an intronic offset (+5, -10, etc.)
+///
+/// Returns [`OFFSET_UNKNOWN_POSITIVE`] / [`OFFSET_UNKNOWN_NEGATIVE`] for the
+/// uncertain forms `+?` / `-?`.
 #[inline]
 fn parse_offset(input: &str) -> IResult<&str, i64> {
     let (input, sign) = alt((char('+'), char('-'))).parse(input)?;

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1163,24 +1163,21 @@ fn self_cancelling_descriptor(
 
 /// Return `Some(offset)` if `raw` is a concrete intronic offset, or
 /// `None` if it is one of the parser's "unknown offset" sentinels
-/// (`+?` → `i64::MAX`, `-?` → `i64::MIN`; see
-/// `parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}` and
-/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`). The
+/// (`+?` / `-?`; see
+/// `parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`). The
 /// self-cancelling detector skips any endpoint with an unknown offset
 /// because overlap is undecidable.
+///
+/// This used to test four names: the parser's pair *and*
+/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`, which were a
+/// separate declaration of the same two values. Those are now aliases of the
+/// constants below, so the extra two arms tested the same values twice —
+/// every axis stores the one pair the parser produces.
 fn certain_offset(raw: Option<i64>) -> Option<i64> {
-    use crate::hgvs::location::{GENOME_OFFSET_UNKNOWN_NEGATIVE, GENOME_OFFSET_UNKNOWN_POSITIVE};
     use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
     match raw {
         None => Some(0),
-        Some(v)
-            if v == OFFSET_UNKNOWN_POSITIVE
-                || v == OFFSET_UNKNOWN_NEGATIVE
-                || v == GENOME_OFFSET_UNKNOWN_POSITIVE
-                || v == GENOME_OFFSET_UNKNOWN_NEGATIVE =>
-        {
-            None
-        }
+        Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE) => None,
         Some(v) => Some(v),
     }
 }
@@ -1281,6 +1278,10 @@ pub(crate) fn cis_member_order_key(
     // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
     // field order, which is exactly the comparison this key wants, so the points
     // go in whole rather than flattened into six scalars.
+    // Unrelated to the unknown-OFFSET sentinels (`OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`,
+    // re-exported as `GENOME_OFFSET_UNKNOWN_*`): this is a sorts-last key for a point
+    // that has no position, not a `+?`/`-?` marker. It happens to reuse `i64::MAX`
+    // because that is what "sorts last" spells.
     let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
     let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
     (accession, start, end, junction_rank(v), descriptor)

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1193,8 +1193,18 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                         msg: "Tx interval start is unknown".to_string(),
                     }
                 })?;
-                let pos =
-                    nr_representative_genome_pos(cdot_tx, start_tx.base, start_tx.offset, false)?;
+                // `start_tx.downstream` is the `n.` axis's `*` marker and must be
+                // passed, exactly as the `Rna` arm below passes `start_rna.utr3`.
+                // Hard-coding `false` here seeded `n.*5` at the genomic coordinate
+                // of *in-transcript* base 5, contradicting this function's own doc
+                // comment, which lists "downstream/utr3 markers" among the cases
+                // that fall back to the first-exon start.
+                let pos = nr_representative_genome_pos(
+                    cdot_tx,
+                    start_tx.base,
+                    start_tx.offset,
+                    start_tx.downstream,
+                )?;
                 Ok((cdot_tx.contig.clone(), pos))
             }
             HgvsVariant::Rna(r) => {
@@ -6370,9 +6380,9 @@ fn variant_decline_explanation(e: &FerroError) -> Option<String> {
 /// (n.) or RNA (r.) transcript coordinate, suitable for seeding
 /// `Projector::project`'s stab query.
 ///
-/// - For "simple" exonic positions (`offset.is_none() && !utr3 &&
+/// - For "simple" exonic positions (`offset.is_none() && !star_marker &&
 ///   base >= 1`), the exact `tx_to_genome` mapping is returned.
-/// - For intronic (`offset.is_some()`), downstream/3'UTR (`utr3`), or
+/// - For intronic (`offset.is_some()`), `*`-marked (`star_marker`), or
 ///   non-positive `base`, the conversion is best-effort: the
 ///   transcript's first-exon genome_start is returned. The stab query
 ///   at that position still lands inside the transcript, and the
@@ -6381,13 +6391,21 @@ fn variant_decline_explanation(e: &FerroError) -> Option<String> {
 ///   inputs the precise tx-to-genome path can't resolve (which is also
 ///   what `project_to_genomic` itself rejects elsewhere for intronic
 ///   non-coding offsets).
+///
+/// `star_marker` is deliberately axis-neutral: it is `RnaPos.utr3` on the `r.`
+/// axis and `TxPos.downstream` on the `n.` axis. The two mean different things
+/// about the sequence — `r.*N` is the 3'UTR, `n.*N` is past the transcript end —
+/// but they answer this function's only question identically, namely "is this a
+/// position `tx_to_genome` can resolve directly?", to which both say no. Naming
+/// the parameter `utr3` was how the `n.` caller came to pass a hard-coded
+/// `false` and seed `n.*5` at the coordinate of `n.5`.
 fn nr_representative_genome_pos(
     cdot_tx: &CdotTranscript,
     base: i64,
     offset: Option<i64>,
-    utr3: bool,
+    star_marker: bool,
 ) -> Result<u64, FerroError> {
-    if offset.is_some() || utr3 || base < 1 {
+    if offset.is_some() || star_marker || base < 1 {
         return cdot_tx
             .exons
             .first()
@@ -9311,6 +9329,76 @@ mod tests {
             results.iter().any(|p| p.transcript_id == "NM_TX1.1"),
             "expected at least the input transcript's projection, got {:?}",
             results.iter().map(|p| &p.transcript_id).collect::<Vec<_>>()
+        );
+    }
+
+    /// The fan-out seed must honour `TxPos.downstream`, exactly as its `r.`
+    /// sibling honours `RnaPos.utr3`.
+    ///
+    /// `extract_contig_and_pos`'s own doc comment already promises this — it
+    /// lists "intronic offsets, **downstream**/utr3 markers, non-positive
+    /// bases" as the cases that fall back to the transcript's first-exon
+    /// genomic start — but the `Tx` arm passed a hard-coded `false`, so `n.*5`
+    /// was seeded at the genomic coordinate of the *in-transcript* base 5.
+    ///
+    /// On this fixture (one exon, genome 1000..1009, tx 0..9) that is the
+    /// difference between 1004 (base 5, wrong) and 1000 (the first-exon
+    /// fallback the contract names). Asserted on the seed rather than on the
+    /// projection so the check cannot be satisfied by a downstream repair.
+    #[test]
+    fn fanout_seed_honours_the_downstream_marker_on_the_n_axis() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::{RnaInterval, TxInterval};
+        use crate::hgvs::location::{RnaPos, TxPos};
+        use crate::hgvs::variant::{Accession, HgvsVariant, LocEdit, RnaVariant, TxVariant};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        let accession = || {
+            parse_accession("NM_TX1.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            ))
+        };
+        let edit = || NaEdit::Substitution {
+            reference: Base::C,
+            alternative: Base::A,
+        };
+        let seed = |variant: HgvsVariant| {
+            vp.extract_contig_and_pos(&variant)
+                .expect("seeding must succeed")
+                .1
+        };
+
+        let plain = seed(HgvsVariant::Tx(TxVariant {
+            accession: accession(),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(TxInterval::point(TxPos::new(5)), edit()),
+        }));
+        assert_eq!(plain, 1004, "control: n.5 seeds at its own exonic position");
+
+        let downstream = seed(HgvsVariant::Tx(TxVariant {
+            accession: accession(),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(TxInterval::point(TxPos::downstream(5)), edit()),
+        }));
+        assert_eq!(
+            downstream, 1000,
+            "n.*5 must take the first-exon fallback the contract names, not \
+             the coordinate of in-transcript base 5"
+        );
+
+        // The `r.` arm already passes its `*` marker through; pinned as the
+        // sibling this is being made to match.
+        let rna_utr3 = seed(HgvsVariant::Rna(RnaVariant {
+            accession: accession(),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(RnaInterval::point(RnaPos::utr3(5)), edit()),
+        }));
+        assert_eq!(
+            rna_utr3, downstream,
+            "the two `*` arms must seed identically"
         );
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -7094,6 +7094,11 @@ impl PyCoordinateMapper {
     ///     downstream: Whether this is a downstream position (n.*100 notation for
     ///         positions past the end of the transcript). Defaults to False.
     ///         Currently refused when True — the conversion does not honour it.
+    ///         It names a nucleotide beyond the transcript's last base, which
+    ///         the n. axis cannot number and which has no CDS position (HGVS
+    ///         background/numbering.md:52, :54). It previously returned a
+    ///         position derived from `tx_position` alone, i.e. a different
+    ///         nucleotide, with no error.
     ///
     /// Returns:
     ///     Tuple of (cds_position, offset, is_utr3), where cds_position is

--- a/src/service/handlers/convert.rs
+++ b/src/service/handlers/convert.rs
@@ -4,6 +4,7 @@ use axum::{extract::State, http::StatusCode, response::Json};
 use std::time::Instant;
 
 use crate::data::cdot::CdsPosition;
+use crate::service::handlers::tx_position::resolve_tx_start;
 use crate::service::{
     server::AppState,
     types::{
@@ -399,48 +400,7 @@ fn perform_conversion(
                 }
             };
 
-            let tx_pos = v
-                .loc_edit
-                .location
-                .start
-                .inner()
-                .map(|p| p.base as u64)
-                .unwrap_or(1);
-
-            match target {
-                CoordinateSystem::C => {
-                    // n. -> c. conversion
-                    if let Some(cds_pos) = cdot_tx.tx_to_cds(tx_pos) {
-                        let converted = match cds_pos {
-                            CdsPosition::Cds(pos) => format!("{}:c.{}", accession, pos),
-                            CdsPosition::FivePrimeUtr(offset) => {
-                                format!("{}:c.-{}", accession, offset)
-                            }
-                            CdsPosition::ThreePrimeUtr(offset) => {
-                                format!("{}:c.*{}", accession, offset)
-                            }
-                        };
-                        (Some(converted), None, None)
-                    } else {
-                        (None, None, Some("Transcript has no CDS".to_string()))
-                    }
-                }
-                CoordinateSystem::G => {
-                    // n. -> g. conversion
-                    if let Some(genomic_pos) = cdot_tx.tx_to_genome(tx_pos) {
-                        let chrom = &cdot_tx.contig;
-                        let converted = format!("{}:g.{}", chrom, genomic_pos);
-                        (Some(converted), None, None)
-                    } else {
-                        (None, None, Some("Position not in exons".to_string()))
-                    }
-                }
-                _ => (
-                    None,
-                    None,
-                    Some(format!("Conversion from n. to {} is not supported", target)),
-                ),
-            }
+            convert_tx_position(cdot_tx, &v.loc_edit.location, accession, target)
         }
         _ => (
             None,
@@ -449,6 +409,70 @@ fn perform_conversion(
                 "Conversion from {} to {} is not supported",
                 source, target
             )),
+        ),
+    }
+}
+
+/// Convert an `n.` position to the requested target system.
+///
+/// Split out of [`perform_conversion`]'s `Tx` arm so the conversion can be
+/// exercised against a hand-built [`CdotTranscript`] without standing up an
+/// `AppState`: the arm's only use of the service state is the transcript
+/// lookup, which stays with the caller.
+///
+/// The start position is resolved through [`resolve_tx_start`], which refuses
+/// `n.*N`. Reading `base` alone — as this arm did — made `n.5` and `n.*5`
+/// resolve to the same coordinate, so the handler reported a `c.` or `g.`
+/// position for a different nucleotide with no diagnostic.
+///
+/// [`CdotTranscript`]: crate::data::cdot::CdotTranscript
+fn convert_tx_position(
+    cdot_tx: &crate::data::cdot::CdotTranscript,
+    location: &crate::hgvs::interval::TxInterval,
+    accession: &str,
+    target: &CoordinateSystem,
+) -> (
+    Option<String>,
+    Option<Vec<ConversionResult>>,
+    Option<String>,
+) {
+    let tx_pos = match resolve_tx_start(location) {
+        Ok(pos) => pos,
+        Err(msg) => return (None, None, Some(msg)),
+    };
+
+    match target {
+        CoordinateSystem::C => {
+            // n. -> c. conversion
+            if let Some(cds_pos) = cdot_tx.tx_to_cds(tx_pos) {
+                let converted = match cds_pos {
+                    CdsPosition::Cds(pos) => format!("{}:c.{}", accession, pos),
+                    CdsPosition::FivePrimeUtr(offset) => {
+                        format!("{}:c.-{}", accession, offset)
+                    }
+                    CdsPosition::ThreePrimeUtr(offset) => {
+                        format!("{}:c.*{}", accession, offset)
+                    }
+                };
+                (Some(converted), None, None)
+            } else {
+                (None, None, Some("Transcript has no CDS".to_string()))
+            }
+        }
+        CoordinateSystem::G => {
+            // n. -> g. conversion
+            if let Some(genomic_pos) = cdot_tx.tx_to_genome(tx_pos) {
+                let chrom = &cdot_tx.contig;
+                let converted = format!("{}:g.{}", chrom, genomic_pos);
+                (Some(converted), None, None)
+            } else {
+                (None, None, Some("Position not in exons".to_string()))
+            }
+        }
+        _ => (
+            None,
+            None,
+            Some(format!("Conversion from n. to {} is not supported", target)),
         ),
     }
 }
@@ -476,6 +500,71 @@ fn extract_chromosome_from_accession(accession: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data::cdot::CdotTranscript;
+    use crate::hgvs::interval::TxInterval;
+    use crate::hgvs::location::TxPos;
+    use crate::reference::Strand;
+
+    /// One 9-base exon at genome 1000..1009, CDS spanning the whole of it, so
+    /// every `n.` base in range converts on both target axes and a divergence
+    /// cannot be an artifact of one of them declining.
+    fn single_exon_transcript() -> CdotTranscript {
+        CdotTranscript {
+            cds_start_incomplete: false,
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        }
+    }
+
+    /// The drop route, at the handler seam: `n.5` and `n.*5` are different
+    /// nucleotides, so the conversion must not answer the same string for both.
+    ///
+    /// Before the fix this arm read `base` alone, so both sides converted as
+    /// in-transcript position 5 — a *collapse* — on both target axes. Asserted
+    /// as a divergence rather than against a pinned message so it cannot be
+    /// satisfied by a wording change.
+    #[test]
+    fn n_to_c_and_n_to_g_do_not_answer_a_downstream_position_as_its_twin() {
+        let tx = single_exon_transcript();
+
+        for target in [CoordinateSystem::C, CoordinateSystem::G] {
+            let convert = |pos: TxPos| {
+                let (converted, _all, error) =
+                    convert_tx_position(&tx, &TxInterval::point(pos), "NM_TEST.1", &target);
+                (converted, error)
+            };
+            let (plain, plain_err) = convert(TxPos::new(5));
+            let (downstream, downstream_err) = convert(TxPos::downstream(5));
+
+            assert!(
+                plain.is_some() && plain_err.is_none(),
+                "control: a plain in-transcript n.5 must still convert to {target}, \
+                 got {plain:?} / {plain_err:?}"
+            );
+            assert_ne!(
+                plain, downstream,
+                "n.5 and n.*5 are different nucleotides and must not convert to \
+                 the same {target} answer"
+            );
+            assert!(
+                downstream.is_none(),
+                "n.*5 names a nucleotide past the transcript's last base and has \
+                 no {target} position; the handler answered {downstream:?} instead \
+                 of refusing"
+            );
+            assert!(
+                downstream_err.is_some_and(|m| m.contains("n.*")),
+                "the decline must name the notation it refused"
+            );
+        }
+    }
 
     #[test]
     fn test_detect_coordinate_system() {

--- a/src/service/handlers/mod.rs
+++ b/src/service/handlers/mod.rs
@@ -7,5 +7,6 @@ pub mod info;
 pub mod liftover;
 pub mod normalize;
 pub mod parse;
+mod tx_position;
 pub mod validate;
 pub mod vcf_convert;

--- a/src/service/handlers/tx_position.rs
+++ b/src/service/handlers/tx_position.rs
@@ -1,0 +1,154 @@
+//! Resolving an `n.` interval's start onto the flat transcript coordinate the
+//! [`CdotMapper`](crate::data::cdot::CdotMapper) API takes.
+//!
+//! `CdotMapper::tx_to_cds` and `tx_to_genome` accept a bare `u64`, so every
+//! caller has to flatten a [`TxPos`] down to one number itself. Two handlers
+//! did that inline, with the same expression, and the same defect: they read
+//! `base` and dropped `downstream`, which is the `n.*N` marker.
+
+use crate::hgvs::interval::TxInterval;
+
+/// Resolve the start of an `n.` interval to a flat transcript coordinate.
+///
+/// # Refuses `n.*N`
+///
+/// [`TxPos::downstream`](crate::hgvs::location::TxPos::downstream) marks the
+/// `n.*N` notation, which names a nucleotide **past the transcript's last
+/// base**. It is not a transcript coordinate and has no `u64` to be flattened
+/// to, so this refuses rather than answering:
+///
+/// - `background/numbering.md:52` gives the whole of `n.` numbering as "`n.1`,
+///   `n.2`, `n.3`, ..., etc., from the first to the last nucleotide of the
+///   reference sequence" — no `*` zone exists on this axis;
+/// - `:54` states that "it is **not** allowed to describe variants in
+///   nucleotides beyond the boundaries of a transcript reference sequence,
+///   using that transcript reference sequence".
+///
+/// This is the service-side twin of the refusal
+/// [`CoordinateMapper::tx_to_cds`](crate::convert::CoordinateMapper::tx_to_cds)
+/// makes, and it exists because that refusal cannot reach here: these handlers
+/// go through `CdotMapper`, whose entry points take the flattened `u64` and so
+/// never see the flag. Dropping it made `n.5` and `n.*5` — two different
+/// nucleotides — resolve to the same `5`, so the handlers reported a `c.` or
+/// `g.` position, or a whole VCF record, for the wrong base with no diagnostic.
+///
+/// # The spelling is unreachable today; the contract still belongs here
+///
+/// **Do not read this as a live service defect.** `n.*N` is refused at parse in
+/// *every* mode by #1748 (`E1003 InvalidPosition`; see
+/// [`crate::hgvs::noncoding_zones`]), and both handlers obtain their variant
+/// from `parse_hgvs_lenient` on the request string — so no HTTP request can
+/// deliver a `TxPos` carrying this flag. Measured on this head: `parse_hgvs`
+/// and `parse_hgvs_lenient` both refuse `NM_TEST.1:n.*5del`.
+///
+/// It is guarded anyway for the reason the PR's own `tx_to_cds` refusal is:
+/// [`TxPos::downstream`](crate::hgvs::location::TxPos::downstream) remains
+/// public API, a Rust caller can construct one, and a contract that holds only
+/// because a *different* layer currently refuses the spelling is one grammar
+/// change away from not holding. Claiming the route is exploitable over HTTP
+/// would be overstating it; claiming it therefore needs no guard would be the
+/// mirror error.
+///
+/// # Two other in-band markers this deliberately does NOT read
+///
+/// Both are pre-existing and neither is widened or narrowed here; they are
+/// named so the omissions are visible rather than looking like oversights.
+///
+/// - **`TxPos::offset`.** `n.5+10` is intronic, and `tx_to_genome(5)` answers
+///   for exonic base 5. That is the same class of silent substitution as the
+///   `downstream` drop, on a far more common shape, so correcting it is a
+///   behaviour change for the service that owes its own measurement and
+///   disclosure rather than riding along here.
+/// - **An absent inner position.** `inner()` returns `None` for an unknown
+///   (`?`) endpoint and for a range boundary (`(1_5)`), and the historical
+///   behaviour is to substitute `1`. Preserved verbatim.
+pub(crate) fn resolve_tx_start(location: &TxInterval) -> Result<u64, String> {
+    match location.start.inner() {
+        Some(pos) if pos.downstream => Err(format!(
+            "n.*{} lies beyond the transcript's last base and has no transcript \
+             coordinate: the n. axis numbers only n.1..n.<length> \
+             (background/numbering.md:52) and a variant outside a transcript's \
+             boundaries may not be described against that transcript \
+             (background/numbering.md:54)",
+            pos.base
+        )),
+        Some(pos) => Ok(pos.base as u64),
+        None => Ok(1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::interval::UncertainBoundary;
+    use crate::hgvs::location::TxPos;
+    use crate::hgvs::uncertainty::Mu;
+
+    /// The defect in its bare form: `n.5` and `n.*5` are different nucleotides,
+    /// so the resolution must not answer the same thing for both.
+    ///
+    /// Before the fix both sides read `5` — a *collapse*. The assertion is
+    /// written as a divergence rather than as a pinned error string so it
+    /// cannot be satisfied by a message change.
+    #[test]
+    fn a_downstream_start_does_not_resolve_to_its_in_transcript_twin() {
+        let plain = resolve_tx_start(&TxInterval::point(TxPos::new(5)));
+        let downstream = resolve_tx_start(&TxInterval::point(TxPos::downstream(5)));
+
+        assert_eq!(plain, Ok(5), "control: n.5 is transcript coordinate 5");
+        assert!(
+            downstream.is_err(),
+            "n.*5 names a nucleotide past the transcript's last base \
+             (background/numbering.md:52, :54) and has no transcript coordinate; \
+             resolution answered {downstream:?} instead of refusing"
+        );
+        assert_ne!(
+            plain, downstream,
+            "n.5 and n.*5 are different nucleotides and must not resolve alike"
+        );
+    }
+
+    /// The refusal is on the flag, not on the base, and it names the notation
+    /// so a caller can tell this decline from a bounds one.
+    #[test]
+    fn every_downstream_start_is_refused_by_name() {
+        for base in [1, 5, 31, 4000] {
+            let err = resolve_tx_start(&TxInterval::point(TxPos::downstream(base)))
+                .expect_err("n.*{base} must be refused");
+            assert!(
+                err.contains("n.*"),
+                "the decline must name the notation it refused, got: {err}"
+            );
+        }
+    }
+
+    /// An offset on a downstream position is refused for the same reason — the
+    /// anchor it is measured from is itself unnumberable.
+    #[test]
+    fn a_downstream_start_carrying_an_offset_is_refused() {
+        assert!(
+            resolve_tx_start(&TxInterval::point(TxPos::downstream_with_offset(5, 10))).is_err(),
+            "n.*5+10 must be refused like n.*5"
+        );
+    }
+
+    /// The two shapes the doc comment names as deliberately unchanged. Pinned
+    /// so that "completing" the fix is a visible decision rather than a silent
+    /// one, and so the `1` substitution is not mistaken for a fix side-effect.
+    #[test]
+    fn the_two_unread_markers_keep_their_historical_answers() {
+        assert_eq!(
+            resolve_tx_start(&TxInterval::point(TxPos::with_offset(5, 10))),
+            Ok(5),
+            "an intronic offset is still dropped; changing that is its own change"
+        );
+        assert_eq!(
+            resolve_tx_start(&TxInterval {
+                start: UncertainBoundary::Single(Mu::Unknown),
+                end: UncertainBoundary::Single(Mu::Unknown),
+            }),
+            Ok(1),
+            "an absent inner position still substitutes 1"
+        );
+    }
+}

--- a/src/service/handlers/vcf_convert.rs
+++ b/src/service/handlers/vcf_convert.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use crate::data::cdot::{CdotMapper, CdsPosition};
 use crate::reference::Strand;
+use crate::service::handlers::tx_position::resolve_tx_start;
 use crate::service::{
     server::AppState,
     types::{
@@ -577,13 +578,14 @@ fn convert_tx_to_vcf(
         }
     };
 
-    // Extract transcript position
-    let tx_pos = loc_edit
-        .location
-        .start
-        .inner()
-        .map(|p| p.base as u64)
-        .unwrap_or(1);
+    // Extract transcript position. `resolve_tx_start` refuses `n.*N`: reading
+    // `base` alone made `n.5` and `n.*5` resolve to the same coordinate, so
+    // this emitted a whole VCF record for a different nucleotide with no
+    // diagnostic.
+    let tx_pos = match resolve_tx_start(&loc_edit.location) {
+        Ok(pos) => pos,
+        Err(msg) => return (None, Some(msg)),
+    };
 
     // Convert to genomic
     let genomic_pos = match cdot_tx.tx_to_genome(tx_pos) {
@@ -775,6 +777,83 @@ fn extract_chromosome_from_accession(accession: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data::cdot::CdotTranscript;
+    use crate::hgvs::edit::{Base, NaEdit};
+    use crate::hgvs::interval::TxInterval;
+    use crate::hgvs::location::TxPos;
+    use crate::hgvs::variant::LocEdit;
+
+    /// One 9-base exon at genome 1000..1009, so every `n.` base in range maps
+    /// to a genomic coordinate and a divergence cannot be an artifact of the
+    /// exon walk declining.
+    fn single_exon_mapper() -> Arc<CdotMapper> {
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_TEST.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: Some("NP_TEST.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        Arc::new(cdot)
+    }
+
+    /// The second drop route, at the handler seam: `n.5` and `n.*5` are
+    /// different nucleotides, so the VCF record emitted for them must not be
+    /// the same.
+    ///
+    /// Before the fix this read `base` alone, so both sides emitted a record at
+    /// the genomic coordinate of in-transcript base 5 — a *collapse*, and one
+    /// that leaves the wrong `POS` in a VCF with no diagnostic. Asserted as a
+    /// divergence rather than against a pinned message so it cannot be
+    /// satisfied by a wording change.
+    #[test]
+    fn n_to_vcf_does_not_emit_a_downstream_position_as_its_in_transcript_twin() {
+        let cdot = single_exon_mapper();
+        let edit = || NaEdit::Substitution {
+            reference: Base::C,
+            alternative: Base::A,
+        };
+        let convert = |pos: TxPos| {
+            convert_tx_to_vcf(
+                "NM_TEST.1",
+                &LocEdit::new(TxInterval::point(pos), edit()),
+                &GenomeBuild::GRCh38,
+                Some(&cdot),
+            )
+        };
+
+        let (plain, plain_err) = convert(TxPos::new(5));
+        let (downstream, downstream_err) = convert(TxPos::downstream(5));
+
+        assert!(
+            plain.is_some() && plain_err.is_none(),
+            "control: a plain in-transcript n.5 must still emit a record, \
+             got {plain:?} / {plain_err:?}"
+        );
+        assert_ne!(
+            plain.map(|r| r.pos),
+            downstream.as_ref().map(|r| r.pos),
+            "n.5 and n.*5 are different nucleotides and must not emit the same POS"
+        );
+        assert!(
+            downstream.is_none(),
+            "n.*5 names a nucleotide past the transcript's last base and has no \
+             genomic position; the handler emitted {downstream:?} instead of refusing"
+        );
+        assert!(
+            downstream_err.is_some_and(|m| m.contains("n.*")),
+            "the decline must name the notation it refused"
+        );
+    }
 
     #[test]
     fn test_get_refseq_accession_grch38() {

--- a/tests/it/downstream_flag_and_offset_sentinel.rs
+++ b/tests/it/downstream_flag_and_offset_sentinel.rs
@@ -1,0 +1,343 @@
+//! Two in-band markers that a boundary was dropping or leaking.
+//!
+//! Both are the same class — data the AST carries in-band, silently discarded
+//! at one seam or emitted raw at another — and both are pinned here so the two
+//! halves are read together.
+//!
+//! Both classes had further instances beyond the first two found, and the
+//! sweeps that missed them are worth naming. The drop was fixed at
+//! `CoordinateMapper::tx_to_cds` while **two service handlers flattened a
+//! `TxPos` to a bare `u64` themselves** — they go through `CdotMapper`, whose
+//! entry points take the flattened number and so never see the flag, which is
+//! why a fix at the `CoordinateMapper` seam could not reach them. Those two are
+//! pinned beside the code, in `service::handlers::tx_position`,
+//! `service::handlers::convert` and `service::handlers::vcf_convert`, because
+//! the handler functions are private. The leak was fixed across the four
+//! **axis** `Display` impls while a **fifth** `Display` renders an offset —
+//! `IvsPos` — and is pinned at the bottom of this file.
+//!
+//! The lesson both halves share: the sweep was over the wrong population. "Every
+//! axis" is not "every renderer", and "the conversion seam" is not "every
+//! caller that flattens a position".
+//!
+//! # A THIRD drop route is KNOWN, MEASURED, AND DELIBERATELY LEFT OPEN
+//!
+//! `CoordinateMapper::tx_to_genomic` — the direct sibling of the `tx_to_cds`
+//! this file's first section fixes, on the same type — reads `tx_pos.base` and
+//! screens only `base < 1`. It never consults `downstream`. Measured on a
+//! single exon at tx 1..10 / genome 1000..1009:
+//!
+//! ```text
+//! tx_to_genomic(n.5)  = Ok(Some(1004))
+//! tx_to_genomic(n.*5) = Ok(Some(1004))     <- collapse, same as the two fixed here
+//! ```
+//!
+//! It is **not fixed here** because its blast radius is not the service layer's:
+//! it has production callers in `vcf/from_hgvs.rs` (`convert_tx`, the library's
+//! own n.→VCF path), `normalize/mod.rs`, `equivalence/checker.rs` and three more
+//! inside `mapper.rs` itself, and its return type (`Result<Option<u64>, _>`)
+//! makes "decline" and "error" two different answers that want their own
+//! decision. That is a change owing its own measurement and disclosure.
+//!
+//! Recorded here rather than left to be re-found: an earlier census of this
+//! defect enumerated **13** other marker-consulting sites and concluded the two
+//! service handlers were the only unguarded ones. All 13 do hold — but the
+//! census was of sites that *already consult* the marker, which cannot discover
+//! one that never mentions it. `tx_to_genomic` is invisible to a `grep` for
+//! `downstream`, which is exactly why it survived.
+//!
+//! # Reachability: real defect, unreachable spelling
+//!
+//! All three routes are reached only by a **Rust caller constructing a
+//! `TxPos` directly**. `n.*N` is refused at parse in *every* mode by #1748 —
+//! measured on this head, `parse_hgvs` and `parse_hgvs_lenient` both return
+//! `E1003 InvalidPosition` for `NM_TEST.1:n.*5del` — so no string entry point,
+//! the web service's included, can deliver the marker. `TxPos::downstream` is
+//! nonetheless public API, and these guards are the same defence-in-depth the
+//! PR's own `tx_to_cds` refusal is: the contract belongs with the function
+//! whether or not today's grammar can reach it.
+//!
+//! **`TxPos.downstream` (`n.*N`).** `CoordinateMapper::tx_to_cds` classified a
+//! position purely by comparing `base` against the CDS bounds, so `n.*5` was
+//! answered as if it were in-transcript position 5. Per
+//! `background/numbering.md:52` `n.` numbering runs "`n.1`, `n.2`, `n.3`, ...,
+//! etc., from the first to the last nucleotide of the reference sequence" — it
+//! admits no `*` zone at all — and `:54` states that "it is **not** allowed to
+//! describe variants in nucleotides beyond the boundaries of a transcript
+//! reference sequence, using that transcript reference sequence". So `n.*N`
+//! names a nucleotide the `n.` axis cannot number, and there is no `c.` position
+//! to map it onto: the conversion must refuse rather than answer for a
+//! different base. This is not a new judgement — `project_*_direct` already
+//! refused `*N` up front *because* `tx_to_cds` ignored the flag; the refusal has
+//! moved to the function whose contract it belongs to.
+//!
+//! **The counter-evidence, recorded rather than left to be re-discovered.** The
+//! competing shape was to *honour* the flag: `Transcript::sequence_length` is
+//! available, so `n.*N` is mechanically `c.*(sequence_length - cds_end + N)` and
+//! the mapping is exact. Two things decided against it. The derived `c.*M` would
+//! itself be past the transcript's last base, so honouring converts one
+//! description `numbering.md:54` forbids into another rather than into a legal
+//! one. And the inverse would have to follow — `cds_to_tx` mapping an
+//! over-length `c.*M` back to `n.*N` — which moves outputs on the coding axis,
+//! where every real description lives, to serve an axis on which the shape does
+//! not occur. What is genuinely on the other side of the ledger is ferro's own
+//! poly-A carve-out (#797), which deliberately entertains a `c.*` position in
+//! the post-transcriptional tail: ferro is not uniformly literal about `:54`.
+//! That is a ferro policy rather than a clause, so it does not outrank `:52`
+//! here, but it is the reason this is a decision and not a foregone conclusion.
+//!
+//! **The unknown-offset sentinels (`+?` / `-?`).** The parser stores them
+//! in-band as `i64::MAX` / `i64::MIN`. `GenomePos` and `CdsPos` render them back
+//! as `+?` / `-?`; `TxPos`, `RnaPos` and `IvsPos` did not, so a parsed `n.5+?`
+//! printed as `5+9223372036854775807` and a `c.100+?` carried into IVS notation
+//! printed as `IVS7+9223372036854775807`. Nothing adjudicates what these should
+//! print: the spelling is the one the parser consumed, and `CdsPos::Display` has
+//! rendered it that way since the sentinels were introduced.
+//!
+//! Four spellings move, not three: `parse_offset` is shared by every axis, so
+//! `r.<b>-?` is accepted and moves exactly as `r.<b>+?` does.
+
+use ferro_hgvs::convert::CoordinateMapper;
+use ferro_hgvs::hgvs::location::{CdsPos, IvsNotation, IvsPos, RnaPos, TxPos};
+use ferro_hgvs::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+
+/// 5bp 5'UTR + 30bp CDS + 3bp 3'UTR over a single 38-base exon, matching the
+/// shape `convert_tests` uses so the two read against the same geometry.
+fn coding_transcript() -> Transcript {
+    Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        "AAAAATGCCCAAAGGGTTTAGGCCCAAAGGGTTATAAA".to_string(),
+        Some(6),
+        Some(35),
+        vec![Exon::new(1, 1, 38)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// `TxPos.downstream` must not be silently dropped by tx -> CDS conversion
+// ---------------------------------------------------------------------------
+
+/// The defect in its bare form: `n.*5` and `n.5` are different nucleotides, so
+/// the conversion must not answer the same thing for both.
+#[test]
+fn tx_to_cds_does_not_answer_a_downstream_position_as_its_in_transcript_twin() {
+    let tx = coding_transcript();
+    let mapper = CoordinateMapper::new(&tx);
+
+    let plain = mapper.tx_to_cds(&TxPos::new(5));
+    let downstream = mapper.tx_to_cds(&TxPos::downstream(5));
+
+    assert!(
+        plain.is_ok(),
+        "control: a plain in-transcript n.5 must still convert"
+    );
+    assert!(
+        downstream.is_err(),
+        "n.*5 names a nucleotide past the transcript's last base \
+         (background/numbering.md:52, :54) and has no c. position; \
+         tx_to_cds answered {:?} instead of refusing",
+        downstream.map(|p| p.to_string())
+    );
+}
+
+/// The refusal is on the flag, not on the base — every `*N` is refused, and the
+/// message names the flag so a caller can tell this decline from a bounds one.
+#[test]
+fn tx_to_cds_refuses_every_downstream_position_by_name() {
+    let tx = coding_transcript();
+    let mapper = CoordinateMapper::new(&tx);
+
+    for base in [1, 5, 31, 4000] {
+        let err = mapper
+            .tx_to_cds(&TxPos::downstream(base))
+            .expect_err("n.*{base} must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("n.*"),
+            "the decline must name the notation it refused, got: {msg}"
+        );
+    }
+}
+
+/// An offset on a downstream position is refused for the same reason — the
+/// anchor it is measured from is itself unnumberable.
+#[test]
+fn tx_to_cds_refuses_a_downstream_position_carrying_an_offset() {
+    let tx = coding_transcript();
+    let mapper = CoordinateMapper::new(&tx);
+    assert!(
+        mapper
+            .tx_to_cds(&TxPos::downstream_with_offset(5, 10))
+            .is_err(),
+        "n.*5+10 must be refused like n.*5"
+    );
+}
+
+/// The sibling direction is deliberately unchanged: `c.*N` is the 3'UTR of a
+/// coding transcript, which is *inside* the transcript, so its `n.` form is a
+/// plain base and `downstream` is correctly false. Pinned so the M1 fix is not
+/// later "completed" by making `cds_to_tx` set the flag.
+#[test]
+fn cds_to_tx_keeps_a_coding_three_prime_utr_position_in_transcript() {
+    let tx = coding_transcript();
+    let mapper = CoordinateMapper::new(&tx);
+
+    let n = mapper
+        .cds_to_tx(&CdsPos::utr3(1))
+        .expect("c.*1 is the first 3'UTR base and converts");
+    assert_eq!(n.base, 36, "c.*1 is transcript base 36 in this fixture");
+    assert!(
+        !n.downstream,
+        "c.*1 is inside the transcript, so its n. form must NOT carry the \
+         past-the-end `*` marker; got {n}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The unknown-offset sentinels must not escape as 19-digit integers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tx_pos_renders_the_unknown_offset_sentinels_as_question_marks() {
+    assert_eq!(
+        TxPos::with_offset(5, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "5+?"
+    );
+    assert_eq!(
+        TxPos::with_offset(5, OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "5-?"
+    );
+    assert_eq!(
+        TxPos::downstream_with_offset(5, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "*5+?"
+    );
+}
+
+#[test]
+fn rna_pos_renders_the_unknown_offset_sentinels_as_question_marks() {
+    assert_eq!(
+        RnaPos::with_offset(5, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "5+?"
+    );
+    assert_eq!(
+        RnaPos::with_offset(5, OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "5-?"
+    );
+}
+
+/// The two axes that already rendered the sentinel keep doing so — this is the
+/// form the fix is being made consistent *with*, not a new decision.
+#[test]
+fn cds_pos_still_renders_the_unknown_offset_sentinels_as_question_marks() {
+    assert_eq!(
+        CdsPos::with_offset(5, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "5+?"
+    );
+    assert_eq!(
+        CdsPos::with_offset(5, OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "5-?"
+    );
+}
+
+/// End to end, through the public entry point: the sentinel is reachable from a
+/// parsed description, so the leak was a round-trip failure and not a latent
+/// constructor-only shape.
+///
+/// All **four** moving shapes are here. `r.<b>-?` is the one the first pass
+/// missed: `parse_offset` is shared by every axis, so the `r.` parser accepts
+/// `-?` exactly as it accepts `+?`, and `RnaPos::Display` had no arm for either.
+#[test]
+fn a_parsed_unknown_offset_round_trips_on_the_n_and_r_axes() {
+    for input in [
+        "NM_TEST.1:n.5+?del",
+        "NM_TEST.1:n.5-?del",
+        "NM_TEST.1:r.5+?del",
+        "NM_TEST.1:r.5-?del",
+    ] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        assert_eq!(
+            parsed.to_string(),
+            input,
+            "an unknown offset must render back as `?`, not as the i64 sentinel"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The FIFTH `Display` that has to ask the same question
+// ---------------------------------------------------------------------------
+
+/// `IvsPos` renders an offset too, and was the arm the four-axis sweep above
+/// missed.
+///
+/// It is reachable from a parsed description through public API and nothing
+/// else: [`IvsNotation::to_ivs`] maps a `CdsPos`/`TxPos` offset **straight in**
+/// (`self.offset.map(|offset| IvsPos::new(intron_number, offset))`), so a
+/// parsed `c.100+?` arrives here carrying the sentinel and printed as
+/// `IVS3+9223372036854775807` — a 19-digit intronic distance no reader could
+/// tell from a measured one.
+///
+/// Asserted as a *divergence* from the sentinel's numeric spelling, not only as
+/// equality with `IVS3+?`, so the guard still fails if a future arm renders
+/// some other digits.
+#[test]
+fn ivs_pos_renders_the_unknown_offset_sentinels_as_question_marks() {
+    let positive = IvsPos::new(3, OFFSET_UNKNOWN_POSITIVE).to_string();
+    let negative = IvsPos::new(3, OFFSET_UNKNOWN_NEGATIVE).to_string();
+
+    assert_eq!(positive, "IVS3+?");
+    assert_eq!(negative, "IVS3-?");
+    for rendered in [&positive, &negative] {
+        assert!(
+            !rendered.contains(|c: char| c.is_ascii_digit() && c != '3'),
+            "the sentinel must not escape as an integer, got: {rendered}"
+        );
+    }
+
+    // A measured offset is untouched — this is a marker guard, not a rewrite of
+    // how distances print.
+    assert_eq!(IvsPos::new(3, 9).to_string(), "IVS3+9");
+    assert_eq!(IvsPos::new(3, -9).to_string(), "IVS3-9");
+}
+
+/// The reachable route, rather than the constructor: a parsed `c.100+?` /
+/// `c.100-?` converted to IVS notation must not leak the sentinel either.
+#[test]
+fn a_parsed_unknown_offset_converted_to_ivs_does_not_leak_the_sentinel() {
+    for (input, expected) in [
+        ("NM_TEST.1:c.100+?del", "IVS7+?"),
+        ("NM_TEST.1:c.100-?del", "IVS7-?"),
+    ] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let HgvsVariant::Cds(v) = &parsed else {
+            panic!("{input} must parse as a c. variant");
+        };
+        let pos = v
+            .loc_edit
+            .location
+            .start
+            .inner()
+            .expect("a point c. position");
+        let ivs = pos
+            .to_ivs(7)
+            .expect("an intronic position has IVS notation");
+        assert_eq!(
+            ivs.to_string(),
+            expected,
+            "an unknown offset carried into IVS notation must render as `?`, \
+             not as the i64 sentinel"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -110,6 +110,7 @@ mod defect_non_idempotent_outputs;
 mod del_shift_matrix;
 mod delins_equal_vs_unequal_length_discriminator;
 mod delins_equal_vs_unequal_length_hermetic;
+mod downstream_flag_and_offset_sentinel;
 mod dup_shift_matrix;
 mod duplication_label_not_partition;
 mod edge_case_notation_tests;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -450,6 +450,7 @@ mod normalize_property_tests;
 mod normalize_reparse_invariant;
 mod normalize_tests;
 mod normalize_warning_seam;
+mod one_unknown_offset_sentinel_definition;
 mod oracle_exclude_invariant;
 mod paraphase_exhaustive_tests;
 mod parser_tests;

--- a/tests/it/one_unknown_offset_sentinel_definition.rs
+++ b/tests/it/one_unknown_offset_sentinel_definition.rs
@@ -1,0 +1,157 @@
+//! One definition of the unknown-offset sentinel pair, guarded against
+//! re-divergence.
+//!
+//! `+?` / `-?` are stored in band, as two extreme `i64` values. Those two values
+//! used to be declared **twice**: once by the parser that produces them
+//! (`parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`) and once, as bare
+//! `i64::MAX` / `i64::MIN` literals, by `location::GENOME_OFFSET_UNKNOWN_*`.
+//! Nothing tied the two declarations together, so changing either would leave
+//! the other behind: the parser would store one value and every `Display` — all
+//! of which key off the parser's pair — would fail to recognise it and print a
+//! raw 19-digit integer where a `?` belongs. That is the leak #1762 fixed for
+//! `TxPos`/`RnaPos`, re-armed by a different mechanism.
+//!
+//! The collapse makes the divergence unrepresentable: `GENOME_OFFSET_UNKNOWN_*`
+//! is now a re-export of the parser's pair, so there is one definition and one
+//! literal `i64::MAX` / `i64::MIN` in the crate. The names are kept because they
+//! are public API of a published crate.
+//!
+//! **Why these assertions are not tautological.** Comparing the two constants to
+//! each other would be — they are the same item today, so `assert_eq!` holds by
+//! definition and would keep holding if the collapse were undone with two
+//! matching literals. So nothing here compares a constant to a constant. Every
+//! assertion compares a **named constant against a value the parser actually
+//! produced** from the text `+?` / `-?`, or against what the renderer actually
+//! prints. The parser is driven by the canonical constant and knows nothing of
+//! the alias; so if the alias is ever re-declared independently and drifts, the
+//! parsed value stops matching the name this test asserts it against, and the
+//! test fails. That is true of a re-declaration that is *initially* equal, too —
+//! it only has to be checked once it drifts, which is exactly when it matters.
+
+use ferro_hgvs::hgvs::location::{
+    CdsPos, GenomePos, RnaPos, TxPos, GENOME_OFFSET_UNKNOWN_NEGATIVE,
+    GENOME_OFFSET_UNKNOWN_POSITIVE,
+};
+use ferro_hgvs::hgvs::parser::position::{
+    parse_cds_pos, parse_genome_pos, parse_rna_pos, parse_tx_pos, OFFSET_UNKNOWN_NEGATIVE,
+    OFFSET_UNKNOWN_POSITIVE,
+};
+use ferro_hgvs::parse_hgvs;
+
+/// The genome axis is the one that carries the alias, so it is the axis where a
+/// re-divergence would first show. `parse_genome_pos` resolves `+?` through the
+/// shared `parse_offset`, which is keyed off the *canonical* constant — so this
+/// asserts the alias against a value produced without reference to it.
+#[test]
+fn the_genome_axis_alias_names_the_value_the_parser_produces() {
+    let (rest, pos) = parse_genome_pos("100+?").expect("g. position with an unknown offset");
+    assert!(rest.is_empty(), "the whole position must be consumed");
+    assert_eq!(
+        pos.offset,
+        Some(GENOME_OFFSET_UNKNOWN_POSITIVE),
+        "the parser stored an offset that GENOME_OFFSET_UNKNOWN_POSITIVE does \
+         not name — the alias has drifted from the definition it re-exports"
+    );
+
+    let (rest, pos) = parse_genome_pos("100-?").expect("g. position with an unknown offset");
+    assert!(rest.is_empty(), "the whole position must be consumed");
+    assert_eq!(
+        pos.offset,
+        Some(GENOME_OFFSET_UNKNOWN_NEGATIVE),
+        "the parser stored an offset that GENOME_OFFSET_UNKNOWN_NEGATIVE does \
+         not name — the alias has drifted from the definition it re-exports"
+    );
+}
+
+/// The same question on the three transcript-relative axes, under the canonical
+/// name. Every axis stores the one pair, which is the fact that makes a
+/// genome-specific spelling of it wrong.
+#[test]
+fn every_axis_stores_the_one_sentinel_pair_the_parser_produces() {
+    let (rest, cds) = parse_cds_pos("100+?").expect("c. position with an unknown offset");
+    assert!(rest.is_empty(), "c.100+? must be consumed whole");
+    assert_eq!(cds.offset, Some(OFFSET_UNKNOWN_POSITIVE), "c.100+?");
+    let (rest, cds) = parse_cds_pos("100-?").expect("c. position with an unknown offset");
+    assert!(rest.is_empty(), "c.100-? must be consumed whole");
+    assert_eq!(cds.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "c.100-?");
+
+    let (rest, tx) = parse_tx_pos("100+?").expect("n. position with an unknown offset");
+    assert!(rest.is_empty(), "n.100+? must be consumed whole");
+    assert_eq!(tx.offset, Some(OFFSET_UNKNOWN_POSITIVE), "n.100+?");
+    let (rest, tx) = parse_tx_pos("100-?").expect("n. position with an unknown offset");
+    assert!(rest.is_empty(), "n.100-? must be consumed whole");
+    assert_eq!(tx.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "n.100-?");
+
+    let (rest, rna) = parse_rna_pos("100+?").expect("r. position with an unknown offset");
+    assert!(rest.is_empty(), "r.100+? must be consumed whole");
+    assert_eq!(rna.offset, Some(OFFSET_UNKNOWN_POSITIVE), "r.100+?");
+    let (rest, rna) = parse_rna_pos("100-?").expect("r. position with an unknown offset");
+    assert!(rest.is_empty(), "r.100-? must be consumed whole");
+    assert_eq!(rna.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "r.100-?");
+}
+
+/// The other half of the seam: a position *built from the named constant* must
+/// render as `?`. Together with the two tests above this closes the loop —
+/// parser -> constant -> renderer — without ever comparing a constant to a
+/// constant. A drifted alias fails here by printing its 19-digit value, which is
+/// the exact symptom the sentinel pair exists to prevent.
+#[test]
+fn a_position_built_from_the_named_sentinel_renders_as_a_question_mark() {
+    assert_eq!(
+        GenomePos::with_offset(100, GENOME_OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+    assert_eq!(
+        GenomePos::with_offset(100, GENOME_OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "100-?"
+    );
+    assert_eq!(
+        CdsPos::with_offset(100, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+    assert_eq!(
+        TxPos::with_offset(100, OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "100-?"
+    );
+    assert_eq!(
+        RnaPos::with_offset(100, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+}
+
+/// End to end through the public entry point, on the genome axis — the axis
+/// #1762's round-trip test did not cover, and the one whose sentinel name is now
+/// an alias. A drifted alias would not fail this on its own; it is here so the
+/// alias's axis has a whole-description guard rather than only a position-level
+/// one.
+#[test]
+fn a_parsed_genomic_unknown_offset_round_trips() {
+    for input in ["NC_000001.11:g.100+?del", "NC_000001.11:g.100-?del"] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        assert_eq!(
+            parsed.to_string(),
+            input,
+            "an unknown offset must render back as `?`, not as the i64 sentinel"
+        );
+    }
+}
+
+/// A control, so the assertions above cannot pass by the renderer printing `?`
+/// for everything: an ordinary offset one step inside the sentinel still renders
+/// as a number. This is what pins the sentinel band at exactly two values.
+#[test]
+fn an_ordinary_offset_next_to_the_sentinel_still_renders_numerically() {
+    let near_positive = OFFSET_UNKNOWN_POSITIVE - 1;
+    let near_negative = OFFSET_UNKNOWN_NEGATIVE + 1;
+
+    assert_eq!(
+        GenomePos::with_offset(100, near_positive).to_string(),
+        format!("100+{near_positive}"),
+        "only the sentinel itself may render as `+?`"
+    );
+    assert_eq!(
+        CdsPos::with_offset(100, near_negative).to_string(),
+        format!("100{near_negative}"),
+        "only the sentinel itself may render as `-?`"
+    );
+}


### PR DESCRIPTION
Three in-band marker defects, one class: data the AST carries in band that a boundary either silently discards or emits raw. They are fixed together because the same one-line omission produced the first two and the same missing `Display` arm produced the third, and reading them apart is what let each survive.

Closes #1754
Closes #1755
Closes #1756

Representation-Change: `n.<b>+?`, `n.<b>-?` and `r.<b>+?` now render as written
  instead of leaking the in-band sentinel — `n.5+?` previously round-tripped as
  `n.5+9223372036854775807`. 3 outputs move. No committed corpus contains an
  input that reaches them: the real corpora carry 709 unknown-offset
  descriptions and every one is on `c.`/`g.`, the two axes that already rendered
  `?`, and `n.*N` occurs 0 times in 103,762 `n.`-axis rows. Separately,
  `tx_to_cds` and the projection fan-out seed now refuse `n.*N` where they
  previously answered — an `Ok` becomes an `Err`, so no string moves, but it is
  a behaviour change and is disclosed here rather than left to be discovered.

## M1 — `tx_to_cds` dropped `TxPos.downstream` (#1754)

`CoordinateMapper::tx_to_cds` classified a position purely by comparing `base` against the CDS bounds, so the `n.*N` marker was never read. On a transcript with a 5-base 5'UTR, `n.*5` was answered as **`c.-1`** — a different nucleotide, on the wrong side of the CDS, with no diagnostic. `n.5` returned the same thing.

It now refuses, citing `background/numbering.md:52` (the `n.` axis is numbered "from the first to the last nucleotide of the reference sequence" and admits no `*` zone) and `:54` (a variant beyond a transcript's boundaries may not be described against that transcript).

The judgement is not new. `project_*_direct` already refused `*N` up front, and its comment says it does so *because* `tx_to_cds` ignored the flag. The workaround existed at the wrong layer; this moves the check onto the contract it belongs to, where every caller gets it — including the callers that never pass through the projector. That earlier refusal still runs first and is unchanged.

`cds_to_tx`'s `downstream: false` is deliberate and unchanged: `c.*N` is the 3'UTR of a *coding* transcript, which lies **inside** it (`c.*1` is the base after the stop codon, still transcribed). The two `*` markers are not the same marker. A new test pins this so nobody later "completes" M1 by making `cds_to_tx` carry the flag across.

## M2 — the fan-out seed hard-coded `false` for the same flag (#1755)

`extract_contig_and_pos`'s `Tx` arm passed a literal `false` to `nr_representative_genome_pos` while the `Rna` arm directly below it passed `start_rna.utr3`. So `n.*5` was seeded at the genomic coordinate of the *in-transcript* base 5 (1004 on the test fixture) rather than at the documented first-exon fallback (1000).

The function's own doc comment already promised otherwise — it lists "downstream/utr3 markers" among the cases that fall back to the first-exon start. The parameter is renamed `utr3` → `star_marker`, because calling it `utr3` is precisely what invited a caller on an axis with no field of that name to pass a hard-coded `false`. The regression asserts on the **seed**, not on the final projection, so it cannot be satisfied by a downstream repair masking a wrong seed.

## M3 — `TxPos`/`RnaPos` `Display` leaked the unknown-offset sentinel (#1756)

The parser stores `+?`/`-?` in band as `i64::MAX`/`i64::MIN`. `GenomePos` and `CdsPos` rendered them back; `TxPos` and `RnaPos` had no arm at all, so a parsed `n.5+?` round-tripped as `n.5+9223372036854775807`.

The pair had three spellings across four types — named constants in `GenomePos`, bare `i64::MAX`/`i64::MIN` literals in `CdsPos`, nothing in the other two. All four now go through one helper keyed off the named constants. That is the actual fix: three spellings of one pair is how the fourth axis came to have none.

## Why this is still load-bearing after the `n.*N` adjudication

The ruling is **refuse**, and #1751 is being changed to refuse `n.*N` at parse in all modes. This branch is not made redundant by that, for two reasons that are structural rather than defensive:

- an internally-constructed `TxPos` never passes through the parser at all;
- the Python `n_to_c(transcript_id, tx_position, downstream=True)` entry point builds a `TxPos` directly from numeric arguments — there is no HGVS string, so there is no parse stage to catch anything.

Both reach `tx_to_cds`. M2 and M3 are untouched by the parse-stage decision in any case.

## The error code: keeping `E5001`, and why not `W4008` or `E4003`

`tx_to_cds` refuses with `FerroError::ConversionError` → **E5001 `ConversionFailed`**. That is a generic bucket and the alternatives deserved a real look. Both were investigated and both are wrong, for reasons found in the code rather than assumed.

**`W4008 NonCodingPositionOutsideTranscript` is not reachable at conversion time, and would be wrong if it were.** Three findings:

1. **It has no structured error code to reuse.** W4008 lives in `error_handling::types::ErrorType`, a different enum from `error::ErrorCode`. In #1751 its reject arm returns `FerroError::Parse { pos: 0, msg, diagnostic: None }`, and the `W4008` identity is a **text prefix** interpolated into `msg`. Because `diagnostic` is `None`, `FerroError::code()` falls to its `_ => None` arm — so W4008 has no `ErrorCode` at all, anywhere. There is no structured value to carry into a conversion error; there is only a string.
2. **Carrying it would mean returning a parse error from a coordinate conversion.** The only way to emit the `[W4008]` text in the established shape is `FerroError::Parse { pos: 0 }`. `tx_to_cds` has no source string and no position — `pos: 0` would be a fabricated location, and the result would report a *parse* failure for something that parsed fine and failed at conversion. That is strictly worse than a generic-but-honest E5001, which at least returns a real structured code in the right category.
3. **Its contract is mode-scoped; this refusal is not.** W4008's whole definition is a mode triple resolved through `ErrorConfig::action_for`: strict rejects at parse, lenient warns and accepts, silent accepts quietly, per the decided `rulings[absolute-prohibition-enforcement-stage]`. `CoordinateMapper` is `struct CoordinateMapper<'a> { transcript: &'a Transcript }` — it holds no `ErrorConfig`, and it should not. `numbering.md:54` prohibits the *nucleotide*, not a spelling, so there is no CDS coordinate to return under any mode. Reusing the code would either make an absolute geometric fact mode-configurable, or leave a user who sets `ignore = ["W4008"]` with a knob that silently does not apply at this layer — a worse failure than a generic code.

**`E4003 UnsupportedProjection` reads as "not supported yet", and its live uses confirm that.** In `projector.rs` it is what the genuinely unimplemented arms return — `Protein`, `Mt`, `Circular`, `RnaFusion`, `GenomeRing`. Using it here would file "this question has no answer" alongside "we have not built this". It is also categorically an E4xxx *normalization* error, while this is a conversion. Notably, #1741's guard uses E4003 **correctly** for what it is: an explicitly temporary capability placeholder. Once the capability gap closes and the answer becomes "no such coordinate exists, ever", E4003 stops being right — the code changing *is* the meaning changing, and that is the correct signal rather than a regression.

**On "one input, one diagnosis".** That goal holds here, by disjoint reachability rather than by sharing a code. Exactly one refusal fires on any given call path: in strict mode #1751 refuses at parse and `tx_to_cds` never runs; in lenient/silent #1751 accepts and the refusal falls to `tx_to_cds`; with no parser involved only `tx_to_cds` fires. The two layers never both render a verdict on one call, they cite the **same two spec lines** (`numbering.md:52`, `:54`), and their stages differ because their mode contracts genuinely differ. Sharing one code across a mode-scoped parse rule and an unconditional geometric refusal would give one code two incompatible meanings — one input, two diagnoses wearing one name, which is worse than two codes.

**Follow-up worth doing, deliberately not done here.** The right end state is a dedicated `E5xxx` in the Conversion category, name-matched to W4008 so the two layers read as one finding at two enforcement stages. Minting it touches `docs/spec/error_code_audit.md` and `tests/fixtures/error_code_audit.json` — the exact two files #1751 is currently rewriting — so doing it now would put a guaranteed conflict into a PR that is still in flux. It should land once #1751 has settled.

## #1741's Python guard should be removed by whichever of the two lands second

#1741 adds `reject_unhonoured_downstream(downstream)` at the top of `PyCoordinateMapper::n_to_c`, before the provider lookup. It fires ahead of this branch's refusal, so today a Python caller's diagnostic depends on merge order.

Its own doc comment names the condition for its removal, and this branch is that condition:

> Honouring the flag is a change to the conversion and is tracked separately; until that lands the honest answer at the boundary is a refusal ... **Lift this once `tx_to_cds` honours the flag.**

Its stated premise also becomes false. The guard's message says the conversion "cannot be answered rather than silently answered as `downstream=False`" — once this lands the conversion *is* answered, with a refusal, and it is no longer silently answered as `downstream=False`. Leaving the guard in place ships a message describing a state that no longer exists.

I have deliberately not touched #1741's branch. The ask for whoever lands second:

- **Remove only `reject_unhonoured_downstream`** and its call. #1741's sibling guards `reject_zero_base` and `reject_sentinel_offset` are unaffected by this branch and must stay — this is not a request to remove the boundary-validation block.
- **The surviving refusal carries E5001**, raised as `ProjectionError` (`ferro_typed("ProjectionError", "Conversion error: …")`), so the Python-visible diagnostic is predictable: `ProjectionError` either way, with the code moving E4003 → E5001 for the reason argued above.
- **One ordering change is expected and is an improvement.** With the guard gone, `n_to_c("BOGUS", 5, downstream=True)` reports `ReferenceDataError` (transcript not found) instead of the downstream complaint, because the provider lookup now runs first. That is the more fundamental and more actionable diagnosis, and it makes `n_to_c` consistent with every sibling method on the class, all of which lead with the lookup. The guard's pre-lookup placement was an artifact of its being a boundary placeholder, not a designed ordering.

## Corpus measurement

`examples/dump_normalized_corpus.rs` reports **0 moved**, and that zero is **structural, not evidence**: the harness emits axis values `{c, cx, g, p}` only, so it cannot construct an `n.` or `r.` description and cannot reach any of the three defects. Reporting it as a real zero would be the failure mode #1456/#1460/#1478 keep producing.

The real corpora were measured instead:

- **709** unknown-offset descriptions, **all** on `c.`/`g.` — the two axes whose `Display` already rendered `?`. So M3 moves nothing that exists today.
- **`n.*N`: 0 occurrences in 103,762 `n.`-axis rows.** This is a *real* zero rather than a structural one: the same harvest over the same rows finds `n.-N` five times, so the shape was reachable and simply does not occur.

## Verification

`cargo fmt --all --check`, `cargo clippy --features dev --lib`, `cargo clippy --features python --lib` and the full `cargo nextest run --features dev` all pass. The `python` feature is linted explicitly because the `dev` feature set does not compile `src/python.rs`.
