### PR TITLE
ci: report every required context on `merge_group`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,31 @@ on:
     # it, adding the trailer a red check just asked for re-runs nothing and the check
     # stays red until an unrelated push.
     types: [opened, synchronize, reopened, edited]
+  # Required for a merge queue, and it is a hard prerequisite rather than an
+  # optimisation: a queue entry is gated on the branch's required status checks
+  # being reported against the MERGE GROUP, and a workflow that does not trigger
+  # on `merge_group` reports nothing there at all. Nine of `main`'s ten required
+  # contexts come from this file (`zizmor + actionlint` is the tenth, in
+  # `lint-workflows.yml`), so without this line every queued pull request would
+  # sit on "Expected — waiting for status to be reported" forever. That is the
+  # same failure mode the `paths:` filter caused in `lint-workflows.yml`, one
+  # event further out: a check that never reports is indistinguishable from a
+  # check that has not finished.
+  #
+  # This is inert until a merge queue is actually enabled on `main` — no
+  # `merge_group` event can be delivered before then — so it is safe to land
+  # ahead of the settings change, and it has to, or the first queued PR hangs.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge-group run. `github.ref` is unique per merge group
+  # (`refs/heads/gh-readonly-queue/main/pr-<n>-<base-sha>`), so a collision needs
+  # the same PR re-queued against an unmoved base — rare, and the cost of losing
+  # that race is not a wasted run but a cancelled required check, which the queue
+  # reads as a failure and which evicts the pull request from the queue. Cheap
+  # insurance; `pull_request` and `push` are unaffected.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read
@@ -272,6 +293,33 @@ jobs:
     # `pull_request` only. The check reads the PR description, which is what becomes the
     # squash commit body and therefore what git-cliff's footer rule matches. A push to
     # `main` has no equivalent to read, and by then the declaration is already merged.
+    #
+    # UNDER `merge_group` THIS JOB IS SKIPPED, AND THAT IS DELIBERATE — but the reason is
+    # not "it would be awkward to run", it is that there is nothing there to read.
+    # `github.event.pull_request` does not exist on a `merge_group` event (nor do
+    # `github.head_ref`/`github.base_ref`), so every one of the steps below would resolve
+    # its inputs to the empty string and the checker would fail on a change that had
+    # already declared correctly.
+    #
+    # A skipped job reports a conclusion of SUCCESS, which satisfies a required status
+    # check — that is GitHub's documented behaviour for a job skipped by a job-level
+    # conditional, and it is what keeps `Representation change declared` from stalling
+    # every queue entry. (The failure mode it must not be confused with is a *workflow*
+    # that never triggers: that reports nothing, stays "Expected — waiting for status to
+    # be reported", and blocks forever. Which is why `merge_group` is in this file's `on:`
+    # block.)
+    #
+    # So in the queue this context is reported and vacuous. Nothing is lost by that,
+    # because the declaration is a property of the PR description and the queue cannot
+    # invalidate it: a merge group changes the BASE, and no base change can turn a present
+    # trailer into an absent one. That is exactly unlike the value-pinned tests the queue
+    # does exist to protect — those are properties of the merged tree. The real
+    # enforcement point is the pull request, where required checks gate entry to the queue.
+    #
+    # Do NOT "fix" this by widening the condition to run here. Reading the declaration
+    # under `merge_group` would mean parsing it back out of the merge commit message,
+    # which is a different and much weaker source than the description GitHub actually
+    # squashes.
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -321,6 +369,17 @@ jobs:
   changelog-grouping:
     name: Changelog grouping audit
     runs-on: ubuntu-latest
+    # Not on `merge_group`. This job judges what a SQUASH will render, and it gets there
+    # by synthesizing that squash commit from the PR title and description (the step
+    # below). A merge group carries the branch's intermediate commits, un-squashed, and
+    # no PR description to synthesize from — so here it would audit commits that will
+    # never exist after the merge and report on a changelog nobody will ship. This
+    # context is not required, so a spurious red would not block the queue; it would do
+    # something slightly worse, which is make a permanently-red check normal to look past.
+    #
+    # The question it asks is answered on the pull request and again on `push: main`
+    # after the squash lands, which are the two places the commit it audits is real.
+    if: github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -21,13 +21,28 @@ on:
   # of them costs well under a minute and buys a context that always reports,
   # which is the price of being able to require it.
   pull_request:
+  # `zizmor + actionlint` is the tenth required context on `main`, and the only one
+  # this file produces. A merge queue gates each entry on the required contexts being
+  # reported against the merge group, so without this trigger every queued pull request
+  # would hang on "Expected — waiting for status to be reported".
+  #
+  # That is the same defect the `paths:` filter caused above, arriving through a
+  # different door — and the note above already states the rule this line follows from:
+  # a check that never reports is indistinguishable, to a required-status-check rule,
+  # from a check that has not finished. A `paths:` filter made this workflow not run for
+  # PRs touching no workflow; no `merge_group:` makes it not run for any queue entry at
+  # all. The fix is the same in both cases, and so is the price: linting the workflows
+  # on a merge group costs about eight seconds.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # See `ci.yml` — a cancelled required check reads to the queue as a failure and evicts
+  # the pull request, so merge-group runs are never cancelled.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   lint:


### PR DESCRIPTION
Adds the `merge_group:` trigger to the two workflows that produce `main`'s required status checks. This is the blocking prerequisite for enabling a merge queue; it does nothing until one is enabled, and a queue enabled without it would hang every pull request.

Representation-Change: none. Workflow triggers only; no watched directory is touched.

## Why

CI tests `refs/pull/<N>/merge` — the head merged with the base **as of the last pull request event** — and GitHub does not re-run an open pull request when its base moves. So a green pull request can be a true statement about a merge that will never happen.

Measured on this base (`0c3400eb`), over the 20 open non-draft pull requests targeting `main`: **18 have merge refs built against a stale base**, `main` being 2–4 commits ahead of what their CI actually tested. Only two are current.

The failure this admits is not a textual conflict. A value pinned on both sides of a merge can carry the *same digits for different reasons* and merge cleanly to a wrong number — `the_index_is_not_vacuous` pins `(records, decided, undecided)` as three integers, and two pull requests that each add one ruling record both rewrite that line to the same value, so git merges it silently and the post-merge ledger has one more record than the pin claims. Branch protection cannot see that; a merge queue tests the merged state and can.

## What this changes

Nine of the ten required contexts come from `ci.yml`; `zizmor + actionlint` comes from `lint-workflows.yml`. Both now trigger on `merge_group`.

Verified mechanically rather than by reading — every context in the live ruleset resolves to a job whose workflow carries the trigger:

```
OK Build                          -> ci.yml               OK Python Wheel Test              -> ci.yml
OK Test                           -> ci.yml               OK abi3 floor ↔ requires-python   -> ci.yml
OK Clippy                         -> ci.yml               OK Representation change declared -> ci.yml
OK Clippy (all features)          -> ci.yml               OK zizmor + actionlint            -> lint-workflows.yml
OK Format                         -> ci.yml
OK Python Lint                    -> ci.yml               MISSING merge_group for: NONE
```

### The two jobs that read a pull request, and what happens to each

`github.event.pull_request` does not exist on a `merge_group` event, and neither does `github.head_ref`/`github.base_ref`. Exactly two jobs reference it.

**`Representation change declared` — reported, and vacuous.** It keeps its `pull_request`-only condition, so in the queue it is skipped. A job skipped by a job-level conditional reports a conclusion of **success**, which satisfies a required status check — that is the documented behaviour, and it is what keeps this context from stalling every entry. The failure mode it must not be confused with is a *workflow* that never triggers: that reports nothing at all and blocks forever, which is precisely what this pull request fixes.

Stating it plainly: **in the merge queue this check verifies nothing.** That is the right answer rather than a gap, because the declaration lives in the pull request description and a merge group only changes the *base* — no base change can turn a present trailer into an absent one. It is the opposite of a value-pinned test, which is a property of the merged tree. Required checks gate entry to the queue as well as the merge group, so the pull request remains the enforcement point.

**`Changelog grouping audit` — excluded.** It judges what a squash will render, and synthesizes that squash commit from the pull request title and description. A merge group carries the branch's un-squashed intermediate commits and no description, so there it would audit commits that never survive the merge. It is not a required context, so the risk was never a block — it was a permanently red check becoming normal to look past.

### The `Test` rollup needs no change

`Test` is the `test-required` job, a rollup over `[test, test-oracle, soak, sweeps]` demanding `result == "success"` from each. It already carries `if: always()`, which is what GitHub's own guidance asks for on a required check with `needs:`, and nothing in its dependency chain (`test-build`, `test-build-soak`, `spec-fixtures`, `fixtures`) is event-gated. So the rollup behaves identically under `merge_group`: a skipped upstream is not a success, and the context goes red.

### Merge-group runs are never cancelled

`cancel-in-progress` becomes `${{ github.event_name != 'merge_group' }}` in both files. `github.ref` is unique per merge group, so a collision needs the same pull request re-queued against an unmoved base — but the cost of losing that race is not a wasted run, it is a *cancelled required check*, which the queue reads as a failure and which evicts the pull request. `pull_request` and `push` are unaffected.

## Side effects worth knowing

- **Caching: the `rust-cache` half is inert, the per-commit half churns faster but stays bounded.** All seven `rust-cache` blocks are `save-if: github.ref == 'refs/heads/main'`, and a merge group's ref is `gh-readonly-queue/...`, so those restore and never save — the outcome to want given #1218. The three `actions/cache/save` families keyed on `${{ github.sha }}` (`nextest-archive-`, `nextest-soak-archive-`, `generated-fixtures-`, ~133 MB per commit) *do* save unconditionally, and a merge group has its own SHA, so queue entries add entries at roughly the rate pull request pushes do. That does not raise the ceiling: `prune-ci-caches.yml` matches those three by key **prefix** and keeps the newest `KEEP_PER_FAMILY: 5` of each daily, so the bound stays ~0.65 GiB however fast they are created. The only real effect is that the five retained slots rotate quicker, making a cache hit on a slightly older commit less likely. Worth watching after enablement, not worth pre-emptively tuning.
- **Coverage deliberately not added.** `codecov/*` is not a required context, so running it per merge group would add ~10 runner-minutes an entry and gate nothing.

## Verification

- `actionlint` 1.7.12 and `zizmor` 1.24.1 — the exact versions `lint-workflows.yml` pins — both clean, and both clean on the base beforehand, so the zero is a comparison and not a default.
- Required-context coverage checked by parsing the live ruleset and both workflows, not by reading them.
- No behaviour change is observable until a merge queue is enabled: `merge_group` events cannot be delivered before then.
