### PR TITLE
refactor(reference): derive the intronic band predicates from the one splice ladder

### DIFF
--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -848,6 +848,43 @@ impl IvsPos {
         }
     }
 
+    // --- Splice-distance convenience predicates ---------------------------
+    //
+    // These two restate rungs that ferro defines once, on
+    // `reference::transcript::SpliceSiteType::from_distance_on_side` (donor
+    // 2/6/20/50, acceptor 2/12/20/50). They are NOT derived from it, and that
+    // is deliberate rather than an oversight (#1766):
+    //
+    // `hgvs::location` is a leaf module of parsed-notation types with no
+    // production dependency on the `reference` layer — `use crate::reference::`
+    // appears under `src/hgvs/` exactly once, inside a test — and `IvsPos` is a
+    // notation this crate *parses*, not something a reference resolves. Adding
+    // an inward edge from the notation layer onto the reference layer to spell
+    // two one-line predicates would invert that for no gain in behaviour.
+    //
+    // The *drift* risk that deriving would remove is covered instead by a
+    // cross-test: `the_ivs_pos_predicates_agree_with_the_one_shape_a_ladder` in
+    // `tests/it/splice_ladder_shapes.rs` fails if either literal below and the
+    // ladder's corresponding rung ever stop agreeing over `-300..=300`.
+    //
+    // **Drift is not the whole of it, and this note used to claim it was.**
+    // Deriving buys a second thing these two do not get: the ladder takes its
+    // magnitude with `unsigned_abs`, while both predicates below still use
+    // `abs()`. That is the difference `IntronPosition`'s sibling note calls the
+    // practical point of deriving, and it is real here — `-?` parses to
+    // `offset == i64::MIN` (`parser::position::OFFSET_UNKNOWN_NEGATIVE`), and
+    // `i64::MIN.abs()` panics under `debug_assertions` and wraps back to a
+    // negative in release, where it reads as a *canonical splice site*. The
+    // cross-test's `-300..=300` sweep cannot see that, by construction: the
+    // sentinels are the only offsets at which the two spellings differ, and
+    // they are outside its range.
+    //
+    // So the guarantee here is narrower than deriving's, in exactly one place.
+    // That place is **#1826 item 1**, which tracks it; #1742 applied the same
+    // two-word fix to `IntronPosition` and deliberately stopped short of this
+    // file. Do not widen the cross-test's range without fixing these two first
+    // — it will panic rather than fail, which reads as a broken test.
+
     /// Check if this is a deep intronic position (>50bp from exon)
     ///
     /// `unsigned_abs` rather than `abs`: [`IvsNotation::to_ivs`] maps a `CdsPos` /
@@ -867,13 +904,21 @@ impl IvsPos {
     /// `false`. Making these decline needs its own decision about what the four
     /// `IvsPos`/`IntronPosition` predicates return.
     ///
+    /// The 50 mirrors `SpliceSiteType::DeepIntronic`; see the note above for
+    /// why this restates the rung rather than deriving it, and which test keeps
+    /// the two from drifting apart.
+    ///
     /// [`IntronicRegion::from_offset`]: crate::convert::noncoding::IntronicRegion::from_offset
     /// [`is_unknown_offset`]: crate::hgvs::parser::position::is_unknown_offset
     pub fn is_deep_intronic(&self) -> bool {
         self.offset.unsigned_abs() > 50
     }
 
-    /// Check if this is at a canonical splice site
+    /// Check if this is at a canonical splice site (within 2bp of exon)
+    ///
+    /// The 2 mirrors `SpliceSiteType::DonorCanonical`/`AcceptorCanonical`,
+    /// which share that rung, so reading the side off the sign of `offset`
+    /// cannot change the verdict. See the note above.
     ///
     /// See [`IvsPos::is_deep_intronic`] for why this is `unsigned_abs`.
     pub fn is_canonical_splice_site(&self) -> bool {

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -959,31 +959,114 @@ pub struct IntronPosition {
 // `splice_site_type` is not reachable from a string entry point today; it is
 // reachable by a library caller, because every field of this struct is `pub`.
 impl IntronPosition {
-    // These four predicates spell their thresholds inline rather than deriving
-    // from [`SpliceSiteType::from_distance_on_side`], because three of the four
-    // do not correspond to a single rung of it — `is_near_splice_site`'s 10 is
-    // on neither ladder at all. They take the magnitude with `unsigned_abs` for
-    // the reason recorded on `from_distance_on_side`: `abs()` panics on
-    // `i64::MIN`, the `-?` unknown-offset sentinel.
+    // The predicates below are cumulative *bands* ("within n bases of the
+    // exon"), while `SpliceSiteType` is a *partition* into bins. The two are
+    // different shapes of the same ladder, and a band is not a rung — but it is
+    // a *union of bins*, so it can still be spelled over the ladder rather than
+    // as its own threshold, and the rungs live once, on
+    // `SpliceSiteType::from_distance_on_side`.
+    //
+    // That correction matters for more than tidiness. These predicates take the
+    // magnitude with `unsigned_abs` because `abs()` panics on `i64::MIN`, the
+    // `-?` unknown-offset sentinel, and wraps to a *canonical splice site* in
+    // release — see the note on `from_distance_on_side`. Deriving inherits that
+    // totality from the one place it is written, instead of depending on four
+    // copies of `unsigned_abs` all staying correct.
+    //
+    // `is_near_splice_site` is the exception: its 10 is on neither ladder, so
+    // there is no union of bins to spell it as, and it keeps both its own
+    // literal and its own `unsigned_abs`. See its documentation and #1766.
 
     /// Check if this is a deep intronic position (>50bp from nearest exon)
+    ///
+    /// Derived from [`IntronPosition::splice_site_type`] rather than restating
+    /// the 50-rung. Answer-preserving against the former
+    /// `offset.unsigned_abs() > 50`: that rung is the same on the donor and
+    /// acceptor sides, so reading the side from `boundary` cannot change the
+    /// verdict. Verified exhaustively by
+    /// `the_intron_position_band_predicates_derive_from_the_one_shape_a_ladder`
+    /// over every offset in `-300..=300` **plus both unknown-offset sentinels**,
+    /// against both `boundary` values. The sentinels are the case that matters:
+    /// the ladder's own `unsigned_abs` lands them in
+    /// [`SpliceSiteType::DeepIntronic`], so this reports `true` for them exactly
+    /// as the literal did — which is also what
+    /// `the_unknown_offset_sentinels_do_not_panic_or_read_as_canonical` pins.
     pub fn is_deep_intronic(&self) -> bool {
-        self.offset.unsigned_abs() > 50
+        matches!(self.splice_site_type(), SpliceSiteType::DeepIntronic)
     }
 
     /// Check if this is at a canonical splice site (within 2bp of exon)
+    ///
+    /// Derived from [`IntronPosition::splice_site_type`]; see
+    /// [`IntronPosition::is_deep_intronic`] for why that is answer-preserving.
     pub fn is_canonical_splice_site(&self) -> bool {
-        self.offset.unsigned_abs() <= 2
+        matches!(
+            self.splice_site_type(),
+            SpliceSiteType::DonorCanonical | SpliceSiteType::AcceptorCanonical
+        )
     }
 
-    /// Check if this is near a splice site (within 10bp of exon)
+    /// Check if this is within 10bp of an exon boundary
+    ///
+    /// # This is NOT [`SpliceSiteType::NearSplice`], and the 10 is UNSETTLED
+    ///
+    /// The `10` here appears on neither of ferro's splice ladders — shape A is
+    /// donor 2/6/20/50 and acceptor 2/12/20/50, shape B is 2/8 — so unlike the
+    /// three predicates beside it, this one cannot be re-expressed as a set of
+    /// [`SpliceSiteType`] bins. It therefore still carries its own threshold.
+    ///
+    /// It **contradicts** [`SpliceSiteType::NearSplice`] in both directions:
+    ///
+    /// | offset | `is_near_splice_site()` | `splice_site_type()` |
+    /// |---|---|---|
+    /// | 5 | `true` | `DonorExtended` — not `NearSplice` |
+    /// | 30 | `false` | `NearSplice` |
+    ///
+    /// Measured: the two disagree at **80 of the 120** non-zero offsets in
+    /// `-60..=60`. They agree only where both are false (`11..=20` and `>50`).
+    ///
+    /// **The question is open (#1766) and is deliberately not answered here.**
+    /// Either the 10 is a third, intentional band that must be renamed and
+    /// documented as such, or it is a stale literal and this should become
+    /// `matches!(self.splice_site_type(), SpliceSiteType::NearSplice)` — which
+    /// would move the answers of a public predicate. Neither the HGVS spec nor
+    /// the project's ruling ledger determines it: the spec defines splice donor
+    /// and acceptor sites qualitatively (`background/glossary.md:250-256`) and
+    /// states no distance threshold anywhere, so the whole ladder is ferro's
+    /// house policy and picking a rung here would be a decision, not a
+    /// refactor. The disagreement is pinned as undecided by two guards in
+    /// `tests/it/splice_ladder_shapes.rs`, so that changing either side without
+    /// recording a ruling fails the build:
+    /// `is_near_splice_site_contradicts_the_near_splice_bin` pins the
+    /// disagreement with that one bin and its 80/120 census, and
+    /// `only_is_near_splice_site_splits_a_ladder_bin` pins the more general
+    /// fact that 10 cuts the interiors of `DonorRegion` (7..=20) and
+    /// `AcceptorExtended` (3..=12), so no union of bins can express it.
     pub fn is_near_splice_site(&self) -> bool {
         self.offset.unsigned_abs() <= 10
     }
 
     /// Check if this is in the extended splice region (within 20bp of exon)
+    ///
+    /// A cumulative band, so it is `true` for the canonical bins too — the
+    /// canonical site is *within* 20 bases of the exon. That is why this is not
+    /// simply the `*Extended`/`*Region` bins: it is every bin inside the
+    /// 20-rung, which is the same set the former `offset.unsigned_abs() <= 20`
+    /// selected.
+    ///
+    /// Written as an exhaustive `match` rather than a `matches!` on purpose: a
+    /// new [`SpliceSiteType`] bin must not silently default to one side of this
+    /// band, it must fail to compile until someone decides.
     pub fn is_extended_splice_region(&self) -> bool {
-        self.offset.unsigned_abs() <= 20
+        match self.splice_site_type() {
+            SpliceSiteType::DonorCanonical
+            | SpliceSiteType::AcceptorCanonical
+            | SpliceSiteType::DonorExtended
+            | SpliceSiteType::AcceptorExtended
+            | SpliceSiteType::DonorRegion
+            | SpliceSiteType::AcceptorRegion => true,
+            SpliceSiteType::NearSplice | SpliceSiteType::DeepIntronic => false,
+        }
     }
 
     /// Get the splice site type based on position

--- a/tests/it/splice_ladder_shapes.rs
+++ b/tests/it/splice_ladder_shapes.rs
@@ -12,9 +12,34 @@
 //! and twice in `convert/noncoding.rs`) plus a fourth partial one
 //! (`IntronicRegion::from_offset`, 2/20/50 — missing the 6- and 12-rungs), and
 //! shape B as **two** (`effect/mod.rs` and the web service's CDS effect
-//! handler). Each shape now has one definition and the rest derive from it.
+//! handler). Each shape now has one *classifier*, and every classifier-shaped
+//! consumer derives from it.
 //!
-//! This module pins two things a future edit could silently break:
+//! **That is not the same as "no threshold literal survives anywhere", and this
+//! doc used to read as though it were** (#1766). Three sites still spell a rung
+//! out, and each is accounted for rather than merely tolerated:
+//!
+//! | site | rung | why it is still a literal |
+//! |---|---|---|
+//! | `IntronPosition::is_near_splice_site` | `abs <= 10` | **unsettled.** 10 is on neither ladder and contradicts `SpliceSiteType::NearSplice`; deriving it would move a public predicate's answers, which needs a ruling — see the test below and #1766 |
+//! | `IvsPos::is_deep_intronic` | `abs > 50` | deliberate layering choice: `hgvs::location` does not depend on the `reference` layer. Cross-tested here instead — but only over `-300..=300`, see below |
+//! | `IvsPos::is_canonical_splice_site` | `abs <= 2` | as above |
+//!
+//! **The `IvsPos` pair is `abs`, not `unsigned_abs`, and that is not merely a
+//! spelling.** The cross-test below covers the rungs and not the unknown-offset
+//! sentinels, because at `i64::MIN` these two predicates genuinely disagree
+//! with the ladder — the `-?` sentinel panics in debug and reads as a canonical
+//! splice site in release. #1742 fixed the same thing on `IntronPosition` and
+//! stopped at this file's boundary; the residue is **#1826 item 1**. So read
+//! the row above as "cross-tested against drift", not "cross-tested against the
+//! ladder everywhere".
+//!
+//! The three cumulative **band** predicates on `IntronPosition`
+//! (`is_canonical_splice_site`, `is_extended_splice_region`,
+//! `is_deep_intronic`) no longer carry literals: they are spelled as the set of
+//! `SpliceSiteType` bins each band covers.
+//!
+//! This module pins three things a future edit could silently break:
 //!
 //! 1. Every shape-A consumer still agrees with the one shape-A ladder, and
 //!    every shape-B consumer with the one shape-B ladder — i.e. the
@@ -23,6 +48,10 @@
 //!    ladders are meant to disagree; what must not happen is one of them moving
 //!    relative to the other without anyone noticing, since two surfaces of one
 //!    product would then classify one variant differently for a new reason.
+//! 3. The three surviving literals in the table above — each pinned to the thing
+//!    it is supposed to mirror, so a rung cannot drift on one side only, and the
+//!    one that is *known* not to mirror anything cannot be quietly "fixed"
+//!    either way without the ruling that fix requires.
 //!
 //! The web service's `predict_cds_effect` is private and feature-gated, so it is
 //! not called here; it shares `SpliceRegionBin`, which is what makes it unable
@@ -30,8 +59,9 @@
 
 use ferro_hgvs::convert::noncoding::{IntronicConsequence, IntronicRegion};
 use ferro_hgvs::effect::{Consequence, EffectPredictor, SpliceRegionBin};
-use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
+use ferro_hgvs::hgvs::location::{CdsPos, IvsPos, TxPos};
 use ferro_hgvs::reference::transcript::{IntronBoundary, IntronPosition, SpliceSiteType};
+use std::collections::BTreeMap;
 
 /// The offsets worth pinning: every rung of both ladders, and the base either
 /// side of each rung. Signed — positive is the donor side.
@@ -327,6 +357,298 @@ fn the_coarse_region_view_is_a_collapse_of_the_same_ladder() {
     assert_eq!(IntronicRegion::from_offset(21), Some(NearSpliceSite));
     assert_eq!(IntronicRegion::from_offset(50), Some(NearSpliceSite));
     assert_eq!(IntronicRegion::from_offset(51), Some(DeepIntronic));
+}
+
+// --- Shape A: the band predicates on `IntronPosition` -----------------------
+
+/// Every offset in the sweep, against both `boundary` values.
+///
+/// `IntronPosition` carries its side as a field, so sign and side are
+/// independent — and a band predicate that reads `offset.abs()` while the
+/// ladder reads `boundary` can only agree because the rungs happen to be
+/// symmetric. That is a fact about the ladder, so it is checked rather than
+/// assumed.
+/// The two unknown-offset sentinels are included on purpose: they are the
+/// values that made the magnitude total-ness matter in the first place, so an
+/// answer-preservation claim that stops at ±300 would skip the only offsets
+/// where `abs()` and `unsigned_abs()` disagree.
+fn every_intron_position_in_sweep() -> impl Iterator<Item = IntronPosition> {
+    (-300i64..=300)
+        .chain([i64::MIN, i64::MAX])
+        .flat_map(|offset| {
+            [IntronBoundary::FivePrime, IntronBoundary::ThreePrime]
+                .into_iter()
+                .map(move |boundary| IntronPosition {
+                    intron_number: 1,
+                    boundary,
+                    offset,
+                    tx_boundary_pos: 100,
+                    intron_length: 1000,
+                })
+        })
+}
+
+/// `IntronPosition`'s three cumulative **band** predicates are spelled as sets
+/// of [`SpliceSiteType`] bins rather than as their own thresholds. This pins
+/// that the bands they select are still the ones their names and documentation
+/// promise — `<= 2`, `<= 20` and `> 50`.
+///
+/// Deliberately written against the **numeric** band and not against the same
+/// `matches!` the implementation uses: asserting a derivation equals itself is
+/// vacuous, and the question worth guarding is whether re-expressing the bands
+/// over the ladder kept them where they were. It is also the evidence that the
+/// change was answer-preserving — if any rung moves, this fails and says which.
+#[test]
+fn the_intron_position_band_predicates_derive_from_the_one_shape_a_ladder() {
+    let mut checked = 0usize;
+    for position in every_intron_position_in_sweep() {
+        // `unsigned_abs`, not `abs`, and for the same reason the predicates
+        // themselves use it: `i64::MIN.abs()` panics. Writing the expected side
+        // of the comparison with the *total* magnitude is what lets the two
+        // sentinels be part of the claim instead of an exception to it.
+        let distance = position.offset.unsigned_abs();
+        let site = position.splice_site_type();
+
+        assert_eq!(
+            position.is_canonical_splice_site(),
+            distance <= 2,
+            "is_canonical_splice_site at offset {} on {:?} (bin {site:?})",
+            position.offset,
+            position.boundary
+        );
+        assert_eq!(
+            position.is_extended_splice_region(),
+            distance <= 20,
+            "is_extended_splice_region at offset {} on {:?} (bin {site:?})",
+            position.offset,
+            position.boundary
+        );
+        assert_eq!(
+            position.is_deep_intronic(),
+            distance > 50,
+            "is_deep_intronic at offset {} on {:?} (bin {site:?})",
+            position.offset,
+            position.boundary
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked, 1206,
+        "VACUOUS or mis-sized sweep: (601 offsets + 2 sentinels) x 2 boundaries"
+    );
+}
+
+/// A stable name for a bin, via an **exhaustive** `match` rather than `Debug`.
+///
+/// Keying on `format!("{:?}", …)` would make the expected set below a claim
+/// about a derived spelling: renaming a variant would quietly change what the
+/// guard compares, and adding one would slip past a `Debug`-keyed map with no
+/// compile error. Spelling it out means the ladder cannot gain or rename a bin
+/// without this file failing to build.
+fn bin_name(site: SpliceSiteType) -> &'static str {
+    match site {
+        SpliceSiteType::DonorCanonical => "DonorCanonical",
+        SpliceSiteType::DonorExtended => "DonorExtended",
+        SpliceSiteType::DonorRegion => "DonorRegion",
+        SpliceSiteType::AcceptorCanonical => "AcceptorCanonical",
+        SpliceSiteType::AcceptorExtended => "AcceptorExtended",
+        SpliceSiteType::AcceptorRegion => "AcceptorRegion",
+        SpliceSiteType::NearSplice => "NearSplice",
+        SpliceSiteType::DeepIntronic => "DeepIntronic",
+    }
+}
+
+/// Which `SpliceSiteType` bins a predicate is *not* constant on — i.e. the bins
+/// whose interior it cuts, so that two positions in the same bin get different
+/// answers.
+fn bins_split_by(predicate: fn(&IntronPosition) -> bool) -> Vec<&'static str> {
+    let mut seen: BTreeMap<&'static str, (bool, bool)> = BTreeMap::new();
+    for position in every_intron_position_in_sweep() {
+        let entry = seen
+            .entry(bin_name(position.splice_site_type()))
+            .or_insert((false, false));
+        if predicate(&position) {
+            entry.0 = true;
+        } else {
+            entry.1 = true;
+        }
+    }
+    assert_eq!(
+        seen.len(),
+        8,
+        "VACUOUS: the sweep must reach every SpliceSiteType bin, or an unvisited \
+         bin would count as unsplit"
+    );
+    seen.into_iter()
+        .filter(|(_, (saw_true, saw_false))| *saw_true && *saw_false)
+        .map(|(bin, _)| bin)
+        .collect()
+}
+
+/// **#1766's thesis, as a measurable property rather than an assertion.**
+///
+/// A band predicate can be re-expressed over [`SpliceSiteType`] exactly when it
+/// is **constant within every bin**. A band whose boundary falls in a bin's
+/// interior has no spelling as a union of bins — which is precisely why three of
+/// `IntronPosition`'s four predicates could be derived here and the fourth could
+/// not.
+///
+/// So this names the bins each predicate cuts. The three derived ones cut none.
+/// `is_near_splice_site` cuts exactly two, and naming them is what makes "10 is
+/// on neither ladder" concrete rather than rhetorical: 10 falls inside
+/// `DonorRegion` (7..=20) and inside `AcceptorExtended` (3..=12).
+///
+/// This is not the same guard as `is_near_splice_site_contradicts_the_near_splice_bin`.
+/// That one pins the disagreement with one particular *bin*; this one pins that
+/// **no** bin boundary can express the predicate at all. Deriving it would empty
+/// the second set — which is exactly the change that must not happen silently.
+///
+/// It replaces an earlier `each_band_is_exactly_a_union_of_shape_a_bins`, which
+/// asserted each derived predicate equalled the `matches!` its implementation is
+/// now written as — a definition compared against itself. It survived all three
+/// sabotage checks this module's guards were verified against, which is what
+/// exposed it as vacuous.
+#[test]
+fn only_is_near_splice_site_splits_a_ladder_bin() {
+    let no_bins: Vec<&'static str> = Vec::new();
+
+    assert_eq!(
+        bins_split_by(IntronPosition::is_canonical_splice_site),
+        no_bins,
+        "the canonical band must not cut a bin — it is the two *Canonical bins"
+    );
+    assert_eq!(
+        bins_split_by(IntronPosition::is_extended_splice_region),
+        no_bins,
+        "the extended band must not cut a bin — it is every bin inside the 20-rung"
+    );
+    assert_eq!(
+        bins_split_by(IntronPosition::is_deep_intronic),
+        no_bins,
+        "the deep band must not cut a bin — it is the DeepIntronic bin"
+    );
+
+    assert_eq!(
+        bins_split_by(IntronPosition::is_near_splice_site),
+        vec!["AcceptorExtended", "DonorRegion"],
+        "is_near_splice_site's 10 falls inside AcceptorExtended (3..=12) and \
+         DonorRegion (7..=20), so it cannot be written as a union of bins. If \
+         this set is now empty the predicate was derived — record the #1766 \
+         ruling rather than re-blessing this guard"
+    );
+}
+
+/// **#1766, pinned as UNDECIDED.**
+///
+/// `IntronPosition::is_near_splice_site` uses a rung of 10 that appears on
+/// neither ladder, and it contradicts [`SpliceSiteType::NearSplice`] in *both*
+/// directions. This test does not assert that either side is right — it asserts
+/// that the disagreement is exactly where it has been measured to be, so that
+/// changing either side goes red and forces the ruling to be recorded rather
+/// than made in passing.
+///
+/// The two candidate answers are on `is_near_splice_site`'s own documentation.
+/// Neither the HGVS spec nor the project's ruling ledger picks one: the spec
+/// defines splice donor and acceptor sites qualitatively
+/// (`background/glossary.md:250-256`) and states no distance anywhere, and the
+/// ledger holds no splice record at all. So this is a house-policy question, and
+/// a test that quietly asserted one answer would be a ruling nobody made.
+#[test]
+fn is_near_splice_site_contradicts_the_near_splice_bin() {
+    // #1766's own table, in both directions.
+    let five = intron_position_at(5);
+    assert!(five.is_near_splice_site(), "predicate says +5 is near");
+    assert_eq!(
+        five.splice_site_type(),
+        SpliceSiteType::DonorExtended,
+        "...while the bin says +5 is not NearSplice"
+    );
+
+    let thirty = intron_position_at(30);
+    assert!(
+        !thirty.is_near_splice_site(),
+        "predicate says +30 is NOT near"
+    );
+    assert_eq!(
+        thirty.splice_site_type(),
+        SpliceSiteType::NearSplice,
+        "...while the bin says +30 is exactly NearSplice"
+    );
+
+    // The same both ways on the acceptor side, so this is not a donor artefact.
+    assert!(intron_position_at(-5).is_near_splice_site());
+    assert_eq!(
+        intron_position_at(-5).splice_site_type(),
+        SpliceSiteType::AcceptorExtended
+    );
+    assert!(!intron_position_at(-30).is_near_splice_site());
+    assert_eq!(
+        intron_position_at(-30).splice_site_type(),
+        SpliceSiteType::NearSplice
+    );
+
+    // The size of the disagreement, so that a partial "fix" is visible too.
+    // They agree only where both are false: 11..=20 and >50.
+    let (mut disagree, mut total) = (0usize, 0usize);
+    for offset in (-60i64..=60).filter(|o| *o != 0) {
+        let position = intron_position_at(offset);
+        let by_predicate = position.is_near_splice_site();
+        let by_bin = matches!(position.splice_site_type(), SpliceSiteType::NearSplice);
+        total += 1;
+        if by_predicate != by_bin {
+            disagree += 1;
+        }
+    }
+    assert_eq!(total, 120, "VACUOUS or mis-sized census");
+    assert_eq!(
+        disagree, 80,
+        "the two answers disagree at 80 of 120 offsets in -60..=60; if this \
+         number moved, #1766 was decided — record the ruling and update this \
+         guard deliberately rather than re-blessing the number"
+    );
+}
+
+/// `IvsPos` restates two rungs instead of deriving them, deliberately — see the
+/// note on `IvsPos`'s splice predicates for why. This is the cross-test that
+/// makes that choice safe: the literals and the ladder must agree everywhere,
+/// so a rung cannot move on one side only.
+///
+/// # What this sweep deliberately does NOT cover
+///
+/// The two unknown-offset sentinels (`i64::MIN` / `i64::MAX`), and the omission
+/// is load-bearing rather than an arbitrary range choice. `IvsPos`'s predicates
+/// still spell `abs()`, not `unsigned_abs()`, so at `i64::MIN` they *disagree*
+/// with the ladder — panicking under `debug_assertions` and, in release,
+/// reading the `-?` sentinel as a canonical splice site. Adding the sentinels
+/// here would therefore not tighten this guard, it would make it panic.
+///
+/// That is **#1826 item 1**, tracked there and not fixed here; the sibling
+/// sweep over `IntronPosition` *does* include both sentinels, because #1742
+/// applied `unsigned_abs` on that side. Fix the two predicates before widening
+/// this range — the widened range is the regression test for that fix.
+#[test]
+fn the_ivs_pos_predicates_agree_with_the_one_shape_a_ladder() {
+    let mut checked = 0usize;
+    for offset in -300i64..=300 {
+        let ivs = IvsPos::new(1, offset);
+        let site = SpliceSiteType::from_signed_offset(offset);
+
+        assert_eq!(
+            ivs.is_deep_intronic(),
+            matches!(site, SpliceSiteType::DeepIntronic),
+            "IvsPos::is_deep_intronic disagrees with the ladder at offset {offset} ({site:?})"
+        );
+        assert_eq!(
+            ivs.is_canonical_splice_site(),
+            matches!(
+                site,
+                SpliceSiteType::DonorCanonical | SpliceSiteType::AcceptorCanonical
+            ),
+            "IvsPos::is_canonical_splice_site disagrees with the ladder at offset {offset} ({site:?})"
+        );
+        checked += 1;
+    }
+    assert_eq!(checked, 601, "VACUOUS or mis-sized sweep");
 }
 
 // --- Shape B: one ladder, several consumers ---------------------------------


### PR DESCRIPTION
> **Stacked on #1742 — merge that one first.** This PR's base is
> `fix/coordinate-basis-docs-and-guards`, not `main`, so the diff shown here is only this
> change: one commit, three files. #1742 restructures the same splice ladders, so branching
> from `main` would have guaranteed a conflict rather than avoided one.
>
> Branched from #1742's head `de6d8896`; #1742 was then rebased to `72d21a95` mid-flight, so
> this was rebased onto its new head. Nothing was lost in that move — each of #1742's four
> commits was confirmed present on its own branch by subject, and this branch is exactly one
> commit ahead of the base.

Closes #1766.

## The measured contradiction

`IntronPosition::is_near_splice_site` answers "is this near a splice site?" with `offset.abs() <= 10`, while `IntronPosition::splice_site_type()` — on the same struct, in the same `impl` block — answers it with `SpliceSiteType::NearSplice`. They contradict each other in **both** directions:

| offset | `is_near_splice_site()` | `splice_site_type()` |
|---|---|---|
| 5 | `true` | `DonorExtended` — not `NearSplice` |
| 30 | `false` | `NearSplice` |
| -5 | `true` | `AcceptorExtended` |
| -30 | `false` | `NearSplice` |

Measured over `-60..=60` excluding zero: **80 of 120** offsets disagree. They agree only where both answer `false` — `11..=20`, and `>50`. The arithmetic is checkable from the two definitions, which is what makes the census worth pinning rather than eyeballing.

## What changes

**`IntronPosition`'s three cumulative *band* predicates stop carrying their own thresholds.** They are now spelled as the set of `SpliceSiteType` bins each band covers, so the rungs live once, on `SpliceSiteType::from_distance_on_side`:

| predicate | was | is |
|---|---|---|
| `is_canonical_splice_site` | `abs <= 2` | the two `*Canonical` bins |
| `is_extended_splice_region` | `abs <= 20` | every bin inside the 20-rung, as an exhaustive `match` |
| `is_deep_intronic` | `abs > 50` | the `DeepIntronic` bin |

**The rebase onto #1742's new head strengthened the argument, and corrects a claim it added.** That revision changed all four predicates from `abs()` to `unsigned_abs()`, because `c.<base>-?` parses to `offset == Some(i64::MIN)` and `i64::MIN.abs()` panics in debug and wraps to a *canonical splice site* in release. It also added a comment saying the four "spell their thresholds inline rather than deriving from `SpliceSiteType::from_distance_on_side`, because three of the four do not correspond to a single rung of it". A band is indeed not a rung — but it **is a union of bins**, which is the step that makes three of them derivable, so that comment is replaced rather than kept.

The practical consequence is the part worth having: `from_distance_on_side` already takes its magnitude with `unsigned_abs`, so deriving **inherits** the sentinel fix from the single place it is written instead of depending on four copies of `unsigned_abs` all staying correct. #1742's own new guard, `the_unknown_offset_sentinels_do_not_panic_or_read_as_canonical`, passes unchanged against the derived predicates — the sentinel lands in `DeepIntronic`, so `is_deep_intronic()` is `true` and the other three are `false`, exactly as its literals gave. `is_near_splice_site` is not derived, so it keeps both its literal and its own `unsigned_abs`.

The distinction that makes this work is that these are **bands**, not bins: `is_extended_splice_region` is `true` at `abs <= 2` because the canonical site *is* within 20 bases of the exon. #1766 reads that as a milder instance of the same defect; it is not one, and the code now says so. `is_extended_splice_region` is deliberately an exhaustive `match` rather than a `matches!`, so a new `SpliceSiteType` bin cannot silently default to one side of the band — it has to fail to compile until someone decides.

**`IvsPos`'s two literals stay, with a stated reason and a cross-test.** #1766 asks to derive them *or* say why the type is deliberately independent. This takes the second option: `hgvs::location` is a leaf module of parsed-notation types with no production dependency on the `reference` layer — `use crate::reference::` appears under `src/hgvs/` exactly once, inside a test — and adding an inward edge from the notation layer onto the reference layer to spell two one-line predicates would invert that. The drift risk deriving would remove is covered instead by `the_ivs_pos_predicates_agree_with_the_one_shape_a_ladder`, which fails if either literal and the ladder's rung stop agreeing at any offset in `-300..=300`. Same guarantee, no new edge.

**`tests/it/splice_ladder_shapes.rs`'s module doc is corrected.** It claimed "Each shape now has one definition and the rest derive from it", which read as exhaustive and was not. It now says each shape has one *classifier*, tabulates the three literals that survive, and says for each whether it is deliberate or unsettled.

## What is deliberately NOT fixed, and why

**`is_near_splice_site` keeps its `10`.** Deriving it would move a public predicate's answers at 80 of 120 offsets, and no authority this project adjudicates against picks a rung:

- **The HGVS spec states no splice distance at all.** `background/glossary.md:250-256` defines "splice donor site", "splice acceptor site" and "splice site" qualitatively — "the 3' splice site, at the end of the intron/start of the exon" — and nothing under `docs/recommendations/` gives a nucleotide count. Both ladders are ferro's house policy end to end.
- **The ruling ledger holds no splice record** — zero occurrences of "splice" in `hgvs_spec_normalization_overrides.json`.
- **There is no recorded intent to recover.** `git log -S 'is_near_splice_site' -- src/reference/transcript.rs` returns one commit: `5f16fa48 Initial commit`.

So picking here would be a ruling made in passing, which is the thing this repo has the most scar tissue about. Instead the contradiction is **pinned as undecided**, at the definition and in a test, with the census asserted at 80/120 — so neither side can move without the guard going red and the ruling being made deliberately. That is the `undecided`-is-first-class discipline `CLAUDE.md` asks for, applied to a house-policy question rather than a spec one.

**The residue is filed as #1824**, with both candidate answers, the measurements above, and the blast radius of each. #1766 bundled four asks and this PR does three of them; closing it without #1824 would have buried the half its own title names, so please carry #1766's `high` label across if you agree with the split.

## Blast radius

`is_near_splice_site` and `is_extended_splice_region` have **zero** production call sites — `grep -rn` returns only their definitions and their tests. `is_canonical_splice_site` likewise. `is_deep_intronic` has **one**: `VcfAnnotation::is_deep_intronic` (`src/vcf/to_hgvs.rs:68`), and the derivation is answer-preserving, so it is unaffected. None of the four has a PyO3 binding. (Small correction to #1766, which says "these predicates have no call sites in `src/` outside their own unit tests" — true of the two it grepped for, not of all four.)

The three re-expressed predicates were measured against the literals they replace at **all 1206** offset × boundary combinations — `-300..=300` plus both unknown-offset sentinels (`i64::MIN`, `i64::MAX`), × `{FivePrime, ThreePrime}` — and **0 differ**.

That is not a structural zero, on either axis it varies. The sweep varies the offset and the `boundary` field **independently**, which is exactly where a band reading the offset's magnitude and a ladder reading `boundary` could diverge; it comes out zero because the 2-, 20- and 50-rungs are symmetric across the two sides, and the same sweep goes red under sabotage (below). And it includes the two sentinels rather than stopping at ±300, so it covers the only offsets where `abs()` and `unsigned_abs()` disagree — the values that motivated #1742's own hardening.

## Sabotage checks — including one that caught a vacuous guard of mine

Each new guard was verified non-vacuous by breaking the thing it claims to catch. All three runs exited **100**, read back from their own logs rather than from a completion notification:

| sabotage | which guards went red |
|---|---|
| ladder's donor canonical rung `2` → `3` | `the_intron_position_band_predicates_derive_from_the_one_shape_a_ladder` **and** `the_ivs_pos_predicates_agree_with_the_one_shape_a_ladder` |
| `is_near_splice_site` → `matches!(splice_site_type(), NearSplice)` | `is_near_splice_site_contradicts_the_near_splice_bin`, alone |
| `IvsPos::is_deep_intronic` rung `50` → `51` | `the_ivs_pos_predicates_agree_with_the_one_shape_a_ladder`, alone |

**The reason this was worth running:** a fourth guard I had written, `each_band_is_exactly_a_union_of_shape_a_bins`, survived **all three**. It asserted each derived predicate equalled the `matches!` its implementation is now written as — a definition compared against itself, and unfalsifiable by construction. It is replaced by `only_is_near_splice_site_splits_a_ladder_bin`, which states the same idea as a property that *can* fail: which `SpliceSiteType` bins each predicate cuts. The three derived bands cut none; `is_near_splice_site` cuts exactly `DonorRegion` (7..=20) and `AcceptorExtended` (3..=12), because 10 falls in both interiors. That set going empty is what "someone derived it" looks like, and it is now the thing that goes red.

## Review

Self-reviewed against `.coderabbit.yaml` (profile `assertive`) with its `src/hgvs/**`, `src/reference/**` and `tests/**` path instructions, plus `.coderabbitai-review/checklist.md`.

**Applied — 2:**

1. `bins_split_by` keyed bins on their `Debug` spelling. A renamed `SpliceSiteType` variant would have quietly changed what the guard compares, and an added one could slip past a `Debug`-keyed map. Replaced with an exhaustive `bin_name` match, so the ladder cannot gain or rename a bin without this file failing to build — the same argument as `is_extended_splice_region`'s exhaustive match.
2. `is_near_splice_site`'s doc named only one of the two guards that now pin it, leaving the second undiscoverable from the definition. Both are named.

**Rejected — 3, with reasons:**

1. *`tests/**` instruction: "flag `issue_*` regression tests that pin the buggy output instead of the fixed one".* `is_near_splice_site_contradicts_the_near_splice_bin` does pin the contradictory behaviour, deliberately. The instruction targets a test that pins a bug **as though it were correct**; this one is named for the contradiction, documented as undecided, and its failure message tells the reader to record the #1766 ruling rather than re-bless the number. Deleting it would let either side move silently, which is the outcome the issue was filed about.
2. *`src/reference/**` instruction's flags* — build-blind placement resolution, unvalidated mmap offsets, cache keying, a provider returning an empty sequence, `legacy_selector` degradation. None is reachable: the diff touches intronic **classification**, not the provider or placement layer. Cleared by reading, not assumed.
3. *`src/hgvs/**` instruction: "public API changes that are semver-breaking without a CHANGELOG entry".* `location.rs`'s change is documentation only — no signature, field or variant moves — and the three re-expressed predicates keep their signatures and (measured) their answers.

Note for the `tests/**` instruction's last clause: none of these guards resolves a prepared reference, so none depends on `FERRO_MANIFEST` and all of them run on PR CI rather than only in the nightly.

## Also checked

A sweep for further sites of the same class across `src/` found none: after this change the only splice-distance literals left are the two ladder definitions (`SpliceSiteType::from_distance_on_side`, `SpliceRegionBin::from_offset`), the unsettled `10`, and `IvsPos`'s documented pair — exactly the table now in the test module's doc. The web service's CDS effect handler already routes through `SpliceRegionBin`.

Representation-Change: none. These are classification predicates over intronic offsets, not normalization; no normalized output is touched, and the three re-expressed predicates were measured identical to the literals they replace at all 1206 offset/boundary combinations, including both unknown-offset sentinels. `src/hgvs/location.rs`'s change is documentation only.
