### PR TITLE
fix(data): refuse an inverted-CDS record instead of underflowing on it

### DIFF
--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -519,11 +519,10 @@ impl CoordinateMapper {
         genome_pos: &GenomePos,
         transcript_id: &str,
     ) -> Result<(CdsPos, MappingInfo), FerroError> {
-        // `transcript_id` is part of the parameter list for API stability but
-        // no in-tree consumer reads `MappingInfo::transcript_id` — leaving it
-        // None avoids a `String::from` allocation per call (~400 calls per
-        // SNP project_all on chr17 fan-out).
-        let _ = transcript_id;
+        // No in-tree consumer reads `MappingInfo::transcript_id`, so it is left
+        // None: that avoids a `String::from` allocation per call (~400 calls per
+        // SNP project_all on chr17 fan-out). `transcript_id` is still named in
+        // the inverted-CDS refusal below, which allocates only on the error path.
         let mut info = MappingInfo::default();
 
         // Check if position is in an exon. `locate_genome_pos` returns both
@@ -693,9 +692,38 @@ impl CoordinateMapper {
                         }
                         CdsPosition::ThreePrimeUtr(utr_offset) => {
                             info.in_3utr = true;
+                            // Both bounds are necessarily `Some` here — `tx_to_cds`
+                            // returns `None` unless both are set, and that `None`
+                            // became the `InvalidCoordinates` above — so the
+                            // fallbacks are unreachable rather than load-bearing.
                             let cds_end = tx.cds_end.unwrap_or(0);
                             let cds_start = tx.cds_start.unwrap_or(0);
-                            let last_cds_pos = (cds_end - cds_start) as i64;
+                            // Refuse an inverted record rather than wrap. `tx_to_cds`
+                            // states no ordering precondition: it tests
+                            // `tx_pos < cds_start` then `tx_pos < cds_end`, so when
+                            // `cds_end < cds_start` every position at or past
+                            // `cds_start` falls through to this arm — making it
+                            // exactly where such a record arrives. The bare
+                            // subtraction then underflowed: a panic in debug, and in
+                            // release a wrap that `as i64` turns into a negative
+                            // `base` flagged `utr3`, returned as success.
+                            //
+                            // `merge.rs`'s `ordered_cds_bounds` refuses the same
+                            // condition on the same ground — an inverted record's
+                            // 5'UTR and 3'UTR halves overlap, so one transcript
+                            // position has two names and any answer here silently
+                            // picks one of them. Refusing does not repair that
+                            // ambiguity; it keeps this conversion from being one
+                            // more place that resolves it arbitrarily.
+                            let last_cds_pos = cds_end.checked_sub(cds_start).ok_or_else(|| {
+                                FerroError::InvalidCoordinates {
+                                    msg: format!(
+                                        "transcript {transcript_id} has inverted CDS bounds \
+                                         (cds_start {cds_start} > cds_end {cds_end}); its c. \
+                                         axis is incoherent, so c.*{utr_offset} cannot be resolved"
+                                    ),
+                                }
+                            })? as i64;
                             Ok((
                                 CdsPos {
                                     base: last_cds_pos,
@@ -1330,6 +1358,133 @@ mod tests {
                 .len(),
             2,
             "second transcript must be visible after add",
+        );
+    }
+
+    /// A record whose CDS bounds are inverted (`cds_end < cds_start`). Nothing
+    /// on the load path rejects one: `RawCdotTranscript::from_genome_build`
+    /// takes `cds_start` / `cds_end` straight from the record's own
+    /// `start_codon` / `stop_codon` whenever either is present, with no ordering
+    /// check, and `reference/validate.rs`'s `cds_end < cds_start` test is a
+    /// report-only pass that gates nothing.
+    fn create_inverted_cds_mapper() -> CoordinateMapper {
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_INVERTED.1".to_string(),
+            CdotTranscript {
+                cds_start_incomplete: false,
+                gene_name: Some("INVERTED".to_string()),
+                contig: "NC_000001.11".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1100, 0, 100], [2000, 2200, 100, 300]],
+                // The CDS "ends" 40 bases before it starts.
+                cds_start: Some(50),
+                cds_end: Some(10),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        CoordinateMapper::new(cdot)
+    }
+
+    /// The same refusal, reached from a cdot JSON document rather than from a
+    /// directly constructed [`CdotTranscript`] — so the guard is pinned on the
+    /// path real input takes.
+    ///
+    /// `from_genome_build` adopts `start_codon` / `stop_codon` verbatim whenever
+    /// either is present, so a record spelling them out of order loads inverted.
+    /// The sibling genomic-CDS fallback orders its endpoints and cannot.
+    #[test]
+    fn an_inverted_cds_record_loaded_from_json_is_refused() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_INVJSON.1": {
+                    "gene_name": "INVJSON",
+                    "genome_builds": {
+                        "GRCh38": {
+                            "contig": "NC_000001.11",
+                            "strand": "+",
+                            "exons": [[1000, 1100, 1, 0, 100, "M100"],
+                                      [2000, 2200, 2, 100, 300, "M200"]]
+                        }
+                    },
+                    "start_codon": 50,
+                    "stop_codon": 10
+                }
+            }
+        }
+        "#;
+        let cdot = CdotMapper::from_reader(json.as_bytes()).unwrap();
+        let tx = cdot
+            .get_transcript("NM_INVJSON.1")
+            .expect("the record must load; nothing on the load path rejects it");
+        assert_eq!(
+            (tx.cds_start, tx.cds_end),
+            (Some(50), Some(10)),
+            "the codon fields must load verbatim, inverted — if this changes, the \
+             load path gained a guard and this test is no longer reaching the one \
+             under test",
+        );
+
+        let mapper = CoordinateMapper::new(cdot);
+        let result = mapper.genome_to_cds("NM_INVJSON.1", &GenomePos::new(1500));
+        // Match on the message, not only on the variant: `InvalidCoordinates` is
+        // this path's catch-all (`Cannot determine CDS position for intronic
+        // position`, `Genomic position … is outside transcript range`), so a
+        // variant-only assertion would still pass if the fixture drifted and the
+        // guard under test were never reached.
+        let msg = match &result {
+            Err(FerroError::InvalidCoordinates { msg }) => msg.as_str(),
+            _ => panic!(
+                "an inverted CDS record loaded from JSON must be refused; got {:?}",
+                result.as_ref().map(|r| &r.variant)
+            ),
+        };
+        assert!(
+            msg.contains("inverted CDS bounds"),
+            "the refusal must come from the inverted-bounds guard, not from another \
+             `InvalidCoordinates` site this call can reach; got: {msg}",
+        );
+    }
+
+    /// An inverted-CDS record must be refused, not answered.
+    ///
+    /// `tx_to_cds` has no ordering precondition: it tests `tx_pos < cds_start`
+    /// then `tx_pos < cds_end`, so on an inverted record *every* position at or
+    /// past `cds_start` falls through to the 3'UTR arm. That arm then computed
+    /// the last CDS position as a bare `cds_end - cds_start` on two `u64`s,
+    /// which underflows. Measured on this case: a panic under
+    /// `debug-assertions`, and in release a wrap to `18446744073709551576`,
+    /// reinterpreted by the `as i64` as `-40` and returned as
+    /// `Ok(CdsPos { base: -40, utr3: true, .. })` — a negative base flagged
+    /// 3'UTR, which is not a position any transcript has.
+    ///
+    /// `merge.rs`'s `ordered_cds_bounds` refuses this exact condition, on the
+    /// ground that an inverted record's 5'UTR and 3'UTR halves overlap so one
+    /// transcript position has two names; this applies that precedent here.
+    #[test]
+    fn intronic_three_prime_utr_on_an_inverted_cds_record_is_refused() {
+        let mapper = create_inverted_cds_mapper();
+        // Genome 1500 is intronic between the two exons. The nearest boundary
+        // anchor is tx 99, which `tx_to_cds` files as 3'UTR because 99 is not
+        // below `cds_end` (10) — so the 3'UTR arm runs with cds_end < cds_start.
+        let result = mapper.genome_to_cds("NM_INVERTED.1", &GenomePos::new(1500));
+        // As above: assert the message, so this pins the inverted-bounds guard
+        // rather than any `InvalidCoordinates` this call happens to produce.
+        let msg = match &result {
+            Err(FerroError::InvalidCoordinates { msg }) => msg.as_str(),
+            _ => panic!(
+                "an inverted CDS record must be refused, not answered with a \
+                 fabricated base; got {:?}",
+                result.as_ref().map(|r| &r.variant)
+            ),
+        };
+        assert!(
+            msg.contains("inverted CDS bounds"),
+            "the refusal must come from the inverted-bounds guard, not from another \
+             `InvalidCoordinates` site this call can reach; got: {msg}",
         );
     }
 }


### PR DESCRIPTION
Closes #1871.

`CoordinateMapper::genome_pos_to_cds_pos`'s intronic 3'UTR arm computed the last CDS position as a bare `cds_end - cds_start` on two `u64`s, with no ordering precondition. `CdotTranscript::tx_to_cds` states no ordering precondition either — it tests `tx_pos < cds_start`, then `tx_pos < cds_end`, and files everything else as 3'UTR — so on a record where `cds_end < cds_start`, every transcript position at or past `cds_start` falls through to exactly this arm and underflows.

The code is unchanged since the initial commit.

## What it did, measured in both profiles

On a two-exon record with `cds_start = 50`, `cds_end = 10`, queried at an intronic genomic position:

```
debug:   panicked at src/data/mapping.rs:698:48: attempt to subtract with overflow
release: Ok(CdsPos { base: -40, offset: Some(491), utr3: true, special: None })
```

`[profile.release]` sets no `overflow-checks`, so release wraps to `18446744073709551576` and `as i64` reinterprets it as `-40`. The release half is the worse one: a negative base flagged `utr3` is not a position any transcript has, and it is returned as success rather than as an error.

## The fix

`checked_sub`, refusing with `InvalidCoordinates` and naming the transcript and both bounds.

Refusing is not a new idiom here — it is the project's established and already-tested position on this exact condition:

- **`merge.rs`'s `ordered_cds_bounds`** refuses it by name, and its doc comment gives the ground: an inverted record's 5'UTR and 3'UTR halves overlap, so one transcript position has two names, and a conversion that does not refuse silently picks one of them.
- **`boundary::get_cds_boundaries_with_axis_info`** guards it the same way (`(Some(s), Some(e)) if e >= s`).
- **#1284 pinned it as behaviour** — `issue_1284_transcript_axis_reparse::inverted_cds_bounds_are_refused_not_guessed`: *"The repair must refuse rather than pick one."*

So this closes the one site that did not yet honour a rule the tree already holds elsewhere — the same asymmetry #1745 reports for `utr5_length` vs `get_amino_acid_at`.

The two `unwrap_or(0)` fallbacks are left alone and are now documented as unreachable: `tx_to_cds` returns `None` unless both bounds are set, and that `None` is already `?`-propagated into an error before this arm runs. The defect was the missing ordering check, not the missing-bound fallback.

## Reach, stated honestly

Reachable from a **cdot JSON document**, not only from a directly constructed `CdotTranscript` — so wider than #1746's Rust-API-only reach. `RawCdotTranscript::from_genome_build` adopts `start_codon` / `stop_codon` verbatim whenever either is present, with no ordering check; the sibling genomic-CDS fallback in the same function *does* order its endpoints and so cannot produce an inverted record. Both reach paths are pinned by a test.

**No shipped reference data is affected.** Scanning all three prepared cdot files for records carrying both codon fields with `start_codon > stop_codon`:

| file | transcripts | both codons | inverted |
|---|---|---|---|
| `cdot-0.2.32.refseq.GRCh38.json` | 482,519 | 355,590 | **0** |
| `cdot-0.2.32.ensembl.GRCh38.json` | 574,584 | 266,774 | **0** |
| `cdot-0.2.32.refseq.GRCh37.json` | 197,846 | 158,791 | **0** |

0 of 781,155. The scan reproduces three figures already recorded in `src/data/cdot.rs`'s own comments (355,590 / 266,774 / the single GRCh38 record carrying `stop_codon` but no `start_codon`), which is what makes the zero trustworthy rather than an artifact of a wrong query.

So this is **defensive hardening against a malformed record, not a live corruption of real output** — worth doing, and worth not overstating.

## Scope

One guard, at one site. `mapping.rs:698` is the only place with this shape: every other CDS-bound subtraction in `src/data/` is already guarded by its enclosing branch condition, and `cds_pos_from_region` — the exonic counterpart — never performs this subtraction, so the exonic path was never affected.

Deliberately **not** widened: `mapping.rs:304`'s `cds_end + (base as u64) - 1` cannot underflow (`base >= 1` is checked immediately above) and its only risk is *overflow* on an absurd coordinate, which is a different defect already tracked by #1690. `merge.rs:4275`'s `map_or(0, …)` is a documented deliberate fallback and is untouched.

## Tests

Two, one per reach path, both pinning refusal rather than the old value. Both were watched failing before the fix — with the guard reverted they panic at the subtraction under `debug-assertions` — and passing after.

Representation-Change: none. No output moves: the change adds a refusal on a condition that 0 of 781,155 real cdot records satisfy, and every previously-answerable input still takes the same path to the same value. The only behaviour change is on an inverted record, which previously panicked in debug and fabricated a negative `utr3` base in release.
