### PR TITLE
ci: record the selection-wide FERRO_ASSERT_SEQUENCE measurement test-oracle asked for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ env:
   # NOTE also: `sweeps` selects on this filter PLUS one module it deliberately
   # re-runs — `issue_1615_denoted_sequence_oracle`, the only test that reads the
   # denoted-sequence oracle's counters, which are meaningless unless
-  # `FERRO_ASSERT_SEQUENCE` is set and `sweeps` is the only job that sets it. So
+  # `FERRO_ASSERT_SEQUENCE` is set and `sweeps` is the only job IN THIS FILE that
+  # sets it (`nightly-mutalyzer.yml` sets it too, non-gating). So
   # "nothing is run twice" holds of this filter and is one module short of
   # holding of that job's `-E`; the reason it is appended there rather than added
   # here is on the job itself.
@@ -1311,14 +1312,55 @@ jobs:
         #     the exon table; genome<->transcript mapping is unchanged and stays
         #     exon- and CIGAR-aware.
         #
-        #   Both rows are green, and the flag is STILL not set here, because
-        #   what was measured is the two rows and not this job's selection:
-        #     FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev --test it \
-        #       -E 'test(test_explicit_base_removal)'     # 2 passed
-        #     FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev --test it \
-        #       -E 'test(repeat_tract_maximization)'      # 3 passed
-        #   Arming it here needs a run over the selection below (whole suite
-        #   minus ORACLE_EXCLUDE, test(proptest) and SWEEP_FILTER) first.
+        #   Both rows are green. THE SELECTION-WIDE RUN THIS COMMENT USED TO ASK
+        #   FOR HAS NOW BEEN DONE, and it is RED — so the two closures were
+        #   necessary and not sufficient, and the flag stays unset. Measured on
+        #   `origin/main` @ 674e9c8b, this job's four flags plus
+        #   `FERRO_ASSERT_SEQUENCE=1`, over the `-E` below with its two `env:`
+        #   filters expanded and no `--partition`:
+        #
+        #     Summary [87.5s] 10383 tests run: 10378 passed, 5 failed, 289 skipped
+        #
+        #   FIVE failures, in two classes, NEITHER of them #1618 or #1619 and
+        #   neither reachable by the two-row check this comment used to rest on:
+        #
+        #   * 3x `issue_1487_canonical_window_overflow` — NOT an oracle fire.
+        #     `attempt to add with overflow` at `src/convert/mapper.rs:114`.
+        #     Arming the flag routes the output through `hgvs_to_spdi`, which
+        #     reaches `cds_to_tx`'s unchecked `cds_start as i64 + pos.base - 1`
+        #     on an `i64::MAX`-adjacent `c.` coordinate. That module already
+        #     records the measurement and names the site; the open issue is
+        #     **#1690**. The three are
+        #     `a_lone_member_at_an_extreme_coordinate_…`,
+        #     `an_extreme_coordinate_…` and
+        #     `two_adjacent_members_at_the_top_of_the_range_…`.
+        #   * 2x `stranded_identity_member` — a genuine fire, of #1281's
+        #     "denotes no sequence" shape, on that module's own sweep:
+        #       input  TEMPLATE:g.[10_11insAT;11_12inv;12_13insA]
+        #       output TEMPLATE:g.[11_12insTA;11_12=;12_13insA]
+        #     The output pairs an insertion at interbase 11|12 with an identity
+        #     claiming 11..12, so it denotes nothing. That module exists to PIN
+        #     a defect (#1655's stranded derived identity, 132 of 132
+        #     non-confluent), which puts it in exactly the class `ORACLE_EXCLUDE`
+        #     documents above — a test that pins a defect and an oracle that
+        #     aborts on it cannot both run.
+        #
+        #   Two further notes from the same measurement, so it is not re-run to
+        #   rediscover them. With `FERRO_MANIFEST` also set — which this job does
+        #   NOT set, so CI does not see these — six `mutalyzer_normalize_tests`
+        #   axis tests fail too, on real `NG_` geometry, e.g.
+        #   `NG_012337.1(NM_012459.2):c.4_5insGTA` -> `c.5_6insTAG`, where the
+        #   input applies `GTAA` and the output `ATAG` over `[34, 35)`: an
+        #   insertion shifted 3' past a base its first payload base does not
+        #   match. Those axes early-return without the manifest, which is why
+        #   they read as 11 failures with it and 5 without. And the proof the
+        #   flag is not a no-op over this selection is
+        #   `issue_1615_denoted_sequence_oracle::the_seam_compares_when_the_flag_is_set`,
+        #   which is IN this selection and asserts the oracle's `compared`
+        #   counter is non-zero; it skips by design when the flag is unset.
+        #
+        #   So arming this is blocked on #1690 and on a home for
+        #   `stranded_identity_member` — NOT on another measurement.
         #
         #     This row replaced an earlier one on the same issue
         #     (`NM_000492.4:c.1520_1522del` -> `c.1521_1523del`), and the swap is
@@ -1338,9 +1380,10 @@ jobs:
         # Suppressing a row would hollow out the oracle, which is why neither was
         # ever exempted. It runs in `sweeps` below — the cis-allele space every
         # one of the eight defects it was built for came from, and where it is
-        # measured green — and non-gating in the nightly. Moving it here is now
-        # unblocked by both rows closing, and gated only on the selection-wide
-        # measurement noted above.
+        # measured green — and non-gating in the nightly. Both rows closing
+        # unblocked the two obstacles this comment knew about; the selection-wide
+        # run above then found two more, so the flag stays out until those are
+        # settled. Do not read "both rows are green" as "it can be armed".
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
@@ -1530,7 +1573,9 @@ jobs:
         # one is exactly the edit that would drop a sweep from CI silently.
         #
         # `issue_1615_denoted_sequence_oracle` is appended to the selection
-        # because this job is the only one that sets `FERRO_ASSERT_SEQUENCE`, and
+        # because this job is the only one IN THIS FILE that sets
+        # `FERRO_ASSERT_SEQUENCE` (`nightly-mutalyzer.yml` sets it too, but it is
+        # non-gating and selects only the reference-aware modules), and
         # that module holds the one test which reads the oracle's counters —
         # `the_seam_compares_when_the_flag_is_set`, the guard that a green run
         # actually compared something rather than the seam call having been

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,8 +325,8 @@ is the only place the check runs against true transcript and contig lengths.
 
 **The fourth flag is not set in all of those places, so do not read "all four"
 off this paragraph.** `FERRO_ASSERT_SEQUENCE` runs in `sweeps` and in the
-nightly, and deliberately not in `test-oracle` — the reason, and the two rows
-that keep it out, are under
+nightly, and deliberately not in `test-oracle` — the reason, and what currently
+keeps it out, are under
 [Where it runs, and the one place it deliberately does not](#normalization-denoted-sequence-oracle)
 below and in `ci.yml`'s comment on the `test-oracle` job.
 
@@ -347,6 +347,13 @@ a local run to that job's selection rather than to the whole suite. Added to
 `ORACLE_EXCLUDE`'s modules it raises **5** further failures beyond the
 idempotency oracle's 7, all in `spec_corpus_regressions` and all the same shape
 as those: a test pinning the CDS-end defect that this oracle aborts on.
+
+**That 5 is about `ORACLE_EXCLUDE`'s modules, and there is a second, unrelated 5
+below.** `test-oracle`'s own selection *excludes* those modules, and arming the
+flag over it raises 5 failures too — none of them in `spec_corpus_regressions`
+and none of them the same defect. The two figures share a digit and nothing
+else, so never carry one over to the other's scope; say which selection a count
+was taken on, every time.
 
 **The other three are all form questions, and a wrong sequence passes all of
 them.** It is a fixed point, so `FERRO_ASSERT_IDEMPOTENT` is satisfied; it
@@ -412,8 +419,9 @@ both were real disagreements inside ferro rather than noise:
 | #1618 — `NC_TEST.1:g.262TG[6]` → `g.259_262GT[6]` | `hgvs_to_spdi` read the anchored spelling as 6 copies replacing a **1**-copy tract, the normalizer's output as 6 copies replacing a **2**-copy tract — 14 bases against 12 | closed before `6116f84a` |
 | #1619 — `NM_033517.1:c.4818dupC` → `c.4818dup` | `hgvs_to_spdi` resolved the `c.` position by **walking** the exon list while the normalizer indexes the **flat** transcript, so the two disagreed across any transcript-coordinate gap: the input applied `C`, the output `T`, at transcript position 4877. `NM_033517.1` carries a real 39-base cdot hole between exons 10 and 11 — see below, because this row **replaced** an earlier one on the same issue | closed by the flat-frame fix: `cds_to_tx`/`tx_to_cds` no longer read the exon table |
 
-**Both are now green, and the flag is still not set here — deliberately, for
-one measurement short of the claim.** Measured on the #1619 branch:
+**Both are now green, and the flag is STILL not set here — the selection-wide
+run those two closures were blocking on has since been done, and it is RED.**
+The two-row measurement, on the #1619 branch, was this:
 
 ```bash
 FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev --test it \
@@ -423,9 +431,27 @@ FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev --test it \
 ```
 
 That is the two named rows, not `test-oracle`'s selection, which is the whole
-suite minus `ORACLE_EXCLUDE`, `test(proptest)` and `SWEEP_FILTER`. Arming the
-flag in that job is a CI change that needs a run over **that** selection before
-anyone can say it is green, so it is a follow-up rather than a rider on the fix.
+suite minus `ORACLE_EXCLUDE`, `test(proptest)` and `SWEEP_FILTER`. Run over
+**that** selection — `origin/main` @ 674e9c8b, this job's own env plus
+`FERRO_ASSERT_SEQUENCE=1`, no `--partition` — it reads
+`10383 tests run: 10378 passed, 5 failed, 289 skipped`. The five are in two
+classes, **neither of them #1618 or #1619**, so neither was reachable by the
+two-row check above:
+
+- **3x `issue_1487_canonical_window_overflow`** — not an oracle fire at all.
+  `attempt to add with overflow` at `src/convert/mapper.rs:114`: arming the flag
+  routes the output through `hgvs_to_spdi`, which reaches `cds_to_tx`'s unchecked
+  `cds_start as i64 + pos.base - 1` on an `i64::MAX`-adjacent `c.` coordinate.
+  The open issue is **#1690**.
+- **2x `stranded_identity_member`** — a genuine fire, of #1281's "denotes no
+  sequence" shape, on a module that exists to PIN a defect (#1655's stranded
+  derived identity). That is the class `ORACLE_EXCLUDE` already documents: a test
+  pinning a defect and an oracle aborting on it cannot both run.
+
+So arming it is blocked on **#1690** and on finding a home for
+`stranded_identity_member` — **not** on another measurement. Do not read "both
+rows are green" as "it can be armed". `ci.yml`'s comment on the `test-oracle`
+job carries the full triage, including what a run with `FERRO_MANIFEST` set adds.
 Suppressing a row would still hollow out the oracle; that has not changed.
 
 **#1619's row was replaced before it was closed, and the swap is the whole

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -51,11 +51,20 @@
 #   scripts/run_oracle_suite.sh -E 'test(foo)'     # extra args go through to nextest
 #
 # The denoted-sequence oracle (`FERRO_ASSERT_SEQUENCE`) is deliberately NOT
-# among the flags this mirrors, because `test-oracle` does not set it -- see
-# that job's comment for the two rows (#1618, #1619) that keep it out. Setting
-# it on this selection adds 5 further failures on `main`, all in
-# `spec_corpus_regressions` and all the same shape: a test pinning a defect the
-# oracle aborts on.
+# among the flags this mirrors, because `test-oracle` does not set it. Nothing
+# has to be done here to keep that true: `oracle_flags` below READS the flag set
+# out of that job, so this script arms it on the day the job does and not
+# before.
+#
+# The figure this header used to quote -- "5 further failures, all in
+# `spec_corpus_regressions`" -- was about `ORACLE_EXCLUDE`'s modules, which this
+# selection does not run, so it never described what it claimed to. Measured
+# over THIS selection instead, on `origin/main` @ 674e9c8b: 5 failures, none of
+# them in `spec_corpus_regressions` -- 3 in `issue_1487_canonical_window_overflow`
+# (an `i64` overflow at `src/convert/mapper.rs:114`, issue #1690) and 2 in
+# `stranded_identity_member` (a real fire on a module that PINS a defect). The
+# blocking rows are no longer #1618/#1619, both of which are closed and green;
+# see `test-oracle`'s own comment in `ci.yml` for the full triage.
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -306,8 +306,11 @@ const LOCAL_RUNNER: &str = "scripts/run_oracle_suite.sh";
 /// Comment lines are skipped for the reason the awk skips them: the job's
 /// comment block *mentions* `FERRO_ASSERT_SEQUENCE` in prose, to explain why it
 /// is absent. A scan that read the prose as a setting would demand the runner
-/// arm an oracle CI does not — and the two rows that comment names (#1618,
-/// #1619) would then be red locally and green in CI.
+/// arm an oracle CI does not — and the rows that comment names would then be red
+/// locally and green in CI. Note those rows are no longer #1618/#1619, which are
+/// both closed: a selection-wide run at `674e9c8b` put the count at 5, in
+/// `issue_1487_canonical_window_overflow` (issue #1690) and
+/// `stranded_identity_member`.
 fn test_oracle_job_flags() -> Vec<String> {
     test_oracle_job_lines()
         .into_iter()
@@ -521,7 +524,9 @@ fn the_ci_oracle_selection_negates_proptest_the_sweeps_and_the_corpus_modules() 
 /// **fewer** makes a local run weaker than CI while reading as an oracle pass.
 /// Arming **more** — `FERRO_ASSERT_SEQUENCE` is the live candidate, since
 /// `test-oracle` deliberately withholds it — makes the runner red on rows no PR
-/// caused, which teaches the operator to ignore it.
+/// caused, which teaches the operator to ignore it. That is not hypothetical:
+/// arming it over this exact selection at `674e9c8b` is red, 5 tests, so a
+/// runner that armed it ahead of the job would be red on every PR.
 #[test]
 fn the_local_oracle_runner_arms_exactly_the_flags_test_oracle_arms() {
     let runner_flags = local_runner_selection().flags;


### PR DESCRIPTION
`test-oracle`'s comment block stated that `FERRO_ASSERT_SEQUENCE` was unset only because the evidence for arming it was two rows rather than the job's own selection, and that arming it "needs a run over the selection below (whole suite minus ORACLE_EXCLUDE, test(proptest) and SWEEP_FILTER) first". Both rows it named — #1618 and #1619 — are now closed and green.

**That run has now been done, and it is red.** The two closures were necessary and not sufficient. This PR records the measurement; it does **not** arm the flag and does **not** change the selection.

## The measurement

Measured on `origin/main` @ `674e9c8b`, with `test-oracle`'s own four flags plus `FERRO_ASSERT_SEQUENCE=1`, over that job's `-E` with `SWEEP_FILTER` and `ORACLE_EXCLUDE` expanded from `ci.yml` and no `--partition`:

```
not test(proptest)
  and not (test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap) + test(issue_1254_sibling_crossing_shift))
  and not (test(spec_conformance_axis) + test(spec_corpus_regressions) + test(corpus_alphabet_and_intronic_validity) + test(corpus_prohibited_inputs) + test(lenient_overlap_and_projection_split) + test(defect_non_idempotent_outputs) + test(issue_1715_rna_alignment_symbol_reach))
```

```
Summary [87.5s] 10383 tests run: 10378 passed, 5 failed, 289 skipped
```

The expression was derived by parsing `ci.yml` rather than transcribed, and cross-checked byte-for-byte against `scripts/run_oracle_suite.sh --print-selection`, which derives it independently.

## The five failures, in two classes

Neither class is #1618 or #1619, and neither is reachable by the two-row check the comment rested on.

**3x `issue_1487_canonical_window_overflow`** — not an oracle fire at all. `attempt to add with overflow` at `src/convert/mapper.rs:114`. Arming the flag routes the normalized output through `hgvs_to_spdi`, which reaches `cds_to_tx`'s unchecked `cds_start as i64 + pos.base - 1` on an `i64::MAX`-adjacent `c.` coordinate. That module already records this measurement in its own comments and names the site; the open issue is **#1690**.

**2x `stranded_identity_member`** — a genuine fire, of #1281's "denotes no sequence" shape:

```
input   TEMPLATE:g.[10_11insAT;11_12inv;12_13insA]
output  TEMPLATE:g.[11_12insTA;11_12=;12_13insA]
```

The output pairs an insertion at interbase 11|12 with an identity claiming 11..12, so it denotes nothing. That module exists to **pin** a defect (#1655's stranded derived identity, 132 of 132 non-confluent), which places it in exactly the class `ORACLE_EXCLUDE`'s comment already documents: a test that pins a defect and an oracle that aborts on it cannot both run.

Neither is suppressed here. Excluding either to get a green would hollow out the oracle, which is the one thing the existing comment is emphatic about.

## Two further findings from the same run, recorded so they are not rediscovered

With `FERRO_MANIFEST` also set — which `test-oracle` does **not** set, so CI does not see these — six `mutalyzer_normalize_tests` axis tests fail as well, on real `NG_` geometry. For example `NG_012337.1(NM_012459.2):c.4_5insGTA` normalizes to `c.5_6insTAG`, where over `[34, 35)` the input applies `GTAA` and the output `ATAG` — an insertion shifted 3' past a base its first payload base does not match. Those axes early-return without the manifest, which is why the run reads 11 failures with it and 5 without.

**Proof the flag is not a no-op over this selection:** `issue_1615_denoted_sequence_oracle::the_seam_compares_when_the_flag_is_set` is in this selection and asserts the oracle's `compared` counter is non-zero; it passes with the flag set and skips by design without it. The five failures are themselves the stronger evidence.

## Also corrected

- `ci.yml`'s two "the only job that sets `FERRO_ASSERT_SEQUENCE`" claims (at the `SWEEP_FILTER` note and on the `sweeps` job) are true only *within this file* — `nightly-mutalyzer.yml:201` sets it too, non-gating. Both now say so.
- `scripts/run_oracle_suite.sh`'s header quoted "5 further failures on `main`, all in `spec_corpus_regressions`". That figure is about `ORACLE_EXCLUDE`'s modules, which this script's selection does not run, so it never described what it claimed to. Replaced with the measurement over the selection it actually mirrors. The script needs no code change to stay correct — `oracle_flags` reads the flag set out of `ci.yml`, so it will arm the flag on the day the job does.
- The two `tests/it/oracle_exclude_invariant.rs` doc comments that still named #1618/#1619 as the blocking rows.

## Scope

Comment-only. `git diff` contains no non-comment line. The flag remains unset, the `-E` selection is untouched, and `sweeps` and `nightly-mutalyzer.yml` are unchanged. Arming `test-oracle` is now blocked on #1690 and on finding a home for `stranded_identity_member` — not on another measurement.

Verified: `actionlint .github/workflows/ci.yml` clean, `cargo fmt --all --check` clean, and all 14 tests that parse `ci.yml` (`oracle_exclude_invariant`, `sweep_filter_invariant`, `generated_fixture_ci_wiring`) pass.

Representation-Change: none. CI comments and test doc comments only; no watched directory is touched and no output moves.