### PR TITLE
fix(benchmark): make the supplemental FASTA the single authority for presence, and upsert by accession

### DIFF
--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -1908,6 +1908,106 @@ pub struct SupplementalMetadata {
     pub transcripts: std::collections::HashMap<String, SupplementalTranscript>,
 }
 
+/// Source of raw NCBI efetch payloads for one batch of accessions.
+///
+/// Exists so the provisioning path can be exercised end-to-end without a network. The
+/// property that matters most about that path — that running it twice is a no-op the
+/// second time — is unstatable in a test that cannot run it at all.
+pub trait EfetchSource {
+    /// GenBank-format payload for a comma-separated accession list.
+    ///
+    /// `Ok(None)` is a failed batch the caller should skip; `Err` is a failure to invoke
+    /// the fetcher at all.
+    fn genbank(&self, ids: &str) -> Result<Option<String>, FerroError>;
+
+    /// FASTA-format payload, used for CON records that carry no `ORIGIN` section.
+    ///
+    /// `None` for any failure: this is already a fallback, and its own fallback is to
+    /// leave the accession unfetched.
+    fn fasta(&self, ids: &str) -> Option<String>;
+
+    /// Delay observed between requests, to respect the endpoint's rate limit.
+    fn rate_delay(&self) -> std::time::Duration;
+}
+
+/// The production [`EfetchSource`]: NCBI's efetch endpoint, over `curl`.
+pub struct NcbiEfetch {
+    rate_delay: std::time::Duration,
+}
+
+impl NcbiEfetch {
+    /// Build a fetcher whose rate limit reflects whether an API key is configured.
+    pub fn new() -> Self {
+        // Rate limiting: 3 req/sec without API key, 10 req/sec with API key.
+        let has_api_key = get_ncbi_api_key().is_some();
+        if has_api_key {
+            eprintln!("  Using NCBI API key (10 req/sec rate limit)");
+        } else {
+            eprintln!("  No NCBI_API_KEY set (3 req/sec rate limit - set key for 3x faster)");
+        }
+        Self {
+            rate_delay: std::time::Duration::from_millis(if has_api_key { 100 } else { 350 }),
+        }
+    }
+
+    /// Run `curl` against an efetch URL, returning its stdout when it succeeded.
+    ///
+    /// Bounded in time deliberately. A provisioning run is hundreds of sequential batches
+    /// against a rate-limited endpoint, so a single stalled connection with no timeout
+    /// hangs the whole run indefinitely. `--max-time` is generous because one batch is up
+    /// to 200 GenBank records and some are megabytes.
+    ///
+    /// `--fail-with-body` makes an HTTP error an unsuccessful exit rather than a
+    /// success carrying an error page. Without it a 429 or 500 body parses to zero
+    /// records and the batch silently "succeeds" having fetched nothing; with it the
+    /// caller reports the batch as failed. Either way the accessions stay unfetched and
+    /// are retried on the next run, so this changes what the operator is told, not what
+    /// ends up on disk.
+    fn curl(url: &str) -> Result<Option<String>, FerroError> {
+        let output = std::process::Command::new("curl")
+            .args([
+                "-s",
+                "-L",
+                "--fail-with-body",
+                "--connect-timeout",
+                "30",
+                "--max-time",
+                "600",
+                url,
+            ])
+            .output()
+            .map_err(|e| FerroError::Io {
+                msg: format!("Failed to fetch batch: {}", e),
+            })?;
+        Ok(output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).into_owned()))
+    }
+}
+
+impl Default for NcbiEfetch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EfetchSource for NcbiEfetch {
+    fn genbank(&self, ids: &str) -> Result<Option<String>, FerroError> {
+        Self::curl(&build_efetch_url("nuccore", ids, "gb", "text"))
+    }
+
+    fn fasta(&self, ids: &str) -> Option<String> {
+        Self::curl(&build_efetch_url("nuccore", ids, "fasta", "text"))
+            .ok()
+            .flatten()
+    }
+
+    fn rate_delay(&self) -> std::time::Duration {
+        self.rate_delay
+    }
+}
+
 /// Fetch sequences from NCBI in GenBank format, extract CDS metadata, and write to files.
 ///
 /// This fetches GenBank format (not FASTA) to get CDS coordinates along with sequences.
@@ -1919,8 +2019,32 @@ pub fn fetch_fasta_to_file(
     output_file: &Path,
     dry_run: bool,
 ) -> Result<usize, FerroError> {
-    use std::io::Write;
-    use std::process::Command;
+    fetch_fasta_to_file_with(accessions, output_file, dry_run, &NcbiEfetch::new())
+}
+
+/// [`fetch_fasta_to_file`] against an arbitrary [`EfetchSource`].
+///
+/// # Presence, and why it is not the sidecar's question
+///
+/// Which accessions still need fetching is derived from the **FASTA**, via
+/// [`SupplementalStore::has_sequence`] — never from `*.metadata.json`. The sidecar records
+/// annotation; a row in it is not a sequence, and treating it as one is what let an
+/// accession whose bases were already on disk be re-fetched and appended a second time.
+///
+/// Fetched records are staged and then merged by accession, so no write path can append
+/// blind: re-fetching an accession that already has a record **replaces** it rather than
+/// duplicating it. That makes the resume predicate free to ask any question it likes —
+/// including PR #1732's "is this record usable?" — without the write path being able to
+/// duplicate anything as a result.
+///
+/// A run with nothing to fetch and nothing to repair writes no byte at all.
+pub fn fetch_fasta_to_file_with(
+    accessions: &[String],
+    output_file: &Path,
+    dry_run: bool,
+    source: &dyn EfetchSource,
+) -> Result<usize, FerroError> {
+    use crate::benchmark::supplemental_store::SupplementalStore;
 
     const BATCH_SIZE: usize = 200; // Larger batches for efficiency (4x fewer requests)
 
@@ -1984,17 +2108,12 @@ pub fn fetch_fasta_to_file(
         return Ok(0);
     }
 
-    // Create/open output file for appending
-    let mut fasta_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(output_file)
-        .map_err(|e| FerroError::Io {
-            msg: format!("Failed to open {}: {}", output_file.display(), e),
-        })?;
+    // The FASTA and the artifacts derived from it. Opening scans the FASTA (and any
+    // staging file an interrupted run left behind), which is what makes presence a
+    // question about sequence rather than about annotation.
+    let mut store = SupplementalStore::open(output_file)?;
 
-    // Metadata file path (same directory, different name)
-    let metadata_path = output_file.with_extension("metadata.json");
+    let metadata_path = store.metadata_path().to_path_buf();
 
     // Load existing metadata if present
     let mut metadata = if metadata_path.exists() {
@@ -2012,11 +2131,22 @@ pub fn fetch_fasta_to_file(
         }
     };
 
-    // Filter out already-fetched accessions
+    let duplicates = store.duplicate_record_count();
+    if duplicates > 0 {
+        eprintln!(
+            "  {} duplicate records across {} accessions in {}; they will be collapsed to one each",
+            duplicates,
+            store.duplicated_accessions().len(),
+            output_file.display()
+        );
+    }
+
+    // Filter out accessions whose bases are already on disk. Keyed on the FASTA, not on
+    // the sidecar: a metadata row is an annotation claim, not a sequence.
     let original_count = nuccore.len();
     let nuccore: Vec<&String> = nuccore
         .into_iter()
-        .filter(|acc| !metadata.transcripts.contains_key(*acc))
+        .filter(|acc| !store.has_sequence(acc))
         .collect();
 
     if nuccore.is_empty() {
@@ -2024,6 +2154,21 @@ pub fn fetch_fasta_to_file(
             "  All {} accessions already fetched (skipping)",
             original_count
         );
+        // Nothing to fetch is not necessarily nothing to do: a duplicate-bearing FASTA or
+        // a sidecar whose keys have drifted from it is repaired here, by the same
+        // merge-and-rename a fetch would have used. When neither holds, this is the fixed
+        // point and not one byte is written.
+        if store.is_dirty(&metadata) {
+            let report = store.commit(&mut metadata)?;
+            eprintln!(
+                "  Repaired {}: {} records, {} duplicates removed, {} metadata rows dropped, {} synthesized",
+                output_file.display(),
+                report.records,
+                report.duplicates_removed,
+                report.metadata_rows_dropped,
+                report.metadata_rows_synthesized
+            );
+        }
         return Ok(0);
     }
 
@@ -2037,10 +2182,7 @@ pub fn fetch_fasta_to_file(
 
     let mut fetched = 0usize;
     let total_batches = nuccore.len().div_ceil(BATCH_SIZE);
-
-    // Rate limiting: 3 req/sec without API key, 10 req/sec with API key
-    let has_api_key = get_ncbi_api_key().is_some();
-    let rate_delay_ms = if has_api_key { 100 } else { 350 };
+    let rate_delay = source.rate_delay();
 
     eprintln!(
         "  Fetching {} nucleotide sequences in {} batches (batch size: {})...",
@@ -2048,11 +2190,6 @@ pub fn fetch_fasta_to_file(
         total_batches,
         BATCH_SIZE
     );
-    if has_api_key {
-        eprintln!("  Using NCBI API key (10 req/sec rate limit)");
-    } else {
-        eprintln!("  No NCBI_API_KEY set (3 req/sec rate limit - set key for 3x faster)");
-    }
 
     let start_time = std::time::Instant::now();
 
@@ -2066,25 +2203,14 @@ pub fn fetch_fasta_to_file(
             std::collections::HashSet::new();
 
         // Fetch GenBank format to get CDS coordinates
-        let url = build_efetch_url("nuccore", &ids, "gb", "text");
-
-        let output = Command::new("curl")
-            .args(["-s", "-L", &url])
-            .output()
-            .map_err(|e| FerroError::Io {
-                msg: format!("Failed to fetch batch: {}", e),
-            })?;
-
-        if !output.status.success() {
+        let Some(genbank_text) = source.genbank(&ids)? else {
             eprintln!(
                 "    Warning: Batch {}/{} failed",
                 batch_idx + 1,
                 total_batches
             );
             continue;
-        }
-
-        let genbank_text = String::from_utf8_lossy(&output.stdout);
+        };
 
         // Parse GenBank records
         let mut batch_count = 0;
@@ -2109,24 +2235,9 @@ pub fn fetch_fasta_to_file(
                 if let Some((seq, cds_start, cds_end, gene_name)) =
                     parse_genbank_record_full(&record)
                 {
-                    // Write FASTA entry
-                    let header = if gene_name.is_empty() {
-                        format!(">{}", acc)
-                    } else {
-                        format!(">{} {}", acc, gene_name)
-                    };
-                    writeln!(fasta_file, "{}", header).map_err(|e| FerroError::Io {
-                        msg: format!("Failed to write to {}: {}", output_file.display(), e),
-                    })?;
-
-                    // Write sequence in 70-char lines
-                    for chunk in seq.as_bytes().chunks(70) {
-                        writeln!(fasta_file, "{}", std::str::from_utf8(chunk).unwrap()).map_err(
-                            |e| FerroError::Io {
-                                msg: format!("Failed to write to {}: {}", output_file.display(), e),
-                            },
-                        )?;
-                    }
+                    // Stage the FASTA entry. The commit merges it by accession, so this
+                    // cannot append a second record for an accession already on disk.
+                    store.stage_record(&acc, &gene_name, &seq)?;
 
                     // Add metadata entry
                     metadata.transcripts.insert(
@@ -2161,12 +2272,9 @@ pub fn fetch_fasta_to_file(
         if !missing_from_batch.is_empty() {
             // Fetch missing accessions using FASTA format
             let missing_ids = missing_from_batch.join(",");
-            let fasta_url = build_efetch_url("nuccore", &missing_ids, "fasta", "text");
 
-            if let Ok(fasta_output) = Command::new("curl").args(["-s", "-L", &fasta_url]).output() {
-                if fasta_output.status.success() {
-                    let fasta_text = String::from_utf8_lossy(&fasta_output.stdout);
-
+            if let Some(fasta_text) = source.fasta(&missing_ids) {
+                {
                     // Parse FASTA records
                     let mut current_acc = String::new();
                     let mut current_seq = String::new();
@@ -2176,16 +2284,8 @@ pub fn fetch_fasta_to_file(
                         if let Some(header) = line.strip_prefix('>') {
                             // Save previous record if any
                             if !current_acc.is_empty() && !current_seq.is_empty() {
-                                // Write to FASTA file
-                                if current_desc.is_empty() {
-                                    writeln!(fasta_file, ">{}", current_acc).ok();
-                                } else {
-                                    writeln!(fasta_file, ">{} {}", current_acc, current_desc).ok();
-                                }
-                                for chunk in current_seq.as_bytes().chunks(70) {
-                                    writeln!(fasta_file, "{}", std::str::from_utf8(chunk).unwrap())
-                                        .ok();
-                                }
+                                // Stage the record; the commit merges it by accession.
+                                store.stage_record(&current_acc, &current_desc, &current_seq)?;
 
                                 // Add metadata (no CDS info for CON records)
                                 metadata.transcripts.insert(
@@ -2222,14 +2322,7 @@ pub fn fetch_fasta_to_file(
 
                     // Save last record
                     if !current_acc.is_empty() && !current_seq.is_empty() {
-                        if current_desc.is_empty() {
-                            writeln!(fasta_file, ">{}", current_acc).ok();
-                        } else {
-                            writeln!(fasta_file, ">{} {}", current_acc, current_desc).ok();
-                        }
-                        for chunk in current_seq.as_bytes().chunks(70) {
-                            writeln!(fasta_file, "{}", std::str::from_utf8(chunk).unwrap()).ok();
-                        }
+                        store.stage_record(&current_acc, &current_desc, &current_seq)?;
 
                         metadata.transcripts.insert(
                             current_acc.clone(),
@@ -2252,7 +2345,7 @@ pub fn fetch_fasta_to_file(
             }
 
             // Small delay between GenBank and FASTA requests
-            std::thread::sleep(std::time::Duration::from_millis(rate_delay_ms));
+            std::thread::sleep(rate_delay);
         }
 
         fetched += batch_count;
@@ -2280,18 +2373,28 @@ pub fn fetch_fasta_to_file(
 
         // Rate limiting - respect NCBI limits
         if batch_idx < total_batches - 1 {
-            std::thread::sleep(std::time::Duration::from_millis(rate_delay_ms));
+            std::thread::sleep(rate_delay);
         }
     }
 
-    // Save metadata
-    let metadata_file = File::create(&metadata_path).map_err(|e| FerroError::Io {
-        msg: format!("Failed to create {}: {}", metadata_path.display(), e),
-    })?;
-    serde_json::to_writer_pretty(metadata_file, &metadata).map_err(|e| FerroError::Io {
-        msg: format!("Failed to write {}: {}", metadata_path.display(), e),
-    })?;
-    eprintln!("  Wrote metadata to {}", metadata_path.display());
+    // Merge the staged records into the FASTA by accession, then rebuild the index and
+    // the sidecar from what the FASTA actually holds. The FASTA's rename is the commit
+    // point; a crash after it leaves both derived artifacts recoverable on the next open.
+    //
+    // Gated on `is_dirty` rather than unconditional: reaching here having staged nothing
+    // is a real outcome — every batch can fail against a down or rate-limiting endpoint —
+    // and a failed run must not rewrite the artifact it could not add to.
+    if store.is_dirty(&metadata) {
+        let report = store.commit(&mut metadata)?;
+        eprintln!(
+            "  Committed {} records to {} ({} replaced, {} duplicates removed)",
+            report.records,
+            output_file.display(),
+            report.records_replaced,
+            report.duplicates_removed
+        );
+        eprintln!("  Wrote metadata to {}", metadata_path.display());
+    }
 
     Ok(fetched)
 }

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -58,6 +58,7 @@ pub mod report;
 pub mod runner;
 pub mod sample;
 pub mod shard;
+pub mod supplemental_store;
 pub mod translate;
 pub mod types;
 pub mod uta_loader;

--- a/src/benchmark/supplemental_store.rs
+++ b/src/benchmark/supplemental_store.rs
@@ -1,0 +1,1505 @@
+//! Upsert-by-accession provisioning for a supplemental transcript FASTA.
+//!
+//! # Why this module exists
+//!
+//! "Do we have sequence for this accession?" used to be answered by the
+//! `*.metadata.json` sidecar, while the sequence itself lived in the FASTA and was
+//! written in **append** mode. Two artifacts, updated non-atomically, answering one
+//! question — so any run that left them disagreeing caused the next run to re-fetch an
+//! accession whose sequence was already on disk and append a second copy of it. A FASTA
+//! has no uniqueness constraint, so a duplicate header is legal FASTA and silently wrong
+//! here: the file is being used as a keyed store with no key.
+//!
+//! # The rule this module establishes
+//!
+//! **The FASTA is the single authority for presence and sequence.** Everything else is
+//! derived from it:
+//!
+//! | artifact | status | recovered how |
+//! |---|---|---|
+//! | `<name>.fna` | **authoritative** | — |
+//! | `<name>.fna.fai` | derived | rebuilt from the committed FASTA on every commit |
+//! | `<name>.metadata.json` | derived *key set*, carried-forward CDS annotation | keys reconciled against the FASTA on every commit; a missing row is synthesized from the FASTA record |
+//!
+//! The sidecar is not *fully* derived and this module does not pretend it is: CDS
+//! coordinates come from a GenBank record and cannot be recovered from a FASTA. What is
+//! derived is the sidecar's **key set** and each row's `sequence_length` — which is
+//! precisely the part that was being asked the presence question. A row whose CDS
+//! annotation already exists is carried forward untouched.
+//!
+//! # Why the FASTA and not the `.fai`
+//!
+//! **This repository already decided this question, for the same defect on the neighbouring
+//! artifact.** `prepare::run_backfill` reads its present set from the backfill FASTA's
+//! headers and says why in so many words (`src/prepare/mod.rs`, at the
+//! `load_fasta_header_accessions` call): "not its derived `.fai`: a prior run interrupted
+//! after the append but before reindex — or a deleted `.fai` — would otherwise look empty
+//! and re-fetch and re-append the same accession, duplicating its `>accession` record".
+//! That is this defect exactly, and the rule it settled on is the one applied here rather
+//! than a second rule invented alongside it.
+//!
+//! The reasoning holds independently: the `.fai` is a *second* artifact that can drift from
+//! the FASTA, which is what the sidecar was. On the operator's shipped reference it is seven
+//! minutes newer than the `.fna` it indexes. Nominating it as the authority inverts the
+//! dependency and reintroduces the defect class one level over.
+//!
+//! Scanning the FASTA's headers instead costs one sequential read — measured at **2.08 s
+//! over the 1.3 GB shipped artifact**, against a provisioning run whose fetch half is a
+//! networked, rate-limited operation measured in hours.
+//!
+//! Writing the index here is therefore load-bearing rather than tidy: the merge re-emits
+//! every record at [`FASTA_LINE_BASES`], so a commit invalidates any externally-built index
+//! it does not replace.
+//!
+//! # Atomicity boundary
+//!
+//! Fetched records are appended to a **staging** file (`<name>.fna.incoming`), which is
+//! durable and resumable: an interrupted run's staged records count as present on the next
+//! run, so no accession is fetched twice. [`SupplementalStore::commit`] then streams the
+//! committed FASTA and the staging file into `<name>.fna.tmp`, keyed by accession — one
+//! record per accession, staged records replacing committed ones — and `fsync`s and
+//! renames it into place.
+//!
+//! **That rename is the commit point, and it is the only artifact that needs one.** The
+//! index and the sidecar are rewritten after it, and a crash between the rename and either
+//! of those is self-healing: the next `open` re-derives both from the FASTA. Making the
+//! derived artifacts genuinely derived is what buys atomicity across three files without
+//! needing a three-file atomic write, which is not available.
+//!
+//! # Idempotence
+//!
+//! [`SupplementalStore::is_dirty`] is the fixed-point test: no staged records, no
+//! duplicate accession in the FASTA, and a sidecar whose key set already equals the
+//! FASTA's. When it is false the store writes **nothing**, so a second provisioning run
+//! over an artifact the first one produced leaves every byte alone. When it is true — the
+//! shipped duplicate-bearing artifact is the case that matters — the commit is also the
+//! repair: dedup-by-accession is not a special mode, it is what the merge does.
+//!
+//! **Start the fixed-point test from a DAMAGED artifact, not a clean one.** Measured by
+//! reconstructing the previous behaviour and re-running these tests: run-twice-from-empty
+//! **passes** on the old code, because on an artifact the old code itself produced, the
+//! FASTA and the sidecar agree and its sidecar-keyed resume filter therefore skips
+//! correctly. That agreement is the coincidence this module exists to stop relying on, so a
+//! fixed-point test seeded from a clean state is satisfied *by* the bug. The tests that
+//! fail on the old behaviour are the ones seeded from a state where the two artifacts
+//! disagree — a FASTA record with no sidecar row, and a duplicate-bearing FASTA.
+
+use crate::benchmark::cache::{SupplementalMetadata, SupplementalTranscript};
+use crate::FerroError;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+/// Bases per sequence line in every FASTA record this module writes.
+///
+/// Matches the width the previous append-based writer used, so a committed record is
+/// byte-identical to the one the old path would have written.
+const FASTA_LINE_BASES: usize = 70;
+
+/// Suffix of the durable, resumable file that fetched records are appended to.
+const STAGING_SUFFIX: &str = ".incoming";
+
+/// Suffix of the transient file that a commit writes before renaming it into place.
+const TEMP_SUFFIX: &str = ".tmp";
+
+/// Return `path` with `suffix` appended to its file name.
+///
+/// Deliberately not `Path::with_extension`, which would *replace* `.fna` rather than
+/// extend it — `patterns_transcripts.fna.with_extension("tmp")` is
+/// `patterns_transcripts.tmp`, which collides across sibling artifacts.
+fn sibling_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = OsString::from(path.as_os_str());
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// The sidecar path for a supplemental FASTA.
+///
+/// `patterns_transcripts.fna` -> `patterns_transcripts.metadata.json`. This *does* replace
+/// the extension, matching the reader in [`crate::reference::multi_fasta`] and the
+/// historical writer, so the name is not this module's to choose.
+fn metadata_path_for(fasta_path: &Path) -> PathBuf {
+    fasta_path.with_extension("metadata.json")
+}
+
+/// One record of a supplemental FASTA.
+///
+/// Deliberately not `pub`: nothing outside this module constructs or inspects one, and
+/// the store's public surface is the accession-keyed questions, not the record type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FastaRecord {
+    /// Accession as it appears first on the header line, without the leading `>`.
+    pub accession: String,
+    /// Remainder of the header line, possibly empty.
+    pub description: String,
+    /// Sequence with all line breaks removed.
+    pub sequence: String,
+}
+
+impl FastaRecord {
+    /// Gene symbol as the sidecar records it for a record with no GenBank annotation.
+    ///
+    /// Mirrors the CON/FASTA-fallback insert exactly: the description up to its first
+    /// `(`, trimmed, and `None` when there is no description at all.
+    fn gene_symbol(&self) -> Option<String> {
+        if self.description.is_empty() {
+            None
+        } else {
+            self.description
+                .split('(')
+                .next()
+                .map(|s| s.trim().to_string())
+        }
+    }
+
+    /// The sidecar row this record implies on its own, carrying no CDS annotation.
+    fn synthesized_metadata(&self) -> SupplementalTranscript {
+        SupplementalTranscript {
+            id: self.accession.clone(),
+            gene_symbol: self.gene_symbol(),
+            cds_start: None,
+            cds_end: None,
+            sequence_length: self.sequence.len(),
+        }
+    }
+}
+
+/// Streaming FASTA reader yielding one [`FastaRecord`] at a time.
+///
+/// Streaming rather than slurping because the artifact this runs against is 1.3 GB.
+struct FastaReader<R: BufRead> {
+    reader: R,
+    /// Header line already read but belonging to the *next* record.
+    pending_header: Option<String>,
+    /// Set once the underlying reader is exhausted.
+    exhausted: bool,
+}
+
+impl<R: BufRead> FastaReader<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader,
+            pending_header: None,
+            exhausted: false,
+        }
+    }
+
+    /// Read the next record, or `None` at end of input.
+    ///
+    /// A header with no sequence is skipped rather than returned: this module's whole
+    /// premise is that a record in the FASTA means bases on disk, and an empty record
+    /// would be a presence claim with nothing behind it.
+    fn next_record(&mut self) -> Result<Option<FastaRecord>, FerroError> {
+        loop {
+            let header = match self.take_header()? {
+                Some(header) => header,
+                None => return Ok(None),
+            };
+
+            let mut sequence = String::new();
+            loop {
+                let mut line = String::new();
+                let read = self
+                    .reader
+                    .read_line(&mut line)
+                    .map_err(|e| FerroError::Io {
+                        msg: format!("Failed to read FASTA: {}", e),
+                    })?;
+                if read == 0 {
+                    self.exhausted = true;
+                    break;
+                }
+                let trimmed = line.trim_end_matches(['\n', '\r']);
+                if let Some(header) = trimmed.strip_prefix('>') {
+                    self.pending_header = Some(header.to_string());
+                    break;
+                }
+                sequence.push_str(trimmed.trim());
+            }
+
+            let (accession, description) = split_header(&header);
+            if accession.is_empty() || sequence.is_empty() {
+                continue;
+            }
+            return Ok(Some(FastaRecord {
+                accession,
+                description,
+                sequence,
+            }));
+        }
+    }
+
+    /// Return the next header line's contents (without `>`), or `None` at end of input.
+    fn take_header(&mut self) -> Result<Option<String>, FerroError> {
+        if let Some(header) = self.pending_header.take() {
+            return Ok(Some(header));
+        }
+        loop {
+            if self.exhausted {
+                return Ok(None);
+            }
+            let mut line = String::new();
+            let read = self
+                .reader
+                .read_line(&mut line)
+                .map_err(|e| FerroError::Io {
+                    msg: format!("Failed to read FASTA: {}", e),
+                })?;
+            if read == 0 {
+                self.exhausted = true;
+                return Ok(None);
+            }
+            let trimmed = line.trim_end_matches(['\n', '\r']);
+            if let Some(header) = trimmed.strip_prefix('>') {
+                return Ok(Some(header.to_string()));
+            }
+        }
+    }
+}
+
+/// Split a FASTA header body into its accession and the rest.
+fn split_header(header: &str) -> (String, String) {
+    match header.split_once(char::is_whitespace) {
+        Some((accession, rest)) => (accession.to_string(), rest.trim().to_string()),
+        None => (header.trim().to_string(), String::new()),
+    }
+}
+
+/// Open a FASTA for streaming, treating an absent file as empty input.
+fn open_fasta(path: &Path) -> Result<Option<FastaReader<BufReader<File>>>, FerroError> {
+    match File::open(path) {
+        Ok(file) => Ok(Some(FastaReader::new(BufReader::new(file)))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(FerroError::Io {
+            msg: format!("Failed to open {}: {}", path.display(), e),
+        }),
+    }
+}
+
+/// Line terminating a completely-written record in the staging file.
+///
+/// The staging file is this module's own format, not a FASTA anyone else reads, so it can
+/// carry a completeness marker that a FASTA cannot. A `;`-prefixed line is the classic
+/// FASTA comment and cannot collide with a header (`>`) or with a sequence line, which
+/// [`write_record`] emits as bases only.
+const STAGED_RECORD_TERMINATOR: &str = ";end";
+
+/// Streaming reader over the staging file that yields only completely-written records.
+///
+/// # Why this exists
+///
+/// Without it, a crash part-way through [`SupplementalStore::stage_record`] leaves a
+/// truncated trailing record, and the next run would count its accession as present —
+/// so the accession is never re-fetched and the *truncated* sequence is merged into the
+/// authoritative FASTA. A torn write silently becoming the authority is the exact defect
+/// class this module exists to close, so the staging file must not reintroduce it one
+/// level down.
+///
+/// A terminator can only be complete if everything before it was written, so its presence
+/// is a sound completeness witness for an append-only sequential writer.
+struct StagedReader<R: BufRead> {
+    reader: R,
+    /// Header of the record currently being accumulated.
+    header: Option<String>,
+    sequence: String,
+    /// Records dropped because they were never terminated.
+    torn: usize,
+}
+
+impl<R: BufRead> StagedReader<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader,
+            header: None,
+            sequence: String::new(),
+            torn: 0,
+        }
+    }
+
+    /// Read the next completely-written record, or `None` at end of input.
+    fn next_record(&mut self) -> Result<Option<FastaRecord>, FerroError> {
+        loop {
+            let mut line = String::new();
+            let read = self
+                .reader
+                .read_line(&mut line)
+                .map_err(|e| FerroError::Io {
+                    msg: format!("Failed to read staging file: {}", e),
+                })?;
+            if read == 0 {
+                // An in-progress record at end of input was never terminated.
+                if self.header.take().is_some() {
+                    self.torn += 1;
+                }
+                self.sequence.clear();
+                return Ok(None);
+            }
+            let trimmed = line.trim_end_matches(['\n', '\r']);
+            if let Some(header) = trimmed.strip_prefix('>') {
+                // A pending header here means the previous record never terminated.
+                if self.header.replace(header.to_string()).is_some() {
+                    self.torn += 1;
+                }
+                self.sequence.clear();
+            } else if trimmed == STAGED_RECORD_TERMINATOR {
+                if let Some(header) = self.header.take() {
+                    let (accession, description) = split_header(&header);
+                    let sequence = std::mem::take(&mut self.sequence);
+                    if !accession.is_empty() && !sequence.is_empty() {
+                        return Ok(Some(FastaRecord {
+                            accession,
+                            description,
+                            sequence,
+                        }));
+                    }
+                }
+            } else {
+                self.sequence.push_str(trimmed.trim());
+            }
+        }
+    }
+}
+
+/// Open the staging file for streaming, treating an absent file as empty input.
+fn open_staged(path: &Path) -> Result<Option<StagedReader<BufReader<File>>>, FerroError> {
+    match File::open(path) {
+        Ok(file) => Ok(Some(StagedReader::new(BufReader::new(file)))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(FerroError::Io {
+            msg: format!("Failed to open {}: {}", path.display(), e),
+        }),
+    }
+}
+
+/// Accessions of every completely-written record in the staging file.
+fn scan_staged_accessions(path: &Path) -> Result<HashSet<String>, FerroError> {
+    let mut accessions = HashSet::new();
+    let Some(mut reader) = open_staged(path)? else {
+        return Ok(accessions);
+    };
+    while let Some(record) = reader.next_record()? {
+        accessions.insert(record.accession);
+    }
+    if reader.torn > 0 {
+        eprintln!(
+            "  Discarding {} incompletely-written record(s) from {}; they will be re-fetched",
+            reader.torn,
+            path.display()
+        );
+    }
+    Ok(accessions)
+}
+
+/// Count records per accession in a FASTA, treating an absent file as empty.
+///
+/// A count above one is a duplicated accession — the damage this module repairs.
+fn scan_accession_counts(path: &Path) -> Result<BTreeMap<String, usize>, FerroError> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    let Some(mut reader) = open_fasta(path)? else {
+        return Ok(counts);
+    };
+    while let Some(record) = reader.next_record()? {
+        *counts.entry(record.accession).or_insert(0) += 1;
+    }
+    Ok(counts)
+}
+
+/// Write one record and return the `.fai` line describing where it landed.
+///
+/// `offset` is advanced by the bytes written, so a caller streaming records into a fresh
+/// file can build an exact index without a second pass over it.
+fn write_record(
+    writer: &mut impl Write,
+    record: &FastaRecord,
+    offset: &mut u64,
+) -> Result<String, FerroError> {
+    let io_err = |e: std::io::Error| FerroError::Io {
+        msg: format!("Failed to write FASTA record {}: {}", record.accession, e),
+    };
+
+    let header = if record.description.is_empty() {
+        format!(">{}\n", record.accession)
+    } else {
+        format!(">{} {}\n", record.accession, record.description)
+    };
+    writer.write_all(header.as_bytes()).map_err(io_err)?;
+    *offset += header.len() as u64;
+
+    let sequence_offset = *offset;
+    for chunk in record.sequence.as_bytes().chunks(FASTA_LINE_BASES) {
+        writer.write_all(chunk).map_err(io_err)?;
+        writer.write_all(b"\n").map_err(io_err)?;
+        *offset += chunk.len() as u64 + 1;
+    }
+
+    // samtools' `.fai` describes the geometry of the *first* sequence line, which for a
+    // record shorter than one full line is the record itself.
+    let line_bases = record.sequence.len().min(FASTA_LINE_BASES);
+    Ok(format!(
+        "{}\t{}\t{}\t{}\t{}\n",
+        record.accession,
+        record.sequence.len(),
+        sequence_offset,
+        line_bases,
+        line_bases + 1
+    ))
+}
+
+/// What a commit did, for the caller to report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CommitReport {
+    /// Records in the committed FASTA afterwards — one per accession, by construction.
+    pub records: usize,
+    /// Duplicate records dropped by this commit.
+    pub duplicates_removed: usize,
+    /// Committed records replaced by a freshly staged one for the same accession.
+    pub records_replaced: usize,
+    /// Sidecar rows dropped because the FASTA has no record for their accession.
+    pub metadata_rows_dropped: usize,
+    /// Sidecar rows synthesized from a FASTA record that had none.
+    pub metadata_rows_synthesized: usize,
+}
+
+/// A supplemental FASTA plus the derived artifacts kept consistent with it.
+///
+/// See the [module documentation](self) for the authority rule and the atomicity boundary.
+pub struct SupplementalStore {
+    fasta_path: PathBuf,
+    staging_path: PathBuf,
+    metadata_path: PathBuf,
+    /// Records per accession in the committed FASTA.
+    committed: BTreeMap<String, usize>,
+    /// Accessions already written to the staging file, committed or not.
+    staged: HashSet<String>,
+    /// Opened lazily, so a run that stages nothing creates no staging file.
+    staging_writer: Option<BufWriter<File>>,
+}
+
+impl SupplementalStore {
+    /// Open the store for `fasta_path`, scanning it and any staging file left behind.
+    ///
+    /// Neither file needs to exist; both are treated as empty when absent, which is what
+    /// a genuine first run looks like.
+    pub fn open(fasta_path: &Path) -> Result<Self, FerroError> {
+        let staging_path = sibling_with_suffix(fasta_path, STAGING_SUFFIX);
+        let committed = scan_accession_counts(fasta_path)?;
+        let staged = scan_staged_accessions(&staging_path)?;
+        Ok(Self {
+            fasta_path: fasta_path.to_path_buf(),
+            staging_path,
+            metadata_path: metadata_path_for(fasta_path),
+            committed,
+            staged,
+            staging_writer: None,
+        })
+    }
+
+    /// Path of the sidecar this store keeps consistent with its FASTA.
+    pub fn metadata_path(&self) -> &Path {
+        &self.metadata_path
+    }
+
+    /// Whether bases for `accession` are already on disk, committed or staged.
+    ///
+    /// **This is the presence question, and the FASTA is the only artifact that answers
+    /// it.** The sidecar is never consulted: a row in it is an annotation claim, not a
+    /// sequence.
+    pub fn has_sequence(&self, accession: &str) -> bool {
+        self.committed.contains_key(accession) || self.staged.contains(accession)
+    }
+
+    /// Number of records the committed FASTA holds beyond one per accession.
+    pub fn duplicate_record_count(&self) -> usize {
+        self.committed.values().map(|n| n.saturating_sub(1)).sum()
+    }
+
+    /// Accessions the committed FASTA holds more than one record for.
+    pub fn duplicated_accessions(&self) -> Vec<&str> {
+        self.committed
+            .iter()
+            .filter(|(_, n)| **n > 1)
+            .map(|(acc, _)| acc.as_str())
+            .collect()
+    }
+
+    /// Whether the on-disk artifacts are anything other than the fixed point.
+    ///
+    /// False means a commit would change no byte, so the caller must not perform one —
+    /// that is what makes a second provisioning run a genuine no-op rather than a rewrite
+    /// that happens to produce the same content.
+    ///
+    /// **Both derived artifacts are terms, not just the sidecar.** Declaring the `.fai`
+    /// derived and then not noticing that it is missing would leave it derived in the
+    /// documentation only — and a deleted index makes this artifact invisible to
+    /// `prepare::load_existing_accessions`, which enumerates references by their `.fai`.
+    pub fn is_dirty(&self, metadata: &SupplementalMetadata) -> bool {
+        !self.staged.is_empty()
+            || self.duplicate_record_count() > 0
+            || self.metadata_keys_disagree(metadata)
+            || self.index_disagrees()
+    }
+
+    /// Whether the sidecar's key set differs from the committed FASTA's accession set.
+    fn metadata_keys_disagree(&self, metadata: &SupplementalMetadata) -> bool {
+        if metadata.transcripts.len() != self.committed.len() {
+            return true;
+        }
+        !self
+            .committed
+            .keys()
+            .all(|acc| metadata.transcripts.contains_key(acc))
+    }
+
+    /// Whether the `.fai` is absent or names a different accession set than the FASTA.
+    ///
+    /// Compares names only. Detecting a *stale offset* would mean re-deriving the whole
+    /// index, which costs what rebuilding it costs — so this catches a deleted, truncated
+    /// or accession-drifted index and deliberately does not claim to catch an index whose
+    /// names are right and whose offsets are wrong. Only this module writes the pair, and
+    /// it writes them in one commit, so that state is not reachable through this code.
+    fn index_disagrees(&self) -> bool {
+        let fai_path = sibling_with_suffix(&self.fasta_path, ".fai");
+        // An absent FASTA needs no index; an absent index for a populated FASTA is drift.
+        if self.committed.is_empty() {
+            return fai_path.exists();
+        }
+        let Ok(text) = std::fs::read_to_string(&fai_path) else {
+            return true;
+        };
+        let indexed: BTreeMap<&str, usize> =
+            text.lines()
+                .filter(|l| !l.is_empty())
+                .fold(BTreeMap::new(), |mut acc, line| {
+                    *acc.entry(line.split('\t').next().unwrap_or(""))
+                        .or_insert(0) += 1;
+                    acc
+                });
+        indexed.len() != self.committed.len()
+            || !self
+                .committed
+                .keys()
+                .all(|acc| indexed.contains_key(acc.as_str()))
+    }
+
+    /// Append a fetched record to the staging file.
+    ///
+    /// Nothing is written to the FASTA itself until [`Self::commit`]. Staging an
+    /// accession makes [`Self::has_sequence`] true for it immediately, so the same run
+    /// cannot fetch it twice.
+    pub fn stage_record(
+        &mut self,
+        accession: &str,
+        description: &str,
+        sequence: &str,
+    ) -> Result<(), FerroError> {
+        if sequence.is_empty() {
+            return Ok(());
+        }
+        if self.staging_writer.is_none() {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.staging_path)
+                .map_err(|e| FerroError::Io {
+                    msg: format!("Failed to open {}: {}", self.staging_path.display(), e),
+                })?;
+            self.staging_writer = Some(BufWriter::new(file));
+        }
+
+        let record = FastaRecord {
+            accession: accession.to_string(),
+            description: description.to_string(),
+            sequence: sequence.to_string(),
+        };
+        let writer = self
+            .staging_writer
+            .as_mut()
+            .expect("staging writer was just opened");
+        let mut ignored_offset = 0u64;
+        write_record(writer, &record, &mut ignored_offset)?;
+        // Marks the record complete. A crash before this line lands leaves the record
+        // unterminated, and the next run discards it rather than treating a truncated
+        // sequence as present. See `StagedReader`.
+        writeln!(writer, "{}", STAGED_RECORD_TERMINATOR).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write {}: {}", self.staging_path.display(), e),
+        })?;
+        self.staged.insert(record.accession);
+        Ok(())
+    }
+
+    /// Merge staged records into the FASTA keyed by accession, then rebuild the derived
+    /// artifacts.
+    ///
+    /// One record survives per accession: a staged record replaces the committed one for
+    /// its accession, and every other committed record is carried through in its original
+    /// order. "Carried through" is about content — accession, description and bases — not
+    /// about bytes: every record is re-emitted at [`FASTA_LINE_BASES`], so a file wrapped
+    /// at some other width is normalized. That is why the `.fai` is rewritten here and not
+    /// left to a later `index_fasta`.
+    ///
+    /// `metadata` is reconciled against the result — orphan rows dropped, missing rows
+    /// synthesized, existing CDS annotation preserved — and written atomically, as is the
+    /// `.fai`.
+    ///
+    /// The caller must have checked [`Self::is_dirty`]; committing a clean store would
+    /// rewrite three files to their existing content.
+    pub fn commit(
+        mut self,
+        metadata: &mut SupplementalMetadata,
+    ) -> Result<CommitReport, FerroError> {
+        // Flush staged bytes to the OS before reading the staging file back.
+        if let Some(writer) = self.staging_writer.take() {
+            let file = writer.into_inner().map_err(|e| FerroError::Io {
+                msg: format!("Failed to flush {}: {}", self.staging_path.display(), e),
+            })?;
+            file.sync_all().map_err(|e| FerroError::Io {
+                msg: format!("Failed to sync {}: {}", self.staging_path.display(), e),
+            })?;
+        }
+
+        let fasta_tmp = sibling_with_suffix(&self.fasta_path, TEMP_SUFFIX);
+        let fai_path = sibling_with_suffix(&self.fasta_path, ".fai");
+        let fai_tmp = sibling_with_suffix(&fai_path, TEMP_SUFFIX);
+
+        let mut report = CommitReport::default();
+        let mut offset = 0u64;
+        // Accessions already written to the merged output, so the *second* record for an
+        // accession is dropped whichever file it came from. This is the uniqueness
+        // constraint the FASTA format does not supply.
+        let mut emitted: HashSet<String> = HashSet::new();
+        // Length and description of every surviving record, for sidecar reconciliation.
+        let mut surviving: HashMap<String, SupplementalTranscript> = HashMap::new();
+
+        {
+            let out = File::create(&fasta_tmp).map_err(|e| FerroError::Io {
+                msg: format!("Failed to create {}: {}", fasta_tmp.display(), e),
+            })?;
+            let mut writer = BufWriter::new(out);
+            // Index lines are streamed alongside the records rather than accumulated:
+            // the shipped artifact's index is 4.9 MB, and a merge must not hold a
+            // multi-megabyte buffer it has somewhere to put.
+            let index_out = File::create(&fai_tmp).map_err(|e| FerroError::Io {
+                msg: format!("Failed to create {}: {}", fai_tmp.display(), e),
+            })?;
+            let mut index_writer = BufWriter::new(index_out);
+            let index_err = |e: std::io::Error| FerroError::Io {
+                msg: format!("Failed to write {}: {}", fai_tmp.display(), e),
+            };
+
+            // Committed records first, in their existing order, minus the ones a staged
+            // record replaces and minus every duplicate.
+            if let Some(mut reader) = open_fasta(&self.fasta_path)? {
+                while let Some(record) = reader.next_record()? {
+                    if self.staged.contains(&record.accession) {
+                        report.records_replaced += 1;
+                        continue;
+                    }
+                    if !emitted.insert(record.accession.clone()) {
+                        report.duplicates_removed += 1;
+                        continue;
+                    }
+                    surviving.insert(record.accession.clone(), record.synthesized_metadata());
+                    let fai_line = write_record(&mut writer, &record, &mut offset)?;
+                    index_writer
+                        .write_all(fai_line.as_bytes())
+                        .map_err(index_err)?;
+                }
+            }
+
+            // Then the staged records, appended in the order they were fetched. A repeat
+            // within one staging file keeps the first, which is unreachable in practice
+            // because staging an accession makes `has_sequence` true for it.
+            //
+            // Read through `StagedReader`, so an incompletely-written trailing record is
+            // dropped instead of being merged as a truncated sequence.
+            if let Some(mut reader) = open_staged(&self.staging_path)? {
+                while let Some(record) = reader.next_record()? {
+                    if !emitted.insert(record.accession.clone()) {
+                        report.duplicates_removed += 1;
+                        continue;
+                    }
+                    surviving.insert(record.accession.clone(), record.synthesized_metadata());
+                    let fai_line = write_record(&mut writer, &record, &mut offset)?;
+                    index_writer
+                        .write_all(fai_line.as_bytes())
+                        .map_err(index_err)?;
+                }
+            }
+
+            let file = writer.into_inner().map_err(|e| FerroError::Io {
+                msg: format!("Failed to flush {}: {}", fasta_tmp.display(), e),
+            })?;
+            file.sync_all().map_err(|e| FerroError::Io {
+                msg: format!("Failed to sync {}: {}", fasta_tmp.display(), e),
+            })?;
+
+            let index_file = index_writer.into_inner().map_err(|e| FerroError::Io {
+                msg: format!("Failed to flush {}: {}", fai_tmp.display(), e),
+            })?;
+            index_file.sync_all().map_err(|e| FerroError::Io {
+                msg: format!("Failed to sync {}: {}", fai_tmp.display(), e),
+            })?;
+        }
+
+        // ---- Commit point. Everything below is derived and re-derivable. ----
+        std::fs::rename(&fasta_tmp, &self.fasta_path).map_err(|e| FerroError::Io {
+            msg: format!(
+                "Failed to install {} over {}: {}",
+                fasta_tmp.display(),
+                self.fasta_path.display(),
+                e
+            ),
+        })?;
+        report.records = emitted.len();
+
+        // The index describes the file that was just installed, so its own rename comes
+        // after that one and never before.
+        std::fs::rename(&fai_tmp, &fai_path).map_err(|e| FerroError::Io {
+            msg: format!(
+                "Failed to install {} over {}: {}",
+                fai_tmp.display(),
+                fai_path.display(),
+                e
+            ),
+        })?;
+
+        // Reconcile the sidecar against what the FASTA actually holds. A row with no
+        // record is an orphan and goes; a record with no row gains one; a row that
+        // already carries CDS annotation keeps it, because a FASTA cannot re-supply it.
+        let before = metadata.transcripts.len();
+        metadata
+            .transcripts
+            .retain(|acc, _| surviving.contains_key(acc));
+        report.metadata_rows_dropped = before - metadata.transcripts.len();
+        for (accession, synthesized) in surviving {
+            metadata.transcripts.entry(accession).or_insert_with(|| {
+                report.metadata_rows_synthesized += 1;
+                synthesized
+            });
+        }
+
+        let json = serde_json::to_vec_pretty(&metadata).map_err(|e| FerroError::Io {
+            msg: format!(
+                "Failed to serialize {}: {}",
+                self.metadata_path.display(),
+                e
+            ),
+        })?;
+        let metadata_tmp = sibling_with_suffix(&self.metadata_path, TEMP_SUFFIX);
+        write_atomically(&metadata_tmp, &self.metadata_path, &json)?;
+
+        // Last, so a crash before this point simply replays a merge that is deterministic
+        // and produces the identical FASTA.
+        if self.staging_path.exists() {
+            std::fs::remove_file(&self.staging_path).map_err(|e| FerroError::Io {
+                msg: format!("Failed to remove {}: {}", self.staging_path.display(), e),
+            })?;
+        }
+
+        Ok(report)
+    }
+}
+
+/// Write `bytes` to `tmp`, `fsync` it, then rename it onto `final_path`.
+fn write_atomically(tmp: &Path, final_path: &Path, bytes: &[u8]) -> Result<(), FerroError> {
+    {
+        let mut file = File::create(tmp).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create {}: {}", tmp.display(), e),
+        })?;
+        file.write_all(bytes).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write {}: {}", tmp.display(), e),
+        })?;
+        file.sync_all().map_err(|e| FerroError::Io {
+            msg: format!("Failed to sync {}: {}", tmp.display(), e),
+        })?;
+    }
+    std::fs::rename(tmp, final_path).map_err(|e| FerroError::Io {
+        msg: format!(
+            "Failed to install {} over {}: {}",
+            tmp.display(),
+            final_path.display(),
+            e
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::benchmark::cache::{fetch_fasta_to_file_with, EfetchSource};
+    use std::cell::RefCell;
+    use std::time::Duration;
+
+    /// Build a sidecar with the given rows.
+    fn metadata(rows: Vec<SupplementalTranscript>) -> SupplementalMetadata {
+        SupplementalMetadata {
+            generated_at: "2026-01-06T00:00:00Z".to_string(),
+            transcripts: rows.into_iter().map(|t| (t.id.clone(), t)).collect(),
+        }
+    }
+
+    /// A sidecar row carrying neither a CDS nor a length — the shape 116,572 of the
+    /// shipped artifact's 140,027 rows have.
+    fn hollow_row(accession: &str) -> SupplementalTranscript {
+        SupplementalTranscript {
+            id: accession.to_string(),
+            gene_symbol: None,
+            cds_start: None,
+            cds_end: None,
+            sequence_length: 0,
+        }
+    }
+
+    fn annotated_row(accession: &str, cds: (u64, u64), length: usize) -> SupplementalTranscript {
+        SupplementalTranscript {
+            id: accession.to_string(),
+            gene_symbol: Some("GENEA".to_string()),
+            cds_start: Some(cds.0),
+            cds_end: Some(cds.1),
+            sequence_length: length,
+        }
+    }
+
+    /// Write a FASTA holding exactly the given `(accession, description, sequence)` records,
+    /// in order, with duplicates preserved.
+    fn write_fasta(path: &Path, records: &[(&str, &str, &str)]) {
+        let mut body = String::new();
+        for (accession, description, sequence) in records {
+            if description.is_empty() {
+                body.push_str(&format!(">{}\n", accession));
+            } else {
+                body.push_str(&format!(">{} {}\n", accession, description));
+            }
+            for chunk in sequence.as_bytes().chunks(FASTA_LINE_BASES) {
+                body.push_str(std::str::from_utf8(chunk).unwrap());
+                body.push('\n');
+            }
+        }
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// Write a staging file: complete records are terminated, and `torn` optionally
+    /// appends an unterminated trailing record — what a crash mid-write leaves behind.
+    fn write_staged(path: &Path, records: &[(&str, &str, &str)], torn: Option<(&str, &str)>) {
+        let mut body = String::new();
+        for (accession, description, sequence) in records {
+            body.push_str(&format!(">{} {}\n", accession, description));
+            for chunk in sequence.as_bytes().chunks(FASTA_LINE_BASES) {
+                body.push_str(std::str::from_utf8(chunk).unwrap());
+                body.push('\n');
+            }
+            body.push_str(STAGED_RECORD_TERMINATOR);
+            body.push('\n');
+        }
+        if let Some((accession, partial)) = torn {
+            body.push_str(&format!(">{}\n{}\n", accession, partial));
+        }
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// Accessions of every record in a FASTA, in file order, duplicates included.
+    fn headers(path: &Path) -> Vec<String> {
+        let text = std::fs::read_to_string(path).unwrap();
+        text.lines()
+            .filter_map(|l| l.strip_prefix('>'))
+            .map(|h| split_header(h).0)
+            .collect()
+    }
+
+    /// Sequence recorded for `accession`, read back through the record stream.
+    fn sequence_of(path: &Path, accession: &str) -> Option<String> {
+        let mut reader = open_fasta(path).unwrap()?;
+        while let Some(record) = reader.next_record().unwrap() {
+            if record.accession == accession {
+                return Some(record.sequence);
+            }
+        }
+        None
+    }
+
+    // ---------------------------------------------------------------- store layer
+
+    #[test]
+    fn presence_is_answered_by_the_fasta_and_never_by_the_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGT")]);
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+
+        // Bases on disk, sidecar row hollow -> still present. This is the accession the
+        // issue's suggested acceptance test is about.
+        assert!(store.has_sequence("NM_000001.1"));
+        // A sidecar row with no FASTA record is not presence: the sidecar is not asked.
+        assert!(!store.has_sequence("NM_000002.1"));
+    }
+
+    #[test]
+    fn a_staged_record_replaces_the_committed_one_rather_than_appending() {
+        // This is the property that makes PR #1732's usability-keyed resume predicate
+        // safe: even when an accession whose bases are already on disk is re-fetched, the
+        // write path upserts rather than appends.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(
+            &fasta,
+            &[
+                ("NM_000001.1", "GENEA", "AAAA"),
+                ("NM_000002.1", "", "CCCC"),
+            ],
+        );
+        let mut meta = metadata(vec![hollow_row("NM_000001.1"), hollow_row("NM_000002.1")]);
+
+        let mut store = SupplementalStore::open(&fasta).unwrap();
+        store
+            .stage_record("NM_000001.1", "GENEA", "GGGGGG")
+            .unwrap();
+        let report = store.commit(&mut meta).unwrap();
+
+        assert_eq!(headers(&fasta), vec!["NM_000002.1", "NM_000001.1"]);
+        assert_eq!(sequence_of(&fasta, "NM_000001.1").unwrap(), "GGGGGG");
+        assert_eq!(sequence_of(&fasta, "NM_000002.1").unwrap(), "CCCC");
+        assert_eq!(report.records, 2);
+        assert_eq!(report.records_replaced, 1);
+        assert_eq!(report.duplicates_removed, 0);
+    }
+
+    #[test]
+    fn a_duplicated_accession_is_collapsed_to_one_record() {
+        // The shipped `patterns_transcripts.fna.bak` is in this state: 159,456 records for
+        // 140,026 unique accessions.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(
+            &fasta,
+            &[
+                ("NM_000001.1", "GENEA", "AAAA"),
+                ("NM_000002.1", "", "CCCC"),
+                ("NM_000001.1", "GENEA", "AAAA"),
+                ("NM_000001.1", "GENEA", "AAAA"),
+            ],
+        );
+        let mut meta = metadata(vec![hollow_row("NM_000001.1"), hollow_row("NM_000002.1")]);
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+        assert_eq!(store.duplicate_record_count(), 2);
+        assert_eq!(store.duplicated_accessions(), vec!["NM_000001.1"]);
+        assert!(store.is_dirty(&meta));
+
+        let report = store.commit(&mut meta).unwrap();
+
+        assert_eq!(headers(&fasta), vec!["NM_000001.1", "NM_000002.1"]);
+        assert_eq!(report.duplicates_removed, 2);
+        assert_eq!(report.records, 2);
+        // The first occurrence is kept, so a repair preserves the record that was already
+        // being served rather than picking an arbitrary copy.
+        assert_eq!(sequence_of(&fasta, "NM_000001.1").unwrap(), "AAAA");
+    }
+
+    #[test]
+    fn an_interrupted_runs_staging_file_counts_as_already_fetched() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "AAAA")]);
+        // What an interrupted run leaves behind: one complete staged record.
+        write_staged(
+            &sibling_with_suffix(&fasta, STAGING_SUFFIX),
+            &[("NM_000002.1", "GENEB", "CCCC")],
+            None,
+        );
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+        assert!(store.has_sequence("NM_000001.1"));
+        assert!(
+            store.has_sequence("NM_000002.1"),
+            "staged bases are on disk"
+        );
+
+        let mut meta = metadata(vec![hollow_row("NM_000001.1")]);
+        assert!(store.is_dirty(&meta));
+        store.commit(&mut meta).unwrap();
+
+        assert_eq!(headers(&fasta), vec!["NM_000001.1", "NM_000002.1"]);
+        assert!(!sibling_with_suffix(&fasta, STAGING_SUFFIX).exists());
+    }
+
+    #[test]
+    fn the_sidecar_key_set_is_reconciled_against_the_fasta() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA (variant 1)", "AAAACCCC")]);
+        // One orphan row (no FASTA record) and no row at all for the record that exists.
+        let mut meta = metadata(vec![hollow_row("NM_999999.9")]);
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+        assert!(store.is_dirty(&meta), "key sets disagree");
+        let report = store.commit(&mut meta).unwrap();
+
+        assert_eq!(report.metadata_rows_dropped, 1);
+        assert_eq!(report.metadata_rows_synthesized, 1);
+        assert_eq!(meta.transcripts.len(), 1);
+        let row = &meta.transcripts["NM_000001.1"];
+        assert_eq!(row.sequence_length, 8);
+        assert_eq!(row.gene_symbol.as_deref(), Some("GENEA"));
+        assert_eq!(row.cds_start, None, "a FASTA cannot supply a CDS");
+    }
+
+    #[test]
+    fn existing_cds_annotation_is_carried_forward_not_overwritten() {
+        // The sidecar's key set is derived; its CDS payload is not, and a commit must not
+        // reset an annotated row to the FASTA-only shape.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "AAAACCCC")]);
+        let mut meta = metadata(vec![
+            annotated_row("NM_000001.1", (2, 7), 8),
+            hollow_row("NM_999999.9"),
+        ]);
+
+        SupplementalStore::open(&fasta)
+            .unwrap()
+            .commit(&mut meta)
+            .unwrap();
+
+        let row = &meta.transcripts["NM_000001.1"];
+        assert_eq!(row.cds_start, Some(2));
+        assert_eq!(row.cds_end, Some(7));
+    }
+
+    #[test]
+    fn a_reconciled_artifact_is_not_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "AAAA")]);
+        // A hollow row is still a row: the key sets agree, so there is nothing to repair
+        // here. Usability is PR #1732's question and deliberately not this predicate's.
+        let meta = metadata(vec![hollow_row("NM_000001.1")]);
+        // A complete artifact carries its index; without one the store is dirty, which
+        // `a_missing_or_drifted_index_makes_the_store_dirty` pins separately.
+        std::fs::write(
+            sibling_with_suffix(&fasta, ".fai"),
+            "NM_000001.1\t4\t19\t4\t5\n",
+        )
+        .unwrap();
+
+        assert!(!SupplementalStore::open(&fasta).unwrap().is_dirty(&meta));
+    }
+
+    #[test]
+    fn the_rebuilt_index_locates_every_record_exactly() {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        // One record shorter than a line, one spanning three lines, so both the
+        // `line_bases` branch and multi-line offset arithmetic are exercised.
+        let long: String = std::iter::repeat_n('G', 155).collect();
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGT")]);
+        let mut store = SupplementalStore::open(&fasta).unwrap();
+        store.stage_record("NM_000002.1", "", &long).unwrap();
+        let mut meta = metadata(vec![]);
+        store.commit(&mut meta).unwrap();
+
+        let fai = std::fs::read_to_string(sibling_with_suffix(&fasta, ".fai")).unwrap();
+        let mut file = File::open(&fasta).unwrap();
+        let mut seen = 0;
+        for line in fai.lines() {
+            let fields: Vec<&str> = line.split('\t').collect();
+            let (length, offset): (usize, u64) =
+                (fields[1].parse().unwrap(), fields[2].parse().unwrap());
+            let line_bases: usize = fields[3].parse().unwrap();
+            let line_bytes: usize = fields[4].parse().unwrap();
+            assert_eq!(line_bytes, line_bases + 1);
+            assert_eq!(line_bases, length.min(FASTA_LINE_BASES));
+
+            // Seek to the recorded offset and read the record's bases back. `take` +
+            // `read_to_end` rather than a bare `read`, which may return a short buffer
+            // and produce a spurious failure rather than a real one.
+            file.seek(SeekFrom::Start(offset)).unwrap();
+            let mut raw = Vec::new();
+            Read::by_ref(&mut file)
+                .take((length + length / FASTA_LINE_BASES + 1) as u64)
+                .read_to_end(&mut raw)
+                .unwrap();
+            let bases: String = String::from_utf8_lossy(&raw)
+                .chars()
+                .filter(|c| c.is_ascii_alphabetic())
+                .take(length)
+                .collect();
+            let expected = sequence_of(&fasta, fields[0]).unwrap();
+            assert_eq!(bases, expected, "index misplaces {}", fields[0]);
+            seen += 1;
+        }
+        assert_eq!(seen, 2);
+    }
+
+    #[test]
+    fn a_header_with_no_sequence_is_not_a_presence_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        std::fs::write(&fasta, ">NM_000001.1 GENEA\n>NM_000002.1\nACGT\n").unwrap();
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+        assert!(!store.has_sequence("NM_000001.1"), "no bases behind it");
+        assert!(store.has_sequence("NM_000002.1"));
+    }
+
+    #[test]
+    fn a_temp_path_extends_the_name_rather_than_replacing_its_extension() {
+        // `with_extension` would turn `supp.fna` into `supp.tmp`, which collides with the
+        // temp path of every sibling artifact in the directory.
+        let path = Path::new("/x/patterns_transcripts.fna");
+        assert_eq!(
+            sibling_with_suffix(path, TEMP_SUFFIX),
+            Path::new("/x/patterns_transcripts.fna.tmp")
+        );
+        assert_eq!(
+            metadata_path_for(path),
+            Path::new("/x/patterns_transcripts.metadata.json")
+        );
+    }
+
+    // ------------------------------------------------- end-to-end provisioning path
+
+    /// An [`EfetchSource`] serving canned payloads and counting what it was asked for.
+    struct FakeEfetch {
+        /// `accession -> (gene, sequence)`.
+        records: HashMap<String, (String, String)>,
+        genbank_calls: RefCell<Vec<String>>,
+        fasta_calls: RefCell<Vec<String>>,
+    }
+
+    impl FakeEfetch {
+        fn new(records: &[(&str, &str, &str)]) -> Self {
+            Self {
+                records: records
+                    .iter()
+                    .map(|(a, g, s)| (a.to_string(), (g.to_string(), s.to_string())))
+                    .collect(),
+                genbank_calls: RefCell::new(Vec::new()),
+                fasta_calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.genbank_calls.borrow().len() + self.fasta_calls.borrow().len()
+        }
+    }
+
+    impl EfetchSource for FakeEfetch {
+        fn genbank(&self, ids: &str) -> Result<Option<String>, FerroError> {
+            self.genbank_calls.borrow_mut().push(ids.to_string());
+            let mut text = String::new();
+            for id in ids.split(',') {
+                let Some((gene, sequence)) = self.records.get(id) else {
+                    continue;
+                };
+                text.push_str(&format!(
+                    "LOCUS       {id}    {len} bp    mRNA\n\
+                     VERSION     {id}\n\
+                     FEATURES             Location/Qualifiers\n     \
+                     gene            1..{len}\n                     \
+                     /gene=\"{gene}\"\n     \
+                     CDS             1..{len}\n\
+                     ORIGIN\n        1 {sequence}\n//\n",
+                    len = sequence.len()
+                ));
+            }
+            Ok((!text.is_empty()).then_some(text))
+        }
+
+        fn fasta(&self, ids: &str) -> Option<String> {
+            self.fasta_calls.borrow_mut().push(ids.to_string());
+            None
+        }
+
+        fn rate_delay(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// Content **and modification time** of the three artifacts.
+    ///
+    /// The mtime is not redundant with the bytes: the merge is deterministic, so a run
+    /// that needlessly rewrote all three would produce byte-identical content and satisfy
+    /// a content-only comparison. "The second run is a no-op" means it performed no write,
+    /// which only the mtime can witness.
+    fn artifact_state(fasta: &Path) -> Vec<(String, Vec<u8>, std::time::SystemTime)> {
+        [
+            fasta.to_path_buf(),
+            sibling_with_suffix(fasta, ".fai"),
+            metadata_path_for(fasta),
+        ]
+        .iter()
+        .map(|p| {
+            let bytes = std::fs::read(p).unwrap_or_else(|e| panic!("read {}: {}", p.display(), e));
+            let mtime = std::fs::metadata(p).unwrap().modified().unwrap();
+            (p.display().to_string(), bytes, mtime)
+        })
+        .collect()
+    }
+
+    #[test]
+    fn provisioning_is_idempotent_and_the_second_run_writes_nothing() {
+        // The acceptance property. It is deliberately not "a hollow row does not
+        // double-append": stated as a fixed point it holds every write path to account
+        // for itself, including ones nobody anticipated.
+        //
+        // NOTE, because this test reads like the guard and is not the whole of it: seeded
+        // from an EMPTY directory it also passes on the pre-fix behaviour, since an
+        // artifact that behaviour produced has a FASTA and a sidecar that agree, so its
+        // sidecar-keyed resume filter skips correctly. The tests that are red on the old
+        // behaviour are the ones seeded from a state where the two disagree —
+        // `an_accession_in_the_fasta_but_missing_from_the_sidecar_is_not_re_fetched` and
+        // `a_duplicate_bearing_artifact_is_repaired_and_then_stable`. Do not delete those
+        // as redundant with this one.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        let source = FakeEfetch::new(&[
+            ("NM_000001.1", "GENEA", "ACGTACGTAC"),
+            ("NM_000002.1", "GENEB", "TTTTGGGGCCCC"),
+        ]);
+        let requested = vec!["NM_000001.1".to_string(), "NM_000002.1".to_string()];
+
+        let first = fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
+        assert_eq!(first, 2);
+        let after_first = artifact_state(&fasta);
+        let calls_after_first = source.calls();
+        assert!(calls_after_first > 0, "the first run must actually fetch");
+
+        let second = fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
+
+        assert_eq!(second, 0);
+        assert_eq!(
+            source.calls(),
+            calls_after_first,
+            "the second run must not fetch anything"
+        );
+        assert_eq!(
+            after_first,
+            artifact_state(&fasta),
+            "the second run must leave every artifact byte-identical"
+        );
+        assert_eq!(headers(&fasta), vec!["NM_000001.1", "NM_000002.1"]);
+        assert!(
+            !sibling_with_suffix(&fasta, STAGING_SUFFIX).exists(),
+            "no staging file survives a clean run"
+        );
+    }
+
+    #[test]
+    fn an_accession_in_the_fasta_but_missing_from_the_sidecar_is_not_re_fetched() {
+        // The route that produced the shipped `.bak`: the sidecar is written once, after
+        // the final batch, so an interrupted run leaves the FASTA ahead of it. Keyed on
+        // the sidecar this re-fetches and appends a second record; keyed on the FASTA it
+        // is already present.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
+        // Sidecar knows nothing about it.
+        std::fs::write(
+            metadata_path_for(&fasta),
+            serde_json::to_vec_pretty(&metadata(vec![])).unwrap(),
+        )
+        .unwrap();
+
+        let source = FakeEfetch::new(&[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
+        let fetched =
+            fetch_fasta_to_file_with(&["NM_000001.1".to_string()], &fasta, false, &source).unwrap();
+
+        assert_eq!(fetched, 0);
+        assert_eq!(source.calls(), 0, "nothing was fetched");
+        assert_eq!(
+            headers(&fasta),
+            vec!["NM_000001.1"],
+            "the FASTA gained no second record"
+        );
+        // The run still repaired the sidecar, because its key set had drifted.
+        let repaired: SupplementalMetadata =
+            serde_json::from_slice(&std::fs::read(metadata_path_for(&fasta)).unwrap()).unwrap();
+        assert_eq!(repaired.transcripts.len(), 1);
+        assert_eq!(repaired.transcripts["NM_000001.1"].sequence_length, 10);
+    }
+
+    #[test]
+    fn a_hollow_sidecar_row_does_not_produce_a_second_fasta_record() {
+        // The issue's own suggested acceptance test: run the resume filter over a cohort
+        // containing a hollow row whose sequence is already in the FASTA, and assert the
+        // FASTA gains no second header for it.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
+        std::fs::write(
+            metadata_path_for(&fasta),
+            serde_json::to_vec_pretty(&metadata(vec![hollow_row("NM_000001.1")])).unwrap(),
+        )
+        .unwrap();
+        // A complete artifact has an index too; it is part of what must not move.
+        std::fs::write(
+            sibling_with_suffix(&fasta, ".fai"),
+            "NM_000001.1\t10\t19\t10\t11\n",
+        )
+        .unwrap();
+
+        let source = FakeEfetch::new(&[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
+        let before = artifact_state(&fasta);
+
+        fetch_fasta_to_file_with(&["NM_000001.1".to_string()], &fasta, false, &source).unwrap();
+
+        assert_eq!(headers(&fasta), vec!["NM_000001.1"]);
+        assert_eq!(source.calls(), 0);
+        // Key sets already agreed, so this was the fixed point and nothing was rewritten.
+        assert_eq!(before, artifact_state(&fasta));
+    }
+
+    #[test]
+    fn a_duplicate_bearing_artifact_is_repaired_and_then_stable() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(
+            &fasta,
+            &[
+                ("NM_000001.1", "GENEA", "ACGTACGTAC"),
+                ("NM_000002.1", "GENEB", "TTTT"),
+                ("NM_000001.1", "GENEA", "ACGTACGTAC"),
+            ],
+        );
+        std::fs::write(
+            metadata_path_for(&fasta),
+            serde_json::to_vec_pretty(&metadata(vec![
+                hollow_row("NM_000001.1"),
+                hollow_row("NM_000002.1"),
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let source = FakeEfetch::new(&[]);
+        let requested = vec!["NM_000001.1".to_string(), "NM_000002.1".to_string()];
+
+        fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
+        assert_eq!(headers(&fasta), vec!["NM_000001.1", "NM_000002.1"]);
+        let repaired = artifact_state(&fasta);
+
+        // Repair reaches a fixed point rather than churning.
+        fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
+        assert_eq!(repaired, artifact_state(&fasta));
+        assert_eq!(source.calls(), 0);
+    }
+
+    #[test]
+    fn an_incompletely_written_staged_record_is_discarded_not_merged() {
+        // A crash part-way through `stage_record` leaves a truncated trailing record. If
+        // it counted as present, the accession would never be re-fetched and the
+        // TRUNCATED sequence would be merged into the authoritative FASTA — a torn write
+        // silently becoming the authority, which is the defect class this module closes.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_staged(
+            &sibling_with_suffix(&fasta, STAGING_SUFFIX),
+            &[("NM_000001.1", "GENEA", "ACGTACGT")],
+            Some(("NM_000002.1", "TTTT")), // header written, terminator never reached
+        );
+
+        let store = SupplementalStore::open(&fasta).unwrap();
+        assert!(store.has_sequence("NM_000001.1"), "complete record counts");
+        assert!(
+            !store.has_sequence("NM_000002.1"),
+            "a torn record is not a presence claim, so it is re-fetched"
+        );
+
+        let mut meta = metadata(vec![]);
+        store.commit(&mut meta).unwrap();
+        assert_eq!(headers(&fasta), vec!["NM_000001.1"]);
+        assert_eq!(
+            sequence_of(&fasta, "NM_000002.1"),
+            None,
+            "the truncated sequence must not reach the committed FASTA"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_drifted_index_makes_the_store_dirty() {
+        // The `.fai` is declared derived, so noticing it is gone is part of that claim
+        // being true rather than documentary. A deleted index also makes this artifact
+        // invisible to `prepare::load_existing_accessions`, which enumerates by `.fai`.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGT")]);
+        let meta = metadata(vec![hollow_row("NM_000001.1")]);
+
+        // No index at all.
+        assert!(SupplementalStore::open(&fasta).unwrap().is_dirty(&meta));
+
+        // An index naming a different accession set.
+        std::fs::write(
+            sibling_with_suffix(&fasta, ".fai"),
+            "NM_999999.9\t4\t19\t4\t5\n",
+        )
+        .unwrap();
+        assert!(SupplementalStore::open(&fasta).unwrap().is_dirty(&meta));
+
+        // A commit reconciles it, and the result is the fixed point.
+        let mut meta2 = meta.clone();
+        SupplementalStore::open(&fasta)
+            .unwrap()
+            .commit(&mut meta2)
+            .unwrap();
+        assert!(!SupplementalStore::open(&fasta).unwrap().is_dirty(&meta2));
+    }
+
+    #[test]
+    fn a_run_whose_every_fetch_failed_rewrites_nothing() {
+        // Reaching the commit having staged nothing is a real outcome — a down or
+        // rate-limiting endpoint fails every batch — and a failed run must not rewrite
+        // the artifact it could not add to.
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
+        std::fs::write(
+            metadata_path_for(&fasta),
+            serde_json::to_vec_pretty(&metadata(vec![hollow_row("NM_000001.1")])).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            sibling_with_suffix(&fasta, ".fai"),
+            "NM_000001.1\t10\t19\t10\t11\n",
+        )
+        .unwrap();
+        let before = artifact_state(&fasta);
+
+        // `NM_000002.1` is requested and genuinely absent, so the fetch loop runs — and
+        // the fake has no record for it, so every batch comes back empty.
+        let source = FakeEfetch::new(&[]);
+        let fetched = fetch_fasta_to_file_with(
+            &["NM_000001.1".to_string(), "NM_000002.1".to_string()],
+            &fasta,
+            false,
+            &source,
+        )
+        .unwrap();
+
+        assert_eq!(fetched, 0);
+        assert!(source.calls() > 0, "the fetch loop must actually have run");
+        assert_eq!(
+            before,
+            artifact_state(&fasta),
+            "a run that staged nothing must not rewrite the artifact"
+        );
+    }
+
+    #[test]
+    fn a_dry_run_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("supp.fna");
+        let source = FakeEfetch::new(&[("NM_000001.1", "GENEA", "ACGT")]);
+
+        fetch_fasta_to_file_with(&["NM_000001.1".to_string()], &fasta, true, &source).unwrap();
+
+        assert!(!fasta.exists());
+        assert!(!metadata_path_for(&fasta).exists());
+        assert_eq!(source.calls(), 0);
+    }
+}


### PR DESCRIPTION
Closes #1758.

Fixes the root cause rather than the appending symptom: **two artifacts, updated non-atomically, were answering one question.** "Do we have sequence for this accession?" was answered by `*.metadata.json` while the sequence itself lived in the FASTA, which `fetch_fasta_to_file` opened in append mode and wrote to unconditionally from all three of its write paths.

That was safe only by coincidence. The resume filter was `!metadata.transcripts.contains_key(acc)` and every FASTA write inserted a metadata key in the same iteration, so "this accession is in the FASTA" implied "this accession is skipped next run" and the duplicate-append path was unreachable via resume. Nobody wrote that coupling down; it emerged. Both routes out of it are observable — #1732 keys resume on usability and breaks it by design, and the shipped `patterns_transcripts.fna.bak` carries **159,456 records for 140,026 unique accessions** (reproduced) from the other route, where the sidecar is written once after the final batch so an interrupted run leaves the FASTA ahead of it.

Underneath both: **a FASTA has no uniqueness constraint.** A duplicate header is legal FASTA and silently wrong here, because the file is being used as a keyed store with no key. The write path has to supply the constraint the format lacks.

## What is authoritative and what is derived

| artifact | status | recovered how |
|---|---|---|
| `<name>.fna` | **authoritative** for presence and sequence | — |
| `<name>.fna.fai` | derived | rebuilt from the committed FASTA at every commit |
| `<name>.metadata.json` | derived **key set** and `sequence_length`; carried-forward CDS annotation | keys reconciled against the FASTA at every commit; a missing row is synthesized from the record |

The sidecar is not *fully* derived and the code does not pretend it is: CDS coordinates come from a GenBank record and a FASTA cannot re-supply them, so an annotated row is carried forward untouched. What is derived is exactly the part that was being asked the presence question.

### Keying on the FASTA rather than the `.fai` is this repo's existing ruling, not a new preference

The issue proposes reading the `.fai`. `prepare::run_backfill` already faced this for the sibling backfill FASTA and decided the other way, saying why at its `load_fasta_header_accessions` call:

> The backfill present set is read from the FASTA headers themselves (the file `execute_backfill` appends to), not its derived `.fai`: a prior run interrupted after the append but before reindex — or a deleted `.fai` — would otherwise look empty and re-fetch and re-append the same accession, duplicating its `>accession` record (and colliding `.fai` keys on the subsequent reindex).

That is this defect, on the neighbouring artifact, with the same remedy. Applying the same rule rather than inventing a second one is the point. The reasoning also holds on its own: the `.fai` is a second artifact that can drift from the FASTA — on the shipped reference it is seven minutes newer than the `.fna` it indexes — so nominating it as the authority inverts the dependency and reintroduces the defect class one level over. Scanning headers costs one sequential read, **measured at 2.08 s over the 1.3 GB shipped artifact**, against a fetch half that is networked, rate-limited and measured in hours.

This also makes *writing* the index load-bearing rather than tidy: the merge re-emits every record at a uniform line width, so a commit invalidates any externally-built index it does not replace.

## Upsert, and where the atomicity boundary is

Fetched records are appended to a durable, resumable staging file (`<name>.fna.incoming`). `SupplementalStore::commit` then streams the committed FASTA and the staging file into `<name>.fna.tmp` keyed by accession — one record per accession, a staged record replacing the committed one, every duplicate dropped — then `fsync`s and renames it over the FASTA.

**That rename is the atomicity boundary, and it is the only one needed.** The index and the sidecar are rewritten after it, and a crash in between is self-healing because the next `open` re-derives both from the FASTA. Making the derived artifacts genuinely derived is what buys consistency across three files without a three-file atomic write, which is not available. The staging file is removed last, so a crash before that replays a merge that is deterministic and produces the identical FASTA.

Staging also makes an interrupted run lose nothing: its records count as present on the next run, so no accession is fetched twice — which closes the `.bak` route directly, and makes the issue's **option 3** (per-batch metadata checkpointing) fall out rather than needing separate work. I agree with that reading, with one correction to the framing: the durable per-batch state is the staged *sequence*, not a checkpointed sidecar. Checkpointing the sidecar would have kept two artifacts and merely made them disagree less often; the sidecar is now reconstructible, so there is nothing left to checkpoint.

## Repair is not a mode

Dedup-by-accession is what the merge does, so a duplicate-bearing artifact is repaired by the next provisioning run and is a fixed point thereafter — no separate command, no operator knowledge required, and covered by the same idempotence property rather than by a parallel one. A run with nothing to fetch and nothing to reconcile writes **no byte at all**.

## The acceptance test is a fixed point — and where that alone is not enough

`provisioning_is_idempotent_and_the_second_run_writes_nothing` runs the real provisioning path twice and asserts the second run fetches nothing and leaves all three artifacts byte-identical **and unmodified by mtime**. The mtime is not redundant with the bytes: the merge is deterministic, so a run that needlessly rewrote all three would produce identical content and satisfy a content-only comparison. "No-op" means no write, and only the mtime witnesses that. Mutation M4 below confirms it — four tests catch a forced rewrite, and they only do so because of the mtime.

**One correction to the framing in the issue, measured rather than argued.** Seeded from an *empty* directory, run-twice-is-a-no-op **passes on the pre-fix behaviour too**: an artifact that behaviour produced has a FASTA and a sidecar that agree, so its sidecar-keyed filter skips correctly. The fixed-point property is satisfied *by* the very coincidence being removed. What is red on the old behaviour is the same property seeded from a state where the two artifacts **disagree**. Both tests exist and are named in a comment on the clean-start test so it is not later deleted as redundant.

`EfetchSource` abstracts the two `curl` invocations so this is a property of the production path rather than of a predicate; it is unstatable in a test that cannot run that path at all.

## Verification

18 unit tests, all green. Full local suite **10486/10486**. `cargo fmt --all --check` and `cargo clippy --features dev --lib --all-targets -- -D warnings` clean.

**Pre-fix reconstruction** — the two defective behaviours restored together (sidecar-keyed resume + blind append), each mutation verified to have actually applied before running:

```
a_duplicated_accession_is_collapsed_to_one_record ............ FAILED
  left: ["NM_000001.1","NM_000002.1","NM_000001.1","NM_000001.1"]
a_staged_record_replaces_the_committed_one_rather_than_appending  FAILED
a_duplicate_bearing_artifact_is_repaired_and_then_stable ..... FAILED
an_accession_in_the_fasta_but_missing_from_the_sidecar_is_not_re_fetched  FAILED
  fetch calls: left 1, right 0        <- the `.bak` route, reproduced
test result: FAILED. 11 passed; 4 failed
```

**Mutation testing — 12 mutations, 12 killed**, call sites included. Each was checked to have changed the file before its run, so a silently-inapplicable mutation cannot read as an uncaught one (one first-round mutation did fail to compile and was rewritten rather than counted):

| mutation | result |
|---|---|
| M1 resume filter keyed on the sidecar (call site in `cache.rs`) | killed by 1 |
| M2 staged record does not replace the committed one | killed by 1 |
| M3 duplicates are not collapsed | killed by 2 |
| M4 `is_dirty` always true (needless rewrite) | killed by 4 |
| M5 `is_dirty` always false (never repairs) | killed by 5 |
| M6 `has_sequence` ignores staged records | killed by 1 |
| M7 sidecar orphan rows are not dropped | killed by 1 |
| M8 index offset off by one | killed by 1 |
| M9 synthesized sidecar row carries no length | killed by 2 |
| N1 torn trailing staged record treated as complete | killed by 1 |
| N2 `is_dirty` ignores the index | killed by 1 |
| N3 final commit not gated on `is_dirty` (call site) | killed by 3 |

Not covered by mutation: the `fsync`/rename ordering, which needs crash injection to exercise. Stated rather than implied.

## Review round: four defects found in this change, and one lesson about my own battery

The `coderabbit --agent` lens raised six findings against this diff. Four were real and are fixed here; the disposition of all six:

- **A torn staged record could become authoritative** (fixed). A crash part-way through `stage_record` leaves a truncated trailing record; counting it as present meant the accession was never re-fetched and the *truncated* sequence was merged into the FASTA — the defect class this PR closes, reintroduced one level down by the staging file. Records now carry a `;end` terminator and an unterminated trailing record is discarded and re-fetched. Without this the PR's "durable and resumable" claim was not true.
- **The final commit was unconditional** (fixed). Reaching it having staged nothing is a real outcome — every batch can fail against a down endpoint — and a failed run rewrote the artifact it could not add to. Now gated on `is_dirty`.
- **`is_dirty` ignored the `.fai`** (fixed). Declaring the index derived and then not noticing it was missing left it derived in the documentation only; a deleted index also makes the artifact invisible to `prepare::load_existing_accessions`, which enumerates by `.fai`. Now a term, on names (a stale *offset* with correct names is not detected, and the code says so).
- **`curl` had no timeouts** (fixed). Hundreds of sequential batches with no `--max-time` means one stalled connection hangs the run. Added, generously, plus `--fail-with-body` so an HTTP error page is a failed batch rather than a batch that silently fetched nothing.
- **A short `read` in the index test** (fixed) — a flake source, not a defect.
- **A store-wide lock file for concurrent runs** (rejected). Concurrent provisioning against one reference directory was already unsafe — the previous code had two processes appending to one FASTA, which is strictly worse — so this neither introduces nor worsens it, and lockfile lifecycle is its own change. Worth filing separately.

**The lesson worth recording:** my mutation battery missed the unconditional-commit defect because every mutation targeted the store, not the call site in `cache.rs` that drives it. A battery that only mutates the unit under test cannot see a caller that fails to use it correctly. N3 was added for exactly that shape and is killed by three tests.

Separately, and consistent with what the #1732 review found: **no `path_instructions` glob in `.coderabbit.yaml` matches `src/benchmark/`.** The nearest, `src/{batch/**/*.rs,parallel.rs,cache.rs}`, expands to `src/cache.rs`, not `src/benchmark/cache.rs`. So the repo's own acquisition-and-caching lens — whose clauses ("a partial download left in place under the final filename instead of being written to a temporary path and renamed", "a cache keyed on fewer inputs than determine the value") describe this PR almost exactly — is configured off for the file it changes. I applied it by hand; it is worth fixing in the config, separately from this PR.

## Relationship to #1732

This supersedes #1732's resume-filter *mechanism* and leaves its *question* intact and safe to ask. Presence now comes from the sequence data rather than the sidecar; #1732's usability clause becomes a one-line extension of the same predicate (`!store.has_sequence(acc) || !metadata.has_usable_record(acc)`), and with the write path upserting it can no longer duplicate anything. `a_staged_record_replaces_the_committed_one_rather_than_appending` pins that property at exactly the layer #1732's predicate feeds. Nothing was pushed to that branch.

On the shipped artifact the mechanism change moves nothing: the FASTA and the sidecar key sets agree exactly — 140,027 each, 0 in either and not the other (verified) — so the same accessions are skipped either way.

#1732's other half (refusing a corrupt sidecar rather than silently treating it as a first run) is untouched here and still worth landing; this PR keeps `unwrap_or_else` exactly as `main` has it so that change stays #1732's to make.

## Provenance of `patterns_transcripts.fna` — answered

The issue records that no producer could be found and that the name may come from an out-of-tree script. It does not: **`src/bin/benchmark.rs` writes it**, in the `ferro-benchmark prepare ferro --patterns` path — the path is the `output_file` argument to `fetch_fasta_to_file`, then the argument to `index_fasta`, then assigned to `manifest.supplemental_fasta`. Two binaries write a supplemental FASTA from the same `--patterns` input under different fixed names: `ferro prepare` writes `clinvar_transcripts.fna` and `ferro-benchmark prepare ferro` writes `patterns_transcripts.fna`. No stem derivation is involved; both literals are hardcoded. The operator's reference matches the benchmark binary's name and its manifest carries `"supplemental_fasta": "supplemental/patterns_transcripts.fna"`.

So the design does not rest on an unevidenced claim about that file's origin — it was written by this repo, by the function this PR fixes.

Representation-Change: none. Producer-side provisioning under `src/benchmark/`; no file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched. Reasoning rather than assertion, because the artifact this writes *is* read by reference-aware runs: what changes about it is that duplicate records are collapsed and the sidecar's key set is reconciled, and no normalization consults either — the consuming side resolves sequence by accession, and a de-duplicated FASTA serves the same bases for every accession it served before. No normalized output moves.
