### PR TITLE
ci: watch src/reference/ and src/error_handling/ for representation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,14 +277,21 @@ jobs:
       - name: Run mypy
         run: uv run poe check-typing
 
-  # A change under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` can move
-  # the normalized string a downstream consumer stores read counts against, so it must say
-  # whether it does. `release-plz.toml` renders the changelog's **Representation changes**
-  # section from a `Representation-Change:` trailer on the squash commit (#1433) — the
-  # machinery works, but across the v0.13.0 cycle 87 commits landed carrying zero trailers
-  # while 46 touched those directories, and the section rendered empty. An empty section
-  # looks identical whether nothing moved or nobody declared, so it went unnoticed for ~90
-  # commits and the disclosure had to be reconstructed by hand before release (#1522).
+  # A change under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
+  # `src/reference/` or `src/error_handling/` can move the normalized string a downstream
+  # consumer stores read counts against, so it must say whether it does.
+  # `release-plz.toml` renders the changelog's **Representation changes** section from a
+  # `Representation-Change:` trailer on the squash commit (#1433) — the machinery works,
+  # but across the v0.13.0 cycle 87 commits landed carrying zero trailers while 46 touched
+  # the four directories watched at the time, and the section rendered empty. An empty
+  # section looks identical whether nothing moved or nobody declared, so it went unnoticed
+  # for ~90 commits and the disclosure had to be reconstructed by hand before release
+  # (#1522). The last two directories were added by #1853, on the finding that every
+  # newly-normalizing row in that reconstruction attributes to one PR touching only
+  # `src/reference/` and one touching only `src/error_handling/`. The authoritative list
+  # is `WATCHED_PREFIXES` in the script this job runs; this comment restates it for the
+  # reader, and `test_the_prose_restatements_name_every_watched_directory` fails when a
+  # watched directory is missing from it — the obligation is enforced, not promised.
   #
   # `Representation-Change: none` passes. The point is to force the judgement, not to force
   # a disclosure; what this rejects is silence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -752,10 +752,19 @@ Because the fixture is no longer in git, per-PR `parse-error → preserved` stat
 
 ### Declaring a representation change: a REQUIRED check, not a convention
 
-A PR touching `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` must carry a
-`Representation-Change:` trailer **in its PR description**, or the `Representation change
-declared` check fails. That context is in `main`'s ruleset, so a missing trailer **blocks the
-merge**.
+A PR touching `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`, `src/reference/`
+or `src/error_handling/` must carry a `Representation-Change:` trailer **in its PR
+description**, or the `Representation change declared` check fails. That context is in
+`main`'s ruleset, so a missing trailer **blocks the merge**.
+
+The last two were added by #1853 on measurement rather than on reasoning, and the reasons
+they are the *only* two added are on `WATCHED_PREFIXES` in
+`scripts/check_representation_change.py` — read that docstring before proposing a seventh.
+In short: the v0.13.0 cycle is the one place output movement was measured without relying
+on anyone declaring it, and its 326,404 newly-normalizing rows attribute to one PR touching
+only `src/reference/` and one touching only `src/error_handling/`. `src/conformance/` stays
+out because it cannot move ferro's output, and `src/data/` stays out because every measured
+disclosure that touches it also touches `src/reference/`.
 
 ```
 Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,8 @@ dash may introduce a reason:
 test(conformance): gate the harvested unguarded cases on every PR
 
 Representation-Change: none. Test-only plus two new `src/conformance/`
-  modules; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or
-  `src/project/` is touched, and no existing expectation was re-blessed.
+  modules; nothing under a watched directory is touched, and no existing
+  expectation was re-blessed.
 ```
 
 A comma is *not* a terminator, because it usually introduces a qualification
@@ -142,9 +142,20 @@ Quantifying a zero is fine and encouraged — `none. 0 of 950 rows move` passes.
 A declining trailer is
 excluded from the changelog's **Representation changes** section, so declaring it
 costs the reader nothing while leaving the judgement on the record. CI enforces
-the distinction: a change touching `src/normalize/`, `src/hgvs/`, `src/spdi/` or
-`src/project/` with no trailer at all fails the `Representation change declared`
-check, because an absent trailer is indistinguishable from an unconsidered one.
+the distinction: a change touching `src/normalize/`, `src/hgvs/`, `src/spdi/`,
+`src/project/`, `src/reference/` or `src/error_handling/` with no trailer at all
+fails the `Representation change declared` check, because an absent trailer is
+indistinguishable from an unconsidered one.
+
+The last two joined that list on measurement (#1853). `src/reference/` decides
+which bases a description resolves against and `src/error_handling/` decides the
+accept/reject boundary, and both have moved consumer-visible output while the
+gate stayed silent — between them they account for every newly-normalizing row
+in the v0.13.0 cycle, whose disclosure had to be reconstructed by hand. Two
+neighbours are deliberately **not** watched: `src/conformance/`, which is
+measurement and adjudication code that cannot move ferro's output, and
+`src/data/`, whose every measured disclosure also touches `src/reference/` and is
+therefore already covered.
 
 **Indent continuation lines**, as above. Git only folds a multi-line trailer
 value into the trailer when the continuations are whitespace-prefixed: measured

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -52,9 +52,9 @@ Reviewer checklist:
       rest, and CI's `Changelog grouping audit` fails until it has been run.
       Re-run it after any push that regenerates this section — it is idempotent.
 
-A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` that
-moved output without declaring it means the trailer is missing. Fix that before
-releasing, not after.
+A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
+`src/reference/` or `src/error_handling/` that moved output without declaring it
+means the trailer is missing. Fix that before releasing, not after.
 
 ---
 

--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -9,10 +9,11 @@ changelog section from a `Representation-Change:` trailer on the squash commit, 
 release PR body carries a reviewer checklist for it (#1433).
 
 That machinery works. Nothing was feeding it: across the v0.13.0 cycle, 87 commits
-landed and **zero** carried the trailer, while 46 touched the directories below. The
-section rendered empty, and an empty section looks identical whether it is empty because
-nothing moved or because nobody declared anything — so it went unnoticed for ~90 commits
-and the disclosure had to be reconstructed by hand before release (#1522).
+landed and **zero** carried the trailer, while 46 touched the four directories watched at
+the time (51 touch the six watched now). The section rendered empty, and an empty section
+looks identical whether it is empty because nothing moved or because nobody declared
+anything — so it went unnoticed for ~90 commits and the disclosure had to be reconstructed
+by hand before release (#1522).
 
 This closes that loop: a change under a watched directory must *say* whether it moves
 output. Saying "no" is a first-class answer — `Representation-Change: none` — because the
@@ -38,12 +39,44 @@ from pathlib import Path
 
 #: Directories whose output a change can move. A variant's canonical form is decided in
 #: `normalize`; `hgvs` owns how it is spelled back out; `spdi` and `project` re-express it
-#: on another axis, and a consumer keys on those renderings too.
+#: on another axis, and a consumer keys on those renderings too. `reference` decides which
+#: bases any of that resolves against, and `error_handling` decides the accept/reject
+#: boundary — an input that starts producing a string, or stops, is as visible to a
+#: consumer as one whose string changes.
+#:
+#: **The last two were added on measurement, not on reasoning** (#1853, #1522). The one
+#: cycle in which movement was measured without relying on anyone declaring it is v0.13.0:
+#: 87 commits landed carrying **zero** trailers (`git rev-list v0.12.0..v0.13.0` counts 88,
+#: the extra being release-plz's own release commit), and the **Representation changes** section
+#: was reconstructed by hand by normalizing 5,761,302 expressions through both releases and
+#: diffing row by row. Its 326,404 newly-normalizing rows attribute to exactly two PRs —
+#: #1490, which touches `src/reference/` and nothing else, and #1501, which touches
+#: `src/error_handling/` and nothing else. Neither was watched. Merged history since the
+#: gate landed agrees: the only real out-of-gate disclosures are #1594 and #1661
+#: (`src/error_handling/`, the second a previously-*accepted* string, so a genuine
+#: migration) and #1724 (`src/reference/`).
+#:
+#: **Two directories are deliberately absent, and both get re-proposed.** `src/conformance/`
+#: is measurement and adjudication code that by construction cannot move ferro's output, so
+#: gating it would demand a declaration about something the directory cannot do — both of
+#: its real disclosures (#1623, #1839) open `0 rows move in this PR`. `src/data/` was
+#: proposed alongside the two above and declined on **zero marginal catch in both measured
+#: populations**: its one real disclosure (#1737) also touches `src/reference/`, so the
+#: entry above already gates it; both its merged gate-era commits (#1786, #1770) declined;
+#: and it was touched by 0 of the commits in the v0.13.0 blind cycle. The single fact
+#: that would earn it a place is a real, non-declining disclosure touching `src/data/` and
+#: **not** `src/reference/` — one PR, no argument needed.
+#:
+#: Widening this tuple adds no required *context* — `Representation change declared` already
+#: runs on every PR — so nothing is stranded on "Expected — waiting for status to be
+#: reported"; only the verdict changes.
 WATCHED_PREFIXES: tuple[str, ...] = (
     "src/normalize/",
     "src/hgvs/",
     "src/spdi/",
     "src/project/",
+    "src/reference/",
+    "src/error_handling/",
 )
 
 #: The trailer git-cliff groups on. Matched at the start of a line, case-insensitively,

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -80,35 +80,159 @@ def test_a_watched_file_among_unwatched_ones_still_requires_a_declaration() -> N
     assert not ok
 
 
-@pytest.mark.parametrize(
-    "path",
-    [
-        "src/normalize/merge.rs",
-        "src/hgvs/variant.rs",
-        "src/spdi/mod.rs",
-        "src/project/projector.rs",
-    ],
+#: One representative path per watched directory. Kept as data because the two tests below
+#: read it from opposite sides — every entry must be gated, and the tuple must contain
+#: nothing this list does not name — which together pin the watched set exactly, through
+#: `check()` rather than by restating the constant.
+_A_FILE_IN_EVERY_WATCHED_DIRECTORY = (
+    "src/normalize/merge.rs",
+    "src/hgvs/variant.rs",
+    "src/spdi/mod.rs",
+    "src/project/projector.rs",
+    # Added by #1853's backtest. `src/reference/` decides which bases a description
+    # resolves against and `src/error_handling/` decides the accept/reject boundary; both
+    # have moved consumer-visible output while the gate stayed silent -- see
+    # `test_the_widened_prefixes_are_the_ones_the_backtest_measured`.
+    "src/reference/multi_fasta.rs",
+    "src/error_handling/mod.rs",
 )
+
+#: Directories that changed output-adjacent code and are deliberately NOT watched. Each
+#: carries its reason, because "not watched" is a decision that gets re-proposed.
+_A_FILE_IN_EVERY_DELIBERATELY_UNWATCHED_DIRECTORY = (
+    # Measurement and adjudication code. It cannot move ferro's output, so requiring a
+    # declaration would demand a statement about something the directory cannot do -- both
+    # of its real disclosures (#1623 merged, #1839 open) declare "0 rows move in this PR".
+    "src/conformance/spec_corpus.rs",
+    # Declined on evidence in #1853's backtest: zero marginal catch in both populations.
+    # Its one real disclosure (#1737) also touches `src/reference/`, so the widening above
+    # already gates it; both its merged gate-era commits (#1786, #1770) declined.
+    "src/data/cdot.rs",
+    # Zero real disclosures in either population.
+    "src/convert/mapper.rs",
+)
+
+
+@pytest.mark.parametrize("path", _A_FILE_IN_EVERY_WATCHED_DIRECTORY)
 def test_every_watched_prefix_triggers(path: str) -> None:
     assert watched_files([path]) == [path]
     ok, _ = check([path], "no trailer")
     assert not ok, f"{path} must require a declaration"
 
 
+@pytest.mark.parametrize("path", _A_FILE_IN_EVERY_DELIBERATELY_UNWATCHED_DIRECTORY)
+def test_a_deliberately_unwatched_directory_needs_no_declaration(path: str) -> None:
+    """The exclusions are decisions, so pin them the same way the inclusions are pinned.
+
+    Without this, widening the tuple by one more directory is a silent change: nothing
+    fails, and the next reader cannot tell an excluded directory from an overlooked one.
+    """
+    assert watched_files([path]) == []
+    ok, _ = check([path], "no trailer")
+    assert ok, f"{path} must not require a declaration"
+
+
+def test_the_widened_prefixes_are_the_ones_the_backtest_measured() -> None:
+    """`src/reference/` and `src/error_handling/` are gated; `src/data/` is not (#1853).
+
+    The three were proposed together and the backtest supports two of them. Both additions
+    are carried by the v0.13.0 cycle, the one place movement was measured without relying
+    on anyone declaring it: its 326,404 newly-normalizing rows attribute to #1490
+    (`src/reference/` and nothing else) and #1501 (`src/error_handling/` and nothing else),
+    and the cycle shipped with zero trailers. `src/data/` was touched by **0** commits in
+    that cycle and has zero marginal catch in either population measured since.
+
+    Asserted through `check()` on synthetic file lists, so it survives any rewrite of how
+    the tuple is spelled -- and paired with the coverage assertion below, which is what
+    makes it a pin rather than three examples: a seventh directory cannot be added in
+    silence.
+    """
+    for path in ("src/reference/multi_fasta.rs", "src/error_handling/mod.rs"):
+        ok, message = check([path], "Fixes a thing.\n\nCloses #1.")
+        assert not ok, f"{path} must require a declaration"
+        assert path in message, "the failure must name the file that demanded the trailer"
+        ok, _ = check([path], "Representation-Change: none")
+        assert ok, "declining must still pass on a newly watched directory"
+
+    ok, _ = check(["src/data/cdot.rs"], "no trailer")
+    assert ok, (
+        "src/data/ was proposed in #1853 and declined on measurement; adding it needs a "
+        "real, non-declining disclosure that touches src/data/ and NOT src/reference/, "
+        "which did not exist in either measured population"
+    )
+
+    # Coverage, not a count. A count is defeated by two compensating edits -- add a
+    # seventh prefix, and add a seventh representative under a directory that is already
+    # covered -- which leaves the lengths equal, every representative gated by
+    # `test_every_watched_prefix_triggers`, and the new directory with no representative
+    # at all. That is the same weakness `test_watched_prefixes_match_the_release_config`
+    # rejects in its own docstring, so do not reintroduce it here: the map from
+    # representatives to prefixes is a bijection only if no two representatives share a
+    # prefix, and nothing asserts that.
+    unrepresented = [
+        prefix
+        for prefix in WATCHED_PREFIXES
+        if not any(path.startswith(prefix) for path in _A_FILE_IN_EVERY_WATCHED_DIRECTORY)
+    ]
+    assert not unrepresented, (
+        f"{sorted(unrepresented)} is watched but has no representative path in "
+        "_A_FILE_IN_EVERY_WATCHED_DIRECTORY; every entry needs one so the gate is pinned "
+        "by behaviour rather than by restating the constant"
+    )
+
+
 def test_watched_prefixes_match_the_release_config() -> None:
     """`release-plz.toml`'s reviewer checklist names the directories this must watch.
 
-    Pinned as a set comparison rather than a count: two compensating edits could keep the
-    count while swapping a directory out, which is exactly the drift that would make this
-    check pass on the changes it exists to catch.
+    A real set comparison, in **both** directions. This test's docstring used to claim it
+    was one while the assertion only ran checker -> config, which left the dangerous
+    direction open: a prefix silently dropped from `WATCHED_PREFIXES` still satisfied
+    "every watched directory is named in the config", and a dropped prefix is exactly the
+    drift that makes this check pass on the changes it exists to catch. A count would not
+    close it either, since two compensating edits keep the count while swapping a
+    directory out.
+
+    The config side is read as every backticked ``src/<dir>/`` token in the file, so the
+    comparison keeps working when the prose is re-wrapped -- which it was here, the list
+    having grown past one line.
     """
     config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    for prefix in WATCHED_PREFIXES:
-        directory = prefix.rstrip("/")
-        assert f"`{directory}/`" in config, (
-            f"{directory} is watched by the check but not named in release-plz.toml's "
-            "checklist; the two must describe the same scope"
-        )
+    documented = {f"{directory}/" for directory in re.findall(r"`(src/[a-z_]+)/`", config)}
+    assert documented == set(WATCHED_PREFIXES), (
+        f"release-plz.toml names {sorted(documented)} but the check watches "
+        f"{sorted(WATCHED_PREFIXES)}; the two must describe the same scope. A directory in "
+        "the config and not the tuple is a gate that does not exist; one in the tuple and "
+        "not the config is a scope the release reviewer is never told to look for."
+    )
+
+
+@pytest.mark.parametrize("document", ["CONTRIBUTING.md", "CLAUDE.md", ".github/workflows/ci.yml"])
+def test_the_prose_restatements_name_every_watched_directory(document: str) -> None:
+    """The list is restated in prose in three more places; none of them was pinned.
+
+    `release-plz.toml` is pinned above, but the same six directories are also written out
+    in `CONTRIBUTING.md` (contributor guidance), `CLAUDE.md` (agent guidance) and the
+    `representation-change` job's comment in `ci.yml` -- which says of itself that it
+    "must be kept in step with" the constant, an obligation nothing enforced. One rule
+    written in several places and then drifting apart is this repository's named recurring
+    failure mode, and the sibling `test_contributing_documents_the_same_decline_vocabulary`
+    already pins the decline vocabulary for exactly that reason.
+
+    **Containment, not set equality**, and the asymmetry is deliberate. All three documents
+    legitimately name directories that are *not* watched -- `src/conformance/` and
+    `src/data/`, whose exclusion is itself a decision worth stating -- so equality would
+    fail on correct prose. The direction that matters is the other one: a directory added
+    to `WATCHED_PREFIXES` and not to the docs is a required check that fails a contributor
+    who was never told the scope had grown.
+    """
+    text = (Path(__file__).resolve().parents[2] / document).read_text(encoding="utf-8")
+    undocumented = [prefix for prefix in WATCHED_PREFIXES if f"`{prefix.rstrip('/')}/`" not in text]
+    assert not undocumented, (
+        f"{document} does not name {sorted(undocumented)}, which "
+        f"scripts/check_representation_change.py watches; the check watches "
+        f"{sorted(WATCHED_PREFIXES)}. A watched directory missing from the prose is a "
+        "required check nobody was told about."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`WATCHED_PREFIXES` in `scripts/check_representation_change.py` named four directories — `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`. This adds two: **`src/reference/`** and **`src/error_handling/`**.

Refs #1853, which proposed **three**. It stays open on purpose: one of its three (`src/data/`) is being declined here on measurement, and that disposition should be recorded there rather than swept up by an auto-close.

## Why these two, and not `src/data/`

The decisive evidence is the v0.13.0 cycle — the one place output movement was measured without relying on anyone declaring it. 87 commits shipped carrying **zero** trailers, and the changelog's **Representation changes** section had to be reconstructed by hand, normalizing 5,761,302 expressions through both releases against the same prepared reference and diffing row by row. Its **326,404** newly-normalizing rows attribute to exactly two PRs, and the attribution is the finding:

| PR | commit | directories touched | watched before? |
|---|---|---|---|
| #1490 | `3ac054d3` | `src/reference/` **only** | no |
| #1501 | `feb5dc9f` | `src/error_handling/` **only** | no |

Merged history since the gate landed agrees. The only real out-of-gate disclosures are #1594 and #1661 (`src/error_handling/`, the second a previously-**accepted** string and therefore a genuine migration, not a free addition) and #1724 (`src/reference/`, merged since the backtest was written).

`src/data/` is dropped from #1853's proposal because **its marginal contribution is exactly zero in both measured populations**:

- its one real disclosure (#1737) also touches `src/reference/`, so the entry added here already gates it;
- both its merged gate-era commits (#1786, #1770) declined;
- **zero** commits touched it in the v0.13.0 blind cycle;
- its only measured effect is turning draft #1156 red.

The single fact that would earn it a place is a real, non-declining disclosure touching `src/data/` and **not** `src/reference/`. That does not exist in either population today. If a successor to #1156 moves cdot's CDS bounds alone and moves output, it earns its place on evidence — one PR, no argument needed. This is written down on `WATCHED_PREFIXES` itself so the next reader does not re-propose it from the mechanism argument.

`src/conformance/` stays excluded too, and deliberately: it is measurement and adjudication code that by construction cannot move ferro's output, so gating it would demand a declaration about something the directory cannot do. Both of its real disclosures (#1623 merged, #1839 open) open `0 rows move in this PR`. After this change the *entire* remaining missed column in both populations is those two conformance decision records.

## Measured

Re-derived independently against `origin/main` @ `2b979da2` (1,003 merged commits; 48 open PRs), using the repo's own `find_declaration` / `declines` / `disclosure_value` and `git show --name-only --no-renames`, matching what `ci.yml` passes the checker.

Merged history — 31 real disclosures, 108 declines, 864 silent:

| configuration | caught | missed | tax (`none`) | extra gated | would go red |
|---|---:|---:|---:|---:|---:|
| Current (4) | 27 | 4 | 30 | — | 0 |
| + `reference` | 28 | 3 | 30 | 1 | 0 |
| #1853 (+ `reference` + `error_handling` + `data`) | 30 | 1 | 32 | 5 | 0 |
| **this PR (+ `reference` + `error_handling`)** | **30** | **1** | **30** | **3** | **0** |
| all of `src/` | 31 | 0 | 50 | 24 | 0 |

This matches #1853's backtest with every cell offset by exactly the merge of **#1724**, which was an *open* `src/reference/` disclosure when the backtest ran and is now merged history. That merge is the only change, and it strengthens the case: `src/reference/` went from zero merged evidence to one merged real disclosure.

This PR reaches #1853's catch rate exactly — 30 caught, **0 real merged moves missed** — while gating two fewer commits and forcing two fewer `none`s.

## Nothing strands, and nothing newly reddens

Widening the tuple adds no required **context**. `Representation change declared` already runs on every PR and already reports; only its verdict changes. So the standing objection — that a new required context strands every open PR on "Expected — waiting for status to be reported" — does not apply.

Re-verified against live PR bodies and the GitHub files API at current heads:

- **12** open PRs touch `src/reference/` or `src/error_handling/`; **12 of 12 already carry a trailer.** Zero go red.
- **6** of those are *newly* gated (they touch a newly watched directory and no previously watched one): #1861, #1851, #1830, #1783, #1741, #1737. All six are non-draft and all six already declare voluntarily.
- The one PR red under this configuration, **#1024**, is red under the *current* four as well — it touches `src/project/projector.rs`. This change neither causes nor fixes it; the fix there is a rebase to mint a fresh run.
- #1156, the single PR #1853's three-directory proposal would have reddened, touches only `src/data/` and is therefore **not gated at all** by this PR.

The earlier "11 touch a newly-gated directory, 10 already declare" figure was measured over the three-directory proposal and a 39-PR population. At current heads, over 48 open PRs and the two directories actually being added, it is 12 of 12 — the reassurance holds and is stronger.

## Tests

`tests/python/test_representation_change_trailer.py` asserts through `check()` on synthetic file lists rather than restating the constant, and pins both sides of the boundary:

- every watched directory demands a declaration (parametrized over one real path per directory, now six);
- every **deliberately unwatched** directory does not — `src/conformance/`, `src/data/`, `src/convert/`, each carrying its reason inline, so an exclusion cannot be mistaken for an oversight;
- a dedicated test pins the two additions and the `src/data/` exclusion end-to-end, plus a length assertion so a seventh directory cannot be added in silence.

Watched fail first, then pass. Before touching `WATCHED_PREFIXES`: 3 failed, 98 passed, both new prefixes reporting `watched_files([path]) == []`. After: 101 passed. Perturbing the tuple with `src/data/` re-reds three tests, including `test_watched_prefixes_match_the_release_config` — so the release-config pin and the exclusion guard are both live rather than vacuous.

One defect fixed while in there. `test_watched_prefixes_match_the_release_config`'s docstring claimed a set comparison against `release-plz.toml` — "exactly the drift that would make this check pass on the changes it exists to catch" — while the assertion only ran checker → config. That left the dangerous direction open: a prefix silently **dropped** from `WATCHED_PREFIXES` still satisfied "every watched directory is named in the config". It is now a real set comparison in both directions, and reads the config side as every backticked `` `src/<dir>/` `` token so it survives the prose re-wrap this PR forces. Verified by deleting `src/spdi/` from the tuple: that test now fails, where before it passed.

## Documentation kept in step

Four places state the gated set and all four are updated: `CONTRIBUTING.md`, `release-plz.toml`'s release-PR reviewer checklist (which `test_watched_prefixes_match_the_release_config` pins the checker against), `.github/workflows/ci.yml`'s job comment, and `CLAUDE.md`. Each now points at `WATCHED_PREFIXES` as the authority rather than competing with it.

One statement of the old four is left alone on purpose: the doc comment in `tests/it/spec_conformance_axis.rs` is a historical record of what a specific past branch touched when it was measured, not a statement of the current gate — editing it would falsify the record it exists to keep.

Representation-Change: none. This is a CI gate and its documentation; no `src/` file changes, so no normalized output can move. What changes is which changes are *required to declare*, which is a property of the checker rather than of ferro's output.
