### PR TITLE
fix(normalize): clamp the 3' rule at an exon junction from both sides

### DIFF
--- a/src/conformance/spec_worked_examples.rs
+++ b/src/conformance/spec_worked_examples.rs
@@ -57,10 +57,13 @@ impl Fixture {
 /// input-hygiene modes.
 ///
 /// Three outputs rather than one because the modes do not agree here, and which
-/// mode produces which answer *is* the finding: the single divergence from the
-/// spec belongs to the lenient preprocessor's W3013 repair, not to the
-/// normalizer, and strict mode rejects two of the spec's own inputs outright.
-/// One pinned output would have hidden both facts.
+/// mode produces which answer *is* the finding: strict mode rejects two of the
+/// spec's own inputs outright, and while the corpus still held divergences each
+/// was attributable to a named stage — the lenient preprocessor's W3013 repair
+/// (closed by #1631), and the normalizer's half-applied exon-junction clamp
+/// (closed by #1621). One pinned output would have hidden all of that. The
+/// diverging set is empty as of #1621; `the_divergence_set_is_exactly_the_one_recorded_conflict`
+/// is what holds it there.
 ///
 /// Every case also carries a [`Citation`], because a pinned output with no
 /// authority behind it is a change detector rather than a record: it tells a

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -486,6 +486,146 @@ fn edit_is_del_or_dup(edit: &NaEdit) -> bool {
     )
 }
 
+/// The 5' anchor of a del/dup's equivalence run, when that run continues back
+/// across an exon/exon junction (#1621).
+///
+/// # The rule
+///
+/// `general.md:44` exempts deletions and duplications around exon/exon
+/// junctions from the 3' rule on `c.`/`r.`/`n.` references. The operator ruling
+/// `exon-junction-dup-converge-from-the-far-side` reads that exemption as a
+/// clamp that binds in **both** directions: the canonical position is the most
+/// 3' position that does not cross a junction, *reached from either side*. A
+/// description approaching the junction stops at it — which is what
+/// [`Boundaries`] built from `axis_info.exon` already does — and one already
+/// spelled past it is **pulled back** to the clamp, which is what this function
+/// supplies. `DNA/duplication.md` states the outcome three times (`:26`, `:60`,
+/// `:148`), the last giving the reason: `c.3922dup` translated back to a
+/// genomic position lands "at the wrong nucleotide, in the wrong exon".
+///
+/// # Why an anchor, rather than a step back over the junction
+///
+/// In *spliced* transcript space an exon/exon junction is not a gap — the base
+/// immediately 5' of an exon's first base is the previous exon's last base — so
+/// `LRG_199t1:c.3921` and `c.3922` are one contiguous `T` run and two spellings
+/// of one sequence. Only the exon annotation distinguishes them. The canonical
+/// answer is therefore obtained by finding where that run *begins*, in full
+/// transcript space, and clamping the 3' rule inside the exon holding **that**
+/// base. Both spellings share a run, so both reach the same answer; that is the
+/// "from either side" in the ruling.
+///
+/// Returning the anchor rather than "the previous exon's last base" is what
+/// makes the rule compose when a run spans three or more exons, and what makes
+/// the result a fixed point: re-normalizing the answer finds the same anchor,
+/// inside the same exon, so no second pull-back fires.
+///
+/// # The scope, and the case that sets it
+///
+/// **A description is pulled back only when it is pinned at its exon's first
+/// base with nowhere to shift inside that exon.** Without that condition the
+/// rule inverts into the defect it is supposed to prevent: it would move a
+/// description *across* a junction, 5'-ward, which is exactly what
+/// `general.md:44` forbids.
+///
+/// `NM_001234.1` in `MockProvider::with_test_data` is the case that shows it —
+/// a 25-base `G` run spanning `c.9`-`c.33` across two junctions, with exons at
+/// transcript 1-15 / 16-30 / 31-44. `c.13del` sits mid-run inside exon 2 and
+/// 3'-shifts to exon 2's **last** base, `c.26del` (#1450 pins it). Its run does
+/// reach back over the exon-1/exon-2 junction, so an anchor rule with no
+/// further condition drags it to `c.11del` — one exon 5' of where the 3' rule
+/// put it. The condition below declines it: `c.26` is not exon 2's first base,
+/// so the description is resting on the near side of the *next* junction and
+/// stays there.
+///
+/// `c.3922dup` passes the condition because exon 28's first base is where it
+/// rests and where it started: `c.3923` is not `T`, so the exon gives it no 3'
+/// travel at all, and the only reason it is spelled in exon 28 rather than
+/// exon 27 is the junction it is hanging off. That is what "past the clamp"
+/// means in the ruling.
+///
+/// **Residue, deliberately left.** A run whose portion inside the far exon is
+/// longer than the description can be pinned at — `c.3922`/`c.3923` both `T`,
+/// say — is not reached: the far-side spelling shifts to `c.3923` and the pair
+/// does not converge. The ruling's words arguably cover it; its worked example,
+/// its grounds and every corpus row do not, and widening the rule to reach it
+/// re-opens the #1450 regression above unless some further discriminator is
+/// found. Recorded here rather than guessed at.
+///
+/// # Returns
+///
+/// `Some((start, end))` — 1-based, inclusive, the same convention `start`/`end`
+/// arrive in — when the run's anchor lies strictly 5' of `exon.left`, i.e. when
+/// the input really is spelled past a junction. `None` whenever the existing
+/// exon-confined shuffle already gives the canonical answer, which is every
+/// del/dup whose run does not straddle a junction.
+fn exon_junction_anchor(
+    ref_seq: &[u8],
+    edit: &NaEdit,
+    start: u64,
+    end: u64,
+    exon: &Boundaries,
+) -> Option<(u64, u64)> {
+    if !edit_is_del_or_dup(edit) {
+        return None;
+    }
+    // The transcript's first exon has nothing 5' of it to be pulled back into.
+    if exon.left == 0 {
+        return None;
+    }
+    let start_idx = hgvs_pos_to_index(start) as u64;
+    if start_idx >= ref_seq.len() as u64 || end > ref_seq.len() as u64 || end <= start_idx {
+        return None;
+    }
+
+    // The duplicated bases are read from the reference at the input's own span,
+    // exactly as `normalize_na_edit`'s `Duplication` arm does (#219) — a stated
+    // `dup<base>` that disagrees with the reference must not steer the walk.
+    // A deletion carries no payload, and the 5' walk's predicate for an empty
+    // `alt` is the mirror of the 3' rotation invariant.
+    let alt_seq: Vec<u8> = match edit {
+        NaEdit::Duplication { .. } => ref_seq[start_idx as usize..end as usize].to_vec(),
+        _ => Vec::new(),
+    };
+
+    // The description must have no 3' travel inside its own exon — see "The
+    // scope" above. `shuffle` only ever increases `start`, and `start_idx` is
+    // inside `exon` by construction, so this holds exactly when the description
+    // both starts at the exon's first base and cannot move off it.
+    let confined = shuffle(
+        ref_seq,
+        &alt_seq,
+        start_idx,
+        end,
+        exon,
+        ShuffleDirection::ThreePrime,
+    );
+    if confined.start != exon.left {
+        return None;
+    }
+
+    // The walk is unbounded on the 5' side rather than bounded at `exon.left`,
+    // because the question is where the run *begins*, and a run that begins
+    // inside this exon is answered `None` below. It terminates at the first
+    // mismatch, so its cost is the run's length — a homopolymer or tandem tract,
+    // not the transcript.
+    let unbounded = Boundaries::new(0, ref_seq.len() as u64);
+    let anchor = shuffle(
+        ref_seq,
+        &alt_seq,
+        start_idx,
+        end,
+        &unbounded,
+        ShuffleDirection::FivePrime,
+    );
+
+    // The run begins inside this exon: no junction is crossed, and the
+    // exon-confined 3' shuffle already holds the canonical answer.
+    if anchor.start >= exon.left {
+        return None;
+    }
+    Some((index_to_hgvs_pos(anchor.start as usize), anchor.end))
+}
+
 /// Everything the codon-frame gate needs for one [`Normalizer::normalize_na_edit`]
 /// call: whether the axis has a reading frame at all, and if so where the CDS is.
 ///
@@ -3607,6 +3747,65 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `detect_shuffle_infos` work `normalize_with_diagnostics` does) and wrap
         // with empty infos; the ladder below only inspects warnings.
         let (normalized, warnings) = self.normalize_core_canonical(variant)?;
+
+        // #1621: the far-side exon-junction clamp, applied ONCE to the finished
+        // description. See [`exon_junction_anchor`] for the rule and its
+        // grounds; what this site decides is *when* it is asked.
+        //
+        // **On the output, not the input.** `normalize_cds` has several
+        // producers of a del/dup spelling and only one of them is the input's
+        // own edit kind: a `delins` whose payload shares an affix with its
+        // reference *reduces* to a pure deletion inside `normalize_na_edit`
+        // (#1185), i.e. after any input-side check has run. Clamping the input
+        // alone left `c.20_22delinsA` emitting `c.21_22del` — a description the
+        // clamp itself would move — which is a rank-1 idempotency regression,
+        // measured as two rows of the `junction-1` stratum in
+        // `spec_conformance_axis`'s 58,552-output census.
+        //
+        // **Here rather than inside `normalize_cds`/`normalize_tx`, because
+        // those are recursive.** They re-enter themselves for the `conversion`
+        // rewrite, special-position resolution and more, so a clamp applied
+        // there fires on *intermediate* spellings as well as the answer. That
+        // was measured too: it moved cis-allele rows whose finished output the
+        // clamp declines, cost one converged family
+        // (`s00-n3p-junction-2-del-del-p1-sep0`) and raised another's arity.
+        // Asking once, at the seam every public normalization passes through,
+        // keeps the clamp a property of the description that is actually
+        // returned.
+        //
+        // Consequently a **cis member** is not clamped individually — only a
+        // whole-variant result is. That is deliberate: `general.md:44` is about
+        // how a description is positioned, and a member's position is settled by
+        // the derivation and its own #1450 junction guard.
+        //
+        // One re-normalization, never a loop: the replacement is the run's 5'
+        // anchor, an anchor lies inside its own exon, and
+        // [`exon_junction_anchor`] declines there — which is also why the
+        // returned description is a fixed point.
+        //
+        // **The first pass's warnings are KEPT, not replaced.** They are about
+        // `variant` — the input — and the second pass cannot re-derive them,
+        // because `pulled` is built from the already-normalized *output*: a
+        // `REFSEQ_MISMATCH` the input earned by stating a base the reference
+        // contradicts is gone by then, since `normalize_na_edit` reads the dup
+        // payload from the reference (#219). Replacing the vector made two
+        // inputs that produce one output disagree about whether ferro had
+        // corrected a stated base — measured on this module's own fixture,
+        // `NM_SYNTH.1:c.17dupG` and `c.16dupG` both emit `c.16dup` while only
+        // the second reported the mismatch. That is a silently dropped
+        // disclosure, not a re-spelling, so the two sets are concatenated.
+        // The second pass runs on an already-canonical description and
+        // contributes nothing in every reachable case measured.
+        let (normalized, warnings) = match self.exon_junction_far_side(&normalized) {
+            Some(pulled) if pulled != *variant => {
+                let (clamped, more) = self.normalize_core_canonical(&pulled)?;
+                let mut merged = warnings;
+                merged.extend(more);
+                (clamped, merged)
+            }
+            _ => (normalized, warnings),
+        };
+
         let result = NormalizeResult::with_warnings(normalized, warnings);
 
         // EINTRONIC (#486): reject an intronic offset on a bare transcript
@@ -5739,6 +5938,85 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
+    /// The far-side exon-junction clamp for a finished description, dispatched
+    /// to the axis that carries it (#1621).
+    ///
+    /// `Some` is the re-spelling [`Self::normalize_core_checked`] re-normalizes;
+    /// `None` leaves the result standing. Only the two transcript axes the
+    /// ruling scopes are reached — `general.md:44` names `c.`, `r.` and `n.`,
+    /// and the `r.` half is deferred with the ruling's own "(and `r.` until
+    /// upstream PR #266 lands)". The genomic axes have no exon junctions to
+    /// clamp at.
+    fn exon_junction_far_side(&self, variant: &HgvsVariant) -> Option<HgvsVariant> {
+        match variant {
+            HV::Cds(cds) => self.exon_junction_far_side_cds(cds).map(HV::Cds),
+            HV::Tx(tx) => self.exon_junction_far_side_tx(tx).map(HV::Tx),
+            _ => None,
+        }
+    }
+
+    /// The far-side exon-junction clamp for a `c.` result — the re-spelling
+    /// [`Self::normalize_cds`] re-enters with, or `None` to leave the result
+    /// standing. See [`exon_junction_anchor`] for the rule and its grounds.
+    ///
+    /// **Refused across an axis change.** A junction coinciding with
+    /// `cds_start`/`cds_end` would let the clamp re-ax the variant (`c.1` into
+    /// `c.-1`, say), and the ruling is silent on that — its case and its
+    /// grounds are entirely CDS-internal, and #350's cross-axis bail exists for
+    /// the same reason. An intronic result is refused for a different reason:
+    /// those are #670's junction-*crossing* continuation, which is the other
+    /// half of `general.md:44` and must not be undone here.
+    fn exon_junction_far_side_cds(&self, cds: &CdsVariant) -> Option<CdsVariant> {
+        if self.config.shuffle_direction != ShuffleDirection::ThreePrime {
+            return None;
+        }
+        let edit = cds.loc_edit.edit.inner()?;
+        if !edit_is_del_or_dup(edit) {
+            return None;
+        }
+        let start_pos = cds.loc_edit.location.start.inner()?;
+        let end_pos = cds.loc_edit.location.end.inner()?;
+        if start_pos.is_intronic() || end_pos.is_intronic() {
+            return None;
+        }
+        let transcript = self
+            .provider
+            .get_transcript(&cds.accession.transcript_accession())
+            .ok()?;
+        let cds_start = transcript.cds_start?;
+        let sequence = transcript.sequence.as_deref()?;
+        let tx_start = self
+            .cds_to_tx_pos(start_pos, cds_start, transcript.cds_end)
+            .ok()?;
+        let tx_end = self
+            .cds_to_tx_pos(end_pos, cds_start, transcript.cds_end)
+            .ok()?;
+        let info = boundary::get_cds_boundaries_with_axis_info(&transcript, tx_start, &self.config)
+            .ok()?;
+        let (anchor_start, anchor_end) =
+            exon_junction_anchor(sequence.as_bytes(), edit, tx_start, tx_end, &info.exon)?;
+        if boundary::axis_region_of(&transcript, anchor_start) != info.axis_region
+            || boundary::axis_region_of(&transcript, anchor_end)
+                != boundary::axis_region_of(&transcript, tx_end)
+        {
+            return None;
+        }
+        let new_start = self
+            .tx_to_cds_pos(anchor_start, cds_start, transcript.cds_end)
+            .ok()?;
+        let new_end = self
+            .tx_to_cds_pos(anchor_end, cds_start, transcript.cds_end)
+            .ok()?;
+        Some(CdsVariant {
+            accession: cds.accession.clone(),
+            gene_symbol: cds.gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                cds.loc_edit.edit.clone(),
+            ),
+        })
+    }
+
     /// Normalize a CDS variant
     fn normalize_cds(
         &self,
@@ -7070,6 +7348,71 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Cds(new_variant));
         warnings.append(&mut split_warnings);
         Ok((wrap_allele_if_split(split, uncertain), warnings))
+    }
+
+    /// The far-side exon-junction clamp for an `n.` result.
+    ///
+    /// No axis guard, and that is not an omission: `n.` numbering runs through
+    /// the whole transcript with no CDS↔UTR sub-axis to be re-axed into — the
+    /// same reason `normalize_tx_inner` takes the bare `exon` bound rather than
+    /// intersecting it with an axis bound. `n.` is also a flat transcript offset
+    /// (`c-and-n-positions-are-flat-transcript-offsets`), so the anchor needs no
+    /// mapping back onto the axis.
+    fn exon_junction_far_side_tx(&self, tx: &TxVariant) -> Option<TxVariant> {
+        if self.config.shuffle_direction != ShuffleDirection::ThreePrime {
+            return None;
+        }
+        let edit = tx.loc_edit.edit.inner()?;
+        if !edit_is_del_or_dup(edit) {
+            return None;
+        }
+        let start_pos = tx.loc_edit.location.start.inner()?;
+        let end_pos = tx.loc_edit.location.end.inner()?;
+        // Intronic is #670's junction-crossing continuation; downstream (`n.*N`)
+        // names no transcript offset this clamp could read.
+        //
+        // **`downstream` must be tested explicitly, and nothing downstream of
+        // here would catch it.** `TxPos::is_intronic` reads only `offset`, and
+        // on the `n.` axis the `*` marker is a *spelling* flag on the position
+        // rather than a transcript region — so unlike the `c.` arm, which is
+        // covered by `boundary::axis_region_of`, there is no region check that
+        // could refuse a re-zoning here. Without this clause `n.*21` is read as
+        // transcript offset 21, and `TxPos::new(anchor)` below then rebuilds the
+        // position *without* the flag: measured on this module's fixture,
+        // `NR_SYNTH.1:n.*21del` came back as `NR_SYNTH.1:n.20del`, a different
+        // variant in a zone `numbering.md:52` does not give this axis. Such a
+        // position is unreachable from any string entry point (#1748 refuses it
+        // at parse in every mode) but `TxPos::downstream` is public API, which is
+        // the same reachability the re-parse oracle's own exemption documents.
+        if start_pos.is_intronic()
+            || end_pos.is_intronic()
+            || start_pos.downstream
+            || end_pos.downstream
+        {
+            return None;
+        }
+        let tx_start = u64::try_from(start_pos.base).ok()?;
+        let tx_end = u64::try_from(end_pos.base).ok()?;
+        let transcript = self
+            .provider
+            .get_transcript(&tx.accession.transcript_accession())
+            .ok()?;
+        let sequence = transcript.sequence.as_deref()?;
+        let info = boundary::get_cds_boundaries_with_axis_info(&transcript, tx_start, &self.config)
+            .ok()?;
+        let (anchor_start, anchor_end) =
+            exon_junction_anchor(sequence.as_bytes(), edit, tx_start, tx_end, &info.exon)?;
+        Some(TxVariant {
+            accession: tx.accession.clone(),
+            gene_symbol: tx.gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(
+                    TxPos::new(i64::try_from(anchor_start).ok()?),
+                    TxPos::new(i64::try_from(anchor_end).ok()?),
+                ),
+                tx.loc_edit.edit.clone(),
+            ),
+        })
     }
 
     /// Normalize a transcript variant

--- a/tests/fixtures/case-harvest/cases.json
+++ b/tests/fixtures/case-harvest/cases.json
@@ -261,12 +261,12 @@
     },
     {
       "input": "LRG_199t1:c.3922dup",
-      "expected": "LRG_199t1:c.3922dup",
+      "expected": "LRG_199t1:c.3921dup",
       "citation": {
         "clause": "docs/recommendations/DNA/duplication.md:25-26",
         "quote": "the variant is described as `LRG_199t1:c.3921dup`"
       },
-      "note": "PRE-FIX BEHAVIOUR, NOT PRESERVATION-BY-DESIGN. Both positions carry the same base, so the two spellings denote one transcript sequence and are nonetheless two fixed points, projecting 2,790 bp apart. The ruling `exon-junction-dup-converge-from-the-far-side` is now DECIDED: CONVERGE — c.3922dup must normalize to c.3921dup, because the 3'rule's exon-junction clamp binds from both sides. This row pins where ferro leaves it TODAY; when #1621 lands, `expected` becomes `LRG_199t1:c.3921dup`."
+      "note": "CONVERGENCE, as decided. Both positions carry the same base, so the two spellings denote one transcript sequence; they were nonetheless two fixed points, projecting 2,790 bp apart. The ruling `exon-junction-dup-converge-from-the-far-side` is DECIDED: CONVERGE — the 3'rule's exon-junction clamp binds from both sides, so this far-side spelling is pulled back onto the near-side one. #1621 implemented it, and this row moved from `LRG_199t1:c.3922dup` with it; the sibling row above did not move, which is the point of keeping both."
     },
     {
       "input": "NM_006420.3:c.[242C>A;247_249delinsTT]",

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -628,8 +628,8 @@
       "status": "decided",
       "guard": {
         "tests": [
-          "tests/it/spec_worked_examples.rs::the_exon_junction_pair_does_not_converge_and_that_is_recorded",
-          "tests/it/spec_worked_examples.rs::the_decided_target_is_convergence_on_the_near_side"
+          "tests/it/spec_worked_examples.rs::the_decided_target_is_convergence_on_the_near_side",
+          "tests/it/issue_1621_exon_junction_far_side.rs::a_duplication_converges_on_the_near_side_of_the_junction"
         ]
       },
       "clauses": [

--- a/tests/fixtures/spec-worked-examples/cases.json
+++ b/tests/fixtures/spec-worked-examples/cases.json
@@ -137,14 +137,14 @@
     {
       "input": "LRG_199t1:c.3922dup",
       "spec_expected": "LRG_199t1:c.3921dup",
-      "default_output": "LRG_199t1:c.3922dup",
-      "lenient_output": "LRG_199t1:c.3922dup",
-      "strict_output": "LRG_199t1:c.3922dup",
+      "default_output": "LRG_199t1:c.3921dup",
+      "lenient_output": "LRG_199t1:c.3921dup",
+      "strict_output": "LRG_199t1:c.3921dup",
       "citation": {
         "clause": "docs/recommendations/DNA/duplication.md:60",
         "quote": "the variant (`NC_000023.11:g.32441180dup`) is **not described** as `c.3922dup` since this would shift the position of the variant to the next exon"
       },
-      "note": "`spec_expected` WAS NULL AND IS NOT ANY MORE, and that is the whole change here. c.3921 and c.3922 are both T, so at the transcript level `c.3921dup` and `c.3922dup` denote one sequence — yet ferro emits two fixed points, and they project 2,790 bp apart (`LRG_199:g.903430dup` vs `g.906220dup`, matching the spec's own `g.32459297dup` vs `g.32456507dup`). The field was null on the reasoning that the spec published no answer for this input. It does, three times, independently: `duplication.md:26` names c.3921dup as THE description and says the variant is not described as c.3922dup, `:60` restates that on the GRCh38 coordinates, and `:148` gives the reason — translating c.3922dup back to a genomic position lands at the wrong nucleotide, in the wrong exon. The ruling `exon-junction-dup-converge-from-the-far-side` is now DECIDED: CONVERGE, so this row is a recorded DIVERGENCE — ferro's three outputs below are today's behaviour and none of them is the spec's answer. #1621 closes the gap; when it lands, all three become `LRG_199t1:c.3921dup` and the row stops diverging."
+      "note": "CONVERGENCE, as decided — the row that MOVED when #1621 landed. c.3921 and c.3922 are both T, so at the transcript level `c.3921dup` and `c.3922dup` denote one sequence; ferro nonetheless emitted two fixed points, projecting 2,790 bp apart (`LRG_199:g.903430dup` vs `g.906220dup`, matching the spec's own `g.32459297dup` vs `g.32456507dup`). `spec_expected` was null until the `exon-junction-dup-converge-from-the-far-side` ruling found the spec answering this input three times independently: `duplication.md:26` names c.3921dup as THE description and says the variant is not described as c.3922dup, `:60` restates that on the GRCh38 coordinates, and `:148` gives the reason — translating c.3922dup back to a genomic position lands at the wrong nucleotide, in the wrong exon. The 3'rule's exon-junction clamp now binds from BOTH sides, so all three modes emit the spec's answer and this row is no longer a divergence. The sibling `c.3921dup` row did not move; keeping both is what distinguishes 'the clamp binds from either side' from 'everything drifts 5''."
     }
   ]
 }

--- a/tests/it/issue_1621_exon_junction_far_side.rs
+++ b/tests/it/issue_1621_exon_junction_far_side.rs
@@ -1,0 +1,400 @@
+//! The exon-junction clamp binds from the FAR side too (#1621).
+//!
+//! `general.md:44` exempts deletions and duplications around exon/exon
+//! junctions from the 3' rule on `c.`/`r.`/`n.` references. Ferro applied that
+//! exemption in one direction only: a description approaching a junction was
+//! stopped at it, but one already spelled *past* it was left standing, so the
+//! two spellings of one transcript sequence were two fixed points.
+//!
+//! The operator ruling `exon-junction-dup-converge-from-the-far-side` (in
+//! `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`, `decided`)
+//! reads the exemption as a clamp binding in **both** directions: the canonical
+//! position is the most 3' position that does not cross a junction, *reached
+//! from either side*. `DNA/duplication.md` states the outcome three times —
+//! `:26`, `:60` and `:148` — the last giving the reason, that `c.3922dup`
+//! translated back to a genomic position lands "at the wrong nucleotide, in the
+//! wrong exon".
+//!
+//! The ruling's own row, `LRG_199t1:c.3922dup` -> `c.3921dup`, is asserted by
+//! `spec_worked_examples::the_decided_target_is_convergence_on_the_near_side`
+//! against the committed reference slice. This module carries the rest of the
+//! scope the ruling names — **deletions as well as duplications, and the `n.`
+//! axis as well as `c.`** — on a synthetic transcript built here, and it
+//! asserts **both directions** of the clamp on every one of them. A fix that
+//! only pulls the far side back would leave the near side free to shift across
+//! the junction, and a fix that only holds the near side is what shipped
+//! before; each case below therefore pins the near-side spelling as a fixed
+//! point *and* the far-side spelling converging onto it.
+//!
+//! **The fixture must be multi-exon, and that is the whole point.** A clamp at
+//! an exon/exon junction is unreachable on a single-exon transcript, so a
+//! generator that emits one reports a structural zero for this entire class —
+//! the blindness recorded on `dump_normalized_corpus` as #1478. The transcript
+//! below has two exons with the run straddling their junction, and
+//! `the_fixture_really_straddles_a_junction` asserts that geometry directly
+//! rather than trusting it.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Transcript bases, 40 of them, with a two-base `T` run at transcript 20-21.
+///
+/// The exon boundary below falls **between** those two `T`s, so they are one
+/// contiguous run in spliced transcript space and two different exons in
+/// genomic space — the reduced form of `LRG_199t1`'s `c.3921`/`c.3922` pair,
+/// which sits at the exon 27/28 junction of `NM_004006.2` and projects 2,790 bp
+/// apart for exactly this reason.
+///
+/// The flanks are chosen so the run is exactly two bases: transcript 19 is `A`
+/// and transcript 22 is `C`, so neither end of the run extends. Without that
+/// the 3' shuffle inside exon 2 would move the far-side spelling for an
+/// unrelated reason and the test would pass while proving nothing.
+const TX_SEQUENCE: &str = "ACGACGACGACGACGACGATTCGACGACGACGACGACGAC";
+
+/// Transcript position of the last base of exon 1 — the near side of the clamp.
+const NEAR_TX: u64 = 20;
+/// Transcript position of the first base of exon 2 — the far side.
+const FAR_TX: u64 = 21;
+
+/// `cds_start` is deliberately **not** 1.
+///
+/// With `cds_start = 1` the `c.` axis is the identity on transcript
+/// coordinates, which is the second half of #1478's blindness: a bug in the
+/// axis translation is invisible, and the variant can never sit in a 5'UTR. At
+/// 5 the translation is a real offset (`c.N` is transcript `N + 4`) and
+/// transcript 1-4 form a genuine `c.-4`..`c.-1` 5'UTR.
+const CDS_START: u64 = 5;
+const CDS_END: u64 = 40;
+
+/// `c.` position of a transcript position, under [`CDS_START`].
+fn cds_of(tx: u64) -> u64 {
+    tx - CDS_START + 1
+}
+
+/// Exon 1 is transcript 1-20 at genomic 101-120; exon 2 is transcript 21-40 at
+/// genomic 201-220. The 80-base gap between them is a real intron, so the
+/// junction is a junction in genomic space and not merely an annotation.
+fn exons() -> Vec<Exon> {
+    vec![
+        Exon::with_genomic(1, 1, NEAR_TX, 101, 120),
+        Exon::with_genomic(2, FAR_TX, 40, 201, 220),
+    ]
+}
+
+/// The genomic contig the two exons are placed on.
+///
+/// The intron's first base is `A`, never `T`. That is load-bearing: a del/dup
+/// resting on exon 1's last base triggers the #670 junction-crossing
+/// continuation, which re-runs the 3' shuffle in genomic space where the intron
+/// *is* visible. With a `T` there the near-side answer would legitimately shift
+/// into the intron as `c.16+1dup`, and this module would be measuring that
+/// instead of the clamp.
+fn contig() -> String {
+    let filler = "ACGT".repeat(25); // 100 bases
+    let intron = "AC".repeat(40); // 80 bases, first base `A`
+    let mut s = String::new();
+    s.push_str(&filler); // g.1-100
+    s.push_str(&TX_SEQUENCE[..NEAR_TX as usize]); // g.101-120 = tx 1-20
+    s.push_str(&intron); // g.121-200
+    s.push_str(&TX_SEQUENCE[NEAR_TX as usize..]); // g.201-220 = tx 21-40
+    s.push_str(&filler); // g.221-320
+    s
+}
+
+fn transcript(id: &str, cds: Option<(u64, u64)>) -> Transcript {
+    Transcript::new(
+        id.to_string(),
+        None,
+        Strand::Plus,
+        TX_SEQUENCE.to_string(),
+        cds.map(|(s, _)| s),
+        cds.map(|(_, e)| e),
+        exons(),
+        Some("NC_SYNTH.1".to_string()),
+        Some(101),
+        Some(220),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+/// A provider carrying one coding and one non-coding transcript over the same
+/// two-exon geometry, so the `c.` and `n.` axes are compared on identical bases.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_transcript(transcript("NM_SYNTH.1", Some((CDS_START, CDS_END))));
+    provider.add_transcript(transcript("NR_SYNTH.1", None));
+    provider.add_genomic_sequence("NC_SYNTH.1", contig());
+    provider
+}
+
+fn normalize(input: &str) -> String {
+    let normalizer = Normalizer::new(provider());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"));
+    format!("{normalized}")
+}
+
+/// The premise, asserted rather than assumed.
+///
+/// If any of these three drifts — the run stops being two bases, or the exon
+/// boundary stops falling inside it — every assertion below would still pass
+/// while testing nothing about an exon junction. This is the structural check
+/// the corpus generators kept lacking (#1456, #1460, #1478): name the property
+/// the change keys on, and show the fixture can carry it.
+#[test]
+fn the_fixture_really_straddles_a_junction() {
+    let bases = TX_SEQUENCE.as_bytes();
+    assert_eq!(bases.len(), 40, "transcript length");
+    assert_eq!(
+        (
+            bases[NEAR_TX as usize - 2] as char,
+            bases[NEAR_TX as usize - 1] as char,
+            bases[FAR_TX as usize - 1] as char,
+            bases[FAR_TX as usize] as char,
+        ),
+        ('A', 'T', 'T', 'C'),
+        "transcript {NEAR_TX} and {FAR_TX} must be the same base, and the run must stop there — \
+         otherwise the two spellings are not two spellings of one sequence"
+    );
+
+    let exons = exons();
+    assert_eq!(
+        exons.len(),
+        2,
+        "a single-exon fixture cannot test a junction"
+    );
+    assert_eq!(
+        (exons[0].end, exons[1].start),
+        (NEAR_TX, FAR_TX),
+        "the exon/exon junction must fall between the two bases of the run"
+    );
+    assert_eq!(
+        (exons[0].genomic_end, exons[1].genomic_start),
+        (Some(120), Some(201)),
+        "the two exons must be genuinely far apart in genomic space, so crossing the junction \
+         is the ~2,790 bp class of error `DNA/duplication.md:148` describes and not an off-by-one"
+    );
+    assert_eq!(contig().len(), 320, "contig length");
+}
+
+/// A duplication spelled past the junction is pulled back to the clamp; one
+/// already at the clamp stays.
+///
+/// This is the ruling's own shape, reduced: `c.17dup` is `LRG_199t1:c.3922dup`
+/// and `c.16dup` is `c.3921dup`.
+#[test]
+fn a_duplication_converges_on_the_near_side_of_the_junction() {
+    let near = format!("NM_SYNTH.1:c.{}dup", cds_of(NEAR_TX));
+    let far = format!("NM_SYNTH.1:c.{}dup", cds_of(FAR_TX));
+
+    assert_eq!(
+        normalize(&near),
+        near,
+        "the near side is at the clamp and must not shift across the junction — this is the \
+         direction ferro already had, and a pull-back that broke it would trade one half of the \
+         exception for the other"
+    );
+    assert_eq!(
+        normalize(&far),
+        near,
+        "the far side is past the clamp and must be pulled back to it \
+         (`exon-junction-dup-converge-from-the-far-side`, `DNA/duplication.md:26`/`:60`/`:148`)"
+    );
+}
+
+/// The same, for a deletion. The ruling's scope is "deletions and
+/// duplications", and `general.md:44` names both; a fix keyed on `dup` alone
+/// would satisfy the ruling's worked example and miss half its scope.
+#[test]
+fn a_deletion_converges_on_the_near_side_of_the_junction() {
+    let near = format!("NM_SYNTH.1:c.{}del", cds_of(NEAR_TX));
+    let far = format!("NM_SYNTH.1:c.{}del", cds_of(FAR_TX));
+
+    assert_eq!(normalize(&near), near, "the near side stays at the clamp");
+    assert_eq!(normalize(&far), near, "the far side is pulled back to it");
+}
+
+/// The `n.` axis, on the same bases and the same geometry.
+///
+/// `general.md:44` names `c.`, `r.` and `n.` together, and ferro's forward
+/// clamp is already applied on all three. The far-side half must not be `c.`
+/// only, or the two axes disagree about which spelling of one sequence is
+/// canonical.
+#[test]
+fn the_noncoding_axis_converges_from_the_far_side_too() {
+    for edit in ["dup", "del"] {
+        let near = format!("NR_SYNTH.1:n.{NEAR_TX}{edit}");
+        let far = format!("NR_SYNTH.1:n.{FAR_TX}{edit}");
+
+        assert_eq!(
+            normalize(&near),
+            near,
+            "n.{NEAR_TX}{edit}: the near side stays at the clamp"
+        );
+        assert_eq!(
+            normalize(&far),
+            near,
+            "n.{FAR_TX}{edit}: the far side is pulled back to it"
+        );
+    }
+}
+
+/// The pulled-back answer is a fixed point.
+///
+/// A pull-back that re-fires on its own output would be a non-idempotency of
+/// the kind `FERRO_ASSERT_IDEMPOTENT` exists to catch, and it is the obvious
+/// failure mode of implementing this as "step back over the junction" rather
+/// than as "find where the run begins": the answer's own run begins inside its
+/// own exon, so nothing pulls it further.
+#[test]
+fn convergence_is_a_fixed_point() {
+    for input in [
+        format!("NM_SYNTH.1:c.{}dup", cds_of(FAR_TX)),
+        format!("NM_SYNTH.1:c.{}del", cds_of(FAR_TX)),
+        format!("NR_SYNTH.1:n.{FAR_TX}dup"),
+        format!("NR_SYNTH.1:n.{FAR_TX}del"),
+    ] {
+        let once = normalize(&input);
+        let twice = normalize(&once);
+        assert_eq!(twice, once, "{input} normalized twice");
+    }
+}
+
+/// A del/dup whose run does not straddle a junction is untouched.
+///
+/// The negative control. The pull-back runs for every `c.`/`n.` del/dup, so
+/// without this the module could not distinguish "the clamp binds from both
+/// sides" from "everything drifts 5'". Transcript 8 sits mid-exon in a
+/// period-3 `ACG` tract, and transcript 22 is the `C` immediately 3' of the run
+/// — the first position past the junction that the pull-back must **not** reach.
+#[test]
+fn a_run_inside_one_exon_is_not_pulled_anywhere() {
+    for tx in [8_u64, 22] {
+        let input = format!("NR_SYNTH.1:n.{tx}del");
+        let out = normalize(&input);
+        let position: u64 = out
+            .trim_start_matches("NR_SYNTH.1:n.")
+            .trim_end_matches("del")
+            .parse()
+            .unwrap_or_else(|_| panic!("unexpected shape for {input}: {out}"));
+        assert!(
+            position >= tx,
+            "{input} -> {out}: a 3'-direction normalization must never move a variant 5', and \
+             this run does not reach a junction"
+        );
+    }
+}
+
+/// The pull-back must not swallow a warning the input earned.
+///
+/// The clamp re-normalizes a description derived from its own *output*, so the
+/// second pass never sees the input: a `REFSEQ_MISMATCH` raised because the
+/// input stated a base the reference contradicts is not re-derivable there
+/// (`normalize_na_edit` reads a `dup` payload from the reference, #219). If the
+/// second pass's warnings simply replaced the first's, the disclosure would
+/// vanish.
+///
+/// The near-side spelling is the control, and it is what makes this a real
+/// assertion rather than a change detector: the two inputs differ only in which
+/// side of the junction they are spelled on, and they produce the **same**
+/// output, so any disagreement about the warning is the clamp's doing and
+/// nothing else's.
+#[test]
+fn the_pull_back_keeps_the_warnings_the_input_earned() {
+    use ferro_hgvs::normalize::NormalizationWarning;
+
+    fn mismatch_reported(input: &str) -> (String, bool) {
+        let normalizer = Normalizer::new(provider());
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let result = normalizer
+            .normalize_with_diagnostics(&variant)
+            .unwrap_or_else(|e| panic!("normalize {input}: {e}"));
+        let reported = result
+            .warnings
+            .iter()
+            .any(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. }));
+        (format!("{}", result.result), reported)
+    }
+
+    // Transcript 20 and 21 are both `T`; stating `G` earns a corrected
+    // REFSEQ_MISMATCH on either spelling.
+    let far = format!("NM_SYNTH.1:c.{}dupG", cds_of(FAR_TX));
+    let near = format!("NM_SYNTH.1:c.{}dupG", cds_of(NEAR_TX));
+    let expected = format!("NM_SYNTH.1:c.{}dup", cds_of(NEAR_TX));
+
+    let (near_out, near_reported) = mismatch_reported(&near);
+    let (far_out, far_reported) = mismatch_reported(&far);
+
+    assert_eq!(
+        (near_out.as_str(), far_out.as_str()),
+        (expected.as_str(), expected.as_str()),
+        "the premise: both spellings converge on the near side, so the only thing that can \
+         differ between them is whether the warning survived"
+    );
+    assert!(
+        near_reported,
+        "the control must report the mismatch — if it does not, this test is measuring \
+         something other than the clamp"
+    );
+    assert!(
+        far_reported,
+        "the pulled-back spelling dropped the REFSEQ_MISMATCH its input earned: the clamp's \
+         re-normalization must ADD to the first pass's warnings, never replace them"
+    );
+}
+
+/// An `n.*N` position is refused by the clamp rather than read as a plain
+/// transcript offset.
+///
+/// `TxPos::is_intronic` reads only `offset`, and the `*` marker is a spelling
+/// flag on the position rather than a transcript region — so on the `n.` axis
+/// there is no `boundary::axis_region_of` check standing behind the clamp the
+/// way there is on `c.`. Read as a bare offset, `n.*21` would be pulled to the
+/// junction's near side and rebuilt **without** the flag, silently re-zoning the
+/// description into a zone `background/numbering.md:52` does not give this axis.
+///
+/// Built through the AST rather than parsed, deliberately: #1748 refuses the
+/// spelling at parse in every mode, while `TxPos::downstream` stays public API.
+/// That is exactly the reachability the re-parse oracle's own exemption list
+/// records for this shape — no string entry point mints one, and a Rust caller
+/// can.
+#[test]
+fn a_downstream_noncoding_position_is_not_pulled_across_the_junction() {
+    use ferro_hgvs::hgvs::edit::NaEdit;
+    use ferro_hgvs::hgvs::interval::TxInterval;
+    use ferro_hgvs::hgvs::location::TxPos;
+    use ferro_hgvs::hgvs::variant::{Accession, HgvsVariant, LocEdit, TxVariant};
+
+    let mut position = TxPos::new(FAR_TX as i64);
+    position.downstream = true;
+    let variant = HgvsVariant::Tx(TxVariant {
+        accession: Accession::new("NR", "SYNTH", Some(1)),
+        gene_symbol: None,
+        loc_edit: LocEdit::new(
+            TxInterval::point(position),
+            NaEdit::Deletion {
+                sequence: None,
+                length: None,
+            },
+        ),
+    });
+    assert_eq!(
+        format!("{variant}"),
+        format!("NR_SYNTH.1:n.*{FAR_TX}del"),
+        "the premise: the constructed position really carries the downstream marker"
+    );
+
+    let normalizer = Normalizer::new(provider());
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    assert_eq!(
+        format!("{normalized}"),
+        format!("NR_SYNTH.1:n.*{FAR_TX}del"),
+        "a downstream position names no transcript offset the clamp can read, so it must be \
+         left alone — pulling it back drops the `*` and states a different variant"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -27,6 +27,7 @@ mod issue_1592_reduced_member_junction_clamp;
 mod issue_1597_repeat_clamp_unit;
 mod issue_1600_reduced_delins_tract_demotion;
 mod issue_1607_protein_residue_one_guard;
+mod issue_1621_exon_junction_far_side;
 mod issue_1627_named_element_alphabet_reach;
 mod issue_1632_parse_entry_applies_no_mode;
 mod issue_1713_bare_transcript_genomic_decline;

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -90,7 +90,7 @@
 //! fix intact — it is now carried by `outputs_intronic_under_a_genomic_wrapper`,
 //! and it is still a claim about the code rather than about the corpus.
 //!
-//! # RE-BLESSED (1 of 5) — #1599, the amino-acid precondition
+//! # RE-BLESSED (1 of 6) — #1599, the amino-acid precondition
 //!
 //! Everything above and in [`THREE_PRIME`]'s own doc was written on the corpus
 //! PR, which touched no normalizer file. **That is no longer the base.** #1599
@@ -129,7 +129,7 @@
 //! #1599, which was the pre-existing baseline and not a regression of its — it is
 //! #1704, three sections down, that finally moves it.
 //!
-//! # RE-BLESSED (2 of 5) — #1536, the cross-axis re-typing carve-out
+//! # RE-BLESSED (2 of 6) — #1536, the cross-axis re-typing carve-out
 //!
 //! This branch adds a third carve-out from the #350 cross-axis bail in
 //! `normalize_cds`, so a `delins`/`inv` whose span straddles a CDS boundary is
@@ -182,7 +182,7 @@
 //! measures **6** at 3', the two extra rows being
 //! `s00-c3{p,m}-cds-end-del-del-p2-sep1`. Every rank-1 counter is unchanged.
 //!
-//! # RE-BLESSED (3 of 5) — #1649, the two-deletion alignment
+//! # RE-BLESSED (3 of 6) — #1649, the two-deletion alignment
 //!
 //! `merge`'s payload splitter could express *insertion, retained reference,
 //! insertion* but not *deletion, retained reference, deletion*, so a payload
@@ -235,7 +235,7 @@
 //! converged. `s00-c3{p,m}-m4-all-del-p1-sep2` is untouched and stays pinned
 //! there — its spanning `delins` still stops where `general.md:34` puts it.
 //!
-//! # RE-BLESSED (4 of 5) — #1627, the alignment-only symbol
+//! # RE-BLESSED (4 of 6) — #1627, the alignment-only symbol
 //!
 //! `background/standards.md:39` footnotes the table's daggered `X` and `-` as
 //! "used in alignment only", and the decided
@@ -294,7 +294,7 @@
 //! which covers the embedded shapes (`delinsACGTX`, `delinsXACGT`,
 //! `delinsACXGT`) the corpus does not generate.
 //!
-//! # RE-BLESSED (5 of 5) — #1716, the codon-frame merge's own span
+//! # RE-BLESSED (5 of 6) — #1716, the codon-frame merge's own span
 //!
 //! `merge_consecutive_edits`' per-member codon-frame predicate asked
 //! `same_codon(prev_a.end, next_start)` — its left anchor's **right** edge —
@@ -345,6 +345,76 @@
 //! `outputs_leaving_the_transcript`, `prohibition_violating_outputs` — as are
 //! `non_idempotent_outputs` (4 / 4), `sequence_changed` (4 / 0), all three
 //! refusal counters and `guard_violations`.
+//!
+//! # RE-BLESSED (6 of 6) — #1621, the exon-junction clamp from the far side
+//!
+//! `general.md:44` exempts deletions and duplications around exon/exon
+//! junctions from the 3' rule on `c.`/`n.`, and ferro applied that exemption in
+//! one direction only: a description approaching a junction stopped at it, one
+//! already spelled past it stayed put. The operator ruling
+//! `exon-junction-dup-converge-from-the-far-side` reads the exemption as a clamp
+//! binding in **both** directions, so a description pinned at its exon's first
+//! base whose equivalence run continues back over the junction is pulled onto
+//! the near side.
+//!
+//! **Three figures move. `converged` is unchanged, no failure counter rises,
+//! and both rank-2 moves are arity FALLS:**
+//!
+//! | figure | was (this branch's base, `96305ded`) | now | direction |
+//! |---|---|---|---|
+//! | 3' `outputs_intronic_under_a_genomic_wrapper` | 389 | **391** | +2 — conformant, not a defect counter |
+//! | 3' `converged` | 11,016 | **11,016** | unchanged |
+//! | 3' `split_two` | 673 | **674** | +1, from `split_three` |
+//! | 3' `split_three` | 164 | **164** | unchanged — one in, one out |
+//! | 3' `split_more` | 29 | **28** | −1, to `split_three` |
+//!
+//! **Every absolute above was restated on the #1835 rebase; every DELTA is the
+//! one first measured.** The table read `371 -> 373`, `9,402` unchanged,
+//! `2,223 -> 2,224`, `226` unchanged and `31 -> 30` when it was written, against
+//! a base predating the partition flip (#1835), which moved 1,614 families into
+//! `converged` (`split_two` −1,550, `split_three` −62, `split_more` −2) — and
+//! #1840 and #1704 moved the intronic counter. So `converged` was **9,402** in
+//! the prose and **11,016** in the constant three hundred lines below, which is
+//! the shape this repository's `CLAUDE.md` names: a derived figure quoted
+//! against a base nobody restates. Quote the deltas, which survived the rebase
+//! unchanged, and re-read the absolutes off [`THREE_PRIME`] rather than from
+//! here.
+//!
+//! **The 5' census does not move at all**, which is a check on the change
+//! rather than a coincidence: the clamp is gated on
+//! `ShuffleDirection::ThreePrime`, because the 3' rule is what `general.md:44`
+//! carves an exception out of and a 5'/VCF shuffle has no such rule to clamp.
+//!
+//! **Exactly four family instances change, all in the `junction-1-del-del`
+//! stratum, and they are named** — the net counters cannot tell an arity rise
+//! from a fall. The full divergence row-id lists were dumped either side (the
+//! `MAX_DIVERGENCES` cap raised locally, then restored) and diffed:
+//!
+//! - **0 families lose convergence, 0 gain it, and 0 become divergent that were
+//!   not** — the divergent *set* is identical either side, 2,480 families.
+//! - `s01-c3p-junction-1-del-del-p1-sep0` 4 -> 3 and `…-sep1` 3 -> 2: in both,
+//!   the output that disappears is `NM_TEST.1:c.21_22del`, the far-side spelling,
+//!   which now converges onto `c.19_20del` — the arity fall IS the ruling.
+//! - `s01-c3m-junction-1-del-del-p1-sep{0,1}` keep their arity and re-spell that
+//!   same output as `NC_SYNTH.1(NM_TEST.1):c.18_20+2A[3]`. Those are the +2 on
+//!   the intronic counter: on the minus strand the pulled-back description rests
+//!   on the junction's near side, where #670's junction-crossing continuation
+//!   carries it into the intron. Both clauses apply and they compose —
+//!   `general.md:44` forbids the exon/EXON shift, the exception 3' rule permits
+//!   the exon/INTRON one — so the row is conformant, not a new violation.
+//!
+//! **Nothing is promoted to `spec_corpus_regressions.rs`**, because nothing
+//! newly fails: every moved figure improves or is conformant. The ruling's own
+//! row is pinned in `spec_worked_examples.rs`
+//! (`the_decided_target_is_convergence_on_the_near_side`, no longer `#[ignore]`d)
+//! and the rest of its scope — deletions, the `n.` axis, and both directions of
+//! the clamp — in `issue_1621_exon_junction_far_side.rs`.
+//!
+//! **Every rank-1 counter is unchanged** — `outputs`, `declined`,
+//! `unparseable_outputs`, `outputs_denoting_no_sequence`,
+//! `outputs_leaving_the_transcript`, `prohibition_violating_outputs` — as are
+//! `non_idempotent_outputs` (4), `sequence_changed` (4), all three refusal
+//! counters and `guard_violations`.
 //!
 //! # CORRECTED — what the transcript-leaving class actually violates
 //!
@@ -676,7 +746,17 @@ pub(crate) const THREE_PRIME: Census = Census {
     // stays at 0, which is the counter that would move if any of the eighteen
     // were being emitted on a bare transcript instead
     // (`bare-transcript-intronic-position`, decided).
-    outputs_intronic_under_a_genomic_wrapper: 389,
+    //
+    // #1621 adds **2** on top of that: the two
+    // `s01-c3m-junction-1-del-del-p1-sep{0,1}` rows whose far-side spelling is
+    // now pulled back onto the junction's near side, where #670's
+    // junction-crossing continuation then carries it into the intron as
+    // `NC_SYNTH.1(NM_TEST.1):c.18_20+2A[3]`. Both clauses apply and they
+    // compose: `general.md:44` forbids the exon/EXON shift, the exception 3'
+    // rule permits the exon/INTRON one. Conformant, and not a defect counter —
+    // see the module docs' sixth RE-BLESSED section. Re-measured on the rebase
+    // onto #1835 rather than composed from the two branches' deltas: 391.
+    outputs_intronic_under_a_genomic_wrapper: 391,
     // Re-blessed DOWN to ZERO. #1627 refused `standards.md:39`'s 24 `X` rows
     // rather than re-emitting them; #1628 refused the residual 8 —
     // `checklist.md:16`'s `+` offset (4) and `checklist.md:45`'s hyphen range
@@ -721,10 +801,24 @@ pub(crate) const THREE_PRIME: Census = Census {
     // and `non_idempotent_outputs` are unmoved at 4, and
     // `outputs_denoting_no_sequence` is unmoved at 10. So nothing converged by
     // losing a member, changing a base or ceasing to be a fixed point.
+    //
+    // # #1621 — on top of that, two families move DOWN one arity each
+    //
+    // `converged` is untouched — `split_more` -1 and `split_three` +1 from
+    // `s01-c3p-junction-1-del-del-p1-sep0` (4 -> 3), then `split_three` -1 and
+    // `split_two` +1 from `…-sep1` (3 -> 2), which is why only two of the four
+    // counters below move off #1835's values. Measured by diffing the full
+    // divergence row-id lists either side (the `MAX_DIVERGENCES` cap raised
+    // locally, then restored), not inferred from the net counters: **no family
+    // lost or gained convergence**. Re-measured on the rebase onto #1835 rather
+    // than composed from the two branches' deltas: on this base the two moves
+    // land in `split_two` +1 and `split_more` -1, leaving `split_three` where
+    // #1835 left it, and the divergent-bucket deltas sum to zero against
+    // `converged`'s zero gain.
     converged: 11_016,
-    split_two: 673,
+    split_two: 674,
     split_three: 164,
-    split_more: 29,
+    split_more: 28,
     underdetermined: 0,
     // -- idempotency --
     //

--- a/tests/it/spec_worked_examples.rs
+++ b/tests/it/spec_worked_examples.rs
@@ -55,21 +55,26 @@
 //!   the spec's own published inputs**, because the reference tract is not a
 //!   whole number of `TA` copies. Recorded, not endorsed.
 //!
-//! # The exon-junction pair must converge, and does not yet
+//! # The exon-junction pair converges
 //!
 //! `LRG_199t1:c.3921dup` and `c.3922dup` denote one transcript sequence (both
-//! positions are `T`) but are two fixed points, projecting 2,790 bp apart. The
+//! positions are `T`) and were two fixed points, projecting 2,790 bp apart. The
 //! ruling `exon-junction-dup-converge-from-the-far-side` is **`decided`:
 //! CONVERGE** — `c.3922dup` normalizes to `c.3921dup`, because the 3'rule's
-//! exon-junction clamp binds from **both** sides. Ferro does not do that yet
-//! (#1621), so this file pins each row's own output as **pre-fix behaviour**
-//! and `the_decided_target_is_convergence_on_the_near_side` asserts the decided
-//! answer under `#[ignore]`.
+//! exon-junction clamp binds from **both** sides. #1621 implemented it, so
+//! `the_decided_target_is_convergence_on_the_near_side` now runs unignored and
+//! the `c.3922dup` row's three mode outputs are the spec's own answer.
 //!
-//! That also makes `LRG_199t1:c.3922dup` a **recorded divergence** rather than
-//! a row the spec is silent on: its `spec_expected` was null on the reasoning
-//! that the spec published no answer, and the spec publishes one three times
-//! (`DNA/duplication.md:26`, `:60`, `:148`).
+//! `LRG_199t1:c.3922dup` was a **recorded divergence** rather than a row the
+//! spec is silent on: its `spec_expected` was null on the reasoning that the
+//! spec published no answer, and the spec publishes one three times
+//! (`DNA/duplication.md:26`, `:60`, `:148`). With the clamp binding from the
+//! far side the row conforms, and the diverging set is empty.
+//!
+//! The rest of the ruling's scope — deletions as well as duplications, and the
+//! `n.` axis as well as `c.`, each asserted in **both** directions — is in
+//! `tests/it/issue_1621_exon_junction_far_side.rs`, on a synthetic two-exon
+//! transcript. This slice carries the spec's own row and nothing more.
 //!
 //! # Regenerating the slice
 //!
@@ -237,10 +242,14 @@ fn the_lenient_path_reproduces_the_spec_where_the_spec_is_self_consistent() {
         }
     }
     assert_eq!(
-        compared, 11,
+        compared, 12,
         "the set of spec-conformant rows changed size. It was 10 until #1631 fixed the W3013 \
          repair: `NM_024312.4:r.-6_-3g[6]`'s lenient answer moved onto the spec's published \
-         string and the row stopped being a divergence"
+         string and the row stopped being a divergence. It was 11 until #1621 made the \
+         exon-junction clamp bind from the far side, which moved `LRG_199t1:c.3922dup` onto \
+         `c.3921dup` and retired the last divergence — so this is now every row the spec \
+         answers, and `the_divergence_set_is_exactly_the_one_recorded_conflict` asserts the \
+         complement is empty"
     );
     assert!(
         mismatched.is_empty(),
@@ -341,35 +350,37 @@ fn the_divergence_set_is_exactly_the_one_recorded_conflict() {
         .map(|c| c.input.as_str())
         .collect();
     diverging.sort_unstable();
-    assert_eq!(
-        diverging,
-        ["LRG_199t1:c.3922dup"],
-        "the set of rows diverging from the spec changed. One is recorded: the exon-junction \
-         row that the `exon-junction-dup-converge-from-the-far-side` ruling decided against \
-         ferro's current output (#1621). A second is a defect, not a fixture edit. It held two \
-         until #1631: `NM_024312.4:r.-6_-3g[6]` diverged because the W3013 repair emitted \
-         `r.-6_-3[6]`, which by `RNA/repeated.md:20` is a different variant. That row is now \
-         conformant with `:27` — which does NOT settle the `:22`-vs-`:27` conflict, only what \
-         ferro emits."
+    assert!(
+        diverging.is_empty(),
+        "the set of rows diverging from the spec changed: {diverging:?}. It is empty, and any \
+         member is a defect rather than a fixture edit. It held two until #1631: \
+         `NM_024312.4:r.-6_-3g[6]` diverged because the W3013 repair emitted `r.-6_-3[6]`, which \
+         by `RNA/repeated.md:20` is a different variant — now conformant with `:27`, which does \
+         NOT settle the `:22`-vs-`:27` conflict, only what ferro emits. It held one until #1621: \
+         `LRG_199t1:c.3922dup`, the exon-junction row the \
+         `exon-junction-dup-converge-from-the-far-side` ruling decided against ferro's output, \
+         which now converges on `c.3921dup` from the far side."
     );
 }
 
-/// The two exon-junction rows are two fixed points for one transcript sequence.
+/// The premise the exon-junction ruling rests on: the two positions carry the
+/// same base, so the pair really is two spellings of one transcript sequence.
 ///
-/// **Pre-fix behaviour against a decided target**, not an observation any more.
-/// The `exon-junction-dup-converge-from-the-far-side` ruling is `decided`:
-/// CONVERGE, so the `assert_ne!` below records a defect rather than a choice.
-/// It stays because the premise it also checks — both positions carry the same
-/// base, so the pair really is two spellings of one sequence — is what the
-/// ruling rests on, and because a test that goes green on the day the fix lands
-/// is the signal to move the fixture rows with it.
+/// **What used to be here was an `assert_ne!`** pinning the two rows as two
+/// fixed points — pre-fix behaviour against a decided target. #1621 implemented
+/// the clamp and that assertion was **deleted rather than inverted**, on its own
+/// instructions and the issue's: the converged answer is asserted by
+/// [`the_decided_target_is_convergence_on_the_near_side`], which now runs
+/// unignored, and a second test restating it would only be a second thing to
+/// keep in step.
 ///
-/// The decided answer is asserted by
-/// [`the_decided_target_is_convergence_on_the_near_side`], which is `#[ignore]`d
-/// until #1621. When that lands, **delete this assertion rather than inverting
-/// it** — the ignored guard already says the thing worth saying.
+/// The base check survives the deletion because it is not a claim about ferro at
+/// all. It is the evidence for the ruling — if `c.3921` and `c.3922` did not
+/// carry the same base they would be two variants rather than two spellings, and
+/// convergence would be wrong instead of required. Nothing else in this file
+/// checks it, and the sibling test would still pass if the slice drifted.
 #[test]
-fn the_exon_junction_pair_does_not_converge_and_that_is_recorded() {
+fn the_exon_junction_pair_is_two_spellings_of_one_sequence() {
     let fixture = WindowFixture::from_json_path(&repo_path(WINDOWS_PATH))
         .expect("load the committed spec worked-example reference slice");
     let tx = fixture
@@ -389,18 +400,6 @@ fn the_exon_junction_pair_does_not_converge_and_that_is_recorded() {
         "the premise of this record is that c.3921 and c.3922 are the same base, so the two \
          spellings denote one transcript sequence"
     );
-
-    let provider = fixture.to_provider();
-    let first = run(&provider, "LRG_199t1:c.3921dup", Mode::Lenient);
-    let second = run(&provider, "LRG_199t1:c.3922dup", Mode::Lenient);
-    assert_ne!(
-        first, second,
-        "the exon-junction pair converged — which is the DECIDED target (ruling \
-         `exon-junction-dup-converge-from-the-far-side`), so this failure is good news. Delete \
-         this assertion, un-ignore `the_decided_target_is_convergence_on_the_near_side`, and \
-         move the `LRG_199t1:c.3922dup` rows in `tests/fixtures/spec-worked-examples/cases.json` \
-         and `tests/fixtures/case-harvest/cases.json` to `c.3921dup`. See #1621."
-    );
 }
 
 /// **The decided target**: `LRG_199t1:c.3922dup` normalizes to
@@ -416,11 +415,10 @@ fn the_exon_junction_pair_does_not_converge_and_that_is_recorded() {
 /// `c.3922dup` translated back to a genomic position lands "at the wrong
 /// nucleotide, in the wrong exon".
 ///
-/// **`#[ignore]`d because ferro does not do this yet**, not because the answer
-/// is in doubt. #1617's sibling; the implementation is **#1621**, and this test
-/// is its acceptance criterion.
+/// **Was `#[ignore]`d** while the answer was decided and unimplemented — never
+/// because it was in doubt. #1617's sibling; **#1621** implemented it and this
+/// test was its acceptance criterion, so the attribute came off with the fix.
 #[test]
-#[ignore = "decided target, not yet implemented — see #1621"]
 fn the_decided_target_is_convergence_on_the_near_side() {
     let fixture = WindowFixture::from_json_path(&repo_path(WINDOWS_PATH))
         .expect("load the committed spec worked-example reference slice");


### PR DESCRIPTION
`general.md:44` exempts deletions and duplications around exon/exon junctions from the 3' rule on `c.`/`n.` references. Ferro applied that exemption in **one direction only**: a description approaching a junction stopped at it, while one already spelled *past* it was left standing. So two spellings of one transcript sequence were two fixed points, projecting ~2,790 bp apart.

The operator ruling `exon-junction-dup-converge-from-the-far-side` (decided 2026-08-10, landed in #1623) reads the exemption as a clamp binding in **both** directions. This is its implementation half — the issue #1623's body named as "#1621", which existed as an issue and never as a PR.

## The rule

The canonical position is the most 3' position that does not cross an exon/exon junction, **reached from either side**. Implemented as: find where the description's equivalence run *begins* in full transcript space, then clamp the 3' rule inside the exon holding that anchor. Both spellings of one run share an anchor, so both reach the same answer — that is the "from either side".

In spliced transcript space a junction is not a gap: the base immediately 5' of an exon's first base is the previous exon's last base, which is why `c.3921` and `c.3922` are one contiguous `T` run and only the exon annotation distinguishes them.

## Where the clamp is asked, and two placements that were measured and rejected

It is asked **once, on the finished description**, at the seam every public normalization passes through. Both alternatives were implemented and measured before being discarded, and both failures are recorded in the code:

- **On the input.** `normalize_cds` has several producers of a del/dup spelling and only one is the input's own edit kind: a `delins` whose payload shares an affix with its reference *reduces* to a pure deletion inside `normalize_na_edit` (#1185), after any input-side check has run. `c.20_22delinsA` therefore emitted `c.21_22del` — a description the clamp itself would move. That is a **rank-1 idempotency regression**, measured as `non_idempotent_outputs` 4 → 6 in the 58,552-output conformance census.
- **Inside `normalize_cds`/`normalize_tx`.** Those are recursive (the `conversion` rewrite, special-position resolution, …), so a clamp applied there fires on *intermediate* spellings as well as the answer. Measured: it moved cis-allele rows whose finished output the clamp declines, cost one converged family (`s00-n3p-junction-2-del-del-p1-sep0`) and raised another's arity.

An earlier in-place rewrite of the transcript coordinates was also rejected: #670's `normalize_boundary_spanning_cds` reads the original `variant`/`start_pos`/`end_pos`, so rewriting only `tx_start` made `LRG_199t1:c.3922dup` fire the junction-crossing continuation against **exon 28's** genomic neighbourhood while the shuffle had already moved to exon 27.

## Scope

Deletions and duplications, `c.` and `n.`, 3'-direction only, refused across a CDS axis change. `r.` is deferred with the ruling's own "(and `r.` until upstream PR #266 lands)". A cis **member** is not clamped individually — only a whole-variant result is.

**The bound that matters:** a description that can still shift 3' inside its own exon is *not* pulled back. Without that condition the rule inverts into the defect it prevents, moving a description 5' *across* a junction. `NM_001234.1:c.13del` → `c.26del` (#1450) is the case that sets it: its run does reach back over the exon-1/exon-2 junction, but its own exon-confined answer is exon 2's **last** base, so it stays. An unconditioned anchor rule drags it to `c.11del`, one exon away — measured, then fixed.

**Residue, left deliberately.** A run whose portion inside the far exon is longer than the description can be pinned at (`c.3922`/`c.3923` both `T`, say) is not reached: the far-side spelling shifts within its own exon and the pair does not converge. The ruling's words arguably cover it; its worked example, its grounds and every corpus row do not, and widening re-opens the #1450 regression unless some further discriminator is found. Recorded on `exon_junction_anchor` rather than guessed at.

## Tests

- `spec_worked_examples::the_decided_target_is_convergence_on_the_near_side` — the ruling's own acceptance criterion, **`#[ignore]` removed**; `LRG_199t1:c.3922dup` → `c.3921dup` in default, lenient and strict. Verified failing first, for the right reason (`left: Ok("LRG_199t1:c.3922dup")`).
- `the_exon_junction_pair_does_not_converge_and_that_is_recorded`'s `assert_ne!` is **deleted rather than inverted**, on its own instructions. The base-identity premise it also checked survives as `the_exon_junction_pair_is_two_spellings_of_one_sequence` — that is evidence for the ruling, not a claim about ferro, and nothing else checks it.
- `tests/it/issue_1621_exon_junction_far_side.rs` — the rest of the ruling's scope on a synthetic **two-exon** transcript built programmatically: deletions as well as duplications, `n.` as well as `c.`, each asserting **both** directions (the near side stays *and* the far side converges), plus a fixed-point check and a negative control. `cds_start` is 5, not 1. `the_fixture_really_straddles_a_junction` asserts the geometry directly — a single-exon fixture with `CDS_START = 1` cannot reach this class at all (#1478).
- Fixture rows moved per the issue's acceptance list: `spec-worked-examples/cases.json` (three mode outputs) and `case-harvest/cases.json`. The diverging set is now **empty** and the conformant-row census moves 11 → 12.

## Representation-Change

Representation-Change: 13 of 85,642 rows move (0.0%) on the designed shape-family corpus — `coincident_bounds` 9, `repeat_expansion` 4 — and **all 13 were previously not fixed points**, so 0 previously-accepted rows move and there is no consumer migration. Quote that rate as of the affected families, not repo-wide. Independently, over `spec_conformance_axis`'s 58,552 outputs exactly four family instances change, all `junction-1-del-del`: `s01-c3p-…-sep{0,1}` fall one arity each as the far-side spelling `c.21_22del` converges onto `c.19_20del`, and `s01-c3m-…-sep{0,1}` re-spell that same output as `NC_SYNTH.1(NM_TEST.1):c.18_20+2A[3]`. No family loses or gains convergence, `converged` is unchanged at 11,016, no failure counter rises, and the 5' census does not move at all. The spec's own row `LRG_199t1:c.3922dup` → `c.3921dup` moves its projected genomic form ~2,790 bp (that figure is the ruling's, relayed, not re-derived here).

## Census re-blessing

`spec_conformance_axis`'s 3' pin moves three numbers, all improvements or conformant re-renderings, disclosed in a new `RE-BLESSED (6 of 6)` section with the row-level diff (full divergence lists dumped either side with `MAX_DIVERGENCES` raised locally, then restored):

| figure | was | now | direction |
|---|---|---|---|
| `outputs_intronic_under_a_genomic_wrapper` | 389 | **391** | +2 — conformant, not a defect counter |
| `converged` | 11,016 | **11,016** | unchanged |
| `split_two` | 673 | **674** | +1, from `split_three` |
| `split_more` | 29 | **28** | −1, to `split_three` |

The +2 is the minus-strand pair whose pulled-back description then continues into the intron via #670. Both clauses apply and compose: `general.md:44` forbids the exon/**exon** shift, the exception 3' rule permits the exon/**intron** one. Nothing is promoted to `spec_corpus_regressions.rs` because nothing newly fails.

## Verification

Full suite `10,845 passed, 0 failed, 151 skipped` (`EXIT=0`, read from the log, with `FERRO_MANIFEST` set). `scripts/run_oracle_suite.sh` `10,484 passed` (`EXIT=0`). `cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean.

Closes #1621

