### PR TITLE
fix(project): record why the g. axis declines on a bare transcript input

### DIFF
--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -592,7 +592,14 @@ mod tests {
 
     #[test]
     fn project_axis_bare_nm_genomic_axis_unavailable() {
-        // A bare NM_ coding input has no genome alignment → g. is None.
+        // A bare `NM_` coding description names no genomic parent, so there is
+        // no reference for the `g.` axis to be written against → `g.` is None.
+        //
+        // This comment previously read "has no genome alignment", which is not
+        // what the fixture models and not why the axis declines — see
+        // `project_axis_bare_nm_genomic_decline_names_cause_and_remedy` below,
+        // which pins that this very fixture aligns the transcript to
+        // `NC_000001.11` and projects against it happily.
         let vp = fixture();
         let variant = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
         let outcome = project_axis(&vp, &variant, Axis::Genomic, None).unwrap();
@@ -600,6 +607,98 @@ mod tests {
             matches!(outcome, AxisOutcome::Unavailable { .. }),
             "got {outcome:?}"
         );
+    }
+
+    /// #1713: the `g.` decline on a bare transcript input must state its own
+    /// cause and the remedy, rather than the string synthesized from the axis
+    /// code alone.
+    ///
+    /// The synthesized wording — "no g. representation for this variant" —
+    /// asserts a property of the **variant**. That is false here and measurably
+    /// misleading: the reference data required to derive the axis is present
+    /// (this fixture aligns `NM_TEST.1` to `NC_000001.11`, and the second half
+    /// of this test renders that very axis), and what is missing is a genomic
+    /// reference in the **description**. #1713 was filed against ferro on the
+    /// strength of that wording, reading it as evidence that the CLI could not
+    /// reach a capability the library had.
+    ///
+    /// `project_to_genomic` declines a parentless accession by design — #327
+    /// specifies it, and `projector.rs` refuses to synthesize a parent from
+    /// cdot — so the decline itself is correct and is not what this pins. What
+    /// is owed is that the reason reaches the user, which is a decline the
+    /// projector articulates and then discards (`AxisDeclineReasons`).
+    #[test]
+    fn project_axis_bare_nm_genomic_decline_names_cause_and_remedy() {
+        let vp = fixture();
+
+        let bare = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+        let outcome = project_axis(&vp, &bare, Axis::Genomic, None).unwrap();
+        let AxisOutcome::Unavailable { reason, .. } = outcome else {
+            panic!("expected Unavailable, got {outcome:?}");
+        };
+        assert!(
+            !reason.contains("no g. representation for this variant"),
+            "the decline must not fall back to the axis-code string, which \
+             states a property of the variant that is false here: {reason}"
+        );
+        assert!(
+            reason.contains("NM_TEST.1"),
+            "the decline must name the accession it is about: {reason}"
+        );
+        assert!(
+            reason.contains("genomic reference"),
+            "the decline must name the missing thing: {reason}"
+        );
+        assert!(
+            reason.contains("NC_000001.11(NM_TEST.1)"),
+            "the decline must show the remedy on this transcript's own genomic \
+             reference, which the projector can see: {reason}"
+        );
+
+        // The other half of the claim, in the same test so the two cannot drift:
+        // name the genomic reference and the identical variant renders. Nothing
+        // about the reference data changed between these two calls, which is
+        // what makes "no g. representation for this variant" the wrong story.
+        let anchored = crate::parse_hgvs("NC_000001.11(NM_TEST.1):c.4C>A").unwrap();
+        let outcome = project_axis(&vp, &anchored, Axis::Genomic, None).unwrap();
+        match outcome {
+            AxisOutcome::Rendered { output, .. } => {
+                assert!(output.starts_with("NC_000001.11:g."), "got {output}");
+            }
+            other => panic!("expected Rendered once the parent is named, got {other:?}"),
+        }
+    }
+
+    /// The remedy is spelled on the axis the user wrote, not always `c.`.
+    ///
+    /// `project_coding_direct` passes a literal `"c."`; `project_noncoding_direct`
+    /// threads its own `axis_label` (`"n."` / `"r."`). That parameter is the only
+    /// behavioural difference between the two paths' declines, and the `c.`-only
+    /// tests beside this one cannot see it — a `project_noncoding_direct` that
+    /// hardcoded `"c."` would pass every other assertion in the tree. So the two
+    /// non-coding axes are pinned here, and pinned as *not* `c.`, since a
+    /// substring check for the accession alone would survive the regression.
+    #[test]
+    fn project_axis_bare_nm_genomic_decline_spells_the_remedy_on_the_inputs_own_axis() {
+        let vp = fixture();
+
+        for (input, axis_label) in [("NM_TEST.1:n.4C>A", "n."), ("NM_TEST.1:r.4c>a", "r.")] {
+            let variant = crate::parse_hgvs(input).unwrap();
+            let outcome = project_axis(&vp, &variant, Axis::Genomic, None).unwrap();
+            let AxisOutcome::Unavailable { reason, .. } = outcome else {
+                panic!("{input}: expected Unavailable, got {outcome:?}");
+            };
+            assert!(
+                reason.contains(&format!("NC_000001.11(NM_TEST.1):{axis_label}")),
+                "{input}: the remedy must be spelled on the input's own axis \
+                 ({axis_label}): {reason}"
+            );
+            assert!(
+                !reason.contains("NC_000001.11(NM_TEST.1):c."),
+                "{input}: the remedy must not fall back to the coding path's \
+                 hardcoded `c.`: {reason}"
+            );
+        }
     }
 
     #[test]

--- a/src/conformance/spec_projection.rs
+++ b/src/conformance/spec_projection.rs
@@ -331,12 +331,36 @@ mod tests {
             pass.axes[&'c'],
             AxisResult::Rendered("NM_TEST.1:c.4C>A".to_string())
         );
-        // This mock transcript carries no genome alignment, so the `g.` axis
-        // declines — and the decline is reported as a first-class outcome with
-        // its reason, not dropped.
-        assert_eq!(
-            pass.axes[&'g'],
-            AxisResult::Unavailable("no g. representation for this variant".to_string())
+        // The `g.` axis declines, and the decline is reported as a first-class
+        // outcome with its reason, not dropped.
+        //
+        // This comment used to say the mock "carries no genome alignment",
+        // which is not true of this fixture and not why the axis declines: the
+        // cdot record aligns `NM_TEST.1` to `NC_000001.11`, and the sibling
+        // tests in this module project a bare `NC_000001.11:g.` input onto it.
+        // The axis declines because the *description* names no genomic parent
+        // (#327), and #1713 records what that misreading cost. The reason string
+        // now says so, so the assertion no longer pins a wording that pointed
+        // the next reader at the reference data.
+        // The negative half is carried too, in step with the two sibling tests
+        // (`src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy`
+        // and `tests/it/issue_1713_bare_transcript_genomic_decline.rs`): three
+        // `contains` on a long string all pass against a reason that *also*
+        // still carries the axis-code fallback, so the thing #1713 is about
+        // has to be asserted absent rather than inferred from the positives.
+        assert!(
+            matches!(
+                &pass.axes[&'g'],
+                AxisResult::Unavailable(reason)
+                    if !reason.contains("no g. representation for this variant")
+                        && reason.contains("NM_TEST.1")
+                        && reason.contains("genomic reference")
+                        && reason.contains("NC_000001.11(NM_TEST.1)")
+            ),
+            "the g. decline must name the accession, the missing genomic \
+             reference, and the remedy, and must not fall back to the \
+             axis-code string: {:?}",
+            pass.axes[&'g']
         );
         assert_eq!(
             pass.axes[&'p'],

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -4577,14 +4577,73 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
     }
 
+    /// The genomic reference this transcript is aligned to, when the reference
+    /// data names one — for phrasing the remedy in
+    /// [`Self::bare_transcript_genomic_decline`], never for deriving an axis.
+    ///
+    /// cdot first (the mapper that would perform the projection), then the
+    /// sequence provider's own transcript record, mirroring the cdot-first /
+    /// provider-fallback resolution the direct paths already use for their
+    /// coding metadata. Runs only on a decline, so it costs nothing on the
+    /// paths that render.
+    fn aligned_genomic_reference(&self, transcript_id: &str) -> Option<String> {
+        if let Some(t) = self.projector.mapper().cdot().get_transcript(transcript_id) {
+            if !t.contig.is_empty() {
+                return Some(t.contig.clone());
+            }
+        }
+        self.provider
+            .get_transcript(transcript_id)
+            .ok()
+            .and_then(|t| t.chromosome.clone())
+            .filter(|c| !c.is_empty())
+    }
+
+    /// Why the `g.` axis declines for a bare transcript description (#1713).
+    ///
+    /// The decline itself is by design and is not this function's subject:
+    /// #327 specifies that a transcript-coordinate input with no resolvable
+    /// parent reference is refused, and `project_to_genomic_nc` deliberately
+    /// does **not** synthesize a parent from cdot. `axis_label` is the input's
+    /// own axis (`c.`/`n.`/`r.`), so the worked remedy is spelled on the axis
+    /// the user actually wrote.
+    ///
+    /// What this fixes is the *reporting*. The reason was articulated inside
+    /// `project_to_genomic_nc` and never recorded, so `ferro project --axis g`
+    /// fell back to `unavailable_reason`'s string synthesized from the axis code
+    /// alone — "no g. representation for this variant" — which asserts a
+    /// property of the **variant**. That is the wrong subject and it is
+    /// routinely false: the alignment is usually present (the projection
+    /// renders the moment the description names a parent), so the missing thing
+    /// is in the description, not in the reference or in the variant. #1713 was
+    /// filed against ferro on the strength of that wording, reading it as a CLI
+    /// path failing to reach a capability the library had; the library declines
+    /// identically, and the wording is what made the two look different.
+    fn bare_transcript_genomic_decline(&self, transcript_id: &str, axis_label: &str) -> String {
+        // Fall back to an elided accession rather than inventing one: a wrong
+        // worked example is worse than a shaped one, and this arm is reached
+        // only when the reference names no alignment at all.
+        let parent = self
+            .aligned_genomic_reference(transcript_id)
+            .unwrap_or_else(|| "NC_…".to_string());
+        format!(
+            "no genomic reference for {transcript_id}: a bare transcript description names no \
+             genomic parent, so the g. axis cannot be derived (see #327); name one in the \
+             description, e.g. {parent}({transcript_id}):{axis_label}…"
+        )
+    }
+
     /// Direct c.→p. projection for a bare transcript coding input (no
-    /// `genomic_context` parent). The c.→g.→CDS roundtrip cannot run without a
-    /// genome alignment, but protein prediction only needs the transcript's
-    /// CDS sequence and the 1-based CDS position — which an exonic c. variant
-    /// already provides. The genomic axis is `None` for a bare `NM_`/`NR_`
-    /// input (no genome alignment), but is filled with the reanchored
-    /// `LRG_<n>:g.…` form when the input is a bare LRG transcript whose
-    /// structural parent resolves (`lrg_genomic_parent`, #886) (#498).
+    /// `genomic_context` parent). The c.→g.→CDS roundtrip cannot run, there
+    /// being no genomic reference in the description to write the `g.` axis
+    /// against (#327) — **not** because the reference lacks an alignment, which
+    /// it usually has; see [`Self::bare_transcript_genomic_decline`] and #1713.
+    /// Protein prediction only needs the transcript's CDS sequence and the
+    /// 1-based CDS position — which an exonic c. variant already provides. The
+    /// genomic axis is `None` for a bare `NM_`/`NR_` input, but is filled with
+    /// the reanchored `LRG_<n>:g.…` form when the input is a bare LRG
+    /// transcript whose structural parent resolves (`lrg_genomic_parent`, #886)
+    /// (#498).
     fn project_coding_direct(
         &self,
         cds: &CdsVariant,
@@ -4715,14 +4774,29 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // #886: a bare LRG transcript has a structurally derivable genomic
         // parent, so its genomic axis IS resolvable (the normalized wrapper
         // fills the LRG parent, reanchors into the LRG frame, and 3'-shifts). A
-        // bare NM_/NR_ has no genome alignment -> stays None. Use
+        // bare NM_/NR_ names no genomic parent for the axis to be written
+        // against (#327), so it stays None — the alignment itself is usually
+        // present, which is the misreading #1713 records. Use
         // `project_to_genomic_normalized` (not the raw pivot) so the reported
         // genomic axis is spec-canonical (#867); `.ok()` degrades to None if the
         // LRG placement is genuinely unavailable.
-        let genomic = if Self::lrg_genomic_parent(&cds.accession).is_some() {
-            self.project_to_genomic_normalized(normalized).ok()
+        //
+        // #1713: either way the axis's absence now carries its reason, so the
+        // CLI reports the real cause instead of synthesizing one from the axis
+        // code. Both arms decline exactly as before — only the record changes.
+        let (genomic, genomic_decline) = if Self::lrg_genomic_parent(&cds.accession).is_some() {
+            match self.project_to_genomic_normalized(normalized) {
+                Ok(g) => (Some(g), None),
+                Err(e) => {
+                    log::trace!("LRG genomic axis declined for {transcript_id}: {e}");
+                    (None, variant_decline_explanation(&e))
+                }
+            }
         } else {
-            None
+            (
+                None,
+                Some(self.bare_transcript_genomic_decline(transcript_id, "c.")),
+            )
         };
 
         // #972: decline coding/protein on a `cds_start_NF` transcript — see the
@@ -4741,6 +4815,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             normalization_warnings: Vec::new(),
             axis_decline_reasons: AxisDeclineReasons {
                 noncoding: noncoding_decline,
+                genomic: genomic_decline,
                 ..Default::default()
             },
             genomic,
@@ -4759,14 +4834,17 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
     /// Direct n./r.→CDS→p. projection for a bare transcript non-coding (`n.`)
     /// or RNA (`r.`) input (no `genomic_context` parent). The c.→g.→CDS
-    /// roundtrip cannot run without a genome alignment, but an `n.` base is a
+    /// roundtrip cannot run, there being no genomic reference in the
+    /// description to write the `g.` axis against (#327) — **not** because the
+    /// reference lacks an alignment; see
+    /// [`Self::bare_transcript_genomic_decline`] and #1713. An `n.` base is a
     /// 1-based transcript position: convert it to a CDS position via the
     /// transcript's `cds_start` (the exon/CIGAR-aware
     /// [`CoordinateMapper::tx_to_cds`]), then run the same protein-consequence
     /// prediction the coding path uses. The genomic axis is `None` for a bare
-    /// `NM_`/`NR_` input (no genome alignment), but is filled with the
-    /// reanchored `LRG_<n>:g.…` form when the input is a bare LRG transcript
-    /// whose structural parent resolves (`lrg_genomic_parent`, #886) (#506).
+    /// `NM_`/`NR_` input, but is filled with the reanchored `LRG_<n>:g.…` form
+    /// when the input is a bare LRG transcript whose structural parent resolves
+    /// (`lrg_genomic_parent`, #886) (#506).
     ///
     /// `normalized` must be an [`HgvsVariant::Tx`] or [`HgvsVariant::Rna`].
     fn project_noncoding_direct(
@@ -5009,10 +5087,27 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // (#867). Computed once here because the two return sites below sit in
         // different branches (the `!is_coding` early return and the tail), so
         // there is no shared tail to set it in.
-        let genomic = normalized
+        //
+        // #1713: the decline carries its reason, on the same terms as the
+        // coding path's. `axis_label` is the input's own axis, so the worked
+        // remedy is spelled `n.`/`r.` rather than always `c.`.
+        let is_lrg = normalized
             .accession()
-            .filter(|acc| Self::lrg_genomic_parent(acc).is_some())
-            .and_then(|_| self.project_to_genomic_normalized(normalized).ok());
+            .is_some_and(|acc| Self::lrg_genomic_parent(acc).is_some());
+        let (genomic, genomic_decline) = if is_lrg {
+            match self.project_to_genomic_normalized(normalized) {
+                Ok(g) => (Some(g), None),
+                Err(e) => {
+                    log::trace!("LRG genomic axis declined for {transcript_id}: {e}");
+                    (None, variant_decline_explanation(&e))
+                }
+            }
+        } else {
+            (
+                None,
+                Some(self.bare_transcript_genomic_decline(transcript_id, axis_label)),
+            )
+        };
 
         // Non-coding transcript: there is no CDS to convert into, so there is
         // no protein consequence and no c. form. The n. form is the input
@@ -5020,7 +5115,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         if !is_coding {
             return Ok(VariantProjection {
                 normalization_warnings: Vec::new(),
-                axis_decline_reasons: AxisDeclineReasons::default(),
+                axis_decline_reasons: AxisDeclineReasons {
+                    genomic: genomic_decline,
+                    ..Default::default()
+                },
                 genomic,
                 coding: None,
                 noncoding: Some(noncoding_axis),
@@ -5099,7 +5197,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),
-            axis_decline_reasons: AxisDeclineReasons::default(),
+            axis_decline_reasons: AxisDeclineReasons {
+                genomic: genomic_decline,
+                ..Default::default()
+            },
             genomic,
             coding,
             // The non-coding axis is the input itself for an `n.` input, and the

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -21,15 +21,22 @@ use crate::normalize::NormalizationWarning;
 ///
 /// **`None` does not mean "no reason exists."** A field is `None` when that axis
 /// is present, when it was never applicable to the input, *or* when its decline
-/// is one this type does not record. Only `noncoding` is populated today — for
-/// both a single variant and an allele, whose members' reasons are carried up —
-/// and the projector still has articulated-but-unrecorded declines on the other
-/// axes: the genomic re-anchor failure in `frame_projection_owned`, the
-/// `cds_start_incomplete` gate that drops `coding`/`protein`/`rna` together, and
-/// the non-initiator protein decline. Wiring each of those is a judgement call
-/// about what is meaningful to a user, not a mechanical extension, so callers
-/// must keep their own fallback wording and must not read an absent reason as
-/// evidence that none was computed.
+/// is one this type does not record. `noncoding` is populated — for both a
+/// single variant and an allele, whose members' reasons are carried up — and
+/// `genomic` is populated at three sites — the withheld non-flanking genomic
+/// insertion (#1264, in `project_variant_inner`), the two bare-transcript direct
+/// paths where the axis declines because the *description* names no genomic
+/// parent rather than because the reference lacks an alignment (#1713), and an
+/// allele's carry-up of whichever member recorded one.
+///
+/// **Populated is not the same as complete.** The projector still has
+/// articulated-but-unrecorded declines: on `genomic`, the re-anchor failure in
+/// `frame_projection_owned`; elsewhere, the `cds_start_incomplete` gate that
+/// drops `coding`/`protein`/`rna` together, and the non-initiator protein
+/// decline. Wiring each of those is a judgement call about what is meaningful to
+/// a user, not a mechanical extension, so callers must keep their own fallback
+/// wording and must not read an absent reason as evidence that none was
+/// computed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AxisDeclineReasons {
@@ -46,9 +53,13 @@ pub struct AxisDeclineReasons {
 /// whatever representations are derivable from the input and the available
 /// reference data, and `None` means "this representation is not available"
 /// (not an error). In particular `genomic` is `None` for a bare transcript
-/// (e.g. bare-`NM_`) coding input that carries no genome alignment — protein
-/// is still predicted directly from the transcript's CDS (#498). For a
-/// genome-anchored input `genomic` is the canonical g. representation.
+/// (e.g. bare-`NM_`) coding input, because the *description* names no genomic
+/// parent for the axis to be written against (#327) — **not** because the
+/// reference lacks an alignment, which it usually has. That misdescription is
+/// what made a specified decline read as a capability gap (#1713); the recorded
+/// reason on [`AxisDeclineReasons::genomic`] says which it is. Protein is still
+/// predicted directly from the transcript's CDS (#498). For a genome-anchored
+/// input `genomic` is the canonical g. representation.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct VariantProjection {

--- a/tests/it/issue_1713_bare_transcript_genomic_decline.rs
+++ b/tests/it/issue_1713_bare_transcript_genomic_decline.rs
@@ -1,0 +1,319 @@
+//! Issue #1713 — `ferro project --axis g` declines every bare `NM_`-rooted
+//! input, and the reason it gave said so in a way that pointed at the wrong
+//! thing.
+//!
+//! **The filed claim does not reproduce, and that is the finding.** #1713
+//! reports the CLI declining an axis "the library demonstrably can produce for
+//! the same inputs on the same reference". Measured against the prepared
+//! GRCh38 reference, the library declines identically:
+//!
+//! ```text
+//! NM_004006.2:c.100del
+//!   CLI  project_axis(.., Genomic, ..)  -> Unavailable
+//!   LIB  project_variant(..).genomic    -> None
+//!   LIB  project_to_genomic(..)         -> Err(UnsupportedProjection:
+//!            "... has no parent reference (genomic_context) ... (see #327)")
+//! ```
+//!
+//! There is no CLI/library asymmetry: `select_axis` reads
+//! `VariantProjection::genomic`, so the CLI reports exactly the value the
+//! library computed. The decline is specified — #327 requires
+//! `UnsupportedProjection` for a transcript-coordinate input with no resolvable
+//! parent, and `project_to_genomic_nc` deliberately refuses to synthesize a
+//! parent from cdot.
+//!
+//! What *was* defective is the reporting, which is the issue's own third
+//! option. The projector articulated the reason and dropped it, so the CLI fell
+//! back to a string synthesized from the axis code alone — "no g.
+//! representation for this variant" — asserting a property of the **variant**.
+//! That is false here in a way anyone can check: the alignment is present, and
+//! naming the genomic reference in the description renders the axis
+//! immediately. The wording is what made a specified decline look like a
+//! capability gap, and it is what this module pins.
+//!
+//! Reference-backed: skips unless `FERRO_MANIFEST` points at a prepared
+//! reference.
+
+use ferro_hgvs::cli::project::{project_axis, Axis, AxisOutcome};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::{MultiFastaProvider, ReferenceProvider, VariantProjector};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+fn manifest_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(
+        &self,
+        id: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_sequence(id, start, end)
+    }
+    fn has_transcript(&self, id: &str) -> bool {
+        self.0.has_transcript(id)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_genomic_sequence(contig, start, end)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_protein_sequence(accession, start, end)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.0.has_protein_data()
+    }
+    fn genomic_placement(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement(parent)
+    }
+    fn get_transcript_for_variant(
+        &self,
+        variant: &ferro_hgvs::hgvs::variant::HgvsVariant,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_variant(variant)
+    }
+    fn get_transcript_for_accession(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_accession(accession)
+    }
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        self.0.has_transcript_version_exact(id)
+    }
+    fn genomic_placement_on_build(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement_on_build(parent, build)
+    }
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
+    }
+    fn sole_hosted_transcript(
+        &self,
+        ng_parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<String> {
+        self.0.sole_hosted_transcript(ng_parent)
+    }
+    fn get_protein_length(&self, accession: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_protein_length(accession)
+    }
+    fn get_sequence_length(&self, id: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_sequence_length(id)
+    }
+}
+
+fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
+    let p = provider()?;
+    let cdot = p.cdot_mapper()?.clone();
+    let projector = Projector::new(cdot);
+    Some(VariantProjector::new(projector, ArcProvider(p)))
+}
+
+/// Every bare-`NM_` input whose genomic axis the CLI declines must be declined
+/// by the library too, for the same variant, on the same projector.
+///
+/// This is the invariant #1713 alleged was broken. It is asserted in both
+/// directions — a CLI decline demands a library `None`, and a CLI render demands
+/// a library `Some` with the identical string — so a future divergence fails
+/// here rather than being re-filed as a capability gap.
+///
+/// `NM_004006.2:c.1704del` is deliberately in the corpus and deliberately not
+/// expected to decline: #1708 re-parents a junction-crossing output onto the
+/// genomic reference the crossing already resolved, so this row *renders*
+/// despite arriving bare. Pinning agreement rather than a verdict is what lets
+/// one corpus carry both classes.
+///
+/// **Agreement alone is too weak for that row**, though, so each input carries
+/// its own expected verdict as well. A generic "either both render or both
+/// decline" match accepts `(Unavailable, None)` for every row — so a regression
+/// of #1708's re-parenting would drop `c.1704del` into the declining arm and
+/// pass, while this doc comment went on claiming the row pins the render. The
+/// `Verdict` column is what makes the two halves of the claim inseparable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// The genomic axis must be derivable for this input.
+    Renders,
+    /// The genomic axis must decline for this input.
+    Declines,
+}
+
+#[test]
+fn cli_and_library_agree_on_the_genomic_axis_for_bare_transcript_inputs() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!(
+            "issue_1713: skipping — no manifest at FERRO_MANIFEST. This is NOT the gate: \
+             the hermetic half runs in CI as \
+             src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy"
+        );
+        return;
+    };
+
+    let mut checked = 0usize;
+    for (input, verdict) in [
+        ("NM_004006.2:c.100del", Verdict::Declines),
+        ("NM_000492.4:c.1521_1523del", Verdict::Declines),
+        // #1708: junction-crossing, re-parented onto the reference the crossing
+        // already resolved, so this one renders despite arriving bare.
+        ("NM_004006.2:c.1704del", Verdict::Renders),
+        ("NC_000023.11(NM_004006.2):c.100del", Verdict::Renders),
+    ] {
+        let v = ferro_hgvs::parse_hgvs(input).expect("parse");
+        let tx = v
+            .accession()
+            .map(|a| a.transcript_accession())
+            .expect("transcript accession");
+
+        let cli = project_axis(&vp, &v, Axis::Genomic, None)
+            .unwrap_or_else(|e| panic!("{input}: CLI hard error {e}"));
+        let lib = vp
+            .project_variant(&v, &tx)
+            .unwrap_or_else(|e| panic!("{input}: library hard error {e}"))
+            .genomic
+            .map(|g| g.to_string());
+
+        match (&cli, &lib) {
+            (AxisOutcome::Rendered { output, .. }, Some(g)) => {
+                assert_eq!(
+                    verdict,
+                    Verdict::Renders,
+                    "{input}: expected the genomic axis to decline, but it rendered {output}"
+                );
+                assert_eq!(
+                    output, g,
+                    "{input}: CLI and library rendered different genomic axes"
+                );
+            }
+            (AxisOutcome::Unavailable { reason, .. }, None) => assert_eq!(
+                verdict,
+                Verdict::Declines,
+                "{input}: expected the genomic axis to render, but it declined: {reason}"
+            ),
+            _ => panic!("{input}: CLI says {cli:?} but the library says {lib:?}"),
+        }
+        checked += 1;
+    }
+    // A corpus that silently shrank to nothing would pass every assertion above.
+    assert_eq!(checked, 4, "the corpus must not shrink silently");
+}
+
+/// The decline a bare-`NM_` input receives must name its own cause and the
+/// remedy, on the real reference.
+///
+/// The hermetic half of this lives in `src/cli/project.rs`
+/// (`project_axis_bare_nm_genomic_decline_names_cause_and_remedy`) and runs in
+/// CI. This half is what makes the wording checkable against *real* cdot: the
+/// worked example it prints has to name the chromosome this transcript is
+/// actually aligned to, which a mock cannot demonstrate.
+#[test]
+fn the_bare_transcript_genomic_decline_names_its_cause_and_the_remedy() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!(
+            "issue_1713: skipping — no manifest at FERRO_MANIFEST. This is NOT the gate: \
+             the hermetic half runs in CI as \
+             src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy"
+        );
+        return;
+    };
+
+    // `NM_004006.2` (DMD) is on chrX; `NM_000492.4` (CFTR) on chr7. Two
+    // different chromosomes, so a hardcoded accession in the message cannot
+    // satisfy both.
+    for (input, expect_parent) in [
+        ("NM_004006.2:c.100del", "NC_000023.11"),
+        ("NM_000492.4:c.1521_1523del", "NC_000007.14"),
+    ] {
+        let v = ferro_hgvs::parse_hgvs(input).expect("parse");
+        let tx = v
+            .accession()
+            .map(|a| a.transcript_accession())
+            .expect("transcript accession");
+
+        let outcome = project_axis(&vp, &v, Axis::Genomic, None).expect("no hard error");
+        let AxisOutcome::Unavailable { reason, .. } = outcome else {
+            panic!("{input}: expected a decline, got {outcome:?}");
+        };
+        assert!(
+            !reason.contains("no g. representation for this variant"),
+            "{input}: the synthesized axis-code string states a property of the \
+             variant, which is false here: {reason}"
+        );
+        assert!(
+            reason.contains(&tx),
+            "{input}: the decline must name the accession: {reason}"
+        );
+        assert!(
+            reason.contains(&format!("{expect_parent}({tx})")),
+            "{input}: the decline must show the remedy on this transcript's own \
+             aligned genomic reference: {reason}"
+        );
+
+        // And the remedy has to actually work — otherwise the message is a
+        // well-formed lie. Rebuild the description the decline recommends and
+        // project it; the axis must render on the named reference.
+        let suffix = input.split_once(':').expect("accession:axis").1;
+        let anchored = format!("{expect_parent}({tx}):{suffix}");
+        let av = ferro_hgvs::parse_hgvs(&anchored)
+            .unwrap_or_else(|e| panic!("the recommended form must parse: {anchored}: {e}"));
+        let outcome = project_axis(&vp, &av, Axis::Genomic, None).expect("no hard error");
+        match outcome {
+            AxisOutcome::Rendered { output, .. } => assert!(
+                output.starts_with(&format!("{expect_parent}:g.")),
+                "{anchored}: expected a g. axis on {expect_parent}, got {output}"
+            ),
+            other => panic!("{anchored}: the recommended form must render, got {other:?}"),
+        }
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -27,6 +27,7 @@ mod issue_1600_reduced_delins_tract_demotion;
 mod issue_1607_protein_residue_one_guard;
 mod issue_1627_named_element_alphabet_reach;
 mod issue_1632_parse_entry_applies_no_mode;
+mod issue_1713_bare_transcript_genomic_decline;
 mod issue_1715_rna_alignment_symbol_reach;
 mod issue_1748_noncoding_axis_zones;
 mod repeat_input_idempotency;


### PR DESCRIPTION
Closes #1713

Representation-Change: none. No axis changes availability and no rendered HGVS description moves — the only string that changes is the `unavailable:` decline *reason* on the `g.` axis of a bare transcript input, which is diagnostic text and is not a representation. `Status::ProjectionUnavailablePinned` is assigned from `AxisResult::Unavailable(_)` with the payload ignored, so the enumeration census is unmoved (verified: 63/63 including `spec_enumeration_tests`).

## The filed claim does not reproduce, and that is the first finding

#1713 reports `ferro project --axis g` declining bare `NM_`-rooted inputs that "the library demonstrably can produce for the same inputs on the same reference". Measured side by side against the prepared GRCh38 reference (546,290 sequences, cdot 0.2.32, 482,519 transcripts), on `origin/main` at `674e9c8b`:

```
NM_004006.2:c.100del
  CLI  project_axis(.., Axis::Genomic, None)  -> Unavailable
  LIB  project_variant(&v, tx).genomic        -> None
  LIB  project_to_genomic(&v)                 -> Err(UnsupportedProjection:
           "input variant has no parent reference (genomic_context) on accession
            NM_004006.2; project_to_genomic requires an explicit NG/NC parent (see #327)")
  DATA provider transcript chromosome         -> Some("NC_000023.11")
```

There is no CLI/library asymmetry. `select_axis` reads `VariantProjection::genomic` directly, so the CLI reports exactly the value the library computed, and `project_to_genomic` — the dedicated library entry point — declines the same input with a hard error. The decline is **specified**: #327's scope says "when the input has no resolvable parent reference (e.g. plain `NM_…:c.…` with no NG/NC context), return `FerroError::UnsupportedProjection`", and `project_to_genomic_nc` carries a standing comment that it does not synthesize a parent from cdot.

The issue's evidence was `mutalyzer_normalize_tests::axis_genomic_idempotent` passing. That test does `let Ok(g1) = projected else { continue }` — every input that fails to project is silently dropped, so a corpus of bare `NM_` rows would be skipped entirely and the test would still pass on its other rows. It cannot witness this class.

This is **not** the same mechanism as #1798/#1632. Those are about `parse_hgvs` applying no `ErrorConfig`, so the plain parse entry accepts what strict rejects — a config-application gap at the parse seam. This is a projection-capability question at a documented refusal, and the two entry points here agree rather than diverge.

## What was actually defective: the reason, not the verdict

The issue's own third option is what stands — the decline is by design and what is owed is a clearer message. `project_coding_direct` and `project_noncoding_direct` left `AxisDeclineReasons::genomic` unset, so `unavailable_reason` fell back to a string synthesized from the axis code alone:

```
# NM_004006.2:c.100del (line 1) [g]: unavailable: no g. representation for this variant
```

That asserts a property of the **variant**. It is false here in a way anyone can check in one command: the alignment is present, and naming the genomic reference renders the axis immediately (`NC_000023.11(NM_004006.2):c.100del` → `NC_000023.11:g.32849814del`, same reference, same session). The wording is what made a specified decline read as a capability gap — it is why this issue was filed, and it caps projection measurements exactly as the issue describes, since a sweep reads "this variant has no genomic form" rather than "these descriptions need a parent".

**After:**

```
# NM_004006.2:c.100del (line 1) [g]: unavailable: no genomic reference for NM_004006.2: a bare
  transcript description names no genomic parent, so the g. axis cannot be derived (see #327);
  name one in the description, e.g. NC_000023.11(NM_004006.2):c.…
# NM_000492.4:c.1521_1523del (line 2) [g]: unavailable: no genomic reference for NM_000492.4: …
  e.g. NC_000007.14(NM_000492.4):c.…
```

The worked remedy names the reference that transcript is *actually* aligned to — chrX for DMD, chr7 for CFTR — resolved cdot-first with a provider fallback, and elided to `NC_…` rather than invented when the reference names no alignment at all. It runs only on the decline path, so nothing that renders pays for it.

Both direct paths' LRG arms previously discarded their declining error via `.ok()`; they now record it on the same terms.

## `--transcript` has no effect in this direction

The issue asks. Measured: for a transcript-rooted input, `project_axis` only cross-checks `--transcript` against the input's own accession — matching is a no-op, mismatching is a hard error. It can never supply the genomic parent, and the flag's documented role ("required for a bare `g.` input") is the forward direction only.

```
--transcript NM_004006.2   ->  unavailable: … (unchanged)
--transcript NC_000023.11  ->  ERROR: --transcript NC_000023.11 does not match the input's
                               transcript NM_004006.2
```

## Two in-tree comments named the wrong cause

Both `src/cli/project.rs`'s `project_axis_bare_nm_genomic_axis_unavailable` and `src/conformance/spec_projection.rs`'s `coding_input_projects_every_axis_from_one_pass` explained this decline as the fixture carrying "no genome alignment". Neither fixture is like that: both align `NM_TEST.1` to `NC_000001.11` with a full cdot exon table, and sibling tests in the same modules project a bare `NC_000001.11:g.` input onto that transcript successfully. The issue body cites the second of these as the only in-tree assertion of the decline string and reads it exactly as written — so the misdescription propagated. Corrected, with the correction stated rather than silently applied.

## What is deliberately not changed

Deriving a genomic parent from cdot for a bare `NM_` input would reverse #327's recorded design decision and is an adjudication, not a bug fix. Worth noting that ferro already does synthesize one in a single narrow case — #1708 re-parents a junction-crossing output onto the reference the crossing had already resolved, which is why `NM_004006.2:c.1704del` renders `NC_000023.11:g.32573745del` despite arriving bare. That is grounded in `checklist.md:20` and is not a general licence; it is included in the new test corpus precisely so the module pins *agreement* rather than a per-row verdict.

## Tests

- `src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy` — hermetic, runs in CI. Asserts the decline names the accession, the missing genomic reference and the remedy, and does **not** fall back to the axis-code string; then renders the identical variant once the parent is named, in the same test, so the two halves cannot drift.
- `tests/it/issue_1713_bare_transcript_genomic_decline.rs` — manifest-backed.
  - `cli_and_library_agree_on_the_genomic_axis_for_bare_transcript_inputs` pins the invariant #1713 alleged was broken, in both directions (a CLI decline demands a library `None`; a CLI render demands an identical library `Some`), with a `checked == 4` guard so the corpus cannot shrink silently.
  - `the_bare_transcript_genomic_decline_names_its_cause_and_the_remedy` checks the message against real cdot across two chromosomes — a hardcoded accession cannot satisfy both — and then **rebuilds the description the message recommends and projects it**, so the remedy cannot be a well-formed lie.

No fixture files added; all inputs are literals.

## Verification

```
cargo fmt --all                                        clean
cargo clippy --features dev --all-targets -- -D warnings   EXIT=0
cargo nextest run --features dev --no-fail-fast --lib      4250 run, 4250 passed
cargo nextest run --features dev --no-fail-fast --test it \
  -E 'test(cli_project) or test(spec_enumeration) or test(hgvs_spec_normalization)
      or test(issue_1713) or test(cross_axis) or test(clause_ruling_index)
      or test(generator_completeness)'                     63 run, 63 passed
```

Both manifest-backed tests were confirmed to have *run* (~26 s each loading the reference), not skipped.
