### PR TITLE
ci: generate and publish the n./r. cis confluence corpus, and guard the wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,7 @@ jobs:
             tests/fixtures/grammar/hgvs_spec_normalization.json
             tests/fixtures/grammar/hgvs_spec_enumeration.json
             tests/fixtures/cis/cis_confluence_corpus.json
+            tests/fixtures/cis/cis_confluence_nr_corpus.json
           key: generated-fixtures-${{ runner.os }}-${{ github.sha }}
       - name: Generate HGVS v21.0 spec fixture
         if: steps.generated-fixtures.outputs.cache-hit != 'true'
@@ -641,21 +642,31 @@ jobs:
       - name: Generate HGVS spec test enumeration
         if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --bin generate_spec_enumeration
-      # The cis confluence corpus, generated here for the same reason and at far
-      # greater saving. `tests/it/cis_confluence_axis.rs` regenerates it on demand
-      # through `common::fixture_gen`, which shells out to a nested `cargo run
-      # --features dev --example generate_cis_confluence_corpus`. The `test` /
-      # `test-oracle` shards run from a nextest **archive** and so have no warm
-      # `target/`: that nested call compiles the crate from scratch *inside the
-      # test*, and the cost lands on whichever of the three `cis_confluence_axis`
-      # tests the shard happens to hold.
+      # The two cis confluence corpora, generated here for the same reason and at
+      # far greater saving. `tests/it/cis_confluence_axis.rs` and
+      # `tests/it/cis_confluence_nr_axis.rs` regenerate theirs on demand through
+      # `common::fixture_gen`, which shells out to a nested `cargo run --features
+      # dev --example generate_cis_confluence_corpus`. The `test` / `test-oracle`
+      # shards run from a nextest **archive** and so have no warm `target/`: that
+      # nested call compiles the crate from scratch *inside the test*, and the
+      # cost lands on whichever of the nine tests the shard happens to hold.
       #
       # Measured on run 31268888323: `the_corpus_is_a_dense_set_of_real_confluence_classes`
       # took 117.6s in `Test (2/6)` and 127.3s in `Test oracle (2/3)` — a test that
       # reads an 8 MB JSON and makes a handful of cheap assertions, and that takes
-      # 0.071s once the file exists. Six jobs paid it per run: the three tests are
-      # spread across the six `test` shards and again across the three
-      # `test-oracle` shards, so three shards of each hold one apiece.
+      # 0.071s once the file exists.
+      #
+      # **The `--axes n,r` corpus is the second step for the same reason, and it
+      # was missing until now.** `cis_confluence_nr_axis` landed with no wiring
+      # here, so every one of its SIX tests paid the nested build in every shard
+      # that held one — the cost is per test *process*, and nextest gives each
+      # test its own. Measured on run 31670057963 (`Test oracle (1/3)`):
+      # `the_rna_axis_is_spelled_in_the_rna_alphabet` took **129.2s** against
+      # 0.15s locally once the file exists — it normalizes nothing, it only
+      # compares strings — and `rna_five_prime_confluence_census` took **205.9s**,
+      # of which the census itself is the ~77s remainder. Its `g,c` sibling
+      # `three_prime_confluence_census` took 88.0s over *twice* the spellings,
+      # because its corpus was downloaded. That asymmetry is the whole tell.
       #
       # It lives in THIS job rather than one of its own, and that was measured both
       # ways. Generation is ~3s but compiling the example is ~50s, so on run
@@ -670,6 +681,16 @@ jobs:
       - name: Generate the cis confluence corpus
         if: steps.generated-fixtures.outputs.cache-hit != 'true'
         run: cargo run --features dev --example generate_cis_confluence_corpus
+      # The transcript-typed half. `--axes` defaults to `g,c` and `--output` to
+      # the corpus above, so BOTH flags are required and the path must match the
+      # one `cis_confluence_nr_axis::CORPUS_RELATIVE_PATH` reads. The example is
+      # already built by the step above, so this costs the ~3s of generation
+      # rather than another ~50s of compiling.
+      - name: Generate the cis confluence n./r. corpus
+        if: steps.generated-fixtures.outputs.cache-hit != 'true'
+        run: |
+          cargo run --features dev --example generate_cis_confluence_corpus -- \
+            --axes n,r --output tests/fixtures/cis/cis_confluence_nr_corpus.json
       # Merged in from the former `generated-docs` job. Those three generators are
       # `cargo run --features dev --example …` — the SAME profile and feature set as
       # the four steps above — so they were compiling an identical dependency tree
@@ -726,6 +747,7 @@ jobs:
             tests/fixtures/grammar/hgvs_spec_normalization.json
             tests/fixtures/grammar/hgvs_spec_enumeration.json
             tests/fixtures/cis/cis_confluence_corpus.json
+            tests/fixtures/cis/cis_confluence_nr_corpus.json
           key: generated-fixtures-${{ runner.os }}-${{ github.sha }}
       # Only the fixtures are published from here. The two generator binaries
       # `spec_generator_preconditions` executes need no staging: they are
@@ -737,14 +759,30 @@ jobs:
           path: |
             tests/fixtures/grammar/hgvs_spec_normalization.json
             tests/fixtures/grammar/hgvs_spec_enumeration.json
+          # As on `bulk-fixtures` below, and with the same limit: this catches an
+          # EMPTY artifact, not a short one. A consumer that downloads an artifact
+          # missing a fixture falls back to `fixture_gen`'s nested `cargo run` and
+          # rebuilds the crate inside the test — silently, since the suite still
+          # passes. `warn` is the wrong default for an artifact anything reads.
+          if-no-files-found: error
           retention-days: 1
       # A second artifact rather than a second path on the one above, because the
       # consumers download `spec-fixtures` with `path: tests/fixtures/grammar/` — a
       # single artifact spanning two fixture directories cannot be unpacked that way.
+      #
+      # Both corpora DO share a directory, so they can ride one artifact: the
+      # upload roots it at their common ancestor (`tests/fixtures/cis`) and the
+      # consumers' `path: tests/fixtures/cis/` unpacks both onto the paths their
+      # tests read. Keep them on separate lines rather than a glob, so adding a
+      # third file to that directory cannot be swept in by accident.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cis-corpus
-          path: tests/fixtures/cis/cis_confluence_corpus.json
+          path: |
+            tests/fixtures/cis/cis_confluence_corpus.json
+            tests/fixtures/cis/cis_confluence_nr_corpus.json
+          # See the note on `spec-fixtures` above.
+          if-no-files-found: error
           retention-days: 1
 
   # Build the test binaries ONCE, then fan out: `test` and `test-oracle` consume
@@ -1092,10 +1130,13 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
-      # Without this the three `cis_confluence_axis` tests regenerate the corpus
-      # themselves, via a nested `cargo run --example` that has to compile the
-      # crate from scratch inside the test — 117.6s on run 31268888323 for the
-      # one that only reads it. See the generating step in `spec-fixtures`.
+      # Carries BOTH confluence corpora — `cis_confluence_axis`'s `g,c` one and
+      # `cis_confluence_nr_axis`'s `n,r` one. Without it those nine tests
+      # regenerate theirs themselves, via a nested `cargo run --example` that has
+      # to compile the crate from scratch inside the test — 117.6s on run
+      # 31268888323 for the `g,c` test that only reads it, and 129.2s on run
+      # 31670057963 for the `n,r` one. See the generating steps in
+      # `spec-fixtures`.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: cis-corpus
@@ -1177,10 +1218,13 @@ jobs:
         with:
           name: spec-fixtures
           path: tests/fixtures/grammar/
-      # Without this the three `cis_confluence_axis` tests regenerate the corpus
-      # themselves, via a nested `cargo run --example` that has to compile the
-      # crate from scratch inside the test — 117.6s on run 31268888323 for the
-      # one that only reads it. See the generating step in `spec-fixtures`.
+      # Carries BOTH confluence corpora — `cis_confluence_axis`'s `g,c` one and
+      # `cis_confluence_nr_axis`'s `n,r` one. Without it those nine tests
+      # regenerate theirs themselves, via a nested `cargo run --example` that has
+      # to compile the crate from scratch inside the test — 117.6s on run
+      # 31268888323 for the `g,c` test that only reads it, and 129.2s on run
+      # 31670057963 for the `n,r` one. See the generating steps in
+      # `spec-fixtures`.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: cis-corpus

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -97,6 +97,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use rayon::prelude::*;
 use serde::Deserialize;
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
@@ -504,15 +505,37 @@ struct Divergence {
     outputs: Vec<String>,
 }
 
-fn measure(direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
-    let classes = &corpus().classes;
-    let mut census = Census::default();
-    let mut worst: Vec<Divergence> = Vec::new();
+impl Census {
+    /// Fold another census in. Every field is a count over a partition of the
+    /// classes, so summing is exact rather than approximate — which is what
+    /// makes [`measure`]'s per-group split safe.
+    fn absorb(&mut self, other: &Census) {
+        self.classes += other.classes;
+        self.spellings += other.spellings;
+        self.declined += other.declined;
+        self.converged += other.converged;
+        self.split_two += other.split_two;
+        self.split_three += other.split_three;
+        self.split_more += other.split_more;
+        self.underdetermined += other.underdetermined;
+        self.sequence_changed += other.sequence_changed;
+    }
+}
 
-    // Classes are sorted by an id that starts with the core index and the axis,
-    // so every class sharing a reference is contiguous. Building one provider
-    // and one normalizer per group instead of per class is the difference
-    // between this running in seconds and in minutes.
+/// How many divergent classes the failure message names. Applied per group and
+/// again to the concatenation, which is what keeps the parallel result
+/// byte-identical to a serial one — see [`measure`].
+const WORST_LIMIT: usize = 10;
+
+/// The contiguous runs of `classes` that share one reference.
+///
+/// Classes are sorted by an id that starts with the core index and the axis, so
+/// every class sharing a reference is contiguous. Building one provider and one
+/// normalizer per group instead of per class is the difference between this
+/// running in seconds and in minutes; [`measure`] additionally runs the groups
+/// concurrently, which it can do only because each one owns its provider.
+fn reference_groups(classes: &[Class]) -> Vec<&[Class]> {
+    let mut groups = Vec::new();
     let mut start = 0usize;
     while start < classes.len() {
         let mut end = start + 1;
@@ -522,60 +545,106 @@ fn measure(direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
         {
             end += 1;
         }
-        let (provider, reference) = reference_for(&classes[start]);
-        let normalizer = Normalizer::with_config(
-            provider.clone(),
-            NormalizeConfig::default().with_direction(direction),
-        );
-
-        for class in &classes[start..end] {
-            census.classes += 1;
-            let expected = expected_sequence(class);
-            let mut outputs: BTreeSet<String> = BTreeSet::new();
-            let mut normalized_spellings = 0usize;
-            for spelling in &class.spellings {
-                census.spellings += 1;
-                let Ok(variant) = parse_hgvs(spelling) else {
-                    census.declined += 1;
-                    continue;
-                };
-                let normalized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    normalizer.normalize(&variant)
-                }));
-                let output = match normalized {
-                    Ok(Ok(value)) => value.to_string(),
-                    _ => {
-                        census.declined += 1;
-                        continue;
-                    }
-                };
-                normalized_spellings += 1;
-                if apply_with(&provider, &reference, &output).as_deref() != Some(expected.as_str())
-                {
-                    census.sequence_changed += 1;
-                }
-                outputs.insert(output);
-            }
-
-            if normalized_spellings < 2 {
-                census.underdetermined += 1;
-                continue;
-            }
-            match outputs.len() {
-                1 => census.converged += 1,
-                2 => census.split_two += 1,
-                3 => census.split_three += 1,
-                _ => census.split_more += 1,
-            }
-            if outputs.len() > 1 && worst.len() < 10 {
-                worst.push(Divergence {
-                    id: class.id.clone(),
-                    outputs: outputs.into_iter().collect(),
-                });
-            }
-        }
+        groups.push(&classes[start..end]);
         start = end;
     }
+    groups
+}
+
+/// Census one reference group. Owns its provider and normalizer, reads nothing
+/// outside its own slice, and so is safe to run alongside its siblings.
+fn measure_group(group: &[Class], direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
+    let mut census = Census::default();
+    let mut worst: Vec<Divergence> = Vec::new();
+
+    let (provider, reference) = reference_for(&group[0]);
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(direction),
+    );
+
+    for class in group {
+        census.classes += 1;
+        let expected = expected_sequence(class);
+        let mut outputs: BTreeSet<String> = BTreeSet::new();
+        let mut normalized_spellings = 0usize;
+        for spelling in &class.spellings {
+            census.spellings += 1;
+            let Ok(variant) = parse_hgvs(spelling) else {
+                census.declined += 1;
+                continue;
+            };
+            let normalized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                normalizer.normalize(&variant)
+            }));
+            let output = match normalized {
+                Ok(Ok(value)) => value.to_string(),
+                _ => {
+                    census.declined += 1;
+                    continue;
+                }
+            };
+            normalized_spellings += 1;
+            if apply_with(&provider, &reference, &output).as_deref() != Some(expected.as_str()) {
+                census.sequence_changed += 1;
+            }
+            outputs.insert(output);
+        }
+
+        if normalized_spellings < 2 {
+            census.underdetermined += 1;
+            continue;
+        }
+        match outputs.len() {
+            1 => census.converged += 1,
+            2 => census.split_two += 1,
+            3 => census.split_three += 1,
+            _ => census.split_more += 1,
+        }
+        if outputs.len() > 1 && worst.len() < WORST_LIMIT {
+            worst.push(Divergence {
+                id: class.id.clone(),
+                outputs: outputs.into_iter().collect(),
+            });
+        }
+    }
+
+    (census, worst)
+}
+
+/// Census one direction over both axes, one reference group per rayon task.
+///
+/// **The result is byte-identical to the serial walk, not merely equivalent**,
+/// which is the only basis on which a pinned census may be parallelized at all:
+///
+/// * every `Census` field is a count over a partition of the classes, so
+///   [`Census::absorb`] over the groups is exact and order-free;
+/// * `par_iter().collect()` preserves *input* order, so the per-group results
+///   are folded in corpus order however they finish;
+/// * `worst` is "the first [`WORST_LIMIT`] divergent classes in corpus order".
+///   Each group keeps its own first `WORST_LIMIT`, and concatenating the groups
+///   in corpus order and truncating again yields exactly that set — the serial
+///   loop's global cap can only have kept the same ones.
+///
+/// Nothing is shared across tasks: each group builds its own `MockProvider` and
+/// `Normalizer` (it already did — that is the per-group loop's whole point), and
+/// the only borrow that crosses is the immutable corpus slice. The normalization
+/// oracles' recursion guard is a thread-local, so it is per-task too.
+fn measure(direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
+    let groups = reference_groups(&corpus().classes);
+
+    let per_group: Vec<(Census, Vec<Divergence>)> = groups
+        .par_iter()
+        .map(|group| measure_group(group, direction))
+        .collect();
+
+    let mut census = Census::default();
+    let mut worst: Vec<Divergence> = Vec::new();
+    for (group_census, group_worst) in per_group {
+        census.absorb(&group_census);
+        worst.extend(group_worst);
+    }
+    worst.truncate(WORST_LIMIT);
 
     (census, worst)
 }

--- a/tests/it/cis_confluence_nr_axis.rs
+++ b/tests/it/cis_confluence_nr_axis.rs
@@ -71,6 +71,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use rayon::prelude::*;
 use serde::Deserialize;
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
@@ -346,21 +347,43 @@ struct Census {
     sequence_changed: usize,
 }
 
+impl Census {
+    /// Fold another census in. Every field is a count over a partition of the
+    /// classes, so summing is exact rather than approximate — which is what
+    /// makes [`measure`]'s per-group split safe.
+    fn absorb(&mut self, other: &Census) {
+        self.classes += other.classes;
+        self.spellings += other.spellings;
+        self.declined += other.declined;
+        self.converged += other.converged;
+        self.split_two += other.split_two;
+        self.split_three += other.split_three;
+        self.split_more += other.split_more;
+        self.underdetermined += other.underdetermined;
+        self.sequence_changed += other.sequence_changed;
+    }
+}
+
 /// A worst-offender line, for the failure message when a pin moves.
 struct Divergence {
     id: String,
     outputs: Vec<String>,
 }
 
-fn measure(direction: ShuffleDirection, axis: &str) -> (Census, Vec<Divergence>) {
-    let classes = &corpus().classes;
-    let mut census = Census::default();
-    let mut worst: Vec<Divergence> = Vec::new();
+/// How many divergent classes the failure message names. Applied per group and
+/// again to the concatenation, which is what keeps the parallel result
+/// byte-identical to a serial one — see [`measure`].
+const WORST_LIMIT: usize = 10;
 
-    // Classes are sorted by an id that starts with the core index and the axis,
-    // so every class sharing a reference is contiguous. Building one provider
-    // and one normalizer per group instead of per class is the difference
-    // between this running in seconds and in minutes.
+/// The contiguous runs of `classes` that share one reference and sit on `axis`.
+///
+/// Classes are sorted by an id that starts with the core index and the axis, so
+/// every class sharing a reference is contiguous. Building one provider and one
+/// normalizer per group instead of per class is the difference between this
+/// running in seconds and in minutes; [`measure`] additionally runs the groups
+/// concurrently, which it can do only because each one owns its provider.
+fn reference_groups<'a>(classes: &'a [Class], axis: &str) -> Vec<&'a [Class]> {
+    let mut groups = Vec::new();
     let mut start = 0usize;
     while start < classes.len() {
         let mut end = start + 1;
@@ -370,64 +393,108 @@ fn measure(direction: ShuffleDirection, axis: &str) -> (Census, Vec<Divergence>)
         {
             end += 1;
         }
-        if classes[start].axis != axis {
-            start = end;
-            continue;
-        }
-        let (provider, reference) = reference_for(&classes[start]);
-        let normalizer = Normalizer::with_config(
-            provider.clone(),
-            NormalizeConfig::default().with_direction(direction),
-        );
-
-        for class in &classes[start..end] {
-            census.classes += 1;
-            let expected = class.denoted.clone();
-            let mut outputs: BTreeSet<String> = BTreeSet::new();
-            let mut normalized_spellings = 0usize;
-            for spelling in &class.spellings {
-                census.spellings += 1;
-                let Ok(variant) = parse_hgvs(spelling) else {
-                    census.declined += 1;
-                    continue;
-                };
-                let normalized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    normalizer.normalize(&variant)
-                }));
-                let output = match normalized {
-                    Ok(Ok(value)) => value.to_string(),
-                    _ => {
-                        census.declined += 1;
-                        continue;
-                    }
-                };
-                normalized_spellings += 1;
-                if apply_with(&provider, &reference, &output).as_deref() != Some(expected.as_str())
-                {
-                    census.sequence_changed += 1;
-                }
-                outputs.insert(output);
-            }
-
-            if normalized_spellings < 2 {
-                census.underdetermined += 1;
-                continue;
-            }
-            match outputs.len() {
-                1 => census.converged += 1,
-                2 => census.split_two += 1,
-                3 => census.split_three += 1,
-                _ => census.split_more += 1,
-            }
-            if outputs.len() > 1 && worst.len() < 10 {
-                worst.push(Divergence {
-                    id: class.id.clone(),
-                    outputs: outputs.into_iter().collect(),
-                });
-            }
+        if classes[start].axis == axis {
+            groups.push(&classes[start..end]);
         }
         start = end;
     }
+    groups
+}
+
+/// Census one reference group. Owns its provider and normalizer, reads nothing
+/// outside its own slice, and so is safe to run alongside its siblings.
+fn measure_group(group: &[Class], direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
+    let mut census = Census::default();
+    let mut worst: Vec<Divergence> = Vec::new();
+
+    let (provider, reference) = reference_for(&group[0]);
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(direction),
+    );
+
+    for class in group {
+        census.classes += 1;
+        let expected = class.denoted.clone();
+        let mut outputs: BTreeSet<String> = BTreeSet::new();
+        let mut normalized_spellings = 0usize;
+        for spelling in &class.spellings {
+            census.spellings += 1;
+            let Ok(variant) = parse_hgvs(spelling) else {
+                census.declined += 1;
+                continue;
+            };
+            let normalized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                normalizer.normalize(&variant)
+            }));
+            let output = match normalized {
+                Ok(Ok(value)) => value.to_string(),
+                _ => {
+                    census.declined += 1;
+                    continue;
+                }
+            };
+            normalized_spellings += 1;
+            if apply_with(&provider, &reference, &output).as_deref() != Some(expected.as_str()) {
+                census.sequence_changed += 1;
+            }
+            outputs.insert(output);
+        }
+
+        if normalized_spellings < 2 {
+            census.underdetermined += 1;
+            continue;
+        }
+        match outputs.len() {
+            1 => census.converged += 1,
+            2 => census.split_two += 1,
+            3 => census.split_three += 1,
+            _ => census.split_more += 1,
+        }
+        if outputs.len() > 1 && worst.len() < WORST_LIMIT {
+            worst.push(Divergence {
+                id: class.id.clone(),
+                outputs: outputs.into_iter().collect(),
+            });
+        }
+    }
+
+    (census, worst)
+}
+
+/// Census one axis in one direction, one reference group per rayon task.
+///
+/// **The result is byte-identical to the serial walk, not merely equivalent**,
+/// which is the only basis on which a pinned census may be parallelized at all:
+///
+/// * every `Census` field is a count over a partition of the classes, so
+///   [`Census::absorb`] over the groups is exact and order-free;
+/// * `par_iter().collect()` preserves *input* order, so the per-group results
+///   are folded in corpus order however they finish;
+/// * `worst` is "the first [`WORST_LIMIT`] divergent classes in corpus order".
+///   Each group keeps its own first `WORST_LIMIT`, and concatenating the groups
+///   in corpus order and truncating again yields exactly that set — the serial
+///   loop's global cap can only have kept the same ones.
+///
+/// Nothing is shared across tasks: each group builds its own `MockProvider` and
+/// `Normalizer` (it already did — that is the per-group loop's whole point), and
+/// the only borrow that crosses is the immutable corpus slice. The normalization
+/// oracles' recursion guard is a thread-local, so it is per-task too.
+fn measure(direction: ShuffleDirection, axis: &str) -> (Census, Vec<Divergence>) {
+    let groups = reference_groups(&corpus().classes, axis);
+
+    let per_group: Vec<(Census, Vec<Divergence>)> = groups
+        .par_iter()
+        .map(|group| measure_group(group, direction))
+        .collect();
+
+    let mut census = Census::default();
+    let mut worst: Vec<Divergence> = Vec::new();
+    for (group_census, group_worst) in per_group {
+        census.absorb(&group_census);
+        worst.extend(group_worst);
+    }
+    worst.truncate(WORST_LIMIT);
 
     (census, worst)
 }
@@ -624,6 +691,57 @@ fn the_rna_axis_is_spelled_in_the_rna_alphabet() {
                 "{spelling} carries a `t`, which RNA spells `u`"
             );
         }
+    }
+}
+
+/// [`measure`]'s byte-identity argument rests on [`reference_groups`] returning
+/// a **partition** of the axis's classes, in corpus order. Nothing else observes
+/// that: the censuses would still sum to something if a class were dropped or
+/// counted twice, and `worst` only ever surfaces inside a failure message — so a
+/// broken partition is invisible on a green run and would move the pins
+/// silently, which is the one way a parallelized census can go wrong without
+/// saying so.
+#[test]
+fn the_reference_groups_partition_each_axis_in_corpus_order() {
+    let classes = &corpus().classes;
+    for axis in ["n", "r"] {
+        let groups = reference_groups(classes, axis);
+        assert!(
+            !groups.is_empty(),
+            "{axis}: no groups, so nothing is measured"
+        );
+
+        // Every group is non-empty and shares one reference, which is what lets
+        // `measure_group` build a single provider from `group[0]`.
+        for group in &groups {
+            assert!(
+                !group.is_empty(),
+                "{axis}: an empty group would panic on group[0]"
+            );
+            assert!(
+                group
+                    .iter()
+                    .all(|c| c.axis == group[0].axis && c.core == group[0].core),
+                "{axis}: a group spans two references, so one provider cannot serve it"
+            );
+        }
+
+        // Concatenating the groups reproduces the axis's classes exactly, in
+        // corpus order — no class dropped, none counted twice, none reordered.
+        let flattened: Vec<&str> = groups
+            .iter()
+            .flat_map(|group| group.iter())
+            .map(|c| c.id.as_str())
+            .collect();
+        let expected: Vec<&str> = classes
+            .iter()
+            .filter(|c| c.axis == axis)
+            .map(|c| c.id.as_str())
+            .collect();
+        assert_eq!(
+            flattened, expected,
+            "{axis}: the groups are not a partition of the axis in corpus order"
+        );
     }
 }
 

--- a/tests/it/generated_fixture_ci_wiring.rs
+++ b/tests/it/generated_fixture_ci_wiring.rs
@@ -1,0 +1,398 @@
+//! Every on-demand generated fixture must be built and shipped by CI.
+//!
+//! # The defect this closes, which shipped and was invisible for weeks
+//!
+//! `common::fixture_gen` gives a test module a fallback: if its generated
+//! fixture is absent, shell out to `cargo run --features dev --example <gen>`
+//! and build it. That fallback exists so a fresh `cargo test` just works, and
+//! locally it costs a few seconds against a warm `target/`.
+//!
+//! In CI it is a trap. `test` and `test-oracle` run from a nextest **archive**
+//! and have no `target/` at all, so the nested `cargo run` compiles the whole
+//! crate *inside the test* — and nextest gives every test its own process, so
+//! **every test in the module pays it**, not the first one.
+//!
+//! `cis_confluence_nr_axis` landed in #1646 with no wiring in `spec-fixtures`,
+//! and nothing went red. Measured on run 31670057963, `Test oracle (1/3)`:
+//! `the_rna_axis_is_spelled_in_the_rna_alphabet` took **129.2s** against 0.15s
+//! once the file exists — a test that normalizes nothing and only compares
+//! strings — while its `g,c` sibling `three_prime_confluence_census` ran
+//! **twice** the spellings in 88.0s, because *its* corpus was downloaded.
+//!
+//! **The failure mode is silence, and the flattering kind of silence.** Nothing
+//! fails, no artifact is missing, no assertion moves; the suite is simply slower
+//! in a way that reads as "those censuses are expensive". That is the same shape
+//! as `oracle_exclude_invariant.rs`'s: a module added later, not named in a CI
+//! list, that degrades quietly rather than loudly.
+//!
+//! # What is checked, and what that is worth
+//!
+//! Three properties, each derived from the workflow rather than from a list
+//! kept here — a hardcoded roster of fixtures would rot in exactly the way the
+//! defect did:
+//!
+//! 1. every generated fixture path a `tests/it` module names is in **every**
+//!    `actions/cache` step's `path:` in `spec-fixtures` (restore and save must
+//!    agree, or the entry saved is not the entry restored);
+//! 2. it is published on some `actions/upload-artifact` from that job;
+//! 3. every job consuming the `nextest-archive` artifact — that is, every job
+//!    that runs the `it` binary with no warm `target/` — downloads each artifact
+//!    carrying a generated fixture.
+//!
+//! The workflow half is **parsed**, for the reason `workflow_gh_repo_context.rs`
+//! gives: which step sits in which job is structural, and a substring scan
+//! cannot answer it. The source half is a **token scan** and is a floor, not a
+//! proof: it finds a `"tests/fixtures/….json"` literal in a file that also
+//! mentions `ensure_generated`, so a module holding its path somewhere else, or
+//! composing it at run time, is invisible to it. What it does buy is that a
+//! fixture declared the way all four current ones are declared cannot be added
+//! in silence, and the question gets asked.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+/// This file. Excluded from the scan for the same reason
+/// `oracle_exclude_invariant.rs` excludes itself: it carries [`CALLS`]'s matcher
+/// literals, so it matches its own consumer test and would be read for fixture
+/// paths it has no business declaring. It happens to declare none today —
+/// [`FIXTURE_PREFIX`] is not `.json`-terminated, so [`fixture_literals`] finds
+/// nothing here — but that is a property of the current wording, not a
+/// guarantee, and the exclusion is what makes it one.
+const SELF: &str = "generated_fixture_ci_wiring.rs";
+
+/// The module that *defines* the fallback rather than using it. It names no
+/// fixture, but it is the one file guaranteed to mention the call.
+const DEFINITION: &str = "fixture_gen.rs";
+
+/// The call that marks a module as depending on a generated fixture, in both its
+/// spellings — the `[[bin]]` door and the `[[example]]` one.
+const CALLS: [&str; 2] = [
+    "ensure_generated_fixture(",
+    "ensure_generated_example_fixture(",
+];
+
+/// The prefix of a fixture path literal, relative to the manifest directory —
+/// the form `fixture_gen::fixture_path` takes.
+const FIXTURE_PREFIX: &str = "tests/fixtures/";
+
+/// The artifact carrying the test binaries that `test` and `test-oracle` run.
+///
+/// Consumers are derived from this rather than named, so a new job that runs the
+/// suite from the archive inherits the requirement. `soak` and `sweeps` consume
+/// `nextest-archive-soak` and a narrow selection, and are deliberately not in
+/// scope: they do not run these modules.
+const TEST_ARCHIVE: &str = "nextest-archive";
+
+/// The job that generates and publishes the fixtures.
+const PRODUCER_JOB: &str = "spec-fixtures";
+
+/// A floor on what the scan must find, so a matcher that silently stops matching
+/// cannot pass as "nothing to check". Four fixtures are wired today: the two
+/// spec artifacts and the two cis confluence corpora.
+const MINIMUM_FIXTURES: usize = 4;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every `tests/it` source that reaches for a generated fixture, as
+/// `(file name, contents)`.
+fn fixture_consuming_sources() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut stack = vec![repo_root().join("tests/it")];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+            .filter_map(Result::ok);
+        for entry in entries {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .expect("a file has a name")
+                .to_string_lossy()
+                .into_owned();
+            if name == SELF || name == DEFINITION {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            if CALLS.iter().any(|call| text.contains(call)) {
+                out.push((name, text));
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// The `tests/fixtures/….json` literals in `text`.
+///
+/// A deliberate token scan, not a parse. It reads from the opening quote of the
+/// prefix to the next quote, so it picks up the `const … : &str = "…"` form
+/// every current caller uses and ignores the same path mentioned in prose,
+/// which has no quote around it.
+fn fixture_literals(text: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let needle = format!("\"{FIXTURE_PREFIX}");
+    let mut rest = text;
+    while let Some(at) = rest.find(&needle) {
+        let after = &rest[at + 1..];
+        if let Some(end) = after.find('"') {
+            let literal = &after[..end];
+            if literal.ends_with(".json") {
+                found.insert(literal.to_string());
+            }
+            rest = &after[end..];
+        } else {
+            break;
+        }
+    }
+    found
+}
+
+/// Every generated fixture path a `tests/it` module names, and the module that
+/// names it.
+fn generated_fixtures() -> BTreeMap<String, String> {
+    let sources = fixture_consuming_sources();
+    assert!(
+        !sources.is_empty(),
+        "no tests/it source mentions {CALLS:?}; the matcher has stopped matching \
+         and this guard is checking nothing"
+    );
+    let mut out = BTreeMap::new();
+    for (name, text) in sources {
+        for literal in fixture_literals(&text) {
+            out.insert(literal, name.clone());
+        }
+    }
+    assert!(
+        out.len() >= MINIMUM_FIXTURES,
+        "found only {} generated fixture path(s) ({:?}); at least {MINIMUM_FIXTURES} are wired \
+         today, so the scan has gone blind rather than the repository having shrunk",
+        out.len(),
+        out.keys().collect::<Vec<_>>()
+    );
+    out
+}
+
+fn ci_workflow() -> Value {
+    let path = repo_root().join(".github/workflows/ci.yml");
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).expect("ci.yml is not valid YAML")
+}
+
+fn job<'a>(workflow: &'a Value, name: &str) -> &'a Value {
+    workflow
+        .get("jobs")
+        .and_then(|jobs| jobs.get(name))
+        .unwrap_or_else(|| panic!("ci.yml has no `{name}` job"))
+}
+
+fn steps(job: &Value) -> &[Value] {
+    job.get("steps")
+        .and_then(Value::as_sequence)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+fn uses(step: &Value) -> &str {
+    step.get("uses").and_then(Value::as_str).unwrap_or_default()
+}
+
+/// A step's `with.path`, split into lines — the multi-line block scalar form the
+/// cache and artifact steps use, and the single-path form too.
+fn with_paths(step: &Value) -> Vec<String> {
+    step.get("with")
+        .and_then(|with| with.get("path"))
+        .and_then(Value::as_str)
+        .map(|paths| {
+            paths
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn with_name(step: &Value) -> Option<&str> {
+    step.get("with")
+        .and_then(|with| with.get("name"))
+        .and_then(Value::as_str)
+}
+
+/// Where a `download-artifact` step unpacks, with any trailing slash trimmed.
+///
+/// `actions/download-artifact` defaults to the workspace root when `path` is
+/// unset, which is why the fallback is `.` rather than a panic — an omitted
+/// `path:` is a legal step and a wrong destination, and [`landing_path`] is what
+/// reports it.
+fn with_dest(step: &Value) -> String {
+    step.get("with")
+        .and_then(|with| with.get("path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|dest| !dest.is_empty())
+        .unwrap_or(".")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Where `fixture` ends up when its artifact is unpacked at `dest`.
+///
+/// `upload-artifact` roots a multi-path artifact at its paths' common ancestor,
+/// and both fixture artifacts here publish files from a single directory — so
+/// each entry is a bare file name and the landing path is `dest/<file name>`.
+fn landing_path(dest: &str, fixture: &str) -> String {
+    let file_name = fixture.rsplit('/').next().unwrap_or(fixture);
+    if dest == "." {
+        file_name.to_string()
+    } else {
+        format!("{dest}/{file_name}")
+    }
+}
+
+/// Every generated fixture is cached by `spec-fixtures` — by **every** cache
+/// step in it, restore and save alike.
+///
+/// Split from the artifact check because the two fail for different reasons and
+/// the fix differs: a path missing from the cache is re-generated on every run
+/// (wasteful but correct), while a path missing from the artifact is not
+/// generated in the consuming job at all (the defect this file records).
+#[test]
+fn every_generated_fixture_is_cached_by_the_producer_job() {
+    let workflow = ci_workflow();
+    let producer = job(&workflow, PRODUCER_JOB);
+
+    let cache_steps: Vec<&Value> = steps(producer)
+        .iter()
+        .filter(|step| uses(step).starts_with("actions/cache"))
+        .collect();
+    assert!(
+        !cache_steps.is_empty(),
+        "`{PRODUCER_JOB}` has no actions/cache step; this check would pass vacuously"
+    );
+
+    for (fixture, module) in generated_fixtures() {
+        for step in &cache_steps {
+            assert!(
+                with_paths(step).contains(&fixture),
+                "{module} regenerates {fixture} on demand, but `{PRODUCER_JOB}`'s \
+                 `{}` step does not list it. Every cache step in that job must \
+                 carry the same paths, or the entry saved is not the entry \
+                 restored.",
+                uses(step)
+            );
+        }
+    }
+}
+
+/// Every generated fixture is published from `spec-fixtures`, and every job that
+/// runs the test archive downloads the artifact carrying it.
+///
+/// This is the one that would have failed on #1646.
+#[test]
+fn every_generated_fixture_reaches_the_jobs_that_run_the_tests() {
+    let workflow = ci_workflow();
+    let producer = job(&workflow, PRODUCER_JOB);
+
+    // artifact name -> the paths it publishes
+    let mut published: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for step in steps(producer) {
+        if !uses(step).starts_with("actions/upload-artifact") {
+            continue;
+        }
+        let name = with_name(step)
+            .unwrap_or_else(|| panic!("`{PRODUCER_JOB}` uploads an artifact with no name"));
+        published
+            .entry(name.to_string())
+            .or_default()
+            .extend(with_paths(step));
+    }
+    assert!(
+        !published.is_empty(),
+        "`{PRODUCER_JOB}` uploads no artifacts; this check would pass vacuously"
+    );
+
+    // Which artifacts the consumers must therefore download, and onto which path
+    // each fixture has to land.
+    let mut required: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (fixture, module) in generated_fixtures() {
+        let carrier = published
+            .iter()
+            .find(|(_, paths)| paths.contains(&fixture))
+            .map(|(name, _)| name.clone())
+            .unwrap_or_else(|| {
+                panic!(
+                    "{module} regenerates {fixture} on demand, and `{PRODUCER_JOB}` \
+                     publishes it on no artifact — so every job running from the \
+                     nextest archive rebuilds the crate inside the test to produce \
+                     it. Add it to an upload-artifact step's `path:`."
+                )
+            });
+        required.entry(carrier).or_default().push(fixture);
+    }
+
+    // Consumers are derived, not named: any job downloading the test archive
+    // runs the `it` binary with no warm `target/`.
+    let mut consumers = 0usize;
+    for (name, definition) in workflow
+        .get("jobs")
+        .and_then(Value::as_mapping)
+        .expect("ci.yml has a jobs mapping")
+    {
+        // artifact name -> where that job unpacks it.
+        let downloads: BTreeMap<&str, String> = steps(definition)
+            .iter()
+            .filter(|step| uses(step).starts_with("actions/download-artifact"))
+            .filter_map(|step| with_name(step).map(|name| (name, with_dest(step))))
+            .collect();
+        if !downloads.contains_key(TEST_ARCHIVE) {
+            continue;
+        }
+        consumers += 1;
+        let job_name = name.as_str().unwrap_or("<unnamed>");
+        for (artifact, fixtures) in &required {
+            let dest = downloads.get(artifact.as_str()).unwrap_or_else(|| {
+                panic!(
+                    "job `{job_name}` runs the `{TEST_ARCHIVE}` test binaries but does \
+                     not download `{artifact}`, which carries a generated fixture. \
+                     Every test needing that fixture will rebuild the crate inside \
+                     its own process to produce it."
+                )
+            });
+            // Downloading it is not enough — it has to unpack where the test
+            // reads it. `upload-artifact` roots a multi-path artifact at its
+            // paths' common ancestor, so `cis-corpus` holds bare basenames and
+            // only lands correctly because the consumer sets `path:
+            // tests/fixtures/cis/`. A `path: .` would put every corpus in the
+            // repository root and send every test straight back to the nested
+            // build, with the name-only check above still green.
+            for fixture in fixtures {
+                let landed = landing_path(dest, fixture);
+                assert_eq!(
+                    &landed, fixture,
+                    "job `{job_name}` downloads `{artifact}` to `{dest}`, so \
+                     {fixture} lands at {landed} — not where the test reads it. \
+                     Set the download `path:` to the fixture's own directory."
+                );
+            }
+        }
+    }
+    assert!(
+        consumers >= 2,
+        "found {consumers} job(s) downloading `{TEST_ARCHIVE}`; `test` and \
+         `test-oracle` both do, so the derivation has gone blind"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -117,6 +117,7 @@ mod from_sequences_roundtrip;
 mod from_sequences_window_condition;
 mod gene_selector_display_preserve;
 mod gene_selector_roundtrip;
+mod generated_fixture_ci_wiring;
 mod generator_completeness;
 mod genome_ring_join;
 mod gnomad_validation;


### PR DESCRIPTION
Representation-Change: none. CI wiring and test-harness only; no watched directory is touched.

## The two `rna_*_confluence_census` tests were not slow — they were building the crate

`tests/it/cis_confluence_nr_axis.rs` landed in #1646 with no wiring in the `spec-fixtures` job. That job generates and publishes only the `g,c` corpus (`cis_confluence_corpus.json`); the `n,r` corpus it needs was never generated and never rode the `cis-corpus` artifact.

So every test in that module hits `common::fixture_gen`'s on-demand fallback: a nested `cargo run --features dev --example generate_cis_confluence_corpus -- --axes n,r`. The `test` / `test-oracle` shards run from a nextest **archive** and have no warm `target/`, so that compiles the whole crate *inside the test* — and the cost is per test **process**, which nextest gives every test.

The `g,c` sibling is the control: it runs **twice** the spellings and was three times faster, because *its* corpus was downloaded.

## Measured, `Test oracle`, before and after

Before is run 31670057963 (`main`); after is this PR's run 31671849564. Same job family, same corpus, same shard assignment.

| test | before | after |
|---|---|---|
| `cis_confluence_nr_axis::the_rna_axis_is_spelled_in_the_rna_alphabet` | 129.2s | **0.83s** |
| `cis_confluence_nr_axis::rna_five_prime_confluence_census` | 205.9s | **41.2s** |
| `cis_confluence_nr_axis::rna_three_prime_confluence_census` | >180s | **38.8s** |
| `cis_confluence_axis::three_prime_confluence_census` (`g,c`) | 88.0s | **55.2s** |

**Nothing is over nextest's 60s SLOW threshold any more.** The `g,c` row is the clean read on the rayon commit alone — that test never paid a nested build, so its 88.0 → 55.2s is parallelism and nothing else. That settles the question this PR opened as a draft: rayon is a real ~1.6× win on a 4-vCPU runner *even with nextest already running other tests concurrently*, not a wash.

The other censuses, from the sibling shards: `noncoding_three_prime` 31.5s, `noncoding_five_prime` 32.7s, `five_prime_confluence_census` 47.6s, `the_nr_corpus_is_a_dense_set…` 0.58s.

## Three commits

**`ci:` generate and publish the `n,r` corpus.** A second generation step (`--axes` defaults to `g,c` and `--output` to the other corpus, so both flags are required), the file added to the `generated-fixtures` cache restore *and* save paths, and both corpora on the one `cis-corpus` artifact — they share a directory, so the upload roots at their common ancestor and the consumers' `path: tests/fixtures/cis/` is unchanged. Verified the step's exact command reproduces byte-for-byte the corpus the tests read.

Also sets `if-no-files-found: error` on both fixture uploads, matching the `bulk-fixtures` sibling. Without it a generation step that stops writing produces a warning and an artifact missing the corpus, and every consumer falls straight back to the nested build — the same silent degradation, re-entered from the other side.

Twelve test processes per run stop paying ~120s each: six tests in the module, across the `test` (6 shards) and `test-oracle` (3 shards) families.

**`perf(test):` one reference group per rayon task.** Both confluence modules already built one provider and one normalizer per reference group; that grouping is also what makes the groups independent. The result is byte-identical to the serial walk rather than merely equivalent, which is the only basis on which a pinned census may be parallelized: every `Census` field counts over a partition of the classes so the fold is exact and order-free; `par_iter().collect()` preserves input order; and `worst` — "the first 10 divergent classes in corpus order" — is reproduced by capping per group and truncating the concatenation. All eleven pins across the two modules are unchanged.

`the_reference_groups_partition_each_axis_in_corpus_order` pins that premise. It is not decoration: the censuses would still sum to *something* if a class were dropped or double-counted, and `worst` only ever surfaces inside a failure message, so a broken partition is invisible on a green run and would move the pins silently. rayon is a non-optional dependency, so nothing is added to the tree.

**`test(ci):` refuse a generated fixture CI does not build and ship.** The guard for the class, not the instance. Three properties, each derived from the workflow rather than from a roster in the test — a hardcoded list would rot exactly the way the defect did:

1. every generated fixture path a `tests/it` module names is in **every** `actions/cache` step's `path:` in `spec-fixtures`, restore and save alike;
2. it is published on some `actions/upload-artifact` from that job;
3. every job downloading the `nextest-archive` artifact also downloads each artifact carrying a generated fixture — **and unpacks it onto the path the test actually reads**. Downloading is not enough: `upload-artifact` roots a multi-path artifact at its paths' common ancestor, so `cis-corpus` holds bare basenames and only lands correctly because the consumer sets `path: tests/fixtures/cis/`. A `path: .` would put every corpus in the repository root and send every test back to the nested build.

Both halves were checked against deliberate sabotage rather than assumed. Against the pre-fix `ci.yml`, both tests go red naming the missing path; with the `cis-corpus` destination rewritten to `path: .`, the third property goes red naming the job, the destination, and where the fixture would land.

The workflow half is parsed rather than grepped, for the reason `workflow_gh_repo_context.rs` gives: which step sits in which job is structural. The source half is a token scan and is documented as a **floor, not a proof** — a module composing its path at run time is invisible to it. Both halves carry a denominator assertion, so a matcher that stops matching fails loudly instead of passing as "nothing to check".

## Note on one earlier claim, now withdrawn

An earlier revision of this description flagged that `cis_confluence_axis::five_prime_confluence_census` read 89.4s locally against `three_prime_confluence_census`'s 7.3s, and said I could not tell whether that asymmetry was the 5' direction's own cost or something this change introduced. CI answers it: 47.6s and 55.2s respectively, with 5' the *faster* of the two. The local reading was a laptop artifact, not a regression.
