### PR TITLE
perf(test): parallelize the three remaining slow censuses, and cut the per-row cost of the two biggest

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,24 @@
 # Codecov configuration
 # https://docs.codecov.com/docs/codecovyml-reference
 
+# The `Code Coverage` job is a 4-way matrix, so a commit gets FOUR uploads and
+# Codecov merges them server-side. Verified: the sharded run reports 82.52%
+# against 82.51-82.53% for the unsharded runs either side of it, so the merge is
+# exact.
+#
+# `after_n_builds` makes it deterministic rather than eventually-consistent.
+# Without it Codecov posts a status as soon as the FIRST upload lands — one
+# shard's quarter of the suite — and corrects as the rest arrive, so anyone
+# reading the check in that window sees a coverage collapse that is not real.
+# Both statuses are `informational: true` so nothing blocks either way; what this
+# removes is the misleading transient.
+#
+# Keep this equal to the shard count in `.github/workflows/coverage.yml`. Set it
+# too HIGH and no status is ever posted; too low and the race returns.
+codecov:
+  notify:
+    after_n_builds: 4
+
 coverage:
   status:
     project:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1184,8 +1184,39 @@ jobs:
   # what the oracle asserts, so re-rolling thousands of random cases here checks
   # nothing the plain run did not already check — it just cost ~80s of every CI
   # run. The deep random coverage lives in the `soak` job below instead.
+  # FOUR shards, and the number is CHOSEN rather than conventional.
+  #
+  # `--partition hash:K/N` assigns each test by a hash of its NAME, so it
+  # balances test *counts* and is blind to duration. At N=3 the two bulk
+  # axis-preservation corpora — the two slowest tests in the repository under the
+  # oracles — both hashed into shard 1, every run, deterministically:
+  #
+  #     Test oracle (1/3)  242s     <- axis_is_preserved_over_the_{cmrg,clinvar_unique}_corpus
+  #     Test oracle (2/3)   94s
+  #     Test oracle (3/3)   77s
+  #
+  # 413s of work split 242/94/77 instead of ~138 each, so the job's critical path
+  # was one unlucky draw.
+  #
+  # N=4 separates them (cmrg -> 1, clinvar_unique -> 3). That is measured, not
+  # hoped for, and it is re-derivable — N=5 also separates them and N=6 puts them
+  # back together, so the number is not monotone and cannot be reasoned about:
+  #
+  #     for K in 1 2 3 4; do
+  #       cargo nextest list --features dev --test it --partition "hash:$K/4" \
+  #         -E 'test(axis_is_preserved_over_the_cmrg_corpus) or
+  #             test(axis_is_preserved_over_the_clinvar_unique_corpus)'
+  #     done
+  #
+  # **This placement is a property of the whole test-NAME set, so adding or
+  # renaming tests re-rolls it.** If this job's shards go lopsided again, re-run
+  # the loop above before assuming anything else changed. The robust alternative
+  # — giving `normalize_axis_preserving` a job of its own and negating it here —
+  # was not taken because this job's `-E` is re-derived by BOTH
+  # `scripts/run_oracle_suite.sh` and `tests/it/oracle_exclude_invariant.rs`, so
+  # a fourth negation term is a three-file change; the shard count is not.
   test-oracle:
-    name: Test oracle (${{ matrix.shard }}/3)
+    name: Test oracle (${{ matrix.shard }}/4)
     needs: [test-build, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
     env:
@@ -1193,7 +1224,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1319,7 +1350,7 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/3 \
+            --partition hash:${{ matrix.shard }}/4 \
             -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE)"
 
   # 1,000,000-case idempotency soak on every PR, split 8 ways.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,9 +28,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Sharded, because this is the longest job in the repository and the only long
+  # one that was not: 609s against 353s for the next slowest, all of it one step,
+  # on one runner.
+  #
+  # `cargo llvm-cov` with no subcommand shells out to `cargo test`, which offers
+  # no way to partition. `cargo llvm-cov nextest` does, and that is the ONLY
+  # reason nextest is back here: unsharded it was measured **worse** — 566s ->
+  # 649s for the run step — because nextest gives each of ~10,400 tests its own
+  # process and llvm-cov must merge a `.profraw` per process, so its cost scales
+  # with the test count that is meant to be its advantage. Sharding is what pays
+  # for that merge: the per-shard test set is a quarter the size, and four
+  # runners absorb it in parallel.
+  #
+  # Codecov merges the four uploads for a commit server-side, which is the
+  # ordinary matrix-build path and needs no merge job here.
+  #
+  # Doctests are NOT here — see the `doctests` job below for why they exist at
+  # all and why they are not a coverage shard.
   coverage:
-    name: Code Coverage
+    name: Code Coverage (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -43,6 +65,9 @@ jobs:
         with:
           toolchain: stable
       - uses: taiki-e/install-action@3f7f2bd74f95d407a45d96b106f26d4f6c238fab  # cargo-llvm-cov
+      # Partitioning is a nextest feature; see the note on the job above for why
+      # that is the whole reason it is here. Same pinned revision `ci.yml` uses.
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       # Cargo caching is delegated to `Swatinem/rust-cache` (#1218) — see the
       # full rationale on the first such step in `ci.yml`. In short: the
       # hand-rolled entries had grown to ~3 GiB each because they cached a whole
@@ -70,6 +95,17 @@ jobs:
           # dependency-bumping PRs, against every cache in the repo currently racing
           # eviction.
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # ONE key across all four shards, deliberately. `--partition hash:K/N`
+          # is a nextest RUNTIME filter: every shard compiles the identical
+          # `target/`, so a per-shard key would store four copies of one tree.
+          # That is not a hypothetical cost — this entry measured 737 MB, and the
+          # repository's cache sits at 10.73 GB against a 10 GiB cap (146 entries,
+          # 2026-08-13), so four generations would add ~2.2 GB to a budget already
+          # at 100% and evict by LRU. #1218 records that exact failure taking the
+          # nightly's 3.25 GB `ferro-manifest-v3` with it.
+          #
+          # Four shards racing one key on `main` is benign: the first save wins
+          # and the rest no-op on "cache already exists".
           key: coverage
           # This job needs it too, and needs it more than `ci.yml`'s two do
           # (#1396). `install-action` puts `cargo-llvm-cov` into
@@ -96,7 +132,9 @@ jobs:
           # Absence of a bulk fixture fails the run rather than skipping it.
           FERRO_REQUIRE_BULK_FIXTURES: "1"
         run: |
-          cargo llvm-cov --features dev --codecov --output-path codecov.json
+          cargo llvm-cov --no-report nextest --features dev \
+            --partition hash:${{ matrix.shard }}/4
+          cargo llvm-cov report --codecov --output-path codecov.json
           cargo llvm-cov report --html --output-dir coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
@@ -105,12 +143,58 @@ jobs:
           fail_ci_if_error: false
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.shard }}
           path: coverage/
           retention-days: 30
 
+  # Doctests, in a job of their own.
+  #
+  # They have to run SOMEWHERE: `nextest` does not run them, this repository has
+  # 230, and `cargo llvm-cov` with no subcommand — the form this workflow used
+  # before it was sharded — ran them via `cargo test`. Dropping them when the
+  # coverage job moved to nextest would have been a speedup made of deleted
+  # checks, which is the failure mode this whole branch keeps running into.
+  #
+  # They are not a coverage shard, and that is deliberate rather than a
+  # simplification: `cargo llvm-cov` excludes doctest coverage unless
+  # `--doctests` is passed, which needs nightly. So their coverage was never
+  # counted here, before or after, and instrumenting them would buy nothing while
+  # adding a fifth `.profraw` set for Codecov to merge.
+  #
+  # Why a job rather than a step on shard 1, which is where they started: at 82s
+  # they were a serial tail on one shard, so `Code Coverage (1/4)` finished at
+  # 458s against its siblings' ~370s and set the whole workflow's wall clock. A
+  # job runs them concurrently with the four shards instead of after one of them.
+  #
+  # It needs no `cargo-llvm-cov`, no bulk fixtures (no doctest reads one) and no
+  # instrumentation, so it is a plain cached `cargo test --doc`. It shares the
+  # coverage cache key: the compiled dependency tree is the same one, and a key of
+  # its own would mint another ~737 MB entry against a budget already at its cap.
+  doctests:
+    name: Doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # The spec generators resolve citations against the vendored checkout;
+          # a doctest that reaches one needs it present rather than empty.
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          # Restore-only on a PR and shared with the shards above, for the reasons
+          # given on that job's cache step.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          key: coverage
+          cache-bin: "false"
+      - name: Doctests
+        run: cargo test --doc --features dev
+
   report-failure:
-    needs: coverage
+    needs: [coverage, doctests]
     if: failure()
     uses: ./.github/workflows/report-failure.yml
     permissions:

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -56,14 +56,43 @@ const REPORTED: usize = 10;
 ///
 /// The counters are counts over a partition of the cases, so summing them is
 /// exact; the two lists are capped samples for the failure message. Returning
-/// them rather than mutating shared state is what makes the sequences
-/// independent.
+/// one of these rather than mutating shared state is what makes the sequences
+/// independent, and [`SweepTally::absorb`] is the one place the fold lives.
+///
+/// It is the **union** of what the three sweeps in this file tally, so two
+/// fields are used by one sweep each and stay zero elsewhere: `residual` by the
+/// genomic two-member sweep (its `dup`+`del`+5' shape), and
+/// `input_declined`/`by_cause` by the three-member sweep. One struct with two
+/// idle fields beats three near-identical ones with three copies of the fold.
+#[derive(Default)]
 struct SweepTally {
     checked: usize,
     residual: usize,
     skipped: usize,
+    input_declined: usize,
+    by_cause: std::collections::BTreeMap<&'static str, usize>,
     overlapping: Vec<String>,
     changed: Vec<String>,
+}
+
+impl SweepTally {
+    /// Fold one sequence's tally in, preserving sweep order.
+    ///
+    /// The caps are re-applied by the caller after the whole concatenation, so
+    /// this appends rather than truncating: each task already kept only its own
+    /// first [`REPORTED`], and truncating the in-order concatenation yields the
+    /// set the serial loop's global cap kept.
+    fn absorb(&mut self, other: SweepTally) {
+        self.checked += other.checked;
+        self.residual += other.residual;
+        self.skipped += other.skipped;
+        self.input_declined += other.input_declined;
+        for (cause, count) in other.by_cause {
+            *self.by_cause.entry(cause).or_default() += count;
+        }
+        self.overlapping.extend(other.overlapping);
+        self.changed.extend(other.changed);
+    }
 }
 
 /// Nine `T` at positions 1-9 — a tract long enough to canonicalise to a repeat.
@@ -693,22 +722,25 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                 skipped,
                 overlapping,
                 changed,
+                ..SweepTally::default()
             }
         })
         .collect();
 
-    let (mut checked, mut residual, mut skipped) = (0usize, 0usize, 0usize);
-    let mut overlapping: Vec<String> = Vec::new();
-    let mut changed: Vec<String> = Vec::new();
+    let mut total = SweepTally::default();
     for tally in per_sequence {
-        checked += tally.checked;
-        residual += tally.residual;
-        skipped += tally.skipped;
-        overlapping.extend(tally.overlapping);
-        changed.extend(tally.changed);
+        total.absorb(tally);
     }
-    overlapping.truncate(REPORTED);
-    changed.truncate(REPORTED);
+    total.overlapping.truncate(REPORTED);
+    total.changed.truncate(REPORTED);
+    let SweepTally {
+        checked,
+        residual,
+        overlapping,
+        changed,
+        skipped,
+        ..
+    } = total;
 
     // Per seed, not absolute (#1295): the seed count is now a knob, so a fixed
     // floor would either fail at the default prefix or be vacuous at the full
@@ -1258,208 +1290,238 @@ fn sweep_one_transcript_axis(accession: &str, axis: &str) {
     /// 1-based inclusive CDS end within the 20-base transcript: six codons.
     const CDS_END: u64 = 18;
 
-    let mut checked = 0usize;
-    let mut skipped = 0usize;
-    let mut overlapping: Vec<String> = Vec::new();
-    let mut changed: Vec<String> = Vec::new();
-
     let seeds = sweep_seeds(48);
-    for seq in sweep_sequences(seeds) {
-        // All three transcript axes share the generator.
-        //
-        // `r.` was excluded until #1471 on two grounds, both of which were
-        // measured and neither of which held:
-        //
-        // * *"its `U`/`T` alphabet makes the payload construction below a
-        //   different problem"* — it does not. The parser accepts the
-        //   DNA-alphabet payloads this generator already builds and renders
-        //   them in the RNA alphabet on output, so not one line below changes:
-        //   `NR_TEST.1:r.5_6insAA` parses as `r.5_6insaa` and `r.5T>A` as
-        //   `r.5u>a`. The oracle needs no adjustment either — `apply_with`
-        //   applies an `r.` description to the same bases as its `n.` twin
-        //   (verified byte-identical), because `hgvs_to_spdi` folds the
-        //   alphabet.
-        // * *"`issue_1235_transcript_axes.rs` pins that axis by hand"* — it
-        //   does, with 13 `r.` cases including a non-coding one, but they are
-        //   substitutions and `delins`. Those reach `canonicalize_from_sequence`
-        //   and never the *repair* passes, so none of them produces two
-        //   junction-occupying members shifting onto one junction.
-        //
-        // That second gap is what #1453 fell through: on a non-coding `r.`
-        // record every repair routed through `respell_at_gap` was a silent
-        // no-op, so `r.[9dup;10dup;11dup]` normalized to `r.[9dup;11dup;11dup]`
-        // — one interbase point claimed twice, denoting no sequence. It was
-        // invisible to this suite and to two of the three seam oracles: the
-        // output is well-formed, so `FERRO_ASSERT_REPARSE` accepts it, and every
-        // coordinate is in range, so `FERRO_ASSERT_IN_BOUNDS` does too. Only the
-        // apply oracle distinguishes it, as `CoincidentInsertions`.
-        //
-        // Verified against the defect rather than assumed: with #1465's fix
-        // reverted, this arm fails at **four** seeds on the earliest shapes it
-        // emits — `r.[2dup;4dup] -> r.[9dup;9dup]` and nine more, the collector's
-        // cap. (The 849-output figure quoted in #1453 and #1471 comes from a
-        // purpose-built 63 nt census in #1465, not from this sweep's 20-mers;
-        // the two corpora are not comparable and only the *direction* carries
-        // over.)
-        //
-        // **Non-coding `r.` only, and coding `r.` is a deliberate remaining
-        // gap** — not a covered one. It would be convenient to say `c.` already
-        // sweeps it, since `axis_frame` gives both `reading_frame: true`, but
-        // that is only true of the frame: the two still take different code
-        // paths (`build_rna_merged` vs `build_cds_merged`, and
-        // `cds_relative_gap(Region::Rna)` vs `(Region::Cds)`), so a coding `r.`
-        // defect could hide exactly the way the non-coding one did.
-        //
-        // The reason to stop here is cost, stated plainly: each axis is +50% on
-        // what is already the slowest test in the suite. Non-coding `r.` buys a
-        // *measured* gap — 849 corrupt outputs — and coding `r.` buys an
-        // unmeasured one. Worth adding if a defect ever turns up there, or if
-        // this sweep is made cheaper.
-        // Built once per (sequence, axis) and cloned per case. `SyntheticBuilder`
-        // pads, maps to a genomic contig and reverse-complements on demand, so
-        // constructing one inside the innermost loop dominated the test:
-        // measured at 39.8s for the 4-seed prefix before hoisting, against
-        // 18.3s for the far larger genomic sweep beside it.
-        // Keyed on the *accession*, not the axis, because that is what the
-        // builders actually decide: `cds` names its transcript `NM_TEST.1` and
-        // `noncoding` names its own `NR_TEST.1`, and every description below is
-        // built as `{accession}:{axis}.…`. Testing `axis == "c"` instead would
-        // route the coding `r.` row named in the gap note above — which is
-        // `("NM_TEST.1", "r")` — to an `NR_TEST.1` provider, so every lookup
-        // would fail to resolve and normalization would hand the input straight
-        // back: a sweep that is green because it checked nothing, with the
-        // axis label in every assertion message still reading `r.`.
-        // `every_transcript_axis_has_its_own_sweep` does not reach this choice,
-        // so an unrecognized accession is loud rather than defaulted.
-        let axis_provider = match accession {
-            "NM_TEST.1" => SyntheticBuilder::cds(&seq, 1, CDS_END, Strand::Plus).build(),
-            "NR_TEST.1" => SyntheticBuilder::noncoding(&seq, Strand::Plus).build(),
-            other => panic!(
-                "no reference shape is wired for `{other}` (sweeping the `{axis}.` axis); add \
+
+    // One rayon task per drawn sequence — see the genomic two-member sweep
+    // above for why this is byte-identical rather than merely equivalent.
+    // Parallelizing only ONE sweep in this file was measured as a wash: the
+    // `Exhaustive sweeps` job runs several at once, so the parallel one simply
+    // took cores from its serial siblings (job 1m42s -> 1m46s, with two
+    // siblings newly crossing the SLOW line). They have to go together.
+    let per_sequence: Vec<SweepTally> = sweep_sequences(seeds)
+        .into_par_iter()
+        .map(|seq| {
+            let mut checked = 0usize;
+            let mut skipped = 0usize;
+            let mut overlapping: Vec<String> = Vec::new();
+            let mut changed: Vec<String> = Vec::new();
+            // All three transcript axes share the generator.
+            //
+            // `r.` was excluded until #1471 on two grounds, both of which were
+            // measured and neither of which held:
+            //
+            // * *"its `U`/`T` alphabet makes the payload construction below a
+            //   different problem"* — it does not. The parser accepts the
+            //   DNA-alphabet payloads this generator already builds and renders
+            //   them in the RNA alphabet on output, so not one line below changes:
+            //   `NR_TEST.1:r.5_6insAA` parses as `r.5_6insaa` and `r.5T>A` as
+            //   `r.5u>a`. The oracle needs no adjustment either — `apply_with`
+            //   applies an `r.` description to the same bases as its `n.` twin
+            //   (verified byte-identical), because `hgvs_to_spdi` folds the
+            //   alphabet.
+            // * *"`issue_1235_transcript_axes.rs` pins that axis by hand"* — it
+            //   does, with 13 `r.` cases including a non-coding one, but they are
+            //   substitutions and `delins`. Those reach `canonicalize_from_sequence`
+            //   and never the *repair* passes, so none of them produces two
+            //   junction-occupying members shifting onto one junction.
+            //
+            // That second gap is what #1453 fell through: on a non-coding `r.`
+            // record every repair routed through `respell_at_gap` was a silent
+            // no-op, so `r.[9dup;10dup;11dup]` normalized to `r.[9dup;11dup;11dup]`
+            // — one interbase point claimed twice, denoting no sequence. It was
+            // invisible to this suite and to two of the three seam oracles: the
+            // output is well-formed, so `FERRO_ASSERT_REPARSE` accepts it, and every
+            // coordinate is in range, so `FERRO_ASSERT_IN_BOUNDS` does too. Only the
+            // apply oracle distinguishes it, as `CoincidentInsertions`.
+            //
+            // Verified against the defect rather than assumed: with #1465's fix
+            // reverted, this arm fails at **four** seeds on the earliest shapes it
+            // emits — `r.[2dup;4dup] -> r.[9dup;9dup]` and nine more, the collector's
+            // cap. (The 849-output figure quoted in #1453 and #1471 comes from a
+            // purpose-built 63 nt census in #1465, not from this sweep's 20-mers;
+            // the two corpora are not comparable and only the *direction* carries
+            // over.)
+            //
+            // **Non-coding `r.` only, and coding `r.` is a deliberate remaining
+            // gap** — not a covered one. It would be convenient to say `c.` already
+            // sweeps it, since `axis_frame` gives both `reading_frame: true`, but
+            // that is only true of the frame: the two still take different code
+            // paths (`build_rna_merged` vs `build_cds_merged`, and
+            // `cds_relative_gap(Region::Rna)` vs `(Region::Cds)`), so a coding `r.`
+            // defect could hide exactly the way the non-coding one did.
+            //
+            // The reason to stop here is cost, stated plainly: each axis is +50% on
+            // what is already the slowest test in the suite. Non-coding `r.` buys a
+            // *measured* gap — 849 corrupt outputs — and coding `r.` buys an
+            // unmeasured one. Worth adding if a defect ever turns up there, or if
+            // this sweep is made cheaper.
+            // Built once per (sequence, axis) and cloned per case. `SyntheticBuilder`
+            // pads, maps to a genomic contig and reverse-complements on demand, so
+            // constructing one inside the innermost loop dominated the test:
+            // measured at 39.8s for the 4-seed prefix before hoisting, against
+            // 18.3s for the far larger genomic sweep beside it.
+            // Keyed on the *accession*, not the axis, because that is what the
+            // builders actually decide: `cds` names its transcript `NM_TEST.1` and
+            // `noncoding` names its own `NR_TEST.1`, and every description below is
+            // built as `{accession}:{axis}.…`. Testing `axis == "c"` instead would
+            // route the coding `r.` row named in the gap note above — which is
+            // `("NM_TEST.1", "r")` — to an `NR_TEST.1` provider, so every lookup
+            // would fail to resolve and normalization would hand the input straight
+            // back: a sweep that is green because it checked nothing, with the
+            // axis label in every assertion message still reading `r.`.
+            // `every_transcript_axis_has_its_own_sweep` does not reach this choice,
+            // so an unrecognized accession is loud rather than defaulted.
+            let axis_provider = match accession {
+                "NM_TEST.1" => SyntheticBuilder::cds(&seq, 1, CDS_END, Strand::Plus).build(),
+                "NR_TEST.1" => SyntheticBuilder::noncoding(&seq, Strand::Plus).build(),
+                other => panic!(
+                    "no reference shape is wired for `{other}` (sweeping the `{axis}.` axis); add \
                  one to this match rather than letting the row fall through to a transcript \
                  whose accession the descriptions never name"
-            ),
-        };
-        for first_start in 2..=11usize {
-            for first_len in 1..=2usize {
-                let first_end = first_start + first_len - 1;
-                let span = if first_len == 1 {
-                    format!("{first_start}")
-                } else {
-                    format!("{first_start}_{first_end}")
-                };
-                // Same payload rule as the genomic sweeps: excluding both
-                // flanking reference bases keeps the `ins` entry from
-                // denoting the `dup` beside it.
-                let first_base = seq.as_bytes()[first_start - 1] as char;
-                let first_next = seq.as_bytes()[first_start] as char;
-                let first_payload = ['A', 'C', 'G', 'T']
-                    .into_iter()
-                    .find(|b| *b != first_base && *b != first_next)
-                    .expect("four bases, at most two excluded");
-                let inserted: String = std::iter::repeat_n(first_payload, first_len).collect();
-                let firsts = [
-                    format!("{span}del"),
-                    format!("{span}dup"),
-                    format!("{first_start}_{}ins{inserted}", first_start + 1),
-                ];
-                for first in firsts {
-                    for second_start in first_end + 2..=(CDS_END as usize - 1) {
-                        let base = seq.as_bytes()[second_start - 1] as char;
-                        let alt = if base == 'A' { 'G' } else { 'A' };
-                        let next_base = seq.as_bytes()[second_start] as char;
-                        let second_payload = ['A', 'C', 'G', 'T']
-                            .into_iter()
-                            .find(|b| *b != base && *b != next_base)
-                            .expect("four bases, at most two excluded");
-                        for second in [
-                            format!("{second_start}del"),
-                            format!("{second_start}{base}>{alt}"),
-                            format!("{second_start}dup"),
-                            format!("{second_start}_{}ins{second_payload}", second_start + 1),
-                        ] {
-                            // Everything that depends only on the *description*
-                            // is hoisted out of the direction loop below. The
-                            // input string, its parse and the bases it denotes
-                            // are all properties of the description, not of the
-                            // shuffle direction, and computing them per
-                            // direction did each of them exactly twice.
-                            let input = format!("{accession}:{axis}.[{first};{second}]");
-                            let variant = parse_hgvs(&input).expect("generated input parses");
-                            // Lazily, and at most once: a case both directions
-                            // decline must stay as cheap as it was.
-                            let mut input_applied: Option<Option<String>> = None;
-                            for direction in
-                                [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
-                            {
-                                // Deliberately built per case rather than once
-                                // per (sequence, axis). Hoisting it is strictly
-                                // less work and IS faster in the unoptimized
-                                // test profile, but it measured **14% slower**
-                                // on this test under the `soak` profile CI's
-                                // `sweeps` job actually uses — 11.54s -> 13.16s,
-                                // three reps a side at CV <= 0.5%. The
-                                // direction-invariant hoisting above (the
-                                // description, its parse, its applied sequence)
-                                // is kept: that is where the duplicated work was.
-                                let normalizer = Normalizer::with_config(
-                                    axis_provider.clone(),
-                                    NormalizeConfig::default()
-                                        .with_direction(direction)
-                                        .allow_crossing_boundaries(),
-                                );
-                                let Ok(normalized) = normalizer.normalize(&variant) else {
-                                    // A refusal is a legitimate answer here —
-                                    // the transcript axes decline shapes the
-                                    // genomic axis accepts — and says nothing
-                                    // about sequence preservation.
-                                    skipped += 1;
-                                    continue;
-                                };
-                                let output = format!("{normalized}");
-                                checked += 1;
+                ),
+            };
+            for first_start in 2..=11usize {
+                for first_len in 1..=2usize {
+                    let first_end = first_start + first_len - 1;
+                    let span = if first_len == 1 {
+                        format!("{first_start}")
+                    } else {
+                        format!("{first_start}_{first_end}")
+                    };
+                    // Same payload rule as the genomic sweeps: excluding both
+                    // flanking reference bases keeps the `ins` entry from
+                    // denoting the `dup` beside it.
+                    let first_base = seq.as_bytes()[first_start - 1] as char;
+                    let first_next = seq.as_bytes()[first_start] as char;
+                    let first_payload = ['A', 'C', 'G', 'T']
+                        .into_iter()
+                        .find(|b| *b != first_base && *b != first_next)
+                        .expect("four bases, at most two excluded");
+                    let inserted: String = std::iter::repeat_n(first_payload, first_len).collect();
+                    let firsts = [
+                        format!("{span}del"),
+                        format!("{span}dup"),
+                        format!("{first_start}_{}ins{inserted}", first_start + 1),
+                    ];
+                    for first in firsts {
+                        for second_start in first_end + 2..=(CDS_END as usize - 1) {
+                            let base = seq.as_bytes()[second_start - 1] as char;
+                            let alt = if base == 'A' { 'G' } else { 'A' };
+                            let next_base = seq.as_bytes()[second_start] as char;
+                            let second_payload = ['A', 'C', 'G', 'T']
+                                .into_iter()
+                                .find(|b| *b != base && *b != next_base)
+                                .expect("four bases, at most two excluded");
+                            for second in [
+                                format!("{second_start}del"),
+                                format!("{second_start}{base}>{alt}"),
+                                format!("{second_start}dup"),
+                                format!("{second_start}_{}ins{second_payload}", second_start + 1),
+                            ] {
+                                // Everything that depends only on the *description*
+                                // is hoisted out of the direction loop below. The
+                                // input string, its parse and the bases it denotes
+                                // are all properties of the description, not of the
+                                // shuffle direction, and computing them per
+                                // direction did each of them exactly twice.
+                                let input = format!("{accession}:{axis}.[{first};{second}]");
+                                let variant = parse_hgvs(&input).expect("generated input parses");
+                                // Lazily, and at most once: a case both directions
+                                // decline must stay as cheap as it was.
+                                let mut input_applied: Option<Option<String>> = None;
+                                for direction in
+                                    [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                                {
+                                    // Deliberately built per case rather than once
+                                    // per (sequence, axis). Hoisting it is strictly
+                                    // less work and IS faster in the unoptimized
+                                    // test profile, but it measured **14% slower**
+                                    // on this test under the `soak` profile CI's
+                                    // `sweeps` job actually uses — 11.54s -> 13.16s,
+                                    // three reps a side at CV <= 0.5%. The
+                                    // direction-invariant hoisting above (the
+                                    // description, its parse, its applied sequence)
+                                    // is kept: that is where the duplicated work was.
+                                    let normalizer = Normalizer::with_config(
+                                        axis_provider.clone(),
+                                        NormalizeConfig::default()
+                                            .with_direction(direction)
+                                            .allow_crossing_boundaries(),
+                                    );
+                                    let Ok(normalized) = normalizer.normalize(&variant) else {
+                                        // A refusal is a legitimate answer here —
+                                        // the transcript axes decline shapes the
+                                        // genomic axis accepts — and says nothing
+                                        // about sequence preservation.
+                                        skipped += 1;
+                                        continue;
+                                    };
+                                    let output = format!("{normalized}");
+                                    checked += 1;
 
-                                let Some(want) = input_applied
-                                    .get_or_insert_with(|| {
-                                        apply_parsed_with(&axis_provider, &seq, &variant)
-                                    })
-                                    .as_deref()
-                                else {
-                                    // An *input* that does not apply is a case
-                                    // this sweep cannot speak for. Counted
-                                    // separately from an unconvertible output,
-                                    // which is a failure.
-                                    skipped += 1;
-                                    checked -= 1;
-                                    continue;
-                                };
-                                // Both collections are capped at ten, matching
-                                // the two sweeps above. The assertions below
-                                // fire on `is_empty()`, so every failure past
-                                // the tenth changes nothing about the verdict
-                                // and only makes the panic output harder to
-                                // read — and a broad regression on the full
-                                // corpus would otherwise accumulate a string
-                                // per case.
-                                match apply_with(&axis_provider, &seq, &output) {
-                                    None if overlapping.len() < 10 => overlapping
-                                        .push(format!("{input} [{direction:?}] -> {output}")),
-                                    None => {}
-                                    Some(got) if got != want && changed.len() < 10 => {
-                                        changed.push(format!(
-                                            "{input} [{direction:?}] -> {output} \
+                                    let Some(want) = input_applied
+                                        .get_or_insert_with(|| {
+                                            apply_parsed_with(&axis_provider, &seq, &variant)
+                                        })
+                                        .as_deref()
+                                    else {
+                                        // An *input* that does not apply is a case
+                                        // this sweep cannot speak for. Counted
+                                        // separately from an unconvertible output,
+                                        // which is a failure.
+                                        skipped += 1;
+                                        checked -= 1;
+                                        continue;
+                                    };
+                                    // Both collections are capped at ten, matching
+                                    // the two sweeps above. The assertions below
+                                    // fire on `is_empty()`, so every failure past
+                                    // the tenth changes nothing about the verdict
+                                    // and only makes the panic output harder to
+                                    // read — and a broad regression on the full
+                                    // corpus would otherwise accumulate a string
+                                    // per case.
+                                    match apply_with(&axis_provider, &seq, &output) {
+                                        None if overlapping.len() < REPORTED => overlapping
+                                            .push(format!("{input} [{direction:?}] -> {output}")),
+                                        None => {}
+                                        Some(got) if got != want && changed.len() < REPORTED => {
+                                            changed.push(format!(
+                                                "{input} [{direction:?}] -> {output} \
                                              (want {want}, got {got})"
-                                        ))
+                                            ))
+                                        }
+                                        Some(_) => {}
                                     }
-                                    Some(_) => {}
                                 }
                             }
                         }
                     }
                 }
             }
-        }
+            SweepTally {
+                checked,
+                skipped,
+                overlapping,
+                changed,
+                ..SweepTally::default()
+            }
+        })
+        .collect();
+
+    let mut total = SweepTally::default();
+    for tally in per_sequence {
+        total.absorb(tally);
     }
+    total.overlapping.truncate(REPORTED);
+    total.changed.truncate(REPORTED);
+    let SweepTally {
+        checked,
+        skipped,
+        overlapping,
+        changed,
+        ..
+    } = total;
 
     // Per seed, for the reason recorded on the floor in the first sweep above.
     // This is the SAME per-axis floor the combined test applied to each axis, so
@@ -1682,15 +1744,6 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
         }
     }
 
-    let mut checked = 0usize;
-    let mut input_declined = 0usize;
-    let mut overlapping: Vec<String> = Vec::new();
-    let mut changed: Vec<String> = Vec::new();
-    // Per-cause tallies for the *input* declines, so the share below is
-    // decomposable rather than another single opaque number.
-    let mut by_cause: std::collections::BTreeMap<&'static str, usize> =
-        std::collections::BTreeMap::new();
-
     // 16 rather than the 48 its neighbours use. Each seed here carries roughly
     // three times their cases, so 16 seeds is comparable *total* coverage — and
     // at 48 this one test was 411s in CI's sweeps job, against 183s for all three
@@ -1698,110 +1751,129 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
     // whose buckets are all currently zero, not a ceiling: raise it if a
     // three-member defect ever turns up in a sequence beyond the sixteenth.
     let seeds = sweep_seeds(16);
-    for seq in sweep_sequences(seeds) {
-        // One provider and one normalizer per direction per sequence. The
-        // innermost loop used to build `genomic_provider(&seq)` three times per
-        // case — for the input apply, the normalizer and the output apply.
-        let template = genomic_provider(&seq);
-        let normalizers =
-            [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime].map(|direction| {
-                (
-                    direction,
-                    Normalizer::with_config(
-                        template.clone(),
-                        NormalizeConfig::default()
-                            .with_direction(direction)
-                            .allow_crossing_boundaries(),
-                    ),
-                )
-            });
-        // Even positions only, and the bound says 8 rather than 9 because
-        // `step_by(2)` from 2 can never reach an odd endpoint — writing `..=9`
-        // named a position this loop does not visit. Sampling every other
-        // position is deliberate (the third member's loop below multiplies this
-        // one), but the range should not claim coverage it does not provide.
-        for first_start in (2..=8usize).step_by(2) {
-            let first_base = seq.as_bytes()[first_start - 1] as char;
-            let first_next = seq.as_bytes()[first_start] as char;
-            let first_payload = ['A', 'C', 'G', 'T']
-                .into_iter()
-                .find(|b| *b != first_base && *b != first_next)
-                .expect("four bases, at most two excluded");
-            let firsts = [
-                format!("{first_start}del"),
-                format!("{first_start}dup"),
-                format!("{first_start}_{}ins{first_payload}", first_start + 1),
-            ];
-            for first in &firsts {
-                // Second and third members walk the remaining positions, each
-                // separated from its predecessor by at least one unchanged base
-                // so every case starts as three genuinely separate members.
-                for second_start in first_start + 2..=14usize {
-                    let second_base = seq.as_bytes()[second_start - 1] as char;
-                    let second_alt = if second_base == 'A' { 'G' } else { 'A' };
-                    for second in [
-                        format!("{second_start}del"),
-                        format!("{second_start}{second_base}>{second_alt}"),
-                        format!("{second_start}dup"),
-                    ] {
-                        // `..=19` is right here, unlike the `first_start` loop
-                        // above: `second_start` walks every integer, so when it
-                        // is odd this range is odd-valued and 19 IS visited.
-                        for third_start in (second_start + 2..=19usize).step_by(2) {
-                            let third_base = seq.as_bytes()[third_start - 1] as char;
-                            let third_alt = if third_base == 'A' { 'G' } else { 'A' };
-                            for third in [
-                                format!("{third_start}del"),
-                                format!("{third_start}{third_base}>{third_alt}"),
-                            ] {
-                                // The description, its parse and the bases it
-                                // denotes do not depend on the shuffle direction,
-                                // so each is computed once per case rather than
-                                // once per direction. A parse failure is folded
-                                // into the `ApplyFailure` the string-taking oracle
-                                // would have reported for it, so the tallying below
-                                // is unchanged — including that it counts a
-                                // declined input once *per direction*, which is the
-                                // quantity the share assertion is written against.
-                                let input = format!("TEMPLATE:g.[{first};{second};{third}]");
-                                let parsed =
-                                    parse_hgvs(&input).map_err(|_| ApplyFailure::Unparseable);
-                                let input_applied =
-                                    parsed.as_ref().map_err(|c| *c).and_then(|variant| {
-                                        apply_parsed_reason(&template, &seq, variant)
-                                    });
-                                for (direction, normalizer) in &normalizers {
-                                    let want = match &input_applied {
-                                        Ok(want) => want.as_str(),
-                                        Err(cause) => {
-                                            // An input this sweep cannot speak
-                                            // for. Tallied by cause so the share
-                                            // asserted below can be read.
-                                            *by_cause.entry(cause_name(*cause)).or_default() += 1;
-                                            input_declined += 1;
-                                            continue;
-                                        }
-                                    };
-                                    let variant = parsed
-                                        .as_ref()
-                                        .expect("a parse failure is reported as a decline above");
-                                    let Ok(normalized) = normalizer.normalize(variant) else {
-                                        input_declined += 1;
-                                        *by_cause.entry("normalize-declined").or_default() += 1;
-                                        continue;
-                                    };
-                                    let output = format!("{normalized}");
-                                    checked += 1;
 
-                                    match apply_reason(&template, &seq, &output) {
-                                        Ok(got) if got == want => {}
-                                        Ok(got) => changed.push(format!(
-                                            "{input} [{direction:?}] -> {output} \
+    // One rayon task per drawn sequence — see the genomic two-member sweep
+    // above for why this is byte-identical rather than merely equivalent.
+    // Parallelizing only ONE sweep in this file was measured as a wash: the
+    // `Exhaustive sweeps` job runs several at once, so the parallel one simply
+    // took cores from its serial siblings (job 1m42s -> 1m46s, with two
+    // siblings newly crossing the SLOW line). They have to go together.
+    let per_sequence: Vec<SweepTally> = sweep_sequences(seeds)
+        .into_par_iter()
+        .map(|seq| {
+            let mut checked = 0usize;
+            let mut input_declined = 0usize;
+            let mut overlapping: Vec<String> = Vec::new();
+            let mut changed: Vec<String> = Vec::new();
+            // Per-cause tallies for the *input* declines, so the share below is
+            // decomposable rather than another single opaque number.
+            let mut by_cause: std::collections::BTreeMap<&'static str, usize> =
+                std::collections::BTreeMap::new();
+            // One provider and one normalizer per direction per sequence. The
+            // innermost loop used to build `genomic_provider(&seq)` three times per
+            // case — for the input apply, the normalizer and the output apply.
+            let template = genomic_provider(&seq);
+            let normalizers =
+                [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime].map(|direction| {
+                    (
+                        direction,
+                        Normalizer::with_config(
+                            template.clone(),
+                            NormalizeConfig::default()
+                                .with_direction(direction)
+                                .allow_crossing_boundaries(),
+                        ),
+                    )
+                });
+            // Even positions only, and the bound says 8 rather than 9 because
+            // `step_by(2)` from 2 can never reach an odd endpoint — writing `..=9`
+            // named a position this loop does not visit. Sampling every other
+            // position is deliberate (the third member's loop below multiplies this
+            // one), but the range should not claim coverage it does not provide.
+            for first_start in (2..=8usize).step_by(2) {
+                let first_base = seq.as_bytes()[first_start - 1] as char;
+                let first_next = seq.as_bytes()[first_start] as char;
+                let first_payload = ['A', 'C', 'G', 'T']
+                    .into_iter()
+                    .find(|b| *b != first_base && *b != first_next)
+                    .expect("four bases, at most two excluded");
+                let firsts = [
+                    format!("{first_start}del"),
+                    format!("{first_start}dup"),
+                    format!("{first_start}_{}ins{first_payload}", first_start + 1),
+                ];
+                for first in &firsts {
+                    // Second and third members walk the remaining positions, each
+                    // separated from its predecessor by at least one unchanged base
+                    // so every case starts as three genuinely separate members.
+                    for second_start in first_start + 2..=14usize {
+                        let second_base = seq.as_bytes()[second_start - 1] as char;
+                        let second_alt = if second_base == 'A' { 'G' } else { 'A' };
+                        for second in [
+                            format!("{second_start}del"),
+                            format!("{second_start}{second_base}>{second_alt}"),
+                            format!("{second_start}dup"),
+                        ] {
+                            // `..=19` is right here, unlike the `first_start` loop
+                            // above: `second_start` walks every integer, so when it
+                            // is odd this range is odd-valued and 19 IS visited.
+                            for third_start in (second_start + 2..=19usize).step_by(2) {
+                                let third_base = seq.as_bytes()[third_start - 1] as char;
+                                let third_alt = if third_base == 'A' { 'G' } else { 'A' };
+                                for third in [
+                                    format!("{third_start}del"),
+                                    format!("{third_start}{third_base}>{third_alt}"),
+                                ] {
+                                    // The description, its parse and the bases it
+                                    // denotes do not depend on the shuffle direction,
+                                    // so each is computed once per case rather than
+                                    // once per direction. A parse failure is folded
+                                    // into the `ApplyFailure` the string-taking oracle
+                                    // would have reported for it, so the tallying below
+                                    // is unchanged — including that it counts a
+                                    // declined input once *per direction*, which is the
+                                    // quantity the share assertion is written against.
+                                    let input = format!("TEMPLATE:g.[{first};{second};{third}]");
+                                    let parsed =
+                                        parse_hgvs(&input).map_err(|_| ApplyFailure::Unparseable);
+                                    let input_applied =
+                                        parsed.as_ref().map_err(|c| *c).and_then(|variant| {
+                                            apply_parsed_reason(&template, &seq, variant)
+                                        });
+                                    for (direction, normalizer) in &normalizers {
+                                        let want = match &input_applied {
+                                            Ok(want) => want.as_str(),
+                                            Err(cause) => {
+                                                // An input this sweep cannot speak
+                                                // for. Tallied by cause so the share
+                                                // asserted below can be read.
+                                                *by_cause.entry(cause_name(*cause)).or_default() +=
+                                                    1;
+                                                input_declined += 1;
+                                                continue;
+                                            }
+                                        };
+                                        let variant = parsed.as_ref().expect(
+                                            "a parse failure is reported as a decline above",
+                                        );
+                                        let Ok(normalized) = normalizer.normalize(variant) else {
+                                            input_declined += 1;
+                                            *by_cause.entry("normalize-declined").or_default() += 1;
+                                            continue;
+                                        };
+                                        let output = format!("{normalized}");
+                                        checked += 1;
+
+                                        match apply_reason(&template, &seq, &output) {
+                                            Ok(got) if got == want => {}
+                                            Ok(got) => changed.push(format!(
+                                                "{input} [{direction:?}] -> {output} \
                                              (want {want}, got {got})"
-                                        )),
-                                        Err(cause) => overlapping.push(format!(
-                                            "{input} [{direction:?}] -> {output} ({cause:?})"
-                                        )),
+                                            )),
+                                            Err(cause) => overlapping.push(format!(
+                                                "{input} [{direction:?}] -> {output} ({cause:?})"
+                                            )),
+                                        }
                                     }
                                 }
                             }
@@ -1809,8 +1881,31 @@ fn no_three_member_allele_normalizes_to_a_different_sequence() {
                     }
                 }
             }
-        }
+            SweepTally {
+                checked,
+                input_declined,
+                by_cause,
+                overlapping,
+                changed,
+                ..SweepTally::default()
+            }
+        })
+        .collect();
+
+    let mut total = SweepTally::default();
+    for tally in per_sequence {
+        total.absorb(tally);
     }
+    total.overlapping.truncate(REPORTED);
+    total.changed.truncate(REPORTED);
+    let SweepTally {
+        checked,
+        input_declined,
+        by_cause,
+        overlapping,
+        changed,
+        ..
+    } = total;
 
     const CASES_PER_SEED_FLOOR: usize = 2_000;
     let floor = CASES_PER_SEED_FLOOR * seeds as usize;

--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -42,6 +42,29 @@ use crate::common::cis_apply_oracle::{
     sweep_seeds, sweep_sequences,
 };
 use ferro_hgvs::{parse_hgvs, ShuffleDirection};
+use rayon::prelude::*;
+
+/// How many offenders a failing sweep names.
+///
+/// Applied per drawn sequence and again to the concatenation, which is what
+/// keeps a parallel sweep's report byte-identical to a serial one: each task
+/// keeps its own first `REPORTED`, and truncating the in-order concatenation
+/// yields the same set the serial loop's global cap kept.
+const REPORTED: usize = 10;
+
+/// What one drawn sequence contributed to a sweep.
+///
+/// The counters are counts over a partition of the cases, so summing them is
+/// exact; the two lists are capped samples for the failure message. Returning
+/// them rather than mutating shared state is what makes the sequences
+/// independent.
+struct SweepTally {
+    checked: usize,
+    residual: usize,
+    skipped: usize,
+    overlapping: Vec<String>,
+    changed: Vec<String>,
+}
 
 /// Nine `T` at positions 1-9 — a tract long enough to canonicalise to a repeat.
 const TRACT: &str = "TTTTTTTTTAATATATTTTA";
@@ -483,11 +506,6 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // `a_five_prime_duplication_beside_a_deletion_keeps_its_sequence`. It was
     // the last residual class here — 74 cases, closed by `blocks_sibling_shift`
     // — and keeping the separate tally says which shape regressed if one does.
-    let mut checked = 0usize;
-    let mut residual = 0usize;
-    let mut skipped = 0usize;
-    let mut overlapping: Vec<String> = Vec::new();
-    let mut changed: Vec<String> = Vec::new();
 
     // 24 seeds, not 48. Widening the second member from 2 shapes to 4 (#1283)
     // doubles the work per sequence, and this is already the suite's slowest
@@ -512,7 +530,27 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
     // 86.6s local suite at 24 seeds, and the prefix is a strict subset of the
     // corpus, not a different one.
     let seeds = sweep_seeds(48);
-    for seq in sweep_sequences(seeds) {
+
+    // One rayon task per drawn sequence. Each already builds its own `template`
+    // provider and its own normalizers — that is what the comment inside is
+    // about — so the sequences share nothing, and this changes the ORDER cases
+    // run in, never which cases run.
+    //
+    // The totals are byte-identical to the serial sweep, which the exactly
+    // pinned `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` and the two bounds below
+    // require. `checked`, `residual` and `skipped` count over a partition of the
+    // cases, so summing is exact; `overlapping` and `changed` are "the first
+    // `REPORTED` offenders in sweep order", reproduced by capping per sequence
+    // and truncating the in-order concatenation — `collect` preserves input
+    // order however the tasks finish.
+    let per_sequence: Vec<SweepTally> = sweep_sequences(seeds)
+        .into_par_iter()
+        .map(|seq| {
+            let mut checked = 0usize;
+            let mut residual = 0usize;
+            let mut skipped = 0usize;
+            let mut overlapping: Vec<String> = Vec::new();
+            let mut changed: Vec<String> = Vec::new();
         // Built once per sequence rather than once per case. `normalize_in` and
         // `apply` each construct a `TEMPLATE` provider internally, so the previous
         // shape built three per case — the normalizer's, the input apply's and the
@@ -629,14 +667,14 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                                 // oracle: re-parsing what the normalizer produced is
                                 // part of what this sweep asserts.
                                 match apply_with(&template, &seq, &output) {
-                                    None if overlapping.len() < 10 => {
+                                    None if overlapping.len() < REPORTED => {
                                         overlapping.push(format!("{seq}: {input} -> {output}"))
                                     }
                                     None => {}
                                     Some(got) if got != want && residual_shape => {
                                         residual += 1;
                                     }
-                                    Some(got) if got != want && changed.len() < 10 => {
+                                    Some(got) if got != want && changed.len() < REPORTED => {
                                         changed.push(format!(
                                             "{seq}: {input} [{direction:?}] -> {output} (want {want}, got {got})"
                                         ));
@@ -649,7 +687,28 @@ fn no_two_member_allele_normalizes_to_a_different_sequence() {
                 }
             }
         }
+            SweepTally {
+                checked,
+                residual,
+                skipped,
+                overlapping,
+                changed,
+            }
+        })
+        .collect();
+
+    let (mut checked, mut residual, mut skipped) = (0usize, 0usize, 0usize);
+    let mut overlapping: Vec<String> = Vec::new();
+    let mut changed: Vec<String> = Vec::new();
+    for tally in per_sequence {
+        checked += tally.checked;
+        residual += tally.residual;
+        skipped += tally.skipped;
+        overlapping.extend(tally.overlapping);
+        changed.extend(tally.changed);
     }
+    overlapping.truncate(REPORTED);
+    changed.truncate(REPORTED);
 
     // Per seed, not absolute (#1295): the seed count is now a knob, so a fixed
     // floor would either fail at the default prefix or be vacuous at the full

--- a/tests/it/normalize_axis_preserving.rs
+++ b/tests/it/normalize_axis_preserving.rs
@@ -173,57 +173,71 @@ enum Disposition {
 /// The comparison is on [`CoordinateAxis`] and on nothing else — in particular
 /// not on the accession or the rendered prefix, both of which normalization is
 /// allowed to move (legacy-selector resolution does exactly that).
-fn classify(variant: &HgvsVariant, normalized: &HgvsVariant) -> Option<Disposition> {
-    let (before, after) = (variant.coordinate_axis()?, normalized.coordinate_axis()?);
-    Some(if before == after {
+/// Which disposition a compared row lands in.
+///
+/// Takes the two axes rather than re-deriving them: the caller has already
+/// resolved both to decide the row *is* comparable, and `coordinate_axis()` was
+/// being called twice more per row for a value already in hand.
+fn classify(variant: &HgvsVariant, before: CoordinateAxis, after: CoordinateAxis) -> Disposition {
+    if before == after {
         Disposition::Preserved
     } else if is_mitochondrial_relabel(variant, before, after) {
         Disposition::MitochondrialRelabel
     } else {
         Disposition::Violation
-    })
+    }
 }
 
 const MAX_REPORTED_VIOLATIONS: usize = 20;
 
 impl AxisCensus {
-    fn of_one(input: &str) -> Self {
-        let mut census = Self {
-            rows: 1,
-            ..Self::default()
-        };
+    /// Fold one input into this census, in place.
+    ///
+    /// **Deliberately not `of_one(input) -> Self`.** That shape allocated a
+    /// whole `AxisCensus` per row — including a `per_axis` `BTreeMap` node on
+    /// every *compared* row — and then merged it pairwise, over corpora of
+    /// millions. Accumulating in place makes it one census per rayon chunk (see
+    /// [`census_of`]), which is the same arithmetic with the per-row allocation
+    /// removed.
+    ///
+    /// The `normalizer` is borrowed for the same reason: it was rebuilt per row.
+    /// Its provider is empty and never populated — deliberately, since the
+    /// property under test is about the axis *label*, which no reference can
+    /// inform — so every row was constructing an identical value.
+    fn absorb_one(&mut self, input: &str, normalizer: &Normalizer<MockProvider>) {
+        self.rows += 1;
         let Ok(variant) = parse_hgvs(input) else {
-            census.unparsed = 1;
-            return census;
+            self.unparsed += 1;
+            return;
         };
-        // An empty provider, deliberately: the property is about the axis label,
-        // which no reference can inform. Normalization degrades leniently
-        // without one, so a large majority of every corpus still normalizes.
-        let normalizer = Normalizer::new(MockProvider::new());
         let Ok(normalized) = normalizer.normalize(&variant) else {
-            census.unnormalizable = 1;
-            return census;
+            self.unnormalizable += 1;
+            return;
         };
         let (Some(before), Some(after)) = (variant.coordinate_axis(), normalized.coordinate_axis())
         else {
-            census.axis_less = 1;
-            return census;
+            self.axis_less += 1;
+            return;
         };
-        census.compared = 1;
-        *census.per_axis.entry(before.code()).or_default() += 1;
-        match classify(&variant, &normalized).expect("both sides carry an axis here") {
-            Disposition::Preserved => census.preserved = 1,
-            Disposition::MitochondrialRelabel => census.mito_relabels = 1,
+        self.compared += 1;
+        *self.per_axis.entry(before.code()).or_default() += 1;
+        match classify(&variant, before, after) {
+            Disposition::Preserved => self.preserved += 1,
+            Disposition::MitochondrialRelabel => self.mito_relabels += 1,
             Disposition::Violation => {
-                census.violations_seen = 1;
-                census.violations.push(format!(
-                    "`{input}` [{}] normalized to `{normalized}` [{}]",
-                    before.code(),
-                    after.code()
-                ));
+                self.violations_seen += 1;
+                // Capped here as well as in `merge`: an uncapped push would
+                // allocate a `String` per violating row, and the report shows
+                // only a sample either way.
+                if self.violations.len() < MAX_REPORTED_VIOLATIONS {
+                    self.violations.push(format!(
+                        "`{input}` [{}] normalized to `{normalized}` [{}]",
+                        before.code(),
+                        after.code()
+                    ));
+                }
             }
         }
-        census
     }
 
     fn merge(mut self, other: Self) -> Self {
@@ -317,6 +331,17 @@ fn is_mitochondrial_relabel(
             .is_some_and(|accession| accession.is_mitochondrial())
 }
 
+/// Census a corpus, one accumulator and one normalizer per rayon chunk.
+///
+/// **The totals are unchanged** — `absorb_one` performs exactly the arithmetic
+/// `of_one` + `merge` did, and `merge` still folds the chunks — so every pinned
+/// figure and the four-way disposition accounting are identical. What changes is
+/// how much is built to get them: `fold` replaces the per-row `AxisCensus` (and
+/// its per-compared-row `BTreeMap` node) with one per chunk, and the closure's
+/// init replaces the per-row `Normalizer<MockProvider>` with one per chunk.
+///
+/// Order-independence is unaffected: `merge` is associative over counts, and the
+/// two `Vec`s it folds are capped samples for a failure message, not results.
 fn census_of<I>(inputs: I) -> AxisCensus
 where
     I: IntoParallelIterator,
@@ -324,7 +349,14 @@ where
 {
     inputs
         .into_par_iter()
-        .map(|input| AxisCensus::of_one(input.as_ref()))
+        .fold(
+            || (AxisCensus::default(), Normalizer::new(MockProvider::new())),
+            |(mut census, normalizer), input| {
+                census.absorb_one(input.as_ref(), &normalizer);
+                (census, normalizer)
+            },
+        )
+        .map(|(census, _)| census)
         .reduce(AxisCensus::default, AxisCensus::merge)
 }
 
@@ -423,9 +455,18 @@ fn the_check_reads_the_axis_letter_not_the_prefix() {
         resolved_form.accession().map(|a| a.to_string()),
         "the two spellings must differ in accession for this to be the near-miss it claims"
     );
+    // Resolved here rather than inside `classify`, which now takes the two axes
+    // the caller has already established — so the `expect`s are part of what
+    // this test pins: both spellings do carry an axis, and it is the same one.
+    let before = selector_form
+        .coordinate_axis()
+        .expect("the selector form carries an axis");
+    let after = resolved_form
+        .coordinate_axis()
+        .expect("the resolved form carries an axis");
     assert_eq!(
-        classify(&selector_form, &resolved_form),
-        Some(Disposition::Preserved),
+        classify(&selector_form, before, after),
+        Disposition::Preserved,
         "the census must read legacy-selector resolution as axis-preserving; a comparison \
          that also looked at the accession or the rendered prefix would call it a violation"
     );

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -468,14 +468,14 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use rayon::prelude::*;
+
 use ferro_hgvs::conformance::spec_corpus::{
-    corpus, denotation_of, denoted_by, CorpusBounds, Denotation, Frame, RefShape, Row, RowKind,
-    SpecCorpus, Strength,
+    corpus, denotation_of, denoted_by, CorpusBounds, Denotation, Row, RowKind, SpecCorpus, Strength,
 };
 use ferro_hgvs::error_handling::ErrorMode;
 use ferro_hgvs::hgvs::interval::{Interval, UncertainBoundary};
 use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
-use ferro_hgvs::reference::MockProvider;
 use ferro_hgvs::{parse_hgvs, HgvsVariant, NormalizeConfig, Normalizer, ShuffleDirection};
 
 // ---------------------------------------------------------------------------
@@ -1088,8 +1088,33 @@ fn measurement_config(direction: ShuffleDirection) -> NormalizeConfig {
     NormalizeConfig::default().with_direction(direction)
 }
 
-fn measure(direction: ShuffleDirection) -> Measured {
-    let built = built();
+/// The contiguous runs of `rows` that share one synthetic reference.
+///
+/// [`grouped`] sorts by `(shape, core, id)`, so every row sharing a reference is
+/// already adjacent — this only names the boundaries. It replaces the running
+/// `frame` cache the serial loop carried: same "one provider per reference, not
+/// per row" property, expressed as an explicit partition so [`measure`] can hand
+/// each group to its own task.
+fn reference_groups<'a>(rows: &'a [&'a Row]) -> Vec<&'a [&'a Row]> {
+    let mut groups = Vec::new();
+    let mut start = 0usize;
+    while start < rows.len() {
+        let mut end = start + 1;
+        while end < rows.len()
+            && rows[end].shape == rows[start].shape
+            && rows[end].core == rows[start].core
+        {
+            end += 1;
+        }
+        groups.push(&rows[start..end]);
+        start = end;
+    }
+    groups
+}
+
+/// Census one reference group. Builds its own frame and normalizer, reads
+/// nothing outside its own slice, and so is safe to run alongside its siblings.
+fn measure_group(group: &[&Row], direction: ShuffleDirection) -> Measured {
     let mut census = Census {
         measured_under: measurement_config(direction).error_config.mode,
         ..Census::default()
@@ -1097,20 +1122,12 @@ fn measure(direction: ShuffleDirection) -> Measured {
     let mut divergences: Vec<Divergence> = Vec::new();
     let mut findings: Vec<Finding> = Vec::new();
 
-    let rows = grouped(&built);
-    let mut frame: Option<(RefShape, String, Frame, Normalizer<MockProvider>)> = None;
-    for row in rows {
-        let key_matches = frame
-            .as_ref()
-            .is_some_and(|(shape, core, _, _)| *shape == row.shape && core == &row.core);
-        if !key_matches {
-            let rebuilt = row.frame();
-            let normalizer =
-                Normalizer::with_config(rebuilt.provider().clone(), measurement_config(direction));
-            frame = Some((row.shape, row.core.clone(), rebuilt, normalizer));
-        }
-        let (_, _, active, normalizer) = frame.as_ref().expect("a frame was just built");
+    let active = group[0].frame();
+    let normalizer =
+        Normalizer::with_config(active.provider().clone(), measurement_config(direction));
+    let (active, normalizer) = (&active, &normalizer);
 
+    for row in group {
         let mut outputs: BTreeSet<String> = BTreeSet::new();
         let mut normalized_spellings = 0usize;
         for spelling in &row.spellings {
@@ -1354,7 +1371,7 @@ fn measure(direction: ShuffleDirection) -> Measured {
                     3 => census.split_three += 1,
                     _ => census.split_more += 1,
                 }
-                if outputs.len() > 1 && divergences.len() < 12 {
+                if outputs.len() > 1 && divergences.len() < MAX_DIVERGENCES {
                     divergences.push(Divergence {
                         id: row.id.clone(),
                         outputs: outputs.into_iter().collect(),
@@ -1369,6 +1386,124 @@ fn measure(direction: ShuffleDirection) -> Measured {
         divergences,
         findings,
     }
+}
+
+/// How many divergent families the failure message names. Applied per group and
+/// again to the concatenation, which is what keeps the parallel result
+/// byte-identical to a serial one — see [`measure`].
+const MAX_DIVERGENCES: usize = 12;
+
+impl Census {
+    /// Fold another census in.
+    ///
+    /// Every field below is a count over a partition of the rows, so summing is
+    /// exact rather than approximate — that is what makes [`measure`]'s
+    /// per-group split safe.
+    ///
+    /// **The destructuring is the point, not style.** It carries no `..`, so
+    /// adding a field to [`Census`] makes this function fail to COMPILE until
+    /// the field is folded. An earlier version of this listed the fields by hand
+    /// and #1710 added two underneath it; they were silently never summed, and
+    /// the census reported `coding_axis_separation_two_or_more_merges` as
+    /// **0 of 0** — a denominator of zero, which is the flattering direction
+    /// this file's own VACUOUS guard exists to catch. It did catch it. This
+    /// makes the next one a build error instead.
+    ///
+    /// [`Census::measured_under`] is bound and deliberately NOT summed: it is a
+    /// mode stamp rather than a counter, and every group is built from the same
+    /// [`measurement_config`], so the accumulator's own stamp already carries
+    /// it. Binding it keeps it inside the exhaustiveness check.
+    fn absorb(&mut self, other: &Census) {
+        let Census {
+            measured_under: _,
+            outputs,
+            declined,
+            unparseable_outputs,
+            outputs_denoting_no_sequence,
+            outputs_leaving_the_transcript,
+            outputs_intronic_under_a_genomic_wrapper,
+            prohibition_violating_outputs,
+            converged,
+            split_two,
+            split_three,
+            split_more,
+            underdetermined,
+            non_idempotent_outputs,
+            sequence_changed,
+            conflicts_accepted,
+            prohibited_absolute_accepted,
+            prohibited_conditional_accepted,
+            guard_violations,
+            coding_axis_separation_two_or_more_rows,
+            coding_axis_separation_two_or_more_merges,
+        } = other;
+        self.outputs += outputs;
+        self.declined += declined;
+        self.unparseable_outputs += unparseable_outputs;
+        self.outputs_denoting_no_sequence += outputs_denoting_no_sequence;
+        self.outputs_leaving_the_transcript += outputs_leaving_the_transcript;
+        self.outputs_intronic_under_a_genomic_wrapper += outputs_intronic_under_a_genomic_wrapper;
+        self.prohibition_violating_outputs += prohibition_violating_outputs;
+        self.converged += converged;
+        self.split_two += split_two;
+        self.split_three += split_three;
+        self.split_more += split_more;
+        self.underdetermined += underdetermined;
+        self.non_idempotent_outputs += non_idempotent_outputs;
+        self.sequence_changed += sequence_changed;
+        self.conflicts_accepted += conflicts_accepted;
+        self.prohibited_absolute_accepted += prohibited_absolute_accepted;
+        self.prohibited_conditional_accepted += prohibited_conditional_accepted;
+        self.guard_violations += guard_violations;
+        self.coding_axis_separation_two_or_more_rows += coding_axis_separation_two_or_more_rows;
+        self.coding_axis_separation_two_or_more_merges += coding_axis_separation_two_or_more_merges;
+    }
+}
+
+/// Census one direction, one reference group per rayon task.
+///
+/// **The result is byte-identical to the serial walk, not merely equivalent**,
+/// which is the only basis on which a pinned census may be parallelized at all:
+///
+/// * every counter is a count over a partition of the rows, so [`Census::absorb`]
+///   over the groups is exact and order-free;
+/// * `par_iter().collect()` preserves *input* order, so the per-group results
+///   fold in corpus order however they finish — which matters for `findings`,
+///   an uncapped list whose order the failure message reproduces;
+/// * `divergences` is "the first [`MAX_DIVERGENCES`] divergent families in
+///   corpus order". Each group keeps its own first `MAX_DIVERGENCES`, and
+///   concatenating in corpus order and truncating again yields exactly that set
+///   — the serial loop's global cap can only have kept the same ones.
+///
+/// Nothing is shared across tasks: [`measure_group`] builds its own `Frame` and
+/// `Normalizer` (the serial loop already rebuilt both per reference — that is
+/// what the `frame` cache was), and the only borrow that crosses is the
+/// immutable corpus slice.
+fn measure(direction: ShuffleDirection) -> Measured {
+    let built = built();
+    let rows = grouped(&built);
+    let groups = reference_groups(&rows);
+
+    let per_group: Vec<Measured> = groups
+        .par_iter()
+        .map(|group| measure_group(group, direction))
+        .collect();
+
+    let mut measured = Measured {
+        census: Census {
+            measured_under: measurement_config(direction).error_config.mode,
+            ..Census::default()
+        },
+        divergences: Vec::new(),
+        findings: Vec::new(),
+    };
+    for group in per_group {
+        measured.census.absorb(&group.census);
+        measured.divergences.extend(group.divergences);
+        measured.findings.extend(group.findings);
+    }
+    measured.divergences.truncate(MAX_DIVERGENCES);
+    measured
 }
 
 fn report(label: &str, measured: &Measured) -> String {


### PR DESCRIPTION
Representation-Change: none. Test harness only; no watched directory is touched.

Follow-up to #1775, which cleared every `cis_confluence_*` test off the SLOW list. This takes the five that were left. **Draft, because CI is doing both the measurement and the verification** — see the last section.

## The five, and what each needed

Measured on run 31673634192 (#1775's merge-queue run):

| test | wall | job | what was wrong |
|---|---|---|---|
| `normalize_axis_preserving::…_over_the_cmrg_corpus` | 148.8s | `Test oracle (1/3)` | already parallel — per-row cost |
| `normalize_axis_preserving::…_over_the_clinvar_unique_corpus` | 134.7s | `Test oracle (1/3)` | same |
| `cis_junction_crossing_shift::no_two_member_allele…` | 65.9s | `Exhaustive sweeps` | serial over 48 independent sequences |
| `spec_conformance_axis::five_prime_conformance_census` | 64.7s | `Test (2/6)` | serial over reference groups |
| `spec_conformance_axis::three_prime_conformance_census` | 63.1s | `Test (5/6)` | same |

The two `spec_conformance_axis` censuses and the sweep are the pattern #1775 proved: work already grouped so that each group owns its provider, run serially. Both become one task per group, with the same byte-identity argument — exact counters over a partition, `collect` preserving input order, and each capped sample list reproduced by capping per task and truncating the in-order concatenation.

## The two biggest are a different problem

They were **already** `into_par_iter`, so parallelism was not the lever. The lever is per-row cost, and three things were being rebuilt for every one of millions of rows:

1. **A whole `AxisCensus` per row.** `of_one` returned one — including a `per_axis` `BTreeMap` node on every *compared* row — which `reduce` then merged pairwise. It becomes `absorb_one`, folding in place, so `fold` builds one accumulator per rayon chunk instead of one per row.
2. **A `Normalizer<MockProvider>` per row.** The provider is empty and never populated — deliberately, since the property under test is the axis *label*, which no reference can inform — so every row was constructing an identical value. It moves to the fold's init.
3. **Two redundant `coordinate_axis()` calls per compared row.** `classify` re-derived both values the caller had already resolved to decide the row was comparable. It now takes them.

The arithmetic is untouched, so every pinned figure and the four-way disposition accounting are identical, and `merge` still folds the chunks.

## What is verified and what is not

**Verified:** `cargo check --features dev --test it` is clean, and `cargo fmt` passes.

**Not verified:** I have not run these tests locally. The dev machine is contended, and a wall-clock number taken on a loaded box is not a measurement — nor is a test run that is competing with four other cargo processes a trustworthy green. So the pinned censuses in all three modules are **unverified against this change**, and that is the first thing to read off CI:

- `spec_conformance_axis`'s seventeen-field `Census` pins (both directions);
- `cis_junction_crossing_shift`'s `FIVE_PRIME_DUP_DEL_SEQUENCE_CHANGES` exact zero, its per-seed case-count floor, and the `skipped * 10 < checked` ratio — the one assertion in that file that is not subset-stable;
- `normalize_axis_preserving`'s disposition accounting, which asserts the four buckets sum to the rows offered.

If any of those moves, the change is wrong and not the pin. None of these commits may re-bless a number.

**Then the timings**, against the table above — `Test oracle (1/3)`, `Test (2/6)`, `Test (5/6)` and `Exhaustive sweeps`.
