### PR TITLE
ci: arm the denoted-sequence oracle in test-oracle behind a two-row debt list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ env:
   # NOTE also: `sweeps` selects on this filter PLUS one module it deliberately
   # re-runs — `issue_1615_denoted_sequence_oracle`, the only test that reads the
   # denoted-sequence oracle's counters, which are meaningless unless
-  # `FERRO_ASSERT_SEQUENCE` is set and `sweeps` is the only job IN THIS FILE that
-  # sets it (`nightly-mutalyzer.yml` sets it too, non-gating). So
-  # "nothing is run twice" holds of this filter and is one module short of
-  # holding of that job's `-E`; the reason it is appended there rather than added
-  # here is on the job itself.
+  # `FERRO_ASSERT_SEQUENCE` is set. `sweeps` was the only job IN THIS FILE that
+  # set it until #1815 armed it in `test-oracle` too (`nightly-mutalyzer.yml`
+  # sets it as well, non-gating). So "nothing is run twice" holds of this filter
+  # and is one module short of holding of that job's `-E`; the reason it is
+  # appended there rather than added here is on the job itself.
   SWEEP_FILTER: >-
     test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap)
     + test(issue_1254_sibling_crossing_shift)
@@ -275,6 +275,53 @@ env:
     + test(issue_1715_rna_alignment_symbol_reach)
     + test(conformance_census_instrument)
     + test(conformance_census_runs)
+  # Withheld from the DENOTED-SEQUENCE oracle and from nothing else.
+  #
+  # `test-oracle` arms `FERRO_ASSERT_SEQUENCE` as of #1815. These are the rows
+  # that stopped it being armed before, each named with the OPEN issue that
+  # retires it. Re-measured on `origin/main` @ 1aecc93a, that job's four flags
+  # over its own `-E` with no `--partition`, bulk fixtures present
+  # (`FERRO_REQUIRE_BULK_FIXTURES=1`, zero `Skipping:` lines):
+  #
+  #   without this filter: 11202 tests run: 11199 passed, 3 failed   EXIT=100
+  #   with    this filter: 11197 tests run: 11197 passed, 0 failed   EXIT=0
+  #
+  #   * `stranded_identity_member` (2 of its 4 tests) — a GENUINE fire, of
+  #     #1281's "denotes no sequence" shape, on a module whose purpose is to PIN
+  #     a defect (**#1655**, 132 of 132 non-confluent). That is exactly the class
+  #     `ORACLE_EXCLUDE` documents: a test that pins a defect and an oracle that
+  #     aborts on it cannot both run.
+  #   * `the_render_time_reference_matches_what_the_pipeline_was_given` (1 test,
+  #     in `examples/dump_normalized_corpus.rs`) — also a genuine fire, and the
+  #     module's other 55 tests stay armed because this names the TEST, not the
+  #     module. #2051 added this gate on 2026-08-16; it re-normalizes each corpus
+  #     row ITSELF, outside the `catch_unwind` `dump`'s own pass uses, so a row
+  #     that trips an oracle takes the test with it. 47 corpus inputs fire:
+  #     **#2140** (38 inputs — a minted repeat tract widened across the CDS start
+  #     into the 5'UTR swallows its sibling), **#1983** (8 — the authored-repeat
+  #     form of the same collision) and **#2139** (1 — an adjacent-junction
+  #     insertion pair straddling the CDS start).
+  #
+  # THIS LIST IS TEMPORARY AND MUST SHRINK, and its composition has already moved
+  # TWICE IN THREE DAYS — which is the reason to re-measure it rather than trust
+  # the figures above. It held `issue_1487_canonical_window_overflow` until #1990
+  # closed #1690 (2026-08-15), and gained the render-time gate when #2051 landed
+  # (2026-08-16). Both times the stale reading was the *flattering* one.
+  #
+  # NOTHING IS TRADED AWAY FOR IT. A nextest `-E` is one expression, so negating
+  # this filter in the armed step would also withdraw these rows from
+  # `FERRO_ASSERT_IDEMPOTENT`, `_REPARSE` and `_IN_BOUNDS`, which they pass —
+  # trading three oracles for one, the swap the `sweeps` job's comment refuses to
+  # make for `issue_1615_denoted_sequence_oracle`. The step after the armed one
+  # re-runs precisely these rows under those three, so this file's oracle
+  # coverage is a strict superset of what it was.
+  #
+  # Kept separate from `ORACLE_EXCLUDE` rather than added to it: that list is a
+  # permanent statement about instruments that destroy each other, this one is a
+  # debt with three issue numbers on it.
+  SEQUENCE_ORACLE_EXCLUDE: >-
+    test(stranded_identity_member)
+    + test(the_render_time_reference_matches_what_the_pipeline_was_given)
 
 # Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
 # 360-minute default, so a wedged runner holds a PR for six hours: observed on
@@ -1487,9 +1534,19 @@ jobs:
         # *does not* provision a manifest, so requiring one here would fail
         # every PR. It is set in `nightly-mutalyzer.yml`, the only job that runs
         # `ferro prepare`. See `src/conformance/manifest_gate.rs`.
+        #
+        # THE SKIP REPORTS AS PASS, NOT SKIP, and that is the half of #1815 this
+        # file does not close. #1815 armed `FERRO_ASSERT_SEQUENCE` in
+        # `test-oracle`, which is the only one of the four oracles that can see a
+        # wrong-bases output on these axes — but that job provisions no manifest
+        # either, so they early-return there too. The one job that sets both is
+        # `nightly-mutalyzer.yml`, and it is `continue-on-error` by design.
+        # Provisioning a reference here is not a small change: that workflow
+        # spends ~30 min in `ferro prepare` per run and the result is deliberately
+        # uncached (a 3.25 GiB entry against a 10 GiB repository budget, #1218).
         if: matrix.shard == 1
         run: |
-          echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."
+          echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip, and nextest reports that skip path as PASS rather than SKIP. No gating job runs those axes, so a denoted-sequence violation on them still cannot redden a required check (#1815). The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest, non-gating."
       - name: Run Rust tests (shard ${{ matrix.shard }} of 6)
         env:
           # Absence of a bulk fixture must FAIL here, never skip. The bulk and
@@ -1631,9 +1688,18 @@ jobs:
         # times (#1274, #1343, #1307) before it was asserted here.
         #
         # `FERRO_ASSERT_SEQUENCE` — the fourth oracle at this same seam (#1615) —
-        # is deliberately **not** set here, and this job is the one place the set
-        # is incomplete. It used to fire on two rows of this job's own selection,
-        # and both were real disagreements rather than noise to be suppressed:
+        # IS set here as of #1815, so this job is no longer the one place the set
+        # is incomplete. It runs over this job's whole selection MINUS
+        # `SEQUENCE_ORACLE_EXCLUDE`, whose rows and their open issues are
+        # documented on that variable; the step after this one re-runs those rows
+        # under the other three oracles, so nothing is traded away.
+        #
+        # EVERYTHING BELOW IS KEPT AS HISTORY, because the exclusion has to be
+        # read against it: three times a "the rows I know about are green" reading
+        # was taken for "it can be armed", and three times a selection-wide run
+        # found rows that reading could not reach. It used to fire on two rows of
+        # this job's own selection, and both were real disagreements rather than
+        # noise to be suppressed:
         #
         #   * #1618 — `NC_TEST.1:g.262TG[6]` -> `g.259_262GT[6]`
         #     (`repeat_tract_maximization`). `hgvs_to_spdi` read the anchored
@@ -1652,10 +1718,10 @@ jobs:
         #
         #   Both rows are green. THE SELECTION-WIDE RUN THIS COMMENT USED TO ASK
         #   FOR HAS NOW BEEN DONE, and it is RED — so the two closures were
-        #   necessary and not sufficient, and the flag stays unset. Measured on
-        #   `origin/main` @ 674e9c8b, this job's four flags plus
-        #   `FERRO_ASSERT_SEQUENCE=1`, over the `-E` below with its two `env:`
-        #   filters expanded and no `--partition`:
+        #   necessary and not sufficient. Measured on `origin/main` @ 674e9c8b,
+        #   this job's then-three flags plus `FERRO_ASSERT_SEQUENCE=1`, over the
+        #   selection THIS JOB HAD AT THAT COMMIT — two `env:` filters, not the
+        #   four below — with them expanded and no `--partition`:
         #
         #     Summary [87.5s] 10383 tests run: 10378 passed, 5 failed, 289 skipped
         #
@@ -1721,8 +1787,35 @@ jobs:
         #   `every_stranded_identity_is_non_confluent_with_its_surviving_member`
         #   and `the_wider_multi_member_census_is_what_the_header_says`.
         #
-        #   So arming this is blocked on a home for `stranded_identity_member`,
-        #   and on that alone — #1690 is closed and is no longer a blocker.
+        #   That put arming it as blocked on a home for
+        #   `stranded_identity_member` and on that alone — #1690 is closed and is
+        #   no longer a blocker.
+        #
+        #   RE-MEASURED AGAIN FOR #1815, on `origin/main` @ 1aecc93a, same recipe:
+        #
+        #     Summary [128.560s] 11202 tests run: 11199 passed, 3 failed, 321 skipped
+        #
+        #   THREE, not two — and the third is a module the two readings above could
+        #   not have named, because it did not exist when either was taken.
+        #   `dump_normalized_corpus`'s
+        #   `the_render_time_reference_matches_what_the_pipeline_was_given` landed
+        #   with #2051 on 2026-08-16 and re-normalizes each corpus row outside
+        #   `catch_unwind`, so 47 corpus inputs abort it: #2140, #1983 and #2139.
+        #   It passes UNARMED in the same tree (measured, EXIT=0), so it is an
+        #   oracle fire and not a pre-existing red.
+        #
+        #   The two `stranded_identity_member` rows are UNCHANGED, and are still
+        #   `every_stranded_identity_is_non_confluent_with_its_surviving_member`
+        #   and `the_wider_multi_member_census_is_what_the_header_says` — verified
+        #   by removing that row from the filter and reading the names off the red
+        #   run, not by matching them against this comment. The module has 4 tests
+        #   and the other 2 pass armed; `SEQUENCE_ORACLE_EXCLUDE` names the MODULE
+        #   anyway, because the module's whole purpose is pinning the defect, and
+        #   names a single TEST only where the surrounding module is innocent (the
+        #   render-time gate, whose other 55 tests stay armed).
+        #
+        #   READ THE PATTERN, NOT THE COUNT: 5 -> 2 -> 3 in three days, changing in
+        #   BOTH directions. Re-measure before trusting any figure in this comment.
         #
         #     This row replaced an earlier one on the same issue
         #     (`NM_000492.4:c.1520_1522del` -> `c.1521_1523del`), and the swap is
@@ -1739,24 +1832,58 @@ jobs:
         #     otherwise lost. See `CDOT_GAP_JUNCTIONS` in
         #     `tests/it/normalization_transcripts_exon_contract.rs`.
         #
-        # Suppressing a row would hollow out the oracle, which is why neither was
-        # ever exempted. It runs in `sweeps` below — the cis-allele space every
-        # one of the eight defects it was built for came from, and where it is
-        # measured green — and non-gating in the nightly. Both rows closing
-        # unblocked the two obstacles this comment knew about; the selection-wide
-        # run above then found two more, so the flag stays out until those are
-        # settled. Do not read "both rows are green" as "it can be armed".
+        # Suppressing a row AT THE SEAM would hollow out the oracle, which is why
+        # none of these is exempted there. The exclusion is a SELECTION TERM in
+        # this file instead — visible, measured, and carrying the open issue that
+        # retires it — and the distinction is the whole reason
+        # `SEQUENCE_ORACLE_EXCLUDE` exists as its own variable. The flag also runs
+        # in `sweeps` below, over the cis-allele space every one of the eight
+        # defects it was built for came from, and non-gating in the nightly.
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
           FERRO_ASSERT_IN_BOUNDS: "1"
+          FERRO_ASSERT_SEQUENCE: "1"
           # As in `test` above: an absent bulk fixture fails rather than skips.
           FERRO_REQUIRE_BULK_FIXTURES: "1"
         run: |
           scripts/run_nextest_archive.sh --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
             --partition hash:${{ matrix.shard }}/4 \
-            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE) and not ($CENSUS_FILTER)"
+            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE) and not ($CENSUS_FILTER) and not ($SEQUENCE_ORACLE_EXCLUDE)"
+      # The other half of the trade, and the reason arming the flag above costs no
+      # coverage: the rows `SEQUENCE_ORACLE_EXCLUDE` withholds from the armed step
+      # still run under the three oracles they pass, exactly as they did before
+      # #1815. Without this step, negating that filter would withdraw them from all
+      # four — three oracles surrendered to gain one.
+      #
+      # Runs on ONE shard and UN-partitioned, deliberately. It selects 5 tests, so
+      # `--partition hash:K/4` would leave some shards selecting none, and neither
+      # answer to that is acceptable: `--no-tests=fail` would redden a shard for
+      # doing its job, and `--no-tests=pass` would be a step that goes green having
+      # run nothing — the vacuous pass this repository keeps meeting. Un-partitioned
+      # on shard 1 with `--no-tests=fail` instead, so a rename that empties the
+      # filter is loud rather than silent. These rows ran exactly once per CI run
+      # before this change too, spread across the shards, so nothing runs twice and
+      # nothing runs less.
+      #
+      # It carries no `if: always()`, so a red armed step on shard 1 skips it. That
+      # is the intended reading: the job is already failing and the useful signal is
+      # the armed step's own failure, not a further confirmation that five withheld
+      # rows still pass. Nothing here can turn a red job green — the concern the
+      # `.github/workflows/**` review rule raises about a skipped step is coverage
+      # lost on a PASSING run, and on a passing run this step always executes.
+      - name: Run the sequence-oracle exclusions under the other three oracles
+        if: matrix.shard == 1
+        env:
+          FERRO_ASSERT_IDEMPOTENT: "1"
+          FERRO_ASSERT_REPARSE: "1"
+          FERRO_ASSERT_IN_BOUNDS: "1"
+          FERRO_REQUIRE_BULK_FIXTURES: "1"
+        run: |
+          scripts/run_nextest_archive.sh --archive-file nextest.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite --no-tests=fail \
+            -E "$SEQUENCE_ORACLE_EXCLUDE"
 
   # 1,000,000-case idempotency soak on every PR, split 8 ways.
   #
@@ -1953,15 +2080,20 @@ jobs:
         # one is exactly the edit that would drop a sweep from CI silently.
         #
         # `issue_1615_denoted_sequence_oracle` is appended to the selection
-        # because this job is the only one IN THIS FILE that sets
-        # `FERRO_ASSERT_SEQUENCE` (`nightly-mutalyzer.yml` sets it too, but it is
-        # non-gating and selects only the reference-aware modules), and
-        # that module holds the one test which reads the oracle's counters —
-        # `the_seam_compares_when_the_flag_is_set`, the guard that a green run
-        # actually compared something rather than the seam call having been
-        # deleted. Without it here that guard would run only in jobs where the
-        # flag is unset, where it skips by design, so the wiring would be
-        # unverified everywhere.
+        # because that module holds the one test which reads the oracle's
+        # counters — `the_seam_compares_when_the_flag_is_set`, the guard that a
+        # green run actually compared something rather than the seam call having
+        # been deleted — and it skips by design wherever the flag is unset.
+        #
+        # It STAYS appended after #1815 armed `FERRO_ASSERT_SEQUENCE` in
+        # `test-oracle` too, and not out of redundancy: this job runs the module
+        # against `FERRO_SWEEP_SEEDS: full`, and its own selection is the
+        # cis-allele space the oracle was built for. `test-oracle` also selects
+        # that module (nothing in its `-E` negates it), so as of #1815 the counter
+        # guard is live in two gating jobs rather than one — read that as defence
+        # in depth, not as a second copy to remove. (`nightly-mutalyzer.yml` sets
+        # the flag as well, but it is non-gating and selects only the
+        # reference-aware modules.)
         #
         # Appended here rather than added to `SWEEP_FILTER` for two reasons.
         # `tests/it/sweep_filter_invariant.rs`'s
@@ -2001,6 +2133,15 @@ jobs:
   # move rather than a change of instrument. `sweeps` does set it, so these
   # modules could not simply be appended there.
   #
+  # #1815 armed that flag in `test-oracle`, so this job's armed step no longer
+  # mirrors that job's flag set — it is now a strict SUBSET of it, deliberately.
+  # Arming a fourth oracle here would be exactly the change of instrument the
+  # paragraph above refuses, and it has NOT been measured over
+  # `ORACLE_ONLY_FILTER`'s modules. Do not "restore parity" by copying the flag
+  # down here without taking that measurement first: `test-oracle`'s own comment
+  # records what a selection-wide armed run cost each of the three times one was
+  # taken, and the answer changed every time.
+  #
   # No `submodules: true`: none of the three modules names a path under
   # `assets/` (the spec worked-examples citation gate, which does, stays in
   # `test`). `spec-fixtures` IS needed —
@@ -2039,8 +2180,10 @@ jobs:
           path: tests/fixtures/
       - name: Run the censuses that need the oracles armed
         env:
-          # The three `test-oracle` sets, and only those three. See that job for
-          # what each asserts and why `FERRO_ASSERT_SEQUENCE` is not among them.
+          # Three of the four `test-oracle` sets, and only those three. See that
+          # job for what each asserts, and this job's own header for why
+          # `FERRO_ASSERT_SEQUENCE` is not among them even though #1815 added it
+          # there.
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
           FERRO_ASSERT_IN_BOUNDS: "1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,21 +243,30 @@ path now excludes it the same way, from the same source of truth.
 
 **The runner reads the whole `-E` selection and the flag set out of `ci.yml`**,
 so neither can drift into a second copy. "Whole" is load-bearing: `test-oracle`
-negates `test(proptest)`, `SWEEP_FILTER` and `CENSUS_FILTER` as well as
-`ORACLE_EXCLUDE`, and a runner that negated only `ORACLE_EXCLUDE` would run the
-proptest modules, the three exhaustive sweeps and the three slow censuses while
-reporting itself as mirroring that job. So the
+negates `test(proptest)`, `SWEEP_FILTER`, `CENSUS_FILTER` and — since #1815 —
+`SEQUENCE_ORACLE_EXCLUDE` as well as `ORACLE_EXCLUDE`, and a runner that negated
+only `ORACLE_EXCLUDE` would run the proptest modules, the three exhaustive sweeps
+and the three slow censuses while reporting itself as mirroring that job. So the
 shape of the expression is read too, and only its variable references are
 expanded — rebuilding it here from a hardcoded `not test(proptest) and not (…)`
-would trade today's drift for tomorrow's.
+would trade today's drift for tomorrow's. **Do not count the negated terms in
+prose**; that number has changed twice and is read off the file.
 
 `tests/it/oracle_exclude_invariant.rs` re-derives all of it in Rust — different
 anchors, deliberately — and compares; separately asserts that the agreed
-selection actually negates all three (a spelling-independent check, since both
-sides otherwise read the same line of `ci.yml` and a matching pair of wrong ones
-would satisfy the equality); and separately forbids the script from hardcoding a
-module name. Each of those guards is checked against a deliberate sabotage
-rather than assumed.
+selection actually negates each of the named filters (a spelling-independent
+check, since both sides otherwise read the same line of `ci.yml` and a matching
+pair of wrong ones would satisfy the equality); separately forbids the script from
+hardcoding a module name; and separately asserts that the rows withheld from the
+denoted-sequence oracle still run under the other three, which is what makes
+#1815 a superset rather than a trade. Each of those guards is checked against a
+deliberate sabotage rather than assumed.
+
+One anchor is worth knowing about because it is the non-obvious consequence of
+#1815: `test-oracle` now has **two** nextest steps, so "the flags of
+`test-oracle`" is no longer well-formed. The Rust side identifies the armed step
+by its `--partition`, and the runner's awk by the step's `name:` — deliberately
+different discriminators, so a rename breaks one and not the other.
 
 #### Normalization idempotency oracle
 
@@ -384,9 +393,12 @@ un-armed); the nightly sets it too, where it is the only place the check runs
 against true transcript and contig lengths.
 
 **The fourth flag is not set in all of those places, so do not read "all four"
-off this paragraph.** `FERRO_ASSERT_SEQUENCE` runs in `sweeps` and in the
-nightly, and deliberately not in `test-oracle` or in `censuses` — the reason, and
-what currently keeps it out, are under
+off this paragraph.** `FERRO_ASSERT_SEQUENCE` runs in `sweeps`, in the nightly,
+and — as of #1815 — in `test-oracle`, where it is armed over that job's selection
+minus a two-row debt list (`SEQUENCE_ORACLE_EXCLUDE`). It is still deliberately
+**not** set in `censuses`, whose armed step is now a strict subset of
+`test-oracle`'s flag set rather than a copy of it. The reason, and what the debt
+list holds, are under
 [Where it runs, and the one place it deliberately does not](#normalization-denoted-sequence-oracle)
 below and in `ci.yml`'s comment on the `test-oracle` job.
 
@@ -397,13 +409,17 @@ asks what the output **means** rather than how it is written: apply the input to
 the reference, apply the output, and assert the bases agree.
 
 ```bash
-FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev -E "$SWEEP_SELECTION"
+scripts/run_oracle_suite.sh    # arms all four, over test-oracle's own selection
 ```
 
-**`scripts/run_oracle_suite.sh` deliberately does NOT arm this one**, because
-`test-oracle` does not — the runner mirrors that job, and mirroring it faithfully
-means inheriting the gap. The job where this flag is green is `sweeps`, so scope
-a local run to that job's selection rather than to the whole suite. Added to
+**`scripts/run_oracle_suite.sh` DOES arm this one as of #1815**, because
+`test-oracle` now does — the runner reads that job's flag set rather than
+carrying its own, so it started arming the fourth oracle on the day the job did,
+with no change to its flag handling. What it did need teaching is the third
+negated filter, `SEQUENCE_ORACLE_EXCLUDE`; a local armed run that omits that
+negation is red by construction on the rows named there. (This paragraph used to
+say the runner deliberately does *not* arm it, "mirroring the gap" — that is the
+statement #1815 changed.) Added to
 `ORACLE_EXCLUDE`'s modules it raises **5** further failures beyond the
 idempotency oracle's own, all in `spec_corpus_regressions` and all the same shape
 as those: a test pinning the CDS-end defect that this oracle aborts on. (That 5
@@ -471,24 +487,43 @@ four when on — one provider fetch and two splices per normalization — so it 
 last in `assert_seam_oracles`, after the cheaper and more specific checks have
 had their chance to name the fault more precisely.
 
-**Where it runs, and the two places it deliberately does not.** `sweeps` sets it
-(gating, measured green over the full corpus) and the nightly sets it
-(non-gating). `test-oracle` does **not**, which is why the set of four is
-incomplete there. `censuses`' armed step does not either, and for a derived
-reason rather than a second one: that step exists to run what `test-oracle` ran,
-on a faster archive, so it inherits that job's flag set exactly — arming a fourth
-oracle there would make the move a change of instrument. Two rows in
-`test-oracle`'s selection used to fire, and both were real disagreements inside
-ferro rather than noise:
+**Where it runs, and the one place it deliberately does not.** `sweeps` sets it
+(gating, measured green over the full corpus), the nightly sets it (non-gating),
+and **`test-oracle` sets it as of #1815** — over that job's whole selection minus
+`SEQUENCE_ORACLE_EXCLUDE`, a debt list of two rows each carrying the open issue
+that retires it. Measured wired, at `1aecc93a`: `11200 tests run: 11200 passed`,
+all four flags armed, zero `Skipping:` lines.
+
+`censuses`' armed step still does **not** set it. That used to be a *derived*
+reason — the step exists to run what `test-oracle` ran, on a faster archive, so it
+inherited that job's flag set exactly, and arming a fourth oracle there would make
+the move a change of instrument. Since #1815 the derivation no longer holds: its
+flag set is now a strict **subset** of `test-oracle`'s, deliberately, and arming
+the fourth there has never been measured over `ORACLE_ONLY_FILTER`'s modules. So
+"restore parity with `test-oracle`" is now the plausible-looking wrong edit, and
+that job's header says so.
+
+**The debt list is what to read before believing any count in this section.** It
+has changed composition twice in three days, in both directions: it held
+`issue_1487_canonical_window_overflow` until #1990 closed #1690 (2026-08-15), and
+gained `dump_normalized_corpus`'s render-time gate when #2051 landed (2026-08-16).
+The selection-wide armed figure has read **5 → 2 → 3** across those three
+measurements. Read it off a run.
+
+Two rows in `test-oracle`'s selection used to fire before any of that, and both
+were real disagreements inside ferro rather than noise:
 
 | row | what disagreed | state |
 |---|---|---|
 | #1618 — `NC_TEST.1:g.262TG[6]` → `g.259_262GT[6]` | `hgvs_to_spdi` read the anchored spelling as 6 copies replacing a **1**-copy tract, the normalizer's output as 6 copies replacing a **2**-copy tract — 14 bases against 12 | closed before `6116f84a` |
 | #1619 — `NM_033517.1:c.4818dupC` → `c.4818dup` | `hgvs_to_spdi` resolved the `c.` position by **walking** the exon list while the normalizer indexes the **flat** transcript, so the two disagreed across any transcript-coordinate gap: the input applied `C`, the output `T`, at transcript position 4877. `NM_033517.1` carries a real 39-base cdot hole between exons 10 and 11 — see below, because this row **replaced** an earlier one on the same issue | closed by the flat-frame fix: `cds_to_tx`/`tx_to_cds` no longer read the exon table |
 
-**Both are now green, and the flag is STILL not set here — the selection-wide
-run those two closures were blocking on has since been done, and it is RED.**
-The two-row measurement, on the #1619 branch, was this:
+**Both are now green, and that was still not enough — the selection-wide run
+those two closures were blocking on came back RED, three times, on a different
+set of rows each time.** The history below is why the flag is armed behind a debt
+list rather than armed outright, and why "the rows I know about are green" has
+never once been sufficient here. The two-row measurement, on the #1619 branch, was
+this:
 
 ```bash
 FERRO_ASSERT_SEQUENCE=1 cargo nextest run --features dev --test it \
@@ -542,11 +577,39 @@ on a census pin reading `unwindowed: 89` against a pinned `90` while
 `sequence_changed` stays `0`. That is the HEAD-drift this file already documents
 for that pin, and it is orthogonal to arming the flag.
 
-So arming it is blocked on finding a home for `stranded_identity_member`, and on
-that alone — **#1690 is closed and is no longer a blocker.** Do not read "both
-rows are green" as "it can be armed". `ci.yml`'s comment on the `test-oracle`
-job carries the full triage, including what a run with `FERRO_MANIFEST` set adds.
-Suppressing a row would still hollow out the oracle; that has not changed.
+**RE-MEASURED A THIRD TIME for #1815, at `1aecc93a`: `11202 tests run: 11199
+passed, 3 failed`.** Three, not two — and the third could not have been named by
+either reading above, because the test did not exist when they were taken. #2051
+(2026-08-16) added
+`dump_normalized_corpus::the_render_time_reference_matches_what_the_pipeline_was_given`,
+which re-normalizes each corpus row **itself, outside** the `catch_unwind` that
+`dump`'s own pass uses, so 47 corpus inputs abort it — **#2140** (38), **#1983**
+(8) and **#2139** (1). It passes unarmed in the same tree, so it is an oracle fire
+and not a pre-existing red.
+
+So arming it is **no longer blocked** — it is armed, behind those two rows.
+`SEQUENCE_ORACLE_EXCLUDE` names them, each with its retiring issue, and
+`test-oracle` gains a second un-partitioned step that re-runs exactly those rows
+under the other three oracles, so the file's oracle coverage is a strict superset
+of what it was rather than a trade. Suppressing a row **at the seam** would still
+hollow out the oracle; a visible, measured, issue-numbered selection term is a
+different thing, and that distinction is why the debt list is its own variable
+rather than two more entries on `ORACLE_EXCLUDE`.
+
+**Do not read "the rows I know about are green" as "it can be armed" — that
+reading has been wrong three times out of three.** `ci.yml`'s comment on the
+`test-oracle` job carries the full triage, including what a run with
+`FERRO_MANIFEST` set adds, and `scripts/run_oracle_suite.sh` reproduces the whole
+measurement locally in one command.
+
+**What #1815 still does NOT close is the manifest half.** `test-oracle` arms the
+flag but provisions no `FERRO_MANIFEST`, so the `mutalyzer_normalize_tests` /
+`biocommons_normalize_tests` axes early-return there exactly as they do in the
+plain `test` job, and nextest reports that skip path as **PASS**. A
+denoted-sequence violation on those axes still cannot redden a required check.
+Provisioning a reference per PR is not a small change — the nightly spends ~30 min
+in `ferro prepare` and the result is deliberately uncached (#1218) — so #1815 stays
+open on that half.
 
 **#1619's row was replaced before it was closed, and the swap is the whole
 point.** The
@@ -560,22 +623,32 @@ The row that stands in its place rides on **cdot's own annotation**.
 `NM_033517.1` is one of the 58 gapped builds, with a genuine 39-base hole
 between exon 10 (ends 1302) and exon 11 (starts 1342), and the fixture now
 carries its real table. So #1619 is demonstrated on real transcript geometry
-rather than on an artifact — which is a *stronger* reason to keep
+rather than on an artifact — which was, at the time, a *stronger* reason to keep
 `FERRO_ASSERT_SEQUENCE` out of `test-oracle`, and it hands the issue the
-reproducer the repair would otherwise have destroyed. The gap is exempted by
+reproducer the repair would otherwise have destroyed. (#1619 is closed and its row
+is green, so that reason no longer applies; the geometry argument is kept because
+it is why the fixture must not be re-flattened.) The gap is exempted by
 name in `CDOT_GAP_JUNCTIONS`
 (`tests/it/normalization_transcripts_exon_contract.rs`), never by loosening the
 contiguity rule.
 
-**No CI job arms the oracle where it fires** — checked, not assumed.
-`FERRO_ASSERT_SEQUENCE` is set in exactly two places: `ci.yml`'s `sweeps`, which
-selects `SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`, and
-`nightly-mutalyzer.yml`, which selects every reference-aware module and is
-`continue-on-error`. `normalize_tests` is in neither selection, so the fire is
-reachable only by setting the flag by hand. (That nightly selection named
-**three** modules until the orphaned-guard sweep; `normalize_tests` was not one
-of the modules added, so this paragraph's conclusion is unchanged — but do not
-re-derive "the three modules" from it.)
+**A CI job now DOES arm the oracle over `normalize_tests`, and it is green** —
+corrected by #1815, which is the change this paragraph is about. It used to read
+"No CI job arms the oracle where it fires", on the true premise that
+`FERRO_ASSERT_SEQUENCE` was set only in `ci.yml`'s `sweeps` (selecting
+`SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)`) and in
+`nightly-mutalyzer.yml` (every reference-aware module, `continue-on-error`) —
+`normalize_tests` being in neither, so the #1619 fire was reachable only by hand.
+
+`test-oracle` now arms it, and nothing in that job's `-E` negates
+`normalize_tests`, so its 453 tests run armed on every PR. Measured green at
+`1aecc93a`. That is a *consequence* of #1619 having been closed rather than a
+contradiction of anything above: the fire the paragraph was written about is
+fixed, so the module can be armed without a debt row.
+
+(That nightly selection named **three** modules until the orphaned-guard sweep;
+`normalize_tests` was not one of the modules added, so do not re-derive "the three
+modules" from it.)
 
 **Here is the command the before/after comes from**, because a figure with no
 command is one nobody can re-derive. Swap only the fixture, and exclude the guard

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -64,11 +64,13 @@
 #   scripts/run_oracle_suite.sh --print-selection  # print what it would run, and stop
 #   scripts/run_oracle_suite.sh -E 'test(foo)'     # extra args go through to nextest
 #
-# The denoted-sequence oracle (`FERRO_ASSERT_SEQUENCE`) is deliberately NOT
-# among the flags this mirrors, because `test-oracle` does not set it. Nothing
-# has to be done here to keep that true: `oracle_flags` below READS the flag set
-# out of that job, so this script arms it on the day the job does and not
-# before.
+# The denoted-sequence oracle (`FERRO_ASSERT_SEQUENCE`) IS among the flags this
+# mirrors as of #1815, and this script needed no change to start arming it:
+# `oracle_flags` below READS the flag set out of that job, so it armed the fourth
+# oracle on the day the job did. What #1815 did have to teach it is the third
+# negated filter, `SEQUENCE_ORACLE_EXCLUDE` -- see the refusal on it below, and
+# note that a run which arms the flag WITHOUT negating that filter is red by
+# construction on the rows named there.
 #
 # The figure this header used to quote -- "5 further failures, all in
 # `spec_corpus_regressions`" -- was about `ORACLE_EXCLUDE`'s modules, which this
@@ -83,8 +85,19 @@
 # RE-MEASURED on `c9207d7e` once #1690 closed (#1990), same selection and flags:
 # `10904 tests run: 10902 passed, 2 failed, 306 skipped`. The 3
 # `issue_1487_canonical_window_overflow` rows are GONE and nothing new fired, so
-# the remaining blocker is `stranded_identity_member` alone -- #1690 is closed
-# and is no longer one.
+# the remaining blocker at that point was `stranded_identity_member` alone --
+# #1690 is closed and is no longer one.
+#
+# RE-MEASURED AGAIN for #1815 on `origin/main` @ 1aecc93a: `11202 tests run:
+# 11199 passed, 3 failed, 321 skipped`. THREE, not two -- #2051 had since added
+# `the_render_time_reference_matches_what_the_pipeline_was_given`, which
+# re-normalizes each corpus row outside `catch_unwind` and so aborts on 47 corpus
+# inputs (#2140, #1983, #2139). Those rows plus `stranded_identity_member` are what
+# `SEQUENCE_ORACLE_EXCLUDE` names, and with it negated the same selection is
+# `11197 passed, 0 failed`.
+#
+# The figure has now been taken three times in three days and read 5 / 2 / 3 --
+# it moves in BOTH directions, so READ IT OFF A RUN rather than off this header.
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -179,6 +192,7 @@ oracle_flags() {
 EXCLUDE="$(folded_scalar ORACLE_EXCLUDE)"
 SWEEPS="$(folded_scalar SWEEP_FILTER)"
 CENSUSES="$(folded_scalar CENSUS_FILTER)"
+SEQUENCE_EXCLUDE="$(folded_scalar SEQUENCE_ORACLE_EXCLUDE)"
 TEMPLATE="$(oracle_selection_template)"
 # A read loop rather than `mapfile`, which is bash 4+: stock macOS still ships
 # bash 3.2 as /bin/bash, and a script that dies on `mapfile: command not found`
@@ -217,6 +231,25 @@ if [[ -z "$CENSUSES" ]]; then
     echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
     exit 1
 fi
+# `SEQUENCE_ORACLE_EXCLUDE` (#1815) is the debt list `test-oracle` negates now that
+# it arms `FERRO_ASSERT_SEQUENCE`.
+#
+# Keyed on whether that job's `-E` STILL REFERENCES the variable, not on whether the
+# variable exists. Retiring the last row is a legitimate end state -- the variable
+# and the `not (...)` term go away together -- and an unconditional refusal here
+# would turn that cleanup into a broken script, which is how a correct change gets
+# reverted. What must not pass silently is the HALF-DONE retirement: the term still
+# in the selection with nothing to expand it to. The `$` refusal further down would
+# catch that too, but only as "references a variable this script does not expand",
+# which sends the reader to the awk rather than to the real cause.
+if [[ "$TEMPLATE" == *'$SEQUENCE_ORACLE_EXCLUDE'* && -z "$SEQUENCE_EXCLUDE" ]]; then
+    echo "error: could not read SEQUENCE_ORACLE_EXCLUDE from $CI_YML," >&2
+    echo "  but test-oracle's -E still references it. Either its formatting changed" >&2
+    echo "  (fix the awk in this script rather than inlining a copy), or the variable" >&2
+    echo "  was retired without removing the 'and not (\$SEQUENCE_ORACLE_EXCLUDE)'" >&2
+    echo "  term from that job's selection." >&2
+    exit 1
+fi
 if [[ -z "$TEMPLATE" ]]; then
     echo "error: could not read test-oracle's -E selection from $CI_YML." >&2
     echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
@@ -226,6 +259,14 @@ fi
 # Expand the two references CI's expression carries. Substitution rather than
 # `eval`, so nothing in `ci.yml` can execute here.
 SELECTION="${TEMPLATE//\$SWEEP_FILTER/$SWEEPS}"
+# ORDER IS IMMATERIAL HERE, and it is worth saying so because it looks as though it
+# should not be: `ORACLE_EXCLUDE` is a suffix of `SEQUENCE_ORACLE_EXCLUDE`, so the
+# shorter substitution appears able to eat the longer reference. It cannot -- the
+# pattern includes the leading `$`, and `$SEQUENCE_ORACLE_EXCLUDE` contains no
+# second `$`. Measured both orders; the longer reference survives either way. Do not
+# "fix" this by reordering on the strength of the resemblance, and do not drop the
+# `$` from any of these patterns, which is what would make the resemblance real.
+SELECTION="${SELECTION//\$SEQUENCE_ORACLE_EXCLUDE/$SEQUENCE_EXCLUDE}"
 SELECTION="${SELECTION//\$ORACLE_EXCLUDE/$EXCLUDE}"
 SELECTION="${SELECTION//\$CENSUS_FILTER/$CENSUSES}"
 
@@ -243,6 +284,7 @@ if [[ "${1:-}" == "--print-selection" ]]; then
     printf 'ORACLE_EXCLUDE=%s\n' "$EXCLUDE"
     printf 'SWEEP_FILTER=%s\n' "$SWEEPS"
     printf 'CENSUS_FILTER=%s\n' "$CENSUSES"
+    printf 'SEQUENCE_ORACLE_EXCLUDE=%s\n' "$SEQUENCE_EXCLUDE"
     printf 'SELECTION=%s\n' "$SELECTION"
     for flag in "${FLAGS[@]}"; do printf 'FLAG=%s\n' "$flag"; done
     exit 0

--- a/tests/it/issue_1487_canonical_window_overflow.rs
+++ b/tests/it/issue_1487_canonical_window_overflow.rs
@@ -330,10 +330,23 @@ fn the_parser_is_what_keeps_an_insertion_anchor_off_i64_max() {
 // identical either side and only the line moved. All three are green now.
 //
 // **Those three are not the regression guard, and that is the point of the
-// test below.** CI's `test-oracle` job does not set `FERRO_ASSERT_SEQUENCE`
-// (`sweeps` and the nightly do, over selections that exclude this module), so
-// the site would go back to being invisible to the required checks the moment
-// the refusal is removed. The guard has to be a test that runs unarmed.
+// test below.** The reason has changed since it was written, and the conclusion
+// has not. It used to be that CI's `test-oracle` job did not set
+// `FERRO_ASSERT_SEQUENCE` at all (`sweeps` and the nightly did, over selections
+// excluding this module), so the site would go back to being invisible to the
+// required checks the moment the refusal was removed.
+//
+// As of #1815 that job DOES set the flag, and this module runs under it: all 8
+// of its tests are armed and green, and — unlike `stranded_identity_member` —
+// it is deliberately NOT named in `ci.yml`'s `SEQUENCE_ORACLE_EXCLUDE`, because
+// #1690 closed and the three failures are gone. (It was on the debt list drafted
+// while #1690 was open; that row was never needed.)
+//
+// The guard below still has to be a test that runs unarmed, for a reason arming
+// the flag does not touch: an armed oracle catches this site only on a row that
+// happens to route through `hgvs_to_spdi` with an `i64::MAX`-adjacent `c.`
+// coordinate, which is a property of the corpus rather than of the refusal. The
+// unarmed test asserts the refusal itself.
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/tests/it/issue_1615_denoted_sequence_oracle.rs
+++ b/tests/it/issue_1615_denoted_sequence_oracle.rs
@@ -487,9 +487,16 @@ fn an_rna_description_over_a_dna_reference_does_not_fire() {
 /// Everything else in this file exercises `compare_denoted_sequences` directly,
 /// so **deleting the `assert_denoted_sequence` call from
 /// `Normalizer::assert_seam_oracles` would leave this whole suite green** — and
-/// `sweeps`, the flag's only gating home, green with zero comparisons made. That
+/// every gating job that arms the flag green with zero comparisons made. That
 /// is the failure mode the counters exist for; this is the assertion that reads
 /// them, rather than leaving it to a human to remember to.
+///
+/// Those jobs are `sweeps`, which appends this module to its selection for
+/// exactly this reason, and — as of #1815 — `test-oracle`, whose own selection
+/// already contains this module (nothing in its `-E` negates it). So the counter
+/// guard is live in two gating jobs rather than one; read that as defence in
+/// depth, not as a second copy to remove. This paragraph used to call `sweeps`
+/// "the flag's only gating home", which was true when it was written.
 ///
 /// `compared` is monotonic and this test contributes to it itself, so a `> 0`
 /// assertion is safe under `cargo test`'s shared process as well as under

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -319,28 +319,96 @@ const LOCAL_RUNNER: &str = "scripts/run_oracle_suite.sh";
 /// rationale).
 ///
 /// Comment lines are skipped for the reason the awk skips them: the job's
-/// comment block *mentions* `FERRO_ASSERT_SEQUENCE` in prose, to explain why it
-/// is absent. A scan that read the prose as a setting would demand the runner
-/// arm an oracle CI does not — and the rows that comment names would then be red
-/// locally and green in CI. Note those rows are no longer #1618/#1619, which are
-/// both closed: a selection-wide run at `674e9c8b` put the count at 5, in
-/// `issue_1487_canonical_window_overflow` (issue #1690) and
-/// `stranded_identity_member`. Re-measured at `c9207d7e` once #1690 closed
-/// (#1990) the count is 2, all of it `stranded_identity_member`.
+/// comment block *mentions* every flag in prose, including the history of why
+/// `FERRO_ASSERT_SEQUENCE` used to be absent. A scan that read prose as a
+/// setting would demand the runner arm oracles CI does not, and the rows that
+/// prose names would then be red locally and green in CI.
+///
+/// **Scoped to the ARMED step, and that scoping is load-bearing as of #1815.**
+/// That change gave `test-oracle` a *second* step — the compensating run that
+/// re-executes `SEQUENCE_ORACLE_EXCLUDE`'s rows under the other three oracles —
+/// which sets three of the same keys. A whole-job scan therefore returns seven
+/// entries with three duplicated, against the awk's four, and this guard fails
+/// on a correctly-wired file. (It did, when the step was first added; that is
+/// how this scoping came to exist.)
+///
+/// The discriminator is deliberately **not** the step's `name:`, which is what
+/// [`LOCAL_RUNNER`]'s awk anchors on: the armed step is the one that
+/// `--partition`s the suite, and the compensating step is un-partitioned by
+/// design. Keying on the `run:` body rather than on the label keeps the two
+/// derivations independent — a renamed step breaks one of them and not the
+/// other, which is the whole point of having two.
 fn test_oracle_job_flags() -> Vec<String> {
-    test_oracle_job_lines()
+    let armed = test_oracle_steps()
         .into_iter()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.starts_with('#') {
-                return None;
+        .find(|step| step.runs.contains("--partition"))
+        .expect(
+            "ci.yml's test-oracle job has a step whose `run:` partitions the suite; \
+             its shape changed and this guard would otherwise read the wrong step's flags",
+        );
+    armed.flags
+}
+
+/// One step of the `test-oracle:` job: the `FERRO_ASSERT_*` keys its `env:`
+/// sets, and the text of its `run:`.
+struct OracleStep {
+    /// `FERRO_ASSERT_*` keys set to `"1"`, in file order, comments skipped.
+    flags: Vec<String>,
+    /// Every line of the step at or after its `run:`, joined.
+    runs: String,
+    /// The `-E` expression the step hands to nextest, if it passes one.
+    selection: Option<String>,
+}
+
+/// The `test-oracle:` job's steps, split on the `- name:` at step indent.
+///
+/// Exists because #1815 made that job carry two nextest steps with overlapping
+/// flag sets, so "the flags of `test-oracle`" stopped being a well-formed
+/// question — every guard below has to say *which* step it means.
+fn test_oracle_steps() -> Vec<OracleStep> {
+    let mut steps: Vec<OracleStep> = Vec::new();
+    let mut in_run = false;
+    for line in test_oracle_job_lines() {
+        let trimmed = line.trim();
+        // A step boundary: `- name:` at the job's step indent.
+        if line.starts_with("      - name:") {
+            steps.push(OracleStep {
+                flags: Vec::new(),
+                runs: String::new(),
+                selection: None,
+            });
+            in_run = false;
+            continue;
+        }
+        let Some(step) = steps.last_mut() else {
+            continue;
+        };
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed == "run: |" || trimmed.starts_with("run:") {
+            in_run = true;
+            continue;
+        }
+        if in_run {
+            step.runs.push('\n');
+            step.runs.push_str(&line);
+            if let Some(at) = line.find("-E \"") {
+                let rest = &line[at + "-E \"".len()..];
+                if let Some(end) = rest.find('"') {
+                    step.selection = Some(rest[..end].to_string());
+                }
             }
-            trimmed
-                .strip_suffix(": \"1\"")
-                .filter(|key| key.starts_with("FERRO_ASSERT_"))
-                .map(str::to_string)
-        })
-        .collect()
+            continue;
+        }
+        if let Some(key) = trimmed
+            .strip_suffix(": \"1\"")
+            .filter(|key| key.starts_with("FERRO_ASSERT_"))
+        {
+            step.flags.push(key.to_string());
+        }
+    }
+    steps
 }
 
 /// The lines of `ci.yml`'s `test-oracle:` job, bounded by indentation.
@@ -376,17 +444,27 @@ fn test_oracle_job_lines() -> Vec<String> {
 /// exclusion could not see that, which is why the whole expression is compared
 /// here.
 fn ci_oracle_selection() -> String {
-    let template = test_oracle_job_lines()
-        .iter()
-        .find_map(|line| {
-            let at = line.find("-E \"")? + "-E \"".len();
-            let rest = &line[at..];
-            rest.find('"').map(|end| rest[..end].to_string())
-        })
-        .expect("ci.yml's test-oracle job passes a -E selection to nextest");
+    // The ARMED step's selection, identified by `--partition` rather than by
+    // position. #1815 gave this job a second nextest step, and "the first `-E` in
+    // the job" is a positional accident rather than a statement about which step
+    // is meant — reordering them would silently retarget this whole comparison.
+    let template = test_oracle_steps()
+        .into_iter()
+        .find(|step| step.runs.contains("--partition"))
+        .and_then(|step| step.selection)
+        .expect("ci.yml's test-oracle job passes a -E selection to nextest in its armed step");
 
     let expanded = template
         .replace("$SWEEP_FILTER", ci_filter("SWEEP_FILTER").trim())
+        // Before `$ORACLE_EXCLUDE` only for readability — the order does not
+        // matter, because the pattern carries the leading `$` and
+        // `$SEQUENCE_ORACLE_EXCLUDE` holds no second one. Measured both ways.
+        // `scripts/run_oracle_suite.sh` carries the same note; the resemblance
+        // between the two names is the trap, and it is not a real one.
+        .replace(
+            "$SEQUENCE_ORACLE_EXCLUDE",
+            ci_filter("SEQUENCE_ORACLE_EXCLUDE").trim(),
+        )
         .replace("$ORACLE_EXCLUDE", ci_filter("ORACLE_EXCLUDE").trim())
         .replace("$CENSUS_FILTER", ci_filter("CENSUS_FILTER").trim());
     assert!(
@@ -526,7 +604,7 @@ fn the_ci_oracle_selection_negates_the_property_tests_the_sweeps_and_the_corpus_
          job owns at 125k cases per shard: {selection}"
     );
 
-    for key in ["SWEEP_FILTER", "ORACLE_EXCLUDE"] {
+    for key in ["SWEEP_FILTER", "ORACLE_EXCLUDE", "SEQUENCE_ORACLE_EXCLUDE"] {
         let value = ci_filter(key);
         let value = value.trim();
         assert!(
@@ -548,12 +626,21 @@ fn the_ci_oracle_selection_negates_the_property_tests_the_sweeps_and_the_corpus_
 ///
 /// Both directions matter and neither is symmetric with the other. Arming
 /// **fewer** makes a local run weaker than CI while reading as an oracle pass.
-/// Arming **more** — `FERRO_ASSERT_SEQUENCE` is the live candidate, since
-/// `test-oracle` deliberately withholds it — makes the runner red on rows no PR
-/// caused, which teaches the operator to ignore it. That is not hypothetical:
-/// arming it over this exact selection at `674e9c8b` is red, 5 tests, so a
-/// runner that armed it ahead of the job would be red on every PR. Still red at
-/// `c9207d7e` (#1990), at 2 tests rather than 5 — #1690 closed the other 3.
+/// Arming **more** makes the runner red on rows no PR caused, which teaches the
+/// operator to ignore it.
+///
+/// `FERRO_ASSERT_SEQUENCE` was the live candidate for the second failure until
+/// #1815, and its history is the argument for keeping this guard: armed over this
+/// selection it read red at 5 tests (`674e9c8b`), 2 (`c9207d7e`, after #1990
+/// closed #1690) and 3 (`1aecc93a`, after #2051 added a gate that fires) — so a
+/// runner that had armed it ahead of the job would have been red on every PR for
+/// months, at a count that moved in both directions. It is armed in both places
+/// now, and the runner did not have to be changed to follow: it reads the flag
+/// set out of the job.
+///
+/// The candidate has not gone away, it has moved. `censuses`' armed step now
+/// arms three where this job arms four, deliberately and unmeasured — see that
+/// job's header — so the next plausible "restore parity" edit is there.
 #[test]
 fn the_local_oracle_runner_arms_exactly_the_flags_test_oracle_arms() {
     let runner_flags = local_runner_selection().flags;
@@ -607,6 +694,213 @@ fn the_local_oracle_runner_does_not_hardcode_the_exclusion() {
          Two copies of one list drift, and this one drifts flatteringly — a stale copy \
          excludes a module CI still runs armed."
     );
+}
+
+/// Every row withheld from the denoted-sequence oracle must name something that
+/// exists.
+///
+/// `test()` is a substring predicate, so a typo does not error — it selects
+/// nothing. In `SEQUENCE_ORACLE_EXCLUDE` that fails in the **loud** direction
+/// (the armed job stops withholding the row and goes red on it), which is the
+/// good case and is why this is a cheap guard rather than a critical one. The
+/// expensive half is the compensating step: `--no-tests=fail` turns a filter that
+/// selects nothing into a red step, so a typo there is loud too, but a filter
+/// with *one* good row and one typo would keep the step green while silently
+/// dropping half of what it exists to re-run.
+///
+/// Checked against the **source tree** rather than by listing tests, so the guard
+/// does not need a nextest subprocess: each name must be either an integration
+/// module (`tests/it/<name>.rs`) or a `fn <name>(` somewhere under `tests/` or
+/// `examples/`. That is a floor and not a proof — it cannot tell a `#[test]` from
+/// a helper — but it catches the failure that actually happens, which is a
+/// misspelling or a rename.
+#[test]
+fn every_row_withheld_from_the_sequence_oracle_names_something_that_exists() {
+    let named = modules_named_in(&ci_filter("SEQUENCE_ORACLE_EXCLUDE"));
+    assert!(
+        !named.is_empty(),
+        "ci.yml's SEQUENCE_ORACLE_EXCLUDE names nothing; either its formatting changed \
+         (in which case fix it) or its last row retired — in which case delete the \
+         variable, the `and not (…)` term in test-oracle's -E, the compensating step, \
+         the block in scripts/run_oracle_suite.sh, and these guards, in one change."
+    );
+
+    let mut haystack = String::new();
+    for dir in ["tests", "examples"] {
+        collect_rust_sources(&repo_root().join(dir), &mut haystack);
+    }
+    assert!(
+        haystack.len() > 100_000,
+        "the source scan read only {} bytes, which cannot be the whole of tests/ and \
+         examples/ — this guard has gone vacuous",
+        haystack.len()
+    );
+
+    let missing: Vec<&String> = named
+        .iter()
+        .filter(|name| {
+            !repo_root().join(format!("tests/it/{name}.rs")).is_file()
+                && !haystack.contains(&format!("fn {name}("))
+        })
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "SEQUENCE_ORACLE_EXCLUDE names these, and nothing in tests/ or examples/ \
+         defines them: {missing:#?}\n\
+         A `test()` term that matches nothing selects nothing, so the compensating \
+         step would silently stop re-running the row it is there to protect."
+    );
+}
+
+/// Append every `.rs` file under `dir`, recursively, to `into`.
+fn collect_rust_sources(dir: &std::path::Path, into: &mut String) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_sources(&path, into);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                into.push_str(&text);
+                into.push('\n');
+            }
+        }
+    }
+}
+
+/// The rows withheld from the denoted-sequence oracle must still run under the
+/// other three.
+///
+/// This is the guard that makes arming the fourth oracle a **superset** of what
+/// `test-oracle` ran before #1815 rather than a trade. A nextest `-E` is one
+/// expression, so the armed step's `and not ($SEQUENCE_ORACLE_EXCLUDE)` withdraws
+/// those rows from all four oracles at once; the compensating step is what puts
+/// three of them back. Delete that step and the change quietly becomes "three
+/// oracles surrendered to gain one" — with nothing red, which is why it is
+/// asserted rather than left to the comment beside it.
+///
+/// Three things are checked, and the third is the one a reader would omit:
+///
+/// 1. the step exists and selects **exactly** `$SEQUENCE_ORACLE_EXCLUDE`, by
+///    reference and not by a copy of its value;
+/// 2. it arms exactly the other three oracles;
+/// 3. it does **not** arm `FERRO_ASSERT_SEQUENCE`. Without this, a copy-paste of
+///    the armed step's `env:` block would satisfy (2) as a subset check and make
+///    the step red on the very rows it exists to run — turning a green job red
+///    for a reason that looks like a real defect.
+#[test]
+fn the_sequence_oracle_exclusions_still_run_under_the_other_three_oracles() {
+    let steps = test_oracle_steps();
+    let armed = steps
+        .iter()
+        .find(|step| step.runs.contains("--partition"))
+        .expect("test-oracle has a partitioned, armed step");
+    assert!(
+        armed.flags.iter().any(|f| f == "FERRO_ASSERT_SEQUENCE"),
+        "test-oracle's armed step no longer sets FERRO_ASSERT_SEQUENCE, so there is \
+         nothing for SEQUENCE_ORACLE_EXCLUDE to withhold it from. If the flag is being \
+         un-armed, remove the filter and this guard in the same change rather than \
+         leaving a compensating step for an exclusion that excludes nothing."
+    );
+
+    let compensating: Vec<&OracleStep> = steps
+        .iter()
+        .filter(|step| {
+            step.selection.as_deref() == Some("$SEQUENCE_ORACLE_EXCLUDE")
+                && !step.runs.contains("--partition")
+        })
+        .collect();
+    assert_eq!(
+        compensating.len(),
+        1,
+        "expected exactly one un-partitioned step in test-oracle selecting \
+         `$SEQUENCE_ORACLE_EXCLUDE`, found {}.\n\
+         Without it, the armed step's `and not ($SEQUENCE_ORACLE_EXCLUDE)` withdraws \
+         those rows from FERRO_ASSERT_IDEMPOTENT, _REPARSE and _IN_BOUNDS as well — \
+         which they pass — so arming the fourth oracle would cost three.\n\
+         Note the selection must be the VARIABLE REFERENCE, not a copy of its value: \
+         two copies of one list drift, and this one drifts flatteringly.",
+        compensating.len()
+    );
+    let compensating = compensating[0];
+
+    let mut expected: Vec<String> = armed
+        .flags
+        .iter()
+        .filter(|f| *f != "FERRO_ASSERT_SEQUENCE")
+        .cloned()
+        .collect();
+    let mut actual = compensating.flags.clone();
+    expected.sort();
+    actual.sort();
+    assert_eq!(
+        actual, expected,
+        "the compensating step must arm exactly the oracles the armed step arms MINUS \
+         FERRO_ASSERT_SEQUENCE.\n\
+         Armed step: {:?}\nCompensating step: {:?}\n\
+         Deriving the expectation from the armed step rather than from a literal list is \
+         deliberate — a fifth oracle added above must reach these rows too, and a hardcoded \
+         three would not notice.",
+        armed.flags, compensating.flags
+    );
+    assert!(
+        !compensating
+            .flags
+            .iter()
+            .any(|f| f == "FERRO_ASSERT_SEQUENCE"),
+        "the compensating step arms FERRO_ASSERT_SEQUENCE, which is the one oracle these \
+         rows are withheld from. It would fire on exactly the rows the step exists to run, \
+         reddening a job that is otherwise green — and the failure would read as a fresh \
+         normalizer defect rather than as this wiring mistake."
+    );
+    assert!(
+        compensating.runs.contains("--no-tests=fail"),
+        "the compensating step must pass --no-tests=fail. Its selection is five tests \
+         named by substring, so a rename that empties the filter would otherwise be a \
+         step that goes green having run nothing — the vacuous pass this repository \
+         keeps meeting."
+    );
+}
+
+/// The debt list must stay disjoint from the two permanent filters.
+///
+/// An overlap is not merely untidy here, unlike the sweep/oracle pair below. A
+/// row in both `ORACLE_EXCLUDE` and `SEQUENCE_ORACLE_EXCLUDE` is withheld from
+/// the armed step twice — harmless — but the compensating step would then run it
+/// under three oracles that the armed job deliberately never runs it under,
+/// because `ORACLE_EXCLUDE`'s whole point is that those instruments destroy each
+/// other on those modules. So the overlap would *create* the red that
+/// `ORACLE_EXCLUDE` exists to prevent, in a new step, for a reason nothing states.
+///
+/// The `SWEEP_FILTER` half is the milder version: those rows run in `sweeps` with
+/// all four oracles armed already, so re-running them here would be redundant
+/// rather than wrong — but it would also mean the debt list silently governs a
+/// job it says nothing about.
+#[test]
+fn the_sequence_oracle_exclude_is_disjoint_from_the_permanent_filters() {
+    let debt = modules_named_in(&ci_filter("SEQUENCE_ORACLE_EXCLUDE"));
+    assert!(
+        !debt.is_empty(),
+        "SEQUENCE_ORACLE_EXCLUDE names nothing; this guard has gone vacuous"
+    );
+    for key in ["ORACLE_EXCLUDE", "SWEEP_FILTER", "CENSUS_FILTER"] {
+        let other = modules_named_in(&ci_filter(key));
+        assert!(
+            !other.is_empty(),
+            "ci.yml's {key} names no module; this guard has gone vacuous"
+        );
+        let both: Vec<&String> = debt.iter().filter(|m| other.contains(m)).collect();
+        assert!(
+            both.is_empty(),
+            "these are named in BOTH SEQUENCE_ORACLE_EXCLUDE and {key}: {both:#?}\n\
+             The debt list is temporary and carries issue numbers; {key} is a standing \
+             statement about what the armed job must never run. A row in both means the \
+             compensating step re-runs, under three armed oracles, a module {key} \
+             withholds from them."
+        );
+    }
 }
 
 /// The two filters must stay disjoint.

--- a/tests/it/stranded_identity_member.rs
+++ b/tests/it/stranded_identity_member.rs
@@ -124,6 +124,29 @@
 //! about an **authored** identity; nothing in the input here asserted `11=`.
 //! Distinguishing the two is a representation decision with a real trailer, so
 //! this file measures and pins rather than fixes.
+//!
+//! # Why this module is named in `SEQUENCE_ORACLE_EXCLUDE`
+//!
+//! The output above — an insertion at interbase 11|12 beside an identity
+//! claiming 11..12 — **denotes no sequence**, which is #1281's shape and which
+//! `FERRO_ASSERT_SEQUENCE` fires on. Two of this module's four tests do:
+//! `every_stranded_identity_is_non_confluent_with_its_surviving_member` and
+//! `the_wider_multi_member_census_is_what_the_header_says`. That is not a false
+//! positive — the oracle is right, and this module pins the defect it is right
+//! about, so a test that pins a defect and an oracle that aborts on it cannot
+//! both run. Exactly the class `ci.yml`'s `ORACLE_EXCLUDE` documents.
+//!
+//! So when #1815 armed that flag in `test-oracle`, this module was named in
+//! `ci.yml`'s `SEQUENCE_ORACLE_EXCLUDE` alongside the issue that retires the
+//! row: **#1655**. It still runs there under the other three oracles, in a
+//! second un-partitioned step of the same job, and it still runs in full in the
+//! plain `test` job — so arming the fourth oracle cost this file nothing.
+//!
+//! **Fixing #1655 means deleting this module's row from that filter**; rehoming
+//! the sweep the way `ORACLE_EXCLUDE`'s pinned-defect modules are homed is the
+//! other way out. Do not silence the fire at the seam — that hollows out the
+//! oracle, and this module's own measurement is the evidence the fire is
+//! correct.
 
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Refs #1815. **Deliberately not `Closes`** — see [What this does NOT fix](#what-this-does-not-fix). The issue has two halves and this closes one; the previous revision of this PR carried `Closes #1815` and its own body called that "optimistic", which was right.

Representation-Change: none. CI wiring, workflow comments, the local oracle runner, `CLAUDE.md` and test-only guards. `scripts/check_representation_change.py` confirms it: *"No file under a watched directory changed; no declaration needed."* No normalized output moves — the point of the change is that an existing oracle now *runs* in a gating job. It asserts; it does not normalize.

## What this does

`FERRO_ASSERT_SEQUENCE` (#1615) is the only oracle that can see a normalized description denoting different bases than its input, or denoting none at all. It ran in exactly two places: `sweeps`, over three cis-sweep modules, and `nightly-mutalyzer.yml`, which is `continue-on-error` by design. `test-oracle` — the job that runs the suite armed — was the one place the set of four was incomplete. That is #1815's surviving half.

This arms it there, behind a two-row `SEQUENCE_ORACLE_EXCLUDE`, and gates through the required `Test` rollup (`test-required` `needs: [test, test-oracle, soak, sweeps]`).

## This revision was re-derived, not rebased — and the debt list is not the one the PR was drafted against

The previous head (`a26f0be4`, base `f1f53a8e`, ~60 commits behind) is **replaced** rather than rebased, because its central factual claim had become wrong in both directions and its `ci.yml`/`CLAUDE.md` hunks *deleted* newer, more accurate records to restore their older selves. Porting it would have regressed the file.

**The selection-wide armed figure has read 5 → 2 → 3 across three measurements in three days:**

| measured | tree | armed failures | why it moved |
|---|---|---:|---|
| #1813 | `674e9c8b` | 5 | 3 × `issue_1487_canonical_window_overflow` (#1690) + 2 × `stranded_identity_member` (#1655) |
| #1990 | `c9207d7e` | 2 | #1690 closed; the three overflow rows are gone |
| **this PR** | `1aecc93a` | **3** | #2051 added a gate that fires — see below |

So the "two-row debt list" in the title is *coincidentally* still two rows, and they are **not the same two**. `issue_1487_canonical_window_overflow` is out (#1690 closed, 2026-08-15) and `dump_normalized_corpus`'s render-time gate is in (#2051, 2026-08-16). Both times the stale reading was the *flattering* one. Every count in the new comments names the tree it was taken on and says to re-measure.

### The debt list, as measured

```
without SEQUENCE_ORACLE_EXCLUDE:  11202 tests run: 11199 passed, 3 failed   EXIT=100
with    SEQUENCE_ORACLE_EXCLUDE:  11200 tests run: 11200 passed, 0 failed   EXIT=0
```

- **`stranded_identity_member`** — 2 of its 4 tests. A genuine fire of #1281's *denotes no sequence* shape, on a module whose purpose is to **pin** that defect (**#1655**, open). A test that pins a defect and an oracle that aborts on it cannot both run: exactly the class `ORACLE_EXCLUDE` already documents. Named at module granularity because the module's whole purpose is the pin.
- **`the_render_time_reference_matches_what_the_pipeline_was_given`** — one **test**, named rather than its module, so the other 55 tests in `examples/dump_normalized_corpus.rs` stay armed. #2051 added it hours before this measurement; it re-normalizes each corpus row **itself, outside** the `catch_unwind` that `dump`'s own pass uses, so a row that trips an oracle takes the test with it. It passes unarmed in the same tree (`EXIT=0`, measured), so it is an oracle fire and not a pre-existing red.

## Two defect classes this surfaced, both filed

47 corpus inputs abort that gate. Eight are **#1983** (already open). The other 39 were unreported:

- **#2140** (38 inputs) — a minted repeat tract widened across the CDS start into the 5'UTR swallows its sibling, so the output denotes no sequence: `NM_TESTX.1:c.[2_3dup;5T>A]` → `c.[-3_6T[11];5T>A]`, where the tract spans `-3..6` and the sibling names base `5`. The same input is **fine** on the single-exon transcript (`c.6_7insAT`) and wrong on the 5'UTR-bearing one, across 5 corpus families / 1,720 `cx` rows. Not #1983: that issue is that `demote_repeats_spanning_siblings` has no `NaEdit::Repeat` arm and so *"covers only the repeats ferro itself mints"* — these **are** the repeats ferro mints, so the pass is reached and still fails.
- **#2139** (1 input) — #1513's adjacent-junction insertion pair still denotes different bases when it straddles the CDS start: `NM_TESTX.1:c.[-1_1insAA;1_2insTT]` inserts `ATTA` at interbase 5, every output inserts `TTAA` at interbase 4. #1513's guards pin the shape only on pairs sitting **entirely inside the CDS**.

**Both are confirmed without the oracle.** `cargo run --features dev --example dump_normalized_corpus -- --verify-spdi` reports `13 denote different bases` of 96,182 verified rows: 6 × #2139, 5 × #1983, 2 × the repeat family. **#2140 is invisible to that instrument** — it files those rows under *"unverifiable (member overlap)"*, 28,368 of 96,182, and grepping its report for `2_3dup;5T>A` returns 0. The denoted-sequence oracle's *denotes-no-sequence* arm is the only thing that reaches them, which is the design decision that makes #1615 worth arming.

## Nothing is traded away

A nextest `-E` is one expression, so negating the filter would also withdraw these rows from `FERRO_ASSERT_IDEMPOTENT`, `_REPARSE` and `_IN_BOUNDS`, which they pass — three oracles surrendered to gain one, the swap the `sweeps` job's comment refuses to make. So `test-oracle` gains a **second, un-partitioned step** that re-runs exactly those rows under those three. This file's oracle coverage is a strict superset of what it was.

`oracle_exclude_invariant.rs` asserts that step exists, selects the variable **by reference** rather than by a copy of its value, arms exactly the other three, does **not** arm the fourth, and passes `--no-tests=fail`.

## Proof the gate can go red

A gate that runs but cannot fail is worse than no gate. Both halves measured on `04a1146e`, the base this PR is rebased onto:

| | armed suite | guard suite |
|---|---|---|
| **as wired** | `11214 passed, 0 failed` — **EXIT=0** | 31/31 pass |
| **one debt row removed** | `11216 passed, 2 failed` — **EXIT=100** | **31/31 still pass** |

Red on the real message, not on a wiring error:

```
FERRO_ASSERT_SEQUENCE: normalization produced a description that denotes no sequence at all,
                       from an input that denotes one
  input:  TEMPLATE:g.[10_11insAT;11_12inv;12_13insA]
  output: TEMPLATE:g.[11_12insTA;11_12=;12_13insA]
```

The right-hand column is the load-bearing part: **the guards cannot see an oracle fire.** They stay green while the armed run is `EXIT=100`, so the arming is doing work no static check substitutes for. `ci.yml` was restored byte-identically after (`cmp` clean, `git status` empty), and zero `Skipping:` lines in every run with `FERRO_REQUIRE_BULK_FIXTURES=1`.

### Sabotage table — each wiring guard, checked rather than assumed

| sabotage | guard that caught it | exit |
|---|---|---|
| delete the compensating step's `-E` | `the_sequence_oracle_exclusions_still_run_under_the_other_three_oracles` | 100 |
| add `FERRO_ASSERT_SEQUENCE` to the compensating step | same | 100 |
| typo a debt row name | `every_row_withheld_from_the_sequence_oracle_names_something_that_exists` | 100 |
| drop `and not ($SEQUENCE_ORACLE_EXCLUDE)` from the armed `-E` | `the_ci_oracle_selection_negates_…` | 100 |
| retire the variable, keep the `-E` term | `run_oracle_suite.sh` refuses, naming the repair | 1 |
| un-arm `FERRO_ASSERT_SEQUENCE`, keep the filter | `the_sequence_oracle_exclusions_still_run_under_…` | 100 |
| *(control — no sabotage)* | — | **0** |

## Review notes on my own diff

- **`test-oracle` now has two nextest steps, which broke a guard on a correct file** and is the non-obvious consequence to know about. `test_oracle_job_flags()` scanned the whole job, so it returned seven keys with three duplicated against the runner's four. It is now scoped to the armed step, identified by its **`--partition`** — deliberately *not* by the step's `name:`, which is what the script's awk anchors on, so a rename breaks one derivation and not the other.
- **`if: matrix.shard == 1` on the compensating step** is the shape `.coderabbit.yaml`'s `.github/workflows/**` instruction says to flag, so it is called out rather than left to be found. The step selects 5 tests and is not partitioned: `--partition hash:K/4` would leave some shards selecting none, and neither answer is acceptable (`--no-tests=fail` reddens a shard for doing its job; `--no-tests=pass` is a step that goes green having run nothing). It carries no `if: always()`, so a red armed step skips it — the concern that rule protects against is coverage lost on a *passing* run, and on a passing run this step always executes.
- **A claim I made and then had to retract**, recorded because the diff would otherwise read as more certain than it was. I wrote in `ci.yml` that one `stranded_identity_member` test had been renamed. It had not — my evidence was a `cargo nextest list` I had truncated with `tail -3`. The red run printed the real names and the comment is corrected to the measured pair, with a note that they were read off a failing run rather than matched against prose. I also asserted a substitution-order hazard between `$ORACLE_EXCLUDE` and `$SEQUENCE_ORACLE_EXCLUDE`; **tested, it does not exist** (the pattern carries the leading `$`), and both the script and the Rust say so rather than carrying a plausible-sounding false reason.
- **Stale claims corrected as part of the change**, each of which this PR would otherwise falsify: `test-oracle`'s own comment block; the `SWEEP_FILTER` note and the `sweeps` job's "only job IN THIS FILE that sets it"; `censuses`' "the three `test-oracle` sets"; `run_oracle_suite.sh`'s header ("deliberately does NOT arm this one"); `CLAUDE.md` in six places, including *"No CI job arms the oracle where it fires"*, which is now false for `normalize_tests` — its 453 tests run armed and green. The useful prose from the replaced commit's three test-file hunks is carried forward, adapted (the `issue_1487` one had to be rewritten, since that module is no longer on the debt list).
- **`censuses` is now where the plausible wrong edit lives.** Its armed step used to mirror `test-oracle`'s flag set; it is now a strict **subset**, deliberately, and arming the fourth there has never been measured over `ORACLE_ONLY_FILTER`. That job's header says so, and `the_local_oracle_runner_arms_exactly_the_flags_test_oracle_arms`'s doc points at it.

## What this does NOT fix

**No pull-request job provisions a manifest, so the reference-aware axes still skip-as-PASS.** `test-oracle` arms the flag but sets no `FERRO_MANIFEST`, so `mutalyzer_normalize_tests` / `biocommons_normalize_tests` early-return there exactly as in the plain `test` job, and nextest reports that skip path as **PASS** rather than SKIP. A denoted-sequence violation on those axes still cannot redden a required check.

That is not an oversight and not a small change: `nightly-mutalyzer.yml` spends ~30 min in `ferro prepare` per run, and the prepared reference is deliberately uncached — a 3.25 GiB entry against a 10 GiB repository budget, measured at a 0 % hit rate over five consecutive nights (#1218). What this PR does do is stop the skip being quiet: the `test` job's `::notice::` now says in those words that the skip reports as PASS and that no gating job runs those axes.

**So #1815 should stay open on the manifest half after this merges**, which is why the trailer is `Refs` and not `Closes`.

## Deferred to a maintainer, deliberately not decided here

**Should `nightly-mutalyzer.yml` keep `continue-on-error: true`?** It is the only lever that makes a manifest-backed oracle fire block anything. It is also deliberate — its purpose is to surface drift in the `ferro-xfail-*` artifact rather than to gate, the corpus runner wraps normalization in `catch_panics` on that assumption, and `report-failure`'s `hint:` is written around it. Removing it converts an informational nightly into a blocking one. Related and already filed: **#1998**, that nothing baselines that workflow's xfail set, so a new failure is indistinguishable from the 37 beside it.

**Retiring the debt list is a four-file change** (`ci.yml`, `scripts/run_oracle_suite.sh`, `tests/it/oracle_exclude_invariant.rs`, plus the module doc that cites the row). A half-done retirement fails loudly rather than handing nextest the literal string `$SEQUENCE_ORACLE_EXCLUDE`, which would parse as a test-name substring and quietly narrow the armed job to nothing. Closing **#1655** deletes one row; closing **#2140**, **#1983** and **#2139** together delete the other, and the variable with it.

## Local verification

Each command run unpiped with `EXIT=$?` captured to a log and read back:

| gate | result |
|---|---|
| `cargo nextest run --features dev --no-fail-fast` | `11389 passed, 151 skipped` — **EXIT=0** |
| `cargo clippy --all-features --all-targets -- -D warnings` | **EXIT=0** |
| `cargo fmt --all --check` | **EXIT=0** |
| `python3 -m pytest tests/python/ -q` | `1137 passed, 8 skipped` — **EXIT=0** |
| `cargo nextest run --features dev --test it -E 'test(workflow_pipefail_gate)'` | `18 passed` — **EXIT=0** |

Guard modules post-rebase, including `ruling_records_are_intact` and `normalization_contract_doc`: 98/98. `scripts/run_oracle_suite.sh` green over 11,214 tests armed with all four oracles.
