### PR TITLE
fix(normalize): refuse a c./r. position on base 0 instead of answering it as -1

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -154,9 +154,24 @@ fn intron_length_at_tx_boundary(
 /// this helper sees `CdsPos { base: 0, utr3: false }`. Special positions
 /// (pter/qter/cen, which also carry `base == 0`) are similarly skipped by
 /// the caller before reaching this helper. The arm is dead code in the
-/// W4004 path; kept here for parity with `Normalizer::cds_to_tx_pos` so
-/// this helper remains a drop-in replacement if a future caller needs it
-/// outside the bounds check.
+/// W4004 path; it is kept rather than deleted for the reason it was
+/// originally kept — parity with `Normalizer::cds_to_tx_pos`, so this
+/// helper stays a drop-in replacement if a future caller needs it outside
+/// the bounds check.
+///
+/// **That parity is what changed it.** The arm used to return
+/// `cds_start - 1`, mirroring what `cds_to_tx_pos` then did; `cds_to_tx_pos`
+/// now refuses, because `background/numbering.md:31` says there is no
+/// nucleotide `c.0`, so the mirror of it here is `None` — no transcript
+/// boundary — not a boundary derived from a position that names no
+/// nucleotide (#1796). Deleting the arm instead would be worse in both
+/// directions: `base == 0` would fall through to the final branch and
+/// evaluate `cds_start + 0 - 1` in `u64`, underflowing on the very value
+/// this note is about, and the helper would silently stop mirroring the
+/// method it exists to mirror. `None` is also already this helper's
+/// vocabulary for "not answerable", and its caller's contract for it is the
+/// conservative skip documented on `check_cds_pos_past_end` — which is the
+/// right outcome for a position no bounds check can be run against.
 fn cds_pos_to_tx_boundary(
     pos: &CdsPos,
     transcript: &crate::reference::transcript::Transcript,
@@ -173,11 +188,12 @@ fn cds_pos_to_tx_boundary(
         let signed = cds_start as i64 + pos.base;
         u64::try_from(signed).ok()
     } else if pos.base == 0 {
-        // Defensive parity with `cds_to_tx_pos`; see helper-level doc
-        // note. Unreachable from `check_cds_pos_past_end` because the
-        // caller short-circuits on `pos.is_unknown()` (which keys off
+        // Defensive parity with `cds_to_tx_pos`, which refuses this position;
+        // see the helper-level doc note. Unreachable from
+        // `check_cds_pos_past_end` because the caller short-circuits on
+        // `pos.is_unknown()` and `pos.is_special()` (both of which key off
         // `CDS_BASE_UNKNOWN == 0`).
-        Some(cds_start.saturating_sub(1))
+        None
     } else {
         // c.<N>: tx_boundary = cds_start + N - 1
         Some(cds_start + (pos.base as u64) - 1)
@@ -9346,7 +9362,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Convert an RNA position to a transcript-1 position.
     ///
     /// Mirrors `cds_to_tx_pos`. `r.*N` maps to `cds_end + N`, `r.-N` to
-    /// `cds_start + N` (HGVS skips the `0` gap).
+    /// `cds_start + N` (HGVS skips the `0` gap), and `r.0` — which that gap
+    /// means names no nucleotide — is refused, exactly as `cds_to_tx_pos`
+    /// refuses `c.0`. See the arm below and #1796.
     fn rna_to_tx_pos(
         &self,
         pos: &crate::hgvs::location::RnaPos,
@@ -9370,7 +9388,51 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 ),
             })
         } else if pos.base == 0 {
-            Ok(cds_start.saturating_sub(1))
+            // The `r.` axis inherits `c.`'s numbering, so it inherits the gap.
+            // The inheritance is what carries a `c.`-axis clause onto this
+            // axis, so cite the lines that establish it rather than only the
+            // gap itself — `background/numbering.md:58`, "nucleotide numbering
+            // for an RNA reference sequence follows that of the associated
+            // coding or non-coding DNA reference sequence; nucleotide `r.123`
+            // relates to `c.123` or `n.123`", with `:61` naming the coding case
+            // this arm is reached on ("in a coding RNA reference sequence,
+            // nucleotide numbering ... follow[s] that of a coding DNA reference
+            // sequence"). `normalize_rna` already cites that same L58/L61 pair
+            // for this proposition. Only then does `:31` — "there is no
+            // nucleotide `c.0`" — reach here, and `r.0` names no nucleotide
+            // either. Refuse rather than answer with `cds_start - 1`, which is
+            // this axis's own `r.-1` and so a different position from the one
+            // asked about. Issue #1796.
+            //
+            // The non-coding half of `:58` needs no arm here: this function is
+            // only called with a resolved `cds_info` (`normalize_rna`'s
+            // `map_in` and `rna_pos_to_txpos` both branch on it first), and the
+            // no-CDS branch already declines `base < 1`, matching `:60`'s
+            // numbering from `r.1`. So the zone set is read off the reference,
+            // never assumed by the parser.
+            //
+            // This arm carried the same `Ok(cds_start.saturating_sub(1))` as
+            // `cds_to_tx_pos` and — unlike its twin — no comment at all, 2,700
+            // lines away from it. Both are load-bearing for a producer that
+            // #1777 fixes; see the fuller note on `cds_to_tx_pos`.
+            //
+            // `RnaPos` has no `special` field and the `utr3` branch above has
+            // already been taken, so `base == 0` is the whole condition here —
+            // and unlike `cds_to_tx_pos`'s twin, `r.{pos}` really does render
+            // as `r.0`, there being no unknown sentinel on this axis.
+            //
+            // Note this message reaches no caller: both call sites discard the
+            // `Err` (`normalize_rna`'s `map_in` and `rna_pos_to_txpos` both
+            // `.ok()` it) and fall back to leaving the description as authored.
+            // It is read only by `rna_to_tx_pos_refuses_a_zero_base`. Keep it
+            // accurate anyway — it is the half of the seam a maintainer
+            // comparing against #1747's mapper-side refusal will read.
+            Err(FerroError::ConversionError {
+                msg: format!(
+                    "cannot resolve r.{pos} to a transcript position: the RNA base is 0, \
+                     which names no nucleotide"
+                ),
+            })
         } else {
             Ok(cds_start + pos.base as u64 - 1)
         }
@@ -12168,10 +12230,52 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 ),
             })
         } else if pos.base == 0 {
-            // c.0 is not a valid HGVS position, but historical inputs
-            // can land here. Preserve the legacy mapping (treat as the
-            // last 5'UTR base, equivalent to c.-1) rather than failing.
-            Ok(cds_start.saturating_sub(1))
+            // `background/numbering.md:31` states, inside the definition of the
+            // `c.` axis itself and alongside `-1` and `*1`: "there is no
+            // nucleotide `c.0`". That is an existence claim, not an
+            // input-hygiene rule — the coordinate names no nucleotide, so
+            // there is no transcript position to answer with. Refuse, which is
+            // what `CoordinateMapper::cds_to_tx` does on the mapper side of
+            // the same seam (#1746/#1747) and what `cds_to_protein` has always
+            // done. Issue #1796.
+            //
+            // This arm used to return `cds_start - 1` — this axis's own `c.-1`
+            // — on the stated ground that "historical inputs can land here".
+            // That premise is false: the parser refuses `c.0` outright (#269),
+            // so nothing a user writes reaches this. What reached it was
+            // ferro's own intermediate. `collapse_overlapping_cis_edits`
+            // computed a 5'-edge insertion anchor as `c.1 - 1 = c.0`, and
+            // `cds_start - 1` happens to be the right transcript coordinate
+            // for `c.-1`, so this arm silently repaired that producer's
+            // off-by-one — which is why removing it turned no test red while
+            // making `NM_TEST.1:c.[1A>G;1dup]` emit the malformed intermediate
+            // `c.?_1insG` to the user. The producer is #1772, fixed by #1777,
+            // which this change is stacked on; after it, nothing in the suite
+            // reaches this arm at all.
+            //
+            // Keyed on `base == 0` rather than on `is_unknown()`, deliberately.
+            // The two coincide at every reachable call site — `normalize_cds`
+            // resolves or refuses every special position before converting —
+            // but `is_unknown()` is false for a `pter`/`qter`/`cen` marker,
+            // which also carries `base == 0`, and such a position falling
+            // through to the arm below would evaluate `cds_start + 0 - 1` in
+            // `u64` and underflow. Base 0 names no nucleotide whatever put it
+            // there, so one predicate covers both and no arithmetic runs on a
+            // value that is not a coordinate.
+            // The rendering will usually NOT read `c.0`, and the message says so
+            // rather than asserting a spelling the reader cannot see.
+            // `CDS_BASE_UNKNOWN` *is* the integer 0, so an unknown position
+            // prints `c.?`; a `pter`/`qter`/`cen` marker carries base 0 too and
+            // prints as the marker. A literal `c.0` is the one occupant that
+            // cannot occur, the parser having refused it since #269.
+            Err(FerroError::ConversionError {
+                msg: format!(
+                    "cannot resolve c.{pos} to a transcript position: it carries CDS base 0, \
+                     which names no nucleotide. That value is shared by the `c.?` unknown \
+                     sentinel and by the pter/qter/cen markers, so the position above may not \
+                     render as `0`"
+                ),
+            })
         } else {
             Ok(cds_start + pos.base as u64 - 1)
         }
@@ -15164,6 +15268,203 @@ mod tests {
         };
         let result = normalizer.cds_to_tx_pos(&cds_pos, 10, Some(50));
         assert!(result.is_ok());
+    }
+
+    // ----------------------------------------------------------------------
+    // Issue #1796 — base 0 names no nucleotide, at all three conversion sites
+    // in this file. `background/numbering.md:31`: "there is no nucleotide
+    // `c.0`", stated inside the definition of the axis itself and alongside
+    // `-1` and `*1`, so it is an existence claim rather than an input-hygiene
+    // rule. These assert the REFUSAL, because the end-to-end strings these
+    // sites feed were already correct — the arms were silently repairing a
+    // producer's off-by-one (#1772, fixed by #1777), which is exactly why
+    // removing them turned no test red. See `tests/it/issue_1796_*` for the
+    // half a user sees.
+    // ----------------------------------------------------------------------
+
+    /// `cds_to_tx_pos` must refuse `c.0` rather than answer with `cds_start - 1`
+    /// — which is this axis's own `c.-1`, a *different* position from the one
+    /// asked about.
+    #[test]
+    fn cds_to_tx_pos_refuses_a_zero_base() {
+        let normalizer = Normalizer::new(MockProvider::with_test_data());
+        let zero = CdsPos {
+            base: 0,
+            offset: None,
+            utr3: false,
+            special: None,
+        };
+        let err = normalizer
+            .cds_to_tx_pos(&zero, 10, Some(50))
+            .expect_err("c.0 names no nucleotide, so it has no transcript position")
+            .to_string();
+        assert!(
+            err.contains("names no nucleotide"),
+            "the diagnostic must say why, not just that it failed; got: {err}"
+        );
+        // The refusal is not a widened 5'UTR refusal: the neighbours on both
+        // sides of the absent coordinate still convert, and to *different*
+        // transcript positions — `cds_start - 1` and `cds_start`. That pair is
+        // what the old arm collapsed, by handing `c.0` the answer for `c.-1`.
+        assert_eq!(
+            normalizer
+                .cds_to_tx_pos(&CdsPos::new(-1), 10, Some(50))
+                .expect("c.-1 is a real position"),
+            9
+        );
+        assert_eq!(
+            normalizer
+                .cds_to_tx_pos(&CdsPos::new(1), 10, Some(50))
+                .expect("c.1 is a real position"),
+            10
+        );
+    }
+
+    /// An offset does not make the base exist: `c.0+5` is anchored on a
+    /// position that names nothing, so there is nothing for the offset to be
+    /// measured from. Mirrors the guard `#1747` puts on `cds_to_tx`.
+    #[test]
+    fn cds_to_tx_pos_refuses_a_zero_base_carrying_an_offset() {
+        let normalizer = Normalizer::new(MockProvider::with_test_data());
+        let zero_with_offset = CdsPos {
+            base: 0,
+            offset: Some(5),
+            utr3: false,
+            special: None,
+        };
+        // `is_err()` alone would pass on any failure — including one from an
+        // unrelated arm — so pin the reason, as the sibling tests here do.
+        let err = normalizer
+            .cds_to_tx_pos(&zero_with_offset, 10, Some(50))
+            .expect_err("an offset does not make the anchor base exist")
+            .to_string();
+        assert!(
+            err.contains("names no nucleotide"),
+            "the refusal must be the base-0 one, not an incidental failure; got: {err}"
+        );
+    }
+
+    /// A special marker (`pter`/`qter`/`cen`) carries `base == 0` too, and is
+    /// resolved or refused by `normalize_cds` long before reaching here — so
+    /// this pins the arm's *predicate*, not a live path.
+    ///
+    /// It is worth pinning because it is the reason the arm keys on
+    /// `base == 0` and not on `CdsPos::is_unknown()`, which the reachable case
+    /// would otherwise suggest. `is_unknown()` is false when `special` is set,
+    /// so keying on it would drop a marker through to the final branch, where
+    /// `cds_start + 0 - 1` underflows in `u64`. Refusing covers both occupants
+    /// of the value and runs no arithmetic on either.
+    #[test]
+    fn cds_to_tx_pos_refuses_a_special_marker_rather_than_underflowing() {
+        let normalizer = Normalizer::new(MockProvider::with_test_data());
+        let pter = CdsPos {
+            base: 0,
+            offset: None,
+            utr3: false,
+            special: Some(crate::hgvs::location::SpecialPosition::Pter),
+        };
+        assert!(
+            !pter.is_unknown(),
+            "precondition: a marker is not `unknown`"
+        );
+        let err = normalizer
+            .cds_to_tx_pos(&pter, 10, Some(50))
+            .expect_err("a marker carries no numeric coordinate, so it has no transcript position")
+            .to_string();
+        assert!(
+            err.contains("names no nucleotide"),
+            "the refusal must be the base-0 one, not an incidental failure; got: {err}"
+        );
+        // A marker renders as `pter`, never as `0`, so the diagnostic must not
+        // claim the reader is looking at a zero. The message says which
+        // occupants share the value instead.
+        assert!(
+            err.contains("pter") && err.contains("markers"),
+            "the diagnostic must account for the rendering the caller sees; got: {err}"
+        );
+    }
+
+    /// The `r.` axis inherits `c.`'s numbering and so inherits the gap. This
+    /// arm is the one that carried no comment at all — 2,700 lines from its
+    /// `cds_` twin, under a doc saying only "Mirrors `cds_to_tx_pos`" — which
+    /// made it the copy most likely to be "cleaned up" into something wrong.
+    #[test]
+    fn rna_to_tx_pos_refuses_a_zero_base() {
+        let normalizer = Normalizer::new(MockProvider::with_test_data());
+        let err = normalizer
+            .rna_to_tx_pos(&crate::hgvs::location::RnaPos::new(0), 10, Some(50))
+            .expect_err("r.0 names no nucleotide, so it has no transcript position")
+            .to_string();
+        assert!(
+            err.contains("names no nucleotide"),
+            "the diagnostic must say why, not just that it failed; got: {err}"
+        );
+        // Same anti-widening control as the `c.` case above.
+        assert_eq!(
+            normalizer
+                .rna_to_tx_pos(&crate::hgvs::location::RnaPos::new(-1), 10, Some(50))
+                .expect("r.-1 is a real position"),
+            9
+        );
+        assert_eq!(
+            normalizer
+                .rna_to_tx_pos(&crate::hgvs::location::RnaPos::new(1), 10, Some(50))
+                .expect("r.1 is a real position"),
+            10
+        );
+    }
+
+    /// The free helper exists to mirror `cds_to_tx_pos`, so it mirrors the
+    /// refusal: `None`, which is already its vocabulary for "not answerable"
+    /// and its caller's contract for the conservative skip.
+    ///
+    /// Its `base == 0` arm documents itself as dead in the W4004 path, and it
+    /// is — `check_cds_pos_past_end` short-circuits on `is_unknown()` and
+    /// `is_special()`. It is pinned rather than deleted because deleting it
+    /// would drop `base == 0` into the final branch and underflow
+    /// `cds_start + 0 - 1` in `u64`, and because a helper whose whole
+    /// justification is parity silently losing that parity is the failure this
+    /// issue is about.
+    #[test]
+    fn cds_pos_to_tx_boundary_declines_a_zero_base() {
+        let transcript = crate::reference::transcript::Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: None,
+            strand: crate::reference::transcript::Strand::Plus,
+            sequence: None,
+            cds_start: Some(10),
+            cds_end: Some(50),
+            exons: vec![crate::reference::transcript::Exon::new(1, 1, 60)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: crate::reference::transcript::ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            cds_start_incomplete: false,
+            exon_cigars: Vec::new(),
+            cached_introns: std::sync::OnceLock::new(),
+        };
+        let zero = CdsPos {
+            base: 0,
+            offset: None,
+            utr3: false,
+            special: None,
+        };
+        assert_eq!(cds_pos_to_tx_boundary(&zero, &transcript), None);
+        // Parity with `cds_to_tx_pos` in both directions: the positions either
+        // side of the absent coordinate still answer, and answer the same
+        // transcript boundaries that method does.
+        assert_eq!(
+            cds_pos_to_tx_boundary(&CdsPos::new(-1), &transcript),
+            Some(9)
+        );
+        assert_eq!(
+            cds_pos_to_tx_boundary(&CdsPos::new(1), &transcript),
+            Some(10)
+        );
     }
 
     #[test]

--- a/tests/it/issue_1796_base_zero_names_no_nucleotide.rs
+++ b/tests/it/issue_1796_base_zero_names_no_nucleotide.rs
@@ -1,0 +1,319 @@
+//! Issue #1796 — `c.0` / `r.0` name no nucleotide, so the normalizer's
+//! conversion sites must refuse them rather than invent a coordinate.
+//!
+//! `background/numbering.md:31` states, *inside* the definition of the `c.`
+//! numbering axis and alongside `-1` and `*1`: *"there is no nucleotide
+//! `c.0`."* That is an existence claim, not an input-hygiene rule — the
+//! coordinate names no nucleotide, so there is nothing to convert it to.
+//! biocommons/hgvs enforces the same in its position type
+//! (`BaseOffsetPosition base may not be 0`), and mutalyzer-crossmapper opens by
+//! naming this exact hazard: `-1` and `1` being adjacent *"gives rise to
+//! various off by one errors when the conversion is not done properly."*
+//!
+//! Three sites in `src/normalize/mod.rs` answered it anyway, all with
+//! `cds_start - 1` — which is the axis's own `-1`, a *different* position from
+//! the one asked about. They now refuse. The mapper half of the same seam is
+//! #1746/#1747.
+//!
+//! # Why the interesting assertions here are about what did NOT move
+//!
+//! These arms were **load-bearing**, and that is the trap this file exists to
+//! keep pinned. `collapse_overlapping_cis_edits` computed a 5'-edge insertion
+//! anchor as `c.1 - 1 = c.0` and built the intermediate member `c.?_1insG`;
+//! `cds_start - 1` happens to be the correct transcript coordinate for `c.-1`,
+//! so the arm silently repaired that producer's off-by-one. Refuse without
+//! fixing the producer and `NM_TEST.1:c.[1A>G;1dup]` emits the malformed
+//! `c.?_1insG` to the user — with **zero** tests going red, because the one
+//! test that reached the arm asserted only that the output re-parses, and
+//! `c.?_1insG` does.
+//!
+//! The producer is #1772, fixed by #1777, which this change is stacked on. So
+//! `the_five_prime_edge_cis_collapse_is_unaffected` is not a change detector
+//! for this diff — it is the guard that the *stack* is right, and it is the
+//! single most important assertion in this file. If it ever reports `c.?_1insG`
+//! the refusal is sitting on top of an unfixed producer.
+//!
+//! What this change does move is a position reached by construction rather than
+//! by parsing — the shape the Python bindings and any other direct API consumer
+//! can build. Reference-free (`MockProvider` via `SyntheticBuilder`), so these
+//! hold with no manifest.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::hgvs::edit::NaEdit;
+use ferro_hgvs::hgvs::interval::{CdsInterval, RnaInterval};
+use ferro_hgvs::hgvs::location::{CdsPos, RnaPos};
+use ferro_hgvs::hgvs::variant::{Accession, CdsVariant, LocEdit, RnaVariant};
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+/// A 35-base transcript whose CDS is `13..=24`, so the 5'UTR runs `-1`..`-12`
+/// and the 3'UTR `*1`..`*11` — real UTRs on both sides, which is what makes the
+/// `cds_start - 1` step the arms used to take observable at all.
+const CORE: &str = "GCAAAGCGCGCGATGAAACCCTAAGGCATTTTTAA";
+const CDS: (u64, u64) = (13, 24);
+
+fn provider() -> MockProvider {
+    SyntheticBuilder::cds(CORE, CDS.0, CDS.1, Strand::Plus).build()
+}
+
+fn normalize(variant: &HgvsVariant) -> String {
+    Normalizer::new(provider())
+        .normalize(variant)
+        .expect("lenient normalization must not reject")
+        .to_string()
+}
+
+/// A `c.` variant built directly on base 0 — the shape a caller reaches through
+/// the API rather than through the parser, which refuses `c.0` outright (#269).
+fn built_cds_base_zero() -> HgvsVariant {
+    HgvsVariant::Cds(CdsVariant {
+        accession: Accession::new("NM", "TEST", Some(1)),
+        gene_symbol: None,
+        loc_edit: LocEdit::new(
+            CdsInterval::new(CdsPos::new(0), CdsPos::new(0)),
+            NaEdit::Deletion {
+                sequence: None,
+                length: None,
+            },
+        ),
+    })
+}
+
+fn built_rna_base_zero() -> HgvsVariant {
+    HgvsVariant::Rna(RnaVariant {
+        accession: Accession::new("NM", "TEST", Some(1)),
+        gene_symbol: None,
+        loc_edit: LocEdit::new(
+            RnaInterval::new(RnaPos::new(0), RnaPos::new(0)),
+            NaEdit::Deletion {
+                sequence: None,
+                length: None,
+            },
+        ),
+    })
+}
+
+// =====================================================================
+// 1. The end-to-end behaviour that MOVES
+// =====================================================================
+
+/// A `c.` position on base 0 must come back as the caller wrote it, not
+/// relabelled as `c.-1`.
+///
+/// Before this change `cds_to_tx_pos` mapped base 0 to `cds_start - 1` and the
+/// whole shuffle proceeded as though the caller had written `c.-1`, so the
+/// output was `NM_TEST.1:c.-1del` — a confident answer about a *different*
+/// position, with no warning and nothing to tell the caller a substitution had
+/// been made. Refusing routes the two call sites in `normalize_cds` to their
+/// canonicalize-only fallback, which is the right outcome for a position naming
+/// no nucleotide: ferro declines to move it rather than moving it somewhere
+/// wrong.
+///
+/// Note what the input renders as. `CDS_BASE_UNKNOWN` **is** the integer 0
+/// (`src/hgvs/location.rs:151`), so `CdsPos { base: 0 }` prints as `c.?` and a
+/// hypothetical `c.0` is byte-identical to a genuine `c.?`. That collision is
+/// why the old behaviour was doubly wrong here: it answered a position declared
+/// *unknown* with a specific coordinate.
+#[test]
+fn a_cds_position_on_base_zero_is_not_relabelled_as_minus_one() {
+    let built = built_cds_base_zero();
+    assert_eq!(
+        built.to_string(),
+        "NM_TEST.1:c.?del",
+        "precondition: base 0 and the `c.?` sentinel are the same value, and print alike"
+    );
+    let output = normalize(&built);
+    assert_eq!(
+        output, "NM_TEST.1:c.?del",
+        "a position naming no nucleotide must be left as authored, not answered"
+    );
+    assert_ne!(
+        output, "NM_TEST.1:c.-1del",
+        "`cds_start - 1` is this axis's own `c.-1` — a different position from the one asked \
+         about; answering with it is the defect"
+    );
+}
+
+/// The **second** public exit must refuse base 0 the same way the first does.
+///
+/// `Normalizer` has exactly two public normalizing methods — `normalize` and
+/// `normalize_with_diagnostics` — and a change can reach one without the other.
+/// Every other test in this file goes through the `normalize` helper above, and
+/// the guards in `src/normalize/mod.rs` exercise `cds_to_tx_pos` /
+/// `rna_to_tx_pos` / `cds_pos_to_tx_boundary` *directly*, at the converter. So
+/// before this test the diagnostics exit had no base-0 coverage at all.
+///
+/// The behaviour was already uniform across both exits — that was measured, not
+/// assumed. What was missing was a test holding it there, which is the shape
+/// that reddens CI when a later change reaches only one exit.
+///
+/// Asserted on the contract rather than on a convenient side effect: the
+/// rendered result, the warnings vector and the infos vector, plus equality
+/// with the plain exit's answer. (`NormalizeResult` carries `result` /
+/// `warnings` / `infos`; it has no `status` or `changed` fields — those belong
+/// to the Python and CLI surfaces, not to this type.)
+#[test]
+fn the_diagnostics_exit_refuses_base_zero_exactly_as_the_plain_exit_does() {
+    let built = built_cds_base_zero();
+    let normalizer = Normalizer::new(provider());
+
+    let diagnosed = normalizer
+        .normalize_with_diagnostics(&built)
+        .expect("lenient normalization must not reject");
+
+    assert_eq!(
+        diagnosed.result.to_string(),
+        "NM_TEST.1:c.?del",
+        "the diagnostics exit must leave a position naming no nucleotide as authored"
+    );
+    assert_ne!(
+        diagnosed.result.to_string(),
+        "NM_TEST.1:c.-1del",
+        "answering with `cds_start - 1` — this axis's own `c.-1` — is the defect, on either exit"
+    );
+
+    // The decline is currently silent, and this pins that as the *measured*
+    // contract rather than asserting it is desirable. If the refusal is ever
+    // surfaced to the caller (a warning, or the `Err` propagated), this is the
+    // assertion that must be updated deliberately, which is the point of it.
+    assert!(
+        diagnosed.warnings.is_empty(),
+        "base 0 currently declines without a warning; got: {:?}",
+        diagnosed.warnings
+    );
+    assert!(
+        diagnosed.infos.is_empty(),
+        "nothing shuffled, so no shift info may be reported; got: {:?}",
+        diagnosed.infos
+    );
+
+    // The property this test exists for: the two public exits agree.
+    assert_eq!(
+        diagnosed.result.to_string(),
+        normalize(&built),
+        "`normalize` and `normalize_with_diagnostics` must not diverge at base 0"
+    );
+}
+
+/// The `r.` half of the same shape is pinned at the conversion itself, in
+/// `normalize::tests::rna_to_tx_pos_refuses_a_zero_base`, and deliberately has
+/// no end-to-end case here.
+///
+/// `RnaPos` has no unknown sentinel, so `RnaPos { base: 0 }` renders as the
+/// literal `r.0` — a string `parse_hgvs` rejects. That makes the axis
+/// unreachable end-to-end by any legitimate route: the parser cannot produce
+/// base 0, and since #1777 neither can the cis collapse. The only way in is to
+/// hand `Normalizer::normalize` a directly-built malformed AST, and doing that
+/// trips `FERRO_ASSERT_REPARSE` — *"normalization was handed an input it cannot
+/// re-parse, and that input is not one of the deliberate non-renderable
+/// shapes"* — so such a test aborts the whole run under the armed CI job rather
+/// than asserting anything.
+///
+/// Worth recording, because the naive reading of that abort is backwards. The
+/// oracle is complaining about the **input**, not the output; before this
+/// change the same input was silently answered with the parseable `r.-1del`,
+/// which is exactly the invention being removed. A normalizer that satisfies
+/// the oracle by fabricating a valid coordinate for an invalid one is the
+/// defect, so the test was dropped rather than the refusal weakened.
+///
+/// The `c.` axis has no such problem, and that is not luck: `CDS_BASE_UNKNOWN`
+/// is `0`, so `CdsPos { base: 0 }` renders as `c.?`, which round-trips.
+#[test]
+fn the_rna_axis_has_no_end_to_end_case_and_this_records_why() {
+    let built = built_rna_base_zero();
+    assert_eq!(
+        built.to_string(),
+        "NM_TEST.1:r.0del",
+        "the premise of the note above: base 0 on `r.` renders as a string the parser rejects"
+    );
+    assert!(
+        parse_hgvs(&built.to_string()).is_err(),
+        "if `r.0` ever becomes parseable, this axis gains a legitimate end-to-end case and \
+         one should be added alongside the `c.` test above"
+    );
+}
+
+// =====================================================================
+// 2. The stack guard — what must NOT move
+// =====================================================================
+
+/// **The load-bearing case.** A cis group netting to a pure insertion at the 5'
+/// edge of its window must still normalize to the `-1` anchor, on every
+/// transcript axis.
+///
+/// This is the assertion that says the refusal above is safe. The producer used
+/// to hand `cds_to_tx_pos` a base-0 anchor and the arm quietly corrected it; now
+/// #1777 names the anchor `-1` at the point the integer becomes a position, so
+/// nothing reaches the arm and the output is unchanged. Were this stacked on a
+/// base without #1777, `c.` and `r.` would report `?_1insG` / `0_1insg` here —
+/// a malformed intermediate promoted to the user-visible answer.
+///
+/// `n.` is included as the control: `rna_to_tx_pos`/`cds_to_tx_pos` never
+/// touched that axis, so it had no repairing arm and #1772 was *visible* there
+/// (it emitted the literal `n.0_1insA`, which ferro's own parser rejects). It
+/// must be unaffected by this change in either direction.
+#[test]
+fn the_five_prime_edge_cis_collapse_is_unaffected() {
+    for (input, expected) in [
+        ("NM_TEST.1:c.[1A>G;1dup]", "NM_TEST.1:c.-1dup"),
+        ("NM_TEST.1:r.[1a>g;1dup]", "NM_TEST.1:r.-1dup"),
+        ("NM_TEST.1:n.[1G>A;1dup]", "NM_TEST.1:n.-1_1insA"),
+    ] {
+        let variant = parse_hgvs(input).expect("input must parse");
+        let output = normalize(&variant);
+        assert_eq!(
+            output, expected,
+            "`{input}` must be unaffected by the base-0 refusal; a `?` or a `0` in this output \
+             means the refusal is sitting on top of an unfixed producer (#1772/#1777)"
+        );
+        assert!(
+            parse_hgvs(&output).is_ok(),
+            "`{input}` -> `{output}` must re-parse"
+        );
+    }
+}
+
+/// The refusal is narrow: it removes exactly the one coordinate that names no
+/// nucleotide, and every position either side of it still converts and still
+/// shuffles.
+///
+/// Without this the previous two tests are satisfiable by a normalizer that has
+/// simply stopped converting `c.`/`r.` positions at all.
+#[test]
+fn the_positions_either_side_of_the_absent_coordinate_still_normalize() {
+    for (input, expected) in [
+        // `c.-1` and `c.1` are the two the old arm collapsed onto one answer.
+        ("NM_TEST.1:c.-1del", "NM_TEST.1:c.-1del"),
+        ("NM_TEST.1:c.1del", "NM_TEST.1:c.1del"),
+        ("NM_TEST.1:r.-1del", "NM_TEST.1:r.-1del"),
+        ("NM_TEST.1:r.1del", "NM_TEST.1:r.1del"),
+        // A 5'UTR deletion that actually shuffles, so the conversion is doing
+        // real work rather than passing an already-canonical string through.
+        // `c.-10` is transcript position 3, inside this core's `AAA` run
+        // (transcript 3..=5), so the 3'-rule carries it to transcript 5 —
+        // `c.-8`. Two bases of movement, entirely within the 5'UTR, which is
+        // the region whose conversion goes through the arm this change touches.
+        ("NM_TEST.1:c.-10del", "NM_TEST.1:c.-8del"),
+        ("NM_TEST.1:c.[*1del;*2dup]", "NM_TEST.1:c.*2="),
+    ] {
+        let variant = parse_hgvs(input).expect("input must parse");
+        assert_eq!(normalize(&variant), expected, "`{input}` must be unchanged");
+    }
+}
+
+/// `c.-1` and `c.1` must still name **different** transcript positions.
+///
+/// The old arm's specific harm was collapsing the gap: it gave `c.0` `c.-1`'s
+/// answer, so three `c.` spellings mapped onto two transcript bases. Deleting
+/// one base at `c.-1` and one at `c.1` must therefore denote different edits —
+/// asserted through the outputs rather than through the private conversion, so
+/// it holds at the layer a consumer sees.
+#[test]
+fn the_gap_the_axis_skips_is_still_a_gap() {
+    let minus_one = normalize(&parse_hgvs("NM_TEST.1:c.-1del").expect("must parse"));
+    let plus_one = normalize(&parse_hgvs("NM_TEST.1:c.1del").expect("must parse"));
+    assert_ne!(
+        minus_one, plus_one,
+        "`c.-1` and `c.1` are adjacent bases, not one base; the axis skips 0 between them"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -34,6 +34,7 @@ mod issue_1715_rna_alignment_symbol_reach;
 mod issue_1748_noncoding_axis_zones;
 mod issue_1764_hgvs_to_vcf_continues;
 mod issue_1767_unknown_offset_splice_classifiers;
+mod issue_1796_base_zero_names_no_nucleotide;
 mod issue_1841_option_returning_splice_classifiers;
 mod issue_1870_cds_less_transcript_refusal;
 mod repeat_input_idempotency;


### PR DESCRIPTION
Closes #1796 — the normalizer half only. The mapper half is #1747, in review; this PR does not touch `src/convert/mapper.rs`, and it touches neither the ruling ledger nor any census pin.

## Stacked on #1777 — read this before rebasing

**Base branch is `fix/allele-insertion-anchor-c-minus-one` (#1777, head `11338b19`), not `main`.** That is a correctness prerequisite, not a convenience, and it is the whole trap in #1796.

Once #1777 squash-merges, this needs:

```
git rebase --onto <#1777-squash-commit> 11338b19
```

and then retargeting to `main` before it can enter the merge queue. A plain `git rebase origin/main` replays #1777's commit and conflicts.

## What the three arms did

`background/numbering.md:31` states, *inside* the definition of the `c.` numbering axis and alongside `-1` and `*1`: *"there is no nucleotide `c.0`."* An existence claim, not an input-hygiene rule — the coordinate names no nucleotide, so there is nothing to convert it to.

Three sites in `src/normalize/mod.rs` answered it anyway, all with `cds_start - 1` — which is the axis's own `-1`, and therefore a *different* position from the one asked about:

| site | before | after |
|---|---|---|
| `Normalizer::cds_to_tx_pos` | `Ok(cds_start.saturating_sub(1))`, under a comment about "historical inputs" | `Err(ConversionError)` |
| `Normalizer::rna_to_tx_pos` | byte-identical arm, **no comment at all**, 2,700 lines from its twin | `Err(ConversionError)` |
| `cds_pos_to_tx_boundary` (free helper) | `Some(cds_start.saturating_sub(1))`, self-documented as dead code | `None` |

The stated premise was false. The parser refuses `c.0` outright (#269), so no *historical input* reaches these arms; what reached them was ferro's own intermediate.

Vocabulary is matched to #1747's mapper-side refusal deliberately, so the two halves agree rather than each inventing one: same error type (`FerroError::ConversionError`) and the same message shape (`cannot resolve <axis>.<pos> to a transcript position: …`).

### The self-declared-dead arm was kept, not deleted

It is genuinely unreachable — `check_cds_pos_past_end` short-circuits on `is_unknown()` and `is_special()` — and the reason it exists is parity with `cds_to_tx_pos`, so parity is what changed it. `None` is already this helper's vocabulary for "not answerable" and its caller's contract for the conservative skip. Deleting the arm would be worse in both directions: `base == 0` would fall into the final branch and evaluate `cds_start + 0 - 1` in `u64`, underflowing on the exact value at issue, and a helper whose whole justification is mirroring `cds_to_tx_pos` would silently stop mirroring it.

### Why the predicate is `base == 0` and not `is_unknown()`

They coincide at every reachable call site — `normalize_cds` resolves or refuses every special position before converting. But `CdsPos::is_unknown()` is false when `special` is set, and `pter`/`qter`/`cen` carry `base == 0` too, so keying on it would drop a marker into the final branch and underflow there. One predicate covers both occupants of the value, and no arithmetic runs on something that is not a coordinate.

## The trap, and the measurement that clears it

These arms were **load-bearing**. `collapse_overlapping_cis_edits` computed a 5'-edge insertion anchor as `c.1 - 1 = c.0` and built the intermediate member `c.?_1insG`; `cds_start - 1` happens to be the correct transcript coordinate for `c.-1`, so the `c.` arm silently repaired that producer's off-by-one.

Refuse without fixing the producer and `NM_TEST.1:c.[1A>G;1dup]` emits the malformed `c.?_1insG` to the user — **with zero tests going red**, because the one test that reached the arm asserted only that the output re-parses, and `c.?_1insG` does.

That producer is #1772, fixed by #1777. **Verified on this branch, with both in:**

| input | on this branch |
|---|---|
| `NM_TEST.1:c.[1A>G;1dup]` | `NM_TEST.1:c.-1dup` — unchanged |
| `NM_TEST.1:r.[1a>g;1dup]` | `NM_TEST.1:r.-1dup` — unchanged |
| `NM_TEST.1:n.[1G>A;1dup]` | `NM_TEST.1:n.-1_1insA` — unchanged (control: `n.` never had a repairing arm) |

`the_five_prime_edge_cis_collapse_is_unaffected` pins all three. It is not a change detector for this diff — it is the guard that the *stack* is right, and it is the most important assertion in the PR.

Note the whole-suite instrumentation can only speak for paths the suite exercises. Any other producer manufacturing a base-0 position that has not been found was also being repaired by these arms, silently, and now will not be.

## Tests, and proof they fail without the change

Reverting only the three arm bodies while keeping every test turns **7 of 10 red**:

- `cds_to_tx_pos_refuses_a_zero_base`, `…_carrying_an_offset`, `…_refuses_a_special_marker_rather_than_underflowing`
- `rna_to_tx_pos_refuses_a_zero_base`
- `cds_pos_to_tx_boundary_declines_a_zero_base`
- `a_cds_position_on_base_zero_is_not_relabelled_as_minus_one`
- (plus the `r.` end-to-end case, since removed — see below)

The 3 that stay green are the intended controls: the stack guard above, an anti-widening check that every position either side of the absent coordinate still converts and still shuffles, and `the_gap_the_axis_skips_is_still_a_gap`. Without those, the refusal tests are satisfiable by a normalizer that has simply stopped converting `c.`/`r.` positions at all.

The end-to-end behaviour that actually moves is a directly-built base-0 position — the shape the Python bindings and any other API consumer can construct, since the parser cannot: `NM_TEST.1:c.?del` normalized to `c.-1del` and now stays `c.?del`. `CDS_BASE_UNKNOWN` **is** the integer `0`, so this was doubly wrong: a position declared *unknown* was answered with a specific coordinate.

**One test was dropped rather than the refusal weakened, and it is worth knowing why.** An `r.` end-to-end case trips `FERRO_ASSERT_REPARSE` — *"normalization was handed an input it cannot re-parse"* — because `RnaPos` has no unknown sentinel, so base 0 renders as the literal `r.0`. The oracle is complaining about the **input**, not the output; before this change the same input was answered with the parseable `r.-1del`, which is precisely the invention being removed. The `r.` refusal is pinned at the conversion instead, and the test file records the reasoning plus a tripwire for the day `r.0` becomes parseable.

## Local gate — real exit codes, read back from the logs

| command | exit |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --features dev --lib -- -D warnings` | 0 |
| `cargo clippy --features python --lib -- -D warnings` | 0 |
| `cargo ta` | 0 — **10,442 run, 10,442 passed**, 152 skipped |

Four seam oracles (`FERRO_ASSERT_IDEMPOTENT` / `REPARSE` / `IN_BOUNDS` / `SEQUENCE`, excluding `normalization_transcripts_exon_contract`), measured on this branch and on its base rather than quoted as a raw count:

- **base `11338b19`: 17 failures**
- **this branch: 17 failures**
- **set difference in both directions: empty — zero new, zero fixed.**

The inherited 17 are the known `defect_non_idempotent_outputs` / `spec_corpus_regressions` CDS-end residue, `issue_1487_canonical_window_overflow`, `spec_conformance_axis`'s two censuses and `stranded_identity_member`.

Representation-Change: Direct-construction only; a structural zero over any parsed corpus. A `c.`/`r.` position built on base 0 was answered as this axis's own `-1` — `NM_TEST.1:c.?del` normalized to `c.-1del` — and is now left as authored. No parseable input can carry the shape: the parser refuses `c.0` (#269), a bare `c.?` maps to `UncertainBoundary::Single(Mu::Unknown)` whose `inner()` is `None` and so exits before the conversion, and with #1777 in the base the cis collapse no longer manufactures a base-0 anchor. Measured: the full suite is unchanged at 10,442 passing, and the four seam oracles show 17 failures on this branch against the same 17 on its base.
