### PR TITLE
refactor(effect)!: decline an unknown offset from the two splice classifiers that could not

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1377,8 +1377,17 @@ class EffectPredictor:
         """Classify an indel by frame effect."""
         ...
 
-    def classify_splice_variant(self, offset: int) -> ProteinEffect:
-        """Classify a splice site variant by distance from splice site."""
+    def classify_splice_variant(self, offset: int) -> ProteinEffect | None:
+        """Classify a splice site variant by distance from splice site.
+
+        Returns ``None`` when the offset is unknown -- ``+?`` / ``-?``, carried
+        as the sentinels ``2**63 - 1`` and ``-2**63``. Such a description states
+        no distance from the splice site, so there is nothing to classify.
+
+        Args:
+            offset: Distance from splice site (negative for acceptor, positive
+                for donor)
+        """
         ...
 
     def classify_utr_variant(self, is_5_prime: bool) -> ProteinEffect:

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -2712,7 +2712,38 @@ fn run_effect(
                     // Check for intronic offsets
                     if let Some(start_pos) = cv.loc_edit.location.start.inner() {
                         if let Some(offset) = start_pos.offset {
-                            predictor.classify_splice_variant(offset)
+                            // `classify_splice_variant` declines an unknown
+                            // offset (`c.100-?`), whose whole content is that
+                            // the distance is not stated (#1841). Refuse the
+                            // description rather than print a consequence, in
+                            // the same register as the unsupported-type arm
+                            // below — printing `intron_variant`/MODIFIER, which
+                            // is what this arm did before, reads as a
+                            // prediction to anything parsing the output.
+                            //
+                            // This is a CLI output change, so state what it
+                            // does to each consumer. Single-variant mode:
+                            // stdout gains no line (for `-f json`, no JSON
+                            // object at all) and the process exits non-zero,
+                            // where it previously printed
+                            // `intron_variant (MODIFIER)` and exited 0. Batch
+                            // mode (`--input` / stdin): the two loops below
+                            // already catch a per-line `Err`, report it to
+                            // **stderr** as `ERROR: <line> - <e>` and continue,
+                            // so one such line does not truncate the stream —
+                            // the #1764 failure mode is not reintroduced here.
+                            match predictor.classify_splice_variant(offset) {
+                                Some(effect) => effect,
+                                None => {
+                                    return Err(format!(
+                                        "Cannot predict an effect for an unknown intronic \
+                                         offset (`+?`/`-?`), which states no distance from \
+                                         the splice site: {}",
+                                        v
+                                    )
+                                    .into());
+                                }
+                            }
                         } else {
                             ProteinEffect {
                                 consequences: vec![Consequence::CodingSequenceVariant],

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -267,19 +267,28 @@ pub enum IntronicRegion {
 }
 
 impl IntronicRegion {
-    /// Create from a *measured* offset value.
+    /// Classify an offset into its distance band, or decline.
     ///
-    /// The argument is a distance from the exon boundary, so the unknown-offset
-    /// sentinels are out of domain: screen them with
-    /// [`CdsPos::has_unknown_offset`] / [`TxPos::has_unknown_offset`] before
-    /// calling, as [`IntronicRegion::from_cds_pos`] and
-    /// [`IntronicRegion::from_tx_pos`] do. The magnitude is taken with
-    /// `unsigned_abs`, so no input can overflow it (#1767); a sentinel passed
-    /// here anyway lands in `DeepIntronic`, which is a distance claim its input
-    /// does not support.
-    pub fn from_offset(offset: i64) -> Self {
+    /// Returns `None` for the unknown-offset sentinels (`+?` / `-?`, carried as
+    /// [`OFFSET_UNKNOWN_POSITIVE`] / [`OFFSET_UNKNOWN_NEGATIVE`]). Every variant
+    /// of this enum names a **distance band**, and a sentinel states that the
+    /// distance is unknown, so none of the four is a true answer for it.
+    ///
+    /// #1767 fixed the arithmetic here — the magnitude is taken with
+    /// `unsigned_abs`, so no `i64` can overflow it — but left the signature
+    /// promising an answer this function cannot always give: a sentinel landed
+    /// in `DeepIntronic`, a distance claim its input does not support. #1841
+    /// took that break. The precondition used to be documented ("screen with
+    /// `has_unknown_offset` before calling"); it is now in the type.
+    ///
+    /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+    /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
+    pub fn from_offset(offset: i64) -> Option<Self> {
+        if crate::hgvs::parser::position::is_unknown_offset(offset) {
+            return None;
+        }
         let abs_offset = offset.unsigned_abs();
-        if abs_offset <= 2 {
+        Some(if abs_offset <= 2 {
             Self::CanonicalSpliceSite
         } else if abs_offset <= 20 {
             Self::ExtendedSpliceRegion
@@ -287,28 +296,29 @@ impl IntronicRegion {
             Self::NearSpliceSite
         } else {
             Self::DeepIntronic
-        }
+        })
     }
 
     /// Create from a CDS position.
     ///
-    /// Returns `None` for an unknown offset — every variant of this enum names
-    /// a distance band, and a sentinel supports none of them (#1767).
+    /// `None` when the position is not intronic, and when its offset is unknown.
+    /// The unknown-offset rule is [`IntronicRegion::from_offset`]'s own since
+    /// #1841, so this no longer screens for it separately — one rule, one site,
+    /// which is the discipline #1767 applied to `is_unknown_offset` itself.
+    ///
+    /// The sibling ladder [`IntronicConsequence`] still screens in *its*
+    /// position constructors rather than in a scalar entry point, and that
+    /// asymmetry is deliberate rather than a missed cleanup: it exposes no
+    /// public `from_offset`, so there is no scalar site to move the rule into.
     pub fn from_cds_pos(pos: &CdsPos) -> Option<Self> {
-        if pos.has_unknown_offset() {
-            return None;
-        }
-        pos.offset.map(Self::from_offset)
+        pos.offset.and_then(Self::from_offset)
     }
 
     /// Create from a transcript position.
     ///
     /// Declines an unknown offset, as [`IntronicRegion::from_cds_pos`] does.
     pub fn from_tx_pos(pos: &TxPos) -> Option<Self> {
-        if pos.has_unknown_offset() {
-            return None;
-        }
-        pos.offset.map(Self::from_offset)
+        pos.offset.and_then(Self::from_offset)
     }
 }
 
@@ -536,27 +546,47 @@ mod tests {
     fn test_intronic_region_from_offset() {
         assert_eq!(
             IntronicRegion::from_offset(1),
-            IntronicRegion::CanonicalSpliceSite
+            Some(IntronicRegion::CanonicalSpliceSite)
         );
         assert_eq!(
             IntronicRegion::from_offset(-2),
-            IntronicRegion::CanonicalSpliceSite
+            Some(IntronicRegion::CanonicalSpliceSite)
         );
         assert_eq!(
             IntronicRegion::from_offset(10),
-            IntronicRegion::ExtendedSpliceRegion
+            Some(IntronicRegion::ExtendedSpliceRegion)
         );
         assert_eq!(
             IntronicRegion::from_offset(-15),
-            IntronicRegion::ExtendedSpliceRegion
+            Some(IntronicRegion::ExtendedSpliceRegion)
         );
         assert_eq!(
             IntronicRegion::from_offset(35),
-            IntronicRegion::NearSpliceSite
+            Some(IntronicRegion::NearSpliceSite)
         );
         assert_eq!(
             IntronicRegion::from_offset(100),
-            IntronicRegion::DeepIntronic
+            Some(IntronicRegion::DeepIntronic)
+        );
+    }
+
+    /// The #1841 break: the sentinels are out of the enum's domain, and the
+    /// signature now says so. `i64::MIN + 1` and `i64::MAX - 1` are the
+    /// discriminating neighbours — they are *not* sentinels, so they must still
+    /// classify (as `DeepIntronic`), which is what keeps the decline keyed on
+    /// the sentinel rather than on "a very large magnitude".
+    #[test]
+    fn test_intronic_region_from_offset_declines_an_unknown_offset() {
+        assert_eq!(IntronicRegion::from_offset(i64::MIN), None);
+        assert_eq!(IntronicRegion::from_offset(i64::MAX), None);
+
+        assert_eq!(
+            IntronicRegion::from_offset(i64::MIN + 1),
+            Some(IntronicRegion::DeepIntronic)
+        );
+        assert_eq!(
+            IntronicRegion::from_offset(i64::MAX - 1),
+            Some(IntronicRegion::DeepIntronic)
         );
     }
 

--- a/src/effect/mod.rs
+++ b/src/effect/mod.rs
@@ -387,30 +387,50 @@ impl EffectPredictor {
         }
     }
 
-    /// Classify a splice site variant by distance.
+    /// Classify a splice site variant by distance, or decline.
     ///
-    /// An unknown offset (`+?` / `-?`, carried as `i64::MAX` / `i64::MIN`) is
-    /// reported as [`Consequence::IntronVariant`]. This entry point returns a
-    /// bare `ProteinEffect` and so cannot decline the way the `Option`-returning
-    /// classifiers do, and `IntronVariant` is the weakest true statement
-    /// available: the position is known to be intronic and its distance from the
-    /// boundary is not known at all. Before #1767 the sentinel's `.abs()`
+    /// Returns `None` for an unknown offset (`+?` / `-?`, carried as
+    /// `i64::MAX` / `i64::MIN`). This function's whole input is a distance, so
+    /// a description that declines to state one leaves it nothing to classify.
+    ///
+    /// The history is worth keeping, because two earlier answers were both
+    /// worse and both looked reasonable. Before #1767 the sentinel's `.abs()`
     /// overflowed — a panic under `overflow-checks`, and in release a wrap back
     /// to `i64::MIN`, which is negative and so passed `<= 2` and was reported as
-    /// a canonical splice site with HIGH impact.
+    /// a canonical splice site with HIGH impact. #1767 replaced that with
+    /// [`Consequence::IntronVariant`] / `Impact::Modifier`, the weakest *true*
+    /// statement available under a signature that could not decline — but a
+    /// caller matching on the consequence still reads a positive
+    /// classification. #1841 took the API break so the answer can be "no
+    /// answer".
     ///
-    /// The returned `intronic_offset` still carries the sentinel, so a caller
-    /// that needs to distinguish "unknown" from "far" can.
-    pub fn classify_splice_variant(&self, offset: i64) -> ProteinEffect {
-        let is_unknown = crate::hgvs::parser::position::is_unknown_offset(offset);
+    /// A caller that wants the old behaviour writes it out, and is thereby
+    /// stating the assumption:
+    ///
+    /// ```
+    /// # use ferro_hgvs::effect::{Consequence, EffectPredictor, ProteinEffect};
+    /// # let predictor = EffectPredictor::new();
+    /// # let offset = i64::MIN;
+    /// let effect = predictor
+    ///     .classify_splice_variant(offset)
+    ///     .unwrap_or_else(|| ProteinEffect {
+    ///         consequences: vec![Consequence::IntronVariant],
+    ///         impact: Consequence::IntronVariant.impact(),
+    ///         amino_acid_change: None,
+    ///         intronic_offset: Some(offset),
+    ///     });
+    /// # assert_eq!(effect.consequences, vec![Consequence::IntronVariant]);
+    /// ```
+    pub fn classify_splice_variant(&self, offset: i64) -> Option<ProteinEffect> {
+        if crate::hgvs::parser::position::is_unknown_offset(offset) {
+            return None;
+        }
         // `unsigned_abs` rather than `abs`: total for every `i64`, so the
         // ladder cannot overflow even on a magnitude that is not a sentinel
         // (`i64::MIN` is the only such value, and it is reachable here).
         let abs_offset = offset.unsigned_abs();
 
-        let consequence = if is_unknown {
-            Consequence::IntronVariant
-        } else if abs_offset <= 2 {
+        let consequence = if abs_offset <= 2 {
             if offset > 0 {
                 Consequence::SpliceDonorVariant
             } else {
@@ -422,12 +442,12 @@ impl EffectPredictor {
             Consequence::IntronVariant
         };
 
-        ProteinEffect {
+        Some(ProteinEffect {
             consequences: vec![consequence],
             impact: consequence.impact(),
             amino_acid_change: None,
             intronic_offset: Some(offset),
-        }
+        })
     }
 
     /// Classify a UTR variant.
@@ -1286,7 +1306,9 @@ mod tests {
     #[test]
     fn test_classify_splice_donor() {
         let predictor = EffectPredictor::new();
-        let effect = predictor.classify_splice_variant(1);
+        let effect = predictor
+            .classify_splice_variant(1)
+            .expect("a measured offset classifies");
 
         assert_eq!(effect.consequences[0], Consequence::SpliceDonorVariant);
         assert_eq!(effect.impact, Impact::High);
@@ -1295,7 +1317,9 @@ mod tests {
     #[test]
     fn test_classify_splice_acceptor() {
         let predictor = EffectPredictor::new();
-        let effect = predictor.classify_splice_variant(-2);
+        let effect = predictor
+            .classify_splice_variant(-2)
+            .expect("a measured offset classifies");
 
         assert_eq!(effect.consequences[0], Consequence::SpliceAcceptorVariant);
         assert_eq!(effect.impact, Impact::High);
@@ -1304,7 +1328,9 @@ mod tests {
     #[test]
     fn test_classify_splice_region() {
         let predictor = EffectPredictor::new();
-        let effect = predictor.classify_splice_variant(5);
+        let effect = predictor
+            .classify_splice_variant(5)
+            .expect("a measured offset classifies");
 
         assert_eq!(effect.consequences[0], Consequence::SpliceRegionVariant);
         assert_eq!(effect.impact, Impact::Low);
@@ -1313,10 +1339,32 @@ mod tests {
     #[test]
     fn test_classify_intron() {
         let predictor = EffectPredictor::new();
-        let effect = predictor.classify_splice_variant(50);
+        let effect = predictor
+            .classify_splice_variant(50)
+            .expect("a measured offset classifies");
 
         assert_eq!(effect.consequences[0], Consequence::IntronVariant);
         assert_eq!(effect.impact, Impact::Modifier);
+    }
+
+    /// The #1841 break. `i64::MIN + 1` and `i64::MAX - 1` are the
+    /// discriminating neighbours: they are not sentinels, so they must still
+    /// classify, which keeps the decline keyed on the sentinel rather than on
+    /// "a very large magnitude" — the #1765 gap, applied here.
+    #[test]
+    fn test_classify_splice_variant_declines_an_unknown_offset() {
+        let predictor = EffectPredictor::new();
+
+        assert!(predictor.classify_splice_variant(i64::MIN).is_none());
+        assert!(predictor.classify_splice_variant(i64::MAX).is_none());
+
+        for offset in [i64::MIN + 1, i64::MAX - 1] {
+            let effect = predictor
+                .classify_splice_variant(offset)
+                .expect("a non-sentinel magnitude still classifies");
+            assert_eq!(effect.consequences[0], Consequence::IntronVariant);
+            assert_eq!(effect.intronic_offset, Some(offset));
+        }
     }
 
     #[test]

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -795,12 +795,20 @@ impl IvsPos {
     ///
     /// `unsigned_abs` rather than `abs`: [`IvsNotation::to_ivs`] maps a `CdsPos` /
     /// `TxPos` offset straight in, so an unknown offset (`c.100-?`) reaches
-    /// this predicate, and `i64::MIN.abs()` overflows (#1767). As with
-    /// [`IntronicRegion::from_offset`], this reads a *measured* distance —
-    /// screen sentinels before asking. `IvsPos` carries a bare `i64`, so the
-    /// applicable screen is the scalar [`is_unknown_offset`], not
-    /// [`CdsPos::has_unknown_offset`] / [`TxPos::has_unknown_offset`], which a
-    /// caller holding only an `IvsPos` no longer has.
+    /// this predicate, and `i64::MIN.abs()` overflows (#1767). This reads a
+    /// *measured* distance, so screen sentinels before asking. `IvsPos` carries
+    /// a bare `i64`, so the applicable screen is the scalar
+    /// [`is_unknown_offset`], not [`CdsPos::has_unknown_offset`] /
+    /// [`TxPos::has_unknown_offset`], which a caller holding only an `IvsPos`
+    /// no longer has.
+    ///
+    /// **This is deliberately unlike [`IntronicRegion::from_offset`], which
+    /// since #1841 declines a sentinel rather than asking the caller to screen.**
+    /// The two are not the same shape and the difference is not an oversight: a
+    /// `bool` predicate has no way to say "no answer", so pushing the rule in
+    /// here would only move the fabricated answer from `DeepIntronic` to
+    /// `false`. Making these decline needs its own decision about what the four
+    /// `IvsPos`/`IntronPosition` predicates return.
     ///
     /// [`IntronicRegion::from_offset`]: crate::convert::noncoding::IntronicRegion::from_offset
     /// [`is_unknown_offset`]: crate::hgvs::parser::position::is_unknown_offset

--- a/src/python.rs
+++ b/src/python.rs
@@ -4038,11 +4038,16 @@ impl PyEffectPredictor {
     ///     offset: Distance from splice site (negative for acceptor, positive for donor)
     ///
     /// Returns:
-    ///     ProteinEffect with consequences and impact
-    fn classify_splice_variant(&self, offset: i64) -> PyProteinEffect {
-        PyProteinEffect {
-            inner: self.inner.classify_splice_variant(offset),
-        }
+    ///     ProteinEffect with consequences and impact, or None when the offset
+    ///     is unknown (`+?` / `-?`, carried as the sentinels 2**63-1 and
+    ///     -2**63). Such a description states no distance, so there is nothing
+    ///     to classify — see #1841. This returned ProteinEffect where it now
+    ///     returns None, so a caller that reads `.consequences` unconditionally
+    ///     must check for None first.
+    fn classify_splice_variant(&self, offset: i64) -> Option<PyProteinEffect> {
+        self.inner
+            .classify_splice_variant(offset)
+            .map(|inner| PyProteinEffect { inner })
     }
 
     /// Classify a UTR variant

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -929,6 +929,29 @@ pub struct IntronPosition {
 // `crate::hgvs::parser::position::is_unknown_offset` first — none of these
 // predicates can decline, and `is_deep_intronic` answers `true` for a sentinel,
 // which is a ">50 bp" claim the input does not support.
+//
+// **Two of the items below are NOT `bool`, so "it cannot decline" is not the
+// reason they were left (#1841).** That PR made `IntronicRegion::from_offset`
+// and `EffectPredictor::classify_splice_variant` return `Option`, on the ground
+// that a value naming a distance band is not a true answer for a sentinel, and
+// it scoped itself to the two entry points whose return type was in the way.
+// The scope, not the shape, is why these stayed:
+//
+// - `splice_site_type` returns `SpliceSiteType` — five distance bands, the same
+//   shape as `IntronicRegion` and no more able to state one for a sentinel. It
+//   would take the identical `Option` treatment; it was simply outside an
+//   approved break. Do not read the `bool` argument above as covering it.
+// - `distance_from_donor` / `distance_from_acceptor` ALREADY return `Option<u64>`,
+//   so they have a decline channel and do not use it. Worse than a fabricated
+//   band: the cross-boundary arm computes `intron_length - offset.unsigned_abs()`,
+//   an unchecked `u64` subtraction that underflows for ANY magnitude exceeding
+//   the intron — panicking under `overflow-checks` and wrapping to a colossal
+//   "distance" in release. `unsigned_abs` closed the ladder's overflow in #1767
+//   and left this subtraction untouched, so the hardening pass is incomplete
+//   here rather than deliberately scoped.
+//
+// Neither is reachable from a string entry point today; both are reachable by a
+// library caller, because every field of this struct is `pub`.
 impl IntronPosition {
     /// Check if this is a deep intronic position (>50bp from nearest exon)
     pub fn is_deep_intronic(&self) -> bool {

--- a/tests/it/issue_1767_unknown_offset_splice_classifiers.rs
+++ b/tests/it/issue_1767_unknown_offset_splice_classifiers.rs
@@ -19,9 +19,13 @@
 //! The contract applied here is the one `CdsPos::has_unknown_offset` already
 //! documents (closing #1087): the sentinels denote an unknown position
 //! unbounded in one direction, so no distance can be derived from them at all.
-//! Classifiers that can say so return `None`; classifiers whose return type
-//! cannot decline fall back to the plain "intronic" answer, which asserts no
-//! distance.
+//! **Every** classifier now says so by returning `None` — #1767 could only give
+//! that answer where the return type already admitted it, and #1841 took the
+//! public-API break for the two that did not (`IntronicRegion::from_offset` and
+//! `EffectPredictor::classify_splice_variant`). The guards that used to pin the
+//! fall-back "intronic" answer for those two now pin the decline; see
+//! `tests/it/issue_1841_option_returning_splice_classifiers.rs` for the
+//! break's own guards.
 //!
 //! [`OFFSET_UNKNOWN_POSITIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
 //! [`OFFSET_UNKNOWN_NEGATIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
@@ -174,30 +178,22 @@ fn an_unknown_offset_is_not_a_clinically_significant_splice_position() {
     }
 }
 
-/// `classify_splice_variant` returns a bare `ProteinEffect`, so it cannot
-/// decline. It must still refuse to claim a splice site: `IntronVariant` is the
-/// weakest true statement about a position that is known to be intronic and
-/// whose distance is unknown.
+/// The property #1767 was filed for, stated in the form it takes after #1841
+/// widened the answer from "the weakest true statement" to "no statement".
+///
+/// What must never happen is a *splice-site* claim — that was the release-mode
+/// defect (`SpliceAcceptorVariant`/HIGH). A decline satisfies that strictly more
+/// than `IntronVariant` did, so this guard is not weakened by the change; it is
+/// the same claim asserted against a return type that can carry it.
 #[test]
 fn classify_splice_variant_makes_no_distance_claim_for_an_unknown_offset() {
     let predictor = EffectPredictor::new();
     for offset in SENTINELS {
-        let effect = predictor.classify_splice_variant(offset);
-        assert_eq!(
-            effect.consequences,
-            vec![Consequence::IntronVariant],
+        assert!(
+            predictor.classify_splice_variant(offset).is_none(),
             "an unknown offset ({offset}) must not be reported as a splice \
-             donor/acceptor or splice-region variant"
-        );
-        assert_eq!(
-            effect.impact,
-            Impact::Modifier,
-            "an unknown offset ({offset}) cannot support a HIGH impact call"
-        );
-        assert_eq!(
-            effect.intronic_offset,
-            Some(offset),
-            "the sentinel is still reported, so a caller can tell `unknown` from `far`"
+             donor/acceptor or splice-region variant, and since #1841 it is not \
+             reported as anything"
         );
     }
 }
@@ -303,22 +299,29 @@ fn the_coordinate_validators_decline_an_unknown_offset() {
 fn measured_offsets_are_unaffected() {
     let predictor = EffectPredictor::new();
 
-    assert_eq!(
-        predictor.classify_splice_variant(1).consequences,
-        vec![Consequence::SpliceDonorVariant]
-    );
-    assert_eq!(
-        predictor.classify_splice_variant(-2).consequences,
-        vec![Consequence::SpliceAcceptorVariant]
-    );
-    assert_eq!(
-        predictor.classify_splice_variant(5).consequences,
-        vec![Consequence::SpliceRegionVariant]
-    );
-    assert_eq!(
-        predictor.classify_splice_variant(50).consequences,
-        vec![Consequence::IntronVariant]
-    );
+    // `.expect` rather than a bare unwrap: since #1841 a `None` here would mean
+    // the decline had widened past the sentinels, which is the failure worth
+    // naming.
+    let classify = |offset: i64| {
+        predictor
+            .classify_splice_variant(offset)
+            .unwrap_or_else(|| panic!("a measured offset ({offset}) must still classify"))
+    };
+
+    // Impact is asserted alongside the consequence because it is the half the
+    // #1767 defect got wrong (HIGH for a position stating no distance), and
+    // because this file's only previous `Impact` assertion was on the sentinel
+    // — which since #1841 has no effect to carry one.
+    for (offset, consequence, impact) in [
+        (1, Consequence::SpliceDonorVariant, Impact::High),
+        (-2, Consequence::SpliceAcceptorVariant, Impact::High),
+        (5, Consequence::SpliceRegionVariant, Impact::Low),
+        (50, Consequence::IntronVariant, Impact::Modifier),
+    ] {
+        let effect = classify(offset);
+        assert_eq!(effect.consequences, vec![consequence]);
+        assert_eq!(effect.impact, impact);
+    }
 
     assert_eq!(
         IntronicConsequence::from_cds_pos(&cds_with_offset(-2)),

--- a/tests/it/issue_1841_option_returning_splice_classifiers.rs
+++ b/tests/it/issue_1841_option_returning_splice_classifiers.rs
@@ -1,0 +1,341 @@
+//! Guards for #1841 — the two splice classifiers whose signatures promised an
+//! answer they cannot give now return `Option`.
+//!
+//! #1806 closed #1767 by teaching every reachable classifier about the
+//! unknown-offset sentinels (`+?` / `-?`, carried as [`OFFSET_UNKNOWN_POSITIVE`]
+//! / [`OFFSET_UNKNOWN_NEGATIVE`]). Two were left with their signatures, and
+//! recorded as needing an API decision:
+//!
+//! * [`IntronicRegion::from_offset`] returned `Self`, so a sentinel landed in
+//!   `DeepIntronic` — every variant of that enum names a **distance band**, and
+//!   a sentinel supports none of them.
+//! * [`EffectPredictor::classify_splice_variant`] returned a bare
+//!   `ProteinEffect`, so the best it could do was `IntronVariant`/`Modifier` —
+//!   true, but still a positive classification to a caller matching on the
+//!   consequence.
+//!
+//! Neither was a live defect at the point the break was taken: `from_offset`'s
+//! two in-repo callers screened first, and `classify_splice_variant`'s answer
+//! was true. The claim these guards make is therefore about the **contract**,
+//! not about a wrong number — which is why each one below pins the discriminating
+//! neighbour alongside the sentinel.
+//!
+//! **The discriminating case is `i64::MIN + 1` / `i64::MAX - 1`.** They are not
+//! sentinels, so they must still classify. A decline keyed on "a very large
+//! magnitude" rather than on the sentinel would pass every assertion that only
+//! looked at `i64::MIN` and `i64::MAX`, and it is exactly the gap #1765 records
+//! one layer up.
+//!
+//! [`OFFSET_UNKNOWN_POSITIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+//! [`OFFSET_UNKNOWN_NEGATIVE`]: ferro_hgvs::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
+
+use std::io::Write;
+use std::process::Command;
+
+use ferro_hgvs::convert::noncoding::IntronicRegion;
+use ferro_hgvs::effect::{Consequence, EffectPredictor, Impact};
+use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
+use ferro_hgvs::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::parse_hgvs;
+
+/// Both sentinels, so each guard is exercised symmetrically — a fix that taught
+/// the classifiers only about `i64::MIN` would leave `+?` answering by accident.
+const SENTINELS: [i64; 2] = [OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE];
+
+/// The neighbours of the sentinels, which are ordinary (if absurd) magnitudes.
+/// Pinning these is what stops the decline from widening into "big offsets do
+/// not classify".
+const SENTINEL_NEIGHBOURS: [i64; 2] = [i64::MIN + 1, i64::MAX - 1];
+
+fn cds_with_offset(offset: i64) -> CdsPos {
+    CdsPos {
+        base: 100,
+        offset: Some(offset),
+        utr3: false,
+        special: None,
+    }
+}
+
+fn tx_with_offset(offset: i64) -> TxPos {
+    TxPos {
+        base: 100,
+        offset: Some(offset),
+        downstream: false,
+    }
+}
+
+/// `IntronicRegion::from_offset` declines a sentinel, and only a sentinel.
+#[test]
+fn intronic_region_from_offset_declines_exactly_the_sentinels() {
+    for offset in SENTINELS {
+        assert_eq!(
+            IntronicRegion::from_offset(offset),
+            None,
+            "every variant of IntronicRegion names a distance band, and an \
+             unknown offset ({offset}) supports none of them"
+        );
+    }
+
+    for offset in SENTINEL_NEIGHBOURS {
+        assert_eq!(
+            IntronicRegion::from_offset(offset),
+            Some(IntronicRegion::DeepIntronic),
+            "{offset} is a measured distance, not a sentinel — the decline must \
+             not widen into a magnitude test"
+        );
+    }
+}
+
+/// The two `Option`-returning constructors that already declined must keep
+/// declining now that the rule lives in `from_offset` rather than in a guard of
+/// their own. This is the discriminating test for the refactor: collapsing the
+/// duplicated `has_unknown_offset()` screens is only safe if the behaviour they
+/// provided survives, on both axes.
+#[test]
+fn the_position_constructors_still_decline_after_the_screens_were_collapsed() {
+    for offset in SENTINELS {
+        assert_eq!(IntronicRegion::from_cds_pos(&cds_with_offset(offset)), None);
+        assert_eq!(IntronicRegion::from_tx_pos(&tx_with_offset(offset)), None);
+    }
+
+    for offset in SENTINEL_NEIGHBOURS {
+        assert_eq!(
+            IntronicRegion::from_cds_pos(&cds_with_offset(offset)),
+            Some(IntronicRegion::DeepIntronic),
+        );
+        assert_eq!(
+            IntronicRegion::from_tx_pos(&tx_with_offset(offset)),
+            Some(IntronicRegion::DeepIntronic),
+        );
+    }
+
+    // A non-intronic position has no offset at all, which is a different reason
+    // to answer `None` and must not have been folded into the sentinel one.
+    let exonic = CdsPos {
+        base: 100,
+        offset: None,
+        utr3: false,
+        special: None,
+    };
+    assert_eq!(IntronicRegion::from_cds_pos(&exonic), None);
+}
+
+/// `classify_splice_variant` declines a sentinel, and only a sentinel.
+#[test]
+fn classify_splice_variant_declines_exactly_the_sentinels() {
+    let predictor = EffectPredictor::new();
+
+    for offset in SENTINELS {
+        assert!(
+            predictor.classify_splice_variant(offset).is_none(),
+            "an unknown offset ({offset}) states no distance, so there is \
+             nothing to classify"
+        );
+    }
+
+    for offset in SENTINEL_NEIGHBOURS {
+        let effect = predictor
+            .classify_splice_variant(offset)
+            .unwrap_or_else(|| panic!("{offset} is a measured distance and must classify"));
+        assert_eq!(
+            effect.consequences,
+            vec![Consequence::IntronVariant],
+            "{offset} is far from any boundary"
+        );
+        assert_eq!(effect.impact, Impact::Modifier);
+        assert_eq!(effect.intronic_offset, Some(offset));
+    }
+}
+
+/// Every ordinary rung still answers. Without this the change could be read as
+/// "the classifier declines more often than it used to" in general, when it
+/// declines on exactly one input class.
+#[test]
+fn every_measured_rung_still_classifies() {
+    let predictor = EffectPredictor::new();
+    for offset in [-2, -1, 1, 2, 5, -8, 9, 50, -1_000] {
+        assert!(
+            predictor.classify_splice_variant(offset).is_some(),
+            "offset {offset} is measured and must still classify"
+        );
+        assert!(
+            IntronicRegion::from_offset(offset).is_some(),
+            "offset {offset} is measured and must still classify"
+        );
+    }
+}
+
+/// The reachability half: the sentinel these functions decline is one a *parsed
+/// description* actually carries. Asserted against the AST rather than a
+/// rendered round-trip, so nothing here depends on how `-?` is printed.
+///
+/// Both spellings are exercised. `+?` is the half a fix keyed on `i64::MIN`
+/// alone would leave answering by accident, which is #1767's own warning and
+/// the reason `SENTINELS` exists.
+#[test]
+fn a_parsed_unknown_offset_reaches_the_classifiers_as_a_sentinel() {
+    let predictor = EffectPredictor::new();
+
+    for (description, expected) in [
+        ("NM_000088.3:c.100-?del", OFFSET_UNKNOWN_NEGATIVE),
+        ("NM_000088.3:c.100+?del", OFFSET_UNKNOWN_POSITIVE),
+    ] {
+        let parsed = parse_hgvs(description).expect("an unknown offset is legal HGVS");
+        let HgvsVariant::Cds(cv) = &parsed else {
+            panic!("expected a c. variant from {description}, got {parsed:?}");
+        };
+        let offset = cv
+            .loc_edit
+            .location
+            .start
+            .inner()
+            .expect("a certain start position")
+            .offset
+            .expect("an unknown offset is still an intronic offset");
+
+        assert_eq!(
+            offset, expected,
+            "the premise of both declines is that the parser hands {description}'s \
+             sentinel on unchanged"
+        );
+
+        assert!(predictor.classify_splice_variant(offset).is_none());
+        assert_eq!(IntronicRegion::from_offset(offset), None);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The CLI surface — the one shipped output this change actually moves
+// ---------------------------------------------------------------------------
+//
+// The library half above pins a *contract*; `ferro effect` is the only place a
+// user sees the change, and it was evidenced only by a before/after table in the
+// PR description. A table is a measurement: it does not survive the merge and it
+// cannot fail. These four turn each row of it into a guard, using the spawned-
+// binary idiom the repo already runs in twenty `tests/it/cli_*.rs` files.
+//
+// The CLI path instruction treats stdout as an API, so each assertion names the
+// stream it is about: the refusal is on **stderr**, stdout stays clean, and the
+// batch loop keeps writing.
+
+/// The `ferro` binary this test crate was built alongside.
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+/// `ferro effect` refuses an unknown intronic offset rather than predicting one.
+///
+/// Both spellings, for the same reason `SENTINELS` has two entries: a change
+/// keyed on `i64::MIN` alone leaves `+?` answering by accident.
+#[test]
+fn the_effect_cli_refuses_an_unknown_intronic_offset() {
+    for description in ["NM_000088.3:c.100-?del", "NM_000088.3:c.100+?del"] {
+        let out = ferro()
+            .args(["effect", description])
+            .output()
+            .expect("the ferro binary runs");
+
+        assert!(
+            !out.status.success(),
+            "{description} must exit non-zero — before #1841 it printed \
+             `intron_variant (MODIFIER)` and exited 0"
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.trim().is_empty(),
+            "a refusal must put nothing on stdout, which a pipeline parses: {stdout}"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("unknown intronic offset"),
+            "the refusal must say why, on stderr: {stderr}"
+        );
+    }
+}
+
+/// The neighbour control. Without it every assertion above is satisfied by a
+/// `ferro effect` that refuses *everything*, which is the failure mode a
+/// decline-shaped change actually has.
+#[test]
+fn the_effect_cli_still_answers_a_measured_offset() {
+    for (description, expected) in [
+        ("NM_000088.3:c.100-2del", "splice_acceptor_variant"),
+        ("NM_000088.3:c.100del", "coding_sequence_variant"),
+    ] {
+        let out = ferro()
+            .args(["effect", description])
+            .output()
+            .expect("the ferro binary runs");
+
+        assert!(
+            out.status.success(),
+            "{description} states a distance and must still be answered; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains(expected),
+            "{description} must still report {expected}: {stdout}"
+        );
+    }
+}
+
+/// Under `-f json` a declined row emits **no JSON object at all**, rather than
+/// an object carrying a fabricated consequence.
+///
+/// Pinned because it is the consumer-visible half of the refusal and the one a
+/// reader of the code would not predict: a pipeline reading JSON lines gets one
+/// fewer line than it sent, and learns which one only from stderr.
+#[test]
+fn the_effect_cli_emits_no_json_object_for_a_declined_row() {
+    let out = ferro()
+        .args(["effect", "NM_000088.3:c.100-?del", "--format", "json"])
+        .output()
+        .expect("the ferro binary runs");
+
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains('{'),
+        "a declined row must not emit a partial or fabricated JSON object: {stdout}"
+    );
+}
+
+/// Batch mode does not regress into #1764: one declining line is reported on
+/// stderr and the stream continues.
+///
+/// The PR that took this break verified it *by reading both loops*. Reading is
+/// not a guard — this is, and it is cheap: the declining line is placed first so
+/// a truncating implementation cannot pass by accident.
+#[test]
+fn the_effect_cli_batch_mode_does_not_truncate_on_a_declining_line() {
+    let mut input = tempfile::Builder::new()
+        .suffix(".txt")
+        .tempfile()
+        .expect("a temp input file");
+    writeln!(input, "NM_000088.3:c.100-?del").unwrap();
+    writeln!(input, "NM_000088.3:c.100-2del").unwrap();
+    input.flush().unwrap();
+
+    let out = ferro()
+        .args([
+            "effect",
+            "--input",
+            input.path().to_str().expect("a utf-8 temp path"),
+        ])
+        .output()
+        .expect("the ferro binary runs");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("splice_acceptor_variant"),
+        "the line AFTER the declining one must still be answered — a truncated \
+         stream is the #1764 failure mode: stdout {stdout}, stderr {stderr}"
+    );
+    assert!(
+        stderr.contains("ERROR:") && stderr.contains("unknown intronic offset"),
+        "the declining line must be reported on stderr rather than dropped: {stderr}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -32,6 +32,7 @@ mod issue_1715_rna_alignment_symbol_reach;
 mod issue_1748_noncoding_axis_zones;
 mod issue_1764_hgvs_to_vcf_continues;
 mod issue_1767_unknown_offset_splice_classifiers;
+mod issue_1841_option_returning_splice_classifiers;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;

--- a/tests/python/test_issue_1841_splice_classifier_decline.py
+++ b/tests/python/test_issue_1841_splice_classifier_decline.py
@@ -1,0 +1,84 @@
+"""Issue #1841: ``EffectPredictor.classify_splice_variant`` returns ``None`` for an unknown offset.
+
+``c.<base>-?`` / ``c.<base>+?`` are legal HGVS: they say the position is
+intronic and decline to say how far from the boundary it sits. The parser
+carries that as a sentinel — ``-2**63`` and ``2**63 - 1`` — and the classifier's
+whole input is a distance, so there is nothing for it to classify.
+
+Before #1806 this was a live defect: the sentinel's ``.abs()`` wrapped negative
+in release, passed the ``<= 2`` rung, and the position was reported as a
+canonical splice site with **HIGH** impact. #1806 fixed the answer to
+``intron_variant``/MODIFIER, which is true, and recorded that the honest answer
+was out of reach because the return type could not decline. #1841 took that
+break: the Rust function returns ``Option<ProteinEffect>``, so the Python method
+returns ``ProteinEffect | None``.
+
+**This is a breaking change to the Python surface.** A caller that reads
+``.consequences`` off the result unconditionally now raises ``AttributeError``
+on these two inputs, where it previously read ``intron_variant``.
+
+There were no Python tests for this method at all before this file, in either
+direction, which is why the sentinel neighbours below are pinned as well as the
+sentinels themselves: a decline keyed on "a very large magnitude" rather than on
+the sentinel would satisfy the first two assertions and be wrong.
+"""
+
+import pytest
+
+import ferro_hgvs
+
+#: How the parser spells an unknown intronic offset, per
+#: ``ferro_hgvs::hgvs::parser::position``.
+OFFSET_UNKNOWN_NEGATIVE = -(2**63)
+OFFSET_UNKNOWN_POSITIVE = 2**63 - 1
+
+SENTINELS = [OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE]
+
+#: Ordinary magnitudes that merely sit next to the sentinels. They are not
+#: sentinels, so they must still classify.
+SENTINEL_NEIGHBOURS = [OFFSET_UNKNOWN_NEGATIVE + 1, OFFSET_UNKNOWN_POSITIVE - 1]
+
+
+@pytest.fixture
+def predictor() -> ferro_hgvs.EffectPredictor:
+    """A predictor; it holds no reference and no state."""
+    return ferro_hgvs.EffectPredictor()
+
+
+@pytest.mark.parametrize("offset", SENTINELS)
+def test_an_unknown_offset_returns_none(predictor: ferro_hgvs.EffectPredictor, offset: int) -> None:
+    """The break itself: no answer is expressed as ``None``, not as a weak answer."""
+    assert predictor.classify_splice_variant(offset) is None
+
+
+@pytest.mark.parametrize("offset", SENTINEL_NEIGHBOURS)
+def test_a_sentinel_neighbour_still_classifies(
+    predictor: ferro_hgvs.EffectPredictor, offset: int
+) -> None:
+    """The discriminating case: the decline is keyed on the sentinel, not on magnitude."""
+    effect = predictor.classify_splice_variant(offset)
+    assert effect is not None
+    assert effect.consequences == [ferro_hgvs.Consequence.IntronVariant]
+    assert effect.impact == ferro_hgvs.Impact.Modifier
+
+
+@pytest.mark.parametrize(
+    ("offset", "consequence", "impact"),
+    [
+        (1, ferro_hgvs.Consequence.SpliceDonorVariant, ferro_hgvs.Impact.High),
+        (-2, ferro_hgvs.Consequence.SpliceAcceptorVariant, ferro_hgvs.Impact.High),
+        (5, ferro_hgvs.Consequence.SpliceRegionVariant, ferro_hgvs.Impact.Low),
+        (50, ferro_hgvs.Consequence.IntronVariant, ferro_hgvs.Impact.Modifier),
+    ],
+)
+def test_a_measured_offset_still_classifies(
+    predictor: ferro_hgvs.EffectPredictor,
+    offset: int,
+    consequence: "ferro_hgvs.Consequence",
+    impact: "ferro_hgvs.Impact",
+) -> None:
+    """Every ordinary rung is unchanged — only the sentinel class moved."""
+    effect = predictor.classify_splice_variant(offset)
+    assert effect is not None
+    assert effect.consequences == [consequence]
+    assert effect.impact == impact


### PR DESCRIPTION
Closes #1841.

Merged PR #1806 settled #1767 by teaching every reachable splice classifier about the unknown-offset sentinels, and deliberately left two functions with their signatures under "Deliberately left open — needs an API call this PR should not make". The operator approved taking that break. This is it.

```rust
-pub fn from_offset(offset: i64) -> Self                                  // IntronicRegion
+pub fn from_offset(offset: i64) -> Option<Self>

-pub fn classify_splice_variant(&self, offset: i64) -> ProteinEffect      // EffectPredictor
+pub fn classify_splice_variant(&self, offset: i64) -> Option<ProteinEffect>
```

## Semver — deliberately breaking, and typed as such

Both functions are `pub` on a published crate (0.13.1), and `classify_splice_variant` additionally has a PyO3 binding, so the Python method's return type moves from `ProteinEffect` to `ProteinEffect | None`. A Python caller reading `.consequences` off the result unconditionally now raises `AttributeError` on `+?` / `-?`.

Typed `refactor(effect)!:`, with the `!` **in the PR title as well as the commit subject** — squash-merge builds the commit from the title, and that is what release-plz reads. `release-plz.toml`'s own comment states the rule this relies on: for a 0.x crate release-plz reserves the minor bump for breaking changes, so the marker is what moves this to 0.14.0 rather than 0.13.2, and git-cliff renders it with the `[**breaking**]` marker. `fix(error-handling)!` (#1674), `fix(spdi)!` (#1363) and `refactor!` (#1168) are the precedents for the form; like all six landed `!` commits, this one hand-edits no changelog — `CONTRIBUTING.md` is explicit that `CHANGELOG.md` is generated by release-plz and must not be edited in a feature PR.

## Why `Option` is the correct answer

`-?` and `+?` are legal HGVS. They say the position is intronic and decline to say how far from the boundary it sits, and the parser carries that as `i64::MIN` / `i64::MAX`.

- **`IntronicRegion`** has four variants and every one of them names a **distance band**. A sentinel supports none of them. Before this change a sentinel landed in `DeepIntronic`, and the function's own doc comment said so in as many words — "a distance claim its input does not support".
- **`classify_splice_variant`** answered `IntronVariant` / `Modifier`, which #1806 chose as "the weakest true statement available" *given a signature that could not decline*. It is true, and it still reads as a positive classification to a caller matching on the consequence.

The rule itself is not new: `CdsPos::has_unknown_offset`'s doc comment carries a MUST from #1087 — the sentinels denote a position unbounded in one direction, so no coordinate can be derived from them at all — and `IntronicConsequence::from_{cds,tx}_pos`, `IntronicRegion::from_{cds,tx}_pos` and both validators already decline on it. This applies that existing contract to the two entry points whose return type was in the way.

## Not a live defect — this is API honesty

Stated plainly so it is not re-triaged as a crash:

- `IntronicRegion::from_offset`'s two in-repo callers screened before reaching it, so no sentinel reached it from inside this repo. A **direct external caller** got `DeepIntronic`.
- `classify_splice_variant` *is* reachable with a sentinel from `ferro effect`, and its answer was true.
- Neither is on the web-service path — `predict_cds_effect` has its own screen and calls neither. The panic and the `splice_site_variant`/HIGH release answer #1767 was filed for are both fixed and are not what this changes.

## Call sites

| symbol | sites | what changed |
|---|---|---|
| `IntronicRegion::from_offset` | `from_cds_pos`, `from_tx_pos` | `.map` → `.and_then`; their own `has_unknown_offset()` screens are **collapsed into `from_offset`**, so the rule has one site rather than three |
| | 6 in its own unit-test module | wrapped in `Some(...)` |
| `classify_splice_variant` | `src/bin/ferro.rs` (the only real caller) | new `None` arm, below |
| | `src/python.rs` PyO3 binding | `-> Option<PyProteinEffect>`, plus `python/ferro_hgvs/__init__.pyi` |
| | 4 in `src/effect/mod.rs`'s unit tests, 6 in `tests/it/issue_1767_*` | `.expect` / rewritten |

## The one behaviour change, measured on both sides

`ferro effect` is the only shipped surface whose output moves. Measured in this worktree, `origin/main` `5bf0b4ff` against the branch, same binary path, same inputs:

| input | before | after |
|---|---|---|
| `NM_000088.3:c.100-?del` | `intron_variant (MODIFIER)`, exit **0** | `Error: "Cannot predict an effect for an unknown intronic offset …"`, exit **1** |
| `NM_000088.3:c.100-2del` | `splice_acceptor_variant (HIGH)`, exit 0 | **unchanged** |
| `NM_000088.3:c.100del` | `coding_sequence_variant (MODIFIER)`, exit 0 | **unchanged** |

The refusal matches `run_effect`'s existing unsupported-type arm rather than inventing an exit status. Under `-f json` the single-variant path now emits no JSON object at all for that input, which is stated in the code comment because a pipeline consumer sees it.

**Batch mode does not regress into #1764.** `--input` and stdin already catch a per-line `Err`, report it to **stderr** as `ERROR: <line> - <e>` and continue, so one declining line does not truncate the stream. Verified by reading both loops, not assumed.

## Tests

New: `tests/it/issue_1841_option_returning_splice_classifiers.rs` (5 tests, registered in `tests/it/main.rs`), `tests/python/test_issue_1841_splice_classifier_decline.py` (8 tests), plus a unit test beside each changed function.

**The discriminating case in every one of them is `i64::MIN + 1` / `i64::MAX - 1`.** Those are not sentinels, so they must still classify as `DeepIntronic` / `IntronVariant`. A decline keyed on "a very large magnitude" rather than on the sentinel passes every assertion that only looks at `i64::MIN` and `i64::MAX` — and that is exactly the gap #1765 records one layer up.

**Sabotage-checked rather than assumed.** With the two `is_unknown_offset` early-returns neutered (`if false && …`), the targeted selection goes `24 passed` → **`16 passed, 8 failed`**, `EXIT=100`. The 8 include `issue_1767_…::intronic_region_declines_an_unknown_offset`, which is what proves the collapsed `has_unknown_offset()` screens were genuinely load-bearing on the new path and not merely redundant.

There were **no** Python tests for `classify_splice_variant` before this PR in either direction, so the binding's behaviour on a sentinel was unpinned; the 8 new ones close that, per the `src/python.rs` path instruction that behaviour reachable from Python needs a test under `tests/python/`.

## Unchanged on purpose

- **`IvsPos::is_deep_intronic` / `is_canonical_splice_site` and `IntronPosition`'s predicates still require the caller to screen.** They return `bool`, which has no way to say "no answer" — pushing the rule in would only move the fabricated answer from `DeepIntronic` to `false`. Their doc comment cross-referenced `from_offset` as an *analogy* ("as with … this reads a measured distance"), which this change falsified; it is rewritten to name the divergence and why. That is the only edit under `src/hgvs/`.
- **`IntronicConsequence` still screens in its position constructors**, not in a scalar entry point, because it exposes no public `from_offset` to move the rule into. Noted in the code so the asymmetry is not "cleaned up" later.
- **`ferro effect`'s batch mode exits 0 even when every line errored.** That is the #1764 shape in a different subcommand, it is pre-existing for every already-failing input class, and fixing it is not part of an approved API break. Recorded here rather than swept in.

## Review

`/coderabbitai-review` on the local diff, `profile: assertive`, walked against the six matching `path_instructions`. Applied: the falsified `IvsPos` cross-reference (outside the diff); `+?` added to the reachability test, which covered only `-?` against a file whose whole discipline is sentinel symmetry; consequence/impact assertions added to the neighbour cases in both the Rust and Python guards; the CLI comment extended to name the JSON and batch-mode consumers. Rejected: *"batch `ferro effect` should count failures and exit non-zero"* — real, pre-existing, and out of scope, so it is disclosed above instead; *"release the GIL"* on the PyO3 binding — the call is O(1) integer arithmetic; *"a panic can cross the FFI boundary"* — the added `expect`s are all in test code, and `Option` mapping introduces none.

## Verification

Every exit code read back from its own uniquely-named log rather than from a completion notification.

| command | exit |
|---|---|
| `cargo fmt --all --check` | `0` |
| `cargo clippy --all-features --all-targets -- -D warnings` | `0` |
| `cargo clippy --features dev --all-targets -- -D warnings` | `0` |
| `cargo check --features python` | `0` |
| `cargo doc --no-deps --features dev` | `0` — no warning from the new intra-doc links |
| `FERRO_SWEEP_SEEDS=full cargo ta` | `0` — **10621 run, 10621 passed**, 152 skipped, 0 FAIL |
| `scripts/run_oracle_suite.sh` | `0` — **10484 run, 10484 passed**, 289 skipped, 0 FAIL |
| `cargo test --doc --features dev` | `0` — 97 passed, 9 ignored (covers the new `classify_splice_variant` example) |
| `ruff check` / `ruff format --check` `python/ tests/python/` | `0` / `0` |
| `mypy python/ferro_hgvs/` | `0` |
| `pytest tests/python/` (against a `maturin develop --features python` build) | `0` — **905 passed**, 8 skipped |
| `scripts/check_representation_change.py` over the real changed-file list | `0` |

The oracle suite was run through `scripts/run_oracle_suite.sh` rather than as a bare armed run. That script reads its selection and flag set straight out of `ci.yml`, so it mirrors the `test-oracle` job including its `ORACLE_EXCLUDE` negation; a bare `FERRO_ASSERT_IDEMPOTENT=1` full-suite run is red on a clean `origin/main` for reasons that have nothing to do with this diff, so it would have said nothing.

Representation-Change: none. Nothing here renders an HGVS description — both functions classify a *consequence* from an integer offset, and the one edit under a watched directory (`src/hgvs/location.rs`) is a doc comment. `c.100-?` still parses and still renders as `c.100-?`, pinned by `a_parsed_unknown_offset_reaches_the_classifiers_as_a_sentinel`.

Related: #1826 asks the same question in wider terms as its item 2, and is not resolved by this PR — its item 1 was already addressed in #1806, and it should be reviewed separately for whatever it still holds.
