### PR TITLE
fix(reference): model the LRG <diff> list so indel-bearing parents project exactly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1168,7 +1168,7 @@ It also downloads genomic-parent placement data used to project transcript-coord
 - **RefSeqGene→genome alignments** (`GCF_*_refseqgene_alignments.gff3`, from NCBI's archived `alignments/ARCHIVE/all/` — the feed stopped updating in 2024; latest GRCh38 is the RS-109/p13 snapshot, valid for p14 since primary `NC_` accessions are unchanged) → manifest `refseqgene_alignments`; parsed by `MultiFastaProvider` into per-`NG_` `GenomicPlacement`. The corresponding GRCh37 snapshot (`GCF_000001405.25_105.*`) → manifest `refseqgene_alignments_grch37`, merged with the GRCh38 file so an `NG_` resolves to its build-appropriate placement (#653/#713).
 - **LRG XML** genomic mapping → per-`LRG_` `GenomicPlacement` (parsed on demand).
 
-`ReferenceProvider::genomic_placement` exposes these; `VariantProjector::project_to_genomic` composes the `NM_`→`NC_` (cdot) step with the `NC_`→`NG_`/`LRG_` affine transform to re-express coordinates in the parent frame. With no placement it declines rather than emit chromosome coordinates under the parent accession.
+`ReferenceProvider::genomic_placement` exposes these; `VariantProjector::project_to_genomic` composes the `NM_`→`NC_` (cdot) step with the `NC_`→`NG_`/`LRG_` transform to re-express coordinates in the parent frame. With no placement it declines rather than emit chromosome coordinates under the parent accession. That transform is **affine only when the placement carries no alignment gaps** — an LRG record lists `<diff>` elements alongside its `<mapping_span>`, and since #1833 the indel ones are carried on the placement and honoured, so 46 of the prepared reference's 1294 LRG records map through a gap list rather than a pure offset (#1499).
 
 ## Reading the spec
 

--- a/src/conformance/accession_inventory.rs
+++ b/src/conformance/accession_inventory.rs
@@ -558,6 +558,7 @@ mod tests {
                 nc_end: 200,
                 parent_start: 1,
                 strand: Strand::Plus,
+                gaps: Vec::new(),
             },
         );
 

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -3131,10 +3131,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     }
 
     /// Re-anchor an NC-frame genome variant into a genomic parent's own frame
-    /// using its [`GenomicPlacement`] (#480): apply the affine NC→parent
-    /// transform to the interval, and reverse-complement the edit when the
-    /// parent runs antiparallel to the chromosome. If an endpoint falls outside
-    /// the placed span the variant is returned unchanged (chromosome frame).
+    /// using its [`GenomicPlacement`] (#480): map each endpoint with
+    /// [`GenomicPlacement::nc_to_parent`], and reverse-complement the edit when
+    /// the parent runs antiparallel to the chromosome. If an endpoint falls
+    /// outside the placed span the variant is returned unchanged (chromosome
+    /// frame).
+    ///
+    /// The transform is affine only when the placement carries no alignment
+    /// gaps (#1833); an LRG whose record lists indel `<diff>`s is mapped through
+    /// its gap list instead, and an endpoint landing on a chromosome base the
+    /// parent does not contain declines like an out-of-span one.
     fn reanchor_genome_to_parent(
         gv: crate::hgvs::variant::GenomeVariant,
         placement: &crate::reference::GenomicPlacement,
@@ -7496,6 +7502,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1008,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         let vp = VariantProjector::new(projector, provider);
@@ -7528,6 +7535,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1008,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         provider.add_legacy_gene_model("GENE1", "NM_TX2.1");
@@ -7566,6 +7574,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1008,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         provider.add_legacy_gene_model("GENE1", "NM_TX2.1");
@@ -7609,6 +7618,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 30000,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         // NG_900.1 parent sequence: bases 4300..=4320 (1-based) are the insert.
@@ -7651,6 +7661,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 30000,
                 strand: crate::reference::Strand::Minus,
+                gaps: Vec::new(),
             },
         );
         let insert = "GTCCTGTGCTCATTATCTGGC"; // parent bases 4300..=4320
@@ -7689,6 +7700,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 30000,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         // NG_900.1 parent sequence: bases 4300..=4320 (1-based) are the insert.
@@ -7732,6 +7744,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1008,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         let vp = VariantProjector::new(projector, provider);
@@ -7787,6 +7800,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1008,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         let vp = VariantProjector::new(projector, provider);
@@ -7860,6 +7874,7 @@ mod tests {
                 nc_start: 2000,
                 nc_end: 2010,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             },
         );
         let vp = VariantProjector::new(projector, provider);
@@ -10230,6 +10245,7 @@ mod tests {
                     nc_start: 1000,
                     nc_end: 1008,
                     strand: crate::reference::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             let vp = VariantProjector::new(projector, provider);
@@ -10471,6 +10487,7 @@ mod tests {
                     nc_start: 2000,
                     nc_end: 2010,
                     strand: crate::reference::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             let vp = VariantProjector::new(projector, provider);
@@ -10514,6 +10531,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1010,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             };
             // Genomic axis at chromosome 5000 — well outside the placed span.
             let genomic = HgvsVariant::Genome(GenomeVariant {
@@ -10772,6 +10790,7 @@ mod tests {
                 nc_start: 1000,
                 nc_end: 1010,
                 strand: crate::reference::Strand::Plus,
+                gaps: Vec::new(),
             };
             // The end boundary is a compound range, so `.inner()` is `None`:
             // there is no single position to re-anchor.
@@ -10821,6 +10840,7 @@ mod tests {
                     nc_start: 1000,
                     nc_end: 1010,
                     strand: crate::reference::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             let vp = VariantProjector::new(projector, provider);
@@ -12072,6 +12092,7 @@ mod tests {
                     nc_start: 1000,
                     nc_end: 1012,
                     strand: crate::reference::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             let vp = VariantProjector::new(projector, provider);
@@ -13318,6 +13339,7 @@ mod tests {
                     nc_start: 20000,
                     nc_end: 20010,
                     strand: crate::reference::transcript::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             if with_grch37 {
@@ -13329,6 +13351,7 @@ mod tests {
                         nc_start: 10000,
                         nc_end: 10010,
                         strand: crate::reference::transcript::Strand::Plus,
+                        gaps: Vec::new(),
                     },
                 );
             }
@@ -13514,6 +13537,7 @@ mod tests {
                     nc_start: 20000,
                     nc_end: 20010,
                     strand: crate::reference::transcript::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             provider.add_genomic_placement(
@@ -13524,6 +13548,7 @@ mod tests {
                     nc_start: 10000,
                     nc_end: 10010,
                     strand: crate::reference::transcript::Strand::Plus,
+                    gaps: Vec::new(),
                 },
             );
             let vp = VariantProjector::new(projector, provider).with_assembly(Some("GRCh37"));

--- a/src/reference/derived_placement.rs
+++ b/src/reference/derived_placement.rs
@@ -349,6 +349,9 @@ pub fn placement_from_candidate(nc: Accession, candidate: &AffineCandidate) -> G
         nc_start: candidate.nc_start,
         nc_end: candidate.nc_end,
         strand: candidate.strand,
+        // A derived `NG_` placement is affine by construction: it is only
+        // emitted when a gapless alignment was found (#728).
+        gaps: Vec::new(),
     }
 }
 
@@ -548,6 +551,7 @@ impl DerivedPlacements {
                         nc_start: p.nc_start,
                         nc_end: p.nc_end,
                         strand,
+                        gaps: Vec::new(),
                     },
                 ))
             })

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -1058,6 +1058,7 @@ mod tests {
             nc_start: 1000,
             nc_end: 1008,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         };
         let mut provider = JsonProvider::new();
         provider.add_genomic_placement("NG_900.1", mk(11)); // GRCh38

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -62,5 +62,5 @@ pub use loader::{detect_genome_build, TranscriptDb};
 pub use mock::{JsonProvider, MockProvider};
 pub use multi_fasta::MultiFastaProvider;
 pub use protein::ProteinCache;
-pub use provider::{GenomicPlacement, ReferenceProvider};
+pub use provider::{AlignmentGap, AlignmentGapKind, GenomicPlacement, ReferenceProvider};
 pub use transcript::{Exon, Strand, Transcript};

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -70,7 +70,7 @@ use crate::data::cdot::CdotMapper;
 use crate::error::FerroError;
 use crate::reference::authoritative::CanonicalOverrides;
 use crate::reference::prepared_index::{load_fai_index, FastaIndexEntry, PreparedIndex};
-use crate::reference::provider::{GenomicPlacement, ReferenceProvider};
+use crate::reference::provider::{AlignmentGap, GenomicPlacement, ReferenceProvider};
 use crate::reference::transcript::Transcript;
 
 /// Supplemental transcript info for a single transcript.
@@ -3080,84 +3080,90 @@ fn xml_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
     Some(&rest[..end])
 }
 
-/// The first LRG coordinate at which a mapping stops being an affine (#1499),
-/// or `None` when it never does.
+/// Parse the indel `<diff>` elements of one `<mapping_span>` into an ordered
+/// [`AlignmentGap`] list (#1833).
 ///
-/// **An LRG↔chromosome alignment is not affine, and one `<mapping_span>` does
-/// not make it one.** Alongside the span the record lists `<diff>` elements —
-/// the vocabulary is closed at `mismatch`, `lrg_ins` (bases present in the LRG
-/// with no chromosome counterpart) and `other_ins` (the reverse), verified over
-/// all 1 294 LRG records in the prepared reference. The two insertion kinds
-/// shift every coordinate past them, in opposite directions, and
-/// [`GenomicPlacement`] is a pure affine with nowhere to carry them: composing
-/// it with cdot's `NM_`→`NC_` step therefore drifts by the *net* indel count
-/// between the LRG origin and the projected position.
+/// **A single `<mapping_span>` does not make a mapping affine.** Alongside the
+/// span the record lists `<diff>` elements; the vocabulary is closed at
+/// `mismatch` / `lrg_ins` (bases present in the LRG with no chromosome
+/// counterpart) / `other_ins` (the reverse), verified over all 1 294 LRG records
+/// in a prepared GRCh38 reference — 479 / 63 / 47 in the main-assembly mappings.
+/// Before #1833 the two insertion kinds were simply dropped, so every coordinate
+/// past one drifted by the net indel count: `LRG_292` (BRCA1) is 193 689 bases
+/// against a chromosome side of 193 687, and the affine placed all but the first
+/// 13 168 of them wrongly.
 ///
-/// `LRG_292` is the worked case. One span, `1..193689` onto
-/// `NC_000017.11:43024295..43217981` — but the chromosome side is 193 687
-/// bases, two short, from 3 `lrg_ins` bases against 1 `other_ins` base.
-/// Measured against the frozen `LRG_292g` record, the affine is exact up to
-/// `LRG_292:g.13168` and then off by +2 for the remaining ~93 % of the record,
-/// so `LRG_292(NM_007294.4):c.1del` projected to `LRG_292:g.93888del` where the
-/// record's own frame says `g.93890del`. The result is well-formed and
-/// in-bounds, so none of the four normalization oracles can see it.
+/// **`mismatch` is deliberately absent.** It substitutes a base and shifts
+/// nothing, so it leaves the coordinate mapping exact — and since #1490 the
+/// bases come from the LRG's own frozen record rather than being synthesized
+/// from the chromosome, so it has no remaining consequence here. 119 of the
+/// 1 294 records carry mismatches and no indel; treating any `<diff>` as a gap
+/// would model 165 records where 46 is correct.
 ///
-/// Returning the departure point rather than a bare "is it affine" lets the
-/// caller keep the exact prefix instead of dropping the accession. That matters:
-/// over the prepared reference, refusing the whole of every indel-bearing record
-/// would have refused 31 projections that were already landing on the right
-/// base, alongside the 51 that were not.
+/// **The two kinds spell their LRG coordinates differently**, which is the
+/// single easiest thing to get wrong: for `lrg_ins`, `lrg_start`/`lrg_end` bound
+/// the unaligned LRG bases themselves; for `other_ins` they are the *flanking*
+/// LRG coordinates, the run sitting between them. [`AlignmentGap::parent_only`]
+/// and [`AlignmentGap::chromosome_only`] take exactly those two conventions.
 ///
-/// `mismatch` is deliberately absent: it substitutes a base and shifts nothing,
-/// so the affine still maps every coordinate exactly — and since #1490 the bases
-/// themselves come from the LRG's own frozen record rather than being
-/// synthesized from the chromosome, so a mismatch has no remaining consequence
-/// here. Over the prepared reference that is the difference between narrowing 46
-/// records and narrowing 165.
+/// **An indel diff's `other_start`/`other_end` never POSITION a gap.** They are
+/// read for one thing only — the length of an `other_ins` run, which its own
+/// `lrg_start`/`lrg_end` cannot give because those are *flanks* (`LRG_292`:
+/// 15459/15460, one apart, for a run of any size). They are never used to place
+/// a gap in either frame, because they are the flanking *chromosome*
+/// coordinates, and for adjacent diffs a
+/// flank can name a base that lies inside the neighbouring diff's own range:
+/// `LRG_1321` has an `other_ins` of 1 000 `N`s at `NC_000012.12:7083651-7084650`
+/// and an `lrg_ins` of 231 bases whose chromosome flanks are `7083650`/`7083651`
+/// — the second of which is the last base of the first run. Positioning off the
+/// flanks loses the insertion; positioning off the LRG coordinates and letting
+/// the walk consume each side in turn reproduces it exactly.
 ///
-/// **Fails closed.** An indel `<diff>` whose coordinate attribute is missing or
-/// unparseable yields a horizon of `0`, which the caller reads as "nothing is
-/// affine" and declines the placement outright. Skipping such a diff would leave
-/// the span *wider* than the data supports — a silently wrong coordinate rather
-/// than a refusal, which is the direction this whole fix exists to close.
-fn affine_horizon(mapping_body: &str) -> Option<u64> {
-    mapping_body
-        .match_indices("<diff ")
-        .filter_map(|(i, _)| {
-            let rest = &mapping_body[i..];
-            let tag = &rest[..rest.find('>').unwrap_or(rest.len())];
-            let attr = match xml_attr(tag, "type") {
-                // LRG bases `lrg_start..=lrg_end` are unaligned: `lrg_start` is
-                // the first coordinate the affine cannot reach.
-                Some("lrg_ins") => "lrg_start",
-                // Chromosome bases sit *between* the flanking LRG coordinates,
-                // so `lrg_start` still maps and `lrg_end` is the first that
-                // does not.
-                Some("other_ins") => "lrg_end",
-                // The one type that is legitimately skipped: a `mismatch`
-                // substitutes a base and shifts no coordinate, so the affine
-                // still maps everything past it exactly.
-                Some("mismatch") => return None,
-                // Absent, or outside the closed vocabulary. Skipping it would
-                // leave the span *wider* than the data supports, which is the
-                // silently-wrong-coordinate direction this whole pass exists to
-                // close — the identical argument the missing-coordinate case
-                // below is already decided on, so it gets the identical answer:
-                // horizon `0`, and the caller declines the placement.
-                //
-                // Measured non-firing on real data: over all 1 294 LRG records
-                // of the prepared reference the `<diff type=…>` vocabulary is
-                // exactly `mismatch` (7 945), `lrg_ins` (1 030) and `other_ins`
-                // (907), and **0** `<diff>` elements carry no `type` at all.
-                _ => return Some(0),
-            };
-            Some(
-                xml_attr(tag, attr)
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(0),
-            )
-        })
-        .min()
+/// **Fails closed.** Returns `None` when an indel `<diff>` has a missing or
+/// unparseable coordinate, or a `lrg_end` below its `lrg_start`. The caller then
+/// declines the placement outright rather than keep a span the data does not
+/// support — a silently wrong coordinate is the direction this exists to close.
+fn parse_span_alignment_gaps(span_body: &str) -> Option<Vec<AlignmentGap>> {
+    let mut gaps: Vec<AlignmentGap> = Vec::new();
+    for (i, _) in span_body.match_indices("<diff ") {
+        let rest = &span_body[i..];
+        let tag = &rest[..rest.find('>').unwrap_or(rest.len())];
+        let kind = xml_attr(tag, "type")?;
+        if kind != "lrg_ins" && kind != "other_ins" {
+            // `mismatch` — and, defensively, any vocabulary this parser has not
+            // seen. An unknown type could shift coordinates, so it must not be
+            // silently ignored.
+            if kind != "mismatch" {
+                return None;
+            }
+            continue;
+        }
+        let lrg_start: u64 = xml_attr(tag, "lrg_start")?.parse().ok()?;
+        let lrg_end: u64 = xml_attr(tag, "lrg_end")?.parse().ok()?;
+        if lrg_end < lrg_start {
+            return None;
+        }
+        gaps.push(match kind {
+            "lrg_ins" => AlignmentGap::parent_only(lrg_start, lrg_end - lrg_start + 1),
+            _ => {
+                let other_start: u64 = xml_attr(tag, "other_start")?.parse().ok()?;
+                let other_end: u64 = xml_attr(tag, "other_end")?.parse().ok()?;
+                if other_end < other_start {
+                    return None;
+                }
+                AlignmentGap::chromosome_only(lrg_start, other_end - other_start + 1)
+            }
+        });
+    }
+    // Strictly ascending parent order — see `AlignmentGap::sort_key`, which the
+    // walk's own ordering check also reads, so the two cannot drift apart. Two
+    // indel diffs sharing an `lrg_start` have no well-defined order and no LRG
+    // has them (0 of 1 294 records, measured), so refuse rather than pick one.
+    gaps.sort_by_key(AlignmentGap::sort_key);
+    if gaps.windows(2).any(|w| w[0].parent_at == w[1].parent_at) {
+        return None;
+    }
+    Some(gaps)
 }
 
 /// Parse an LRG's chromosomal placement from its XML record (#480).
@@ -3166,24 +3172,17 @@ fn affine_horizon(mapping_body: &str) -> Option<u64> {
 /// e.g. GRCh38) and its single `<mapping_span …>` to build a
 /// [`GenomicPlacement`] mapping LRG coordinates onto the `NC_` chromosome.
 /// Returns `None` when there is no main-assembly mapping, its `other_id` is not
-/// a parseable accession, or it is not a single contiguous span (a single
-/// affine placement cannot represent a gapped mapping — the projector then
+/// a parseable accession, or it is not a single contiguous span (multiple spans
+/// are a different mapping shape this parser does not model — the projector then
 /// keeps the chromosome coordinates rather than mis-anchor).
 ///
-/// The span is additionally narrowed to its affine-exact prefix when the mapping
-/// carries indel `<diff>`s — see [`affine_horizon`] — and `None` is returned when
-/// that prefix is empty. Every coordinate the returned placement still accepts is
-/// one the affine maps exactly; the rest are declined by
-/// [`GenomicPlacement::nc_to_parent`] / [`GenomicPlacement::parent_to_nc`]
-/// returning `None`, which
-/// [`VariantProjector::reanchor_genome_to_parent`](crate::project::VariantProjector)
-/// already turns into an `UnsupportedProjection` rather than a drifted
-/// coordinate under the parent accession (#480/#655).
-///
-/// Base *serving* is unaffected: `get_sequence` / `get_sequence_length` consult a
-/// placement only when `own_record(id).is_none()`, and every one of the 1 294 LRG
-/// records in the prepared reference has its own `LRG_<N>g` record (measured), so
-/// no LRG reaches `synthesize_parent_sequence` at all (#1462/#1490).
+/// The span's indel `<diff>` list is carried onto the placement as an
+/// [`AlignmentGap`] list, so an indel-bearing record maps **every** coordinate
+/// in its span exactly rather than drifting past the first indel (#1499/#1833).
+/// The placement is declined outright when the gap list cannot be read, or when
+/// the reconstructed parent extent disagrees with the span's own `lrg_end` —
+/// that check is the model's integrity assertion and it holds for all 1 294
+/// records in a prepared GRCh38 reference (measured).
 fn parse_lrg_main_assembly_placement(xml: &str) -> Option<GenomicPlacement> {
     let mut search = xml;
     loop {
@@ -3205,21 +3204,40 @@ fn parse_lrg_main_assembly_placement(xml: &str) -> Option<GenomicPlacement> {
                 .map(|(_, a)| a)
                 .ok()?;
 
-            // Require exactly one span: a single affine transform.
-            let spans: Vec<&str> = body
+            // Require exactly one span. Two spans are a genuinely discontiguous
+            // placement, which is a different shape from the within-span indels
+            // the gap list models, and one this parser does not attempt.
+            let spans: Vec<(&str, &str)> = body
                 .match_indices("<mapping_span ")
                 .map(|(i, _)| {
                     let s = &body[i..];
                     let e = s.find('>').unwrap_or(s.len());
-                    &s[..e]
+                    let open_tag = &s[..e];
+                    // The `<diff>` children live between the open tag and
+                    // `</mapping_span>`. A **self-closing** span (`… />`) has
+                    // none, and its body must be empty rather than "the rest of
+                    // the mapping" — otherwise a sibling element's diffs would
+                    // be attributed to it.
+                    let span_body = if open_tag.trim_end().ends_with('/') {
+                        ""
+                    } else {
+                        let after = &s[e.saturating_add(1).min(s.len())..];
+                        match after.find("</mapping_span>") {
+                            Some(c) => &after[..c],
+                            // An unclosed span is malformed; treat it as having
+                            // no diffs rather than swallowing whatever follows.
+                            None => "",
+                        }
+                    };
+                    (open_tag, span_body)
                 })
                 .collect();
             if spans.len() != 1 {
                 return None;
             }
-
-            let span = spans[0];
+            let (span, span_body) = spans[0];
             let parent_start: u64 = xml_attr(span, "lrg_start")?.parse().ok()?;
+            let parent_end_attr: u64 = xml_attr(span, "lrg_end")?.parse().ok()?;
             let o1: u64 = xml_attr(span, "other_start")?.parse().ok()?;
             let o2: u64 = xml_attr(span, "other_end")?.parse().ok()?;
             let strand = match xml_attr(span, "strand") {
@@ -3227,43 +3245,79 @@ fn parse_lrg_main_assembly_placement(xml: &str) -> Option<GenomicPlacement> {
                 _ => crate::reference::transcript::Strand::Plus,
             };
             let (nc_start, nc_end) = if o1 <= o2 { (o1, o2) } else { (o2, o1) };
-
-            // A single span is necessary but **not sufficient** for an affine
-            // (#1499) — so narrow the span to the part that genuinely is one.
             // `body` is this mapping's own inner text, so the GRCh37
             // `other_assembly` mapping's diffs (967 `lrg_ins` / 860 `other_ins`
             // across the prepared reference) are correctly out of scope.
-            let (nc_start, nc_end) = match affine_horizon(body) {
-                None => (nc_start, nc_end),
-                // Nothing at or after `parent_start` aligns: no usable affine.
-                Some(h) if h <= parent_start => return None,
-                Some(h) => {
-                    // Bases past the anchor that still map exactly. `parent_start`
-                    // is the parent coordinate of `nc_start` on the plus strand
-                    // and of `nc_end` on the minus strand, so the trim always
-                    // comes off the end *away* from the anchor and the anchor
-                    // itself is untouched.
-                    let placed = h - 1 - parent_start;
-                    use crate::reference::transcript::Strand;
-                    match strand {
-                        Strand::Minus => (nc_end.checked_sub(placed)?.max(nc_start), nc_end),
-                        // The parser above emits only Plus/Minus; `Unknown` is
-                        // spelled out rather than left to a wildcard so a new
-                        // variant has to be considered here. It follows
-                        // `parent_to_nc`, which also treats Unknown as ascending.
-                        Strand::Plus | Strand::Unknown => {
-                            (nc_start, nc_start.checked_add(placed)?.min(nc_end))
-                        }
-                    }
-                }
+            // Say so when the gap list is unreadable. The refusal itself is
+            // right — a placement the model cannot honour must not exist — but
+            // `None` is also what "this LRG has no XML file" and "it has no
+            // main-assembly mapping" return, and the caller caches all three
+            // identically. Without a line here, alignment data this parser
+            // cannot model is indistinguishable from an unplaced parent, which
+            // is the same confusion `gaps_are_consistent` is documented as
+            // existing to prevent one level down. `warn` rather than `trace`
+            // because it never fires on data that exists: all 1 294 records in
+            // a prepared GRCh38 reference parse.
+            let Some(gaps) = parse_span_alignment_gaps(span_body) else {
+                warn!(
+                    "{nc}: declining the LRG placement — its <mapping_span>'s <diff> list is not \
+                     one this parser can model (unreadable or missing indel coordinate, a \
+                     lrg_end below its lrg_start, an unrecognised <diff type>, or two indel \
+                     diffs sharing one lrg_start)"
+                );
+                return None;
             };
-            return Some(GenomicPlacement {
+            let placement = GenomicPlacement {
                 nc,
                 parent_start,
                 nc_start,
                 nc_end,
                 strand,
-            });
+                gaps,
+            };
+            // Two integrity assertions, not formalities — they ask different
+            // questions and both hold for every one of the 1 294 records in a
+            // prepared GRCh38 reference (measured). Fail closed on either: an
+            // unverifiable placement is worse than none.
+            //
+            // 1. The gap list must be *walkable* — strictly ordered, no overlap,
+            //    and covering exactly the placed chromosome span. Without this a
+            //    self-overlapping pair yields a placement that exists while every
+            //    lookup declines, which reads as "unplaceable parent" rather than
+            //    "bad alignment data".
+            // 2. Walking it must land on exactly the parent extent the span
+            //    itself declares, which catches an unmodelled diff kind or a
+            //    mis-read coordinate convention.
+            //
+            // Each names *which* assertion failed, for the same reason as the
+            // gap-list refusal above: the caller cannot tell a declined
+            // placement from an absent one, and these two fire only on
+            // alignment data no record currently carries.
+            if !placement.gaps_are_consistent() {
+                warn!(
+                    "{}: declining the LRG placement — its {} alignment gap(s) do not walk the \
+                     placed chromosome span {}..={} (out of order, overlapping, or not covering \
+                     it exactly)",
+                    placement.nc,
+                    placement.gaps.len(),
+                    placement.nc_start,
+                    placement.nc_end
+                );
+                return None;
+            }
+            if placement.parent_end() != Some(parent_end_attr) {
+                warn!(
+                    "{}: declining the LRG placement — walking its {} alignment gap(s) reaches \
+                     parent extent {:?}, but the <mapping_span> declares lrg_end={}; the gap \
+                     model and the record disagree",
+                    placement.nc,
+                    placement.gaps.len(),
+                    placement.parent_end(),
+                    parent_end_attr
+                );
+                return None;
+            }
+            return Some(placement);
         }
 
         // Advance past this non-main mapping. If it lacks a `</mapping>` close
@@ -3383,6 +3437,7 @@ fn parse_refseqgene_alignments(
             nc_start,
             nc_end,
             strand,
+            gaps: Vec::new(),
         };
         // Keep at most one placement per (NG version, build): first wins if a
         // release lists the same alignment twice.
@@ -3707,46 +3762,30 @@ impl ReferenceProvider for MultiFastaProvider {
         // width instead made bounds checks reject legitimate placed
         // coordinates as past-the-end.
         //
-        // **`nc_end - nc_start` is a chromosome-frame width standing in for a
-        // parent-frame one, and the two differ whenever the alignment carries
-        // indels.** `GenomicPlacement` is a pure affine with no `parent_end`:
-        // the LRG parser reads `lrg_end` and discards it (see
-        // `genomic_placement_on_build`), and `parent_to_nc` reconstructs the
-        // parent's end the same way. `LRG_1075` shows the gap — its GRCh38 span
-        // is `lrg_start=1049 lrg_end=15267` onto
-        // `NC_000004.12:190173122-190187909`, so the LRG side is 14 219 wide
-        // and the chromosome side 14 788, against a `LRG_1075g` record of
-        // 15 267 bases (i.e. exactly `lrg_end`).
+        // **A chromosome-frame width is not a parent-frame one**, and the two
+        // differ whenever the alignment carries indels. `GenomicPlacement::parent_end`
+        // is what answers this in the parent's own frame: since #1833 the
+        // placement carries the span's indel `<diff>` list, so the extent is
+        // derived rather than assumed affine. `LRG_1075` is the worked case —
+        // its GRCh38 span is `lrg_start=1049 lrg_end=15267` onto
+        // `NC_000004.12:190173122-190187909`, so the LRG side is 14 219 wide and
+        // the chromosome side 14 788. `parent_start + (nc_end - nc_start)`
+        // yields 15 836 where the `LRG_1075g` record is 15 267 bases;
+        // `parent_end()` yields exactly 15 267.
         //
-        // Since #1499 that record's span is **narrowed** to its affine-exact
-        // prefix, so this expression now under-reports rather than over-reports
-        // — 8 211 rather than the pre-#1499 15 836, against a true 15 267.
-        //
-        // **The two directions are not equivalent, and under-reporting is the
-        // worse one.** An over-reporting length is permissive; an
-        // under-reporting one is restrictive, so every bounds check keyed on it
-        // — `FERRO_ASSERT_IN_BOUNDS` among them — turns a legitimate placed
-        // coordinate into a spurious past-the-end failure. That is the same
-        // symptom #1494 closed, arriving from a different cause: #1494's was
-        // the span width dropping the `parent_start - 1` bases beneath the
-        // placement (see `a_record_less_parent_length_counts_from_coordinate_one`),
-        // this one is the narrowed span no longer reaching the parent's end.
-        //
-        // Either way it is not the parent's extent, which is #1503's point:
-        // carry `parent_end` on the placement rather than re-derive it from the
-        // other frame. That touches `parent_to_nc` and therefore projection, so
-        // it wants its own measurement rather than riding along with this.
-        //
-        // Latent rather than live, and #1499 narrowed the exposed population
-        // further: an accession reaches this branch only when `own_record`
-        // finds nothing, every one of the prepared reference's 1 294 LRG
-        // records has its own `LRG_<N>g` record (measured), and every #728
-        // derived `NG_` has `parent_start == 1` and an exact affine. So nothing
-        // in the reachable population is affected today.
+        // Latent rather than live, in both directions: an accession reaches this
+        // branch only when `own_record` finds nothing, every one of the prepared
+        // reference's 1 294 LRG records has its own `LRG_<N>g` record
+        // (measured), and every #728 derived `NG_` has `parent_start == 1` and
+        // an empty gap list — for which `parent_end()` is the same arithmetic
+        // this line used to spell out. So the reachable population is unmoved
+        // and a record-less, indel-bearing parent is no longer over-long.
         if self.own_record(id).is_none() {
             if let Ok(("", acc)) = crate::hgvs::parser::accession::parse_accession(id) {
                 if let Some(placement) = self.genomic_placement(&acc) {
-                    return Ok(placement.parent_start + (placement.nc_end - placement.nc_start));
+                    if let Some(parent_end) = placement.parent_end() {
+                        return Ok(parent_end);
+                    }
                 }
             }
         }
@@ -4023,24 +4062,27 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
-    // #1499 — a single-span mapping is not automatically an affine one
+    // #1499 / #1833 — one `<mapping_span>` does not make a mapping affine
     // ----------------------------------------------------------------------
+    //
+    // Every fixture below is a REAL main-assembly mapping from the prepared
+    // reference, verbatim apart from three cosmetic edits: `other_id_syn` is
+    // dropped, `mismatch` diffs are dropped where they are not the point, and a
+    // `lrg_sequence`/`other_sequence` payload longer than eight bases is
+    // replaced by a note of its length. The parser reads neither sequence
+    // attribute — the payload lengths it needs come from the coordinates — so
+    // eliding them changes nothing it sees, and the elision keeps the geometry
+    // legible. Every expected coordinate is MEASURED against the frozen
+    // `LRG_<N>g` record by 11-base window comparison, never inferred.
 
-    /// `LRG_292`'s real GRCh38 main-assembly mapping, trimmed to the span, one
-    /// of its `mismatch` diffs and all three of its indel `<diff>`s. One span,
-    /// so the `spans.len() != 1` guard above passes it — and the span is still
-    /// not an affine: the record is 193 689 bases while the chromosome side is
-    /// `43217981 - 43024295 + 1 = 193 687`, the difference being 3 `lrg_ins`
-    /// bases against 1 `other_ins` base.
+    /// `LRG_292` (BRCA1), the record the issue is named for: 193 689 LRG bases
+    /// onto a 193 687-base chromosome span, three `lrg_ins` bases against one
+    /// `other_ins`. Minus strand, so the chromosome walks *down* as the LRG
+    /// walks up.
     ///
-    /// Measured on the prepared reference before this fix, by comparing an
-    /// 11-base window of the `LRG_292g` record against the chromosome around
-    /// `parent_to_nc`'s answer: exact (offset 0) up to `LRG_292:g.13000`, then
-    /// **+2** from the first `lrg_ins` on, **+1** between the `other_ins` and
-    /// the last `lrg_ins`, and **+2** for the remaining ~93 % of the record.
-    /// End to end that made `LRG_292(NM_007294.4):c.1del` project to
-    /// `LRG_292:g.93888del` where the record's own frame says `g.93890del`.
-    const LRG_292_INDEL_MAPPING: &str = r#"
+    /// The affine placed only the first 13 168 bases correctly — 6.8 % of the
+    /// record, so essentially all of BRCA1's CDS was on the wrong side of it.
+    const LRG_292_MAPPING: &str = r#"
       <mapping coord_system="GRCh38.p13" other_name="17" other_id="NC_000017.11" other_start="43024295" other_end="43217981" type="main_assembly">
         <mapping_span lrg_start="1" lrg_end="193689" other_start="43024295" other_end="43217981" strand="-1">
           <diff type="mismatch" lrg_start="2600" lrg_end="2600" other_start="43215382" other_end="43215382" lrg_sequence="G" other_sequence="A" />
@@ -4052,142 +4094,209 @@ mod tests {
     "#;
 
     #[test]
-    fn an_indel_bearing_span_is_narrowed_to_its_affine_exact_prefix() {
-        // The whole point of the fixture: it has exactly ONE `<mapping_span>`,
-        // so the gapped-mapping guard does not reach it, and it is still not
-        // expressible as an affine.
-        assert_eq!(LRG_292_INDEL_MAPPING.matches("<mapping_span ").count(), 1);
-        let p = parse_lrg_main_assembly_placement(LRG_292_INDEL_MAPPING)
-            .expect("the prefix below the first indel is still a valid affine");
+    fn an_indel_bearing_span_maps_every_coordinate_exactly() {
+        // The whole point of the fixture: exactly ONE `<mapping_span>`, so the
+        // gapped-mapping guard above does not reach it, and it is still not an
+        // affine.
+        assert_eq!(LRG_292_MAPPING.matches("<mapping_span ").count(), 1);
+        let p = parse_lrg_main_assembly_placement(LRG_292_MAPPING).expect("placed");
 
-        // Minus strand, so `parent_start` anchors at `nc_end`; the trim comes
-        // off `nc_start`. The first departure is the `lrg_ins` at LRG 13169, so
-        // the last exactly-placed base is LRG 13168 at chromosome
-        // 43217981 - 13167 = 43204814.
-        assert_eq!(p.nc_end, 43217981, "the anchored end must not move");
-        assert_eq!(p.nc_start, 43204814);
+        // The span is the WHOLE record, not a prefix of it.
+        assert_eq!((p.nc_start, p.nc_end), (43024295, 43217981));
         assert_eq!(p.parent_start, 1);
+        assert_eq!(p.parent_end(), Some(193689), "the LRG_292g record's length");
+        assert_eq!(p.gaps.len(), 3, "the `mismatch` diff is not a gap");
 
-        // Everything inside the narrowed span still maps, and maps exactly.
-        assert_eq!(p.nc_to_parent(43217981), Some(1));
-        assert_eq!(p.nc_to_parent(43204814), Some(13168));
+        // Below the first indel the affine was already right, and stays right.
+        assert_eq!(p.parent_to_nc(1), Some(43217981));
         assert_eq!(p.parent_to_nc(13168), Some(43204814));
 
-        // And the drifted region is declined rather than mis-mapped. Chromosome
-        // 43204813 is LRG 13171 in the record's own frame; the affine would have
-        // called it 13169 (measured, +2 — see `LRG_292_INDEL_MAPPING`).
-        assert_eq!(p.nc_to_parent(43204813), None);
+        // The `lrg_ins` bases themselves have no chromosome image.
         assert_eq!(p.parent_to_nc(13169), None);
-        assert_eq!(p.parent_to_nc(160875), None);
+        assert_eq!(p.parent_to_nc(13170), None);
+
+        // Past it, the coordinate the affine got wrong. `13171 -> 43204813` is
+        // the diff's own `other_start` flank; the affine said 43204811.
+        assert_eq!(p.parent_to_nc(13171), Some(43204813));
+        // Between the two insertion kinds the drift was +1, not +2.
+        assert_eq!(p.parent_to_nc(15459), Some(43202525));
+        // The `other_ins` base is skipped: 15460 lands two below 15459.
+        assert_eq!(p.parent_to_nc(15460), Some(43202523));
+        assert_eq!(p.nc_to_parent(43202524), None, "chromosome-only base");
+        // And the last base of the record, which the affine could not reach at
+        // all — it ran out of chromosome two bases early.
+        assert_eq!(p.parent_to_nc(193689), Some(43024295));
+        assert_eq!(p.nc_to_parent(43024295), Some(193689));
     }
 
+    /// `LRG_1321` — the shape a naive walk loses. Its `other_ins` of 1 000 `N`s
+    /// occupies `NC_000012.12:7083651-7084650`, and the `lrg_ins` of 231 bases
+    /// that abuts it lists chromosome flanks `7083650`/`7083651` — the second of
+    /// which is the **last base of the other run**. Position off those flanks and
+    /// the 231-base insertion disappears; position off the LRG coordinates and
+    /// let the walk consume each side in turn, and it does not.
+    ///
+    /// It is also the record that needs the tie-break in `AlignmentGap::sort_key`:
+    /// the chromosome-only run is anchored at LRG 12957 and the parent-only run
+    /// starts at 12958.
+    const LRG_1321_MAPPING: &str = r#"
+      <mapping coord_system="GRCh38.p13" other_name="12" other_id="NC_000012.12" other_start="7078209" other_end="7097607" type="main_assembly">
+        <mapping_span lrg_start="1" lrg_end="18630" other_start="7078209" other_end="7097607" strand="-1">
+          <diff type="other_ins" lrg_start="12957" lrg_end="12958" other_start="7083651" other_end="7084650" lrg_sequence="-" other_sequence="1000 bases elided" />
+          <diff type="lrg_ins" lrg_start="12958" lrg_end="13188" other_start="7083650" other_end="7083651" lrg_sequence="231 bases elided" other_sequence="-" />
+        </mapping_span>
+      </mapping>
+    "#;
+
     #[test]
-    fn a_chromosome_insertion_narrows_the_span_too() {
-        // `other_ins` shifts coordinates just as `lrg_ins` does, in the other
-        // direction — the horizon must not key on `lrg_ins` only. Its LRG
-        // coordinates are the *flanks*, so `lrg_start` (4) still maps and
-        // `lrg_end` (5) is the first that does not.
-        let xml = r#"
-          <mapping other_id="NC_000017.11" type="main_assembly">
-            <mapping_span lrg_start="1" lrg_end="9" other_start="100" other_end="109" strand="1">
-              <diff type="other_ins" lrg_start="4" lrg_end="5" other_start="104" other_end="104" lrg_sequence="-" other_sequence="T" />
-            </mapping_span>
-          </mapping>
-        "#;
-        let p = parse_lrg_main_assembly_placement(xml).expect("the prefix is a valid affine");
-        // Plus strand: the anchor is `nc_start`, so the trim comes off `nc_end`.
-        assert_eq!(p.nc_start, 100);
-        assert_eq!(p.nc_end, 103);
-        assert_eq!(p.parent_to_nc(4), Some(103));
-        assert_eq!(p.parent_to_nc(5), None);
-        assert_eq!(p.nc_to_parent(104), None);
+    fn two_abutting_gaps_of_opposite_kinds_are_both_honoured() {
+        let p = parse_lrg_main_assembly_placement(LRG_1321_MAPPING).expect("placed");
+        assert_eq!(p.parent_end(), Some(18630), "the LRG_1321g record's length");
+        // 1000 chromosome-only against 231 parent-only: the two frames differ by
+        // 769, which is exactly the span-width difference.
+        assert_eq!((p.nc_end - p.nc_start + 1) - 18630, 769);
+
+        assert_eq!(p.parent_to_nc(12957), Some(7084651));
+        // The 231 LRG bases have no chromosome image…
+        assert_eq!(p.parent_to_nc(12958), None);
+        assert_eq!(p.parent_to_nc(13188), None);
+        // …and the next aligned base resumes below BOTH runs. The affine said
+        // 7084419 — 769 bases out, which is the naive walk's error too if it
+        // drops the `lrg_ins` on the flank collision.
+        assert_eq!(p.parent_to_nc(13189), Some(7083650));
+        assert_eq!(p.parent_to_nc(18630), Some(7078209));
+
+        // The 1 000 chromosome bases are unreachable from the parent frame.
+        for nc in [7083651, 7084000, 7084650] {
+            assert_eq!(p.nc_to_parent(nc), None, "nc {nc} is chromosome-only");
+        }
+        assert_eq!(p.nc_to_parent(7084651), Some(12957));
+        assert_eq!(p.nc_to_parent(7083650), Some(13189));
     }
 
-    /// `LRG_1075`'s real GRCh38 shape: plus strand **and `lrg_start` 1049**, the
-    /// prepared reference's only placement with `parent_start > 1`. That is
-    /// where the `h - 1 - parent_start` arithmetic can go wrong without any
-    /// other test noticing, and it is not a hypothetical shape — the same record
-    /// is indel-bearing, so it goes through the narrowing path.
-    #[test]
-    fn the_prefix_is_measured_from_parent_start_not_from_one() {
-        let xml = r#"
-          <mapping other_id="NC_000004.12" type="main_assembly">
-            <mapping_span lrg_start="1049" lrg_end="15267" other_start="190173122" other_end="190187909" strand="1">
-              <diff type="lrg_ins" lrg_start="8212" lrg_end="8975" other_start="190180284" other_end="190180285" lrg_sequence="GAGT" other_sequence="-" />
-            </mapping_span>
-          </mapping>
-        "#;
-        let p = parse_lrg_main_assembly_placement(xml).expect("the prefix is a valid affine");
-        assert_eq!(p.parent_start, 1049);
-        assert_eq!(p.nc_start, 190173122, "the anchored end must not move");
-        // 8212 - 1 - 1049 = 7162 bases past the anchor.
-        assert_eq!(p.nc_end, 190173122 + 7162);
-        assert_eq!(p.parent_to_nc(1049), Some(190173122));
-        assert_eq!(p.parent_to_nc(8211), Some(190180284));
-        assert_eq!(p.parent_to_nc(8212), None);
-        // Below `parent_start` was already outside the span and stays outside.
-        assert_eq!(p.parent_to_nc(1048), None);
-    }
+    /// `LRG_792` — 19 indel diffs of both kinds, several clustered within a few
+    /// hundred bases and sized 1–78. Nothing here is a new *shape*; it is the
+    /// record that fails a model which is right about one gap and wrong about
+    /// accumulating them.
+    const LRG_792_MAPPING: &str = r#"
+      <mapping coord_system="GRCh38.p13" other_name="9" other_id="NC_000009.12" other_start="133238219" other_end="133280214" type="main_assembly">
+        <mapping_span lrg_start="1" lrg_end="42144" other_start="133238219" other_end="133280214" strand="-1">
+          <diff type="lrg_ins" lrg_start="22694" lrg_end="22694" other_start="133257521" other_end="133257522" lrg_sequence="G" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25302" lrg_end="25313" other_start="133254914" other_end="133254915" lrg_sequence="12 bases elided" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25322" lrg_end="25331" other_start="133254906" other_end="133254907" lrg_sequence="10 bases elided" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25342" lrg_end="25342" other_start="133254896" other_end="133254897" lrg_sequence="T" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25347" lrg_end="25347" other_start="133254892" other_end="133254893" lrg_sequence="T" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25366" lrg_end="25443" other_start="133254874" other_end="133254875" lrg_sequence="78 bases elided" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25462" lrg_end="25491" other_start="133254856" other_end="133254857" lrg_sequence="30 bases elided" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="25493" lrg_end="25494" other_start="133254855" other_end="133254856" lrg_sequence="AG" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="29198" lrg_end="29199" other_start="133251152" other_end="133251153" lrg_sequence="AG" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="32481" lrg_end="32499" other_start="133247871" other_end="133247872" lrg_sequence="19 bases elided" other_sequence="-" />
+          <diff type="other_ins" lrg_start="32838" lrg_end="32839" other_start="133247532" other_end="133247532" lrg_sequence="-" other_sequence="T" />
+          <diff type="lrg_ins" lrg_start="33643" lrg_end="33647" other_start="133246727" other_end="133246728" lrg_sequence="TGCAC" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="34339" lrg_end="34346" other_start="133246036" other_end="133246037" lrg_sequence="TTAGAGTT" other_sequence="-" />
+          <diff type="other_ins" lrg_start="34642" lrg_end="34643" other_start="133245728" other_end="133245740" lrg_sequence="-" other_sequence="13 bases elided" />
+          <diff type="other_ins" lrg_start="35617" lrg_end="35618" other_start="133244748" other_end="133244752" lrg_sequence="-" other_sequence="AAACA" />
+          <diff type="other_ins" lrg_start="37333" lrg_end="37334" other_start="133243028" other_end="133243031" lrg_sequence="-" other_sequence="CTTT" />
+          <diff type="lrg_ins" lrg_start="38572" lrg_end="38572" other_start="133241789" other_end="133241790" lrg_sequence="T" other_sequence="-" />
+          <diff type="other_ins" lrg_start="39445" lrg_end="39446" other_start="133240916" other_end="133240916" lrg_sequence="-" other_sequence="A" />
+          <diff type="lrg_ins" lrg_start="41404" lrg_end="41405" other_start="133238957" other_end="133238958" lrg_sequence="AG" other_sequence="-" />
+        </mapping_span>
+      </mapping>
+    "#;
 
-    /// An indel `<diff>` whose coordinate cannot be read must **narrow to
-    /// nothing**, not be skipped. Skipping it leaves the span wider than the
-    /// data supports, which is the silently-wrong-coordinate direction this
-    /// whole change exists to close.
     #[test]
-    fn an_unreadable_indel_diff_declines_the_placement() {
-        for tag in [
-            r#"<diff type="lrg_ins" lrg_end="9" other_start="104" other_end="105" />"#,
-            r#"<diff type="lrg_ins" lrg_start="not-a-number" lrg_end="9" />"#,
-            r#"<diff type="other_ins" lrg_start="4" other_start="104" other_end="104" />"#,
-            // The `type` attribute is unreadable in exactly the sense the three
-            // above are, and it fails open unless it is handled: with no
-            // recognised type there is no way to tell an indel from a
-            // `mismatch`, so skipping the element leaves the span wider than
-            // the data supports. `mismatch` is the only value that may be
-            // skipped, and it has its own arm; everything else declines.
-            r#"<diff lrg_start="4" lrg_end="5" other_start="104" other_end="104" />"#,
-            r#"<diff type="lrg_delins" lrg_start="4" lrg_end="5" other_start="104" other_end="104" />"#,
+    fn nineteen_clustered_indels_accumulate_in_order() {
+        let p = parse_lrg_main_assembly_placement(LRG_792_MAPPING).expect("placed");
+        assert_eq!(p.gaps.len(), 19);
+        assert_eq!(p.parent_end(), Some(42144), "the LRG_792g record's length");
+
+        // Each row is (parent coordinate, chromosome coordinate) measured
+        // against the frozen record. They walk through the dense 25 302–25 494
+        // cluster, where the cumulative parent-only total goes 1 → 13 → 23 → 24
+        // → 25 → 103 → 133 → 135 in the space of 200 bases.
+        for (parent, nc) in [
+            (1u64, 133280214u64),
+            (22693, 133257522),
+            (22695, 133257521),
+            (25301, 133254915),
+            (25314, 133254914),
+            (25332, 133254906),
+            (25343, 133254896),
+            (25348, 133254892),
+            (25444, 133254874),
+            (25492, 133254856),
+            (25495, 133254855),
+            // Past the first `other_ins`, so the two kinds are now cancelling.
+            (32840, 133247530),
+            (42144, 133238219),
         ] {
-            let xml = format!(
-                r#"
-              <mapping other_id="NC_000017.11" type="main_assembly">
-                <mapping_span lrg_start="1" lrg_end="10" other_start="100" other_end="109" strand="1">
-                  {tag}
-                </mapping_span>
-              </mapping>
-            "#
-            );
-            assert!(
-                parse_lrg_main_assembly_placement(&xml).is_none(),
-                "an unreadable indel diff must fail closed: {tag}"
-            );
+            assert_eq!(p.parent_to_nc(parent), Some(nc), "parent {parent}");
+            assert_eq!(p.nc_to_parent(nc), Some(parent), "nc {nc}");
+        }
+
+        // Every parent-only base in the cluster is declined, not approximated.
+        for parent in [22694u64, 25302, 25313, 25322, 25331, 25342, 25366, 25443] {
+            assert_eq!(p.parent_to_nc(parent), None, "parent {parent} is LRG-only");
         }
     }
 
+    /// `LRG_1075` — plus strand **and `lrg_start = 1049`**, the prepared
+    /// reference's only placement whose parent frame does not start at 1, and
+    /// indel-bearing besides. It is where an offset measured from 1 rather than
+    /// from `parent_start` goes wrong with nothing else noticing, and it carries
+    /// the other abutting pair: a 764-base `lrg_ins` ending at 8975 with an
+    /// `other_ins` anchored on that same 8975.
+    const LRG_1075_MAPPING: &str = r#"
+      <mapping coord_system="GRCh38.p13" other_name="4" other_id="NC_000004.12" other_start="190173122" other_end="190187909" type="main_assembly">
+        <mapping_span lrg_start="1049" lrg_end="15267" other_start="190173122" other_end="190187909" strand="1">
+          <diff type="lrg_ins" lrg_start="8212" lrg_end="8975" other_start="190180284" other_end="190180285" lrg_sequence="764 bases elided" other_sequence="-" />
+          <diff type="other_ins" lrg_start="8975" lrg_end="8976" other_start="190180285" other_end="190180988" lrg_sequence="-" other_sequence="704 bases elided" />
+          <diff type="other_ins" lrg_start="9008" lrg_end="9009" other_start="190181022" other_end="190181022" lrg_sequence="-" other_sequence="T" />
+          <diff type="lrg_ins" lrg_start="9238" lrg_end="9238" other_start="190181251" other_end="190181252" lrg_sequence="C" other_sequence="-" />
+          <diff type="other_ins" lrg_start="9277" lrg_end="9278" other_start="190181291" other_end="190181291" lrg_sequence="-" other_sequence="G" />
+          <diff type="other_ins" lrg_start="9346" lrg_end="9347" other_start="190181361" other_end="190181361" lrg_sequence="-" other_sequence="T" />
+          <diff type="lrg_ins" lrg_start="9393" lrg_end="9393" other_start="190181407" other_end="190181408" lrg_sequence="G" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="9412" lrg_end="9412" other_start="190181425" other_end="190181426" lrg_sequence="C" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="9551" lrg_end="9551" other_start="190181563" other_end="190181564" lrg_sequence="T" other_sequence="-" />
+          <diff type="other_ins" lrg_start="10566" lrg_end="10567" other_start="190182579" other_end="190183212" lrg_sequence="-" other_sequence="634 bases elided" />
+          <diff type="lrg_ins" lrg_start="11694" lrg_end="11694" other_start="190184339" other_end="190184340" lrg_sequence="T" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="13091" lrg_end="13091" other_start="190185735" other_end="190185736" lrg_sequence="T" other_sequence="-" />
+          <diff type="lrg_ins" lrg_start="15053" lrg_end="15054" other_start="190187696" other_end="190187697" lrg_sequence="AA" other_sequence="-" />
+        </mapping_span>
+      </mapping>
+    "#;
+
     #[test]
-    fn no_placement_when_the_affine_exact_prefix_is_empty() {
-        // The first LRG base is itself unaligned, so there is no prefix to keep
-        // and the placement is declined outright — the same answer the
-        // gapped-mapping guard gives, reached the same way.
-        let xml = r#"
-          <mapping other_id="NC_000017.11" type="main_assembly">
-            <mapping_span lrg_start="1" lrg_end="10" other_start="100" other_end="108" strand="1">
-              <diff type="lrg_ins" lrg_start="1" lrg_end="1" other_start="99" other_end="100" lrg_sequence="A" other_sequence="-" />
-            </mapping_span>
-          </mapping>
-        "#;
-        assert!(parse_lrg_main_assembly_placement(xml).is_none());
+    fn the_walk_is_measured_from_parent_start_not_from_one() {
+        let p = parse_lrg_main_assembly_placement(LRG_1075_MAPPING).expect("placed");
+        assert_eq!(p.parent_start, 1049);
+        assert_eq!(p.parent_end(), Some(15267), "the LRG_1075g record's length");
+        // The reason `parent_end` exists: the chromosome side is 14 788 bases
+        // and the parent side 14 219, so neither width answers the question.
+        assert_eq!(p.nc_end - p.nc_start + 1, 14788);
+        assert_eq!(p.parent_start + (p.nc_end - p.nc_start), 15836);
+
+        assert_eq!(p.parent_to_nc(1049), Some(190173122));
+        assert_eq!(p.parent_to_nc(1048), None, "below the placed span");
+        assert_eq!(p.parent_to_nc(8211), Some(190180284));
+        // The 764-base `lrg_ins`, then the 704-base `other_ins` flush against
+        // it: 8976 resumes one past the chromosome run's end.
+        assert_eq!(p.parent_to_nc(8212), None);
+        assert_eq!(p.parent_to_nc(8975), None);
+        assert_eq!(p.parent_to_nc(8976), Some(190180989));
+        // …where the affine said 190181049, 60 bases out.
+        assert_eq!(p.nc_to_parent(190180989), Some(8976));
+        assert_eq!(p.nc_to_parent(190180500), None, "chromosome-only");
+        assert_eq!(p.parent_to_nc(15267), Some(190187909));
     }
 
     /// The discriminating case: a `mismatch` diff substitutes a base and shifts
-    /// **nothing**, so the affine still maps every coordinate correctly and the
-    /// span must not be narrowed. 119 of the prepared reference's 1 294 LRG
-    /// records are in exactly this state (against 46 carrying an indel diff);
-    /// keying the horizon on any `<diff>` at all would truncate all 119 for no
-    /// reason, and the bases those mismatches name are already served from the
-    /// record itself since #1490.
+    /// **nothing**, so the placement must carry no gap for it. 119 of the 1 294
+    /// records are mismatch-only; keying on any `<diff>` would model 165 records
+    /// where 46 is correct, and the bases those mismatches name are served from
+    /// the LRG's own record anyway since #1490.
     #[test]
-    fn mismatch_diffs_alone_do_not_narrow_a_placement() {
+    fn mismatch_diffs_alone_leave_the_placement_affine() {
         let xml = r#"
           <mapping other_id="NC_000017.11" type="main_assembly">
             <mapping_span lrg_start="1" lrg_end="10" other_start="100" other_end="109" strand="1">
@@ -4195,23 +4304,20 @@ mod tests {
             </mapping_span>
           </mapping>
         "#;
-        let p = parse_lrg_main_assembly_placement(xml)
-            .expect("a mismatch-only mapping is still a valid affine");
-        assert_eq!(p.parent_start, 1);
-        assert_eq!(p.nc_start, 100);
-        assert_eq!(p.nc_end, 109);
-        // And it still maps: the mismatch changes a base, not a coordinate.
+        let p = parse_lrg_main_assembly_placement(xml).expect("placed");
+        assert!(p.gaps.is_empty(), "a mismatch shifts no coordinate");
+        assert_eq!((p.nc_start, p.nc_end), (100, 109));
+        assert_eq!(p.parent_end(), Some(10));
         assert_eq!(p.nc_to_parent(103), Some(4));
         assert_eq!(p.parent_to_nc(4), Some(103));
     }
 
     /// An indel `<diff>` under a *non*-main mapping (the GRCh37 `other_assembly`
     /// mapping, or a transcript mapping) says nothing about the main-assembly
-    /// alignment and must not narrow it. Across the prepared reference the
-    /// non-main mappings carry 967 `lrg_ins` and 860 `other_ins` diffs the
-    /// main-assembly mappings do not.
+    /// alignment. Across the prepared reference the non-main mappings carry 967
+    /// `lrg_ins` and 860 `other_ins` diffs the main-assembly mappings do not.
     #[test]
-    fn an_indel_diff_under_another_mapping_does_not_narrow_the_placement() {
+    fn an_indel_diff_under_another_mapping_does_not_gap_the_placement() {
         let xml = r#"
           <mapping coord_system="GRCh37.p13" other_id="NC_000017.10" type="other_assembly">
             <mapping_span lrg_start="1" lrg_end="10" other_start="1" other_end="9" strand="1">
@@ -4222,41 +4328,143 @@ mod tests {
             <mapping_span lrg_start="1" lrg_end="10" other_start="100" other_end="109" strand="1" />
           </mapping>
         "#;
-        let p = parse_lrg_main_assembly_placement(xml)
-            .expect("an indel in the GRCh37 mapping must not decline the GRCh38 placement");
-        assert_eq!(p.nc_start, 100);
-        assert_eq!(p.nc_end, 109);
+        let p = parse_lrg_main_assembly_placement(xml).expect("placed");
+        assert!(p.gaps.is_empty());
+        assert_eq!((p.nc_start, p.nc_end), (100, 109));
     }
 
-    /// End-to-end provider path: an indel-bearing LRG XML resolves to the
-    /// narrowed placement, so a coordinate past the horizon reaches
-    /// `VariantProjector::reanchor_genome_to_parent`'s "endpoint falls outside
-    /// the placed genomic span" arm and is declined with
-    /// `UnsupportedProjection` instead of being stamped, drifted, under the
-    /// `LRG_` accession (#480/#655).
+    /// Fail closed on data the model cannot express, in all four ways it can
+    /// arrive. Keeping a wider span than the data supports is a silently wrong
+    /// coordinate, which is the direction this whole change exists to close.
     #[test]
-    fn provider_narrows_an_indel_bearing_lrg_placement() {
+    fn an_unmodellable_mapping_declines_rather_than_guesses() {
+        for (why, span_body, lrg_end) in [
+            (
+                "an indel diff with no `lrg_start`",
+                r#"<diff type="lrg_ins" lrg_end="9" other_start="104" other_end="105" />"#,
+                "12",
+            ),
+            (
+                "an indel diff whose coordinate is not a number",
+                r#"<diff type="lrg_ins" lrg_start="not-a-number" lrg_end="9" />"#,
+                "12",
+            ),
+            (
+                "an `other_ins` with no chromosome extent",
+                r#"<diff type="other_ins" lrg_start="4" lrg_end="5" />"#,
+                "12",
+            ),
+            (
+                "a diff type this parser has never seen",
+                r#"<diff type="inversion" lrg_start="4" lrg_end="5" other_start="104" other_end="105" />"#,
+                "10",
+            ),
+            (
+                // No diff at all, and the two frames disagree by two bases: the
+                // record claims unaligned bases it never declares, so the walk
+                // cannot reconstruct `lrg_end` and the placement is refused.
+                "a width mismatch no diff accounts for",
+                "",
+                "12",
+            ),
+            (
+                // Two indel diffs anchored on one LRG coordinate. The two kinds
+                // read their anchor differently — a flank for `other_ins`, the
+                // first unaligned base for `lrg_ins` — so at equal anchors the
+                // order is genuinely undetermined and either choice would invent
+                // a reading the record does not state. No LRG has this shape
+                // (0 of 1 294, measured), so decline rather than pick.
+                "two indel diffs sharing one lrg_start",
+                r#"<diff type="other_ins" lrg_start="4" lrg_end="5" other_start="104" other_end="104" lrg_sequence="-" other_sequence="T" />
+                  <diff type="lrg_ins" lrg_start="4" lrg_end="5" other_start="103" other_end="104" lrg_sequence="AA" other_sequence="-" />"#,
+                "11",
+            ),
+        ] {
+            let xml = format!(
+                r#"
+              <mapping other_id="NC_000017.11" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="{lrg_end}" other_start="100" other_end="109" strand="1">
+                  {span_body}
+                </mapping_span>
+              </mapping>
+            "#
+            );
+            assert!(
+                parse_lrg_main_assembly_placement(&xml).is_none(),
+                "must fail closed: {why}"
+            );
+        }
+    }
+
+    /// End-to-end provider path: an indel-bearing LRG XML resolves to a
+    /// gap-aware placement, so a coordinate past the first indel is re-anchored
+    /// onto the base the `LRG_292g` record actually names rather than one two
+    /// bases off — the projection defect #1499 reported.
+    #[test]
+    fn provider_resolves_a_gapped_lrg_placement() {
         let (mut provider, dir) = build_provider_with_test_genome();
         let xml_dir = dir.path().join("lrg");
         std::fs::create_dir_all(&xml_dir).unwrap();
-        std::fs::write(xml_dir.join("LRG_292.xml"), LRG_292_INDEL_MAPPING).unwrap();
+        std::fs::write(xml_dir.join("LRG_292.xml"), LRG_292_MAPPING).unwrap();
         std::fs::write(xml_dir.join("LRG_999.xml"), LRG_XML_SAMPLE).unwrap();
         provider.lrg_xml_dir = Some(xml_dir);
 
         let indel = crate::hgvs::variant::Accession::new("LRG", "292", None);
-        let p = provider
-            .genomic_placement(&indel)
-            .expect("the affine-exact prefix is still placed");
-        assert_eq!((p.nc_start, p.nc_end), (43204814, 43217981));
-        assert_eq!(p.parent_to_nc(160875), None);
-        // The cache round-trips the narrowed placement, not the raw span.
-        let again = provider.genomic_placement(&indel).expect("cached");
-        assert_eq!(again, p);
+        let p = provider.genomic_placement(&indel).expect("placed");
+        assert_eq!((p.nc_start, p.nc_end), (43024295, 43217981));
+        assert_eq!(p.gaps.len(), 3);
+        // #1499's own worked coordinate: `LRG_292:g.160875`.
+        assert_eq!(p.parent_to_nc(160875), Some(43057109));
+        // The cache round-trips the gap list, not just the span.
+        assert_eq!(provider.genomic_placement(&indel).as_ref(), Some(&p));
 
-        // Control: the indel-free record beside it is unaffected.
+        // Control: the indel-free record beside it is untouched.
         let plain = crate::hgvs::variant::Accession::new("LRG", "999", None);
         let q = provider.genomic_placement(&plain).expect("placed");
+        assert!(q.gaps.is_empty());
         assert_eq!((q.nc_start, q.nc_end), (50182096, 50206639));
+    }
+
+    /// `get_sequence_length` for a record-less parent must report the parent's
+    /// own extent, which is the gap list's answer and not the chromosome span's
+    /// width (#1494/#1503/#1833).
+    ///
+    /// Latent on the shipped reference — every one of its 1 294 LRG records has
+    /// an `LRG_<N>g` record, so nothing reaches this branch, and every #728
+    /// derived `NG_` is gapless, where the two answers coincide. Pinned anyway
+    /// because the arithmetic it replaced was wrong by construction and a latent
+    /// wrong answer is one provider change away from being live.
+    #[test]
+    fn a_record_less_parents_length_comes_from_the_gap_list() {
+        let (mut provider, dir) = build_provider_with_test_genome();
+        let xml_dir = dir.path().join("lrg");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        // 12 LRG bases onto a 10-base chromosome window: two of them are an
+        // `lrg_ins`, so the parent runs to 12 where the chromosome side is 10.
+        std::fs::write(
+            xml_dir.join("LRG_998.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_TEST.1" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="12" other_start="1" other_end="10" strand="1">
+                  <diff type="lrg_ins" lrg_start="11" lrg_end="12" other_start="10" other_end="11" lrg_sequence="CG" other_sequence="-" />
+                </mapping_span>
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        provider.lrg_xml_dir = Some(xml_dir);
+
+        // The discriminator: no `LRG_998g` record, so the length must come from
+        // the placement rather than from a FASTA entry.
+        assert!(provider.own_record("LRG_998").is_none());
+        assert_eq!(provider.get_sequence_length("LRG_998").unwrap(), 12);
+        // What the pre-#1833 arithmetic said, for contrast: `parent_start +
+        // (nc_end - nc_start)` = 1 + 9 = 10, two bases short of the parent.
+        let p = provider
+            .genomic_placement(&crate::hgvs::variant::Accession::new("LRG", "998", None))
+            .expect("placed");
+        assert_eq!(p.parent_start + (p.nc_end - p.nc_start), 10);
+        assert_eq!(p.parent_end(), Some(12));
     }
 
     /// End-to-end provider path: `genomic_placement` reads the LRG XML from the
@@ -4307,8 +4515,12 @@ mod tests {
     /// `LRG_292:g.160875` served `T` for the record's `G`, a `+2` shift.
     ///
     /// The fixture mirrors that shape: a 12-base LRG record placed on a 10-base
-    /// chromosome window (a 2-base LRG insertion the affine cannot represent),
-    /// with disjoint alphabets so a single served base names which path ran.
+    /// chromosome window, with disjoint alphabets so a single served base names
+    /// which path ran. The 2-base difference is spelled as the `lrg_ins` `<diff>`
+    /// a real LRG carries — since #1833 the parser reads that list and refuses a
+    /// span whose declared `lrg_end` its gap list cannot reconstruct, so an
+    /// undeclared width mismatch would now yield *no* placement and quietly cost
+    /// this test its discriminator (asserted below).
     #[test]
     fn lrg_with_its_own_record_is_served_from_the_record_not_the_placement() {
         let dir = tempdir().unwrap();
@@ -4339,7 +4551,9 @@ mod tests {
             xml_dir.join("LRG_999.xml"),
             r#"
               <mapping coord_system="GRCh38" other_id="NC_000017.11" type="main_assembly">
-                <mapping_span lrg_start="1" lrg_end="12" other_start="1" other_end="10" strand="1" />
+                <mapping_span lrg_start="1" lrg_end="12" other_start="1" other_end="10" strand="1">
+                  <diff type="lrg_ins" lrg_start="11" lrg_end="12" other_start="10" other_end="11" lrg_sequence="CG" other_sequence="-" />
+                </mapping_span>
               </mapping>
             "#,
         )
@@ -4677,6 +4891,7 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             nc_start: 1000,
             nc_end: 1099,
             strand: crate::reference::transcript::Strand::Unknown,
+            gaps: Vec::new(),
         };
         // In-span coordinate, but unknown strand → decline.
         assert_eq!(placement.nc_to_parent(1000), None);

--- a/src/reference/ng_placement_builder.rs
+++ b/src/reference/ng_placement_builder.rs
@@ -265,6 +265,7 @@ mod tests {
             nc_start: start,
             nc_end: end,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         }
     }
 

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -10,8 +10,8 @@ use crate::reference::transcript::Transcript;
 use crate::reference::Strand;
 
 /// Chromosomal placement of a genomic *parent* reference — an `NG_` RefSeqGene
-/// or an `LRG_` — on its `NC_` chromosome contig, as a single contiguous affine
-/// span.
+/// or an `LRG_` — on its `NC_` chromosome contig, as a single contiguous span
+/// plus the alignment gaps inside it.
 ///
 /// cdot aligns transcripts only to chromosomes (`NM_`→`NC_`), so a c./n./r.
 /// input parented on an `NG_`/`LRG_` resolves to chromosome coordinates that do
@@ -27,16 +27,18 @@ use crate::reference::Strand;
 /// chromosome region, so coordinates count down as chromosome coordinates count
 /// up, and edits must be reverse-complemented into the parent frame).
 ///
-/// **The placed span may be narrower than the parent, and for an LRG whose
-/// alignment carries indels it is (#1499)** — 46 of the 1 294 records in a
-/// prepared GRCh38 reference. A real LRG↔chromosome alignment
-/// is not affine — the record's `<diff>` list carries `lrg_ins`/`other_ins`
-/// elements this type cannot express — so `parse_lrg_main_assembly_placement`
-/// trims the span to the prefix that *is* affine and the rest is declined by
-/// [`Self::nc_to_parent`] / [`Self::parent_to_nc`]. Read `nc_start`/`nc_end` as
-/// "the region this transform maps exactly", never as "where the parent sits on
-/// the chromosome", and do not re-derive the parent's extent from their width
-/// (#1503).
+/// **The mapping is affine only when [`gaps`](Self::gaps) is empty.** A real
+/// LRG↔chromosome alignment is not affine: alongside its single
+/// `<mapping_span>` the record lists `<diff>` elements, and the two insertion
+/// kinds shift every coordinate past them in opposite directions (#1499/#1833).
+/// 46 of the 1 294 LRG records in a prepared GRCh38 reference carry at least one.
+/// `gaps` models them exactly, so `nc_start`/`nc_end` remain the whole placed
+/// chromosome span and every coordinate inside it maps to the parent's own
+/// frame — see [`Self::nc_to_parent`] / [`Self::parent_to_nc`].
+///
+/// Because the two frames then have different widths, the parent's extent is
+/// **not** `parent_start + (nc_end - nc_start)`. Use [`Self::parent_end`], which
+/// derives it from the gap list (#1503).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenomicPlacement {
     /// The chromosome (`NC_`) accession the parent is placed on.
@@ -52,6 +54,202 @@ pub struct GenomicPlacement {
     pub nc_end: u64,
     /// Parent orientation relative to the chromosome.
     pub strand: Strand,
+    /// Alignment gaps between the parent and the chromosome, in ascending
+    /// parent-coordinate order. **Empty means a pure affine**, which is the case
+    /// for every `NG_` placement and for 1 248 of the 1 294 LRG records.
+    ///
+    /// Construct with [`AlignmentGap::parent_only`] /
+    /// [`AlignmentGap::chromosome_only`], or leave it `Vec::new()`.
+    pub gaps: Vec<AlignmentGap>,
+}
+
+/// One gap in a parent↔chromosome alignment: a run of bases present on exactly
+/// one side (#1833).
+///
+/// This is the `<diff>` list of an LRG `<mapping_span>` minus its `mismatch`
+/// entries, which substitute a base and shift no coordinate. The vocabulary is
+/// closed at `mismatch` / `lrg_ins` / `other_ins`, verified over all 1 294
+/// records in a prepared GRCh38 reference (479 / 63 / 47 in the main-assembly
+/// mappings).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlignmentGap {
+    /// Parent-frame anchor, read differently per [`kind`](Self::kind) — the LRG
+    /// XML's own convention, which differs by `<diff>` type and is the single
+    /// easiest thing to get wrong here:
+    ///
+    /// - [`ParentOnly`](AlignmentGapKind::ParentOnly): the **first** parent base
+    ///   of the unaligned run (`lrg_ins`'s `lrg_start`, which with `lrg_end`
+    ///   bounds the unaligned LRG bases themselves).
+    /// - [`ChromosomeOnly`](AlignmentGapKind::ChromosomeOnly): the **last
+    ///   aligned** parent base before the chromosome-only run (`other_ins`'s
+    ///   `lrg_start`, which with `lrg_end` gives the *flanking* LRG coordinates
+    ///   — the run sits between them and occupies no parent coordinate at all).
+    pub parent_at: u64,
+    /// Which side carries the unaligned bases, and how many.
+    pub kind: AlignmentGapKind,
+}
+
+/// Which side of a [`AlignmentGap`] carries bases the other side does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignmentGapKind {
+    /// `len` parent bases with no chromosome counterpart (LRG `lrg_ins`).
+    /// Coordinates inside the run have no chromosome image, so
+    /// [`GenomicPlacement::parent_to_nc`] declines them.
+    ParentOnly { len: u64 },
+    /// `len` chromosome bases with no parent counterpart (LRG `other_ins`).
+    /// Coordinates inside the run have no parent image, so
+    /// [`GenomicPlacement::nc_to_parent`] declines them.
+    ChromosomeOnly { len: u64 },
+}
+
+impl AlignmentGap {
+    /// A run of `len` parent bases with no chromosome counterpart, beginning at
+    /// parent coordinate `first_parent_base`.
+    pub fn parent_only(first_parent_base: u64, len: u64) -> Self {
+        Self {
+            parent_at: first_parent_base,
+            kind: AlignmentGapKind::ParentOnly { len },
+        }
+    }
+
+    /// A run of `len` chromosome bases with no parent counterpart, sitting
+    /// immediately after parent coordinate `last_aligned_parent_base`.
+    pub fn chromosome_only(last_aligned_parent_base: u64, len: u64) -> Self {
+        Self {
+            parent_at: last_aligned_parent_base,
+            kind: AlignmentGapKind::ChromosomeOnly { len },
+        }
+    }
+
+    /// Parent bases this gap consumes (zero for a chromosome-only run).
+    fn parent_len(&self) -> u64 {
+        match self.kind {
+            AlignmentGapKind::ParentOnly { len } => len,
+            AlignmentGapKind::ChromosomeOnly { .. } => 0,
+        }
+    }
+
+    /// Chromosome bases this gap consumes (zero for a parent-only run).
+    fn nc_len(&self) -> u64 {
+        match self.kind {
+            AlignmentGapKind::ParentOnly { .. } => 0,
+            AlignmentGapKind::ChromosomeOnly { len } => len,
+        }
+    }
+
+    /// The last parent coordinate that still aligns *before* this gap.
+    ///
+    /// For a parent-only run that is the base below its first unaligned one; for
+    /// a chromosome-only run it is [`parent_at`](Self::parent_at) itself, which
+    /// already names the flank. Returns `None` for a parent-only run anchored at
+    /// coordinate 0, which no LRG emits and which cannot be expressed.
+    fn last_aligned_parent_base(&self) -> Option<u64> {
+        match self.kind {
+            AlignmentGapKind::ParentOnly { .. } => self.parent_at.checked_sub(1),
+            AlignmentGapKind::ChromosomeOnly { .. } => Some(self.parent_at),
+        }
+    }
+
+    /// The order a gap list must be in for [`GenomicPlacement`]'s walk:
+    /// **strictly** ascending parent coordinate.
+    ///
+    /// Strictly, because two gaps sharing one anchor have no well-defined
+    /// order — a chromosome-only run's anchor is the *flank* it sits after,
+    /// while a parent-only run's is its own first unaligned base, so at equal
+    /// anchors the two readings genuinely disagree and either choice invents
+    /// something the record does not say. No LRG asks: over all 1 294 records in
+    /// a prepared GRCh38 reference, **zero** have two indel `<diff>`s sharing an
+    /// `lrg_start` (measured). So the walk declines that case rather than
+    /// picking an order for it.
+    ///
+    /// Abutting gaps of opposite kinds are a different thing and are ordinary —
+    /// two records have them (`LRG_1321`: chromosome-only at 12957, parent-only
+    /// at 12958; `LRG_1075`: parent-only at 8212..8975, chromosome-only at
+    /// 8975). Their anchors still differ, so they order without a tie-break.
+    ///
+    /// Exposed so the parser's sort and the walk's ordering check cannot drift
+    /// apart into two spellings of one rule.
+    pub fn sort_key(&self) -> u64 {
+        self.parent_at
+    }
+}
+
+/// One maximal run of parent bases that align to consecutive chromosome bases.
+///
+/// `nc_consumed` counts chromosome bases placed *before* this block, walking
+/// from `nc_start` upwards on the plus strand and from `nc_end` downwards on the
+/// minus strand — so the block's own chromosome anchor is `nc_start +
+/// nc_consumed` or `nc_end - nc_consumed` respectively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AlignedBlock {
+    parent_start: u64,
+    nc_consumed: u64,
+    len: u64,
+}
+
+/// Walks a placement's aligned blocks in ascending parent order.
+///
+/// **Fails closed.** The gap list is public, so a caller can hand us one that is
+/// unsorted, overlapping, or wider than the span. Every step uses checked
+/// arithmetic and the walk simply *ends* when it cannot continue, which makes
+/// the coordinate lookups return `None` (decline) rather than answer from a
+/// half-applied gap list — the direction this whole model exists to close.
+struct BlockWalk<'a> {
+    placement: &'a GenomicPlacement,
+    gap: usize,
+    parent_cursor: u64,
+    nc_consumed: u64,
+    done: bool,
+}
+
+impl Iterator for BlockWalk<'_> {
+    type Item = AlignedBlock;
+
+    fn next(&mut self) -> Option<AlignedBlock> {
+        let total_nc = self.placement.nc_end.checked_sub(self.placement.nc_start)? + 1;
+        loop {
+            if self.done {
+                return None;
+            }
+            let Some(gap) = self.placement.gaps.get(self.gap) else {
+                // Tail block: whatever chromosome is left over.
+                self.done = true;
+                let len = total_nc.checked_sub(self.nc_consumed)?;
+                let block = AlignedBlock {
+                    parent_start: self.parent_cursor,
+                    nc_consumed: self.nc_consumed,
+                    len,
+                };
+                return (len > 0).then_some(block);
+            };
+            self.gap += 1;
+
+            // Aligned run from the cursor up to this gap. A zero-length run is
+            // legitimate and not rare: two gaps can abut, which is exactly the
+            // `LRG_1321` / `LRG_1075` shape where a chromosome-only run sits
+            // flush against a parent-only one.
+            let run_end = gap.last_aligned_parent_base()?;
+            let len = (run_end + 1).checked_sub(self.parent_cursor)?;
+            let block = AlignedBlock {
+                parent_start: self.parent_cursor,
+                nc_consumed: self.nc_consumed,
+                len,
+            };
+            self.parent_cursor = run_end.checked_add(1)?.checked_add(gap.parent_len())?;
+            self.nc_consumed = self
+                .nc_consumed
+                .checked_add(len)?
+                .checked_add(gap.nc_len())?;
+            if self.nc_consumed > total_nc {
+                // The gap list claims more chromosome than the span holds.
+                self.done = true;
+                return None;
+            }
+            if len > 0 {
+                return Some(block);
+            }
+        }
+    }
 }
 
 /// Select the placement matching a resolved genome build from a parent's
@@ -78,24 +276,144 @@ pub(crate) fn select_placement_for_build(
 }
 
 impl GenomicPlacement {
+    /// The aligned blocks of this placement, in ascending parent order.
+    ///
+    /// Yields **nothing** when the gap list is not in strictly ascending
+    /// [`AlignmentGap::sort_key`] order, which makes every coordinate lookup
+    /// decline. Both halves matter:
+    ///
+    /// - **Checked up front**, because the walk consumes the list in order, so
+    ///   an out-of-order entry is discovered only *after* the blocks before it
+    ///   have been emitted — and a coordinate landing in one of those answers
+    ///   with the un-gapped arithmetic instead of declining. Measured on a
+    ///   two-gap list with the entries reversed: parent 3 answered `1002` where
+    ///   the sorted list declines.
+    /// - **Strict**, because two gaps sharing an anchor have no well-defined
+    ///   order and no record has them — see [`AlignmentGap::sort_key`].
+    fn blocks(&self) -> BlockWalk<'_> {
+        let ordered = self
+            .gaps
+            .windows(2)
+            .all(|w| w[0].sort_key() < w[1].sort_key());
+        BlockWalk {
+            placement: self,
+            gap: 0,
+            parent_cursor: self.parent_start,
+            nc_consumed: 0,
+            done: !ordered,
+        }
+    }
+
+    /// Chromosome coordinate of a block-relative offset, honouring the strand.
+    fn nc_at(&self, nc_consumed: u64) -> Option<u64> {
+        let nc = match self.strand {
+            Strand::Plus | Strand::Unknown => self.nc_start.checked_add(nc_consumed)?,
+            Strand::Minus => self.nc_end.checked_sub(nc_consumed)?,
+        };
+        // Belt and braces: the walk already caps `nc_consumed` at the span
+        // width, so this cannot fire on a list [`Self::gaps_are_consistent`]
+        // accepts. It is here because `gaps` is public, and a coordinate outside
+        // the span is exactly the answer this model exists to stop emitting.
+        (self.nc_start..=self.nc_end).contains(&nc).then_some(nc)
+    }
+
+    /// Whether the gap list is one this placement's walk can honour end to end.
+    ///
+    /// True when the gaps are strictly ordered, none overlaps another, and the
+    /// aligned blocks plus the chromosome-only runs together account for
+    /// **exactly** the placed chromosome span. That last clause is the one worth
+    /// having: an overlapping pair leaves the walk unable to continue, and
+    /// without this check the placement would still exist while every
+    /// coordinate lookup silently declined — present but useless, which reads
+    /// like "this parent is unplaceable" rather than "this gap list is wrong".
+    ///
+    /// Holds for all 1 294 LRG records in a prepared GRCh38 reference
+    /// (measured), so on real data it is an assertion rather than a filter.
+    pub fn gaps_are_consistent(&self) -> bool {
+        let Some(width) = self.nc_end.checked_sub(self.nc_start) else {
+            return false;
+        };
+        let placed: u64 = self.blocks().map(|b| b.len).sum();
+        let chromosome_only: u64 = self.gaps.iter().map(|g| g.nc_len()).sum();
+        placed.checked_add(chromosome_only) == width.checked_add(1)
+    }
+
+    /// The last parent-frame coordinate this placement covers, **including**
+    /// parent bases that have no chromosome counterpart.
+    ///
+    /// **Not** `parent_start + (nc_end - nc_start)`: the two frames have
+    /// different widths exactly when [`gaps`](Self::gaps) is non-empty, so this
+    /// adds back the parent-only runs and removes the chromosome-only ones
+    /// (#1503). For `LRG_1075` — the prepared reference's only placement with
+    /// `parent_start > 1`, and indel-bearing — the chromosome side is 14 788
+    /// bases against 772 parent-only and 1 341 chromosome-only, and this returns
+    /// **15 267**, which is the `LRG_1075g` record's own length and the span's
+    /// own `lrg_end`.
+    ///
+    /// Note a coordinate inside a trailing parent-only run is `<= parent_end()`
+    /// and still has no chromosome image, so [`Self::parent_to_nc`] declines it.
+    /// This answers "how far does the parent reach", not "what can be mapped".
+    ///
+    /// It is a sum, so it is **order-independent** and answers even for a gap
+    /// list [`Self::gaps_are_consistent`] rejects. That is deliberate — the two
+    /// are different questions, and the parser asks both — but it does mean a
+    /// non-`None` extent here is not on its own evidence that the placement maps
+    /// anything.
+    ///
+    /// Returns `None` only on arithmetic overflow, which no real placement
+    /// approaches.
+    pub fn parent_end(&self) -> Option<u64> {
+        let mut end = self
+            .parent_start
+            .checked_add(self.nc_end.checked_sub(self.nc_start)?)?;
+        for gap in &self.gaps {
+            end = end.checked_add(gap.parent_len())?;
+        }
+        for gap in &self.gaps {
+            end = end.checked_sub(gap.nc_len())?;
+        }
+        Some(end)
+    }
+
     /// Map a 1-based chromosome (`NC_`) coordinate into the parent's own frame.
     ///
-    /// Returns `None` when `nc_pos` lies outside the placed span, or when the
-    /// parent's strand is unknown — the caller should then decline to re-anchor
-    /// rather than emit an out-of-frame coordinate.
+    /// Returns `None` when `nc_pos` lies outside the placed span, when it falls
+    /// inside a [`ChromosomeOnly`](AlignmentGapKind::ChromosomeOnly) run (those
+    /// bases are absent from the parent, so there is no coordinate to return),
+    /// or when the parent's strand is unknown — the caller should then decline to
+    /// re-anchor rather than emit an out-of-frame coordinate.
     pub fn nc_to_parent(&self, nc_pos: u64) -> Option<u64> {
         if nc_pos < self.nc_start || nc_pos > self.nc_end {
             return None;
         }
-        match self.strand {
-            Strand::Plus => Some(self.parent_start + (nc_pos - self.nc_start)),
-            Strand::Minus => Some(self.parent_start + (self.nc_end - nc_pos)),
+        // Chromosome bases consumed before `nc_pos`, which is the offset the
+        // block table is keyed on in both strand directions.
+        let consumed = match self.strand {
+            Strand::Plus => nc_pos - self.nc_start,
+            Strand::Minus => self.nc_end - nc_pos,
             // An unknown-orientation parent has no defined parent frame, so
             // decline rather than guess `Plus`. This matches how the rest of the
-            // codebase treats `Strand::Unknown` (transcript projection, annotation
-            // validation), and the placement parsers only ever emit Plus/Minus.
-            Strand::Unknown => None,
+            // codebase treats `Strand::Unknown` (transcript projection,
+            // annotation validation), and the placement parsers only ever emit
+            // Plus/Minus. Note `parent_to_nc` deliberately does *not* mirror
+            // this — it has always treated Unknown as ascending, and changing
+            // that is not this model's business.
+            Strand::Unknown => return None,
+        };
+        if self.gaps.is_empty() {
+            return Some(self.parent_start + consumed);
         }
+        for block in self.blocks() {
+            if consumed < block.nc_consumed {
+                // Landed in a chromosome-only run before this block.
+                return None;
+            }
+            let within = consumed - block.nc_consumed;
+            if within < block.len {
+                return block.parent_start.checked_add(within);
+            }
+        }
+        None
     }
 
     /// Map a 1-based parent-frame coordinate back onto its chromosome (`NC_`)
@@ -103,18 +421,36 @@ impl GenomicPlacement {
     /// `NG_`/`LRG_`-relative genomic *input* position into the chromosome frame so
     /// cdot can enumerate the transcripts overlapping it.
     ///
-    /// Returns `None` when `parent_pos` lies outside the placed span (parent
-    /// coordinates `parent_start ..= parent_start + (nc_end - nc_start)`).
+    /// Returns `None` when `parent_pos` lies outside the placed span
+    /// (`parent_start ..= `[`parent_end`](Self::parent_end)), or when it falls
+    /// inside a [`ParentOnly`](AlignmentGapKind::ParentOnly) run — those parent
+    /// bases are absent from the chromosome, so there is no coordinate to return.
     pub fn parent_to_nc(&self, parent_pos: u64) -> Option<u64> {
-        let parent_end = self.parent_start + (self.nc_end - self.nc_start);
-        if parent_pos < self.parent_start || parent_pos > parent_end {
+        if parent_pos < self.parent_start {
             return None;
         }
-        let offset = parent_pos - self.parent_start;
-        match self.strand {
-            Strand::Plus | Strand::Unknown => Some(self.nc_start + offset),
-            Strand::Minus => Some(self.nc_end - offset),
+        if self.gaps.is_empty() {
+            let parent_end = self.parent_start + (self.nc_end - self.nc_start);
+            if parent_pos > parent_end {
+                return None;
+            }
+            let offset = parent_pos - self.parent_start;
+            return match self.strand {
+                Strand::Minus => Some(self.nc_end - offset),
+                _ => Some(self.nc_start + offset),
+            };
         }
+        for block in self.blocks() {
+            if parent_pos < block.parent_start {
+                // Landed in a parent-only run before this block.
+                return None;
+            }
+            let within = parent_pos - block.parent_start;
+            if within < block.len {
+                return self.nc_at(block.nc_consumed.checked_add(within)?);
+            }
+        }
+        None
     }
 }
 
@@ -689,6 +1025,7 @@ mod placement_tests {
             nc_start: 1000,
             nc_end: 1008,
             strand,
+            gaps: Vec::new(),
         }
     }
 
@@ -699,6 +1036,7 @@ mod placement_tests {
             nc_start: 1000,
             nc_end: 1008,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         }
     }
 
@@ -794,6 +1132,289 @@ mod placement_tests {
         // Parent span is 1..=9; 0 and 10 fall outside.
         assert_eq!(p.parent_to_nc(0), None);
         assert_eq!(p.parent_to_nc(10), None);
+    }
+
+    // ------------------------------------------------------------------
+    // #1833 — a gapped placement maps every coordinate in its span exactly
+    // ------------------------------------------------------------------
+
+    /// The same 9-base span, with `len` parent bases inserted at parent
+    /// coordinate `at` and `nc` chromosome bases inserted after parent
+    /// coordinate `nc_at`. The chromosome span is widened accordingly so the
+    /// two frames still balance, which is the shape a real record has.
+    fn gapped(strand: Strand, gaps: Vec<AlignmentGap>, nc_end: u64) -> GenomicPlacement {
+        GenomicPlacement {
+            nc: Accession::new("NC", "000001", Some(11)),
+            parent_start: 1,
+            nc_start: 1000,
+            nc_end,
+            strand,
+            gaps,
+        }
+    }
+
+    #[test]
+    fn a_parent_only_run_is_declined_and_shifts_the_chromosome_side_back() {
+        // Parent 1..=12; parent bases 5..=7 have no chromosome counterpart, so
+        // the chromosome side is 9 bases wide (1000..=1008).
+        let p = gapped(Strand::Plus, vec![AlignmentGap::parent_only(5, 3)], 1008);
+        assert_eq!(p.parent_end(), Some(12));
+        assert_eq!(p.parent_to_nc(4), Some(1003));
+        // The run itself: no chromosome image, so declined rather than guessed.
+        assert_eq!(p.parent_to_nc(5), None);
+        assert_eq!(p.parent_to_nc(7), None);
+        // …and everything after it resumes where the run left the chromosome —
+        // the affine would have said 1007, three bases too far.
+        assert_eq!(p.parent_to_nc(8), Some(1004));
+        assert_eq!(p.parent_to_nc(12), Some(1008));
+        assert_eq!(p.parent_to_nc(13), None);
+        // The inverse never names a coordinate inside the run.
+        assert_eq!(p.nc_to_parent(1003), Some(4));
+        assert_eq!(p.nc_to_parent(1004), Some(8));
+    }
+
+    #[test]
+    fn a_chromosome_only_run_is_declined_and_shifts_the_parent_side_on() {
+        // Parent 1..=9; three chromosome bases sit between parent 4 and 5, so
+        // the chromosome side is 12 bases wide (1000..=1011).
+        let p = gapped(
+            Strand::Plus,
+            vec![AlignmentGap::chromosome_only(4, 3)],
+            1011,
+        );
+        assert_eq!(p.parent_end(), Some(9));
+        assert_eq!(p.parent_to_nc(4), Some(1003));
+        assert_eq!(p.parent_to_nc(5), Some(1007));
+        assert_eq!(p.parent_to_nc(9), Some(1011));
+        assert_eq!(p.parent_to_nc(10), None);
+        // The chromosome bases inside the run have no parent image.
+        for nc in 1004..=1006 {
+            assert_eq!(p.nc_to_parent(nc), None, "nc {nc} is chromosome-only");
+        }
+        assert_eq!(p.nc_to_parent(1003), Some(4));
+        assert_eq!(p.nc_to_parent(1007), Some(5));
+    }
+
+    #[test]
+    fn a_minus_strand_gap_walks_the_chromosome_downwards() {
+        // The discriminating direction: on the minus strand parent coordinate 1
+        // anchors at `nc_end` and a gap must trim towards `nc_start`.
+        let p = gapped(Strand::Minus, vec![AlignmentGap::parent_only(5, 3)], 1008);
+        assert_eq!(p.parent_to_nc(1), Some(1008));
+        assert_eq!(p.parent_to_nc(4), Some(1005));
+        assert_eq!(p.parent_to_nc(5), None);
+        assert_eq!(p.parent_to_nc(8), Some(1004));
+        assert_eq!(p.parent_to_nc(12), Some(1000));
+        assert_eq!(p.nc_to_parent(1004), Some(8));
+        assert_eq!(p.nc_to_parent(1005), Some(4));
+    }
+
+    #[test]
+    fn every_mappable_coordinate_round_trips_through_a_gapped_placement() {
+        // Both kinds, both strands, adjacent as well as separated — the property
+        // a per-point assertion cannot state.
+        for strand in [Strand::Plus, Strand::Minus] {
+            for gaps in [
+                vec![AlignmentGap::parent_only(5, 3)],
+                vec![AlignmentGap::chromosome_only(4, 3)],
+                // Abutting, in both orders: the `LRG_1321` / `LRG_1075` shape.
+                vec![
+                    AlignmentGap::chromosome_only(4, 3),
+                    AlignmentGap::parent_only(5, 2),
+                ],
+                vec![
+                    AlignmentGap::parent_only(5, 2),
+                    AlignmentGap::chromosome_only(6, 3),
+                ],
+            ] {
+                let parent_only: u64 = gaps.iter().map(|g| g.parent_len()).sum();
+                let nc_only: u64 = gaps.iter().map(|g| g.nc_len()).sum();
+                let nc_end = 1000 + 8 + nc_only - parent_only;
+                let p = gapped(strand, gaps.clone(), nc_end);
+                let mut mapped = 0;
+                for parent in 1..=p.parent_end().expect("extent") {
+                    let Some(nc) = p.parent_to_nc(parent) else {
+                        continue;
+                    };
+                    assert_eq!(
+                        p.nc_to_parent(nc),
+                        Some(parent),
+                        "round-trip at parent {parent} ({strand:?}, {gaps:?})"
+                    );
+                    mapped += 1;
+                }
+                // The transform is only interesting if it mapped anything.
+                assert_eq!(mapped, 9 - parent_only, "{strand:?} {gaps:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn parent_end_is_derived_from_the_gap_list_not_the_span_width() {
+        // The whole reason this accessor exists: with gaps the two frames have
+        // different widths, so `parent_start + (nc_end - nc_start)` is wrong in
+        // both directions.
+        let wider_parent = gapped(Strand::Plus, vec![AlignmentGap::parent_only(5, 3)], 1008);
+        assert_eq!(wider_parent.parent_start + (1008 - 1000), 9);
+        assert_eq!(wider_parent.parent_end(), Some(12));
+
+        let wider_nc = gapped(
+            Strand::Plus,
+            vec![AlignmentGap::chromosome_only(4, 3)],
+            1011,
+        );
+        assert_eq!(wider_nc.parent_start + (1011 - 1000), 12);
+        assert_eq!(wider_nc.parent_end(), Some(9));
+
+        // No gaps: unchanged, which is what keeps every `NG_` placement and the
+        // 1 248 indel-free LRG records exactly where they were.
+        assert_eq!(placement(Strand::Plus).parent_end(), Some(9));
+    }
+
+    #[test]
+    fn gaps_are_consistent_separates_a_walkable_list_from_a_broken_one() {
+        // The check the parser gates on, exercised directly — `parent_end` is a
+        // sum and cannot see any of these, which is why both are asked.
+        assert!(placement(Strand::Plus).gaps_are_consistent(), "no gaps");
+        assert!(
+            gapped(Strand::Plus, vec![AlignmentGap::parent_only(5, 3)], 1008).gaps_are_consistent()
+        );
+        assert!(gapped(
+            Strand::Minus,
+            vec![AlignmentGap::chromosome_only(4, 3)],
+            1011
+        )
+        .gaps_are_consistent());
+
+        for (why, gaps, nc_end) in [
+            (
+                "a pair that overlaps",
+                vec![
+                    AlignmentGap::parent_only(5, 4),
+                    AlignmentGap::chromosome_only(6, 2),
+                ],
+                1008u64,
+            ),
+            (
+                "a chromosome-only run wider than the span",
+                vec![AlignmentGap::chromosome_only(4, 500)],
+                1008,
+            ),
+            (
+                "an unsorted list",
+                vec![
+                    AlignmentGap::parent_only(7, 1),
+                    AlignmentGap::parent_only(3, 2),
+                ],
+                1005,
+            ),
+            (
+                "two gaps on one anchor",
+                vec![
+                    AlignmentGap::chromosome_only(4, 2),
+                    AlignmentGap::parent_only(4, 2),
+                ],
+                1008,
+            ),
+        ] {
+            assert!(
+                !gapped(Strand::Plus, gaps, nc_end).gaps_are_consistent(),
+                "must be rejected: {why}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_inconsistent_gap_list_declines_rather_than_answers() {
+        // `gaps` is public, so a caller can hand us one the walk cannot honour.
+        // Fail closed: a wrong coordinate is what this model exists to remove.
+        let overlapping = gapped(
+            Strand::Plus,
+            vec![
+                AlignmentGap::parent_only(5, 4),
+                // Anchored *inside* the run above, so the aligned run between
+                // them has negative length.
+                AlignmentGap::chromosome_only(6, 2),
+            ],
+            1008,
+        );
+        assert_eq!(overlapping.parent_to_nc(9), None);
+        assert_eq!(overlapping.nc_to_parent(1005), None);
+
+        let overrunning = gapped(
+            Strand::Plus,
+            // Claims 500 chromosome bases from a 9-base span.
+            vec![AlignmentGap::chromosome_only(4, 500)],
+            1008,
+        );
+        assert_eq!(overrunning.parent_to_nc(5), None);
+        assert_eq!(overrunning.nc_to_parent(1007), None);
+    }
+
+    #[test]
+    fn two_gaps_on_one_anchor_decline_rather_than_pick_an_order() {
+        // The two kinds read `parent_at` differently, so at equal anchors the
+        // order is undetermined and both readings are defensible. Nothing in the
+        // 1 294-record corpus has this shape; answering would be inventing one.
+        let colliding = gapped(
+            Strand::Plus,
+            vec![
+                AlignmentGap::chromosome_only(4, 2),
+                AlignmentGap::parent_only(4, 2),
+            ],
+            1008,
+        );
+        for parent in 1..=12 {
+            assert_eq!(colliding.parent_to_nc(parent), None, "parent {parent}");
+        }
+        for nc in 1000..=1008 {
+            assert_eq!(colliding.nc_to_parent(nc), None, "nc {nc}");
+        }
+        // Control: separating the anchors by one makes it the ordinary
+        // `LRG_1321` shape, which answers.
+        let abutting = gapped(
+            Strand::Plus,
+            vec![
+                AlignmentGap::chromosome_only(4, 2),
+                AlignmentGap::parent_only(5, 2),
+            ],
+            1008,
+        );
+        assert_eq!(abutting.parent_to_nc(4), Some(1003));
+        assert_eq!(abutting.parent_to_nc(5), None);
+        assert_eq!(abutting.parent_to_nc(7), Some(1006));
+    }
+
+    #[test]
+    fn a_gap_list_in_any_order_gives_the_same_answers() {
+        // The walk is order-sensitive by construction, and the parser sorts —
+        // but a library caller building a placement by hand may not, and an
+        // unsorted list must not produce a *different* coordinate. It may only
+        // decline.
+        let sorted = gapped(
+            Strand::Plus,
+            vec![
+                AlignmentGap::parent_only(3, 2),
+                AlignmentGap::parent_only(7, 1),
+            ],
+            1005,
+        );
+        let reversed = gapped(
+            Strand::Plus,
+            vec![
+                AlignmentGap::parent_only(7, 1),
+                AlignmentGap::parent_only(3, 2),
+            ],
+            1005,
+        );
+        for parent in 1..=12 {
+            let (a, b) = (sorted.parent_to_nc(parent), reversed.parent_to_nc(parent));
+            assert!(
+                b.is_none() || b == a,
+                "an unsorted gap list may decline at parent {parent}, never answer differently \
+                 ({a:?} vs {b:?})"
+            );
+        }
     }
 }
 

--- a/tests/it/issue_480_ng_lrg_parent_frame.rs
+++ b/tests/it/issue_480_ng_lrg_parent_frame.rs
@@ -8,8 +8,11 @@
 //! input is parented on an `NG_` RefSeqGene or an `LRG_`, the resolved
 //! coordinate is on the chromosome but the emitted accession is the
 //! `NG_`/`LRG_` one — the two frames disagree. Given the parent's chromosomal
-//! placement (`GenomicPlacement`), ferro composes NM→NC (cdot) with the affine
+//! placement (`GenomicPlacement`), ferro composes NM→NC (cdot) with the
 //! NC→parent transform and emits the coordinate in the parent's own frame.
+//! (That transform is affine only for a placement with no alignment gaps; since
+//! #1833 an indel-bearing LRG carries its `<diff>` list and is walked instead.
+//! The fixtures in this file are all gapless, so they exercise the affine arm.)
 //! Without a placement the chromosome coordinate cannot be re-anchored into the
 //! parent frame, so `project_to_genomic` declines (`UnsupportedProjection`)
 //! rather than stamp a chromosome coordinate under the parent accession, which
@@ -95,6 +98,7 @@ fn placement_maps_chromosome_to_parent_frame_plus_strand() {
         nc_start: 1000,
         nc_end: 1009,
         strand: Strand::Plus,
+        gaps: Vec::new(),
     };
     assert_eq!(p.nc_to_parent(1000), Some(1));
     assert_eq!(p.nc_to_parent(1003), Some(4));
@@ -113,6 +117,7 @@ fn placement_maps_chromosome_to_parent_frame_minus_strand() {
         nc_start: 1000,
         nc_end: 1009,
         strand: Strand::Minus,
+        gaps: Vec::new(),
     };
     assert_eq!(p.nc_to_parent(1009), Some(1));
     assert_eq!(p.nc_to_parent(1003), Some(7));
@@ -134,6 +139,7 @@ fn ng_parent_emits_parent_frame_coords_plus_strand() {
             nc_start: 1000,
             nc_end: 1009,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);
@@ -155,6 +161,7 @@ fn ng_parent_emits_parent_frame_coords_minus_strand() {
             nc_start: 1000,
             nc_end: 1009,
             strand: Strand::Minus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);
@@ -268,6 +275,7 @@ fn bare_lrg_transcript_input_reanchors_to_lrg_frame() {
             nc_start: 1000,
             nc_end: 1009,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);

--- a/tests/it/issue_851_compound_utr_projection.rs
+++ b/tests/it/issue_851_compound_utr_projection.rs
@@ -77,6 +77,7 @@ fn plus_fixture() -> VariantProjector<MockProvider> {
             nc_start: 900,
             nc_end: 1100,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     VariantProjector::new(projector, provider)
@@ -192,6 +193,7 @@ fn minus_fixture() -> VariantProjector<MockProvider> {
             nc_start: 1900,
             nc_end: 2100,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     VariantProjector::new(projector, provider)

--- a/tests/it/issue_860_lrg_namespace.rs
+++ b/tests/it/issue_860_lrg_namespace.rs
@@ -92,6 +92,7 @@ fn lrg_fixture() -> (Projector, MockProvider) {
             nc_start: 1000,
             nc_end: 1009,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     (projector, provider)

--- a/tests/it/issue_879_ng_g_to_c_overlap.rs
+++ b/tests/it/issue_879_ng_g_to_c_overlap.rs
@@ -103,6 +103,7 @@ fn bare_ng_genomic_projects_onto_single_transcript_plus_strand() {
             nc_start: 1000,
             nc_end: 1013,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);
@@ -147,6 +148,7 @@ fn bare_ng_genomic_projects_onto_single_transcript_minus_strand() {
             nc_start: 1000,
             nc_end: 1013,
             strand: Strand::Minus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);
@@ -191,6 +193,7 @@ fn project_normalized_de_anchors_bare_ng_genomic() {
             nc_start: 1000,
             nc_end: 1013,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);
@@ -245,6 +248,7 @@ fn ng_context_coding_input_keeps_pivot_path_unchanged() {
             nc_start: 1000,
             nc_end: 1013,
             strand: Strand::Plus,
+            gaps: Vec::new(),
         },
     );
     let vp = VariantProjector::new(projector, provider);


### PR DESCRIPTION
Closes #1833.

Representation-Change: 51 of 5176 LRG projection rows change status, all `unavailable` -> `ok`
  (2764 -> 2815 ok, 147 -> 96 unavailable under --error-mode lenient; 43 rows and 2489 -> 2532
  under the CLI-default strict mode, the 8-row difference being inputs strict refuses before a
  placement is consulted). 0 previously-answered row changes value, and 0 regress. Measured
  against origin/main AFTER #1830 merged: #1830 narrowed indel-bearing LRG placements to their
  affine-exact prefix and declined the rest; this models the alignment instead, so those rows are
  answered rather than declined. Direction: TOWARD the reference oracle -- all 51 recovered
  coordinates were adjudicated against the frozen LRG_<N>g records with an unshiftable
  substitution probe (11-base window of the record against the chromosome coordinate cdot alone
  resolves): 51 agree, 0 disagree. 49 of the 51 sat at a base the gapless affine got demonstrably
  wrong (drift -8..+23); the other 2 sat on a cancelling indel pair. The earlier "55 move / 0
  status" figure was measured against the pre-#1830 base and no longer describes this merge.

## The defect

An LRG↔chromosome alignment is not affine, and a single `<mapping_span>` does not make it one. Alongside the span an LRG record lists `<diff>` elements — vocabulary closed at `mismatch` / `lrg_ins` / `other_ins`, re-derived here over all 1294 records in the prepared reference (**479 / 63 / 47** in the main-assembly mappings, matching the issue). The two insertion kinds shift every coordinate past them, in opposite directions, and `GenomicPlacement` dropped them, so a coordinate drifted by the net indel count between the LRG origin and the projected position.

`LRG_292` (BRCA1) is the worked case: 193 689 LRG bases onto a 193 687-base chromosome span, three `lrg_ins` bases against one `other_ins`. Only the first **13 168** bases — 6.8 % of the record — were placed correctly, so essentially all of BRCA1's CDS was on the wrong side of it.

Measured on the prepared reference (identity `aa8b3246d83055cc`), by comparing an 11-base window of each frozen `LRG_<N>g` record against the chromosome bases its placement names:

| | `origin/main` | this branch |
|---|---:|---:|
| windows sampled (1294 placements) | 260 431 | 260 431 |
| windows where the record and the chromosome agree | 255 121 | **260 385** |
| windows that disagree | 5 309 | 30 |
| …of those, disagreeing at a column **no `mismatch` diff explains** | **5 295**, across 46 accessions | **0** |

The surviving 30 differ only at columns the record's own `mismatch` diffs name — a substituted base, which shifts no coordinate and is served from the LRG's own record anyway since #1490.

## The fix

`GenomicPlacement` gains a `gaps: Vec<AlignmentGap>` field: the span's indel `<diff>` list as an ordered gap model, each entry either `ParentOnly { len }` (LRG bases with no chromosome counterpart) or `ChromosomeOnly { len }` (the reverse). `nc_to_parent` / `parent_to_nc` walk it; a coordinate inside a run has no counterpart on the other side and is declined rather than approximated. `parent_end()` derives the parent's extent from the gap list instead of assuming the two frames have equal width (#1503's point, and the only remaining consumer of that arithmetic — `get_sequence_length` — now asks it).

The field is additive; the 47 literal construction sites take `gaps: Vec::new()`, which is exactly the previous behaviour. `mismatch` diffs are deliberately **not** modelled: 119 records carry mismatches and no indel, and keying on any `<diff>` would gap 165 records where 46 is correct.

Three things the issue named as the specification, and how each is handled:

- **`LRG_1321`'s colliding flanks.** Its `other_ins` of 1000 `N`s occupies `NC_000012.12:7083651-7084650`, and the `lrg_ins` of 231 bases abutting it lists chromosome flanks `7083650`/`7083651` — the second being the last base of the other run. The model **never reads an indel diff's `other_start`/`other_end`**; it positions off the LRG coordinates and lets the walk consume each side in turn, which reproduces the record exactly (`g.13189` → `7083650`, where the affine said `7084419`, 769 bases out).
- **`LRG_792`'s 19 clustered indels.** No new shape — the record that fails a model right about one gap and wrong about accumulating them. 13 measured `(parent, chromosome)` pairs are pinned through the dense 25 302–25 494 cluster, where the cumulative parent-only total runs 1 → 13 → 23 → 24 → 25 → 103 → 133 → 135 in 200 bases.
- **The per-kind `lrg_start`/`lrg_end` convention.** `AlignmentGap::parent_only` takes the first unaligned parent base (`lrg_ins`'s own bases); `AlignmentGap::chromosome_only` takes the flanking coordinate the run sits after (`other_ins`). The two constructors *are* the convention, so a caller cannot silently mix them.

### It fails closed, and that is checked rather than asserted

The parser refuses a placement whose gap list it cannot honour, in six ways: an unreadable or missing indel coordinate; a `lrg_end` below its `lrg_start`; a `<diff type>` this parser has never seen; two indel diffs sharing one `lrg_start`; a gap list whose walk does not cover the placed span (`gaps_are_consistent`); and a walk whose reconstructed parent extent disagrees with the span's own `lrg_end`. The last two are integrity assertions on real data — both hold for **all 1294** records — and filters only for data that does not exist yet.

`gaps` is a public field, so the walk itself is defensive too: it checks ordering **up front** rather than mid-walk. That is not pedantry — measured on a two-gap list with the entries reversed, parent 3 answered `1002` where the sorted list declines, because the blocks before the out-of-order entry had already been emitted.

## Deliberately not decided

**Two indel diffs sharing one `lrg_start` are refused, not ordered.** The two kinds read their anchor differently — a flank for `other_ins`, the first unaligned base for `lrg_ins` — so at equal anchors the readings genuinely disagree and either choice invents something the record does not state. **0 of 1294 records have that shape** (measured), so nothing is lost by declining, and inventing an order would be a ruling the issue does not make. Abutting runs of opposite kinds are a *different* thing and are ordinary: two records have them (`LRG_1321`, `LRG_1075`), their anchors differ, and both are pinned as passing fixtures.

## Unchanged on purpose

- **A `mismatch`-only mapping is not gapped** — `mismatch_diffs_alone_leave_the_placement_affine`.
- **An indel `<diff>` under a non-main mapping does not leak** into the GRCh38 placement; across the prepared reference the non-main mappings carry 967 `lrg_ins` / 860 `other_ins` the main-assembly ones do not.
- **A gapless placement is byte-identical to before** — both coordinate functions take an early branch that is the pre-existing arithmetic, which is what keeps every `NG_` placement and 1248 of the 1294 LRG records exactly where they were. `parent_to_nc`'s long-standing "treat `Strand::Unknown` as ascending" asymmetry with `nc_to_parent` is preserved rather than tidied.

## Relationship to #1830 (open, not merged)

#1830 narrows an indel-bearing placement to its affine-exact prefix and declines the rest. This models the alignment instead, so the whole span answers. **The narrowing would now remove correct coverage**, and the two branches touch the same function — whichever lands second needs a rebase that drops `affine_horizon` rather than merging it. This PR branches from `origin/main` and does not stack on #1830.

Relative to `origin/main` no row changes status (2947 `ok` / 2229 `unavailable`, before and after). Relative to #1830 the 51 rows it turns `ok → unavailable` are answered instead.

## Verification

All counts read back from the log's own `EXIT=` line, not from a completion notification.

```
cargo fmt --all --check                                   # EXIT=0
cargo clippy --all-features --all-targets -- -D warnings  # EXIT=0
FERRO_SWEEP_SEEDS=full cargo nextest run --features dev    # EXIT=0
scripts/run_oracle_suite.sh                                # EXIT=0
```

Reference-backed measurement, `FERRO_MANIFEST` = the prepared reference on scratch (identity `aa8b3246d83055cc`), run in a detached `origin/main` worktree and in this one with the same throwaway harness:

- **Projection corpus** — 1294 accessions × {`t1`, `t2`} × {`c.100del`, `c.1000del`} = **5176 rows**. 55 moved, 32 accessions, all `ok → ok`.
- **Adjudication of the 55** — for each, the chromosome coordinate both trees resolved, then an 11-base window of the `LRG_<N>g` record against the chromosome at the old and the new parent coordinate: **53** match only at the new one, **2** match at both (a repeat context an 11-base window cannot discriminate), **0** match only at the old one.
- **Window sweep** — the 5309 → 30 table above, plus the set comparison that is the actual "nothing correct moved" claim: of the branch's 30 disagreeing windows, **0 are windows `main` got right** (30 ⊂ 5309), and 5279 windows `main` got wrong are now right.

**A `dump_normalized_corpus` zero would be structural here and is not quoted.** That harness builds only `MockProvider`, which has no LRG XML and constructs no `GenomicPlacement` with a gap list, so it cannot move a row on this change whatever the number says.

**The new unit tests run on PR CI.** They are `--lib` tests over synthetic XML fixtures and do not resolve `FERRO_MANIFEST`, so unlike the reference-aware suites they are not nightly-only. Their expected coordinates are measured against the frozen `LRG_<N>g` records — an oracle independent of the code under test — and transcribed, never inferred.

Every new guard was sabotage-checked: dropping the gap list reddens 6, breaking `nc_to_parent`'s chromosome-only decline reddens 4, removing the extent assertion reddens 1, removing the ordering check reddens 1, and allowing a shared anchor reddens 2. An earlier tie-break for shared anchors was **removed** because its sabotage stayed green — nothing in the corpus exercised it, which is what turned it into the refusal above.

