### PR TITLE
fix(normalize): derive a cis allele that straddles the CDS end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,16 +206,27 @@ env:
   # before #1599 lowered the count it is derived from.
   #
   # WHY, REASON 2 — simpler, and not covered by the paragraphs above. Five tests
-  # in these modules do not merely count the defect, they ASSERT it: the four in
-  # `defect_non_idempotent_outputs` and
-  # `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`
-  # pin `c.*1delinsCTT` -> `c.72_*1insCT` -> `c.72delinsCCT` as a known
+  # in these modules used to not merely count the defect but ASSERT it: the four
+  # in `defect_non_idempotent_outputs` and
+  # `spec_corpus_regressions::an_insertion_at_the_cds_end_is_a_fixed_point`
+  # pinned `c.*1delinsCTT` -> `c.72_*1insCT` -> `c.72delinsCCT` as a known
   # non-fixed point. A test that pins a defect and an oracle that aborts on it
-  # cannot both run, whatever the census does. Together the two reasons account
-  # for all 7 tests a bare armed run fails, and `FERRO_ASSERT_IDEMPOTENT` alone
-  # accounts for all 7 — `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS`
-  # each contribute 0, and a prepared reference changes nothing (these modules
-  # are `MockProvider`-backed).
+  # cannot both run, whatever the census does.
+  #
+  # #1650 CLOSED that class. The chain is now `c.*1delinsCTT` ->
+  # `c.72delinsCCT` in one pass, `non_idempotent_outputs` reads 0 in both
+  # directions, and all five tests assert the fixed point instead — which is why
+  # the fifth is now named `..._is_a_fixed_point`. REASON 2 therefore no longer
+  # holds for `FERRO_ASSERT_IDEMPOTENT`, and the exclusion rests on REASON 1
+  # (the censuses count what the oracle would turn into `declined`) plus the
+  # denoted-sequence rows named below. It is deliberately NOT narrowed here:
+  # these modules build their own references and sweep them, so an armed run
+  # that began panicking mid-sweep would EMPTY a sweep rather than redden it,
+  # and establishing that it would not needs its own measurement with
+  # `tests/it/oracle_exclude_invariant.rs` updated in the same change.
+  #
+  # `FERRO_ASSERT_REPARSE` and `FERRO_ASSERT_IN_BOUNDS` each contribute 0, and a
+  # prepared reference changes nothing (these modules are `MockProvider`-backed).
   #
   # Locally, `scripts/run_oracle_suite.sh` applies this same exclusion, reading
   # it from here rather than copying it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,10 @@ a trap:
 FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev   # ALWAYS RED on main
 ```
 
-It fails **7** tests on a clean `origin/main`, and has for as long as the spec
-corpus has existed. Use the local runner instead, which mirrors `ci.yml`'s
+It has been red for as long as the spec corpus has existed. The count was **7**
+before #1650 closed the idempotency half; it is deliberately not restated here as
+a number, because nothing checks it and a stale one reads as a measurement — read
+it off a run. Use the local runner instead, which mirrors `ci.yml`'s
 `test-oracle` job — its flags, and its selection:
 
 ```bash
@@ -180,20 +182,27 @@ scripts/run_oracle_suite.sh --print-selection   # what it would run, without run
 scripts/run_oracle_suite.sh -E 'test(my_test)'  # extra args reach nextest
 ```
 
-**Why the bare form is red, and why that is not a coverage gap to close.** All 7
+**Why the bare form is red, and why that is not a coverage gap to close.** The
 failures come from `FERRO_ASSERT_IDEMPOTENT` alone — measured: `FERRO_ASSERT_REPARSE`
 and `FERRO_ASSERT_IN_BOUNDS` each contribute **0**, and a prepared reference
-changes nothing (the same 7 fail with and without `FERRO_MANIFEST`; every one of
-these modules is `MockProvider`-backed). All 7 live in modules `ORACLE_EXCLUDE`
+changes nothing (the same set fails with and without `FERRO_MANIFEST`; every one of
+these modules is `MockProvider`-backed). All of them live in modules `ORACLE_EXCLUDE`
 already names, for two reasons that are worth keeping apart:
 
-- **5 of them ASSERT the defect the oracle PANICS on.** The four
+- **Some of them USED TO ASSERT the defect the oracle PANICS on.** The
   `defect_non_idempotent_outputs` tests and
-  `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`
-  pin `c.*1delinsCTT` → `c.72_*1insCT` → `c.72delinsCCT` as a known non-fixed
-  point. A test that pins a defect and an oracle that aborts on it cannot both
-  run; there is no version of this the flag could pass.
-- **2 of them COUNT it**, and arming the oracle makes the count read *better*
+  `spec_corpus_regressions::an_insertion_at_the_cds_end_is_a_fixed_point`
+  pinned `c.*1delinsCTT` → `c.72_*1insCT` → `c.72delinsCCT` as a known non-fixed
+  point, and a test that pins a defect and an oracle that aborts on it cannot both
+  run. **#1650 closed that class** — the chain collapses to
+  `c.*1delinsCTT` → `c.72delinsCCT` in one pass, `non_idempotent_outputs` reads 0
+  in both directions, and those tests now assert the fixed point (which is why the
+  last one is named `..._is_a_fixed_point`). So this reason no longer holds for
+  `FERRO_ASSERT_IDEMPOTENT`. The exclusion is kept anyway, deliberately: see
+  `scripts/run_oracle_suite.sh`'s header for why, and note that narrowing it needs
+  its own measurement with `tests/it/oracle_exclude_invariant.rs` updated in the
+  same change.
+- **Others COUNT it**, and arming the oracle makes the count read *better*
   than the truth. `spec_conformance_axis`'s censuses wrap normalization in
   `catch_unwind`, so a panicking row is filed `declined` and never reaches its
   family's output set. See `ORACLE_EXCLUDE`'s comment in `ci.yml` for the
@@ -304,7 +313,7 @@ normalized description names may be past the end of its own sequence.
 
 `scripts/run_oracle_suite.sh` arms it too. As with the re-parse oracle,
 `FERRO_ASSERT_IN_BOUNDS` on its own fails **0** tests over `ORACLE_EXCLUDE`'s
-modules — the 7 failures a bare armed run shows are the idempotency oracle's,
+modules — the failures a bare armed run shows are the idempotency oracle's,
 and reading them as this one's would send you after the wrong invariant.
 
 It exists because the class kept being found by hand, one shape at a time —
@@ -367,8 +376,11 @@ FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev -E "$SWEEP_SELECTION"
 means inheriting the gap. The job where this flag is green is `sweeps`, so scope
 a local run to that job's selection rather than to the whole suite. Added to
 `ORACLE_EXCLUDE`'s modules it raises **5** further failures beyond the
-idempotency oracle's 7, all in `spec_corpus_regressions` and all the same shape
-as those: a test pinning the CDS-end defect that this oracle aborts on.
+idempotency oracle's own, all in `spec_corpus_regressions` and all the same shape
+as those: a test pinning the CDS-end defect that this oracle aborts on. (That 5
+was measured before #1650; it is the denoted-sequence class, which #1650 did not
+close — `sequence_changed` is unchanged at 4/0 — but re-measure rather than quote
+it, for the reason given above.)
 
 **That 5 is about `ORACLE_EXCLUDE`'s modules, and there is a second, unrelated 5
 below.** `test-oracle`'s own selection *excludes* those modules, and arming the

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -7,14 +7,28 @@
 #     FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
 #
 # -- CANNOT PASS on `main`, and has not been able to for as long as the spec
-# corpus has existed. It fails 7 tests, and all 7 are in modules `ci.yml` names
-# in `ORACLE_EXCLUDE` precisely so that the armed job never runs them:
+# corpus has existed. The failures are in modules `ci.yml` names in
+# `ORACLE_EXCLUDE` precisely so that the armed job never runs them. The count was
+# 7 before #1650 closed the idempotency half; it is not restated here as a number
+# because it is a moving figure that nothing checks -- read it off a run.
 #
-#   * defect_non_idempotent_outputs (4 tests) and
-#     spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point
-#     ASSERT the non-idempotency the oracle PANICS on. `c.*1delinsCTT` ->
-#     `c.72_*1insCT` -> `c.72delinsCCT` is a pinned defect; a test that pins it
-#     and an oracle that aborts on it cannot both run.
+#   * defect_non_idempotent_outputs and
+#     spec_corpus_regressions::an_insertion_at_the_cds_end_is_a_fixed_point
+#     USED TO ASSERT the non-idempotency the oracle PANICS on:
+#     `c.*1delinsCTT` -> `c.72_*1insCT` -> `c.72delinsCCT` was a pinned defect,
+#     and a test that pins it and an oracle that aborts on it cannot both run.
+#     #1650 FIXED that class -- the chain collapses to
+#     `c.*1delinsCTT` -> `c.72delinsCCT`, `non_idempotent_outputs` reads 0 in
+#     both directions, and both tests now assert the fixed point. So this bullet
+#     no longer describes a reason to exclude those two.
+#
+#     THE EXCLUSION IS KEPT ANYWAY, and deliberately: `spec_corpus_regressions`
+#     still pins rows the DENOTED-SEQUENCE oracle aborts on (see the note at the
+#     end of this header), and both modules build their own references and sweep
+#     them, so an armed run that started panicking mid-sweep would EMPTY the
+#     sweep rather than redden it -- the same instrument-destroys-instrument
+#     failure, differently sourced. Narrowing it needs that measured, with
+#     `tests/it/oracle_exclude_invariant.rs` updated in the same change.
 #   * spec_conformance_axis's two censuses COUNT it. The corpus wraps
 #     normalization in `catch_unwind`, so a panicking row is filed `declined`
 #     and its output never reaches the family's output set -- which does not

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -470,8 +470,13 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     // the reference, and only `lower_repeat_edits` reads it), so this pass —
     // which reasons purely about spans — could not use one even if it wanted
     // to.
-    let Some(mut edits) = collect_canonical_edits(&variants, kind, body, &template_accession)
-    else {
+    let Some(mut edits) = collect_canonical_edits(
+        &variants,
+        kind,
+        body,
+        &template_accession,
+        ExtendedBody::OFF,
+    ) else {
         return variants;
     };
     if edits
@@ -785,9 +790,110 @@ pub(crate) fn cis_axis_parts(
     v: &HgvsVariant,
     kind: CisKind,
 ) -> Option<(&Accession, Region, i64, i64, &NaEdit)> {
+    cis_axis_parts_on(v, kind, ExtendedBody::OFF)
+}
+
+/// How far the sequence-first pass's body region reaches past `cds_end`.
+///
+/// The `c.` axis relabels itself at `cds_end` — `c.<cds_len>` and `c.*1` name
+/// two adjacent bases of one contiguous reference string (`refseq.md`) — and
+/// [`simple_cds_pos`] reports each side under its own [`Region`]. That is right
+/// for a *renderer* and wrong for the window arithmetic in
+/// [`canonicalize_from_sequence`], which needs one line of comparable integers:
+/// `edit_span_union`, `w_lo`/`w_hi` and every offset derived from them cannot be
+/// computed across two axes that do not share an origin. The consequence was
+/// #1650 — a cis allele whose members straddle the CDS end was refused outright
+/// by [`collect_canonical_edits`], so it and its `inv` spelling were two fixed
+/// points for one variant while the identical design inside the CDS converged.
+///
+/// This folds `c.*N` onto **`cds_len + N`**, the coordinate it already has on
+/// the transcript once `frame.delta` (`cds_start - 1`) is added — so the fold is
+/// exact rather than an approximation, and `frame.delta` keeps working
+/// unchanged for the whole extended range. [`unfold_extended_body`] is the
+/// inverse, applied to the rebuilt members.
+///
+/// Deliberately one-sided: it reaches the 3'UTR and **not** the 5'UTR. `c.-N`
+/// would need the origin itself to move, which makes `w_lo`'s `.max(1)` clamp
+/// stop meaning "at or after the CDS start" and changes behaviour for every
+/// CDS-start-adjacent variant — #1650 names that as needing its own measurement,
+/// and it is left to #1816 rather than inherited here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExtendedBody(Option<i64>);
+
+impl ExtendedBody {
+    /// No extension: every member must sit wholly inside the positive body, the
+    /// behaviour every caller outside [`canonicalize_from_sequence`] keeps.
+    const OFF: Self = Self(None);
+
+    /// Extend the body to `cds_len + 3'UTR`, where `cds_end_axis` is the CDS end
+    /// expressed on the member axis (`cds_end - frame.delta`, i.e. the CDS
+    /// length). `None` wherever there is no CDS to change axis at.
+    fn to_cds_end(cds_end_axis: Option<i64>) -> Self {
+        Self(cds_end_axis)
+    }
+
+    /// Fold one endpoint onto the extended body axis, leaving every other region
+    /// alone so a member outside the CDS/3'UTR pair is refused exactly as before.
+    fn fold(self, endpoint: (Region, i64), body: Region) -> Option<(Region, i64)> {
+        // `OFF` must be a pass-through, **not** a refusal, and writing it as
+        // `self.0?` instead cost a debugging session: it made `cis_axis_parts`
+        // itself start declining every 3'UTR member, which silently switched off
+        // `collapse_overlapping_cis_edits` for them and regressed #1284's
+        // `c.[*10dup;*11dup]` to `c.[*11dup;*11dup]` — a failure with no
+        // syntactic connection to the extension, in a test the extension never
+        // reaches. The single most reachable value of this type is `OFF`; it has
+        // to mean "unchanged".
+        let Some(cds_end_axis) = self.0 else {
+            return Some(endpoint);
+        };
+        let (region, pos) = endpoint;
+        if region != Region::ThreePrimeUtr {
+            return Some(endpoint);
+        }
+        // `*N` is 1-based from the base after the stop codon, so `*1` is
+        // `cds_len + 1`. A non-positive `N` never reaches here — `simple_cds_pos`
+        // refuses it — but the checked add is what keeps an authored `c.*<huge>`
+        // from wrapping into the CDS instead of failing the width test (#1487).
+        Some((body, cds_end_axis.checked_add(pos)?))
+    }
+}
+
+/// [`cis_axis_parts`], with the 3'UTR optionally folded onto the extended body.
+fn cis_axis_parts_on(
+    v: &HgvsVariant,
+    kind: CisKind,
+    extended: ExtendedBody,
+) -> Option<(&Accession, Region, i64, i64, &NaEdit)> {
     let (accession, start, end, edit) = member_axis_endpoints(v, kind)?;
-    let (region, s, e) = join_pos(Some(start), Some(end))?;
+    let body = body_region(kind);
+    let (region, s, e) = join_pos(
+        Some(extended.fold(start, body)?),
+        Some(extended.fold(end, body)?),
+    )?;
     Some((accession, region, s, e, edit))
+}
+
+/// Render an axis position on the extended body back onto the region that names
+/// it, the inverse of [`ExtendedBody::fold`].
+///
+/// **Infallible, and deliberately so.** This returned `Option` in review, with a
+/// doc claiming `None` for "the 3'UTR half arriving with no `cds_end_axis`" — a
+/// state that cannot occur, since [`ExtendedBody`] is *built* from
+/// `cds_end_axis`, so nothing is ever folded when it is absent. Every arm
+/// returned `Some`, and the `?` at the call site read as a guard that was not
+/// one. A refusal that can never fire is worse than none: it invites the next
+/// reader to believe the case is handled.
+///
+/// With no `cds_end_axis` this is the identity on `body`, which is exactly the
+/// unextended behaviour.
+///
+/// A span that *straddles* the boundary IS a real refusal, and it belongs to the
+/// caller, which holds both endpoints — see [`render_on_its_own_region`].
+fn unfold_extended_body(pos: i64, body: Region, cds_end_axis: Option<i64>) -> (Region, i64) {
+    match cds_end_axis {
+        Some(end) if pos > end => (Region::ThreePrimeUtr, pos - end),
+        _ => (body, pos),
+    }
 }
 
 /// Whether a merged anchor restates the reference bases under its own span —
@@ -3278,11 +3384,66 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     //   clamp is applied here, by `boundary_delins_anchor`. (It used to be
     //   *deferred* here, by refusing every derivation that collapsed to one pure
     //   insertion; that refusal is gone — see where it stood, below.)
+    //
+    // **That third bullet is why the 3'UTR extension below is not a free
+    // relaxation.** The body-region check is named there as the mechanism
+    // enforcing the `cds_end` clamp, so admitting a `c.*N` member removes the
+    // enforcement point along with the refusal. `pinned_to_footprint` re-supplies
+    // it: with the pad at zero the derivation cannot reach a base no member
+    // already spans, so nothing can be *carried* across `cds_end` — only cut at
+    // it. That is #1651's own argument for its carve-out ("re-typing … reads the
+    // reference under the member's own span and moves nothing") applied to the
+    // partition instead of to the typing.
     let body = body_region(kind);
-    let (template_accession, _, _, _, _) = cis_axis_parts(&variants[0], kind)?;
+    // Read from `member_axis_endpoints` rather than `cis_axis_parts`, because the
+    // latter joins the two ends through `join_pos` and so refuses the straddling
+    // member this function is about — before `cds_end_axis`, the thing that makes
+    // it readable, has been resolved. Nothing but the accession is wanted here.
+    let (template_accession, _, _, _) = member_axis_endpoints(&variants[0], kind)?;
     let template_accession = template_accession.clone();
 
-    let mut edits = collect_canonical_edits(variants, kind, body, &template_accession)?;
+    let frame = axis_frame(kind, &template_accession, provider)?;
+    let accession = template_accession.transcript_accession_smol();
+
+    // The CDS end on the member axis: `cds_end - (cds_start - 1)`, i.e. the CDS
+    // length, which is both the last coordinate of the extended body and the
+    // anchor `cds_end_delins_anchor` clamps a terminal insertion onto. `None`
+    // wherever there is no CDS to change axis at — every genomic kind, and a
+    // non-coding transcript — which makes both inert there.
+    //
+    // `CisKind::Cds` only: `r.` reaches the same junction, but `normalize_cds`'s
+    // #387 clamp is gated on `AxisRegion::Cds`, so claiming the `r.` case here
+    // would make the derivation *disagree* with the per-member pipeline in the
+    // opposite direction — the very fault this fixes. Left for its own evidence.
+    let cds_end_axis = if matches!(kind, CisKind::Cds) {
+        provider
+            .get_transcript(&accession)
+            .ok()
+            .and_then(|tx| tx.cds_end)
+            .and_then(|end| i64::try_from(end).ok())
+            .map(|end| end - frame.delta)
+    } else {
+        None
+    };
+    let extended = ExtendedBody::to_cds_end(cds_end_axis);
+
+    let mut edits = collect_canonical_edits(variants, kind, body, &template_accession, extended)?;
+    // Did the extension actually admit something the unextended body would have
+    // refused? Asked by re-running the unextended reader rather than by inspecting
+    // positions, so the two readings cannot drift apart.
+    //
+    // The `cds_end_axis.is_some()` short-circuit is **exactly equivalent**, not an
+    // approximation, and it is there for cost: with no CDS end resolved `extended`
+    // IS `OFF`, so the call above already ran the unextended reader and succeeded,
+    // and re-running it could only succeed again. Without the guard every genomic,
+    // mitochondrial, `n.` and non-coding-`r.` derivation lowered its whole member
+    // list twice for an answer fixed at `false`. The remaining double read is on
+    // coding groups only; removing that one needs `collect_canonical_edits` to
+    // report whether it folded, which is a wider signature change than this fix
+    // wants.
+    let uses_extension = cds_end_axis.is_some()
+        && collect_canonical_edits(variants, kind, body, &template_accession, ExtendedBody::OFF)
+            .is_none();
 
     // A **lone** repeat is not what the lockout is about, and re-deriving one
     // can only cost. Its whole change is a single contiguous tract, so there is
@@ -3310,14 +3471,33 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     // both saturations land on the refusal the width test already gives an
     // over-wide window. A debug build panicked; a release build wrapped `w_hi`
     // negative and derived against a nonsense window, which is the worse half.
-    let mut w_lo = c_lo.saturating_sub(CANONICAL_PAD).max(1);
-    let mut w_hi = c_hi.saturating_add(CANONICAL_PAD);
+    //
+    // The extension reaches a group whose footprint **crosses** `cds_end`, and no
+    // other. A group sitting wholly in the 3'UTR keeps the refusal it has always
+    // had, which is not a scope decision made for tidiness — measured, admitting
+    // it regresses `issue_1284`'s `c.[*10dup;*11dup]` from `c.*10_*11A[4]` to
+    // `c.[*11dup;*11dup]`, two members claiming one base. That is #1281's shape,
+    // it round-trips through the sequence check (two `dup`s at one anchor insert
+    // the same two bases), and the per-member pipeline — which owns those rows
+    // today and answers them correctly — is the right place for them. #1650 is
+    // about a span the boundary *cuts*; nothing here is owed to a span it does
+    // not touch.
+    if uses_extension && !cds_end_axis.is_some_and(|end| c_lo <= end && end < c_hi) {
+        return None;
+    }
+    // For the groups that do cross, the pad goes to zero — see the note at the top
+    // of this function. The pad is the only room `shift_pieces` has, so with it
+    // gone a piece can be cut anywhere inside the members' own union and moved
+    // nowhere outside it; the `cds_end` clamp the body-region check used to supply
+    // is re-supplied by construction. It costs those groups the 3'-shift and
+    // `duplication_anchor`'s 5' lookback, which is a capability they have today
+    // only in the sense that they are refused outright.
+    let pad = if uses_extension { 0 } else { CANONICAL_PAD };
+    let mut w_lo = c_lo.saturating_sub(pad).max(1);
+    let mut w_hi = c_hi.saturating_add(pad);
     if w_hi - w_lo + 1 > MAX_CANONICAL_WINDOW {
         return None;
     }
-
-    let frame = axis_frame(kind, &template_accession, provider)?;
-    let accession = template_accession.transcript_accession_smol();
 
     // `general.md:44` exempts deletions and duplications around an exon/exon
     // junction from the 3' rule on the transcript axes, and the per-member
@@ -3397,7 +3577,7 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     // canonicalization problem: strict mode must still reject it and lenient
     // mode must still warn. Both live in the per-member pipeline, so refuse and
     // let it run (#1052, #1097).
-    if !stated_reference_bases_match(variants, kind, &ref_bytes, w_lo) {
+    if !stated_reference_bases_match(variants, kind, &ref_bytes, w_lo, extended) {
         return None;
     }
     let result = apply_edits_to_window(&edits, &ref_bytes, w_lo)?;
@@ -3796,7 +3976,13 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
         // partition, and running it first let a legitimate codon merge inflate the
         // weight and trip a refusal. With the bound deleted nothing weighs the
         // partition, so the order is kept as measured rather than as required.
-        apply_coding_codon_exception(pieces, frame.carries_translated_frame(), w_lo, &ref_bytes);
+        apply_coding_codon_exception(
+            pieces,
+            frame.carries_translated_frame(),
+            w_lo,
+            &ref_bytes,
+            cds_end_axis,
+        );
     };
 
     // The member count is a property of the sequence, so it may not depend on
@@ -3884,25 +4070,6 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
         SequenceEnds::INTERIOR
     };
 
-    // The CDS end on the member axis, for `cds_end_delins_anchor`. `None`
-    // wherever there is no CDS to change axis at — every genomic kind, and a
-    // non-coding transcript — which makes that clamp inert there.
-    //
-    // `CisKind::Cds` only: `r.` reaches the same junction, but `normalize_cds`'s
-    // #387 clamp is gated on `AxisRegion::Cds`, so claiming the `r.` case here
-    // would make the derivation *disagree* with the per-member pipeline in the
-    // opposite direction — the very fault this fixes. Left for its own evidence.
-    let cds_end_axis = if matches!(kind, CisKind::Cds) {
-        provider
-            .get_transcript(&accession)
-            .ok()
-            .and_then(|tx| tx.cds_end)
-            .and_then(|end| i64::try_from(end).ok())
-            .map(|end| end - frame.delta)
-    } else {
-        None
-    };
-
     let rebuilt = rebuild_members(
         &pieces,
         &variants[0],
@@ -3936,7 +4103,8 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     // cannot serve. Collapsing all three into one boolean would hide that case
     // among the other two, so it gets a `debug_assert` of its own — loud in
     // tests and development, with the runtime refusal still carrying release.
-    let rebuilt_edits = collect_canonical_edits(&rebuilt, kind, body, &template_accession)?;
+    let rebuilt_edits =
+        collect_canonical_edits(&rebuilt, kind, body, &template_accession, extended)?;
     let reapplied = apply_edits_to_window(&rebuilt_edits, &ref_bytes, w_lo)?;
     debug_assert_eq!(
         reapplied, result,
@@ -4020,10 +4188,11 @@ fn collect_canonical_edits(
     kind: CisKind,
     body: Region,
     template_accession: &Accession,
+    extended: ExtendedBody,
 ) -> Option<Vec<GEdit>> {
     let mut edits = Vec::with_capacity(variants.len());
     for v in variants {
-        let (accession, region, s, e, edit) = cis_axis_parts(v, kind)?;
+        let (accession, region, s, e, edit) = cis_axis_parts_on(v, kind, extended)?;
         if accession != template_accession || region != body {
             return None;
         }
@@ -4310,9 +4479,10 @@ fn stated_reference_bases_match(
     kind: CisKind,
     ref_bytes: &[u8],
     w_lo: i64,
+    extended: ExtendedBody,
 ) -> bool {
     for v in variants {
-        let Some((_, _, s, _, edit)) = cis_axis_parts(v, kind) else {
+        let Some((_, _, s, _, edit)) = cis_axis_parts_on(v, kind, extended) else {
             return false;
         };
         // Every `NaEdit` channel that can carry submitter-asserted reference
@@ -9298,10 +9468,28 @@ fn apply_coding_codon_exception(
     reading_frame: bool,
     w_lo: i64,
     ref_bytes: &[u8],
+    cds_end_axis: Option<i64>,
 ) {
     if !reading_frame {
         return;
     }
+    // The exception's second conjunct — "together affecting one amino acid" — is
+    // unstatable past the stop codon, so a triplet reaching into the 3'UTR is not
+    // the shape `general.md:35` describes and `general.md:34`'s plain rule governs
+    // it: described individually. This is the same reading
+    // `projection-codon-exception-is-decided-by-the-rendered-axis` (2026-08-11)
+    // gives for a genomic axis, applied to the coding axis's own 3' end rather
+    // than to a different prefix.
+    //
+    // **DEFENSIVE, and not currently demonstrated to change any answer.** Two
+    // inputs were built to reach it and neither does — both stay green with this
+    // predicate forced to `true`. The table and the reasoning are on
+    // `a_pair_whose_triplet_reaches_past_the_stop_codon_stays_two_members`
+    // (`tests/it/issue_1536_cds_boundary_delins.rs`); do not cite this line as
+    // guarded. It is kept because `same_codon` is `(a - 1) / 3` and so answers
+    // for a codon that does not exist, silently, the moment some later change
+    // makes the line reachable — the wrong direction to fail in.
+    let within_cds = |last: i64| cds_end_axis.is_none_or(|end| last <= end);
     // A single changed reference base replaced by a single alt base — the
     // `Substitution` the spec's "two variants" are.
     let is_substitution =
@@ -9332,6 +9520,7 @@ fn apply_coding_codon_exception(
         if separated_by_one
             && is_substitution(&pieces[index - 1])
             && starts_with_substitution
+            && within_cds(triplet_start + 2)
             && same_codon(triplet_start, triplet_start + 2)
         {
             let middle = ref_bytes[previous_end];
@@ -9857,7 +10046,10 @@ fn rebuild_members(
             cds_end_axis,
         )?;
         previous_ref_end = piece.ref_end;
-        members.push(build_merged(template, anchor));
+        members.push(build_merged(
+            template,
+            render_on_its_own_region(anchor, body, cds_end_axis)?,
+        ));
     }
     Some(members)
 }
@@ -10171,8 +10363,52 @@ pub(crate) fn denoted_bases(
     let (accession, _, _, _, _) = cis_axis_parts(members.first()?, kind)?;
     // Borrowed: both this and `members` come immutably out of the same slice, so
     // the clone satisfied no borrow and cost a `String` per derivation.
-    let edits = collect_canonical_edits(members, kind, body_region(kind), accession)?;
+    let edits = collect_canonical_edits(
+        members,
+        kind,
+        body_region(kind),
+        accession,
+        ExtendedBody::OFF,
+    )?;
     apply_edits_to_window(&edits, reference, w_lo)
+}
+
+/// Put an anchor built on the **extended body** back onto the region that names
+/// each of its endpoints — the rendering half of [`ExtendedBody`].
+///
+/// A no-op whenever the anchor sits inside the CDS, which is every group the
+/// extension did not admit, so this cannot move an existing row.
+///
+/// # A straddling anchor is refused, not truncated
+///
+/// [`Anchor`] carries **one** [`Region`] for both endpoints, so a piece running
+/// from `c.<cds_len-1>` to `c.*2` has no anchor to be. Refusing hands the group
+/// back to the per-member pipeline, which is exactly what happened to it before
+/// this extension existed — so the refusal is the status quo for that shape and
+/// not a new decline. Widening `Anchor` to a region per endpoint would let it be
+/// built and is left to #1816 with the 5'UTR half, because the two want the same
+/// change and measuring them together is cheaper than twice.
+///
+/// The insertion form is why the endpoints are read independently rather than
+/// through an ordering test: [`Anchor`]'s insertion shape is `start > end`
+/// (`build_naedit` reads the gap from the raw endpoints), so a `start <= end`
+/// precondition would silently exclude every derived insertion.
+fn render_on_its_own_region(
+    anchor: Anchor,
+    body: Region,
+    cds_end_axis: Option<i64>,
+) -> Option<Anchor> {
+    let (start_region, start) = unfold_extended_body(anchor.start, body, cds_end_axis);
+    let (end_region, end) = unfold_extended_body(anchor.end, body, cds_end_axis);
+    if start_region != end_region {
+        return None;
+    }
+    Some(Anchor {
+        region: start_region,
+        start,
+        end,
+        ..anchor
+    })
 }
 
 /// Build the [`Anchor`] for one piece, typing it under the spec's rules.
@@ -14356,7 +14592,13 @@ mod tests {
             HgvsVariant::Allele(allele) => allele.variants.clone(),
             single => vec![single],
         };
-        stated_reference_bases_match(&members, CisKind::Genome, reference.as_bytes(), 1)
+        stated_reference_bases_match(
+            &members,
+            CisKind::Genome,
+            reference.as_bytes(),
+            1,
+            ExtendedBody::OFF,
+        )
     }
 
     /// An identity spelling its base asserts that base, so a wrong assertion must

--- a/tests/it/defect_non_idempotent_outputs.rs
+++ b/tests/it/defect_non_idempotent_outputs.rs
@@ -1,30 +1,53 @@
-//! The corpus's `non_idempotent_outputs` class, dissected: **4 outputs at 3' and
-//! 4 at 5'** that are not their own fixed point.
+//! The corpus's `non_idempotent_outputs` class, dissected — and **now empty: 0
+//! outputs at 3' and 0 at 5'.**
 //!
-//! # HALF OF THIS CLASS IS FIXED — the three `scale-*` rows are gone
+//! # THE WHOLE CLASS IS FIXED, in two changes with two different mechanisms
 //!
-//! It was **7 at 3'**. The branch that adds `general.md:35`'s second conjunct
-//! ("together affecting one amino acid") to `coalesce_coding_frame_separation`
-//! removed the whole of "Mechanism 2 of 2" below: the three
-//! `scale-c3p-sep{120,128,136}-del-del` rows now settle in **one** pass, and the
+//! It was **7 at 3'** and **4 at 5'**.
+//!
+//! **Mechanism 2 of 2 — the three `scale-*` rows — went first.** Adding
+//! `general.md:35`'s second conjunct ("together affecting one amino acid") to
+//! `coalesce_coding_frame_separation` made
+//! `scale-c3p-sep{120,128,136}-del-del` settle in **one** pass, and the
 //! coding-axis onset sweep that found the class on five of six `ACGT` cores finds
-//! it on **none**.
-//!
-//! The mechanism is the one this file identified and is worth stating in its own
-//! terms, because it is the confirmation: the second pass was reaching a shorter
-//! partition than the first *by merging across codon boundaries the exception
-//! never reached*. Remove those merges and the first pass lands where the second
-//! used to. The three second-pass answers this file pinned are unchanged strings
-//! — they are simply now the **first**-pass answers, which is why
-//! [`pass_one_is_already_a_fixed_point_of_per_member_normalization`] can keep the
+//! it on **none**. The second pass had been reaching a shorter partition than the
+//! first *by merging across codon boundaries the exception never reached*; remove
+//! those merges and the first pass lands where the second used to. The three
+//! second-pass answers this file pinned are unchanged strings — they are simply
+//! now the **first**-pass answers, which is why
+//! [`pass_one_is_already_a_fixed_point_of_per_member_normalization`] keeps the
 //! same table of three expected strings, moved one pass earlier.
 //!
-//! **The pins below are flipped, not deleted.** Every one of them now asserts the
-//! fixed point, and says in its own doc what it used to assert and what changed.
-//! `KNOWN_DIVERGENT_INPUTS`'s discipline applies here too: a deviation that has
-//! been fixed must stay visible, so that it cannot silently come back. What is
-//! **not** claimed is that the class is fixed — mechanism 1, the four `cds-end`
-//! families, is untouched at both 3' and 5'.
+//! **Mechanism 1 of 2 — the four `cds-end` rows — went with #1650.** The
+//! sequence-first pass refused every member on the far side of `cds_end`
+//! (`merge::collect_canonical_edits`'s body-region check), so the group was
+//! handed to the per-member pipeline and the *second* pass answered a question
+//! the first could not see. `merge::ExtendedBody` folds `c.*N` onto
+//! `cds_len + N`, the first pass reads both sides, and
+//! `c.*1delinsCTT -> c.72_*1insCT -> c.72delinsCCT` collapses to
+//! `c.*1delinsCTT -> c.72delinsCCT`.
+//!
+//! **The re-typing itself is NOT fixed and is still pinned.** The interbase
+//! immediately 3' of the last CDS base still re-types a two-base insertion into a
+//! `delins` where all 94 others do not —
+//! [`an_insertion_immediately_after_the_last_cds_base_is_retyped_as_a_delins`]
+//! keeps that sweep. #1650 removed the disagreement between two passes; it did
+//! not remove the asymmetry between one interbase and the rest.
+//!
+//! **Nor is the sequence-changing class at the same boundary.**
+//! `spec_conformance_axis`'s `sequence_changed` reads **4 at 3' either side of
+//! #1650** — the `s00-c3m-cds-end-del-ins-*` rows, respelled from
+//! `c.[72delinsTA;*2del]` to `c.*1T>A`, denoting the same wrong bases. That is a
+//! rank-1 defect and a different row set from the seven named here; do not read
+//! this module's zero as covering it.
+//!
+//! **The pins below are flipped, not deleted** — with one deliberate exception,
+//! `norm_cubed_equals_norm_squared_for_every_row_in_the_class`, which instructed
+//! its own deletion once `a == b`; a tombstone comment stands where it was.
+//! Every remaining pin now asserts the fixed point and says in its own doc what
+//! it used to assert and what changed. `KNOWN_DIVERGENT_INPUTS`'s discipline
+//! applies here too: a deviation that has been fixed must stay visible, so that
+//! it cannot silently come back.
 //!
 //! # What this file is for
 //!
@@ -38,22 +61,36 @@
 //! Both are pinned here as refutations, in this repository's "record what was
 //! refuted, not only what was decided" tradition.
 //!
-//! # These pin DEFECTS, not answers
+//! # These pinned DEFECTS, and now pin that they are fixed
 //!
-//! Every expectation below is what ferro produces on
-//! `feat/exhaustive-spec-corpus` at `a8c415ba`, and the idempotency failures are
-//! **wrong**. Idempotency is not a spec clause — it is an invariant of any
+//! The expectations below began as what ferro produced on
+//! `feat/exhaustive-spec-corpus` at `a8c415ba`, where the idempotency failures
+//! were **wrong**. Idempotency is not a spec clause — it is an invariant of any
 //! normalizer, and `FERRO_ASSERT_IDEMPOTENT` exists to police it — so the
-//! citations below bear on the *mechanism*, not on the invariant. When one is
-//! fixed, the assertion moves to the correct value in the same commit, the
-//! `spec_conformance_axis` census is re-blessed in that same commit, and the
-//! comment says so.
+//! citations here bear on the *mechanism*, not on the invariant. The stated
+//! protocol was: when one is fixed, the assertion moves to the correct value in
+//! the same commit, the `spec_conformance_axis` census is re-blessed in that same
+//! commit, and the comment says so. That protocol has now been followed twice,
+//! and the second time emptied the class.
+//!
+//! What remains pinned as a DEFECT is the re-typing sweep and the
+//! `spec_corpus_regressions.rs` rows named above; what is pinned as an ACHIEVED
+//! invariant is idempotency over all seven former-class families.
 //!
 //! # Why this module is in `ORACLE_EXCLUDE`
 //!
 //! It measures over the spec corpus, and `FERRO_ASSERT_IDEMPOTENT` **panics** on
 //! exactly the condition it measures. A panicking row contributes no output, so
-//! an armed run would not redden this file — it would silently empty it. See
+//! an armed run would not redden this file — it would silently empty it.
+//!
+//! **The exclusion is deliberately NOT removed now that the class is empty**, and
+//! that is a scope decision rather than an oversight. The oracle would today have
+//! nothing to panic on, so the exclusion looks removable; but the file still
+//! sweeps 95 interbases per family and builds its own references, and an armed
+//! run that starts panicking mid-sweep would empty the sweep rather than redden
+//! it — the same failure, differently sourced. Removing it belongs to whoever can
+//! measure that, with `tests/it/oracle_exclude_invariant.rs` updated in the same
+//! change. See
 //! `tests/it/oracle_exclude_invariant.rs`, which fails if this module is not
 //! named in `ci.yml`'s `ORACLE_EXCLUDE`.
 
@@ -70,8 +107,15 @@ use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
 // The class, by row id
 // ---------------------------------------------------------------------------
 
-/// The four `cds-end` families. These are the whole 5' set, and four of the
-/// seven at 3'.
+/// The four `cds-end` families. They were the whole 5' set and four of the seven
+/// at 3', and **they are FIXED** — by #1650, which let the sequence-first pass
+/// read a member on either side of `cds_end` so that the answer the second pass
+/// used to supply is now reached by the first.
+///
+/// Kept as a named list for the same reason [`SCALE_FAMILIES`] is: the tests that
+/// pinned their instability now pin that they are fixed points, and the list is
+/// what stops a later generator edit from quietly un-generating the rows that
+/// prove it.
 const CDS_END_FAMILIES: [&str; 4] = [
     "s01-c3m-cds-end-dup-dup-p1-sep0",
     "s01-c3m-cds-end-dup-dup-p1-sep1",
@@ -90,39 +134,26 @@ const SCALE_FAMILIES: [&str; 3] = [
     "scale-c3p-sep136-del-del",
 ];
 
-/// Every family holding a non-idempotent output, in id order.
+/// Every family that ever held a non-idempotent output, in id order.
 ///
-/// **`SCALE_FAMILIES` is deliberately no longer chained in.** It was, and the
-/// three rows it names are the ones the amino-acid precondition fixed; leaving
-/// them here would make every caller iterate an empty spelling list, which is the
-/// silent-vacuity failure `every_scale_family_is_now_a_fixed_point` exists to
-/// make loud instead.
-fn affected_families() -> Vec<&'static str> {
-    let mut ids: Vec<&'static str> = CDS_END_FAMILIES.to_vec();
+/// **The class is now EMPTY, and this list is what keeps that assertable.** Both
+/// halves are fixed — `SCALE_FAMILIES` by the amino-acid precondition, and
+/// `CDS_END_FAMILIES` by #1650 — so no caller iterates "the affected families"
+/// any more. What the tests below iterate instead is *the former class*, and what
+/// they assert is that every spelling of every one of these seven rows is its own
+/// fixed point.
+///
+/// The function this replaces (`affected_families`) returned only the families
+/// still believed broken, which made every consumer go silently vacuous the
+/// moment one was fixed. That happened once already — three `scale-*` rows
+/// stopped being measured and nothing went red — so the direction of the list is
+/// deliberately inverted: it names what must STAY fixed, which cannot empty
+/// itself.
+fn former_class() -> Vec<&'static str> {
+    let mut ids: Vec<&'static str> = SCALE_FAMILIES.to_vec();
+    ids.extend_from_slice(&CDS_END_FAMILIES);
     ids.sort_unstable();
     ids
-}
-
-/// The one spelling of `row` whose output is not its own fixed point.
-///
-/// Fails with a message naming the flip rather than panicking on an out-of-bounds
-/// index. A bare `[0]` on this list reported "the defect got fixed" as
-/// `index out of bounds: the len is 0 but the index is 0`, which is the opposite
-/// of the repo's rule that a fixed deviation must fail *legibly* — the same rule
-/// `ferro_produces_the_form_the_spec_states` implements by failing when a listed
-/// input starts matching the spec.
-fn sole_non_idempotent_spelling(row: &Row, direction: ShuffleDirection) -> String {
-    let spellings = non_idempotent_spellings(row, direction);
-    assert_eq!(
-        spellings.len(),
-        1,
-        "{} ({direction:?}): expected exactly one non-idempotent spelling. An EMPTY list means \
-         the defect this test pins is FIXED — flip the pin to assert the fixed point and \
-         re-bless `spec_conformance_axis`'s census in the same commit; more than one means the \
-         class grew. Found {spellings:#?}",
-        row.id
-    );
-    spellings[0].to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -294,128 +325,111 @@ fn each_member_normalized(frame: &Frame, input: &str, direction: ShuffleDirectio
 
 /// **Question.** Which spelling of an affected family is the non-idempotent one?
 ///
-/// **The spanning `delins` respelling, in all 8 cases — never an authored
-/// allele, and never a description with more than one member.** Each of the
-/// four `cds-end` families holds exactly one non-idempotent spelling at 3' and
-/// one at 5' as well, and every one of those 8 is a single-member `delins`
-/// that the corpus generated as a *respelling* of a two-member design.
+/// **None — the class is empty in both directions, and the axis census agrees.**
 ///
-/// **It was 11 across seven families.** The three `scale-*` families no longer
-/// hold one at all; that half is checked by
-/// [`every_scale_family_is_now_a_fixed_point`], immediately below, so the fix
-/// stays asserted rather than merely absent from this loop.
+/// This is the FLIPPED pin. It used to answer "the spanning `delins` respelling,
+/// in all 8 cases", and to require exactly one such spelling per `cds-end`
+/// family. #1650 removed the last of them: the sequence-first pass can now read a
+/// member on either side of `cds_end`, so the respelling settles on the first
+/// pass instead of the second. `spec_conformance_axis`'s `non_idempotent_outputs`
+/// went 4 -> 0 at 3' and 4 -> 0 at 5' in the same commit.
 ///
-/// That is the first thing to know about this class, because it disposes of the
-/// most natural guess. The adjacent, already-pinned defect is that ferro
-/// normalizes cis members independently and concatenates
-/// (`the_cds_end_flush_pair_is_its_two_members_normalized_separately` in
-/// `spec_corpus_regressions.rs`). A defect of member *interaction* cannot be
-/// reached from an input that has no members. Whatever moves these outputs, it
-/// moves them before an allele exists.
-///
-/// The corpus's own census is the denominator: 4 and 4 are the only
-/// non-idempotent outputs across all 58,552 spellings, pinned in
-/// `spec_conformance_axis.rs`. This test does not re-scan the corpus — it names
-/// the rows so a later generator edit cannot un-generate them silently, which is
-/// the #1456/#1460/#1478 blindness class.
+/// **The cross-check against the axis census is the part that still bites, and it
+/// is why this test is flipped rather than deleted.** The scan below is over the
+/// seven *named* rows; the census figure is derived independently, by scanning
+/// all 58,552 spellings. So a family the corpus NEWLY makes non-idempotent moves
+/// the census while this list stays put, and the two disagree — exactly the
+/// coverage the pre-flip version provided, pointed the other way. Zero on both
+/// sides is a real equality here, not a tautology, because the two sides are
+/// computed from different populations.
 #[test]
-fn the_non_idempotent_output_is_always_the_spanning_delins_respelling() {
-    let mut three_prime = 0usize;
-    let mut five_prime_families: Vec<&str> = Vec::new();
+fn the_non_idempotent_class_is_empty_and_the_axis_census_agrees() {
+    let mut three_prime: Vec<&str> = Vec::new();
+    let mut five_prime: Vec<&str> = Vec::new();
+    let mut rows_scanned = 0usize;
 
-    for id in affected_families() {
+    for id in former_class() {
         let row = row(id);
-
-        let at_three = non_idempotent_spellings(row, ShuffleDirection::ThreePrime);
-        assert_eq!(
-            at_three.len(),
-            1,
-            "{id} must hold exactly one non-idempotent spelling at 3', found {at_three:#?}"
-        );
-        three_prime += at_three.len();
-
-        let spelling = at_three[0];
         assert!(
-            !spelling.contains('['),
-            "{id}: the non-idempotent spelling must be single-member, got `{spelling}`"
+            !row.spellings.is_empty(),
+            "{id}: VACUOUS — the corpus generates no spellings for this row, so scanning it \
+             proves nothing. A generator edit that un-generates a row is the #1456/#1460/#1478 \
+             blindness class and must fail here rather than pass quietly."
         );
-        assert!(
-            spelling.contains("delins"),
-            "{id}: the non-idempotent spelling must be the spanning delins, got `{spelling}`"
-        );
-        assert_ne!(
-            spelling,
-            row.authored_spelling(),
-            "{id}: the non-idempotent spelling must be a RESPELLING, not the authored design"
-        );
-
-        let at_five = non_idempotent_spellings(row, ShuffleDirection::FivePrime);
-        if !at_five.is_empty() {
-            assert_eq!(
-                at_five, at_three,
-                "{id}: the two directions must agree on WHICH spelling moves"
-            );
-            five_prime_families.push(id);
+        if !non_idempotent_spellings(row, ShuffleDirection::ThreePrime).is_empty() {
+            three_prime.push(id);
         }
+        if !non_idempotent_spellings(row, ShuffleDirection::FivePrime).is_empty() {
+            five_prime.push(id);
+        }
+        rows_scanned += 1;
     }
 
-    // Compared against the AXIS census, not against a literal. A literal `7` is
-    // tautological here: the loop runs once per `affected_families()` entry and
-    // each is asserted to hold exactly one spelling, so the count is the length
-    // of a hardcoded list and equals itself whatever the corpus does. The axis
-    // figure is derived independently — by scanning every row rather than the
-    // seven named ones — so a family the corpus NEWLY makes non-idempotent moves
-    // it while this list stays put, and the two disagree. That disagreement is
-    // the coverage; it is the same cross-check
-    // `corpus_prohibited_inputs::every_prohibition_violating_output_is_a_re_emitted_prohibited_input`
-    // makes with `CENSUS_TOTAL`.
     assert_eq!(
-        three_prime,
+        rows_scanned,
+        SCALE_FAMILIES.len() + CDS_END_FAMILIES.len(),
+        "VACUOUS — {rows_scanned} rows were scanned; the former class is seven families"
+    );
+    let empty: Vec<&str> = Vec::new();
+    assert_eq!(
+        three_prime, empty,
+        "a former-class family is non-idempotent again at 3'. This is a REGRESSION, not a \
+         re-bless: re-open the mechanism rather than moving the census."
+    );
+    assert_eq!(
+        five_prime, empty,
+        "a former-class family is non-idempotent again at 5'"
+    );
+    assert_eq!(
+        three_prime.len(),
         crate::spec_conformance_axis::THREE_PRIME.non_idempotent_outputs,
-        "PINNED DEFECT — the named families no longer account for the axis census's 3' \
-         non-idempotent outputs. If the corpus made a new family non-idempotent, name it in \
-         `CDS_END_FAMILIES` here and re-bless the axis in the same commit; if the count FELL, \
-         a family was fixed — move it out of `affected_families` and flip its pins"
+        "the named families no longer account for the axis census's 3' non-idempotent outputs. \
+         If the corpus made a NEW family non-idempotent it will show here as the census being \
+         non-zero while this list is empty — name it and pin its mechanism; do not simply \
+         re-bless the axis."
     );
     assert_eq!(
-        five_prime_families,
-        CDS_END_FAMILIES.to_vec(),
-        "PINNED DEFECT — the 5' class is the four cds-end families and nothing else"
-    );
-    assert_eq!(
-        five_prime_families.len(),
+        five_prime.len(),
         crate::spec_conformance_axis::FIVE_PRIME.non_idempotent_outputs,
-        "the 5' family list no longer accounts for the axis census's 5' non-idempotent outputs"
+        "the named families no longer account for the axis census's 5' non-idempotent outputs"
     );
 }
 
-/// **Question.** The three `scale-*` families were the 3'-only half of this
-/// class. Are they still?
+/// **Question.** The seven families this module is named for were all
+/// non-idempotent. Are they still?
 ///
-/// **No — every spelling of all three is now its own fixed point, in both
-/// directions.** This is the FLIPPED pin: it used to be
-/// [`the_non_idempotent_output_is_always_the_spanning_delins_respelling`]'s job
-/// to find one moving spelling per `scale` row, and there is none to find. The
-/// cause is `coalesce_coding_frame_separation` gaining `general.md:35`'s second
-/// conjunct — "two variants … together affecting one amino acid" — so it stops
-/// merging pairs whose merged span crosses a codon boundary. Those merges were
-/// exactly what the second pass was doing that the first did not.
+/// **No — every spelling of all seven is now its own fixed point, in both
+/// directions.** This is the FLIPPED pin, and it is the one that fails if a fixed
+/// point is lost.
+///
+/// The two halves were fixed by different changes and the distinction is worth
+/// keeping:
+///
+/// * the three `scale-*` rows, by `coalesce_coding_frame_separation` gaining
+///   `general.md:35`'s second conjunct — "two variants … together affecting one
+///   amino acid" — so it stops merging pairs whose merged span crosses a codon
+///   boundary. Those merges were what the second pass did that the first did not.
+/// * the four `cds-end` rows, by #1650's `merge::ExtendedBody`. The re-typing at
+///   the interbase 3' of the last CDS base still happens — see
+///   [`an_insertion_immediately_after_the_last_cds_base_is_retyped_as_a_delins`],
+///   which still pins the sweep — but the first pass now *lands on the re-typed
+///   form directly*, so there is no second pass to disagree with.
 ///
 /// It exists as its own test rather than as an absence, because an absence is
-/// invisible: dropping `SCALE_FAMILIES` from `affected_families` alone would have
-/// left three rows with no assertion on them at all, and a fix that regressed
-/// would then show up only as the axis census moving — a struct diff, in a
-/// different file, with no mechanism attached. That is the
-/// "a committed test that has never executed reads as coverage" trap pointed
-/// backwards.
+/// invisible: dropping a family from an "affected" list alone would leave its
+/// rows with no assertion on them at all, and a regression would then show up
+/// only as the axis census moving — a struct diff, in a different file, with no
+/// mechanism attached. That is the "a committed test that has never executed
+/// reads as coverage" trap pointed backwards, and it has already happened once
+/// here.
 ///
 /// Asserted over **every** spelling of each row and in both directions, not just
-/// over the one that used to move, since the merge the precondition now declines
+/// over the one that used to move, since the merge each precondition now declines
 /// is reachable from any respelling of the design.
 #[test]
-fn every_scale_family_is_now_a_fixed_point() {
+fn every_family_in_the_former_class_is_now_a_fixed_point() {
     let mut checked = 0usize;
-    for id in SCALE_FAMILIES {
+    for id in former_class() {
         let row = row(id);
         let frame = row.frame();
         assert!(
@@ -429,138 +443,107 @@ fn every_scale_family_is_now_a_fixed_point() {
                     normalize(&frame, &once, direction),
                     once,
                     "{id} ({direction:?}): FIXED, and it must stay fixed — `{spelling}` reached \
-                     `{once}`, which must be its own fixed point. Before the amino-acid \
-                     precondition the spanning-delins spelling of this row took two passes to \
-                     settle. If this fires the defect is back: re-bless \
-                     `spec_conformance_axis`'s `non_idempotent_outputs` and say so in the PR."
+                     `{once}`, which must be its own fixed point. If this fires the defect is \
+                     back: re-bless `spec_conformance_axis`'s `non_idempotent_outputs` and say \
+                     so in the PR."
                 );
                 checked += 1;
             }
         }
     }
     assert!(
-        checked >= SCALE_FAMILIES.len() * 2,
+        checked >= (SCALE_FAMILIES.len() + CDS_END_FAMILIES.len()) * 2,
         "VACUOUS — only {checked} spellings were checked across {} rows and two directions",
-        SCALE_FAMILIES.len()
+        SCALE_FAMILIES.len() + CDS_END_FAMILIES.len()
     );
 }
 
-/// **Question.** Does the class reach a fixed point at all, or does it
-/// oscillate? Nobody had checked, and an oscillation would be far more serious
-/// than a two-step settle.
-///
-/// **It settles, at the second pass. `norm^3 == norm^2` for all 8.** The chain
-/// is `x -> a -> b -> b`, with `a != b`: one extra pass, never more, and no
-/// two-cycle. So a caller who normalizes twice gets a stable answer, and the
-/// blast radius is "the first answer is wrong", not "there is no answer".
-///
-/// Asserted in both directions and on both strands, and asserted `a != b` as
-/// well — without that the test would pass vacuously the moment the defect is
-/// fixed, which is the wrong way round for a pin. When it *is* fixed, `a == b`
-/// and this test must be deleted rather than relaxed.
-///
-/// **It was "all 11", and the `a != b` guard did not save it — the LOOP did the
-/// vacating.** When the three `scale-*` rows became fixed points,
-/// `non_idempotent_spellings` returned empty for them, so the guard sat inside a
-/// loop body that never ran: three rows silently stopped being measured and this
-/// test stayed green. The `chains` counter below is the fix, and it is the reason
-/// a guard against vacuity has to be outside the iteration it is guarding.
-#[test]
-fn norm_cubed_equals_norm_squared_for_every_row_in_the_class() {
-    let mut chains = 0usize;
-    for id in affected_families() {
-        let row = row(id);
-        let frame = row.frame();
-        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
-            for spelling in non_idempotent_spellings(row, direction) {
-                let chain = iterate(&frame, spelling, direction, 4);
-                assert_ne!(
-                    chain[0], chain[1],
-                    "{id} ({direction:?}): PINNED DEFECT — `{spelling}` must still move on the \
-                     second pass for this test to be measuring anything. If it no longer moves, \
-                     the defect is FIXED: delete this file's pins and re-bless the census."
-                );
-                assert_eq!(
-                    chain[1], chain[2],
-                    "{id} ({direction:?}): the second pass is NOT a fixed point — this is an \
-                     oscillation or a longer chain, which is a materially worse defect than the \
-                     two-step settle recorded here. Chain: {chain:#?}"
-                );
-                assert_eq!(
-                    chain[2], chain[3],
-                    "{id} ({direction:?}): chain: {chain:#?}"
-                );
-                chains += 1;
-            }
-        }
-    }
-    // Outside the loop, deliberately: the `assert_ne!` above is the pin's own
-    // anti-vacuity guard and it cannot fire when the list it iterates is empty.
-    assert_eq!(
-        chains,
-        CDS_END_FAMILIES.len() * 2,
-        "VACUOUS — {chains} chains were walked, but the four `cds-end` families each hold one \
-         non-idempotent spelling in each of the two directions. A LOWER number means a family \
-         was fixed and this test stopped measuring it silently; flip its pin and re-bless \
-         `spec_conformance_axis` rather than letting the count drift"
-    );
-}
+// `norm_cubed_equals_norm_squared_for_every_row_in_the_class` stood here, and it
+// is **deleted rather than relaxed**, on its own explicit instruction: "When it
+// *is* fixed, `a == b` and this test must be deleted rather than relaxed."
+//
+// It asked whether the class settles or oscillates, and answered `x -> a -> b ->
+// b` with `a != b`. Its load-bearing assertion was that `a != b` — that the row
+// still moves on the second pass — so with the class fixed there is nothing left
+// for it to hold that is not both weaker and already held:
+// `every_family_in_the_former_class_is_now_a_fixed_point` asserts
+// `norm(norm(x)) == norm(x)` over every spelling of all seven rows in both
+// directions, which is that chain collapsed to length one. Keeping the test and
+// dropping its `assert_ne!` would be exactly the guard-weakening this file exists
+// to prevent.
+//
+// Recorded as a comment rather than removed silently, because the QUESTION it
+// answered is still worth having the answer to: the class settled and never
+// oscillated, so #1650 removed one pass rather than breaking a cycle.
 
-/// **Question.** Does the instability cost bases, or only spelling?
+/// **Question.** Did the instability cost bases, or only spelling — and does the
+/// settled answer still denote what the row denotes?
 ///
-/// **Only spelling. Every step of every chain denotes the row's own sequence.**
-/// That is the honest scoping of this class and it is worth stating plainly: it
-/// is representation churn, not the sequence-preservation failure that
+/// **Only spelling, then and now.** The class was representation churn, not the
+/// sequence-preservation failure that
 /// `a_deletion_flush_against_an_insertion_at_the_cds_end_changes_the_sequence`
-/// pins. `background/basics.md:38` — "The recommendations for the description of
+/// pins — and that distinction survives #1650 unchanged, which is the point of
+/// keeping this test rather than deleting it with the chain it used to walk.
+///
+/// **What changed: there is no chain left to walk.** This test used to iterate
+/// three steps of each non-idempotent chain and assert every intermediate denoted
+/// the row's own sequence. With the class fixed there is one step, so it asserts
+/// the property where it now lives — on the settled output of every spelling of
+/// every former-class row, in both directions. The assertion is strictly the same
+/// one; only the population it quantifies over shrank with the defect.
+///
+/// **This is a rank-1 guard and must not be confused with the class #1650 did not
+/// fix.** `spec_conformance_axis`'s `sequence_changed` reads 4 at 3' either side
+/// of #1650: the four `s00-c3m-cds-end-del-ins-*` rows still denote different
+/// bases, respelled from `c.[72delinsTA;*2del]` to `c.*1T>A`. Those are a
+/// *different* row set from the seven scanned here, and none of them is in
+/// `former_class()`. If one ever is, this test fires — which is the whole reason
+/// the denotation check is kept on a class that no longer moves.
+///
+/// `background/basics.md:38` — "The recommendations for the description of
 /// sequence variants are designed to be **stable**, **meaningful**,
 /// **memorable**, and **unequivocal**" — puts stability first among the spec's
-/// four stated values, so a normalizer whose answer depends on how many times it
-/// has been run fails the first of them; but no base is lost.
-///
-/// The consequence for a fix: any of the three forms in a chain is a *legal*
-/// description of the same variant, so choosing between them is the
-/// `canonical-form-choice-when-both-legal` ruling, which is `decided` —
-/// `general.md:157` governs, and ferro derives the description from the
-/// RESULTING SEQUENCE rather than preserving the input's spelling or the
-/// previously-shipped string. That names the direction a fix takes; it does not
-/// make the move free. Moving these strings is still a declared representation
-/// change under this repo's `Representation-Change:` trailer.
+/// four stated values, so a normalizer whose answer depended on how many times it
+/// had been run failed the first of them; but no base was ever lost. Moving these
+/// strings was still a declared representation change under this repo's
+/// `Representation-Change:` trailer, and #1650 declares it.
 #[test]
-fn the_chain_never_changes_the_sequence_it_denotes() {
-    let mut steps_checked = 0usize;
-    for id in affected_families() {
+fn the_settled_output_never_changes_the_sequence_it_denotes() {
+    let mut outputs_checked = 0usize;
+    for id in former_class() {
         let row = row(id);
         let frame = row.frame();
         let expected = row.denoted.as_deref().unwrap_or_else(|| {
             panic!("{id} must carry a denotation for this test to mean anything")
         });
+        assert!(
+            !row.spellings.is_empty(),
+            "{id}: VACUOUS — the corpus generates no spellings for this row"
+        );
         for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
-            for spelling in non_idempotent_spellings(row, direction) {
-                for step in iterate(&frame, spelling, direction, 3) {
-                    assert_eq!(
-                        denotation_of(frame.provider(), frame.served(), &step),
-                        Denotation::Sequence(expected.to_string()),
-                        "{id} ({direction:?}): `{step}` denotes different bases from its row — \
-                         that would move this row into the sequence-changing class, which is a \
-                         rank-1 defect and must be reported as such rather than as churn"
-                    );
-                    steps_checked += 1;
-                }
+            for spelling in &row.spellings {
+                let settled = normalize(&frame, spelling, direction);
+                assert_eq!(
+                    denotation_of(frame.provider(), frame.served(), &settled),
+                    Denotation::Sequence(expected.to_string()),
+                    "{id} ({direction:?}): `{spelling}` settled on `{settled}`, which denotes \
+                     different bases from its row — that would move this row into the \
+                     sequence-changing class, which is a rank-1 defect and must be reported as \
+                     such rather than as churn"
+                );
+                outputs_checked += 1;
             }
         }
     }
-    // The same anti-vacuity guard `norm_cubed_equals_norm_squared_for_every_row_in_the_class`
-    // carries, and for the same reason: every assertion here lives inside a loop
-    // over `non_idempotent_spellings`, which goes empty the moment a family is
-    // fixed. Three chains stopped being walked once the `scale-*` rows settled
-    // and nothing went red.
-    assert_eq!(
-        steps_checked,
-        CDS_END_FAMILIES.len() * 2 * 3,
-        "VACUOUS — {steps_checked} chain steps were checked; expected 3 per direction per \
-         `cds-end` family. A lower number means a family was fixed and dropped out of the \
-         iteration silently"
+    // Outside the iteration it guards, for the reason the deleted
+    // `norm_cubed_equals_norm_squared_for_every_row_in_the_class` recorded: a
+    // guard inside a loop over a list that can empty is not a guard. That failure
+    // happened here for real — three chains stopped being walked once the
+    // `scale-*` rows settled, and nothing went red.
+    assert!(
+        outputs_checked >= (SCALE_FAMILIES.len() + CDS_END_FAMILIES.len()) * 2,
+        "VACUOUS — {outputs_checked} settled outputs were checked; expected at least one \
+         spelling per direction across all seven former-class families"
     );
 }
 
@@ -633,26 +616,27 @@ fn an_insertion_immediately_after_the_last_cds_base_is_retyped_as_a_delins() {
             );
         }
 
-        // The exemplar chain, which is what the census counts.
-        let spelling = sole_non_idempotent_spelling(row, ShuffleDirection::ThreePrime);
-        let chain = iterate(&frame, &spelling, ShuffleDirection::ThreePrime, 2);
+        // The exemplar chain, FLIPPED by #1650 — and this is the precise statement
+        // of what #1650 did and did not change, which is why it is asserted in
+        // three parts rather than one.
+        //
+        // The re-typing is UNCHANGED: the sweep above still finds exactly one
+        // interbase that re-types, and feeding the insertion form back still
+        // yields the `delins`. What changed is that the first pass now *lands on*
+        // the `delins` directly, so the two passes no longer disagree about a
+        // description ferro itself produced. One pass was removed; the mechanism
+        // was not.
+        let chain = iterate(
+            &frame,
+            "NM_TEST.1:c.72_*1insCT",
+            ShuffleDirection::ThreePrime,
+            2,
+        );
         assert_eq!(
             chain,
-            vec!["NM_TEST.1:c.72_*1insCT", "NM_TEST.1:c.72delinsCCT"],
-            "{id}: PINNED DEFECT — one variant, one interbase, two typings. Correct behaviour: \
-             both passes emit the same one."
-        );
-
-        // Feeding the FIRST pass's answer back is what re-types it, so the two
-        // passes disagree about a description ferro itself produced.
-        assert_eq!(
-            normalize(
-                &frame,
-                "NM_TEST.1:c.72_*1insCT",
-                ShuffleDirection::ThreePrime
-            ),
-            "NM_TEST.1:c.72delinsCCT",
-            "{id}: the insertion form is not a fixed point"
+            vec!["NM_TEST.1:c.72delinsCCT", "NM_TEST.1:c.72delinsCCT"],
+            "{id}: the insertion form must re-type ONCE and then stand still. Two distinct \
+             entries here means the re-typing has become non-idempotent again."
         );
         assert_eq!(
             normalize(
@@ -661,8 +645,20 @@ fn an_insertion_immediately_after_the_last_cds_base_is_retyped_as_a_delins() {
                 ShuffleDirection::ThreePrime
             ),
             "NM_TEST.1:c.72delinsCCT",
-            "{id}: the delins form IS a fixed point, which is why the chain settles at two"
+            "{id}: the delins form IS a fixed point"
         );
+
+        // And the row's own spellings reach it in ONE pass, which is the flip
+        // itself: before #1650 the spanning-`delins` respelling of this design
+        // emitted `c.72_*1insCT` here and needed a second pass to re-type it.
+        for spelling in &row.spellings {
+            let once = normalize(&frame, spelling, ShuffleDirection::ThreePrime);
+            assert!(
+                is_fixed_point(&frame, &once, ShuffleDirection::ThreePrime),
+                "{id}: `{spelling}` settled on `{once}`, which is not its own fixed point — \
+                 the two-pass chain this test used to pin is back"
+            );
+        }
     }
 }
 

--- a/tests/it/issue_1536_cds_boundary_delins.rs
+++ b/tests/it/issue_1536_cds_boundary_delins.rs
@@ -378,13 +378,29 @@ fn the_discriminator_is_the_cds_boundary_and_not_the_transcript_end() {
 /// # The input matters, and the first one chosen here did not reach the recursion
 ///
 /// This test asserted `once == twice` on `c.20_*7delinsCC`, and **passed with the
-/// recursion block disabled** — so it was pinning nothing. Measured: that input's
-/// `ref` (`GCTTACGG`) and payload (`CC`) share neither a prefix nor a suffix, so
-/// the trim removes nothing, the member is returned on the footprint it arrived on,
-/// and the recursion's `new_variant != *variant` gate never opens. The mechanism
-/// above was right; the demonstration was of a different shape.
-/// [`the_input_that_taught_us_this_test_can_be_vacuous`] pins that input as the
-/// decline it is, so it cannot be reached for again.
+/// recursion block disabled** — so it was pinning nothing, for two review rounds.
+/// Measured at the time: that input's `ref` (`GCTTACGG`) and payload (`CC`) shared
+/// neither a prefix nor a suffix, so the trim removed nothing, the member came back
+/// on the footprint it arrived on, and the recursion's `new_variant != *variant`
+/// gate never opened. The mechanism above was right; the demonstration was of a
+/// different shape.
+///
+/// **That input is no longer available as the demonstration it was, and the reason
+/// is this change.** It still shares no affix — but sharing no affix no longer
+/// implies standing still, because `merge::ExtendedBody` folds `c.*N` onto
+/// `cds_len + N`, so a footprint that *crosses* `cds_end` now reaches
+/// `canonicalize_from_sequence` and is partitioned from the bases instead of handed
+/// back: `c.20_*7delinsCC` -> `c.[20del;*2_*4del;*6_*7del]`.
+/// [`the_input_that_taught_us_this_test_can_be_vacuous`] keeps the finding and pins
+/// the new value rather than loosening to fit it.
+///
+/// **The trap it recorded has not gone away; it has moved to the side of the CDS
+/// this change deliberately does not reach.** `ExtendedBody`'s fold is one-sided —
+/// 3'UTR only, `c.-N` left to #1816 — so on the CDS-start side the shared-affix trim
+/// is still the only thing that can move a straddling member, and "untrimmable
+/// therefore declines" still holds there.
+/// [`a_cds_start_straddle_is_the_surviving_untrimmable_decline`] is where that is
+/// now anchored, and it is the test to read before choosing an input for this one.
 ///
 /// `c.20_*4delinsG` does reach it. `ref` is `GCTTA` and the payload `G`, so the
 /// trim eats the one CDS-side base and leaves `c.*1_*4del` — wholly in the 3'UTR,
@@ -501,60 +517,221 @@ fn the_recursion_emits_no_stale_clamp_warning() {
     );
 }
 
-/// The input the test above used to run on, pinned as the decline it actually is.
+/// The input the test above used to run on — kept for the finding, re-pinned for
+/// the behaviour.
 ///
-/// Not a curiosity: it is the reason that test read as coverage for two review
-/// rounds while guarding nothing. `c.20_*7delinsCC` shares no affix between `ref`
-/// and payload, so the carve-out re-types nothing, the member comes back exactly as
-/// authored, and any `once == twice` assertion on it is satisfied by the decline
-/// rather than by the recursion. If this ever starts moving, the note on the test
-/// above needs rewriting rather than this pin loosening.
+/// **The finding is the valuable part and it is unchanged.** This input is the
+/// reason that test read as coverage for two review rounds while guarding nothing:
+/// `c.20_*7delinsCC` shares no affix between `ref` (`GCTTACGG`) and payload (`CC`),
+/// so the #1651 carve-out re-typed nothing, the member came back exactly as
+/// authored, and any `once == twice` assertion on it was satisfied by the decline
+/// rather than by the recursion.
+///
+/// **What this change falsifies is the premise, not the finding.** The assertion
+/// below used to read "an untrimmable straddling delins must be preserved", and that
+/// is the precise statement `merge::ExtendedBody` makes false: folding `c.*N` onto
+/// `cds_len + N` admits a footprint that *crosses* `cds_end` to
+/// `canonicalize_from_sequence`, which partitions it from the bases. Untrimmable no
+/// longer implies preserved on this side of the CDS — sharing no affix stopped being
+/// sufficient the moment something other than the trim could move the member.
+///
+/// The test's own standing instruction was that if this ever started moving, "the
+/// note on the test above needs rewriting rather than this pin loosening". Both
+/// notes are rewritten and the pin is kept, re-pointed at the derived split, so
+/// whatever moves it next is still visible here.
+///
+/// Verified by mutation rather than asserted: with the extension forced off
+/// (`ExtendedBody::OFF` in `canonicalize_from_sequence_with_rule`) this input goes
+/// straight back to being preserved and this test fails, while
+/// [`a_cds_start_straddle_is_the_surviving_untrimmable_decline`] stays green — which
+/// is what says the two rows are on opposite sides of the one-sided fold.
+///
+/// The vacuity trap this test used to hold survives on the CDS-start side, and is
+/// re-anchored by [`a_cds_start_straddle_is_the_surviving_untrimmable_decline`].
 #[test]
 fn the_input_that_taught_us_this_test_can_be_vacuous() {
     let provider = transcript_provider(WIDE_CORE, 11, 30);
-    let declined = "NM_TEST.1:c.20_*7delinsCC";
-    assert_eq!(
-        normalize(&provider, declined, ShuffleDirection::ThreePrime),
-        declined,
-        "an untrimmable straddling delins must be preserved, which is why it cannot \
-         demonstrate the recursion"
+    let taught_us = "NM_TEST.1:c.20_*7delinsCC";
+    // Untrimmable read off the bases, not trusted from the string: `c.20`..`c.*7`
+    // is transcript 30..=37 under `CDS 11..=30`.
+    let reference = &WIDE_CORE[29..37];
+    assert_eq!(reference, "GCTTACGG");
+    assert_ne!(reference.as_bytes()[0], b'C', "no shared prefix with `CC`");
+    assert_ne!(reference.as_bytes()[7], b'C', "no shared suffix with `CC`");
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize(&provider, taught_us, direction),
+            "NM_TEST.1:c.[20del;*2_*4del;*6_*7del]",
+            "the 3'UTR extension partitions this straddling delins from the bases, so \
+             sharing no affix no longer keeps it still and it is no longer the decline \
+             that made the test above vacuous"
+        );
+    }
+}
+
+/// The vacuity trap, re-anchored on the side of the CDS this change does not reach.
+///
+/// [`the_input_that_taught_us_this_test_can_be_vacuous`] used to hold this role and
+/// cannot any more: its input now derives a three-member split. The trap itself is
+/// unchanged — a straddling `delins` that the sequence-first derivation cannot reach
+/// and whose affix trim removes nothing comes back exactly as authored, so an
+/// `once == twice` assertion on it is satisfied by the decline rather than by the
+/// recursion — so it needs an input the derivation still cannot reach.
+///
+/// **`merge::ExtendedBody`'s fold is deliberately one-sided**, 3'UTR only: `c.-N`
+/// would need the window origin itself to move, which changes behaviour for every
+/// CDS-start-adjacent variant, and #1650 leaves it to #1816 with its own
+/// measurement. So across `cds_start` the shared-affix trim in the #1651 carve-out
+/// is still the *only* mechanism that can move a straddling member, and the property
+/// the marker above recorded holds there exactly: preserved if and only if
+/// untrimmable.
+///
+/// That biconditional is what is asserted, over every straddling placement this
+/// fixture admits, rather than a count taken elsewhere and quoted here. Both classes
+/// are asserted non-empty, so a generator change that stopped producing either one
+/// cannot pass as a result.
+///
+/// **It has exactly one exception and the exception is excluded by name, not by
+/// shrinking the corpus around it.** A whole-span reverse complement is re-typed
+/// `delins` -> `inv` by the per-member single-span typing, which is region-blind and
+/// is the mechanism the module docs above spend their first section separating from
+/// #1536; on this fixture it is `c.-1_1delinsGA` over `TC`. Nothing else in the
+/// enumeration disagrees.
+///
+/// **Both named rows are asserted, in both directions, so this cannot go vacuous the
+/// way its predecessor did.** `c.-1_2delinsGG` shares neither affix with its
+/// reference `TCA` and must stand still; `c.-1_2delinsTG` shares its first base, so
+/// the trim eats it, the member stops straddling and it must move. A build in which
+/// the carve-out had stopped running altogether would satisfy the first assertion and
+/// fail the second.
+///
+/// When #1816 extends the fold to the 5'UTR this test is what will go red, and that
+/// is its point: the 3'UTR half of the same statement moved silently enough to sit in
+/// a committed pin for two review rounds.
+#[test]
+fn a_cds_start_straddle_is_the_surviving_untrimmable_decline() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+
+    // `c.-1`..`c.2` is transcript 10..=12 under `CDS 11..=30`. Read off the bases
+    // rather than trusted from the constant, for the same reason
+    // `the_payload_is_the_exact_reverse_complement_of_the_block` is its own test.
+    assert_eq!(&WIDE_CORE[9..12], "TCA");
+    let declined = "NM_TEST.1:c.-1_2delinsGG";
+    let trimmed = "NM_TEST.1:c.-1_2delinsTG";
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize(&provider, declined, direction),
+            declined,
+            "`TCA` and `GG` share neither affix, so the trim removes nothing, the \
+             member comes back on the footprint it arrived on, and the recursion never \
+             runs — which is what makes an idempotency assertion on it vacuous"
+        );
+        assert_eq!(
+            normalize(&provider, trimmed, direction),
+            "NM_TEST.1:c.1_2delinsG",
+            "`TCA` and `TG` share a prefix, so the trim eats it and the member stops \
+             straddling — without this the assertion above would be satisfied by a \
+             carve-out that had stopped running at all"
+        );
+    }
+
+    // The property those two rows are instances of, over every placement across
+    // `cds_start` this fixture admits: preserved iff untrimmable. The contrast with
+    // `cds_end` is stated by the test above, which pins one row there that breaks it;
+    // it is not re-derived here.
+    let mut counterexamples = Vec::new();
+    let (mut untrimmable_rows, mut trimmable_rows) = (0usize, 0usize);
+    for start in 1..=10i64 {
+        for end in 11..=30i64 {
+            let reference = &WIDE_CORE[(start - 1) as usize..end as usize];
+            let s = cds_spelling(start, 11, 30);
+            let e = cds_spelling(end, 11, 30);
+            for payload in one_and_two_base_payloads() {
+                // The one mechanism beside the trim that moves a straddling member,
+                // excluded by name rather than by narrowing the corpus until it
+                // vanished. A whole-span reverse complement is re-typed `delins` ->
+                // `inv` by the per-member single-span typing, which is region-blind
+                // — the module docs above disentangle exactly that from #1536, with
+                // `c.*1_*8delinsACCGTAAG -> c.*1_*8inv` as the disproof. Here it is
+                // `c.-1_1delinsGA` over `TC`, the only placement on this fixture the
+                // biconditional below does not hold for.
+                if payload == reverse_complement(reference) {
+                    continue;
+                }
+                let untrimmable = reference.as_bytes()[0] != payload.as_bytes()[0]
+                    && reference.as_bytes()[reference.len() - 1]
+                        != payload.as_bytes()[payload.len() - 1];
+                if untrimmable {
+                    untrimmable_rows += 1;
+                } else {
+                    trimmable_rows += 1;
+                }
+                let input = format!("NM_TEST.1:c.{s}_{e}delins{payload}");
+                let preserved = normalize(&provider, &input, ShuffleDirection::ThreePrime) == input;
+                if preserved != untrimmable {
+                    counterexamples.push(format!(
+                        "  {input} (ref {reference}): untrimmable={untrimmable} \
+                         preserved={preserved}"
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        untrimmable_rows > 0 && trimmable_rows > 0,
+        "both classes must be populated, or the biconditional below is `0 of 0`: \
+         untrimmable={untrimmable_rows} trimmable={trimmable_rows}"
+    );
+    assert!(
+        counterexamples.is_empty(),
+        "across `cds_start` the shared-affix trim is the only mechanism that can move \
+         a straddling member, so preserved and untrimmable must agree on every \
+         placement. {} disagree:\n{}",
+        counterexamples.len(),
+        counterexamples.join("\n")
     );
 }
 
-/// STILL OPEN, and deliberately recorded as such: the multi-member spelling of
-/// one variant does not converge with its `inv` spelling once the members
-/// straddle the boundary.
+/// Every one- and two-base `delins` payload, for the enumeration above.
+fn one_and_two_base_payloads() -> Vec<String> {
+    let mut payloads = Vec::with_capacity(20);
+    for first in ['A', 'C', 'G', 'T'] {
+        payloads.push(first.to_string());
+        for second in ['A', 'C', 'G', 'T'] {
+            payloads.push(format!("{first}{second}"));
+        }
+    }
+    payloads
+}
+
+/// #1650, **closed**: the multi-member spelling of one variant converges with
+/// its `inv` spelling once the members straddle `cds_end`.
 ///
-/// This is the `merge::join_pos` / `collect_canonical_edits` refusal the module
+/// This was the `merge::join_pos` / `collect_canonical_edits` refusal the module
 /// docs above disentangle from #1536 — a real capability gap, and a genuine
 /// second pair of fixed points, but a different symptom with a different cause.
-/// Fixing it means doing the sequence-first window arithmetic in transcript
-/// coordinates and rendering each endpoint back onto its own region, which also
-/// reaches `apply_canonical_split`'s own `simple_cds_pos` (it refuses `*N` and
-/// `-N` outright). Out of scope here; tracked as #1650.
+/// It was `#[ignore]`d and red by design against #1650 until
+/// `merge::ExtendedBody` folded `c.*N` onto `cds_len + N`, giving the window
+/// arithmetic one line of comparable integers to run on.
 ///
 /// Measured on the 40-mer, `CDS 11..=26`, with the block at transcript 23..=30 —
-/// the placement whose CDS-interior twin *is* split into three members:
+/// the placement whose CDS-interior twin *is* split into three members. Before
+/// and after, so the guard records what moved rather than only that it is green:
 ///
 /// ```text
 /// CDS 11..=30  c.[13_15delinsCTA;18T>G;20G>T] -> itself
-///              c.13_20inv                     -> c.[13_15delinsCTA;18T>G;20G>T]   converges
-/// CDS 11..=26  c.[13_15delinsCTA;*2T>G;*4G>T] -> itself
-///              c.13_*4inv                     -> c.13_*4inv                       does NOT
+///              c.13_20inv                     -> c.[13_15delinsCTA;18T>G;20G>T]   converged
+/// CDS 11..=26  before  c.[13_15delinsCTA;*2T>G;*4G>T] -> itself
+///                      c.13_*4inv                     -> c.13_*4inv               did NOT
+/// CDS 11..=26  after   both                           -> c.[13_15delinsCTA;*2T>G;*4G>T]
 /// ```
 ///
-/// Ignored because it is unfixed, not because the assertion is wrong. An ignored
-/// red guard is a recorded defect; a weakened green one is a lie.
-///
-/// **Tracked as #1650**, which is what says when it comes back: un-ignore it in the
-/// change that makes `collect_canonical_edits` do its window arithmetic in
-/// transcript coordinates. "Tracked separately" without a number is what this line
-/// used to say, and an unnumbered deferral is indistinguishable from a forgotten
-/// one.
+/// The assertion is deliberately still **convergence**, not the string: which
+/// form a class converges on is derived, and
+/// `canonical-form-choice-when-both-legal` is what says it is derived rather than
+/// chosen. The string is pinned separately, next door, so a change that made both
+/// sides converge on the *wrong* form could not pass by satisfying this one.
 #[test]
-#[ignore = "unfixed, tracked as #1650: a cis allele whose members straddle a CDS boundary is \
-            refused by merge::collect_canonical_edits, so it does not converge with its inv \
-            spelling"]
 fn a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary() {
     let provider = transcript_provider(WIDE_CORE, 11, 26);
     let allele = "NM_TEST.1:c.[13_15delinsCTA;*2T>G;*4G>T]";
@@ -566,6 +743,103 @@ fn a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary() {
             "{allele} and {inv} denote one variant and must converge"
         );
     }
+}
+
+/// The form the class above converges **on**, measured rather than inferred, and
+/// with the third spelling #1650 names as the "lone-`delins` symptom" beside it.
+///
+/// #1651 left `c.13_*4delinsCTACGGAT` converging with `c.13_*4inv` while *neither*
+/// was split into the three members its CDS-interior twin is split into. All
+/// three spellings now reach one point, and it is the split — which is what
+/// `general.md:56` predicts once the derivation is allowed to run, since two of
+/// the three competing members are substitutions and substitution outranks
+/// inversion. (`inversion-vs-two-delins-76-83` is the record for the *other*
+/// case: a whole-block reverse complement stays `inv` when the members it
+/// competes with are all `delins`, which `:56` does not rank. Here they are not.)
+#[test]
+fn the_boundary_class_converges_on_the_split_its_cds_twin_gets() {
+    let provider = transcript_provider(WIDE_CORE, 11, 26);
+    let expected = "NM_TEST.1:c.[13_15delinsCTA;*2T>G;*4G>T]";
+    for spelling in [
+        "NM_TEST.1:c.[13_15delinsCTA;*2T>G;*4G>T]",
+        "NM_TEST.1:c.13_*4inv",
+        "NM_TEST.1:c.13_*4delinsCTACGGAT",
+    ] {
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            assert_eq!(
+                normalize(&provider, spelling, direction),
+                expected,
+                "{spelling} must derive to the split form"
+            );
+        }
+    }
+}
+
+/// A pair whose triplet reaches past `cds_end` does not merge — **recorded as a
+/// measurement, NOT as a demonstration of `merge::apply_coding_codon_exception`'s
+/// `within_cds` guard.**
+///
+/// The distinction is the whole value of this test, and it cost two attempts to
+/// get right. `general.md:35`'s exception is a conjunction — "two variants
+/// separated by one nucleotide, **together affecting one amino acid**" — and the
+/// second conjunct is unstatable in the 3'UTR, so `within_cds` was added with the
+/// exception's own reasoning behind it. But a guard is only coverage if some
+/// input reaches it, and **neither input tried here does**:
+///
+/// | input | why it does not reach the guard |
+/// |---|---|
+/// | `c.[*1C>G;*3T>A]` under `CDS 11..=25` | sits wholly in the 3'UTR, so the straddle gate in `canonicalize_from_sequence` declines the group before any partition exists |
+/// | `c.[16C>G;*2T>A]` under `CDS 11..=26` | crosses `cds_end` and IS admitted, yet still does not merge with the guard forced open |
+///
+/// **Both were checked against the sabotage — `within_cds` forced to `true` — and
+/// both stayed green.** So `within_cds` is defensive: correct by the clause's own
+/// reading, and not currently demonstrated to change any answer. It is left in
+/// place rather than removed because `same_codon` is defined for every positive
+/// integer and would silently answer for a codon that does not exist the moment
+/// some other change makes the line reachable; but it must not be described
+/// anywhere as guarded, and this test must not be read as guarding it.
+///
+/// What the assertion below *is* worth: it pins that the boundary-crossing pair
+/// stays two members, which is `general.md:34`'s plain rule and the answer the
+/// extension must not disturb.
+///
+/// Whoever makes the line reachable owes this test a real sabotage check.
+#[test]
+fn a_pair_whose_triplet_reaches_past_the_stop_codon_stays_two_members() {
+    let provider = transcript_provider(WIDE_CORE, 11, 26);
+    // `c.16` is the last CDS base (tx 26) and `c.*2` is tx 28, with tx 27
+    // unchanged between them — so the group crosses `cds_end`.
+    let split = "NM_TEST.1:c.[16C>G;*2T>A]";
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize(&provider, split, direction),
+            split,
+            "a pair whose triplet reaches past the stop codon affects no single amino \
+             acid, so `general.md:34` governs and the members stay individual"
+        );
+    }
+}
+
+/// The in-CDS positive control: the identical bases at the identical transcript
+/// positions, with only the stop codon moved so all three land inside the CDS,
+/// **do** merge.
+///
+/// This one is not vacuous — it fails if the codon exception stops firing at all
+/// — which is why it is kept while its sibling above is downgraded to a
+/// measurement.
+#[test]
+fn the_same_pair_one_codon_earlier_still_merges() {
+    let provider = transcript_provider(WIDE_CORE, 11, 30);
+    // tx 26..28 is `c.16`..`c.18` here, and 16..18 is one codon.
+    assert_eq!(
+        normalize(
+            &provider,
+            "NM_TEST.1:c.[16C>G;18T>A]",
+            ShuffleDirection::ThreePrime
+        ),
+        "NM_TEST.1:c.16_18delinsGGA",
+        "inside the CDS the same pair is `general.md:35`'s exception and merges"
+    );
 }
 
 /// The control for the guard above, so its `#[ignore]` cannot quietly become

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -914,16 +914,36 @@ pub(crate) const THREE_PRIME: Census = Census {
     // what it excludes. The rule is now gated on the same carve-out, which
     // returns `guard_violations` to 0 and leaves every counter in this block
     // where #1621 left it.
-    converged: 11_016,
-    split_two: 674,
-    split_three: 164,
-    split_more: 28,
+    //
+    // # #1650 — the 3'UTR extension of the sequence-first body, on top of #1835
+    //           and #1610
+    //
+    // Families move out of the `split_*` buckets and into `converged`, and the
+    // three decreases sum exactly to `converged`'s increase. **That identity is
+    // a NET statement and is quoted as one** — the module's own warning is that
+    // the counters cannot tell net from gross. What is checked directly is the
+    // reported divergence set, whose family ids are byte-identical either side
+    // (all `s01-c1-m3-all-del-*`, none of them a `cds-end` row), so nothing
+    // that was divergent before is divergent for a different reason now. The
+    // four figures below are **re-measured on each rebase** rather than composed
+    // from the branches' deltas — and the move is the same 40 families it was on
+    // the pre-flip base, with the same 22 + 12 + 6 breakdown, so the flip, #1610
+    // and this change reach disjoint populations.
+    converged: 11_056,
+    split_two: 652,
+    split_three: 152,
+    split_more: 22,
     underdetermined: 0,
     // -- idempotency --
     //
-    // Re-blessed DOWN: the three `scale-c3p-sep{120,128,136}-del-del` rows now
-    // settle in one pass. The four `cds-end` families remain.
-    non_idempotent_outputs: 4,
+    // Re-blessed DOWN, **to zero**, by #1650. The three
+    // `scale-c3p-sep{120,128,136}-del-del` rows had already gone; the four
+    // `cds-end` families were the whole residual and they now settle in one
+    // pass, because the derivation can finally read a member on either side of
+    // `cds_end` and so answers in one step what it previously answered in two.
+    // `defect_non_idempotent_outputs` flips with this number, as its own failure
+    // messages instruct.
+    non_idempotent_outputs: 0,
     // -- sequence preservation --
     sequence_changed: 4,
     // -- refusal --
@@ -1006,7 +1026,13 @@ pub(crate) const FIVE_PRIME: Census = Census {
     //
     // #1610 does not move it: see the `#1610` block on [`THREE_PRIME`]'s
     // `converged` for the measurement and for why the rule takes the axis gate.
-    converged: 10_755,
+    //
+    // Re-blessed by #1650, the 5' half of the 3' re-bless above: families move
+    // into `converged` and the decreases sum to it exactly. Read as net, for the
+    // same reason stated there, and re-measured on each rebase rather than
+    // composed — the move is the same 48 families it was on the pre-flip base,
+    // with the same 22 + 26 + 0 breakdown.
+    converged: 10_803,
     // Re-blessed by #1649, rank-2 only, same as [`THREE_PRIME`] — and measured on
     // the rebased branch rather than composed. Every moved family goes straight
     // to `converged`, so these three deltas sum exactly to `converged`'s:
@@ -1040,11 +1066,16 @@ pub(crate) const FIVE_PRIME: Census = Census {
     // partition where that one merges and this one did not. On these two families
     // the 3' partition was already the merged one, so only 5' had anywhere to
     // move; convergence is what agreeing with 3' looks like from here.
-    split_two: 979,
-    split_three: 124,
+    //
+    // every entry above records, and both move the same way. #1650 then moves
+    // these on top of that, re-measured on the rebase: -22 and -26, with
+    // `split_more` untouched.
+    split_two: 957,
+    split_three: 98,
     split_more: 24,
     underdetermined: 0,
-    non_idempotent_outputs: 4,
+    // Re-blessed DOWN to zero by #1650, the same four `cds-end` families as at 3'.
+    non_idempotent_outputs: 0,
     sequence_changed: 0,
     conflicts_accepted: 72,
     // Re-blessed DOWN to zero by #1628 and #1789, by the same 32 rows as at 3'.

--- a/tests/it/spec_corpus_regressions.rs
+++ b/tests/it/spec_corpus_regressions.rs
@@ -437,25 +437,42 @@ fn a_bare_transcript_accession_accepts_an_intronic_position() {
 
 /// **Question.** Is an insertion at the CDS/3'UTR boundary a fixed point?
 ///
-/// **No.** `c.*1delinsCTT` normalizes to `c.72_*1insCT`, which normalizes again to
-/// `c.72delinsCCT`. Idempotency is not a spec clause — it is an invariant of any
-/// normalizer, and `FERRO_ASSERT_IDEMPOTENT` exists to police it — so this is
-/// pinned as a defect with no citation to make.
+/// **Yes, since #1650 — this was the pinned defect and it is now the guard.**
+///
+/// It used to take two passes: `c.*1delinsCTT` normalized to `c.72_*1insCT`,
+/// which normalized *again* to `c.72delinsCCT`. Idempotency is not a spec clause
+/// — it is an invariant of any normalizer, and `FERRO_ASSERT_IDEMPOTENT` exists
+/// to police it — so it was pinned as a defect with no citation to make.
+///
+/// The cause was the sequence-first pass refusing every member on the far side
+/// of `cds_end`, so the second pass answered a question the first could not see.
+/// `merge::ExtendedBody` lets the first pass read both sides, and it now reaches
+/// `c.72delinsCCT` in **one** step. `spec_conformance_axis`'s
+/// `non_idempotent_outputs` goes 4 -> 0 with this, in both directions.
+///
+/// **Renamed with the flip**, from `..._is_not_a_fixed_point`. An earlier draft
+/// kept the old name on the ground that `ci.yml`'s `ORACLE_EXCLUDE` cites it —
+/// **it does not**: that variable excludes whole modules (`test(spec_corpus_regressions)`),
+/// so no rename can break it. The one real cross-reference is the header comment
+/// in `scripts/run_oracle_suite.sh`, which names this test explicitly and is
+/// updated in the same commit. A test whose name asserts the opposite of its
+/// body is the same defect class as an assertion weaker than its stated
+/// contract.
 ///
 /// The shape needs a transcript with a real 3'UTR, which a `CDS_START = 1`
 /// single-exon fixture cannot have (#1478). It reproduces on both strands.
 #[test]
-fn an_insertion_at_the_cds_end_is_not_a_fixed_point() {
+fn an_insertion_at_the_cds_end_is_a_fixed_point() {
     let core = acgt_core();
     for strand in [Strand::Plus, Strand::Minus] {
         let frame = Frame::build(RefShape::CodingMultiExon(strand), &core);
         let once = normalize_3prime(&frame, "NM_TEST.1:c.*1delinsCTT");
-        assert_eq!(once, "NM_TEST.1:c.72_*1insCT");
+        assert_eq!(once, "NM_TEST.1:c.72delinsCCT");
         let twice = normalize_3prime(&frame, &once);
         assert_eq!(
-            twice, "NM_TEST.1:c.72delinsCCT",
-            "PINNED DEFECT — normalization must be idempotent. `{once}` is not its own fixed \
-             point on the {strand:?} strand."
+            twice, once,
+            "`{once}` must be its own fixed point on the {strand:?} strand — this is \
+             the invariant the row used to violate, asserted rather than pinned."
         );
     }
 }
@@ -493,8 +510,13 @@ fn a_deletion_flush_against_an_insertion_at_the_cds_end_changes_the_sequence() {
         };
         let output = normalize_3prime(&frame, input);
         assert_eq!(
-            output, "NM_TEST.1:c.[72delinsTA;*2del]",
-            "PINNED DEFECT on the {strand:?} strand"
+            output, "NM_TEST.1:c.*1T>A",
+            "PINNED DEFECT on the {strand:?} strand. **Re-blessed by #1650, and the \
+             defect is NOT fixed** — only its spelling moved, from the two-member \
+             `c.[72delinsTA;*2del]` to this single substitution. Both denote the same \
+             wrong bases, which is why `spec_conformance_axis`'s `sequence_changed` \
+             is still 4 either side; what #1650 changed is that the wrong answer is \
+             now reached in one pass instead of two."
         );
         assert_ne!(
             denotation_of(frame.provider(), frame.served(), &output),
@@ -662,22 +684,39 @@ fn a_flush_deletion_and_insertion_preserves_the_sequence_in_every_run_but_one() 
 /// **Question.** Why does that one row change its sequence, when each of the two
 /// members is placed legally and the pair denotes an ordinary substitution?
 ///
-/// **Because ferro normalizes the members separately and concatenates the
-/// answers.** Measured on a core carrying `CCC` across `c.72`/`c.*1`/`c.*2`, so
-/// the deletion is ambiguous across the CDS/3'UTR boundary:
+/// **The answer CHANGED with #1650, and the old one is kept because it is what
+/// makes the new one legible.** Measured on a core carrying `CCC` across
+/// `c.72`/`c.*1`/`c.*2`, so the deletion is ambiguous across the CDS/3'UTR
+/// boundary:
 ///
 /// ```text
-/// c.72del            -> c.*2del         correct alone: 3'-most in the CCC run
-/// c.72_*1insG        -> c.72delinsCG    correct alone: collapses the flush pair
-/// c.[72del;72_*1insG] -> c.[72delinsCG;*2del]   <- exactly the two, side by side
+/// c.72del             -> c.*2del        correct alone: 3'-most in the CCC run
+/// c.72_*1insG         -> c.72delinsCG   correct alone: collapses the flush pair
+/// c.[72del;72_*1insG] -> c.[72delinsCG;*2del]   BEFORE #1650: exactly the two, side by side
+///                     -> c.*1C>G                AFTER  #1650: one re-derived member
 /// ```
 ///
-/// Each member's answer is right in isolation. Together they are wrong, because
-/// the deletion's 3' shift runs over a homopolymer that its sibling has already
-/// split: once `G` sits between `c.72` and `c.*1`, `CCC` is no longer a run in
-/// the derived sequence and the deletion is no longer ambiguous. The pair
-/// denotes `c.72C>G`; ferro's answer transposes the inserted base past the one
-/// it should have replaced.
+/// Before #1650 the explanation was **concatenation**: the sequence-first pass
+/// refused every group with a member past `cds_end`, so each member was
+/// normalized in isolation and the answers were placed side by side. Each is
+/// right alone and they are wrong together, because the deletion's 3' shift runs
+/// over a homopolymer its sibling has already split — once `G` sits between
+/// `c.72` and `c.*1`, `CCC` is no longer a run in the derived sequence.
+///
+/// #1650 lets the pass read both sides of `cds_end`, so the group **is** now
+/// re-derived rather than concatenated, and the concatenation identity below is
+/// asserted to have stopped holding. **The class did not move with it.** The
+/// pair denotes `c.72C>G` — `CCC` becomes `GCC` — and both the old answer and
+/// the new one denote `CGC`. `spec_conformance_axis`'s `sequence_changed` reads
+/// **4 either side**, which is the measurement that says so over the whole
+/// corpus rather than over this row.
+///
+/// **So the diagnosis this module shipped is now half wrong, and that is the
+/// finding.** "Ferro concatenates independently-normalized members" was never
+/// the root cause; it was the route. The root cause survives re-derivation,
+/// which localises it to how the boundary run is partitioned rather than to
+/// where the members came from. Tracked in the sibling test's own pin, which
+/// still fires.
 ///
 /// **This is the sequence-preservation class**, the one property no
 /// representation argument can excuse — `background/basics.md:38` puts
@@ -690,17 +729,18 @@ fn the_cds_end_flush_pair_is_its_two_members_normalized_separately() {
     let insertion_alone = normalize_3prime(&frame, "NM_TEST.1:c.72_*1insG");
     let pair = normalize_3prime(&frame, "NM_TEST.1:c.[72del;72_*1insG]");
 
-    // Each member is correct on its own.
+    // Each member is still correct on its own, and #1650 does not touch either —
+    // a lone member is not a group the extension can admit.
     assert_eq!(deletion_alone, "NM_TEST.1:c.*2del");
     assert_eq!(insertion_alone, "NM_TEST.1:c.72delinsCG");
 
-    // And the pair is precisely those two answers, side by side — which is the
-    // whole defect, stated as an equality rather than asserted in prose.
     assert_eq!(
-        pair, "NM_TEST.1:c.[72delinsCG;*2del]",
-        "PINNED DEFECT — the pair denotes c.72C>G. Ferro reaches this by shifting \
-         the deletion 3' through a run its sibling insertion has already split."
+        pair, "NM_TEST.1:c.*1C>G",
+        "PINNED DEFECT — the pair denotes c.72C>G (`CCC` -> `GCC`) and this answer \
+         denotes `CGC`. Re-blessed by #1650 from `c.[72delinsCG;*2del]`, which \
+         denotes the same wrong bases; the spelling moved and the class did not."
     );
+
     let concatenated = format!(
         "NM_TEST.1:c.[{};{}]",
         insertion_alone
@@ -710,9 +750,11 @@ fn the_cds_end_flush_pair_is_its_two_members_normalized_separately() {
             .strip_prefix("NM_TEST.1:c.")
             .expect("a c. description")
     );
-    assert_eq!(
+    assert_ne!(
         pair, concatenated,
-        "the pair's output IS the two members normalized independently"
+        "the pair is now RE-DERIVED, not concatenated — if this equality comes \
+         back, #1650's extension has stopped admitting the group and the \
+         explanation in this test's doc comment reverts with it"
     );
 }
 


### PR DESCRIPTION
Closes #1650.

## The defect

A cis allele whose members straddle the CDS/3'UTR boundary was refused by the sequence-first pass, so the multi-member spelling and the `inv` spelling of one variant were two fixed points. The identical design converges when the members sit inside the CDS — same bases, same payload, only the stop codon moved:

```text
CDS 11..=30   c.[13_15delinsCTA;18T>G;20G>T] -> itself
              c.13_20inv                     -> c.[13_15delinsCTA;18T>G;20G>T]   converged
CDS 11..=26   c.[13_15delinsCTA;*2T>G;*4G>T] -> itself
              c.13_*4inv                     -> c.13_*4inv                        did NOT
```

This is the refusal #1536 originally named. #1536 turned out to be a different defect with a different cause (the #350 cross-axis bail, fixed by #1651), and this half was left behind it as a measured, `#[ignore]`d, red-by-design guard naming #1650 in both the attribute and the doc comment.

Reproduced on `origin/main` before any code was written — `cargo nextest run --features dev --test it -E 'test(issue_1536)' --run-ignored all` exits **100**, with the guard failing on exactly the two strings above and its CDS-interior control green.

After: all three spellings, in both directions, reach one point.

```text
CDS 11..=26   c.[13_15delinsCTA;*2T>G;*4G>T]  ┐
              c.13_*4inv                      ├-> c.[13_15delinsCTA;*2T>G;*4G>T]
              c.13_*4delinsCTACGGAT           ┘
```

The third is the "lone-`delins` symptom" #1650 names: #1651 left it converging with `c.13_*4inv` while *neither* was split into the three members its CDS-interior twin gets.

## Why a fix is owed, given that rule 3 is best effort

Two fixed points for one variant is a rule 3 (confluent) failure, and `README.md` marks rule 3 *best effort*. That does not by itself settle whether a fix is owed, so it was checked rather than assumed:

- `README.md` bounds best effort by **the spec's determinacy and what a normalizer's inputs can decide — "not by ferro's implementation quality"**, and states that a rule 2 or 3 failure caused by ferro's code is a bug under rule 7. None of the four listed ways the spec can fail to determine an answer applies here, and the CDS-interior control is the proof: if the spec did not determine an answer for this sequence, the interior twin would diverge too.
- Which form wins needs no new adjudication. `canonical-form-choice-when-both-legal` (`decided`) supplies the method — derive from the resulting sequence — and the guard asserts *convergence*, not a string. `general.md:56` ranks substitution above inversion and two of the three competing members are substitutions, so the split falls out. (`inversion-vs-two-delins-76-83` governs the other case — a whole-block reverse complement whose competitors are all `delins`, which `:56` does not rank. Here they are not.)
- `confluence-gate-is-apply-equality-on-every-determined-axis` (`decided`) is what makes these one equivalence class: single-exon transcript, same span, both axes agree.

## Correcting the issue on one point, because it changes the fix

#1650 says of the two refusals: *"Neither refusal is a policy. `merge`'s is an accident of doing the window arithmetic in **axis** coordinates."*

**That is wrong about `merge`'s.** `src/normalize/merge.rs` names the body-region check in `collect_canonical_edits` as the enforcement point for the CDS/UTR and transcript-end insertion clamps of #1202, #1205, #1207, #1209, #383 and #387, and for `general.md:44`'s exon-junction exception. Relaxing it removes an enforcement point along with the refusal, so the fix has to re-supply it — which is what the zero pad below does.

The half of the issue's diagnosis that *is* right is the mechanism: `simple_cds_pos` returns a coordinate *within* a region, those numbers are not on one line, and `edit_span_union` and the `w_lo`/`w_hi` arithmetic cannot be done across a boundary.

## The fix

`merge::ExtendedBody` folds `c.*N` onto `cds_len + N` — the coordinate it already has on the transcript once `frame.delta` (`cds_start - 1`) is added. The fold is therefore exact rather than an approximation, and `frame.delta`, `crosses_exon_junction`, `enclosing_exon` and `start0`/`end0` all keep working unchanged for the whole extended range. `render_on_its_own_region` is the inverse, applied to the rebuilt members.

Scoped three ways. Each is a measurement, not a preference:

1. **3'UTR only.** `c.-N` needs the origin itself to move, which changes what `w_lo`'s `.max(1)` clamp *means* — today it clamps at `c.1`, in transcript coordinates it would clamp at the transcript start and let the window reach into the 5'UTR. That is a behaviour change for every CDS-start-adjacent variant, not only the straddling ones. #1650 names it as needing its own measurement; it is filed as #1816 rather than inherited here.
2. **Straddling groups only.** A group sitting wholly in the 3'UTR keeps its refusal. Measured: admitting it regressed #1284's `c.[*10dup;*11dup]` to `c.[*11dup;*11dup]` — two members claiming one base, which round-trips through the sequence check because two `dup`s at one anchor insert the same bases. #1650 is about a span the boundary *cuts*; nothing is owed to a span it does not touch.
3. **The pad goes to zero for an extended group.** This is what re-supplies the clamp the body-region check was carrying. The pad is the only room `shift_pieces` has, so with it gone a piece can be cut anywhere inside the members' own union and carried nowhere outside it. That is #1651's own argument for its carve-out — "re-typing … reads the reference under the member's own span and moves nothing" — applied to the partition instead of to the typing.

## What this also fixes, and what it does not

**Fixed: the CDS-end non-idempotency family, 4 → 0 in both directions.** The class was `c.*1delinsCTT -> c.72_*1insCT -> c.72delinsCCT`; the second pass was answering a question the first could not see, because the first refused the group. It now settles in one pass. `defect_non_idempotent_outputs`'s pins are flipped accordingly, following the `every_scale_family_is_now_a_fixed_point` template that module set when the three `scale-*` rows were fixed.

**NOT fixed: the four rows that denote different bases.** `spec_conformance_axis`'s `sequence_changed` reads **4 at 3' either side of this branch**. The rows are respelled — `c.[72del;72_*1insA]` was `c.[72delinsTA;*2del]` and is now `c.*1T>A` — and both spellings denote `CGC` where the input denotes `GCC`. The spelling moved; the class did not. `spec_corpus_regressions`'s pins are re-blessed to the new strings and say plainly that this is a re-bless of a defect, not a fix.

That correction matters beyond the numbers: `the_cds_end_flush_pair_is_its_two_members_normalized_separately` explained the class as *"ferro normalizes the members separately and concatenates"*. The group is now genuinely re-derived — the test asserts the concatenation identity has stopped holding — and the wrong answer survives that. So concatenation was the route, not the root cause, which localises the remaining defect to how the boundary run is partitioned. The test records this.

**NOT fixed: the re-typing asymmetry itself.** The interbase immediately 3' of the last CDS base still re-types a two-base insertion into a `delins` where all 94 others do not. `an_insertion_immediately_after_the_last_cds_base_is_retyped_as_a_delins` keeps that sweep. This PR removed the disagreement between two passes, not the asymmetry between one interbase and the rest.

## A guard that reads as coverage and guards nothing

`apply_coding_codon_exception` gained a `within_cds` guard: `general.md:35`'s exception is a conjunction — "two variants separated by one nucleotide, **together affecting one amino acid**" — and the second conjunct is unstatable past the stop codon, while `same_codon` is `(a - 1) / 3` and answers happily for a codon that does not exist.

**It is marked defensive and NOT demonstrated, because sabotage-checking it twice showed the test was vacuous.** Two inputs were built to reach the line and neither does — `c.[*1C>G;*3T>A]` is declined at the straddle gate, and `c.[16C>G;*2T>A]` is admitted but still does not merge with the guard forced open. Both stayed green with `within_cds` forced to `true`.

Rather than ship a test that reads as coverage, the test is downgraded to a recorded measurement carrying the table of why each input misses, and `merge.rs` says the line is defensive. Whoever makes it reachable owes it a real sabotage check. The guard is kept rather than deleted because the failure direction is silent.

## Representation stability

Measured with the committed harness, `examples/dump_normalized_corpus`, dumped at `439617c2` and at this branch and diffed by `--compare` — not composed from deltas.

| | rows |
|---|---|
| total | 85 642 |
| **moved** | **780 (0.9 %)** |
| of which previously **accepted** (a migration) | 534 |
| of which previously **not** a fixed point (free) | 246 |

**The property this keys on is a `c.` member at or across `cds_end`, and it is not a structural zero.** The generator's own committed guards assert the coding corpus emits 3'UTR (`c.*N`) rows *and* rows straddling `CDS_END`; `CDS_END = 15` on a 20-mer gives the single-exon axis a real 3'UTR, and #1478's `cx.` axis adds `CDS_START_MULTI = 4` / `CDS_END_MULTI = 15`. Movement is confined to the families that can carry such a member — `dup_plus_sub` 308, `delins_hiding_an_inversion` 140, `del_plus_sub` 110, `dup_plus_ins` 93, `split_vs_spanning_delins` 79, `adjacent_junction_ins` 41, `junction_interior_to_span` 5, `long_block_inversion` 4 — and every protein family, `inv_member`, `nested_spans`, `partial_overlap_spans`, `coincident_bounds`, `identity_member` and `three_member_allele` move **0**, which is the expected zero rather than a blind one.

Axis censuses, both directions, re-blessed in the same commit:

| | 3' before | 3' after | 5' before | 5' after |
|---|---|---|---|---|
| converged | 9402 | **9442** | 9228 | **9276** |
| split 2 / 3 / 4+ | 2223 / 226 / 31 | 2201 / 214 / 25 | 2462 / 168 / 24 | 2440 / 142 / 24 |
| non-idempotent | 4 | **0** | 4 | **0** |
| sequence_changed | 4 | 4 | 0 | 0 |
| every other rank-1 counter | — | unchanged | — | unchanged |

The three `split_*` decreases sum exactly to the `converged` increase in each direction (22 + 12 + 6 = 40; 22 + 26 + 0 = 48). **That identity is quoted as a NET statement**, because the module's own warning is that the counters cannot tell net from gross. What is checked directly is the reported divergence set, whose 12 family ids are byte-identical either side and contain no `cds-end` row.

`coding_axis_separation_two_or_more_merges` stays **0 of 997**, so no allele separated by two or more unchanged nucleotides was merged.

## Deliberately left open

- **#1816** — the 5'UTR half, plus `Anchor` carrying a region per endpoint so a *derived* member that straddles the boundary can be built rather than declined. The two want the same change, which is why they are filed together.
- `uses_extension` runs `collect_canonical_edits` a second time on a coding group, so such a derivation lowers its member list twice. A `cds_end_axis.is_some()` short-circuit — provably equivalent, since with no CDS end `extended` *is* `OFF` — removes it for every genomic, mitochondrial, `n.` and non-coding-`r.` derivation. Removing the coding-group case needs `collect_canonical_edits` to report whether it folded, a wider signature change than this fix wants. **Flagged for a reviewer** rather than left implicit.
- `ORACLE_EXCLUDE` is not narrowed. Its reason-2 (five tests assert the non-idempotency the oracle panics on) no longer holds, and both `ci.yml` and `scripts/run_oracle_suite.sh` are corrected to say so; the exclusion is kept for reason 1 and for the denoted-sequence rows, and narrowing it needs its own measurement.

## Verification

All on this branch at `05adb623`, rebased onto `439617c2`, with every exit status read back out of the log rather than from a completion notification.

| command | rc | result |
|---|---|---|
| `cargo fmt --all --check` | 0 | no output |
| `cargo clippy --all-features --all-targets -- -D warnings` | 0 | clean (one pre-existing third-party future-incompat notice for `proc-macro-error2 v2.0.1`) |
| `cargo nextest run --features dev --lib --test it` | 0 | `10339 tests run: 10339 passed, 149 skipped` |
| `scripts/run_oracle_suite.sh` | 0 | `10394 tests run: 10394 passed, 287 skipped` |
| `dump_normalized_corpus --out` ×2 + `--compare` | 0 | 85 642 rows each side, 780 moved |
| `... -E 'test(issue_1536)' --run-ignored all` on `origin/main` | 100 | the guard, red by design, before any code |

`scripts/run_oracle_suite.sh` rather than a bare armed run: a bare `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run` cannot pass on `main` and never could, for the reasons that script's header sets out.

Both public normalizing entry points are reached — `canonicalize_from_sequence` is called from the shared path that `normalize()` and `normalize_with_diagnostics()` both run — so the idempotency oracle covers this change on both exits. No new early return bypasses the shared checked exit; the added `return None` is inside `canonicalize_from_sequence`, whose `None` is the established "decline and let the per-member pipeline stand".

No reference-aware test was added, so nothing here depends on `FERRO_MANIFEST` and everything above runs on PR CI.

Representation-Change: 1671 of 96 182 corpus rows move (1.7%) — 1191 were previously accepted forms (a migration) and 480 were not fixed points, so moving those is free. Every move is a cis allele straddling `cds_end` being re-derived from the bases it already denoted; no move changes what a description denotes, and `sequence_changed` is unchanged at 4/0. Both axis censuses are re-blessed on the current base: converged 11 016 -> 11 056 at 3' and 10 755 -> 10 803 at 5', with the three `split_*` decreases summing exactly to each gain (22+12+6 and 22+26+0), and `non_idempotent_outputs` 4 -> 0 in both directions.

