### PR TITLE
fix(normalize): refuse to clamp a repeat onto bases that are not its unit

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -9929,6 +9929,153 @@ fn blocks_sibling_shift(edit: &NaEdit) -> bool {
         || matches!(edit, NaEdit::Duplication { .. } | NaEdit::DupIns { .. })
 }
 
+/// The repeat unit an edit spells out, or `None` for anything else.
+///
+/// Deliberately narrow — `NaEdit::Repeat` carrying an explicit unit, and nothing
+/// else — because this is the only shape #1597 measured, and the two neighbours
+/// are not verifiable rather than merely untested:
+///
+/// - **A repeat with no stated unit** (`g.269_271[3]`) makes no claim about the
+///   bases under its span, so there is nothing to check it against.
+/// - **`MultiRepeat`** (`GT[2]GC[2]…`) states several units whose reference
+///   footprint is not one tandem tract of one unit, so the containment test
+///   below would be answering a different question.
+///
+/// Both therefore keep today's behaviour. That is the conservative direction:
+/// [`repeat_would_land_off_its_unit`] only ever *declines* a pull, so a shape it
+/// cannot read must fall through to "no objection" rather than block a
+/// repositioning on a guess.
+fn stated_repeat_unit(edit: &NaEdit) -> Option<&Sequence> {
+    match edit {
+        NaEdit::Repeat {
+            sequence: Some(unit),
+            ..
+        } if !unit.is_empty() => Some(unit),
+        _ => None,
+    }
+}
+
+/// Whether translating this member by `delta` would land a repeat on reference
+/// bases that are **not** its unit.
+///
+/// A repeat's span is not merely where the member sits: `g.269A[3]` asserts that
+/// the reference under `g.269` is a tandem tract of `A`, and states a copy count
+/// against it. Every other edit type this pass moves makes no such claim — a
+/// `del` deletes whatever is under it, a `sub` spells its own reference base —
+/// which is why [`translate_member`]'s `landed` check verifies the span alone
+/// and is right to. Slide a repeat one base 5' onto a base that is not its unit
+/// and the description stops being about the sequence it sits on, while still
+/// parsing, still naming an in-range coordinate and still being a fixed point.
+/// Measured on `origin/main` at `439617c2`, over the contig
+/// `TCAACGTATAGCAGCACTAC` with core base 1 at `g.257`:
+///
+/// ```text
+/// NC_TEST.1:g.[267_268insCA;268C>A;269_270insAA]
+///   before this pass   [g.269A[3];g.269A[3]]
+///   after  this pass   [g.268A[3];g.269A[3]]   <-- g.268 is C, not A
+/// ```
+///
+/// `junction_of` reports no junction for a `Repeat`, so such a member takes the
+/// `translate_member` arm and never reaches [`translate_junction_member`] — the
+/// arm that already carries this hazard for `dup`, whose payload is likewise
+/// read from under its own span (#1280, #1292). This is the same class for an
+/// edit type that arm does not cover.
+///
+/// **Answers `false` whenever it cannot read the bases**, which is the whole of
+/// its conservatism: a region with no sequence conversion (`region_sequence_delta`
+/// declines the two `n.` regions outside the transcript, which hold no bases), a
+/// provider that cannot serve the window, or a short read at the sequence end.
+/// None of those is evidence of a mismatch, and declining a pull on one would
+/// widen this guard from "the landing is measurably wrong" into "the landing is
+/// unproven" — a different and much larger change.
+fn repeat_would_land_off_its_unit<P: ReferenceProvider>(
+    variant: &HgvsVariant,
+    kind: CisKind,
+    delta: i64,
+    provider: &P,
+) -> bool {
+    let Some((accession, region, axis_start, axis_end, edit)) = cis_axis_parts(variant, kind)
+    else {
+        return false;
+    };
+    let Some(unit) = stated_repeat_unit(edit) else {
+        return false;
+    };
+    // `r.` spells its unit in the RNA alphabet while the transcript is served as
+    // DNA, so a truthful `r.269a[3]` over an `A` would otherwise read as a
+    // mismatch and this guard would decline a legitimate pull. Same rewrite
+    // `authored_reference_mismatch` makes before it compares (#736).
+    let unit: Vec<u8> = unit
+        .to_string()
+        .bytes()
+        .map(|b| match b.to_ascii_uppercase() {
+            b'U' if matches!(kind, CisKind::Rna) => b'T',
+            other => other,
+        })
+        .collect();
+
+    let provider_key = accession.transcript_accession();
+    // `region_sequence_delta`, not the `region_span_delta` behind `MemberSpan`:
+    // the span reader widens to regions with *virtual* positions so a member
+    // there is still visible to its siblings, and no bases can be read through
+    // one. Reading is exactly what this function does, so it takes the stricter
+    // conversion and declines where that one does.
+    let Some(sequence_delta) = region_sequence_delta(region, &provider_key, provider) else {
+        return false;
+    };
+    // Checked arithmetic throughout: `axis_*` come off a parsed description and
+    // `delta` off this pass's own bound, so an adversarial span could otherwise
+    // overflow and panic in a debug build where answering "no objection" is the
+    // conservative result.
+    let Some(start) = axis_start
+        .checked_add(delta)
+        .and_then(|p| p.checked_add(sequence_delta))
+    else {
+        return false;
+    };
+    let Some(end) = axis_end
+        .checked_add(delta)
+        .and_then(|p| p.checked_add(sequence_delta))
+    else {
+        return false;
+    };
+    if start < 1 || end < start {
+        return false;
+    }
+    let Some(span) = end
+        .checked_sub(start)
+        .and_then(|w| w.checked_add(1))
+        .and_then(|w| usize::try_from(w).ok())
+    else {
+        return false;
+    };
+    let (Ok(from), Ok(to)) = (u64::try_from(start - 1), u64::try_from(end)) else {
+        return false;
+    };
+    let Ok(bases) = provider.get_sequence(&provider_key, from, to) else {
+        return false;
+    };
+    // A short read means the landing span runs off the end of the sequence.
+    // That is `FERRO_ASSERT_IN_BOUNDS`' finding, not this one; comparing against
+    // a truncated window would report a mismatch that is really an overrun.
+    if bases.len() != span {
+        return false;
+    }
+    // Compared **cyclically**, so a span that is not a whole number of copies of
+    // the unit is judged on its bases like any other rather than being declined
+    // for its length. Chunking instead — and treating a non-multiple span as
+    // wrong on arithmetic alone — would have declined a pull for
+    // `g.1_9AT[4]`-shaped members sitting on a genuine tract with a partial
+    // trailing copy, which is a shape nothing here measured and so must not be a
+    // shape this guard moves. Case-insensitive because providers serve
+    // soft-masked references lower-case (see `fetch_window`'s note).
+    !bases
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .all(|(i, base)| base.eq_ignore_ascii_case(&unit[i % unit.len()]))
+}
+
 /// Pull back any cis member whose shift carried it over a sibling's bases.
 ///
 /// The 3' rule (`general.md:41`) is stated per description, with no
@@ -10158,7 +10305,39 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
             // `c.14_15`, not `c.14_*0`. Such a member is *visible* here now,
             // which is the point, but it is repaired by the restore below rather
             // than by arithmetic on a number that means two things.
+
             if a.region == b.region && !a.crosses_regions && !b.crosses_regions {
+                // A repeat's span asserts that the bases under it are a tandem
+                // tract of its unit, so a pull landing it on anything else emits
+                // a description that is no longer about the sequence it sits on
+                // (#1597). Nothing below catches that: `translate_member`
+                // verifies the span and never the bases, and a repeat states no
+                // junction, so it takes that arm rather than
+                // `translate_junction_member`'s.
+                //
+                // Declining leaves the member where its own shift put it, which
+                // is deliberately *not* the pre-shift restore the `else` branch
+                // below uses. The two failures differ in what is broken: there
+                // the pull itself is inexpressible on the member's axis while
+                // some pull is still owed, so the strongest available one is
+                // taken; here the pull is expressible and simply lands wrong.
+                // Restoring `before[i]` instead is the other defensible answer;
+                // it is not taken because it re-spells the member entirely
+                // rather than withholding the one move that was shown to be
+                // wrong, which is a wider change than the defect needs and one
+                // this PR did not measure.
+                //
+                // **Inside this arm, not in front of the whole `if`**, and that
+                // placement is the argument for it: the `else` branch does not
+                // translate by `-pull` at all, it restores the pre-shift member,
+                // which is sequence-correct by construction and so needs no unit
+                // check. Guarding both arms would let a repeat that changed
+                // region during its shift skip that restore and stay past the
+                // sibling it crossed — trading a #1597 mis-spelling for a #1254
+                // wrong-sequence, which is the worse of the two.
+                if repeat_would_land_off_its_unit(&after[i], kind, -pull, provider) {
+                    continue;
+                }
                 // A duplication blocks a sibling's shift without claiming bases,
                 // so it reaches this pass too — and its payload is read from
                 // under its own span, so it cannot simply be slid (#1280, #1292).

--- a/tests/it/issue_1597_repeat_clamp_unit.rs
+++ b/tests/it/issue_1597_repeat_clamp_unit.rs
@@ -1,0 +1,147 @@
+//! #1597: a `Repeat` member must never be clamped onto bases that are not its unit.
+//!
+//! `clamp_sibling_crossing_shifts` pulls a member back when its standalone
+//! 3'-shift carried it over a sibling's bases. The pull is a plain translation
+//! of the member's coordinates, and `translate_member`'s `landed` check verifies
+//! only that the span arrived where it was aimed — never what the reference
+//! holds there. For every other edit type that is enough, because the span is
+//! the only claim the spelling makes.
+//!
+//! A repeat is the exception: `g.269A[3]` asserts that the bases under its span
+//! are a tandem tract of `A`. Slide it one base 5' onto `g.268` — a `C` on this
+//! contig — and the description is no longer about the sequence it sits on. It
+//! still parses, still occupies a legal coordinate and is still a fixed point,
+//! so `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and
+//! `FERRO_ASSERT_IDEMPOTENT` all pass on the result; only the bases disagree.
+//!
+//! Measured on `origin/main` at `439617c2`:
+//!
+//! ```text
+//! in                    NC_TEST.1:g.[267_268insCA;268C>A;269_270insAA]
+//! before the clamp      [NC_TEST.1:g.269A[3];NC_TEST.1:g.269A[3]]
+//! after  the clamp      [NC_TEST.1:g.268A[3];NC_TEST.1:g.269A[3]]   <-- g.268 is C
+//! emitted               NC_TEST.1:g.[268A[3];269A[3]]  (members overlap; denotes nothing)
+//! ```
+//!
+//! `junction_of` reports no junction for a `Repeat`, so such a member never
+//! reaches `translate_junction_member` — the arm that already carries this
+//! hazard for `dup` (#1280, #1292). This is the same class for an edit type that
+//! arm does not cover.
+//!
+//! **Not an adjudication.** There is no competing-legal-forms question here, so
+//! `canonical-form-choice-when-both-legal` does not reach it: the output denotes
+//! a different sequence than the input, which `README.md`'s ruleset makes a
+//! rule-7 **bug** rather than a house-style choice ("best effort is bounded by
+//! the spec's determinacy … not by ferro's implementation quality"). Hence an
+//! ordinary regression test and no `rulings` record.
+
+use crate::common::cis_apply_oracle::{apply_parsed_reason, apply_reason};
+use crate::common::synthetic::{padded, SyntheticBuilder};
+use ferro_hgvs::hgvs::edit::NaEdit;
+use ferro_hgvs::hgvs::uncertainty::Mu;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// The contig the sweep in #1597 drew these rows from. Core base 1 sits at
+/// `g.257`, so `g.268` is core index 11 — a `C`, and the reason this core is the
+/// one pinned here rather than a homopolymer where every slide lands on an `A`
+/// and the defect is invisible.
+const CORE: &str = "TCAACGTATAGCAGCACTAC";
+
+/// Every `(start, end, unit)` triple a normalized description states for the
+/// repeat members it contains, on the genomic axis it was written on.
+fn repeat_members(variant: &HgvsVariant) -> Vec<(u64, u64, String)> {
+    let members: Vec<&HgvsVariant> = match variant {
+        HgvsVariant::Allele(allele) => allele.variants.iter().collect(),
+        single => vec![single],
+    };
+    members
+        .into_iter()
+        .filter_map(|member| {
+            let HgvsVariant::Genome(g) = member else {
+                return None;
+            };
+            let NaEdit::Repeat {
+                sequence: Some(unit),
+                ..
+            } = g.loc_edit.edit.inner()?
+            else {
+                return None;
+            };
+            let (Some(Mu::Certain(start)), Some(Mu::Certain(end))) = (
+                g.loc_edit.location.start.as_single(),
+                g.loc_edit.location.end.as_single(),
+            ) else {
+                return None;
+            };
+            Some((start.base, end.base, unit.to_string()))
+        })
+        .collect()
+}
+
+/// Assert that every repeat member of `input`'s normalized form sits on a tract
+/// of its own unit, and that the allele still denotes the input's sequence.
+fn assert_repeats_sit_on_their_unit(input: &str, direction: ShuffleDirection) -> String {
+    let provider = SyntheticBuilder::genomic(CORE).build();
+    let reference = padded(CORE);
+    let normalizer = Normalizer::with_config(
+        provider.clone(),
+        NormalizeConfig::default().with_direction(direction),
+    );
+    let variant = parse_hgvs(input).expect("input parses");
+    let want =
+        apply_parsed_reason(&provider, &reference, &variant).expect("input denotes a sequence");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    let output = normalized.to_string();
+
+    for (start, end, unit) in repeat_members(&normalized) {
+        // `padded` is 1-based genomic, so `g.N` is `reference[N - 1]`.
+        let bases = &reference[(start - 1) as usize..end as usize];
+        // Cyclic, matching what the fix enforces: the span must read as the unit
+        // repeated, allowing a partial trailing copy. Asserting a whole number of
+        // copies instead would pin a stricter contract than the code makes, and
+        // would go red on a legitimate `g.1_9AT[4]`-shaped member.
+        let expected: String = unit.chars().cycle().take(bases.len()).collect();
+        assert_eq!(
+            bases, expected,
+            "{input} ({direction:?}) -> {output}: repeat g.{start}_{end}{unit}[..] claims a \
+             tract of {unit}, but the reference reads {bases} there"
+        );
+    }
+
+    // A repeat on the wrong bases is not merely mis-spelled — it changes what the
+    // allele denotes, which is the rule-1 failure #1597 is about. Assert that too,
+    // so the guard cannot be satisfied by a differently-wrong output.
+    let got = apply_reason(&provider, &reference, &output);
+    assert_eq!(
+        got.as_deref(),
+        Ok(want.as_str()),
+        "{input} ({direction:?}) -> {output}: output does not denote the input's sequence"
+    );
+    output
+}
+
+#[test]
+fn a_repeat_is_not_clamped_onto_a_base_that_is_not_its_unit() {
+    // The row the clamp trace was taken from. Both directions emit the same
+    // wrong allele on `main`, so both are pinned.
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let output = assert_repeats_sit_on_their_unit(
+            "NC_TEST.1:g.[267_268insCA;268C>A;269_270insAA]",
+            direction,
+        );
+        assert_eq!(output, "NC_TEST.1:g.269A[5]");
+    }
+}
+
+#[test]
+fn the_clamped_repeat_survives_beside_a_sibling_it_cannot_merge_with() {
+    // Same slide, but the third member's payload keeps the two members distinct,
+    // so the repeat stays a member rather than being coalesced away. This is the
+    // discriminating case: a fix that repaired the row above only by letting the
+    // two repeats collapse would leave this one wrong.
+    let output = assert_repeats_sit_on_their_unit(
+        "NC_TEST.1:g.[267_268insCA;268C>A;269_270insTA]",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(output, "NC_TEST.1:g.[269A[3];269_270insTA]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,6 +24,7 @@ mod issue_1472_zero_length_read;
 mod issue_1524_adjacent_split_members;
 mod issue_1539_split_member_separation;
 mod issue_1592_reduced_member_junction_clamp;
+mod issue_1597_repeat_clamp_unit;
 mod issue_1600_reduced_delins_tract_demotion;
 mod issue_1607_protein_residue_one_guard;
 mod issue_1627_named_element_alphabet_reach;


### PR DESCRIPTION
Closes #1597.

Representation-Change: 98 rows respell, of 98 measured over the #1597 corpus. All 98 previously denoted a **different sequence than their own input**, so every moved string was wrong — this is a correction, not a re-spelling of correct output. Separately, 0 of 85,642 rows move in the committed corpus harness; that one is a **structural** zero and is evidenced as such below.

## The defect

`clamp_sibling_crossing_shifts` pulls a member back when its standalone 3'-shift carried it over a sibling's bases. The pull is a plain translation of the member's coordinates, and `translate_member`'s `landed` check verifies only that the span arrived where it was aimed — never what the reference holds there.

For every other edit type that is enough, because the span is the only claim the spelling makes: a `del` deletes whatever is under it, a `sub` spells its own reference base. A repeat is the exception. `g.269A[3]` asserts that the bases under its span are a tandem tract of `A`, so sliding it one base 5' onto a base that is not `A` leaves a description that is no longer about the sequence it sits on.

Traced on this branch's base (`439617c2`), contig `TCAACGTATAGCAGCACTAC`, core base 1 at `g.257`:

```
in                    NC_TEST.1:g.[267_268insCA;268C>A;269_270insAA]
before this pass      [NC_TEST.1:g.269A[3];NC_TEST.1:g.269A[3]]
after  this pass      [NC_TEST.1:g.268A[3];NC_TEST.1:g.269A[3]]   <-- g.268 is C, not A
emitted               NC_TEST.1:g.[268A[3];269A[3]]  (members overlap; denotes nothing)
```

Nothing existing catches it. The output parses, names an in-range coordinate and is a fixed point, so `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS` and `FERRO_ASSERT_IDEMPOTENT` all pass on it — only the bases disagree. And `junction_of` reports no junction for a `Repeat`, so such a member takes the `translate_member` arm and never reaches `translate_junction_member`, the arm that already carries exactly this hazard for `dup`, whose payload is likewise read from under its own span (#1280, #1292). This is the same class for an edit type that arm does not cover.

**Confirmed by disabling the mechanism**, not inferred: with the clamp suppressed, all four traced reproducers become correct. That is not a shippable fix — the clamp exists for #1254 — but it establishes the clamp as the producer.

## The fix

One decline-only guard at the clamp's translate decision point, plus the predicate behind it (`repeat_would_land_off_its_unit`). If the pull would land a repeat on reference bases that are not its unit, the pull is withheld and the member stays where its own shift put it.

Scoped deliberately, and the scope is the argument:

- **Only `NaEdit::Repeat` with a spelled-out unit.** A repeat with no stated unit (`g.269_271[3]`) makes no claim about the bases, and `MultiRepeat`'s reference footprint is not one tandem tract of one unit — neither is *verifiable*, rather than merely untested, so both keep today's behaviour.
- **Only where the mismatch is measured.** The predicate answers "no objection" whenever it cannot read the bases: a region with no sequence conversion (the two `n.` regions outside the transcript hold none), an unservable window, or a short read at the sequence end. Declining on any of those would widen the guard from *the landing is measurably wrong* to *the landing is unproven*, which is a much larger change.
- **Bases compared cyclically and case-insensitively.** Cyclic so a span that is not a whole number of unit copies is judged on its bases like any other rather than declined on arithmetic; case-insensitive because providers serve soft-masked references lower-case.

**Not** the wider remedy of making `translate_member` verify denoted bases for all edit types. That was one of three candidates in the triage and was not the one selected; this PR does the narrow one and re-measures, so the remaining candidates can be judged on numbers rather than on argument.

### Deliberately not done

Restoring `before[i]` — the pre-shift member — is the other defensible fallback, and is what the sibling `else` branch does when a pull is inexpressible on the member's axis. It is not taken here: that branch's problem is that *some* pull is owed and none can be written, whereas here the pull is expressible and simply lands wrong. Restoring would re-spell the member entirely rather than withhold the one move shown to be wrong, and this PR did not measure it.

## Re-measurement

The issue's own sweep, re-run in full. Base is this branch's own base, `439617c2` — not the older tree the triage ran on — so both arms are same-commit and the denominator is identical.

| | cases checked | sequence-changed | no resulting sequence | failing rows | unique inputs |
|---|---:|---:|---:|---:|---:|
| base `439617c2` | 19,656,000 | 38 | 60 | 98 | 58 |
| this branch | 19,656,000 | **0** | **0** | **0** | **0** |

**The zero is not structural, and the control says so.** The same harness produces 98 failures on the base tree — verified two ways: it reproduces the triage's census exactly (38 `CHANGED` + 60 `NOSEQ`, 58 unique inputs), and replaying those 98 rows against `439617c2` fails all 98 while the identical replay against this branch passes all 98. Only the commit changed.

Correctness is judged by applying input and output to the reference through `cis_apply_oracle::apply_reason` — a walk over SPDI triples, independent of the normalizer — and comparing the **denoted bases**, never the spelling.

Both families the issue names are closed, including Family A (`g.[266_267insAT;267_268insTA;268T>A]` → `g.268_269insATAA`), whose rows the issue attributed to a different root cause. They share this one: the members pass through a repeat spelling in the intermediate state, and the clamp slides it there. That is the correction to the issue's own account — the two families have one root cause, not two.

Note the issue's headline figure of 206 was already stale before this PR; the triage re-measured it to 98 rows / 58 unique inputs, and that is the number closed here.

## Representation stability

`examples/dump_normalized_corpus.rs`, base vs this branch: **0 of 85,642 rows moved**.

**That zero is structural, and reporting it as anything else would be wrong.** The property this change keys on is *a `Repeat` member in a multi-member cis allele whose clamp-pull lands on non-unit bases*. The corpus cannot build it:

- `three_member_allele` is three **substitutions** — nothing shuffles and no member becomes a repeat.
- `repeat_expansion` is a **single-member** description, and the clamp returns early below two members.

Measured rather than argued: instrumenting the guard to log every fire gives **0 fires across all 85,642 corpus rows**, and **98 fires on the 98 #1597 rows** with the same binary. So the instrument is live and the corpus is blind to this shape — the fifth instance of the corpus-blindness class the harness itself documents (#1456 member geometry, #1460 scale, #1478 transcript geometry, #1606 protein axis).

Adding a family that builds it would be the durable fix and is **not** done here, to keep this PR to the defect.

## What is still not measured

The sweep above is the issue's corpus: three-member cis alleles from `{del, sub, dup, 1-base ins, 2-base ins}` within a 9-base window, over eight 20-mers, both directions. It does not reach multi-base repeat units, `MultiRepeat`, or the `c.`/`n.`/`r.` axes — the guard is written to decline on those rather than act, but that refusal is reasoned, not measured.

The nearest risk from a decline-only guard is that withholding a pull leaves a member past a sibling — the #1254 class. That is covered by the three committed exhaustive cis sweeps, which run at `FERRO_SWEEP_SEEDS=full` in the verification below and pass.

## Verification

All exit statuses read back from the log, not from a completion notification.

```
cargo fmt --all --check                                             # EXIT=0
cargo clippy --all-features --all-targets -- -D warnings            # EXIT=0
FERRO_SWEEP_SEEDS=full cargo nextest run --features dev             # EXIT=0
    10529 tests run: 10529 passed, 152 skipped
scripts/run_oracle_suite.sh                                         # EXIT=0
    10392 tests run: 10392 passed, 289 skipped
#1597 sweep, 19,656,000 cases, both arms                            # EXIT=0
    base 98 failing rows -> this branch 0
```

`scripts/run_oracle_suite.sh` rather than a bare armed run, per the repo's own guidance — the bare form cannot pass on `main`. No Python surface is touched, so the Python-only required checks are unaffected. No proptest strategy is touched (`tests/proptest-regressions/` is unchanged, so no pinned seed is re-pointed).

## Tests

`tests/it/issue_1597_repeat_clamp_unit.rs`, two tests. Both assert the property — every repeat member sits on a tract of its own unit — **and** that the allele still denotes the input's sequence, so neither can be satisfied by a differently-wrong output. Exact output strings are pinned, and were measured after the fix rather than inferred.

The second test is the discriminating one: it uses a sibling payload that keeps the two members distinct, so the repeat survives as a member. A fix that repaired the first row only by letting two repeats collapse into one would leave it red.

## Self-review

Applied, found against this PR's own code: the guard originally treated a span that is not a whole multiple of the unit length as wrong *on arithmetic alone*, before reading any bases. That would have withheld a pull for a `g.1_9AT[4]`-shaped member sitting on a genuine tract with a partial trailing copy — a shape nothing here measured, and so not one this guard may move. Replaced with a cyclic base comparison, and the test's assertion was relaxed to the same contract so it does not pin a stricter one than the code makes.

Rejected: a sibling-completeness flag on `clamp_sibling_crossing_junctions`. It translates only junction-carrying members via `translate_junction_member`, and a `Repeat` reports no junction, so it cannot reach the same hazard — there is no second site to fix.
