### PR TITLE
docs: audit each normalization stage as governed, ruled, or undecided

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ from, and why. Those records are published in full, with their clause quotes, in
 That document is generated from the records and gated against them, so it cannot drift; it
 deliberately does not restate the seven rules above, which are stated only here.
 
+The inverse index — for each stage of the normalizer, *which* record or clause governs it, and
+which decisions are governed by **nothing** — is
+[docs/NORMALIZATION_STAGE_AUDIT.md](docs/NORMALIZATION_STAGE_AUDIT.md). Read that one if what
+you want to know is whether a behaviour you are looking at was chosen or merely happened.
+
 ## Deriving a description from sequences
 
 If what you have is **bases** rather than a description — a window out of a BAM, a VCF row, an

--- a/docs/NORMALIZATION_STAGE_AUDIT.md
+++ b/docs/NORMALIZATION_STAGE_AUDIT.md
@@ -1,0 +1,312 @@
+<!--
+GENERATED FILE — do not edit by hand.
+
+Rendered from tests/fixtures/grammar/normalization_stage_audit.json and the
+adjudication ledger, by tests/it/normalization_stage_audit_doc.rs. Edit the
+fixture, then regenerate:
+
+    BLESS_STAGE_AUDIT_DOC=1 cargo nextest run --features dev --test it \
+      -E 'test(normalization_stage_audit_doc)'
+-->
+
+# What governs each normalization stage
+
+Ferro's normalizer makes a decision at every stage of its pipeline. Some of those decisions are
+backed by a clause of the HGVS recommendations, some by an adjudication record, and some by
+nothing more than what the implementation happens to do. This document is the inventory of
+which is which, so that a deliberate choice can be told from an accident — by a contributor
+deciding a new case, and by a reviewer reading a diff.
+
+**7 stages. 3 of the records cited below are still open. 2 decisions are
+governed by nothing.**
+
+## How to read it
+
+Each stage names the decision it makes, the records that rule on it, and the clauses it is
+decided under. A record's status is read from the ledger when this file is generated and is
+never copied into the fixture, so a stage cannot be described as settled by a record that is
+not.
+
+The rows worth reading first are the **ungoverned** ones. Each is classified as either a
+*genuine gap* — a decision with real consequences that no clause and no record settles — or as
+*no record warranted*, meaning the spec settles it so plainly that writing a record would be
+ceremony. Only the first kind is a finding.
+
+## What this document is not
+
+**It is not the ruleset.** What ferro's output is allowed to be, and what happens where the
+spec determines no answer, is stated once, in
+[README.md, *Normalization rules*](../README.md#normalization-rules), and is deliberately not
+restated here.
+
+**It is not the records.** It says which record governs a stage; it does not reproduce the
+record. The records live in
+[`tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`](../tests/fixtures/grammar/hgvs_spec_normalization_overrides.json).
+
+**It is not exhaustive about clauses.** A stage's clause list carries the clauses that decide
+it, not every clause that touches it.
+
+## The ungoverned decisions
+
+### Axis projection — genuine-gap
+
+*How two `c.` positions in different numbering zones (`-n` upstream of the ATG, plain `n` in the CDS, `*n` downstream of the stop) are ordered against each other.*
+
+Ferro needs a total order on `c.` endpoints to sort an allele's members, detect overlap between them, and compute the separation that the merge/split stage keys on. `background/numbering.md` defines each zone and states no rule for comparing positions across them; it never speaks about alleles at all. So the ordering is a house rule with no clause behind it — and, unlike every other house rule at this grain, it carries no ruling record either. It is currently written down only as repository prose. This is not theoretical: the sequence-changing and denotes-no-sequence classes the spec corpus found localise to the `c.72`/`c.*1` transition and to nothing else.
+
+### Shifting — genuine-gap
+
+*What the 5' direction does — at an exon/exon junction, in a repeat tract, and at a reference boundary.*
+
+The recommendations state a 3' rule and only a 3' rule; `5' rule` and `5'-rule` occur nowhere in the checkout. Ferro nevertheless offers a 5' direction, and the direction is not an orthogonal knob — it selects the frame every other rule is evaluated in, which is why the README claims its best-effort rules per direction rather than across the two. So every clause and every ruling at this stage is authority for the 3' arm; the 5' arm's answers are ferro's own, mirrored by construction rather than by a decision anyone recorded. That is defensible and may well be the only possible answer, but it is nowhere adjudicated, and the mirroring is not obviously right at a junction, where the 3' answer is itself an exception.
+
+## The stages
+
+### Parse / validate (`parse-validate`)
+
+**Decides.** Which authored forms are refused, which are repaired, and at which stage the refusal happens.
+
+**Ruled by.**
+
+- `absolute-prohibition-enforcement-stage` — decided
+- `alignment-only-symbol-in-a-description` — decided
+- `rna-axis-alignment-only-symbol-reach` — decided
+- `bare-transcript-intronic-position` — decided
+- `conflicting-member-geometry-refusal-scope` — decided
+- `ring-telomere-anchoring` — undecided
+- `rna-repeat-range-plus-unit-redundancy` — undecided
+
+**Governed by nothing.** Nothing recorded at this stage.
+
+The stage question itself is settled — `absolute-prohibition-enforcement-stage` rules that enforcement is mode-dependent and uniform: strict fails at parse, lenient fails only when it cannot normalize. What that record leaves open is coverage, clause by clause, and it names the remaining clauses itself. Two further questions at this stage carry open records rather than no record, which is the state this audit is looking for and does not need to add to.
+
+### Axis projection (`axis-projection`)
+
+**Decides.** How a coordinate maps across axes, and what happens at boundaries.
+
+**Ruled by.**
+
+- `projection-codon-exception-is-decided-by-the-rendered-axis` — decided
+- `c-and-n-positions-are-flat-transcript-offsets` — decided
+- `junction-exit-wrapper-scope-in-a-mixed-allele` — undecided
+
+**Decided under.**
+
+- `docs/background/numbering.md:52`
+  > nucleotide numbering is `n.1`, `n.2`, `n.3`, ..., etc., from the first to the last nucleotide of the reference sequence
+
+**Governed by nothing.**
+
+- **genuine-gap** — How two `c.` positions in different numbering zones (`-n` upstream of the ATG, plain `n` in the CDS, `*n` downstream of the stop) are ordered against each other.
+
+### Sequence derivation (`sequence-derivation`)
+
+**Decides.** How the resulting sequence is computed from the authored edits, and what may bound that computation.
+
+**Ruled by.**
+
+- `canonical-form-choice-when-both-legal` — decided
+- `derivation-may-not-be-bounded-by-the-inputs-spelling` — decided
+- `confluence-gate-is-apply-equality-on-every-determined-axis` — decided
+
+**Decided under.**
+
+- `docs/background/basics.md:38`
+  > The recommendations for the description of sequence variants are designed to be **stable**, **meaningful**, **memorable**, and **unequivocal**.
+
+**Governed by nothing.** Nothing recorded at this stage.
+
+The most heavily ruled stage in the pipeline, and the one the rest depend on: `canonical-form-choice-when-both-legal` makes the resulting sequence the thing every other rule is evaluated over, and `derivation-may-not-be-bounded-by-the-inputs-spelling` removes the one comparand that contradicted it. Note what `background/basics.md:38` is cited for here — it lists the design values and minimality is absent from them, so ferro's column-minimal objective is policy and never compliance.
+
+### Partition + typing (`partition-and-typing`)
+
+**Decides.** Which of several legal descriptions is emitted: how the edit set is cut into members, and what each piece is labelled.
+
+**Ruled by.**
+
+- `canonical-form-choice-when-both-legal` — decided
+- `separation-is-a-property-of-the-spelling-not-of-the-variant` — decided
+- `duplication-must-ranks-the-label-not-the-partition` — decided
+- `inversion-vs-two-delins-76-83` — decided
+- `inversion-vs-a-mixed-member-competitor` — decided
+- `contiguous-insertion-split-by-a-blocked-derivation` — decided
+
+**Decided under.**
+
+- `docs/recommendations/general.md:56`
+  > when a description is possible according to several types, the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion
+
+**Governed by nothing.** Nothing recorded at this stage.
+
+Settled at the level of principle and in flight at the level of shipped behaviour: several of these rulings are implemented only under a candidate partitioner arm, and the default is being flipped separately. #1553 places this stage out of scope for re-litigation, and this row is an index into the records rather than an invitation to reopen them.
+
+### Shifting (`shifting`)
+
+**Decides.** Where the 3' rule places a change within a run of equivalent positions, and where that placement is clamped.
+
+**Ruled by.**
+
+- `exon-junction-dup-converge-from-the-far-side` — decided
+
+**Decided under.**
+
+- `docs/recommendations/general.md:41`
+  > **3'rule**: for all descriptions, the most 3' position possible of the reference sequence is arbitrarily assigned to have been changed.
+- `docs/recommendations/general.md:44`
+  > **exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** or **n.** reference sequences
+- `docs/recommendations/DNA/complex.md:50`
+  > the general HGVS rule of maintaining the longest unchanged sequence applies (the 3' rule)
+
+**Governed by nothing.**
+
+- **genuine-gap** — What the 5' direction does — at an exon/exon junction, in a repeat tract, and at a reference boundary.
+
+### Merge / split (`merge-split`)
+
+**Decides.** When consecutive or separated changes combine into one description rather than staying individual.
+
+**Ruled by.**
+
+- `delins-merge-vs-individual-gap-two-or-more` — decided
+- `delins-codon-carve-out-gap-one` — decided
+- `delins-adjacent-members-when-both-consume-reference` — decided
+- `codon-carve-out-shape-restriction` — decided
+- `separation-rule-force-modal-or-negation` — decided
+- `separation-is-a-property-of-the-spelling-not-of-the-variant` — decided
+- `self-cancelling-across-ring-junctions` — decided
+
+**Decided under.**
+
+- `docs/recommendations/general.md:34`
+  > two variants separated by one or more nucleotides should be described individually and **not** as a "delins"
+- `docs/recommendations/DNA/substitution.md:32`
+  > changes involving two or more consecutive nucleotides are described as deletion-insertion (delins)
+
+**Governed by nothing.** Nothing recorded at this stage.
+
+Seven records, more than any other stage, and the residue is named inside them rather than missing from them: `delins-adjacent-members-when-both-consume-reference` is explicitly scoped to members that consume reference bases and records the `dup` and repeat-expansion cases as still open. An audit row that reported this stage as fully settled would be reading the ruling and not its scope.
+
+### Re-spelling (`re-spelling`)
+
+**Decides.** Terminal coalescing and type re-selection, applied to pieces that are already derived.
+
+**Ruled by.**
+
+- `delins-payload-coincidence-carve-out-is-coding-dna-scoped` — decided
+- `delins-recommendation-reach-when-the-input-arrives-split` — decided
+
+**Governed by nothing.** Nothing recorded at this stage.
+
+Both records here are axis- or mechanism-scoped rather than general, and both were decided in the direction of narrowing what the carve-out reaches. Neither is live on the shipped default, so this stage's rulings and this stage's behaviour are currently different questions.
+
+## The axis dimension
+
+The recommendations are not uniform across axes, and the non-uniformity is deliberate rather
+than accidental. `general.md:162` settles that outright: asked whether the `g.` and `c.`
+descriptions of one variant may name different nucleotides, the spec answers **yes**, for a
+gene on the minus strand inside a repeated sequence.
+
+That matters because a normalizer's axes disagreeing has, in this repository, always turned out
+to be a bug — a dropped offset, a skipped pass, a missing gate. Every such case so far was an
+*accidental* divergence, and none was a deliberate axis-scoped rule. Without a table recording
+which is which, the next deliberate divergence is indistinguishable from the next defect.
+
+Two things shape the table. **Rules are keyed on the property, not on the axis label**: what
+matters for the codon carve-out is having a reading frame, which correctly groups `n.` with
+`g.` rather than with `c.`, a pairing an axis-name-keyed table would get wrong. And **some
+rules cannot be modelled at all** — a clause keyed on provenance or on population frequency is
+not a function of the sequences a normalizer holds — so those are recorded as `unmodellable`
+rather than left looking unimplemented.
+
+| clause | scope | normalization-relevant? |
+|---|---|---|
+| `docs/recommendations/general.md:35` | Coding only by construction — the condition names amino acids, which an axis with no reading frame cannot state. | modelled |
+| `docs/recommendations/general.md:44` | `c.`, `r.` and `n.` only — the spec scopes the exception by naming prefixes. | modelled |
+| `docs/recommendations/DNA/repeated.md:21` | `c.` only. | modelled |
+| `docs/recommendations/general.md:162-167` | The `g.`/`c.` pair, on the minus strand, inside a repeated sequence. | modelled |
+| `docs/recommendations/general.md:13` | RNA and protein axes. | modelled |
+| `docs/recommendations/general.md:136` | `c.` only. | not-a-normalization-rule |
+| `docs/recommendations/RNA/adjoined_transcript.md:18` | `r.` only. | not-a-normalization-rule |
+| `docs/background/refseq.md:47` | Intronic positions on transcript axes. | not-a-normalization-rule |
+| `docs/recommendations/DNA/delins.md:83` | Axis-neutral. Listed here because it is the clearest case of a rule this table must record as unmodellable rather than leave looking unimplemented. | unmodellable |
+| `docs/recommendations/RNA/delins.md:41` | `r.`. | unmodellable |
+
+### The clauses, with their text
+
+#### `docs/recommendations/general.md:35` — modelled
+
+> **exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins"
+
+**Scope.** Coding only by construction — the condition names amino acids, which an axis with no reading frame cannot state.
+
+Keyed on the property, not on the axis label: `axis_min_separation(reading_frame: bool)` selects the floor, which correctly groups `n.` — a transcript axis with no frame — with `g.` rather than with `c.`. An axis-name-keyed table would get that pair wrong.
+
+#### `docs/recommendations/general.md:44` — modelled
+
+> **exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** or **n.** reference sequences
+
+**Scope.** `c.`, `r.` and `n.` only — the spec scopes the exception by naming prefixes.
+
+Also precedent, cited as such by `projection-codon-exception-is-decided-by-the-rendered-axis`: the spec does scope a rule by naming prefixes, so an axis-scoped reading of another clause is not an invention.
+
+#### `docs/recommendations/DNA/repeated.md:21` — modelled
+
+> using a coding DNA reference sequence ("c." description), a repeated sequence variant description can be used only for repeat units with a length which is a multiple of 3
+
+**Scope.** `c.` only.
+
+#### `docs/recommendations/general.md:162-167` — modelled
+
+> Yes, when a gene is on the minus strand of a chromosome (opposite transcriptional orientation) and the change is located in a repeated sequence (mono-, di-, tri-, etc. nucleotide stretches), the 3'rule has this as a consequence.
+
+**Scope.** The `g.`/`c.` pair, on the minus strand, inside a repeated sequence.
+
+The load-bearing row of this table, and the reason the table exists. The Q&A answers **yes**: `g.` and `c.` descriptions of one variant may legitimately name different nucleotides and different positions. So cross-axis divergence is endorsed by the spec, not a defect — while this repository has historically filed axis disagreement as a bug, correctly in every case so far, because every one of those was an accidental divergence rather than a deliberate axis-scoped rule. Without a table recording which is which, the next deliberate divergence is indistinguishable from the next bug.
+
+#### `docs/recommendations/general.md:13` — modelled
+
+> descriptions on RNA/protein level should describe the changes observed on that level (RNA/protein) and not try to incorporate any knowledge regarding the change on
+
+**Scope.** RNA and protein axes.
+
+The method half of `canonical-form-choice-when-both-legal`, whose governing clause is `general.md:157` — the same statement made for protein and extended here to RNA.
+
+#### `docs/recommendations/general.md:136` — not-a-normalization-rule
+
+> The minus sign should only be used as a minus in the description of variants based on a coding DNA reference sequence.
+
+**Scope.** `c.` only.
+
+A parser constraint. It decides which strings are well formed, not which of several well-formed descriptions is emitted.
+
+#### `docs/recommendations/RNA/adjoined_transcript.md:18` — not-a-normalization-rule
+
+> This syntax is for RNA sequence only (no use of coding (`c.`) / non-coding DNA (`n.`) reference sequences).
+
+**Scope.** `r.` only.
+
+Expressibility. It says a syntax is unavailable on an axis, which is upstream of any choice between forms.
+
+#### `docs/background/refseq.md:47` — not-a-normalization-rule
+
+> intronic sequences are considered to be **within the boundaries** of a transcript reference sequence and may only be used to describe a variant when a genomic r
+
+**Scope.** Intronic positions on transcript axes.
+
+Reference selection rather than form selection — though the sibling clause `checklist.md:20` is what `bare-transcript-intronic-position` rules under, and that ruling does move output.
+
+#### `docs/recommendations/DNA/delins.md:83` — unmodellable
+
+> First, the two variants may have been reported (or might occur) individually.
+
+**Scope.** Axis-neutral. Listed here because it is the clearest case of a rule this table must record as unmodellable rather than leave looking unimplemented.
+
+The discriminator is **provenance** — whether the two variants were reported individually — which is not a function of (reference, observed) and is unrecoverable from any description. `canonical-form-choice-when-both-legal` records this among its counter-evidence and adopts re-derivation over it deliberately; `separation-is-a-property-of-the-spelling-not-of-the-variant` records the departure formally, in its `deviates_from`.
+
+#### `docs/recommendations/RNA/delins.md:41` — unmodellable
+
+> This format is preferred when either of the two variants is known as a frequently occurring variant ("polymorphism").
+
+**Scope.** `r.`.
+
+Population frequency, like the row above, is not a function of the sequences a normalizer holds. Recording it as unmodellable is the point: an audit that left it blank would read as a gap someone could close.

--- a/tests/fixtures/grammar/normalization_stage_audit.json
+++ b/tests/fixtures/grammar/normalization_stage_audit.json
@@ -1,0 +1,235 @@
+{
+  "_comment": [
+    "Stage-by-stage inventory of what governs each decision ferro's normalization",
+    "pipeline makes (#1553). Curated, and checked: every `rulings` id must exist in",
+    "hgvs_spec_normalization_overrides.json, and every clause quote must be found at",
+    "the cited lines of the assets/hgvs-nomenclature checkout. Rendered to",
+    "docs/NORMALIZATION_STAGE_AUDIT.md by tests/it/normalization_stage_audit_doc.rs.",
+    "",
+    "NOTHING HERE STATES A RULING. A row cites the record that rules; the record's",
+    "status is read from the ledger at render time and is deliberately not copied",
+    "into this file. What this file adds is the inverse index the ledger does not",
+    "carry: which stage a record governs, and — the point of the exercise — which",
+    "decisions no record governs at all."
+  ],
+  "stages": [
+    {
+      "id": "parse-validate",
+      "title": "Parse / validate",
+      "decision": "Which authored forms are refused, which are repaired, and at which stage the refusal happens.",
+      "rulings": [
+        "absolute-prohibition-enforcement-stage",
+        "alignment-only-symbol-in-a-description",
+        "rna-axis-alignment-only-symbol-reach",
+        "bare-transcript-intronic-position",
+        "conflicting-member-geometry-refusal-scope",
+        "ring-telomere-anchoring",
+        "rna-repeat-range-plus-unit-redundancy"
+      ],
+      "clauses": [],
+      "ungoverned": [],
+      "note": "The stage question itself is settled — `absolute-prohibition-enforcement-stage` rules that enforcement is mode-dependent and uniform: strict fails at parse, lenient fails only when it cannot normalize. What that record leaves open is coverage, clause by clause, and it names the remaining clauses itself. Two further questions at this stage carry open records rather than no record, which is the state this audit is looking for and does not need to add to."
+    },
+    {
+      "id": "axis-projection",
+      "title": "Axis projection",
+      "decision": "How a coordinate maps across axes, and what happens at boundaries.",
+      "rulings": [
+        "projection-codon-exception-is-decided-by-the-rendered-axis",
+        "c-and-n-positions-are-flat-transcript-offsets",
+        "junction-exit-wrapper-scope-in-a-mixed-allele"
+      ],
+      "clauses": [
+        {
+          "clause": "docs/background/numbering.md:52",
+          "quote": "nucleotide numbering is `n.1`, `n.2`, `n.3`, ..., etc., from the first to the last nucleotide of the reference sequence"
+        }
+      ],
+      "ungoverned": [
+        {
+          "decision": "How two `c.` positions in different numbering zones (`-n` upstream of the ATG, plain `n` in the CDS, `*n` downstream of the stop) are ordered against each other.",
+          "verdict": "genuine-gap",
+          "why": "Ferro needs a total order on `c.` endpoints to sort an allele's members, detect overlap between them, and compute the separation that the merge/split stage keys on. `background/numbering.md` defines each zone and states no rule for comparing positions across them; it never speaks about alleles at all. So the ordering is a house rule with no clause behind it — and, unlike every other house rule at this grain, it carries no ruling record either. It is currently written down only as repository prose. This is not theoretical: the sequence-changing and denotes-no-sequence classes the spec corpus found localise to the `c.72`/`c.*1` transition and to nothing else."
+        }
+      ],
+      "note": null
+    },
+    {
+      "id": "sequence-derivation",
+      "title": "Sequence derivation",
+      "decision": "How the resulting sequence is computed from the authored edits, and what may bound that computation.",
+      "rulings": [
+        "canonical-form-choice-when-both-legal",
+        "derivation-may-not-be-bounded-by-the-inputs-spelling",
+        "confluence-gate-is-apply-equality-on-every-determined-axis"
+      ],
+      "clauses": [
+        {
+          "clause": "docs/background/basics.md:38",
+          "quote": "The recommendations for the description of sequence variants are designed to be **stable**, **meaningful**, **memorable**, and **unequivocal**."
+        }
+      ],
+      "ungoverned": [],
+      "note": "The most heavily ruled stage in the pipeline, and the one the rest depend on: `canonical-form-choice-when-both-legal` makes the resulting sequence the thing every other rule is evaluated over, and `derivation-may-not-be-bounded-by-the-inputs-spelling` removes the one comparand that contradicted it. Note what `background/basics.md:38` is cited for here — it lists the design values and minimality is absent from them, so ferro's column-minimal objective is policy and never compliance."
+    },
+    {
+      "id": "partition-and-typing",
+      "title": "Partition + typing",
+      "decision": "Which of several legal descriptions is emitted: how the edit set is cut into members, and what each piece is labelled.",
+      "rulings": [
+        "canonical-form-choice-when-both-legal",
+        "separation-is-a-property-of-the-spelling-not-of-the-variant",
+        "duplication-must-ranks-the-label-not-the-partition",
+        "inversion-vs-two-delins-76-83",
+        "inversion-vs-a-mixed-member-competitor",
+        "contiguous-insertion-split-by-a-blocked-derivation"
+      ],
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:56",
+          "quote": "when a description is possible according to several types, the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion"
+        }
+      ],
+      "ungoverned": [],
+      "note": "Settled at the level of principle and in flight at the level of shipped behaviour: several of these rulings are implemented only under a candidate partitioner arm, and the default is being flipped separately. #1553 places this stage out of scope for re-litigation, and this row is an index into the records rather than an invitation to reopen them."
+    },
+    {
+      "id": "shifting",
+      "title": "Shifting",
+      "decision": "Where the 3' rule places a change within a run of equivalent positions, and where that placement is clamped.",
+      "rulings": ["exon-junction-dup-converge-from-the-far-side"],
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:41",
+          "quote": "**3'rule**: for all descriptions, the most 3' position possible of the reference sequence is arbitrarily assigned to have been changed."
+        },
+        {
+          "clause": "docs/recommendations/general.md:44",
+          "quote": "**exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** or **n.** reference sequences"
+        },
+        {
+          "clause": "docs/recommendations/DNA/complex.md:50",
+          "quote": "the general HGVS rule of maintaining the longest unchanged sequence applies (the 3' rule)"
+        }
+      ],
+      "ungoverned": [
+        {
+          "decision": "What the 5' direction does — at an exon/exon junction, in a repeat tract, and at a reference boundary.",
+          "verdict": "genuine-gap",
+          "why": "The recommendations state a 3' rule and only a 3' rule; `5' rule` and `5'-rule` occur nowhere in the checkout. Ferro nevertheless offers a 5' direction, and the direction is not an orthogonal knob — it selects the frame every other rule is evaluated in, which is why the README claims its best-effort rules per direction rather than across the two. So every clause and every ruling at this stage is authority for the 3' arm; the 5' arm's answers are ferro's own, mirrored by construction rather than by a decision anyone recorded. That is defensible and may well be the only possible answer, but it is nowhere adjudicated, and the mirroring is not obviously right at a junction, where the 3' answer is itself an exception."
+        }
+      ],
+      "note": null
+    },
+    {
+      "id": "merge-split",
+      "title": "Merge / split",
+      "decision": "When consecutive or separated changes combine into one description rather than staying individual.",
+      "rulings": [
+        "delins-merge-vs-individual-gap-two-or-more",
+        "delins-codon-carve-out-gap-one",
+        "delins-adjacent-members-when-both-consume-reference",
+        "codon-carve-out-shape-restriction",
+        "separation-rule-force-modal-or-negation",
+        "separation-is-a-property-of-the-spelling-not-of-the-variant",
+        "self-cancelling-across-ring-junctions"
+      ],
+      "clauses": [
+        {
+          "clause": "docs/recommendations/general.md:34",
+          "quote": "two variants separated by one or more nucleotides should be described individually and **not** as a \"delins\""
+        },
+        {
+          "clause": "docs/recommendations/DNA/substitution.md:32",
+          "quote": "changes involving two or more consecutive nucleotides are described as deletion-insertion (delins)"
+        }
+      ],
+      "ungoverned": [],
+      "note": "Seven records, more than any other stage, and the residue is named inside them rather than missing from them: `delins-adjacent-members-when-both-consume-reference` is explicitly scoped to members that consume reference bases and records the `dup` and repeat-expansion cases as still open. An audit row that reported this stage as fully settled would be reading the ruling and not its scope."
+    },
+    {
+      "id": "re-spelling",
+      "title": "Re-spelling",
+      "decision": "Terminal coalescing and type re-selection, applied to pieces that are already derived.",
+      "rulings": [
+        "delins-payload-coincidence-carve-out-is-coding-dna-scoped",
+        "delins-recommendation-reach-when-the-input-arrives-split"
+      ],
+      "clauses": [],
+      "ungoverned": [],
+      "note": "Both records here are axis- or mechanism-scoped rather than general, and both were decided in the direction of narrowing what the carve-out reaches. Neither is live on the shipped default, so this stage's rulings and this stage's behaviour are currently different questions."
+    }
+  ],
+  "axis_scoped_clauses": [
+    {
+      "clause": "docs/recommendations/general.md:35",
+      "quote": "**exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a \"delins\"",
+      "scope": "Coding only by construction — the condition names amino acids, which an axis with no reading frame cannot state.",
+      "relevance": "modelled",
+      "note": "Keyed on the property, not on the axis label: `axis_min_separation(reading_frame: bool)` selects the floor, which correctly groups `n.` — a transcript axis with no frame — with `g.` rather than with `c.`. An axis-name-keyed table would get that pair wrong."
+    },
+    {
+      "clause": "docs/recommendations/general.md:44",
+      "quote": "**exception**: deletions/duplications around exon/exon junctions using **c.**, **r.** or **n.** reference sequences",
+      "scope": "`c.`, `r.` and `n.` only — the spec scopes the exception by naming prefixes.",
+      "relevance": "modelled",
+      "note": "Also precedent, cited as such by `projection-codon-exception-is-decided-by-the-rendered-axis`: the spec does scope a rule by naming prefixes, so an axis-scoped reading of another clause is not an invention."
+    },
+    {
+      "clause": "docs/recommendations/DNA/repeated.md:21",
+      "quote": "using a coding DNA reference sequence (\"c.\" description), a repeated sequence variant description can be used only for repeat units with a length which is a multiple of 3",
+      "scope": "`c.` only.",
+      "relevance": "modelled",
+      "note": null
+    },
+    {
+      "clause": "docs/recommendations/general.md:162-167",
+      "quote": "Yes, when a gene is on the minus strand of a chromosome (opposite transcriptional orientation) and the change is located in a repeated sequence (mono-, di-, tri-, etc. nucleotide stretches), the 3'rule has this as a consequence.",
+      "scope": "The `g.`/`c.` pair, on the minus strand, inside a repeated sequence.",
+      "relevance": "modelled",
+      "note": "The load-bearing row of this table, and the reason the table exists. The Q&A answers **yes**: `g.` and `c.` descriptions of one variant may legitimately name different nucleotides and different positions. So cross-axis divergence is endorsed by the spec, not a defect — while this repository has historically filed axis disagreement as a bug, correctly in every case so far, because every one of those was an accidental divergence rather than a deliberate axis-scoped rule. Without a table recording which is which, the next deliberate divergence is indistinguishable from the next bug."
+    },
+    {
+      "clause": "docs/recommendations/general.md:13",
+      "quote": "descriptions on RNA/protein level should describe the changes observed on that level (RNA/protein) and not try to incorporate any knowledge regarding the change on",
+      "scope": "RNA and protein axes.",
+      "relevance": "modelled",
+      "note": "The method half of `canonical-form-choice-when-both-legal`, whose governing clause is `general.md:157` — the same statement made for protein and extended here to RNA."
+    },
+    {
+      "clause": "docs/recommendations/general.md:136",
+      "quote": "The minus sign should only be used as a minus in the description of variants based on a coding DNA reference sequence.",
+      "scope": "`c.` only.",
+      "relevance": "not-a-normalization-rule",
+      "note": "A parser constraint. It decides which strings are well formed, not which of several well-formed descriptions is emitted."
+    },
+    {
+      "clause": "docs/recommendations/RNA/adjoined_transcript.md:18",
+      "quote": "This syntax is for RNA sequence only (no use of coding (`c.`) / non-coding DNA (`n.`) reference sequences).",
+      "scope": "`r.` only.",
+      "relevance": "not-a-normalization-rule",
+      "note": "Expressibility. It says a syntax is unavailable on an axis, which is upstream of any choice between forms."
+    },
+    {
+      "clause": "docs/background/refseq.md:47",
+      "quote": "intronic sequences are considered to be **within the boundaries** of a transcript reference sequence and may only be used to describe a variant when a genomic r",
+      "scope": "Intronic positions on transcript axes.",
+      "relevance": "not-a-normalization-rule",
+      "note": "Reference selection rather than form selection — though the sibling clause `checklist.md:20` is what `bare-transcript-intronic-position` rules under, and that ruling does move output."
+    },
+    {
+      "clause": "docs/recommendations/DNA/delins.md:83",
+      "quote": "First, the two variants may have been reported (or might occur) individually.",
+      "scope": "Axis-neutral. Listed here because it is the clearest case of a rule this table must record as unmodellable rather than leave looking unimplemented.",
+      "relevance": "unmodellable",
+      "note": "The discriminator is **provenance** — whether the two variants were reported individually — which is not a function of (reference, observed) and is unrecoverable from any description. `canonical-form-choice-when-both-legal` records this among its counter-evidence and adopts re-derivation over it deliberately; `separation-is-a-property-of-the-spelling-not-of-the-variant` records the departure formally, in its `deviates_from`."
+    },
+    {
+      "clause": "docs/recommendations/RNA/delins.md:41",
+      "quote": "This format is preferred when either of the two variants is known as a frequently occurring variant (\"polymorphism\").",
+      "scope": "`r.`.",
+      "relevance": "unmodellable",
+      "note": "Population frequency, like the row above, is not a function of the sequences a normalizer holds. Recording it as unmodellable is the point: an audit that left it blank would read as a gap someone could close."
+    }
+  ]
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -435,6 +435,7 @@ mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;
 mod network_benchmark_tests;
 mod normalization_contract_doc;
+mod normalization_stage_audit_doc;
 mod normalization_transcripts_exon_contract;
 mod normalize_axis_preserving;
 mod normalize_config_disambiguation;

--- a/tests/it/normalization_stage_audit_doc.rs
+++ b/tests/it/normalization_stage_audit_doc.rs
@@ -1,0 +1,804 @@
+//! Generates and gates `docs/NORMALIZATION_STAGE_AUDIT.md` — the stage-by-stage
+//! inventory of what governs each decision the normalizer makes (#1553).
+//!
+//! # The question it answers
+//!
+//! Ferro's normalization pipeline makes a decision at every stage, and only some
+//! of those decisions are backed by a governing clause or a ruling record. The
+//! rest are backed by whatever the implementation happens to do. Without an
+//! inventory saying which is which, a contributor cannot tell a deliberate
+//! choice from an accident, and neither can a reviewer.
+//!
+//! The audit is `tests/fixtures/grammar/normalization_stage_audit.json`: one row
+//! per stage, naming the decision the stage makes, the records and clauses that
+//! govern it, and — the deliverable — the decisions that **nothing** governs,
+//! each classified as a genuine gap or as a case the spec settles so plainly no
+//! record is warranted.
+//!
+//! # What is curated and what is checked
+//!
+//! The assignment of a record to a stage is editorial. Everything a reader might
+//! act on is not:
+//!
+//! * every `rulings` id must exist in the adjudication ledger
+//!   ([`every_cited_ruling_exists_in_the_ledger`]);
+//! * every clause must resolve to real lines of the pinned spec checkout, and
+//!   the quote must be found there
+//!   ([`every_cited_clause_quote_is_in_the_spec_checkout`]);
+//! * the stage list must be exactly the closed set the issue enumerated, in
+//!   pipeline order ([`the_audit_covers_every_stage_exactly_once`]).
+//!
+//! **No status is written down in the fixture.** A row cites a record; whether
+//! that record is decided or open is read from the ledger when the document is
+//! rendered. That is deliberate — a copied status is the drift this repository
+//! has been bitten by more than once, and here it would be worse than usual,
+//! because "this stage is settled" is exactly the claim the audit exists to
+//! test.
+//!
+//! # Relationship to the sibling document
+//!
+//! This inventory says *which* record governs a stage. The records themselves —
+//! question, verdict, clauses, quotes and reasoning — are published separately.
+//! Neither document restates `README.md`'s ruleset; that is stated once, there,
+//! and both link to it.
+//!
+//! Regenerate with:
+//!
+//! ```text
+//! BLESS_STAGE_AUDIT_DOC=1 cargo nextest run --features dev --test it \
+//!   -E 'test(normalization_stage_audit_doc)'
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use super::common::rulings::records;
+
+/// Where the curated audit lives, relative to the crate root.
+const AUDIT_RELATIVE_PATH: &str = "tests/fixtures/grammar/normalization_stage_audit.json";
+
+/// Where the generated document lives, relative to the crate root.
+const DOC_RELATIVE_PATH: &str = "docs/NORMALIZATION_STAGE_AUDIT.md";
+
+/// The pinned upstream spec checkout, which every clause citation resolves into.
+const SPEC_DIR: &str = "assets/hgvs-nomenclature";
+
+/// The environment variable that turns [`the_published_document_is_current`]
+/// from a comparison into a write.
+const BLESS_VAR: &str = "BLESS_STAGE_AUDIT_DOC";
+
+/// The stages, in pipeline order.
+///
+/// A closed list, held in code rather than inferred from the fixture, so a stage
+/// cannot be dropped from the audit by deleting its row — which is the one edit
+/// that would make the inventory read as complete while covering less. The set
+/// is the one #1553 enumerates.
+const STAGES: [&str; 7] = [
+    "parse-validate",
+    "axis-projection",
+    "sequence-derivation",
+    "partition-and-typing",
+    "shifting",
+    "merge-split",
+    "re-spelling",
+];
+
+/// The verdicts an ungoverned decision may carry.
+///
+/// The distinction is the whole point of recording an ungoverned decision at
+/// all: #1553 asks for it explicitly, because "nothing governs this" is a
+/// finding only when the spec has not in fact settled it plainly.
+const UNGOVERNED_VERDICTS: [&str; 2] = ["genuine-gap", "no-record-warranted"];
+
+/// How normalization-relevant an axis-scoped clause is.
+///
+/// `unmodellable` is a first-class answer, not a synonym for `open`: a clause
+/// keyed on provenance or on population frequency is not a function of the
+/// sequences a normalizer holds, so no amount of work closes it. Leaving such a
+/// clause blank would read as a gap someone could close.
+const RELEVANCES: [&str; 4] = [
+    "modelled",
+    "open",
+    "not-a-normalization-rule",
+    "unmodellable",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// --------------------------------------------------------------------------
+// The curated audit.
+// --------------------------------------------------------------------------
+
+/// One clause a row cites, with the text it is cited for.
+struct Clause {
+    clause: String,
+    quote: String,
+}
+
+/// A decision at a stage that nothing governs.
+struct Ungoverned {
+    decision: String,
+    verdict: String,
+    why: String,
+}
+
+/// One pipeline stage.
+struct Stage {
+    id: String,
+    title: String,
+    decision: String,
+    rulings: Vec<String>,
+    clauses: Vec<Clause>,
+    ungoverned: Vec<Ungoverned>,
+    note: Option<String>,
+}
+
+/// One clause whose reach is scoped to particular axes.
+struct AxisClause {
+    clause: String,
+    quote: String,
+    scope: String,
+    relevance: String,
+    note: Option<String>,
+}
+
+/// The whole curated audit.
+struct Audit {
+    stages: Vec<Stage>,
+    axis_scoped_clauses: Vec<AxisClause>,
+}
+
+/// A required string field, reported by name.
+fn field<'a>(value: &'a serde_json::Value, name: &str, subject: &str) -> &'a str {
+    match value.get(name) {
+        None | Some(serde_json::Value::Null) => panic!("{subject} has no `{name}`"),
+        Some(found) => found
+            .as_str()
+            .unwrap_or_else(|| panic!("{subject} has a non-string `{name}`: {found}")),
+    }
+}
+
+/// An optional string field. Absent, `null` and a blank string all read as
+/// absent — a note present but empty renders as an empty paragraph, which looks
+/// like a dropped sentence rather than like no note.
+fn optional_field(value: &serde_json::Value, name: &str, subject: &str) -> Option<String> {
+    match value.get(name) {
+        None | Some(serde_json::Value::Null) => None,
+        Some(found) => {
+            let text = found
+                .as_str()
+                .unwrap_or_else(|| panic!("{subject} has a non-string `{name}`: {found}"));
+            (!text.trim().is_empty()).then(|| text.to_string())
+        }
+    }
+}
+
+fn string_list(value: &serde_json::Value, name: &str, subject: &str) -> Vec<String> {
+    match value.get(name) {
+        None | Some(serde_json::Value::Null) => Vec::new(),
+        Some(found) => found
+            .as_array()
+            .unwrap_or_else(|| panic!("{subject} has a non-array `{name}`: {found}"))
+            .iter()
+            .map(|entry| {
+                entry
+                    .as_str()
+                    .unwrap_or_else(|| panic!("{subject} has a non-string `{name}` entry: {entry}"))
+                    .to_string()
+            })
+            .collect(),
+    }
+}
+
+fn clauses(value: &serde_json::Value, subject: &str) -> Vec<Clause> {
+    match value.get("clauses") {
+        None | Some(serde_json::Value::Null) => Vec::new(),
+        Some(found) => found
+            .as_array()
+            .unwrap_or_else(|| panic!("{subject} has a non-array `clauses`: {found}"))
+            .iter()
+            .map(|entry| Clause {
+                clause: field(entry, "clause", subject).to_string(),
+                quote: field(entry, "quote", subject).to_string(),
+            })
+            .collect(),
+    }
+}
+
+/// Parse the curated audit. Panics on anything malformed, for the reason
+/// `common::rulings` gives: a broken fixture is not a case to degrade through.
+fn audit() -> Audit {
+    let text = read(AUDIT_RELATIVE_PATH);
+    let value: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {AUDIT_RELATIVE_PATH}: {e}"));
+
+    let stages = value
+        .get("stages")
+        .and_then(|s| s.as_array())
+        .unwrap_or_else(|| panic!("{AUDIT_RELATIVE_PATH} has no `stages` array"))
+        .iter()
+        .map(|entry| {
+            let id = field(entry, "id", "a stage").to_string();
+            let subject = format!("stage {id}");
+            Stage {
+                title: field(entry, "title", &subject).to_string(),
+                decision: field(entry, "decision", &subject).to_string(),
+                rulings: string_list(entry, "rulings", &subject),
+                clauses: clauses(entry, &subject),
+                ungoverned: match entry.get("ungoverned") {
+                    None | Some(serde_json::Value::Null) => Vec::new(),
+                    Some(found) => found
+                        .as_array()
+                        .unwrap_or_else(|| panic!("{subject} has a non-array `ungoverned`"))
+                        .iter()
+                        .map(|u| {
+                            let verdict = field(u, "verdict", &subject).to_string();
+                            assert!(
+                                UNGOVERNED_VERDICTS.contains(&verdict.as_str()),
+                                "{subject} records an ungoverned decision with verdict \
+                                 {verdict:?}, which is not one of {UNGOVERNED_VERDICTS:?} — the \
+                                 distinction between a genuine gap and a case the spec settles \
+                                 plainly is what makes the row a finding"
+                            );
+                            Ungoverned {
+                                decision: field(u, "decision", &subject).to_string(),
+                                verdict,
+                                why: field(u, "why", &subject).to_string(),
+                            }
+                        })
+                        .collect(),
+                },
+                note: optional_field(entry, "note", &subject),
+                id,
+            }
+        })
+        .collect();
+
+    let axis_scoped_clauses = value
+        .get("axis_scoped_clauses")
+        .and_then(|s| s.as_array())
+        .unwrap_or_else(|| panic!("{AUDIT_RELATIVE_PATH} has no `axis_scoped_clauses` array"))
+        .iter()
+        .map(|entry| {
+            let clause = field(entry, "clause", "an axis-scoped clause").to_string();
+            let subject = format!("axis-scoped clause {clause}");
+            let relevance = field(entry, "relevance", &subject).to_string();
+            assert!(
+                RELEVANCES.contains(&relevance.as_str()),
+                "{subject} has relevance {relevance:?}, which is not one of {RELEVANCES:?}"
+            );
+            AxisClause {
+                quote: field(entry, "quote", &subject).to_string(),
+                scope: field(entry, "scope", &subject).to_string(),
+                note: optional_field(entry, "note", &subject),
+                relevance,
+                clause,
+            }
+        })
+        .collect();
+
+    Audit {
+        stages,
+        axis_scoped_clauses,
+    }
+}
+
+// --------------------------------------------------------------------------
+// Resolving a clause into the spec checkout.
+// --------------------------------------------------------------------------
+
+/// The cited lines of the spec checkout, joined by spaces.
+///
+/// `docs/recommendations/general.md:34` and `…:79-84` are both accepted; a range
+/// is joined, which is what makes a quote spanning several lines resolvable.
+/// This mirrors what the spec-fixture generator does for the ledger's own
+/// citations, and shares its limit: the comparison is whitespace-collapsed
+/// containment, not a byte-for-byte match. It catches a clause moving out from
+/// under a citation; it does not certify that a quote is exact.
+fn cited_text(clause: &str) -> String {
+    let (path, span) = clause
+        .rsplit_once(':')
+        .unwrap_or_else(|| panic!("clause {clause:?} carries no `:line`"));
+    let (first, last) = match span.split_once('-') {
+        Some((a, b)) => (parse_line(a, clause), parse_line(b, clause)),
+        None => {
+            let only = parse_line(span, clause);
+            (only, only)
+        }
+    };
+    assert!(
+        first >= 1 && last >= first,
+        "clause {clause:?} names an empty or inverted line range"
+    );
+
+    let file = repo_root().join(SPEC_DIR).join(path);
+    let text = std::fs::read_to_string(&file).unwrap_or_else(|e| {
+        panic!(
+            "clause {clause:?} names {}, which cannot be read: {e}. If the spec checkout is \
+             empty, initialise it:\n    git submodule update --init {SPEC_DIR}",
+            file.display()
+        )
+    });
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(
+        last <= lines.len(),
+        "clause {clause:?} names line {last} of a {}-line file",
+        lines.len()
+    );
+    collapse(&lines[first - 1..last].join(" "))
+}
+
+fn parse_line(raw: &str, clause: &str) -> usize {
+    raw.parse()
+        .unwrap_or_else(|_| panic!("clause {clause:?} has a non-numeric line number {raw:?}"))
+}
+
+/// Runs of whitespace collapsed to single spaces.
+fn collapse(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+// --------------------------------------------------------------------------
+// Rendering.
+// --------------------------------------------------------------------------
+
+/// `id -> status`, from the ledger. Never from the fixture.
+fn ledger_statuses() -> BTreeMap<String, String> {
+    records().into_iter().map(|r| (r.id, r.status)).collect()
+}
+
+fn render() -> String {
+    let audit = audit();
+    let statuses = ledger_statuses();
+
+    let open_rulings: BTreeSet<&str> = audit
+        .stages
+        .iter()
+        .flat_map(|s| s.rulings.iter())
+        .filter(|id| statuses.get(*id).map(String::as_str) == Some("undecided"))
+        .map(String::as_str)
+        .collect();
+    let gaps: Vec<(&Stage, &Ungoverned)> = audit
+        .stages
+        .iter()
+        .flat_map(|s| s.ungoverned.iter().map(move |u| (s, u)))
+        .collect();
+
+    let mut out = String::new();
+    out.push_str(&preamble(audit.stages.len(), open_rulings.len(), &gaps));
+
+    let _ = writeln!(out, "## The stages\n");
+    for stage in &audit.stages {
+        out.push_str(&render_stage(stage, &statuses));
+    }
+
+    out.push_str(&render_axis_table(&audit.axis_scoped_clauses));
+
+    let mut out: String = out
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    out.truncate(out.trim_end().len());
+    out.push('\n');
+    out
+}
+
+fn preamble(stages: usize, open: usize, gaps: &[(&Stage, &Ungoverned)]) -> String {
+    let mut out = String::new();
+    let _ = write!(
+        out,
+        r#"<!--
+GENERATED FILE — do not edit by hand.
+
+Rendered from tests/fixtures/grammar/normalization_stage_audit.json and the
+adjudication ledger, by tests/it/normalization_stage_audit_doc.rs. Edit the
+fixture, then regenerate:
+
+    BLESS_STAGE_AUDIT_DOC=1 cargo nextest run --features dev --test it \
+      -E 'test(normalization_stage_audit_doc)'
+-->
+
+# What governs each normalization stage
+
+Ferro's normalizer makes a decision at every stage of its pipeline. Some of those decisions are
+backed by a clause of the HGVS recommendations, some by an adjudication record, and some by
+nothing more than what the implementation happens to do. This document is the inventory of
+which is which, so that a deliberate choice can be told from an accident — by a contributor
+deciding a new case, and by a reviewer reading a diff.
+
+**{stages} stages. {open} of the records cited below are still open. {gap_count} decisions are
+governed by nothing.**
+
+## How to read it
+
+Each stage names the decision it makes, the records that rule on it, and the clauses it is
+decided under. A record's status is read from the ledger when this file is generated and is
+never copied into the fixture, so a stage cannot be described as settled by a record that is
+not.
+
+The rows worth reading first are the **ungoverned** ones. Each is classified as either a
+*genuine gap* — a decision with real consequences that no clause and no record settles — or as
+*no record warranted*, meaning the spec settles it so plainly that writing a record would be
+ceremony. Only the first kind is a finding.
+
+## What this document is not
+
+**It is not the ruleset.** What ferro's output is allowed to be, and what happens where the
+spec determines no answer, is stated once, in
+[README.md, *Normalization rules*](../README.md#normalization-rules), and is deliberately not
+restated here.
+
+**It is not the records.** It says which record governs a stage; it does not reproduce the
+record. The records live in
+[`tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`](../tests/fixtures/grammar/hgvs_spec_normalization_overrides.json).
+
+**It is not exhaustive about clauses.** A stage's clause list carries the clauses that decide
+it, not every clause that touches it.
+
+## The ungoverned decisions
+
+"#,
+        gap_count = gaps.len()
+    );
+
+    for (stage, gap) in gaps {
+        let _ = writeln!(
+            out,
+            "### {} — {}\n\n*{}*\n\n{}\n",
+            stage.title,
+            gap.verdict,
+            collapse(&gap.decision),
+            collapse(&gap.why)
+        );
+    }
+
+    out
+}
+
+fn render_stage(stage: &Stage, statuses: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "### {} (`{}`)\n", stage.title, stage.id);
+    let _ = writeln!(out, "**Decides.** {}\n", collapse(&stage.decision));
+
+    if stage.rulings.is_empty() {
+        let _ = writeln!(out, "**Ruled by.** No adjudication record.\n");
+    } else {
+        let _ = writeln!(out, "**Ruled by.**\n");
+        for id in &stage.rulings {
+            let status = statuses
+                .get(id)
+                .unwrap_or_else(|| panic!("stage {} cites unknown record {id}", stage.id));
+            let _ = writeln!(out, "- `{id}` — {status}");
+        }
+        let _ = writeln!(out);
+    }
+
+    if !stage.clauses.is_empty() {
+        let _ = writeln!(out, "**Decided under.**\n");
+        for clause in &stage.clauses {
+            let _ = writeln!(
+                out,
+                "- `{}`\n  > {}",
+                clause.clause,
+                collapse(&clause.quote)
+            );
+        }
+        let _ = writeln!(out);
+    }
+
+    if stage.ungoverned.is_empty() {
+        let _ = writeln!(
+            out,
+            "**Governed by nothing.** Nothing recorded at this stage.\n"
+        );
+    } else {
+        let _ = writeln!(out, "**Governed by nothing.**\n");
+        for gap in &stage.ungoverned {
+            let _ = writeln!(out, "- **{}** — {}", gap.verdict, collapse(&gap.decision));
+        }
+        let _ = writeln!(out);
+    }
+
+    if let Some(note) = &stage.note {
+        let _ = writeln!(out, "{}\n", collapse(note));
+    }
+    out
+}
+
+fn render_axis_table(clauses: &[AxisClause]) -> String {
+    let mut out = String::new();
+    let _ = write!(
+        out,
+        r#"## The axis dimension
+
+The recommendations are not uniform across axes, and the non-uniformity is deliberate rather
+than accidental. `general.md:162` settles that outright: asked whether the `g.` and `c.`
+descriptions of one variant may name different nucleotides, the spec answers **yes**, for a
+gene on the minus strand inside a repeated sequence.
+
+That matters because a normalizer's axes disagreeing has, in this repository, always turned out
+to be a bug — a dropped offset, a skipped pass, a missing gate. Every such case so far was an
+*accidental* divergence, and none was a deliberate axis-scoped rule. Without a table recording
+which is which, the next deliberate divergence is indistinguishable from the next defect.
+
+Two things shape the table. **Rules are keyed on the property, not on the axis label**: what
+matters for the codon carve-out is having a reading frame, which correctly groups `n.` with
+`g.` rather than with `c.`, a pairing an axis-name-keyed table would get wrong. And **some
+rules cannot be modelled at all** — a clause keyed on provenance or on population frequency is
+not a function of the sequences a normalizer holds — so those are recorded as `unmodellable`
+rather than left looking unimplemented.
+
+| clause | scope | normalization-relevant? |
+|---|---|---|
+"#
+    );
+    for clause in clauses {
+        let _ = writeln!(
+            out,
+            "| `{}` | {} | {} |",
+            clause.clause,
+            collapse(&clause.scope),
+            clause.relevance
+        );
+    }
+    let _ = writeln!(out, "\n### The clauses, with their text\n");
+    for clause in clauses {
+        let _ = writeln!(
+            out,
+            "#### `{}` — {}\n\n> {}\n\n**Scope.** {}\n",
+            clause.clause,
+            clause.relevance,
+            collapse(&clause.quote),
+            collapse(&clause.scope)
+        );
+        if let Some(note) = &clause.note {
+            let _ = writeln!(out, "{}\n", collapse(note));
+        }
+    }
+    out
+}
+
+// --------------------------------------------------------------------------
+// Tests.
+// --------------------------------------------------------------------------
+
+/// The committed document matches what the audit and the ledger render to.
+#[test]
+fn the_published_document_is_current() {
+    let rendered = render();
+    let path = repo_root().join(DOC_RELATIVE_PATH);
+
+    if std::env::var(BLESS_VAR).is_ok() {
+        std::fs::write(&path, &rendered)
+            .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "read {}: {e}\n\nGenerate it with:\n  {BLESS_VAR}=1 cargo nextest run --features dev \
+             --test it -E 'test(normalization_stage_audit_doc)'",
+            path.display()
+        )
+    });
+    assert!(
+        committed == rendered,
+        "{DOC_RELATIVE_PATH} is stale against the audit fixture or the ledger. Regenerate it — \
+         do not edit it by hand:\n  {BLESS_VAR}=1 cargo nextest run --features dev --test it \
+         -E 'test(normalization_stage_audit_doc)'"
+    );
+}
+
+/// Every record the audit cites is in the ledger.
+///
+/// Without this the inventory could name a record that had been renamed or
+/// retired, and read as coverage while pointing at nothing.
+#[test]
+fn every_cited_ruling_exists_in_the_ledger() {
+    let statuses = ledger_statuses();
+    let audit = audit();
+    let mut cited = 0usize;
+    for stage in &audit.stages {
+        for id in &stage.rulings {
+            assert!(
+                statuses.contains_key(id),
+                "stage {} cites `{id}`, which is not a record in the ledger",
+                stage.id
+            );
+            cited += 1;
+        }
+    }
+    assert!(
+        cited > 0,
+        "the audit cites no records at all, so this check is vacuous"
+    );
+}
+
+/// Every clause the audit cites resolves in the spec checkout, and the quote is
+/// found at the cited lines.
+///
+/// A `file:line` nobody checks is the failure mode the ledger's own citations
+/// were given quotes to close; an inventory of what governs each stage must not
+/// reintroduce it one file over.
+#[test]
+fn every_cited_clause_quote_is_in_the_spec_checkout() {
+    let audit = audit();
+    let mut checked = 0usize;
+
+    let mut check = |clause: &str, quote: &str, subject: &str| {
+        let cited = cited_text(clause);
+        assert!(
+            cited.contains(&collapse(quote)),
+            "{subject}: the quote for `{clause}` is not at those lines.\n  quoted: {}\n  found:  \
+             {cited}",
+            collapse(quote)
+        );
+        checked += 1;
+    };
+
+    for stage in &audit.stages {
+        for clause in &stage.clauses {
+            check(
+                &clause.clause,
+                &clause.quote,
+                &format!("stage {}", stage.id),
+            );
+        }
+    }
+    for clause in &audit.axis_scoped_clauses {
+        check(&clause.clause, &clause.quote, "the axis table");
+    }
+    assert!(
+        checked > 0,
+        "no clause was checked, so this test would pass over an empty audit"
+    );
+}
+
+/// The audit covers exactly the stages [`STAGES`] names, once each, in order.
+///
+/// Held in code rather than derived from the fixture: deleting a row is the one
+/// edit that makes the inventory read as complete while covering less.
+#[test]
+fn the_audit_covers_every_stage_exactly_once() {
+    let ids: Vec<String> = audit().stages.into_iter().map(|s| s.id).collect();
+    assert_eq!(
+        ids,
+        STAGES.map(String::from).to_vec(),
+        "the audit's stages differ from the closed list this pipeline has. Adding a stage is a \
+         legitimate answer; dropping one silently is not"
+    );
+}
+
+/// Every stage says something about every field a reader relies on.
+///
+/// A row that names a stage and leaves the governance blank is worse than no
+/// row: it occupies the place where the answer would be.
+#[test]
+fn no_stage_row_is_blank() {
+    for stage in audit().stages {
+        assert!(
+            !stage.title.trim().is_empty() && !stage.decision.trim().is_empty(),
+            "stage {} has no title or no decision",
+            stage.id
+        );
+        assert!(
+            !stage.rulings.is_empty() || !stage.clauses.is_empty() || !stage.ungoverned.is_empty(),
+            "stage {} records neither a record, nor a clause, nor an ungoverned decision — the \
+             row states nothing",
+            stage.id
+        );
+    }
+}
+
+/// Every ungoverned decision the audit records reaches the document, with its
+/// verdict.
+///
+/// These rows are the deliverable. Rendering them only inside their stage would
+/// bury the finding in the middle of a long file, so they are also collected at
+/// the top, and this asserts both copies exist.
+#[test]
+fn every_ungoverned_decision_is_published_with_its_verdict() {
+    let rendered = render();
+    let audit = audit();
+    let mut found = 0usize;
+    for stage in &audit.stages {
+        for gap in &stage.ungoverned {
+            let decision = collapse(&gap.decision);
+            assert!(
+                rendered.matches(decision.as_str()).count() >= 2,
+                "the ungoverned decision at stage {} is not published both in the summary and \
+                 under its stage: {decision}",
+                stage.id
+            );
+            assert!(
+                rendered.contains(&collapse(&gap.why)),
+                "the ungoverned decision at stage {} is published without its reasoning",
+                stage.id
+            );
+            assert!(
+                rendered.contains(&format!("### {} — {}", stage.title, gap.verdict)),
+                "the ungoverned decision at stage {} is published without its verdict",
+                stage.id
+            );
+            found += 1;
+        }
+    }
+    assert!(
+        found > 0,
+        "the audit records no ungoverned decision anywhere. That is a possible answer, but it is \
+         the one that would make this document pointless, so it must be arrived at deliberately \
+         rather than by an empty fixture"
+    );
+}
+
+/// The document does not restate the README ruleset.
+///
+/// Same reason as its sibling: single-sourcing that ruleset is part of a ruling
+/// in the ledger this audit indexes.
+#[test]
+fn the_document_does_not_restate_the_readme_ruleset() {
+    let rendered = render();
+    assert!(
+        rendered.contains("../README.md#normalization-rules"),
+        "the document must send the reader to the README ruleset rather than restating it"
+    );
+
+    let readme = read("README.md");
+    let section = readme
+        .split_once("\n## Normalization rules\n")
+        .expect("README has a Normalization rules section")
+        .1
+        .split_once("\n## ")
+        .expect("the section is followed by another")
+        .0;
+    let openers: Vec<&str> = section
+        .lines()
+        .filter_map(|line| {
+            let rest = line
+                .trim_start()
+                .strip_prefix(char::is_numeric)?
+                .strip_prefix(". **")?;
+            rest.split_once("**").map(|(opener, _)| opener)
+        })
+        .collect();
+    assert!(
+        openers.len() >= 7,
+        "found {} rule openers in the README ruleset, expected seven — the section's shape moved \
+         and this guard is no longer reading it",
+        openers.len()
+    );
+    for opener in openers {
+        assert!(
+            !rendered.contains(&format!("**{opener}**")),
+            "the document restates the README ruleset's rule {opener:?}; link to it instead"
+        );
+    }
+}
+
+/// The render is already in the shape the file-hygiene pre-commit hooks want, so
+/// committing it cannot rewrite it into a failure that reads as drift.
+#[test]
+fn the_render_survives_the_file_hygiene_hooks() {
+    let rendered = render();
+    assert!(
+        rendered.ends_with('\n') && !rendered.ends_with("\n\n"),
+        "the render must end with exactly one newline"
+    );
+    for (number, line) in rendered.lines().enumerate() {
+        assert_eq!(
+            line.trim_end(),
+            line,
+            "line {} of the render carries trailing whitespace: {line:?}",
+            number + 1
+        );
+    }
+}


### PR DESCRIPTION
Closes #1553

Representation-Change: none. A fixture, a doc, one integration-test module and a README pointer. No `src/` file is touched.

**Stacked on #1850.** Base is `docs/issue-1552-shadow-spec`, so the diff shown here is this PR's own work; GitHub retargets to `main` when #1850 merges. `git log --oneline origin/main..HEAD` is two commits, the first of which is #1850's.

## What this adds

An inventory: for each stage of the normalizer, what governs the decision that stage makes. The data is `tests/fixtures/grammar/normalization_stage_audit.json`; `docs/NORMALIZATION_STAGE_AUDIT.md` is generated from it and from the ledger.

The expected outcome, and the actual one, is that most stages resolve to an existing record. The deliverable is the residue.

## The residue — two decisions governed by nothing

Both classified as **genuine gaps** rather than as cases the spec settles so plainly no record is warranted:

**Ordering `c.` positions across numbering zones.** A `c.` position sits in one of three zones (`-n`, plain `n`, `*n`) and a cis allele's members can sit in different ones, so the normalizer needs a total order on endpoints — to sort members, to detect overlap, and to compute the separation the merge/split stage keys on. `background/numbering.md` defines each zone and states no rule for comparing across them; it never speaks about alleles at all. So the ordering is a house rule with no clause behind it, and unlike every other house rule at this grain it carries no ruling record either. It is written down as repository prose and nowhere else. This is not theoretical: the sequence-changing and denotes-no-sequence classes the spec corpus found localise to the `c.72`/`c.*1` transition and to nothing else.

**What the 5' direction does.** The recommendations state a 3' rule and only a 3' rule — `5' rule` and `5'-rule` occur nowhere in the checkout. Ferro offers a 5' direction, and the direction is not orthogonal: it selects the frame every other rule is evaluated in, which is why the README claims its best-effort rules per direction rather than across the two. So every clause and every record at the shifting stage is authority for the 3' arm only; the 5' arm is mirrored by construction rather than by a decision anyone made. That may well be the only possible answer, but it is nowhere adjudicated, and the mirroring is least obviously right at a junction, where the 3' answer is itself an exception.

Neither is proposed for a ruling record here — a record is for clauses in tension, and both of these are spec *silence*, which README rule 5 routes differently. Filing them is what this PR does; deciding them is not.

## The axis dimension

The second half of #1553, from its comment. The spec settles outright that cross-axis divergence is legitimate — asked whether the `g.` and `c.` descriptions of one variant may name different nucleotides, `general.md:162-167` answers **yes**, for a minus-strand gene inside a repeated sequence. Every axis disagreement this repository has filed was nevertheless a real bug: a dropped offset, a skipped pass, a missing gate. Without a table recording which is which, the next deliberate divergence is indistinguishable from the next defect.

The table's third column is what keeps it closeable. Of ten axis-scoped clauses, three are normalization rules and all three are already modelled; three are parser, expressibility or reference-selection constraints; two are `unmodellable` — keyed on provenance and on population frequency, so no work closes them and leaving them blank would read as a gap; and the remaining two are the endorsement itself and the derivation mandate.

Rules are keyed on the **property, not the axis label**, as the issue asks: what matters for the codon carve-out is having a reading frame, which correctly groups `n.` with `g.` rather than with `c.` — a pairing an axis-name-keyed table gets wrong.

## What is curated and what is checked

The assignment of a record to a stage is editorial. Nothing a reader might act on is:

- every cited record must exist in the ledger;
- every cited clause must resolve to real lines of the pinned spec checkout, and its quote must be found there — the same whitespace-collapsed containment the ledger's own citations are checked with, with the same stated limit (it catches a clause moving; it does not certify a quote is byte-exact);
- the stage list is a **closed set held in code**, so a stage cannot be dropped from the inventory by deleting its row, which is the one edit that would make it read as complete while covering less;
- no row may be blank, and no ungoverned decision may carry a verdict outside the two-value set — the genuine-gap / no-record-warranted distinction is what makes a row a finding.

**No status is written into the fixture.** A row cites a record; whether that record is decided or open is read from the ledger at render time. "This stage is settled" is precisely the claim the audit exists to test, so it may not be a copied string.

The document restates none of README's ruleset and is guarded against doing so, as its sibling is.

## Out of scope, deliberately

Partition + typing is settled at the level of principle and in flight at the level of shipped behaviour. #1553 places it out of scope for re-litigation; its row is an index into the records rather than an invitation to reopen them.

Full local suite on this branch: 10456 passed, 0 failed. `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings` and the generated-doc `--check` gates all clean.

