### PR TITLE
fix(effect): decline the unknown-offset sentinel instead of classifying it as a splice site

### DIFF
--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -43,7 +43,13 @@ pub fn validate_cds_pos(pos: &CdsPos, transcript: &Transcript) -> Result<(), Fer
     } else if pos.base < 0 {
         // 5' UTR position
         let utr5_length = (cds_start - 1) as i64;
-        if pos.base.abs() > utr5_length {
+        // `unsigned_abs` for the same reason as the offset checks below:
+        // `i64::MIN.abs()` overflows, and `CdsPos`'s fields are public, so a
+        // library caller can hand this a magnitude no parse can produce
+        // (`parse_cds_pos` negates a `digit1`, whose minimum is
+        // `-i64::MAX`). `utr5_length` is non-negative by construction, so
+        // `max(0)` only makes the `u64` comparison well-typed (#1767).
+        if pos.base.unsigned_abs() > utr5_length.max(0) as u64 {
             return Err(FerroError::InvalidCoordinates {
                 msg: format!(
                     "5' UTR position {} is out of range (min -{})",
@@ -61,9 +67,20 @@ pub fn validate_cds_pos(pos: &CdsPos, transcript: &Transcript) -> Result<(), Fer
         });
     }
 
+    // An unknown offset (`c.100+?` / `c.100-?`) is not a distance, so it is not
+    // a coordinate this can validate — say so rather than reporting it as an
+    // out-of-range number (#1767).
+    if pos.has_unknown_offset() {
+        return Err(FerroError::InvalidCoordinates {
+            msg: "Unknown intronic offset (`+?` / `-?`) denotes no transcript coordinate"
+                .to_string(),
+        });
+    }
+
     // Validate intronic offset if present
     if let Some(offset) = pos.offset {
-        if offset.abs() > 1_000_000 {
+        // `unsigned_abs` because `i64::MIN.abs()` overflows (#1767).
+        if offset.unsigned_abs() > 1_000_000 {
             // Sanity check for very large offsets
             return Err(FerroError::InvalidCoordinates {
                 msg: format!("Intronic offset {} is unreasonably large", offset),

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -36,11 +36,22 @@ pub fn validate_tx_pos(pos: &TxPos, transcript: &Transcript) -> Result<(), Ferro
         });
     }
 
+    // An unknown offset (`n.100+?` / `n.100-?`) is not a distance, so it is
+    // not a coordinate this can validate — say so rather than reporting it as
+    // an out-of-range number (#1767).
+    if pos.has_unknown_offset() {
+        return Err(FerroError::InvalidCoordinates {
+            msg: "Unknown intronic offset (`+?` / `-?`) denotes no transcript coordinate"
+                .to_string(),
+        });
+    }
+
     // Check if offset is within bounds (intronic positions)
     if let Some(offset) = pos.offset {
         // For non-coding transcripts, offsets are typically not used
-        // but we still validate they're reasonable
-        if offset.abs() > 100000 {
+        // but we still validate they're reasonable. `unsigned_abs` because
+        // `i64::MIN.abs()` overflows.
+        if offset.unsigned_abs() > 100_000 {
             return Err(FerroError::InvalidCoordinates {
                 msg: format!("Offset {} is unreasonably large", offset),
             });
@@ -121,14 +132,20 @@ impl IntronicConsequence {
         }
     }
 
-    /// Create from a CDS position with intronic offset
+    /// Create from a CDS position with intronic offset.
+    ///
+    /// Returns `None` for an unknown offset (`c.100+?` / `c.100-?`): every
+    /// variant of this enum states a distance from the exon boundary, and the
+    /// sentinels denote a position unbounded in one direction, so there is no
+    /// distance to state (#1767). `is_intronic` is satisfied by a sentinel, so
+    /// this guard is what keeps it out — not the check above.
     pub fn from_cds_pos(pos: &CdsPos) -> Option<Self> {
-        if !pos.is_intronic() {
+        if !pos.is_intronic() || pos.has_unknown_offset() {
             return None;
         }
 
         let offset = pos.offset?;
-        let abs_offset = offset.abs();
+        let abs_offset = offset.unsigned_abs();
 
         Some(if offset > 0 {
             // 5' end of intron (splice donor side)
@@ -159,14 +176,17 @@ impl IntronicConsequence {
         })
     }
 
-    /// Create from a transcript position with intronic offset
+    /// Create from a transcript position with intronic offset.
+    ///
+    /// Declines an unknown offset (`n.100+?` / `n.100-?`) for the same reason
+    /// as [`IntronicConsequence::from_cds_pos`] (#1767).
     pub fn from_tx_pos(pos: &TxPos) -> Option<Self> {
-        if !pos.is_intronic() {
+        if !pos.is_intronic() || pos.has_unknown_offset() {
             return None;
         }
 
         let offset = pos.offset?;
-        let abs_offset = offset.abs();
+        let abs_offset = offset.unsigned_abs();
 
         Some(if offset > 0 {
             if abs_offset <= 2 {
@@ -247,9 +267,18 @@ pub enum IntronicRegion {
 }
 
 impl IntronicRegion {
-    /// Create from an offset value
+    /// Create from a *measured* offset value.
+    ///
+    /// The argument is a distance from the exon boundary, so the unknown-offset
+    /// sentinels are out of domain: screen them with
+    /// [`CdsPos::has_unknown_offset`] / [`TxPos::has_unknown_offset`] before
+    /// calling, as [`IntronicRegion::from_cds_pos`] and
+    /// [`IntronicRegion::from_tx_pos`] do. The magnitude is taken with
+    /// `unsigned_abs`, so no input can overflow it (#1767); a sentinel passed
+    /// here anyway lands in `DeepIntronic`, which is a distance claim its input
+    /// does not support.
     pub fn from_offset(offset: i64) -> Self {
-        let abs_offset = offset.abs();
+        let abs_offset = offset.unsigned_abs();
         if abs_offset <= 2 {
             Self::CanonicalSpliceSite
         } else if abs_offset <= 20 {
@@ -261,13 +290,24 @@ impl IntronicRegion {
         }
     }
 
-    /// Create from a CDS position
+    /// Create from a CDS position.
+    ///
+    /// Returns `None` for an unknown offset — every variant of this enum names
+    /// a distance band, and a sentinel supports none of them (#1767).
     pub fn from_cds_pos(pos: &CdsPos) -> Option<Self> {
+        if pos.has_unknown_offset() {
+            return None;
+        }
         pos.offset.map(Self::from_offset)
     }
 
-    /// Create from a transcript position
+    /// Create from a transcript position.
+    ///
+    /// Declines an unknown offset, as [`IntronicRegion::from_cds_pos`] does.
     pub fn from_tx_pos(pos: &TxPos) -> Option<Self> {
+        if pos.has_unknown_offset() {
+            return None;
+        }
         pos.offset.map(Self::from_offset)
     }
 }

--- a/src/effect/mod.rs
+++ b/src/effect/mod.rs
@@ -388,10 +388,29 @@ impl EffectPredictor {
     }
 
     /// Classify a splice site variant by distance.
+    ///
+    /// An unknown offset (`+?` / `-?`, carried as `i64::MAX` / `i64::MIN`) is
+    /// reported as [`Consequence::IntronVariant`]. This entry point returns a
+    /// bare `ProteinEffect` and so cannot decline the way the `Option`-returning
+    /// classifiers do, and `IntronVariant` is the weakest true statement
+    /// available: the position is known to be intronic and its distance from the
+    /// boundary is not known at all. Before #1767 the sentinel's `.abs()`
+    /// overflowed — a panic under `overflow-checks`, and in release a wrap back
+    /// to `i64::MIN`, which is negative and so passed `<= 2` and was reported as
+    /// a canonical splice site with HIGH impact.
+    ///
+    /// The returned `intronic_offset` still carries the sentinel, so a caller
+    /// that needs to distinguish "unknown" from "far" can.
     pub fn classify_splice_variant(&self, offset: i64) -> ProteinEffect {
-        let abs_offset = offset.abs();
+        let is_unknown = crate::hgvs::parser::position::is_unknown_offset(offset);
+        // `unsigned_abs` rather than `abs`: total for every `i64`, so the
+        // ladder cannot overflow even on a magnitude that is not a sentinel
+        // (`i64::MIN` is the only such value, and it is reachable here).
+        let abs_offset = offset.unsigned_abs();
 
-        let consequence = if abs_offset <= 2 {
+        let consequence = if is_unknown {
+            Consequence::IntronVariant
+        } else if abs_offset <= 2 {
             if offset > 0 {
                 Consequence::SpliceDonorVariant
             } else {

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -194,11 +194,8 @@ impl CdsPos {
     /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
     /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
     pub fn has_unknown_offset(&self) -> bool {
-        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
-        matches!(
-            self.offset,
-            Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE)
-        )
+        self.offset
+            .is_some_and(crate::hgvs::parser::position::is_unknown_offset)
     }
 
     /// Create a CDS position with intronic offset
@@ -354,6 +351,24 @@ impl TxPos {
 
     pub fn is_intronic(&self) -> bool {
         self.offset.is_some() && self.offset != Some(0)
+    }
+
+    /// Whether the offset is one of the parser's unknown-offset sentinels
+    /// (`+?` → [`OFFSET_UNKNOWN_POSITIVE`], `-?` → [`OFFSET_UNKNOWN_NEGATIVE`])
+    /// rather than a measured intronic distance.
+    ///
+    /// The n.-axis sibling of [`CdsPos::has_unknown_offset`], with the same
+    /// contract: the sentinels are `i64::MAX` / `i64::MIN`, so using one as a
+    /// distance overflows, and per the spec they denote an unknown position
+    /// unbounded in one direction, from which no distance can be derived at
+    /// all. Callers that classify or measure an offset MUST check this first
+    /// (issues #1087, #1767).
+    ///
+    /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+    /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
+    pub fn has_unknown_offset(&self) -> bool {
+        self.offset
+            .is_some_and(crate::hgvs::parser::position::is_unknown_offset)
     }
 
     /// Check if this is an upstream position (negative base)
@@ -777,13 +792,27 @@ impl IvsPos {
     }
 
     /// Check if this is a deep intronic position (>50bp from exon)
+    ///
+    /// `unsigned_abs` rather than `abs`: [`IvsNotation::to_ivs`] maps a `CdsPos` /
+    /// `TxPos` offset straight in, so an unknown offset (`c.100-?`) reaches
+    /// this predicate, and `i64::MIN.abs()` overflows (#1767). As with
+    /// [`IntronicRegion::from_offset`], this reads a *measured* distance —
+    /// screen sentinels before asking. `IvsPos` carries a bare `i64`, so the
+    /// applicable screen is the scalar [`is_unknown_offset`], not
+    /// [`CdsPos::has_unknown_offset`] / [`TxPos::has_unknown_offset`], which a
+    /// caller holding only an `IvsPos` no longer has.
+    ///
+    /// [`IntronicRegion::from_offset`]: crate::convert::noncoding::IntronicRegion::from_offset
+    /// [`is_unknown_offset`]: crate::hgvs::parser::position::is_unknown_offset
     pub fn is_deep_intronic(&self) -> bool {
-        self.offset.abs() > 50
+        self.offset.unsigned_abs() > 50
     }
 
     /// Check if this is at a canonical splice site
+    ///
+    /// See [`IvsPos::is_deep_intronic`] for why this is `unsigned_abs`.
     pub fn is_canonical_splice_site(&self) -> bool {
-        self.offset.abs() <= 2
+        self.offset.unsigned_abs() <= 2
     }
 }
 

--- a/src/hgvs/parser/position.rs
+++ b/src/hgvs/parser/position.rs
@@ -101,6 +101,27 @@ pub const OFFSET_UNKNOWN_POSITIVE: i64 = i64::MAX;
 /// Sentinel value for unknown negative offset (`-?` in HGVS notation)
 pub const OFFSET_UNKNOWN_NEGATIVE: i64 = i64::MIN;
 
+/// Whether a raw offset is one of the unknown-offset sentinels rather than a
+/// measured intronic distance.
+///
+/// The scalar form of [`CdsPos::has_unknown_offset`] /
+/// [`TxPos::has_unknown_offset`], for the entry points that take a bare `i64`.
+/// Those two methods delegate here so the rule has **one** definition — it was
+/// previously spelled out at each site, which is how such rules drift apart.
+///
+/// Anything measuring or classifying an offset must ask this first: the
+/// sentinels are `i64::MAX` / `i64::MIN`, so using one as a distance overflows
+/// (`i64::MIN.abs()` panics under `overflow-checks` and wraps to a *negative*
+/// value in release), and per the spec they denote a position unbounded in one
+/// direction, from which no distance can be derived at all (#1087, #1767).
+///
+/// [`CdsPos::has_unknown_offset`]: crate::hgvs::location::CdsPos::has_unknown_offset
+/// [`TxPos::has_unknown_offset`]: crate::hgvs::location::TxPos::has_unknown_offset
+#[inline]
+pub fn is_unknown_offset(offset: i64) -> bool {
+    offset == OFFSET_UNKNOWN_POSITIVE || offset == OFFSET_UNKNOWN_NEGATIVE
+}
+
 #[inline]
 fn parse_offset(input: &str) -> IResult<&str, i64> {
     let (input, sign) = alt((char('+'), char('-'))).parse(input)?;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -73,7 +73,6 @@ use crate::hgvs::interval::{CdsInterval, Interval, ProtInterval};
 use crate::hgvs::location::{
     AminoAcid, CdsPos, GenomePos, ProtPos, RnaPos, SpecialPosition, TxPos,
 };
-use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
     Accession, AllelePhase, AlleleVariant, CdsVariant, GenomeVariant, HgvsVariant, LocEdit,
@@ -383,12 +382,13 @@ fn check_tx_pos_past_end(
     None
 }
 
-/// Check if a TxPos has an unknown (?) offset sentinel value
+/// Check if a TxPos has an unknown (?) offset sentinel value.
+///
+/// Delegates to [`TxPos::has_unknown_offset`] so the predicate has one
+/// definition. It used to be spelled out here as well, and a rule written in
+/// several places is how they drift apart.
 fn has_unknown_offset_tx(pos: &TxPos) -> bool {
-    matches!(
-        pos.offset,
-        Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE)
-    )
+    pos.has_unknown_offset()
 }
 
 /// If `pos.base` lies past the contig length on a mitochondrial accession,

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -916,30 +916,43 @@ pub struct IntronPosition {
     pub intron_length: u64,
 }
 
+// Every predicate below reads `offset` as a *magnitude*, via `unsigned_abs`
+// rather than `abs`. `IntronPosition` is derived from genomic coordinates and
+// so is bounded by its own intron in practice, but its fields are public and
+// `i64::MIN.abs()` overflows — a panic under `overflow-checks` and a wrap to a
+// negative value in release, which passes every `<= n` test below. Sibling
+// `distance_from_donor` / `distance_from_acceptor` already used `unsigned_abs`;
+// these now agree with them (#1767).
+//
+// Totality is not a distance claim: `offset` here is a bare `i64`, so a caller
+// that may hold an unknown-offset sentinel must screen it with
+// `crate::hgvs::parser::position::is_unknown_offset` first — none of these
+// predicates can decline, and `is_deep_intronic` answers `true` for a sentinel,
+// which is a ">50 bp" claim the input does not support.
 impl IntronPosition {
     /// Check if this is a deep intronic position (>50bp from nearest exon)
     pub fn is_deep_intronic(&self) -> bool {
-        self.offset.abs() > 50
+        self.offset.unsigned_abs() > 50
     }
 
     /// Check if this is at a canonical splice site (within 2bp of exon)
     pub fn is_canonical_splice_site(&self) -> bool {
-        self.offset.abs() <= 2
+        self.offset.unsigned_abs() <= 2
     }
 
     /// Check if this is near a splice site (within 10bp of exon)
     pub fn is_near_splice_site(&self) -> bool {
-        self.offset.abs() <= 10
+        self.offset.unsigned_abs() <= 10
     }
 
     /// Check if this is in the extended splice region (within 20bp of exon)
     pub fn is_extended_splice_region(&self) -> bool {
-        self.offset.abs() <= 20
+        self.offset.unsigned_abs() <= 20
     }
 
     /// Get the splice site type based on position
     pub fn splice_site_type(&self) -> SpliceSiteType {
-        let abs_offset = self.offset.abs();
+        let abs_offset = self.offset.unsigned_abs();
         match self.boundary {
             IntronBoundary::FivePrime => {
                 // 5' end of intron = splice donor site

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -565,16 +565,33 @@ fn predict_cds_effect(
     cds_pos: &CdsPos,
 ) -> SequenceEffect {
     if is_intronic {
-        // Check for splice site impact
-        if let Some(offset) = cds_pos.offset {
-            if offset.abs() <= 2 {
+        // Check for splice site impact.
+        //
+        // An unknown offset (`c.100-?`) reaches here straight from a parsed
+        // request field: `CdsPos::is_intronic` is satisfied by the `i64::MAX` /
+        // `i64::MIN` sentinels. Taking a magnitude from one is meaningless, and
+        // `.abs()` on `i64::MIN` panicked the worker under `overflow-checks`
+        // while wrapping to a *negative* value in release, where it passed the
+        // `<= 2` test and was answered `splice_site_variant` / HIGH (#1767).
+        // Skip the distance ladder entirely and fall through to
+        // `intron_variant`, which is what is actually known about the position.
+        let measured_offset = if cds_pos.has_unknown_offset() {
+            None
+        } else {
+            cds_pos.offset
+        };
+        if let Some(offset) = measured_offset {
+            // `unsigned_abs` so the ladder is total for every `i64`, not only
+            // for the two values spelled `?`.
+            let abs_offset = offset.unsigned_abs();
+            if abs_offset <= 2 {
                 return SequenceEffect {
                     so_term: "SO:0001629".to_string(),
                     name: "splice_site_variant".to_string(),
                     description: "A sequence variant that changes the first two or last two bases of an intron".to_string(),
                     impact: "HIGH".to_string(),
                 };
-            } else if offset.abs() <= 8 {
+            } else if abs_offset <= 8 {
                 return SequenceEffect {
                     so_term: "SO:0001630".to_string(),
                     name: "splice_region_variant".to_string(),
@@ -2248,6 +2265,31 @@ mod tests {
         let effect = predict_cds_effect("deletion", true, false, &cds_pos);
         assert_eq!(effect.name, "splice_site_variant");
         assert_eq!(effect.impact, "HIGH");
+    }
+
+    /// #1767 — an unknown intronic offset reaches `predict_cds_effect` straight
+    /// from a parsed request field. It must not be answered as a canonical
+    /// splice site: before the fix this panicked the worker under
+    /// `overflow-checks` and returned `splice_site_variant` / HIGH in release.
+    #[test]
+    fn an_unknown_intronic_offset_is_not_a_splice_site() {
+        for offset in [
+            crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE,
+            crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE,
+        ] {
+            let cds_pos = CdsPos {
+                base: 117,
+                offset: Some(offset),
+                utr3: false,
+                special: None,
+            };
+            let effect = predict_cds_effect("deletion", true, false, &cds_pos);
+            assert_eq!(
+                effect.name, "intron_variant",
+                "offset {offset} states no distance, so no splice claim is supported"
+            );
+            assert_eq!(effect.impact, "MODIFIER", "offset {offset}");
+        }
     }
 
     #[test]

--- a/tests/it/issue_1767_unknown_offset_splice_classifiers.rs
+++ b/tests/it/issue_1767_unknown_offset_splice_classifiers.rs
@@ -1,0 +1,342 @@
+//! Regression guards for #1767 — the `+?` / `-?` unknown-offset sentinels must
+//! never be classified as if they were a *measured* intronic distance.
+//!
+//! `parse_offset` represents `+?` as [`OFFSET_UNKNOWN_POSITIVE`] (`i64::MAX`)
+//! and `-?` as [`OFFSET_UNKNOWN_NEGATIVE`] (`i64::MIN`), and `CdsPos::is_intronic`
+//! is satisfied by both. So a description spelled `…:c.100-?del` carried the
+//! sentinel straight into every splice classifier's `.abs()`:
+//!
+//! * **debug** — `i64::MIN.abs()` is `attempt to negate with overflow`, a panic;
+//! * **release** — `i64::MIN.wrapping_abs()` is `i64::MIN`, which is *negative*,
+//!   so every `abs_offset <= 2` test passed and an unknown offset was reported
+//!   as a canonical splice site with HIGH impact.
+//!
+//! The two profiles disagreed, which is why the assertions below are written
+//! against the *value* rather than against a panic: after the fix both profiles
+//! produce the same answer, so one set of assertions covers both. The debug
+//! panic is covered implicitly — these tests run under `overflow-checks`.
+//!
+//! The contract applied here is the one `CdsPos::has_unknown_offset` already
+//! documents (closing #1087): the sentinels denote an unknown position
+//! unbounded in one direction, so no distance can be derived from them at all.
+//! Classifiers that can say so return `None`; classifiers whose return type
+//! cannot decline fall back to the plain "intronic" answer, which asserts no
+//! distance.
+//!
+//! [`OFFSET_UNKNOWN_POSITIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+//! [`OFFSET_UNKNOWN_NEGATIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
+
+use ferro_hgvs::convert::coding::validate_cds_pos;
+use ferro_hgvs::convert::noncoding::{
+    is_clinically_significant_splice_position, validate_tx_pos, IntronicConsequence, IntronicRegion,
+};
+use ferro_hgvs::effect::{Consequence, EffectPredictor, Impact};
+use ferro_hgvs::hgvs::location::{CdsPos, IvsNotation, TxPos};
+use ferro_hgvs::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::transcript::{
+    Exon, GenomeBuild, IntronBoundary, IntronPosition, ManeStatus, SpliceSiteType, Strand,
+    Transcript,
+};
+
+/// Both unknown-offset sentinels, so every guard below is exercised
+/// symmetrically. #1767 notes that a fix teaching the classifiers only about
+/// `i64::MIN` would leave `+?` classifying as deep-intronic "by accident
+/// rather than by decision".
+const SENTINELS: [i64; 2] = [OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE];
+
+fn cds_with_offset(offset: i64) -> CdsPos {
+    CdsPos {
+        base: 100,
+        offset: Some(offset),
+        utr3: false,
+        special: None,
+    }
+}
+
+fn tx_with_offset(offset: i64) -> TxPos {
+    TxPos {
+        base: 100,
+        offset: Some(offset),
+        downstream: false,
+    }
+}
+
+/// A minimal coding transcript, built programmatically, whose only job is to
+/// let the two validators get as far as the offset check. Base 100 is well
+/// inside its CDS, so anything the validators reject is about the offset.
+fn single_exon_transcript() -> Transcript {
+    Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        "A".repeat(300),
+        Some(1),
+        Some(300),
+        vec![Exon::new(1, 1, 300)],
+        None,
+        None,
+        None,
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    )
+}
+
+/// The premise of the issue: `c.100-?del` really does parse to the sentinel,
+/// and really does satisfy `is_intronic`, so it reaches the classifiers.
+/// Asserted against the AST rather than the rendered string — a round-trip
+/// would hold even if the offset were carried some other way.
+#[test]
+fn an_unknown_offset_description_carries_the_sentinel_into_the_classifiers() {
+    let variant = parse_hgvs("NM_000088.3:c.100-?del").expect("`c.100-?del` is legal HGVS");
+    let HgvsVariant::Cds(cds) = &variant else {
+        panic!("expected a c. variant, got {variant:?}");
+    };
+    let start = cds
+        .loc_edit
+        .location
+        .start
+        .inner()
+        .expect("`c.100-?` has a certain start position");
+
+    assert_eq!(
+        start.offset,
+        Some(OFFSET_UNKNOWN_NEGATIVE),
+        "`-?` must parse to the sentinel — the whole issue rests on this"
+    );
+    assert!(
+        start.is_intronic(),
+        "`is_intronic` is `offset.is_some() && offset != Some(0)`, so the \
+         sentinel satisfies it and reaches every splice classifier"
+    );
+    assert!(
+        start.has_unknown_offset(),
+        "and the shared predicate recognises it, which is what the fix keys on"
+    );
+    assert!(
+        variant.to_string().contains("100-?"),
+        "the sentinel still renders as `-?`, so no output moves"
+    );
+}
+
+#[test]
+fn intronic_consequence_declines_an_unknown_cds_offset() {
+    for offset in SENTINELS {
+        assert_eq!(
+            IntronicConsequence::from_cds_pos(&cds_with_offset(offset)),
+            None,
+            "an unknown offset ({offset}) has no derivable distance, so it cannot \
+             be classified as a splice consequence"
+        );
+    }
+}
+
+#[test]
+fn intronic_consequence_declines_an_unknown_tx_offset() {
+    for offset in SENTINELS {
+        assert_eq!(
+            IntronicConsequence::from_tx_pos(&tx_with_offset(offset)),
+            None,
+            "an unknown offset ({offset}) has no derivable distance on the n. axis either"
+        );
+    }
+}
+
+#[test]
+fn intronic_region_declines_an_unknown_offset() {
+    for offset in SENTINELS {
+        assert_eq!(
+            IntronicRegion::from_cds_pos(&cds_with_offset(offset)),
+            None,
+            "every `IntronicRegion` variant asserts a distance band, so an unknown \
+             offset ({offset}) must decline rather than pick one"
+        );
+        assert_eq!(
+            IntronicRegion::from_tx_pos(&tx_with_offset(offset)),
+            None,
+            "same on the n. axis for offset {offset}"
+        );
+    }
+}
+
+/// The release-mode outcome the issue calls out: an unknown offset wrapped to a
+/// negative `abs`, passed `<= 2`, and was reported as clinically significant.
+#[test]
+fn an_unknown_offset_is_not_a_clinically_significant_splice_position() {
+    for offset in SENTINELS {
+        assert!(
+            !is_clinically_significant_splice_position(&cds_with_offset(offset)),
+            "an unknown offset ({offset}) is not *known* to affect splicing"
+        );
+    }
+}
+
+/// `classify_splice_variant` returns a bare `ProteinEffect`, so it cannot
+/// decline. It must still refuse to claim a splice site: `IntronVariant` is the
+/// weakest true statement about a position that is known to be intronic and
+/// whose distance is unknown.
+#[test]
+fn classify_splice_variant_makes_no_distance_claim_for_an_unknown_offset() {
+    let predictor = EffectPredictor::new();
+    for offset in SENTINELS {
+        let effect = predictor.classify_splice_variant(offset);
+        assert_eq!(
+            effect.consequences,
+            vec![Consequence::IntronVariant],
+            "an unknown offset ({offset}) must not be reported as a splice \
+             donor/acceptor or splice-region variant"
+        );
+        assert_eq!(
+            effect.impact,
+            Impact::Modifier,
+            "an unknown offset ({offset}) cannot support a HIGH impact call"
+        );
+        assert_eq!(
+            effect.intronic_offset,
+            Some(offset),
+            "the sentinel is still reported, so a caller can tell `unknown` from `far`"
+        );
+    }
+}
+
+/// The #1765 lesson applied here: a guard keyed on sentinel *identity* leaves
+/// the neighbouring magnitudes broken. `i64::MIN` is the only value whose
+/// `.abs()` overflows, so the classifiers must be total for every `i64` —
+/// not merely for the two values that happen to be spelled `?`.
+#[test]
+fn the_classifiers_are_total_over_every_offset_magnitude() {
+    let predictor = EffectPredictor::new();
+    for offset in [i64::MIN, i64::MIN + 1, i64::MAX - 1, i64::MAX, 0, -1, 1] {
+        // Each of these overflowed (debug: panic) or wrapped (release) before
+        // the fix; the assertion is simply that they now return.
+        let _ = predictor.classify_splice_variant(offset);
+        let _ = IntronicConsequence::from_cds_pos(&cds_with_offset(offset));
+        let _ = IntronicConsequence::from_tx_pos(&tx_with_offset(offset));
+        let _ = IntronicRegion::from_cds_pos(&cds_with_offset(offset));
+        let _ = IntronicRegion::from_tx_pos(&tx_with_offset(offset));
+        let _ = is_clinically_significant_splice_position(&cds_with_offset(offset));
+        let _ = IntronicRegion::from_offset(offset);
+    }
+}
+
+/// `IntronPosition` is normally derived from genomic coordinates, but its
+/// fields are public, and its five predicates all read `offset` as a magnitude.
+/// They must be total: before the fix each overflowed on `i64::MIN`, and in
+/// release the wrapped negative value made `is_canonical_splice_site` answer
+/// `true` for an offset that states no distance.
+#[test]
+fn the_intron_position_predicates_are_total() {
+    for offset in [i64::MIN, i64::MIN + 1, i64::MAX - 1, i64::MAX] {
+        let pos = IntronPosition {
+            intron_number: 1,
+            boundary: IntronBoundary::ThreePrime,
+            offset,
+            tx_boundary_pos: 100,
+            intron_length: 1_000,
+        };
+        assert!(
+            pos.is_deep_intronic(),
+            "a magnitude of {offset} is not within 50bp of an exon"
+        );
+        assert!(!pos.is_canonical_splice_site(), "offset {offset}");
+        assert!(!pos.is_near_splice_site(), "offset {offset}");
+        assert!(!pos.is_extended_splice_region(), "offset {offset}");
+        assert_eq!(
+            pos.splice_site_type(),
+            SpliceSiteType::DeepIntronic,
+            "offset {offset}"
+        );
+    }
+}
+
+/// `IvsPos` carries the same two predicate names and the same defect, and
+/// `IvsNotation::to_ivs` maps a `CdsPos`/`TxPos` offset straight into it — so the
+/// sentinel reaches it from exactly the description this issue is about.
+#[test]
+fn the_ivs_predicates_are_total_and_reachable_from_an_unknown_offset() {
+    for offset in SENTINELS {
+        let ivs = cds_with_offset(offset)
+            .to_ivs(1)
+            .expect("a position with an offset converts to IVS notation");
+        assert_eq!(ivs.offset, offset, "the offset is carried through verbatim");
+        assert!(!ivs.is_canonical_splice_site(), "offset {offset}");
+        assert!(ivs.is_deep_intronic(), "offset {offset}");
+    }
+}
+
+/// Coordinate conversion must decline an unknown offset distinguishably rather
+/// than overflow on it. Both validators previously panicked under
+/// `overflow-checks` for `-?`; `+?` was rejected, but as an out-of-range
+/// number rather than as the unknown it is.
+#[test]
+fn the_coordinate_validators_decline_an_unknown_offset() {
+    let transcript = single_exon_transcript();
+
+    for offset in SENTINELS {
+        let cds_err = validate_cds_pos(&cds_with_offset(offset), &transcript)
+            .expect_err("an unknown offset denotes no coordinate");
+        assert!(
+            cds_err.to_string().contains("Unknown intronic offset"),
+            "offset {offset} must be declined as unknown, not as out of range; got {cds_err}"
+        );
+
+        let tx_err = validate_tx_pos(&tx_with_offset(offset), &transcript)
+            .expect_err("an unknown offset denotes no coordinate");
+        assert!(
+            tx_err.to_string().contains("Unknown intronic offset"),
+            "offset {offset} on the n. axis; got {tx_err}"
+        );
+    }
+
+    // A measured intronic offset still validates, so the guard is scoped to
+    // the sentinels rather than rejecting intronic positions generally.
+    assert!(validate_cds_pos(&cds_with_offset(-2), &transcript).is_ok());
+    assert!(validate_tx_pos(&tx_with_offset(-2), &transcript).is_ok());
+}
+
+/// Guard the fix against over-reach: *measured* offsets must classify exactly
+/// as they did before. These are the values the existing unit tests pin.
+#[test]
+fn measured_offsets_are_unaffected() {
+    let predictor = EffectPredictor::new();
+
+    assert_eq!(
+        predictor.classify_splice_variant(1).consequences,
+        vec![Consequence::SpliceDonorVariant]
+    );
+    assert_eq!(
+        predictor.classify_splice_variant(-2).consequences,
+        vec![Consequence::SpliceAcceptorVariant]
+    );
+    assert_eq!(
+        predictor.classify_splice_variant(5).consequences,
+        vec![Consequence::SpliceRegionVariant]
+    );
+    assert_eq!(
+        predictor.classify_splice_variant(50).consequences,
+        vec![Consequence::IntronVariant]
+    );
+
+    assert_eq!(
+        IntronicConsequence::from_cds_pos(&cds_with_offset(-2)),
+        Some(IntronicConsequence::SpliceAcceptorVariant)
+    );
+    assert_eq!(
+        IntronicConsequence::from_cds_pos(&cds_with_offset(1)),
+        Some(IntronicConsequence::SpliceDonorVariant)
+    );
+    assert_eq!(
+        IntronicRegion::from_cds_pos(&cds_with_offset(-2)),
+        Some(IntronicRegion::CanonicalSpliceSite)
+    );
+    assert_eq!(
+        IntronicRegion::from_cds_pos(&cds_with_offset(100)),
+        Some(IntronicRegion::DeepIntronic)
+    );
+    assert!(is_clinically_significant_splice_position(&cds_with_offset(
+        -2
+    )));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -30,6 +30,7 @@ mod issue_1632_parse_entry_applies_no_mode;
 mod issue_1715_rna_alignment_symbol_reach;
 mod issue_1748_noncoding_axis_zones;
 mod issue_1764_hgvs_to_vcf_continues;
+mod issue_1767_unknown_offset_splice_classifiers;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Closes #1767

`-?` and `+?` parse to the sentinels `i64::MIN` / `i64::MAX`, and `CdsPos::is_intronic` is `offset.is_some() && offset != Some(0)`, which both satisfy. So `NM_000088.3:c.100-?del` carried the sentinel into every splice classifier's `.abs()`.

## Reproduced on both profiles, before any fix

The issue traced this from source and flagged it as reasoned rather than measured, so it was measured first, on `cc8407bc`.

**Debug** (`overflow-checks`, the default for `dev`/`test`) — 6 of 8 new tests fail, every one with `attempt to negate with overflow`:

```
thread '…::the_classifiers_are_total_over_every_offset_magnitude' panicked at
  library/core/src/num/mod.rs:450:5: attempt to negate with overflow
Summary  8 tests run: 2 passed, 6 failed
```

**Release** — no panic, which is the worse half. 5 fail on the *value*:

| entry point | release answer for `c.100-?` |
|---|---|
| `IntronicRegion::from_cds_pos` | `Some(CanonicalSpliceSite)` |
| `IntronicConsequence::from_cds_pos` | `Some(SpliceAcceptorVariant)` — HIGH |
| `IntronicConsequence::from_tx_pos` | `Some(SpliceAcceptorVariant)` |
| `EffectPredictor::classify_splice_variant` | `[SpliceAcceptorVariant]` — HIGH |
| `is_clinically_significant_splice_position` | `true` |

`i64::MIN.wrapping_abs()` is `i64::MIN`, which is negative, so every `abs_offset <= 2` test passes.

`predict_cds_effect` (`src/service/handlers/effect.rs`) reaches the ladder straight from a parsed request field, so the debug panic takes down the worker — exactly what `.coderabbit.yaml`'s `src/service/**/*.rs` instruction names.

## The fix, and why it needed no new ruling

The issue lists three options and asks which to take. The repo had already answered: `CdsPos::has_unknown_offset` carries a **MUST** in its doc comment (closing #1087) — *"the sentinels denote an unknown position unbounded in that direction, so no coordinate can be derived from them at all"* — and `certain_offset` (`variant.rs`), `has_unknown_offset_tx` (`normalize/`) and `intronic_to_genomic` all already decline on it. This applies that existing contract to the classifiers that were never taught it; it does not mint a new one.

- **Return type can decline → it declines.** `IntronicConsequence::from_{cds,tx}_pos`, `IntronicRegion::from_{cds,tx}_pos`, and hence `is_clinically_significant_splice_position`. All four already returned `Option`, so no signature moves.
- **Return type cannot decline → the weakest true statement.** `classify_splice_variant` and `predict_cds_effect` return `IntronVariant` / `intron_variant` + MODIFIER: the position *is* known to be intronic, and that answer asserts no distance. `ProteinEffect::intronic_offset` still carries the sentinel, so a caller can distinguish "unknown" from "far".
- **Both validators decline it by name** rather than reporting it as an out-of-range number.

Separately from the sentinel question, every magnitude is now `unsigned_abs` rather than `abs`, so the ladders are total for **every** `i64`. `i64::MIN` is the only overflowing input, and a guard keyed on sentinel *identity* alone is precisely the gap #1765 records one layer up.

The rule had four copies and now has one: `is_unknown_offset` sits beside the constants it tests, and `CdsPos::has_unknown_offset`, the new `TxPos::has_unknown_offset` and `normalize`'s `has_unknown_offset_tx` all delegate to it.

## What the pre-push review found

A class-exhaustion sweep over the diff found **two sites the first pass missed** — `IvsPos::is_canonical_splice_site` and `is_deep_intronic` (`src/hgvs/location.rs`). Not theoretical: `IvsNotation::to_ivs` maps a `CdsPos`/`TxPos` offset straight into `IvsPos`, so the same `c.100-?` reaches them. `the_ivs_predicates_are_total_and_reachable_from_an_unknown_offset` pins that reachability.

Also applied: the premise test now asserts the **AST** offset rather than a rendered round-trip; coverage added for the five `IntronPosition` predicates and both validators (7 changed functions that had none); the fourth copy of the sentinel rule collapsed into `is_unknown_offset`; and a `.filter(|_| …)` guard rewritten as an explicit binding.

Rejected, with reasons: `src/benchmark/compare.rs`'s `.abs()` calls are deltas of two positions, not offsets, and cannot carry a sentinel. `certain_offset` in `variant.rs` was left alone — it tests four constants spanning the genome axis too, which is a wider question than this issue.

## Deliberately left open — needs an API call this PR should not make

`IntronicRegion::from_offset(i64) -> Self` keeps its signature. Every variant of that enum states a distance band, so there is no honest answer for a sentinel; the type would have to become `Option<Self>`. Its two in-repo callers now guard before reaching it, and it is documented as taking a *measured* distance, so nothing reaches it with a sentinel today — but a direct caller passing one still gets `DeepIntronic`. Making it `Option` is a public-API break (measured blast radius: 6 call sites, all in its own test module) and is the "widest blast radius" trade-off #1767 flags as needing a decision. Same for `classify_splice_variant`, which additionally has a PyO3 binding. Happy to take either in a follow-up.

## Verification

All run in `issue-1767/`, exit codes read back from each log rather than from the completion status:

| command | exit |
|---|---|
| `cargo nextest run --features dev -E 'test(issue_1767)'` (before fix, debug) | `100` — 6/8 fail, panic |
| `cargo nextest run --release --features dev -E 'test(issue_1767)'` (before fix) | `100` — 5/8 fail on value, no panic |
| `cargo fmt --all -- --check` | `0` |
| `cargo clippy --features dev --all-targets -- -D warnings` | `0` |
| `cargo doc --no-deps --features dev` | `0` — no warnings from the new links |
| `cargo ta` (full suite) | `0` — 10523/10523 passed, 152 skipped |

Representation-Change: none. No normalized output string moves — the two `src/hgvs/` predicates are new or delegate to an identical body, `normalize`'s helper is byte-equivalent after delegating, and every behaviour change is in effect/consequence classification, which renders no HGVS description. `c.100-?` still renders as `c.100-?`, pinned by `an_unknown_offset_description_carries_the_sentinel_into_the_classifiers`.
