### PR TITLE
fix(project): stop renaming the n. axis onto an LRG transcript with a different frame

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1606,9 +1606,46 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 // The rna axis can be an allele needing apply_rna_framing-style
                 // recursion; no #860 corpus row exercises rna under an LRG parent,
                 // so it is intentionally out of scope here.
-                for field in [&mut result.coding, &mut result.noncoding] {
-                    if let Some(v) = field.as_mut() {
+                if let Some(v) = result.coding.as_mut() {
+                    Self::set_bare_accession(v, lrg_tx_acc.clone());
+                }
+                // The `n.` axis is the only one whose numbers are stated in the
+                // transcript's *own* frame, so it is the only one this rename can
+                // misplace (#1712). `c.` is CDS-relative and `p.` is
+                // residue-relative, and both survive a differing 5'UTR length; a
+                // transcript coordinate does not.
+                //
+                // Measured: `LRG_24t1` is 1191 bases with `cds_start = 127` while
+                // the `NM_001114101.3` it resolves to is 1181 with
+                // `cds_start = 119` — an eight-base 5' extension. Renaming the
+                // accession while keeping the number turned
+                // `NM_001114101.3:n.245_252del` (which deletes `GGGGCACC`) into
+                // `LRG_24t1:n.245_252del`, which on the LRG transcript's own bases
+                // deletes `GCCTGCCC`. That is a wrong denotation, not a spelling
+                // choice, and the non-idempotency #1712 measured
+                // (`n.245_252del` -> `n.246_253del`) was only its symptom.
+                //
+                // So rename only when the two sequences are byte-identical, which
+                // is the precondition under which a transcript coordinate carries
+                // over unchanged. Otherwise leave the axis on its resolved
+                // transcript accession — still framed under the LRG parent by
+                // `relabel_under_parent` above, rendering
+                // `LRG_24(NM_001114101.3):n.245_252del`, which is the shape the
+                // other LRG-parented `n.` rows already take.
+                //
+                // Declining is deliberate rather than re-deriving the coordinate:
+                // `LRG_24t2` has no `cds_start` at all in the prepared reference
+                // (and is 1139 bases against `NM_172369.5`'s 1158), so there is no
+                // CDS anchor to reframe through and any offset would be invented.
+                if let Some(v) = result.noncoding.as_mut() {
+                    if self.shares_transcript_frame(&lrg_tx, v) {
                         Self::set_bare_accession(v, lrg_tx_acc.clone());
+                    } else {
+                        log::trace!(
+                            "frame_projection_owned: {lrg_tx} does not share a transcript \
+                             coordinate frame with the resolved transcript; keeping the \
+                             resolved accession on the n. axis rather than renaming it (#1712)"
+                        );
                     }
                 }
                 if let (Some(protein), Some(lrg_p)) =
@@ -1656,6 +1693,52 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             }
         }
         result
+    }
+
+    /// Whether `candidate` serves byte-identical bases to the transcript `axis`
+    /// currently names — i.e. whether an `n.` coordinate carries from one
+    /// accession to the other unchanged (#1712).
+    ///
+    /// Used to gate the #860 LRG namespace echo on the `n.` axis. Sequence
+    /// equality is the honest predicate: a transcript coordinate is an offset
+    /// into the served bases, so two records share a frame exactly when those
+    /// bases agree. Comparing `(cds_start, len)` instead would be a proxy that
+    /// two same-length records with different bases would pass.
+    ///
+    /// Returns `false` when either sequence is unavailable — an unverifiable
+    /// frame must not be treated as a matching one, since the cost of the wrong
+    /// answer is a description that denotes different bases.
+    ///
+    /// The two fetches deliberately do **not** go through
+    /// [`Self::cached_get_transcript_for_variant`]: that cache resolves a record
+    /// *for a variant* (`get_transcript_for_variant`, with a parent-scoped key),
+    /// which is a different question from "what does this accession serve", and
+    /// there is no variant at all for the LRG candidate. They therefore do not
+    /// collapse the way `projection::transcript_cache_collapses_repeat_lookups`
+    /// pins for the protein-prediction path. That is affordable because the call
+    /// is reached only under a bare `LRG_` parent, and `str` equality compares
+    /// lengths first, so a differing record costs no byte scan.
+    fn shares_transcript_frame(&self, candidate: &str, axis: &HgvsVariant) -> bool {
+        let Some(resolved) = axis.accession().map(|a| a.transcript_accession()) else {
+            return false;
+        };
+        // Defensive on today's routes — `lrg_transcript_for_parent` maps an
+        // `NM_`/`NR_` to an `LRG_`, so the two never match here. Kept so a caller
+        // that hands over an already-LRG-named axis is a no-op rather than two
+        // provider fetches that compare a record against itself.
+        if resolved == candidate {
+            return true;
+        }
+        let (Ok(a), Ok(b)) = (
+            self.provider.get_transcript(candidate),
+            self.provider.get_transcript(&resolved),
+        ) else {
+            return false;
+        };
+        match (a.sequence.as_deref(), b.sequence.as_deref()) {
+            (Some(x), Some(y)) => x == y,
+            _ => false,
+        }
     }
 
     /// Return a clone of `variant` whose top-level accession carries `parent` as
@@ -4611,6 +4694,30 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     ///
     /// Returns `(axis, decline_reason)`; the reason is `None` whenever the axis
     /// is `Some`.
+    ///
+    /// # The axis is NOT re-normalized on its own reference (#1712)
+    ///
+    /// The coordinates reframe and the `c.` form's edit is cloned verbatim, so
+    /// the `n.` axis inherits whatever canonical form the *coding* frame settled
+    /// on — including forms the coding frame chose because it has a reading
+    /// frame and `n.` does not. Bare normalization of the resulting `n.` string
+    /// therefore rewrites 61 of the 681 projected axes measured against the
+    /// prepared GRCh38 reference (`c.3305_3306del` -> `n.3709_3710del`, which
+    /// normalizes on to `n.3708_3710T[1]`).
+    ///
+    /// Read that 61 off `NONCODING_NON_IDEMPOTENT` rather than from here — it
+    /// tracks the shipped `FERRO_PARTITION` default, and #1835 moved it from 21
+    /// to 62 by making `canonical-coalesced` that default; this branch takes it
+    /// to 61.
+    ///
+    /// Adding a `normalize` here closes all 61 and is the obvious symmetry with
+    /// the genomic axis ([`Self::normalize_or_fallback`], #737) — but it is
+    /// **not** a free correction. Which of the projector and the normalizer is
+    /// the wrong side of the `n.`-versus-`c.` disagreement is a question the
+    /// decided record `projection-codon-exception-is-decided-by-the-rendered-axis`
+    /// declines to reach: its scope paragraph names the `n.` axis and rules only
+    /// on the genomic one. See the residue pinned by `axis_noncoding_idempotent`
+    /// and #1712.
     fn noncoding_axis_with_reason(
         &self,
         normalized: &HgvsVariant,
@@ -10462,6 +10569,125 @@ mod tests {
             assert!(
                 framed.protein.unwrap().to_string().starts_with("LRG_24p1:"),
                 "protein should render bare LRG_24p1"
+            );
+        }
+
+        /// #1712: the #860 namespace echo may only rename the `n.` axis when the
+        /// LRG transcript and the resolved transcript serve the same bases.
+        ///
+        /// `c.` is CDS-relative and `p.` is residue-relative, so a differing
+        /// 5'UTR length leaves both alone. A transcript coordinate is an offset
+        /// into the served sequence, so the same difference silently moves the
+        /// `n.` axis onto other bases — which is what
+        /// `LRG_24t1:n.245_252del` was, against the real reference where
+        /// `LRG_24t1` carries eight extra 5' bases.
+        ///
+        /// The first two arms are the discriminating pair: identical sequences
+        /// must still rename (or the fix would be a blanket refusal that quietly
+        /// retires #860 for this axis), differing ones must not.
+        ///
+        /// The third arm pins the *unverifiable* case, which
+        /// [`Self::shares_transcript_frame`] documents and which neither of the
+        /// other two reaches: a provider that resolves the `LRG_<n>t<k>` record
+        /// but serves no bases for it. It declines, like a differing sequence —
+        /// an unverifiable frame must not be treated as a matching one. It is
+        /// pinned rather than left implicit because it is the arm with the
+        /// widest blast radius: a provider that carries no transcript sequences
+        /// at all would lose the #860 `n.`-axis echo for *every* row, and the
+        /// only report of that is a `log::trace!`.
+        ///
+        /// Deliberately a unit test rather than one of the `tests/it/projection*`
+        /// suites the repo normally asks projection changes to land in. This
+        /// isolates `frame_projection_owned` by handing it a `VariantProjection`
+        /// directly; routing the same case through `project_variant_all` would
+        /// measure transcript enumeration and the reference's own LRG records
+        /// instead of the rename gate. It is also the coverage that actually runs
+        /// on PR CI — the reference-aware sibling
+        /// (`mutalyzer_normalize_tests::lrg_noncoding_axis_names_the_transcript_it_was_measured_against`)
+        /// needs `FERRO_MANIFEST` and only executes in the nightly job.
+        #[test]
+        fn frame_projection_owned_renames_the_noncoding_axis_only_on_a_shared_frame() {
+            fn tx(id: &str, sequence: &str) -> Transcript {
+                Transcript {
+                    id: id.to_string(),
+                    sequence: Some(sequence.to_string()),
+                    cds_start: Some(1),
+                    cds_end: Some(sequence.len() as u64),
+                    exons: vec![Exon::new(1, 1, sequence.len() as u64)],
+                    ..Default::default()
+                }
+            }
+            /// The same record with no served bases — the LRG transcript is
+            /// resolvable but its frame is unverifiable.
+            fn tx_without_sequence(id: &str, len: u64) -> Transcript {
+                Transcript {
+                    id: id.to_string(),
+                    sequence: None,
+                    cds_start: Some(1),
+                    cds_end: Some(len),
+                    exons: vec![Exon::new(1, 1, len)],
+                    ..Default::default()
+                }
+            }
+            fn framed_noncoding(lrg: Transcript) -> String {
+                let mut cdot = CdotMapper::new();
+                cdot.insert_lrg_mapping("LRG_24t1".to_string(), "NM_001114101.1".to_string());
+                let mut provider = MockProvider::new();
+                provider.add_transcript(tx("NM_001114101.3", "ACGTACGTACGT"));
+                provider.add_transcript(lrg);
+                let vp = VariantProjector::new(Projector::new(cdot), provider);
+
+                let noncoding = HgvsVariant::Tx(TxVariant {
+                    accession: parse_accession("NM_001114101.3"),
+                    gene_symbol: None,
+                    loc_edit: LocEdit::new(
+                        TxInterval::point(TxPos::new(5)),
+                        NaEdit::Substitution {
+                            reference: Base::A,
+                            alternative: Base::G,
+                        },
+                    ),
+                });
+                let proj = VariantProjection {
+                    normalization_warnings: Vec::new(),
+                    axis_decline_reasons: AxisDeclineReasons::default(),
+                    genomic: None,
+                    coding: None,
+                    noncoding: Some(noncoding),
+                    protein: None,
+                    rna: None,
+                    transcript_id: "NM_001114101.3".to_string(),
+                    gene_symbol: None,
+                    is_frameshift: false,
+                    is_intronic: false,
+                    is_utr: false,
+                    affects_init: false,
+                };
+                vp.frame_projection_owned(proj, &parse_accession("LRG_24"), None)
+                    .noncoding
+                    .expect("noncoding axis retained")
+                    .to_string()
+            }
+
+            assert_eq!(
+                framed_noncoding(tx("LRG_24t1", "ACGTACGTACGT")),
+                "LRG_24t1:n.5A>G",
+                "identical sequences share a transcript frame, so the #860 \
+                 namespace echo still applies"
+            );
+            assert_eq!(
+                framed_noncoding(tx("LRG_24t1", "TTTTTTTTACGTACGTACGT")),
+                "LRG_24(NM_001114101.3):n.5A>G",
+                "an eight-base 5' extension means n.5 names a different base on \
+                 each accession, so the axis must keep the transcript it was \
+                 measured against"
+            );
+            assert_eq!(
+                framed_noncoding(tx_without_sequence("LRG_24t1", 12)),
+                "LRG_24(NM_001114101.3):n.5A>G",
+                "the LRG record resolves but serves no bases, so the frame is \
+                 unverifiable and must not be treated as a matching one — even \
+                 though every other field (length, cds_start, exons) agrees"
             );
         }
 

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -4706,7 +4706,7 @@ fn axis_noncoding_idempotent() {
     // fewer means something was fixed and this pin went stale without anyone
     // noticing, which is how a partial fix comes to read as a complete one.
     //
-    // The 62 fall into three shapes, and they are not equally serious:
+    // The residue falls into two shapes, and they are not equally serious:
     //
     // * 16 re-render as a repeat — `n.3709_3710del` -> `n.3708_3710T[1]`,
     //   `n.36_37insGCGCGC` -> `n.33_36GC[5]`. Tract maximization runs on the
@@ -4714,11 +4714,14 @@ fn axis_noncoding_idempotent() {
     // * 45 re-partition into members — `n.309delinsCTGA` ->
     //   `n.[308_309insCT;310dup]`, from cross-reference `delins` inputs (the
     //   #422 family).
-    // * 1 is NOT 3'-shifted, asserted separately below.
     //
     // The residue moved UP, 21 -> 62, and the whole of that movement is in the
     // second shape: 16 + 4 + 1 became 16 + 45 + 1. The repeat shape and the
-    // non-3'-shifted row are byte-for-byte what they were.
+    // non-3'-shifted row were byte-for-byte what they were. **This branch then
+    // removes the third shape**: the one non-3'-shifted row was the LRG one,
+    // closed by the transcript-frame guard in `frame_projection_owned`, so the
+    // breakdown is now 16 + 45 + 0 and its absence is asserted separately
+    // below.
     //
     // WHAT THIS IS AND IS NOT. The cause is this PR making `canonical-coalesced`
     // the shipped rule, so more blocks are re-partitioned into members — and the
@@ -4736,6 +4739,18 @@ fn axis_noncoding_idempotent() {
     // making the members non-canonical — that would contradict the direction
     // scope above. The fix is for the projection to derive what a second
     // normalization would.
+    //
+    // Both surviving shapes are also the `n.` axis inheriting a form the
+    // *coding* frame chose because it declares a reading frame and `n.` does
+    // not, so re-deriving on the `n.` reference disagrees. Closing them means
+    // settling which of the projector and the normalizer is the wrong side of
+    // that, and the decided record
+    // `projection-codon-exception-is-decided-by-the-rendered-axis` states that
+    // it does not reach the `n.` axis — its scope paragraph names that axis and
+    // declines to rule on it. Measured: adding a `normalize` to
+    // `noncoding_axis_with_reason` takes this count to zero, and turns three
+    // committed guards red, each of which pins today's answer to that same
+    // question. So the count stays here until it is ruled on.
     assert_eq!(
         failures.len(),
         NONCODING_NON_IDEMPOTENT,
@@ -4744,40 +4759,141 @@ fn axis_noncoding_idempotent() {
         failures.join("\n")
     );
 
-    // Called out by name because it is the only one of the 21 that is a rule 2
-    // miss rather than a re-spelling: the output is simply not 3'-shifted, on a
-    // user-facing axis, and README rule 2 names the 3' rule in its own scope.
-    // Buried inside the aggregate it would survive a fix to the other twenty
-    // without anyone noticing it had.
+    // The non-3'-shifted row is gone, and this asserts it stays gone. It was
+    // `LRG_24t1:n.245_252del -> LRG_24t1:n.246_253del`, filed as "not
+    // 3'-shifted" — but the shift was the symptom. `LRG_24t1` is a different
+    // sequence from the `NM_001114101.3` the projection resolved (1191 bases /
+    // `cds_start = 127` against 1181 / 119), so renaming the accession while
+    // keeping the transcript coordinate moved the description onto other bases.
+    // `frame_projection_owned` now renames the `n.` axis only when the two
+    // sequences are identical, so this row renders
+    // `LRG_24(NM_001114101.3):n.245_252del` and is a fixed point.
+    //
+    // Asserted as an absence *plus* the surviving shapes above, so a regression
+    // that reintroduced it would fail on the count as well.
     assert!(
-        failures
-            .iter()
-            .any(|f| f.contains(NONCODING_NOT_THREE_PRIME_SHIFTED)),
-        "the one non-3'-shifted row is gone from the residue. If it was fixed, \
-         drop this assertion and lower the pin; do not leave both in place:\n{}",
+        !failures.iter().any(|f| f.contains("LRG_24t1:n.")),
+        "the LRG transcript-frame row is back in the residue (#1712): renaming \
+         the `n.` axis to an LRG transcript accession is only sound when that \
+         transcript's sequence matches the resolved one:\n{}",
         failures.join("\n")
     );
 }
 
 /// The measured non-idempotency residue on the `n.` axis — see #1712.
 ///
-/// Measured at `origin/main` `9fb126ba` against the prepared GRCh38 reference:
-/// 681 axes tested, 21 non-idempotent. The genomic control
+/// Measured at `origin/main` `5bf0b4ff` against the prepared GRCh38 reference:
+/// 681 axes tested, **20** non-idempotent. The genomic control
 /// ([`axis_genomic_idempotent`]) reads 214 tested / 0 non-idempotent on the same
 /// run, which is what isolates this to the non-coding path rather than to
 /// normalization generally.
 ///
-/// Re-measured on this branch, where `FERRO_PARTITION` defaults to
-/// `canonical-coalesced`, against the same reference: 681 axes tested — the
+/// Re-measured when #1835 made `canonical-coalesced` the default
+/// `FERRO_PARTITION` arm, against the same reference: 681 axes tested — the
 /// denominator is unchanged, so this is not a fan-out change — and 62
-/// non-idempotent. `FERRO_PARTITION=live` on this same tree still produces 21;
-/// that arm passed against the old pin before it was raised, which is what
-/// attributes the movement to the default flip rather than to anything else on
-/// the branch. One consequence to expect: this pin tracks the SHIPPED default,
-/// so running under `FERRO_PARTITION=live` now fails this assertion by
-/// construction, reporting 21 against a pin of 62. That is the pin doing its
-/// job, not a second defect.
-const NONCODING_NON_IDEMPOTENT: usize = 62;
+/// non-idempotent. `FERRO_PARTITION=live` on that tree still produced 21; that
+/// arm passed against the old pin before it was raised, which is what
+/// attributes the movement to the default flip rather than to anything else.
+/// One consequence to expect: this pin tracks the SHIPPED default, so running
+/// under `FERRO_PARTITION=live` fails this assertion by construction. That is
+/// the pin doing its job, not a second defect.
+///
+/// This branch then removes one more. The row that leaves is the LRG one,
+/// closed by the transcript-frame guard in `frame_projection_owned`; the
+/// assertion below keeps it from coming back.
+const NONCODING_NON_IDEMPOTENT: usize = 61;
 
-/// The one row in that residue whose output is not 3'-shifted (#1712).
-const NONCODING_NOT_THREE_PRIME_SHIFTED: &str = "LRG_24t1:n.245_252del -> LRG_24t1:n.246_253del";
+/// The `n.` axis of an LRG-parented projection names the transcript whose bases
+/// it was computed against (#1712).
+///
+/// This is the measurement behind the guard, on the real reference: `LRG_24t1`
+/// and the `NM_001114101.3` the fan-out resolves are **not** the same sequence,
+/// so an `n.` coordinate does not carry between them. The first assertion is the
+/// one that makes the rest mean anything — it reads the two references' bases
+/// directly, so the test states a fact about the reference rather than about the
+/// projector, and cannot go quietly green if the projector stops rendering.
+///
+/// The `c.` axis is the control: it is CDS-relative, so the same eight-base 5'
+/// difference does not move it, and it keeps the `LRG_24t1` namespace echo #860
+/// added. That contrast is the whole scope of the fix — `n.` is the only axis
+/// whose numbers are stated in the transcript's own frame.
+#[test]
+fn lrg_noncoding_axis_names_the_transcript_it_was_measured_against() {
+    let (Some(vp), Some(p)) = (variant_projector(), provider()) else {
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::lrg_noncoding_axis_names_the_transcript_it_was_measured_against",
+        );
+        return;
+    };
+    use ferro_hgvs::reference::ReferenceProvider;
+
+    // The premise, read off the reference: same locus, different sequences.
+    let lrg_bases = p
+        .get_sequence("LRG_24t1", 244, 252)
+        .expect("LRG_24t1 n.245_252 must be servable");
+    let nm_bases = p
+        .get_sequence("NM_001114101.3", 244, 252)
+        .expect("NM_001114101.3 n.245_252 must be servable");
+    assert_ne!(
+        lrg_bases, nm_bases,
+        "the premise of this test is that n.245_252 names different bases on \
+         LRG_24t1 than on NM_001114101.3; if they now agree the reference \
+         changed and the guard below is no longer testing anything"
+    );
+
+    let variant = parse_hgvs("LRG_24:g.5526_5533del").expect("parse");
+    let results = vp.project_variant_all(&variant).expect("project");
+    let rendered: Vec<String> = results
+        .iter()
+        .filter(|r| r.transcript_id == "NM_001114101.3")
+        .filter_map(|r| {
+            let n = r.noncoding.as_ref()?.to_string();
+            let c = r.coding.as_ref()?.to_string();
+            Some(format!("{n} | {c}"))
+        })
+        .collect();
+    assert_eq!(
+        rendered,
+        vec!["LRG_24(NM_001114101.3):n.245_252del | LRG_24t1:c.127_134del".to_string()],
+        "the n. axis must keep the accession its coordinate was computed \
+         against, while the CDS-relative c. axis keeps the LRG namespace echo"
+    );
+
+    // The SECOND transcript this input fans out onto, pinned for the same
+    // reason and separately because it is a different shape: `LRG_24t2` has no
+    // `cds_start` at all in the prepared reference (1139 bases against
+    // `NM_172369.5`'s 1158), where `LRG_24t1` has one and merely disagrees by
+    // eight. Both rows move — measured over the whole 681-axis corpus, this
+    // change moves exactly these two and nothing else — but only this one is
+    // idempotent either way, so `axis_noncoding_idempotent`'s count cannot see
+    // it and its absence assertion (keyed on `LRG_24t1:n.`) does not reach it.
+    // Without this it is the moved row that no guard pins.
+    let lrg_t2_bases = p
+        .get_sequence("LRG_24t2", 221, 229)
+        .expect("LRG_24t2 n.222_229 must be servable");
+    let nm_t2_bases = p
+        .get_sequence("NM_172369.5", 221, 229)
+        .expect("NM_172369.5 n.222_229 must be servable");
+    assert_ne!(
+        lrg_t2_bases, nm_t2_bases,
+        "the premise of this arm is that n.222_229 names different bases on \
+         LRG_24t2 than on NM_172369.5; if they now agree the reference changed \
+         and the guard below is no longer testing anything"
+    );
+    let rendered_t2: Vec<String> = results
+        .iter()
+        .filter(|r| r.transcript_id == "NM_172369.5")
+        .filter_map(|r| {
+            let n = r.noncoding.as_ref()?.to_string();
+            let c = r.coding.as_ref()?.to_string();
+            Some(format!("{n} | {c}"))
+        })
+        .collect();
+    assert_eq!(
+        rendered_t2,
+        vec!["LRG_24(NM_172369.5):n.222_229del | LRG_24t2:c.127_134del".to_string()],
+        "the n. axis must keep the accession its coordinate was computed \
+         against on LRG_24t2 too, while the CDS-relative c. axis keeps the LRG \
+         namespace echo"
+    );
+}


### PR DESCRIPTION
Refs #1712.

#1712 measured **21 of 681** projected `n.` axes moving under bare re-normalization. This PR closes **one** of them — the one that is not a spelling question — and leaves the other twenty pinned, because closing them settles a question the ruling ledger deliberately leaves open. Both halves are stated below.

## The row this closes, and why it is not what the issue called it

#1712 filed this row as "the output is not 3'-shifted", the only rule 2 miss among the 21:

```
LRG_24:g.5526_5533del : LRG_24t1:n.245_252del -> LRG_24t1:n.246_253del
```

The shift was the symptom. Measured against the prepared GRCh38 reference:

| accession | length | `cds_start` | bases at `n.245_252` |
|---|---:|---:|---|
| `NM_001114101.3` (what the projection resolved) | 1181 | 119 | `GGGGCACC` |
| `LRG_24t1` (what it was renamed to) | 1191 | 127 | `GCCTGCCC` |

`LRG_24t1` carries eight extra 5' bases. The #860 LRG namespace echo in `frame_projection_owned` renamed the axis's accession while keeping its transcript coordinate, so the emitted description **denotes different bases** — a rule 1 defect, with the failed 3' shift downstream of it. `n.245_252` on `LRG_24t1` is the same eight bases as `n.253_260`, and the normalizer was 3'-shifting the wrong span rather than failing to shift the right one.

`LRG_24t2` is the same shape and worse: 1139 bases against `NM_172369.5`'s 1158, and **no `cds_start` at all** in the prepared reference. Its corpus row was a *stable* wrong answer rather than a non-idempotent one, so #1712's residue never contained it — but it is the same defect, and measured the same way: `n.222_229` reads `TACGACGG` on `LRG_24t2` and `GGGGCACC` on `NM_172369.5`.

## The fix

`c.` is CDS-relative and `p.` is residue-relative, so a differing 5'UTR length leaves both alone — which is why the `c.` axis of that very row (`LRG_24t1:c.127_134del`) is correct and idempotent today. A transcript coordinate is an offset into the served sequence, so `n.` is the only axis the rename can misplace.

So the rename is gated on the two accessions serving byte-identical bases. When they do not, the axis keeps the transcript it was measured against and stays framed under the LRG parent by `relabel_under_parent` — rendering `LRG_24(NM_001114101.3):n.245_252del`, which is the shape **22 of the 29** LRG-parented `n.` axes already take.

Sequence equality rather than a `(cds_start, len)` proxy: two same-length records with different bases would pass the proxy, and an unavailable sequence returns `false` because an unverifiable frame must not be treated as a matching one.

Declining rather than re-deriving the coordinate is deliberate: `LRG_24t2` has no CDS anchor to reframe through, so any offset would be invented.

## Unchanged on purpose

- **`c.` and `p.` keep the #860 echo**, including on the very rows whose `n.` axis stops taking it. `LRG_24t1:c.127_134del` is pinned alongside the new `n.` string in the same assertion.
- **An LRG transcript that does match still gets renamed.** `LRG_303t1` and `NM_000106.6` are byte-identical — asserted on the sequences, not inferred from `(1588, cds_start = 20)` agreeing — and its **5** corpus rows do not move. Of the 7 axes rendered in the bare `LRG_<n>t<k>` form, 5 stay and 2 move. The unit test's first arm is exactly this case, so the fix cannot degenerate into a blanket refusal that quietly retires #860 for this axis.
- **The other twenty rows of #1712 are untouched**, and the pin now says so in its own comment.

## What is NOT fixed, and the ruling it waits on

The remaining twenty have one cause: `noncoding_from_coding` reframes coordinates and clones the `c.` edit verbatim, so `n.` inherits a form the **coding** frame chose *because it declares a reading frame*. Two clauses do that work on `c.` and neither reaches `n.`: `repeated.md`'s codon gate (16 rows — `n.3709_3710del` -> `n.3708_3710T[1]`) and the `delins.md:18` / `general.md:35` codon carve-out (4 rows — `n.309delinsCTGA` -> `n.[308_309insCT;310dup]`).

The obvious remedy is to normalize the derived axis on its own reference, symmetric with the genomic axis's `normalize_or_fallback` (#737). **Measured: it takes the residue 21 -> 0.** It is not applied here because the decided record `projection-codon-exception-is-decided-by-the-rendered-axis` says, in its own words:

> The `n.` axis is NOT settled by this record: it declares a non-coding DNA reference and so carries no frame, yet projection renders it merged because the axis is derived from the `c.` form by CDS-offset arithmetic rather than normalized on its own reference […] Which side of that is wrong is an open question, deliberately left open.

Applying it turns three committed guards red, and each is a pin of the current answer rather than a stale expectation:

| guard | what it pins today |
|---|---|
| `lenient_overlap_and_projection_split::the_codon_delins_merges_only_on_an_axis_that_declares_a_frame` | `split == ['g']`; its doc comment records the `n.` row as **"pinned as OBSERVED, not as adjudicated"** and names this same open question |
| `lenient_overlap_and_projection_split::the_same_codon_delins_renders_alike_whichever_axis_it_is_authored_on` | `('n', "tx:n.4_6delinsATA")` as the merged control |
| `projection::transcript_cache_collapses_repeat_lookups` | one `get_transcript` call across three variants; normalizing per axis takes it to ten, since the normalizer's fetches do not go through the projector's cache |

So the question for the operator is narrow: **on the `n.` axis, is the projector wrong (it should re-derive on the `n.` reference, splitting and repeat-maximizing like `g.`) or is the normalizer wrong (it should treat `n.` on a coding transcript as frame-aware)?** The second direction re-opens #1241, whose fix made `codon_frame_aware` false for `Tx` precisely so `n.` and `r.` spellings of one non-coding change would not settle on two strings.

## Representation stability

Measured on the mutalyzer corpus against the prepared GRCh38 reference, `project_variant_all` over every `to_test` row, all 681 `n.` axes compared:

| | rows |
|---|---:|
| compared | 681 |
| moved | 2 |
| kind of move | accession only — `LRG_24t1:n.245_252del` -> `LRG_24(NM_001114101.3):n.245_252del`, `LRG_24t2:n.222_229del` -> `LRG_24(NM_172369.5):n.222_229del` |
| already unstable | 1 of 2 (the `LRG_24t1` row is #1712's; the `LRG_24t2` row was a stable wrong answer) |

No coordinate changes and no edit changes. Both moved rows previously named a sequence they did not denote, so this is a correction rather than churn. `axis_noncoding`'s corpus expectations are unaffected: the fixture lists **zero** `LRG_…:n.` expectations, so no subset check gains or loses a member.

`examples/dump_normalized_corpus.rs` reports **0 rows moved, and that zero is structural** — not evidence. The harness contains zero occurrences of `LRG` and never constructs a `VariantProjector` at all; it drives `Normalizer` over synthetic `NC_TEST.1`/`NM_TEST.1` accessions. The property this change keys on is "the projection is framed under a bare `LRG_` genomic parent", which that generator cannot vary. The 681-axis measurement above is the one that can move, and does.

## Which of these tests is pre-merge coverage

Stated because `.coderabbit.yaml`'s `tests/it/{mutalyzer_*.rs,…}` instruction asks for it, and it is easy to get wrong:

- **`project::projector::tests::…::frame_projection_owned_renames_the_noncoding_axis_only_on_a_shared_frame` is the gate.** It is a `MockProvider` unit test built programmatically, needs no manifest, and runs on PR CI. Its two arms are the discriminating pair — identical sequences must still rename, differing ones must not — so it fails both by regressing the fix and by over-generalising it into a blanket refusal.
- **`mutalyzer_normalize_tests::lrg_noncoding_axis_names_the_transcript_it_was_measured_against` is NOT pre-merge coverage.** It resolves `FERRO_MANIFEST` and silently returns when unset, which is what PR CI does; only the nightly reference-aware job runs it. It is here because it states the defect against the real reference — including reading `LRG_24t1`'s and `NM_001114101.3`'s bases directly, so its premise is a fact about the reference rather than about the projector.

It is a unit test rather than one in `tests/it/projection.rs` because it isolates `frame_projection_owned` by handing it a `VariantProjection` directly; routing the case through `project_variant_all` would measure transcript enumeration and the reference's LRG records instead of the rename gate. Recorded in the test's own doc comment.

## Verification

Commands and the counts read back out of their own logs, never from a completion notification (one run here reported `exit code 0` while its log held `EXIT=100`):

- `axis_noncoding_idempotent`, manifest-backed: `681 tested, 20 non-idempotent` (was `681 tested, 21`), `EXIT=0`. `axis_genomic_idempotent` control on the same run: `214 tested, 0`.
- Manifest-backed conformance selection (`mutalyzer_*`, `biocommons_*`, `hgvs_rs_projection_tests`, `conformance`): `348 tests run: 348 passed`, `EXIT=0`.
- The new unit test is **sabotage-checked**: forcing `shares_transcript_frame` to return `true` fails it with `left: "LRG_24t1:n.5A>G"` / `right: "LRG_24(NM_001114101.3):n.5A>G"`, so it is testing the guard and not the scaffolding.
- `cargo fmt --all --check`: clean. `cargo clippy --all-features --all-targets -- -D warnings`: clean.

One note on the two generated spec artifacts: `spec_enumeration_tests` and `ruling_citation_currency` were red mid-run for reasons unrelated to this diff — `tests/fixtures/grammar/hgvs_spec_{normalization,enumeration}.json` had been generated earlier in the session while an experiment was in the tree. Regenerating both (`generate_spec_fixture`, `generate_spec_enumeration`) clears them; `24 tests run: 24 passed`, `EXIT=0`.

Representation-Change: 2 of 681 projected non-coding axis rows respell. Previously-accepted output; both moved rows previously named bases they did not denote, so this is a correction rather than churn.
