### PR TITLE
ci: skip the LFS smudge while release-plz walks history

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,3 +38,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # release-plz determines the next version by walking history one
+          # commit at a time with `git checkout <sha>`, running `cargo package`
+          # at each. Every commit before #1750 still tracks the four bulk
+          # fixtures through Git LFS, and the account's LFS budget is
+          # exhausted, so stepping across that boundary makes git run the
+          # smudge filter, fail the download, and ABORT THE CHECKOUT PART-WAY
+          # — leaving 34 files from the older commit in the tree. release-plz
+          # reads that error as "there are no other commits", stops walking,
+          # and its final `git checkout main` then dies on the dirty tree.
+          #
+          # The failure surfaces as a git error naming an unrelated file
+          # (`.github/workflows/ci.yml`, the only one of the 34 that has since
+          # changed on main), which is why it looks nothing like an LFS
+          # problem. It was silent before that: the truncated walk analysed 4-8
+          # commits instead of ~90, so the version bump was computed from a
+          # fraction of the cycle while the job still reported success.
+          #
+          # Skipping the smudge leaves those paths as pointer files, which is
+          # harmless here: they are `exclude`d from the package in Cargo.toml,
+          # so they never enter the comparison release-plz is making.
+          GIT_LFS_SKIP_SMUDGE: "1"


### PR DESCRIPTION
Every push to `main` since #1735 has failed the `release` job ([run 31674038109](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31674038109/job/94364576334), and the three before it):

```
failed to determine next versions
  1: failed to retrieve difference of package ferro-hgvs
  2: can't checkout to head after calculating diff
  4: error while running git ... with args ["checkout", "main"]:
     - stderr: error: Your local changes to the following files would be overwritten by checkout:
       .github/workflows/ci.yml
```

Nothing in that job writes `ci.yml`. The cause is Git LFS, and the named file is a bystander.

## What actually happens

release-plz determines the next version by walking `main` backwards one commit at a time — `git checkout <sha>`, then `cargo package` — until the packaged files match the published crate. Every commit before #1750 still tracks the four bulk fixtures through LFS, and the account's LFS budget is exhausted (that is what #1750 was about). So the first step across that boundary, from `e98fa77e` to its parent `b49c5ce3`, makes git run the smudge filter:

```
Downloading tests/fixtures/bulk/clinvar_hgvs_500k.json.gz (18 MB)
Error downloading object: ... This repository exceeded its LFS budget.
error: external filter 'git-lfs filter-process' failed
fatal: tests/fixtures/bulk/clinvar_hgvs_500k.json.gz: smudge filter lfs failed
```

The checkout **aborts part-way**: HEAD stays at `e98fa77e`, but 34 files from `b49c5ce3` have already been written into the tree. release-plz treats any failure there as "there are no other commits" ([`updater.rs`](https://github.com/release-plz/release-plz/blob/main/crates/release_plz_core/src/command/update/updater.rs)), breaks out of the walk, and its closing `git checkout main` then refuses because the tree is dirty.

`.github/workflows/ci.yml` is named because it is the **only one of those 34 files that has changed on `main` since #1750**. Before #1735 all 34 were byte-identical between `e98fa77e` and `main`, so git carried the modifications across the branch switch and the job went green. That is the whole of why this started when it did, and why the error points at a file that has nothing to do with it.

## It was already broken before it was red

The truncated walk analysed **4–8** commits instead of the ~90 the cycle contains. Runs before #1750 analysed 78–84; the runs on 2026-08-13 between 00:45 and 04:09 that *reported success* analysed 4–8. Those green runs were computing the version bump and changelog from a fraction of the release cycle. Measured by counting `Getting packaged files` in each run's log.

## The fix

`GIT_LFS_SKIP_SMUDGE: "1"` on the release-plz step, so a historical checkout leaves those paths as pointer files instead of aborting. They are `exclude`d from the package in `Cargo.toml`, so they never enter the comparison release-plz is making.

## Verification

Against release-plz 0.3.160 on a fresh clone of `main`, reproducing the CI failure exactly (same error, same file):

| | result |
|---|---|
| without the variable | exit 1, walk stops after 8 commits, dies on `checkout main` |
| with the variable | exit 0, walks 92 commits, reports `0.13.1 -> 0.14.0` |

The full walk takes ~5 min locally, so expect the job to get noticeably longer — that is the work it should have been doing all along.

`actionlint` and `zizmor 1.24.1` are clean over `.github/workflows/`.

## Note

This does not restore LFS access, and nothing here depends on it. If the budget is ever topped up, the variable stays correct: it only says this job has no use for the objects.

Representation-Change: none. CI-only; no file under `src/` is touched.
