### PR TITLE
fix(cli): report a declined description in hgvs-to-vcf and keep going

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1339,80 +1339,132 @@ fn run_hgvs_to_vcf(
     use ferro_hgvs::hgvs::variant::HgvsVariant;
     use ferro_hgvs::vcf::genomic_hgvs_to_vcf;
 
+    // OutputFormat: FromStr is Infallible, so the never-taken error arm falls
+    // back to the default (Text) — same idiom as `run_project`. Parsed once and
+    // used for every decision below, rather than re-matching the `&str` in
+    // parallel: one value read two ways is one of them going stale later.
+    let out_format: OutputFormat = format.parse().unwrap_or_default();
+
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
     // Print VCF header if outputting VCF format
-    if format == "vcf" {
+    if out_format == OutputFormat::Vcf {
         writeln!(handle, "##fileformat=VCFv4.2")?;
         writeln!(handle, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO")?;
     }
 
-    let process_variant = |v: &str,
-                           handle: &mut io::StdoutLock|
-     -> Result<(), Box<dyn std::error::Error>> {
+    // Convert one description. Returns that record's own failure instead of
+    // propagating it out of the command (#1764): a description the converter
+    // declines is a property of the *record*, not of the run, so it must not
+    // discard the input lines that follow. The set of declined descriptions is
+    // growing — #1734 correctly refuses `g.10+2del` and `g.pter_4del`, and the
+    // provider-less path declines insertions and deletions by design — so an
+    // abort turns one wrong row into a truncated VCF for anyone processing a
+    // file.
+    //
+    // The reporting contract this returns into is the one `run_normalize`,
+    // `run_parse` and `run_project` already share: continue, format the
+    // diagnostic to stderr with the input line number, count it, and fail the
+    // run at the end. `hgvs-to-vcf` was the only batch driver here that did not.
+    let convert = |v: &str, handle: &mut io::StdoutLock| -> Result<(), FerroError> {
         let parsed = parse_hgvs(v)?;
 
-        // Convert genomic variants directly
-        if let HgvsVariant::Genome(ref gv) = parsed {
-            let vcf = genomic_hgvs_to_vcf(gv)?;
-            match format {
-                "vcf" => {
-                    writeln!(handle, "{}", vcf)?;
-                }
-                "json" => {
-                    writeln!(
-                        handle,
-                        r#"{{"hgvs": "{}", "chrom": "{}", "pos": {}, "ref": "{}", "alt": "{}"}}"#,
-                        v,
-                        vcf.chrom,
-                        vcf.pos,
-                        vcf.reference,
-                        vcf.alternate.first().unwrap_or(&String::new())
-                    )?;
-                }
-                _ => {
-                    writeln!(
-                        handle,
-                        "{} -> {}:{}:{}/{}",
-                        v,
-                        vcf.chrom,
-                        vcf.pos,
-                        vcf.reference,
-                        vcf.alternate.first().unwrap_or(&String::new())
-                    )?;
-                }
-            }
-        } else {
-            writeln!(handle, "ERROR: {} is not a genomic variant (g.)", v)?;
+        // Only genomic descriptions convert. This used to write an `ERROR: …`
+        // line to *stdout*, i.e. into the VCF body, which corrupts a downstream
+        // parse — and the run still exited 0, so the failure was invisible. It
+        // is a per-record decline like any other and is reported like one.
+        let HgvsVariant::Genome(ref gv) = parsed else {
+            return Err(FerroError::UnsupportedVariant {
+                variant_type: "only genomic (g.) descriptions convert to VCF".to_string(),
+            });
+        };
+
+        let vcf = genomic_hgvs_to_vcf(gv)?;
+        // A failed write to the result stream must not be reported as success:
+        // count it so the exit status reflects the truncated output. Same
+        // reasoning as `run_project`'s write-failure arm.
+        let io_err = |e: io::Error| FerroError::Io { msg: e.to_string() };
+        match out_format {
+            OutputFormat::Vcf => writeln!(handle, "{}", vcf).map_err(io_err),
+            OutputFormat::Json => writeln!(
+                handle,
+                r#"{{"hgvs": "{}", "chrom": "{}", "pos": {}, "ref": "{}", "alt": "{}"}}"#,
+                v,
+                vcf.chrom,
+                vcf.pos,
+                vcf.reference,
+                vcf.alternate.first().unwrap_or(&String::new())
+            )
+            .map_err(io_err),
+            OutputFormat::Text => writeln!(
+                handle,
+                "{} -> {}:{}:{}/{}",
+                v,
+                vcf.chrom,
+                vcf.pos,
+                vcf.reference,
+                vcf.alternate.first().unwrap_or(&String::new())
+            )
+            .map_err(io_err),
         }
-        Ok(())
     };
 
+    // Diagnostics go to stderr, never to the result stream, and carry the
+    // 1-based input line so the caller can tell *which* row was declined.
+    // Format-aware (`--format json` stays parseable) because it routes through
+    // the same helper the sibling drivers use.
+    let report = |v: &str, e: &FerroError, line: Option<usize>| {
+        let _ = cli_output_error_with_context(&mut io::stderr(), v, e, out_format, line);
+    };
+
+    let mut error_count = 0usize;
+
     if let Some(v) = variant {
-        process_variant(v, &mut handle)?;
+        // Single-variant path: no line number, there being no file to number
+        // lines in. Mirrors `run_normalize`/`run_project`, which special-case it
+        // the same way.
+        if let Err(e) = convert(v, &mut handle) {
+            report(v, &e, None);
+            error_count += 1;
+        }
     } else if let Some(input_path) = input {
         let file = std::fs::File::open(input_path)?;
         let reader = io::BufReader::new(file);
-        for line in reader.lines() {
+        for (line_num, line) in reader.lines().enumerate() {
             let line = line?;
-            let trimmed = line.trim();
-            if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                process_variant(trimmed, &mut handle)?;
+            // `process_input_line` in place of the ad-hoc trim/`#` test this
+            // used to do: it is what the three sibling drivers use, and it also
+            // strips a UTF-8 BOM on the first line and trailing inline comments.
+            if let Some(v) = process_input_line(&line, line_num == 0) {
+                if let Err(e) = convert(v, &mut handle) {
+                    report(v, &e, Some(line_num + 1));
+                    error_count += 1;
+                }
             }
         }
     } else {
         let stdin = io::stdin();
-        for line in stdin.lock().lines() {
+        for (line_num, line) in stdin.lock().lines().enumerate() {
             let line = line?;
-            let trimmed = line.trim();
-            if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                process_variant(trimmed, &mut handle)?;
+            if let Some(v) = process_input_line(&line, line_num == 0) {
+                if let Err(e) = convert(v, &mut handle) {
+                    report(v, &e, Some(line_num + 1));
+                    error_count += 1;
+                }
             }
         }
     }
 
-    Ok(())
+    // A run that declined some records is a failure: the caller must be able to
+    // tell a complete conversion from a partial one. Same terminal shape as the
+    // three sibling drivers, so `hgvs-to-vcf` reports partial failure exactly
+    // the way `normalize`, `parse` and `project` already do.
+    if error_count > 0 {
+        Err(format!("{} variant(s) failed to convert", error_count).into())
+    } else {
+        Ok(())
+    }
 }
 
 /// Outcome of processing one input line in the batch normalize/parse driver.

--- a/tests/it/issue_1764_hgvs_to_vcf_continues.rs
+++ b/tests/it/issue_1764_hgvs_to_vcf_continues.rs
@@ -1,0 +1,303 @@
+//! `ferro hgvs-to-vcf` must report a declined description and keep going (#1764).
+//!
+//! The batch loop used to propagate a per-record conversion error out of the
+//! whole command, so one description the converter declines discarded every
+//! remaining line — leaving the caller a *truncated* VCF on stdout plus a
+//! non-zero exit, with no indication of which input line was responsible.
+//!
+//! The convention these tests pin is not new. `run_normalize`, `run_parse` and
+//! `run_project` in the same binary already all: continue past a per-record
+//! failure, format the diagnostic to **stderr** through
+//! `output_error_with_context` with the 1-based input line number, count the
+//! failures, and end the run with `Err("<n> variant(s) failed to …")` so the
+//! exit status is non-zero whenever any record was declined. `hgvs-to-vcf` was
+//! the odd one out; these tests hold it to the same contract.
+//!
+//! Deliberately spawned-binary tests rather than in-process ones: the behaviour
+//! under test *is* the command's contract — stream completeness, stream
+//! separation and exit status — and none of those three is observable from a
+//! library call.
+//!
+//! Every pinned string below was **measured** from a run of the fixed binary,
+//! not inferred from reading the formatter.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::NamedTempFile;
+
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+/// The three-line reproducer from #1764, plus a fourth row: a convertible row,
+/// a row the converter declines (#1734 correctly refuses an offset on a genomic
+/// position), then two more convertible rows.
+const DECLINE_IN_THE_MIDDLE: &str = "NC_000001.11:g.10C>T\n\
+                                     NC_000001.11:g.10+2del\n\
+                                     NC_000001.11:g.12C>A\n\
+                                     NC_000001.11:g.20A>G\n";
+
+/// The exact VCF rows the three convertible descriptions above produce.
+const ROW_10: &str = "chr1\t10\t.\tC\tT\t.\tPASS\t.";
+const ROW_12: &str = "chr1\t12\t.\tC\tA\t.\tPASS\t.";
+const ROW_20: &str = "chr1\t20\t.\tA\tG\t.\tPASS\t.";
+
+/// The declined row's diagnostic, as far as the wording is this command's
+/// contract: the `ERROR (line N): <input> - ` shape plus the start of the
+/// converter's own refusal. The rest of the converter's message is #1734's to
+/// word, so pinning it here would make this test fail on an unrelated reword.
+const DECLINE_REPORT: &str =
+    "ERROR (line 2): NC_000001.11:g.10+2del - Invalid coordinates: genomic position 10+2";
+
+/// Write `lines` to a temp file and hand back the handle. The handle is
+/// returned (not just its path) so the caller keeps it alive for the run — a
+/// dropped `NamedTempFile` deletes the file.
+fn input_file(lines: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("create temp input");
+    f.write_all(lines.as_bytes()).expect("write temp input");
+    f.flush().expect("flush temp input");
+    f
+}
+
+/// Run `hgvs-to-vcf -i <temp file> -f <format>`, returning
+/// `(stdout, stderr, success)`.
+fn run_on_file(lines: &str, format: &str) -> (String, String, bool) {
+    let input = input_file(lines);
+    let out = ferro()
+        .args(["hgvs-to-vcf", "-i"])
+        .arg(input.path())
+        .args(["-f", format])
+        .output()
+        .expect("spawn ferro");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// The exact reproducer from #1764. All three convertible rows must reach
+/// stdout — the two *after* the declined one are what the abort discarded.
+#[test]
+fn a_declined_description_does_not_truncate_the_stream() {
+    let (stdout, stderr, ok) = run_on_file(DECLINE_IN_THE_MIDDLE, "vcf");
+
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.starts_with('#')).collect();
+    assert_eq!(
+        rows,
+        vec![ROW_10, ROW_12, ROW_20],
+        "every convertible row must be emitted, in input order;\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // The declined row is reported on stderr, naming its 1-based input line and
+    // the description — the `ERROR (line N): <input> - <error>` shape the
+    // sibling drivers emit.
+    assert!(
+        stderr.contains(DECLINE_REPORT),
+        "stderr must carry {DECLINE_REPORT:?}; got:\n{stderr}"
+    );
+
+    // A run in which some records were declined is a failure, per the sibling
+    // convention (`run_normalize`/`run_parse`/`run_project` all end with
+    // `Err("<n> variant(s) failed to …")`). Silence here would make a partial
+    // conversion indistinguishable from a complete one.
+    assert!(
+        !ok,
+        "a run with declined records must exit non-zero; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("1 variant(s) failed to convert"),
+        "the run must say how many records it declined:\n{stderr}"
+    );
+}
+
+/// A non-genomic description is a per-record decline like any other: it belongs
+/// on stderr and it must make the run fail. Before #1764 it was written to
+/// **stdout**, inside the VCF body — which corrupts a downstream parse — and
+/// the run still exited 0, so the failure was invisible.
+#[test]
+fn a_non_genomic_description_is_reported_on_stderr_and_fails_the_run() {
+    let (stdout, stderr, ok) = run_on_file(
+        "NC_000001.11:g.10C>T\n\
+         NM_000088.3:c.459A>G\n\
+         NC_000001.11:g.12C>A\n",
+        "vcf",
+    );
+
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.starts_with('#')).collect();
+    assert_eq!(
+        rows,
+        vec![ROW_10, ROW_12],
+        "both genomic rows must convert, and nothing else may enter the VCF body;\nstdout:\n{stdout}"
+    );
+
+    assert!(
+        stderr.contains(
+            "ERROR (line 2): NM_000088.3:c.459A>G - Unsupported variant type: \
+             only genomic (g.) descriptions convert to VCF"
+        ),
+        "the non-genomic description must be reported on stderr with its line:\n{stderr}"
+    );
+    assert!(
+        !ok,
+        "a non-genomic record is a failure, not a silent skip; stderr:\n{stderr}"
+    );
+}
+
+/// The failure counter must accumulate, and every declined line must be named.
+///
+/// Every other test in this module declines exactly **one** record, so all of
+/// them pass against a run that hardcoded `1 variant(s) failed to convert` — a
+/// `error_count = 1` where the code means `error_count += 1` is invisible to
+/// them. Two declines, of two different kinds (a refused genomic offset and a
+/// non-genomic description), on non-adjacent lines, so the count, the plural
+/// wording and the per-line attribution are all separated from the single-
+/// failure case.
+#[test]
+fn two_declines_are_counted_and_reported_line_by_line() {
+    let (stdout, stderr, ok) = run_on_file(
+        "NC_000001.11:g.10C>T\n\
+         NC_000001.11:g.10+2del\n\
+         NC_000001.11:g.12C>A\n\
+         NM_000088.3:c.459A>G\n\
+         NC_000001.11:g.20A>G\n",
+        "vcf",
+    );
+
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.starts_with('#')).collect();
+    assert_eq!(
+        rows,
+        vec![ROW_10, ROW_12, ROW_20],
+        "both declines must be stepped over, not one;\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    assert!(
+        stderr.contains(DECLINE_REPORT),
+        "the line-2 decline must be reported against line 2:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("ERROR (line 4): NM_000088.3:c.459A>G - "),
+        "the line-4 decline must be reported against line 4:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("2 variant(s) failed to convert"),
+        "the terminal report must count both declines, not just the last:\n{stderr}"
+    );
+    assert!(!ok, "stderr:\n{stderr}");
+}
+
+/// The all-convertible case must stay exactly as it was: every row on stdout,
+/// nothing on stderr, exit 0. This is the discriminating test against "report
+/// everything as a failure" — an exit status that is always non-zero separates
+/// nothing, which is precisely what the CLI contract asks it to separate.
+#[test]
+fn a_fully_convertible_run_still_exits_zero_with_a_quiet_stderr() {
+    let (stdout, stderr, ok) = run_on_file("NC_000001.11:g.10C>T\nNC_000001.11:g.12C>A\n", "vcf");
+
+    assert!(ok, "an all-convertible run must exit 0; stderr:\n{stderr}");
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.starts_with('#')).collect();
+    assert_eq!(rows, vec![ROW_10, ROW_12], "stdout:\n{stdout}");
+    assert!(
+        stderr.is_empty(),
+        "an all-convertible run must not report anything:\n{stderr}"
+    );
+}
+
+/// `--format json` keeps the result stream parseable: the decline is a JSON
+/// object on **stderr** carrying the `line`, and the success objects on stdout
+/// are uninterrupted. This is the format-awareness the sibling drivers get from
+/// routing declines through `output_error_with_context` rather than a bare
+/// `writeln!`.
+#[test]
+fn json_format_reports_the_decline_as_json_on_stderr() {
+    let (stdout, stderr, ok) = run_on_file(DECLINE_IN_THE_MIDDLE, "json");
+
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        rows,
+        vec![
+            r#"{"hgvs": "NC_000001.11:g.10C>T", "chrom": "chr1", "pos": 10, "ref": "C", "alt": "T"}"#,
+            r#"{"hgvs": "NC_000001.11:g.12C>A", "chrom": "chr1", "pos": 12, "ref": "C", "alt": "A"}"#,
+            r#"{"hgvs": "NC_000001.11:g.20A>G", "chrom": "chr1", "pos": 20, "ref": "A", "alt": "G"}"#,
+        ],
+        "the JSON result stream must carry every convertible row and nothing else;\nstdout:\n{stdout}"
+    );
+
+    assert!(
+        stderr.contains(r#""input": "NC_000001.11:g.10+2del""#)
+            && stderr.contains(r#""line": 2"#)
+            && stderr.contains(r#""status": "error""#),
+        "the decline must be a JSON status:error object naming its input line:\n{stderr}"
+    );
+    assert!(!ok, "stderr:\n{stderr}");
+}
+
+/// The stdin path is a third copy of the batch loop, alongside `--input` and the
+/// single-variant path. Pinned separately because a fix applied to only one of
+/// the three would leave the spellings disagreeing — and stdin is how the
+/// command is used in a pipeline, which is exactly where a truncated stream
+/// does the most damage.
+#[test]
+fn the_stdin_path_continues_past_a_decline_too() {
+    let mut child = ferro()
+        .args(["hgvs-to-vcf", "-f", "vcf"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ferro");
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(DECLINE_IN_THE_MIDDLE.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait for ferro");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    let rows: Vec<&str> = stdout.lines().filter(|l| !l.starts_with('#')).collect();
+    assert_eq!(
+        rows,
+        vec![ROW_10, ROW_12, ROW_20],
+        "the stdin path must emit every convertible row;\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DECLINE_REPORT),
+        "the stdin path must report the decline with its line number:\n{stderr}"
+    );
+    assert!(!out.status.success(), "stderr:\n{stderr}");
+}
+
+/// The single-variant path (`ferro hgvs-to-vcf <variant>`) declines the same
+/// way, minus the line number — there is no file to number lines in. Pinned
+/// because `run_normalize` and `run_project` both special-case that path.
+#[test]
+fn the_single_variant_path_reports_on_stderr_without_a_line_number() {
+    let out = ferro()
+        .args(["hgvs-to-vcf", "NC_000001.11:g.10+2del", "-f", "vcf"])
+        .output()
+        .expect("spawn ferro");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(!out.status.success(), "stderr:\n{stderr}");
+    assert!(
+        stderr
+            .contains("ERROR: NC_000001.11:g.10+2del - Invalid coordinates: genomic position 10+2"),
+        "stderr must name the description, with no line number:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("line 1"),
+        "there is no input line to name on the single-variant path:\n{stderr}"
+    );
+    // Only the header reached stdout — no data row, and no diagnostic.
+    assert_eq!(
+        stdout.lines().filter(|l| !l.starts_with('#')).count(),
+        0,
+        "nothing but the header may reach stdout:\n{stdout}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -29,6 +29,7 @@ mod issue_1627_named_element_alphabet_reach;
 mod issue_1632_parse_entry_applies_no_mode;
 mod issue_1715_rna_alignment_symbol_reach;
 mod issue_1748_noncoding_axis_zones;
+mod issue_1764_hgvs_to_vcf_continues;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Closes #1764.

Representation-Change: none. CLI-only; `src/bin/ferro.rs` is not a watched directory and no normalized output moves.

## The defect

`ferro hgvs-to-vcf` propagated a per-record conversion error out of the whole command, so one description the converter declines terminated the run and discarded every remaining input line.

Measured on `origin/main` at `674e9c8b`, using the issue's own reproducer plus one more row:

```console
$ printf 'NC_000001.11:g.10C>T\nNC_000001.11:g.10+2del\nNC_000001.11:g.12C>A\nNC_000001.11:g.20A>G\n' > in.txt
$ ferro hgvs-to-vcf -i in.txt -f vcf
##fileformat=VCFv4.2
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr1	10	.	C	T	.	PASS	.
$ echo $?
1
```

Two of four rows are convertible and silently lost. The propagated error text names the description but not the input line, and stdout is a *truncated but well-formed* VCF — the shape most likely to be consumed as complete.

After:

```console
$ ferro hgvs-to-vcf -i in.txt -f vcf
##fileformat=VCFv4.2
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr1	10	.	C	T	.	PASS	.
chr1	12	.	C	A	.	PASS	.
chr1	20	.	A	G	.	PASS	.
# stderr:
ERROR (line 2): NC_000001.11:g.10+2del - Invalid coordinates: genomic position 10+2 (interval start) carries a +/- offset: …
Error: "1 variant(s) failed to convert"
$ echo $?
1
```

### A second defect, found while reproducing

A **non-genomic** description wrote `ERROR: <v> is not a genomic variant (g.)` to **stdout**, inside the VCF body — and the run still exited **0**. Measured on the same base:

```console
$ printf 'NC_000001.11:g.10C>T\nNM_000088.3:c.459A>G\nNC_000001.11:g.12C>A\n' | ferro hgvs-to-vcf -f vcf; echo $?
##fileformat=VCFv4.2
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr1	10	.	C	T	.	PASS	.
ERROR: NM_000088.3:c.459A>G is not a genomic variant (g.)
chr1	12	.	C	A	.	PASS	.
0
```

That is the worse of the two: a corrupt VCF body *and* an exit status asserting success. It is the same routing bug, so it is fixed here rather than filed separately.

## The design choices, and where each comes from

The issue asks for four decisions. **None of them needed a new ruling — three sibling drivers in the same file already answer all four**, and the most valuable part of this change was confirming that rather than inventing a convention. `run_normalize`, `run_parse` and `run_project` each:

1. **Continue** past a per-record failure — none of them aborts the stream.
2. Format the diagnostic to **stderr** via `output_error_with_context`, carrying the **1-based input line number** (`ERROR (line N): <input> - <error>`, or a JSON object with a `"line"` field under `--format json`).
3. **Count** the failures and end with `Err(format!("{n} variant(s) failed to …"))`, so the process exits non-zero whenever any record was declined.
4. Do **not** gate any of this on `--error-mode` — they continue unconditionally, and `hgvs-to-vcf` takes no such flag.

So this PR adds **no flag** and invents **no new exit code**: `hgvs-to-vcf` now reports partial failure exactly the way `normalize`, `parse` and `project` already do. Exit 0 means everything converted; non-zero means some records were declined and stderr says which lines. That satisfies `.coderabbit.yaml`'s `src/{cli,commands,bin}/**/*.rs` instruction on both counts it raises here — "diagnostics written to stdout instead of stderr (that corrupts a downstream parse)" and "a process exit code that does not distinguish 'ran, found nothing' from 'failed'".

## The fix

`run_hgvs_to_vcf` only. The per-record closure returns `Result<(), FerroError>` instead of propagating out of the command; each of the three input paths (single variant, `--input`, stdin) reports and counts rather than `?`-ing.

Incidental, in the same function:

- The ad-hoc `trim()` / `starts_with('#')` line test is replaced with `process_input_line`, the helper the three siblings use — it additionally strips a UTF-8 BOM on the first line and trailing inline comments.
- `OutputFormat` is parsed once and used for every decision, replacing a second parallel `match` on the raw `&str`. Clap pins `--format` to `["vcf", "text", "json"]`, so the two readings could not disagree today; removing one is so they cannot start.

No library change — `src/vcf/from_hgvs.rs` was already returning the right thing, as the issue says.

## Unchanged on purpose

`a_fully_convertible_run_still_exits_zero_with_a_quiet_stderr` is the discriminating test: an all-convertible run still emits every row on stdout, writes **nothing** to stderr, and exits **0**. An exit status that is always non-zero would separate nothing, which is precisely what the CLI instruction asks it to separate.

## Tests

`tests/it/issue_1764_hgvs_to_vcf_continues.rs`, six spawned-binary tests — the behaviour under test *is* the command's contract (stream completeness, stream separation, exit status), and none of the three is observable from a library call. Every pinned string was measured from a run, not inferred from reading the formatter.

| test | pins |
|---|---|
| `a_declined_description_does_not_truncate_the_stream` | the issue's reproducer: all three convertible rows, in input order; the decline named with its line; exit non-zero |
| `a_non_genomic_description_is_reported_on_stderr_and_fails_the_run` | the second defect: nothing but header and data rows in the VCF body; decline on stderr; exit non-zero |
| `a_fully_convertible_run_still_exits_zero_with_a_quiet_stderr` | the discriminating case (see above) |
| `json_format_reports_the_decline_as_json_on_stderr` | `--format json` result stream stays parseable; decline is a `status:error` object carrying `"line": 2` |
| `the_stdin_path_continues_past_a_decline_too` | stdin is a third copy of the loop — pipelines are where a truncated stream does the most damage |
| `the_single_variant_path_reports_on_stderr_without_a_line_number` | the special-cased path: no line number, nothing but the header on stdout |

Row assertions compare the **whole row vector** against measured VCF lines rather than substring-matching a position, so a dropped, duplicated or reordered row fails.

## Self-review findings applied

Ran `/coderabbitai-review` against the local diff before pushing. Three findings, all applied, none rejected:

1. **Duplicate source of truth for the output format** — a `match` on the raw `&str` alongside the new `OutputFormat`. Collapsed onto the parsed value (exhaustive match, no `_` arm).
2. **Untested third input path** — the stdin loop was fixed but uncovered, and it is the one a pipeline uses. Added `the_stdin_path_continues_past_a_decline_too`.
3. **Assertions weaker than the stated contract** (`tests/**/*.rs` path instruction, verbatim) — `contains("\t12\t")` would pass on a duplicated or reordered stream. Replaced with whole-row-vector equality against measured output.

## Verification

All commands run in `issue-1764/`, exit status read back from the log file rather than from a notification.

| command | result |
|---|---|
| `cargo fmt --all --check` | `FMT_CHECK_EXIT=0` |
| `cargo clippy --all-features --all-targets -- -D warnings` | `CLIPPY_EXIT=0` |
| `FERRO_SWEEP_SEEDS=full cargo nextest run --features dev` | `SUITE_EXIT=0` — 10526 passed, 0 failed, 152 skipped |
| `scripts/run_oracle_suite.sh` | `ORACLE_EXIT=0` — 10389 passed, 0 failed, 289 skipped |

`git status --porcelain tests/proptest-regressions/` is empty — no `*_strategy()` was touched, so no pinned seed was re-pointed.