### PR TITLE
fix(cli): reject an unrecognized --direction instead of silently 3'-shifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Default::default()` was the only reachable constructor — the two documented knobs could not be
   set by any downstream caller.
 
+### Fixed
+
+- **`ferro normalize --direction` now rejects an unrecognized value instead of silently 3'-shifting.**
+  The flag carried no `value_parser`, and the function behind it ends in a catch-all, so
+  `--direction banana` ran a **3'** normalization and exited **0** — producing output
+  byte-identical to `--direction 3prime`. Since direction changes the answer, a typo returned a
+  plausible result to a question the user did not ask. It is now a clap usage error naming the
+  accepted values.
+
+  This was the CLI half of the defect fixed for the Python bindings in 0.8.0; the CLI has its own
+  independent copy of the parsing logic, which was left untouched at the time. Both surfaces now
+  accept exactly the same set — `3prime`/`3'`/`3` and `5prime`/`5'`/`5`, case-insensitively — and
+  every previously-valid spelling still works.
+
+  `ferro_hgvs::cli::parse_shuffle_direction` is unchanged: it is public, doctested API, so
+  tightening its signature would be a breaking change. A direct Rust caller still receives
+  `ThreePrime` for an unrecognized string; `ferro_hgvs::python_helpers::parse_direction` is the
+  validating form.
+
 ## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
 
 ### Representation changes

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -283,8 +283,21 @@ UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
         #[arg(short = 'f', long, default_value = "text", value_parser = ["text", "json", "tsv"])]
         format: String,
 
-        /// Shuffle direction (3prime or 5prime)
-        #[arg(long, default_value = "3prime")]
+        /// Shuffle direction. `3prime`/`3'`/`3` or `5prime`/`5'`/`5`,
+        /// case-insensitively — the same set the Python bindings accept.
+        ///
+        /// The values are listed here rather than left to
+        /// `parse_shuffle_direction` because that function ends in a catch-all
+        /// (`_ => ThreePrime`): without a `value_parser`, `--direction banana`
+        /// silently 3'-shifted and exited 0 (#1863, the CLI half of #1016).
+        /// `ignore_case` is load-bearing — the function lowercases its input,
+        /// so `--direction 5PRIME` has always worked and must keep working.
+        #[arg(
+            long,
+            default_value = "3prime",
+            ignore_case = true,
+            value_parser = ["3prime", "3'", "3", "5prime", "5'", "5"]
+        )]
         direction: String,
 
         /// Reference directory (with manifest.json from 'ferro prepare')

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -37,6 +37,25 @@ pub fn parse_genome_build(build: &str) -> GenomeBuild {
 /// - 5prime, 5', 5 -> FivePrime
 /// - Other values default to ThreePrime
 ///
+/// # The lenient fallback is legacy, and is no longer how the CLI validates
+///
+/// The final arm accepts anything, which is why `ferro normalize --direction
+/// banana` used to 3'-shift and exit 0 (#1863, the CLI half of #1016). The flag
+/// now carries its own `value_parser` listing the six aliases, so **the
+/// fallback is unreachable from the CLI** and an unrecognized value is a clap
+/// usage error naming the accepted values.
+///
+/// The fallback is retained here, rather than made fallible, only because this
+/// function is public API — re-exported from [`crate::cli`] and doctested — so
+/// tightening its signature is a breaking change and a decision separate from
+/// the defect. It is also entangled with #1857, which may remove the 5'
+/// direction (and this function) outright.
+///
+/// **A direct Rust caller therefore still gets `ThreePrime` for an
+/// unrecognized string.** Prefer [`crate::python_helpers::parse_direction`],
+/// which returns `Option<ShuffleDirection>` and is what the Python bindings
+/// validate with; it accepts exactly the same six aliases, case-insensitively.
+///
 /// # Examples
 ///
 /// ```
@@ -45,11 +64,19 @@ pub fn parse_genome_build(build: &str) -> GenomeBuild {
 ///
 /// assert!(matches!(parse_shuffle_direction("3prime"), ShuffleDirection::ThreePrime));
 /// assert!(matches!(parse_shuffle_direction("5'"), ShuffleDirection::FivePrime));
+///
+/// // The legacy fallback, documented above. The CLI no longer reaches it —
+/// // `--direction unknown` is rejected by clap before this function is called.
 /// assert!(matches!(parse_shuffle_direction("unknown"), ShuffleDirection::ThreePrime));
 /// ```
 pub fn parse_shuffle_direction(direction: &str) -> ShuffleDirection {
     match direction.to_lowercase().as_str() {
         "5prime" | "5'" | "5" => ShuffleDirection::FivePrime,
+        // The 3' aliases are spelled out rather than left to the catch-all, so
+        // the mapping the CLI's `value_parser` promises is stated here too. The
+        // catch-all is the legacy fallback described above; it is not the route
+        // by which a valid 3' spelling resolves.
+        "3prime" | "3'" | "3" => ShuffleDirection::ThreePrime,
         _ => ShuffleDirection::ThreePrime,
     }
 }

--- a/tests/it/issue_1863_cli_direction_validation.rs
+++ b/tests/it/issue_1863_cli_direction_validation.rs
@@ -1,0 +1,152 @@
+//! CLI surface test for `ferro normalize --direction` (#1863).
+//!
+//! `--direction` was declared with no `value_parser`
+//! (`src/bin/ferro.rs:284-286` on `64fc76df`), and the function behind it,
+//! `parse_shuffle_direction` (`src/cli/parse.rs:50-55`), ended in
+//! `_ => ShuffleDirection::ThreePrime`. Between them, `ferro normalize
+//! --direction banana` ran a **3'** normalization and exited **0** — the user
+//! got a plausible answer to a question they did not ask.
+//!
+//! This is the CLI half of #1016. #1017 fixed the Python boundary only: it made
+//! `python_helpers::parse_direction` fallible and raised `PyValueError`, and its
+//! description notes that "`parse_direction` has no non-Python (pure-Rust/CLI)
+//! callers, so no core path needed changes". That is true of `parse_direction`
+//! itself, and is exactly why the CLI's independent near-duplicate was never
+//! brought into scope.
+//!
+//! **These tests must drive the binary, not the library.** The defect lives in
+//! the clap declaration — the seam between the flag and the parse function — so
+//! a library-level test calling `parse_shuffle_direction` directly would pass
+//! against the bug and keep passing after the fix. Only the binary witnesses the
+//! flag.
+//!
+//! No reference is needed. Argument validation happens before any provider is
+//! constructed, and `ferro normalize` already runs without `--reference` (see
+//! `cli_normalize_tsv.rs`), so both arms are cheap and hermetic.
+//!
+//! Scope note: this pins the CLI flag only. `pub fn parse_shuffle_direction`
+//! keeps its lenient fallback and its signature — it is public, re-exported at
+//! `src/cli/mod.rs:18`, and doctested, so tightening it is a SemVer decision
+//! rather than a bug fix, and it is entangled with the open question in #1857
+//! of whether the 5' direction survives at all. With clap validating upstream,
+//! the fallback is no longer reachable from the CLI.
+
+use std::process::Command;
+
+/// Every spelling the shipped parser resolves to a direction, and must keep
+/// resolving after the fix. The 3' forms are the load-bearing ones: on
+/// `origin/main` they are **not** matched explicitly — they resolve only by
+/// falling into the same catch-all that swallowed `banana` — so a fix that
+/// merely removed the catch-all without listing them would break the default.
+const VALID_DIRECTIONS: &[&str] = &[
+    "3prime", "3'", "3", "5prime", "5'", "5", // case-insensitive: `parse_shuffle_direction`
+    // lowercases its input, so these work today and must keep working.
+    "5PRIME", "5Prime", "3PRIME", "3Prime",
+];
+
+/// Values that must be rejected. `banana` is the reported case; the rest are the
+/// near-misses that motivated #1016 (a typo produces wrong-but-plausible
+/// output), plus the empty string.
+const INVALID_DIRECTIONS: &[&str] = &["banana", "5prim", "3prine", "five", "threeprime", ""];
+
+/// A variant that `ferro normalize` handles with no reference directory, taken
+/// from `cli_normalize_tsv.rs`.
+const VARIANT: &str = "NM_000088.3:c.16del";
+
+struct Run {
+    stdout: String,
+    stderr: String,
+    success: bool,
+}
+
+/// Run `ferro normalize --direction <direction> <VARIANT>`.
+fn normalize_with_direction(direction: &str) -> Run {
+    let out = Command::new(env!("CARGO_BIN_EXE_ferro"))
+        .args(["normalize", "--direction", direction, VARIANT])
+        .output()
+        .expect("run ferro normalize");
+    Run {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        success: out.status.success(),
+    }
+}
+
+/// The reported defect: an unrecognized `--direction` must be a hard failure,
+/// not a silent 3' run.
+#[test]
+fn an_unrecognized_direction_is_rejected() {
+    for bad in INVALID_DIRECTIONS {
+        let run = normalize_with_direction(bad);
+        assert!(
+            !run.success,
+            "`--direction {bad:?}` exited 0 — this is the #1863 bug: the flag has \
+             no value_parser and `parse_shuffle_direction` falls back to ThreePrime, \
+             so a bogus direction silently 3'-shifts. stdout: {:?} stderr: {:?}",
+            run.stdout, run.stderr
+        );
+    }
+}
+
+/// The rejection must name the accepted values, so the user can fix it without
+/// reading the source. This is what `--format` and `--error-mode` already do,
+/// and using clap's own `value_parser` is what makes the message consistent
+/// with them rather than hand-rolled.
+#[test]
+fn the_rejection_names_the_accepted_values() {
+    let run = normalize_with_direction("banana");
+    let combined = format!("{}{}", run.stdout, run.stderr);
+    assert!(
+        !run.success,
+        "`--direction banana` must fail; got: {combined:?}"
+    );
+    for expected in ["3prime", "5prime"] {
+        assert!(
+            combined.contains(expected),
+            "the rejection must name the accepted value {expected:?} so the user can \
+             correct the invocation; got: {combined:?}"
+        );
+    }
+}
+
+/// Every spelling the shipped parser accepted must keep working. Enumerated
+/// from `parse_shuffle_direction`'s match arms rather than from the `--help`
+/// text, because the 3' aliases are absent from the arms and survive only via
+/// the catch-all — guessing from the doc comment ("3prime or 5prime") would
+/// have silently dropped `3`, `3'`, and every mixed-case form.
+#[test]
+fn every_documented_spelling_is_still_accepted() {
+    for good in VALID_DIRECTIONS {
+        let run = normalize_with_direction(good);
+        assert!(
+            run.success,
+            "`--direction {good:?}` must still be accepted; stdout: {:?} stderr: {:?}",
+            run.stdout, run.stderr
+        );
+    }
+}
+
+/// The sharp shape of the regression, stated as a difference rather than as an
+/// exit code: before the fix, `--direction banana` produced output
+/// **byte-identical** to `--direction 3prime`. That equality is the defect — it
+/// is what "silently 3'-shifts" means — so it is asserted directly. An exit-code
+/// check alone would keep passing if a future change made garbage fail for some
+/// unrelated reason while still normalizing.
+#[test]
+fn an_unrecognized_direction_does_not_masquerade_as_three_prime() {
+    let three_prime = normalize_with_direction("3prime");
+    assert!(
+        three_prime.success,
+        "the control arm must succeed; stderr: {:?}",
+        three_prime.stderr
+    );
+
+    let garbage = normalize_with_direction("banana");
+    assert!(
+        !(garbage.success && garbage.stdout == three_prime.stdout),
+        "`--direction banana` produced the same successful output as \
+         `--direction 3prime` ({:?}) — the user asked for a direction that does \
+         not exist and was silently given 3'.",
+        three_prime.stdout
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -287,6 +287,7 @@ mod issue_1691_homopolymer_convergence;
 mod issue_1716_codon_frame_merged_span;
 mod issue_180_allele_3prime_shift;
 mod issue_182_postcanon_adjacency;
+mod issue_1863_cli_direction_validation;
 mod issue_207_multi_repeat_compound_roundtrip;
 mod issue_209_repeat_3prime_remaining;
 mod issue_214_repeat_unit_divides;


### PR DESCRIPTION
## Problem

`ferro normalize --direction <anything>` silently accepted an unrecognized value, ran a **3'** normalization, and exited **0**. Measured on `origin/main` at `64fc76df`, `--direction banana` produced output byte-identical to `--direction 3prime`:

```
$ ferro normalize --direction banana NM_000088.3:c.16del
NM_000088.3:c.16del -> NM_000088.3:c.19del      # rc=0
$ ferro normalize --direction 3prime NM_000088.3:c.16del
NM_000088.3:c.16del -> NM_000088.3:c.19del      # rc=0  — identical
$ ferro normalize --direction 5prime NM_000088.3:c.16del
NM_000088.3:c.16del                             # rc=0  — genuinely different
```

The user asked for a direction that does not exist and was given 3' without a word. Direction changes the answer, so this is a correctness footgun rather than an ergonomics one.

Two halves produced it:

- **`src/bin/ferro.rs:284-286`** declared the flag with no `value_parser`, unlike its immediate siblings — `format` at `:281` (`["text", "json", "tsv"]`) and `error_mode` at `:293` (`["strict", "lenient", "silent"]`). The omission was a local inconsistency, not a house style.
- **`src/cli/parse.rs:50-55`** ended in `_ => ShuffleDirection::ThreePrime`. Note the 3' spellings were **not** matched explicitly — they resolved only by falling into the same catch-all that swallowed `banana`.

## This is the CLI half of #1016

#1017 fixed the **Python** boundary only: it made `python_helpers::parse_direction` fallible (`src/python_helpers.rs:105-111`) and raised `PyValueError`. Its description reads "`parse_direction` has no non-Python (pure-Rust/CLI) callers, so no core path needed changes" — true of `parse_direction` itself, and exactly why the CLI's independent near-duplicate `parse_shuffle_direction` was never brought into scope. The two functions are separate copies of the same logic; only one was fixed. This closes the other.

**Should the Rust fix mirror the Python one or differ?** It should differ in *mechanism* and agree on *policy*. Python must validate at runtime because an arbitrary string arrives at the API boundary, so a hand-written `Option` + `PyValueError` is the only option there. The CLI has clap, which rejects before any code runs and produces the same usage error as every other constrained flag — so this uses `value_parser` rather than hand-rolling a check, per the brief. The **accepted value set is identical** to Python's, deliberately, so the two surfaces cannot drift.

## Fix

`--direction` now carries clap's own `value_parser` listing the six aliases, plus `ignore_case = true`:

```rust
#[arg(
    long,
    default_value = "3prime",
    ignore_case = true,
    value_parser = ["3prime", "3'", "3", "5prime", "5'", "5"]
)]
direction: String,
```

`ignore_case` is not decoration: `parse_shuffle_direction` lowercases its input, so `--direction 5PRIME` works on `main` today and dropping it would be a gratuitous break. The rejection is now a standard clap error naming the accepted values, and exits **2**:

```
error: invalid value 'banana' for '--direction <DIRECTION>'
  [possible values: 3prime, 3', 3, 5prime, 5', 5]
```

## Why this is worth doing now

Beyond the silent-failure bug itself: #1857 records that the 5' direction is adjudicated by nothing, and its removal is under consideration (scoping report exists). **With the catch-all reachable, removing the 5' direction would turn every existing `--direction 5prime` invocation into a silent 3' run** rather than a clear error — converting a deprecation into data corruption at the customer. This PR is a precondition for that removal and stands on its own regardless of whether it happens.

**This PR does not remove the 5' direction.** That decision is the operator's and remains open in #1857.

## `parse_shuffle_direction` is public API — and is deliberately left alone

It is `pub`, re-exported at `src/cli/mod.rs:18`, and **doctested**, so it is documented API. Its signature and behaviour are **unchanged** here, which makes this PR non-breaking: no SemVer bump is implied, and no downstream caller can be affected.

That is a deliberate scoping decision rather than an oversight, for three reasons:

1. **It buys nothing for this defect.** With clap validating upstream, the catch-all is unreachable from the CLI — the surface the issue is about.
2. **Tightening it to `Option<ShuffleDirection>` (mirroring `python_helpers::parse_direction`) is a breaking change to a documented public function.** At `0.13.1` that is a `0.14.0` minor bump under Cargo's SemVer rules. Shipping that inside a bug-fix PR is a bigger decision than the bug, and it belongs to the operator.
3. **It may be moot.** #1857 may delete the function outright; the scoping report already lists it as a straight API deletion.

So the residual library-level hole — a Rust caller of `ferro_hgvs::cli::parse_shuffle_direction("banana")` still gets `ThreePrime` — is **disclosed, not fixed**. The function's doc comment now says so, points at `python_helpers::parse_direction` as the validating form, and records that the CLI no longer depends on the fallback. If you would rather take the breaking change now, say so and I will fold it in.

## Tests

`tests/it/issue_1863_cli_direction_validation.rs` drives the **binary**, not the library — the defect lives in the clap declaration, so a library-level test calling `parse_shuffle_direction` directly would pass against the bug and keep passing after the fix. No reference is needed; argument validation precedes provider construction.

- `an_unrecognized_direction_is_rejected` — `banana`, `5prim`, `3prine`, `five`, `threeprime` and `""` all exit non-zero.
- `the_rejection_names_the_accepted_values` — the message contains `3prime` and `5prime`.
- `every_documented_spelling_is_still_accepted` — all ten currently-working spellings.
- `an_unrecognized_direction_does_not_masquerade_as_three_prime` — asserts the *difference*, since the defect is precisely that garbage produced output byte-identical to `3prime`. An exit-code check alone would keep passing if garbage later failed for some unrelated reason while still normalizing.

The valid spellings were enumerated **from the match arms**, not from the flag's doc comment ("3prime or 5prime") — guessing from the docs would have silently dropped `3`, `3'`, and every mixed-case form, since those survive only via the catch-all being removed.

## Verification

The tests were watched red before the fix, on the unfixed tree at `64fc76df`:

```
Summary [2.246s] 4 tests run: 1 passed, 3 failed, 10783 skipped

  `--direction "banana"` exited 0 — this is the #1863 bug: the flag has no value_parser
  and `parse_shuffle_direction` falls back to ThreePrime, so a bogus direction silently
  3'-shifts. stdout: "NM_000088.3:c.16del -> NM_000088.3:c.19del\n"
```

The one that passed is `every_documented_spelling_is_still_accepted` — the control arm, which must be green on both sides, and is what shows the other three are not trivially red.

After the fix:

```
$ ferro normalize --direction banana NM_000088.3:c.16del
error: invalid value 'banana' for '--direction <DIRECTION>'
  [possible values: 3prime, 3', 3, 5prime, 5', 5]
rc=2
```

and all ten spellings still resolve, with 3' and 5' still producing genuinely different output (`c.19del` vs `c.16del`).

Full local gate, each exit status read back out of its own log rather than from the runner's notification:

| check | result |
|---|---|
| `cargo nextest run --features dev --lib --test it --no-fail-fast` | `SUITE_EXIT=0` — 10444 passed, 0 failed |
| `cargo test --features dev --doc parse_shuffle_direction` | `DOCTEST_EXIT=0` — 1 passed |
| `cargo fmt --all --check` | `FMT_EXIT=0` |
| `cargo clippy --all-features --all-targets -- -D warnings` | `CLIPPY_EXIT=0` |

Closes #1863

Representation-Change: none. Input validation only — `src/bin/ferro.rs` and `src/cli/parse.rs` docs; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, and every valid direction produces the same output it did before. The only behaviour change is that a previously silently-accepted invalid value is now rejected, which moves no normalized row.
