### PR TITLE
ci: run the 45 orphaned reference-aware guards, and fail on a missing manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1154,6 +1154,14 @@ jobs:
         # suite both silently no-op when `FERRO_MANIFEST` is unset (PR CI does
         # not provision the multi-GB reference manifest). Surface a GitHub
         # annotation so reviewers see the skip explicitly. #397 item 6.
+        #
+        # `FERRO_REQUIRE_MANIFEST` is deliberately NOT set anywhere in this
+        # workflow. It is the sibling of `FERRO_REQUIRE_BULK_FIXTURES` below —
+        # it promotes a manifest-absence skip to a failure — and the two differ
+        # in exactly one respect: PR CI *does* provision the bulk fixtures and
+        # *does not* provision a manifest, so requiring one here would fail
+        # every PR. It is set in `nightly-mutalyzer.yml`, the only job that runs
+        # `ferro prepare`. See `src/conformance/manifest_gate.rs`.
         if: matrix.shard == 1
         run: |
           echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -1,11 +1,16 @@
 name: Nightly reference-aware tests
 
-# Runs the mutalyzer / biocommons / hgvs-rs-projection reference-aware test
-# suites against a real ferro-prepared manifest. PR CI silently skips these
-# tests (see
-# the `::notice::` annotation in `ci.yml`) because provisioning a
-# multi-GB reference manifest would multiply PR CI time. This workflow
-# runs nightly so manifest-dependent regressions surface within 24h.
+# Runs every reference-aware test suite in the repository against a real
+# ferro-prepared manifest — see `REFERENCE_AWARE_SELECTION` below for the list
+# and for why it is enumerated rather than matched by pattern. PR CI silently
+# skips these tests (see the `::notice::` annotation in `ci.yml`) because
+# provisioning a multi-GB reference manifest would multiply PR CI time. This
+# workflow runs nightly so manifest-dependent regressions surface within 24h.
+#
+# `FERRO_REQUIRE_MANIFEST` is set on the test step, so a guard that finds no
+# prepared reference FAILS here instead of skipping green. Without it, the
+# widened selection would be worth very little: a `ferro prepare` that produced
+# nothing would still report a green — and faster — run.
 #
 # Caching: the prepared reference directory is keyed on the Cargo.lock
 # hash (changes when the `prepare` crate's deps shift) + a fixed
@@ -48,24 +53,67 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      # The three reference-aware modules this job exists to run, defined ONCE
-      # because two steps need them: the run itself, and the reproduction recipe
-      # the summary step prints when that run fails. A second copy would drift —
-      # and it would drift in the direction that matters least visibly, since a
-      # stale recipe still looks like a working command to whoever pastes it.
+      # Every reference-aware guard in the repository, defined ONCE because two
+      # steps need them: the run itself, and the reproduction recipe the summary
+      # step prints when that run fails. A second copy would drift — and it
+      # would drift in the direction that matters least visibly, since a stale
+      # recipe still looks like a working command to whoever pastes it.
       #
       # This is the same rule `scripts/run_oracle_suite.sh` applies to
       # `test-oracle`'s selection: read it from one place, never copy it.
+      #
+      # This list used to name three modules. The other 45 guards below were
+      # manifest-gated, checked in, and executed by NO automated job — PR CI
+      # provisions no manifest, so they skipped green there, and they were in no
+      # nightly selection, so they skipped green here too. A skip is
+      # indistinguishable from a pass in every signal CI reports; the runtime is
+      # the only tell (0.02-0.08 s skipped against 9-58 s armed).
+      #
+      # That is not a hypothetical. `multi_member_cis_axis::axis_normalized` was
+      # provably red on `main` from at least 2026-08-08 to 2026-08-10 — 13
+      # merged commits, every PR green — because the guard took 0.04 s and
+      # returned. It surfaced four days later as a test-only re-bless of its
+      # census pin, and was then chased as an "inconsistency between worktrees".
+      #
+      # ENUMERATE, DO NOT GLOB. Widening this to a pattern was considered and
+      # rejected: it imports the seven modules `ci.yml`'s `ORACLE_EXCLUDE`
+      # withholds from an armed job, which fail on `main` for reasons no nightly
+      # caused, and it makes the xfail artifact — the only channel a non-gating
+      # job has — unreadable. The reproduce-text below says the same thing.
+      #
+      # ADDING A MANIFEST-GATED GUARD? Add its module here. `FERRO_REQUIRE_MANIFEST`
+      # below cannot catch an omission from this list — it fires when a SELECTED
+      # guard finds no manifest, not when an unselected one is never asked.
       REFERENCE_AWARE_SELECTION: >-
         test(/mutalyzer_normalize_tests::/) |
         test(/biocommons_normalize_tests::/) |
-        test(/hgvs_rs_projection_tests::/)
+        test(/hgvs_rs_projection_tests::/) |
+        test(/delins_equal_vs_unequal_length_discriminator::/) |
+        test(/inversion_sweep::/) |
+        test(/issue_1086_c_axis_genomic_context::/) |
+        test(/issue_1086_cross_axis_projection::/) |
+        test(/issue_1217_mito_terminus_insertion_clamp::/) |
+        test(/issue_1539_split_member_separation::/) |
+        test(/issue_1713_bare_transcript_genomic_decline::/) |
+        test(/issue_498_whole_exon_deletion::/) |
+        test(/issue_806_effect_real_residues::/) |
+        test(/issue_843_allele_rna_build_scoping::/) |
+        test(/issue_944_cds_to_tx_transcript_native::/) |
+        test(/issue_972_cds_start_nf_decline::/) |
+        test(/multi_member_cis_axis::/) |
+        test(/protein_cis_delins_decomposition::/) |
+        test(/real_data_normalization_tests::/) |
+        test(/accession_inventory::tests::corpus_missing_ng_against_real_reference_when_available/) |
+        test(/ng_placement_builder::tests::derive_for_real_reference_when_available/)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # No `lfs: true`: nothing in this repository is LFS-tracked any more,
-          # and `REFERENCE_AWARE_SELECTION` above names three modules, none of
-          # which reads a bulk corpus.
+          # and none of the modules `REFERENCE_AWARE_SELECTION` above names reads
+          # a bulk corpus (re-checked when the selection was widened; the four
+          # release-asset corpora are read only by `clinvar_hgvs_tests`,
+          # `cmrg_exhaustive_tests`, `paraphase_exhaustive_tests` and
+          # `normalize_axis_preserving`, none of which is manifest-gated).
           submodules: true
           persist-credentials: false
 
@@ -167,6 +215,20 @@ jobs:
         continue-on-error: true
         env:
           FERRO_MANIFEST: ${{ github.workspace }}/benchmark-output/manifest.json
+          # A manifest-absence skip is a FAILURE here, never a green pass. Every
+          # guard in the selection above `return`s early when it finds no
+          # prepared reference, so without this a `ferro prepare` that produced
+          # nothing — or a manifest written where the test step cannot see it —
+          # would delete the entire reference-aware surface and report a
+          # *faster* green run. That is the same outcome `FERRO_REQUIRE_BULK_FIXTURES`
+          # exists to prevent in `ci.yml`, and this is deliberately the same
+          # mechanism rather than a second convention:
+          # `src/conformance/manifest_gate.rs`.
+          #
+          # This job is the only one that runs `ferro prepare`, so it is the
+          # only one that may set this. PR CI must not — see the annotation step
+          # in `ci.yml`, which says so at the point someone would be tempted.
+          FERRO_REQUIRE_MANIFEST: "1"
           # This is the only job that provisions a manifest, so it is the only
           # place the idempotency oracle sees the reference-backed corpora at
           # all (PR CI's copy of this gate runs manifest-free — see the
@@ -232,7 +294,7 @@ jobs:
             echo
             echo "These axes only run with a prepared reference (\`FERRO_MANIFEST\`), so they"
             echo "cannot run on a pull request. Reproduce on a box with the reference, with the"
-            echo "same four oracles armed and over the same three modules:"
+            echo "same four oracles armed and over the same modules:"
             echo
             echo '```'
             echo "FERRO_MANIFEST=<ref>/manifest.json \\"
@@ -241,11 +303,17 @@ jobs:
             echo "  cargo nextest run --features dev -E '${REFERENCE_AWARE_SELECTION}'"
             echo '```'
             echo
-            echo "Keep the \`-E\` selection. Dropping it while keeping the flags widens the run"
-            echo "onto the modules \`ci.yml\`'s \`ORACLE_EXCLUDE\` withholds from an armed job,"
-            echo "which fail on \`main\` for reasons no nightly caused — see that variable's"
-            echo "comment, and \`scripts/run_oracle_suite.sh\` for the local runner that applies"
-            echo "the same exclusion."
+            echo "Keep the \`-E\` selection, and keep it ENUMERATED. Dropping it while keeping the"
+            echo "flags — or replacing it with a pattern — widens the run onto the modules"
+            echo "\`ci.yml\`'s \`ORACLE_EXCLUDE\` withholds from an armed job, which fail on"
+            echo "\`main\` for reasons no nightly caused — see that variable's comment, and"
+            echo "\`scripts/run_oracle_suite.sh\` for the local runner that applies the same"
+            echo "exclusion."
+            echo
+            echo "\`FERRO_REQUIRE_MANIFEST=1\` is set in this job so a guard that finds no"
+            echo "prepared reference FAILS rather than skipping green. If you reproduce"
+            echo "without a manifest, leave it unset — otherwise every selected guard fails"
+            echo "for that reason and tells you nothing about the run you are chasing."
             echo
             echo "A moved conformance baseline is re-blessable; a new live divergence is not."
             echo "Read which it is out of the \`${XFAIL_ARTIFACT}\` artifact"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,9 +476,12 @@ contiguity rule.
 **No CI job arms the oracle where it fires** — checked, not assumed.
 `FERRO_ASSERT_SEQUENCE` is set in exactly two places: `ci.yml`'s `sweeps`, which
 selects `SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`, and
-`nightly-mutalyzer.yml`, which selects the three reference-aware modules and is
+`nightly-mutalyzer.yml`, which selects every reference-aware module and is
 `continue-on-error`. `normalize_tests` is in neither selection, so the fire is
-reachable only by setting the flag by hand.
+reachable only by setting the flag by hand. (That nightly selection named
+**three** modules until the orphaned-guard sweep; `normalize_tests` was not one
+of the modules added, so this paragraph's conclusion is unchanged — but do not
+re-derive "the three modules" from it.)
 
 **Here is the command the before/after comes from**, because a figure with no
 command is one nobody can re-derive. Swap only the fixture, and exclude the guard

--- a/src/conformance/accession_inventory.rs
+++ b/src/conformance/accession_inventory.rs
@@ -571,9 +571,17 @@ mod tests {
 
     #[test]
     fn corpus_missing_ng_against_real_reference_when_available() {
-        let manifest = match std::env::var("FERRO_MANIFEST") {
+        let manifest = match std::env::var(crate::conformance::manifest_gate::MANIFEST_ENV) {
             Ok(m) => std::path::PathBuf::from(m),
-            Err(_) => return, // skip without a prepared reference
+            Err(_) => {
+                // Skip without a prepared reference — unless the run demands
+                // one, in which case a skip would be coverage loss wearing a
+                // pass's clothes. See `conformance::manifest_gate`.
+                crate::conformance::manifest_gate::absent(
+                    "accession_inventory::corpus_missing_ng_against_real_reference_when_available",
+                );
+                return;
+            }
         };
         let provider =
             crate::reference::multi_fasta::MultiFastaProvider::from_manifest(&manifest).unwrap();

--- a/src/conformance/manifest_gate.rs
+++ b/src/conformance/manifest_gate.rs
@@ -1,0 +1,197 @@
+//! One place that decides what an ABSENT reference manifest means.
+//!
+//! Dozens of reference-aware guards need a ferro-prepared manifest — real
+//! contigs, real transcripts, real cdot — which is multi-gigabyte and takes
+//! ~25 min to build, so it is not provisioned for a pull request. Every one of
+//! those guards therefore ends its gate the same way:
+//!
+//! ```ignore
+//! let Some(provider) = provider() else {
+//!     eprintln!("<module>: skipping — no manifest");
+//!     return;
+//! };
+//! ```
+//!
+//! That is the right behaviour for a developer without a prepared reference,
+//! and exactly the wrong behaviour in the one job that *does* prepare one: a
+//! `ferro prepare` that produced nothing, a manifest written to a path the test
+//! step cannot see, or a module that quietly stopped being selected all read as
+//! a green pass. **The runtime is the only tell** — these guards take 10–70 s
+//! armed and 0.02–0.08 s skipped — and no exit status, summary line or check
+//! row distinguishes the two.
+//!
+//! That is not hypothetical. `multi_member_cis_axis::axis_normalized` was
+//! provably red on `main` for at least two days across 13 merged commits while
+//! every PR reported green, because the guard took 0.04 s and returned.
+//!
+//! So the skip is made conditional here rather than at ~50 call sites.
+//! `FERRO_REQUIRE_MANIFEST=1` turns every such skip into a panic naming the
+//! guard and the fix. The nightly reference-aware job — the only job that
+//! prepares a manifest — sets it, so absence can no longer masquerade as a
+//! pass; it stays unset locally and in PR CI, where skipping is the useful
+//! default.
+//!
+//! This is deliberately the same shape as `tests/it/common/bulk_fixtures.rs`,
+//! which solved the identical problem for the four release-asset corpora. Two
+//! conventions for "a missing input must not read as a pass" would be one too
+//! many.
+//!
+//! It lives in the library, rather than beside `bulk_fixtures` in the test
+//! tree, for the same reason the rest of this module does: the guards that need
+//! it are not all in one crate. Most are in the `it` integration binary, and
+//! two are `#[cfg(test)]` units inside `src/` itself
+//! (`accession_inventory::tests::corpus_missing_ng_against_real_reference_when_available`
+//! and `ng_placement_builder::tests::derive_for_real_reference_when_available`),
+//! which cannot see `tests/it/common/`. A second copy for those two is exactly
+//! the drift this module exists to prevent.
+
+/// The environment variable that promotes a manifest-absence skip to a failure.
+pub const REQUIRE_ENV: &str = "FERRO_REQUIRE_MANIFEST";
+
+/// The environment variable naming the prepared manifest itself.
+pub const MANIFEST_ENV: &str = "FERRO_MANIFEST";
+
+/// Whether an absent reference manifest must fail the guard rather than skip it.
+///
+/// True when `FERRO_REQUIRE_MANIFEST` is set to anything other than the empty
+/// string or `0`. Read on every call rather than cached in a `OnceLock`: these
+/// guards are few and slow, the read is trivially cheap beside them, and a
+/// cache would make the variable unsettable from within a test — which is what
+/// this module's own coverage needs.
+pub fn manifest_is_required() -> bool {
+    value_requires_manifest(std::env::var(REQUIRE_ENV).ok().as_deref())
+}
+
+/// The predicate itself, over an explicit value so it is testable without
+/// touching the process environment.
+fn value_requires_manifest(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.is_empty() && v != "0")
+}
+
+/// Called when a reference manifest is not available: panics under
+/// `FERRO_REQUIRE_MANIFEST`, otherwise reports the skip on stderr.
+///
+/// `context` identifies the guard that is standing down — a module or test
+/// name — so the failure text says which coverage was about to be dropped.
+///
+/// Returns `()` rather than `!` deliberately, and for the same reason
+/// `bulk_fixtures::absent` does: the call sites keep their own `return`, so
+/// what a reader sees at each one is still an ordinary early exit rather than
+/// control flow that depends on an environment variable.
+pub fn absent(context: &str) {
+    assert!(
+        !manifest_is_required(),
+        "{}",
+        missing_manifest_message(context)
+    );
+    eprintln!(
+        "{context}: skipping — no reference manifest \
+         (set {MANIFEST_ENV}=<prepared-dir>/manifest.json)"
+    );
+}
+
+/// The failure text, factored out so it can be asserted on rather than
+/// re-typed in a test.
+fn missing_manifest_message(context: &str) -> String {
+    format!(
+        "{REQUIRE_ENV} is set, but `{context}` found no reference manifest.\n\
+         \n\
+         This guard needs a ferro-prepared reference, which it locates through\n\
+         {MANIFEST_ENV} (or `benchmark-output/manifest.json`). Without one the guard\n\
+         would SKIP GREEN, silently dropping its coverage — and a skip is\n\
+         indistinguishable from a pass in every signal CI reports — so under\n\
+         {REQUIRE_ENV} an absent manifest is a failure instead.\n\
+         \n\
+         Prepare a reference with:\n\
+         \n    ferro prepare --output-dir benchmark-output --genome grch38 --ensembl \\\
+         \n        --derive-ng-placements tests/fixtures/mutalyzer-normalize/ng_accessions.txt\n\
+         \n\
+         then point {MANIFEST_ENV} at `benchmark-output/manifest.json`.\n\
+         \n\
+         In CI this means the nightly's `ferro prepare` step did not leave a manifest\n\
+         where the test step reads it."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The message must name the guard that stood down and the remedy. A guard
+    /// whose failure text does not say what to run gets worked around rather
+    /// than fixed.
+    #[test]
+    fn the_missing_manifest_message_names_the_guard_and_the_remedy() {
+        let message = missing_manifest_message("multi_member_cis_axis::axis_normalized");
+        assert!(message.contains("multi_member_cis_axis::axis_normalized"));
+        assert!(message.contains("ferro prepare"));
+        assert!(message.contains(REQUIRE_ENV));
+        assert!(message.contains(MANIFEST_ENV));
+    }
+
+    /// The remedy must survive being **pasted**, which "contains `ferro
+    /// prepare`" does not check. The command spans two lines joined by a shell
+    /// `\`, and a blank line after that continuation ends the command early:
+    /// the shell then runs `ferro prepare` *without* `--derive-ng-placements`
+    /// — a 25-minute build producing a manifest with `ng_hosted_transcripts`
+    /// unset, i.e. exactly the reference the guards under it go on to
+    /// disagree with — and executes the flag line as a command of its own.
+    ///
+    /// So this asserts the shape a shell reads rather than the substring a
+    /// reader recognises: every continued line is followed immediately by the
+    /// line that continues it.
+    #[test]
+    fn the_remedy_command_survives_being_pasted_into_a_shell() {
+        let message = missing_manifest_message("some_module::some_guard");
+        let lines: Vec<&str> = message.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.trim_end().ends_with('\\') {
+                continue;
+            }
+            let next = lines
+                .get(index + 1)
+                .unwrap_or_else(|| panic!("line {index} continues onto nothing: {line:?}"));
+            assert!(
+                !next.trim().is_empty(),
+                "line {index} ends with a shell continuation but line {} is blank, \
+                 so a pasted command stops there:\n{message}",
+                index + 1
+            );
+        }
+        // Anti-vacuity: the loop above says nothing if the message carries no
+        // continuation at all.
+        assert!(
+            lines.iter().any(|line| line.trim_end().ends_with('\\')),
+            "no continued line found — the remedy no longer spans two lines, so this \
+             guard is vacuous and should be re-aimed:\n{message}"
+        );
+    }
+
+    /// The predicate's contract, pinned against the spellings CI and a
+    /// developer shell actually produce. `0` and the empty string are the two
+    /// ways a variable is "set but off", and reading either as *on* would make
+    /// every manifest-less run in the project fail at once.
+    ///
+    /// Uses the private helper over an explicit value rather than the process
+    /// environment: mutating the environment is a process-global side effect
+    /// and tests run in threads, so a test that set the real variable could
+    /// change what a concurrently running sibling sees.
+    #[test]
+    fn only_a_non_empty_non_zero_value_requires_the_manifest() {
+        assert!(!value_requires_manifest(None));
+        assert!(!value_requires_manifest(Some("")));
+        assert!(!value_requires_manifest(Some("0")));
+        assert!(value_requires_manifest(Some("1")));
+        assert!(value_requires_manifest(Some("true")));
+    }
+
+    /// The promotion is off by default, so a developer with no prepared
+    /// reference keeps the skip. If this ever reads `true` in an unset
+    /// environment, every manifest-less run in the project turns red at once.
+    #[test]
+    fn a_manifest_is_not_required_unless_the_variable_asks_for_it() {
+        if std::env::var_os(REQUIRE_ENV).is_none() {
+            assert!(!manifest_is_required());
+        }
+    }
+}

--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -18,6 +18,7 @@ pub mod completeness;
 pub mod error_mode_stamp;
 pub mod hgvs_rs_projection;
 pub mod inversion_sweep;
+pub mod manifest_gate;
 pub mod mutalyzer;
 pub mod protein_corpus;
 pub mod reference_snapshot;

--- a/src/reference/ng_placement_builder.rs
+++ b/src/reference/ng_placement_builder.rs
@@ -348,9 +348,16 @@ mod tests {
     #[test]
     fn derive_for_real_reference_when_available() {
         // Gated: only runs against a prepared reference (repo convention).
-        let manifest = match std::env::var("FERRO_MANIFEST") {
+        let manifest = match std::env::var(crate::conformance::manifest_gate::MANIFEST_ENV) {
             Ok(m) => std::path::PathBuf::from(m),
-            Err(_) => return, // skip when no reference is configured
+            Err(_) => {
+                // Skip when no reference is configured — unless the run demands
+                // one. See `conformance::manifest_gate`.
+                crate::conformance::manifest_gate::absent(
+                    "ng_placement_builder::derive_for_real_reference_when_available",
+                );
+                return;
+            }
         };
         let provider = crate::reference::multi_fasta::MultiFastaProvider::from_manifest(&manifest)
             .expect("load manifest");

--- a/tests/it/biocommons_normalize_tests.rs
+++ b/tests/it/biocommons_normalize_tests.rs
@@ -248,10 +248,7 @@ fn loads_fixture() {
 fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("biocommons-normalize: using manifest {}", p.display()),
-        None => println!(
-            "biocommons-normalize: skipping — no manifest at FERRO_MANIFEST \
-             or benchmark-output/manifest.json"
-        ),
+        None => crate::common::manifest::absent("biocommons_normalize_tests::manifest_or_skip"),
     }
 }
 
@@ -658,9 +655,8 @@ fn axis_normalized_hermetic() {
 #[test]
 fn axis_normalized() {
     let Some(provider) = provider() else {
-        eprintln!(
-            "axis_normalized: skipping — no manifest (per-PR gate is axis_normalized_hermetic)"
-        );
+        // The per-PR gate is `axis_normalized_hermetic`, which needs no manifest.
+        crate::common::manifest::absent("biocommons_normalize_tests::axis_normalized");
         return;
     };
     run_normalized_axis(ArcProvider(provider)).finish();

--- a/tests/it/common/manifest.rs
+++ b/tests/it/common/manifest.rs
@@ -1,0 +1,22 @@
+//! The integration tree's handle on the one place that decides what an ABSENT
+//! reference manifest means.
+//!
+//! The policy, the `FERRO_REQUIRE_MANIFEST` predicate and the failure text all
+//! live in [`ferro_hgvs::conformance::manifest_gate`], which is where their
+//! reasoning is written down. They are in the library rather than here because
+//! two of the manifest-gated guards are `#[cfg(test)]` units inside `src/`
+//! itself and cannot see this tree — and a second copy for those two is the
+//! drift the whole mechanism exists to prevent.
+//!
+//! This module is the re-export, so integration modules can keep writing
+//! `crate::common::manifest::absent(..)` alongside
+//! `crate::common::bulk_fixtures::absent(..)` and read as one convention.
+
+// `allow(unused_imports)`: the same reason `mod.rs` carries `allow(dead_code)` —
+// this tree is compiled into one binary and only `absent` has call sites today.
+// The other three are the module's stated surface, and a re-export that
+// disappears whenever its last caller does is one nobody can find again.
+#[allow(unused_imports)]
+pub use ferro_hgvs::conformance::manifest_gate::{
+    absent, manifest_is_required, MANIFEST_ENV, REQUIRE_ENV,
+};

--- a/tests/it/common/mod.rs
+++ b/tests/it/common/mod.rs
@@ -15,6 +15,11 @@
 //!   bulk parser fixtures (cmrg, paraphase, clinvar 500K + unique). See
 //!   `failure_expectations.rs` for the snapshot shape and contract;
 //!   tracking issue: #174.
+//! - `manifest`: the sibling of `bulk_fixtures` for the other input that can
+//!   go missing without anything going red — a ferro-prepared reference. Every
+//!   reference-aware guard skips green without one, so
+//!   `FERRO_REQUIRE_MANIFEST` promotes that skip to a failure in the one job
+//!   that prepares a manifest.
 //! - `fixture_gen`: the shared on-demand regeneration flow (locking,
 //!   subprocess, atomic rename) that `spec_fixture` and `spec_enumeration`
 //!   both wrap.
@@ -37,6 +42,7 @@ pub mod bulk_fixtures;
 pub mod cis_apply_oracle;
 pub mod failure_expectations;
 pub mod fixture_gen;
+pub mod manifest;
 pub mod rulings;
 pub mod spec_enumeration;
 pub mod spec_fixture;

--- a/tests/it/delins_equal_vs_unequal_length_discriminator.rs
+++ b/tests/it/delins_equal_vs_unequal_length_discriminator.rs
@@ -209,10 +209,7 @@ const MSH2_RULING_CONFORMANT: &str = "NC_000002.11:g.47639670_47639673delinsTT";
 #[test]
 fn equal_and_unequal_length_delins_get_opposite_verdicts() {
     let Some(path) = manifest_path() else {
-        eprintln!(
-            "delins_equal_vs_unequal_length_discriminator: skipping — FERRO_MANIFEST unset. \
-             Set it to the prepared reference's manifest.json to run these two rows."
-        );
+        crate::common::manifest::absent("delins_equal_vs_unequal_length_discriminator");
         return;
     };
     // FERRO_MANIFEST is an explicit opt-in: once set, a missing or unloadable

--- a/tests/it/hgvs_rs_projection_tests.rs
+++ b/tests/it/hgvs_rs_projection_tests.rs
@@ -1066,10 +1066,7 @@ fn loads_fixture() {
 fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("hgvs-rs-projection: using manifest {}", p.display()),
-        None => println!(
-            "hgvs-rs-projection: skipping — no manifest at FERRO_MANIFEST \
-             or benchmark-output/manifest.json"
-        ),
+        None => crate::common::manifest::absent("hgvs_rs_projection_tests::manifest_or_skip"),
     }
 }
 
@@ -1080,7 +1077,9 @@ fn manifest_or_skip() {
 #[test]
 fn axis_coding_protein_descriptions() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_coding_protein_descriptions: skipping — no manifest");
+        crate::common::manifest::absent(
+            "hgvs_rs_projection_tests::axis_coding_protein_descriptions",
+        );
         return;
     };
 
@@ -1197,7 +1196,7 @@ fn axis_coding_protein_descriptions() {
 #[test]
 fn axis_protein_description() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_protein_description: skipping — no manifest");
+        crate::common::manifest::absent("hgvs_rs_projection_tests::axis_protein_description");
         return;
     };
 
@@ -1237,7 +1236,7 @@ fn axis_protein_description() {
 #[test]
 fn axis_coding() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_coding: skipping — no manifest");
+        crate::common::manifest::absent("hgvs_rs_projection_tests::axis_coding");
         return;
     };
 
@@ -1304,7 +1303,7 @@ fn axis_coding() {
 #[test]
 fn axis_noncoding() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_noncoding: skipping — no manifest");
+        crate::common::manifest::absent("hgvs_rs_projection_tests::axis_noncoding");
         return;
     };
 

--- a/tests/it/inversion_sweep.rs
+++ b/tests/it/inversion_sweep.rs
@@ -984,16 +984,19 @@ fn the_committed_slice_serves_the_transcript_whole() {
 /// through any legitimate representation change.
 #[test]
 fn hermetic_normalization_matches_the_prepared_reference() {
+    // The per-PR gates are `every_authored_inversion_produces_its_pinned_output`
+    // and `no_authored_inversion_leaves_the_inversion_family`, which never skip.
     let Some(manifest) = std::env::var_os("FERRO_MANIFEST").map(PathBuf::from) else {
-        eprintln!(
-            "hermetic_normalization_matches_the_prepared_reference: skipping — no FERRO_MANIFEST. \
-             The per-PR gates are every_authored_inversion_produces_its_pinned_output and \
-             no_authored_inversion_leaves_the_inversion_family, which never skip."
+        crate::common::manifest::absent(
+            "inversion_sweep::hermetic_normalization_matches_the_prepared_reference",
         );
         return;
     };
     if !manifest.exists() {
-        eprintln!("hermetic_normalization_matches_the_prepared_reference: skipping — FERRO_MANIFEST does not exist");
+        crate::common::manifest::absent(
+            "inversion_sweep::hermetic_normalization_matches_the_prepared_reference \
+             (FERRO_MANIFEST points at a path that does not exist)",
+        );
         return;
     }
     let real = std::sync::Arc::new(

--- a/tests/it/issue_1086_c_axis_genomic_context.rs
+++ b/tests/it/issue_1086_c_axis_genomic_context.rs
@@ -139,7 +139,7 @@ fn assert_coding(vp: &VariantProjector<ArcProvider>, input: &str, expected: &str
 macro_rules! skip_without_manifest {
     ($vp:ident) => {
         let Some($vp) = manifest_projector() else {
-            eprintln!("issue_1086: skipping — no FERRO_MANIFEST / benchmark-output manifest");
+            crate::common::manifest::absent("issue_1086_c_axis_genomic_context");
             return;
         };
     };

--- a/tests/it/issue_1086_cross_axis_projection.rs
+++ b/tests/it/issue_1086_cross_axis_projection.rs
@@ -172,7 +172,7 @@ fn project(vp: &VariantProjector<ArcProvider>, input: &str, tx: &str) -> Variant
 #[test]
 fn intronic_start_offset_declines_rna_axis() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1086_cross_axis_projection");
         return;
     };
     let proj = project(&vp, "NM_000552.3:c.3675-45_3692del", "NM_000552.3");
@@ -193,7 +193,7 @@ fn intronic_start_offset_declines_rna_axis() {
 #[test]
 fn intronic_offset_utr_span_declines_rna_axis() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1086_cross_axis_projection");
         return;
     };
     let proj = project(&vp, "NM_004006.2:c.123-65_-50", "NM_004006.2");
@@ -213,7 +213,7 @@ fn intronic_offset_utr_span_declines_rna_axis() {
 #[test]
 fn exonic_edit_still_projects_to_rna_axis() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1086_cross_axis_projection");
         return;
     };
     let proj = project(&vp, "NM_004006.2:c.897T>G", "NM_004006.2");
@@ -244,7 +244,7 @@ fn exonic_edit_still_projects_to_rna_axis() {
 #[test]
 fn rna_input_noncoding_axis_is_an_n_description() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1086_cross_axis_projection");
         return;
     };
     let proj = project(&vp, "LRG_199t1:r.11u>g", "LRG_199t1");
@@ -266,7 +266,7 @@ fn rna_input_noncoding_axis_is_an_n_description() {
 #[test]
 fn noncoding_input_noncoding_axis_unchanged() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1086_cross_axis_projection");
         return;
     };
     let proj = project(&vp, "LRG_199t1:n.11T>G", "LRG_199t1");

--- a/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
+++ b/tests/it/issue_1217_mito_terminus_insertion_clamp.rs
@@ -335,7 +335,7 @@ fn manifest_path() -> Option<PathBuf> {
 /// is not worth two cases.)
 fn check_rcrs(dir: ShuffleDirection, cases: &[(&str, &str)]) {
     let Some(path) = manifest_path() else {
-        eprintln!("issue_1217: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_1217_mito_terminus_insertion_clamp");
         return;
     };
     let provider = ferro_hgvs::MultiFastaProvider::from_manifest(&path)

--- a/tests/it/issue_1539_split_member_separation.rs
+++ b/tests/it/issue_1539_split_member_separation.rs
@@ -822,15 +822,21 @@ fn the_committed_windows_serve_every_transcript_whole() {
 /// which fail on the defect this test was written for.
 #[test]
 fn hermetic_normalization_matches_the_prepared_reference() {
+    // The per-PR gate is
+    // `no_emitted_member_separates_two_changes_with_an_unchanged_base`.
     let Some(manifest) = std::env::var_os("FERRO_MANIFEST").map(std::path::PathBuf::from) else {
-        eprintln!(
-            "hermetic_normalization_matches_the_prepared_reference: skipping — no FERRO_MANIFEST \
-             (the per-PR gate is no_emitted_member_separates_two_changes_with_an_unchanged_base)"
+        crate::common::manifest::absent(
+            "issue_1539_split_member_separation::\
+             hermetic_normalization_matches_the_prepared_reference",
         );
         return;
     };
     if !manifest.exists() {
-        eprintln!("hermetic_normalization_matches_the_prepared_reference: skipping — FERRO_MANIFEST does not exist");
+        crate::common::manifest::absent(
+            "issue_1539_split_member_separation::\
+             hermetic_normalization_matches_the_prepared_reference \
+             (FERRO_MANIFEST points at a path that does not exist)",
+        );
         return;
     }
     let real = Arc::new(

--- a/tests/it/issue_1713_bare_transcript_genomic_decline.rs
+++ b/tests/it/issue_1713_bare_transcript_genomic_decline.rs
@@ -193,11 +193,9 @@ enum Verdict {
 #[test]
 fn cli_and_library_agree_on_the_genomic_axis_for_bare_transcript_inputs() {
     let Some(vp) = manifest_projector() else {
-        eprintln!(
-            "issue_1713: skipping — no manifest at FERRO_MANIFEST. This is NOT the gate: \
-             the hermetic half runs in CI as \
-             src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy"
-        );
+        // NOT the gate: the hermetic half runs in CI as
+        // src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy
+        crate::common::manifest::absent("issue_1713_bare_transcript_genomic_decline");
         return;
     };
 
@@ -260,11 +258,9 @@ fn cli_and_library_agree_on_the_genomic_axis_for_bare_transcript_inputs() {
 #[test]
 fn the_bare_transcript_genomic_decline_names_its_cause_and_the_remedy() {
     let Some(vp) = manifest_projector() else {
-        eprintln!(
-            "issue_1713: skipping — no manifest at FERRO_MANIFEST. This is NOT the gate: \
-             the hermetic half runs in CI as \
-             src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy"
-        );
+        // NOT the gate: the hermetic half runs in CI as
+        // src/cli/project.rs::project_axis_bare_nm_genomic_decline_names_cause_and_remedy
+        crate::common::manifest::absent("issue_1713_bare_transcript_genomic_decline");
         return;
     };
 

--- a/tests/it/issue_498_whole_exon_deletion.rs
+++ b/tests/it/issue_498_whole_exon_deletion.rs
@@ -183,7 +183,9 @@ fn protein_of(vp: &VariantProjector<ArcProvider>, input: &str, tx: &str) -> Opti
 #[test]
 fn vsir_whole_exon_deletion_reverse_strand_frameshift() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("vsir_whole_exon_deletion_reverse_strand_frameshift: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_498_whole_exon_deletion::vsir_whole_exon_deletion_reverse_strand_frameshift",
+        );
         return;
     };
     let got = protein_of(
@@ -211,7 +213,9 @@ fn vsir_whole_exon_deletion_reverse_strand_frameshift() {
 #[test]
 fn dmd_exon10_whole_exon_deletion_inframe() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("dmd_exon10_whole_exon_deletion_inframe: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_498_whole_exon_deletion::dmd_exon10_whole_exon_deletion_inframe",
+        );
         return;
     };
     let got = protein_of(&vp, "NM_004006.2:c.961-1_1149+3del", "NM_004006.2");
@@ -240,7 +244,9 @@ fn dmd_exon10_whole_exon_deletion_inframe() {
 #[test]
 fn dmd_exons10_11_whole_exon_deletion_frameshift() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("dmd_exons10_11_whole_exon_deletion_frameshift: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_498_whole_exon_deletion::dmd_exons10_11_whole_exon_deletion_frameshift",
+        );
         return;
     };
     let got = protein_of(&vp, "NM_004006.2:c.961-1_1331+1del", "NM_004006.2");

--- a/tests/it/issue_806_effect_real_residues.rs
+++ b/tests/it/issue_806_effect_real_residues.rs
@@ -51,7 +51,7 @@ fn real_state(provider: Arc<MultiFastaProvider>) -> AppState {
 #[tokio::test]
 async fn real_missense_resolves_concrete_residues() {
     let Some(path) = manifest_path() else {
-        eprintln!("issue-806: skipping — FERRO_MANIFEST unset");
+        crate::common::manifest::absent("issue_806_effect_real_residues");
         return;
     };
     // FERRO_MANIFEST is an explicit opt-in: once set, a missing manifest or one

--- a/tests/it/issue_843_allele_rna_build_scoping.rs
+++ b/tests/it/issue_843_allele_rna_build_scoping.rs
@@ -204,7 +204,7 @@ fn oracle(vp: &VariantProjector<ArcProvider>) -> Option<Oracle> {
 #[test]
 fn g_allele_predict_rna_is_build_scoped_on_real_reference() {
     let Some(vp) = manifest_projector() else {
-        eprintln!("issue_843: skipping — no manifest");
+        crate::common::manifest::absent("issue_843_allele_rna_build_scoping");
         return;
     };
     let Some(o) = oracle(&vp) else {

--- a/tests/it/issue_944_cds_to_tx_transcript_native.rs
+++ b/tests/it/issue_944_cds_to_tx_transcript_native.rs
@@ -42,7 +42,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 #[test]
 fn nm_015120_cds_to_tx_transcript_native_across_insertion() {
     let Some(provider) = provider() else {
-        eprintln!("issue_944: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_944_cds_to_tx_transcript_native");
         return;
     };
     let tx = provider
@@ -72,7 +72,7 @@ fn nm_000277_cds_to_tx_naive_across_deletion() {
     // PAH — carries a CIGAR deletion; the transcript axis must stay naive
     // (deletions add no transcript bases), i.e. contiguous with no shift.
     let Some(provider) = provider() else {
-        eprintln!("issue_944: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("issue_944_cds_to_tx_transcript_native");
         return;
     };
     let tx = provider

--- a/tests/it/issue_972_cds_start_nf_decline.rs
+++ b/tests/it/issue_972_cds_start_nf_decline.rs
@@ -504,14 +504,16 @@ fn vps13d_coding_variant(
 #[test]
 fn vps13d_bare_coding_input_declines_protein_but_derives_noncoding() {
     let Some(raw_provider) = provider() else {
-        eprintln!(
-            "vps13d_bare_coding_input_declines_protein_but_derives_noncoding: skipping — no manifest"
+        crate::common::manifest::absent(
+            "issue_972_cds_start_nf_decline::\
+             vps13d_bare_coding_input_declines_protein_but_derives_noncoding",
         );
         return;
     };
     let Some(vp) = manifest_projector() else {
-        eprintln!(
-            "vps13d_bare_coding_input_declines_protein_but_derives_noncoding: skipping — no manifest"
+        crate::common::manifest::absent(
+            "issue_972_cds_start_nf_decline::\
+             vps13d_bare_coding_input_declines_protein_but_derives_noncoding",
         );
         return;
     };
@@ -551,11 +553,15 @@ fn vps13d_bare_coding_input_declines_protein_but_derives_noncoding() {
 #[test]
 fn vps13d_cli_axis_c_and_p_unavailable_n_rendered() {
     let Some(raw_provider) = provider() else {
-        eprintln!("vps13d_cli_axis_c_and_p_unavailable_n_rendered: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_972_cds_start_nf_decline::vps13d_cli_axis_c_and_p_unavailable_n_rendered",
+        );
         return;
     };
     let Some(vp) = manifest_projector() else {
-        eprintln!("vps13d_cli_axis_c_and_p_unavailable_n_rendered: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_972_cds_start_nf_decline::vps13d_cli_axis_c_and_p_unavailable_n_rendered",
+        );
         return;
     };
     let variant = vps13d_coding_variant(&raw_provider);
@@ -1002,7 +1008,9 @@ fn vps13d_strict_mode_rejects_bare_coding_input() {
     use ferro_hgvs::{FerroError, NormalizeConfig, Normalizer};
 
     let Some(raw_provider) = provider() else {
-        eprintln!("vps13d_strict_mode_rejects_bare_coding_input: skipping — no manifest");
+        crate::common::manifest::absent(
+            "issue_972_cds_start_nf_decline::vps13d_strict_mode_rejects_bare_coding_input",
+        );
         return;
     };
     let variant = vps13d_coding_variant(&raw_provider);

--- a/tests/it/multi_member_cis_axis.rs
+++ b/tests/it/multi_member_cis_axis.rs
@@ -1253,10 +1253,7 @@ fn describe_convergence_move(started: &[&str], stopped: &[&str], pinned: usize) 
 #[test]
 fn axis_normalized() {
     let Some(provider) = provider() else {
-        println!(
-            "multi-member-cis: skipping — no reference manifest at FERRO_MANIFEST or \
-             benchmark-output/manifest.json"
-        );
+        crate::common::manifest::absent("multi_member_cis_axis::axis_normalized");
         return;
     };
     let (census, converged_rows) = measure_axis(&provider);

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -141,7 +141,9 @@ fn fixture() -> &'static Fixture {
 #[test]
 fn comparator_provenance_reference_identity_matches_live() {
     let Some(live) = reference_identity() else {
-        eprintln!("comparator_provenance_reference_identity_matches_live: skipping — no manifest");
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::comparator_provenance_reference_identity_matches_live",
+        );
         return;
     };
     let recorded = &fixture()
@@ -1095,10 +1097,7 @@ fn loads_fixture() {
 fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("mutalyzer-normalize: using manifest {}", p.display()),
-        None => println!(
-            "mutalyzer-normalize: skipping — no manifest at FERRO_MANIFEST \
-             or benchmark-output/manifest.json"
-        ),
+        None => crate::common::manifest::absent("mutalyzer_normalize_tests::manifest_or_skip"),
     }
 }
 
@@ -1296,7 +1295,9 @@ fn normalized_axis_covers_both_member_arities() {
 #[test]
 fn issue_506_bare_n_transcript_predicts_protein() {
     let Some(vp) = variant_projector() else {
-        eprintln!("issue_506_bare_n_transcript_predicts_protein: skipping — no manifest");
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::issue_506_bare_n_transcript_predicts_protein",
+        );
         return;
     };
     let v = ferro_hgvs::parse_hgvs("NM_003002.4:n.206_210del").expect("parse n. input");
@@ -1355,7 +1356,9 @@ fn issue_506_bare_n_transcript_predicts_protein() {
 #[test]
 fn issue_506_bare_downstream_position_is_rejected() {
     let Some(vp) = variant_projector() else {
-        eprintln!("issue_506_bare_downstream_position_is_rejected: skipping — no manifest");
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::issue_506_bare_downstream_position_is_rejected",
+        );
         return;
     };
 
@@ -1405,7 +1408,7 @@ fn issue_506_bare_downstream_position_is_rejected() {
 #[test]
 fn axis_normalized() {
     let Some(normalizer) = normalizer() else {
-        eprintln!("axis_normalized: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_normalized");
         return;
     };
 
@@ -1493,7 +1496,9 @@ fn project_genomic_userfacing(
 #[test]
 fn project_genomic_userfacing_routing() {
     let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
-        eprintln!("project_genomic_userfacing_routing: skipping — no manifest");
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::project_genomic_userfacing_routing",
+        );
         return;
     };
 
@@ -1550,7 +1555,7 @@ fn project_genomic_userfacing_routing() {
 #[test]
 fn axis_genomic() {
     let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
-        eprintln!("axis_genomic: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_genomic");
         return;
     };
 
@@ -1598,7 +1603,7 @@ fn axis_genomic() {
 #[test]
 fn axis_protein_description() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_protein_description: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_protein_description");
         return;
     };
 
@@ -1641,7 +1646,9 @@ fn axis_protein_description() {
 #[test]
 fn axis_coding_protein_descriptions() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_coding_protein_descriptions: skipping — no manifest");
+        crate::common::manifest::absent(
+            "mutalyzer_normalize_tests::axis_coding_protein_descriptions",
+        );
         return;
     };
 
@@ -1708,7 +1715,7 @@ fn axis_coding_protein_descriptions() {
 #[test]
 fn axis_rna_description() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_rna_description: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_rna_description");
         return;
     };
 
@@ -1751,7 +1758,7 @@ fn axis_rna_description() {
 #[test]
 fn axis_noncoding() {
     let Some(vp) = variant_projector() else {
-        eprintln!("axis_noncoding: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_noncoding");
         return;
     };
 
@@ -1831,7 +1838,7 @@ fn axis_noncoding() {
 #[test]
 fn axis_errors() {
     let Some(p) = provider() else {
-        eprintln!("axis_errors: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_errors");
         return;
     };
     // The errors axis asserts STRICT-mode behavior for reference mismatches:
@@ -1911,7 +1918,7 @@ fn axis_errors() {
 #[test]
 fn axis_infos() {
     let Some(normalizer) = normalizer() else {
-        eprintln!("axis_infos: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_infos");
         return;
     };
 
@@ -4528,7 +4535,7 @@ fn renormalize_once(normalizer: &Normalizer<ArcProvider>, s: &str) -> Result<Str
 #[test]
 fn axis_normalized_idempotent() {
     let Some(normalizer) = normalizer() else {
-        eprintln!("axis_normalized_idempotent: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_normalized_idempotent");
         return;
     };
     let mut tested = 0usize;
@@ -4586,7 +4593,7 @@ fn axis_normalized_idempotent() {
 #[test]
 fn axis_genomic_idempotent() {
     let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
-        eprintln!("axis_genomic_idempotent: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_genomic_idempotent");
         return;
     };
     let mut tested = 0usize;
@@ -4650,7 +4657,7 @@ fn axis_genomic_idempotent() {
 #[test]
 fn axis_noncoding_idempotent() {
     let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
-        eprintln!("axis_noncoding_idempotent: skipping — no manifest");
+        crate::common::manifest::absent("mutalyzer_normalize_tests::axis_noncoding_idempotent");
         return;
     };
     let mut tested = 0usize;

--- a/tests/it/protein_cis_delins_decomposition.rs
+++ b/tests/it/protein_cis_delins_decomposition.rs
@@ -91,7 +91,7 @@ fn project_protein(
 #[test]
 fn decomposed_delins_projects_to_one_combined_protein_consequence() {
     let Some(projector) = manifest_projector() else {
-        eprintln!("protein_cis_delins_decomposition: skipping — no manifest at FERRO_MANIFEST");
+        crate::common::manifest::absent("protein_cis_delins_decomposition");
         return;
     };
 

--- a/tests/it/real_data_normalization_tests.rs
+++ b/tests/it/real_data_normalization_tests.rs
@@ -5,13 +5,41 @@
 use ferro_hgvs::{parse_hgvs, MultiFastaProvider, Normalizer, ReferenceProvider};
 use std::path::Path;
 
-fn get_provider() -> Option<MultiFastaProvider> {
-    let manifest_path = Path::new("benchmark-output/manifest.json");
-    if manifest_path.exists() {
-        MultiFastaProvider::from_manifest(manifest_path).ok()
-    } else {
-        None
+/// The prepared manifest, by the same convention every other reference-aware
+/// module here uses: `FERRO_MANIFEST` is authoritative when set, with
+/// `benchmark-output/manifest.json` as the well-known fallback.
+///
+/// This module used to consult **only** the relative path, which made it
+/// orphaned in a stronger sense than its siblings: an operator following the
+/// documented local recipe (`export FERRO_MANIFEST=…`) did not arm it either,
+/// so it was dead even for the developer trying to reproduce a nightly result.
+fn manifest_path() -> Option<std::path::PathBuf> {
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let path = std::path::PathBuf::from(path);
+        return path.exists().then_some(path);
     }
+    let fallback = Path::new("benchmark-output/manifest.json");
+    fallback.exists().then(|| fallback.to_path_buf())
+}
+
+/// The provider, or `None` when there is no manifest to build one from.
+///
+/// A manifest that is **present but will not load** panics rather than
+/// returning `None`, which is the other half of the convention `manifest_path`
+/// above adopts — `biocommons_normalize_tests::provider` and
+/// `multi_member_cis_axis::provider` each say so in their own words. It matters
+/// more here than the wording suggests: `None` reaches
+/// `common::manifest::absent`, whose text states that no manifest was found and
+/// tells the reader to prepare one. For a manifest that *is* there and is
+/// broken that is a wrong diagnosis, and under `FERRO_REQUIRE_MANIFEST` it is a
+/// wrong diagnosis on the one job whose whole purpose is to notice that
+/// `ferro prepare` did not leave a usable reference behind.
+fn get_provider() -> Option<MultiFastaProvider> {
+    let path = manifest_path()?;
+    Some(
+        MultiFastaProvider::from_manifest(&path)
+            .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+    )
 }
 
 #[test]
@@ -24,7 +52,7 @@ fn test_nm_001408491_c517dela_should_shift() {
     // Ferro output (before fix): NM_001408491.1:c.517del
 
     let Some(provider) = get_provider() else {
-        eprintln!("Skipping test: benchmark-output not available");
+        crate::common::manifest::absent("real_data_normalization_tests");
         return;
     };
 
@@ -141,7 +169,7 @@ fn test_potential_bug_deletion_shift_nm033517() {
     // Investigate: ferro outputs c.1324del, mutalyzer outputs c.1326del
     // One of these is wrong about 3' shifting
     let Some(provider) = get_provider() else {
-        eprintln!("Skipping test: benchmark-output not available");
+        crate::common::manifest::absent("real_data_normalization_tests");
         return;
     };
 
@@ -190,7 +218,7 @@ fn test_potential_bug_delins_shift() {
     //
     // HGVS spec: delins should NOT be 3' shifted like del/dup
     let Some(provider) = get_provider() else {
-        eprintln!("Skipping test: benchmark-output not available");
+        crate::common::manifest::absent("real_data_normalization_tests");
         return;
     };
 
@@ -247,7 +275,7 @@ fn test_5utr_duplication_shifting() {
     // In 5'UTR, the 3' direction is towards the start codon (+1)
     // So -55 is more 3' than -56
     let Some(provider) = get_provider() else {
-        eprintln!("Skipping test: benchmark-output not available");
+        crate::common::manifest::absent("real_data_normalization_tests");
         return;
     };
 
@@ -298,7 +326,7 @@ fn test_5utr_duplication_shifting() {
 fn test_compare_with_mutalyzer_sequence() {
     // Compare what we have in cdot vs what mutalyzer reports
     let Some(provider) = get_provider() else {
-        eprintln!("Skipping test: benchmark-output not available");
+        crate::common::manifest::absent("real_data_normalization_tests");
         return;
     };
 


### PR DESCRIPTION
Closes #1849.

45 checked-in reference-aware guards were executed by **no automated job**. They gate on a ferro-prepared manifest and `return` early without one, so they skipped green in PR CI (which provisions no manifest) and skipped green in `nightly-mutalyzer.yml`, whose `REFERENCE_AWARE_SELECTION` named three modules — none of them these.

A skip is indistinguishable from a pass in every signal CI reports. The runtime is the only tell: 0.01–0.08 s skipped against 9–58 s armed, with nothing in between.

## Why now

The imminent partition flip (#1835, `Live` → `CanonicalCoalesced`) aggravates #1712: `mutalyzer_normalize_tests::axis_noncoding_idempotent` goes from 21 non-idempotent rows of 681 to **62**, `EXIT=0` → `EXIT=100`. That module *is* in the nightly's selection, so the regression is at least armed and visible. **The 45 guards this PR wires are exactly where the same class of regression would be visible nowhere** — that is the concrete argument for the change, and it is not retrospective.

It is not retrospective in the other direction either. `multi_member_cis_axis::axis_normalized` carries a ratchet-style census pin and was provably red on `main` at both `30ca8f7d` (2026-08-08) and `9cf8efc9` (2026-08-10), measuring `respelling_converged: 395` against a pinned `376`, across 13 merged commits that every one reported green. It surfaced four days later as #1581 — a commit moving the pin `376 → 395` while touching only the test file — and was then investigated as an "inconsistency between worktrees" with an assumed environmental cause. It was a guard that had stopped guarding.

## What changed

**1. `REFERENCE_AWARE_SELECTION` now enumerates every reference-aware module.** Deliberately enumerated, not globbed: widening by pattern imports the seven modules `ci.yml`'s `ORACLE_EXCLUDE` withholds from an armed job, which fail on `main` for reasons no nightly caused, and it makes the `ferro-xfail-*` artifact — the only channel a non-gating job has — unreadable. The workflow now says so at the point someone would be tempted, and so does the reproduce-recipe the summary step prints.

**2. `FERRO_REQUIRE_MANIFEST=1`, set on the nightly test step.** Adding modules to the selection without this is half a fix: they would still skip green if a `ferro prepare` produced nothing, or wrote a manifest where the test step cannot see it — reporting a *faster* green run, which is the worst outcome available. The promotion is built on the existing `FERRO_REQUIRE_BULK_FIXTURES` pattern and reuses its shape, predicate semantics (`0` and empty are "set but off") and message discipline rather than inventing a second convention.

The policy lives in `src/conformance/manifest_gate.rs` rather than beside `bulk_fixtures.rs` in the test tree for one reason: two of the guards are `#[cfg(test)]` units inside `src/` itself and cannot see `tests/it/common/`. A second copy for those two is exactly the drift the mechanism exists to prevent. `tests/it/common/manifest.rs` is a thin re-export so integration modules keep reading as one convention.

**3. `real_data_normalization_tests` gains the standard gate.** It consulted only `Path::new("benchmark-output/manifest.json")` and ignored `FERRO_MANIFEST`, so it was orphaned in a stronger sense than its siblings — dead even for a developer following the documented local recipe. It now uses the `FERRO_MANIFEST`-then-`benchmark-output` convention every other module uses.

## The count: 45, re-derived — the costing note said 41

Measured empirically as a duration diff (32 candidate modules, same selection run twice). Static analysis was tried first and gets this wrong.

```
A (FERRO_MANIFEST unset): Summary [   5.176s] 779 tests run: 779 passed   EXIT=0
B (FERRO_MANIFEST set):   Summary [ 307.469s] 779 tests run: 779 passed   EXIT=0
```

**38 `FERRO_MANIFEST`-gated tests across 14 modules**, plus **5** in `real_data_normalization_tests` (invisible to a `FERRO_MANIFEST` census — it gates on the relative path), plus **2** `#[cfg(test)]` units in `src/`. Reconciliation against the 41:

| | |
|---|---:|
| prior figure | 41 |
| `issue_1713_bare_transcript_genomic_decline` — module landed on `main` after the prior measurement commit | +2 |
| `conformance::accession_inventory::tests::corpus_missing_ng_against_real_reference_when_available` and `reference::ng_placement_builder::tests::derive_for_real_reference_when_available` — lib units, outside a `tests/it/`-scoped census | +2 |
| **re-derived** | **45** |

For scale, the three modules the nightly already selected contribute 19 armed tests. **The orphaned surface was more than twice the size of the covered one.**

## Proof the promotion actually fails

Same binary, same commit, same selection; only the manifest differs.

```
manifest ABSENT + FERRO_REQUIRE_MANIFEST=1
  Summary [   0.671s] 291 tests run: 223 passed, 68 failed, 10495 skipped
  EXIT=100
```

68 unique failures, which reconcile exactly: 38 orphans + 5 `real_data_normalization_tests` + 2 lib units + 19 already-covered armed guards + 3 `manifest_or_skip` canaries + `comparator_provenance_reference_identity_matches_live`. The failure text names the guard and the remedy:

```
FERRO_REQUIRE_MANIFEST is set, but `multi_member_cis_axis::axis_normalized` found no reference manifest.
...
Without one the guard would SKIP GREEN, silently dropping its coverage — and a skip is
indistinguishable from a pass in every signal CI reports — so under FERRO_REQUIRE_MANIFEST
an absent manifest is a failure instead.
```

```
manifest PRESENT + FERRO_REQUIRE_MANIFEST=1 + the nightly's four oracle flags
  Summary [  66.964s] 291 tests run: 291 passed, 10495 skipped
  EXIT=0
```

Zero `skipping — no reference manifest` lines in that log, and the timings confirm arming rather than skipping (slowest 22.9 s). Measured against the blessed scratch reference, identity `aa8b3246d83055cc`.

## Which of the newly-wired guards are RED

**None.** All 45 pass under the nightly's exact four oracle flags on the blessed reference. The value of this change is prospective, and it should be read that way rather than as a bug hunt.

The prior costing note recorded 6 pre-existing failures in `mutalyzer_normalize_tests` at its measurement commit, attributed (relayed, unverified there) to an SPDI reference-frame defect. That attribution now checks out by measurement rather than by relay: #1821 merged 2026-08-13, and the old three-module selection under the same flags on current `main` reads `170 tests run: 170 passed, EXIT=0`. The six are gone, and nothing here suppressed them.

No guard was excluded to make the job green.

## Cost

| selection | wall | result |
|---|---:|---|
| old (3 modules), armed, four oracles | 43.5 s | 170 pass |
| new (all reference-aware), armed, four oracles | **67.0 s** | 291 pass |

**+23.5 s of nextest wall, a 1.54× multiplier on the test step**, for +121 tests of which +45 are manifest-armed. That lands on a job whose wall clock is ~77 % `ferro prepare` (24 m 51 s of a 32 m job), so the total moves by single-digit percent. This is a local wall-clock measurement on a shared box, not a CI benchmark — treat the ratio, not the absolute.

## Residual — stated rather than fixed

**`nightly-mutalyzer.yml`'s test step is `continue-on-error: true`, so this buys detection without enforcement.** A broken pin lands in the `ferro-xfail-<run_id>` artifact and the workflow still reports `success`. That is a deliberate design choice with its reasoning on the flag itself — the nightly exists to surface drift in the xfail report, not to gate PRs — and this PR does not change it.

So the honest statement is: **a guard that runs in a non-gating job is better than one that never runs, and it is not the same as covered.** Making the nightly gating is a separate change and is blocked behind that job's pre-existing failures, in particular `comparator_provenance_reference_identity_matches_live` — whose failure says the nightly's own ephemeral `ferro prepare` output is not the blessed identity, which has to be answered before "is ferro correct?" can be. Deliberately not expanded into here.

Three smaller residuals, none of them closed by this PR:

- **`FERRO_REQUIRE_MANIFEST` cannot catch an omission from the selection.** It fires when a *selected* guard finds no manifest, not when an unselected one is never asked. A newly-added manifest-gated module in a new file is still invisible until someone adds it to the list; the workflow now says so where the list is defined.
- **`real_data_normalization_tests` still skips green on `Skipping test: transcript not found`.** A manifest that is present but lacks the transcript is the same defect class one level down. Left as-is rather than widened in passing.
- **`idempotency_tests::test_clinvar_sample_parsing_idempotency` reads `clinvar_1000.txt` from the repo root**, a file that exists nowhere in the tree and is fetched by no script. It is a permanently-green no-op. Out of scope here; worth its own issue.

## Verification

```
cargo fmt --all --check                                              EXIT=0
cargo clippy --all-features --all-targets -- -D warnings             EXIT=0
actionlint / zizmor on both changed workflows                        EXIT=0, no findings
cargo nextest run --features dev  (full suite, manifest-free)        EXIT=0, 10634 passed
```

The manifest-free run is the PR-CI condition, and it is the one that matters for this change: `FERRO_REQUIRE_MANIFEST` is unset there, so every promoted guard must still skip exactly as before. It does.

Representation-Change: none
