### PR TITLE
fix(reference): serve the synthesized transcript's exon table on its own axis

### DIFF
--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -2310,6 +2310,65 @@ impl MultiFastaProvider {
             })
             .collect();
 
+        // #1783 — publish the genome axis only when the transcript axis this
+        // table is stated on IS the axis `n.`/`c.` positions are stated on.
+        //
+        // The table above is on the gap-COLLAPSED axis, which is the axis of
+        // the bytes this function serves. `n.k`, though, names the k-th base of
+        // the DEPOSITED transcript — the FLAT axis, which is the one cdot's own
+        // `tx_start`/`tx_end` are stated in. And that flat axis is what the
+        // OTHER transcript→genome route reads: `CdotTranscript::tx_to_genome`
+        // offsets from each exon's own `tx_start` and returns `None` for a base
+        // no exon covers. It is reached from `project/projector.rs`,
+        // `data/mapping.rs` and `service/handlers/convert.rs`, and it never
+        // touches this `Transcript` — so it is invisible to any census of who
+        // reads `Transcript.exons`.
+        //
+        // When the two axes coincide (a table contiguous from 0) the two routes
+        // are the same function and both are served. When they do not, a genome
+        // coordinate published here answers a question the deposited axis
+        // answers differently. Measured on the head-offset shape: this route
+        // says `n.1` → 1 where `tx_to_genome` declines, and `n.10` → 15 where
+        // `tx_to_genome` says 3 — two `Ok`s, different coordinates, no warning,
+        // and nothing in the answer telling a consumer which route produced it.
+        //
+        // So withhold the alignment rather than serve a second answer. This is
+        // `tx_to_genome_extending_polya`'s own rule one level up ("a gap/hole
+        // […] decline rather than guess"), and it is what biocommons/hgvs does
+        // with such a transcript from any provider. The bases, the collapsed
+        // exon table and the CDS bounds are still served — they are on the
+        // collapsed axis and are correct there, which is what the rest of this
+        // fix buys; only the cross-axis question is refused.
+        //
+        // The FASTA-backed path is unaffected: it serves the flat deposited
+        // sequence beside cdot's flat table, so its two routes already agree
+        // base for base, including declining together inside a hole.
+        let axes_coincide = tx
+            .exons
+            .iter()
+            .zip(exons.iter())
+            .all(|(e, published)| published.start == e[2] + 1 && published.end == e[3]);
+        let exons: Vec<TxExon> = if axes_coincide {
+            exons
+        } else {
+            warn!(
+                "{id}: cdot's exon table is not on the axis of the bases synthesis serves (a \
+                 head offset, an internal hole, or an exon emitting a different number of \
+                 bases than its declared transcript span), so the synthesized transcript is \
+                 served WITHOUT a genome alignment — a c./n. position on it resolves to a \
+                 genome coordinate only through the cdot record itself, which states the \
+                 deposited transcript's axis (issues #1773, #1783)"
+            );
+            exons
+                .into_iter()
+                .map(|e| TxExon {
+                    genomic_start: None,
+                    genomic_end: None,
+                    ..e
+                })
+                .collect()
+        };
+
         let (genomic_start, genomic_end) = {
             let min_start = exons.iter().filter_map(|e| e.genomic_start).min();
             let max_end = exons.iter().filter_map(|e| e.genomic_end).max();
@@ -6808,13 +6867,19 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             "the last exon must end at the last served base"
         );
 
-        // The genome axis is cdot's alignment and must not move with it.
+        // The genome axis is NOT re-tiled with it — cdot's alignment is stated
+        // in genome coordinates and no transcript-space question can move it.
+        // On this record it is withheld instead: the collapsed axis the table
+        // above is on is not the deposited axis `n.` positions are stated on,
+        // and publishing a genome coordinate against it would contradict
+        // `CdotTranscript::tx_to_genome` (#1783). See
+        // `route_parity_declines_when_the_flat_and_collapsed_axes_differ`.
         assert_eq!(
             tx.exons
                 .iter()
                 .map(|e| (e.genomic_start, e.genomic_end))
                 .collect::<Vec<_>>(),
-            vec![(Some(1), Some(9)), (Some(15), Some(23))]
+            vec![(None, None), (None, None)]
         );
     }
 
@@ -7014,6 +7079,418 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             vec![(1, 9)],
             "the exon must claim the 9 bases it served, not its declared span of 4"
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // #1783 — ROUTE PARITY for a cdot-synthesized transcript.
+    //
+    // Enumerated by ROUTE to the answer, not by consumer of a structure: a
+    // census of `Transcript.exons`' readers cannot see route B below, because
+    // route B never mentions `Transcript` at all.
+    //
+    //   Route A — the published `Transcript`. `CoordinateMapper::tx_to_genomic`
+    //     and `tx_to_genomic_with_intron` walk `Transcript.exons`, which for a
+    //     cdot-synthesized transcript is the table this file builds. Reached
+    //     from `normalize/mod.rs`, `vcf/from_hgvs.rs`,
+    //     `equivalence/checker.rs` and
+    //     `error_handling/corrections.rs::resolve_cds_endpoint_to_genomic`.
+    //
+    //   Route B — the raw cdot arrays. `CdotTranscript::tx_to_genome` and
+    //     `tx_to_genome_extending_polya` offset from each exon's own
+    //     `tx_start` and return `None` when no exon covers the position.
+    //     Reached from `project/projector.rs` (the non-coding arm and the
+    //     poly-A walk), `data/mapping.rs` (which every coding
+    //     `cds_to_genome*` call bottoms out in) and
+    //     `service/handlers/convert.rs`.
+    //
+    // Route B is the authority: `n.k` names the k-th base of the DEPOSITED
+    // transcript, cdot's `tx_start`/`tx_end` are offsets into that same flat
+    // sequence, and a base that aligns nowhere gets no genome coordinate —
+    // "decline rather than guess", the rule `tx_to_genome_extending_polya`
+    // already states in its own body.
+    //
+    // Route A on a synthesized transcript is asked the same `n.k` but reads a
+    // table on the gap-COLLAPSED axis, so for any record whose flat and
+    // collapsed axes differ it answers about a different base. The failure
+    // mode this guard exists to prevent is both routes returning `Ok` with
+    // different coordinates and nothing noticing.
+    // ----------------------------------------------------------------------
+
+    /// What one route answered at one transcript position.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum RouteAnswer {
+        Genome(u64),
+        Declined,
+    }
+
+    impl RouteAnswer {
+        fn genome(self) -> Option<u64> {
+            match self {
+                RouteAnswer::Genome(g) => Some(g),
+                RouteAnswer::Declined => None,
+            }
+        }
+    }
+
+    /// Every route's answer at one deposited transcript position `n`.
+    struct ParityRow {
+        n: i64,
+        route_a: RouteAnswer,
+        route_a_intron: RouteAnswer,
+        route_b: RouteAnswer,
+        route_b_polya: RouteAnswer,
+    }
+
+    impl ParityRow {
+        fn all(&self) -> [(&'static str, RouteAnswer); 4] {
+            [
+                ("A tx_to_genomic", self.route_a),
+                ("A tx_to_genomic_with_intron", self.route_a_intron),
+                ("B tx_to_genome", self.route_b),
+                ("B tx_to_genome_extending_polya", self.route_b_polya),
+            ]
+        }
+    }
+
+    /// The whole observation for one exon-table geometry.
+    struct ParityProbe {
+        /// The synthesized transcript, if synthesis served one at all.
+        served: Option<std::sync::Arc<Transcript>>,
+        rows: Vec<ParityRow>,
+    }
+
+    /// Seat a two-exon cdot record over `NC_ORF.1` with the given exon table
+    /// and no CDS, so the transcript-space geometry is the only variable.
+    fn seat_parity_tx(exons: Vec<[u64; 4]>) -> CdotMapper {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::transcript::Strand;
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NR_PARITY.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("PARITY".to_string()),
+                contig: "NC_ORF.1".to_string(),
+                exons,
+                strand: Strand::Plus,
+                cds_start: None,
+                cds_end: None,
+                gene_id: None,
+                protein: None,
+                exon_cigars: vec![None, None],
+            },
+        );
+        cdot
+    }
+
+    /// Drive every enumerated route at every deposited transcript position.
+    ///
+    /// The sweep runs `n.1 ..= flat_tx_end` — the positions the cdot exon
+    /// table itself spans — so `tx_to_genome_extending_polya` is never asked
+    /// about the poly-A region, where declining to extend is by design and not
+    /// a parity question.
+    fn probe_routes(exons: Vec<[u64; 4]>) -> ParityProbe {
+        use crate::convert::mapper::CoordinateMapper;
+        use crate::hgvs::location::TxPos;
+
+        let flat_tx_end = exons.iter().map(|e| e[3]).max().expect("non-empty table");
+        let (mut provider, _kept) = build_provider_with_orf_genome();
+        let cdot = seat_parity_tx(exons);
+        let cdot_tx = cdot
+            .get_transcript("NR_PARITY.1")
+            .expect("fixture seats the record")
+            .clone();
+        provider.cdot_mapper = Some(cdot);
+
+        let served = provider.get_transcript("NR_PARITY.1").ok();
+
+        let rows = (1..=flat_tx_end as i64)
+            .map(|n| {
+                let (route_a, route_a_intron) = match served.as_ref() {
+                    // Synthesis declined, so route A has no transcript to walk
+                    // and every consumer of it declines with it.
+                    None => (RouteAnswer::Declined, RouteAnswer::Declined),
+                    Some(tx) => {
+                        let mapper = CoordinateMapper::new(tx);
+                        let a = match mapper.tx_to_genomic(&TxPos::new(n)) {
+                            Ok(Some(g)) => RouteAnswer::Genome(g),
+                            Ok(None) | Err(_) => RouteAnswer::Declined,
+                        };
+                        let a_intron = match mapper.tx_to_genomic_with_intron(&TxPos::new(n)) {
+                            Ok(g) => RouteAnswer::Genome(g),
+                            Err(_) => RouteAnswer::Declined,
+                        };
+                        (a, a_intron)
+                    }
+                };
+                let tx_pos_0based = (n - 1) as u64;
+                let route_b = match cdot_tx.tx_to_genome(tx_pos_0based) {
+                    Some(g) => RouteAnswer::Genome(g),
+                    None => RouteAnswer::Declined,
+                };
+                let route_b_polya = match cdot_tx.tx_to_genome_extending_polya(tx_pos_0based) {
+                    Some(g) => RouteAnswer::Genome(g),
+                    None => RouteAnswer::Declined,
+                };
+                ParityRow {
+                    n,
+                    route_a,
+                    route_a_intron,
+                    route_b,
+                    route_b_polya,
+                }
+            })
+            .collect();
+
+        ParityProbe { served, rows }
+    }
+
+    /// Collect every violation of the two parity invariants, so a failure
+    /// reports the whole disagreement rather than only its first row.
+    fn parity_violations(probe: &ParityProbe) -> Vec<String> {
+        let mut out = Vec::new();
+        for row in &probe.rows {
+            let routes = row.all();
+            // INV1 — no two routes may both answer with DIFFERENT coordinates.
+            for (i, (ln, la)) in routes.iter().enumerate() {
+                for (rn, ra) in routes.iter().skip(i + 1) {
+                    if let (Some(l), Some(r)) = (la.genome(), ra.genome()) {
+                        if l != r {
+                            out.push(format!(
+                                "n.{}: {ln} -> {l} but {rn} -> {r} (both answered, different)",
+                                row.n
+                            ));
+                        }
+                    }
+                }
+            }
+            // INV2 — route A may never answer where route B declines. Route B
+            // is the authority on which deposited bases have a genome
+            // coordinate at all.
+            if row.route_b == RouteAnswer::Declined {
+                for (ln, la) in routes.iter().take(2) {
+                    if let Some(g) = la.genome() {
+                        out.push(format!(
+                            "n.{}: {ln} -> {g} but B tx_to_genome declined (answer where the \
+                             authority declines)",
+                            row.n
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// The control: a cdot exon table that is contiguous and starts at 0, so
+    /// the flat and collapsed transcript axes are the same axis. Every route
+    /// must answer at every position, and answer the same thing.
+    ///
+    /// This is the half of the guard that can only pass by routes actually
+    /// ANSWERING — without it the invariants above are satisfiable by a
+    /// transcript nothing serves, and the guard would pass while checking
+    /// nothing.
+    #[test]
+    fn route_parity_holds_when_the_flat_and_collapsed_axes_coincide() {
+        let probe = probe_routes(vec![[1, 10, 0, 9], [15, 24, 9, 18]]);
+
+        let tx = probe
+            .served
+            .as_ref()
+            .expect("a contiguous zero-based exon table must still synthesize");
+        assert_eq!(
+            tx.sequence.as_deref(),
+            Some("ATGCCCGGGAAACCCTAA"),
+            "the served bases are unchanged by the parity guard"
+        );
+
+        assert!(
+            parity_violations(&probe).is_empty(),
+            "identity geometry must not disagree: {:?}",
+            parity_violations(&probe)
+        );
+        assert_eq!(probe.rows.len(), 18, "the sweep must cover every position");
+        for row in &probe.rows {
+            for (name, answer) in row.all() {
+                assert!(
+                    matches!(answer, RouteAnswer::Genome(_)),
+                    "n.{}: {name} declined on an identity-axis transcript",
+                    row.n
+                );
+            }
+        }
+        // And the answers are the genome windows the fixture states.
+        assert_eq!(probe.rows[0].route_a, RouteAnswer::Genome(1));
+        assert_eq!(probe.rows[9].route_a, RouteAnswer::Genome(15));
+    }
+
+    /// The three geometries where the flat and collapsed axes differ. cdot has
+    /// all of them — 167 GRCh38 and 442 GRCh37 records, the head offset the
+    /// larger class on both.
+    ///
+    /// Route B is right and stays untouched. Route A must decline rather than
+    /// serve a second, different coordinate for the same `n.` position: on the
+    /// head-offset shape it previously answered `n.1 -> 1` where route B
+    /// declines, and `n.10 -> 15` where route B says `3`.
+    #[test]
+    fn route_parity_declines_when_the_flat_and_collapsed_axes_differ() {
+        // (name, exon table, whether route B ever declines inside the sweep)
+        let geometries: Vec<(&str, Vec<[u64; 4]>)> = vec![
+            ("head offset only", vec![[1, 10, 7, 16], [15, 24, 16, 25]]),
+            ("internal hole only", vec![[1, 10, 0, 9], [15, 24, 20, 29]]),
+            ("both", vec![[1, 10, 7, 16], [15, 24, 27, 36]]),
+        ];
+
+        for (name, exons) in geometries {
+            let probe = probe_routes(exons);
+
+            let violations = parity_violations(&probe);
+            assert!(
+                violations.is_empty(),
+                "{name}: routes disagree ({} violations): {violations:#?}",
+                violations.len()
+            );
+
+            // Non-vacuity, both directions. Route B must be live — answering
+            // somewhere and declining somewhere — or the invariants above
+            // would hold for a fixture that asks nothing.
+            assert!(
+                probe
+                    .rows
+                    .iter()
+                    .any(|r| matches!(r.route_b, RouteAnswer::Genome(_))),
+                "{name}: route B answered nowhere, so the fixture proves nothing"
+            );
+            assert!(
+                probe
+                    .rows
+                    .iter()
+                    .any(|r| r.route_b == RouteAnswer::Declined),
+                "{name}: route B declined nowhere, so this geometry has no gap"
+            );
+
+            // Route A must be silent across the whole transcript: the
+            // collapsed axis is not the axis `n.` is stated on, so there is no
+            // position at which it may answer.
+            for row in &probe.rows {
+                assert_eq!(
+                    row.route_a,
+                    RouteAnswer::Declined,
+                    "{name}: route A answered at n.{}",
+                    row.n
+                );
+            }
+        }
+    }
+
+    /// The same divergent geometry, served from a transcript FASTA instead of
+    /// synthesized — the case where both routes must ANSWER, and answer the
+    /// same thing, including declining together inside the hole.
+    ///
+    /// This is the control that stops the fix from being "make route A silent
+    /// whenever the geometry is awkward": here the deposited bases exist, the
+    /// served sequence IS the flat transcript, cdot's flat table is the right
+    /// table for it, and the genome axis is published in full. If the
+    /// withholding leaked onto this path the parity assertions below would
+    /// still pass (silence never contradicts) but the non-vacuity assertions
+    /// would not.
+    #[test]
+    fn route_parity_holds_on_the_fasta_backed_path_with_a_divergent_geometry() {
+        use crate::convert::mapper::CoordinateMapper;
+        use crate::hgvs::location::TxPos;
+
+        let exons = vec![[1u64, 10, 7, 16], [15, 24, 27, 36]];
+        let dir = tempdir().unwrap();
+        {
+            let mut f = File::create(dir.path().join("genome.fna")).unwrap();
+            writeln!(f, ">NC_ORF.1").unwrap();
+            writeln!(f, "ATGCCCGGGTTTTTAAACCCTAA").unwrap();
+            let mut i = File::create(dir.path().join("genome.fna.fai")).unwrap();
+            writeln!(i, "NC_ORF.1\t23\t10\t23\t24").unwrap();
+        }
+        {
+            // The deposited transcript on the flat axis the table states: 7
+            // unaligned head bases, exon 1's 9, an 11-base hole, exon 2's 9.
+            let mut f = File::create(dir.path().join("tx.fna")).unwrap();
+            writeln!(f, ">NR_PARITY.1").unwrap();
+            writeln!(f, "GGGGGGGATGCCCGGGNNNNNNNNNNNAAACCCTAA").unwrap();
+            let mut i = File::create(dir.path().join("tx.fna.fai")).unwrap();
+            writeln!(i, "NR_PARITY.1\t36\t13\t36\t37").unwrap();
+        }
+        let mut provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+        let cdot = seat_parity_tx(exons.clone());
+        let cdot_tx = cdot
+            .get_transcript("NR_PARITY.1")
+            .expect("fixture seats the record")
+            .clone();
+        provider.cdot_mapper = Some(cdot);
+
+        let tx = provider
+            .get_transcript("NR_PARITY.1")
+            .expect("the FASTA record must serve this accession");
+        assert_eq!(
+            tx.sequence.as_deref().map(str::len),
+            Some(36),
+            "the FASTA path serves the flat deposited sequence"
+        );
+
+        let mapper = CoordinateMapper::new(&tx);
+        let mut answered = 0usize;
+        let mut declined = 0usize;
+        for n in 1..=36i64 {
+            let route_a = match mapper.tx_to_genomic(&TxPos::new(n)) {
+                Ok(Some(g)) => RouteAnswer::Genome(g),
+                Ok(None) | Err(_) => RouteAnswer::Declined,
+            };
+            let route_b = match cdot_tx.tx_to_genome((n - 1) as u64) {
+                Some(g) => RouteAnswer::Genome(g),
+                None => RouteAnswer::Declined,
+            };
+            assert_eq!(
+                route_a, route_b,
+                "n.{n}: the FASTA-backed routes must agree exactly"
+            );
+            match route_a {
+                RouteAnswer::Genome(_) => answered += 1,
+                RouteAnswer::Declined => declined += 1,
+            }
+        }
+        // 18 aligned bases answer; the 7-base head and the 11-base hole
+        // decline — on BOTH routes, which is the "agreeing to decline" half.
+        assert_eq!((answered, declined), (18, 18));
+    }
+
+    /// The bases and the transcript-axis table are NOT withdrawn — only the
+    /// genome axis is. #1783's fix stands: the published exon table still
+    /// tiles the served sequence from 1.
+    #[test]
+    fn a_divergent_axis_withholds_the_genome_alignment_not_the_bases() {
+        let probe = probe_routes(vec![[1, 10, 7, 16], [15, 24, 27, 36]]);
+        let tx = probe
+            .served
+            .as_ref()
+            .expect("a divergent-axis record still serves its bases");
+
+        assert_eq!(tx.sequence.as_deref(), Some("ATGCCCGGGAAACCCTAA"));
+        assert_eq!(
+            tx.exons
+                .iter()
+                .map(|e| (e.start, e.end))
+                .collect::<Vec<_>>(),
+            vec![(1, 9), (10, 18)],
+            "#1783's collapsed exon table is unchanged"
+        );
+        assert!(
+            tx.exons
+                .iter()
+                .all(|e| e.genomic_start.is_none() && e.genomic_end.is_none()),
+            "the genome axis must be withheld, got {:?}",
+            tx.exons
+                .iter()
+                .map(|e| (e.genomic_start, e.genomic_end))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!((tx.genomic_start, tx.genomic_end), (None, None));
     }
 
     #[test]

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -2039,10 +2039,19 @@ impl MultiFastaProvider {
     /// version-stripped); callers that rely on a different contig version should
     /// keep the genome FASTA in sync with cdot.
     ///
-    /// `tx.strand` is honored; metadata fields are projected onto the returned
-    /// `Transcript` using the same conventions as the FASTA-backed path so
-    /// downstream consumers see one shape regardless of which path served
-    /// them. `genome_build` is derived from `build_hint` when the caller
+    /// The sequence this serves is therefore the **gap-collapsed** transcript —
+    /// exon bases only, with no position for any transcript base cdot's exon
+    /// table does not cover. The exon table and CDS bounds published on the
+    /// returned `Transcript` are stated on that same axis, so the three agree
+    /// with each other (#1773); cdot's own `tx_start`/`tx_end`, which are flat
+    /// transcript offsets, are **not** carried through. That is the one place
+    /// this path deliberately differs from the FASTA-backed path, which serves
+    /// the flat deposited sequence and for which the flat table is correct.
+    ///
+    /// `tx.strand` is honored; the remaining metadata fields are projected onto
+    /// the returned `Transcript` using the same conventions as the FASTA-backed
+    /// path so downstream consumers see one shape regardless of which path
+    /// served them. `genome_build` is derived from `build_hint` when the caller
     /// supplied one; otherwise from the attached [`CdotMapper`]'s primary
     /// build (this entry point is only reachable through that mapper, so
     /// the cdot-less branch of
@@ -2094,6 +2103,11 @@ impl MultiFastaProvider {
         // pre-#807 behavior — the overwhelming common, non-indel case).
         let is_minus = matches!(tx.strand, Strand::Minus);
         let mut sequence = String::new();
+        // Bases each exon actually contributed to `sequence`, in tx-order. The
+        // exon table published below is built from these rather than from cdot's
+        // own `tx_start`/`tx_end`, so it tiles the served sequence by
+        // construction — see the coordinate-space note there (#1773).
+        let mut emitted_per_exon: Vec<u64> = Vec::with_capacity(tx.exons.len());
         for (i, e) in tx.exons.iter().enumerate() {
             let g_start_hgvs = e[0];
             let g_end_excl_hgvs = e[1];
@@ -2145,10 +2159,62 @@ impl MultiFastaProvider {
                             ),
                         });
                     }
+                    emitted_per_exon.push(applied.len() as u64);
                     sequence.push_str(&applied);
                 }
                 // No per-exon CIGAR data: keep the whole window (pre-#807 behavior).
-                _ => sequence.push_str(&tx_oriented),
+                _ => {
+                    // Guard-set parity with the CIGAR arm above, scoped to the
+                    // records where the mismatch can do damage (#1773).
+                    //
+                    // The CIGAR arm refuses when the emitted length disagrees
+                    // with the declared span `e[3] - e[2]`. This arm never asked,
+                    // because a no-CIGAR exon emits its whole genome window by
+                    // design and the exon table published below deliberately
+                    // follows the bases served rather than the declaration
+                    // (`synthesized_exon_table_follows_the_bases_served_not_the_declared_span`).
+                    //
+                    // That is the right answer for the exon table and the WRONG
+                    // one for the CDS. cdot states `start_codon`/`stop_codon`
+                    // over the concatenation of the exons' DECLARED spans, so
+                    // when a no-CIGAR exon emits a different number of bases the
+                    // two disagree and the CDS silently names different bases in
+                    // the sequence this function serves — no error, no warning
+                    // that discriminates it, and an exon table that tiles
+                    // perfectly while the CDS inside it is displaced.
+                    //
+                    // Do NOT rely on `cdot_synthesis_has_unverified_exon` to make
+                    // this loud: it fires for EVERY no-CIGAR exon, which is the
+                    // overwhelming common case, so it cannot single out the one
+                    // record where the lengths disagree.
+                    //
+                    // Measured 0 of 482,519 GRCh38 and 0 of 197,846 GRCh37 builds
+                    // carry such an exon, so this refuses nothing in the current
+                    // cdot — but that zero is a property of this release (its Gap
+                    // attribute is written exactly when the alignment has indels),
+                    // not a guarantee, which is why it is enforced rather than
+                    // assumed. Scoped to records that publish a CDS: with no CDS
+                    // there is nothing stated in the declared-span frame, and the
+                    // emitted-bases table is unambiguously correct.
+                    let emitted = tx_oriented.len() as u64;
+                    if tx.cds_start.is_some() || tx.cds_end.is_some() {
+                        let declared = e[3].saturating_sub(e[2]);
+                        if emitted != declared {
+                            return Err(FerroError::InvalidCoordinates {
+                                msg: format!(
+                                    "cdot exon {} for {id} has no CIGAR and emits {emitted} \
+                                     transcript base(s) from its genome window, but its declared \
+                                     transcript span is {declared}; the record's CDS bounds are \
+                                     stated over the declared spans, so serving this would \
+                                     displace the CDS within the synthesized sequence",
+                                    i + 1
+                                ),
+                            });
+                        }
+                    }
+                    emitted_per_exon.push(emitted);
+                    sequence.push_str(&tx_oriented);
+                }
             }
         }
 
@@ -2173,23 +2239,74 @@ impl MultiFastaProvider {
             );
         }
 
-        // Project cdot exons + CDS metadata onto the transcript struct using the
-        // same conventions as the FASTA-backed `get_transcript` path above so
-        // downstream consumers see one shape regardless of which path served them.
+        // Project cdot exons + CDS metadata onto the transcript struct.
+        //
+        // #1773 — the transcript axis here is NOT the one the FASTA-backed path
+        // publishes, and the two must not be conflated. A cdot record states two
+        // transcript coordinate spaces and labels neither:
+        //   - the exon table's `tx_start`/`tx_end` are absolute offsets into the
+        //     **flat** transcript sequence, so a base that fails to align to the
+        //     genome still occupies a position in them;
+        //   - `start_codon`/`stop_codon` (`CdotTranscript.cds_start`/`cds_end`)
+        //     are offsets into the gap-**collapsed** transcript — exon bases only.
+        // The sequence synthesized above is the concatenation of the exons'
+        // emitted bases, so it *is* the collapsed transcript: it has no position
+        // for any base the exon table does not cover. Publishing cdot's flat
+        // `tx_start`/`tx_end` over it therefore mis-states every exon boundary by
+        // the leading offset plus every preceding hole, and every consumer that
+        // walks the table — genome↔transcript mapping, exon/intron geometry,
+        // junction-crossing checks — then indexes the served bytes with a
+        // position that is not on their axis.
+        //
+        // The two spaces coincide only for an exon table that is contiguous
+        // **and** starts at 0. Measured over the prepared reference's cdot
+        // 0.2.32: 167 of 482,519 GRCh38 builds and 442 of 197,846 GRCh37 builds
+        // fail that, split between a non-zero head offset and an internal hole,
+        // with the head offset the larger class on both.
+        //
+        // So build the table from the bases each exon actually contributed. It
+        // then tiles `sequence` from 1 by construction, which is also what makes
+        // it agree with `cds_start`/`cds_end` below.
+        //
+        // The FASTA-backed path above is deliberately untouched: there the
+        // served sequence is the flat deposited one, so cdot's flat exon table
+        // is the correct table for it.
+        let mut compact_offset: u64 = 0;
+        // The loop above pushes exactly one entry per exon or returns `Err`, so
+        // these lengths agree. Said out loud because the `zip` below would
+        // otherwise absorb a disagreement by TRUNCATING the published table, and
+        // a short table still tiles a prefix of the sequence — so the guards
+        // would keep passing while the last exons quietly vanished.
+        debug_assert_eq!(
+            emitted_per_exon.len(),
+            tx.exons.len(),
+            "{id}: synthesis must record one emitted length per exon"
+        );
         let exons: Vec<TxExon> = tx
             .exons
             .iter()
+            .zip(emitted_per_exon.iter())
             .enumerate()
-            .map(|(i, e)| TxExon {
-                number: (i + 1) as u32,
-                // #742: `CdotTranscript.exons` is now HGVS-convention
-                // ([genome 1-based incl/excl, tx 0-based incl/excl]); `TxExon`
-                // is 1-based-inclusive on both axes. (This also resolves the
-                // former #331 genomic-coordinate off-by-one noted here.)
-                start: e[2] + 1,             // tx_start: 0-based incl → 1-based incl
-                end: e[3],                   // tx_end: 0-based excl = 1-based incl
-                genomic_start: Some(e[0]),   // genome_start: already 1-based incl
-                genomic_end: Some(e[1] - 1), // genome_end: 1-based excl → 1-based incl
+            .map(|(i, (e, &emitted))| {
+                // `TxExon` is 1-based-inclusive on both axes. An exon that
+                // emitted no bases (only reachable from a degenerate record)
+                // yields `end < start`, which is the honest encoding of an empty
+                // span and is what every other empty-span check in the crate
+                // already tolerates.
+                let exon = TxExon {
+                    number: (i + 1) as u32,
+                    start: compact_offset + 1,
+                    end: compact_offset + emitted,
+                    // The genome axis is unchanged — it is cdot's alignment and
+                    // is stated in genome coordinates, which no transcript-space
+                    // question can move. (#742 put these in the HGVS convention:
+                    // `genome_start` 1-based inclusive, `genome_end` 1-based
+                    // exclusive.)
+                    genomic_start: Some(e[0]),
+                    genomic_end: Some(e[1] - 1),
+                };
+                compact_offset += emitted;
+                exon
             })
             .collect();
 
@@ -2204,6 +2321,35 @@ impl MultiFastaProvider {
             gene_symbol: tx.gene_name.clone(),
             strand: tx.strand,
             sequence: Some(sequence),
+            // cdot's `start_codon`/`stop_codon` are offsets into the
+            // gap-**collapsed** transcript, which is the space the sequence
+            // above is in, so they are carried through with only the 0-based →
+            // 1-based shift. Verified against the deposited transcript FASTA
+            // rather than assumed: over the GRCh38 non-identity records that
+            // carry both a CDS and a sequence, slicing the flat deposited
+            // sequence at these bounds read as **collapsed** offsets yields a
+            // valid ORF 50/50 (gapped) and 41/46 (head-offset, the residue
+            // failing under both readings for its own reasons), while reading
+            // them as **flat** offsets yields 0/50 and 0/46.
+            //
+            // Read precisely, cdot states those offsets over the concatenation
+            // of the exons' DECLARED transcript spans (`e[3] - e[2]`), while the
+            // sequence above is the concatenation of what each exon EMITTED. The
+            // two agree for every CIGAR-bearing exon, which synthesis checks
+            // (#807), and for every exon whose genome window is its declared
+            // span — which is every no-CIGAR exon in this cdot: measured 0 of
+            // 482,519 GRCh38 and 0 of 197,846 GRCh37 builds carry a no-CIGAR
+            // exon whose genome span differs from its declared transcript span.
+            // A record that broke it would already be warning loudly through
+            // `cdot_synthesis_has_unverified_exon`, so the case is not silent,
+            // but the assumption belongs here rather than in a reader's head.
+            //
+            // #1773 — THIS IS THE SEAM. Anything that moves
+            // `CdotTranscript::cds_start`/`cds_end` into the flat transcript
+            // space must map them back to the collapsed space here, or the CDS
+            // stops naming positions in the sequence this function serves. The
+            // guard is
+            // `synthesized_cds_bounds_are_on_the_served_sequences_axis`.
             cds_start: tx.cds_start.map(|s| s + 1),
             cds_end: tx.cds_end,
             exons,
@@ -6571,6 +6717,303 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             .get_transcript("NM_MIX.1")
             .expect("mixed deletion + missing-CIGAR record must synthesize, not decline");
         assert_eq!(tx.sequence.as_deref(), Some("GGTTAAAACCCCGGGGTT"));
+    }
+
+    // ----------------------------------------------------------------------
+    // #1773 — the synthesized transcript's own coordinate space.
+    //
+    // Synthesis concatenates the exons' bases, so what it serves is the
+    // gap-COLLAPSED transcript. cdot's exon table is stated in FLAT transcript
+    // offsets and its `start_codon`/`stop_codon` in collapsed ones; publishing
+    // the former over the collapsed sequence puts the exon table on an axis the
+    // bytes are not on.
+    // ----------------------------------------------------------------------
+
+    /// A genome whose two exon windows concatenate to a valid ORF, so the CDS
+    /// bounds can be checked by what they DENOTE rather than by their numbers.
+    ///
+    /// `NC_ORF.1` = `ATGCCCGGG` `TTTTT` `AAACCCTAA` (23 bases). The two windows
+    /// are HGVS `[1,10)` and `[15,24)`; concatenated they read
+    /// `ATG CCC GGG AAA CCC TAA` — start codon, no internal stop, terminator.
+    fn build_provider_with_orf_genome() -> (MultiFastaProvider, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let fasta_path = dir.path().join("genome.fna");
+        let fai_path = dir.path().join("genome.fna.fai");
+        {
+            let mut f = File::create(&fasta_path).unwrap();
+            writeln!(f, ">NC_ORF.1").unwrap();
+            writeln!(f, "ATGCCCGGGTTTTTAAACCCTAA").unwrap();
+        }
+        {
+            let mut f = File::create(&fai_path).unwrap();
+            // Header ">NC_ORF.1\n" is 10 bytes, so the sequence offset is 10.
+            writeln!(f, "NC_ORF.1\t23\t10\t23\t24").unwrap();
+        }
+        let provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+        (provider, dir)
+    }
+
+    /// `NM_ORF.1` over `build_provider_with_orf_genome`, carrying BOTH shapes
+    /// that make the flat and collapsed spaces differ: a 7-base head offset
+    /// (the first exon starts at flat tx 7, not 0) and an 11-base hole between
+    /// the exons. Real cdot has both — 167 GRCh38 and 442 GRCh37 builds, the
+    /// head offset the larger class on each.
+    ///
+    /// The CDS is stated the way cdot states it, as gap-collapsed offsets
+    /// `[0, 18)` — the whole served transcript.
+    fn seat_headed_and_gapped_orf_tx() -> CdotMapper {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::transcript::Strand;
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_ORF.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("ORF".to_string()),
+                contig: "NC_ORF.1".to_string(),
+                // [genome_start (1-based incl), genome_end (1-based excl),
+                //  tx_start (0-based incl), tx_end (0-based excl)] — the tx
+                // bounds are FLAT: head offset 7, then a hole of 11 (16 → 27).
+                exons: vec![[1, 10, 7, 16], [15, 24, 27, 36]],
+                strand: Strand::Plus,
+                cds_start: Some(0),
+                cds_end: Some(18),
+                gene_id: None,
+                protein: None,
+                exon_cigars: vec![None, None],
+            },
+        );
+        cdot
+    }
+
+    #[test]
+    fn synthesized_exon_table_tiles_the_served_sequence() {
+        let (mut provider, _kept) = build_provider_with_orf_genome();
+        provider.cdot_mapper = Some(seat_headed_and_gapped_orf_tx());
+
+        let tx = provider
+            .get_transcript("NM_ORF.1")
+            .expect("head-offset + gapped record must synthesize");
+        let seq = tx.sequence.as_deref().expect("synthesis serves bases");
+        assert_eq!(seq, "ATGCCCGGGAAACCCTAA");
+
+        // The published table is on the served sequence's axis: it starts at 1,
+        // ends at its last base, and leaves no hole. cdot's flat table would say
+        // 8..=16 and 28..=36 over these 18 bytes.
+        let spans: Vec<(u64, u64)> = tx.exons.iter().map(|e| (e.start, e.end)).collect();
+        assert_eq!(spans, vec![(1, 9), (10, 18)]);
+        assert_eq!(
+            tx.exons.last().map(|e| e.end),
+            Some(seq.len() as u64),
+            "the last exon must end at the last served base"
+        );
+
+        // The genome axis is cdot's alignment and must not move with it.
+        assert_eq!(
+            tx.exons
+                .iter()
+                .map(|e| (e.genomic_start, e.genomic_end))
+                .collect::<Vec<_>>(),
+            vec![(Some(1), Some(9)), (Some(15), Some(23))]
+        );
+    }
+
+    #[test]
+    fn synthesized_cds_bounds_are_on_the_served_sequences_axis() {
+        let (mut provider, _kept) = build_provider_with_orf_genome();
+        provider.cdot_mapper = Some(seat_headed_and_gapped_orf_tx());
+
+        let tx = provider
+            .get_transcript("NM_ORF.1")
+            .expect("head-offset + gapped record must synthesize");
+        let seq = tx.sequence.as_deref().expect("synthesis serves bases");
+        let (cds_start, cds_end) = (
+            tx.cds_start.expect("fixture has a CDS"),
+            tx.cds_end.expect("fixture has a CDS"),
+        );
+
+        // Judged by what the bounds DENOTE, not by their numbers: on the served
+        // sequence's axis they must slice the reading frame the fixture's genome
+        // windows were built to spell. Read as flat offsets they would name
+        // 8..=36 on an 18-base sequence and slice nothing at all.
+        assert!(
+            cds_start >= 1 && cds_end <= seq.len() as u64 && cds_start <= cds_end,
+            "CDS {cds_start}..={cds_end} is not inside the {}-base served sequence",
+            seq.len()
+        );
+        let cds = &seq[(cds_start - 1) as usize..cds_end as usize];
+        assert_eq!(cds, "ATGCCCGGGAAACCCTAA");
+        assert!(cds.starts_with("ATG"), "CDS must open on the start codon");
+        assert_eq!(cds.len() % 3, 0, "CDS must be a whole number of codons");
+        assert_eq!(&cds[cds.len() - 3..], "TAA", "CDS must close on its stop");
+
+        // And the CDS must sit inside the exon table it is published beside,
+        // which is the coherence the two halves of this fix buy together.
+        assert!(
+            tx.exons
+                .iter()
+                .any(|e| e.start <= cds_start && cds_start <= e.end),
+            "cds_start {cds_start} falls in no exon of {:?}",
+            tx.exons
+                .iter()
+                .map(|e| (e.start, e.end))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fasta_backed_transcript_keeps_cdots_flat_exon_table() {
+        // The other half of #1773, and the half that must NOT move: when the
+        // transcript FASTA carries the accession, the served sequence is the
+        // FLAT deposited one — head offset and hole included as real bases — so
+        // cdot's flat `tx_start`/`tx_end` is the correct table for it and is
+        // published verbatim. Re-tiling this path the way synthesis is re-tiled
+        // would be a regression, and nothing in the suite noticed it before this
+        // test: the mutation that subtracts the head offset here passed all 4194
+        // `--lib` tests.
+        let dir = tempdir().unwrap();
+        {
+            let mut f = File::create(dir.path().join("genome.fna")).unwrap();
+            writeln!(f, ">NC_ORF.1").unwrap();
+            writeln!(f, "ATGCCCGGGTTTTTAAACCCTAA").unwrap();
+            // ">NC_ORF.1\n" is 10 bytes, so the sequence offset is 10.
+            let mut i = File::create(dir.path().join("genome.fna.fai")).unwrap();
+            writeln!(i, "NC_ORF.1\t23\t10\t23\t24").unwrap();
+        }
+        {
+            // The deposited transcript, on the flat axis the exon table states:
+            // 7 unaligned head bases, exon 1's 9, an 11-base hole, exon 2's 9.
+            let mut f = File::create(dir.path().join("tx.fna")).unwrap();
+            writeln!(f, ">NM_ORF.1").unwrap();
+            writeln!(f, "GGGGGGGATGCCCGGGNNNNNNNNNNNAAACCCTAA").unwrap();
+            let mut i = File::create(dir.path().join("tx.fna.fai")).unwrap();
+            writeln!(i, "NM_ORF.1\t36\t10\t36\t37").unwrap();
+        }
+        let mut provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+        provider.cdot_mapper = Some(seat_headed_and_gapped_orf_tx());
+
+        let tx = provider
+            .get_transcript("NM_ORF.1")
+            .expect("the FASTA record must serve this accession");
+        assert_eq!(
+            tx.sequence.as_deref().map(str::len),
+            Some(36),
+            "the FASTA path serves the flat deposited sequence"
+        );
+        assert_eq!(
+            tx.exons
+                .iter()
+                .map(|e| (e.start, e.end))
+                .collect::<Vec<_>>(),
+            vec![(8, 16), (28, 36)],
+            "cdot's flat exon table is correct against a flat sequence"
+        );
+    }
+
+    /// The other side of `..._follows_the_bases_served_not_the_declared_span`,
+    /// and the case that test could not cover because it deliberately carries no
+    /// CDS.
+    ///
+    /// A no-CIGAR exon emits its whole genome window whatever its declared
+    /// transcript span says, and the published exon table follows those bases —
+    /// correct, and what the sibling test pins. But cdot states
+    /// `start_codon`/`stop_codon` over the concatenation of the exons'
+    /// **declared** spans, so on a record that also carries a CDS the two frames
+    /// disagree and the CDS silently names different bases in the served
+    /// sequence. The exon table still tiles perfectly, so nothing downstream
+    /// looks wrong.
+    ///
+    /// Synthesis must refuse rather than serve that. Two exons, the FIRST
+    /// mismatching (window 9, declared 4) and the CDS opening in the second, so
+    /// the displacement is real rather than incidental.
+    ///
+    /// Measured 0 of 482,519 GRCh38 and 0 of 197,846 GRCh37 builds carry such an
+    /// exon, so this refuses nothing in the shipped cdot — the guard exists
+    /// because that zero is a property of the release, not a guarantee, and
+    /// because `cdot_synthesis_has_unverified_exon` fires for every no-CIGAR
+    /// exon and so cannot single this one out.
+    #[test]
+    fn synthesis_refuses_a_no_cigar_exon_whose_window_contradicts_its_declared_span_when_a_cds_is_published(
+    ) {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::transcript::Strand;
+
+        let (mut provider, _kept) = build_provider_with_orf_genome();
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_MISMATCH.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("MISMATCH".to_string()),
+                contig: "NC_ORF.1".to_string(),
+                // Exon 1: genome window [1,10) is 9 bases, declared span is 4.
+                // Exon 2: genome window [15,24) is 9 bases, declared span is 9.
+                exons: vec![[1, 10, 0, 4], [15, 24, 4, 13]],
+                strand: Strand::Plus,
+                // A CDS in the declared-span frame — which is the frame the
+                // mismatch invalidates.
+                cds_start: Some(4),
+                cds_end: Some(13),
+                gene_id: None,
+                protein: None,
+                exon_cigars: vec![None, None],
+            },
+        );
+        provider.cdot_mapper = Some(cdot);
+
+        let err = provider
+            .get_transcript("NM_MISMATCH.1")
+            .expect_err("a declared-span mismatch must be refused when a CDS is published");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("declared transcript span") && msg.contains("displace the CDS"),
+            "expected the declared-span refusal, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn synthesized_exon_table_follows_the_bases_served_not_the_declared_span() {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::transcript::Strand;
+
+        // An exon with no CIGAR emits its WHOLE genome window, whatever its
+        // declared transcript span says — that is the pre-#807 behavior the
+        // "unverified exon" warning is about. So the table has to be built from
+        // the bases actually emitted; a table built from `tx_end - tx_start`
+        // would claim 4 bases for an exon that served 9.
+        let (mut provider, _kept) = build_provider_with_orf_genome();
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_SPAN.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("SPAN".to_string()),
+                contig: "NC_ORF.1".to_string(),
+                // Genome window [1,10) is 9 bases; the declared tx span is 4.
+                exons: vec![[1, 10, 0, 4]],
+                strand: Strand::Plus,
+                cds_start: None,
+                cds_end: None,
+                gene_id: None,
+                protein: None,
+                exon_cigars: vec![None],
+            },
+        );
+        provider.cdot_mapper = Some(cdot);
+
+        let tx = provider
+            .get_transcript("NM_SPAN.1")
+            .expect("a no-CIGAR exon serves its whole window");
+        let seq = tx.sequence.as_deref().expect("synthesis serves bases");
+        assert_eq!(seq, "ATGCCCGGG");
+        assert_eq!(
+            tx.exons
+                .iter()
+                .map(|e| (e.start, e.end))
+                .collect::<Vec<_>>(),
+            vec![(1, 9)],
+            "the exon must claim the 9 bases it served, not its declared span of 4"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1773.

**Merge-order note:** this is deliberately standalone and off `origin/main` (`57f71d31`), and it is meant to land **before #1737**. The half of the incoherence it fixes is pre-existing; the half #1737 introduces is left to #1737, with a guard here that fails if #1737 lands without it. See "What this leaves to #1737" below — that section is the one to read if you are reviewing the two together.

`synthesize_transcript_from_cdot` builds a transcript by concatenating each exon's genome window after applying that exon's CIGAR, so what it serves is the **gap-collapsed** transcript: exon bases only, with no position for any transcript base cdot's exon table does not cover. It then published cdot's `tx_start`/`tx_end` over those bytes, and those are absolute offsets into the **flat** transcript. Nothing reconciled the two.

The spaces coincide only for an exon table that is contiguous **and** starts at 0. A non-zero head offset is exactly as non-identity as an internal hole, and on this cdot it is the larger class.

## Population, measured

Independently of ferro, straight off the prepared reference's cdot JSON (`compact != flat` defined as `sum(exon tx spans) != last exon tx_end`):

| build | records with an exon table | compact != flat | head-offset only | internal hole only | both |
|---|---:|---:|---:|---:|---:|
| refseq GRCh38 | 482,519 | **167** | 109 | 58 | 0 |
| refseq GRCh37 | 197,846 | **442** | 283 | 153 | 6 |

Neither file has a record whose *only* source of non-identity is overlapping exon transcript spans.

## What actually reaches this code path, end to end

Synthesis is the last resort: `resolve_name` prefers any FASTA record and falls through a version-strip, so an accession reaches it only when no FASTA record exists at all. Resolving all 167 / 442 through `MultiFastaProvider` against the local prepared reference:

| build | reach synthesis | decline (insertion CIGAR, E2005) | **served** | not measured |
|---|---:|---:|---:|---:|
| GRCh38 (primary path) | 13 | 9 | **4** | 0 |
| GRCh37 (parented) | 15 | 3 | **11** | 1 |

All 15 served transcripts had `tiles == false` before this change: the published table neither started at the first served base nor ended at the last.

The one not measured is `NR_073509.1` on GRCh37 — the harness reaches a build hint by spelling a parented `c.` variant, which a non-coding accession refuses, so nothing is claimed about it on that build. It *is* served on GRCh38 and moves there.

**On GRCh38, 0 of the 58 gapped records are served — and that zero is a property of this reference, not a structural one.** All 4 GRCh38 records served are head-offset. The GRCh37 arm is the disproof of any structural reading: `NM_020979.5` (SH2B2) is a genuinely *gapped* record, 249 bases, and it is served. A consumer with a thinner transcript FASTA routes more of both classes here.

## What moves

For each served transcript, the genomic position of the first served base, the last served base, and `c.1` — `origin/main` against this branch:

| build | `n.1` moves | last base moves | `c.1` moves |
|---|---:|---:|---:|
| GRCh38 | 4 / 4 | 4 / 4 | 3 / 4 (the fourth is an `NR_`, no CDS) |
| GRCh37 | 10 / 11 | 11 / 11 | 10 / 11 |

Before the fix, `n.1` resolved to **nothing** on 14 of the 15: the flat table started past it, so the first `head` bases of the served sequence were unreachable from the transcript axis. Worked rows:

```
NM_001354366.1  (ELOA3C, GRCh38, head 423)  n.1  none -> 46969912   c.1  none -> 46969912
NM_001387112.1  (POLK,   GRCh38, head  24)  n.1  none -> 75547010   c.1  75582117 -> 75583310
NM_004007.2     (DMD,    GRCh37, head  46)  n.1  none -> 33038317   c.1  32841445 -> 32834745
NM_020979.5     (SH2B2,  GRCh37, gap  249)  n.1  unchanged          last base 101961929 -> 101962178
```

`NM_020979.5` is the shape that shows the hole rather than the head: its `n.1` and `c.1` are before the gap and do not move, and everything past the gap does.

## The fix

Build the exon table from the bases each exon actually contributed, accumulated during synthesis. It then tiles the served sequence from 1 by construction, and agrees with the CDS bounds published beside it. The genome axis of each exon is untouched — that is cdot's alignment, stated in genome coordinates, and no transcript-space question can move it.

Building from `tx_end - tx_start` instead would be wrong for a second reason: an exon with no CIGAR emits its **whole genome window** whatever its declared transcript span says (the pre-#807 behaviour the "unverified exon" warning is about), so the table has to follow the bases, not the declaration. Pinned.

## What this leaves to #1737, deliberately

**The CDS bounds are already in the served sequence's space on `main`, and this PR does not touch them.** cdot's `start_codon`/`stop_codon` are gap-collapsed offsets — the same space the synthesized sequence is in — so carrying them through with only the 0-based → 1-based shift is correct here today. That was verified rather than assumed, by slicing the deposited transcript FASTA for every GRCh38 non-identity record that has both a CDS and a sequence:

| reading of `start_codon`/`stop_codon` | valid ORF, gapped | valid ORF, head-offset |
|---|---|---|
| as flat offsets | 0 / 50 | 0 / 46 |
| as gap-collapsed offsets | **50 / 50** | **41 / 46** |

(The 5 head-offset residue records fail under both readings for their own reasons — no ATG, or a span that is not a multiple of 3 — so they discriminate nothing. The gapped column reproduces #1737's own measurement; the head-offset column extends it to the class #1737 did not measure, and agrees.)

#1737 moves those bounds into **flat** space, which is right for the FASTA-backed path and makes them wrong for this one. Under #1737 all 15 served transcripts get a CDS shifted by their head offset plus enclosed holes: 1 per build lands **past the end** of its own served sequence (`NM_001354366.1`, `cds_end` 1218 → 1641 on 1218 bases; `NM_020979.5`, 1797 → 2046 on 1878 bases) and the remaining 2 (GRCh38) and 10 (GRCh37) shift **silently**, staying in range while naming different bases.

Writing that mapping here would be wrong today — it would move values that are currently correct. So instead this PR marks the seam in the code and pins the invariant with `synthesized_cds_bounds_are_on_the_served_sequences_axis`, which judges the bounds by what they **denote** (they must slice a start codon, a whole number of codons, and a terminator out of the served sequence) rather than by their numbers. Simulating #1737 at that seam fails it. That is the intended handshake: #1737 maps the bounds back to the collapsed space inside this function, and the test goes green.

## No cache version bump, and why that differs from #1737

#1737 had to bump `RKYV_FORMAT_VERSION` and `CDOT_BINCODE_VERSION` because it changed the **parsed cdot values** that both caches persist, so a stale cache would keep serving the old ones. This change persists nothing: it is a read-time transformation of a `CdotTranscript` into a `Transcript`, and the only thing memoizing that is the in-process `transcript_cache` (an `LruCache` keyed on `(id, build_hint)`, rebuilt every run). Existing prepared references need no re-prepare and no re-parse.

## One assumption, named rather than assumed

cdot states `start_codon`/`stop_codon` over the concatenation of the exons' **declared** transcript spans, while the served sequence is the concatenation of what each exon **emitted**. Those agree for every CIGAR-bearing exon (#807 checks it) and for every no-CIGAR exon whose genome window equals its declared span. Measured: **0 of 482,519** GRCh38 and **0 of 197,846** GRCh37 builds have a no-CIGAR exon where they differ.

That zero is a property of this cdot release — its Gap attribute is written exactly when the alignment has indels — not a structural guarantee, so it is written down at the seam rather than relied on. A record that broke it would already be warning through `cdot_synthesis_has_unverified_exon`, so the case is loud rather than silent, and `synthesized_exon_table_follows_the_bases_served_not_the_declared_span` builds exactly that shape (with no CDS) to pin which side wins.

## What is deliberately not touched

The **FASTA-backed** path. There the served sequence is the flat deposited one — head offset and hole present as real bases — so cdot's flat table is the correct table for it and is published verbatim. That is now guarded (`fasta_backed_transcript_keeps_cdots_flat_exon_table`), because it was not: the mutation that shifts that table by the head offset passed all 4194 `--lib` tests. `cds_to_tx`/`tx_to_cds` are also untouched — the flat reading is `c-and-n-positions-are-flat-transcript-offsets` and is not in question here.

## Verification

`cargo fmt --all`, `cargo clippy --features dev --all-targets` clean. Full suite `cargo nextest run --features dev --test-threads=4 --no-fail-fast` with `FERRO_MANIFEST` set (so the reference-aware suites run rather than skip): **10,434 run, 10,434 passed, 152 skipped**, exit 0.

Test names by set difference against `origin/main` at the same base (`cargo nextest list`), never by count: 10,430 → 10,434, **+4 / -0**, the four added being exactly the tests below.

Five mutants, each applied to this branch and each killed:

| mutant | killed by |
|---|---|
| publish cdot's flat table again | all 3 synthesis tests |
| off-by-one on the compact start | 2 of them |
| build the table from `tx_end - tx_start` | `..._follows_the_bases_served_not_the_declared_span` |
| CDS bounds arrive flat (simulating #1737) | `synthesized_cds_bounds_are_on_the_served_sequences_axis` |
| shift the **FASTA** path's table by the head offset | `fasta_backed_transcript_keeps_cdots_flat_exon_table` (and nothing else — that mutant passed all 4194 `--lib` tests before this guard existed, which is why it was added) |

Representation-Change: on a cdot-SYNTHESIZED transcript (one no transcript FASTA record serves) whose cdot exon table is not contiguous from 0 — a head offset, an internal hole, or an exon emitting a different number of bases than its declared transcript span — the genome alignment is now withheld: every exon's `genomic_start`/`genomic_end` and the transcript's own `genomic_start`/`genomic_end` are `None`, so `CoordinateMapper::tx_to_genomic` and every consumer above it (normalize, VCF conversion, equivalence checking, W-code correction) now REFUSE a c./n. position that previously received a genomic coordinate. Measured on the prepared reference, 15 such transcripts are served, on 14 distinct accessions — 4 on the GRCh38 primary path and 11 on GRCh37, among them NM_001354366.1, NM_001387112.1, NM_004007.2 and NM_020979.5. Nothing else moves: 482,352 of 482,519 GRCh38 and 197,404 of 197,846 GRCh37 cdot records have a contiguous zero-based table and keep their genome axis unchanged, no FASTA-backed transcript is affected, and for the 15 the served bases, the (gap-collapsed) exon table and the CDS bounds are all still served. The genome coordinate for those accessions remains available on the route stated on the deposited transcript's own axis — `CdotTranscript::tx_to_genome`, used by the projector's non-coding arm, `data/mapping.rs` and the convert service — which is untouched. That route is why the withholding is a fix rather than a loss: publishing both axes left ferro returning two different coordinates for the same n. position, each an `Ok`, with nothing in the answer to say which route produced it (head-offset shape: n.1 -> 1 against a decline, n.10 -> 15 against 3).
