### PR TITLE
test(conformance): a codon-designed protein corpus, and the protein axis's first census

### DIFF
--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -19,6 +19,7 @@ pub mod error_mode_stamp;
 pub mod hgvs_rs_projection;
 pub mod inversion_sweep;
 pub mod mutalyzer;
+pub mod protein_corpus;
 pub mod reference_snapshot;
 pub mod reference_window;
 pub mod schema;

--- a/src/conformance/protein_corpus.rs
+++ b/src/conformance/protein_corpus.rs
@@ -1,0 +1,1809 @@
+//! A codon-designed **protein** conformance corpus, enumerated deterministically.
+//!
+//! # The measurement gap this closes
+//!
+//! [`synthetic_protein`](super::synthetic_protein) supplies a protein reference
+//! coupled to its transcript, and an amino-acid-level denotation oracle over it.
+//! It deliberately adds no corpus rows, so the protein axis has been
+//! *measurable* and not *measured*. This module is the rows.
+//!
+//! # Why the cores had to be redesigned rather than reused
+//!
+//! [`spec_corpus`](super::spec_corpus) draws its cores from a xorshift stream
+//! over an `AT` or `ACGT` alphabet and lays a CDS over them at
+//! `(tx_len/8 + 1, tx_len - tx_len/8)` — a *ratio*, not a codon boundary. Such a
+//! core is an open reading frame only by accident: it need not start with a
+//! start codon, its CDS length need not be a multiple of three, and any of its
+//! interior codons may be a terminator, which truncates the translation. Almost
+//! none of them translate to anything a `p.` description can be written against,
+//! so a protein stratum could not have been drawn from them.
+//!
+//! [`codon_core`] designs the CDS instead: an `ATG`, a body of sense codons
+//! drawn from ferro's own [`CodonTable`], and a terminator. It is handed to
+//! [`ProteinFrame::from_cds`], which **translates** it — so the peptide is
+//! derived from the codons rather than the codons back-derived from a peptide,
+//! and the frame's round-trip check still guarantees that what the provider
+//! serves as `NP_TEST.1` is what `NM_TEST.1`'s CDS translates to.
+//!
+//! Back-translation would not have done. [`ProteinFrame::build`] takes the
+//! table's *first* codon for each residue, so every CDS it can build holds at
+//! most 20 distinct codons and no synonymous pair at all — and the single most
+//! interesting property a protein corpus has over a nucleotide one is
+//! unreachable in it: **a tandem repeat of one residue spelled in four
+//! different synonymous codons**, which is an ambiguous run on the protein axis
+//! and no run whatsoever on the nucleotide axis. [`RUN_RESIDUE`]'s tract is
+//! exactly that shape, and `tests::the_ambiguous_run_is_invisible_to_the_nucleotide_axis`
+//! is the demonstration.
+//!
+//! # #1810's generator was read and NOT reused
+//!
+//! `tests/it/codon_frame_deep_window_offset.rs` builds `"ATG" + "GCT".repeat(199)`
+//! for the *coding* axis's codon exception. Its two design choices are both
+//! deliberately wrong for this corpus: a **uniform** codon (so every residue is
+//! `Ala` and no residue identity varies) and **no UTR** with `cds_start = 1` (so
+//! there is no 5'UTR for an N-terminal extension to start in and no 3'UTR for a
+//! C-terminal one to read into). What is taken from it is its finding rather
+//! than its code — that a site near `c.1` has its window clamped and therefore
+//! its phase forced to zero — which is why [`CoreDesign::body_codons`] is large
+//! enough to place the designed sites deep in the CDS.
+//!
+//! # The structural-blindness audit
+//!
+//! Five blindnesses have been found in this repository's generators, each
+//! invisible until the one before it was fixed. A protein stratum is exactly the
+//! kind of generator that acquires a sixth, so every property it varies is named
+//! here **and demonstrated by a test**, and every property it provably cannot
+//! reach is stated as a limit rather than left to read as coverage.
+//!
+//! | property | varied by | demonstrated by |
+//! |---|---|---|
+//! | residue position class | [`Site`] — initiator, second residue, deep interior, last residue, the terminator, and past the end | `every_site_class_is_reached` |
+//! | reading-frame phase at a splice junction | [`CoreDesign::body_codons`] mod 3; see [`CoreDesign::junction_phase`] | `both_junction_phases_are_reached_and_so_is_neither` |
+//! | transcript geometry | [`ProteinRefShape`] — one exon (the #1478 control) and three exons | `every_shape_is_reached` |
+//! | strand | [`ProteinRefShape::ThreeExon`] on both strands | `every_shape_is_reached` |
+//! | synonymous codon identity | [`codon_core`] draws filler codons from the whole table, not one per residue | `the_generator_reaches_most_of_the_codon_table` |
+//! | protein-axis ambiguity with no nucleotide-axis ambiguity | [`RUN_RESIDUE`]'s synonymous tract | `the_ambiguous_run_is_invisible_to_the_nucleotide_axis` |
+//! | terminator codon identity | [`CoreDesign::stop_index`] | `every_stop_codon_is_reached` |
+//! | edit type | [`Kind`] | `every_kind_is_reached` |
+//! | determinacy class | [`ProteinDenotation`] — a sequence, an [`Indeterminate`](super::synthetic_protein::Indeterminate), `p.0`, or none | `every_determinacy_class_is_reached` |
+//! | member count | 1 and 2, in cis | `every_kind_is_reached` |
+//! | epistemic claim, at one denotation | [`RowKind::Distinguished`] — a description beside its parenthesised twin | `every_kind_is_reached` |
+//!
+//! ## What it provably cannot reach — declared, not omitted
+//!
+//! - **`Sec` and `Pyl`.** `Sec`'s only codon is read as a terminator by the
+//!   standard table and `Pyl` has none at all, so neither can appear in a
+//!   designed CDS. Any defect specific to them is outside this corpus.
+//! - **`Xaa` in the reference.** A reference residue is whatever a codon
+//!   translates to, and no codon translates to "unknown". `Xaa` is reachable
+//!   only in a *description* (`insXaa[n]`), which the corpus does generate.
+//! - **A non-standard genetic code.** [`CodonTable::standard`] is the only table
+//!   used, so the mitochondrial reassignments are unreachable and an `m.`-axis
+//!   protein defect is invisible here.
+//! - **An incomplete or non-triplet CDS.** [`ProteinFrame::from_cds`] refuses
+//!   one, by construction — the frame's round trip is what makes the oracle's
+//!   answers mean anything, and it cannot hold for a CDS that does not
+//!   translate. A transcript annotated with a partial CDS is therefore a real
+//!   shape this corpus cannot express.
+//! - **Codon-level ambiguity *within* one residue.** Two spellings of a `p.`
+//!   description cannot differ in codon, because a `p.` description names no
+//!   codons — see the next section.
+//! - **An intronic or UTR position.** `p.` numbering has no zone outside the
+//!   protein, so [`Region`](super::spec_corpus::Region)'s nine placements
+//!   collapse to the seven in [`Site`] here, and the two axes' position
+//!   taxonomies overlap only at "somewhere in the middle".
+//!
+//! ## And one limit that is a property of the AXIS, not of the generator
+//!
+//! A `p.` description has no codons of its own — `tests/it/protein_axis_split_move.rs`
+//! states it in as many words, arguing from `general.md:35-38` being a
+//! *reading-frame* exception. So the phase and strand dimensions above are
+//! varied in the **frame** and may well be inert in a `p.`-only measurement.
+//! That is measured rather than assumed: `shape_is_inert_for_the_protein_axis`
+//! in `tests/it/protein_conformance_axis.rs` reports whether any row's outcome
+//! differs across the three geometries. A measured inertness is a fact about the
+//! axis worth recording; an *assumed* one would be the sixth blindness.
+//!
+//! # What a green run does NOT say
+//!
+//! The oracle judges **denotation** and not validity, deliberately: a
+//! one-for-one `delins`, a `Cys76_Cys76` range and `p.[Arg76Ser;Cys77Trp]` all
+//! denote a sequence perfectly well while the recommendations rule against each
+//! spelling. The protein slice is **205 clause units** across nine files —
+//! re-derived here from the checkout with the inventory's own definition, "a
+//! line opening a bullet (`- `/`* `), a numbered item (`1. `), or an admonition
+//! block (`!!! `)". **All 205 are classified `not-generatable`** by the
+//! inventory, and this change does not reclassify one of them: a denotation
+//! oracle cannot test a requirement on how a description is *written*, and that
+//! is what a validity clause is.
+//!
+//! **A figure inherited from `synthetic_protein.rs` does not reconcile and is
+//! not restated here.** That module's docs say "149 clauses (102 of them
+//! validity requirements)". The committed rule inventory
+//! (`tests/fixtures/spec-corpus/spec_rule_inventory.json`) counts **205** clause
+//! units over `docs/recommendations/protein/*` at spec checkout `6f85311`, which
+//! an independent re-derivation reproduces file for file; and nothing in the
+//! repository classifies a clause as a "validity requirement", so the 102 has no
+//! recoverable denominator either. Quote 205, or re-derive; do not quote 149.
+//!
+//! The rule inventory's `not-generatable` classification for
+//! `docs/recommendations/protein/*` is therefore **left in place** by this
+//! module, and must not be lifted on the strength of a green census.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::backtranslate::codon::{Codon, CodonTable};
+use crate::conformance::synthetic_protein::{
+    protein_denotation_of, ProteinDenotation, ProteinFrame, ProteinRefShape,
+};
+use crate::hgvs::location::AminoAcid;
+
+// ---------------------------------------------------------------------------
+// The designed core
+// ---------------------------------------------------------------------------
+
+/// The residue the ambiguous tract is built from.
+///
+/// `Ala` because the standard table gives it four codons (`GCA/GCC/GCG/GCT`),
+/// which is enough for every residue of a four-copy tract to be spelled
+/// differently — the property that makes the tract ambiguous on the protein axis
+/// and not on the nucleotide one.
+pub const RUN_RESIDUE: AminoAcid = AminoAcid::Ala;
+
+/// Copies of [`RUN_RESIDUE`] in the ambiguous tract.
+///
+/// Four, because that is the largest tract every four-codon residue can spell
+/// without repeating a codon, and because a tract of `n` copies yields `n`
+/// equivalent single-residue deletions and `n` equivalent duplications — the
+/// corpus's whole confluence signal comes from here.
+pub const RUN_COPIES: usize = 4;
+
+/// Residues the filler is drawn from, in a fixed order.
+///
+/// Chosen so no two adjacent filler residues are equal (which would create an
+/// undesigned ambiguous run beside the designed one) and so that none of them is
+/// [`RUN_RESIDUE`] (which would extend the designed tract past its intended
+/// bounds). `Met` is included so an **interior** `Met` exists and start-codon
+/// reasoning has something other than residue 1 to look at.
+const FILLER: &[AminoAcid] = &[
+    AminoAcid::Arg,
+    AminoAcid::Ser,
+    AminoAcid::Trp,
+    AminoAcid::Gly,
+    AminoAcid::Cys,
+    AminoAcid::Met,
+    AminoAcid::Leu,
+    AminoAcid::Thr,
+    AminoAcid::Tyr,
+    AminoAcid::Pro,
+    AminoAcid::Val,
+    AminoAcid::His,
+    AminoAcid::Phe,
+    AminoAcid::Gln,
+    AminoAcid::Ile,
+    AminoAcid::Asn,
+    AminoAcid::Glu,
+    AminoAcid::Lys,
+    AminoAcid::Asp,
+];
+
+/// 1-based residue the ambiguous tract starts at.
+///
+/// Deep enough that the tract sits past the regime
+/// `tests/it/codon_frame_deep_window_offset.rs` shows is structurally blind: a
+/// site within `CANONICAL_PAD` (128) of the transcript start has its canonical
+/// window clamped there, which forces the trim offset to a multiple of three and
+/// therefore the codon phase to zero. Residue 50's codon starts at `c.148`,
+/// transcript position 160, which clears it.
+///
+/// **It buys nothing for the `p.`-only census, and it is here on purpose.** A
+/// protein description names no codons, so the nucleotide canonical window is
+/// not consulted at all for the rows this corpus measures today. What the depth
+/// removes is a caveat: any later stratum pairing a `c.` spelling with its `p.`
+/// consequence inherits a frame that is already out of the clamped regime,
+/// rather than one whose zeros would have to be re-derived.
+///
+/// See `tests::the_tract_clears_the_canonical_window_clamp`, which checks the
+/// arithmetic rather than trusting this comment.
+pub const RUN_START: u64 = 50;
+
+/// One designed reading frame.
+///
+/// Three knobs, and each one exists to vary a property that would otherwise be
+/// structurally unreachable — see [`Self::junction_phase`] for the third, which
+/// is the subtle one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CoreDesign {
+    /// Which deterministic draw the filler residues and their codons come from.
+    pub seed: u32,
+    /// Codons in the CDS, terminator included.
+    ///
+    /// **This is the phase knob.** See [`Self::junction_phase`].
+    pub body_codons: usize,
+    /// Which of the three terminators ends the CDS.
+    pub stop_index: usize,
+}
+
+impl CoreDesign {
+    /// Where the exon-1/exon-2 junction falls relative to a codon, on a
+    /// [`ProteinRefShape::ThreeExon`] frame: `0` when it falls on a codon
+    /// boundary, otherwise the number of the straddling codon's bases that lie
+    /// in exon 1.
+    ///
+    /// # Why this is derivable at all, which is the point
+    ///
+    /// [`ProteinFrame`] wraps the CDS in a fixed 12-base UTR each side and lays
+    /// the result out with `three_exon_layout`, whose first exon ends at
+    /// `tx_len / 3`. With `c` codons, `tx_len = 24 + 3c`, so the junction sits
+    /// after transcript position `8 + c` — and residue `r`'s codon starts at
+    /// transcript position `3r + 10`. Solving `8 + c = 3r + 9 + k` gives
+    /// `c = 3r + 1 + k`, so the phase is `(c - 1) mod 3` and **nothing else**.
+    ///
+    /// A generator that fixed the CDS length would therefore have fixed the
+    /// phase, and every row it built would have agreed with every other on the
+    /// one dimension a splice-junction defect lives in. That is the #1478 shape
+    /// exactly, one level down. Varying `body_codons` over three consecutive
+    /// values reaches all three phases; [`all_designs`] does.
+    #[must_use]
+    pub fn junction_phase(self) -> usize {
+        (self.body_codons + 2) % 3
+    }
+
+    /// Stable label, used in row ids.
+    #[must_use]
+    pub fn label(self) -> String {
+        format!("s{}c{}t{}", self.seed, self.body_codons, self.stop_index)
+    }
+
+    /// Residues in the peptide the design translates to — the terminator is a
+    /// codon of the CDS and not a residue of the protein.
+    #[must_use]
+    pub fn residues(self) -> usize {
+        self.body_codons - 1
+    }
+}
+
+/// Every design the corpus enumerates.
+///
+/// Three consecutive `body_codons` so all three junction phases are reached
+/// (see [`CoreDesign::junction_phase`]), each with its own terminator so the
+/// three stop codons are reached too, and two seeds so no measured figure rests
+/// on one draw of the filler.
+#[must_use]
+pub fn all_designs() -> Vec<CoreDesign> {
+    let mut designs = Vec::new();
+    for seed in 0..2u32 {
+        for (offset, stop_index) in (0..3usize).enumerate() {
+            designs.push(CoreDesign {
+                seed,
+                // 100, 101, 102 — phases 0, 1, 2 respectively, and all of them
+                // long enough to put `RUN_START`'s tract past the canonical
+                // window clamp and to leave a determinate interior, a last
+                // residue and a terminator beyond it.
+                body_codons: 100 + offset,
+                stop_index,
+            });
+        }
+    }
+    designs
+}
+
+/// Build the CDS for `design`: a start codon, a body of sense codons holding the
+/// designed ambiguous tract, and a terminator.
+///
+/// The tract's `RUN_COPIES` residues are all [`RUN_RESIDUE`] and each is spelled
+/// with a **different** synonymous codon, which is the corpus's one shape that a
+/// nucleotide-axis corpus structurally cannot hold. Everything else is filler,
+/// drawn so that no residue adjacent to the tract equals [`RUN_RESIDUE`] — an
+/// accidental fifth copy would silently change every ambiguity the tract is
+/// there to create.
+///
+/// # Panics
+///
+/// If `design.body_codons` is too small to hold the tract at [`RUN_START`], or
+/// if ferro's own codon table cannot spell a residue this module names — both of
+/// which are programming errors in this module rather than inputs.
+#[must_use]
+pub fn codon_core(design: CoreDesign) -> String {
+    let table = CodonTable::standard();
+    let run_codons = table.codons_for(&RUN_RESIDUE);
+    assert!(
+        run_codons.len() >= RUN_COPIES,
+        "{RUN_RESIDUE:?} has {} codons, too few for a {RUN_COPIES}-copy tract",
+        run_codons.len()
+    );
+    let residues = design.residues();
+    let run_start = usize::try_from(RUN_START).expect("RUN_START fits a usize");
+    assert!(
+        run_start + RUN_COPIES <= residues,
+        "design {} has {residues} residues, too few for a tract at {run_start}",
+        design.label()
+    );
+
+    let mut state = u64::from(design.seed)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(0x0123_4567_89AB_CDEF)
+        | 1;
+    let mut draw = move |modulus: usize| {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        (state % modulus as u64) as usize
+    };
+
+    let mut cds = String::with_capacity(design.body_codons * 3);
+    // Residue 1 is the initiator. `ATG` is the only `Met` codon, so this is not
+    // a choice.
+    cds.push_str(&codon_for(&table, AminoAcid::Met, 0).to_string());
+    let mut previous = AminoAcid::Met;
+    for residue in 2..=residues {
+        let (aa, codon) = if (run_start..run_start + RUN_COPIES).contains(&residue) {
+            let copy = residue - run_start;
+            (RUN_RESIDUE, run_codons[copy].clone())
+        } else {
+            // Never `RUN_RESIDUE` and never the residue before it, so the only
+            // tandem run in the protein is the designed one.
+            let mut aa = FILLER[draw(FILLER.len())];
+            let mut guard = 0usize;
+            while aa == previous && guard < FILLER.len() {
+                aa = FILLER[draw(FILLER.len())];
+                guard += 1;
+            }
+            let options = table.codons_for(&aa);
+            let pick = draw(options.len().max(1));
+            (aa, codon_for(&table, aa, pick))
+        };
+        previous = aa;
+        cds.push_str(&codon.to_string());
+    }
+    let stops = table.stop_codons();
+    cds.push_str(&stops[design.stop_index % stops.len()].to_string());
+    cds
+}
+
+/// The `pick`-th codon the standard table lists for `aa`.
+///
+/// # Panics
+///
+/// If the table lists none, or lists only terminators — neither of which is true
+/// for any residue [`FILLER`] or [`RUN_RESIDUE`] names.
+fn codon_for(table: &CodonTable, aa: AminoAcid, pick: usize) -> Codon {
+    let options: Vec<&Codon> = table
+        .codons_for(&aa)
+        .iter()
+        .filter(|codon| !table.is_stop(codon))
+        .collect();
+    assert!(
+        !options.is_empty(),
+        "the standard table cannot spell {aa:?} without a terminator"
+    );
+    options[pick % options.len()].clone()
+}
+
+/// Build the frame for `design` on `shape`.
+///
+/// # Panics
+///
+/// If the designed CDS does not round-trip through [`ProteinFrame::from_cds`],
+/// which would mean [`codon_core`] built something that is not an open reading
+/// frame — a defect in this module, and one that must be loud rather than
+/// silently dropped from the corpus.
+#[must_use]
+pub fn frame_for(shape: ProteinRefShape, design: CoreDesign) -> ProteinFrame {
+    let cds = codon_core(design);
+    ProteinFrame::from_cds(shape, &cds)
+        .unwrap_or_else(|why| panic!("designed core {} is not a CDS: {why}", design.label()))
+}
+
+// ---------------------------------------------------------------------------
+// The row taxonomy
+// ---------------------------------------------------------------------------
+
+/// Where in the protein a row's edit sits.
+///
+/// The protein analogue of [`Region`](super::spec_corpus::Region), and shorter
+/// for a reason worth stating: `p.` numbering has exactly one zone, so the
+/// 5'UTR / intronic / junction placements a `c.` row can take do not exist
+/// here. What replaces them is the terminator, which a `c.` row has no analogue
+/// of at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Site {
+    /// Residue 1, the initiator `Met`.
+    ///
+    /// **A substitution here is structurally undescribable, and that is
+    /// correct.** `protein/substitution.md:49` forbids `p.Met1Xxx` and ferro's
+    /// parser enforces it, naming the legal alternatives (`p.0`, `p.0?`,
+    /// `p.(Met1?)`, or the insertion form). So the substitution and uncertainty
+    /// strata both drop their initiator row, 36 drops in all, and the drop is
+    /// evidence the clause is enforced rather than a hole in the corpus. The
+    /// site is still reached, by `p.0`, `p.0?` and the N-terminal extension.
+    Initiator,
+    /// Residue 2 — adjacent to the initiator, so an edit here is the first that
+    /// does not engage `protein/substitution.md:49`'s `p.Met1` rule.
+    SecondResidue,
+    /// Inside the designed ambiguous tract.
+    AmbiguousRun,
+    /// A determinate interior residue, deep in the CDS.
+    DeepInterior,
+    /// The last residue before the terminator.
+    LastResidue,
+    /// The terminator itself, at protein position `len + 1`.
+    Terminator,
+    /// A position past the terminator, which the reference does not have.
+    PastEnd,
+}
+
+impl Site {
+    /// Every site, in a deterministic order.
+    #[must_use]
+    pub fn all() -> Vec<Self> {
+        vec![
+            Self::Initiator,
+            Self::SecondResidue,
+            Self::AmbiguousRun,
+            Self::DeepInterior,
+            Self::LastResidue,
+            Self::Terminator,
+            Self::PastEnd,
+        ]
+    }
+
+    /// Stable label, used in row ids and censuses.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Initiator => "initiator",
+            Self::SecondResidue => "second",
+            Self::AmbiguousRun => "run",
+            Self::DeepInterior => "interior",
+            Self::LastResidue => "last",
+            Self::Terminator => "terminator",
+            Self::PastEnd => "past-end",
+        }
+    }
+
+    /// The 1-based protein position this site names on `frame`.
+    #[must_use]
+    pub fn position(self, frame: &ProteinFrame) -> u64 {
+        let residues = frame.residues().len() as u64;
+        match self {
+            Self::Initiator => 1,
+            Self::SecondResidue => 2,
+            Self::AmbiguousRun => RUN_START,
+            // Between the tract and the last residue, so it is neither.
+            Self::DeepInterior => RUN_START + RUN_COPIES as u64 + 2,
+            Self::LastResidue => residues,
+            Self::Terminator => residues + 1,
+            Self::PastEnd => residues + 2,
+        }
+    }
+}
+
+/// The edit types a row is built from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Kind {
+    /// A one-residue substitution, and its `delins` and parenthesised spellings.
+    Substitution,
+    /// A deletion inside the ambiguous tract, spelled at every equivalent
+    /// position.
+    Deletion,
+    /// A duplication inside the ambiguous tract, likewise.
+    Duplication,
+    /// An insertion of the tract's own residue at a junction inside it.
+    Insertion,
+    /// A repeat count over the tract, against the explicit del/dup spellings of
+    /// the same protein.
+    Repeat,
+    /// An edit that denotes the reference.
+    Identity,
+    /// A frameshift.
+    Frameshift,
+    /// An extension, N- or C-terminal.
+    Extension,
+    /// A payload stated by count rather than by identity.
+    ByCount,
+    /// `p.0` / `p.0?`.
+    NoProtein,
+    /// Two members in cis.
+    CisAllele,
+    /// A description beside its parenthesised, evidence-declining twin.
+    Uncertainty,
+}
+
+impl Kind {
+    /// Stable label, used in row ids and censuses.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Substitution => "sub",
+            Self::Deletion => "del",
+            Self::Duplication => "dup",
+            Self::Insertion => "ins",
+            Self::Repeat => "repeat",
+            Self::Identity => "identity",
+            Self::Frameshift => "fs",
+            Self::Extension => "ext",
+            Self::ByCount => "by-count",
+            Self::NoProtein => "no-protein",
+            Self::CisAllele => "cis",
+            Self::Uncertainty => "uncertainty",
+        }
+    }
+}
+
+/// Which properties a row can be asked about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RowKind {
+    /// Two or more spellings the oracle agrees denote one protein **and** which
+    /// make the same claim about it. Confluence, idempotency and protein
+    /// preservation all apply.
+    Family,
+    /// One spelling. Idempotency and protein preservation apply; confluence is
+    /// vacuous and is reported as such rather than counted as a pass.
+    Single,
+    /// Two or more spellings that denote one protein and **must not** converge,
+    /// because they make different *epistemic* claims about it.
+    ///
+    /// # Why this is a kind of its own rather than a family
+    ///
+    /// `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`
+    /// states the hazard in its own words: "two descriptions can be apply-equal
+    /// on every axis and still make different epistemic claims, which is a
+    /// canonical-form question and must not be encoded as a rung." The
+    /// motivating pair is here — `protein/substitution.md:16` says "predicted
+    /// consequences, i.e. without experimental evidence (no RNA or protein
+    /// sequence analysed), should be given in parentheses", so `p.(Arg727Ser)`
+    /// asserts less than `p.Arg727Ser` while denoting the same molecule.
+    ///
+    /// The oracle deliberately reads through the wrapper — refusing the
+    /// parenthesised form would drop most of the spec's own worked examples
+    /// from any census — so denotation equality **cannot** be the confluence
+    /// relation for this pair. Filed as a `Family` it produced 90 of the first
+    /// run's 90 `split_two` rows, every one of them correct behaviour: a
+    /// confluence figure whose bulk is the normalizer doing the right thing
+    /// hides the rows where it does not.
+    ///
+    /// The property measured over these is **preservation**, not convergence.
+    Distinguished,
+    /// A description that denotes no single protein. The property is that the
+    /// implementation refuses it.
+    Conflict,
+}
+
+impl fmt::Display for RowKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Family => "family",
+            Self::Single => "single",
+            Self::Distinguished => "distinguished",
+            Self::Conflict => "conflict",
+        })
+    }
+}
+
+/// How determinate a row's denotation is.
+///
+/// **[`Self::Indeterminate`] is a first-class verdict and gets its own census
+/// column.** That is not a stylistic choice: `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`
+/// rules that "confluence is asserted only over DECIDED pairs; the
+/// `Indeterminate` count is reported alongside and never folded into either
+/// side". Folding it into `converged` would flatter the implementation, and
+/// folding it into the divergent side would invent failures — the description
+/// genuinely does not fix the protein, and no normalizer can be blamed for that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Determinacy {
+    /// The description fixes the whole protein.
+    Determined,
+    /// It fixes part of it and leaves the rest open.
+    Indeterminate,
+    /// It says no protein is produced.
+    NoProtein,
+    /// It denotes no single protein at all.
+    Undenoted,
+}
+
+impl Determinacy {
+    /// Read the class off an oracle answer.
+    #[must_use]
+    pub fn of(denotation: &ProteinDenotation) -> Self {
+        match denotation {
+            ProteinDenotation::Sequence(_) => Self::Determined,
+            ProteinDenotation::Indeterminate(_) => Self::Indeterminate,
+            ProteinDenotation::NoProtein { .. } => Self::NoProtein,
+            ProteinDenotation::Unparseable
+            | ProteinDenotation::NotProteinAxis
+            | ProteinDenotation::NoSingleSequence(_) => Self::Undenoted,
+        }
+    }
+
+    /// Stable label, used in censuses.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Determined => "determined",
+            Self::Indeterminate => "indeterminate",
+            Self::NoProtein => "no-protein",
+            Self::Undenoted => "undenoted",
+        }
+    }
+}
+
+/// One corpus row.
+#[derive(Debug, Clone)]
+pub struct Row {
+    /// Deterministic identifier, derived from the design parameters. Unique
+    /// within a corpus and independent of iteration order, so a failing row can
+    /// be named in a committed regression test.
+    pub id: String,
+    /// Which stratum enumerated it.
+    pub stratum: &'static str,
+    /// Which properties apply.
+    pub kind: RowKind,
+    /// The transcript geometry the protein's CDS is laid on.
+    pub shape: ProteinRefShape,
+    /// The designed reading frame.
+    pub design: CoreDesign,
+    /// Where in the protein the edit sits.
+    pub site: Site,
+    /// The edit type.
+    pub edit: Kind,
+    /// Members in the authored description.
+    pub members: usize,
+    /// What the authored spelling denotes, per the oracle.
+    pub denoted: ProteinDenotation,
+    /// Distinct spellings the oracle agrees denote [`Self::denoted`]. At least
+    /// two for a [`RowKind::Family`], exactly one otherwise.
+    pub spellings: Vec<String>,
+    /// Clauses this row exercises, for a coverage join.
+    pub rules: Vec<&'static str>,
+}
+
+impl Row {
+    /// The design as authored — the first spelling.
+    #[must_use]
+    pub fn authored_spelling(&self) -> &str {
+        self.spellings
+            .first()
+            .map_or("", std::string::String::as_str)
+    }
+
+    /// How determinate the row's denotation is.
+    #[must_use]
+    pub fn determinacy(&self) -> Determinacy {
+        Determinacy::of(&self.denoted)
+    }
+
+    /// The frame the row's coordinates resolve against.
+    ///
+    /// Rebuilt from [`Self::shape`] and [`Self::design`] rather than stored, so
+    /// the corpus does not carry one synthetic transcript per row. Rows sharing
+    /// a `(shape, design)` share a frame, which is what keeps a census's cost
+    /// linear in rows rather than in bases.
+    #[must_use]
+    pub fn frame(&self) -> ProteinFrame {
+        frame_for(self.shape, self.design)
+    }
+
+    /// The key rows sharing one frame agree on.
+    #[must_use]
+    pub fn frame_key(&self) -> (ProteinRefShape, CoreDesign) {
+        (self.shape, self.design)
+    }
+}
+
+/// Why a design produced no row.
+///
+/// Counted rather than skipped, for the reason
+/// [`spec_corpus::DropReason`](super::spec_corpus::DropReason) is: a generator
+/// whose designs all collapsed into one of these would produce an empty corpus
+/// that reads as "nothing to find".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DropReason {
+    /// The site does not exist on this frame.
+    SiteUnavailable,
+    /// A spelling the generator built does not parse, so it cannot be measured.
+    Unspellable,
+    /// The oracle could not name what the authored spelling denotes, in a
+    /// stratum that expected an answer.
+    NoDenotation,
+    /// Fewer than two spellings survived the oracle's agreement filter, so
+    /// confluence is not decidable for the row.
+    Singleton,
+    /// The design denotes the reference protein, in a stratum that expected a
+    /// change.
+    DenotesTheReference,
+}
+
+impl DropReason {
+    /// Stable label, grouped in the census.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::SiteUnavailable => "site unavailable",
+            Self::Unspellable => "spelling does not parse",
+            Self::NoDenotation => "no denotation",
+            Self::Singleton => "fewer than two spellings",
+            Self::DenotesTheReference => "denotes the reference",
+        }
+    }
+}
+
+/// One enumerated design: either a row, or the reason it produced none.
+pub type Attempt = Result<Row, (String, DropReason)>;
+
+/// A corpus, folded from [`enumerate`].
+#[derive(Debug, Clone)]
+pub struct ProteinCorpus {
+    /// Designs the enumeration proposed, before any filtering.
+    pub designs_considered: usize,
+    /// Drops, by reason.
+    pub drops: BTreeMap<&'static str, usize>,
+    /// Every drop, by design id and reason.
+    ///
+    /// Kept rather than folded away because a drop is where a generator goes
+    /// silently blind: `spelling does not parse` counted 45 on the first run
+    /// and the *reason* — a `p.Met1Xxx` the parser refuses, and a short-format
+    /// frameshift whose residue makes it ambiguous — was only recoverable by
+    /// naming the designs. A census that reports a drop count without the ids
+    /// cannot answer "which shape stopped being generated".
+    pub dropped: Vec<(String, DropReason)>,
+    /// The rows.
+    pub rows: Vec<Row>,
+}
+
+impl ProteinCorpus {
+    /// Fold [`enumerate`]'s attempts.
+    #[must_use]
+    pub fn from_attempts(attempts: Vec<Attempt>) -> Self {
+        let designs_considered = attempts.len();
+        let mut drops: BTreeMap<&'static str, usize> = BTreeMap::new();
+        let mut dropped = Vec::new();
+        let mut rows = Vec::new();
+        for attempt in attempts {
+            match attempt {
+                Ok(row) => rows.push(row),
+                Err((id, reason)) => {
+                    *drops.entry(reason.label()).or_default() += 1;
+                    dropped.push((id, reason));
+                }
+            }
+        }
+        rows.sort_by(|a, b| a.id.cmp(&b.id));
+        dropped.sort();
+        Self {
+            designs_considered,
+            drops,
+            dropped,
+            rows,
+        }
+    }
+
+    /// Spellings across every row — the number of normalizations a consumer
+    /// will perform.
+    #[must_use]
+    pub fn spellings(&self) -> usize {
+        self.rows.iter().map(|row| row.spellings.len()).sum()
+    }
+
+    /// Rows per [`RowKind`].
+    #[must_use]
+    pub fn by_kind(&self) -> BTreeMap<RowKind, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.kind).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per [`Determinacy`] — the census column
+    /// `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`
+    /// requires be kept apart.
+    #[must_use]
+    pub fn by_determinacy(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.determinacy().label()).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per stratum.
+    #[must_use]
+    pub fn by_stratum(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.stratum).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per [`Site`].
+    #[must_use]
+    pub fn by_site(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.site.label()).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per [`Kind`].
+    #[must_use]
+    pub fn by_edit(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.edit.label()).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per transcript geometry.
+    #[must_use]
+    pub fn by_shape(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            *counts.entry(row.shape.label()).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Rows per junction phase, which is the dimension #1478's protein analogue
+    /// lives in.
+    #[must_use]
+    pub fn by_junction_phase(&self) -> BTreeMap<usize, usize> {
+        let mut counts = BTreeMap::new();
+        for row in &self.rows {
+            // A single-exon frame has no junction, so it has no phase.
+            if matches!(row.shape, ProteinRefShape::ThreeExon(_)) {
+                *counts.entry(row.design.junction_phase()).or_default() += 1;
+            }
+        }
+        counts
+    }
+}
+
+/// Enumerate every design, in a fixed order.
+///
+/// The order is set by the loop nesting and does not depend on hashing, so two
+/// runs produce byte-identical output.
+#[must_use]
+pub fn enumerate() -> Vec<Attempt> {
+    let mut attempts = Vec::new();
+    for shape in ProteinRefShape::all() {
+        for design in all_designs() {
+            let frame = frame_for(shape, design);
+            enumerate_substitutions(&frame, shape, design, &mut attempts);
+            enumerate_run_shifts(&frame, shape, design, &mut attempts);
+            enumerate_identities(&frame, shape, design, &mut attempts);
+            enumerate_indeterminates(&frame, shape, design, &mut attempts);
+            enumerate_alleles(&frame, shape, design, &mut attempts);
+            enumerate_conflicts(&frame, shape, design, &mut attempts);
+        }
+    }
+    attempts
+}
+
+/// Build the corpus.
+#[must_use]
+pub fn corpus() -> ProteinCorpus {
+    ProteinCorpus::from_attempts(enumerate())
+}
+
+// ---------------------------------------------------------------------------
+// The strata
+// ---------------------------------------------------------------------------
+
+/// The residue at 1-based protein `position`, terminator included, or `None`
+/// past the end.
+fn residue_at(frame: &ProteinFrame, position: u64) -> Option<AminoAcid> {
+    let with_stop = frame.residues_with_stop();
+    usize::try_from(position)
+        .ok()
+        .and_then(|index| index.checked_sub(1))
+        .and_then(|index| with_stop.get(index).copied())
+}
+
+/// Three-letter code for the residue at `position`.
+fn code_at(frame: &ProteinFrame, position: u64) -> Option<&'static str> {
+    residue_at(frame, position).map(|aa| aa.to_three_letter())
+}
+
+/// A residue that is not the one at `position` and is spellable, so a
+/// substitution is never an identity.
+fn alternative_to(aa: AminoAcid) -> AminoAcid {
+    if aa == AminoAcid::Gly {
+        AminoAcid::Ala
+    } else {
+        AminoAcid::Gly
+    }
+}
+
+/// Assemble a row, keeping only the spellings the oracle agrees denote the same
+/// thing as the authored one.
+///
+/// The filter is what makes a family's confluence claim mean something: a
+/// spelling that does *not* denote the authored protein would make every output
+/// difference a property of the corpus rather than of the normalizer. It is also
+/// where a generator bug surfaces, because a dropped spelling is counted rather
+/// than silently discarded.
+#[allow(clippy::too_many_arguments)]
+fn build_row(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    stratum: &'static str,
+    site: Site,
+    edit: Kind,
+    tag: &str,
+    members: usize,
+    rules: Vec<&'static str>,
+    spellings: Vec<String>,
+) -> Attempt {
+    let id = format!(
+        "{}-{}-{stratum}-{}-{}-{tag}",
+        shape.label(),
+        design.label(),
+        site.label(),
+        edit.label()
+    );
+    let Some(authored) = spellings.first() else {
+        return Err((id, DropReason::Unspellable));
+    };
+    let denoted = protein_denotation_of(frame.provider(), authored);
+    if matches!(
+        denoted,
+        ProteinDenotation::Unparseable | ProteinDenotation::NotProteinAxis
+    ) {
+        return Err((id, DropReason::Unspellable));
+    }
+    let kept: Vec<String> = spellings
+        .iter()
+        .filter(|spelling| protein_denotation_of(frame.provider(), spelling) == denoted)
+        .cloned()
+        .collect();
+    let kind = match &denoted {
+        ProteinDenotation::NoSingleSequence(_) => RowKind::Conflict,
+        // The uncertainty stratum's rows are the only ones whose spellings
+        // denote one protein while claiming different things about it; see
+        // `RowKind::Distinguished`.
+        _ if stratum == "uncertainty" && kept.len() > 1 => RowKind::Distinguished,
+        _ if kept.len() > 1 => RowKind::Family,
+        _ => RowKind::Single,
+    };
+    Ok(Row {
+        id,
+        stratum,
+        kind,
+        shape,
+        design,
+        site,
+        edit,
+        members,
+        denoted,
+        spellings: kept,
+        rules,
+    })
+}
+
+/// A single-member `p.` descriptor.
+fn p(suffix: &str) -> String {
+    ProteinFrame::protein_descriptor(suffix)
+}
+
+/// The substitution stratum: one residue replaced, spelled three ways.
+///
+/// `protein/delins.md:17` rules that one residue replaced by one is a
+/// substitution rather than a `delins`, and `protein/substitution.md:16` that a
+/// predicted consequence is parenthesised. Both are rules about **spelling**, so
+/// all three spellings denote one protein and the family is a legitimate
+/// confluence question rather than a validity one.
+fn enumerate_substitutions(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    for site in Site::all() {
+        let position = site.position(frame);
+        let Some(from) = residue_at(frame, position) else {
+            attempts.push(Err((
+                format!(
+                    "{}-{}-substitution-{}",
+                    shape.label(),
+                    design.label(),
+                    site.label()
+                ),
+                DropReason::SiteUnavailable,
+            )));
+            continue;
+        };
+        let to = alternative_to(from);
+        let (from, to) = (from.to_three_letter(), to.to_three_letter());
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "substitution",
+            site,
+            Kind::Substitution,
+            "three-spellings",
+            1,
+            vec![
+                "protein/substitution.md:5-sub-format",
+                "protein/delins.md:17-one-for-one-is-a-substitution",
+            ],
+            vec![
+                p(&format!("{from}{position}{to}")),
+                p(&format!("{from}{position}_{from}{position}delins{to}")),
+            ],
+        ));
+        // The parenthesised twin is deliberately NOT a member of the family
+        // above — see `RowKind::Distinguished`.
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "uncertainty",
+            site,
+            Kind::Uncertainty,
+            "parenthesised-twin",
+            1,
+            vec!["protein/substitution.md:16-predicted-in-parentheses"],
+            vec![
+                p(&format!("{from}{position}{to}")),
+                p(&format!("({from}{position}{to})")),
+            ],
+        ));
+    }
+}
+
+/// The ambiguous-tract stratum — the corpus's confluence workhorse.
+///
+/// Every spelling below denotes one protein **by construction**, because the
+/// tract is `RUN_COPIES` copies of one residue: deleting any one of them leaves
+/// the same protein, duplicating any one of them leaves the same protein, and
+/// inserting the residue at any junction inside the tract leaves the same
+/// protein. `general.md:43` makes the 3' rule reach "ALL descriptions (genome,
+/// gene, transcript, and protein)", so exactly one of each family is the
+/// recommended form and a divergence is a real finding.
+fn enumerate_run_shifts(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    let code = RUN_RESIDUE.to_three_letter();
+    let first = RUN_START;
+    let last = RUN_START + RUN_COPIES as u64 - 1;
+
+    // Deleting any one copy.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "ambiguous-run",
+        Site::AmbiguousRun,
+        Kind::Deletion,
+        "one-copy",
+        1,
+        vec![
+            "protein/deletion.md:5-del-format",
+            "general.md:43-three-prime-rule-reaches-protein",
+        ],
+        (first..=last)
+            .map(|position| p(&format!("{code}{position}del")))
+            .collect(),
+    ));
+
+    // Duplicating any one copy.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "ambiguous-run",
+        Site::AmbiguousRun,
+        Kind::Duplication,
+        "one-copy",
+        1,
+        vec![
+            "protein/duplication.md:5-dup-format",
+            "general.md:43-three-prime-rule-reaches-protein",
+        ],
+        (first..=last)
+            .map(|position| p(&format!("{code}{position}dup")))
+            .collect(),
+    ));
+
+    // Inserting the tract's own residue at any junction inside it — the same
+    // protein a duplication of any copy denotes, spelled as an insertion.
+    // `general.md:57`'s "dup outranks ins" analogue is what a normalizer is
+    // expected to apply here.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "ambiguous-run",
+        Site::AmbiguousRun,
+        Kind::Insertion,
+        "inside-the-tract",
+        1,
+        vec![
+            "protein/insertion.md:5-ins-flanking-format",
+            "protein/duplication.md:18-dup-not-ins",
+        ],
+        (first..last)
+            .map(|position| p(&format!("{code}{position}_{code}{}ins{code}", position + 1)))
+            .collect(),
+    ));
+
+    // A two-residue deletion, anchored at each equivalent start.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "ambiguous-run",
+        Site::AmbiguousRun,
+        Kind::Repeat,
+        "two-copies",
+        1,
+        vec![
+            "protein/repeated.md:5-repeat-format",
+            "protein/deletion.md:5-del-format",
+        ],
+        (first..last)
+            .map(|position| p(&format!("{code}{position}_{code}{}del", position + 1)))
+            .chain(std::iter::once(p(&format!(
+                "{code}{first}[{}]",
+                RUN_COPIES - 2
+            ))))
+            .collect(),
+    ));
+}
+
+/// The identity stratum: descriptions that denote the reference protein.
+///
+/// Kept apart from the others because an identity is where a normalizer's
+/// collapse rules meet a description that must not disappear:
+/// `protein/substitution.md:36-38` publishes `p.Cys188=` for exactly this.
+fn enumerate_identities(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    for site in [Site::SecondResidue, Site::DeepInterior, Site::LastResidue] {
+        let position = site.position(frame);
+        let Some(code) = code_at(frame, position) else {
+            continue;
+        };
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "identity",
+            site,
+            Kind::Identity,
+            "three-spellings",
+            1,
+            vec!["protein/substitution.md:36-silent-equals"],
+            vec![
+                p(&format!("{code}{position}=")),
+                p(&format!("{code}{position}delins{code}")),
+                p(&format!("{code}{position}_{code}{position}delins{code}")),
+            ],
+        ));
+    }
+}
+
+/// The indeterminate stratum — the rows whose census column exists because of
+/// `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`.
+///
+/// Each shape here fixes part of the protein and leaves the rest open, and the
+/// oracle says exactly which part. They are generated as their own stratum so
+/// the count can be reported beside the confluence figures and never folded into
+/// them.
+fn enumerate_indeterminates(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    let residues = frame.residues().len() as u64;
+    let interior = Site::DeepInterior.position(frame);
+    let Some(interior_code) = code_at(frame, interior) else {
+        return;
+    };
+    // `protein/frameshift.md:19`: "the description of a frameshift starts with
+    // the **first new** amino acid". A generator that hard-coded `Gly` there
+    // emitted `p.Gly36GlyfsTer12` on every design whose residue 36 is already
+    // `Gly` — a frameshift whose first new residue is the old one, which ferro
+    // refuses at parse. Nine rows vanished into the drop ledger before the ids
+    // were read back out of it.
+    let new_residue =
+        alternative_to(residue_at(frame, interior).unwrap_or(AminoAcid::Gly)).to_three_letter();
+    let terminator = residues + 1;
+
+    // A frameshift, long and short form. `protein/frameshift.md:18-23`.
+    for (tag, suffix) in [
+        (
+            "stated-stop",
+            format!("{interior_code}{interior}{new_residue}fsTer12"),
+        ),
+        // `protein/frameshift.md:23`'s short format names the first amino acid
+        // changed, its position and `fs` — and no new residue.
+        ("short-format", format!("{interior_code}{interior}fs")),
+    ] {
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "indeterminate",
+            Site::DeepInterior,
+            Kind::Frameshift,
+            tag,
+            1,
+            vec!["protein/frameshift.md:18-frameshift-format"],
+            vec![p(&suffix)],
+        ));
+    }
+
+    // A C-terminal extension past the terminator (`protein/extension.md:30-34`)
+    // and an N-terminal one from upstream (`:22-24`).
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "indeterminate",
+        Site::Terminator,
+        Kind::Extension,
+        "c-terminal",
+        1,
+        vec!["protein/extension.md:30-c-terminal-extension"],
+        vec![p(&format!("Ter{terminator}GlnextTer17"))],
+    ));
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "indeterminate",
+        Site::Initiator,
+        Kind::Extension,
+        "n-terminal",
+        1,
+        vec!["protein/extension.md:22-n-terminal-extension"],
+        vec![p("Met1ext-5")],
+    ));
+
+    // A payload stated by count rather than by identity
+    // (`protein/insertion.md:45-51`).
+    let next = interior + 1;
+    if let Some(next_code) = code_at(frame, next) {
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "indeterminate",
+            Site::DeepInterior,
+            Kind::ByCount,
+            "unknown-residues",
+            1,
+            vec!["protein/insertion.md:45-insert-by-count"],
+            vec![p(&format!(
+                "{interior_code}{interior}_{next_code}{next}insXaa[7]"
+            ))],
+        ));
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "indeterminate",
+            Site::DeepInterior,
+            Kind::ByCount,
+            "to-a-stop",
+            1,
+            vec!["protein/insertion.md:49-insert-to-a-stop"],
+            vec![p(&format!(
+                "{interior_code}{interior}_{next_code}{next}ins*9"
+            ))],
+        ));
+    }
+
+    // `p.0` and `p.0?` — no protein at all (`protein/substitution.md:46-48`).
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "indeterminate",
+        Site::Initiator,
+        Kind::NoProtein,
+        "stated",
+        1,
+        vec!["protein/substitution.md:46-no-protein"],
+        vec![p("0")],
+    ));
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "indeterminate",
+        Site::Initiator,
+        Kind::NoProtein,
+        "predicted",
+        1,
+        vec!["protein/substitution.md:47-no-protein-predicted"],
+        vec![p("0?")],
+    ));
+}
+
+/// The cis-allele stratum: two members on one molecule.
+///
+/// `protein/delins.md:62` publishes the `p.[Ser44Arg;Trp46Arg]` form. The two
+/// members are placed far apart so neither the merge nor the split move is in
+/// play, and the row's two spellings differ **only** in member order — which
+/// denotes the same protein and must reach one output.
+fn enumerate_alleles(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    let left = Site::SecondResidue.position(frame);
+    let right = Site::DeepInterior.position(frame);
+    let (Some(left_aa), Some(right_aa)) = (residue_at(frame, left), residue_at(frame, right))
+    else {
+        return;
+    };
+    let member = |position: u64, aa: AminoAcid| {
+        format!(
+            "{}{position}{}",
+            aa.to_three_letter(),
+            alternative_to(aa).to_three_letter()
+        )
+    };
+    let first = member(left, left_aa);
+    let second = member(right, right_aa);
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "cis-allele",
+        Site::DeepInterior,
+        Kind::CisAllele,
+        "member-order",
+        2,
+        vec!["protein/alleles.md:5-cis-allele-format"],
+        vec![
+            p(&format!("[{first};{second}]")),
+            p(&format!("[{second};{first}]")),
+        ],
+    ));
+}
+
+/// The conflict stratum: descriptions that denote no single protein.
+///
+/// The property is **refusal**, so these rows carry one spelling and the census
+/// counts how many the implementation accepts. Each shape cites the clause it
+/// violates, and every one of them is a shape the oracle independently reports
+/// as [`ProteinDenotation::NoSingleSequence`] — so the corpus and the clause
+/// agree before the normalizer is consulted.
+fn enumerate_conflicts(
+    frame: &ProteinFrame,
+    shape: ProteinRefShape,
+    design: CoreDesign,
+    attempts: &mut Vec<Attempt>,
+) {
+    let residues = frame.residues().len() as u64;
+    let low = Site::AmbiguousRun.position(frame);
+    let high = Site::DeepInterior.position(frame);
+    let (Some(low_code), Some(high_code)) = (code_at(frame, low), code_at(frame, high)) else {
+        return;
+    };
+
+    // A range written 3'->5' (`protein/deletion.md:18`).
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "conflict",
+        Site::DeepInterior,
+        Kind::Deletion,
+        "reversed-range",
+        1,
+        vec!["protein/deletion.md:18-list-five-to-three"],
+        vec![p(&format!("{high_code}{high}_{low_code}{low}del"))],
+    ));
+
+    // An insertion whose two positions do not flank one junction
+    // (`protein/insertion.md:17-18`).
+    let far = low + 2;
+    if let Some(far_code) = code_at(frame, far) {
+        attempts.push(build_row(
+            frame,
+            shape,
+            design,
+            "conflict",
+            Site::AmbiguousRun,
+            Kind::Insertion,
+            "non-flanking",
+            1,
+            vec!["protein/insertion.md:17-two-flanking-residues"],
+            vec![p(&format!("{low_code}{low}_{far_code}{far}insGly"))],
+        ));
+    }
+
+    // Two members claiming one residue — the protein twin of the nucleotide
+    // corpus's overlapping geometry.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "conflict",
+        Site::DeepInterior,
+        Kind::CisAllele,
+        "overlapping-members",
+        2,
+        vec!["protein/alleles.md:5-cis-allele-format"],
+        // BOTH members must differ from the reference residue, or one of them
+        // is a silent identity and the row is a weaker conflict than it reads
+        // as. `Gly`/`Ala` are the two `alternative_to` ever returns, so the
+        // reference residue is excluded by construction.
+        vec![p(&format!(
+            "[{high_code}{high}{first};{high_code}{high}{second}]",
+            first =
+                alternative_to(residue_at(frame, high).unwrap_or(AminoAcid::Gly)).to_three_letter(),
+            second = if residue_at(frame, high) == Some(AminoAcid::Ser) {
+                AminoAcid::Trp.to_three_letter()
+            } else {
+                AminoAcid::Ser.to_three_letter()
+            },
+        ))],
+    ));
+
+    // A position past the terminator.
+    attempts.push(build_row(
+        frame,
+        shape,
+        design,
+        "conflict",
+        Site::PastEnd,
+        Kind::Substitution,
+        "past-the-terminator",
+        1,
+        vec!["protein/substitution.md:5-sub-format"],
+        vec![p(&format!("Gly{}Ala", residues + 5))],
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conformance::spec_corpus::corpus_cores;
+    use crate::reference::transcript::Strand;
+
+    #[test]
+    fn a_designed_core_is_an_open_reading_frame_that_round_trips() {
+        for design in all_designs() {
+            let cds = codon_core(design);
+            assert_eq!(cds.len(), design.body_codons * 3, "{}", design.label());
+            assert!(cds.starts_with("ATG"), "{}", design.label());
+            let frame = frame_for(ProteinRefShape::SingleExon, design);
+            assert_eq!(
+                frame.residues().len(),
+                design.residues(),
+                "{} translated to the wrong length",
+                design.label()
+            );
+            assert_eq!(frame.residues()[0], AminoAcid::Met, "{}", design.label());
+        }
+    }
+
+    /// The blocker this module exists to remove, demonstrated rather than
+    /// asserted: `spec_corpus`'s cores do not translate, so a protein stratum
+    /// could not have been drawn from them.
+    #[test]
+    fn the_nucleotide_corpuss_cores_are_not_reading_frames() {
+        let table = CodonTable::standard();
+        let mut translatable = 0usize;
+        let cores = corpus_cores(16, 96);
+        for core in &cores {
+            let starts = core.starts_with("ATG");
+            let whole_codons = core.len().is_multiple_of(3);
+            let no_internal_stop = (0..core.len() / 3).all(|index| {
+                Codon::parse(&core[index * 3..index * 3 + 3])
+                    .is_some_and(|codon| !table.is_stop(&codon))
+            });
+            if starts && whole_codons && no_internal_stop {
+                translatable += 1;
+            }
+        }
+        assert_eq!(
+            translatable,
+            0,
+            "{translatable} of {} nucleotide-corpus cores are open reading frames; if this is \
+             no longer zero the protein stratum's premise has changed",
+            cores.len()
+        );
+    }
+
+    /// The designed tract is ambiguous on the protein axis and holds **no**
+    /// repeat at all on the nucleotide axis, because each copy is spelled with a
+    /// different synonymous codon.
+    ///
+    /// This is the one property a nucleotide corpus structurally cannot carry,
+    /// and it is checked rather than described because "the codons differ" is
+    /// exactly the kind of claim that survives a refactor as a stale comment.
+    #[test]
+    fn the_ambiguous_run_is_invisible_to_the_nucleotide_axis() {
+        for design in all_designs() {
+            let frame = frame_for(ProteinRefShape::SingleExon, design);
+            let start = usize::try_from(RUN_START).expect("fits");
+            let residues = frame.residues();
+            for offset in 0..RUN_COPIES {
+                assert_eq!(
+                    residues[start - 1 + offset],
+                    RUN_RESIDUE,
+                    "{} residue {} is not the tract residue",
+                    design.label(),
+                    start + offset
+                );
+            }
+            // The tract is bounded: neither flank is the tract residue, so the
+            // ambiguity has exactly the extent the corpus believes it has.
+            assert_ne!(residues[start - 2], RUN_RESIDUE, "{}", design.label());
+            assert_ne!(
+                residues[start - 1 + RUN_COPIES],
+                RUN_RESIDUE,
+                "{}",
+                design.label()
+            );
+
+            // And the codons are all different, so the CDS holds no tandem
+            // repeat over the tract.
+            let cds = frame.cds();
+            let codons: Vec<&str> = (0..RUN_COPIES)
+                .map(|offset| {
+                    let at = (start - 1 + offset) * 3;
+                    &cds[at..at + 3]
+                })
+                .collect();
+            let mut distinct = codons.clone();
+            distinct.sort_unstable();
+            distinct.dedup();
+            assert_eq!(
+                distinct.len(),
+                RUN_COPIES,
+                "{}: the tract's codons are not all distinct: {codons:?}",
+                design.label()
+            );
+        }
+    }
+
+    /// Both ways a codon can straddle a splice junction are reached, **and** so
+    /// is the codon-aligned case that is the control.
+    ///
+    /// The phase is derived from the frame rather than from
+    /// [`CoreDesign::junction_phase`]'s arithmetic, so the two are independent
+    /// and a mistake in the arithmetic fails here rather than being confirmed by
+    /// itself.
+    #[test]
+    fn both_junction_phases_are_reached_and_so_is_neither() {
+        let mut seen: BTreeMap<usize, usize> = BTreeMap::new();
+        for design in all_designs() {
+            let frame = frame_for(ProteinRefShape::ThreeExon(Strand::Plus), design);
+            let observed: Vec<usize> = (1..=frame.residues().len() as u64)
+                .filter_map(|residue| frame.junction_phase_of_residue(residue))
+                .collect();
+            let phase = observed.first().copied().unwrap_or(0);
+            assert_eq!(
+                phase,
+                design.junction_phase(),
+                "{}: measured phase {phase}, `junction_phase()` says {}",
+                design.label(),
+                design.junction_phase()
+            );
+            *seen.entry(design.junction_phase()).or_default() += 1;
+        }
+        assert_eq!(
+            seen.keys().copied().collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "the designs do not reach all three junction phases: {seen:?}"
+        );
+    }
+
+    /// The designed tract sits past `CANONICAL_PAD`, so a frame built here is
+    /// outside the regime `codon_frame_deep_window_offset.rs` shows is blind.
+    ///
+    /// Checked rather than commented, because "deep enough" is a claim about
+    /// three constants that can each move independently.
+    #[test]
+    fn the_tract_clears_the_canonical_window_clamp() {
+        /// `merge.rs`'s private window pad, mirrored for the assertion only —
+        /// exactly as `codon_frame_deep_window_offset.rs` mirrors it.
+        const CANONICAL_PAD: usize = 128;
+        for design in all_designs() {
+            let frame = frame_for(ProteinRefShape::SingleExon, design);
+            let coding = frame
+                .cds_position_of_residue(RUN_START)
+                .expect("the tract's first residue has a codon");
+            let (cds_start, _) = frame.cds_bounds();
+            let transcript_position = cds_start + usize::try_from(coding).expect("fits") - 1;
+            assert!(
+                transcript_position > CANONICAL_PAD,
+                "{}: the tract starts at transcript position {transcript_position}, inside \
+                 the clamped window (CANONICAL_PAD = {CANONICAL_PAD})",
+                design.label()
+            );
+        }
+    }
+
+    #[test]
+    fn every_stop_codon_is_reached() {
+        let table = CodonTable::standard();
+        let stops: Vec<String> = table
+            .stop_codons()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let mut seen: Vec<String> = all_designs()
+            .into_iter()
+            .map(|design| {
+                let cds = codon_core(design);
+                cds[cds.len() - 3..].to_string()
+            })
+            .collect();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            stops.len(),
+            "stops reached: {seen:?} of {stops:?}"
+        );
+    }
+
+    /// The filler draws widely from the codon table, so the corpus is not a
+    /// measurement of twenty codons wearing a disguise.
+    #[test]
+    fn the_generator_reaches_most_of_the_codon_table() {
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for design in all_designs() {
+            let cds = codon_core(design);
+            for index in 0..cds.len() / 3 {
+                seen.insert(cds[index * 3..index * 3 + 3].to_string());
+            }
+        }
+        assert!(
+            seen.len() >= 40,
+            "only {} distinct codons are reachable, which is close enough to \
+             back-translation's 20 that the codon design buys nothing: {seen:?}",
+            seen.len()
+        );
+    }
+
+    #[test]
+    fn every_site_class_is_reached() {
+        let built = corpus();
+        let by_site = built.by_site();
+        for site in Site::all() {
+            assert!(
+                by_site.get(site.label()).copied().unwrap_or(0) > 0,
+                "no row at site {}: {by_site:?}",
+                site.label()
+            );
+        }
+    }
+
+    #[test]
+    fn every_shape_is_reached() {
+        let built = corpus();
+        let by_shape = built.by_shape();
+        for shape in ProteinRefShape::all() {
+            assert!(
+                by_shape.get(shape.label()).copied().unwrap_or(0) > 0,
+                "no row on shape {}: {by_shape:?}",
+                shape.label()
+            );
+        }
+        let by_phase = built.by_junction_phase();
+        assert_eq!(
+            by_phase.keys().copied().collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "the corpus's multi-exon rows do not span every junction phase: {by_phase:?}"
+        );
+    }
+
+    #[test]
+    fn every_determinacy_class_is_reached() {
+        let built = corpus();
+        let by_determinacy = built.by_determinacy();
+        for class in [
+            Determinacy::Determined,
+            Determinacy::Indeterminate,
+            Determinacy::NoProtein,
+            Determinacy::Undenoted,
+        ] {
+            assert!(
+                by_determinacy.get(class.label()).copied().unwrap_or(0) > 0,
+                "no row in determinacy class {}: {by_determinacy:?}",
+                class.label()
+            );
+        }
+    }
+
+    #[test]
+    fn every_kind_is_reached() {
+        let built = corpus();
+        let by_edit = built.by_edit();
+        for edit in [
+            Kind::Substitution,
+            Kind::Deletion,
+            Kind::Duplication,
+            Kind::Insertion,
+            Kind::Repeat,
+            Kind::Identity,
+            Kind::Frameshift,
+            Kind::Extension,
+            Kind::ByCount,
+            Kind::NoProtein,
+            Kind::CisAllele,
+            Kind::Uncertainty,
+        ] {
+            assert!(
+                by_edit.get(edit.label()).copied().unwrap_or(0) > 0,
+                "no row of kind {}: {by_edit:?}",
+                edit.label()
+            );
+        }
+        assert!(
+            built.rows.iter().any(|row| row.members == 2),
+            "no two-member row"
+        );
+    }
+
+    /// Every family's spellings really do denote one protein, checked through
+    /// the oracle rather than trusted from the generator.
+    #[test]
+    fn every_family_denotes_one_protein() {
+        let built = corpus();
+        let mut families = 0usize;
+        for row in &built.rows {
+            if row.kind != RowKind::Family {
+                continue;
+            }
+            families += 1;
+            let frame = row.frame();
+            for spelling in &row.spellings {
+                assert_eq!(
+                    protein_denotation_of(frame.provider(), spelling),
+                    row.denoted,
+                    "{}: {spelling} does not denote the row's protein",
+                    row.id
+                );
+            }
+        }
+        assert!(families > 0, "the corpus holds no families at all");
+    }
+
+    /// A row id names its design uniquely, so a failure can be pinned.
+    #[test]
+    fn row_ids_are_unique() {
+        let built = corpus();
+        let mut ids: Vec<&str> = built.rows.iter().map(|row| row.id.as_str()).collect();
+        let total = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), total, "duplicate row ids");
+    }
+
+    /// Enumeration is deterministic.
+    #[test]
+    fn the_corpus_is_deterministic() {
+        let first = corpus();
+        let second = corpus();
+        assert_eq!(first.rows.len(), second.rows.len());
+        for (a, b) in first.rows.iter().zip(second.rows.iter()) {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.spellings, b.spellings);
+        }
+    }
+}

--- a/src/conformance/synthetic_protein.rs
+++ b/src/conformance/synthetic_protein.rs
@@ -63,7 +63,7 @@
 
 use std::fmt;
 
-use crate::backtranslate::codon::CodonTable;
+use crate::backtranslate::codon::{Codon, CodonTable};
 use crate::conformance::spec_corpus::{three_exon_layout, transcript_provider, CODING_ACCESSION};
 use crate::hgvs::edit::{
     AminoAcidSeq, ExtDirection, FrameshiftTer, ProteinEdit, ProteinInsSeq, RepeatCount,
@@ -282,7 +282,77 @@ impl ProteinFrame {
     /// See [`ProteinFrameError`].
     pub fn build(shape: ProteinRefShape, peptide: &[AminoAcid]) -> Result<Self, ProteinFrameError> {
         let cds_bases = back_translate_cds(peptide)?;
+        Self::assemble(shape, &cds_bases, peptide)
+    }
 
+    /// Build a frame from a **designed CDS** rather than from a peptide.
+    ///
+    /// The inverse entry point to [`Self::build`], and the one a codon-designed
+    /// corpus needs. [`Self::build`] back-translates, so it can only ever emit
+    /// the codon table's *first* codon for each residue — a CDS with exactly 20
+    /// distinct codons in it, in which no synonymous pair, no alternative stop
+    /// and no codon-level property is expressible. A caller that has designed
+    /// the codons hands them in here instead and the peptide is **derived** by
+    /// translating them, which is the direction the coupling should run.
+    ///
+    /// `cds` must be a whole number of codons, start with a start codon, hold
+    /// no internal terminator, and end with one. Those are checked rather than
+    /// assumed, and the same re-read-and-translate round trip [`Self::build`]
+    /// performs still runs afterwards, so this constructor cannot produce a
+    /// frame whose protein is not its transcript's translation either.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProteinFrameError`]. [`ProteinFrameError::Empty`] additionally
+    /// covers a CDS that is not a whole number of codons or carries no
+    /// terminator, and [`ProteinFrameError::NotMetInitiated`] a CDS whose first
+    /// codon is not read as `Met`.
+    pub fn from_cds(shape: ProteinRefShape, cds: &str) -> Result<Self, ProteinFrameError> {
+        if cds.len() < 6 || !cds.len().is_multiple_of(3) {
+            return Err(ProteinFrameError::Empty);
+        }
+        let table = CodonTable::standard();
+        let codons: Vec<Codon> = (0..cds.len() / 3)
+            .map(|index| Codon::parse(&cds[index * 3..index * 3 + 3]))
+            .collect::<Option<_>>()
+            .ok_or(ProteinFrameError::Empty)?;
+        let (last, body) = codons.split_last().ok_or(ProteinFrameError::Empty)?;
+        if !table.is_stop(last) {
+            return Err(ProteinFrameError::Empty);
+        }
+        let mut peptide = Vec::with_capacity(body.len());
+        for (index, codon) in body.iter().enumerate() {
+            match table.amino_acid_for(codon) {
+                // An internal stop truncates translation, so the CDS would not
+                // be the protein's. Reported with the residue number the
+                // peptide-first path would report.
+                Some(AminoAcid::Ter) | None => {
+                    return Err(ProteinFrameError::InternalStop(index + 1))
+                }
+                Some(aa) => peptide.push(aa),
+            }
+        }
+        // Translation initiation installs `Met` whatever the start codon is
+        // (`background/standards.md:229`), so the check is on the *residue*, as
+        // in `back_translate_cds`.
+        match peptide.first() {
+            Some(AminoAcid::Met) => {}
+            Some(other) => return Err(ProteinFrameError::NotMetInitiated(*other)),
+            None => return Err(ProteinFrameError::Empty),
+        }
+        Self::assemble(shape, cds, &peptide)
+    }
+
+    /// Wrap `cds_bases` in UTRs, lay it on `shape`'s exon geometry, and verify
+    /// the transcript the provider serves translates back to `peptide`.
+    ///
+    /// Shared by [`Self::build`] and [`Self::from_cds`] so the two entry points
+    /// cannot drift on UTR length, exon layout, or the round-trip guarantee.
+    fn assemble(
+        shape: ProteinRefShape,
+        cds_bases: &str,
+        peptide: &[AminoAcid],
+    ) -> Result<Self, ProteinFrameError> {
         let filler = |len: usize| UTR_FILLER.chars().cycle().take(len).collect::<String>();
         let utr5 = filler(UTR_LEN);
         let utr3 = filler(UTR_LEN);
@@ -413,6 +483,43 @@ impl ProteinFrame {
             return None;
         }
         i64::try_from(index * 3 + 1).ok()
+    }
+
+    /// The exon boundaries the frame was laid out on, 1-based inclusive
+    /// transcript coordinates.
+    #[must_use]
+    pub fn exons(&self) -> Vec<(usize, usize)> {
+        match self.shape {
+            ProteinRefShape::SingleExon => vec![(1, self.transcript.len())],
+            ProteinRefShape::ThreeExon(_) => three_exon_layout(self.transcript.len()),
+        }
+    }
+
+    /// How the codon for 1-based `residue` sits relative to the exon junctions:
+    /// `None` when it lies wholly inside one exon, otherwise `Some(k)` with `k`
+    /// the number of its three bases that fall in the earlier exon — so `1` and
+    /// `2` are the two ways a codon can straddle a junction.
+    ///
+    /// This is the protein axis's reading-frame **phase** observable, and the
+    /// reason it is a method rather than a comment: a corpus that never returns
+    /// `Some(1)` and `Some(2)` here is blind in exactly the dimension #1478 was
+    /// about, and would report that blindness as coverage. `None` for a residue
+    /// past the terminator, which has no codon.
+    #[must_use]
+    pub fn junction_phase_of_residue(&self, residue: u64) -> Option<usize> {
+        let first = usize::try_from(self.cds_position_of_residue(residue)?).ok()?;
+        // Transcript coordinates of the codon's three bases, 1-based.
+        let start = self.cds.0 + first - 1;
+        let exons = self.exons();
+        let exon_of = |position: usize| {
+            exons
+                .iter()
+                .position(|&(lo, hi)| (lo..=hi).contains(&position))
+        };
+        let first_exon = exon_of(start)?;
+        (0..3usize)
+            .map(|offset| exon_of(start + offset))
+            .position(|exon| exon != Some(first_exon))
     }
 
     /// A `p.` description against this frame's protein accession.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -447,6 +447,7 @@ mod projection_coverage;
 mod property_tests;
 mod protein_axis_split_move;
 mod protein_cis_delins_decomposition;
+mod protein_conformance_axis;
 mod protein_construct_boundaries;
 mod protein_frameshift_alternatives;
 mod protein_frameshift_legacy_stop_modes;

--- a/tests/it/protein_conformance_axis.rs
+++ b/tests/it/protein_conformance_axis.rs
@@ -1,0 +1,1080 @@
+//! The protein axis's first measurement, over the codon-designed protein corpus.
+//!
+//! # What this measures, and why it can measure it without a published answer
+//!
+//! `ferro_hgvs::conformance::protein_corpus` generates many spellings of one
+//! protein change — a deletion at each equivalent position of a synonymous
+//! tandem tract, a substitution beside its `delins` and parenthesised twins, a
+//! cis allele in both member orders — and
+//! `synthetic_protein::protein_denotation_of` confirms, independently of the
+//! normalizer, that every spelling in a family denotes one protein. That makes
+//! four properties checkable with no spec-published form at all:
+//!
+//! | rank | property | how it is checked |
+//! |---|---|---|
+//! | 1 | **validity** | the output re-parses and denotes a protein |
+//! | 2 | **confluence** | every spelling of one protein reaches ONE output |
+//! | — | **idempotency** | each output is its own fixed point |
+//! | — | **protein preservation** | each output denotes the input's residues, via the oracle |
+//!
+//! # `Indeterminate` is its own column, on a ruling
+//!
+//! `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`
+//! (decided 2026-08-10) states it: "Confluence is asserted only over DECIDED
+//! pairs; the `Indeterminate` count is reported alongside and never folded into
+//! either side." A frameshift, an extension and an `insXaa[n]` payload each fix
+//! part of a protein and leave the rest open — the description genuinely does
+//! not determine the molecule, so counting such a family as `converged` would
+//! flatter the normalizer and counting it as divergent would invent a failure.
+//! [`Census::indeterminate_families`] and its two companions therefore sit apart
+//! from [`Census::converged`] and the three `split_*` figures, and the two sets
+//! are never summed.
+//!
+//! # The first measurement — read the four findings before quoting a figure
+//!
+//! Over **540 rows / 1,044 spellings**, in both shuffle directions (which agree
+//! byte for byte):
+//!
+//! | figure | value | reading |
+//! |---|---|---|
+//! | `unparseable_outputs` | **0** | every output re-parses |
+//! | `outputs_denoting_no_protein` | **0** | no output denotes nothing |
+//! | `protein_changed` | **0** | no output denotes a different protein from its input |
+//! | `non_idempotent_outputs` | **0** | every output is its own fixed point |
+//! | `converged` / `split_two` | **198 / 18** | over DETERMINED families only |
+//! | `indeterminate_families` | **18**, all converged | its own column, per the ruling |
+//! | `distinguished_preserved` | **90 of 90** | no parenthesised twin is collapsed |
+//! | `conflicts_accepted` | **72 of 72** | **a rank-1 finding** |
+//!
+//! Four things to carry away, in descending order of how much they matter:
+//!
+//! 1. **`conflicts_accepted` is 72 of 72, in strict mode as well as lenient.**
+//!    A reversed range, a non-flanking insertion, two allele members claiming
+//!    one residue and a position past the terminator are each normalized and
+//!    emitted unchanged. `rulings[absolute-prohibition-enforcement-stage]` makes
+//!    lenient's behaviour arguably correct and strict's not, and says the ruling
+//!    is unimplemented (#1630); `no_conflicting_description_is_refused_in_strict_mode_either`
+//!    pins the protein axis's share of that.
+//! 2. **The 18 divergent families are one class, and it is a contested
+//!    adjudication rather than a defect** — see
+//!    `the_repeat_count_and_the_explicit_deletion_of_one_tract_do_not_converge`,
+//!    which is `#[ignore]`d with the question written on it.
+//! 3. **Transcript geometry is inert for a `p.`-only measurement**, measured
+//!    over all three exon layouts and both strands by
+//!    `shape_is_inert_for_the_protein_axis`. So the corpus's phase dimension is
+//!    a *guard* — it is what would catch the axis becoming geometry-sensitive —
+//!    and not, today, a source of signal.
+//! 4. **The four zeros above are real but narrow.** They say the normalizer does
+//!    not break a protein description it accepts. They say nothing about the
+//!    102 validity clauses; see the section below.
+//!
+//! # This is a census, not a gate
+//!
+//! Every figure is a **pinned baseline** measured on this branch. A change that
+//! moves one must re-bless the pin in the same commit and say which way it
+//! moved and why.
+//!
+//! # What a green run does NOT say — read this before quoting any figure
+//!
+//! The oracle judges **denotation**, deliberately and by design. A one-for-one
+//! `delins`, a `Cys76_Cys76` range and a `p.[Arg76Ser;Cys77Trp]` that
+//! `protein/delins.md:21` says should be one `delins` all denote a protein
+//! perfectly well, and this census scores each of them as sound.
+//!
+//! The protein slice is **205 clause units** across nine files — the committed
+//! rule inventory's figure, reproduced by re-deriving it from the spec checkout
+//! with the inventory's own definition of a clause unit — and the great majority
+//! state how a description may be **written**. A green census here is evidence
+//! about none of those.
+//!
+//! (`synthetic_protein.rs` says "149 clauses (102 of them validity
+//! requirements)". Neither number reconciles with the inventory and nothing in
+//! the repository classifies a clause as a validity requirement, so that figure
+//! is not restated here. See `protein_corpus`'s module docs.)
+//!
+//! So the rule inventory's `not-generatable` classification for
+//! `docs/recommendations/protein/*` is **left in place** by this module and its
+//! corpus. Lifting it needs a validity judge, which is a separate piece of work
+//! and not one a denotation oracle can stand in for.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ferro_hgvs::conformance::protein_corpus::{
+    corpus, Determinacy, ProteinCorpus, Row, RowKind, Site,
+};
+use ferro_hgvs::conformance::synthetic_protein::{
+    protein_denotation_of, ProteinDenotation, ProteinFrame, ProteinRefShape,
+};
+use ferro_hgvs::error_handling::ErrorMode;
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+// ---------------------------------------------------------------------------
+// The pinned shape
+// ---------------------------------------------------------------------------
+
+/// The corpus's shape, independent of any property measured over it.
+///
+/// Pinned for the reason `spec_conformance_axis`'s twin is: a generator change
+/// that halved the corpus would improve every rate below while measuring less,
+/// which is the #1460 failure mode.
+///
+/// # Every figure here and below is exactly **3x** an independent measurement
+///
+/// State this whenever one of these numbers is quoted, because it is provable
+/// rather than estimated and it changes what they mean. Two committed tests pin
+/// it between them: `shape_is_inert_for_the_protein_axis` asserts that every row
+/// group is built on **all three** of `ProteinRefShape::all()` — so
+/// `rows == 3 * groups` — and then that the three replicas produce byte-identical
+/// output. So the replicas are not three measurements; they are one measurement
+/// written down three times.
+///
+/// Read every count accordingly: `rows: 540` is 180 designs on three geometries,
+/// `conflicts_accepted: 72` is 24 distinct conflicting descriptions, and the
+/// census's 18 divergent families are **6** distinct divergences. Quoting `72 of
+/// 72` as seventy-two independent conflicts overstates the evidence threefold.
+///
+/// This is deliberate and is not a defect to fix here: the geometry dimension is
+/// carried as a **guard** against `p.` output becoming splice-structure
+/// dependent, not as a source of signal, and the day it stops being inert those
+/// tests fail and the replication becomes real. But the multiplier is invisible
+/// in the constants themselves, which is why it is written down.
+const SHAPE: CorpusShape = CorpusShape {
+    designs_considered: 594,
+    rows: 540,
+    spellings: 1_044,
+    family_rows: 234,
+    single_rows: 144,
+    distinguished_rows: 90,
+    conflict_rows: 72,
+    determined_rows: 288,
+    indeterminate_rows: 144,
+    no_protein_rows: 36,
+    undenoted_rows: 72,
+};
+
+/// The 3'-direction census, pinned.
+const THREE_PRIME: Census = Census {
+    measured_under: ErrorMode::Lenient,
+    outputs: 1_044,
+    declined: 0,
+    unparseable_outputs: 0,
+    outputs_denoting_no_protein: 0,
+    protein_changed: 0,
+    non_idempotent_outputs: 0,
+    // 198 of the 216 determined families reach one output. The 18 that do not
+    // are one class, one row per frame — see
+    // `the_repeat_count_and_the_explicit_deletion_of_one_tract_do_not_converge`,
+    // which names the open question rather than pinning an answer to it.
+    converged: 198,
+    split_two: 18,
+    split_three: 0,
+    split_more: 0,
+    // The terminator substitution and its `delins` twin: both read past the
+    // stop, so the oracle fixes only the prefix. Counted here and in neither
+    // figure above.
+    indeterminate_families: 18,
+    indeterminate_converged: 18,
+    indeterminate_split: 0,
+    // Every parenthesised twin survives, so no evidential claim is destroyed.
+    distinguished_rows: 90,
+    distinguished_preserved: 90,
+    distinguished_collapsed: 0,
+    // 72 of 72 — every conflicting description is normalized rather than
+    // refused. A rank-1 finding, and the same figure in strict mode; see
+    // `no_conflicting_description_is_refused_in_strict_mode_either`.
+    conflicts_accepted: 72,
+};
+
+/// The 5'-direction census, pinned.
+///
+/// Measured in full rather than assumed identical: confluence is a property of
+/// the normalizer, not of one shuffle direction, so a figure that appears at 3'
+/// and not at 5' is a claim about the code.
+///
+/// **It is byte-identical to [`THREE_PRIME`], and that is a result rather than
+/// a copy.** `general.md:43` makes the 3' rule reach protein descriptions, so a
+/// direction-sensitive protein normalizer is conceivable; measured, this one is
+/// not. The two constants are written out separately so the day one of them
+/// moves, the other does not move with it.
+const FIVE_PRIME: Census = Census {
+    measured_under: ErrorMode::Lenient,
+    outputs: 1_044,
+    declined: 0,
+    unparseable_outputs: 0,
+    outputs_denoting_no_protein: 0,
+    protein_changed: 0,
+    non_idempotent_outputs: 0,
+    // 198 of the 216 determined families reach one output. The 18 that do not
+    // are one class, one row per frame — see
+    // `the_repeat_count_and_the_explicit_deletion_of_one_tract_do_not_converge`,
+    // which names the open question rather than pinning an answer to it.
+    converged: 198,
+    split_two: 18,
+    split_three: 0,
+    split_more: 0,
+    // The terminator substitution and its `delins` twin: both read past the
+    // stop, so the oracle fixes only the prefix. Counted here and in neither
+    // figure above.
+    indeterminate_families: 18,
+    indeterminate_converged: 18,
+    indeterminate_split: 0,
+    // Every parenthesised twin survives, so no evidential claim is destroyed.
+    distinguished_rows: 90,
+    distinguished_preserved: 90,
+    distinguished_collapsed: 0,
+    // 72 of 72 — every conflicting description is normalized rather than
+    // refused. A rank-1 finding, and the same figure in strict mode; see
+    // `no_conflicting_description_is_refused_in_strict_mode_either`.
+    conflicts_accepted: 72,
+};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct CorpusShape {
+    designs_considered: usize,
+    rows: usize,
+    spellings: usize,
+    family_rows: usize,
+    single_rows: usize,
+    distinguished_rows: usize,
+    conflict_rows: usize,
+    determined_rows: usize,
+    indeterminate_rows: usize,
+    no_protein_rows: usize,
+    undenoted_rows: usize,
+}
+
+impl CorpusShape {
+    fn of(built: &ProteinCorpus) -> Self {
+        let by_kind = built.by_kind();
+        let by_determinacy = built.by_determinacy();
+        let count = |label: &str| by_determinacy.get(label).copied().unwrap_or(0);
+        Self {
+            designs_considered: built.designs_considered,
+            rows: built.rows.len(),
+            spellings: built.spellings(),
+            family_rows: by_kind.get(&RowKind::Family).copied().unwrap_or(0),
+            single_rows: by_kind.get(&RowKind::Single).copied().unwrap_or(0),
+            distinguished_rows: by_kind.get(&RowKind::Distinguished).copied().unwrap_or(0),
+            conflict_rows: by_kind.get(&RowKind::Conflict).copied().unwrap_or(0),
+            determined_rows: count(Determinacy::Determined.label()),
+            indeterminate_rows: count(Determinacy::Indeterminate.label()),
+            no_protein_rows: count(Determinacy::NoProtein.label()),
+            undenoted_rows: count(Determinacy::Undenoted.label()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The census
+// ---------------------------------------------------------------------------
+
+/// One direction's measurement.
+///
+/// The `indeterminate_*` block is deliberately NOT summable with the confluence
+/// block above it — see the module docs and the ruling they cite.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Census {
+    /// Which error mode produced these figures. Recorded because refusal
+    /// counters are mode-dependent and a census with no mode on it invites
+    /// being compared against one measured under another.
+    measured_under: ErrorMode,
+
+    // -- validity (rank 1) --
+    /// Spellings the census attempted to normalize.
+    outputs: usize,
+    /// Spellings that did not parse or whose normalization failed, where that
+    /// was not the row's property.
+    declined: usize,
+    /// Outputs `parse_hgvs` cannot read back.
+    unparseable_outputs: usize,
+    /// Outputs the oracle says denote no single protein — the protein twin of
+    /// `outputs_denoting_no_sequence`.
+    outputs_denoting_no_protein: usize,
+
+    // -- protein preservation --
+    /// Outputs denoting a different protein from their input, counted **per
+    /// spelling** over rows whose input denotation is
+    /// [`Determinacy::Determined`]. So its denominator is those rows' spellings,
+    /// not `determined_rows` — a determined family contributes once per
+    /// spelling, and reading this against the row count would understate it.
+    protein_changed: usize,
+
+    // -- idempotency --
+    /// Outputs that are not their own fixed point.
+    non_idempotent_outputs: usize,
+
+    // -- confluence (rank 2), over DETERMINED families only --
+    /// Families whose spellings all reached one output.
+    converged: usize,
+    /// Families reaching exactly two distinct outputs.
+    split_two: usize,
+    /// Three.
+    split_three: usize,
+    /// Four or more.
+    split_more: usize,
+
+    // -- the Indeterminate column: reported alongside, never folded --
+    /// Families whose denotation is [`ProteinDenotation::Indeterminate`].
+    indeterminate_families: usize,
+    /// …of which reached one output.
+    indeterminate_converged: usize,
+    /// …of which did not.
+    indeterminate_split: usize,
+
+    // -- distinguished pairs: apply-equal, epistemically different --
+    /// Rows whose spellings denote one protein and must NOT converge.
+    distinguished_rows: usize,
+    /// …whose spellings stayed distinct, which is the wanted answer.
+    distinguished_preserved: usize,
+    /// …that were collapsed onto one output, destroying the evidential claim
+    /// `protein/substitution.md:16` attaches to the parentheses.
+    distinguished_collapsed: usize,
+
+    // -- refusal --
+    /// Conflicting descriptions the normalizer produced an output for.
+    conflicts_accepted: usize,
+}
+
+/// A family that did not converge, for the report.
+#[derive(Debug, Clone)]
+struct Divergence {
+    id: String,
+    determinacy: &'static str,
+    outputs: Vec<String>,
+}
+
+/// Anything worth naming in the report that is not a counter.
+#[derive(Debug, Clone)]
+struct Finding {
+    id: String,
+    what: String,
+}
+
+#[derive(Debug, Default)]
+struct Measured {
+    census: Census,
+    divergences: Vec<Divergence>,
+    findings: Vec<Finding>,
+}
+
+/// How many divergences the report prints before eliding.
+const MAX_DIVERGENCES: usize = 12;
+
+impl Census {
+    fn absorb(&mut self, other: &Census) {
+        self.outputs += other.outputs;
+        self.declined += other.declined;
+        self.unparseable_outputs += other.unparseable_outputs;
+        self.outputs_denoting_no_protein += other.outputs_denoting_no_protein;
+        self.protein_changed += other.protein_changed;
+        self.non_idempotent_outputs += other.non_idempotent_outputs;
+        self.converged += other.converged;
+        self.split_two += other.split_two;
+        self.split_three += other.split_three;
+        self.split_more += other.split_more;
+        self.indeterminate_families += other.indeterminate_families;
+        self.indeterminate_converged += other.indeterminate_converged;
+        self.indeterminate_split += other.indeterminate_split;
+        self.distinguished_rows += other.distinguished_rows;
+        self.distinguished_preserved += other.distinguished_preserved;
+        self.distinguished_collapsed += other.distinguished_collapsed;
+        self.conflicts_accepted += other.conflicts_accepted;
+    }
+}
+
+fn built() -> ProteinCorpus {
+    corpus()
+}
+
+/// Rows sorted so every row sharing one frame is adjacent.
+fn grouped(built: &ProteinCorpus) -> Vec<&Row> {
+    let mut rows: Vec<&Row> = built.rows.iter().collect();
+    rows.sort_by(|a, b| {
+        (a.shape.label(), a.design, &a.id).cmp(&(b.shape.label(), b.design, &b.id))
+    });
+    rows
+}
+
+/// The contiguous runs of `rows` sharing one frame.
+fn frame_groups<'a>(rows: &'a [&'a Row]) -> Vec<&'a [&'a Row]> {
+    let mut groups = Vec::new();
+    let mut start = 0usize;
+    while start < rows.len() {
+        let mut end = start + 1;
+        while end < rows.len() && rows[end].frame_key() == rows[start].frame_key() {
+            end += 1;
+        }
+        groups.push(&rows[start..end]);
+        start = end;
+    }
+    groups
+}
+
+fn measurement_config(direction: ShuffleDirection) -> NormalizeConfig {
+    NormalizeConfig::default().with_direction(direction)
+}
+
+/// Normalize one frame's rows and census them.
+fn measure_group(group: &[&Row], direction: ShuffleDirection) -> Measured {
+    let mut census = Census {
+        measured_under: measurement_config(direction).error_config.mode,
+        ..Census::default()
+    };
+    let mut divergences: Vec<Divergence> = Vec::new();
+    let mut findings: Vec<Finding> = Vec::new();
+
+    let frame = group[0].frame();
+    let normalizer =
+        Normalizer::with_config(frame.provider().clone(), measurement_config(direction));
+
+    for row in group {
+        let mut outputs: BTreeSet<String> = BTreeSet::new();
+        for spelling in &row.spellings {
+            census.outputs += 1;
+            let Ok(parsed) = parse_hgvs(spelling) else {
+                // A corpus spelling that does not parse is expected only where
+                // refusal IS the row's property.
+                if row.kind != RowKind::Conflict {
+                    census.declined += 1;
+                }
+                continue;
+            };
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                normalizer.normalize(&parsed)
+            }));
+            let Ok(Ok(value)) = result else {
+                if row.kind != RowKind::Conflict {
+                    census.declined += 1;
+                }
+                continue;
+            };
+            let output = value.to_string();
+
+            if row.kind == RowKind::Conflict {
+                census.conflicts_accepted += 1;
+                findings.push(Finding {
+                    id: row.id.clone(),
+                    what: format!("conflicting description accepted: {spelling} -> {output}"),
+                });
+            }
+
+            // --- rank 1: validity -----------------------------------------
+            if parse_hgvs(&output).is_err() {
+                census.unparseable_outputs += 1;
+                findings.push(Finding {
+                    id: row.id.clone(),
+                    what: format!("output does not re-parse: {spelling} -> {output}"),
+                });
+                continue;
+            }
+            let output_denotation = protein_denotation_of(frame.provider(), &output);
+            if matches!(Determinacy::of(&output_denotation), Determinacy::Undenoted)
+                && row.kind != RowKind::Conflict
+            {
+                census.outputs_denoting_no_protein += 1;
+                findings.push(Finding {
+                    id: row.id.clone(),
+                    what: format!(
+                        "output denotes no single protein: {spelling} -> {output} \
+                         ({output_denotation:?})"
+                    ),
+                });
+            }
+
+            // --- protein preservation --------------------------------------
+            if row.determinacy() == Determinacy::Determined
+                && output_denotation != row.denoted
+                && row.kind != RowKind::Conflict
+            {
+                census.protein_changed += 1;
+                findings.push(Finding {
+                    id: row.id.clone(),
+                    what: format!("output denotes a different protein: {spelling} -> {output}"),
+                });
+            }
+
+            // --- idempotency ----------------------------------------------
+            if let Ok(reparsed) = parse_hgvs(&output) {
+                let again = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    normalizer.normalize(&reparsed)
+                }));
+                if let Ok(Ok(second)) = again {
+                    if second.to_string() != output {
+                        census.non_idempotent_outputs += 1;
+                        findings.push(Finding {
+                            id: row.id.clone(),
+                            what: format!("output is not a fixed point: {output} -> {}", second),
+                        });
+                    }
+                }
+            }
+
+            outputs.insert(output);
+        }
+
+        // --- distinguished pairs -------------------------------------------
+        //
+        // Measured BEFORE the confluence block and never inside it: the
+        // wanted answer here is more than one output, which is the opposite of
+        // what `converged` rewards.
+        if row.kind == RowKind::Distinguished {
+            census.distinguished_rows += 1;
+            if outputs.len() >= row.spellings.len() {
+                census.distinguished_preserved += 1;
+            } else {
+                census.distinguished_collapsed += 1;
+                findings.push(Finding {
+                    id: row.id.clone(),
+                    what: format!(
+                        "distinguished spellings collapsed: {:?} -> {:?}",
+                        row.spellings, outputs
+                    ),
+                });
+            }
+            continue;
+        }
+
+        // --- rank 2: confluence, over families only ------------------------
+        if row.kind != RowKind::Family {
+            continue;
+        }
+        let arity = outputs.len();
+        let determinacy = row.determinacy();
+        // The ruling's split: DETERMINED families are the confluence
+        // denominator; INDETERMINATE ones are counted beside it and never in it.
+        match determinacy {
+            Determinacy::Indeterminate => {
+                census.indeterminate_families += 1;
+                if arity <= 1 {
+                    census.indeterminate_converged += 1;
+                } else {
+                    census.indeterminate_split += 1;
+                    divergences.push(Divergence {
+                        id: row.id.clone(),
+                        determinacy: determinacy.label(),
+                        outputs: outputs.iter().cloned().collect(),
+                    });
+                }
+            }
+            Determinacy::Determined | Determinacy::NoProtein => {
+                // Arity 0 — every spelling declined — is folded into
+                // `converged` rather than given an arm, and that is only safe
+                // because each of those declines already incremented
+                // `declined`, which both censuses pin at 0. So a family that
+                // converged by producing nothing cannot reach this figure
+                // without failing the census first. If `declined` ever stops
+                // being pinned at zero, split this arm out.
+                match arity {
+                    0 | 1 => census.converged += 1,
+                    2 => census.split_two += 1,
+                    3 => census.split_three += 1,
+                    _ => census.split_more += 1,
+                }
+                if arity > 1 {
+                    divergences.push(Divergence {
+                        id: row.id.clone(),
+                        determinacy: determinacy.label(),
+                        outputs: outputs.iter().cloned().collect(),
+                    });
+                }
+            }
+            // A family whose authored spelling denotes nothing is a
+            // `RowKind::Conflict`, so this arm is unreachable through `corpus()`.
+            // It is written out rather than folded into either branch above,
+            // because folding it would put an undenoted family into a
+            // confluence figure the ruling scopes to decided pairs.
+            Determinacy::Undenoted => {}
+        }
+    }
+
+    Measured {
+        census,
+        divergences,
+        findings,
+    }
+}
+
+fn measure(direction: ShuffleDirection) -> Measured {
+    let built = built();
+    let rows = grouped(&built);
+    let mut total = Measured {
+        census: Census {
+            measured_under: measurement_config(direction).error_config.mode,
+            ..Census::default()
+        },
+        ..Measured::default()
+    };
+    for group in frame_groups(&rows) {
+        let measured = measure_group(group, direction);
+        total.census.absorb(&measured.census);
+        total.divergences.extend(measured.divergences);
+        total.findings.extend(measured.findings);
+    }
+    total.divergences.sort_by(|a, b| a.id.cmp(&b.id));
+    total.findings.sort_by(|a, b| a.id.cmp(&b.id));
+    total
+}
+
+fn report(label: &str, measured: &Measured) -> String {
+    use std::fmt::Write;
+    let census = &measured.census;
+    let mut out = String::new();
+    let _ = writeln!(out, "== protein conformance census: {label} ==");
+    let _ = writeln!(out, "measured under: {:?}", census.measured_under);
+    let _ = writeln!(out, "-- validity --");
+    let _ = writeln!(out, "outputs                     {}", census.outputs);
+    let _ = writeln!(out, "declined                    {}", census.declined);
+    let _ = writeln!(
+        out,
+        "unparseable_outputs         {}",
+        census.unparseable_outputs
+    );
+    let _ = writeln!(
+        out,
+        "outputs_denoting_no_protein {}",
+        census.outputs_denoting_no_protein
+    );
+    let _ = writeln!(out, "-- protein preservation --");
+    let _ = writeln!(
+        out,
+        "protein_changed             {}",
+        census.protein_changed
+    );
+    let _ = writeln!(out, "-- idempotency --");
+    let _ = writeln!(
+        out,
+        "non_idempotent_outputs      {}",
+        census.non_idempotent_outputs
+    );
+    let _ = writeln!(out, "-- confluence (DETERMINED families only) --");
+    let _ = writeln!(out, "converged                   {}", census.converged);
+    let _ = writeln!(out, "split_two                   {}", census.split_two);
+    let _ = writeln!(out, "split_three                 {}", census.split_three);
+    let _ = writeln!(out, "split_more                  {}", census.split_more);
+    let _ = writeln!(
+        out,
+        "-- INDETERMINATE (its own column; never folded into the block above) --"
+    );
+    let _ = writeln!(
+        out,
+        "indeterminate_families      {}",
+        census.indeterminate_families
+    );
+    let _ = writeln!(
+        out,
+        "indeterminate_converged     {}",
+        census.indeterminate_converged
+    );
+    let _ = writeln!(
+        out,
+        "indeterminate_split         {}",
+        census.indeterminate_split
+    );
+    let _ = writeln!(
+        out,
+        "-- DISTINGUISHED (apply-equal, epistemically different; must NOT converge) --"
+    );
+    let _ = writeln!(
+        out,
+        "distinguished_rows          {}",
+        census.distinguished_rows
+    );
+    let _ = writeln!(
+        out,
+        "distinguished_preserved     {}",
+        census.distinguished_preserved
+    );
+    let _ = writeln!(
+        out,
+        "distinguished_collapsed     {}",
+        census.distinguished_collapsed
+    );
+    let _ = writeln!(out, "-- refusal --");
+    let _ = writeln!(
+        out,
+        "conflicts_accepted          {}",
+        census.conflicts_accepted
+    );
+    if !measured.divergences.is_empty() {
+        let _ = writeln!(out, "-- divergences --");
+        for divergence in measured.divergences.iter().take(MAX_DIVERGENCES) {
+            let _ = writeln!(
+                out,
+                "  {} [{}] -> {:?}",
+                divergence.id, divergence.determinacy, divergence.outputs
+            );
+        }
+        if measured.divergences.len() > MAX_DIVERGENCES {
+            let _ = writeln!(
+                out,
+                "  … and {} more",
+                measured.divergences.len() - MAX_DIVERGENCES
+            );
+        }
+    }
+    if !measured.findings.is_empty() {
+        let _ = writeln!(out, "-- findings --");
+        for finding in measured.findings.iter().take(MAX_DIVERGENCES) {
+            let _ = writeln!(out, "  {}: {}", finding.id, finding.what);
+        }
+        if measured.findings.len() > MAX_DIVERGENCES {
+            let _ = writeln!(
+                out,
+                "  … and {} more",
+                measured.findings.len() - MAX_DIVERGENCES
+            );
+        }
+    }
+    out
+}
+
+fn assert_census(direction: ShuffleDirection, label: &str, pinned: &Census) {
+    let measured = measure(direction);
+    assert_eq!(
+        &measured.census,
+        pinned,
+        "the {label} protein census moved.\n{}",
+        report(label, &measured)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_corpus_has_the_shape_its_censuses_are_measured_over() {
+    let built = built();
+    let shape = CorpusShape::of(&built);
+    assert_eq!(
+        shape,
+        SHAPE,
+        "the protein corpus's shape moved, so every figure below is measured over a \
+         different population:\n  by kind      {:?}\n  by stratum   {:?}\n  by site      {:?}\n  \
+         by edit      {:?}\n  by shape     {:?}\n  by phase     {:?}\n  by determinacy {:?}\n  \
+         drops        {:?}",
+        built.by_kind(),
+        built.by_stratum(),
+        built.by_site(),
+        built.by_edit(),
+        built.by_shape(),
+        built.by_junction_phase(),
+        built.by_determinacy(),
+        built.drops,
+    );
+    // Naming the drops is part of the shape: a design that stops being
+    // generated is invisible in a bare count.
+    let dropped: Vec<String> = built
+        .dropped
+        .iter()
+        .map(|(id, reason)| format!("{id} [{}]", reason.label()))
+        .collect();
+    assert_eq!(
+        dropped.len(),
+        built.designs_considered - built.rows.len(),
+        "the drop list and the drop count disagree: {dropped:?}"
+    );
+}
+
+/// Every family's spellings denote one protein, established through the oracle
+/// and not through the normalizer.
+///
+/// Without this the confluence figures would be unattributable: a family whose
+/// spellings denote different proteins *should* reach different outputs, so a
+/// divergence would say nothing about the normalizer.
+#[test]
+fn every_family_denotes_one_protein_independently_of_the_normalizer() {
+    let built = built();
+    let mut checked = 0usize;
+    for row in &built.rows {
+        if row.kind != RowKind::Family {
+            continue;
+        }
+        let frame = row.frame();
+        for spelling in &row.spellings {
+            assert_eq!(
+                protein_denotation_of(frame.provider(), spelling),
+                row.denoted,
+                "{}: {spelling} does not denote the row's protein",
+                row.id
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "no family spellings were checked at all");
+}
+
+/// The corpus reaches every determinacy class, so the `Indeterminate` column
+/// has a non-empty denominator.
+///
+/// `0 of 0` is what a census with a vacuous column looks like, and it reads
+/// identically to a clean one.
+#[test]
+fn the_indeterminate_column_has_a_non_empty_denominator() {
+    let built = built();
+    let by_determinacy = built.by_determinacy();
+    let indeterminate = by_determinacy
+        .get(Determinacy::Indeterminate.label())
+        .copied()
+        .unwrap_or(0);
+    assert!(
+        indeterminate > 0,
+        "no indeterminate rows, so the column reports 0 of 0: {by_determinacy:?}"
+    );
+}
+
+/// **Is transcript geometry inert for a `p.`-only measurement?**
+///
+/// `tests/it/protein_axis_split_move.rs` argues that "a protein description has
+/// no codons of its own", from which it follows that the exon layout under a
+/// protein should not change what a `p.` description normalizes to. That is a
+/// claim about the axis, and this test measures it rather than assuming it —
+/// assuming it would be the sixth structural blindness, since the corpus varies
+/// phase and strand precisely so a junction-sensitive defect *could* show.
+///
+/// The assertion is on the measured verdict, so if the answer ever changes the
+/// test fails and the corpus's geometry dimension stops being decoration.
+#[test]
+fn shape_is_inert_for_the_protein_axis() {
+    let built = built();
+    let mut outputs_by_design: BTreeMap<String, BTreeMap<&'static str, Vec<String>>> =
+        BTreeMap::new();
+    for group in frame_groups(&grouped(&built)) {
+        let frame = group[0].frame();
+        let normalizer = Normalizer::with_config(
+            frame.provider().clone(),
+            measurement_config(ShuffleDirection::ThreePrime),
+        );
+        for row in group {
+            // The row id is `<shape>-<rest>`; the rest is the design.
+            let (shape_label, rest) = row.id.split_once('-').expect("row ids carry a shape");
+            let rendered: Vec<String> = row
+                .spellings
+                .iter()
+                .map(|spelling| match parse_hgvs(spelling) {
+                    Ok(parsed) => std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        normalizer.normalize(&parsed)
+                    }))
+                    .ok()
+                    .and_then(Result::ok)
+                    .map_or_else(|| "<declined>".to_string(), |value| value.to_string()),
+                    Err(_) => "<unparseable>".to_string(),
+                })
+                .collect();
+            let entry = outputs_by_design.entry(rest.to_string()).or_default();
+            let label = ProteinRefShape::all()
+                .into_iter()
+                .find(|shape| shape.label() == shape_label)
+                .expect("a row id names a known shape")
+                .label();
+            entry.insert(label, rendered);
+        }
+    }
+
+    let mut differing: Vec<&String> = Vec::new();
+    for (design, per_shape) in &outputs_by_design {
+        let distinct: BTreeSet<&Vec<String>> = per_shape.values().collect();
+        if distinct.len() > 1 {
+            differing.push(design);
+        }
+    }
+    assert!(
+        outputs_by_design.len() > 1,
+        "nothing to compare across geometries"
+    );
+    // …and that is a count of GROUPS, not of comparisons. A group holding one
+    // geometry cannot disagree with itself, so it contributes agreement it never
+    // demonstrated — the `0 of 0` shape `spec_conformance_axis` already guards
+    // its own denominators against. Every row is built on every shape today, so
+    // the contract is the full set, not merely "more than one".
+    let geometries = ProteinRefShape::all().len();
+    let short: Vec<(&String, usize)> = outputs_by_design
+        .iter()
+        .filter(|(_, per_shape)| per_shape.len() != geometries)
+        .map(|(design, per_shape)| (design, per_shape.len()))
+        .collect();
+    assert!(
+        short.is_empty(),
+        "{} of {} row groups were measured on fewer than all {geometries} geometries, so those \
+         rows were never compared across shapes at all and their inertness is unmeasured. \
+         Starting with {:?}. Fix the generator or scope the claim — do not relax this, because a \
+         group with one shape reads exactly like a group that agreed.",
+        short.len(),
+        outputs_by_design.len(),
+        short.iter().take(5).collect::<Vec<_>>()
+    );
+    assert!(
+        differing.is_empty(),
+        "transcript geometry is NOT inert for the protein axis — {} of {} designs differ across \
+         the three exon layouts, starting with {:?}. That is a finding, not a test to relax: it \
+         means a `p.` output depends on the splice structure under it, and the corpus's phase \
+         dimension has become load-bearing.",
+        differing.len(),
+        outputs_by_design.len(),
+        differing.iter().take(5).collect::<Vec<_>>()
+    );
+}
+
+/// A conflicting description denotes no protein, so a census that counted zero
+/// of them would be measuring nothing.
+#[test]
+fn the_conflict_stratum_denotes_nothing_before_the_normalizer_is_asked() {
+    let built = built();
+    let mut conflicts = 0usize;
+    for row in &built.rows {
+        if row.kind != RowKind::Conflict {
+            continue;
+        }
+        conflicts += 1;
+        assert!(
+            matches!(row.denoted, ProteinDenotation::NoSingleSequence(_)),
+            "{} is filed as a conflict but the oracle says {:?}",
+            row.id,
+            row.denoted
+        );
+    }
+    assert!(conflicts > 0, "the corpus holds no conflicting rows");
+}
+
+/// Every site the corpus declares is reachable on a real frame, including the
+/// two a nucleotide corpus has no analogue of.
+#[test]
+fn the_terminator_and_past_end_sites_resolve_where_the_corpus_says_they_do() {
+    let frame = ProteinFrame::from_cds(
+        ProteinRefShape::SingleExon,
+        &ferro_hgvs::conformance::protein_corpus::codon_core(
+            ferro_hgvs::conformance::protein_corpus::all_designs()[0],
+        ),
+    )
+    .expect("the first design is a CDS");
+    let residues = frame.residues().len() as u64;
+    assert_eq!(Site::Terminator.position(&frame), residues + 1);
+    assert_eq!(Site::PastEnd.position(&frame), residues + 2);
+    assert_eq!(
+        frame.residues_with_stop().len(),
+        residues as usize + 1,
+        "the terminator is addressable"
+    );
+}
+
+/// **CONTESTED — an open question, deliberately left failing and `#[ignore]`d.**
+///
+/// `p.Ala50[2]` and `p.Ala52_Ala53del` denote one protein: the reference tract
+/// holds four `Ala`, so stating two copies and deleting two residues leave the
+/// same molecule. Ferro preserves both spellings, so the pair is the whole of
+/// this census's `split_two`.
+///
+/// # Why it is not obviously a defect
+///
+/// `protein/repeated.md:22` states a preference and **conditions it on
+/// provenance ferro cannot recover**:
+///
+/// > "**NOTE**: when the repeat is variable in the population and the reference
+/// > sequence has 10 units, the description `p.Ala2[9]` is preferred over
+/// > `p.Ala11del`."
+///
+/// "when the repeat is variable in the population" is a fact about a population,
+/// not about the reference or the description, so a normalizer holding only a
+/// protein sequence cannot evaluate the antecedent. That is the same shape
+/// `rulings[separation-is-a-property-of-the-spelling-not-of-the-variant]`
+/// records for `delins.md:79-84`'s provenance rationale, and the shape
+/// `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]` warns
+/// about in terms: "two descriptions can be apply-equal on every axis and still
+/// make different epistemic claims, which is a canonical-form question and must
+/// not be encoded as a rung."
+///
+/// # What is actually open
+///
+/// Whether `[n]` is ferro's canonical form for a change wholly inside a tandem
+/// tract, unconditionally — which would satisfy `:22`'s consequent while
+/// ignoring its antecedent — or whether the two spellings stay distinct because
+/// the antecedent is unrecoverable. That is an operator decision under the
+/// escalation register in `rulings[adjudication-precedence-order]`, and it is
+/// not one this test may make. It is written as an assertion so the question is
+/// executable the moment it is answered, and `#[ignore]`d so it does not assert
+/// an answer nobody has given.
+#[test]
+#[ignore = "open question: protein/repeated.md:22 prefers the [n] form only under a \
+            population condition ferro cannot evaluate; needs an operator ruling"]
+fn the_repeat_count_and_the_explicit_deletion_of_one_tract_do_not_converge() {
+    let measured = measure(ShuffleDirection::ThreePrime);
+    assert_eq!(
+        measured.census.split_two,
+        0,
+        "the repeat-count and explicit-deletion spellings of one tract still \
+         diverge:\n{}",
+        report("3'", &measured)
+    );
+}
+
+/// **A rank-1 finding, measured rather than argued.**
+///
+/// Every conflicting description in the corpus is normalized in lenient mode —
+/// 72 of 72 — and the four shapes are a reversed range
+/// (`protein/deletion.md:18`), a non-flanking insertion
+/// (`protein/insertion.md:17-18`), two allele members claiming one residue, and
+/// a position past the terminator.
+///
+/// `rulings[absolute-prohibition-enforcement-stage]` (decided 2026-08-10) makes
+/// the enforcement stage mode-dependent: "strict fails at PARSE (strict
+/// validates input conformance, not merely parseability); lenient does not
+/// validate input conformance and fails only when it cannot NORMALIZE". So
+/// lenient's 72 is arguably the decided behaviour and strict's is not — which
+/// makes strict the measurement that matters, and it is taken here rather than
+/// inferred.
+///
+/// The record itself says the ruling is **not implemented** (#1630), so this
+/// pins the protein axis's share of that gap. The figure is asserted equal to
+/// the lenient one, so the day strict starts refusing, this fails and the gap is
+/// closed on the record.
+#[test]
+fn no_conflicting_description_is_refused_in_strict_mode_either() {
+    let built = built();
+    let mut conflicts = 0usize;
+    let mut accepted = 0usize;
+    let mut examples: Vec<String> = Vec::new();
+    for group in frame_groups(&grouped(&built)) {
+        let frame = group[0].frame();
+        let normalizer = Normalizer::with_config(
+            frame.provider().clone(),
+            NormalizeConfig::default()
+                .with_direction(ShuffleDirection::ThreePrime)
+                .with_error_mode(ErrorMode::Strict),
+        );
+        for row in group {
+            if row.kind != RowKind::Conflict {
+                continue;
+            }
+            conflicts += 1;
+            for spelling in &row.spellings {
+                let Ok(parsed) = parse_hgvs(spelling) else {
+                    continue;
+                };
+                if let Ok(value) = normalizer.normalize(&parsed) {
+                    accepted += 1;
+                    if examples.len() < 4 {
+                        examples.push(format!("{spelling} -> {value}"));
+                    }
+                }
+            }
+        }
+    }
+    assert!(conflicts > 0, "no conflicting rows to measure");
+    assert_eq!(
+        accepted, conflicts,
+        "strict mode's refusal rate on the protein axis moved — {accepted} of {conflicts} \
+         accepted, examples {examples:?}. If this is now LOWER, #1630 has progressed and the \
+         pin should come down with a note saying which shape strict began refusing."
+    );
+}
+
+#[test]
+fn three_prime_conformance_census() {
+    assert_census(ShuffleDirection::ThreePrime, "3'", &THREE_PRIME);
+}
+
+#[test]
+fn five_prime_conformance_census() {
+    assert_census(ShuffleDirection::FivePrime, "5'", &FIVE_PRIME);
+}


### PR DESCRIPTION
The protein axis has been *measurable* since the synthetic provider and the denotation oracle landed, and not *measured* — the corpus had no protein rows. This adds them, and reports the first census.

## Why the cores had to be redesigned

`spec_corpus`'s cores are xorshift draws over an `AT`/`ACGT` alphabet with a CDS laid over them at `(tx_len/8 + 1, tx_len - tx_len/8)` — a ratio, not a codon boundary. Such a core need not start at a start codon, need not be a whole number of codons, and may carry an interior terminator. Measured, **0 of 32** are open reading frames (`the_nucleotide_corpuss_cores_are_not_reading_frames` pins it, so the premise fails loudly if it ever stops holding).

`protein_corpus::codon_core` designs the CDS instead — a start codon, a body of sense codons, a terminator — and `ProteinFrame::from_cds` **translates** it. Back-translation would not have done: `ProteinFrame::build` takes the table's first codon per residue, so every CDS it can build holds at most 20 distinct codons and no synonymous pair, and the one shape a protein corpus has that a nucleotide corpus structurally cannot hold is unreachable in it — a tandem repeat of one residue spelled in four different synonymous codons, which is an ambiguous run on the protein axis and no run at all on the nucleotide one.

**#1810's generator (`codon_frame_deep_window_offset.rs`) was read and not reused.** Its two design choices are deliberately wrong here: a uniform `GCT` codon, so no residue identity varies, and no UTR with `cds_start = 1`, so there is nowhere for an N-terminal extension to start or a C-terminal one to read into. What is taken from it is its *finding* — that a site near `c.1` has its canonical window clamped and its phase forced to zero — which is why the designed sites sit at transcript position 160, past `CANONICAL_PAD`.

## The structural-blindness audit

Eleven properties are varied, each demonstrated by a test rather than asserted in prose. The phase knob is the one worth naming: the exon-1 junction's offset from a codon boundary works out to `(body_codons - 1) mod 3` and nothing else, so a generator that fixed the CDS length would have fixed the phase and agreed with itself on the one dimension a junction defect lives in. Three consecutive `body_codons` reach all three phases, and the arithmetic is checked against the frame rather than against itself.

Six properties are declared as limits the corpus **provably cannot reach**: `Sec`/`Pyl` (no non-terminator codon), `Xaa` in a reference, a non-standard genetic code, an incomplete or non-triplet CDS, codon-level ambiguity within one residue, and intronic/UTR positions.

One further limit is a property of the **axis**, not of the generator: a `p.` description has no codons of its own, so transcript geometry may be inert. That is measured, not assumed — `shape_is_inert_for_the_protein_axis` compares every design's outputs across all three exon layouts and both strands, and it is inert today. The phase dimension is therefore a guard against that changing, not a source of signal.

## `Indeterminate` is its own census column

On `rulings[confluence-gate-is-apply-equality-on-every-determined-axis]`: "confluence is asserted only over DECIDED pairs; the `Indeterminate` count is reported alongside and never folded into either side."

`RowKind::Distinguished` applies the same discipline one step further out, on the same record's caveat that "two descriptions can be apply-equal on every axis and still make different epistemic claims". A description and its parenthesised twin denote one protein — the oracle reads through the wrapper deliberately — but `protein/substitution.md:16` makes the parentheses an **evidential** claim, so convergence would destroy information. Filed as a family they produced 90 of the first run's 90 `split_two` rows, every one of them correct behaviour; a confluence figure whose bulk is the normalizer doing the right thing hides the rows where it does not.

## The measurement

540 rows / 1,044 spellings, byte-identical in both shuffle directions:

| figure | value |
|---|---|
| `unparseable_outputs` | 0 |
| `outputs_denoting_no_protein` | 0 |
| `protein_changed` | 0 |
| `non_idempotent_outputs` | 0 |
| `converged` / `split_two` | 198 / 18 (determined families only) |
| `indeterminate_families` | 18, all converged — its own column |
| `distinguished_preserved` | 90 of 90 |
| `conflicts_accepted` | **72 of 72** |

**`conflicts_accepted` 72 of 72 is the rank-1 finding**, and it holds in strict mode as well as lenient — a reversed range (`protein/deletion.md:18`), a non-flanking insertion (`protein/insertion.md:17-18`), two allele members claiming one residue, and a position past the terminator are each normalized and emitted unchanged. `rulings[absolute-prohibition-enforcement-stage]` makes lenient's behaviour arguably decided and strict's not, and records that the ruling is unimplemented (#1630); `no_conflicting_description_is_refused_in_strict_mode_either` pins the protein axis's share of that gap so it fails the day strict starts refusing.

The 18 divergent families are **one class and one open question**: `p.Ala50[2]` against `p.Ala52_Ala53del`. `protein/repeated.md:22` prefers the `[n]` form but conditions it on "when the repeat is variable in the population" — provenance a normalizer holding a protein sequence cannot evaluate. That needs an operator ruling, so it is carried as an `#[ignore]`d test with the question written on the attribute, not pinned to an answer nobody has given.

Two generator defects the drop ledger caught, both fixed here and both invisible without it: a hard-coded `Gly` as a frameshift's "first new amino acid" collided with the reference residue on 9 designs, and an overlapping-members conflict whose first member was a silent identity. The drop ids are now retained on the corpus, because a drop *count* cannot answer "which shape stopped being generated".

## What this deliberately does NOT do

**It does not lift the protein slice's blanket clause exemption, and a green census is not evidence for lifting it.** The oracle judges denotation and not validity — a one-for-one `delins`, a `Cys76_Cys76` range and a `p.[Arg76Ser;Cys77Trp]` all denote a protein perfectly well while the recommendations rule against each spelling. All **205** protein clause units stay `not-generatable` in the rule inventory, untouched by this change.

(A figure inherited from `synthetic_protein.rs`'s docs — "149 clauses (102 of them validity requirements)" — does not reconcile: the committed inventory counts 205 clause units over `docs/recommendations/protein/*`, which an independent re-derivation reproduces file for file, and nothing in the repository classifies a clause as a validity requirement. The new docs say so and quote 205; correcting the older comment is left for a change that can derive the right split.)

## CI cost

**~1.3 s**, over 23 tests: the six-frame corpus is rebuilt per test and normalization is 1,044 protein descriptions. Measured against a 105 s `--lib --test it` run, that is ~1.2 %. It belongs in the **default** selection and is not put behind `SWEEP_FILTER` — this repo already has a live example of a guard that quietly stopped running by being moved into a reduced selection, and 1.3 s does not buy that risk.

## Verification

`cargo nextest run --features dev --lib --test it --no-fail-fast` → **10,353 passed, 0 failed**. `cargo fmt --all --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean. The `#[ignore]`d test was run with `--run-ignored all` and confirmed to fail, so the open question is executable rather than decorative.

Representation-Change: none. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched; the change adds a conformance corpus, a census and a frame constructor, and moves no normalized output.
