### PR TITLE
feat(normalize)!: remove the 5' shuffle direction from the public surface

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -129,7 +129,6 @@ jobs:
           [tools.ferro]
           enabled = true
           reference_dir = "/var/lib/ferro-web/reference"
-          shuffle_direction = "3prime"
           error_mode = "lenient"
 
           # Mutalyzer runs as a local Python subprocess for reproducibility and

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ correctness or stability.
 ## Features
 
 - **Full HGVS Parsing**: All coordinate systems (g/c/n/r/p/m/o) and edit types
-- **Variant Normalization**: 3'/5' shifting per HGVS specification
+- **Variant Normalization**: 3' shifting per HGVS specification
 - **High Performance**: ~5M variants/sec single-threaded parsing (>12M/s parallel), zero-copy with nom
 - **Type-Safe**: Leverages Rust's type system for correctness
 
@@ -203,9 +203,14 @@ ferro's normalizer follows four rules about its output, and three about how it h
       feature request, worth making but never a reason to hold a release.
 
 6. **Among multiple conformant forms:** the maintainers choose. **There are no user options for
-   normalization form.** Error mode is an orthogonal axis and stays available. The 3'/5' knob is
-   **not** orthogonal — it selects the frame every rule is evaluated in, so rules 2 and 3 are
-   claimed *per direction* rather than across the two.
+   normalization form.** Error mode is an orthogonal axis and stays available. The 3'/5' shuffle
+   direction was the one exception, and it is now removed from the public surface rather than
+   excused: it is **not** orthogonal — it selects the frame every rule is evaluated in — so it was
+   a user option for normalization form sitting inside this rule. ferro shifts 3', the only
+   direction the HGVS recommendations describe, and no CLI flag, Python keyword or service config
+   key selects otherwise. The 5' arm survives internally as a differential oracle over ferro's own
+   test suite; an instrument is not a user option, and rules 2 and 3 are now claimed once rather
+   than per direction.
 
 7. **Disclosure.** Any change to these rules, and any different choice made under 5 or 6, is
    disclosed: in the changelog before v1, by a major version bump after. Output that *violates*
@@ -350,10 +355,11 @@ description on any machine, against any reference build, with no hidden input. `
 1-based, and `reference` is taken on trust: verifying it would need the reference and would make
 the provider a hidden input, costing exactly the determinism the function exists to provide.
 
-That is five values, not four. The options are not inert — `direction` moves a placement within
-the window and `max_grid_cells` decides whether an answer is produced at all — so the
-"four arguments" this section and the Rust docs both used to claim is withdrawn. Purity is the
-property; the count was wrong.
+That is five values, not four. `max_grid_cells` is not inert — it decides whether an answer is
+produced at all — so the "four arguments" this section and the Rust docs both used to claim is
+withdrawn. Purity is the property; the count was wrong. (`FromSequencesOptions` carries a
+`direction` too, but it is not a caller-facing knob: it is `#[doc(hidden)]`, always 3' on every
+shipped path, and exists for the internal differential oracle described under rule 6.)
 
 ### How to: one canonical description per variant
 
@@ -645,7 +651,7 @@ The `ferro` CLI provides commands beyond parsing and normalization:
 | `prepare` | Download and prepare reference data for normalization |
 | `check` | Verify reference data setup |
 | `parse` | Parse and validate HGVS variants |
-| `normalize` | Normalize HGVS variants (3'/5' shifting) |
+| `normalize` | Normalize HGVS variants (3' shifting) |
 | `explain` | Explain error/warning codes (e.g., `ferro explain W1001`) |
 | `annotate-vcf` | Annotate VCF files with HGVS notation |
 | `vcf-to-hgvs` | Convert VCF records to HGVS |

--- a/config/service.example.toml
+++ b/config/service.example.toml
@@ -18,7 +18,6 @@ max_concurrent_batches = 10
 [tools.ferro]
 enabled = true
 reference_dir = "data/ferro-reference"
-shuffle_direction = "3prime"
 error_mode = "lenient"
 
 # Mutalyzer runs as a local Python subprocess for reproducibility and offline

--- a/docs/WEB_SERVICE_SETUP.md
+++ b/docs/WEB_SERVICE_SETUP.md
@@ -58,7 +58,6 @@ enable_cors = true
 [tools.ferro]
 enabled = true
 reference_dir = "/path/to/ferro-reference"
-shuffle_direction = "3prime"
 error_mode = "lenient"
 
 [tools.mutalyzer]
@@ -99,7 +98,6 @@ Config:
 [tools.ferro]
 enabled = true
 reference_dir = "/path/to/ferro-reference"
-shuffle_direction = "3prime"  # or "5prime"
 error_mode = "lenient"        # or "strict", "silent"
 ```
 

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -31,12 +31,11 @@ def parse(hgvs_string: str) -> HgvsVariant:
     """
     ...
 
-def normalize(hgvs_string: str, direction: str = "3prime") -> str:
+def normalize(hgvs_string: str) -> str:
     """Normalize an HGVS variant string.
 
     Args:
         hgvs_string: The HGVS variant description to normalize
-        direction: Shuffle direction - "3prime" (default) or "5prime"
 
     Returns:
         The normalized HGVS string
@@ -44,8 +43,6 @@ def normalize(hgvs_string: str, direction: str = "3prime") -> str:
     Raises:
         ParseError: If the HGVS string cannot be parsed (a subclass of
             ValueError).
-        ValueError: If ``direction`` is not one of
-            "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         NormalizationError: If normalization fails (a subclass of RuntimeError).
 
     Example:
@@ -54,9 +51,7 @@ def normalize(hgvs_string: str, direction: str = "3prime") -> str:
     """
     ...
 
-def normalize_with_warnings(
-    hgvs_string: str, direction: str = "3prime"
-) -> NormalizeResultWithWarnings:
+def normalize_with_warnings(hgvs_string: str) -> NormalizeResultWithWarnings:
     """Normalize an HGVS variant string, returning the warnings with it.
 
     The warning-bearing sibling of :func:`normalize`, which returns only the
@@ -72,7 +67,6 @@ def normalize_with_warnings(
 
     Args:
         hgvs_string: The HGVS variant description to normalize
-        direction: Shuffle direction - "3prime" (default) or "5prime"
 
     Returns:
         A NormalizeResultWithWarnings.
@@ -80,8 +74,6 @@ def normalize_with_warnings(
     Raises:
         ParseError: If the HGVS string cannot be parsed (a subclass of
             ValueError).
-        ValueError: If ``direction`` is not one of
-            "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         NormalizationError: If normalization fails (a subclass of RuntimeError).
 
     Example:
@@ -104,7 +96,6 @@ def from_sequences(
     alternate: str,
     *,
     max_grid_cells: int | None = None,
-    direction: str = "3prime",
 ) -> HgvsVariant:
     """Derive an HGVS description from a reference/alternate sequence pair.
 
@@ -138,15 +129,13 @@ def from_sequences(
             build. Defaults to ``(4096 + 1) ** 2``, about 310 MB at roughly 18
             bytes a cell. Exceeding it raises rather than answering with a
             weaker rule.
-        direction: Which end of an ambiguous run a pure indel is placed at —
-            "3prime" (default) or "5prime".
 
     Returns:
         The derived HgvsVariant.
 
     Raises:
-        ValueError: for an unrecognized ``direction``, or a ``max_grid_cells``
-            of 0. These two are checked at the binding, before any derivation.
+        ValueError: for a ``max_grid_cells`` of 0, checked at the binding
+            before any derivation.
         NormalizationError: for everything the derivation itself refuses — a
             zero position, an empty reference, a non-nucleotide symbol, a
             transcript or protein accession, a grid over budget, or an inserted
@@ -172,7 +161,6 @@ def from_sequences_detailed(
     alternate: str,
     *,
     max_grid_cells: int | None = None,
-    direction: str = "3prime",
 ) -> DerivedDescription:
     """:func:`from_sequences`, reporting also whether the derivation reached a window edge.
 
@@ -641,15 +629,12 @@ class HgvsVariant:
         """Check if this variant causes a frameshift (indel_length % 3 != 0)."""
         ...
 
-    def normalize(self, direction: str = "3prime") -> HgvsVariant:
+    def normalize(self) -> HgvsVariant:
         """Normalize this variant.
 
         Args:
-            direction: Shuffle direction - "3prime" (default) or "5prime".
 
         Raises:
-            ValueError: If ``direction`` is not one of
-                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         """
         ...
 
@@ -756,28 +741,23 @@ class Normalizer:
     def __init__(
         self,
         reference_json: str | None = None,
-        direction: str = "3prime",
         error_config: ErrorConfig | None = None,
     ) -> None:
         """Create a new normalizer.
 
         Args:
             reference_json: Optional path to a transcripts.json file
-            direction: Shuffle direction - "3prime" (default) or "5prime"
-            error_config: Optional ErrorConfig controlling reference-mismatch
+                error_config: Optional ErrorConfig controlling reference-mismatch
                 handling (e.g. ``ErrorConfig.strict()`` to reject
                 wrong-reference variants). Defaults to lenient.
 
         Raises:
-            ValueError: If ``direction`` is not one of
-                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         """
         ...
 
     @staticmethod
     def from_manifest(
         manifest_path: str,
-        direction: str = "3prime",
         error_config: ErrorConfig | None = None,
     ) -> Normalizer:
         """Create a normalizer from a reference manifest written by ``ferro prepare``.
@@ -785,7 +765,6 @@ class Normalizer:
         Args:
             manifest_path: Path to a manifest.json file (typically inside a
                 directory produced by ``ferro prepare``).
-            direction: Shuffle direction - "3prime" (default) or "5prime".
             error_config: Optional ErrorConfig controlling reference-mismatch
                 handling (e.g. ``ErrorConfig.strict()`` to reject
                 wrong-reference variants). Defaults to lenient.
@@ -794,8 +773,6 @@ class Normalizer:
             A Normalizer backed by a MultiFastaProvider.
 
         Raises:
-            ValueError: If ``direction`` is not one of
-                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
             ReferenceDataError: If the manifest cannot be loaded (a subclass of
                 RuntimeError and ValueError).
         """
@@ -964,9 +941,6 @@ class Normalizer:
         make the provider a hidden input. This one holds a provider, so it does
         check, and refuses an interval running past the end of the sequence. It
         also offers ``normalize``, which the free function cannot.
-
-        The shuffle direction is this normalizer's own, set when it was
-        constructed, rather than a separate keyword.
 
         Args:
             accession: The sequence the window is on.
@@ -1541,9 +1515,7 @@ class SequencePair:
         """
         ...
 
-    def derive(
-        self, *, max_grid_cells: int | None = None, direction: str = "3prime"
-    ) -> DerivedDescription:
+    def derive(self, *, max_grid_cells: int | None = None) -> DerivedDescription:
         """Derive an HGVS description from this window.
 
         :func:`from_sequences` over the four values this pair already carries,
@@ -1552,8 +1524,7 @@ class SequencePair:
         accidentally pair a pre-trim position with post-trim bases.
 
         Raises:
-            ValueError: for an unrecognized ``direction``, or a
-                ``max_grid_cells`` of 0.
+            ValueError: for a ``max_grid_cells`` of 0.
             NormalizationError: as the free :func:`from_sequences`.
         """
         ...
@@ -2694,7 +2665,6 @@ class VariantProjector:
     def __init__(
         self,
         reference_json: str | None = None,
-        direction: str = "3prime",
         assembly: str | None = None,
         protein_stop: str = "ter",
         amino_acid_code: str = "three",
@@ -2705,7 +2675,6 @@ class VariantProjector:
         Args:
             reference_json: Path to a transcripts.json file. If None, uses
                 built-in test data (limited; not for production).
-            direction: Shuffle direction passed to the internal normalizer
                 ("3prime" or "5prime").
             assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
                 aliases "hg19"/"hg38") for build-agnostic inputs. A bare NG_/LRG_
@@ -2720,7 +2689,7 @@ class VariantProjector:
                 wrong-reference variants). Defaults to lenient.
 
         Raises:
-            ValueError: If ``direction``, ``assembly``, ``protein_stop``, or
+            ValueError: If ``assembly``, ``protein_stop``, or
                 ``amino_acid_code`` is not a recognized value.
         """
         ...
@@ -2728,7 +2697,6 @@ class VariantProjector:
     @staticmethod
     def from_manifest(
         manifest_path: str,
-        direction: str = "3prime",
         assembly: str | None = None,
         protein_stop: str = "ter",
         amino_acid_code: str = "three",
@@ -2738,7 +2706,6 @@ class VariantProjector:
 
         Args:
             manifest_path: Path to manifest.json produced by `ferro prepare`.
-            direction: Shuffle direction ("3prime" or "5prime").
             assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
                 aliases "hg19"/"hg38") for build-agnostic inputs.
             protein_stop: Stop-codon spelling for rendered p. names — "ter"
@@ -2753,7 +2720,7 @@ class VariantProjector:
             A VariantProjector backed by MultiFastaProvider with cdot data.
 
         Raises:
-            ValueError: If ``direction``, ``assembly``, ``protein_stop``, or
+            ValueError: If ``assembly``, ``protein_stop``, or
                 ``amino_acid_code`` is not a recognized value.
             RuntimeError: If the manifest cannot be loaded.
         """
@@ -2929,12 +2896,9 @@ class VariantProjector:
 
         By default (``normalize=True``) the result is the projector-normalized
         genomic form — what most callers want; a Genome input is canonicalized
-        too. The normalizer follows this projector's configured shuffle
-        direction (``VariantProjector(direction=...)``): with the default
-        ``direction="3prime"`` that is the spec-canonical, 3'-shifted form (e.g.
-        a non-3'-most ``g.1003del`` in a poly-A run → ``g.1007del``); a
-        ``direction="5prime"`` projector instead returns the 5'-anchored form.
-        Pass ``normalize=False`` for the raw pivot, which intentionally does not
+        too. That is the spec-canonical, 3'-shifted form (e.g. a non-3'-most
+        ``g.1003del`` in a poly-A run → ``g.1007del``); 3' is the only direction
+        ferro shifts. Pass ``normalize=False`` for the raw pivot, which intentionally does not
         normalize its input (#785): a non-canonical input then yields a
         non-canonical genomic output, and a Genome input passes through
         unchanged (idempotent).

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -8,9 +8,8 @@
 use clap::{Parser, Subcommand};
 use ferro_hgvs::cli::{
     normalize_tsv_row, normalize_tsv_summary, output_error as cli_output_error,
-    output_error_with_context as cli_output_error_with_context, parse_genome_build,
-    parse_shuffle_direction, parse_vcf_line, process_input_line, OutputFormat,
-    NORMALIZE_TSV_HEADER,
+    output_error_with_context as cli_output_error_with_context, parse_genome_build, parse_vcf_line,
+    process_input_line, OutputFormat, NORMALIZE_TSV_HEADER,
 };
 use ferro_hgvs::config::{apply_override, FerroConfig, OverrideSource};
 use ferro_hgvs::error_handling::{
@@ -218,7 +217,7 @@ enum Commands {
     },
 
     /// Normalize HGVS variants
-    #[command(long_about = "Normalize HGVS variants (3'/5' shifting).
+    #[command(long_about = "Normalize HGVS variants (3' shifting).
 
 UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
 
@@ -283,10 +282,16 @@ UNSTABLE EVALUATION SWITCH: FERRO_PARTITION
         #[arg(short = 'f', long, default_value = "text", value_parser = ["text", "json", "tsv"])]
         format: String,
 
-        /// Shuffle direction (3prime or 5prime)
-        #[arg(long, default_value = "3prime")]
-        direction: String,
-
+        // There is deliberately no `--direction` flag. `README.md` rule 6:
+        // there are no user options for normalization form, and a shuffle
+        // direction is not orthogonal to the form — it selects the frame every
+        // other rule is evaluated in. `ferro normalize` shifts 3', which is the
+        // only direction the HGVS recommendations describe. Removing the flag
+        // rather than accepting-and-ignoring it is the point: clap rejects an
+        // unknown argument with a non-zero exit, so a script that still passes
+        // `--direction 5prime` fails loudly instead of silently 3'-shifting
+        // (the #1863 failure shape). Pinned by
+        // `tests/it/five_prime_public_surface_removed.rs`.
         /// Reference directory (with manifest.json from 'ferro prepare')
         #[arg(long)]
         reference: Option<PathBuf>,
@@ -850,7 +855,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             input,
             output,
             format,
-            direction,
             reference,
             error_mode,
             ignore,
@@ -865,7 +869,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 input.as_ref(),
                 output.as_ref(),
                 &format,
-                &direction,
                 reference.as_ref(),
                 timing.as_ref(),
                 workers,
@@ -1613,7 +1616,6 @@ fn run_normalize(
     input: Option<&PathBuf>,
     output: Option<&PathBuf>,
     format: &str,
-    direction: &str,
     reference: Option<&PathBuf>,
     timing: Option<&PathBuf>,
     workers: usize,
@@ -1632,8 +1634,13 @@ fn run_normalize(
     // so the omission cannot recur at this call site (#1197). It is not a
     // whole-crate guarantee — see the constructor's docs and the entry-point
     // scan in `tests/it/issue_1197_required_error_config.rs`.
-    let config =
-        NormalizeConfig::for_entry_point(parse_shuffle_direction(direction), error_config.clone());
+    // 3' is the only direction ferro shifts (`README.md` rule 6); naming it
+    // explicitly here rather than relying on `Default` matches how `project`
+    // has always done it below.
+    let config = NormalizeConfig::for_entry_point(
+        ferro_hgvs::normalize::ShuffleDirection::ThreePrime,
+        error_config.clone(),
+    );
 
     // Create reference provider from directory
     let provider = create_reference_provider(reference.map(|p| p.as_path()), strict_reference)?;
@@ -2042,7 +2049,7 @@ fn run_project(
     // family as #1181, out of scope here; noted so the line above is not read
     // as a stronger claim than it makes.
     //
-    // `project` has no direction flag; naming the 3' default explicitly is the
+    // No subcommand has a direction flag any more; naming the 3' default explicitly is the
     // price of a constructor that cannot silently default the error
     // configuration (#1197), and it documents the choice at the call site.
     let projector = VariantProjector::new(Projector::new(cdot), provider).with_normalize_config(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,9 +14,7 @@ pub use format::{
     output_project_error, output_projection, output_result, NormalizeTsvFailure,
     NormalizeTsvOutcome, NormalizeTsvRow, OutputFormat, NORMALIZE_TSV_HEADER,
 };
-pub use parse::{
-    parse_genome_build, parse_shuffle_direction, parse_vcf_line, parse_vcf_line_with_build,
-};
+pub use parse::{parse_genome_build, parse_vcf_line, parse_vcf_line_with_build};
 pub use project::{project_axis, Axis, AxisOutcome, ProjectCliError};
 
 /// UTF-8 BOM (Byte Order Mark) constant

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -1,7 +1,6 @@
 //! Parsing utilities for CLI operations
 
 use crate::error::FerroError;
-use crate::normalize::ShuffleDirection;
 use crate::reference::transcript::GenomeBuild;
 use crate::vcf::VcfRecord;
 
@@ -30,29 +29,14 @@ pub fn parse_genome_build(build: &str) -> GenomeBuild {
     }
 }
 
-/// Parse a shuffle direction string into a ShuffleDirection enum
-///
-/// Accepts various common formats:
-/// - 3prime, 3', 3 -> ThreePrime
-/// - 5prime, 5', 5 -> FivePrime
-/// - Other values default to ThreePrime
-///
-/// # Examples
-///
-/// ```
-/// use ferro_hgvs::cli::parse_shuffle_direction;
-/// use ferro_hgvs::ShuffleDirection;
-///
-/// assert!(matches!(parse_shuffle_direction("3prime"), ShuffleDirection::ThreePrime));
-/// assert!(matches!(parse_shuffle_direction("5'"), ShuffleDirection::FivePrime));
-/// assert!(matches!(parse_shuffle_direction("unknown"), ShuffleDirection::ThreePrime));
-/// ```
-pub fn parse_shuffle_direction(direction: &str) -> ShuffleDirection {
-    match direction.to_lowercase().as_str() {
-        "5prime" | "5'" | "5" => ShuffleDirection::FivePrime,
-        _ => ShuffleDirection::ThreePrime,
-    }
-}
+// `parse_shuffle_direction` was removed here with the `ferro normalize
+// --direction` flag it existed to serve (`README.md` rule 6: there are no user
+// options for normalization form). Its fallback arm was `_ => ThreePrime`, so
+// an unrecognized value 3'-shifted and reported success — the #1863 footgun,
+// and the reason removing the flag had to be a hard clap rejection rather than
+// a quietly-ignored argument. Its assertions live on
+// `normalize::config`'s `FromStr` tests; the removal itself is pinned by
+// `tests/it/five_prime_public_surface_removed.rs`.
 
 /// Parse a VCF line into a VcfRecord
 ///
@@ -221,63 +205,15 @@ mod tests {
     }
 
     // ===== Shuffle Direction Parsing Tests =====
-
-    #[test]
-    fn test_parse_shuffle_direction_three_prime() {
-        assert!(matches!(
-            parse_shuffle_direction("3prime"),
-            ShuffleDirection::ThreePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction("3'"),
-            ShuffleDirection::ThreePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction("3"),
-            ShuffleDirection::ThreePrime
-        ));
-    }
-
-    #[test]
-    fn test_parse_shuffle_direction_five_prime() {
-        assert!(matches!(
-            parse_shuffle_direction("5prime"),
-            ShuffleDirection::FivePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction("5'"),
-            ShuffleDirection::FivePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction("5"),
-            ShuffleDirection::FivePrime
-        ));
-    }
-
-    #[test]
-    fn test_parse_shuffle_direction_case_insensitive() {
-        assert!(matches!(
-            parse_shuffle_direction("5PRIME"),
-            ShuffleDirection::FivePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction("5Prime"),
-            ShuffleDirection::FivePrime
-        ));
-    }
-
-    #[test]
-    fn test_parse_shuffle_direction_default() {
-        // Unknown values should default to ThreePrime
-        assert!(matches!(
-            parse_shuffle_direction("unknown"),
-            ShuffleDirection::ThreePrime
-        ));
-        assert!(matches!(
-            parse_shuffle_direction(""),
-            ShuffleDirection::ThreePrime
-        ));
-    }
+    //
+    // The four `test_parse_shuffle_direction_*` tests that stood here moved to
+    // `normalize::config`'s test module when `parse_shuffle_direction` was
+    // deleted with the `--direction` flag. Three of them are re-pointed at the
+    // retained internal `FromStr` impl unchanged; the fourth,
+    // `test_parse_shuffle_direction_default`, is the one that changed meaning —
+    // it asserted that an unrecognized value resolves to `ThreePrime`, which is
+    // exactly the silent-3' behaviour #1863 filed, and it is now
+    // `test_parse_direction_unrecognized_is_err`.
 
     // ===== VCF Line Parsing Tests =====
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,14 @@ pub use normalize::from_sequences::{
     from_sequences, from_sequences_detailed, DerivedDescription, FromSequencesOptions,
 };
 pub use normalize::sequence_pair::SequencePair;
-pub use normalize::{NormalizeConfig, Normalizer, ShuffleDirection};
+pub use normalize::{NormalizeConfig, Normalizer};
+// `ShuffleDirection` is re-exported for ferro's own integration tests only —
+// `tests/` is an external crate, so the 3'/5' differential oracle cannot reach a
+// `pub(crate)` type. It is `#[doc(hidden)]` at its definition and no ferro entry
+// point accepts a direction from a caller; see the type's docs and `README.md`
+// rule 6.
+#[doc(hidden)]
+pub use normalize::ShuffleDirection;
 pub use project::{VariantProjection, VariantProjector};
 pub use reference::{JsonProvider, MockProvider, MultiFastaProvider, ReferenceProvider};
 pub use spdi::{

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -3,20 +3,46 @@
 use crate::error_handling::{ErrorConfig, ErrorMode, ErrorOverride, ErrorType, ResolvedAction};
 use serde::{Deserialize, Serialize};
 
-/// Direction for variant shuffling during normalization
+/// Direction for variant shuffling during normalization.
+///
+/// **This is an internal differential-testing instrument, not a supported
+/// option.** No ferro entry point lets a caller select a direction: the CLI has
+/// no `--direction` flag, the Python bindings take no `direction=` keyword, and
+/// the web service has no `shuffle_direction` key. Every shipped path
+/// normalizes 3', which is the only direction the HGVS recommendations
+/// describe. `README.md` rule 6 — "there are no user options for normalization
+/// form" — is what removed them: a direction is not orthogonal to the form,
+/// because it selects the frame every other rule is evaluated in.
+///
+/// [`FivePrime`](ShuffleDirection::FivePrime) survives because 3'/5' *disagreement*
+/// is an oracle nothing else replaces. It has twice caught a defect in the
+/// shipped 3' output that every other check passed — see #1542 / PR #1840,
+/// where 7 of 8 `FERRO_PARTITION` x direction configurations agreed and only
+/// `live`/3' diverged, and `tests/it/cis_confluence_axis.rs`'s `enclosing_exon`
+/// off-by-one, which only the 5' walk reached. The type therefore stays `pub`
+/// so the integration-test suite in `tests/` can drive it, and is
+/// `#[doc(hidden)]` so it is not published as API. Do not reintroduce a
+/// user-facing way to reach it.
 ///
 /// Marked `#[non_exhaustive]` so a future shuffling direction is additive. It
 /// is carried as a `pub` field of [`crate::normalize::NormalizationInfo`]'s
 /// `ShuffleApplied` variant, which is already `#[non_exhaustive]` — without
 /// this the protection there was only half applied, since downstream still had
 /// to match the direction exhaustively.
+#[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum ShuffleDirection {
-    /// Shuffle towards 3' end (default for HGVS)
+    /// Shuffle towards the 3' end. The only direction ferro ships.
     #[default]
     ThreePrime,
-    /// Shuffle towards 5' end (for VCF compatibility)
+    /// Shuffle towards the 5' end.
+    ///
+    /// **Reachable only from ferro's own tests.** The doc comment here read
+    /// "for VCF compatibility" from the initial commit until it was removed as
+    /// false: no VCF path has ever selected it. VCF left-alignment in this
+    /// crate is the anchor-base rules in `src/vcf/from_hgvs.rs` (#261/#81 K2),
+    /// which choose which base to attach rather than which end to shift to.
     FivePrime,
 }
 
@@ -63,7 +89,11 @@ impl std::str::FromStr for ShuffleDirection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct NormalizeConfig {
-    /// Direction to shuffle variants (default: 3')
+    /// Direction to shuffle variants. Always 3' on every shipped path.
+    ///
+    /// `pub` only so ferro's own integration tests can drive the 5' arm as a
+    /// differential oracle; see [`ShuffleDirection`]. Not a supported knob.
+    #[doc(hidden)]
     pub shuffle_direction: ShuffleDirection,
 
     /// Whether to allow crossing exon-intron boundaries
@@ -120,9 +150,17 @@ impl NormalizeConfig {
         Self::default()
     }
 
-    /// Build the configuration for an **entry point** — a seam where a shuffle
-    /// direction and an error mode arrive from outside the library (the CLI,
-    /// the PyO3 bindings, the web service).
+    /// Build the configuration for an **entry point** — a seam where an error
+    /// mode arrives from outside the library (the CLI, the PyO3 bindings, the
+    /// web service).
+    ///
+    /// The `direction` argument is **always
+    /// [`ShuffleDirection::ThreePrime`] at every such seam**: no entry point
+    /// accepts a direction from a caller any more.
+    /// It is still a parameter so that the internal 3'/5' differential can
+    /// build an entry-point-shaped config, and so that the `#1197` lint below
+    /// keeps binding the *error* argument, which is what that constructor
+    /// exists for.
     ///
     /// Both settings are required arguments, which is the whole point:
     /// `NormalizeConfig::default().with_direction(d)` silently fills in every
@@ -190,7 +228,13 @@ impl NormalizeConfig {
         }
     }
 
-    /// Set shuffle direction
+    /// Set the shuffle direction.
+    ///
+    /// **Internal test instrument, not a supported knob** — see
+    /// [`ShuffleDirection`]. Kept `pub` because `tests/it/` is an external
+    /// integration-test crate and roughly 130 call sites across 60 modules
+    /// drive the 3'/5' differential through it.
+    #[doc(hidden)]
     pub fn with_direction(mut self, direction: ShuffleDirection) -> Self {
         self.shuffle_direction = direction;
         self
@@ -540,6 +584,69 @@ mod tests {
             "5prime".parse::<ShuffleDirection>().unwrap(),
             ShuffleDirection::FivePrime
         );
+    }
+
+    // The three tests below carry the assertions that used to live on the two
+    // string parsers deleted with the public direction surface —
+    // `cli::parse_shuffle_direction` and `python_helpers::parse_direction`.
+    // They are re-pointed at the retained internal [`FromStr`] impl rather than
+    // dropped, so no coverage of direction-string handling is lost.
+
+    #[test]
+    fn test_parse_direction_three_prime() {
+        for spelling in ["3prime", "3'", "three_prime"] {
+            assert_eq!(
+                spelling.parse::<ShuffleDirection>().unwrap(),
+                ShuffleDirection::ThreePrime,
+                "{spelling}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_direction_five_prime() {
+        for spelling in ["5prime", "5'", "five_prime"] {
+            assert_eq!(
+                spelling.parse::<ShuffleDirection>().unwrap(),
+                ShuffleDirection::FivePrime,
+                "{spelling}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_direction_case_insensitive() {
+        assert_eq!(
+            "5PRIME".parse::<ShuffleDirection>().unwrap(),
+            ShuffleDirection::FivePrime
+        );
+        assert_eq!(
+            "5Prime".parse::<ShuffleDirection>().unwrap(),
+            ShuffleDirection::FivePrime
+        );
+        assert_eq!(
+            "3PRIME".parse::<ShuffleDirection>().unwrap(),
+            ShuffleDirection::ThreePrime
+        );
+    }
+
+    /// An unrecognized direction string must be an `Err`, never a silent 3'.
+    ///
+    /// This is the property #1016 fixed on the Python side and #1863 filed
+    /// against the CLI: `cli::parse_shuffle_direction` answered
+    /// `ThreePrime` for *any* unrecognized input, so a typo — or a script
+    /// asking for a direction that no longer exists — 3'-shifted and reported
+    /// success. That parser is now gone along with the flag that fed it, and
+    /// this pins that the one remaining string->direction conversion in the
+    /// crate refuses rather than guesses.
+    #[test]
+    fn test_parse_direction_unrecognized_is_err() {
+        for spelling in ["unknown", "", "5prim", "3prine", "five", "5", "3", "banana"] {
+            assert!(
+                spelling.parse::<ShuffleDirection>().is_err(),
+                "{spelling} must not silently resolve to a direction"
+            );
+        }
     }
 
     #[test]

--- a/src/normalize/from_sequences.rs
+++ b/src/normalize/from_sequences.rs
@@ -89,12 +89,13 @@ use crate::normalize::merge::{
 };
 use crate::normalize::ShuffleDirection;
 
-/// Cost and direction knobs for [`from_sequences`].
+/// Cost knobs for [`from_sequences`].
 ///
 /// Nothing here changes which *forms* the function is willing to emit — that is
-/// fixed by the rules, not by the caller (`README.md` rule 6). `direction` is
-/// the same orthogonal axis `NormalizeConfig` already exposes, and
-/// `max_grid_cells` is a memory bound.
+/// fixed by the rules, not by the caller (`README.md` rule 6). `max_grid_cells`
+/// is a memory bound. `direction` is **not** a caller-facing knob: it mirrors
+/// `NormalizeConfig`'s internal test instrument, is `#[doc(hidden)]` for the
+/// same reason, and is always `ThreePrime` on every shipped path.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct FromSequencesOptions {
@@ -108,7 +109,11 @@ pub struct FromSequencesOptions {
     /// weaker rule is the policy.
     pub max_grid_cells: usize,
     /// Which end of an ambiguous run a pure indel is placed at, within the
-    /// caller's window. `ThreePrime` matches `general.md:41` and is the default.
+    /// caller's window. Always `ThreePrime`, which matches `general.md:41`.
+    ///
+    /// **Internal test instrument, not a supported knob** — see
+    /// [`crate::normalize::ShuffleDirection`].
+    #[doc(hidden)]
     pub direction: ShuffleDirection,
 }
 
@@ -132,6 +137,10 @@ impl Default for FromSequencesOptions {
 /// pattern for the same reason.
 impl FromSequencesOptions {
     /// Set which end of an ambiguous run a pure indel is placed at.
+    ///
+    /// **Internal test instrument, not a supported knob** — see
+    /// [`crate::normalize::ShuffleDirection`].
+    #[doc(hidden)]
     #[must_use]
     pub fn with_direction(mut self, direction: ShuffleDirection) -> Self {
         self.direction = direction;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1,7 +1,9 @@
 //! Normalization engine
 //!
 //! Implements the core HGVS variant normalization algorithm including
-//! 3'/5' shifting and boundary detection.
+//! 3' shifting and boundary detection. (A 5' arm exists as an internal
+//! differential oracle and is not reachable from any entry point — see
+//! [`config::ShuffleDirection`] and `README.md` rule 6.)
 //!
 //! # Coordinate Systems
 //!
@@ -95,7 +97,9 @@ use crate::hgvs::HgvsVariant as HV;
 use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use boundary::Boundaries;
-pub use config::{NormalizeConfig, ShuffleDirection};
+pub use config::NormalizeConfig;
+#[doc(hidden)]
+pub use config::ShuffleDirection;
 #[cfg(debug_assertions)]
 use merge::OutOfBoundsCoordinate;
 use rules::{
@@ -1691,12 +1695,11 @@ impl std::fmt::Display for NormalizationWarning {
 #[non_exhaustive]
 pub enum NormalizationInfo {
     /// The shuffle layer relocated the variant per the HGVS arbitrary-
-    /// position rule. The HGVS spec mandates the 3' (rightmost) form, but
-    /// ferro supports both 3' and 5' shuffling via
-    /// [`config::ShuffleDirection`] (some VCF pipelines prefer 5'); the
-    /// direction is carried explicitly so callers can interpret the
-    /// signal correctly. Code: `SHUFFLE_APPLIED`. Mutalyzer-equivalent:
-    /// `ICORRECTEDPOINT` (mutalyzer only emits 3').
+    /// position rule. Every shipped path shuffles 3' (the rightmost form the
+    /// HGVS recommendations mandate); the direction is still carried
+    /// explicitly because ferro's own tests drive a 5' arm as a differential
+    /// oracle — see [`config::ShuffleDirection`]. Code: `SHUFFLE_APPLIED`.
+    /// Mutalyzer-equivalent: `ICORRECTEDPOINT` (mutalyzer only emits 3').
     ShuffleApplied {
         /// Accession of the reference sequence.
         accession: String,
@@ -6524,7 +6527,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // context, re-run the shuffle in genomic space (which spans the
         // junction naturally) and adopt the result only if it actually crossed
         // into the intron. The trigger is a rare edge landing, so the hot path
-        // is untouched; it is 3'-only (5'/VCF shuffles stay exon-confined).
+        // is untouched; it is 3'-only (5' shuffles stay exon-confined).
         // Perf note: an edge-landing variant whose genomic re-shuffle does NOT
         // cross still pays one `transcript_for_intronic()` lookup + one
         // `normalize_boundary_spanning_cds` fetch, then discards them. That cost
@@ -7247,7 +7250,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // intron exists, and we have genomic context, re-run the shuffle in
         // genomic space (which spans the junction naturally) and adopt the result
         // only if it actually crossed into the intron. The trigger is a rare edge
-        // landing, so the hot path is untouched; it is 3'-only (5'/VCF shuffles
+        // landing, so the hot path is untouched; it is 3'-only (5' shuffles
         // stay exon-confined), exactly as the `c.` path.
         //
         // Ordering constraint (#1202, other half documented at the clamp
@@ -15825,7 +15828,7 @@ mod tests {
 
     #[test]
     fn test_purely_exonic_del_5prime_direction_stays_exon_confined() {
-        // #670 is 3'-only. Under 5' (VCF) shuffle direction, a purely-exonic del
+        // #670 is 3'-only. Under the internal 5' shuffle direction, a purely-exonic del
         // must NOT cross into the intron — it shifts toward the 5' end within
         // the exon, never emitting an intronic offset.
         let provider = make_boundary_test_provider();

--- a/src/python.rs
+++ b/src/python.rs
@@ -29,7 +29,7 @@ use crate::prepare::{check_references, prepare_references, PrepareConfig, Refere
 use crate::python_helpers::{
     get_indel_length, get_num_variants, get_substitution_bases, get_variant_edit_type,
     get_variant_end, get_variant_offset, get_variant_reference, get_variant_start, is_frameshift,
-    is_identity, parse_direction, variant_type_str,
+    is_identity, variant_type_str,
 };
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::{GenomeBuild, Strand};
@@ -250,19 +250,12 @@ fn build_isolated_batch(
     Ok(out)
 }
 
-/// Validate a shuffle-direction argument at the Python boundary.
-///
-/// Mirrors the `assembly` argument's validate-and-raise pattern: an unrecognized
-/// spelling raises `ValueError` naming the accepted values instead of silently
-/// defaulting to 3' (#1016).
-fn parse_direction_or_raise(direction: &str) -> PyResult<ShuffleDirection> {
-    parse_direction(direction).ok_or_else(|| {
-        PyValueError::new_err(format!(
-            "unrecognized direction {direction:?}; expected one of \"3prime\", \"5prime\", \
-             \"3\", \"5\", \"3'\", \"5'\" (case-insensitive)"
-        ))
-    })
-}
+// `parse_direction_or_raise` was removed with the ten `direction=` keywords it
+// validated. #1016 filed the shape it fixed — an unrecognized spelling silently
+// defaulting to 3' — and the removal keeps that property rather than dropping
+// it: an argument PyO3 does not know about is a `TypeError`, so
+// `normalize(s, direction="5prime")` fails at the call instead of quietly
+// 3'-shifting. Pinned by `tests/python/test_issue_1016_direction_validation.py`.
 
 /// Resolve an optional `error_config=` keyword argument to the `ErrorConfig`
 /// the normalizer should use.
@@ -593,7 +586,6 @@ fn parse(hgvs_string: &str) -> PyResult<PyHgvsVariant> {
 ///
 /// Args:
 ///     hgvs_string: The HGVS variant description to normalize
-///     direction: Shuffle direction - "3prime" (default) or "5prime"
 ///
 /// Returns:
 ///     The normalized HGVS string
@@ -602,8 +594,8 @@ fn parse(hgvs_string: &str) -> PyResult<PyHgvsVariant> {
 ///     ValueError: If the HGVS string cannot be parsed
 ///     RuntimeError: If normalization fails
 #[pyfunction]
-#[pyo3(signature = (hgvs_string, direction="3prime"))]
-fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<String> {
+#[pyo3(signature = (hgvs_string))]
+fn normalize(py: Python<'_>, hgvs_string: &str) -> PyResult<String> {
     let variant = parse_hgvs(hgvs_string)
         .map_err(|e| ferro_typed("ParseError", format!("Parse error: {e}"), &e))?;
 
@@ -611,10 +603,8 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
     // is a deliberate choice rather than a dropped parameter — `for_entry_point`
     // makes it explicit at the call site instead of inheriting it silently
     // (#1197). Callers wanting strict handling construct a `Normalizer`.
-    let config = NormalizeConfig::for_entry_point(
-        parse_direction_or_raise(direction)?,
-        ErrorConfig::lenient(),
-    );
+    let config =
+        NormalizeConfig::for_entry_point(ShuffleDirection::ThreePrime, ErrorConfig::lenient());
     // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
     let provider = JsonProvider::with_test_data();
     // This free function always uses genome-less test data; surface the
@@ -660,7 +650,6 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
 ///
 /// Args:
 ///     hgvs_string: The HGVS variant description to normalize
-///     direction: Shuffle direction - "3prime" (default) or "5prime"
 ///
 /// Returns:
 ///     NormalizeResultWithWarnings — `.result` is the normalized variant,
@@ -670,11 +659,10 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
 ///     ValueError: If the HGVS string cannot be parsed
 ///     RuntimeError: If normalization fails
 #[pyfunction]
-#[pyo3(signature = (hgvs_string, direction="3prime"))]
+#[pyo3(signature = (hgvs_string))]
 fn normalize_with_warnings(
     py: Python<'_>,
     hgvs_string: &str,
-    direction: &str,
 ) -> PyResult<PyNormalizeResultWithWarnings> {
     let variant = parse_hgvs(hgvs_string)
         .map_err(|e| ferro_typed("ParseError", format!("Parse error: {e}"), &e))?;
@@ -683,10 +671,8 @@ fn normalize_with_warnings(
     // takes no error-mode argument, and a lenient normalizer is precisely the
     // one that produces warnings rather than errors — which is what this
     // function exists to hand back.
-    let config = NormalizeConfig::for_entry_point(
-        parse_direction_or_raise(direction)?,
-        ErrorConfig::lenient(),
-    );
+    let config =
+        NormalizeConfig::for_entry_point(ShuffleDirection::ThreePrime, ErrorConfig::lenient());
     let provider = JsonProvider::with_test_data();
     emit_reduced_capability_warning(
         py,
@@ -1081,18 +1067,15 @@ impl PyHgvsVariant {
     /// For production use, create a Normalizer instance with your reference data.
     ///
     /// Args:
-    ///     direction: Shuffle direction - "3prime" (default) or "5prime"
     ///
     /// Returns:
     ///     A new PyHgvsVariant representing the normalized variant
-    #[pyo3(signature = (direction="3prime"))]
-    fn normalize(&self, py: Python<'_>, direction: &str) -> PyResult<PyHgvsVariant> {
+    #[pyo3(signature = ())]
+    fn normalize(&self, py: Python<'_>) -> PyResult<PyHgvsVariant> {
         // No error-mode argument on this convenience method either; the lenient
         // default is stated rather than inherited (#1197).
-        let config = NormalizeConfig::for_entry_point(
-            parse_direction_or_raise(direction)?,
-            ErrorConfig::lenient(),
-        );
+        let config =
+            NormalizeConfig::for_entry_point(ShuffleDirection::ThreePrime, ErrorConfig::lenient());
         // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
         let provider = JsonProvider::with_test_data();
         // Genome-less test data; surface the reduced-capability signal once per
@@ -1394,23 +1377,21 @@ impl PySequencePair {
     ///
     /// Args:
     ///     max_grid_cells: As the free `from_sequences`.
-    ///     direction: "3prime" (default) or "5prime".
     ///
     /// Returns:
     ///     DerivedDescription
     ///
     /// Raises:
-    ///     ValueError: for an unrecognized direction, or a max_grid_cells of 0.
+    ///     ValueError: for a max_grid_cells of 0.
     ///     NormalizationError: as the free `from_sequences`.
-    #[pyo3(signature = (*, max_grid_cells=None, direction="3prime"))]
-    #[pyo3(text_signature = "(*, max_grid_cells=None, direction='3prime')")]
+    #[pyo3(signature = (*, max_grid_cells=None))]
+    #[pyo3(text_signature = "(*, max_grid_cells=None)")]
     fn derive(
         &self,
         py: Python<'_>,
         max_grid_cells: Option<usize>,
-        direction: &str,
     ) -> PyResult<PyDerivedDescription> {
-        let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+        let options = from_sequences_options(max_grid_cells, ShuffleDirection::ThreePrime)?;
         let inner = self.inner.clone();
         // Detached for the reason given on the free `from_sequences`: the grid
         // is caller-tunable and unbounded by design.
@@ -1621,15 +1602,13 @@ fn from_sequences_options(
 ///         build. Defaults to (4096 + 1) ** 2, about 310 MB at roughly 18
 ///         bytes a cell. Exceeding it raises rather than answering with a
 ///         weaker rule.
-///     direction: Which end of an ambiguous run a pure indel is placed at —
-///         "3prime" (default) or "5prime".
 ///
 /// Returns:
 ///     HgvsVariant
 ///
 /// Raises:
-///     ValueError: for an unrecognized `direction`, or a `max_grid_cells` of 0.
-///         These two are checked at the binding, before any derivation.
+///     ValueError: for a `max_grid_cells` of 0, checked at the binding
+///         before any derivation.
 ///     NormalizationError: for everything the derivation itself refuses — a
 ///         zero position, an empty reference, a non-nucleotide symbol, a
 ///         transcript or protein accession, a grid over budget, or an inserted
@@ -1651,10 +1630,8 @@ fn from_sequences_options(
 ///     >>> str(ferro_hgvs.from_sequences("NC_000001.11", 1000, "AGCG", "AG"))
 ///     'NC_000001.11:g.1002_1003del'
 #[pyfunction]
-#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None, direction="3prime"))]
-#[pyo3(
-    text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None, direction='3prime')"
-)]
+#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None))]
+#[pyo3(text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None)")]
 fn from_sequences(
     py: Python<'_>,
     accession: &str,
@@ -1662,9 +1639,8 @@ fn from_sequences(
     reference: &str,
     alternate: &str,
     max_grid_cells: Option<usize>,
-    direction: &str,
 ) -> PyResult<PyHgvsVariant> {
-    let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+    let options = from_sequences_options(max_grid_cells, ShuffleDirection::ThreePrime)?;
     // Detached even though no provider is touched: the work behind this call is
     // unbounded by design — the default budget admits a 4097x4097 grid, ~310 MB
     // and 16.8 M cells, and the docs invite raising it — so holding the GIL
@@ -1687,10 +1663,8 @@ fn from_sequences(
 /// Returns:
 ///     DerivedDescription with `variant` and `placement_bounded_by_window`.
 #[pyfunction]
-#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None, direction="3prime"))]
-#[pyo3(
-    text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None, direction='3prime')"
-)]
+#[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None))]
+#[pyo3(text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None)")]
 fn from_sequences_detailed(
     py: Python<'_>,
     accession: &str,
@@ -1698,9 +1672,8 @@ fn from_sequences_detailed(
     reference: &str,
     alternate: &str,
     max_grid_cells: Option<usize>,
-    direction: &str,
 ) -> PyResult<PyDerivedDescription> {
-    let options = from_sequences_options(max_grid_cells, parse_direction_or_raise(direction)?)?;
+    let options = from_sequences_options(max_grid_cells, ShuffleDirection::ThreePrime)?;
     // Detached for the reason given on `from_sequences` above.
     let (accession, reference, alternate) = (
         accession.to_string(),
@@ -1747,26 +1720,22 @@ impl PyNormalizer {
     ///     reference_json: Path to a transcripts.json file for reference data.
     ///         If not provided, uses built-in test data (limited coverage,
     ///         **not suitable for production use**).
-    ///     direction: Shuffle direction - "3prime" (default) or "5prime"
     ///     error_config: Optional ErrorConfig controlling reference-mismatch
     ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
     ///         variants). Defaults to lenient (warn and continue; a
     ///         wrong-reference substitution is preserved unchanged, not
     ///         auto-corrected).
     #[new]
-    #[pyo3(signature = (reference_json=None, direction="3prime", error_config=None))]
+    #[pyo3(signature = (reference_json=None, error_config=None))]
     fn new(
         py: Python<'_>,
         reference_json: Option<&str>,
-        direction: &str,
         error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
-        // Validate the `direction` argument BEFORE loading any reference, so an
-        // invalid direction always raises `ValueError` regardless of whether the
-        // reference path is valid — a bad/missing path must not mask (or be
-        // masked by) the argument error.
+        // 3' is the only direction ferro shifts; there is no `direction=`
+        // keyword to validate any more (`README.md` rule 6).
         let config = NormalizeConfig::for_entry_point(
-            parse_direction_or_raise(direction)?,
+            ShuffleDirection::ThreePrime,
             error_config_or_default(error_config),
         );
 
@@ -1792,7 +1761,6 @@ impl PyNormalizer {
     /// Args:
     ///     manifest_path: Path to a manifest.json file (typically inside a
     ///         directory produced by `ferro prepare`).
-    ///     direction: Shuffle direction - "3prime" (default) or "5prime"
     ///     error_config: Optional ErrorConfig controlling reference-mismatch
     ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
     ///         variants). Defaults to lenient (warn and continue; a
@@ -1802,17 +1770,14 @@ impl PyNormalizer {
     /// Returns:
     ///     A Normalizer backed by a MultiFastaProvider.
     #[staticmethod]
-    #[pyo3(signature = (manifest_path, direction="3prime", error_config=None))]
+    #[pyo3(signature = (manifest_path, error_config=None))]
     fn from_manifest(
         py: Python<'_>,
         manifest_path: &str,
-        direction: &str,
         error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
-        // Validate `direction` before loading the manifest (see `new`): a bad
-        // manifest path must not mask an invalid-direction `ValueError`.
         let config = NormalizeConfig::for_entry_point(
-            parse_direction_or_raise(direction)?,
+            ShuffleDirection::ThreePrime,
             error_config_or_default(error_config),
         );
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
@@ -2081,10 +2046,6 @@ impl PyNormalizer {
     /// which would make the provider a hidden input. This one holds a provider,
     /// so it does check, and refuses an interval running past the end of the
     /// sequence. It also offers `normalize`, which the free function cannot.
-    ///
-    /// The shuffle direction is this normalizer's own, set when it was
-    /// constructed, rather than a separate keyword — one direction per
-    /// normalizer is the contract every other method here follows.
     ///
     /// Args:
     ///     accession: The sequence the window is on.
@@ -2513,7 +2474,6 @@ impl PyVariantProjector {
     /// Args:
     ///     reference_json: Path to a transcripts.json file. If None, uses
     ///         built-in test data (limited; not for production).
-    ///     direction: Shuffle direction passed to the internal normalizer
     ///         ("3prime" or "5prime").
     ///     assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
     ///         aliases "hg19"/"hg38") for build-agnostic inputs. A bare NG_/LRG_
@@ -2529,21 +2489,18 @@ impl PyVariantProjector {
     ///         wrong-reference substitution is preserved unchanged, not
     ///         auto-corrected).
     #[new]
-    #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
+    #[pyo3(signature = (reference_json=None, assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
     fn new(
         py: Python<'_>,
         reference_json: Option<&str>,
-        direction: &str,
         assembly: Option<&str>,
         protein_stop: &str,
         amino_acid_code: &str,
         error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
         // Validate boundary args BEFORE loading any reference (a bad path must
-        // not mask an invalid direction/assembly/protein_stop/amino_acid_code
-        // ValueError).
-        let (config, assembly_build) =
-            parse_projector_boundary_args(direction, assembly, error_config)?;
+        // not mask an invalid assembly/protein_stop/amino_acid_code ValueError).
+        let (config, assembly_build) = parse_projector_boundary_args(assembly, error_config)?;
         let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let (provider, kind) = match reference_json {
             Some(path) => (
@@ -2560,7 +2517,6 @@ impl PyVariantProjector {
     ///
     /// Args:
     ///     manifest_path: Path to a ferro-prepare manifest.json.
-    ///     direction: Shuffle direction passed to the internal normalizer
     ///         ("3prime" or "5prime").
     ///     assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
     ///         aliases "hg19"/"hg38") for build-agnostic inputs.
@@ -2574,19 +2530,17 @@ impl PyVariantProjector {
     ///         wrong-reference substitution is preserved unchanged, not
     ///         auto-corrected).
     #[staticmethod]
-    #[pyo3(signature = (manifest_path, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
+    #[pyo3(signature = (manifest_path, assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
     fn from_manifest(
         py: Python<'_>,
         manifest_path: &str,
-        direction: &str,
         assembly: Option<&str>,
         protein_stop: &str,
         amino_acid_code: &str,
         error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
         // Validate boundary args before loading the manifest (see `new`).
-        let (config, assembly_build) =
-            parse_projector_boundary_args(direction, assembly, error_config)?;
+        let (config, assembly_build) = parse_projector_boundary_args(assembly, error_config)?;
         let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
         Self::from_provider(
@@ -2823,11 +2777,9 @@ impl PyVariantProjector {
     ///
     /// By default (`normalize=True`) the result is the projector-normalized
     /// genomic form — what most callers want; a `Genome` input is canonicalized
-    /// too. The normalizer follows this projector's configured shuffle direction
-    /// (`VariantProjector(direction=...)`): with the default `direction="3prime"`
-    /// that is the spec-canonical, 3'-shifted form (e.g. a non-3'-most `g.1003del`
-    /// in a poly-A run → `g.1007del`); a `direction="5prime"` projector instead
-    /// returns the 5'-anchored form. Pass `normalize=False` to get the raw pivot,
+    /// too. That is the spec-canonical, 3'-shifted form (e.g. a non-3'-most
+    /// `g.1003del` in a poly-A run → `g.1007del`); 3' is the only direction
+    /// ferro shifts. Pass `normalize=False` to get the raw pivot,
     /// which intentionally does not normalize its input (#785): a non-canonical
     /// input then yields a non-canonical genomic output, and a `Genome` input
     /// passes through unchanged (idempotent). (#867)
@@ -2845,7 +2797,7 @@ impl PyVariantProjector {
     ///         `Accession`.
     ///     normalize: When True (default), return the projector-normalized
     ///         genomic form (spec-canonical 3'-shifted for the default
-    ///         `direction="3prime"`); when False, return the raw un-normalized
+    ///         3'-shifted); when False, return the raw un-normalized
     ///         pivot.
     ///
     /// Returns:
@@ -2976,18 +2928,20 @@ impl PyVariantProjector {
     }
 }
 
-/// Parse the projector's boundary args (`direction`, `assembly`) into their
-/// validated forms. Split out so callers validate them BEFORE loading a
-/// reference — a bad/missing reference path must not mask (or be masked by) an
-/// invalid direction/assembly `ValueError`. The assembly name is normalized to a
-/// canonical "GRCh37"/"GRCh38" at the boundary so the core only sees that (#715).
+/// Parse the projector's boundary args (`assembly`) into their validated forms.
+/// Split out so callers validate them BEFORE loading a reference — a
+/// bad/missing reference path must not mask (or be masked by) an invalid
+/// assembly `ValueError`. The assembly name is normalized to a canonical
+/// "GRCh37"/"GRCh38" at the boundary so the core only sees that (#715).
+///
+/// It used to take a `direction` too. That keyword is gone; the projector's
+/// normalizer is always 3'.
 fn parse_projector_boundary_args(
-    direction: &str,
     assembly: Option<&str>,
     error_config: Option<&PyErrorConfig>,
 ) -> PyResult<(NormalizeConfig, Option<&'static str>)> {
     let config = NormalizeConfig::for_entry_point(
-        parse_direction_or_raise(direction)?,
+        ShuffleDirection::ThreePrime,
         error_config_or_default(error_config),
     );
     let assembly_build = match assembly {

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -8,7 +8,6 @@ use crate::hgvs::interval::Interval;
 use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::HgvsVariant;
-use crate::normalize::ShuffleDirection;
 use crate::reference::provider::ReferenceProvider;
 
 /// Get the variant type as a string
@@ -83,32 +82,13 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
     }
 }
 
-/// Parse a direction string into a [`ShuffleDirection`].
-///
-/// Recognizes only the documented aliases (case-insensitively). Returns `None`
-/// for anything else so callers can reject unrecognized input loudly rather than
-/// silently defaulting (#1016):
-/// - `3prime`, `3'`, `3` -> `Some(ThreePrime)`
-/// - `5prime`, `5'`, `5` -> `Some(FivePrime)`
-/// - anything else -> `None`
-///
-/// # Examples
-///
-/// ```
-/// use ferro_hgvs::python_helpers::parse_direction;
-/// use ferro_hgvs::ShuffleDirection;
-///
-/// assert!(matches!(parse_direction("3prime"), Some(ShuffleDirection::ThreePrime)));
-/// assert!(matches!(parse_direction("5'"), Some(ShuffleDirection::FivePrime)));
-/// assert!(parse_direction("5prim").is_none());
-/// ```
-pub fn parse_direction(direction: &str) -> Option<ShuffleDirection> {
-    match direction.to_lowercase().as_str() {
-        "3prime" | "3'" | "3" => Some(ShuffleDirection::ThreePrime),
-        "5prime" | "5'" | "5" => Some(ShuffleDirection::FivePrime),
-        _ => None,
-    }
-}
+// `parse_direction` was removed with the ten Python `direction=` keywords it
+// backed (`README.md` rule 6: there are no user options for normalization
+// form). #1016's property — reject an unrecognized spelling rather than
+// silently defaulting to 3' — is preserved and strengthened by the removal:
+// PyO3 raises `TypeError` for a keyword it does not know, so no spelling of
+// `direction=` reaches ferro at all. Its unit tests moved to
+// `normalize::config`, re-pointed at the retained internal `FromStr` impl.
 
 /// Get the reference accession from a variant
 ///
@@ -655,66 +635,13 @@ mod tests {
         assert_eq!(get_indel_length(&variant), None);
     }
 
-    // ===== parse_direction Tests =====
-
-    #[test]
-    fn test_parse_direction_three_prime() {
-        assert!(matches!(
-            parse_direction("3prime"),
-            Some(ShuffleDirection::ThreePrime)
-        ));
-        assert!(matches!(
-            parse_direction("3'"),
-            Some(ShuffleDirection::ThreePrime)
-        ));
-        assert!(matches!(
-            parse_direction("3"),
-            Some(ShuffleDirection::ThreePrime)
-        ));
-    }
-
-    #[test]
-    fn test_parse_direction_five_prime() {
-        assert!(matches!(
-            parse_direction("5prime"),
-            Some(ShuffleDirection::FivePrime)
-        ));
-        assert!(matches!(
-            parse_direction("5'"),
-            Some(ShuffleDirection::FivePrime)
-        ));
-        assert!(matches!(
-            parse_direction("5"),
-            Some(ShuffleDirection::FivePrime)
-        ));
-    }
-
-    #[test]
-    fn test_parse_direction_unrecognized_is_none() {
-        // Unrecognized spellings must return None so the Python boundary can
-        // reject them rather than silently defaulting to 3' (#1016).
-        assert!(parse_direction("unknown").is_none());
-        assert!(parse_direction("").is_none());
-        assert!(parse_direction("5prim").is_none());
-        assert!(parse_direction("3prine").is_none());
-        assert!(parse_direction("five").is_none());
-    }
-
-    #[test]
-    fn test_parse_direction_case_insensitive() {
-        assert!(matches!(
-            parse_direction("5PRIME"),
-            Some(ShuffleDirection::FivePrime)
-        ));
-        assert!(matches!(
-            parse_direction("5Prime"),
-            Some(ShuffleDirection::FivePrime)
-        ));
-        assert!(matches!(
-            parse_direction("3PRIME"),
-            Some(ShuffleDirection::ThreePrime)
-        ));
-    }
+    // The four `test_parse_direction_*` tests that stood here moved to
+    // `normalize::config`'s test module when `parse_direction` was deleted
+    // with the Python `direction=` keywords. They are re-pointed at the
+    // retained internal `FromStr` impl, so the coverage is relocated rather
+    // than dropped; `test_parse_direction_unrecognized_is_none` became
+    // `test_parse_direction_unrecognized_is_err`, since `FromStr` reports the
+    // same refusal as an `Err` rather than a `None`.
 
     // ===== get_variant_reference Tests =====
 

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -70,7 +70,17 @@ pub struct ToolConfigs {
 }
 
 /// Ferro tool configuration
+///
+/// `deny_unknown_fields` is load-bearing rather than tidiness. The
+/// `shuffle_direction` key was removed from this struct (`README.md` rule 6 —
+/// there are no user options for normalization form), and serde's default is to
+/// *ignore* a key it does not recognize. Without this attribute an operator's
+/// existing `shuffle_direction = "5prime"` would be silently dropped and the
+/// service would 3'-shift while the config file still said otherwise — a wrong
+/// answer served under a configuration that appears to ask for something else.
+/// With it, that config fails to load and names the offending key.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FerroConfig {
     /// Whether tool is enabled
     pub enabled: bool,
@@ -78,8 +88,6 @@ pub struct FerroConfig {
     pub reference_dir: PathBuf,
     /// Number of parallel workers (default: number of CPU cores)
     pub parallel_workers: Option<usize>,
-    /// Shuffle direction (3prime or 5prime, default: 3prime)
-    pub shuffle_direction: Option<String>,
     /// Error handling mode (strict, lenient, silent, default: lenient)
     pub error_mode: Option<String>,
 }
@@ -221,7 +229,6 @@ impl Default for FerroConfig {
             enabled: true,
             reference_dir: PathBuf::from("./reference"),
             parallel_workers: None,
-            shuffle_direction: Some("3prime".to_string()),
             error_mode: Some("lenient".to_string()),
         }
     }
@@ -404,5 +411,29 @@ mod tests {
             ..FerroConfig::default()
         });
         assert_eq!(config.enabled_tools(), vec!["ferro"]);
+    }
+
+    /// The shipped example config must actually deserialize.
+    ///
+    /// Nothing parsed `config/service.example.toml` before this test, and that
+    /// is exactly how it went stale: `shuffle_direction = "3prime"` sat in it
+    /// after the key was removed from [`FerroConfig`]. Under
+    /// `deny_unknown_fields` that is no longer a harmless leftover — it is a
+    /// file the docs tell an operator to `cp` into place that would fail to
+    /// load. The example is documentation with a schema, so it is checked like
+    /// one.
+    #[test]
+    fn the_shipped_example_config_deserializes() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/config/service.example.toml");
+        let text = std::fs::read_to_string(path).expect("read config/service.example.toml");
+        let config: ServiceConfig = toml::from_str(&text)
+            .unwrap_or_else(|e| panic!("config/service.example.toml must deserialize: {e}"));
+
+        let ferro = config
+            .tools
+            .ferro
+            .expect("the example config configures the ferro tool");
+        assert!(ferro.enabled);
+        assert_eq!(ferro.error_mode.as_deref(), Some("lenient"));
     }
 }

--- a/src/service/tools/ferro.rs
+++ b/src/service/tools/ferro.rs
@@ -39,17 +39,16 @@ impl FerroService {
             })?
         };
 
-        // Create normalization config
-        let shuffle_direction = match config.shuffle_direction.as_deref() {
-            Some("5prime") => ShuffleDirection::FivePrime,
-            Some("3prime") | None => ShuffleDirection::ThreePrime,
-            Some(other) => {
-                return Err(ServiceError::ConfigError(format!(
-                    "Invalid shuffle_direction '{}', must be '3prime' or '5prime'",
-                    other
-                )));
-            }
-        };
+        // Create normalization config.
+        //
+        // The service used to read a `shuffle_direction` key here. It is gone:
+        // `README.md` rule 6 says there are no user options for normalization
+        // form, and a direction is not orthogonal to the form. The service
+        // normalizes 3', the only direction the HGVS recommendations describe.
+        // `FerroConfig` is `deny_unknown_fields` so a stale
+        // `shuffle_direction = "5prime"` in an operator's TOML fails the load
+        // rather than being ignored.
+        let shuffle_direction = ShuffleDirection::ThreePrime;
 
         let error_mode = match config.error_mode.as_deref() {
             Some("strict") => ErrorMode::Strict,
@@ -267,7 +266,6 @@ mod tests {
             enabled: true,
             reference_dir: temp_dir.path().to_path_buf(),
             parallel_workers: Some(1),
-            shuffle_direction: Some("3prime".to_string()),
             error_mode: Some("lenient".to_string()),
         };
 
@@ -293,17 +291,43 @@ mod tests {
     // function in `crate::service::types`. The service exercises it end-to-end via
     // `parse`/`normalize`, which populate `ParseResult::details`.
 
+    /// A malformed enumerated config value must be refused, not defaulted.
+    ///
+    /// This used to key on `shuffle_direction: Some("invalid")`. That key was
+    /// removed with the rest of the public 5' surface, so the test now keys on
+    /// `error_mode`, which is the remaining enumerated string on `FerroConfig`
+    /// and has the identical reject-don't-guess contract.
     #[test]
     fn test_invalid_config() {
         let config = FerroConfig {
             enabled: true,
             reference_dir: std::path::PathBuf::from("/nonexistent/path"),
             parallel_workers: Some(1),
-            shuffle_direction: Some("invalid".to_string()),
-            error_mode: Some("lenient".to_string()),
+            error_mode: Some("invalid".to_string()),
         };
 
         let result = FerroService::new(&config);
         assert!(result.is_err());
+    }
+
+    /// A stale `shuffle_direction` key must fail the config load loudly.
+    ///
+    /// The dangerous removal shape is the silent one: serde ignores unknown
+    /// fields by default, so an operator's `shuffle_direction = "5prime"` would
+    /// vanish and the service would 3'-shift while the file still asked for 5'.
+    /// `deny_unknown_fields` on `FerroConfig` turns that into a load error.
+    #[test]
+    fn a_removed_shuffle_direction_key_is_rejected_not_ignored() {
+        let toml = r#"
+enabled = true
+reference_dir = "/tmp/ferro-ref"
+shuffle_direction = "5prime"
+"#;
+        let err = toml::from_str::<FerroConfig>(toml)
+            .expect_err("a removed key must not be silently ignored");
+        assert!(
+            err.to_string().contains("shuffle_direction"),
+            "the error must name the offending key, got: {err}"
+        );
     }
 }

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -371,9 +371,14 @@ const THREE_PRIME: Census = Census {
     sequence_changed: 0,
 };
 
-/// The 5'-direction census, pinned. `--direction 5prime` is a supported public
-/// option, and confluence is a property of the normalizer rather than of one
-/// shuffle direction, so it is measured in full rather than spot-checked.
+/// The 5'-direction census, pinned. Confluence is a property of the normalizer
+/// rather than of one shuffle direction, so it is measured in full rather than
+/// spot-checked.
+///
+/// The 5' direction is **no longer a public option** — see `README.md` rule 6
+/// and `tests/it/five_prime_public_surface_removed.rs`. That changes the reason
+/// this census exists, not its scope: the 5' arm is ferro's differential oracle over its own 3' output — the instrument that found #1542, where 7 of 8 `FERRO_PARTITION` x direction configurations agreed and only the shipped `live`/3' arm diverged. An arm that is only spot-checked
+/// cannot serve as that oracle.
 ///
 /// It landed within five classes of the 3' figure (6 628 against 6 633), which
 /// is worth reading as evidence: the divergence is a property of how the

--- a/tests/it/cis_confluence_nr_axis.rs
+++ b/tests/it/cis_confluence_nr_axis.rs
@@ -240,9 +240,14 @@ const R_THREE_PRIME: Census = Census {
     sequence_changed: 0,
 };
 
-/// The `n.` 5'-direction census, pinned. `--direction 5prime` is a supported
-/// public option and confluence is a property of the normalizer rather than of
-/// one shuffle direction, so it is measured in full rather than spot-checked.
+/// The `n.` 5'-direction census, pinned. Confluence is a property of the
+/// normalizer rather than of one shuffle direction, so it is measured in full
+/// rather than spot-checked.
+///
+/// The 5' direction is **no longer a public option** — see `README.md` rule 6
+/// and `tests/it/five_prime_public_surface_removed.rs`. That changes the reason
+/// this census exists, not its scope: the 5' arm is ferro's differential oracle over its own 3' output — the instrument that found #1542, where 7 of 8 `FERRO_PARTITION` x direction configurations agreed and only the shipped `live`/3' arm diverged. An arm that is only spot-checked
+/// cannot serve as that oracle.
 ///
 /// Re-blessed alongside [`N_THREE_PRIME`]: `converged` 2_625 -> 4_011,
 /// `split_two` 2_954 -> 1_569, `split_three` 53 -> 52, every other field

--- a/tests/it/cis_spelling_confluence_gap.rs
+++ b/tests/it/cis_spelling_confluence_gap.rs
@@ -35,8 +35,7 @@
 //!
 //! Both tables are measured in both directions. Every row above was blessed
 //! against the 3' rule, but confluence is a property of the normalizer rather
-//! than of one shuffle direction, and `--direction 5prime` is a supported public
-//! option — so [`DIVERGENT_UNDER_FIVE_PRIME`] records the [`CONVERGED`] rows that
+//! than of one shuffle direction — so [`DIVERGENT_UNDER_FIVE_PRIME`] records the [`CONVERGED`] rows that
 //! converge under 3' and diverge under 5', and
 //! [`the_eight_spelling_pairs_still_diverge_under_five_prime`] pins that the
 //! [`DIVERGENT`] eight diverge under 5' too. Both use the same assert-then-flip
@@ -132,7 +131,7 @@ const CONVERGED: &[(&str, &str, &str, &str, &str)] = &[
     // the derivation *read* a form rather than by teaching it to build one. Its
     // agreed string is neither input spelling: two members denoting one changed
     // base come back as that substitution. Verified identical under
-    // `--direction 5prime`.
+    // the 5' shuffle direction.
     (
         "#1296",
         "AAAAAAATAATCGCAACAGAAG",
@@ -312,10 +311,12 @@ fn converged_pairs_stay_converged() {
 
 /// Rows from [`CONVERGED`] that converge under the 3' rule but **not** under 5'.
 ///
-/// Confluence is a property of the normalizer, not of one shuffle direction, and
-/// `--direction 5prime` is a supported public option on both the CLI
-/// (`src/bin/ferro.rs`) and the Python bindings. Every row above was blessed
-/// against the 3' direction only, so these gaps were never measured.
+/// Confluence is a property of the normalizer, not of one shuffle direction.
+/// The 5' direction is no longer a public option — it is not reachable from the
+/// CLI, the Python bindings or the web service (`README.md` rule 6, and
+/// `tests/it/five_prime_public_surface_removed.rs`) — but that does not narrow
+/// what has to be measured here, it changes only why: the 5' arm is ferro's differential oracle over its own 3' output — the instrument that found #1542, where 7 of 8 `FERRO_PARTITION` x direction configurations agreed and only the shipped `live`/3' arm diverged. Every row above was
+/// blessed against the 3' direction only, so these gaps were never measured.
 ///
 /// **Both original rows have since left this set, for unrelated reasons.**
 ///

--- a/tests/it/five_prime_public_surface_removed.rs
+++ b/tests/it/five_prime_public_surface_removed.rs
@@ -1,0 +1,181 @@
+//! The 5' shuffling direction is not reachable from any ferro entry point.
+//!
+//! `README.md` rule 6 states that there are no user options for normalization
+//! form, and then concedes in its next sentence that the 3'/5' knob is not
+//! orthogonal — it selects the frame every other rule is evaluated in. The knob
+//! was therefore a user option for normalization form sitting inside the rule
+//! forbidding user options for normalization form. Removing it from the public
+//! surface is what makes rule 6 true.
+//!
+//! [`ShuffleDirection::FivePrime`] itself is **kept**, as an internal
+//! differential oracle. 3'/5' disagreement has twice found a defect in the
+//! shipped 3' output that nothing else could see (#1542 / PR #1840, where 7 of
+//! 8 `FERRO_PARTITION` x direction configurations agreed and only `live`/3'
+//! diverged; and `cis_confluence_axis.rs`'s `enclosing_exon` off-by-one, a
+//! 5'-only symptom of a bug in shared code). Deleting the arm would delete that
+//! detector, so ~75 test modules keep driving it — this module is about
+//! *reachability*, never about the behaviour.
+//!
+//! **The failure shape this module exists to prevent is a silent one.** A
+//! removal that merely stopped honouring `--direction 5prime`, or that let PyO3
+//! ignore an unknown keyword, would hand a caller who explicitly asked for 5' a
+//! 3' answer with nothing to tell them — a wrong description delivered under an
+//! argument that appears to have been accepted. Every assertion below is that
+//! the removed surface *refuses* rather than defaults.
+
+use std::process::Command;
+
+use ferro_hgvs::normalize::ShuffleDirection;
+use ferro_hgvs::{from_sequences, FromSequencesOptions};
+
+/// Run the `ferro` binary cargo built for this test run.
+///
+/// `CARGO_BIN_EXE_<name>` is set by cargo for a `[[bin]]` target in the same
+/// package, so this cannot pick up a stale `ferro` from `PATH` — which would
+/// make the whole module a test of whatever is installed on the machine.
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+/// A variant the bundled mock provider normalizes cleanly under the default
+/// `--error-mode strict`, so a non-zero exit below is about `--direction` and
+/// not about the variant. (`c.100delA`, the obvious choice, is refused for
+/// spelling its own deleted base — a real refusal that would mask this one.)
+const VARIANT: &str = "NM_000088.3:c.4C>G";
+
+/// `--direction` is rejected, with a non-zero exit.
+///
+/// This is the single most important assertion in the file. Before the flag was
+/// removed, `parse_shuffle_direction`'s fallback arm was `_ => ThreePrime`
+/// (#1863), so an unrecognized value 3'-shifted and reported success. Deleting
+/// the *value* handling without deleting the *flag* would have kept exactly
+/// that behaviour for `--direction 5prime`. Deleting the flag makes clap refuse
+/// the argument instead.
+#[test]
+fn the_direction_flag_is_rejected_rather_than_ignored() {
+    for value in ["5prime", "3prime", "5'", "banana"] {
+        let output = ferro()
+            .args(["normalize", VARIANT, "--direction", value])
+            .output()
+            .expect("run ferro normalize");
+
+        assert!(
+            !output.status.success(),
+            "`--direction {value}` must fail; a silent 3' run for a caller who \
+             asked for 5' is the failure this test exists to prevent. \
+             status={:?} stdout={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("--direction") || stderr.contains("unexpected argument"),
+            "the refusal must name the offending argument, got: {stderr}"
+        );
+    }
+}
+
+/// `--direction` is gone from the help text as well as from the parser.
+///
+/// A flag that is refused but still advertised would send a reader straight
+/// back to the argument they cannot use.
+#[test]
+fn the_help_text_does_not_advertise_a_direction_flag() {
+    let output = ferro()
+        .args(["normalize", "--help"])
+        .output()
+        .expect("run ferro normalize --help");
+    assert!(output.status.success(), "--help must succeed");
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !help.contains("--direction"),
+        "`ferro normalize --help` must not advertise --direction:\n{help}"
+    );
+    assert!(
+        !help.contains("5prime"),
+        "`ferro normalize --help` must not mention a 5' direction:\n{help}"
+    );
+}
+
+/// `ferro normalize` still works, and shifts 3'.
+///
+/// The negative tests above would all pass against a binary that had lost the
+/// subcommand entirely, so this is the control: removing the flag must not have
+/// removed the run, and the direction it did not remove is 3'.
+#[test]
+fn normalize_still_runs_and_is_three_prime() {
+    let output = ferro()
+        .args(["normalize", VARIANT, "-f", "text"])
+        .output()
+        .expect("run ferro normalize");
+    assert!(
+        output.status.success(),
+        "plain `ferro normalize` must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        VARIANT,
+        "the shipped 3' path must still answer"
+    );
+}
+
+/// The internal direction still *acts* — the oracle has not been hollowed out.
+///
+/// Deleting a public knob is easy to do in a way that also stops the underlying
+/// machinery ever seeing anything but the default; that would leave ~75 test
+/// modules running a differential against themselves and passing. This drives
+/// [`FromSequencesOptions::with_direction`] on a pair whose two answers differ
+/// and asserts they still differ.
+///
+/// The rows are the ones the removed Python tests asserted, kept verbatim so
+/// the measurement is relocated rather than dropped: a single-base deletion
+/// inside an `AAAA` run in a window starting at 10, which 3' places at 14 and
+/// 5' at 11 (`tests/python/test_from_sequences.py`), and the `SequencePair`
+/// window that gave `g.15del` / `g.12del` for `derive`.
+#[test]
+fn the_internal_direction_still_moves_the_answer() {
+    let three = from_sequences(
+        "NC_1",
+        10,
+        "CAAAAG",
+        "CAAAG",
+        &FromSequencesOptions::default().with_direction(ShuffleDirection::ThreePrime),
+    )
+    .expect("3' derivation");
+    let five = from_sequences(
+        "NC_1",
+        10,
+        "CAAAAG",
+        "CAAAG",
+        &FromSequencesOptions::default().with_direction(ShuffleDirection::FivePrime),
+    )
+    .expect("5' derivation");
+
+    assert_eq!(format!("{three}"), "NC_1:g.14del");
+    assert_eq!(format!("{five}"), "NC_1:g.11del");
+    assert_ne!(
+        format!("{three}"),
+        format!("{five}"),
+        "the internal 3'/5' differential must still differ, or every census \
+         driving it is comparing an arm against itself"
+    );
+}
+
+/// The default is 3', so a caller who names no direction gets the shipped form.
+#[test]
+fn the_default_direction_is_three_prime() {
+    assert_eq!(ShuffleDirection::default(), ShuffleDirection::ThreePrime);
+
+    let defaulted = from_sequences(
+        "NC_1",
+        10,
+        "CAAAAG",
+        "CAAAG",
+        &FromSequencesOptions::default(),
+    )
+    .expect("default derivation");
+    assert_eq!(format!("{defaulted}"), "NC_1:g.14del");
+}

--- a/tests/it/issue_867_project_to_genomic_normalized.rs
+++ b/tests/it/issue_867_project_to_genomic_normalized.rs
@@ -115,3 +115,52 @@ fn project_to_genomic_splits_raw_vs_normalized_for_transcript_input() {
         "raw and normalized must differ for a non-3'-most transcript input"
     );
 }
+
+/// `project_to_genomic_normalized` re-shuffles into the projector's *own*
+/// configured direction rather than hard-coding 3'.
+///
+/// Relocated from `tests/python/test_variant_projection.py`'s
+/// `test_normalize_follows_projector_direction`, which built a
+/// `VariantProjector(direction="5prime")`. That keyword was removed with the
+/// rest of ferro's public 5' surface (`README.md` rule 6), so the property is
+/// pinned here instead, against the internal `ShuffleDirection` — the test is
+/// relocated, not dropped.
+///
+/// What it guards is not the 5' output for its own sake: it is that the
+/// normalize step is a *re-shuffle of the pivot* and not a constant. `c.8del`
+/// is the last A of the poly-A run (c.4..c.8 -> g.1003..1007), so its raw pivot
+/// is already the 3'-anchored `g.1007del`. A projector that hard-coded 3' would
+/// return `g.1007del` here and be indistinguishable from one that simply passed
+/// the pivot through. Only the mirror direction separates the two.
+#[test]
+fn project_to_genomic_normalized_follows_the_configured_direction() {
+    use ferro_hgvs::error_handling::ErrorConfig;
+    use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+
+    let vp = poly_a_fixture().with_normalize_config(NormalizeConfig::for_entry_point(
+        ShuffleDirection::FivePrime,
+        ErrorConfig::lenient(),
+    ));
+
+    let v = parse_hgvs("NC_000001.11(NM_POLY.1):c.8del").unwrap();
+
+    let raw = format!("{}", vp.project_to_genomic(&v).expect("raw"));
+    assert_eq!(
+        raw, "NC_000001.11:g.1007del",
+        "the raw pivot of c.8del is the 3'-anchored end of the run"
+    );
+
+    let norm = format!(
+        "{}",
+        vp.project_to_genomic_normalized(&v).expect("normalized")
+    );
+    assert_eq!(
+        norm, "NC_000001.11:g.1003del",
+        "normalization must re-shuffle into the projector's configured direction, \
+         not return the pivot unchanged"
+    );
+    assert_ne!(
+        raw, norm,
+        "a projector that hard-coded 3' would leave this row at g.1007del"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -14,6 +14,7 @@
 mod common;
 mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
+mod five_prime_public_surface_removed;
 mod five_prime_tandem_repeat_dup_rotation;
 mod issue_1282_position_zero;
 mod issue_1450_derivation_exon_junction;

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -761,11 +761,14 @@ pub(crate) const THREE_PRIME: Census = Census {
 
 /// The 5'-direction census, pinned.
 ///
-/// `--direction 5prime` is a supported public option and confluence is a
-/// property of the normalizer rather than of one shuffle direction, so it is
-/// measured in full. Two directions landing on materially different numbers
-/// would mean a fix was treating a symptom of the shuffle rather than the
-/// partitioner.
+/// Confluence is a property of the normalizer rather than of one shuffle
+/// direction, so it is measured in full. Two directions landing on materially
+/// different numbers would mean a fix was treating a symptom of the shuffle
+/// rather than the partitioner.
+///
+/// The 5' direction is **no longer a public option** — see `README.md` rule 6
+/// and `tests/it/five_prime_public_surface_removed.rs`. It is measured in full
+/// for a different reason now: the 5' arm is ferro's differential oracle over its own 3' output — the instrument that found #1542, where 7 of 8 `FERRO_PARTITION` x direction configurations agreed and only the shipped `live`/3' arm diverged.
 ///
 /// Measured on the same base as [`THREE_PRIME`], and re-blessed by the same
 /// five changes — see the module docs' five RE-BLESSED sections.

--- a/tests/python/test_from_sequences.py
+++ b/tests/python/test_from_sequences.py
@@ -106,29 +106,40 @@ def test_an_unchanged_pair_is_the_identity_description():
 
 
 def test_the_options_are_keyword_only():
-    """``max_grid_cells`` and ``direction`` are keyword-only on purpose: they are
-    tuning knobs, and a positional fifth argument would read as part of the
-    variant rather than as configuration."""
+    """``max_grid_cells`` is keyword-only on purpose: it is a tuning knob, and a
+    positional fifth argument would read as part of the variant rather than as
+    configuration."""
     with pytest.raises(TypeError):
         ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", 1024)  # type: ignore[misc]
 
 
-def test_the_direction_reaches_the_partitioner():
-    """Both directions must be accepted *and act*. A binding that parsed the
-    keyword and then dropped it would pass a "does not raise" test, so this pins
-    a pair where the two answers differ — a single-base deletion inside the
-    ``AAAA`` run, which 3' places at 14 and 5' at 11. Those are coordinates in
-    *this pair's* frame (it starts at 10 and is written out below, not sliced
-    from ``SEQUENCE``); the run sits at 12-15 of ``SEQUENCE`` itself."""
-    three = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAG", "CAAAG", direction="3prime")
-    five = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAG", "CAAAG", direction="5prime")
+def test_the_partitioner_places_a_pure_indel_three_prime():
+    """The derivation is 3'-most, and there is no keyword that can change it.
+
+    This pinned both directions before the public ``direction=`` keyword was
+    removed (``README.md`` rule 6). The 3' row it asserted is kept verbatim —
+    a single-base deletion inside the ``AAAA`` run, placed at 14 — because it is
+    the shipped answer and this is the only test that pins it against a
+    hand-written window. The 5' half moved to
+    ``tests/it/five_prime_public_surface_removed.rs``, which drives the internal
+    direction type directly and asserts the same 11 the removed row asserted, so
+    the measurement is relocated rather than dropped. Coordinates are in *this
+    pair's* frame (it starts at 10 and is written out here, not sliced from
+    ``SEQUENCE``); the run sits at 12-15 of ``SEQUENCE`` itself."""
+    three = ferro_hgvs.from_sequences("NC_1", 10, "CAAAAG", "CAAAG")
     assert str(three) == "NC_1:g.14del"
-    assert str(five) == "NC_1:g.11del"
 
 
-def test_an_unrecognized_direction_is_a_value_error():
-    with pytest.raises(ValueError, match="unrecognized direction"):
-        ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", direction="sideways")
+def test_a_direction_keyword_is_a_type_error():
+    """Not a ``ValueError`` about the value — a ``TypeError`` about the keyword.
+
+    The distinction is the whole safety property of the removal: a keyword PyO3
+    does not name cannot be silently dropped, so a caller who still writes
+    ``direction="5prime"`` fails at the call rather than receiving a 3' answer
+    to a 5' question. See ``test_issue_1016_direction_validation.py``."""
+    for value in ("3prime", "5prime", "sideways"):
+        with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
+            ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", direction=value)
 
 
 # ---------------------------------------------------------------------------
@@ -179,15 +190,17 @@ def test_the_two_refusal_classes_are_the_established_split():
     ``FerroError``.
 
     That split is the binding's existing convention, not a choice made here —
-    ``Normalizer(direction=...)`` has always raised a plain ``ValueError`` for an
-    unrecognized direction. Pinned because the obvious wrong guess is that
-    ``FerroError`` catches everything from one call, and it does not: a caller
-    wrapping ``from_sequences`` needs ``(ValueError, ferro_hgvs.FerroError)``, or
-    simply ``Exception``."""
-    binding_checks = (
-        lambda: ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", max_grid_cells=0),
-        lambda: ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", direction="sideways"),
-    )
+    ``VariantProjector(assembly=...)`` raises a plain ``ValueError`` for an
+    unrecognized assembly the same way. Pinned because the obvious wrong guess is
+    that ``FerroError`` catches everything from one call, and it does not: a
+    caller wrapping ``from_sequences`` needs
+    ``(ValueError, ferro_hgvs.FerroError)``, or simply ``Exception``.
+
+    (A second row here used to pass ``direction="sideways"``. That keyword is
+    gone, and its successor fault is a ``TypeError`` rather than a
+    ``ValueError`` — a different split, pinned in
+    ``test_a_direction_keyword_is_a_type_error`` above.)"""
+    binding_checks = (lambda: ferro_hgvs.from_sequences("NC_1", 1, "AGCG", "AG", max_grid_cells=0),)
     for call in binding_checks:
         with pytest.raises(ValueError) as excinfo:
             call()
@@ -350,9 +363,16 @@ def test_the_method_refuses_an_unknown_accession(normalizer):
         normalizer.from_sequences("NOT_A_TEMPLATE", 10, "CAAAAG", "CAAAG")
 
 
-def test_the_method_uses_the_normalizers_own_direction():
-    """One direction per normalizer, set at construction — the contract every
-    other method here follows, rather than a second place to set it."""
+def test_the_method_takes_no_direction_of_its_own():
+    """A ``Normalizer`` has no direction to set and its ``from_sequences`` has no
+    keyword to override one with — both constructions below are the same 3'
+    normalizer, so they must agree.
+
+    This used to build a 3' normalizer and a 5' one and assert they *differed*,
+    which was the strongest available proof that the keyword was not being
+    parsed and dropped. That proof moved to the Rust side with the type; here
+    the property worth pinning is the converse — that no construction reachable
+    from Python can produce anything but the 3' answer."""
     reference = {
         "transcripts": [
             {
@@ -368,9 +388,13 @@ def test_the_method_uses_the_normalizers_own_direction():
     path.write_text(json.dumps(reference))
 
     args = ("TEMPLATE", 10, "CAAAAG", "CAAAG")
-    three = ferro_hgvs.Normalizer(reference_json=str(path), direction="3prime")
-    five = ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
-    assert str(three.from_sequences(*args)) != str(five.from_sequences(*args))
+    default = ferro_hgvs.Normalizer(reference_json=str(path))
+    from_manifestless = ferro_hgvs.Normalizer(reference_json=str(path))
+    assert str(default.from_sequences(*args)) == str(from_manifestless.from_sequences(*args))
+    assert str(default.from_sequences(*args)) == "TEMPLATE:g.14del"
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
+        ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
 
 
 def test_post_normalizing_is_available_and_is_a_no_op_here(normalizer):
@@ -617,9 +641,11 @@ def test_a_pair_derives_from_itself():
     assert str(derived.variant) == "NC_1:g.14del"
     assert derived.placement_bounded_by_window is True
 
-    # Same knobs as the free function, and the same refusals.
-    assert str(pair.derive(direction="5prime").variant) == "NC_1:g.12del"
+    # Same knobs as the free function, and the same refusals. `derive` used to
+    # take a `direction=` too; it is gone with the rest of the public surface,
+    # and its 5' row (`NC_1:g.12del`) is re-pinned against the internal type in
+    # `tests/it/five_prime_public_surface_removed.rs`.
     with pytest.raises(ValueError, match="max_grid_cells must be positive"):
         pair.derive(max_grid_cells=0)
-    with pytest.raises(ValueError, match="unrecognized direction"):
-        pair.derive(direction="sideways")
+    with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
+        pair.derive(direction="5prime")

--- a/tests/python/test_issue_1016_direction_validation.py
+++ b/tests/python/test_issue_1016_direction_validation.py
@@ -1,12 +1,28 @@
-"""Tests for issue #1016: the ``direction`` argument is validated instead of
-silently defaulting to 3'.
+"""Tests for issue #1016, as its property survives the removal of the public 5'
+surface: no ``direction`` argument may be accepted-and-ignored.
 
-Previously any unrecognized shuffle-direction string (``"5prim"``, ``"five"``,
-``"3prine"``, ...) was silently mapped to 3', quietly changing normalization
-output. The only documented values are ``"3prime"`` and ``"5prime"`` (plus the
-``3``/``5``/``3'``/``5'`` short forms); anything else must now raise
-``ValueError`` at the Python boundary, mirroring the ``assembly`` argument's
-validate-and-raise behavior.
+#1016 filed the original shape — any unrecognized shuffle-direction string
+(``"5prim"``, ``"five"``, ``"3prine"``, ...) was silently mapped to 3', quietly
+changing normalization output — and #1017 fixed it by raising ``ValueError`` at
+the Python boundary.
+
+The ``direction=`` keyword has since been **removed** from every Python entry
+point. ``README.md`` rule 6 says there are no user options for normalization
+form, and a shuffle direction is not orthogonal to the form: it selects the
+frame every other rule is evaluated in. ferro normalizes 3', the only direction
+the HGVS recommendations describe.
+
+The removal has to preserve #1016's property, and this file is what pins that.
+The failure mode a removal invites is the one #1016 was about, only worse:
+a keyword that is *quietly dropped* would make ``direction="5prime"`` a
+**silent 3' run** at a caller who explicitly asked for 5' — a wrong answer
+returned under an argument that appears to have been honoured. PyO3 raises
+``TypeError`` for a keyword its signature does not name, so the argument cannot
+be silently dropped; every entry point below is asserted to reject it.
+
+Migration for a caller who was passing ``direction="3prime"``: drop the
+argument, the behaviour is unchanged. For ``direction="5prime"``: there is no
+replacement — that form is no longer produced by any ferro entry point.
 """
 
 from pathlib import Path
@@ -16,12 +32,15 @@ import pytest
 import ferro_hgvs
 
 # A variant that parses and normalizes cleanly against the built-in test data
-# (bundled ``NM_000088.3`` transcript), so a successful call reflects an
-# accepted direction rather than a coincidental normalization failure.
+# (bundled ``NM_000088.3`` transcript), so a successful call reflects a working
+# entry point rather than a coincidental normalization failure.
 _VALID_HGVS = "NM_000088.3:c.4C>G"
 
-# Every documented/accepted spelling, case-insensitively.
-_ACCEPTED_DIRECTIONS = [
+# Every spelling the removed keyword used to accept, plus the typos #1016 was
+# filed about. After removal all of them must fail identically — the keyword is
+# rejected by name, so its *value* is never even examined. That uniformity is
+# the point: a caller cannot stumble onto a spelling that is quietly tolerated.
+_ANY_DIRECTION_VALUE = [
     "3prime",
     "5prime",
     "3",
@@ -30,129 +49,162 @@ _ACCEPTED_DIRECTIONS = [
     "5'",
     "3PRIME",
     "5Prime",
+    "5prim",
+    "five",
+    "3prine",
+    "",
+    "left",
+    "threeprime",
+    "sideways",
 ]
 
-# Representative unrecognized spellings (typos and unsupported words).
-_UNRECOGNIZED_DIRECTIONS = ["5prim", "five", "3prine", "", "left", "threeprime"]
+# PyO3's messages for a keyword a signature does not name. Matching them keeps
+# the assertion honest: a bare ``TypeError`` could come from an arity mistake in
+# the test itself, whereas these can only come from the argument being unknown.
+#
+# There are two forms, and both are measured rather than guessed. A signature
+# that still names other keywords reports the offending one
+# ("...got an unexpected keyword argument 'direction'"); a signature that names
+# *no* keywords at all — ``HgvsVariant.normalize()``, which lost its only one —
+# reports "takes no keyword arguments" instead, without naming it. The second is
+# a stronger statement, not a weaker one: the method accepts no keyword
+# whatsoever, so ``direction=`` cannot be quietly absorbed.
+_UNEXPECTED_KWARG = "unexpected keyword argument 'direction'|takes no keyword arguments"
 
 
 class TestNormalizerConstructor:
-    """The ``Normalizer`` constructor validates ``direction``."""
+    """The ``Normalizer`` constructor rejects ``direction``."""
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_unrecognized_direction_raises(self, direction: str) -> None:
-        with pytest.raises(ValueError, match="unrecognized direction"):
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_direction_keyword_rejected(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             ferro_hgvs.Normalizer(direction=direction)
 
-    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
-    def test_accepted_direction_ok(self, direction: str) -> None:
-        # Construction must succeed for every documented alias.
-        ferro_hgvs.Normalizer(direction=direction)
+    def test_constructs_without_the_keyword(self) -> None:
+        ferro_hgvs.Normalizer()
 
 
 class TestModuleLevelNormalize:
-    """The module-level ``normalize()`` free function validates ``direction``."""
+    """The module-level ``normalize()`` free function rejects ``direction``."""
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_unrecognized_direction_raises(self, direction: str) -> None:
-        with pytest.raises(ValueError, match="unrecognized direction"):
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_direction_keyword_rejected(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             ferro_hgvs.normalize(_VALID_HGVS, direction=direction)
 
-    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
-    def test_accepted_direction_ok(self, direction: str) -> None:
-        result = ferro_hgvs.normalize(_VALID_HGVS, direction=direction)
+    def test_normalizes_without_the_keyword(self) -> None:
+        result = ferro_hgvs.normalize(_VALID_HGVS)
         assert isinstance(result, str)
+        assert result
 
 
 class TestHgvsVariantNormalize:
-    """``HgvsVariant.normalize()`` validates ``direction``."""
+    """``HgvsVariant.normalize()`` rejects ``direction``."""
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_unrecognized_direction_raises(self, direction: str) -> None:
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_direction_keyword_rejected(self, direction: str) -> None:
         variant = ferro_hgvs.parse(_VALID_HGVS)
-        with pytest.raises(ValueError, match="unrecognized direction"):
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             variant.normalize(direction=direction)
 
-    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
-    def test_accepted_direction_ok(self, direction: str) -> None:
+    def test_normalizes_without_the_keyword(self) -> None:
         variant = ferro_hgvs.parse(_VALID_HGVS)
-        result = variant.normalize(direction=direction)
-        # A recognized direction normalizes to a non-empty rendered variant
-        # (`isinstance(str(x), str)` is vacuously true — assert real content).
+        result = variant.normalize()
+        # Assert real content — `isinstance(str(x), str)` is vacuously true.
         assert str(result)
 
 
 class TestVariantProjectorConstructor:
-    """The ``VariantProjector`` constructor validates ``direction`` too — it is
-    the fifth Python entry point that routes through the same boundary helper."""
+    """The ``VariantProjector`` constructor rejects ``direction`` too — it was
+    the fifth Python entry point routing through the removed boundary helper."""
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_unrecognized_direction_raises(self, direction: str) -> None:
-        with pytest.raises(ValueError, match="unrecognized direction"):
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_direction_keyword_rejected(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             ferro_hgvs.VariantProjector(direction=direction)
 
-    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
-    def test_accepted_direction_ok(self, direction: str) -> None:
-        # Constructs against built-in test data; a recognized direction must not
-        # raise (construction alone exercises the boundary validation).
-        ferro_hgvs.VariantProjector(direction=direction)
+    def test_constructs_without_the_keyword(self) -> None:
+        # Constructs against built-in test data.
+        ferro_hgvs.VariantProjector()
 
 
-# The two `from_manifest` entry points route through the same boundary helper, so
-# an invalid direction must raise there too — and, crucially, BEFORE the manifest
-# is loaded, so the reject path needs no real reference data.
+# The two `from_manifest` entry points routed through the same boundary helper,
+# so they must reject the keyword too — and, as before, without needing real
+# reference data, since an unknown keyword is refused before any body runs.
 MANIFEST_TINY = (
     Path(__file__).parent.parent / "fixtures" / "python" / "manifest_tiny" / "manifest.json"
 )
 
 
 class TestFromManifestDirection:
-    """`Normalizer.from_manifest` / `VariantProjector.from_manifest` validate
+    """`Normalizer.from_manifest` / `VariantProjector.from_manifest` reject
     ``direction`` — the two entry points that were otherwise uncovered."""
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_normalizer_from_manifest_unrecognized_raises(self, direction: str) -> None:
-        with pytest.raises(ValueError, match="unrecognized direction"):
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_normalizer_from_manifest_rejects(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY), direction=direction)
 
-    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
-    def test_projector_from_manifest_unrecognized_raises(self, direction: str) -> None:
-        with pytest.raises(ValueError, match="unrecognized direction"):
+    @pytest.mark.parametrize("direction", _ANY_DIRECTION_VALUE)
+    def test_projector_from_manifest_rejects(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
             ferro_hgvs.VariantProjector.from_manifest(str(MANIFEST_TINY), direction=direction)
 
-    def test_normalizer_from_manifest_accepted_ok(self) -> None:
-        # A recognized direction loads the (tiny) manifest without raising.
-        ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY), direction="5prime")
+    def test_normalizer_from_manifest_loads_without_the_keyword(self) -> None:
+        ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY))
 
 
-class TestDirectionValidatedBeforeReferenceLoad:
-    """``direction`` (and ``assembly``) are validated BEFORE any reference is
-    loaded, so a bad/missing reference path cannot mask an invalid argument: the
-    boundary ``ValueError`` must win over the load's reference error. Uses a
-    nonexistent path so the load *would* fail if it were reached first."""
+class TestFromSequencesEntryPoints:
+    """The four sequence-first entry points carried the keyword as well."""
 
-    def test_normalizer_new_bad_json_and_bad_direction(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("direction", ["3prime", "5prime"])
+    def test_free_from_sequences_rejects(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.from_sequences("NC_000001.11", 100, "A", "AT", direction=direction)
+
+    @pytest.mark.parametrize("direction", ["3prime", "5prime"])
+    def test_free_from_sequences_detailed_rejects(self, direction: str) -> None:
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.from_sequences_detailed("NC_000001.11", 100, "A", "AT", direction=direction)
+
+    def test_free_from_sequences_works_without_the_keyword(self) -> None:
+        assert str(ferro_hgvs.from_sequences("NC_000001.11", 100, "A", "AT"))
+
+
+class TestDirectionRejectedBeforeReferenceLoad:
+    """The keyword is refused BEFORE any reference is loaded, so a bad/missing
+    reference path cannot mask it: the ``TypeError`` must win over the load's
+    reference error. Uses a nonexistent path so the load *would* fail if it were
+    reached first. This is the guarantee #1016's fix established for the
+    argument's ``ValueError``, carried over to its removal — a caller must never
+    be told their path is wrong when what is actually wrong is that they asked
+    for a direction that no longer exists."""
+
+    def test_normalizer_new_bad_json_and_direction(self, tmp_path: Path) -> None:
         missing = tmp_path / "does_not_exist.json"
-        with pytest.raises(ValueError, match="unrecognized direction"):
-            ferro_hgvs.Normalizer(reference_json=str(missing), direction="sideways")
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.Normalizer(reference_json=str(missing), direction="5prime")
 
-    def test_normalizer_from_manifest_bad_path_and_bad_direction(self, tmp_path: Path) -> None:
+    def test_normalizer_from_manifest_bad_path_and_direction(self, tmp_path: Path) -> None:
         missing = tmp_path / "does_not_exist.json"
-        with pytest.raises(ValueError, match="unrecognized direction"):
-            ferro_hgvs.Normalizer.from_manifest(str(missing), direction="sideways")
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.Normalizer.from_manifest(str(missing), direction="5prime")
 
-    def test_projector_new_bad_json_and_bad_direction(self, tmp_path: Path) -> None:
+    def test_projector_new_bad_json_and_direction(self, tmp_path: Path) -> None:
         missing = tmp_path / "does_not_exist.json"
-        with pytest.raises(ValueError, match="unrecognized direction"):
-            ferro_hgvs.VariantProjector(reference_json=str(missing), direction="sideways")
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.VariantProjector(reference_json=str(missing), direction="5prime")
 
-    def test_projector_from_manifest_bad_path_and_bad_direction(self, tmp_path: Path) -> None:
+    def test_projector_from_manifest_bad_path_and_direction(self, tmp_path: Path) -> None:
         missing = tmp_path / "does_not_exist.json"
-        with pytest.raises(ValueError, match="unrecognized direction"):
-            ferro_hgvs.VariantProjector.from_manifest(str(missing), direction="sideways")
+        with pytest.raises(TypeError, match=_UNEXPECTED_KWARG):
+            ferro_hgvs.VariantProjector.from_manifest(str(missing), direction="5prime")
 
     def test_projector_bad_assembly_validated_before_bad_path(self, tmp_path: Path) -> None:
-        # The `assembly` argument carries the same before-load guarantee.
+        # The `assembly` argument still carries the same before-load guarantee,
+        # and still reports it as a `ValueError` — it is a live keyword whose
+        # *value* was wrong, which is a different fault from a keyword that no
+        # longer exists. Keeping this row here pins that the two stay distinct.
         missing = tmp_path / "does_not_exist.json"
         with pytest.raises(ValueError, match="unrecognized assembly"):
             ferro_hgvs.VariantProjector.from_manifest(str(missing), assembly="bogus")

--- a/tests/python/test_issue_1018_typed_exceptions.py
+++ b/tests/python/test_issue_1018_typed_exceptions.py
@@ -194,10 +194,18 @@ class TestEquivalenceError:
 class TestArgumentValidationStaysPlain:
     """Pure argument-validation errors are plain ValueError, not FerroError."""
 
-    def test_unrecognized_direction_is_plain_value_error(self) -> None:
-        with pytest.raises(ValueError) as info:
+    def test_a_removed_direction_keyword_is_a_plain_type_error(self) -> None:
+        """``direction=`` was removed from every entry point (``README.md``
+        rule 6), so the fault it used to raise — a ``ValueError`` naming an
+        unrecognized *value* — no longer exists. What replaces it is a
+        ``TypeError`` about the *keyword*, and it must stay just as plain: a
+        caller catching ``FerroError`` must not swallow it, or a request for a
+        direction ferro no longer has would look like a normalization failure
+        rather than an API change."""
+        with pytest.raises(TypeError) as info:
             ferro_hgvs.normalize("NM_000088.3:c.100A>G", direction="sideways")
         assert not isinstance(info.value, ferro_hgvs.FerroError)
+        assert "direction" in str(info.value)
 
     def test_empty_ref_base_is_plain_value_error(self) -> None:
         with pytest.raises(ValueError) as info:

--- a/tests/python/test_issue_1282_position_zero.py
+++ b/tests/python/test_issue_1282_position_zero.py
@@ -2,19 +2,26 @@
 
 A 5'-shuffled cis allele can denote "the reference with bases added at the very
 front". Before this fix the derived member reached ``hgvs_pos_to_index`` with
-``start == 0`` and the subtraction underflowed. The Rust suite
-(``tests/it/issue_1282_position_zero.rs``) covers the fix at the library level;
-this file exists because ``Normalizer.normalize`` is the surface where the
-underflow did the most damage.
+``start == 0`` and the subtraction underflowed.
 
-A Rust panic crosses PyO3 as ``pyo3_runtime.PanicException``, which subclasses
-``BaseException`` rather than ``Exception`` — so it slips straight through the
-``except Exception`` a caller would reasonably wrap ``normalize`` in. And the
-wheel is built ``--release`` (``ci.yml``'s Python Wheel Test job, and every
-published artifact), where ``[profile.release]`` sets no ``overflow-checks`` —
-so there the subtraction wrapped silently to an index near ``usize::MAX``
-rather than panicking at all. Both doors are shut by the same rewrite, and
-both are only observable from here.
+**The 5' arm is no longer reachable from Python.** ``direction=`` was removed
+from every Python entry point with the rest of ferro's public 5' surface
+(``README.md`` rule 6), so the reproducers below can no longer be driven into
+the underflowing path from here. The behavioural coverage is unchanged and
+lives in ``tests/it/issue_1282_position_zero.rs``, whose five tests all pin the
+5' arm against the internal direction type — nothing was dropped, the guard
+simply has one owner now instead of two.
+
+What is still worth pinning *here*, and what this file was always really about,
+is the PyO3 boundary. A Rust panic crosses PyO3 as
+``pyo3_runtime.PanicException``, which subclasses ``BaseException`` rather than
+``Exception`` — so it slips straight through the ``except Exception`` a caller
+would reasonably wrap ``normalize`` in. And the wheel is built ``--release``
+(``ci.yml``'s Python Wheel Test job, and every published artifact), where
+``[profile.release]`` sets no ``overflow-checks`` — so there the subtraction
+wrapped silently to an index near ``usize::MAX`` rather than panicking at all.
+Both doors are only observable from here, so the reproducers are still driven
+through the boundary, now on the shipped 3' path.
 
 ``tests/python/test_coordinates.py`` covers the other half — the standalone
 ``hgvs_pos_to_index(0)`` conversion — but that is the helper, not the path that
@@ -47,32 +54,56 @@ REPRODUCERS = [
 
 # "Insert ``A`` immediately 5' of base 1" spelled as the boundary delins that
 # every other bound in ``src/normalize/mod.rs`` already uses, because
-# ``g.0_1ins`` is not a position any HGVS axis has.
+# ``g.0_1ins`` is not a position any HGVS axis has. Still the 5' answer, and
+# still asserted — in ``tests/it/issue_1282_position_zero.rs``.
 BOUNDARY_DELINS = "TEMPLATE:g.1delinsAT"
 
 
 def _normalizer(tmp_path: Path) -> "ferro_hgvs.Normalizer":
-    """Build a 5'-shuffling normalizer over the synthetic reference."""
+    """Build a normalizer over the synthetic reference.
+
+    There is no direction to choose: ferro shuffles 3'.
+    """
     reference = {"transcripts": [], "genomic_sequences": {CONTIG: SEQ}}
     path = tmp_path / "reference.json"
     path.write_text(json.dumps(reference))
-    return ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
+    return ferro_hgvs.Normalizer(reference_json=str(path))
+
+
+def test_the_five_prime_direction_is_not_reachable_from_python(tmp_path: Path) -> None:
+    """The keyword that drove these reproducers into the underflow is gone.
+
+    Asserted rather than assumed, because the dangerous removal would be a
+    *silently ignored* keyword: a caller writing ``direction="5prime"`` would
+    then get a 3' answer to a 5' question with nothing to tell them.
+    """
+    reference = {"transcripts": [], "genomic_sequences": {CONTIG: SEQ}}
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(reference))
+    with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
+        ferro_hgvs.Normalizer(reference_json=str(path), direction="5prime")
 
 
 @pytest.mark.parametrize("variant", REPRODUCERS)
 def test_payload_before_the_first_base_normalizes(tmp_path: Path, variant: str) -> None:
     """The reported crash: a description comes back instead of a panic.
 
-    Reaching the assertion at all is half the test — a ``PanicException`` would
-    abort the call rather than return.
+    Reaching the assertion at all is the point — a ``PanicException`` would
+    abort the call rather than return, and in a release wheel the underflow
+    wrapped silently instead. Driven on the shipped 3' path now that 5' is not
+    reachable from Python; the 5' arm's exact outputs are pinned in
+    ``tests/it/issue_1282_position_zero.rs``.
     """
-    assert _normalizer(tmp_path).normalize(variant) == BOUNDARY_DELINS
+    result = _normalizer(tmp_path).normalize(variant)
+    assert result.startswith(f"{CONTIG}:g.")
 
 
-def test_the_boundary_delins_is_a_fixed_point(tmp_path: Path) -> None:
+def test_the_output_is_a_fixed_point(tmp_path: Path) -> None:
     """Re-normalizing the output must not move it, or the clamp is a one-pass patch."""
     normalizer = _normalizer(tmp_path)
 
+    once = normalizer.normalize(REPRODUCERS[0])
+    assert normalizer.normalize(once) == once
     assert normalizer.normalize(BOUNDARY_DELINS) == BOUNDARY_DELINS
 
 
@@ -84,5 +115,11 @@ def test_an_interior_payload_keeps_its_insertion_spelling(tmp_path: Path) -> Non
     """
     normalizer = _normalizer(tmp_path)
 
-    assert normalizer.normalize("TEMPLATE:g.3_4insT") == "TEMPLATE:g.1dup"
     assert normalizer.normalize("TEMPLATE:g.1T>A") == "TEMPLATE:g.1T>A"
+    # An interior insertion into the leading T-run. On the shipped 3' path it
+    # 3'-shifts to the end of that run and types as a duplication; the value is
+    # measured, not assumed. What matters for this guard is the negative: it is
+    # NOT rewritten into the interbase-0 boundary delins.
+    interior = normalizer.normalize("TEMPLATE:g.3_4insT")
+    assert interior == "TEMPLATE:g.9dup"
+    assert interior != BOUNDARY_DELINS

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -699,14 +699,6 @@ def poly_projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
     return ferro_hgvs.VariantProjector(reference_json=_write_poly_reference(tmp_path))
 
 
-@pytest.fixture
-def poly_projector_5prime(tmp_path: Path) -> ferro_hgvs.VariantProjector:
-    """5'-shifting projector over the shared poly-A reference (#867 direction)."""
-    return ferro_hgvs.VariantProjector(
-        reference_json=_write_poly_reference(tmp_path), direction="5prime"
-    )
-
-
 class TestProjectToGenomicNormalize:
     """#867: project_to_genomic(normalize=...) — default normalizes, False=raw."""
 
@@ -743,17 +735,29 @@ class TestProjectToGenomicNormalize:
             str(poly_projector.project_to_genomic(v, normalize=False)) == "NC_000001.11:g.1003del"
         )
 
-    def test_normalize_follows_projector_direction(
-        self, poly_projector_5prime: ferro_hgvs.VariantProjector
-    ) -> None:
-        # normalize=True must honor the projector's configured shuffle direction,
-        # not hard-code 3'. c.8del is the last A of the poly-A run (c.4..c.8 →
-        # g.1003..1007), so its raw pivot is the 3'-anchored g.1007del; a
-        # 5'-shifting projector re-shuffles that to the 5'-anchored g.1003del.
-        # (The default 3'-shifting projector would leave it at g.1007del.)
+    def test_the_projector_takes_no_direction(self, tmp_path: Path) -> None:
+        """``VariantProjector`` has no ``direction=`` keyword to configure.
+
+        This test used to build a 5'-shifting projector and assert that
+        ``normalize=True`` honoured it rather than hard-coding 3' — the only
+        check that could tell a re-shuffle from a pass-through, since ``c.8del``
+        pivots to the 3'-anchored ``g.1007del`` already. The keyword was removed
+        with the rest of ferro's public 5' surface (``README.md`` rule 6), and
+        that property moved to
+        ``tests/it/issue_867_project_to_genomic_normalized.rs``'s
+        ``project_to_genomic_normalized_follows_the_configured_direction``,
+        which drives the internal direction type and asserts the same
+        ``g.1007del`` -> ``g.1003del`` pair. What remains to pin here is the
+        Python boundary: the keyword must be refused, not ignored, or a caller
+        asking for 5' would silently receive the 3' answer."""
+        reference = _write_poly_reference(tmp_path)
+        with pytest.raises(TypeError, match="unexpected keyword argument 'direction'"):
+            ferro_hgvs.VariantProjector(reference_json=reference, direction="5prime")
+
+        # And the 3' behaviour the removed fixture's sibling rows relied on is
+        # unchanged: c.8del's pivot is already 3'-anchored, so normalization is
+        # a no-op on it rather than a move.
+        projector = ferro_hgvs.VariantProjector(reference_json=reference)
         v = ferro_hgvs.parse("NC_000001.11(NM_POLY.1):c.8del")
-        assert str(poly_projector_5prime.project_to_genomic(v)) == "NC_000001.11:g.1003del"
-        assert (
-            str(poly_projector_5prime.project_to_genomic(v, normalize=False))
-            == "NC_000001.11:g.1007del"
-        )
+        assert str(projector.project_to_genomic(v)) == "NC_000001.11:g.1007del"
+        assert str(projector.project_to_genomic(v, normalize=False)) == "NC_000001.11:g.1007del"


### PR DESCRIPTION
## Why

`README.md` rule 6 is the authority here, and it argues against itself today. It states **"There are no user options for normalization form"**, and then, in its very next sentence, concedes that the 3'/5' knob is *not* orthogonal — it selects the frame every other rule is evaluated in, so rules 2 and 3 had to be claimed *per direction* rather than across the two (`README.md:206-208`).

So the knob was a user option for normalization form, sitting inside the rule that forbids user options for normalization form. **Removing it from the public surface is what makes rule 6 true.** An internal oracle is not a user option, so keeping the arm internally costs rule 6 nothing.

Two claims in the tree are also simply false, and are corrected here rather than left for the next reader:

- `src/normalize/config.rs` has said `/// Shuffle towards 5' end (for VCF compatibility)` since the initial commit. **No VCF path has ever selected it.** VCF left-alignment in this crate is the anchor-base rules in `src/vcf/from_hgvs.rs` (#261, closing #81 K2) — which base you attach, not which end you shift to. Related prose in `src/normalize/mod.rs` calling the arm "5'/VCF shuffles" goes with it.
- `README.md:38`'s "3'/5' shifting **per HGVS specification**" describes a rule the spec does not contain.

This references #1857 as context but does not claim it as the mandate. #1857 asks for the 5' arm to be *adjudicated* — exact mirror, mirror with exceptions re-derived, or other — and removal is a fourth answer it does not enumerate. The authority cited is rule 6.

## Why the internal instrument is kept

`ShuffleDirection::FivePrime`, the shuffle machinery, all 7 filename-level 5' test modules, all 9 pinned census constants and the 6-cell corpus matrix are **untouched**.

3'/5' disagreement is a differential oracle over ferro's own *shipped 3' output*, and it has twice caught a defect nothing else could see:

- **#1542 / PR #1840** — `NC_000017.11:g.80110044_80110047delinsGTTGG` normalized to different member counts by direction alone. PR #1840 measured all four `FERRO_PARTITION` arms x both directions: **7 of 8 configurations emitted the merged two-member form; only `live`/3' produced the split.** The shipped default was the outlier, both answers were fixed points, and `FERRO_ASSERT_IDEMPOTENT`, `_REPARSE`, `_IN_BOUNDS`, `_SEQUENCE` and every confluence class were all satisfied by the wrong answer. 5' was the only instrument that saw it.
- `tests/it/cis_confluence_axis.rs` — an off-by-one in `enclosing_exon` let a member on an exon's first base escape the window clamp. A 5'-only *symptom* of a bug in *shared* code; the 3' walk moves away from the exon start and never reached it.

Deleting the arm would not merely make those harder to find, it would make that class of defect structurally invisible. So this PR changes **reachability only** — never behaviour.

The census modules that justified measuring 5' "because `--direction 5prime` is a supported public option" have had that justification rewritten. The measurement is unchanged; the reason is now the oracle.

## What is removed, verified against `origin/main`

| surface | what went |
|---|---|
| CLI | `ferro normalize --direction`, and `cli::parse_shuffle_direction` (+ its `cli::mod` re-export) behind it |
| Python | the ten `direction=` keywords, `parse_direction_or_raise`, `python_helpers::parse_direction`, and the stub sites in `__init__.pyi` |
| Web service | `tools.ferro.shuffle_direction`, its `docs/WEB_SERVICE_SETUP.md` lines, and the value `deploy-local.yml` wrote |
| Docs | `README.md:38`, rule 6's concession, the `from_sequences` options prose, and the subcommand table row |

`ShuffleDirection`, `NormalizeConfig::{shuffle_direction, with_direction, for_entry_point}` and `FromSequencesOptions::{direction, with_direction}` **stay `pub` and become `#[doc(hidden)]`**, documented as an internal instrument. Verified in the rendered docs: after this change `ShuffleDirection` has no rustdoc page and appears **zero** times in `target/doc/ferro_hgvs/index.html` or in `normalize/index.html`.

**That is a deliberate deviation and it is worth being explicit about.** `tests/` is an external integration-test crate, so a `pub(crate)` demotion is not available: **126 call sites across 67 files** under `tests/` and `examples/` drive the differential through `with_direction`, and **82 files** there name `ShuffleDirection` at all (`grep -rn with_direction tests examples` / `grep -rl ShuffleDirection tests examples`, excluding this PR's own new module). Demoting it would mean deleting the oracle this PR exists to protect. `#[doc(hidden)]` removes it from the published API surface while keeping it compilable from `tests/`. The door is closed to documentation and to every entry point; a Rust library caller who goes looking for a hidden item can still find it, and that is the one honest limit of this change.

## Every removal refuses — it does not default

This is the part that matters most, and each was measured rather than assumed. **A silent 3' run for a caller who asked for 5' is data corruption at the customer**, and it is the exact shape a careless removal produces.

**CLI — exit 2, nothing on stdout:**

```
$ ferro normalize NM_000088.3:c.4C>G --direction 5prime
error: unexpected argument '--direction' found
  tip: a similar argument exists: '--reject'
EXIT=2
```

Same for `3prime`, `5'` and `banana`. This is *stronger* than #1866's `value_parser` fix, which is still open and not on `main` — the flag is gone, so there is no value to mis-parse. Note the removed `parse_shuffle_direction` had `_ => ShuffleDirection::ThreePrime` as its fallback arm, which is precisely the #1863 footgun; deleting the value handling without deleting the flag would have preserved it for `--direction 5prime`.

**Python — `TypeError` at the call, on all ten entry points:**

```
normalize(s, direction="5prime")          TypeError: normalize() got an unexpected keyword argument 'direction'
Normalizer(direction="5prime")            TypeError: Normalizer.__new__() got an unexpected keyword argument 'direction'
VariantProjector(direction="5prime")      TypeError: VariantProjector.__new__() got an unexpected keyword argument 'direction'
from_sequences(..., direction="5prime")   TypeError: from_sequences() got an unexpected keyword argument 'direction'
parse(s).normalize(direction="5prime")    TypeError: HgvsVariant.normalize() takes no keyword arguments
```

Measured from a release wheel in a clean venv, the way CI runs it. The last message is a different form because that signature now names *no* keywords at all — a stronger statement, not a weaker one.

**Web service — the load fails and names the key.** `FerroConfig` gains `serde(deny_unknown_fields)`, because serde's default is to *ignore* an unknown field: without it, an operator's existing `shuffle_direction = "5prime"` would be dropped and the service would 3'-shift while the config file still said otherwise.

That attribute promptly caught a real miss in this very PR. `config/service.example.toml` — the file `docs/WEB_SERVICE_SETUP.md` tells operators to `cp` into place — still carried `shuffle_direction = "3prime"`, so the shipped example would have failed to load. **Nothing in the repo parsed that file**, which is precisely how it went stale unnoticed. Fixed, and `service::config::tests::the_shipped_example_config_deserializes` now parses it into `ServiceConfig` so it cannot drift again; the guard was confirmed to fail (`TOML parse error at line 21`) with the key put back.

**Migration.** `direction="3prime"` / `--direction 3prime`: drop the argument, behaviour unchanged. `5prime`: there is no replacement; that form is no longer produced by any entry point.

## Tests: zero suites deleted, net +8 test functions

Counted mechanically over the diff against `origin/main` (`#[test]` / `def test_`, across the 28 touched files): **476 -> 484, net +8**.

- **8 unit-test functions were relocated, not dropped.** `cli::parse::test_parse_shuffle_direction_*` (4) and `python_helpers::test_parse_direction_*` (4) tested two mutually duplicate string parsers that no longer exist. Their assertions are re-pointed at the retained internal `FromStr` impl in `normalize::config` (4 functions, deduplicated). The one that changed meaning is called out in place: `test_parse_shuffle_direction_default` asserted that an unrecognized value resolves to `ThreePrime` — the #1863 behaviour — and is now `test_parse_direction_unrecognized_is_err`.
- **The two behavioural rows that only Python covered were moved to Rust, not lost.** `tests/python/test_variant_projection.py`'s `test_normalize_follows_projector_direction` was the only guard that could tell a re-shuffle from a pass-through (`c.8del` pivots to the 3'-anchored `g.1007del` already, so only the mirror separates them); it is now `issue_867_project_to_genomic_normalized::project_to_genomic_normalized_follows_the_configured_direction`, asserting the same `g.1007del` -> `g.1003del` pair. `test_from_sequences.py`'s 5' row (`g.11del`) is re-pinned in the new module.
- `tests/python/test_issue_1282_position_zero.py`'s 5' reproducers are already covered in full by `tests/it/issue_1282_position_zero.rs` (5 tests, all `FivePrime`); the Python file keeps its real job — the PyO3 boundary, where a panic crosses as `BaseException` and a release wheel wraps silently instead — on the shipped 3' path.
- New `tests/it/five_prime_public_surface_removed.rs` (5 tests) pins the refusals **and** that the internal differential still *acts*, so the oracle cannot be hollowed out into 60 modules comparing an arm against itself.

Instrument intact, measured: `ShuffleDirection::FivePrime` occurrences under `tests/` **229 -> 232**, under `examples/` **8 -> 8**; test modules naming it **59 -> 61**; all 7 filename-level 5' modules present.

**Every new guard was watched failing.** Seven sabotages, each restored with `cp`: re-adding the flag as accepted-and-ignored (2 CLI guards red), dropping `deny_unknown_fields` (service guard red), making `FromStr` guess (parse guard red), no-oping `FromSequencesOptions::with_direction` and `for_entry_point` (both differential guards red), and rebuilding the wheel with `normalize()` accepting-and-ignoring `direction` (16 Python rows red). The suite also caught three assertions I had guessed rather than measured, which is the reason to run it before believing it.

## SemVer

Breaking three independent ways, so this lands at **0.14.0** (`release-plz.toml` sets `features_always_increment_minor`, and the crate is at 0.13.1):

1. Removing a variant from a `pub enum` is breaking regardless of `#[non_exhaustive]` — that attribute forbids downstream *exhaustive matching*, not naming the variant. (Not done here: the variant survives.) What *is* removed is `pub fn parse_shuffle_direction`, which was **doctested**, hence documented API.
2. `python_helpers::parse_direction`, also `pub` and doctested.
3. The Python keywords, which are the sharp edge: Python has no compiler, so this surfaces at the customer's site rather than at their build.

Worth flagging for the release: **no `cargo-semver-checks` runs in CI.** It appears only in the release-plz PR body via `{{ release.semver_check }}`, so the break is reported at release time, not at PR review.

## Gate

- `cargo nextest run --features dev --no-fail-fast` — **10684 passed, 0 failed**, 152 skipped
- `pytest tests/python/` against a release wheel in a clean venv — **981 passed**, 0 failed, 8 skipped
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `generate_tool_support_tables -- --check` — clean (my `README.md` edits are outside the generated blocks)
- Rustdoc: this PR removes one broken intra-doc link of its own making and adds none (134 -> 133 pre-existing errors, all in untouched files; CI does not gate on rustdoc)

**One `--direction` flag deliberately survives**, in `examples/dump_confluence_divergences.rs`. That is a `dev`-gated example generator rather than a shipped entry point — it *is* the instrument, the tool you run to measure the divergence this PR keeps — so removing its flag would remove the ability to use the oracle it protects. `ferro normalize` was the only shipped subcommand that ever had the flag; `project` never did.

Not stacked on #1835; this targets `main` directly.

Refs #1857

Representation-Change: none. The default was already `ThreePrime` on every entry point, so no shipped output moves — the CLI, Python and service paths all constructed a 3' config before this change and construct the same one after it. Nothing under `src/normalize/` changes behaviour: the diff there is the `#[doc(hidden)]` attributes, doc comments, and one `for_entry_point` argument that was already always `ThreePrime` at every seam. The full suite is byte-identical at 10684 passing, including all 9 pinned direction-paired census constants, which would move if any frame had shifted.
