### PR TITLE
fix(cdot): propagate cds_start_incomplete through Transcript to CdotTranscript

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1653,6 +1653,11 @@ impl CdotMapper {
     ///   inclusive end equals 0-based exclusive end).
     /// - `cds_start`: 0-based. Conversion: `cds_start = Transcript.cds_start - 1`.
     /// - `cds_end`: 0-based exclusive. Same numeric value as `Transcript.cds_end`.
+    /// - `cds_start_incomplete`: propagated verbatim from
+    ///   `Transcript.cds_start_incomplete` (the Ensembl `cds_start_NF` flag, #972). Not a
+    ///   coordinate, but listed here because the projector's decline gate reads the *cdot*
+    ///   record in preference to the source `Transcript`, so dropping it on this edge
+    ///   silently re-enables the `c.`/`p.`/`r.` axes for such a transcript.
     ///
     /// Defaults to GRCh38 for contig alias resolution (so `chr17` ↔ `NC_000017.11`
     /// works after construction). Use [`from_transcripts_with_build`] to specify a
@@ -1728,10 +1733,12 @@ impl CdotMapper {
                 // needing a cdot JSON. See #310.
                 protein: tx.protein_id.clone(),
                 exon_cigars: Vec::new(),
-                // Not propagated here (out of this task's scope per brief);
-                // a follow-up can wire tx.cds_start_incomplete through this
-                // reverse Transcript → CdotTranscript direction too.
-                cds_start_incomplete: false,
+                // #972: carry the `cds_start_NF` flag through this reverse
+                // Transcript → CdotTranscript direction. The projector's
+                // decline gate reads the cdot transcript in preference to the
+                // source `Transcript`, so hardcoding `false` here shadowed a
+                // correct `true` and re-enabled c./p./r. for such transcripts.
+                cds_start_incomplete: tx.cds_start_incomplete,
             };
             mapper.add_transcript(tx.id.clone(), cdot_tx);
         }
@@ -4364,6 +4371,85 @@ mod tests {
         assert_eq!(
             stored.cds_start, None,
             "cds_start=Some(0) must become None, not a wrapped u64"
+        );
+    }
+
+    /// #972: `cds_start_incomplete` must survive the reverse
+    /// `Transcript` → `CdotTranscript` construction. The projector's decline
+    /// gate reads the *cdot* transcript first (`projector.rs`
+    /// `terminus_multiaxis_projection`), so a dropped flag here silently
+    /// shadows a correct `true` on the source `Transcript` and re-enables the
+    /// `c.`/`p.`/`r.` axes for a `cds_start_NF` transcript.
+    #[test]
+    fn test_from_transcripts_propagates_cds_start_incomplete() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        let make_tx = |incomplete: bool| Transcript {
+            cds_start_incomplete: incomplete,
+            id: "NM_CDSNF.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        // `from_transcripts` (defaults to GRCh38) must carry the flag through.
+        let incomplete = make_tx(true);
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&incomplete));
+        assert!(
+            mapper
+                .get_transcript("NM_CDSNF.1")
+                .expect("transcript should be present (exon coords are valid)")
+                .cds_start_incomplete,
+            "cds_start_incomplete=true must survive Transcript -> CdotTranscript"
+        );
+
+        // `from_transcripts_with_build` is the underlying constructor; pin it
+        // directly so a future refactor of the `from_transcripts` wrapper
+        // cannot quietly reintroduce the drop on the build-specific path.
+        let mapper =
+            CdotMapper::from_transcripts_with_build(std::iter::once(&incomplete), "GRCh37");
+        assert!(
+            mapper
+                .get_transcript("NM_CDSNF.1")
+                .expect("transcript should be present (exon coords are valid)")
+                .cds_start_incomplete,
+            "cds_start_incomplete=true must survive from_transcripts_with_build too"
+        );
+
+        // Guardrail: the flag is propagated, not hardcoded the other way. Cover
+        // both constructors here too, so a hardcode in the opposite direction on
+        // the build-specific path is caught from either side.
+        let complete = make_tx(false);
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&complete));
+        assert!(
+            !mapper
+                .get_transcript("NM_CDSNF.1")
+                .expect("transcript should be present (exon coords are valid)")
+                .cds_start_incomplete,
+            "cds_start_incomplete=false must stay false (propagated, not forced true)"
+        );
+        let mapper = CdotMapper::from_transcripts_with_build(std::iter::once(&complete), "GRCh37");
+        assert!(
+            !mapper
+                .get_transcript("NM_CDSNF.1")
+                .expect("transcript should be present (exon coords are valid)")
+                .cds_start_incomplete,
+            "cds_start_incomplete=false must stay false on from_transcripts_with_build too"
         );
     }
 

--- a/tests/it/issue_972_cds_start_nf_decline.rs
+++ b/tests/it/issue_972_cds_start_nf_decline.rs
@@ -224,6 +224,133 @@ fn cli_axis_c_and_p_are_unavailable_n_and_g_are_rendered() {
     }
 }
 
+/// `fixture()`'s geometry, but with the cdot side **derived** from the
+/// `Transcript` via `CdotMapper::from_transcripts` instead of hand-written — so
+/// the derivation is what is under test. The resulting `CdotTranscript` is
+/// field-for-field identical to `fixture()`'s (`exons: [[1000, 1009, 0, 9]]`,
+/// `cds_start: Some(0)`, `cds_end: Some(9)`, `protein: Some("NP_TEST.1")`);
+/// `cds_start_incomplete` is the one thing the derivation has to carry across,
+/// and it is set on the `Transcript` per `incomplete`.
+fn from_transcripts_fixture(incomplete: bool) -> VariantProjector<MockProvider> {
+    let mut tx = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    );
+    tx.cds_start_incomplete = incomplete;
+    tx.protein_id = Some("NP_TEST.1".to_string());
+
+    let projector = Projector::new(CdotMapper::from_transcripts(std::iter::once(&tx)));
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(tx);
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+
+    VariantProjector::new(projector, provider)
+}
+
+/// Same decline, but with the `CdotMapper` built by
+/// `CdotMapper::from_transcripts` from the `Transcript` itself, rather than
+/// from a hand-written `CdotTranscript` like `fixture()` above.
+///
+/// This is the path `PyProvider::Mock::cdot_mapper()` (`src/python.rs`) takes,
+/// and it used to hardcode `cds_start_incomplete: false`, dropping the flag.
+/// That drop is invisible to `fixture()` (which seats the `CdotTranscript`
+/// directly) and it is *not* caught by the `to_hgvs.rs` annotation gate either,
+/// since that gate reads the source `Transcript`. It bites in the projector,
+/// which consults the cdot transcript first — so a dropped `false` there
+/// shadows the correct `true` on the `Transcript` and re-enables c./p./r. for a
+/// `cds_start_NF` transcript.
+///
+/// `ReferenceSnapshot::to_cdot` calls the same constructor but is **not**
+/// affected, in two independent ways: its `build_transcripts` emits
+/// `chromosome: None` and genomic-less `Exon::new(..)` exons, both of which make
+/// `from_transcripts_with_build` skip the transcript before the
+/// `CdotTranscript` is ever built (pinned by
+/// `test_from_transcripts_skips_missing_chromosome` and
+/// `test_from_transcripts_skips_exon_missing_genomic_coords`); and
+/// `TranscriptSnapshot` carries no `cds_start_NF`-equivalent field to
+/// propagate in the first place.
+#[test]
+fn cdot_built_from_transcripts_still_declines_coding_protein_rna() {
+    let vp = from_transcripts_fixture(true);
+    let result: VariantProjection = vp
+        .project("NC_000001.11:g.1003C>A", "NM_TEST.1")
+        .expect("projection itself must succeed — only the coding/protein axes decline");
+
+    assert!(
+        result.coding.is_none(),
+        "cds_start_NF must survive CdotMapper::from_transcripts: c. must decline, got {:?}",
+        result.coding.map(|v| v.to_string())
+    );
+    assert!(
+        result.protein.is_none(),
+        "cds_start_NF must survive CdotMapper::from_transcripts: p. must decline, got {:?}",
+        result.protein.map(|v| v.to_string())
+    );
+    assert!(
+        result.rna.is_none(),
+        "cds_start_NF must survive CdotMapper::from_transcripts: r. must decline, got {:?}",
+        result.rna.map(|v| v.to_string())
+    );
+    assert!(
+        result.noncoding.is_some(),
+        "n. does not depend on the initiation codon and must still render"
+    );
+    assert!(
+        result.genomic.is_some(),
+        "g. does not depend on the initiation codon and must still render"
+    );
+}
+
+/// Guardrail contrast for the derived-cdot path: the identical
+/// `from_transcripts` derivation with `cds_start_incomplete: false` still
+/// predicts c./p./r.
+///
+/// Without this arm the decline above is not diagnostic — "c./p./r. are `None`"
+/// is also what a *degraded* derivation looks like, and the `n.`/`g.`
+/// assertions cannot rule that out because neither axis consults the CDS. Pairs
+/// with `genomic_input_predicts_coding_protein_when_cds_start_is_complete`,
+/// which pins the exact rendered forms (`:c.4C>A`, `NP_TEST.1:p.(Arg2Ser)`) on
+/// this same geometry; this arm's contract is only that the derived record can
+/// still drive all three axes, so it asserts presence rather than re-pinning
+/// those strings.
+#[test]
+fn cdot_built_from_transcripts_predicts_coding_protein_rna_when_cds_start_is_complete() {
+    let vp = from_transcripts_fixture(false);
+    let result: VariantProjection = vp
+        .project("NC_000001.11:g.1003C>A", "NM_TEST.1")
+        .expect("projection should succeed");
+
+    assert!(
+        result.coding.is_some(),
+        "c. must predict when cds_start is complete — the decline in the sibling \
+         test must come from the flag, not from a degraded from_transcripts \
+         derivation"
+    );
+    assert!(
+        result.protein.is_some(),
+        "p. must predict when cds_start is complete (guardrail for the derived-cdot path)"
+    );
+    assert!(
+        result.rna.is_some(),
+        "r. must predict when cds_start is complete (guardrail for the derived-cdot path)"
+    );
+}
+
 // =============================================================================
 // Real-reference test — ENST00000011700 (VPS13D), genuinely `cds_start_NF`.
 // =============================================================================


### PR DESCRIPTION
`CdotMapper::from_transcripts_with_build` builds a `CdotTranscript` from a `Transcript` and hardcoded `cds_start_incomplete: false`, dropping the `cds_start_NF` flag on that reverse direction. The existing comment documented the gap as a deliberate follow-up ("a follow-up can wire `tx.cds_start_incomplete` through this reverse `Transcript` → `CdotTranscript` direction too"). This is that follow-up.

## Why it is not merely lossy

The #972 decline gate in `src/project/projector.rs` consults the **cdot** transcript in preference to the source `Transcript` — `terminus_multiaxis_projection` falls back to the `Transcript` only when the cdot lookup misses:

```rust
let cds_start_incomplete = match self.projector.mapper().cdot().get_transcript(transcript_id) {
    Some(t) => t.cds_start_incomplete,
    None => self.cached_get_transcript_for_variant(normalized, transcript_id)
                .map(|tx| tx.cds_start_incomplete)
                .unwrap_or(false),
};
```

So the hardcoded `false` did not just lose information, it **shadowed** a correct `true` carried on the `Transcript`, re-enabling the `c.`/`p.`/`r.` axes for a transcript with no confirmed start codon. Reproduced directly: before this change the new end-to-end test emitted `NC_000001.11(NM_TEST.1):c.4C>A` for a `cds_start_NF` transcript.

## Reachability — deliberately narrow, and stated plainly

This is **not** a live annotation defect against a real prepared reference. The construction path has two non-`#[cfg(test)]` callers in the library:

- `src/python.rs`, `PyProvider::cdot_mapper()` — and only via the `PyProvider::Mock` arm. The `MultiFasta` arm returns the provider's own already-built mapper and never takes this lossy path.
- `src/conformance/reference_snapshot.rs`, `ReferenceSnapshot::to_cdot` — a public conformance-harness helper whose in-repo callers are all test code.

Beyond those, roughly a dozen `tests/it/*` suites build their mapper this way. So the reachable impact is the Python mock / test-data / conformance-harness path: the defect made **tests** lie about a guarantee the library otherwise upholds, which is worth fixing precisely because a green suite was the evidence for that guarantee.

Worth noting what this is *not*: `src/vcf/to_hgvs.rs:180` (`if self.transcript.is_coding() && !self.transcript.cds_start_incomplete`) reads a `reference::transcript::Transcript`, i.e. the *input* to this conversion, so that annotation gate never observed the loss and is unaffected.

## Tests

Both fail before the one-line change and pass after.

- `data::cdot::tests::test_from_transcripts_propagates_cds_start_incomplete` — asserts the flag survives both `from_transcripts` and `from_transcripts_with_build`, plus a `false` guardrail so the field is shown to be propagated rather than flipped.
- `issue_972_cds_start_nf_decline::cdot_built_from_transcripts_still_declines_coding_protein_rna` — end-to-end through the projector gate, with the mapper derived by `from_transcripts` rather than hand-seated as the existing `fixture()` does (which is exactly why the existing #972 suite could not see this). Asserts `c.`/`p.`/`r.` decline while `n.`/`g.` still render.

## Scope

One production line plus tests. `src/reference/derived_tx_structure.rs` already propagates correctly and is untouched. The diff is kept minimal and localized so it and #1737, which also edits `src/data/cdot.rs`, rebase trivially over one another whichever lands second.

Full local gate green: `cargo fmt --all --check`, `cargo clippy --features dev --lib -- -D warnings`, `cargo clippy --features python --lib -- -D warnings` all exit 0; `cargo ta` runs 10431 tests, 10431 passed, 0 failed.

Representation-Change: none. `src/data/` only; nothing under `src/normalize/`, `src/hgvs/`,
  `src/spdi/` or `src/project/` is touched and no normalized output moves. The behavioural
  change is confined to restoring the #972 projection-axis decline on transcripts built
  through this construction path.


Closes #1771
