### PR TITLE
test: give the five real-data normalization guards assertions that can fail

### DIFF
--- a/tests/it/real_data_normalization_tests.rs
+++ b/tests/it/real_data_normalization_tests.rs
@@ -6,15 +6,72 @@
 //! `FERRO_REQUIRE_MANIFEST` standing down is a failure, whether the manifest is
 //! absent or merely does not carry the transcript a guard names.
 //!
-//! **That promotion buys execution, not verification.** Three of the five
-//! guards below (`test_potential_bug_deletion_shift_nm033517`,
-//! `test_potential_bug_delins_shift`, `test_5utr_duplication_shifting`) contain
-//! no assertion at all — they are investigation scripts that print — and
-//! `test_compare_with_mutalyzer_sequence` keeps both of its assertions inside a
-//! bounds check, so an out-of-range coordinate leaves it asserting nothing.
-//! Tracked as #1858; do not read a green run here as coverage of those four.
+//! **That promotion bought execution, not verification, and #1858 is the
+//! difference.** Three of these guards used to carry no assertion at all — they
+//! were investigation scripts that printed a finding and returned successfully,
+//! so the condition each existed to detect was reported by *passing* — and
+//! `test_compare_with_mutalyzer_sequence` kept both of its assertions inside a
+//! bounds check. This module now asserts, and what each guard asserts is chosen
+//! by what the reference can actually decide.
+//!
+//! # The one property that needs no adjudication
+//!
+//! Which of two legal spellings ferro ships is a rule 6 choice (`README.md`'s
+//! ruleset) and needs an operator to settle. Whether the shipped spelling still
+//! denotes the input's bases is rule 1, and a failure there is a bug under
+//! every reading of the recommendations. So [`assert_denotes_the_same_bases`]
+//! carries the load wherever the spelling question is open, and no guard here
+//! pins a string that nobody has justified.
+//!
+//! # `unwrap_or(1)` is removed because it *can* fabricate, not because it did
+//!
+//! Every guard used to read its CDS origin as `transcript.cds_start
+//! .unwrap_or(1)`. That substitutes an origin when the reference serves none,
+//! and the substituted coordinates print exactly like real ones — a guard
+//! reporting `c.1324` would be naming a base the description does not name,
+//! with nothing in its output saying so. The fallback is gone; an unserved CDS
+//! now routes through [`cds_start_or_skip`], which stands the guard down and
+//! records it.
+//!
+//! **On the blessed reference that branch is dead, and this is the correction
+//! of a claim this module previously shipped as measured fact.** It stated that
+//! `NM_033517` is served as bare sequence with no cdot record —
+//! `cds_start: None`, `cds_end: None`, zero exons. Re-measured 2026-08-14
+//! against both prepared volumes, all four accessions this module names come
+//! back annotated:
+//!
+//! ```text
+//! NM_033517.1/.2/.3  cds_start=Some(1)   cds_end=Some(5157)  exons=22  len=7113
+//! NM_001408491.1     cds_start=Some(296) cds_end=Some(2365)  exons=23  len=3748
+//! NM_001282424.3     cds_start=Some(169) cds_end=Some(3060)  exons=25  len=3791
+//! NM_001394148.2     cds_start=Some(137) cds_end=Some(328)   exons=3   len=570
+//! ```
+//!
+//! `NM_033517`'s cdot record carries `start_codon: 0`, so `cds_start` is 1 and
+//! a `c.N` on it resolves to transcript offset `N` — the old fallback happened
+//! to agree with the reference here rather than fabricate against it. Only the
+//! length (7113) survives from the withdrawn reading. Removing the fallback is
+//! still right, and [`cds_start_or_skip`] is still the right shape; what is
+//! withdrawn is the claim that anything was observed going through it.
+//!
+//! Note `cds_end` is the one figure above that is **cdot-version-dependent**,
+//! and nothing here keys on it. Read out of both cdot builds directly:
+//! `data_v0.2.32` — the version the prepared manifest pins — collapses this
+//! accession's 39-base alignment gap (transcript 1302..1342, between exons 10
+//! and 11) into the stop codon and records `stop_codon: 5157`, while
+//! `data_v0.2.34` records `stop_codon: 5196`, which is what RefSeq/GenBank
+//! annotate (`CDS 1..5196`). That discrepancy is the open sibling of
+//! `rulings[c-and-n-positions-are-flat-transcript-offsets]` and is not this
+//! module's business.
+//!
+//! **Both versions carry the record**, with 22 exons and `start_codon: 0`, so
+//! `cds_start` is 1 either way and no cdot in play yields the record-less state
+//! the withdrawn reading described. The correction above therefore does not
+//! depend on which cdot the reference was prepared from.
 
+use ferro_hgvs::hgvs::HgvsVariant;
 use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::spdi::{compare_denoted_sequences, DenotedSequenceComparison};
 use ferro_hgvs::{parse_hgvs, MultiFastaProvider, Normalizer, ReferenceProvider};
 use std::path::Path;
 use std::sync::Arc;
@@ -79,6 +136,97 @@ fn transcript_or_skip(provider: &MultiFastaProvider, accession: &str) -> Option<
     }
 }
 
+/// The transcript's CDS origin, or `None` after recording the stand-down.
+///
+/// **Never substitute a default here.** `cds_start.unwrap_or(1)` turns "the
+/// reference cannot resolve this accession's `c.` axis" into "every `c.N` is
+/// transcript offset `N`" — real bases, at coordinates the description does not
+/// name, printed identically to a resolved reading. A guard that publishes a
+/// ferro-versus-Mutalyzer verdict off that has measured something other than
+/// what it reports, and nothing in its output distinguishes the two.
+///
+/// **No accession this module names currently reaches the `None` branch** — see
+/// the module header for the measured `cds_start` of all four. So this is a
+/// safety net rather than a repair of an observed failure, and it must not be
+/// cited as evidence that one occurred. It earns its place from the shape of
+/// the failure it removes, not from a sighting: a stand-down is loud and a
+/// substituted origin is silent, and #1858 is the record of what silence costs.
+/// Since #1870, `Normalizer::normalize` refuses a `c.` description against an
+/// unresolvable CDS rather than answering, so the branch would now be reached
+/// before the normalizer is asked
+/// (`rulings[c-description-against-an-unresolvable-cds-is-refused]`).
+///
+/// A served sequence with no served CDS is the same coverage loss as an
+/// unserved transcript one level up, so it is promoted by the same
+/// `FERRO_REQUIRE_MANIFEST` and through the same
+/// `ferro_hgvs::conformance::manifest_gate::unserved`.
+fn cds_start_or_skip(transcript: &Transcript, accession: &str) -> Option<u64> {
+    match transcript.cds_start {
+        Some(cds_start) => Some(cds_start),
+        None => {
+            crate::common::manifest::unserved(
+                MODULE,
+                &format!("{accession} CDS annotation"),
+                "the reference serves this accession's bases but no cdot record, so it has no \
+                 CDS origin and a `c.` position does not resolve",
+            );
+            None
+        }
+    }
+}
+
+/// The transcript's cached bases, or `None` after recording the stand-down.
+fn bases_or_skip<'a>(transcript: &'a Transcript, accession: &str) -> Option<&'a [u8]> {
+    match transcript.sequence.as_deref() {
+        Some(sequence) => Some(sequence.as_bytes()),
+        None => {
+            crate::common::manifest::unserved(
+                MODULE,
+                &format!("{accession} cached bases"),
+                "the reference serves this accession's metadata but not its sequence",
+            );
+            None
+        }
+    }
+}
+
+/// Fail unless normalization left the bases the description denotes untouched.
+///
+/// Asserts on the **bases** rather than on the output string, so it keeps its
+/// meaning if a canonical spelling is ever revised: the property is that
+/// normalization does not change what the description means, which is rule 1 of
+/// `README.md`'s ruleset and is not open to a rule 6 choice. That makes it the
+/// assertion the guards below can carry without an operator settling which of
+/// two conformant spellings ferro should ship.
+///
+/// A `NotComparable` verdict is a **panic**, not a pass. This module exists
+/// because a guard that declines to check reads exactly like a guard that
+/// checked and agreed (#1858), and folding the skips in with the agreements
+/// would rebuild that hole inside the very helper meant to close it.
+fn assert_denotes_the_same_bases(
+    provider: &MultiFastaProvider,
+    input: &HgvsVariant,
+    output: &HgvsVariant,
+) {
+    match compare_denoted_sequences(input, output, provider) {
+        DenotedSequenceComparison::Agree => {}
+        DenotedSequenceComparison::Differ {
+            accession,
+            start,
+            reference,
+            from_input,
+            from_output,
+        } => panic!(
+            "normalization changed the sequence the description denotes\n  input     {input}\n  \
+             output    {output}\n  over {accession} from {start}\n  reference   {reference}\n  \
+             from input  {from_input}\n  from output {from_output}"
+        ),
+        other => panic!(
+            "expected a base-level verdict, got {other:?}\n  input  {input}\n  output {output}"
+        ),
+    }
+}
+
 #[test]
 fn test_nm_001408491_c517dela_should_shift() {
     // This test reproduces the issue found in mutalyzer comparison:
@@ -114,7 +262,9 @@ fn test_nm_001408491_c517dela_should_shift() {
     }
 
     // Calculate transcript positions for c.517 and c.518
-    let cds_start = transcript.cds_start.unwrap_or(1);
+    let Some(cds_start) = cds_start_or_skip(&transcript, "NM_001408491.1") else {
+        return;
+    };
     let tx_pos_517 = cds_start + 517 - 1; // c.517 -> tx position
     let tx_pos_518 = cds_start + 518 - 1; // c.518 -> tx position
 
@@ -132,38 +282,47 @@ fn test_nm_001408491_c517dela_should_shift() {
     );
 
     // Get the bases at these positions
-    let seq = transcript
-        .sequence
-        .as_deref()
-        .expect("real-data test requires cached transcript bases")
-        .as_bytes();
+    let Some(seq) = bases_or_skip(&transcript, "NM_001408491.1") else {
+        return;
+    };
     let idx_517 = (tx_pos_517 - 1) as usize; // 0-based
     let idx_518 = (tx_pos_518 - 1) as usize; // 0-based
 
-    if idx_517 < seq.len() && idx_518 < seq.len() {
-        println!("\nSequence around c.517-518:");
-        // Show context
-        let start = idx_517.saturating_sub(3);
-        let end = (idx_518 + 4).min(seq.len());
-        let context: String = seq[start..end].iter().map(|&b| b as char).collect();
-        println!("  ... {} ...", context);
-        println!(
-            "  c.517 (tx pos {}, 0-based {}): {}",
-            tx_pos_517, idx_517, seq[idx_517] as char
-        );
-        println!(
-            "  c.518 (tx pos {}, 0-based {}): {}",
-            tx_pos_518, idx_518, seq[idx_518] as char
-        );
+    // Asserted rather than tested, for the reason given on the same bound in
+    // `test_compare_with_mutalyzer_sequence`: skipping the premise check when
+    // the premise is unavailable is how a guard passes without checking.
+    assert!(
+        idx_517 < seq.len() && idx_518 < seq.len(),
+        "c.517/c.518 are past the end of NM_001408491.1 ({} bases): the reference no longer \
+         carries the coordinates this guard is about",
+        seq.len()
+    );
 
-        // The key assertion: both should be 'A' for the 3' shift to apply
-        if seq[idx_517] == b'A' && seq[idx_518] == b'A' {
-            println!("\n  CONFIRMED: Both c.517 and c.518 are 'A'");
-            println!("  According to 3' rule, c.517delA should shift to c.518del");
-        }
-    } else {
-        eprintln!("Position out of range!");
-    }
+    println!("\nSequence around c.517-518:");
+    // Show context
+    let start = idx_517.saturating_sub(3);
+    let end = (idx_518 + 4).min(seq.len());
+    let context: String = seq[start..end].iter().map(|&b| b as char).collect();
+    println!("  ... {} ...", context);
+    println!(
+        "  c.517 (tx pos {}, 0-based {}): {}",
+        tx_pos_517, idx_517, seq[idx_517] as char
+    );
+    println!(
+        "  c.518 (tx pos {}, 0-based {}): {}",
+        tx_pos_518, idx_518, seq[idx_518] as char
+    );
+
+    // The premise the 3' shift rests on: the two bases must be equal, or
+    // moving the deletion between them would change what it denotes. Checked
+    // here rather than printed, so a reference that stopped satisfying it
+    // could not leave the assertion below passing for the wrong reason.
+    assert_eq!(
+        seq[idx_517], seq[idx_518],
+        "c.517 ({}) and c.518 ({}) differ, so no 3' shift between them is sequence-preserving \
+         and the expectation below no longer follows from the reference",
+        seq[idx_517] as char, seq[idx_518] as char
+    );
 
     // Find which exon contains c.517
     println!("\nExon containing c.517 (tx pos {}):", tx_pos_517);
@@ -195,12 +354,56 @@ fn test_nm_001408491_c517dela_should_shift() {
         "Expected c.517delA to normalize to c.518del (3' rule), got: {}",
         output
     );
+
+    // …and that the re-spelling is sequence-preserving. The assertion above
+    // fixes the string; this one fixes its meaning, so a future change that
+    // moved the deletion to c.518 by some route that also changed the bases
+    // could not satisfy the guard.
+    assert_denotes_the_same_bases(normalizer.provider(), &variant, &result);
 }
 
+/// The guard's original question — "ferro outputs `c.1324del`, Mutalyzer
+/// outputs `c.1326del`, one of these is wrong about 3' shifting" — **is
+/// answered: they agree, and the disagreement the comment recorded no longer
+/// occurs.**
+///
+/// Measured 2026-08-14 against both prepared volumes, `NM_033517.1:c.1324del`
+/// normalizes to **`NM_033517.1:c.1326del`** — the Mutalyzer answer. It is a
+/// real 3' shift and the reference says why: `c.1324`, `c.1325` and `c.1326`
+/// are all `C`, `c.1327` is `G`, so the deleted base moves to the 3' end of a
+/// `CCC` run and stops there. Four further deletions on this accession shift in
+/// the same run — `c.125del` -> `c.127del`, `c.160del` -> `c.162del`,
+/// `c.164del` -> `c.167del`, `c.517del` -> `c.518del` — so the 3' rule is
+/// plainly reaching this transcript.
+///
+/// **An earlier version of this comment said the opposite, and the retraction
+/// is left in place on purpose.** It claimed the reference serves this
+/// accession as bare FASTA with `cds_start: None`, `cds_end: None` and zero
+/// exons, and that `c.1324del` therefore came back unchanged as a passthrough
+/// rather than a 3'-rule decision. None of that reproduces: the module header
+/// carries the measured annotation for all four accessions, `cds_start` is
+/// `Some(1)`, and every input listed above shifts. So there is no CDS-less
+/// state here, no fabricated coordinate, and no ferro-versus-Mutalyzer
+/// disagreement — and correspondingly no open question for an operator about
+/// whether `ferro prepare` should serve `NM_033517` with a cdot record. It
+/// does.
+///
+/// **Why the guard still asserts sequence preservation rather than pinning
+/// `c.1326del`.** Nothing about the measurement forbids the pin — it would be
+/// stable across the cdot versions in play, since `cds_start` is 1 under both
+/// and the shift is decided by bases rather than by the `cds_end` those
+/// versions disagree on. It is not added because this module's policy (see the
+/// header) is that a guard here carries the rule 1 property, which needs no
+/// adjudication, and leaves the choice of spelling to whoever adjudicates it;
+/// `assert_denotes_the_same_bases` fails for any shift out of the `CCC` run,
+/// which is how a 3'-rule defect actually presents. Pinning the string is a
+/// separate, defensible change and should be argued as one.
+///
+/// `#1619` is the neighbouring work on this accession, but it runs on
+/// `MockProvider` and a committed fixture, so it says nothing about what the
+/// prepared reference serves.
 #[test]
 fn test_potential_bug_deletion_shift_nm033517() {
-    // Investigate: ferro outputs c.1324del, mutalyzer outputs c.1326del
-    // One of these is wrong about 3' shifting
     let Some(provider) = get_provider() else {
         crate::common::manifest::absent(MODULE);
         return;
@@ -210,12 +413,16 @@ fn test_potential_bug_deletion_shift_nm033517() {
         return;
     };
 
-    let cds_start = transcript.cds_start.unwrap_or(1);
-    let seq = transcript
-        .sequence
-        .as_deref()
-        .expect("real-data test requires cached transcript bases")
-        .as_bytes();
+    // Resolves to 1 on the blessed reference — this does not stand down, and an
+    // earlier version of this comment claiming it did is withdrawn (see the doc
+    // comment above). The call stays because the guard must not substitute an
+    // origin the reference did not give it, whatever today's reference gives.
+    let Some(cds_start) = cds_start_or_skip(&transcript, "NM_033517.1") else {
+        return;
+    };
+    let Some(seq) = bases_or_skip(&transcript, "NM_033517.1") else {
+        return;
+    };
 
     // Check c.1324, c.1325, c.1326
     for pos in 1324..=1328 {
@@ -229,23 +436,58 @@ fn test_potential_bug_deletion_shift_nm033517() {
         }
     }
 
-    // The 3' rule: if there are consecutive identical bases, shift to rightmost
-    // If c.1324-1326 are all the same base, the deletion should be at c.1326
     let normalizer = Normalizer::new(provider);
     let variant = parse_hgvs("NM_033517.1:c.1324del").unwrap();
     let result = normalizer.normalize(&variant).unwrap();
     println!("\nInput:  NM_033517.1:c.1324del");
     println!("Output: {}", result);
+
+    // What is assertable without settling either open question above: whichever
+    // position ferro names, it must denote the bases the input denotes. A 3'
+    // shift within a run is sequence-preserving by construction, so this passes
+    // for `c.1324del` and for `c.1326del` alike and takes no side between them
+    // — while a shift that landed outside the run, which is the way a 3'-rule
+    // defect actually goes wrong, fails it.
+    assert_denotes_the_same_bases(normalizer.provider(), &variant, &result);
 }
 
+/// Whether ferro may re-spell `NM_001282424.3:c.2139_2140delinsTATGCA`.
+///
+/// **The guard's original premise is withdrawn.** It read "HGVS spec: delins
+/// should NOT be 3' shifted like del/dup", which grades a description by its
+/// *edit type* — a property of the input's spelling. `README.md` rule 3 says
+/// every rule is evaluated over the resulting sequence "never over the input's
+/// spelling", and `canonical-form-choice-when-both-legal` (decided 2026-08-07)
+/// says ferro derives from the resulting sequence and emits what falls out. So
+/// "delins does not shift" is not a rule this project holds, and the guard
+/// cannot be repaired by asserting it.
+///
+/// **What it was really written to catch is still real, and is now asserted.**
+/// The feared output, `c.2140_2141delinsTATGCA`, does not denote the input's
+/// bases. Over the measured reference (`c.2138` = A, `c.2139` = G, `c.2140` =
+/// C, `c.2141` = T) the input yields `A TATGCA T` while that spelling yields
+/// `A G TATGCA T` — a different sequence, so it would be a rule 1 violation
+/// rather than a debatable choice. [`assert_denotes_the_same_bases`] is exactly
+/// the test that separates the two, and it needs no ruling to do it.
+///
+/// Measured 2026-08-13, ferro emits neither form: it returns
+/// `c.[2138_2139insTAT;2140_2141insA]`, a two-insertion split that leaves the
+/// reference's `GC` at `c.2139_2140` in place and is sequence-preserving. That
+/// is what re-derivation produces here, and it is the form the ledger predicts
+/// — this is a **net insertion** (6 payload bases for a 2-base span), and
+/// `delins-merge-vs-individual-gap-two-or-more` scopes the merge ruling to the
+/// net-deletion case, leaving `general.md:34`'s individual description
+/// governing. The exact spelling is deliberately **not** pinned here: it is a
+/// rule 6 choice, and this module is not where that gets decided.
+///
+/// The old body ended by printing "POTENTIAL BUG: Ferro shifted delins from
+/// 2139_2140 to 2140_2141" whenever the output contained `2140_2141`. That
+/// substring now matches the `insA` member of a correct split, so the warning
+/// fired on conforming output — a detector that had gone wrong in both
+/// directions at once, reporting its finding by passing and reporting the wrong
+/// finding as well.
 #[test]
 fn test_potential_bug_delins_shift() {
-    // Investigate: ferro shifts delins positions
-    // Input:     c.2139_2140delinsTATGCA
-    // Ferro:     c.2140_2141delinsTATGCA
-    // Mutalyzer: c.2139_2140delinsTATGCA
-    //
-    // HGVS spec: delins should NOT be 3' shifted like del/dup
     let Some(provider) = get_provider() else {
         crate::common::manifest::absent(MODULE);
         return;
@@ -255,12 +497,12 @@ fn test_potential_bug_delins_shift() {
         return;
     };
 
-    let cds_start = transcript.cds_start.unwrap_or(1);
-    let seq = transcript
-        .sequence
-        .as_deref()
-        .expect("real-data test requires cached transcript bases")
-        .as_bytes();
+    let Some(cds_start) = cds_start_or_skip(&transcript, "NM_001282424.3") else {
+        return;
+    };
+    let Some(seq) = bases_or_skip(&transcript, "NM_001282424.3") else {
+        return;
+    };
 
     // Check sequence around c.2139-2141
     println!("Sequence around c.2139-2141:");
@@ -281,24 +523,38 @@ fn test_potential_bug_delins_shift() {
     println!("\nInput:  NM_001282424.3:c.2139_2140delinsTATGCA");
     println!("Output: {}", result);
 
-    // Check if ferro is incorrectly shifting delins
-    let output = format!("{}", result);
-    if output.contains("2140_2141") {
-        println!("\n⚠️  POTENTIAL BUG: Ferro shifted delins from 2139_2140 to 2140_2141");
-        println!("    HGVS spec says delins should use original position, not shift");
-    }
+    // The assertion the printed warning should always have been: not "did the
+    // span move" but "does the output still mean what the input meant". It
+    // fires on `c.2140_2141delinsTATGCA` — the shift the guard was named for —
+    // and stays silent for any re-spelling that denotes the same bases.
+    assert_denotes_the_same_bases(normalizer.provider(), &variant, &result);
 }
 
+/// **This input cannot answer the question the guard was written to ask, and
+/// that is now asserted rather than left as a note.**
+///
+/// The question was "does the 3' rule reach the 5'UTR (negative coordinates)?",
+/// posed because ferro once emitted `c.-55_-46dup` where Mutalyzer emitted
+/// `c.-56_-47dup`. It is a real question. This input does not discriminate it,
+/// because over the measured reference the duplicated unit cannot rotate 3' at
+/// all: a duplication of `[a, b]` may be re-spelled `[a+1, b+1]` only when
+/// `seq[a] == seq[b+1]`, and here `c.-56` is `T` while `c.-46` is `G`. Both
+/// readings of the 5'UTR question therefore predict the same output, so a green
+/// run is evidence about neither. The old body said the answer "depends on HGVS
+/// spec interpretation" and asserted nothing; the non-discrimination is
+/// checkable, so it is checked.
+///
+/// **What the guard does still cover, and why it is worth keeping.** The 1-base
+/// difference it was filed for was never a 3'-rule ruling — it was an off-by-one
+/// in the 5'UTR CDS-to-transcript mapping, fixed in #97. So this is a
+/// coordinate-mapping regression guard, and the shift it must not see is
+/// arithmetic rather than adjudicated. The expected string is not invented
+/// here: `normalize_tests::clinvar_normalization` already pins this exact input
+/// to this exact output hermetically, and this guard re-checks it against the
+/// real prepared reference — a different provider, a different coordinate path,
+/// the same answer.
 #[test]
 fn test_5utr_duplication_shifting() {
-    // Investigate: ferro shifts 5'UTR duplications, mutalyzer doesn't
-    // Input:     c.-56_-47dup
-    // Ferro:     c.-55_-46dup
-    // Mutalyzer: c.-56_-47dup
-    //
-    // Question: Does 3' rule apply to 5'UTR (negative coordinates)?
-    // In 5'UTR, the 3' direction is towards the start codon (+1)
-    // So -55 is more 3' than -56
     let Some(provider) = get_provider() else {
         crate::common::manifest::absent(MODULE);
         return;
@@ -308,12 +564,12 @@ fn test_5utr_duplication_shifting() {
         return;
     };
 
-    let cds_start = transcript.cds_start.unwrap_or(1);
-    let seq = transcript
-        .sequence
-        .as_deref()
-        .expect("real-data test requires cached transcript bases")
-        .as_bytes();
+    let Some(cds_start) = cds_start_or_skip(&transcript, "NM_001394148.2") else {
+        return;
+    };
+    let Some(seq) = bases_or_skip(&transcript, "NM_001394148.2") else {
+        return;
+    };
 
     // Check sequence around c.-56 to c.-45
     println!("CDS start: {}", cds_start);
@@ -332,15 +588,51 @@ fn test_5utr_duplication_shifting() {
         }
     }
 
+    // `c.-N` resolves to transcript position `cds_start + (-N)`, so the
+    // duplicated unit c.-56_-47 occupies these two 0-based bounds.
+    let idx_first = (cds_start as i64 - 56 - 1) as usize;
+    let idx_last = (cds_start as i64 - 47 - 1) as usize;
+    assert!(
+        idx_last + 1 < seq.len(),
+        "c.-47 and its 3' neighbour are past the end of NM_001394148.2 ({} bases)",
+        seq.len()
+    );
+
+    // The non-discrimination, asserted. If this ever fails, the reference has
+    // changed such that a 3' rotation *is* available, this input starts telling
+    // the two readings apart, and the expectation below must be re-derived
+    // rather than kept — so the failure is the signal to reopen the question,
+    // not a defect to route around.
+    assert_ne!(
+        seq[idx_first],
+        seq[idx_last + 1],
+        "c.-56 ({}) and c.-46 ({}) are equal, so the duplicated unit CAN be re-spelled one base \
+         3' and this input now discriminates whether the 3' rule reaches the 5'UTR — a question \
+         this guard has never answered. Re-derive the expectation; do not update it to match.",
+        seq[idx_first] as char,
+        seq[idx_last + 1] as char
+    );
+
     let normalizer = Normalizer::new(provider);
     let variant = parse_hgvs("NM_001394148.2:c.-56_-47dup").unwrap();
     let result = normalizer.normalize(&variant).unwrap();
     println!("\nInput:  NM_001394148.2:c.-56_-47dup");
     println!("Output: {}", result);
 
-    // Note: The correct behavior depends on HGVS spec interpretation
-    // If 3' rule applies to 5'UTR, ferro is correct (shift towards +1)
-    // If 3' rule doesn't apply to 5'UTR, mutalyzer is correct
+    // No rotation exists, so the input is already the only spelling of this
+    // duplication — which makes this a pin on the 5'UTR coordinate arithmetic
+    // (#97), not on a normalization preference. It cross-checks the hermetic
+    // pin in `normalize_tests::clinvar_normalization` against the real
+    // reference.
+    assert_eq!(
+        result.to_string(),
+        "NM_001394148.2:c.-56_-47dup",
+        "the 5'UTR duplication moved, but the assertion above says no sequence-preserving \
+         re-spelling exists — so this is the #97 CDS-to-transcript off-by-one, not a 3'-rule \
+         choice"
+    );
+
+    assert_denotes_the_same_bases(normalizer.provider(), &variant, &result);
 }
 
 #[test]
@@ -360,33 +652,49 @@ fn test_compare_with_mutalyzer_sequence() {
     // - This means the deleted base shifts from c.517 to c.518
     // - This is only correct if c.517 == c.518 (both are the same base)
 
-    let cds_start = transcript.cds_start.unwrap_or(1);
+    let Some(cds_start) = cds_start_or_skip(&transcript, "NM_001408491.1") else {
+        return;
+    };
     let tx_pos_517 = cds_start + 517 - 1;
     let tx_pos_518 = cds_start + 518 - 1;
 
-    let seq = transcript
-        .sequence
-        .as_deref()
-        .expect("real-data test requires cached transcript bases")
-        .as_bytes();
+    let Some(seq) = bases_or_skip(&transcript, "NM_001408491.1") else {
+        return;
+    };
     let idx_517 = (tx_pos_517 - 1) as usize;
     let idx_518 = (tx_pos_518 - 1) as usize;
 
-    if idx_517 < seq.len() && idx_518 < seq.len() {
-        let base_517 = seq[idx_517] as char;
-        let base_518 = seq[idx_518] as char;
+    // This was an `if`, and the two assertions below were its body — so the one
+    // condition it exists to detect, a coordinate the reference cannot serve,
+    // used to leave the whole test asserting nothing and passing (#1858).
+    //
+    // On the blessed reference the bound is never false, and measurably so:
+    // `NM_001408491.1` is 3748 bases with `cds_start` 296, putting these two at
+    // 0-based 811 and 812 — inside by a factor of four. So the change is not
+    // fixing a live failure; it is removing the one way this guard could go
+    // quiet, which is precisely the shape that cannot be seen from a run's
+    // duration or its pass/fail.
+    assert!(
+        idx_517 < seq.len() && idx_518 < seq.len(),
+        "c.517 (0-based {idx_517}) and c.518 (0-based {idx_518}) must both be inside \
+         NM_001408491.1, which is {} bases: a reference that no longer serves them cannot \
+         support the comparison this guard makes, and must not pass it by skipping",
+        seq.len()
+    );
 
-        println!("cdot sequence at c.517: {}", base_517);
-        println!("cdot sequence at c.518: {}", base_518);
+    let base_517 = seq[idx_517] as char;
+    let base_518 = seq[idx_518] as char;
 
-        // For the mutalyzer result to be correct, both must be 'A'
-        assert_eq!(
-            base_517, 'A',
-            "Expected c.517 to be 'A' per mutalyzer result"
-        );
-        assert_eq!(
-            base_518, 'A',
-            "Expected c.518 to be 'A' for 3' shift to be valid"
-        );
-    }
+    println!("cdot sequence at c.517: {}", base_517);
+    println!("cdot sequence at c.518: {}", base_518);
+
+    // For the mutalyzer result to be correct, both must be 'A'
+    assert_eq!(
+        base_517, 'A',
+        "Expected c.517 to be 'A' per mutalyzer result"
+    );
+    assert_eq!(
+        base_518, 'A',
+        "Expected c.518 to be 'A' for 3' shift to be valid"
+    );
 }


### PR DESCRIPTION
Was stacked on #1861, which has since squash-merged as `471c1217`. Rebased with `git rebase --onto origin/main <old-parent>`, so this PR is now a single commit against `main` and its diff is one file, `tests/it/real_data_normalization_tests.rs`.

Closes #1858.

## What was wrong

Three of the five guards in `tests/it/real_data_normalization_tests.rs` carried no assertion at all, and a fourth kept both of its assertions inside a bounds check. Wiring the module into the nightly (#1851) guaranteed it *ran*; it never guaranteed it *checked*. This is the third shape of that defect family and the one no instrument used so far can see — an assertionless guard does the same work and costs the same wall clock as an armed one.

## What each guard now asserts

The load is carried by two properties that need no adjudication, so nothing here pins a value nobody has justified.

**Sequence preservation.** Which of two legal spellings ferro ships is a rule 6 choice (`README.md`); whether the shipped spelling still denotes the input's bases is rule 1, and a failure there is a bug under every reading. `assert_denotes_the_same_bases` carries the guards whose spelling question is open. A `NotComparable` verdict is a panic, not a pass — folding skips in with agreements would rebuild the hole inside the helper meant to close it.

**A required CDS origin.** Every guard read `transcript.cds_start.unwrap_or(1)`. That substitutes an origin when the reference serves none, and the substituted coordinates print exactly like real ones. The fallback is removed for the shape of the failure it hides, not because one was observed — see below, where the claim that one *was* observed is withdrawn. An unserved CDS now routes through `manifest_gate::unserved`.

## The headline finding is withdrawn — it does not reproduce

An earlier revision of this description, and of the module's own doc comments, stated as measured fact that `MultiFastaProvider::get_transcript("NM_033517.1")` returns 7113 cached bases with `cds_start: None`, `cds_end: None` and zero exons — bare FASTA, no cdot record — and that `NM_033517.1:c.1324del` therefore came back unchanged as a passthrough rather than a 3'-rule decision.

Re-measured 2026-08-14, identically on both prepared volumes, all four accessions this module names are fully annotated:

```
NM_033517.1/.2/.3  cds_start=Some(1)   cds_end=Some(5157)  exons=22  len=7113
NM_001408491.1     cds_start=Some(296) cds_end=Some(2365)  exons=23  len=3748
NM_001282424.3     cds_start=Some(169) cds_end=Some(3060)  exons=25  len=3791
NM_001394148.2     cds_start=Some(137) cds_end=Some(328)   exons=3   len=570
```

Only the length (7113) survives from the withdrawn reading. Three consequences, each a separate correction:

- **`unwrap_or(1)` fabricated nothing here.** cdot's record for this accession carries `start_codon: 0`, so `cds_start` really is 1 and the fallback happened to agree with the reference. Removing it is still right — it removes a *possible* substitution — but there is no sighting behind it.
- **`c.1324del` is not a passthrough.** It normalizes to **`c.1326del`**, which is the Mutalyzer answer, and the reference says why: `c.1324`/`c.1325`/`c.1326` are all `C` and `c.1327` is `G`, so the deletion shifts to the 3' end of a `CCC` run and stops. The four further inputs the old text called unshifted all shift too: `c.125del` → `c.127del`, `c.160del` → `c.162del`, `c.164del` → `c.167del`, `c.517del` → `c.518del`. So there is no ferro-versus-Mutalyzer disagreement on this accession, and the guard's original question is answered rather than blocked.
- **There is no open question for an operator.** "Should `ferro prepare` serve `NM_033517` with a cdot record?" — it does. That paragraph is deleted rather than rephrased. (The `#1870` sentence in the guard's doc — "with no CDS the normalizer … returns the description unchanged" — is deleted with it: `rulings[c-description-against-an-unresolvable-cds-is-refused]` makes that a refusal, and the premise does not obtain here anyway.)

One figure above is **cdot-version-dependent, and nothing in this PR keys on it.** Read out of both cdot builds directly:

| | `data_v0.2.32` (what the manifest pins) | `data_v0.2.34` |
|---|---|---|
| record present | yes | yes |
| `exons` | 22 | 22 |
| `start_codon` → `cds_start` | `0` → **1** | `0` → **1** |
| `stop_codon` → `cds_end` | `5157` | `5196` |

`0.2.32` collapses this accession's 39-base alignment gap (transcript 1302..1342, between exons 10 and 11) into the stop codon; `0.2.34` does not, and 5196 is what RefSeq/GenBank annotate (`CDS 1..5196`). That is the open sibling of `rulings[c-and-n-positions-are-flat-transcript-offsets]` and is not this module's business. `cds_start` is the only CDS figure any guard here reads, and it is 1 under both — so the correction above does not depend on which cdot the reference was prepared from, and the corrected doc comments say so rather than hard-coding 5157 as a fact about the accession.

**The cdot-version question is therefore settled in one direction and left open in the other.** Settled: no cdot version in play produces the withdrawn reading. Both builds carry the record with 22 exons and a start codon, so an older or newer cdot moves `cds_end`, it does not delete the record — the claim could not have been true against a *version* difference. Not settled: what state actually produced the original reading. It does not hold on either blessed volume today, and `main`'s own ruling `c-and-n-positions-are-flat-transcript-offsets`, decided 2026-08-12 — the day *before* the original measurement — already records "the live provider serves `NM_033517.1` `cds_end = 5157`", i.e. an annotated CDS on this same reference. That is strong evidence of an error rather than a genuine earlier state, and it is short of proof, so no history is invented for it.

**The promotion is dormant, not firing.** With the CDS served, `cds_start_or_skip` never takes its `None` branch on this reference, so no guard stands down and none fails under `FERRO_REQUIRE_MANIFEST`. The gate is a safety net whose value is the shape of failure it removes — a stand-down is loud, a substituted origin is silent. It was measured live rather than assumed: see the Verification section.
## Two premises withdrawn rather than propped up

- **"delins should NOT be 3' shifted like del/dup"** grades a description by its edit type — a property of the input's spelling, which rule 3 and `canonical-form-choice-when-both-legal` both exclude. What the guard was really written to catch is real: `c.2140_2141delinsTATGCA` denotes different bases (`GTATGCA` against the input's `TATGCAT`), so sequence preservation is exactly the right test. Ferro in fact emits neither form but `c.[2138_2139insTAT;2140_2141insA]`, a sequence-preserving split — and the old body printed "POTENTIAL BUG" whenever the output contained `2140_2141`, which that correct split matches. The detector had gone wrong in both directions at once.
- **"Does the 3' rule reach the 5'UTR?"** is a real question that this input cannot answer. `c.-56` is `T` and `c.-46` is `G`, so no sequence-preserving rotation of the duplicated unit exists and both readings predict the same output. The non-discrimination is checkable, so it is now checked, with a message saying to re-derive rather than update if it ever fires. The guard is documented as what it actually is: the #97 5'UTR coordinate-mapping regression pin, cross-checking `normalize_tests::clinvar_normalization`'s hermetic pin against the real reference.

## The bounds check

Never false on the blessed reference, and measurably so: `NM_001408491.1` is 3748 bases with `cds_start` 296, putting `c.517`/`c.518` at 0-based 811 and 812. So promoting the `if` to an `assert!` fixes no live failure — it removes the one way the guard could go quiet, which is the shape that cannot be seen from a run's duration or its pass/fail.

## Verification
Every assertion was watched fail before being kept — sabotaged, run red, restored from a pre-edit `cp` (`md5` byte-identical afterwards, `git status` clean).

| assertion | proven red by |
|---|---|
| guard 1 — `seq[idx_517] == seq[idx_518]` | comparing against `seq[idx_518 + 2]` |
| guard 1 — `output.contains("c.518del")` | expecting `c.519del` |
| guard 1 — `assert_denotes_the_same_bases` | comparing the input against `c.517_520del` |
| guard 2 — `assert_denotes_the_same_bases` (its only one) | comparing the input against `c.1324_1330del` → `normalization changed the sequence the description denotes` |
| guard 3 — `assert_denotes_the_same_bases` (its only one) | comparing the input against `c.2140_2141delinsTATGCA` → `Differ`, `from input TATGCAT` / `from output GTATGCA` |
| guard 4 — `assert_ne!(seq[idx_first], seq[idx_last + 1])` | comparing the base against itself |
| guard 4 — the `c.-56_-47dup` output pin | expecting `c.-55_-46dup` |
| guard 5 — bounds `idx_517 < seq.len() && idx_518 < seq.len()` | `idx_517 + seq.len() < seq.len()` |
| guard 5 — `base_517 == 'A'` | expecting `'T'` |

Armed against the prepared reference (`FERRO_MANIFEST` set, read-only; nothing under `data/ferro` modified):

- **without** `FERRO_REQUIRE_MANIFEST`: `5 tests run: 5 passed`, `EXIT=0`, and **no `skipping —` line anywhere** in the run.
- **with** `FERRO_REQUIRE_MANIFEST=1`: identical — `5 tests run: 5 passed`, `EXIT=0`. Guard 2 does **not** stand down and does **not** fail. An earlier revision of this table claimed it fired here; that row is withdrawn.
- **`cds_start_or_skip` forced to `None`, `FERRO_REQUIRE_MANIFEST=1`**: `5 tests run: 0 passed, 5 failed`, `EXIT=100`, each naming its own accession — `could not get \`NM_033517.1 CDS annotation\` from it: … a \`c.\` position does not resolve`. That is what proves the gate is armed rather than inert, since the shipped run cannot demonstrate it.

None of the above is inferred from timing: `CLAUDE.md` records that a guard which stands down *after* loading the reference costs the same as an armed one (12.086 s vs 12.027 s), so every row is a watched failure.

`cargo fmt --all --check`, `cargo clippy --profile soak --all-features --all-targets -- -D warnings` and the full `cargo nextest run --cargo-profile soak --features dev --no-fail-fast` gate all clean.

Representation-Change: none. Tests and doc comments only; no file under src/normalize/, src/hgvs/, src/spdi/, src/project/, src/reference/ or src/error_handling/ is touched — the diff is one file, tests/it/real_data_normalization_tests.rs.
