### PR TITLE
fix: make the applier's overlap verdict order-independent, and let reanchor widen a pure-deletion window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,7 +562,7 @@ which is what makes it an argument for the fix beside it:
 | class | fires | why it was not a defect |
 |---|---|---|
 | output cannot be transliterated | 328 | the input states its own deleted bases (`g.1000delC`) and converts with no provider; the output (`g.1000del`) must read the reference, which the fixture does not hold |
-| insertion flush against a deletion | 233 | `triples_are_disjoint` calls it an overlap; `cis_apply_oracle`'s tie-break does not, and it is well defined |
+| insertion flush against a deletion | 233 | `triples_are_disjoint` called it an overlap; `cis_apply_oracle`'s tie-break does not, and it is well defined. **No longer true of the applier as of #1831** — `apply_triples` now sorts longer deletions first among triples sharing a position, the key `splice_denoted_sequence` and `conformance::spec_corpus`'s applier already used, so `triples_are_disjoint` sees correctly-ordered input and no longer reports this shape. The 233 is the size of the class when it was diagnosed, and is kept as that |
 | overlap-conflicting input | ~12 | an insertion *interior* to a deletion — the input denotes nothing, so there is no baseline |
 | `pter`/`qter` | 6 | carry no numeric coordinate (`base: 0`); `hgvs_to_spdi` reads `base` and silently resolves `c.pterdel` to the sequence's **last** base |
 | corrected `REFSEQ_MISMATCH` | 5 | `c.10dupA` where the reference reads `C`: normalization is *supposed* to change the denoted sequence here |

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1508,6 +1508,11 @@ class SequencePair:
         the point when the bound is a requirement and a footgun when it is
         arbitrary. The derivation reports it as ``placement_bounded_by_window``.
 
+        A narrowing that removes nothing is always accepted, which
+        ``Normalizer.reanchor`` depends on: it narrows to the intersection
+        before it widens, so a request that contains this window narrows by a
+        no-op.
+
         Raises:
             NormalizationError: for a bound that would widen the window, cut
                 into a base the two sequences disagree on, empty the reference,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2237,7 +2237,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// * a bound the provider cannot serve;
     /// * anything [`crate::SequencePair::trim_to`] refuses, for the narrowing
     ///   side — a cut through a base the two sequences disagree on, an emptied
-    ///   reference, `start` past `end`.
+    ///   reference, `start` past `end`. The *conditions* are `trim_to`'s; the
+    ///   **message** is not, because that method names itself and the
+    ///   intersection coordinates rather than the ones the caller passed. Its
+    ///   reason is kept and wrapped in this method's own request (#1832).
     pub fn reanchor(
         &self,
         pair: &crate::normalize::sequence_pair::SequencePair,
@@ -2293,7 +2296,37 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 pair.end()
             )));
         }
-        let narrowed = pair.trim_to(Some(overlap_start), Some(overlap_end))?;
+        // The same reasoning as the non-overlap branch above, applied to every
+        // other way the narrowing can fail: `trim_to`'s message names its own
+        // method and the *intersection* coordinates, so a `reanchor(13, 20)`
+        // came back as `trim_to(13, 15) …`, quoting an end the caller never
+        // passed. The underlying reason is kept — it is the accurate half — and
+        // the caller's own request is restored around it (#1832).
+        let narrowed = pair
+            .trim_to(Some(overlap_start), Some(overlap_end))
+            .map_err(|e| match e {
+                // Re-frame rather than nest. `trim_to` returns this same
+                // variant, and `FerroError`'s `Display` prepends the kind — so
+                // wrapping the whole rendered error produced "Invalid
+                // coordinates: reanchor(…): … failed: Invalid coordinates:
+                // trim_to(…)", with the kind and the accession each printed
+                // twice. Taking the inner `msg` keeps the reason, which is the
+                // accurate half, and states it once.
+                //
+                // The accession is deliberately not repeated here either: the
+                // reason carries it. The non-overlap branch above does name it,
+                // because that message stands alone and nests nothing.
+                FerroError::InvalidCoordinates { msg } => invalid(format!(
+                    "reanchor({start}, {end}): narrowing to the overlap with the pair's own \
+                     window [{}, {}] failed: {msg}",
+                    pair.position,
+                    pair.end()
+                )),
+                // Any other kind is passed through unchanged rather than
+                // flattened into `InvalidCoordinates`, which would lose the
+                // caller's ability to match on it.
+                other => other,
+            })?;
 
         // Both edges are read before either string moves — `end()` is derived
         // from `reference`, so consuming it first would make the 3' test consult

--- a/src/normalize/sequence_pair.rs
+++ b/src/normalize/sequence_pair.rs
@@ -168,6 +168,12 @@ impl SequencePair {
     ///   alternate is ordinary input, and the comparison folds;
     /// * a bound that would leave the reference empty, or `start` past `end`.
     ///
+    /// A narrowing that removes **nothing** is accepted unconditionally, and
+    /// that is load-bearing rather than incidental: [`crate::Normalizer::reanchor`]
+    /// narrows to the intersection before it widens, so for a request that
+    /// *contains* this window the narrowing is exactly the no-op. Refusing it
+    /// made `reanchor` unable to widen any pure deletion (#1832).
+    ///
     /// Case is otherwise preserved: this method fetches nothing, so it cannot
     /// manufacture a mixed-case pair and has no reason to rewrite the caller's
     /// bases. [`crate::Normalizer::reanchor`], which does fetch, folds instead.
@@ -202,7 +208,23 @@ impl SequencePair {
         // The two sequences differ in length, so a 3' trim is counted from each
         // one's own end rather than from a shared index.
         let (ref_len, alt_len) = (self.reference.len(), self.alternate.len());
-        if head + tail >= ref_len || head + tail >= alt_len {
+        // `head + tail > 0` first, because the rest of this guard is about what
+        // a trim would *remove* and a no-op trim removes nothing.
+        //
+        // Without it, `alt_len == 0` makes the test read `0 >= 0` and refuses a
+        // request that was going to return `self` unchanged. That is not a
+        // corner case: `Normalizer::to_sequences(v, 0)` returns exactly that
+        // shape for any pure deletion, and `Normalizer::reanchor` narrows to the
+        // intersection before it widens — so a *widen* of such a pair arrived
+        // here as a no-op narrowing and was refused, making `reanchor`
+        // unreachable for the commonest window a caller holds (#1832). Even
+        // `reanchor(pair, pair.position, pair.end())` failed.
+        //
+        // The guard is still needed for `head + tail > 0`, and for two reasons
+        // rather than one: it stops a trim consuming an entire string, and it is
+        // what keeps the "matching bases only" comparison below from indexing
+        // `a[..head]` past the end of an empty alternate.
+        if head + tail > 0 && (head + tail >= ref_len || head + tail >= alt_len) {
             return Err(invalid(format!(
                 "trim_to({start}, {end}) on {} would leave nothing of the {ref_len}-base \
                  reference or the {alt_len}-base alternate",

--- a/src/python.rs
+++ b/src/python.rs
@@ -1355,6 +1355,10 @@ impl PySequencePair {
     /// point when the bound is a requirement and a footgun when it is
     /// arbitrary. The derivation reports it as `placement_bounded_by_window`.
     ///
+    /// A narrowing that removes nothing is always accepted, which
+    /// `Normalizer.reanchor` depends on: it narrows to the intersection before
+    /// it widens, so a request that contains this window narrows by a no-op.
+    ///
     /// Raises:
     ///     NormalizationError: for a bound that would widen the window, cut into
     ///         a base the two sequences disagree on, empty the reference, or put

--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -435,7 +435,16 @@ fn trim_common_flanks<'a>(reference: &'a [u8], resulting: &'a [u8]) -> (usize, &
 /// interval that begins at `win_start` — and return the edited sequence.
 ///
 /// Triples are applied from the 3' end (descending position) so that an earlier
-/// splice never shifts the coordinates of a later one. Each triple's stated
+/// splice never shifts the coordinates of a later one, and — among triples that
+/// share a position — **longer deletions first**, so a span-claiming member is
+/// always applied before the zero-length one flush against it. The second
+/// component is not cosmetic: [`triples_are_disjoint`] walks this slice in
+/// reverse and would otherwise report an insertion abutting a `sub`/`del` as an
+/// overlap or not depending on the order the caller's members were written in
+/// (#1831). [`splice_denoted_sequence`] and `conformance::spec_corpus`'s own
+/// applier both sort the same way.
+///
+/// Each triple's stated
 /// deleted bases are validated against the actual reference bases at that span;
 /// if they disagree (a ref-mismatched input — e.g. `c.5A>G` where the reference
 /// base is not `A`), we cannot faithfully reconstruct the edit, so we decline
@@ -451,7 +460,37 @@ pub(crate) fn apply_triples(
     let ref_bytes = reference.as_bytes();
     let mut bytes = ref_bytes.to_vec();
     let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
-    ordered.sort_by_key(|t| std::cmp::Reverse(t.position));
+    // Descending position, and **longer deletions first** among triples at one
+    // position — the same key [`splice_denoted_sequence`] already uses, for the
+    // same reason it states: a span-claiming member must be applied before the
+    // zero-length one flush against it.
+    //
+    // Without the second component the sort is stable on a tie, so two triples
+    // sharing a position keep the order the *author* happened to write their
+    // members in. An insertion at interbase `p` and a `sub`/`del` starting at
+    // `p` share that position, and [`triples_are_disjoint`]'s running-reach walk
+    // then reads them as overlapping or not depending on which came first:
+    // visiting the length-1 member first sets `reach = p + 1`, and the
+    // zero-length insertion at `p` is rejected. So `g.[129_130insT;130G>A]` was
+    // refused while `g.[130G>A;129_130insT]` — the same variant, members
+    // written the other way round — applied cleanly (#1831).
+    //
+    // That contradicted this module's own contract, stated on
+    // `triples_are_disjoint`: an insertion deletes nothing and therefore claims
+    // no base, so the two members do not claim the same base and the resulting
+    // sequence is well defined. It also contradicted #1098, which settled that
+    // member order carries no meaning.
+    //
+    // Two or more *pure* insertions at one interbase tie on both components, so
+    // the stable sort still preserves authored order there and the walk's
+    // `p > p` test still passes — that shape is deliberately unchanged, and
+    // `variant_edit_triples_reason` is what refuses it where it must be refused.
+    ordered.sort_by_key(|t| {
+        (
+            std::cmp::Reverse(t.position),
+            std::cmp::Reverse(t.deletion.len()),
+        )
+    });
     if !triples_are_disjoint(&ordered) {
         return None;
     }
@@ -483,8 +522,16 @@ pub(crate) fn apply_triples(
 
 /// Whether no two of `ordered` claim the same reference base.
 ///
-/// `ordered` must be sorted by descending position, as [`apply_triples`] leaves
-/// it. That descending application order is what lets each stated deletion be
+/// `ordered` must be sorted by descending position **and, among triples sharing
+/// a position, by descending deletion length**, as [`apply_triples`] leaves it.
+/// The second component is load-bearing rather than cosmetic: this predicate
+/// walks the slice in reverse and compares each triple against the furthest 3'
+/// reach seen so far, so a zero-length insertion visited *after* a
+/// reference-consuming member at the same position is reported as an overlap
+/// although it claims no base. Sorting on position alone left that to the
+/// author's member order (#1831).
+///
+/// That descending application order is what lets each stated deletion be
 /// validated against the pristine reference: every already-applied splice sits
 /// strictly 3' of the next one, so the span about to be read is untouched. The
 /// argument holds only while the triples are disjoint — overlapping ones both
@@ -922,17 +969,34 @@ enum SpliceFailure {
 /// Splice `triples` into `reference` — the bases beginning at interbase
 /// `win_start` — and return the resulting sequence.
 ///
-/// Deliberately **not** [`apply_triples`], which is shared with
-/// `EquivalenceChecker` and whose [`triples_are_disjoint`] guard reports a pure
-/// insertion flush against the 5' end of a deletion as an overlap. That
+/// Deliberately **not** [`apply_triples`] — but **no longer for the reason this
+/// comment used to give**, which #1831 falsified and which is kept below only as
+/// the measurement the tie-break was derived from.
+///
+/// **What changed (#1831).** [`apply_triples`] now sorts longer deletions first
+/// among triples sharing a position — this walk's own key — so
+/// [`triples_are_disjoint`] sees correctly-ordered input, no longer reports a
+/// pure insertion flush against the 5' end of a deletion as an overlap, and no
+/// longer decides that shape by the order the author wrote the members in. The
+/// two walks now *agree* there.
+///
+/// **The measurement, kept because it is the argument for the tie-break.** That
 /// combination is well defined — the payload lands at the junction, then the
 /// span is removed — and it is a shape cis alleles reach constantly: measured
 /// over one suite run, reading it as an overlap produced **233** false alarms,
-/// nearly all of them `g.[…;261_262insA;262_264A[5]]`-shaped. (Its verdict there
-/// is also input-order dependent, since the sort breaks position ties by input
-/// order.) Changing that predicate is out of scope — two pinned tests depend on
-/// its permissiveness in the other direction — so this walk is the one used for
-/// the comparison.
+/// nearly all of them `g.[…;261_262insA;262_264A[5]]`-shaped. The 233 is the
+/// size of that class when it was diagnosed and is kept as that.
+///
+/// **Why this walk stays separate anyway**, since the historical reason no
+/// longer carries it: it answers a question [`apply_triples`] cannot, returning
+/// a typed [`SpliceFailure`] that separates an overlap from a stated-bases
+/// mismatch. [`compare_denoted_sequences`] routes those to opposite verdicts —
+/// an overlap is the output's own fault and fires, while a stated base
+/// disagreeing with the reference is unadjudicable and is what a
+/// `REFSEQ_MISMATCH` input looks like — and [`apply_triples`] collapses both
+/// into `None`. Independently, [`triples_are_disjoint`] is depended on *in the
+/// other direction* by pinned tests, so it is not a predicate to retune
+/// casually.
 ///
 /// The walk is `tests/it/common/cis_apply_oracle.rs`'s, the applier every
 /// sibling-crossing test already rests on: 3'→5' so an applied splice never

--- a/tests/it/issue_1301_adjacent_gap_member_order.rs
+++ b/tests/it/issue_1301_adjacent_gap_member_order.rs
@@ -67,7 +67,24 @@ fn assert_preserving(input: &str, output: &str) {
         for member in &members {
             triples.push(hgvs_to_spdi(member, &provider).ok()?);
         }
-        triples.sort_by_key(|t| std::cmp::Reverse(t.position));
+        // Descending position, and **longer deletions first** among triples at
+        // one position — the key `spdi::apply::splice_denoted_sequence`, the
+        // conformance corpus applier, and (since #1831)
+        // `spdi::apply::apply_triples` all use. The path form of that middle
+        // name is deliberately not written here: `oracle_exclude_invariant`
+        // scans for it as a literal, and a module that merely mentions it in a
+        // comment reads as one measuring over the corpus. Without the second
+        // component this walk's `end > claimed` test
+        // reads an insertion flush against a sibling as an overlap or not
+        // depending on the order the members were written in, so a *local* oracle
+        // would carry exactly the defect #1831 removed from the applier it exists
+        // to check independently of.
+        triples.sort_by_key(|t| {
+            (
+                std::cmp::Reverse(t.position),
+                std::cmp::Reverse(t.deletion.len()),
+            )
+        });
         let mut edited = reference.as_bytes().to_vec();
         let mut claimed = reference.len();
         for triple in &triples {

--- a/tests/it/issue_1831_applier_member_order.rs
+++ b/tests/it/issue_1831_applier_member_order.rs
@@ -1,0 +1,327 @@
+//! #1831 — the applier's overlap verdict must not depend on member order.
+//!
+//! An insertion at interbase `p` and a `sub`/`del` starting at `p` share an SPDI
+//! position. `apply_triples` sorted on position alone with a **stable** sort, so
+//! the two kept whatever order the author wrote them in, and
+//! `triples_are_disjoint`'s running-reach walk then called the pair overlapping
+//! or disjoint accordingly. `g.[9_10insT;10G>A]` was refused; `g.[10G>A;9_10insT]`
+//! — the same variant — applied.
+//!
+//! Both halves of that are pinned here, and pinned as **equality between the two
+//! orderings** rather than as "the first one now applies": the property is that
+//! member order carries no meaning (#1098), so a future change that made the
+//! *second* ordering refuse would be just as wrong and must fail this too.
+//!
+//! # What must NOT change
+//!
+//! The fix is a sort key, not a loosening of the disjointness rule, and the two
+//! shapes below are the discriminating cases. A tempting wider fix — dropping or
+//! weakening `triples_are_disjoint` — passes every assertion above and fails
+//! these:
+//!
+//! * members that genuinely claim the same base still refuse;
+//! * two pure insertions at one interbase still refuse, because their order is
+//!   unstated and so their result is undefined — that refusal comes from
+//!   `variant_edit_triples_reason`, not from this sort, and it is a different
+//!   message.
+//!
+//! # One direction, deliberately
+//!
+//! Every normalizer here is built `ThreePrime`. That is not an omission:
+//! `apply_triples` takes no `ShuffleDirection` and reads none, so there is no
+//! second arm to cover — the sort key is a function of the triples alone. A
+//! `FivePrime` copy of each test would re-run identical code and read as
+//! coverage of a distinction that does not exist.
+
+use crate::common::cis_apply_oracle::normalizer_for;
+use ferro_hgvs::{MockProvider, Normalizer, ShuffleDirection};
+
+/// 1-based:      1234567890
+///
+/// Position 9 is `G` and 10 is `G`, so an insertion at `9_10` sits flush against
+/// a member acting on 10. The `A` run at 12-15 is not used here; the contig is
+/// shared with the rest of the cis tests so this module cannot drift onto a
+/// fixture of its own.
+const SEQUENCE: &str = "GGATTACAGGCAAAAGCCTGAGGATTACAGGCATTAGCCT";
+
+/// The window `to_sequences` returns for `spelling`, or the refusal.
+fn applied(n: &Normalizer<MockProvider>, spelling: &str) -> Result<(u64, String, String), String> {
+    let variant = ferro_hgvs::parse_hgvs(spelling).expect("committed row parses");
+    n.to_sequences(&variant, 3)
+        .map(|p| (p.position, p.reference, p.alternate))
+        .map_err(|e| e.to_string())
+}
+
+/// **An insertion flush against a sibling applies, and applies the same way
+/// whichever order the two are written in.**
+///
+/// The resulting bases are pinned exactly, not merely compared between the two
+/// orderings: two orderings agreeing on a *wrong* sequence would satisfy an
+/// equality-only test, and the payload's placement relative to the substituted
+/// base is precisely what the sort decides.
+#[test]
+fn an_insertion_flush_against_a_sibling_applies_in_either_member_order() {
+    let n = normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime);
+
+    for (label, insertion_first, sibling_first, expected) in [
+        (
+            "insertion flush against a substitution",
+            "TEMPLATE:g.[9_10insT;10G>A]",
+            "TEMPLATE:g.[10G>A;9_10insT]",
+            // 7-13 is `CAGGCAA`; the payload lands 5' of the substituted base.
+            (7u64, "CAGGCAA", "CAGTACAA"),
+        ),
+        (
+            "insertion flush against a deletion",
+            "TEMPLATE:g.[9_10insT;10del]",
+            "TEMPLATE:g.[10del;9_10insT]",
+            (7, "CAGGCAA", "CAGTCAA"),
+        ),
+    ] {
+        let first = applied(&n, insertion_first);
+        let second = applied(&n, sibling_first);
+
+        assert_eq!(
+            first,
+            Ok((expected.0, expected.1.to_string(), expected.2.to_string())),
+            "{label}: the insertion-first spelling did not apply to the expected bases"
+        );
+        assert_eq!(
+            first, second,
+            "{label}: the two member orders denote different things, so the applier is \
+             still reading order as meaning (#1098 says it carries none)"
+        );
+    }
+}
+
+/// **The same property over a grid, because two rows cannot carry it.**
+///
+/// The test above pins the two shapes the defect was reported on, exactly. That
+/// is the right test for those bases and the wrong one for the *claim*: member
+/// order carries no meaning (#1098) is a property of every allele, and a pair of
+/// rows can only witness it at one locus. A sort key is exactly the kind of fix
+/// that can be right where it was measured and wrong one base over — the old one
+/// was, since `Reverse(position)` decides correctly wherever no two members
+/// share a position.
+///
+/// So the grid walks the contig: at every interior site, an insertion at the 5'
+/// flank, at the 3' flank, and one base clear, against four sibling edits — and
+/// asserts the two authorings agree, whatever the verdict. A refusal is a
+/// verdict too, and both orders must reach it, which is what makes this a
+/// symmetry test rather than a "these now apply" test.
+///
+/// The two sides are compared on the **applied window**, not on the error
+/// string: a refusal message may quote the description it refused, which
+/// differs between the orders by construction. `Ok(w) == Ok(w)` is agreement on
+/// the bases, `None == None` is agreement that there is no single resulting
+/// sequence, and the two floors below stop either from being reached vacuously.
+///
+/// Measured on this contig: **336 pairs, 280 of which apply and 56 refuse**.
+/// The floors sit well under both, so a legitimate change to what
+/// `to_sequences` accepts does not force a re-bless, while a grid that stopped
+/// exercising either verdict still fails.
+#[test]
+fn the_verdict_is_order_independent_over_a_grid_of_flush_and_clear_pairs() {
+    let n = normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime);
+    let bases = SEQUENCE.as_bytes();
+
+    let (mut pairs, mut applied_pairs, mut refused_pairs) = (0usize, 0usize, 0usize);
+    for site in 6..=33usize {
+        let base = bases[site - 1] as char;
+        let alt = if base == 'A' { 'C' } else { 'A' };
+        // Flush against the site's 5' flank, flush against its 3' flank, and one
+        // base clear of it — so the grid holds both sides of the shared-position
+        // case and a control that never shared one.
+        for insertion_point in [site - 1, site, site - 2] {
+            let insertion = format!("{}_{}insT", insertion_point, insertion_point + 1);
+            for sibling in [
+                format!("{site}{base}>{alt}"),
+                format!("{site}del"),
+                format!("{}_{}del", site, site + 1),
+                format!("{}_{}delinsTT", site, site + 1),
+            ] {
+                let insertion_first = format!("TEMPLATE:g.[{insertion};{sibling}]");
+                let sibling_first = format!("TEMPLATE:g.[{sibling};{insertion}]");
+                let first = applied(&n, &insertion_first);
+                let second = applied(&n, &sibling_first);
+
+                assert_eq!(
+                    first.as_ref().ok(),
+                    second.as_ref().ok(),
+                    "`{insertion_first}` and `{sibling_first}` are the same variant written in \
+                     the two orders, and they do not denote the same thing — the applier is \
+                     still reading member order as meaning (#1098 says it carries none)"
+                );
+
+                pairs += 1;
+                if first.is_ok() {
+                    applied_pairs += 1;
+                } else {
+                    refused_pairs += 1;
+                }
+            }
+        }
+    }
+
+    // A symmetry assertion is satisfied by a grid that refuses everything, and
+    // one that applies everything never reaches the disjointness walk this
+    // change orders the input for. Both floors are therefore part of the test.
+    assert_eq!(
+        pairs, 336,
+        "the grid changed shape; the floors below were measured on it"
+    );
+    assert!(
+        applied_pairs >= 200,
+        "only {applied_pairs} of {pairs} grid pairs apply, so the agreement above is mostly \
+         two refusals agreeing"
+    );
+    assert!(
+        refused_pairs >= 40,
+        "only {refused_pairs} of {pairs} grid pairs refuse, so the grid no longer exercises the \
+         disjointness verdict this change orders the input for"
+    );
+}
+
+/// **A sibling one base clear of the insertion is unaffected**, and so is a pair
+/// of plain substitutions.
+///
+/// The negative control for the assertion above: these applied before the fix
+/// and must apply identically after it, or the sort has moved something it was
+/// not supposed to reach.
+#[test]
+fn members_that_already_applied_are_byte_identical() {
+    let n = normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime);
+
+    assert_eq!(
+        applied(&n, "TEMPLATE:g.[9_10insT;11C>A]"),
+        Ok((7, "CAGGCAAA".to_string(), "CAGTGAAAA".to_string())),
+        "an insertion with one base of clearance moved"
+    );
+    assert_eq!(
+        applied(&n, "TEMPLATE:g.[10G>A;11C>A]"),
+        Ok((7, "CAGGCAAA".to_string(), "CAGAAAAA".to_string())),
+        "two plain substitutions moved"
+    );
+}
+
+/// **Members that genuinely claim the same base still refuse.**
+///
+/// The discriminating case. `10G>A` sits *inside* `9_11del`, so the two claim
+/// base 10 between them and there is no single resulting sequence — which is
+/// what `triples_are_disjoint` is for. A fix that reached this would have
+/// deleted the guard rather than ordered its input.
+///
+/// # Why the message alone cannot carry this
+///
+/// `src/spdi/apply.rs` emits one string for two causes — "its members overlap,
+/// **or** a stated reference base disagrees with the reference" — so
+/// `contains("members overlap")` is satisfied by a refusal that was really a
+/// base mismatch, and this test would stay green if a future change broke base
+/// resolution instead of the overlap guard.
+///
+/// The positive control closes that: the same members with the substitution
+/// moved *outside* the deletion's span apply cleanly, which can only happen if
+/// every stated reference base here is correct. So the refusal above is the
+/// overlap, by elimination rather than by trusting a disjunction.
+#[test]
+fn a_member_interior_to_a_deletion_still_refuses() {
+    let n = normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime);
+    let error = applied(&n, "TEMPLATE:g.[9_11del;10G>A]")
+        .expect_err("a substitution interior to a deletion claims a base the deletion also claims");
+    assert!(
+        error.contains("members overlap"),
+        "the refusal no longer names the overlap: {error}"
+    );
+
+    // 9-11 is `GGC`; 12 is the first base of the `A` run, and `12A>T` claims no
+    // base the deletion claims.
+    assert!(
+        applied(&n, "TEMPLATE:g.[9_11del;12A>T]").is_ok(),
+        "the control does not apply, so the refusal above cannot be attributed \
+         to the overlap rather than to a stated base disagreeing"
+    );
+}
+
+/// **Two pure insertions at one interbase still refuse**, and still refuse for
+/// their own reason.
+///
+/// They tie on both sort components, so the stable sort leaves them in authored
+/// order and this module's change cannot reach them. The refusal comes from
+/// `variant_edit_triples_reason` — an unstated order between two payloads at one
+/// point has no defined result — and the message is asserted so that a future
+/// change cannot silently reroute it through the overlap path instead.
+#[test]
+fn coincident_pure_insertions_still_refuse_for_their_own_reason() {
+    let n = normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime);
+    let error = applied(&n, "TEMPLATE:g.[9_10insT;9_10insA]")
+        .expect_err("two payloads at one interbase have no stated order");
+    assert!(
+        error.contains("no single resulting sequence"),
+        "the refusal is no longer the undefined-result one: {error}"
+    );
+    // That message is itself a disjunction of four causes, so the positive
+    // content above is weak on its own. What distinguishes this path from the
+    // one this change touches is that it is NOT the overlap path — asserted
+    // directly, so a future edit cannot reroute it there unnoticed.
+    assert!(
+        !error.contains("members overlap"),
+        "coincident insertions are now refused as an overlap, which is the path \
+         this change orders the input for — they claim no base: {error}"
+    );
+}
+
+/// **#1420's alignment rows reach the applier at all.**
+///
+/// The reason this defect mattered. Comment 2 of #1420 states one read against
+/// one reference under four gap placements — the only alignment-varying material
+/// in the reported corpus — and two of the four carry `129_130insT` flush
+/// against `130G>A`, so neither could be applied, and the shape most worth
+/// testing was the one that could not be reached.
+///
+/// Run here against the contig those rows are drawn on, which is **139 bases**
+/// — `reported_confluence_pairs::TEMPLATE` is the same sequence truncated to
+/// 125, and positions 129-136 do not exist in it.
+#[test]
+fn the_1420_alignment_rows_now_apply_and_denote_one_sequence() {
+    let n = normalizer_for(
+        concat!(
+            "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCG",
+            "TACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA",
+            "TTTAGGCGACATTT",
+        ),
+        ShuffleDirection::ThreePrime,
+    );
+
+    // All four spellings of the one read, as #1420 comment 2 states them.
+    let spellings = [
+        "TEMPLATE:g.[130_131del;131_132insTAC;134_135insG;135_136insTT]",
+        "TEMPLATE:g.[129_130insT;130G>A;131G>C;134_135insG;135_136insTT]",
+        "TEMPLATE:g.[129_130insT;130G>A;131G>C;134_135insGCT;135C>T]",
+        "TEMPLATE:g.[130_132del;133G>T;135_136insCGAGCTT]",
+    ];
+
+    for spelling in spellings {
+        assert_eq!(
+            applied(&n, spelling),
+            // Derived from #1420's own read, not echoed back from ferro. The
+            // issue states the alignment over 126-139 as
+            //
+            //     ref : TTTAGGCGACATTT
+            //     read: TTTATACCGAGCTTATTT
+            //
+            // and `applied` asks for `pad = 3`, giving 127-138 — one base of
+            // flank trimmed from each end of both strings. `TTTAGGCGACATTT`
+            // minus its first and last `T` is `TTAGGCGACATT`; `TTTATACCGAGCTTATTT`
+            // minus its first and last `T` is `TTATACCGAGCTTATT`. So the
+            // expected value is the issue's, transformed by an arithmetic a
+            // reader can check, which is what keeps this an oracle rather than
+            // a change detector.
+            Ok((
+                127,
+                "TTAGGCGACATT".to_string(),
+                "TTATACCGAGCTTATT".to_string()
+            )),
+            "{spelling} does not apply to the read the issue draws it from"
+        );
+    }
+}

--- a/tests/it/issue_1832_reanchor_empty_alternate.rs
+++ b/tests/it/issue_1832_reanchor_empty_alternate.rs
@@ -1,0 +1,217 @@
+//! #1832 — `reanchor` must be able to widen a window whose alternate is empty.
+//!
+//! `Normalizer::reanchor` narrows to the intersection of the requested window
+//! and the pair's own before it widens, and delegates that narrowing to
+//! `SequencePair::trim_to`. When the request *contains* the pair's window the
+//! intersection is the pair's window, so nothing is trimmed — but `trim_to`'s
+//! emptiness guard read `head + tail >= alt_len`, which is `0 >= 0` on an empty
+//! alternate, and refused.
+//!
+//! An empty alternate is not exotic: it is what `Normalizer::to_sequences(v, 0)`
+//! returns for any pure deletion, so the shape `reanchor` could not widen was
+//! the minimal window for the commonest edit a caller holds.
+//!
+//! # What must NOT change
+//!
+//! The guard is still doing two jobs for `head + tail > 0`, and the second is
+//! easy to miss: it stops a trim consuming a whole string, **and** it is what
+//! keeps the "matching bases only" comparison from indexing `a[..head]` past the
+//! end of an empty alternate. `a_narrowing_into_the_deleted_block_still_refuses`
+//! is the discriminating case — a fix that dropped the guard outright passes
+//! every widening assertion here and fails that one.
+
+use crate::common::cis_apply_oracle::normalizer_for;
+use ferro_hgvs::{
+    from_sequences, FromSequencesOptions, MockProvider, Normalizer, SequencePair, ShuffleDirection,
+};
+
+/// 1-based:      1234567890
+///
+/// A 4-base `A` run at 12-15. The same contig the rest of the re-anchoring tests
+/// use, deliberately: this module is about a pair shape they never build, not
+/// about a sequence they never draw.
+const SEQUENCE: &str = "GGATTACAGGCAAAAGCCTGAGGATTACAGGCATTAGCCT";
+
+fn normalizer() -> Normalizer<MockProvider> {
+    normalizer_for(SEQUENCE, ShuffleDirection::ThreePrime)
+}
+
+/// The whole `A` run deleted, with no flanking matched base — exactly the pair
+/// `to_sequences(g.12_15del, 0)` produces.
+fn whole_window_deleted() -> SequencePair {
+    SequencePair::new("TEMPLATE", 12, "AAAA", "").expect("a well-formed pair")
+}
+
+/// **`reanchor` widens a pair whose alternate is empty**, on either edge or
+/// both, and the identity request is not an error either.
+///
+/// Each result is pinned as bases rather than as `is_ok()`: the whole point of
+/// widening is *which* flank arrives, and an assertion that only checked for
+/// success would pass on a window that fetched the wrong bases.
+#[test]
+fn reanchor_widens_a_window_whose_alternate_is_empty() {
+    let n = normalizer();
+    let pair = whole_window_deleted();
+
+    for (label, start, end, expect) in [
+        ("identity", 12u64, 15u64, ("AAAA", "")),
+        ("widen 5'", 9, 15, ("GGCAAAA", "GGC")),
+        ("widen 3'", 12, 20, ("AAAAGCCTG", "GCCTG")),
+        ("widen both", 9, 20, ("GGCAAAAGCCTG", "GGCGCCTG")),
+    ] {
+        let widened = n
+            .reanchor(&pair, Some(start), Some(end))
+            .unwrap_or_else(|e| panic!("{label}: reanchor({start}, {end}) refused: {e}"));
+        assert_eq!(
+            (
+                widened.position,
+                widened.end(),
+                widened.reference.as_str(),
+                widened.alternate.as_str()
+            ),
+            (start, end, expect.0, expect.1),
+            "{label}: reanchor did not produce the requested window"
+        );
+    }
+}
+
+/// **A narrowing that would cut into the deleted block still refuses.**
+///
+/// The discriminating case for the guard. `head = 1` here, so there is genuinely
+/// nothing in the alternate to trim, and refusing is both correct and what stops
+/// the "matching bases only" comparison below it from indexing out of range.
+#[test]
+fn a_narrowing_into_the_deleted_block_still_refuses() {
+    let n = normalizer();
+    let error = n
+        .reanchor(&whole_window_deleted(), Some(13), Some(15))
+        .expect_err("there is no alternate base to trim")
+        .to_string();
+    assert!(
+        error.contains("would leave nothing"),
+        "the refusal is no longer the emptiness one: {error}"
+    );
+}
+
+/// **A widened window derives, and derives the same description the unwidened
+/// one does.**
+///
+/// The reason the refusal mattered rather than a restatement of it. `g.12_15del`
+/// deletes the whole `A` run, so its placement is settled by the run's own
+/// extent and does not move as flank arrives — which makes it the case where
+/// widening must be a no-op on the *answer* while being the difference between
+/// an answer and a refusal on the *call*.
+#[test]
+fn every_widened_window_derives_the_same_description() {
+    let n = normalizer();
+    let pair = whole_window_deleted();
+    let options = FromSequencesOptions::default();
+
+    let mut derived = std::collections::BTreeSet::new();
+    for (start, end) in [(12u64, 15u64), (9, 15), (12, 20), (9, 20)] {
+        let widened = n
+            .reanchor(&pair, Some(start), Some(end))
+            .expect("legal after #1832");
+        derived.insert(
+            from_sequences(
+                &widened.accession,
+                widened.position,
+                &widened.reference,
+                &widened.alternate,
+                &options,
+            )
+            .unwrap_or_else(|e| panic!("window {start}-{end} did not derive: {e}"))
+            .to_string(),
+        );
+    }
+
+    assert_eq!(
+        derived,
+        ["TEMPLATE:g.12_15del".to_string()].into_iter().collect(),
+        "widening the window moved the answer"
+    );
+}
+
+/// **Widening carries `window_is_final` through, on a pair that had none.**
+///
+/// `reanchor` computes it as `end == length || (end == pair.end() &&
+/// pair.window_is_final)`, and the source records that recomputing only the
+/// first disjunct was a defect once — an identity re-anchor and a 5'-only widen
+/// both downgraded a settled window. A caller-built pair starts `false`, so the
+/// `end == length` arm is the only one reachable here, and it is the one worth
+/// pinning: widening to the contig's own end settles a window that was not.
+#[test]
+fn widening_to_the_sequence_end_settles_the_window() {
+    let n = normalizer();
+    let pair = whole_window_deleted();
+    assert!(
+        !pair.window_is_final,
+        "a caller-supplied pair carries no evidence about its 3' edge"
+    );
+
+    let length = SEQUENCE.len() as u64;
+    assert!(
+        n.reanchor(&pair, Some(9), Some(length))
+            .expect("legal")
+            .window_is_final,
+        "widening 3' to the sequence end did not settle the window"
+    );
+    assert!(
+        !n.reanchor(&pair, Some(9), Some(length - 1))
+            .expect("legal")
+            .window_is_final,
+        "a window stopping one base short of the end reads as settled"
+    );
+}
+
+/// **A refusal from the narrowing step names the caller's own request.**
+///
+/// #1832's second half. `reanchor` delegates narrowing to `trim_to`, whose
+/// message names its own method and the *intersection* coordinates — so
+/// `reanchor(13, 20)` reported `trim_to(13, 15)`, quoting an end the caller
+/// never passed. That is the failure `reanchor`'s non-overlap branch already
+/// carries a bespoke message to avoid; this pins the other exit.
+#[test]
+fn a_narrowing_refusal_names_the_callers_window() {
+    let n = normalizer();
+    let error = n
+        .reanchor(&whole_window_deleted(), Some(13), Some(20))
+        .expect_err("13 cuts into the deleted block")
+        .to_string();
+
+    assert!(
+        error.contains("reanchor(13, 20)"),
+        "the refusal does not name the caller's own request: {error}"
+    );
+    assert!(
+        error.contains("[12, 15]"),
+        "the refusal does not name the pair's own window, so the caller cannot \
+         see why 13-20 was narrowed at all: {error}"
+    );
+    // The accurate half of `trim_to`'s message is kept rather than replaced —
+    // it is what says *why* the narrowing was impossible.
+    assert!(
+        error.contains("would leave nothing"),
+        "the underlying reason was dropped: {error}"
+    );
+}
+
+/// **A pair carrying a single matched base was always widenable**, and still is.
+///
+/// The negative control: it is what made the defect look like a property of the
+/// *request* rather than of the pair, since every existing re-anchoring test
+/// builds its pairs through a helper that always includes flanking matched
+/// bases, so none of them could construct an empty alternate.
+#[test]
+fn a_pair_with_one_matched_base_is_unchanged() {
+    let n = normalizer();
+    let pair = SequencePair::new("TEMPLATE", 11, "CAAAA", "C").expect("well-formed");
+    let widened = n
+        .reanchor(&pair, Some(9), Some(20))
+        .expect("legal before and after");
+    assert_eq!(
+        (widened.reference.as_str(), widened.alternate.as_str()),
+        ("GGCAAAAGCCTG", "GGCGCCTG"),
+        "the control pair's widening moved"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -518,6 +518,7 @@ mod weight_bound_worked_examples;
 mod workflow_gh_repo_context;
 
 mod issue_1618_anchored_repeat_semantics;
+mod issue_1831_applier_member_order;
 mod report_failure_degrades;
 mod report_failure_provenance;
 mod reported_confluence_pairs;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -519,6 +519,7 @@ mod workflow_gh_repo_context;
 
 mod issue_1618_anchored_repeat_semantics;
 mod issue_1831_applier_member_order;
+mod issue_1832_reanchor_empty_alternate;
 mod report_failure_degrades;
 mod report_failure_provenance;
 mod reported_confluence_pairs;

--- a/tests/python/test_from_sequences.py
+++ b/tests/python/test_from_sequences.py
@@ -649,3 +649,52 @@ def test_a_pair_derives_from_itself():
         pair.derive(max_grid_cells=0)
     with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
         pair.derive(direction="5prime")
+
+
+def test_reanchor_widens_a_pair_whose_alternate_is_empty(normalizer):
+    """#1832, through the binding rather than only in Rust.
+
+    ``reanchor`` narrows to the intersection before it widens, and delegated
+    that to ``trim_to``, whose emptiness guard read ``head + tail >= alt_len``
+    — ``0 >= 0`` on an empty alternate. So a *widen* arrived as a no-op
+    narrowing and was refused, and the shape it could not widen is what
+    ``to_sequences(v, 0)`` returns for any pure deletion.
+
+    Worth having here and not only in Rust: the binding is where the exception
+    mapping breaks, and the narrowing refusal now travels through a new
+    ``map_err`` on the Rust side, so nothing in the Rust tests can see whether
+    ``NormalizationError`` survived the re-wrap."""
+    # The whole 12-15 `A` run deleted, with no flanking matched base.
+    pair = ferro_hgvs.SequencePair("TEMPLATE", 12, "AAAA", "")
+    assert (pair.position, pair.end) == (12, 15)
+
+    identity = normalizer.reanchor(pair, start=12, end=15)
+    assert (identity.reference, identity.alternate) == ("AAAA", "")
+
+    widened = normalizer.reanchor(pair, start=9, end=20)
+    assert (widened.position, widened.end) == (9, 20)
+    assert widened.reference == SEQUENCE[8:20]
+    assert widened.alternate == SEQUENCE[8:11] + SEQUENCE[15:20]
+
+    # …and the derivation the widened window supports is the one the unwidened
+    # pair gives, which is why the refusal mattered rather than merely annoyed.
+    assert str(widened.derive().variant) == "TEMPLATE:g.12_15del"
+
+
+def test_reanchor_narrowing_refusal_names_the_callers_window(normalizer):
+    """The second half of #1832, and on the exact exception class.
+
+    A narrowing that would cut into the deleted block still refuses — there is
+    no alternate base to trim. What changed is the message: ``reanchor``
+    delegated to ``trim_to``, which named its own method and the *intersection*
+    coordinates, so ``reanchor(13, 20)`` reported ``trim_to(13, 15)`` — an end
+    the caller never passed."""
+    pair = ferro_hgvs.SequencePair("TEMPLATE", 12, "AAAA", "")
+    with pytest.raises(ferro_hgvs.NormalizationError) as excinfo:
+        normalizer.reanchor(pair, start=13, end=20)
+
+    message = str(excinfo.value)
+    assert "reanchor(13, 20)" in message, message
+    assert "[12, 15]" in message, message
+    # `trim_to`'s own reason is the accurate half and is kept, not replaced.
+    assert "would leave nothing" in message, message


### PR DESCRIPTION
Closes #1831. Closes #1832.

Representation-Change: none. 0 of 85,642 corpus rows move, and that zero is structural rather than lucky — see **Representation stability** below.

Two defects in the surfaces `from_sequences` is reached through. Both were found while enumerating window families over the descriptions reported in #1157 / #1229–#1235 / #1419–#1421, and both were blocking that material rather than showing up as a wrong answer, which is why neither had been noticed: each presents as a legitimate-looking refusal, and every corpus that feeds `to_sequences` counts a refusal as a skip.

## Defect 1 (#1831) — the applier's overlap verdict depended on member order

`apply_triples` sorted its triples with `sort_by_key(Reverse(t.position))`. That sort is **stable**, so two triples sharing an SPDI position kept the order the author happened to write their members in. An insertion at interbase `p` and a `sub`/`del` starting at `p` share that position, and `triples_are_disjoint`'s running-reach walk then read them as overlapping or not depending on which came first.

Measured on this branch's base, same contig, same pad:

| description | before | after |
|---|---|---|
| `g.[9_10insT;10G>A]` | REFUSED "members overlap" | `ref=CAGGCAA alt=CAGTACAA` |
| `g.[10G>A;9_10insT]` | `ref=CAGGCAA alt=CAGTACAA` | unchanged |
| `g.[9_10insT;10del]` | REFUSED | `ref=CAGGCAA alt=CAGTCAA` |
| `g.[10del;9_10insT]` | `ref=CAGGCAA alt=CAGTCAA` | unchanged |

The refusing branch contradicted this module's own contract, stated on `triples_are_disjoint`: "an insertion deletes nothing and therefore claims no base". It also contradicted #1098, which settled that member order carries no meaning.

**The fix is the sort key its own siblings already use.** There are three appliers in the tree and `apply_triples` was the only one missing it:

| applier | sort key |
|---|---|
| `spdi::apply::splice_denoted_sequence` | `(Reverse(position), Reverse(deletion.len()))` |
| `conformance::spec_corpus::apply_triples` | `(Reverse(position), Reverse(deletion.len()))` |
| `spdi::apply::apply_triples` | `Reverse(position)` — **the outlier** |

`splice_denoted_sequence`'s doc comment even states the reason verbatim: "**longer deletions first** among members at one position so a span-claiming member is always applied before the zero-length one flush against it". So this is not a new rule; it is the existing one applied at the third call site.

### Why it mattered

Two of the four alignment spellings in #1420 (comment 2) could not be applied at all. Those three rows are the only place in the reported corpus that varies the **alignment** rather than the spelling — one read, one reference, four gap placements — so the shape most worth testing was the one that could not be reached. All four now apply, and all four denote one sequence, pinned by `the_1420_alignment_rows_now_apply_and_denote_one_sequence`.

Across the 85 harvested rows this moves 4 from "cannot be applied" to "applies". Attribution confirmed rather than assumed, by re-authoring each with the insertion last:

| as authored | insertion moved last |
|---|---|
| `g.[4_5insA;5A>C;6C>A;7C>G;9G>T;10T>A]` REFUSED | `g.[5A>C;…;4_5insA]` OK |
| `g.[5_6insA;6C>A;8A>G;9G>A]` REFUSED | `g.[6C>A;…;5_6insA]` OK |

## Defect 2 (#1832) — `reanchor` could not widen a pure-deletion window

`Normalizer::reanchor` narrows to the intersection of the requested window and the pair's own before it widens, delegating that narrowing to `SequencePair::trim_to`. When the request *contains* the pair's window, the intersection is the pair's window and nothing is trimmed — but `trim_to`'s emptiness guard read `head + tail >= alt_len`, which is `0 >= 0` on an empty alternate, and refused.

An empty alternate is what `to_sequences(v, 0)` returns for **any pure deletion**, so the shape `reanchor` could not widen was the minimal window for the commonest edit a caller holds. Every call below was refused before, including the identity:

| call on `SequencePair::new("TEMPLATE", 12, "AAAA", "")` | before | after |
|---|---|---|
| `reanchor(12, 15)` (identity) | ERR | `ref=AAAA alt=` |
| `reanchor(9, 15)` | ERR | `ref=GGCAAAA alt=GGC` |
| `reanchor(12, 20)` | ERR | `ref=AAAAGCCTG alt=GCCTG` |
| `reanchor(9, 20)` | ERR | `ref=GGCAAAAGCCTG alt=GGCGCCTG` |

The fix is `head + tail > 0 &&` in front of the existing guard. The guard is still needed for `head + tail > 0`, and for **two** reasons rather than one — it stops a trim consuming a whole string, and it is what keeps the "matching bases only" comparison below it from indexing `a[..head]` past the end of an empty alternate. That second reason is why the guard is narrowed rather than removed.

#1832's **second** point is also fixed: `reanchor` delegated narrowing to `trim_to`, whose message names its own method and the *intersection* coordinates, so `reanchor(13, 20)` reported `trim_to(13, 15)` — an end the caller never passed. That is precisely the failure `reanchor`'s non-overlap branch already carries a bespoke message to avoid; the other exit now does too, keeping `trim_to`'s reason (the accurate half) wrapped in the caller's own request. Pinned by `a_narrowing_refusal_names_the_callers_window`.

The re-frame **matches on the error rather than wrapping its rendered form**, which a second review pass found necessary rather than tidy: `trim_to` returns the same `FerroError::InvalidCoordinates` variant and `Display` prepends the kind, so nesting the whole rendered error produced `Invalid coordinates: reanchor(…): … failed: Invalid coordinates: trim_to(…) on TEMPLATE`, printing both the kind and the accession twice. Taking the inner `msg` states each once; any other error kind is passed through unchanged rather than flattened into `InvalidCoordinates`, which would cost a caller the ability to match on it. The message now reads:

```
Invalid coordinates: reanchor(13, 20): narrowing to the overlap with the pair's own
window [12, 15] failed: trim_to(13, 15) on TEMPLATE would leave nothing of the
4-base reference or the 0-base alternate
```

## Unchanged on purpose

The discriminating cases, each of which a wider "fix" would break:

* `g.[9_11del;10G>A]` — a substitution interior to a deletion still refuses. A fix that deleted `triples_are_disjoint` instead of ordering its input passes everything else and fails this.
* `g.[9_10insT;9_10insA]` — two pure insertions at one interbase still refuse, and still with their own message (`no single resulting sequence`, from `variant_edit_triples_reason`) rather than the overlap one. They tie on both sort components, so the stable sort leaves them in authored order and this change cannot reach them.
* `g.[9_10insT;11C>A]` and `g.[10G>A;11C>A]` — byte-identical before and after.
* `reanchor(pair, 13, 15)` on the empty-alternate pair still refuses: `head = 1`, so there is genuinely nothing to trim.
* A pair carrying one matched base (`"CAAAA"` / `"C"`) widens exactly as before.

Of the 12 tests in the two new modules, **4 fail on this branch's base** — the rest are negative controls and message-accuracy pins.

Two assertion-strength points worth calling out, since both were self-review findings: `src/spdi/apply.rs` emits **disjunctive** refusal messages ("its members overlap, **or** a stated reference base disagrees"), so a bare `contains("members overlap")` cannot prove its own cause. `a_member_interior_to_a_deletion_still_refuses` therefore carries a positive control — the same members with the substitution moved outside the deletion's span apply cleanly — so the refusal is attributed to the overlap by elimination; and the coincident-insertion test additionally asserts the message is **not** the overlap one.

## Representation stability

`Representation-Change: none`, and the zero is structural rather than a corpus miss.

`examples/dump_normalized_corpus.rs` reports **0 of 85,642 rows moved** across all 21 shape families, `origin/main` @ `7cc9846c` against this branch. On its own that would be weak evidence, since this repo's doctrine is that a corpus zero is a claim about the corpus. The stronger argument is reachability, checked from the tree:

* `apply_triples` is called from `spdi::apply_to_reference`, `equivalence::checker` and `conformance::spec_corpus`. It is **not** on `Normalizer::normalize`'s path.
* `trim_to` / `reanchor` are called from `python.rs` and from `Normalizer::reanchor`. Also not on the normalize path.

So no normalized output can move, whatever the corpus contains.

**What can move, and is a widening rather than a re-spelling:** descriptions that `apply_to_reference` / `to_sequences` / `Normalizer::reanchor` previously **refused** now succeed. Nothing that succeeded before returns a different value — the ordering only becomes deterministic where it was previously authored-order-dependent, and the deterministic choice is the one already produced for the accepted spelling. `EquivalenceChecker` reaches `apply_triples`, so a pair where one side previously could not be applied may now upgrade its verdict; that is the same direction, and is #1158's complaint class.

## Coverage on both surfaces

`Normalizer.reanchor` and `SequencePair(accession, position, reference, alternate)` are both exposed to Python, so #1832's shape is reachable there and the binding is where the exception mapping can break — the narrowing refusal now travels through a new `map_err`, which no Rust test can see the far side of. `tests/python/test_from_sequences.py` gains two tests covering the widen and the refusal, the latter asserting `NormalizationError` specifically rather than a bare exception.

Verified red on the base by reverting **only** the `head + tail > 0` guard in place and rebuilding the extension — not by checking a file out of `origin/main`, which has moved twice under this branch and produces a build failure that lets `pytest` silently run against the previously-installed wheel.

## Verification

Run on the rebased tree, at `main` including #1806 and #1706:

```
cargo fmt --all --check                                     # 0
cargo clippy --all-features --all-targets -- -D warnings    # 0
scripts/run_oracle_suite.sh                                 # 10,505 passed, 0 failed
FERRO_SWEEP_SEEDS=full cargo nextest run --features dev     # 10,642 passed, 0 failed
cargo check --features python                               # 0
ruff check / ruff format --check / mypy                     # 0
uv run pytest tests/python/test_from_sequences.py           # 45 passed
```

Note `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev` is **not** the gate — that bare armed form is red on a clean `main` by construction, and `scripts/run_oracle_suite.sh` is the runner that mirrors CI's `test-oracle` selection.

## Follow-up, not in this PR

#1834 records what this work was actually looking for: `normalize` and `from_sequences` run **different block partitioners** by construction — `derive_block_members` calls `partition_block_canonical_within` unconditionally, while `canonicalize_from_sequence` defaults to `PartitionRule::Live` — and 32 of 79 rows (3'; 36 of 79 under 5') disagree between the two surfaces, with nothing in the suite reporting it. It also records that `FERRO_PARTITION` moves only the `normalize` arm, so a bake-off including a `from_sequences` figure compares a moved surface against a fixed one. Converging them is #1419–#1421's open product decision; the tripwire proposed there does not depend on it.
