### PR TITLE
fix(normalize): anchor a 5'-edge cis insertion on -1, not the axis's absent 0

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1276,9 +1276,69 @@ fn build_genome_merged(template: &GenomeVariant, merged: Anchor) -> GenomeVarian
     }
 }
 
+/// Name a cis-collapse anchor coordinate on a signed transcript axis
+/// (`c.` / `n.` / `r.`), where the integer `0` names no nucleotide.
+///
+/// The collapse works in dense window arithmetic — `del_start - 1` for a group
+/// that nets to a pure insertion at the window's 5' edge — so the coordinate
+/// immediately 5' of `1` arrives here as `0`. The `c.`/`n.`/`r.` axes skip
+/// zero: `background/numbering.md:31`, *"there is no nucleotide `c.0`"*, and
+/// `:29` numbers the bases upstream of the start codon `c.-1`, `c.-2`, `c.-3`.
+/// So the position below `1` is named `-1`, which is the same step-down
+/// `Normalizer::cds_to_tx_pos` and `tx_to_cds_pos` make for issue #97.
+///
+/// Only `0` is remapped. The collapse restricts a group to the positive body
+/// region (issue #920) and refuses a window starting below `1`, so a body
+/// anchor endpoint is never negative on entry, and `0` arises only from the
+/// 5'-edge insertion case above.
+///
+/// Without this the builders emit `CdsPos { base: 0 }` — rendered `c.?` by
+/// `CdsPos::Display`, since `CDS_BASE_UNKNOWN` *is* `0`, so a fully known
+/// position is described as an unknown one — and `TxPos`/`RnaPos { base: 0 }`,
+/// rendered as the literal `n.0`/`r.0`, which ferro's own parser rejects.
+/// Issue #1772.
+///
+/// Deliberately **not** applied to the genomic axis: `g.`/`m.` have no negative
+/// coordinate, so an insertion 5' of `g.1` has no two-position anchor and needs
+/// its own answer rather than this one.
+///
+/// # The citation above scopes `c.`, and the three axes are not equally served
+///
+/// `:29` and `:31` sit under `numbering.md:28`'s "untranslated region (UTR)"
+/// bullet inside *"### coding DNA reference sequences"*, so on its own the
+/// clause licenses `-1` on the `c.` axis only. Read what each axis inherits
+/// before citing it here:
+///
+/// - **`c.`** — governed directly. `c.-1` is a conformant 5'UTR position.
+/// - **`r.`** — `:58` gives an RNA reference "that of the associated **coding
+///   or non-coding** DNA reference sequence", so `r.-1` is conformant against a
+///   coding RNA reference and is not against a non-coding one. This builder,
+///   like the parser (`src/hgvs/noncoding_zones.rs`), cannot tell which it has.
+/// - **`n.`** — **not** governed by `:31`. The non-coding DNA axis is `:50`-`:54`,
+///   which grants `n.1..n.N` plus intronic offsets and nothing else, and `:54`
+///   forbids naming a nucleotide beyond a transcript's boundaries using that
+///   transcript. PR #1751 (merged) implements exactly that: `n.-N` is refused at
+///   **strict** parse (`W4008`) and accepted only by lenient, silent and the
+///   bare [`crate::parse_hgvs`] entry — the last kept open for five real ClinVar
+///   rows.
+///
+/// So on `n.` this is a strict improvement and not a resolution: it replaces
+/// `n.0`, which every mode rejects and which names a nucleotide no axis has,
+/// with `n.-1`, which strict still refuses. The residue is the same open
+/// question as the genomic axis's — what a cis group nets to a pure insertion 5'
+/// of the first base of a transcript should be called at all — and it belongs
+/// with #1772 rather than to this rename.
+fn name_on_zeroless_axis(base: i64) -> i64 {
+    if base == 0 {
+        -1
+    } else {
+        base
+    }
+}
+
 fn build_cds_merged(template: &CdsVariant, merged: Anchor) -> CdsVariant {
     let (location, edit) = build_naedit(merged, |region, b| match region {
-        Region::Cds | Region::FivePrimeUtr => CdsPos::new(b),
+        Region::Cds | Region::FivePrimeUtr => CdsPos::new(name_on_zeroless_axis(b)),
         Region::ThreePrimeUtr => CdsPos {
             base: b,
             offset: None,
@@ -1296,7 +1356,7 @@ fn build_cds_merged(template: &CdsVariant, merged: Anchor) -> CdsVariant {
 
 fn build_tx_merged(template: &TxVariant, merged: Anchor) -> TxVariant {
     let (location, edit) = build_naedit(merged, |region, b| match region {
-        Region::Tx | Region::TxUpstream => TxPos::new(b),
+        Region::Tx | Region::TxUpstream => TxPos::new(name_on_zeroless_axis(b)),
         Region::TxDownstream => TxPos::downstream(b),
         _ => unreachable!("non-n. region {:?} on TxVariant", region),
     });
@@ -1309,7 +1369,7 @@ fn build_tx_merged(template: &TxVariant, merged: Anchor) -> TxVariant {
 
 fn build_rna_merged(template: &RnaVariant, merged: Anchor) -> RnaVariant {
     let (location, edit) = build_naedit(merged, |region, b| match region {
-        Region::Rna | Region::FivePrimeUtr => RnaPos::new(b),
+        Region::Rna | Region::FivePrimeUtr => RnaPos::new(name_on_zeroless_axis(b)),
         Region::ThreePrimeUtr => RnaPos::utr3(b),
         _ => unreachable!("non-r. region {:?} on RnaVariant", region),
     });
@@ -12792,6 +12852,104 @@ mod tests {
             cached_introns: std::sync::OnceLock::new(),
         });
         provider
+    }
+
+    /// A cis group that nets to a pure insertion at the 5' edge of its window
+    /// must anchor on `-1`, never on the axis's non-existent `0`.
+    ///
+    /// # Why this asserts the intermediate rather than the final string
+    ///
+    /// `collapse_overlapping_cis_edits` is the producer, and on the `c.` and
+    /// `r.` axes its output is silently repaired downstream: the `base == 0`
+    /// arms in `Normalizer::cds_to_tx_pos` and `rna_to_tx_pos` map `0` to
+    /// `cds_start - 1`, which happens to be the correct transcript coordinate
+    /// for `-1`. So `NM_TEST.1:c.[1A>G;1dup]` already normalizes to
+    /// `c.-1dup` end-to-end, and a test on that string passes with the defect
+    /// present. Asserting here, on what the collapse itself builds, is what
+    /// makes this a guard rather than a change detector — and it keeps holding
+    /// when those conversion arms are eventually retired (they are a separate
+    /// change, needing their own ruling).
+    ///
+    /// The `n.` axis has no such arm, which is why it is the one that escapes:
+    /// before this fix `NM_TEST.1:n.[1G>A;1dup]` normalized to the literal
+    /// `n.0_1insA`, a description `parse_hgvs` rejects. That is asserted too,
+    /// as the user-visible half. Issue #1772.
+    #[test]
+    fn a_five_prime_edge_insertion_anchors_below_one_not_on_zero() {
+        let provider = bounds_transcript_provider();
+        // (members, expected collapsed member)
+        let cases = [
+            (
+                ["NM_TEST.1:c.1A>G", "NM_TEST.1:c.1dup"],
+                "NM_TEST.1:c.-1_1insG",
+            ),
+            (
+                ["NM_TEST.1:n.1G>A", "NM_TEST.1:n.1dup"],
+                "NM_TEST.1:n.-1_1insA",
+            ),
+            (
+                ["NM_TEST.1:r.1a>g", "NM_TEST.1:r.1dup"],
+                "NM_TEST.1:r.-1_1insg",
+            ),
+        ];
+        for (members, expected) in cases {
+            let parsed: Vec<_> = members
+                .iter()
+                .map(|m| parse_hgvs(m).unwrap_or_else(|e| panic!("fixture {m} must parse: {e}")))
+                .collect();
+            let collapsed = collapse_overlapping_cis_edits(parsed, AllelePhase::Cis, &provider);
+            let rendered: Vec<String> = collapsed.iter().map(|v| v.to_string()).collect();
+            assert_eq!(
+                rendered,
+                vec![expected.to_string()],
+                "{members:?} must collapse onto a `-1` anchor"
+            );
+            // The half a user sees: ferro must be able to read back what it
+            // wrote. `n.0_1insA` and `r.0_1insg` both failed this before.
+            //
+            // `parse_hgvs` is the bare, mode-less entry, and on the `n.` row
+            // that is load-bearing rather than incidental: PR #1751 refuses
+            // `n.-N` at *strict* parse (`W4008`) while lenient, silent and this
+            // entry keep accepting it, for the five real ClinVar rows named in
+            // `src/hgvs/noncoding_zones.rs`. So this assertion says the output
+            // is readable on the entry every `ferro` subcommand uses — not that
+            // `n.-1_1insA` is conformant on the non-coding axis, which
+            // `numbering.md:52`/`:54` say it is not. See
+            // `name_on_zeroless_axis`'s doc comment for why that residue is
+            // still an improvement over `n.0`, and #1772 for where it is owed.
+            for r in &rendered {
+                assert!(
+                    parse_hgvs(r).is_ok(),
+                    "collapsed output {r} must re-parse (from {members:?})"
+                );
+            }
+        }
+    }
+
+    /// The same geometry away from the axis origin is untouched — the fix
+    /// remaps the single coordinate that names no nucleotide and nothing else.
+    #[test]
+    fn an_interior_insertion_anchor_is_unchanged() {
+        let provider = bounds_transcript_provider();
+        let cases = [
+            (
+                ["NM_TEST.1:c.2A>T", "NM_TEST.1:c.2dup"],
+                "NM_TEST.1:c.2_3insT",
+            ),
+            (
+                ["NM_TEST.1:n.13A>G", "NM_TEST.1:n.13dup"],
+                "NM_TEST.1:n.12_13insG",
+            ),
+        ];
+        for (members, expected) in cases {
+            let parsed: Vec<_> = members
+                .iter()
+                .map(|m| parse_hgvs(m).unwrap_or_else(|e| panic!("fixture {m} must parse: {e}")))
+                .collect();
+            let collapsed = collapse_overlapping_cis_edits(parsed, AllelePhase::Cis, &provider);
+            let rendered: Vec<String> = collapsed.iter().map(|v| v.to_string()).collect();
+            assert_eq!(rendered, vec![expected.to_string()], "{members:?}");
+        }
     }
 
     fn overrun(descriptor: &str, provider: &MockProvider) -> Option<OutOfBoundsCoordinate> {


### PR DESCRIPTION
Closes #1772.

`collapse_overlapping_cis_edits` derives an insertion anchor as `del_start - 1` in dense window arithmetic (`src/normalize/merge.rs:606-612`). When a cis group nets to a pure insertion at the 5' edge of its window, that is `0` — and the `c.`/`n.`/`r.` axes have no nucleotide `0`. The builders named the dense integer verbatim, so the anchor became `CdsPos { base: 0 }`, which `CdsPos::Display` renders as `c.?` because `CDS_BASE_UNKNOWN` *is* `0` — a fully known position described as an unknown one — and `TxPos`/`RnaPos { base: 0 }`, rendered as the literal `n.0`/`r.0`, which ferro's own parser rejects.

`background/numbering.md:31` says *"there is no nucleotide `c.0`"* and `:29` numbers the bases upstream of the start codon `c.-1`, `c.-2`, `c.-3`. So the position below `1` is `-1`. That is the same step-down `cds_to_tx_pos` and `tx_to_cds_pos` already make for #97, and the shape `respell_at_gap` already produces by converting through transcript space (`merge.rs:11193-11206`).

## Measured, before and after

Fixture is the one already in the file — `bounds_transcript_provider` (`merge.rs:11822`), CDS `13..=24` — plus `bounds_genomic_provider` for the `g.` row.

| input | collapse emits, before | after | end-to-end, before | after |
|---|---|---|---|---|
| `NM_TEST.1:c.[1A>G;1dup]` | `c.?_1insG` | `c.-1_1insG` | `c.-1dup` | `c.-1dup` |
| `NM_TEST.1:r.[1a>g;1dup]` | `r.0_1insg` (unparseable) | `r.-1_1insg` | `r.-1dup` | `r.-1dup` |
| `NM_TEST.1:n.[1G>A;1dup]` | `n.0_1insA` (unparseable) | `n.-1_1insA` | **`n.0_1insA`** (unparseable) | **`n.-1_1insA`** |
| `NM_TEST.1:c.[2A>T;2dup]` | `c.2_3insT` | unchanged | `c.2dup` | `c.2dup` |
| `NM_TEST.1:n.[13A>G;13dup]` | `n.12_13insG` | unchanged | `n.12dup` | `n.12dup` |
| `NC_TEST.1:g.[1T>A;1dup]` | `g.0_1insA` (unparseable) | unchanged, see scope | `g.1delinsAT` | `g.1delinsAT` |

**Exactly one end-to-end output moves: the `n.` row.** The `c.` and `r.` rows do not, because their malformed intermediate was already being silently repaired downstream — see below. Control rows away from the axis origin are untouched, which is the point of the second guard.

## Why the guards assert the intermediate, not the final string

On `c.` and `r.` the broken anchor never reaches the user: the `base == 0` arms in `Normalizer::cds_to_tx_pos` (`src/normalize/mod.rs:11754-11758`) and `rna_to_tx_pos` (`mod.rs:8994-8996`) map `0` to `cds_start - 1`, which happens to be the correct transcript coordinate for `-1`. So an end-to-end assertion on `c.-1dup` passes with the defect fully present, and would be a change detector rather than a guard.

`a_five_prime_edge_insertion_anchors_below_one_not_on_zero` therefore asserts what `collapse_overlapping_cis_edits` itself builds, on all three axes, plus that each collapsed member re-parses — the user-visible half, which `n.` and `r.` both failed. Sabotage check: reverting `name_on_zeroless_axis` to the identity turns it red with `left: ["NM_TEST.1:c.?_1insG"]` / `right: ["NM_TEST.1:c.-1_1insG"]`, while the interior-anchor control stays green.

## This is the prerequisite PR 10 was missing

**This PR deliberately does not touch the `base == 0` arm in `cds_to_tx_pos`, or its siblings in `rna_to_tx_pos` and `cds_pos_to_tx_boundary.`** Retiring them is a separate change: the two conversion layers currently answer base 0 differently (`CoordinateMapper::cds_to_tx` treats it as `c.1`, `Normalizer::cds_to_tx_pos` as `c.-1`), which needs its own ruling and its own disclosure.

What this PR does is remove the arm's remaining reason to exist on this path. Measured with a `panic!` in that arm over the full `--lib --test it` suite:

- on `origin/main`: exactly **one** test reaches it, `issue_1284_transcript_axis_reparse::no_transcript_axis_two_member_allele_fails_to_reparse`, with `CdsPos { base: 0, offset: None, utr3: false, special: None }` and `cds_start = 13` — i.e. this defect, and nothing else;
- with this fix: **zero** hits, 10,240 passed.

Fixing the consumer first would not have been safe. With the arm replaced by an error and this producer unfixed, `NM_TEST.1:c.[1A>G;1dup]` normalizes to `NM_TEST.1:c.?_1insG` — the malformed intermediate becomes the user-visible answer — and **no test goes red** (10,238 passed either way), because the one test that reaches the arm asserts only that the output re-parses, and `c.?_1insG` does.

## Scope

The `g.`/`m.` axis hits the same two lines and also builds a `g.0` anchor, and is deliberately left alone: there is no negative genomic coordinate, so an insertion 5' of `g.1` has no two-position anchor and needs its own answer rather than this one. Its end-to-end output already recovers to a valid `g.1delinsAT`, so nothing is emitted broken today. Noted in #1772.

The dense window arithmetic and the `start == end + 1` insertion invariant (`merge.rs:1374-1378`) are untouched — only the step that names a dense integer as a position changes, which is where the axis is known.

## Verification

Real exit codes, each captured immediately after its command rather than read through a pipe.

```
cargo fmt --all --check                              EXIT=0
cargo clippy --features dev --lib -- -D warnings     EXIT=0
cargo clippy --features python --lib -- -D warnings  EXIT=0
cargo ta                                             EXIT=0   10431 passed, 152 skipped
```

Four seam oracles, same command and same selection on both sides, `origin/main` as the baseline:

```
FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 FERRO_ASSERT_SEQUENCE=1 \
  cargo nextest run --features dev --lib --test it \
  -E 'not test(normalization_transcripts_exon_contract)'
```

**17 failures before, 17 after — identical sets, zero new and zero fixed.** All 17 are inherited from `origin/main` (`defect_non_idempotent_outputs`, `issue_1487_canonical_window_overflow`, `spec_conformance_axis`, `spec_corpus_regressions`, `stranded_identity_member`); this change neither adds to nor clears that residue.

Representation-Change: 1 shape moves. A cis allele that nets to a pure insertion at the 5' edge of the window on the `n.` axis respells from `n.0_1insA` to `n.-1_1insA` — measured on `NM_TEST.1:n.[1G>A;1dup]`. The previous output names a position that does not exist and `parse_hgvs` rejects it, so no consumer can be holding it as a parsed value; this replaces an unreadable description with a readable one. The `c.` and `r.` equivalents do **not** move (`c.-1dup` and `r.-1dup` on both sides, measured), because their malformed intermediate was already repaired downstream by the `base == 0` conversion arms. No genomic-axis row moves, and no row away from the axis origin moves.
