### PR TITLE
refactor(hgvs): one definition of the unknown-offset sentinel pair

### DIFF
--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -45,7 +45,15 @@ pub struct GenomePos {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub special: Option<SpecialPosition>,
     /// Optional offset from the base position (e.g., -? for uncertain upstream, +? for uncertain downstream)
-    /// Uses i64::MIN for uncertain negative offset (-?) and i64::MAX for uncertain positive offset (+?)
+    ///
+    /// The uncertain forms are stored in band, as
+    /// [`OFFSET_UNKNOWN_POSITIVE`] (`+?`) and [`OFFSET_UNKNOWN_NEGATIVE`]
+    /// (`-?`). Name the constants rather than their current values: they are
+    /// defined in exactly one place, and a doc that respells them as literals
+    /// is a second declaration in prose.
+    ///
+    /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+    /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
 }
@@ -100,10 +108,25 @@ impl GenomePos {
     }
 }
 
-/// Sentinel value for unknown positive offset (+?)
-pub const GENOME_OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
-/// Sentinel value for unknown negative offset (-?)
-pub const GENOME_OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
+/// The unknown-offset sentinels, under their historical genome-axis names.
+///
+/// These are **re-exports**, not a second definition. The pair is defined once,
+/// by the parser that produces it
+/// ([`crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE`] and its negative
+/// twin), because the values enter the AST there and every axis — `g.`, `c.`,
+/// `n.`, `r.` — stores the same two.
+///
+/// They were previously declared here as their own `pub const`s, spelled as
+/// bare `i64::MAX` / `i64::MIN` literals. That is the same failure mode
+/// `unknown_offset_marker` was extracted to remove, one level up: two
+/// independent definitions of one value pair, where changing either leaves the
+/// other silently behind and the rendering stops matching the parser. Kept as
+/// aliases rather than deleted because they are public API of a published
+/// crate.
+pub use crate::hgvs::parser::position::{
+    OFFSET_UNKNOWN_NEGATIVE as GENOME_OFFSET_UNKNOWN_NEGATIVE,
+    OFFSET_UNKNOWN_POSITIVE as GENOME_OFFSET_UNKNOWN_POSITIVE,
+};
 
 /// The rendered form of an unknown-offset sentinel (`+?` / `-?`), or `None`
 /// when `offset` is a measured intronic distance.

--- a/src/hgvs/parser/position.rs
+++ b/src/hgvs/parser/position.rs
@@ -74,7 +74,7 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
     }
 }
 
-/// Parse an intronic offset (+5, -10, etc.)
+/// Sentinel value for unknown positive offset (`+?` in HGVS notation)
 ///
 /// # Sentinel Values for Unknown Offsets
 ///
@@ -89,6 +89,9 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
 /// 2. Using the type's extreme values avoids the need for an Option wrapper
 /// 3. Callers can check for unknown offsets by comparing against these constants
 ///
+/// This pair is the crate's single definition of the two values;
+/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}` re-exports it.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -96,11 +99,16 @@ pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
 ///     // Handle unknown positive offset (+?)
 /// }
 /// ```
-/// Sentinel value for unknown positive offset (`+?` in HGVS notation)
 pub const OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
 /// Sentinel value for unknown negative offset (`-?` in HGVS notation)
+///
+/// See [`OFFSET_UNKNOWN_POSITIVE`] for why these values were chosen.
 pub const OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
 
+/// Parse an intronic offset (+5, -10, etc.)
+///
+/// Returns [`OFFSET_UNKNOWN_POSITIVE`] / [`OFFSET_UNKNOWN_NEGATIVE`] for the
+/// uncertain forms `+?` / `-?`.
 #[inline]
 fn parse_offset(input: &str) -> IResult<&str, i64> {
     let (input, sign) = alt((char('+'), char('-'))).parse(input)?;

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1278,6 +1278,10 @@ pub(crate) fn cis_member_order_key(
     // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
     // field order, which is exactly the comparison this key wants, so the points
     // go in whole rather than flattened into six scalars.
+    // Unrelated to the unknown-OFFSET sentinels (`OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`,
+    // re-exported as `GENOME_OFFSET_UNKNOWN_*`): this is a sorts-last key for a point
+    // that has no position, not a `+?`/`-?` marker. It happens to reuse `i64::MAX`
+    // because that is what "sorts last" spells.
     let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
     let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
     (accession, start, end, junction_rank(v), descriptor)

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1163,24 +1163,21 @@ fn self_cancelling_descriptor(
 
 /// Return `Some(offset)` if `raw` is a concrete intronic offset, or
 /// `None` if it is one of the parser's "unknown offset" sentinels
-/// (`+?` → `i64::MAX`, `-?` → `i64::MIN`; see
-/// `parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}` and
-/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`). The
+/// (`+?` / `-?`; see
+/// `parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`). The
 /// self-cancelling detector skips any endpoint with an unknown offset
 /// because overlap is undecidable.
+///
+/// This used to test four names: the parser's pair *and*
+/// `location::GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`, which were a
+/// separate declaration of the same two values. Those are now aliases of the
+/// constants below, so the extra two arms tested the same values twice —
+/// every axis stores the one pair the parser produces.
 fn certain_offset(raw: Option<i64>) -> Option<i64> {
-    use crate::hgvs::location::{GENOME_OFFSET_UNKNOWN_NEGATIVE, GENOME_OFFSET_UNKNOWN_POSITIVE};
     use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
     match raw {
         None => Some(0),
-        Some(v)
-            if v == OFFSET_UNKNOWN_POSITIVE
-                || v == OFFSET_UNKNOWN_NEGATIVE
-                || v == GENOME_OFFSET_UNKNOWN_POSITIVE
-                || v == GENOME_OFFSET_UNKNOWN_NEGATIVE =>
-        {
-            None
-        }
+        Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE) => None,
         Some(v) => Some(v),
     }
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -430,6 +430,7 @@ mod normalize_property_tests;
 mod normalize_reparse_invariant;
 mod normalize_tests;
 mod normalize_warning_seam;
+mod one_unknown_offset_sentinel_definition;
 mod oracle_exclude_invariant;
 mod paraphase_exhaustive_tests;
 mod parser_tests;

--- a/tests/it/one_unknown_offset_sentinel_definition.rs
+++ b/tests/it/one_unknown_offset_sentinel_definition.rs
@@ -1,0 +1,157 @@
+//! One definition of the unknown-offset sentinel pair, guarded against
+//! re-divergence.
+//!
+//! `+?` / `-?` are stored in band, as two extreme `i64` values. Those two values
+//! used to be declared **twice**: once by the parser that produces them
+//! (`parser::position::OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`) and once, as bare
+//! `i64::MAX` / `i64::MIN` literals, by `location::GENOME_OFFSET_UNKNOWN_*`.
+//! Nothing tied the two declarations together, so changing either would leave
+//! the other behind: the parser would store one value and every `Display` — all
+//! of which key off the parser's pair — would fail to recognise it and print a
+//! raw 19-digit integer where a `?` belongs. That is the leak #1762 fixed for
+//! `TxPos`/`RnaPos`, re-armed by a different mechanism.
+//!
+//! The collapse makes the divergence unrepresentable: `GENOME_OFFSET_UNKNOWN_*`
+//! is now a re-export of the parser's pair, so there is one definition and one
+//! literal `i64::MAX` / `i64::MIN` in the crate. The names are kept because they
+//! are public API of a published crate.
+//!
+//! **Why these assertions are not tautological.** Comparing the two constants to
+//! each other would be — they are the same item today, so `assert_eq!` holds by
+//! definition and would keep holding if the collapse were undone with two
+//! matching literals. So nothing here compares a constant to a constant. Every
+//! assertion compares a **named constant against a value the parser actually
+//! produced** from the text `+?` / `-?`, or against what the renderer actually
+//! prints. The parser is driven by the canonical constant and knows nothing of
+//! the alias; so if the alias is ever re-declared independently and drifts, the
+//! parsed value stops matching the name this test asserts it against, and the
+//! test fails. That is true of a re-declaration that is *initially* equal, too —
+//! it only has to be checked once it drifts, which is exactly when it matters.
+
+use ferro_hgvs::hgvs::location::{
+    CdsPos, GenomePos, RnaPos, TxPos, GENOME_OFFSET_UNKNOWN_NEGATIVE,
+    GENOME_OFFSET_UNKNOWN_POSITIVE,
+};
+use ferro_hgvs::hgvs::parser::position::{
+    parse_cds_pos, parse_genome_pos, parse_rna_pos, parse_tx_pos, OFFSET_UNKNOWN_NEGATIVE,
+    OFFSET_UNKNOWN_POSITIVE,
+};
+use ferro_hgvs::parse_hgvs;
+
+/// The genome axis is the one that carries the alias, so it is the axis where a
+/// re-divergence would first show. `parse_genome_pos` resolves `+?` through the
+/// shared `parse_offset`, which is keyed off the *canonical* constant — so this
+/// asserts the alias against a value produced without reference to it.
+#[test]
+fn the_genome_axis_alias_names_the_value_the_parser_produces() {
+    let (rest, pos) = parse_genome_pos("100+?").expect("g. position with an unknown offset");
+    assert!(rest.is_empty(), "the whole position must be consumed");
+    assert_eq!(
+        pos.offset,
+        Some(GENOME_OFFSET_UNKNOWN_POSITIVE),
+        "the parser stored an offset that GENOME_OFFSET_UNKNOWN_POSITIVE does \
+         not name — the alias has drifted from the definition it re-exports"
+    );
+
+    let (rest, pos) = parse_genome_pos("100-?").expect("g. position with an unknown offset");
+    assert!(rest.is_empty(), "the whole position must be consumed");
+    assert_eq!(
+        pos.offset,
+        Some(GENOME_OFFSET_UNKNOWN_NEGATIVE),
+        "the parser stored an offset that GENOME_OFFSET_UNKNOWN_NEGATIVE does \
+         not name — the alias has drifted from the definition it re-exports"
+    );
+}
+
+/// The same question on the three transcript-relative axes, under the canonical
+/// name. Every axis stores the one pair, which is the fact that makes a
+/// genome-specific spelling of it wrong.
+#[test]
+fn every_axis_stores_the_one_sentinel_pair_the_parser_produces() {
+    let (rest, cds) = parse_cds_pos("100+?").expect("c. position with an unknown offset");
+    assert!(rest.is_empty(), "c.100+? must be consumed whole");
+    assert_eq!(cds.offset, Some(OFFSET_UNKNOWN_POSITIVE), "c.100+?");
+    let (rest, cds) = parse_cds_pos("100-?").expect("c. position with an unknown offset");
+    assert!(rest.is_empty(), "c.100-? must be consumed whole");
+    assert_eq!(cds.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "c.100-?");
+
+    let (rest, tx) = parse_tx_pos("100+?").expect("n. position with an unknown offset");
+    assert!(rest.is_empty(), "n.100+? must be consumed whole");
+    assert_eq!(tx.offset, Some(OFFSET_UNKNOWN_POSITIVE), "n.100+?");
+    let (rest, tx) = parse_tx_pos("100-?").expect("n. position with an unknown offset");
+    assert!(rest.is_empty(), "n.100-? must be consumed whole");
+    assert_eq!(tx.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "n.100-?");
+
+    let (rest, rna) = parse_rna_pos("100+?").expect("r. position with an unknown offset");
+    assert!(rest.is_empty(), "r.100+? must be consumed whole");
+    assert_eq!(rna.offset, Some(OFFSET_UNKNOWN_POSITIVE), "r.100+?");
+    let (rest, rna) = parse_rna_pos("100-?").expect("r. position with an unknown offset");
+    assert!(rest.is_empty(), "r.100-? must be consumed whole");
+    assert_eq!(rna.offset, Some(OFFSET_UNKNOWN_NEGATIVE), "r.100-?");
+}
+
+/// The other half of the seam: a position *built from the named constant* must
+/// render as `?`. Together with the two tests above this closes the loop —
+/// parser -> constant -> renderer — without ever comparing a constant to a
+/// constant. A drifted alias fails here by printing its 19-digit value, which is
+/// the exact symptom the sentinel pair exists to prevent.
+#[test]
+fn a_position_built_from_the_named_sentinel_renders_as_a_question_mark() {
+    assert_eq!(
+        GenomePos::with_offset(100, GENOME_OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+    assert_eq!(
+        GenomePos::with_offset(100, GENOME_OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "100-?"
+    );
+    assert_eq!(
+        CdsPos::with_offset(100, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+    assert_eq!(
+        TxPos::with_offset(100, OFFSET_UNKNOWN_NEGATIVE).to_string(),
+        "100-?"
+    );
+    assert_eq!(
+        RnaPos::with_offset(100, OFFSET_UNKNOWN_POSITIVE).to_string(),
+        "100+?"
+    );
+}
+
+/// End to end through the public entry point, on the genome axis — the axis
+/// #1762's round-trip test did not cover, and the one whose sentinel name is now
+/// an alias. A drifted alias would not fail this on its own; it is here so the
+/// alias's axis has a whole-description guard rather than only a position-level
+/// one.
+#[test]
+fn a_parsed_genomic_unknown_offset_round_trips() {
+    for input in ["NC_000001.11:g.100+?del", "NC_000001.11:g.100-?del"] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        assert_eq!(
+            parsed.to_string(),
+            input,
+            "an unknown offset must render back as `?`, not as the i64 sentinel"
+        );
+    }
+}
+
+/// A control, so the assertions above cannot pass by the renderer printing `?`
+/// for everything: an ordinary offset one step inside the sentinel still renders
+/// as a number. This is what pins the sentinel band at exactly two values.
+#[test]
+fn an_ordinary_offset_next_to_the_sentinel_still_renders_numerically() {
+    let near_positive = OFFSET_UNKNOWN_POSITIVE - 1;
+    let near_negative = OFFSET_UNKNOWN_NEGATIVE + 1;
+
+    assert_eq!(
+        GenomePos::with_offset(100, near_positive).to_string(),
+        format!("100+{near_positive}"),
+        "only the sentinel itself may render as `+?`"
+    );
+    assert_eq!(
+        CdsPos::with_offset(100, near_negative).to_string(),
+        format!("100{near_negative}"),
+        "only the sentinel itself may render as `-?`"
+    );
+}


### PR DESCRIPTION
Follow-up to #1762, completing the same finding. #1762 removed the *third* spelling of the unknown-offset sentinel pair — `CdsPos::Display` no longer compares bare `i64::MAX` / `i64::MIN` literals, and `TxPos`/`RnaPos` render through the shared `unknown_offset_marker` helper. What it left behind is the residue: the pair was still **defined twice**.

```rust
src/hgvs/parser/position.rs  pub const OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
src/hgvs/parser/position.rs  pub const OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
src/hgvs/location.rs         pub const GENOME_OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
src/hgvs/location.rs         pub const GENOME_OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
```

Two independent definitions of one value pair, with nothing tying them together. Change either and the other is silently left behind: the parser stores one value while every `Display` — all of which key off the parser's pair — stops recognising it and prints a raw 19-digit integer where a `?` belongs. That is exactly the leak #1762 fixed for `TxPos`/`RnaPos`, still armed by a different mechanism.

## The parser's name is canonical

`OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}` wins on three grounds:

- **It is not genome-specific, and the value isn't either.** All four axes store the same two values — `parse_genome_pos`, `parse_cds_pos`, `parse_tx_pos` and `parse_rna_pos` all resolve `+?` / `-?` through the one shared `parse_offset`. A `GENOME_`-prefixed name for a value the `c.`, `n.` and `r.` axes carry equally is a misnomer, and the misnomer is what made a second declaration look reasonable in the first place.
- **The values originate there.** `parse_offset` is the sole producer — the fast path defers `+?` / `-?` to the generic parser rather than synthesising its own (`scan_cds_sub_position`), so there is one point of entry into the AST.
- **It is already the name in use.** Before this change `GENOME_OFFSET_UNKNOWN_*` had exactly one consumer outside its own declaration; the parser's pair is used across `location.rs`, `parser/position.rs`, `variant.rs`, `data/mapping.rs`, `normalize/mod.rs` and the tests.

## The old name is kept, as a re-export

`GENOME_OFFSET_UNKNOWN_*` is `pub` in a published crate, so deleting it is a breaking change for external consumers. It stays, as a re-export of the canonical pair:

```rust
pub use crate::hgvs::parser::position::{
    OFFSET_UNKNOWN_NEGATIVE as GENOME_OFFSET_UNKNOWN_NEGATIVE,
    OFFSET_UNKNOWN_POSITIVE as GENOME_OFFSET_UNKNOWN_POSITIVE,
};
```

A re-export rather than `pub const GENOME_… : i64 = OFFSET_…;` because it makes divergence *unrepresentable* rather than merely unlikely — it is literally the same item, not a second item that currently agrees. It also matches how the crate re-exports elsewhere (`lib.rs` is all `pub use`). Every path that resolved `ferro_hgvs::hgvs::location::GENOME_OFFSET_UNKNOWN_POSITIVE` still resolves.

There is **one** literal `i64::MAX` / `i64::MIN` definition of the pair left in the crate, in `parser/position.rs`.

The Python surface is unaffected: neither name appears in `src/python.rs` or `python/ferro_hgvs/__init__.pyi`, so there is no second compatibility surface to preserve.

## The one comparison site

`variant.rs::certain_offset` tested four names for two values. It now tests two, in the constant-pattern form the rest of the file already uses. This is a no-op — the two dropped arms compared the same two values a second time.

## The divergence guard

`tests/it/one_unknown_offset_sentinel_definition.rs` is the tripwire for someone re-introducing a second declaration.

**Nothing in it compares a constant to a constant.** That assertion would be tautological today — after the collapse the two names *are* one item, so it holds by definition, and it would keep holding if the collapse were undone with two literals that happen to match. Instead every assertion compares a **named constant against a value the parser actually produced** from the text `+?` / `-?`, or against what the renderer actually prints:

- `parse_genome_pos("100+?")` / `("100-?")` must yield exactly `GENOME_OFFSET_UNKNOWN_{POSITIVE,NEGATIVE}`. This is the load-bearing one: the parser is driven by the *canonical* constant and knows nothing of the alias, so a re-declared alias that drifts stops matching the name this asserts it against.
- The same question on `c.`, `n.` and `r.` under the canonical name — the fact that pins "one pair, every axis".
- A position **built from** each named constant must render as `+?` / `-?`, closing the parser → constant → renderer loop from the other end. A drifted alias fails here by printing its 19-digit value, which is the symptom the sentinel exists to prevent.
- A whole-description round trip on the genome axis (`NC_000001.11:g.100+?del`), the axis that carries the alias and the one #1762's round-trip test did not cover.
- A control: an ordinary offset one step inside each sentinel still renders numerically, so the sentinel band is pinned at exactly two values and the assertions above cannot pass by the renderer printing `?` for everything.

## Stacking — this PR is based on #1762, not on `main`

This branch is based on `fix/downstream-flag-and-offset-sentinel` (#1762), at **`d8e3cd0bcb27d312ac0efce46bbb03988d688292`**, and its base branch is set accordingly.

Because the repo squash-merges, once #1762 lands this branch must be re-parented onto #1762's **squash commit** and retargeted to `main` before it can enter the merge queue:

```bash
git rebase --onto <#1762-squash-commit-on-main> d8e3cd0bcb27d312ac0efce46bbb03988d688292 \
  refactor/one-unknown-offset-sentinel-definition
gh pr edit <this-PR> --base main
```

A plain `git rebase origin/main` will **not** work — it replays #1762's own commit on top of the squash of that same commit and conflicts. (#1747 is sitting `CONFLICTING` right now for exactly this reason after its base merged.)

Representation-Change: none. Two constants holding equal values are collapsed into one definition plus a re-export; no value and no rendered string changes. The only behavioural code touched is `certain_offset`, where two of four comparison arms tested the same two values a second time and were dropped. The rest is a new test and documentation.
