### PR TITLE
feat(equivalence): drive the cross-axis rung over constructed forms, not a diverging corpus pair

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -383,17 +383,18 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 
             // A description that names no definite bases denotes no sequence,
             // so no rung below may report a positive denotational verdict about
-            // it. The check runs here rather than only on the fall-through path
-            // because normalization *expands* `insN[10]` into a literal run of
-            // `N`s: by the time the sequence rung compares two reconstructed
-            // windows, two indeterminate payloads can be byte-equal, and the
-            // rung would report agreement on a pair where neither side denotes
-            // anything to agree about.
+            // it. The check runs on the **inputs**, here, and not only on the
+            // normalized pair `denotational_verdict` re-checks, because
+            // normalization *expands* `insN[10]` into a literal run of `N`s: by
+            // the time the sequence rung compares two reconstructed windows, two
+            // indeterminate payloads can be byte-equal, and the rung would
+            // report agreement on a pair where neither side denotes anything to
+            // agree about.
             //
             // No input reaching `SequenceVerdict::Same` this way has been
             // measured — every constructed candidate either converges at
-            // `NormalizedMatch` above or is caught by the identical check on
-            // the fall-through path below. This is therefore stated as an
+            // `NormalizedMatch` above or is caught by the same check on the
+            // normalized pair. This is therefore stated as an
             // invariant rather than as a fix for an observed wrong answer, and
             // `an_indeterminate_input_never_wins_a_decided_denotational_rung`
             // pins it as one: the rule is a property of `check`, not of
@@ -406,83 +407,194 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                 }
             }
 
-            // Sequence-level equivalence (issue #1158): two variants may
-            // normalize to different HGVS strings yet produce the same edited
-            // reference sequence — e.g. a length-changing `delins` vs a
-            // decomposed cis allele of the same edit, which ferro deliberately
-            // keeps in distinct canonical forms. Reconstruct each edited window
-            // from SPDI triples and compare. This is best-effort: any variant
-            // that cannot be projected (unsupported edit, missing reference,
-            // mixed accessions, or a multi-molecule allele) simply declines, so
-            // the rung only ever upgrades a `NotEquivalent` verdict.
-            match self.same_resulting_sequence(&norm1, &norm2) {
-                SequenceVerdict::Same => {
-                    let (level, note) = self.strengthen_across_axes(&norm1, &norm2);
-                    return Ok(EquivalenceResult::new(level)
-                        .with_normalized(norm_str1, norm_str2)
-                        .with_note(note));
-                }
-                // The reference window needed to compare them is wider than the
-                // cap, so nothing was reconstructed and nothing was compared.
-                SequenceVerdict::WindowTooWide => {
-                    return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
-                        .with_normalized(norm_str1, norm_str2)
-                        .with_note(format!(
-                            "The reference window covering both variants exceeds \
-                             {MAX_SEQUENCE_COMPARE_WINDOW} bases, so neither resulting \
-                             sequence was reconstructed"
-                        )));
-                }
-                SequenceVerdict::Different | SequenceVerdict::Declined => {}
-            }
-
-            // #1578 follow-up: `NotEquivalent` is a *positive claim* that two
-            // descriptions denote different variants, and it is only sound if
-            // some rung above actually examined them. For a structural
-            // rearrangement both deciding rungs are blind at once — see
-            // `undecidable_reason` — so falling through here would answer a
-            // question nobody asked. Decline instead, which is what the other
-            // three modules that hand-roll `Allele` recursion already do with a
-            // ring (`spdi::apply`, `vcf::from_hgvs`, `project::projector`).
-            //
-            // `Indeterminate` below says the same thing as a *verdict* rather
-            // than as an error. The two are kept apart deliberately: the error
-            // is the shipped contract for a ring and a `sup` marker (pinned by
-            // `issue_1578_followup_equivalence_rungs`), and turning it into a
-            // verdict would be a silent API change for every caller that
-            // matches on the `Err`. A future change may fold them together;
-            // until then, read them as one idea with two spellings.
-            for side in [&norm1, &norm2] {
-                if let Some(reason) = self.undecidable_reason(side) {
-                    return Err(FerroError::UnsupportedVariant {
-                        variant_type: reason,
-                    });
-                }
-            }
-
-            // Nothing above could compute a denotation for one of the sides, so
-            // there is no negative to report either.
-            //
-            // Only the **normalized** forms are examined here. The inputs were
-            // already cleared above the sequence rung — re-checking them would
-            // be dead work, and worse, would read as though this were the only
-            // place the rule is applied. The normalized forms still have to be
-            // checked on their own account, in the other direction from the
-            // hoisted check: normalization can *introduce* an indeterminate
-            // payload that the input did not name, by resolving a shape into a
-            // literal run of `N`s.
-            for side in [&norm1, &norm2] {
-                if let Some(reason) = indeterminate_reason(side) {
-                    return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
-                        .with_normalized(norm_str1, norm_str2)
-                        .with_note(reason));
-                }
-            }
-
-            Ok(EquivalenceResult::new(EquivalenceLevel::NotEquivalent)
-                .with_normalized(norm_str1, norm_str2)
-                .with_note("Variants do not normalize to the same form"))
+            self.denotational_verdict(&norm1, &norm2, norm_str1, norm_str2)
         }
+    }
+
+    /// Decide the **denotational** relation between two descriptions, as
+    /// written, without ever asking whether they normalize to one string.
+    ///
+    /// This is the relation
+    /// `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`
+    /// defines: apply-equality on every *determined* axis, a relation over
+    /// `apply` whose codomain is bases. [`Self::check`] answers a wider
+    /// question — it is the whole ladder, textual rungs included, and it
+    /// short-circuits at [`EquivalenceLevel::NormalizedMatch`] the moment the
+    /// two normalized forms coincide. That short-circuit is correct for a
+    /// caller asking "are these the same?" and useless to one asking "did the
+    /// denotational comparison agree?", because a converged pair never reaches
+    /// a denotational rung at all — and `NormalizedMatch` is deliberately off
+    /// the order, so `is_at_least(CrossAxisSequenceMatch)` *rejects* it.
+    ///
+    /// So this entry point starts one rung lower and reports what the
+    /// comparison found:
+    ///
+    /// * **Nothing is normalized.** The two variants are compared exactly as
+    ///   handed over, so a caller that wants normalized forms compared must
+    ///   normalize them itself. That is what makes the answer independent of
+    ///   how confluent the normalizer happens to be.
+    /// * **There is no `Identical` rung here.** Two identical descriptions are
+    ///   re-derived and compared like any other pair, which reports
+    ///   [`EquivalenceLevel::CrossAxisSequenceMatch`] when every determined axis
+    ///   could be computed, and a lower rung when one could not.
+    /// * **`AccessionVersionDifference` is still answered**, because it needs no
+    ///   normalizer; without it, one variant spelled on two versions of an
+    ///   accession would fall through to a `NotEquivalent` no rung examined.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+    /// use ferro_hgvs::{parse_hgvs, MockProvider};
+    ///
+    /// let checker = EquivalenceChecker::new(MockProvider::with_test_data());
+    /// let v = parse_hgvs("NM_000088.3:c.10del").unwrap();
+    ///
+    /// // `check` stops at the textual rung; the denotational entry point
+    /// // re-derives the bases and reports what it compared.
+    /// assert_eq!(checker.check(&v, &v).unwrap().level, EquivalenceLevel::Identical);
+    /// assert!(checker.compare_denotations(&v, &v).unwrap().level.is_decided());
+    /// ```
+    pub fn compare_denotations(
+        &self,
+        v1: &HgvsVariant,
+        v2: &HgvsVariant,
+    ) -> Result<EquivalenceResult, FerroError> {
+        let str1 = v1.to_string();
+        let str2 = v2.to_string();
+        if let Some(result) = self.check_accession_version_difference(v1, v2, &str1, &str2) {
+            return Ok(result);
+        }
+
+        // The same hoist [`Self::check`] performs above its own call into
+        // `denotational_verdict`, and for the same reason: a description that
+        // names no definite bases denotes no sequence, so no rung below may
+        // report a positive denotational verdict about it.
+        //
+        // It cannot be left to the fall-through check inside
+        // `denotational_verdict`, because that one runs *after* the sequence
+        // rung has had its chance to return. Two byte-equal indeterminate
+        // payloads reconstruct to byte-equal windows, so the rung answers
+        // `SequenceVerdict::Same` and returns before the fall-through is
+        // reached. Measured: `NC_…:g.1001_1002insNNN` against itself reported
+        // `CrossAxisSequenceMatch` — a *decided positive* about a pair where
+        // neither side denotes anything, and one that
+        // `is_at_least(CrossAxisSequenceMatch)` accepts, i.e. exactly what a
+        // confluence gate written as the module docs prescribe would swallow.
+        // `check` never showed it because its string-identity rung answers
+        // `Identical` first; this entry point has no such rung by design.
+        //
+        // Pinned by
+        // `an_indeterminate_input_never_wins_a_decided_denotational_rung`,
+        // which drives both entry points — the invariant is a property of the
+        // denotational rungs, not of whichever entry point reaches them.
+        for side in [v1, v2] {
+            if let Some(reason) = indeterminate_reason(side) {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
+                    .with_normalized(str1, str2)
+                    .with_note(reason));
+            }
+        }
+
+        self.denotational_verdict(v1, v2, str1, str2)
+    }
+
+    /// The denotational half of the ladder: the sequence rung, the cross-axis
+    /// strengthening above it, and the three ways of declining below it.
+    ///
+    /// Shared verbatim by [`Self::check`] — which reaches it with the
+    /// *normalized* pair — and by [`Self::compare_denotations`], which reaches
+    /// it with the pair as written. `str1`/`str2` are the two descriptions'
+    /// rendered forms, recorded on the result so a caller can see which pair a
+    /// verdict was reached over.
+    fn denotational_verdict(
+        &self,
+        v1: &HgvsVariant,
+        v2: &HgvsVariant,
+        str1: String,
+        str2: String,
+    ) -> Result<EquivalenceResult, FerroError> {
+        // Sequence-level equivalence (issue #1158): two variants may normalize
+        // to different HGVS strings yet produce the same edited reference
+        // sequence — e.g. a length-changing `delins` vs a decomposed cis allele
+        // of the same edit, which ferro deliberately keeps in distinct
+        // canonical forms. Reconstruct each edited window from SPDI triples and
+        // compare. This is best-effort: any variant that cannot be projected
+        // (unsupported edit, missing reference, mixed accessions, or a
+        // multi-molecule allele) simply declines, so the rung only ever
+        // upgrades a `NotEquivalent` verdict.
+        match self.same_resulting_sequence(v1, v2) {
+            SequenceVerdict::Same => {
+                let (level, note) = self.strengthen_across_axes(v1, v2);
+                return Ok(EquivalenceResult::new(level)
+                    .with_normalized(str1, str2)
+                    .with_note(note));
+            }
+            // The reference window needed to compare them is wider than the
+            // cap, so nothing was reconstructed and nothing was compared.
+            SequenceVerdict::WindowTooWide => {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
+                    .with_normalized(str1, str2)
+                    .with_note(format!(
+                        "The reference window covering both variants exceeds \
+                         {MAX_SEQUENCE_COMPARE_WINDOW} bases, so neither resulting \
+                         sequence was reconstructed"
+                    )));
+            }
+            SequenceVerdict::Different | SequenceVerdict::Declined => {}
+        }
+
+        // #1578 follow-up: `NotEquivalent` is a *positive claim* that two
+        // descriptions denote different variants, and it is only sound if
+        // some rung above actually examined them. For a structural
+        // rearrangement both deciding rungs are blind at once — see
+        // `undecidable_reason` — so falling through here would answer a
+        // question nobody asked. Decline instead, which is what the other
+        // three modules that hand-roll `Allele` recursion already do with a
+        // ring (`spdi::apply`, `vcf::from_hgvs`, `project::projector`).
+        //
+        // `Indeterminate` below says the same thing as a *verdict* rather
+        // than as an error. The two are kept apart deliberately: the error
+        // is the shipped contract for a ring and a `sup` marker (pinned by
+        // `issue_1578_followup_equivalence_rungs`), and turning it into a
+        // verdict would be a silent API change for every caller that
+        // matches on the `Err`. A future change may fold them together;
+        // until then, read them as one idea with two spellings.
+        for side in [v1, v2] {
+            if let Some(reason) = self.undecidable_reason(side) {
+                return Err(FerroError::UnsupportedVariant {
+                    variant_type: reason,
+                });
+            }
+        }
+
+        // Nothing above could compute a denotation for one of the sides, so
+        // there is no negative to report either.
+        //
+        // Only the pair handed to *this* function is examined. On
+        // [`Self::check`]'s path that is the **normalized** pair, and its
+        // inputs were already cleared above the sequence rung — re-checking
+        // them would be dead work, and worse, would read as though this were
+        // the only place the rule is applied. The normalized forms still have
+        // to be checked on their own account, in the other direction from that
+        // hoisted check: normalization can *introduce* an indeterminate payload
+        // the input did not name, by resolving a shape into a literal run of
+        // `N`s.
+        for side in [v1, v2] {
+            if let Some(reason) = indeterminate_reason(side) {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
+                    .with_normalized(str1, str2)
+                    .with_note(reason));
+            }
+        }
+
+        // The note says "no rung found them equivalent" rather than the older
+        // "do not normalize to the same form", because this function is also
+        // reached from [`Self::compare_denotations`], where nothing was
+        // normalized and the old wording named a comparison that never ran.
+        Ok(EquivalenceResult::new(EquivalenceLevel::NotEquivalent)
+            .with_normalized(str1, str2)
+            .with_note("The two descriptions differ and no rung found them equivalent"))
     }
 
     /// Given that the two variants agree on the axis their descriptions are
@@ -2088,6 +2200,53 @@ mod tests {
                 .transcript_triples_to_genomic("NM_ZEROBASED.1", &triples)
                 .is_none(),
             "a genomic position with no interbase point to its left must be declined"
+        );
+    }
+
+    /// `compare_denotations` deliberately has no `Identical` rung: it answers
+    /// what the *comparison* found, so an identical pair is re-derived and
+    /// compared like any other. Without this, a caller could not tell "the
+    /// bases agree" from "the strings agree", which is the distinction the
+    /// entry point exists for.
+    #[test]
+    fn compare_denotations_re_derives_an_identical_pair_instead_of_short_circuiting() {
+        let checker = checker();
+        let v = parse_hgvs("NM_000088.3:c.10del").unwrap();
+
+        assert_eq!(
+            checker.check(&v, &v).unwrap().level,
+            EquivalenceLevel::Identical
+        );
+        // The exact rung, not merely "not `Identical`". `assert_ne!` alone is
+        // satisfied by `NotEquivalent` — a *decided negative* about a
+        // description compared with itself — and by `Indeterminate`, which
+        // would mean the re-derivation this test is named for never happened.
+        //
+        // `SequenceMatch` rather than `CrossAxisSequenceMatch` is the measured
+        // answer and is correct here: `MockProvider::with_test_data` serves no
+        // genomic sequence for `NM_000088.3`, so the second determined axis
+        // cannot be computed and the verdict stops one rung short. The note
+        // says so in as many words — "a determined axis could not be computed"
+        // — so a future fixture that *does* serve that axis will fail here and
+        // be re-pinned deliberately rather than drift.
+        let denoted = checker.compare_denotations(&v, &v).unwrap();
+        assert_eq!(denoted.level, EquivalenceLevel::SequenceMatch);
+        assert!(denoted.level.is_decided());
+    }
+
+    /// The accession-version rung needs no normalizer, so it is answered here
+    /// too. Dropping it would report a decided `NotEquivalent` for one variant
+    /// spelled on two versions of its accession — a positive claim no rung
+    /// examined, since apply-equality is not defined across two references.
+    #[test]
+    fn compare_denotations_still_answers_an_accession_version_difference() {
+        let checker = checker();
+        let v1 = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
+        let v2 = parse_hgvs("NM_000088.4:c.10A>G").unwrap();
+
+        assert_eq!(
+            checker.compare_denotations(&v1, &v2).unwrap().level,
+            EquivalenceLevel::AccessionVersionDifference
         );
     }
 }

--- a/src/equivalence/mod.rs
+++ b/src/equivalence/mod.rs
@@ -67,6 +67,22 @@
 //! rung consults the normalizer, so gating on it would restore the circularity
 //! above.
 //!
+//! # Two entry points, because the short-circuit is not always wanted
+//!
+//! [`EquivalenceChecker::check`] walks the whole ladder and answers the first
+//! rung that fires, so a pair whose normalized forms coincide is reported
+//! `NormalizedMatch` and no denotational rung is reached for it. That is the
+//! right answer to "are these the same?", and the wrong one to "what did the
+//! denotational comparison find?" — two questions that only look alike while
+//! the normalizer is non-confluent over the pair in front of you.
+//!
+//! [`EquivalenceChecker::compare_denotations`] answers the second question. It
+//! runs the sequence rung and the cross-axis strengthening over the two
+//! descriptions **as written**, normalizing neither, so its answer does not
+//! depend on how confluent the normalizer happens to be. Reach for it when the
+//! comparison itself is the subject — a confluence gate, or a test of these
+//! rungs (#1800).
+//!
 //! The list is open-ended — [`EquivalenceLevel`] is `#[non_exhaustive]`, so
 //! recognizing a new class of equivalence adds a level without breaking
 //! downstream matches.

--- a/tests/it/equivalence_cross_axis_rung.rs
+++ b/tests/it/equivalence_cross_axis_rung.rs
@@ -21,6 +21,39 @@
 //! These tests pin that with a two-exon synthetic transcript, because
 //! `SyntheticBuilder` builds single-exon transcripts only and so cannot express
 //! the geometry at all.
+//!
+//! # Why the denotational tests do not go through `check` (#1800)
+//!
+//! `check` is the whole ladder, and it short-circuits at `NormalizedMatch` the
+//! moment two spellings normalize to one string — so a denotational rung is
+//! reached only for a pair that **diverges**. Driving these tests through
+//! `check` therefore made every one of them depend on the normalizer staying
+//! non-confluent over some pair, and reducing divergence is the project's own
+//! goal (README rule 3). Twice now a confluence PR has destroyed the pair a
+//! test here was standing on: #1649 converged #1419's `[19_23del;27_33del]` /
+//! `19_33delinsCGG`, and #1616 converges #1420-v2's `c.[48dup;52del]` /
+//! `c.49_52delinsATTG` and its genomic sibling.
+//!
+//! Swapping in a fresh diverging pair buys one PR and guarantees a third
+//! occurrence, and it also requires proving the replacement's divergence is not
+//! itself a defect tracked elsewhere — otherwise the guard is pinned on a bug
+//! and retires the day it is fixed.
+//!
+//! So the denotational tests below call
+//! [`EquivalenceChecker::compare_denotations`], which runs the same rung logic
+//! over the pair **as written** and never asks whether the two normalize alike.
+//! The precondition is then *built* rather than *found*: the two forms differ
+//! because this file spells them differently, which no normalization change can
+//! undo. `check`'s own ladder is still pinned, by
+//! `check_stops_at_normalized_match_and_so_cannot_reach_a_denotational_rung` —
+//! which asserts the short-circuit that made the old strategy fragile, and is
+//! the one test here that *wants* a converging pair.
+//!
+//! **Re-pinning to `NormalizedMatch` was never an option.**
+//! `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]` holds
+//! that equivalence is apply-equality on every determined axis and never
+//! `NormalizedMatch` — "a relation over `apply`, whose codomain is bases, so it
+//! cannot collapse into the normalizer it gates".
 
 use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel, EquivalenceResult};
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
@@ -41,13 +74,24 @@ const TX: &str = "NM_TWOEXON.1";
 /// the same transcript sequence and two different genomic sequences, which is
 /// the whole point of the fixture.
 ///
-/// The rest of exon 2 is the `reported_partition_verdicts` contig, so a
-/// partition pair that is known to stay in two distinct canonical forms —
-/// #1420-v2's `[37dup;41del]` against `38_41delinsATTG` — can be written on
-/// this transcript. Transcript position = that contig's position + 11.
+/// The rest of exon 2 is the `reported_partition_verdicts` contig, so
+/// #1420-v2's partition pair — `[37dup;41del]` against `38_41delinsATTG` — can
+/// be written on this transcript. Transcript position = that contig's position
+/// + 11.
 ///
-/// #1419's `[19_23del;27_33del]` / `19_33delinsCGG` was the pair used here
-/// until #1649 converged it; do not reach for it again without re-measuring.
+/// **What that pair is used for here has changed (#1800).** It is a *partition*
+/// of one edit: two spellings whose SPDI triple lists have different shapes (two
+/// triples against one) and whose reconstructed windows agree. That is what
+/// makes it a real exercise of the sequence rung and of the genomic
+/// re-derivation above it — a pair spelled identically would compare a triple
+/// list against itself and measure nothing. Whether the *normalizer* keeps the
+/// two apart is no longer load-bearing: these tests never normalize.
+///
+/// Two earlier readings of this fixture are recorded so they are not
+/// re-attempted. #1419's `[19_23del;27_33del]` / `19_33delinsCGG` stood here
+/// until #1649 converged it, and #1420-v2 replaced it on the strength of
+/// staying divergent — which #1616 then ended. Divergence is not a property to
+/// build on; see the module header.
 const EXON1_TX: &str = "ACGCACGCAT";
 const EXON2_TX: &str = "TATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCGTACGTA";
 
@@ -135,30 +179,43 @@ fn check(provider: &MockProvider, a: &str, b: &str) -> EquivalenceResult {
         .unwrap()
 }
 
-/// Assert the two normalized forms a verdict was reached over.
+/// Drive the denotational ladder over two **constructed** forms, and assert it
+/// was reached over exactly those two.
 ///
-/// Every denotational rung below sits *between* two normalized strings, so a
-/// test that pins only the level cannot tell "the rung fired" from "the two
-/// spellings converged and the rung was never reached". That is not a
-/// hypothetical: these tests were first written over #1419's partition pair,
-/// #1649 converged it, and both of them silently started asserting
-/// `NormalizedMatch` against a rung they no longer exercised. Pinning the pair
-/// of strings makes that failure name itself.
-fn assert_normalized(result: &EquivalenceResult, first: &str, second: &str) {
+/// This is the whole of #1800's restructure. `compare_denotations` runs the
+/// sequence rung and the cross-axis strengthening above it over the pair as
+/// written, so the precondition every rung below needs — two distinct
+/// descriptions to compare — is supplied by this file rather than borrowed from
+/// whatever the normalizer currently declines to converge.
+///
+/// Both halves of the postcondition matter and neither implies the other:
+///
+/// * the two spellings must differ, or the comparison is a description against
+///   itself and any rung it reports is unearned; and
+/// * the result must have been reached over those same two strings, which is
+///   what proves nothing normalized them out from under the assertion. A future
+///   change routing this entry point back through the normalizer would fail
+///   here instead of silently restoring the fragility.
+fn denotational(provider: &MockProvider, first: &str, second: &str) -> EquivalenceResult {
+    assert_ne!(
+        first, second,
+        "a denotational rung sits between two distinct descriptions; comparing one with itself \
+         measures nothing"
+    );
+    let checker = EquivalenceChecker::new(provider.clone());
+    let result = checker
+        .compare_denotations(&parse_hgvs(first).unwrap(), &parse_hgvs(second).unwrap())
+        .unwrap();
     assert_eq!(
         (
             result.normalized_first.as_deref(),
             result.normalized_second.as_deref()
         ),
         (Some(first), Some(second)),
-        "the normalized forms this verdict was reached over have moved; the level below is \
-         measuring something other than what it says"
+        "the verdict was reached over a different pair than the one constructed, so the level \
+         below is measuring something other than what it says"
     );
-    assert_ne!(
-        first, second,
-        "the two spellings converged, so `check` returned at the NormalizedMatch rung and no \
-         denotational rung was exercised"
-    );
+    result
 }
 
 // ---------------------------------------------------------------------------
@@ -172,18 +229,19 @@ fn assert_normalized(result: &EquivalenceResult, first: &str, second: &str) {
 ///
 /// The pair must reach `SequenceMatch` (the transcript axis agrees) and must
 /// **not** reach `CrossAxisSequenceMatch` (the genomic axis does not).
+///
+/// This is the negative control for the cross-axis comparison, so it is driven
+/// the same way as the positive one: a `strengthen_across_axes` that stopped
+/// consulting the genomic axis and reported `CrossAxisSequenceMatch` for every
+/// own-axis agreement would fail *here*, and nowhere else in this file.
 #[test]
 fn a_junction_straddling_dup_pair_agrees_on_the_transcript_and_not_on_the_genome() {
     let provider = two_exon_provider();
-    let result = check(
+    let result = denotational(
         &provider,
         &format!("{TX}:c.10dup"),
         &format!("{TX}:c.11dup"),
     );
-    // Neither spelling moves: the exon boundary bounds the duplication on the
-    // transcript, so the two stay on opposite sides of it and the rung below is
-    // reached over a genuinely distinct pair.
-    assert_normalized(&result, &format!("{TX}:c.10dup"), &format!("{TX}:c.11dup"));
     let observed = result.level;
     assert_eq!(
         observed,
@@ -200,37 +258,59 @@ fn a_junction_straddling_dup_pair_agrees_on_the_transcript_and_not_on_the_genome
 // 2. The positive case: agreement on every determined axis
 // ---------------------------------------------------------------------------
 
-/// #1420-v2's partition pair, written on the transcript. The two spellings stay
-/// in distinct canonical forms — that is the open non-confluence the issue is
-/// about — so they reach a sequence rung rather than `NormalizedMatch`; and
-/// they sit wholly inside exon 2, so the genomic axis is a contiguous
-/// re-expression of the same edit and agrees. The pair therefore clears the
-/// gate.
+/// #1420-v2's partition pair, written on the transcript: a two-member cis
+/// allele against the single `delins` spanning the same block. The two denote
+/// one transcript sequence, and they sit wholly inside exon 2, so the genomic
+/// axis is a contiguous re-expression of the same edit and agrees there too.
+/// The pair therefore clears the gate.
 ///
-/// **#1419's pair used to stand here and no longer can.** #1649 gave the
-/// splitter the two-deletion shape, which converged
-/// `c.[30_34del;38_44del]` with `c.30_44delinsCGG`; both tests then asserted
-/// against `NormalizedMatch` without exercising any denotational rung. #1420-v2
-/// is the replacement because it is a *dup*-plus-*del* partition, which the
-/// splitter does not reach — see `reported_partition_verdicts`, where its two
-/// rows are still pinned as divergent. `assert_normalized` is what makes a
-/// repeat of that convergence fail loudly instead of quietly.
+/// **The pair is constructed, not normalized (#1800).** It used to be handed to
+/// `check`, which required the normalizer to keep the two apart — and #1616
+/// merges them, so that reading of the test is gone. What is being exercised is
+/// the rung, and the rung's input is two descriptions: `[48dup;52del]` derives
+/// two SPDI triples, `49_52delinsATTG` derives one, both are re-expressed on the
+/// genome through the exon alignment, and both reconstructions are compared
+/// against the reference window. None of that consults the normalizer, so none
+/// of it can be undone by making the normalizer more confluent.
 #[test]
 fn a_pair_agreeing_on_both_determined_axes_reaches_the_cross_axis_rung() {
     let provider = two_exon_provider();
-    let result = check(
+    let result = denotational(
         &provider,
-        &format!("{TX}:c.[48dup;52del]"),
-        &format!("{TX}:c.49_52delinsATTG"),
-    );
-    assert_normalized(
-        &result,
         &format!("{TX}:c.[48dup;52del]"),
         &format!("{TX}:c.49_52delinsATTG"),
     );
     let observed = result.level;
     assert_eq!(observed, EquivalenceLevel::CrossAxisSequenceMatch);
     assert!(observed.is_at_least(EquivalenceLevel::CrossAxisSequenceMatch));
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|note| note.contains("every determined axis")),
+        "the note must record that the second axis was consulted and agreed, not merely that the \
+         own axis did: {:?}",
+        result.notes
+    );
+}
+
+/// The same shape, one base of payload apart, must come back a decided
+/// negative.
+///
+/// Without it, a `same_resulting_sequence` that agreed unconditionally would
+/// satisfy every positive assertion in this file. The control is on the
+/// transcript rather than the genome so it also covers the derivation the
+/// positive above depends on.
+#[test]
+fn a_partition_that_denotes_different_bases_is_a_decided_negative() {
+    let provider = two_exon_provider();
+    let result = denotational(
+        &provider,
+        &format!("{TX}:c.[48dup;52del]"),
+        &format!("{TX}:c.49_52delinsATTC"),
+    );
+    assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
+    assert!(result.level.is_decided());
 }
 
 /// A genomic description determines exactly one axis — the genome. Apply-
@@ -243,22 +323,77 @@ fn a_pair_agreeing_on_both_determined_axes_reaches_the_cross_axis_rung() {
 fn a_genomic_pair_determines_one_axis_and_so_reaches_the_cross_axis_rung() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence(CONTIG, format!("{}{EXON2_TX}", "A".repeat(1000)));
-    // The same #1420-v2 pair, shifted onto the contig at g.1001 + n. The span
-    // spelling re-derives here — a genomic axis carries no reading frame, so
-    // `delins.md:47`'s payload-coincidence carve-out does not reach it and the
-    // members stay individual — which is exactly why the pinned pair below is
-    // not the pair pinned on the transcript.
-    let result = check(
+    // The same #1420-v2 pair, shifted onto the contig at g.1001 + n.
+    //
+    // This test used to pin the pair's *normalized* forms, and they were not
+    // the two written here: the span spelling re-derived to
+    // `g.[1039T>A;1041_1042delinsTG]`, because a genomic axis carries no reading
+    // frame and so `delins.md:47`'s payload-coincidence carve-out does not reach
+    // it. That asymmetry is `delins-payload-coincidence-carve-out-is-coding-dna-scoped`
+    // and is still true; it is simply no longer this test's business, because
+    // the rung is now driven over the constructed pair.
+    let result = denotational(
         &provider,
         &format!("{CONTIG}:g.[1038dup;1042del]"),
         &format!("{CONTIG}:g.1039_1042delinsATTG"),
     );
-    assert_normalized(
-        &result,
-        &format!("{CONTIG}:g.[1038dup;1042del]"),
-        &format!("{CONTIG}:g.[1039T>A;1041_1042delinsTG]"),
-    );
     assert_eq!(result.level, EquivalenceLevel::CrossAxisSequenceMatch);
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|note| note.contains("the one axis they determine")),
+        "a genomic pair reaches the rung by determining one axis, not by corroboration: {:?}",
+        result.notes
+    );
+}
+
+/// The short-circuit that made the old fixture strategy fragile, pinned as
+/// behaviour so the restructure above is anchored to something rather than
+/// merely asserted in a comment.
+///
+/// `check` answers `NormalizedMatch` for a converging pair, and
+/// `NormalizedMatch` is deliberately off the denotational order — so
+/// `is_at_least(CrossAxisSequenceMatch)` *rejects* a pair whose two spellings
+/// normalize alike, and no denotational rung is reached for it at all. Every
+/// test in this file that went through `check` therefore needed the normalizer
+/// to keep its pair apart, which is the dependency #1800 removes.
+///
+/// The pair here is chosen to converge and to keep converging: `general.md:56`
+/// ranks a substitution above a one-base `delins` of the same base, so
+/// `g.1005delinsG` canonicalizes onto `g.1005C>G`. This is the one test in the
+/// file that wants convergence, and it is the only one a *further* confluence
+/// improvement can strengthen rather than break.
+#[test]
+fn check_stops_at_normalized_match_and_so_cannot_reach_a_denotational_rung() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(CONTIG, format!("{}{EXON2_TX}", "A".repeat(1000)));
+
+    let converged = check(
+        &provider,
+        &format!("{CONTIG}:g.1005C>G"),
+        &format!("{CONTIG}:g.1005delinsG"),
+    );
+    assert_eq!(converged.level, EquivalenceLevel::NormalizedMatch);
+    assert!(
+        !converged
+            .level
+            .is_at_least(EquivalenceLevel::CrossAxisSequenceMatch),
+        "the whole hazard in one assertion: `check` reports a rung that a confluence gate must \
+         reject, for a pair that is genuinely one variant"
+    );
+
+    // The same pair, same provider, through the denotational entry point: the
+    // rung is reached and answers.
+    let denoted = denotational(
+        &provider,
+        &format!("{CONTIG}:g.1005C>G"),
+        &format!("{CONTIG}:g.1005delinsG"),
+    );
+    assert_eq!(denoted.level, EquivalenceLevel::CrossAxisSequenceMatch);
+    assert!(denoted
+        .level
+        .is_at_least(EquivalenceLevel::CrossAxisSequenceMatch));
 }
 
 // ---------------------------------------------------------------------------
@@ -304,16 +439,29 @@ fn an_unspecified_insertion_count_is_indeterminate() {
 }
 
 /// No input that denotes no sequence may reach a **positive denotational**
-/// rung, by whichever path `check` happens to take.
+/// rung, by whichever path — and through whichever **entry point** — the
+/// denotational rungs are reached.
 ///
-/// This is stated as an invariant over `check` rather than as a regression for
-/// one measured pair, because the hazard is precisely that the rule was applied
-/// on one path and not another. `check` has two ways to report agreement — the
-/// `SequenceVerdict::Same` branch and the fall-through — and normalization
-/// *expands* `insN[10]` into a literal `N` run, so an indeterminate payload
-/// arrives at the sequence rung looking definite. Asserting the property over a
-/// table, rather than pinning one path's answer, is what makes a future third
-/// path fail here instead of silently reporting a positive.
+/// This is stated as an invariant over the rungs rather than as a regression
+/// for one measured pair, because the hazard is precisely that the rule was
+/// applied on one path and not another. There are two ways to report agreement
+/// — the `SequenceVerdict::Same` branch and the fall-through — and
+/// normalization *expands* `insN[10]` into a literal `N` run, so an
+/// indeterminate payload arrives at the sequence rung looking definite.
+/// Asserting the property over a table, rather than pinning one path's answer,
+/// is what makes a future third path fail here instead of silently reporting a
+/// positive.
+///
+/// **Both entry points are driven, and that is not redundant.** `#1800` added
+/// `compare_denotations`, which reaches the same rungs without normalizing —
+/// and therefore without `check`'s string-identity rung in front of it. A pair
+/// of byte-equal indeterminate payloads reconstructs to byte-equal windows, so
+/// the sequence rung answers `Same` and returns *before* the fall-through
+/// indeterminacy check: `g.1001_1002insNNN` against itself reported
+/// `CrossAxisSequenceMatch`, which `is_at_least(CrossAxisSequenceMatch)`
+/// accepts. `check` could never show it, because string identity answers
+/// `Identical` first. Driving one entry point would leave the other's copy of
+/// this invariant unmeasured.
 ///
 /// Every row below is apply-*shaped* like a match — same accession, overlapping
 /// spans, payloads that expand to comparable runs — so a checker that consulted
@@ -344,8 +492,39 @@ fn an_indeterminate_input_never_wins_a_decided_denotational_rung() {
             format!("{TX}:c.20_21insN[3]"),
             format!("{TX}:c.20delinsANNN"),
         ),
+        // Two byte-equal literal `N` payloads: the sequence rung reconstructs
+        // identical windows and answers `Same`, so this is the row that reaches
+        // the rung *without* needing normalization to expand anything. It is
+        // invisible through `check` — string identity answers `Identical` — and
+        // is the row that caught `compare_denotations` skipping the hoisted
+        // indeterminacy guard.
+        (
+            format!("{CONTIG}:g.1001_1002insNNN"),
+            format!("{CONTIG}:g.1001_1002insNNN"),
+        ),
     ] {
-        let observed = level(&provider, &a, &b);
+        // `compare_denotations` is called directly rather than through
+        // `denotational`, because that helper refuses an identical pair — which
+        // is exactly the row that broke this invariant, so it must not be the
+        // one row exempted from it.
+        let via_denotations = EquivalenceChecker::new(provider.clone())
+            .compare_denotations(&parse_hgvs(&a).unwrap(), &parse_hgvs(&b).unwrap())
+            .unwrap()
+            .level;
+        // `check` short-circuits on string identity, so it has nothing to say
+        // about the identical row; everywhere it does answer, the two entry
+        // points must agree, or the invariant holds on one and not the other.
+        let observed = if a == b {
+            via_denotations
+        } else {
+            let via_check = level(&provider, &a, &b);
+            assert_eq!(
+                via_check, via_denotations,
+                "{a} vs {b}: the two entry points disagree about an indeterminate pair, so the \
+                 invariant holds on one and not the other"
+            );
+            via_check
+        };
         assert!(
             !observed.is_at_least(EquivalenceLevel::SequenceMatch),
             "{a} vs {b}: reported {observed:?}, a positive denotational verdict about a pair \
@@ -415,11 +594,20 @@ fn a_span_past_the_compare_window_cap_is_indeterminate() {
         &format!("{CONTIG}:g.150000del"),
     );
     // Neither spelling moved, so the 149,901-base union span is what exceeds
-    // the cap — not a shuffle that walked one of them somewhere else.
-    assert_normalized(
-        &far,
-        &format!("{CONTIG}:g.100del"),
-        &format!("{CONTIG}:g.150000del"),
+    // the cap — not a shuffle that walked one of them somewhere else. This test
+    // stays on `check` deliberately: the cap is reached through normalization,
+    // and pinning the normalized pair is what rules out the alternative
+    // explanation.
+    assert_eq!(
+        (
+            far.normalized_first.as_deref(),
+            far.normalized_second.as_deref()
+        ),
+        (
+            Some(format!("{CONTIG}:g.100del").as_str()),
+            Some(format!("{CONTIG}:g.150000del").as_str())
+        ),
+        "one of the two deletions shuffled, so the union span is not the variable under test"
     );
     assert_eq!(far.level, EquivalenceLevel::Indeterminate);
     assert!(!far.level.is_decided());
@@ -462,13 +650,8 @@ fn a_span_past_the_compare_window_cap_is_indeterminate() {
 #[test]
 fn a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung() {
     let provider = two_exon_provider_without_a_contig();
-    let result = check(
+    let result = denotational(
         &provider,
-        &format!("{TX}:c.[48dup;52del]"),
-        &format!("{TX}:c.49_52delinsATTG"),
-    );
-    assert_normalized(
-        &result,
         &format!("{TX}:c.[48dup;52del]"),
         &format!("{TX}:c.49_52delinsATTG"),
     );
@@ -501,11 +684,12 @@ fn a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung() {
     // cross-axis rung. Without it, a `SequenceMatch` from any other cause would
     // read as a pass.
     assert_eq!(
-        level(
+        denotational(
             &two_exon_provider(),
             &format!("{TX}:c.[48dup;52del]"),
             &format!("{TX}:c.49_52delinsATTG"),
-        ),
+        )
+        .level,
         EquivalenceLevel::CrossAxisSequenceMatch
     );
 }
@@ -694,14 +878,22 @@ fn complement(base: u8) -> u8 {
 
 /// `c.3921dup` and `c.3922dup` on the real minus-strand geometry: apply-equal on
 /// the transcript, and *not* on the genome.
+///
+/// Driven over the constructed pair for the same reason as its plus-strand twin
+/// — and here the hazard is not hypothetical:
+/// `rulings[exon-junction-dup-converge-from-the-far-side]` is **decided** and
+/// says `c.3922dup` normalizes to `c.3921dup`, so the day it is implemented a
+/// `check`-driven version of this test would answer `NormalizedMatch` and stop
+/// exercising the mapper's minus-strand arm without saying so.
 #[test]
 fn the_spec_pair_at_its_own_coordinates_is_single_axis_only() {
     let fixture = DmdFixture::new();
-    let observed = level(
+    let observed = denotational(
         &fixture.provider,
         &format!("{DMD_TX}:c.3921dup"),
         &format!("{DMD_TX}:c.3922dup"),
-    );
+    )
+    .level;
     assert_eq!(
         observed,
         EquivalenceLevel::SequenceMatch,


### PR DESCRIPTION
`tests/it/equivalence_cross_axis_rung.rs` exercised the denotational rungs (`SequenceMatch`, `CrossAxisSequenceMatch`) by handing `check` two spellings of one variant that normalize apart, and its helper enforced that with an `assert_ne!`. The guard was right — if the pair converges, `check` short-circuits at `NormalizedMatch` and the rung under test is never reached — but its precondition is a **divergence**, and reducing divergence is the project's own goal (README rule 3). So every confluence improvement destroys an instance of what the test needs. #1649 converged the pair the file was first written on; #1616 converges its replacement and three tests with it.

## What this does

Adds `EquivalenceChecker::compare_denotations`, which runs the sequence rung and the cross-axis strengthening above it over two descriptions **as written** — normalizing neither. `check` keeps its ladder exactly as it was and now reaches the same code through a shared private `denotational_verdict`.

The rung tests call the new entry point, so their precondition — two distinct descriptions to compare — is built by the test file rather than borrowed from whatever the normalizer currently declines to converge. It is not test-only scaffolding: a confluence gate is written `is_at_least(CrossAxisSequenceMatch)` and `NormalizedMatch` is deliberately off that order, so `check` reports a rung such a gate must reject for a pair that is genuinely one variant. `check_stops_at_normalized_match_and_so_cannot_reach_a_denotational_rung` pins that as behaviour, and is the one test in the file that *wants* a converging pair.

`rulings[confluence-gate-is-apply-equality-on-every-determined-axis]` is why none of this was fixed by re-pinning to `NormalizedMatch`: equivalence is apply-equality on every determined axis and never `NormalizedMatch` — "a relation over `apply`, whose codomain is bases, so it cannot collapse into the normalizer it gates".

No ledger record is added. The restructure adjudicates nothing; the ruling it rests on is already `decided`.

## The rung is still reached — measured, not asserted

Two mutations, each run against the restructured file:

| mutation | tests that go red |
|---|---|
| the cross-axis comparison agrees but reports `SequenceMatch` (`strengthen_across_axes`, same-accession `Genomic`/`Genomic` arm, `SequenceVerdict::Same`) | `a_pair_agreeing_on_both_determined_axes_reaches_the_cross_axis_rung`, `a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung` |
| the second axis is never consulted at all — `strengthen_across_axes` returns `CrossAxisSequenceMatch` unconditionally | those two, plus `a_junction_straddling_dup_pair_agrees_on_the_transcript_and_not_on_the_genome`, `a_genomic_pair_determines_one_axis_and_so_reaches_the_cross_axis_rung`, `the_spec_pair_at_its_own_coordinates_is_single_axis_only` |

## Robust to the convergence that motivated it — demonstrated

#1616's convergence was reproduced locally without touching that branch, by forcing `NM_TWOEXON.1:c.[48dup;52del]` and `chr_two_exon:g.[1038dup;1042del]` onto their merged forms immediately after normalization inside `check`:

* the **previous** version of the file: 3 failed / 11 passed — exactly `a_pair_agreeing_on_both_determined_axes_reaches_the_cross_axis_rung`, `a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung` and `a_genomic_pair_determines_one_axis_and_so_reaches_the_cross_axis_rung`, the three #1800 names;
* the **restructured** file: 16 / 16 passed.

Two further tests were converted for the same reason although #1800 does not name them: `a_junction_straddling_dup_pair_...` is the negative control for the very comparison the positive test makes, and `the_spec_pair_at_its_own_coordinates_is_single_axis_only` sits directly under a *decided* ruling — `exon-junction-dup-converge-from-the-far-side` says `c.3922dup` normalizes to `c.3921dup` — so a `check`-driven version of it would stop exercising the mapper's minus-strand arm the day that lands, without saying so.

## Scope

Restructure only. The two-exon fixture and its geometry are unchanged; `reported_partition_verdicts.rs` is untouched (#1802); #1616 is untouched.

The one behaviour change is a note string: the `NotEquivalent` fall-through said "Variants do not normalize to the same form", which names a comparison that never runs on the new path. Nothing pinned it. Levels, normalized forms and errors are unchanged.

## Verification

* full suite, prepared reference wired (`FERRO_MANIFEST` on scratch): **10515 passed, 0 failed**, exit 0
* `scripts/run_oracle_suite.sh`: **10378 passed, 0 failed**, exit 0
* `cargo test --doc --features dev`: 96 passed, exit 0
* `cargo fmt --all -- --check`, `cargo clippy --features dev --all-targets -- -D warnings`: clean, exit 0
* both spec generators regenerate cleanly

Representation-Change: none. Tests plus a new library entry point; `src/equivalence/` is not a watched directory and no normalized output changes.

Closes #1800
