### PR TITLE
feat(rulings): make a record state what enforces it, and reject silence

### DIFF
--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -225,6 +225,59 @@ mod overrides {
         /// Equivalence-class ids the ruling bears on, if any.
         #[serde(default)]
         pub equivalence_classes: Vec<String>,
+        /// What enforces the ruling, or the stated reason nothing does.
+        ///
+        /// **`Option<Guard>`, not `Guard`.** The type is what carries this, and
+        /// it carries two separate things.
+        ///
+        /// It makes the field **optional at deserialize**. As a bare `Guard`, a
+        /// record lacking the key failed to deserialize — and this struct is the
+        /// generator's entry to the whole ledger, so the failure was not "one
+        /// record is unanswered" but "the ledger cannot be read".
+        /// `generate_spec_fixture` exited 1, the generated fixture never existed,
+        /// and every test downstream of it failed for a reason mentioning neither
+        /// guards nor the record at fault. Measured on this branch rebased onto
+        /// `origin/main` at `426a944b`, for two records missing one field each:
+        /// **20** failures from this alone, on top of the **28** the ledger
+        /// reader's own panic produced.
+        ///
+        /// And it keeps absence **distinguishable**. As a bare `Guard`, an absent
+        /// key and a written `"guard": {}` would both arrive as
+        /// `Guard { tests: [], none: None }`, and [`validate_guard_shape`] would
+        /// have to give one message for two different mistakes. `None` is
+        /// reachable only by the key being absent.
+        ///
+        /// The `#[serde(default)]` below is **redundant and deliberate**. Serde
+        /// already treats a missing `Option` field as `None`, so removing it
+        /// changes nothing today — verified, not assumed: with the attribute
+        /// deleted the generator still exits 0 on a ledger carrying a guardless
+        /// record. It is kept because the *intent* is "absent is allowed here",
+        /// and a future change of this field's type away from `Option` would
+        /// otherwise silently restore the cascade above. Do not read it as the
+        /// thing that makes absence legal; the `Option` is.
+        ///
+        /// **This is a change of stage, not a relaxation.** A record with no
+        /// guard still cannot merge: it is refused by
+        /// `tests/it/ruling_guard_field.rs::every_record_declares_a_guard`, in
+        /// one targeted failure that names the record and the fix. What the
+        /// generator keeps refusing is a guard that is *present and malformed*,
+        /// because that is a broken record rather than an unanswered question.
+        #[serde(default)]
+        pub guard: Option<Guard>,
+    }
+
+    /// See [`Ruling::guard`]. Exactly one of the two keys may be set;
+    /// `validate_ruling_shape` enforces that, because serde cannot express
+    /// "one of these, not both, not neither" on its own.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Guard {
+        /// `<path>.rs::<function>` citations of the enforcing tests.
+        #[serde(default)]
+        pub tests: Vec<String>,
+        /// A stated, reasoned declaration that no test enforces this record.
+        #[serde(default)]
+        pub none: Option<String>,
     }
 
     /// `spec_expected` uses the doubly-optional pattern so the override file
@@ -934,7 +987,103 @@ mod decisions {
             ),
             _ => {}
         }
+        validate_guard_shape(owner, ruling.guard.as_ref())?;
         Ok(())
+    }
+
+    /// A `guard`, if the record carries one, must state exactly one of the two
+    /// things it can state, and must state it resolvably.
+    ///
+    /// This is the build-time half of the field, and it exists for the reason
+    /// the unknown-equivalence-class check does: a pointer nothing validates is
+    /// prose with punctuation. What is checked here is the shape and the
+    /// **file**; whether the named function exists, runs and asserts needs the
+    /// whole tree walked and is `tests/it/ruling_guard_field.rs`'s job.
+    ///
+    /// **`None` — no `guard` key at all — is passed through here deliberately**,
+    /// and it is the one case this function declines to judge. Refusing it would
+    /// put the generator back in the position the `#[serde(default)]` on
+    /// [`overrides::Ruling::guard`] exists to get it out of: the generator is a
+    /// *build step*, so a refusal from it is not one failure but every failure
+    /// downstream of the artifact it did not write. The presence rule is
+    /// enforced instead by a test that can name the record and print the fix,
+    /// and that test is not optional, so nothing is weakened by declining here.
+    ///
+    /// Note the asymmetry that makes this safe: a record that says nothing is
+    /// still *readable*, so the fixture built from it is correct as far as it
+    /// goes. A record whose `guard` contradicts itself is not, which is why
+    /// `Some(..)` is still judged in full.
+    fn validate_guard_shape(owner: &str, guard: Option<&overrides::Guard>) -> anyhow::Result<()> {
+        let Some(guard) = guard else {
+            return Ok(());
+        };
+        match (guard.tests.is_empty(), guard.none.as_deref()) {
+            (false, Some(_)) => anyhow::bail!(
+                "{owner}: `guard` sets both `tests` and `none` — it has both named an enforcing \
+                 test and declared that nothing enforces it"
+            ),
+            (true, None) => anyhow::bail!(
+                "{owner}: `guard` states nothing. Set `tests` to the tests that fail when this \
+                 ruling stops holding, or `none` to the reason nothing enforces it. An empty \
+                 `guard` is the silence the field exists to reject"
+            ),
+            (true, Some(reason)) if reason.trim().is_empty() => anyhow::bail!(
+                "{owner}: `guard.none` is blank; declining is a first-class answer only when it \
+                 says why"
+            ),
+            (true, Some(_)) => Ok(()),
+            (false, None) => {
+                for citation in &guard.tests {
+                    let (path, _) = split_guard_citation(citation).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "{owner}: guard citation {citation:?} is not of the form \
+                             `<path>.rs::<function>` — a citation that does not resolve \
+                             mechanically is the prose this field replaces"
+                        )
+                    })?;
+                    if !crate_relative(path).is_file() {
+                        anyhow::bail!(
+                            "{owner}: guard citation {citation:?} names {path:?}, which is not a \
+                             file in this tree (typo, or the guard moved)"
+                        );
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Splits `<path>.rs::<function>`; `None` for anything outside that grammar.
+    ///
+    /// Deliberately duplicated from `tests/it/common/rulings.rs` rather than
+    /// shared: this binary and the integration-test crate do not link to each
+    /// other, and the two copies are held together by
+    /// `the_generator_and_the_ledger_reader_agree_on_the_citation_grammar`
+    /// there, which is a check rather than a hope.
+    fn split_guard_citation(token: &str) -> Option<(&str, &str)> {
+        let (path, function) = token.split_once("::")?;
+        if !path.ends_with(".rs") || path.starts_with('/') || path.contains("..") {
+            return None;
+        }
+        if function.is_empty() || function.contains("::") {
+            return None;
+        }
+        if !function.starts_with(|c: char| c.is_ascii_lowercase()) {
+            return None;
+        }
+        if !function
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return None;
+        }
+        Some((path, function))
+    }
+
+    /// A repo-relative path resolved against the crate root, so the generator
+    /// answers the same way whatever directory it is invoked from.
+    fn crate_relative(path: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
     }
 
     /// Split a `path:line` or `path:start-end` clause into its parts.
@@ -1195,6 +1344,19 @@ mod decisions {
                 rationale: "because".to_string(),
                 applies_to: Vec::new(),
                 equivalence_classes: Vec::new(),
+                guard: Some(guard_citing(&[
+                    "examples/generate_spec_fixture.rs::a_guard",
+                ])),
+            }
+        }
+
+        /// A `guard` naming the given citations. The default fixture cites a
+        /// file that really exists, so `validate_guard_shape`'s file check is
+        /// exercised positively rather than skipped.
+        fn guard_citing(tests: &[&str]) -> overrides::Guard {
+            overrides::Guard {
+                tests: tests.iter().map(|t| t.to_string()).collect(),
+                none: None,
             }
         }
 
@@ -1251,6 +1413,147 @@ mod decisions {
                 &ruling(Decided, &["a.md:1"], Some("a.md:1"), &["z.md:9"])
             )
             .is_err());
+        }
+
+        /// The build refuses a `guard` that is present and says nothing usable.
+        ///
+        /// The positive control is first, so a `should`-fail below cannot pass
+        /// because the fixture is broken for an unrelated reason.
+        #[test]
+        fn a_ruling_must_state_what_enforces_it() {
+            use overrides::RulingStatus::Decided;
+            let base = || ruling(Decided, &["a.md:1"], Some("a.md:1"), &[]);
+
+            assert!(
+                validate_ruling_shape("r", &base()).is_ok(),
+                "positive control"
+            );
+
+            // Silence — the state the field exists to abolish. Written out as an
+            // empty object, so it is the AUTHOR's blank rather than an absent
+            // key; the absent key is `an_absent_guard_is_left_to_the_ledger_test`.
+            let mut silent = base();
+            silent.guard = Some(overrides::Guard {
+                tests: Vec::new(),
+                none: None,
+            });
+            assert!(validate_ruling_shape("r", &silent).is_err());
+
+            // Declining IS an answer, and needs no test to exist.
+            let mut declined = base();
+            declined.guard = Some(overrides::Guard {
+                tests: Vec::new(),
+                none: Some("process record; it mandates no output".to_string()),
+            });
+            assert!(validate_ruling_shape("r", &declined).is_ok());
+
+            // …but only when it says why.
+            let mut blank = base();
+            blank.guard = Some(overrides::Guard {
+                tests: Vec::new(),
+                none: Some("  ".to_string()),
+            });
+            assert!(validate_ruling_shape("r", &blank).is_err());
+
+            // Both at once is a contradiction, not a belt-and-braces.
+            let mut both = base();
+            both.guard = Some(overrides::Guard {
+                tests: vec!["examples/generate_spec_fixture.rs::a_guard".to_string()],
+                none: Some("and also nothing".to_string()),
+            });
+            assert!(validate_ruling_shape("r", &both).is_err());
+        }
+
+        /// An **absent** `guard` deserializes and passes the generator, and is
+        /// left to `tests/it/ruling_guard_field.rs::every_record_declares_a_guard`.
+        ///
+        /// Both halves matter and neither implies the other. The deserialize
+        /// half is what stops a missing field taking the whole ledger — and
+        /// therefore the generated fixture, and everything downstream of it —
+        /// with it; the validate half is what stops the generator re-imposing
+        /// the same refusal one function later, which would restore the cascade
+        /// while looking like a shape check.
+        ///
+        /// Read alongside [`a_ruling_must_state_what_enforces_it`]: absence is
+        /// passed through, a written-out blank is still refused. If those two
+        /// ever agree, the distinction the `Option` exists for has been lost.
+        #[test]
+        fn an_absent_guard_is_left_to_the_ledger_test() {
+            use overrides::RulingStatus::Decided;
+
+            // Deserializes: a record with no `guard` key at all.
+            let json = serde_json::json!({
+                "id": "a-record",
+                "status": "decided",
+                "question": "does an absent guard deserialize?",
+                "rationale": "it must, or one unanswered record breaks the build",
+                "governing": "a.md:1",
+                "clauses": [{ "clause": "a.md:1", "quote": "q" }],
+            });
+            let parsed: overrides::Ruling =
+                serde_json::from_value(json).expect("a record with no `guard` must deserialize");
+            assert!(
+                parsed.guard.is_none(),
+                "an absent key must arrive as `None`, distinguishable from a written `{{}}`"
+            );
+
+            // …and passes validation, which is where the generator stops caring.
+            let mut absent = ruling(Decided, &["a.md:1"], Some("a.md:1"), &[]);
+            absent.guard = None;
+            assert!(
+                validate_ruling_shape("r", &absent).is_ok(),
+                "the generator must not refuse an absent guard — refusing it here is what \
+                 turned one unanswered record into a fixture-wide cascade"
+            );
+        }
+
+        /// A guard citation must be resolvable, and must name a file that is
+        /// really there — the same class of check as "names unknown equivalence
+        /// class", which is the only other structured pointer a record carries.
+        #[test]
+        fn a_guard_citation_must_name_a_file_in_this_tree() {
+            use overrides::RulingStatus::Decided;
+            let with = |tests: &[&str]| {
+                let mut r = ruling(Decided, &["a.md:1"], Some("a.md:1"), &[]);
+                r.guard = Some(guard_citing(tests));
+                r
+            };
+
+            assert!(validate_ruling_shape(
+                "r",
+                &with(&["examples/generate_spec_fixture.rs::a_guard"])
+            )
+            .is_ok());
+
+            // Outside the grammar: a module path names no file, and a bare path
+            // names no proposition.
+            assert!(validate_ruling_shape("r", &with(&["merge::a_guard"])).is_err());
+            assert!(
+                validate_ruling_shape("r", &with(&["examples/generate_spec_fixture.rs"])).is_err()
+            );
+            // Well-formed and pointing at nothing.
+            assert!(validate_ruling_shape("r", &with(&["tests/it/no_such_file.rs::a"])).is_err());
+        }
+
+        /// The grammar itself, since the generator keeps its own copy of it.
+        #[test]
+        fn the_guard_citation_grammar_admits_a_path_and_nothing_else() {
+            assert_eq!(
+                split_guard_citation("tests/it/foo.rs::a_guard_name"),
+                Some(("tests/it/foo.rs", "a_guard_name"))
+            );
+            for rejected in [
+                "merge::a_guard_name",
+                "tests/it/foo.rs",
+                "a_guard_name",
+                "tests/it/foo.rs::mod::a_guard",
+                "tests/it/foo.rs::AGuard",
+                "tests/it/foo.rs::",
+                "/abs/foo.rs::a_guard",
+                "tests/../../foo.rs::a_guard",
+            ] {
+                assert_eq!(split_guard_citation(rejected), None, "{rejected}");
+            }
         }
 
         #[test]

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -346,6 +346,12 @@
       "governing": "docs/recommendations/DNA/delins.md:47",
       "question": "When two variants are separated by two or more nucleotides and part of an inserted sequence aligns with the reference, does `delins.md:17`'s instruction to describe them individually govern, or `delins.md:47`'s recommendation of the delins format?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/cis_confluence_adjudication.rs::a_spanning_delins_and_its_aligned_split_are_two_fixed_points",
+          "tests/it/cis_adjudication_enumeration.rs::the_spanning_versus_split_class_partitions_as_measured"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:17",
@@ -397,6 +403,13 @@
       "id": "inversion-vs-two-delins-76-83",
       "question": "For `c.76_83inv`, whose reverse complement coincides with the reference at its four interior columns, is the edit one inversion or the two `delins` members those columns separate?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1517_inv_priority_over_delins.rs::a_reverse_complement_competing_with_delins_members_is_an_inversion",
+          "tests/it/issue_1517_inv_priority_over_delins.rs::a_reverse_complement_competing_with_substitutions_stays_split",
+          "tests/it/inversion_sweep.rs::the_delins_spelling_converges_on_the_spec_inversion"
+        ]
+      },
       "governing": "docs/recommendations/DNA/inversion.md:5",
       "clauses": [
         {
@@ -429,6 +442,11 @@
       "id": "inversion-vs-a-mixed-member-competitor",
       "question": "When a whole-span reverse complement competes with a multi-member description that is neither uniformly `delins` nor uniformly substitutions, but a mix of substitutions and multi-column members, which form is canonical?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1517_inv_priority_over_delins.rs::a_reverse_complement_competing_with_mixed_members_is_an_inversion"
+        ]
+      },
       "governing": "docs/recommendations/DNA/inversion.md:5",
       "clauses": [
         {
@@ -454,6 +472,12 @@
       "id": "adjudication-precedence-order",
       "question": "Where the spec does not settle a normalization question, what ranks next — the reference implementation, the downstream consumer's already-shipped representation, or the filer's open issues?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/readme_normalization_rules.rs::the_ledgers_pointer_at_the_readme_ruleset_resolves",
+          "tests/it/hgvs_spec_normalization_tests.rs::precedence_escalations_are_censused"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:56",
@@ -487,6 +511,12 @@
       "id": "canonical-form-choice-when-both-legal",
       "question": "When two descriptions of one variant are both legal under the recommendations, which one does ferro ship?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/spec_worked_example_rules.rs::the_two_svd_wg010_spellings_converge_on_the_conformant_split",
+          "tests/it/cis_junction_crossing_shift.rs::the_three_member_spelling_and_its_one_member_form_are_two_fixed_points"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:157",
@@ -520,6 +550,12 @@
       "id": "codon-carve-out-shape-restriction",
       "question": "`delins.md:18`'s exception names no edit type, but ferro applies it only to a substitution / unchanged base / substitution shape. Does the exception reach other shapes?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1716_codon_frame_merged_span.rs::frameshift_pair_inside_one_codon_is_left_open",
+          "tests/it/spec_corpus_regressions.rs::the_codon_gate_splits_a_spanning_delins_its_own_members_do_not"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:18",
@@ -542,6 +578,12 @@
       "id": "delins-codon-carve-out-gap-one",
       "question": "Do two variants separated by exactly one nucleotide, together affecting one amino acid, merge into a delins?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/merge_consecutive_edits_tests.rs::coding_length_changing_block_across_codons_is_described_individually",
+          "tests/it/lenient_overlap_and_projection_split.rs::the_codon_delins_merges_only_on_an_axis_that_declares_a_frame"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:18",
@@ -584,6 +626,12 @@
       "id": "exon-junction-dup-converge-from-the-far-side",
       "question": "When a duplication is already spelled on the far (3') side of an exon/exon junction — `LRG_199t1:c.3922dup`, which denotes the same transcript sequence as `c.3921dup` because both positions carry a `T` — must normalization shift it 5' back to `c.3921dup`, or is `c.3922dup` a legitimate description of a different genomic event that happens to yield the same transcript?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/spec_worked_examples.rs::the_exon_junction_pair_does_not_converge_and_that_is_recorded",
+          "tests/it/spec_worked_examples.rs::the_decided_target_is_convergence_on_the_near_side"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/duplication.md:26",
@@ -611,6 +659,9 @@
     {
       "id": "rna-repeat-range-plus-unit-redundancy",
       "status": "undecided",
+      "guard": {
+        "none": "Undecided: the record puts upstream's own conflict on the record (`RNA/repeated.md:22` calls the shape invalid, `:27` publishes it) and names no side, so there is no ruling for a test to enforce. The record states in terms that ferro's present agreement with `:27` is an artifact of two independent passes rather than the question being decided, so pinning that agreement would read as enforcement of a ruling nobody made."
+      },
       "question": "On an RNA reference, may a repeat be written with BOTH a position range and the repeat unit (`r.-6_-3g[6]`)? `RNA/repeated.md:22` marks that shape invalid as redundant; `:27` publishes exactly that shape as valid.",
       "clauses": [
         {
@@ -630,6 +681,12 @@
       "id": "delins-adjacent-members-when-both-consume-reference",
       "question": "When a normalized cis allele leaves two members with no unchanged nucleotide between them, and both members consume reference bases, is that a description the recommendations admit?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/cis_confluence_adjudication.rs::two_adjacent_members_that_both_consume_reference_are_one_delins",
+          "tests/it/cis_adjudication_enumeration.rs::the_dup_flush_carve_out_class_partitions_as_measured"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:16",
@@ -685,6 +742,12 @@
       "id": "separation-is-a-property-of-the-spelling-not-of-the-variant",
       "question": "The separation rule keys on the number of unchanged nucleotides between two variants, but two spellings of one variant can present different separations. On which of them is the rule to be evaluated?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/cis_confluence_adjudication.rs::the_separation_two_members_present_is_not_a_property_of_the_variant",
+          "tests/it/cis_adjudication_enumeration.rs::the_separation_class_converges_over_its_whole_description_space"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:34",
@@ -721,6 +784,9 @@
       "id": "separation-rule-force-modal-or-negation",
       "question": "Does the negation in “should be described individually and not as a ‘delins’” carry prohibition force of its own, making `general.md:34` a README rule 1 (Conformant, absolute), or does the modal grade the whole clause, making it rule 2 (Recommended form, best effort)?",
       "status": "decided",
+      "guard": {
+        "none": "Decided and deliberately unguarded, because the ruling grades a clause rather than mandating an output: `general.md:34` is README rule 2 in its entirety, and the record's own closing sentence is that this `changes classification only`. No description's normalized form turns on it, so there is no behaviour a test could fail on. What the grading buys is that a departure is a disclosable deviation rather than a rule-7 bug; that obligation is carried by the `Representation-Change` check and by the tripwires in `tests/it/codon_frame_deep_window_offset.rs`, whose module doc cites this record for exactly that reason \u2014 and neither of those fails if the grading itself is reversed."
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:34",
@@ -750,6 +816,13 @@
       "id": "coding-axis-merges-are-a-disclosed-general-34-deviation",
       "question": "#1616 merges eight coding-axis multi-member alleles whose members are authored two or more unchanged nucleotides apart. `general.md:34` and `DNA/delins.md:17` say such members are described individually. Is that a deviation to disclose, or does `general.md:34` fail to reach a partition that re-derives to a single member?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/spec_conformance_axis.rs::three_prime_conformance_census",
+          "tests/it/spec_conformance_axis.rs::five_prime_conformance_census",
+          "tests/it/spec_conformance_axis.rs::the_coding_axis_merge_counter_can_observe_a_merge"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:34",
@@ -783,6 +856,11 @@
       "id": "contiguous-insertion-split-by-a-blocked-derivation",
       "question": "A single contiguous insertion inside a tandem tract can be spelled as an insertion at one junction plus a duplication inserting at the next, with one unchanged reference base between them. Does `general.md:34` license that two-member description?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/cis_junction_crossing_shift.rs::the_three_member_spelling_and_its_one_member_form_are_two_fixed_points"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:34",
@@ -813,6 +891,12 @@
       "id": "self-cancelling-across-ring-junctions",
       "question": "Does `general.md:58`'s prohibition on removing part of a reference sequence and replacing it with part of the same sequence reach the `::`-joined segments of a ring chromosome, as it reaches the members of a `[a;b]` cis allele?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/ring_segment_wellformedness.rs::the_three_malformed_rings_the_ruling_named_are_now_rejected",
+          "tests/it/issue_1578_followup_self_cancelling_rings.rs::the_specs_own_ring_shapes_are_accepted"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:56",
@@ -870,6 +954,12 @@
       "id": "alignment-only-symbol-in-a-description",
       "question": "`background/standards.md` lists `X` and `-` in the DNA symbol table and daggers both, footnoting them at `:39` as used in alignment only. May a description state one of them, and if not, is refusing it a conformance requirement or a style preference?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/corpus_prohibited_inputs.rs::an_alignment_only_symbol_is_refused_in_every_mode_for_both_x_and_dash",
+          "tests/it/spec_corpus_regressions.rs::an_alignment_only_x_base_is_refused_rather_than_re_emitted"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/background/standards.md:36",
@@ -895,6 +985,12 @@
       "id": "bare-transcript-intronic-position",
       "question": "`checklist.md:20` says an `NM_` reference can describe an intronic position only when a genomic reference sequence is given. Must ferro refuse a bare `NM_…:c.20+2del`, and in which input-hygiene mode?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/corpus_prohibited_inputs.rs::a_bare_transcript_intronic_position_is_refused_in_strict_only",
+          "tests/it/defect_371_transcript_exit.rs::an_authored_intronic_position_is_left_as_authored"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/checklist.md:20",
@@ -916,6 +1012,12 @@
       "id": "conflicting-member-geometry-refusal-scope",
       "question": "`general.md:58` prohibits one member-vs-member geometry outright and illustrates it with a `del` beside an overlapping `dup`. Does the prohibition reach the CLASS of alleles whose members claim intersecting reference territory — nested, partially overlapping, and two insertions at one interbase — or only the edit-type pair it names?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/corpus_prohibited_inputs.rs::the_three_conflicting_geometries_are_refused_in_strict_mode_on_every_axis",
+          "tests/it/corpus_prohibited_inputs.rs::a_nested_pair_is_refused_on_geometry_not_on_redundancy"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/alleles.md:5",
@@ -941,6 +1043,12 @@
       "id": "absolute-prohibition-enforcement-stage",
       "question": "The checklist enumerates the spec's absolute prohibitions. Is a violation to be refused at PARSE — unconditionally, in every mode — or at strict-mode normalize, where a caller can opt out of it?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/corpus_prohibited_inputs.rs::the_absolute_prohibitions_ferro_refuses_at_parse",
+          "tests/it/corpus_prohibited_inputs.rs::the_decided_target_is_a_mode_gated_refusal"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/checklist.md:5",
@@ -966,6 +1074,9 @@
       "id": "ring-telomere-anchoring",
       "question": "Must a ring chromosome's first `::` segment start at `pter` and its last end at `qter`, so that a ring whose segments name only interior coordinates is refused?",
       "status": "undecided",
+      "guard": {
+        "none": "Undecided: the record asks whether a ring naming only interior coordinates must be refused, and answers neither way. `tests/it/ring_segment_wellformedness.rs::a_ring_with_no_telomere_anchor_is_still_accepted` pins today's acceptance, which the record itself calls the status quo rather than a ruling \u2014 it would go on passing under one answer and would have to be deleted under the other, so it is not this record's guard."
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/complex.md:28",
@@ -990,6 +1101,11 @@
       "id": "delins-payload-coincidence-carve-out-is-coding-dna-scoped",
       "question": "`delins.md:47` recommends the single `delins` where a split exists only because payload bases coincide with reference bases. Which axes does that carve-out reach?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "src/normalize/merge.rs::the_payload_coalesce_needs_both_the_arm_and_the_coding_dna_axis"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:17",
@@ -1029,6 +1145,11 @@
       "id": "delins-recommendation-reach-when-the-input-arrives-split",
       "question": "`DNA/delins.md:44-47` recommends the spanning `delins` where parts of the payload align with the reference, while `:17` and `general.md:34` describe separated variants individually. `canonical-form-choice-when-both-legal` settles that the input's spelling does not decide. Which of the two clauses then selects the form a re-derivation must land on?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "src/normalize/merge.rs::an_all_survivor_payload_is_not_an_alignment_artifact"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:47",
@@ -1059,6 +1180,11 @@
       "id": "projection-codon-exception-is-decided-by-the-rendered-axis",
       "question": "When a coding description merges under `DNA/delins.md:18`, does its derived genomic axis inherit that merge?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/lenient_overlap_and_projection_split.rs::the_codon_delins_merges_only_on_an_axis_that_declares_a_frame"
+        ]
+      },
       "governing": "docs/recommendations/DNA/delins.md:42",
       "applies_to": [
         "LRG_199t1:c.145_147delinsTGG",
@@ -1100,6 +1226,12 @@
       "id": "confluence-gate-is-apply-equality-on-every-determined-axis",
       "question": "Is \"equivalent inputs produce one canonical output\" still the release gate, and what does \"equivalent\" mean when it cannot be defined by the normalizer the gate is about?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/equivalence_cross_axis_rung.rs::normalized_match_can_neither_satisfy_nor_be_a_gate",
+          "tests/it/equivalence_cross_axis_rung.rs::a_junction_straddling_dup_pair_agrees_on_the_transcript_and_not_on_the_genome"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/general.md:43",
@@ -1125,6 +1257,11 @@
       "id": "rna-axis-alignment-only-symbol-reach",
       "question": "`background/standards.md` prints TWO symbol tables. The DNA one (`:19`-`:37`) daggers `X` and `-`; the RNA one (`:47`-`:61`) is the DNA table's fifteen NON-daggered rows lowercased with `u` for `t`, and lists neither daggered row. `general.md:50` puts an `r.` description's nucleotides in lower case. Does an `r.` description therefore state no `x`, so that ferro must refuse `r.10delinsacgux` exactly as `alignment-only-symbol-in-a-description` makes it refuse `g.10delinsACGTX`?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1715_rna_alignment_symbol_reach.rs::a_lowercase_masked_nucleotide_on_the_rna_axis_is_refused_at_the_ruled_stage"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/background/standards.md:36",
@@ -1155,6 +1292,12 @@
       "governing": "docs/recommendations/DNA/delins.md:47",
       "question": "May a canonicalization be refused because the description it derives is 'heavier' than the spelling the input happened to use?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/weight_bound_worked_examples.rs::a_span_outweighs_a_split_that_keeps_reference_bases",
+          "tests/it/reported_confluence_pairs.rs::the_1420_v2_pair_does_not_converge_by_re_derivation"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/delins.md:47",
@@ -1195,6 +1338,12 @@
       "id": "c-and-n-positions-are-flat-transcript-offsets",
       "question": "A `c.`/`n.` position is written against a transcript accession whose cdot exon table has a transcript-coordinate gap. Does it name the base at that offset in the flat transcript sequence, or the base reached by walking the exon table across the gap?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1619_flat_transcript_frame.rs::a_coding_position_resolves_on_the_flat_transcript_axis",
+          "tests/it/normalization_transcripts_exon_contract.rs::fixture_exercises_the_contiguity_property"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/background/numbering.md:21",
@@ -1220,6 +1369,9 @@
       "id": "junction-exit-wrapper-scope-in-a-mixed-allele",
       "question": "An allele holds one member whose intronic offset ferro MANUFACTURED and one the author spelled intronic, both on one bare transcript. `checklist.md:20` wants a genomic reference for the manufactured member; `DNA/alleles.md:16` wants one reference factored out of the whole allele. Lift the wrapper to the whole description, or expand to per-member accessions?",
       "status": "undecided",
+      "guard": {
+        "none": "Undecided: #1723 made both answers expressible and picked neither, so ferro's present decline is the status quo the record names rather than a ruling. `tests/it/defect_371_transcript_exit.rs::a_mixed_allele_still_ships_a_manufactured_offset_bare` pins that status quo and would go on passing whichever way the question is settled, so it is not this record's guard."
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/checklist.md:20",
@@ -1236,6 +1388,11 @@
       "id": "duplication-must-ranks-the-label-not-the-partition",
       "question": "`DNA/duplication.md:18` is one of the spec's genuine MUSTs: a variant that can be described as a duplication must be. Does it bind on each MEMBER of a cis allele — so that a partition exposing a describable duplication is required, and a coarser derivation that merges the `dup` away evades the clause — or does it bind on each CHANGE ferro derives from the resulting sequence, ranking only the type label applied to it?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/duplication_label_not_partition.rs::no_emitted_insertion_repeats_its_five_prime_flank"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/recommendations/DNA/duplication.md:17",
@@ -1278,6 +1435,14 @@
       "id": "c-description-against-an-unresolvable-cds-is-refused",
       "question": "The reference serves a transcript's bases but resolves no CDS start. A `c.` description against it is conformant as a string, but ferro has no origin to number from. Does it normalize silently — returning the input as its own output — or is it refused?",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1870_cds_less_transcript_refusal.rs::the_refusal_is_unconditional_across_every_mode",
+          "tests/it/issue_1870_cds_less_transcript_refusal.rs::the_n_axis_still_shifts_on_the_same_record",
+          "tests/it/issue_1870_cds_less_transcript_refusal.rs::a_record_whose_cds_resolves_is_untouched_and_still_shifts",
+          "tests/it/issue_1870_cds_less_transcript_refusal.rs::a_bare_genomic_parent_is_out_of_scope_and_still_answers"
+        ]
+      },
       "clauses": [
         {
           "clause": "docs/background/numbering.md:21",
@@ -1302,6 +1467,12 @@
     {
       "id": "unchanged-is-read-over-every-minimal-alignment",
       "status": "decided",
+      "guard": {
+        "tests": [
+          "tests/it/issue_1284_transcript_axis_collision.rs::a_noncoding_del_dup_collision_is_repaired",
+          "tests/it/normalize_reparse_invariant.rs::a_del_beside_a_dup_re_spells_instead_of_colliding"
+        ]
+      },
       "governing": "docs/recommendations/general.md:34",
       "question": "`general.md:34` keys on variants 'separated by one or more nucleotides' and `DNA/delins.md:16` on 'two or more consecutive nucleotides'. Both quantify over nucleotides being unchanged or changed, and neither names an alignment. Against WHICH alignment is a reference base judged unchanged — the position-wise correspondence available when the two sides are the same length, or the minimal-edit alignment?",
       "clauses": [

--- a/tests/it/common/rulings.rs
+++ b/tests/it/common/rulings.rs
@@ -1,14 +1,16 @@
 //! Reads the adjudication ledger — the `rulings` section of
 //! `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`.
 //!
-//! Three integration tests need the same file for different reasons:
+//! Four integration tests need the same file for different reasons:
 //! `ruling_citation_currency.rs` wants `id -> status` so it can judge prose that
 //! makes a status claim, `clause_ruling_index.rs` wants the citations so it
-//! can invert the ledger into a clause-to-record index, and
+//! can invert the ledger into a clause-to-record index,
 //! `ledger_clause_jurisdiction.rs` wants the citations, their quotes and
 //! `applies_to` so it can compare what a record rules on against the molecule
-//! directories it cites. Parsing it three times would give three definitions of
-//! "a record", so all three read it from here.
+//! directories it cites, and `ruling_guard_field.rs` wants the `guard` field so
+//! it can resolve each record's declared enforcement against the tree. Parsing
+//! it four times would give four definitions of "a record", so all four read it
+//! from here.
 //!
 //! Nothing in this module names a record id, deliberately: it is scanned by
 //! `ruling_citation_currency.rs` along with every other `.rs` file in the tree.
@@ -72,6 +74,129 @@ pub struct Citation {
     pub role: Role,
 }
 
+/// What enforces a record's ruling — or the record's stated reason that nothing
+/// does.
+///
+/// Modelled on the `Representation-Change:` trailer, where declining is a
+/// first-class answer and what is rejected is *silence*. A record may name the
+/// tests that fail when its ruling stops holding, or it may say in words that no
+/// test enforces it and why. What it may not do is leave the question open: an
+/// absent field is indistinguishable from an unconsidered one, and reads as
+/// enforcement that is not there.
+///
+/// The precedent is [`Record::equivalence_classes`], the ledger's only other
+/// structured pointer at pinned evidence. This is the same move for the much
+/// larger population of records whose evidence is an ordinary test.
+///
+/// # Silence is REPRESENTED here, and rejected one layer out
+///
+/// [`Guard::Absent`] exists so that a record which never mentions `guard` still
+/// *parses*. That is not a softening of the rule — the rule is enforced by
+/// [`ruling_guard_field::every_record_declares_a_guard`], which names the
+/// offending records and the fix. It is a change of *stage*, and the stage is
+/// the whole point.
+///
+/// Refusing at parse made silence fatal to every consumer of the ledger rather
+/// than to the check that cares. Measured on this branch, rebased onto
+/// `origin/main` at `426a944b`, with the two records `main` had added carrying
+/// no `guard`: **50** tests failed — 28 on this reader's own panic, 20 because
+/// `generate_spec_fixture` could not deserialize the ledger at all (so the
+/// generated fixture never existed and everything downstream of it died too),
+/// and 2 in the generator's own precondition suite. **Five** of the fifty were
+/// about guards. Seven open PRs write ledger records at any given time, so every
+/// one of them met that wall on rebase, and what it told them was that the spec
+/// fixture was broken.
+///
+/// The variant is deliberately a **third state** rather than a reuse of an
+/// existing one. Mapping absence onto `Tests(vec![])` or `Declined(String::new())`
+/// would make it indistinguishable from a record whose author deliberately wrote
+/// an empty list or a blank reason — and those two are separately rejected, with
+/// separate messages, precisely because they are different mistakes. No JSON a
+/// record can carry produces `Absent`: it is reachable only by the key not being
+/// there.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Guard {
+    /// `<path>.rs::<function>` citations of the tests that enforce the ruling.
+    /// Never empty; see [`split_guard_citation`] for the grammar.
+    Tests(Vec<String>),
+    /// A stated, reasoned declaration that no test enforces this record.
+    ///
+    /// Carries the reason rather than a bare flag, for the reason
+    /// `RETIRED_RECORD_IDS`'s second field is prose: "nothing enforces this"
+    /// is only a usable answer when it says *why*, and the whys differ —
+    /// an undecided record has no ruling to enforce, while a decided one may
+    /// rule on how a departure is classified rather than on any output.
+    Declined(String),
+    /// The record carries no `guard` key at all — the silence the field exists
+    /// to abolish.
+    ///
+    /// Constructed only from a missing or `null` key, never from anything an
+    /// author could write, so it cannot be confused with a deliberate blank.
+    /// Every reader below treats it as "names no test and declines nothing",
+    /// which is the honest reading; the state is *reported* by
+    /// [`ruling_guard_field::every_record_declares_a_guard`] rather than
+    /// tolerated.
+    Absent,
+}
+
+impl Guard {
+    /// The cited tests, or an empty slice for a declared exemption or silence.
+    pub fn tests(&self) -> &[String] {
+        match self {
+            Guard::Tests(tests) => tests,
+            Guard::Declined(_) | Guard::Absent => &[],
+        }
+    }
+
+    /// The stated reason, for a declared exemption only.
+    ///
+    /// [`Guard::Absent`] answers `None` — it states no reason, which is what is
+    /// wrong with it. Use [`Guard::is_absent`] to ask about silence; asking this
+    /// would conflate "declined nothing" with "declined without saying why".
+    pub fn declined_reason(&self) -> Option<&str> {
+        match self {
+            Guard::Tests(_) | Guard::Absent => None,
+            Guard::Declined(reason) => Some(reason),
+        }
+    }
+
+    /// Whether the record said nothing at all about what enforces it.
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Guard::Absent)
+    }
+}
+
+/// Splits a guard citation into the file it names and the function within it.
+///
+/// The grammar is deliberately narrow — a repo-relative path ending in `.rs`,
+/// then `::`, then a single snake_case identifier — so that a citation is
+/// resolvable *mechanically* rather than by judgement. That is the whole
+/// difference between this field and the prose it replaces: a bare
+/// `tests/….rs` path names a file, not a proposition, and a module-qualified
+/// `foo::bar` does not say which of several `foo.rs` it means.
+///
+/// Returns `None` for anything outside the grammar; callers report that as a
+/// malformed citation rather than silently skipping it.
+pub fn split_guard_citation(token: &str) -> Option<(&str, &str)> {
+    let (path, function) = token.split_once("::")?;
+    if !path.ends_with(".rs") || path.starts_with('/') || path.contains("..") {
+        return None;
+    }
+    if function.is_empty() || function.contains("::") {
+        return None;
+    }
+    if !function.starts_with(|c: char| c.is_ascii_lowercase()) {
+        return None;
+    }
+    if !function
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return None;
+    }
+    Some((path, function))
+}
+
 /// One adjudication record.
 #[derive(Clone, Debug)]
 pub struct Record {
@@ -113,6 +238,9 @@ pub struct Record {
     /// fails if the ruling stops holding — and a published rendering of a record
     /// that omitted it would drop the only link from the prose to the guard.
     pub equivalence_classes: Vec<String>,
+    /// What enforces this record's ruling, or its stated reason that nothing
+    /// does. Required — see [`Guard`].
+    pub guard: Guard,
     /// Every clause the record names, in the ledger's own order, each tagged
     /// with the role the record's verdict fields give it.
     pub citations: Vec<Citation>,
@@ -223,6 +351,93 @@ fn string_array(record: &serde_json::Value, field: &str, id: &str) -> Vec<String
                     .to_string()
             })
             .collect(),
+    }
+}
+
+/// The `guard` field of one record.
+///
+/// **Absence parses, as [`Guard::Absent`], and is refused one layer out** by
+/// `ruling_guard_field::every_record_declares_a_guard`. Everything below that is
+/// *malformed* rather than *absent* still panics here, and the split is
+/// deliberate: absence is what a record in flight legitimately looks like before
+/// its author has answered the question, so it must reach a check that can name
+/// the fix; a `guard` that is present and self-contradictory is a broken record
+/// and there is nothing useful to do with it but refuse.
+///
+/// The states this has to keep apart are "enforced by these tests", "enforced by
+/// nothing, for this stated reason", and "said nothing". The third reads from
+/// the outside exactly like the first, which is why it needs a name of its own
+/// rather than being folded into an empty list.
+///
+/// Exactly one of `tests` / `none` may be set, for the same reason
+/// `governing` and `deviates_from` may not name the same clause: a record
+/// carrying both has said two incompatible things, and any reader that tested
+/// one key first would resolve the contradiction silently in its favour.
+fn guard_from(record: &serde_json::Value, id: &str) -> Guard {
+    let value = match record.get("guard") {
+        None | Some(serde_json::Value::Null) => return Guard::Absent,
+        Some(value) => value,
+    };
+    let object = value
+        .as_object()
+        .unwrap_or_else(|| panic!("record {id} has a non-object `guard`: {value}"));
+    for key in object.keys() {
+        assert!(
+            key == "tests" || key == "none",
+            "record {id} has an unknown `guard` key {key:?}; only `tests` and `none` parse"
+        );
+    }
+
+    let tests = object.get("tests");
+    let none = object.get("none");
+    match (tests, none) {
+        (Some(_), Some(_)) => panic!(
+            "record {id} sets both `guard.tests` and `guard.none` — it has both named an \
+             enforcing test and declared that nothing enforces it"
+        ),
+        (None, None) => {
+            panic!("record {id} has an empty `guard` object; set exactly one of `tests` or `none`")
+        }
+        (Some(tests), None) => {
+            let entries = tests
+                .as_array()
+                .unwrap_or_else(|| panic!("record {id} has a non-array `guard.tests`: {tests}"));
+            assert!(
+                !entries.is_empty(),
+                "record {id} has an empty `guard.tests`; an empty list claims enforcement and \
+                 supplies none — declare `guard.none` with a reason instead"
+            );
+            let citations: Vec<String> = entries
+                .iter()
+                .map(|entry| {
+                    let token = entry.as_str().unwrap_or_else(|| {
+                        panic!("record {id} has a non-string `guard.tests` entry: {entry}")
+                    });
+                    assert!(
+                        split_guard_citation(token).is_some(),
+                        "record {id} cites {token:?} as a guard, which is not of the form \
+                         `<path>.rs::<function>` — a citation that does not resolve \
+                         mechanically is the prose this field replaces"
+                    );
+                    token.to_string()
+                })
+                .collect();
+            Guard::Tests(citations)
+        }
+        (None, Some(none)) => {
+            let reason = none
+                .as_str()
+                .unwrap_or_else(|| panic!("record {id} has a non-string `guard.none`: {none}"));
+            // A blank reason is the absent case wearing a string: it satisfies
+            // the key and states nothing, which is precisely the silence the
+            // field exists to reject.
+            assert!(
+                !reason.trim().is_empty(),
+                "record {id} declines a guard with a blank reason; `guard.none` is a first-class \
+                 answer only when it says why"
+            );
+            Guard::Declined(reason.to_string())
+        }
     }
 }
 
@@ -341,6 +556,8 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
 
             let equivalence_classes: Vec<String> = string_array(record, "equivalence_classes", &id);
 
+            let guard = guard_from(record, &id);
+
             Record {
                 id,
                 status,
@@ -348,6 +565,7 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
                 rationale,
                 applies_to,
                 equivalence_classes,
+                guard,
                 citations,
                 governing: governing.map(str::to_string),
             }
@@ -400,6 +618,7 @@ fn one_valid_record() -> serde_json::Value {
             "question": "Does a well-formed record parse?",
             "rationale": "A test record, with prose that cites no other record.",
             "governing": "docs/a.md:1",
+            "guard": { "tests": ["tests/it/a_file.rs::a_guard"] },
             "clauses": [{ "clause": "docs/a.md:1", "quote": "a quoted clause" }],
         }],
     })
@@ -585,4 +804,177 @@ fn a_null_verdict_field_reads_as_absent() {
     document["rulings"][0]["deviates_from"] = serde_json::Value::Null;
     let records = records_from_value(&document, "<test>");
     assert_eq!(records[0].citations[0].role, Role::Cited);
+}
+
+// --------------------------------------------------------------------------
+// `guard`.
+//
+// The field's whole purpose is that ONE of its states is unrepresentable, so
+// the mutations below are the specification. Each one used to be expressible
+// — as an absent field, an empty list, a blank string — and each reads from
+// the outside like a record whose ruling something enforces.
+// --------------------------------------------------------------------------
+
+/// A record with no `guard` **parses**, as [`Guard::Absent`].
+///
+/// It is refused by `ruling_guard_field::every_record_declares_a_guard`, not
+/// here. Rejecting it at parse took the whole ledger down with it — 50 tests on
+/// the measurement recorded on [`Guard`] — for a fault in one record, so the
+/// reader's job is to *represent* the silence faithfully and let the check that
+/// is about guards be the one that fails.
+#[test]
+fn a_record_with_no_guard_parses_as_absent() {
+    let mut document = one_valid_record();
+    document["rulings"][0]
+        .as_object_mut()
+        .expect("record is an object")
+        .remove("guard");
+    let records = records_from_value(&document, "<test>");
+    assert_eq!(records[0].guard, Guard::Absent);
+    assert!(records[0].guard.is_absent());
+}
+
+/// An explicit `null` guard is the same silence spelled differently, and reads
+/// the same way.
+#[test]
+fn a_null_guard_parses_as_absent() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] = serde_json::Value::Null;
+    let records = records_from_value(&document, "<test>");
+    assert_eq!(records[0].guard, Guard::Absent);
+}
+
+/// Silence is a state of its own, distinct from every blank an author could
+/// deliberately write.
+///
+/// This is the property the whole staging change rests on. If absence collapsed
+/// onto an empty `tests` list or a blank `none`, the check one layer out could
+/// not tell "unconsidered" from "considered and mis-stated" — and those need
+/// different messages, because they are different mistakes.
+///
+/// The two deliberate blanks are refused at parse and stay refused; that half is
+/// pinned by [`an_empty_guard_test_list_is_rejected`] and
+/// [`a_blank_exemption_reason_is_rejected`]. What is asserted here is the half
+/// those cannot state: that the value absence *does* produce is equal to neither
+/// of them, so no reader can conflate the three.
+#[test]
+fn absence_is_a_state_of_its_own() {
+    let mut document = one_valid_record();
+    document["rulings"][0]
+        .as_object_mut()
+        .expect("record is an object")
+        .remove("guard");
+    let absent = records_from_value(&document, "<test>")[0].guard.clone();
+
+    assert_eq!(absent, Guard::Absent);
+    assert_ne!(
+        absent,
+        Guard::Tests(Vec::new()),
+        "silence must not read as an empty citation list"
+    );
+    assert_ne!(
+        absent,
+        Guard::Declined(String::new()),
+        "silence must not read as an exemption with a blank reason"
+    );
+    // And it answers the accessors the way the checks below read them: it names
+    // no test, and it declines nothing.
+    assert!(absent.tests().is_empty());
+    assert_eq!(absent.declined_reason(), None);
+}
+
+/// A declared exemption parses, and carries its reason.
+#[test]
+fn a_declared_exemption_parses() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] =
+        serde_json::json!({ "none": "process record; it mandates no output" });
+    let records = records_from_value(&document, "<test>");
+    assert_eq!(
+        records[0].guard,
+        Guard::Declined("process record; it mandates no output".to_string())
+    );
+    assert!(records[0].guard.tests().is_empty());
+}
+
+/// A blank reason is the absent case wearing a string: it satisfies the key and
+/// states nothing.
+#[test]
+#[should_panic(expected = "blank reason")]
+fn a_blank_exemption_reason_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] = serde_json::json!({ "none": "   " });
+    records_from_value(&document, "<test>");
+}
+
+/// An empty `tests` array claims enforcement and supplies none — the same
+/// silence, one level in.
+#[test]
+#[should_panic(expected = "empty `guard.tests`")]
+fn an_empty_guard_test_list_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] = serde_json::json!({ "tests": [] });
+    records_from_value(&document, "<test>");
+}
+
+/// Setting both keys is a contradiction, and must not be resolved silently in
+/// favour of whichever is tested first.
+#[test]
+#[should_panic(expected = "both `guard.tests` and `guard.none`")]
+fn a_guard_that_both_cites_and_declines_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] =
+        serde_json::json!({ "tests": ["tests/it/a.rs::b"], "none": "and also nothing" });
+    records_from_value(&document, "<test>");
+}
+
+/// An unknown key is rejected rather than ignored, so a typo (`test`, `tests_`)
+/// cannot read as a record that declared nothing.
+#[test]
+#[should_panic(expected = "unknown `guard` key")]
+fn an_unknown_guard_key_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] = serde_json::json!({ "test": ["tests/it/a.rs::b"] });
+    records_from_value(&document, "<test>");
+}
+
+/// A citation outside the grammar is rejected at parse, not skipped by the
+/// resolver — a skipped citation is a guard nobody checks.
+#[test]
+#[should_panic(expected = "which is not of the form")]
+fn a_guard_citation_outside_the_grammar_is_rejected() {
+    let mut document = one_valid_record();
+    document["rulings"][0]["guard"] = serde_json::json!({ "tests": ["tests/it/a_file.rs"] });
+    records_from_value(&document, "<test>");
+}
+
+/// The grammar, both ways. Too loose and a bare module path (`merge::foo`)
+/// passes while naming no file; too tight and a real `src/` unit test stops
+/// being citable.
+#[test]
+fn the_guard_citation_grammar_admits_a_path_and_nothing_else() {
+    assert_eq!(
+        split_guard_citation("tests/it/foo.rs::a_guard_name"),
+        Some(("tests/it/foo.rs", "a_guard_name"))
+    );
+    assert_eq!(
+        split_guard_citation("src/normalize/merge.rs::a_unit_test_2"),
+        Some(("src/normalize/merge.rs", "a_unit_test_2"))
+    );
+    for rejected in [
+        "merge::a_guard_name",           // a module path names no file
+        "tests/it/foo.rs",               // a file names no proposition
+        "a_guard_name",                  // a bare function name
+        "tests/it/foo.rs::mod::a_guard", // more than one `::`
+        "tests/it/foo.rs::AGuard",       // not a function name
+        "tests/it/foo.rs::",             // nothing after the separator
+        "/abs/foo.rs::a_guard",          // not repo-relative
+        "tests/../../foo.rs::a_guard",   // escapes the tree
+    ] {
+        assert_eq!(
+            split_guard_citation(rejected),
+            None,
+            "{rejected} must not parse as a guard citation"
+        );
+    }
 }

--- a/tests/it/ledger_clause_jurisdiction.rs
+++ b/tests/it/ledger_clause_jurisdiction.rs
@@ -567,6 +567,7 @@ fn record(
         // a record assembled from parts must state every part it carries.
         question: format!("A synthetic record for {id}."),
         equivalence_classes: Vec::new(),
+        guard: rulings::Guard::Declined("a synthetic record, enforced by this file".to_string()),
         rationale: rationale.to_string(),
         applies_to: applies_to.iter().map(|s| s.to_string()).collect(),
         citations: clauses

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -490,6 +490,7 @@ mod rewrite_target_corpus;
 mod rna_coding_consistency;
 mod rna_spl_marker;
 mod ruling_citation_currency;
+mod ruling_guard_field;
 mod service_tools_tests;
 mod spdi_dup_recovery;
 mod spdi_tests;

--- a/tests/it/ruling_guard_field.rs
+++ b/tests/it/ruling_guard_field.rs
@@ -1,0 +1,1125 @@
+//! Every record in the adjudication ledger must say what enforces its ruling,
+//! and what it says must resolve.
+//!
+//! # The gap this closes
+//!
+//! A record and the test that enforces it were connected by nothing but prose,
+//! and often by no prose at all. Measured over the ledger as it stood when this
+//! file was written — 28 records, 25 `decided`, 3 `undecided`. (The ledger has
+//! since gained #1882's `c-description-against-an-unresolvable-cds-is-refused`,
+//! so the current census is 29 / 26 / 3; the table below is the *historical*
+//! measurement of the gap and is deliberately not restated against it.)
+//!
+//! | how a record pointed at its enforcement | records |
+//! |---|---:|
+//! | a `<path>.rs::<function>` citation somewhere in its prose | 5 |
+//! | a bare `tests/….rs` path, naming a file but no proposition | 12 |
+//! | an `equivalence_classes` array — the one structured pointer | 4 |
+//! | **nothing, by any mechanism** | **8** |
+//!
+//! (The first three overlap; the last does not.) So for eight records the
+//! ledger read as enforced while pointing at nothing, and for twelve more it
+//! pointed at a file — which cannot go stale in any way a reader would notice,
+//! because a file that still exists still resolves however much its contents
+//! have moved on.
+//!
+//! # Why a field and not a scan
+//!
+//! Prose can be scanned, and `ruling_citation_currency.rs` scans it. But a scan
+//! is *opportunistic*: it judges the records that happen to cite a guard and is
+//! structurally blind to the ones that cite nothing, which is exactly the
+//! population that most needs judging. No cleverer matcher fixes that — there
+//! is nothing in the text to match.
+//!
+//! So the pointer is declared instead, in the ledger, as a field. The model is
+//! the `Representation-Change:` trailer: **declining is a first-class answer,
+//! and what is rejected is silence.** A record may name its guards, or it may
+//! say that nothing enforces it and why — and both of those are answers. What
+//! it may not do is omit the field, because an absent one is indistinguishable
+//! from an unconsidered one.
+//!
+//! The precedent inside the ledger is `equivalence_classes`, which is already
+//! enforced end to end: the generator refuses an unknown class id, and the
+//! guard that reads it asserts and checks its own vacuity. This field is that
+//! same shape, for the much larger population whose evidence is an ordinary
+//! test rather than a curated class.
+//!
+//! # It composes with `ruling_citation_currency.rs`; neither subsumes the other
+//!
+//! They ask different questions and both are worth asking:
+//!
+//! - **This file** asks whether every record *has* an enforcement story, and
+//!   whether the story resolves. It is exhaustive over records by construction.
+//! - **That file** asks whether the discursive prose *around* a record stays
+//!   true — that a comment does not call a settled record open, and that an id
+//!   named in a rationale still exists. A record can carry a perfectly good
+//!   `guard` field and still be described wrongly three files away.
+//!
+//! The interaction worth knowing about: a record's prose may name a guard that
+//! has been renamed out from under it while this field names the live one. That
+//! is not a contradiction to be resolved here — the prose sentence is the
+//! record's own argument and repairing it is an adjudication, not a rename.
+//! This file deliberately reads **only** the field.
+//!
+//! # What is checked, and what is deliberately not
+//!
+//! Checked: the field is **present** (here, in
+//! [`every_record_declares_a_guard`] — see that test for why the check lives at
+//! this stage rather than at parse); that it is well-formed, once present (in
+//! `common::rulings`, at parse); that every citation names a `#[test]` which
+//! exists in the file it names; that at least one of them **runs** (a record
+//! guarded only by `#[ignore]`d tests is guarded by nothing today); and that
+//! every named test contains an assertion, because a test that runs and asserts
+//! nothing passes (#1858).
+//!
+//! The presence check and the well-formedness checks sit at different stages on
+//! purpose. A record that has not answered the question yet is the ordinary
+//! state of a PR in flight, and it must produce a failure that names the fix; a
+//! record whose `guard` contradicts itself is broken, and there is nothing
+//! downstream that can use it.
+//!
+//! Not checked: whether the named test enforces *this* ruling rather than a
+//! neighbouring one. That is a judgement a matcher cannot make, and pretending
+//! otherwise would put a veneer of mechanism over the thing that actually
+//! carries it, which is review. What the field buys is that the judgement is
+//! **written down, once, in the ledger** — so it can be argued with — instead of
+//! being reconstructed from prose by each reader.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::common::rulings::{self, split_guard_citation, Guard, LEDGER_RELATIVE_PATH};
+
+/// Floor for how many guard citations the ledger must carry.
+///
+/// Measured at **46** over the 29 records currently in the ledger (42 when this
+/// file was written, plus the four #1882's record names). The floor sits well
+/// below that so ordinary ledger edits cannot trip it, while a reader that
+/// stopped seeing citations — the failure that would make every check here pass
+/// by looking at an empty set — still would.
+const GUARD_CITATION_FLOOR: usize = 20;
+
+/// Floor for how many `#[test]` functions the tree scan must find.
+///
+/// Measured at over nine thousand. A scan that found a handful would resolve
+/// nothing and report every citation as missing, which is a loud failure; a
+/// scan that found *most* of them would resolve most citations and silently
+/// stop judging the rest, which is not.
+const SCANNED_TEST_FLOOR: usize = 5_000;
+
+/// Roots scanned for test functions, relative to the crate root.
+const SCAN_ROOTS: &[&str] = &["src", "tests"];
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// One `#[test]` function found in the tree.
+#[derive(Clone, Debug)]
+struct TestFunction {
+    /// 1-based line of the `fn` keyword, for failure messages.
+    line: usize,
+    /// Whether the function carries `#[ignore]`.
+    ignored: bool,
+    /// Whether anything in its body — directly or through a helper defined in
+    /// the same file — asserts. See [`asserts_directly`].
+    asserts: bool,
+}
+
+/// Every `#[test]` in the tree, keyed by `(scan-relative path, function name)`.
+///
+/// Keyed by path as well as by name because two files may legitimately hold
+/// tests of the same name, and a citation that resolved to "some test called
+/// this, somewhere" would let a guard move between modules unnoticed.
+fn test_functions() -> BTreeMap<(String, String), TestFunction> {
+    let root = crate_root();
+    let mut found = BTreeMap::new();
+    for scan_root in SCAN_ROOTS {
+        let dir = root.join(scan_root);
+        assert!(
+            dir.is_dir(),
+            "scan root {} does not exist — every citation would report as missing",
+            dir.display()
+        );
+        collect(&dir, scan_root, &mut found);
+    }
+    found
+}
+
+fn collect(dir: &Path, rel: &str, out: &mut BTreeMap<(String, String), TestFunction>) {
+    let entries =
+        std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+    let mut paths: Vec<PathBuf> = entries
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|err| panic!("dir entry under {}: {err}", dir.display()))
+                .path()
+        })
+        .collect();
+    paths.sort();
+    for path in paths {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let child_rel = format!("{rel}/{name}");
+        if path.is_dir() {
+            collect(&path, &child_rel, out);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        // Parsed once and shared with the assertion pass. Parsing per file was
+        // previously done twice — once here and once inside
+        // `asserts_transitively` — over every `.rs` file in the tree.
+        let functions = functions_in(&text);
+        for function in &functions {
+            if function.is_test {
+                out.insert(
+                    (child_rel.clone(), function.name.clone()),
+                    TestFunction {
+                        line: function.line,
+                        ignored: function.ignored,
+                        asserts: false, // filled in below, once helpers are known
+                    },
+                );
+            }
+        }
+        // Assertion detection is per file, because a helper is resolved within
+        // the file that defines it — see `asserts_transitively`.
+        for (name, asserts) in asserts_transitively(&functions) {
+            if let Some(entry) = out.get_mut(&(child_rel.clone(), name)) {
+                entry.asserts = asserts;
+            }
+        }
+    }
+}
+
+/// One function found in a source file, test or not.
+struct ParsedFunction {
+    name: String,
+    line: usize,
+    is_test: bool,
+    ignored: bool,
+    /// Whether the function carries `#[should_panic]`, which is an assertion
+    /// living in an attribute rather than in the body. See [`asserts_directly`].
+    should_panic: bool,
+    body: String,
+}
+
+/// Which lines of `text` sit inside a raw string literal.
+///
+/// The scan reads source text, and this repository embeds Rust source *as
+/// data*: [`the_assertion_detector_follows_a_local_helper`] puts three
+/// `#[test] fn`s inside an `r#"…"#` literal precisely so the detector has
+/// something to read. Without this mask those declarations register as real
+/// tests, and a ledger citation naming one **resolves** — the record then
+/// passes every check in this file while nothing enforces it, which is the
+/// exact state the `guard` field exists to abolish, reached through this
+/// file's own fixtures. Measured before this mask: six such declarations in
+/// the tree, five of them here.
+///
+/// The mask is **generic over the hash count** (`r"`, `r#"`, `r##"`, …) and
+/// closes only on a `"` followed by at least as many `#`. A mask hardcoded to
+/// one hash count is not a floor but a bug waiting for the first nested
+/// fixture: [`a_test_declared_inside_a_raw_string_literal_does_not_register`]
+/// has to wrap a `r#"…"#` fixture in a `r##"…"##` one, and a `r#"`-only mask
+/// would leave that test's *own* inner declarations registering as phantoms.
+///
+/// A line that only *opens* a literal is reported as outside, because the code
+/// before the delimiter is real. An ordinary `"…"` literal cannot span a line
+/// break, so it can never hide a `fn` declaration line and is not tracked; the
+/// `r` must not be preceded by an identifier character, so `for`, `char` and
+/// friends do not open anything.
+/// Scans bytes rather than `char`s, and skips any line with no `"` at all.
+/// Both matter: this runs over every `.rs` file under [`SCAN_ROOTS`], and a
+/// first cut that collected each line into a `Vec<char>` took the five checks
+/// here from ~7 s to ~68 s each — past nextest's 60 s SLOW threshold. Every
+/// delimiter byte is ASCII, so byte indexing cannot split a multi-byte
+/// character in a way that changes an answer.
+fn raw_string_lines(lines: &[&str]) -> Vec<bool> {
+    let mut inside = Vec::with_capacity(lines.len());
+    let mut open: Option<usize> = None;
+    for line in lines {
+        inside.push(open.is_some());
+        let bytes = line.as_bytes();
+        // Every raw-string delimiter contains a `"`, so a line without one can
+        // neither open nor close a literal. Most lines in the tree are of that
+        // shape, and this runs over ~9,800 tests' worth of source.
+        if !bytes.contains(&b'"') {
+            continue;
+        }
+        // An opener is `r"` or `<#>"`, so a line holding neither byte pair can
+        // only ever *close* one. Skipping the scan when nothing is open is the
+        // difference between reading every quoted line and reading the few that
+        // can matter.
+        if open.is_none() && !has_opener_bytes(bytes) {
+            continue;
+        }
+        let mut index = 0;
+        while index < bytes.len() {
+            match open {
+                // Closing: `"` then at least `hashes` `#`.
+                Some(hashes) => {
+                    if bytes[index] == b'"' && run_of_hashes(bytes, index + 1) >= hashes {
+                        open = None;
+                        index += 1 + hashes;
+                        continue;
+                    }
+                    index += 1;
+                }
+                // Opening: a non-identifier `r`, then `#`*n, then `"`.
+                None => {
+                    let preceded_by_ident = index
+                        .checked_sub(1)
+                        .is_some_and(|p| bytes[p].is_ascii_alphanumeric() || bytes[p] == b'_');
+                    if bytes[index] == b'r' && !preceded_by_ident {
+                        let hashes = run_of_hashes(bytes, index + 1);
+                        if bytes.get(index + 1 + hashes) == Some(&b'"') {
+                            open = Some(hashes);
+                            index += 2 + hashes;
+                            continue;
+                        }
+                    }
+                    index += 1;
+                }
+            }
+        }
+    }
+    inside
+}
+
+/// Whether `bytes` could hold a raw-string *opener* at all.
+///
+/// A necessary condition, not a sufficient one: an opener is `r` then zero or
+/// more `#` then `"`, so the two bytes before the quote are either `r"` or
+/// `#"`. A line containing neither pair cannot open a literal, whatever else it
+/// contains — so the full scan can be skipped for it. Being merely necessary is
+/// what keeps this safe: a false positive costs a scan that finds nothing, and
+/// a false negative is impossible.
+fn has_opener_bytes(bytes: &[u8]) -> bool {
+    bytes
+        .windows(2)
+        .any(|pair| pair[1] == b'"' && (pair[0] == b'r' || pair[0] == b'#'))
+}
+
+/// How many consecutive `#` start at `from`.
+fn run_of_hashes(bytes: &[u8], from: usize) -> usize {
+    bytes[from.min(bytes.len())..]
+        .iter()
+        .take_while(|b| **b == b'#')
+        .count()
+}
+
+/// Every function in `text`, with its attributes and its body.
+///
+/// A hand-rolled scanner rather than a parser: the properties wanted are
+/// coarse (does this carry `#[test]`, does its body mention an assertion), and
+/// a syntax-tree dependency for that would be a large amount of machinery
+/// pointed at a small question.
+///
+/// Declarations inside a raw string literal are skipped — see
+/// [`raw_string_lines`] for why that is load-bearing rather than tidiness.
+fn functions_in(text: &str) -> Vec<ParsedFunction> {
+    let lines: Vec<&str> = text.lines().collect();
+    let in_raw_string = raw_string_lines(&lines);
+    let mut found = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if in_raw_string[index] {
+            continue;
+        }
+        let Some(name) = function_name(line) else {
+            continue;
+        };
+        // Walk back over the contiguous attribute/comment/blank block above.
+        //
+        // `unclosed` tracks `]` that have not yet met their `[` as the walk moves
+        // upward, which is how a **multi-line attribute** is recognised from
+        // below. Without it the walk stops on the continuation line, never
+        // reaches the `#[test]` above it, and a real test becomes invisible:
+        //
+        //     #[test]
+        //     #[ignore = "one row still open: … see #1627. The \
+        //                 other three rows pass"]
+        //     fn the_decided_target_is_a_mode_gated_refusal() {
+        //
+        // That is not hypothetical — it is how this scanner met `main`. #1872
+        // reflowed exactly that attribute onto four lines, and the ledger's
+        // citation of that test began reporting as unresolved on rebase, while
+        // the test sat there running. Measured over the tree at that point:
+        // **30** `#[test]` functions were invisible for this reason, and the
+        // failure mode is the worst available here, because it is the one this
+        // file exists to prevent wearing the opposite sign — a guard that is
+        // real and reads as missing today, and (once a citation is "repaired"
+        // to something else) a record that resolves while nothing enforces it.
+        //
+        // Comment lines are excluded from the bracket count deliberately: a doc
+        // comment may carry unbalanced brackets in prose or in a Markdown link,
+        // and letting those open a phantom attribute would walk the scan up
+        // through the *previous* function's body and let its `#[test]` leak onto
+        // a plain `fn`. An attribute continuation is never a comment line.
+        let mut is_test = false;
+        let mut ignored = false;
+        let mut should_panic = false;
+        let mut above = index;
+        let mut unclosed = 0i32;
+        while above > 0 {
+            let raw = lines[above - 1];
+            let candidate = raw.trim_start();
+            let is_comment = candidate.starts_with("//");
+            let delta = if is_comment || candidate.is_empty() {
+                0
+            } else {
+                raw.matches(']').count() as i32 - raw.matches('[').count() as i32
+            };
+            // Inside a multi-line attribute either because one was already open
+            // below, or because this very line closes one that must open above.
+            let inside_attribute = unclosed > 0 || unclosed + delta > 0;
+            let is_preamble = inside_attribute
+                || candidate.starts_with("#[")
+                || is_comment
+                || candidate.is_empty();
+            if !is_preamble {
+                break;
+            }
+            if candidate.starts_with("#[test") || candidate.starts_with("#[rstest") {
+                is_test = true;
+            }
+            if candidate.starts_with("#[ignore") {
+                ignored = true;
+            }
+            if candidate.starts_with("#[should_panic") {
+                should_panic = true;
+            }
+            unclosed += delta;
+            above -= 1;
+        }
+        found.push(ParsedFunction {
+            name,
+            line: index + 1,
+            is_test,
+            ignored,
+            should_panic,
+            body: body_from(&lines, index),
+        });
+    }
+    found
+}
+
+/// The function name on a `fn` declaration line, if it is one.
+fn function_name(line: &str) -> Option<String> {
+    let rest = line.trim_start();
+    let rest = rest.strip_prefix("pub ").unwrap_or(rest);
+    let rest = rest.strip_prefix("async ").unwrap_or(rest);
+    let rest = rest.strip_prefix("fn ")?;
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() || !rest[name.len()..].starts_with(['(', '<']) {
+        return None;
+    }
+    Some(name)
+}
+
+/// The text of the function body starting at `start`, by brace matching.
+///
+/// **The signature is dropped**, everything up to and including the opening
+/// brace. That is not tidiness: the assertion scan below is a substring test
+/// for `assert`, and a function *named* `asserts_nothing_at_all` would
+/// otherwise match on its own declaration line and report itself as asserting —
+/// which is the #1858 shape the scan exists to catch, passed by the scan
+/// meant to catch it. Caught by
+/// [`the_assertion_detector_follows_a_local_helper`]'s negative control before
+/// this file was ever run against the ledger.
+///
+/// Braces inside string literals and comments are not excluded. That is a
+/// deliberate floor: the worst it can do is end a body early or late, and both
+/// scans over this text are substring tests, so a slightly wrong extent changes
+/// an answer only for a function whose assertion sits in the disputed region.
+fn body_from(lines: &[&str], start: usize) -> String {
+    let mut depth = 0i32;
+    let mut opened = false;
+    let mut body = String::new();
+    for line in &lines[start..] {
+        body.push_str(line);
+        body.push('\n');
+        depth += line.matches('{').count() as i32;
+        depth -= line.matches('}').count() as i32;
+        if line.contains('{') {
+            opened = true;
+        }
+        if opened && depth <= 0 {
+            break;
+        }
+    }
+    match body.find('{') {
+        Some(brace) => body.split_off(brace + 1),
+        // No brace at all: a trait method or an `fn` declaration with no body.
+        // Nothing to read, which is the honest answer rather than the signature.
+        None => String::new(),
+    }
+}
+
+/// Whether `body` asserts anything, reading only the body itself.
+///
+/// `assert` covers `assert!`, `assert_eq!`, `assert_ne!` and `debug_assert*`,
+/// and also catches an assertion made through a helper *named* for it
+/// (`assert_normalizes_preserving_in`) — which is the shape a macro-only
+/// matcher gets wrong. `expect_err` and `unwrap_err` are how this repo spells
+/// "this must fail".
+///
+/// **`#[should_panic]` is deliberately not read here**, and listing it here is
+/// what the earlier revision got wrong: it is an *attribute*, and [`body_from`]
+/// strips everything above the opening brace, so this function can never see
+/// one. The term matched nothing and the guarantee it advertised was absent —
+/// a real `#[should_panic]` test whose body holds no `assert` (there are eight
+/// in this tree, e.g. `src/coords/mod.rs::test_one_based_rejects_zero`) was
+/// reported as asserting nothing, so citing one as a guard failed
+/// [`every_declared_guard_asserts`]. It is read in [`functions_in`] alongside
+/// `#[ignore]` and folded in by [`asserts_transitively`] instead, which also
+/// lets it propagate through a local helper.
+fn asserts_directly(body: &str) -> bool {
+    body.contains("assert") || body.contains("expect_err") || body.contains("unwrap_err")
+}
+
+/// Whether each function in `text` asserts, following calls to helpers defined
+/// in the same file.
+///
+/// The transitive step is not a refinement, it is required for correctness on
+/// this tree. Three of the guards the ledger cites have a body that is one call
+/// to a local `converges_to(…)` helper, which is where the assertions live —
+/// and a direct-only matcher reads all three as assertionless, reporting real
+/// guards as the #1858 shape. Pinned by
+/// [`the_assertion_detector_follows_a_local_helper`].
+///
+/// Resolution is within one file, because that is where it can be done without
+/// a name resolver, and it is where this repo's assertion helpers live. A
+/// helper imported from `common/` is not followed; such a test is reported as
+/// assertionless, and the answer is to name a different guard or to make the
+/// assertion visible, not to widen the matcher until it says yes to everything.
+fn asserts_transitively(functions: &[ParsedFunction]) -> BTreeMap<String, bool> {
+    let mut asserts: BTreeMap<String, bool> = functions
+        .iter()
+        .map(|f| (f.name.clone(), asserts_directly(&f.body) || f.should_panic))
+        .collect();
+    let bodies: BTreeMap<&str, &str> = functions
+        .iter()
+        .map(|f| (f.name.as_str(), f.body.as_str()))
+        .collect();
+
+    // Fixpoint. Bounded by the function count, and in practice by one or two
+    // passes; the bound is what stops a mutually recursive pair looping.
+    for _ in 0..functions.len().min(8) {
+        let mut moved = false;
+        for (name, body) in &bodies {
+            if asserts.get(*name) == Some(&true) {
+                continue;
+            }
+            let reached = bodies.keys().any(|callee| {
+                callee != name
+                    && asserts.get(*callee) == Some(&true)
+                    && body.contains(&format!("{callee}("))
+            });
+            if reached {
+                asserts.insert((*name).to_string(), true);
+                moved = true;
+            }
+        }
+        if !moved {
+            break;
+        }
+    }
+    asserts
+}
+
+// ---------------------------------------------------------------------------
+// The checks
+// ---------------------------------------------------------------------------
+
+/// The scan is not vacuous, and neither is the ledger side of it.
+///
+/// Without this, every assertion below passes trivially when the roots move,
+/// the `.rs` filter breaks, or the ledger reader stops returning citations —
+/// the structural zero this repository's `CLAUDE.md` warns about.
+#[test]
+fn the_guard_scan_reads_the_tree_and_the_ledger() {
+    let records = rulings::records();
+    assert!(
+        records.len() >= 10,
+        "only {} records read from {LEDGER_RELATIVE_PATH}",
+        records.len()
+    );
+
+    let citations: usize = records.iter().map(|r| r.guard.tests().len()).sum();
+    assert!(
+        citations >= GUARD_CITATION_FLOOR,
+        "only {citations} guard citations in {LEDGER_RELATIVE_PATH}, below the floor of \
+         {GUARD_CITATION_FLOOR} — the reader is probably broken, and every check below would \
+         pass by resolving nothing"
+    );
+
+    let tests = test_functions();
+    assert!(
+        tests.len() >= SCANNED_TEST_FLOOR,
+        "only {} test functions found under {SCAN_ROOTS:?}, below the floor of \
+         {SCANNED_TEST_FLOOR} — the walker or the `fn` matcher is broken",
+        tests.len()
+    );
+
+    // Both arms of the field must be exercised by the ledger, or one of them is
+    // dead code that nothing has ever run.
+    assert!(
+        records.iter().any(|r| matches!(r.guard, Guard::Tests(_))),
+        "no record names a guard — the citing arm is untested"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|r| matches!(r.guard, Guard::Declined(_))),
+        "no record declares an exemption — the declining arm is untested, and a first-class \
+         answer nobody uses is one nobody has checked works"
+    );
+}
+
+/// Every record must say what enforces it. **This is where silence is
+/// refused.**
+///
+/// # Why it is here and not at parse
+///
+/// It used to be at parse: `common::rulings` panicked on a record with no
+/// `guard`, so a single silent record took down every test that reads the ledger
+/// *and* `generate_spec_fixture`, which meant the generated fixture never
+/// existed and everything downstream of it failed too. Measured on this branch
+/// rebased onto `origin/main` at `426a944b`, with the two records `main` had
+/// just added carrying no `guard`: **50 failed** — 28 on the reader's panic, 20
+/// on the generator cascade, 2 on the generator's own precondition tests. Five
+/// of the fifty were about guards.
+///
+/// That is the wrong failure to hand someone. Seven open PRs write ledger
+/// records at any one time, so every one of them met that wall on rebase, and
+/// what it told them was that the spec fixture was broken. The fix is one line
+/// in a JSON file, and nothing in those fifty failures said so.
+///
+/// So the rejection moved out here, where it is **one** failure that names the
+/// records and the two shapes of answer. The rule is unchanged — a record with
+/// no `guard` still cannot merge, because this test is not optional — only the
+/// blast radius is. Everything that is *malformed* rather than *absent* (both
+/// keys set, an empty list, a blank reason, an unparseable citation) still fails
+/// at parse, because those are broken records rather than unanswered ones and
+/// there is nothing downstream that can do anything useful with them.
+///
+/// The staging is only sound because absence is representable without being
+/// confusable: see [`rulings::Guard::Absent`], which no JSON an author can write
+/// produces.
+#[test]
+fn every_record_declares_a_guard() {
+    let records = rulings::records();
+    assert!(
+        records.len() >= 10,
+        "only {} records read from {LEDGER_RELATIVE_PATH} — this check would pass by reading \
+         nothing",
+        records.len()
+    );
+
+    let silent: Vec<&str> = records
+        .iter()
+        .filter(|record| record.guard.is_absent())
+        .map(|record| record.id.as_str())
+        .collect();
+
+    assert!(
+        silent.is_empty(),
+        "these records in {LEDGER_RELATIVE_PATH} carry no `guard`, so the ledger reads as \
+         though something enforces them while nothing is named:\n  {}\n\nAdd the field to each. \
+         Either name the tests that fail when the ruling stops holding:\n    \
+         \"guard\": {{ \"tests\": [\"tests/it/foo.rs::a_guard_name\"] }}\nor declare the \
+         exemption, with the reason it is one:\n    \
+         \"guard\": {{ \"none\": \"why nothing enforces this\" }}\nDeclining is a first-class \
+         answer. Silence is not one: an absent field is indistinguishable from an unconsidered \
+         one.",
+        silent.join("\n  ")
+    );
+}
+
+/// Every guard a record names must exist, in the file the record names.
+///
+/// This is the check the field exists for. A guard renamed out from under a
+/// record leaves the ledger reading as enforced while enforcing nothing, and
+/// until the field existed there was nothing to check — for most records there
+/// was no citation at all.
+#[test]
+fn every_declared_guard_resolves() {
+    let tests = test_functions();
+    let mut unresolved: Vec<String> = Vec::new();
+
+    for record in rulings::records() {
+        for citation in record.guard.tests() {
+            let (path, function) = split_guard_citation(citation)
+                .unwrap_or_else(|| panic!("{citation} passed the parser but not the splitter"));
+            if !tests.contains_key(&(path.to_string(), function.to_string())) {
+                let elsewhere: Vec<&String> = tests
+                    .keys()
+                    .filter(|(_, name)| name == function)
+                    .map(|(file, _)| file)
+                    .collect();
+                let hint = if elsewhere.is_empty() {
+                    format!("no `#[test] fn {function}` exists anywhere under {SCAN_ROOTS:?}")
+                } else {
+                    format!("a test of that name exists in {elsewhere:?}, but not in {path}")
+                };
+                unresolved.push(format!("`{}` names `{citation}`: {hint}", record.id));
+            }
+        }
+    }
+
+    assert!(
+        unresolved.is_empty(),
+        "these guard citations in {LEDGER_RELATIVE_PATH} name a test that cannot enforce the \
+         record. Repair the citation — or, if the guard was renamed in a way that changed what \
+         it claims, that is an adjudication and belongs in the record:\n  {}",
+        unresolved.join("\n  ")
+    );
+}
+
+/// A record must be guarded by at least one test that actually runs.
+///
+/// An `#[ignore]`d guard is a legitimate thing to name — this repository uses
+/// one to record a deferral, asserting the decided answer with an issue as its
+/// un-ignore criterion. What is not legitimate is a record guarded *only* by
+/// tests that never run: that is a declaration of enforcement with no
+/// enforcement behind it, which is the state the whole field exists to make
+/// unrepresentable.
+#[test]
+fn no_record_is_guarded_only_by_tests_that_never_run() {
+    let tests = test_functions();
+    let mut dormant: Vec<String> = Vec::new();
+
+    for record in rulings::records() {
+        let citations = record.guard.tests();
+        if citations.is_empty() {
+            continue;
+        }
+        let running = citations.iter().filter(|citation| {
+            split_guard_citation(citation)
+                .and_then(|(path, function)| tests.get(&(path.to_string(), function.to_string())))
+                .is_some_and(|found| !found.ignored)
+        });
+        if running.count() == 0 {
+            dormant.push(format!("`{}` names only {citations:?}", record.id));
+        }
+    }
+
+    assert!(
+        dormant.is_empty(),
+        "these records name guards that are all `#[ignore]`d, so nothing enforces them today. \
+         Name a running guard alongside the deferral, or declare `guard.none` with the \
+         reason:\n  {}",
+        dormant.join("\n  ")
+    );
+}
+
+/// Every named guard must assert something.
+///
+/// A test that runs and asserts nothing passes (#1858), and reads as coverage
+/// from every angle except the one that matters. Naming such a test as a guard
+/// is worse than naming none, because it survives this file's resolution check.
+#[test]
+fn every_declared_guard_asserts() {
+    let tests = test_functions();
+    let mut silent: Vec<String> = Vec::new();
+
+    for record in rulings::records() {
+        for citation in record.guard.tests() {
+            let Some((path, function)) = split_guard_citation(citation) else {
+                continue;
+            };
+            let Some(found) = tests.get(&(path.to_string(), function.to_string())) else {
+                continue; // reported by `every_declared_guard_resolves`
+            };
+            if !found.asserts {
+                silent.push(format!(
+                    "`{}` names `{citation}` ({path}:{}), whose body asserts nothing",
+                    record.id, found.line
+                ));
+            }
+        }
+    }
+
+    assert!(
+        silent.is_empty(),
+        "these guards run and check nothing, so they cannot fail when the ruling stops \
+         holding:\n  {}",
+        silent.join("\n  ")
+    );
+}
+
+/// A declared exemption may not smuggle in a dangling citation.
+///
+/// The reason is prose, so a `path::function` inside it is checked by nothing —
+/// "the status quo is pinned by `tests/it/foo.rs::bar`" would read as a
+/// complete declaration while naming a test that does not exist. That is the
+/// same defect this file exists to close, one level up, and it is the reason
+/// `RETIRED_RECORD_IDS`'s notes are checked in `ruling_citation_currency.rs`.
+///
+/// Naming no test at all is legitimate: several exemptions here are for
+/// records that rule on nothing a test could observe.
+#[test]
+fn an_exemption_reason_names_no_test_that_is_missing() {
+    let tests = test_functions();
+    let mut dangling: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for record in rulings::records() {
+        let Some(reason) = record.guard.declined_reason() else {
+            continue;
+        };
+        for token in backticked_tokens(reason) {
+            let Some((path, function)) = split_guard_citation(&token) else {
+                continue;
+            };
+            checked += 1;
+            if !tests.contains_key(&(path.to_string(), function.to_string())) {
+                dangling.push(format!("`{}`'s exemption names `{token}`", record.id));
+            }
+        }
+    }
+
+    assert!(
+        dangling.is_empty(),
+        "a `guard.none` reason names a test that does not exist:\n  {}",
+        dangling.join("\n  ")
+    );
+
+    // Non-vacuity, scoped honestly: this only fires if some exemption names a
+    // test, which is a property of the current ledger rather than a rule. The
+    // assertion is on the extractor, not on the ledger's content.
+    if checked == 0 {
+        assert!(
+            backticked_tokens("see `tests/it/a.rs::b` for the pin").contains("tests/it/a.rs::b"),
+            "no exemption named a test, and the extractor cannot find one in a string that \
+             holds one — it is broken, and this check would pass by reading nothing"
+        );
+    }
+}
+
+/// Backticked runs in `prose`.
+fn backticked_tokens(prose: &str) -> BTreeSet<String> {
+    prose
+        .split('`')
+        .enumerate()
+        .filter(|(index, _)| index % 2 == 1)
+        .map(|(_, chunk)| chunk.to_string())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The scanner's own tests
+// ---------------------------------------------------------------------------
+
+/// The assertion detector must follow a call to a helper defined beside the
+/// test, or it reports real guards as assertionless.
+///
+/// Not hypothetical: three of the guards this ledger cites have a body that is
+/// exactly one `converges_to(…)` call. A direct-only matcher called all three
+/// the #1858 shape — a false positive on the very defect the check is for.
+/// Both directions are pinned, because too loose is as bad as too tight: a
+/// matcher that said "yes" for any call at all would stop distinguishing an
+/// assertionless test from an asserting one.
+#[test]
+fn the_assertion_detector_follows_a_local_helper() {
+    let source = r#"
+fn converges_to(a: &str, b: &str) {
+    assert_eq!(a, b);
+}
+
+fn just_logs(a: &str) {
+    println!("{a}");
+}
+
+#[test]
+fn asserts_through_a_helper() {
+    converges_to("x", "x");
+}
+
+#[test]
+fn asserts_directly_itself() {
+    assert!(true);
+}
+
+#[test]
+fn asserts_nothing_at_all() {
+    just_logs("x");
+}
+"#;
+    let verdicts = asserts_transitively(&functions_in(source));
+    assert_eq!(verdicts.get("asserts_through_a_helper"), Some(&true));
+    assert_eq!(verdicts.get("asserts_directly_itself"), Some(&true));
+    assert_eq!(
+        verdicts.get("asserts_nothing_at_all"),
+        Some(&false),
+        "a call to a helper that asserts nothing must not read as an assertion"
+    );
+    assert_eq!(verdicts.get("just_logs"), Some(&false));
+}
+
+/// The `#[test]` and `#[ignore]` attributes are read from the block above the
+/// declaration, and a plain function is not mistaken for a test.
+#[test]
+fn the_scanner_reads_test_and_ignore_attributes() {
+    let source = r#"
+/// A doc comment, then the attributes.
+#[test]
+#[ignore = "waiting on #1"]
+fn a_deferred_guard() {
+    assert!(true);
+}
+
+#[test]
+fn a_running_guard() {
+    assert!(true);
+}
+
+fn not_a_test_at_all() {
+    assert!(true);
+}
+"#;
+    let parsed = functions_in(source);
+    let by_name: BTreeMap<&str, &ParsedFunction> =
+        parsed.iter().map(|f| (f.name.as_str(), f)).collect();
+
+    let deferred = by_name["a_deferred_guard"];
+    assert!(deferred.is_test && deferred.ignored);
+    let running = by_name["a_running_guard"];
+    assert!(running.is_test && !running.ignored);
+    let plain = by_name["not_a_test_at_all"];
+    assert!(!plain.is_test, "a bare fn must not read as a test");
+}
+
+/// An attribute spread over several lines must not hide the `#[test]` above it.
+///
+/// The walk-back that reads attributes runs upward from the `fn`, and a
+/// continuation line — the second and later lines of `#[ignore = "… \` — starts
+/// with none of `#[`, `//` or nothing at all. A walk that stops there never sees
+/// the `#[test]`, so the function is not a test as far as this file is
+/// concerned, and a record citing it fails
+/// [`every_declared_guard_resolves`] while the test runs perfectly well.
+///
+/// Not hypothetical, and not caught by review: this scanner was written against
+/// a tree where `corpus_prohibited_inputs.rs::the_decided_target_is_a_mode_gated_refusal`
+/// carried a one-line `#[ignore]`. #1872 reflowed it onto four lines, and on the
+/// next rebase the ledger's citation of it reported as naming a test that "does
+/// not exist anywhere". **30** tests in the tree were invisible for this reason
+/// at that point.
+///
+/// Both directions are pinned. The negative control is the one that matters: the
+/// mechanism keys on an unmatched `]`, so it must not run away up the file and
+/// collect the *previous* function's attributes onto a plain `fn`.
+#[test]
+fn a_multi_line_attribute_does_not_hide_the_test_attribute() {
+    let source = r#"
+#[test]
+#[ignore = "one row still open: see #1627. The \
+            other three rows pass (#1627's delinsX), \
+            as does checklist.md:20"]
+fn a_deferred_guard_with_a_reflowed_ignore() {
+    assert!(true);
+}
+
+#[test]
+#[should_panic(
+    expected = "a message long enough that rustfmt \
+                puts it on its own line"
+)]
+fn a_negative_guard_with_a_wrapped_should_panic() {
+    reject("nonsense");
+}
+
+fn a_plain_helper_after_all_that() {
+    assert!(true);
+}
+"#;
+    let parsed = functions_in(source);
+    let by_name: BTreeMap<&str, &ParsedFunction> =
+        parsed.iter().map(|f| (f.name.as_str(), f)).collect();
+
+    let deferred = by_name["a_deferred_guard_with_a_reflowed_ignore"];
+    assert!(
+        deferred.is_test,
+        "a `#[test]` above a reflowed `#[ignore]` must still register"
+    );
+    assert!(
+        deferred.ignored,
+        "the `#[ignore]` itself must still be read, or a dormant guard reads as running"
+    );
+
+    let negative = by_name["a_negative_guard_with_a_wrapped_should_panic"];
+    assert!(negative.is_test);
+    assert!(
+        negative.should_panic,
+        "`#[should_panic]` spread over lines is still the assertion"
+    );
+
+    // The negative control: the bracket tracking must not walk past a real body
+    // and hand this helper the `#[test]` belonging to the function above it.
+    let plain = by_name["a_plain_helper_after_all_that"];
+    assert!(
+        !plain.is_test,
+        "a bare `fn` below a test body must not inherit that test's attributes"
+    );
+}
+
+/// A doc comment carrying an unbalanced bracket must not open a phantom
+/// attribute.
+///
+/// This is the failure mode the comment exclusion in [`functions_in`] exists to
+/// prevent, and it is worth its own control because it is invisible from the
+/// positive test above: prose and Markdown links routinely carry `]` without
+/// `[`, and treating one as an attribute continuation would let the walk-back
+/// run up through the previous function's body.
+#[test]
+fn an_unbalanced_bracket_in_prose_does_not_open_an_attribute() {
+    let source = r#"
+#[test]
+fn a_real_test_whose_body_has_brackets() {
+    let v = vec![1, 2, 3];
+    assert_eq!(v[0], 1);
+}
+
+/// A doc comment whose prose closes a bracket it never opened: see 3] above.
+fn not_a_test_despite_the_bracket() {
+    assert!(true);
+}
+"#;
+    let parsed = functions_in(source);
+    let by_name: BTreeMap<&str, &ParsedFunction> =
+        parsed.iter().map(|f| (f.name.as_str(), f)).collect();
+
+    assert!(by_name["a_real_test_whose_body_has_brackets"].is_test);
+    assert!(
+        !by_name["not_a_test_despite_the_bracket"].is_test,
+        "an unbalanced `]` in a doc comment must not make the walk-back climb \
+         into the previous function and inherit its `#[test]`"
+    );
+}
+
+/// A `fn` inside a raw string literal is source *data*, and must not register
+/// as a test.
+///
+/// This is the negative control for [`raw_string_lines`], and the defect it
+/// pins was live: citing
+/// `tests/it/ruling_guard_field.rs::asserts_directly_itself` — one of this
+/// file's own fixtures, which exists only inside an `r#"…"#` literal — made
+/// every check in this file pass on a record that nothing enforces. Resolution
+/// succeeded because the scan could not tell code from a string.
+#[test]
+fn a_test_declared_inside_a_raw_string_literal_does_not_register() {
+    let source = r##"
+#[test]
+fn a_real_test() {
+    assert!(true);
+}
+
+fn holds_a_fixture() {
+    let fixture = r#"
+#[test]
+fn a_phantom_test() {
+    assert!(true);
+}
+"#;
+    drop(fixture);
+}
+"##;
+    let names: Vec<String> = functions_in(source)
+        .iter()
+        .filter(|f| f.is_test)
+        .map(|f| f.name.clone())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "a_real_test"),
+        "a real `#[test]` must still register; found {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "a_phantom_test"),
+        "a `#[test] fn` inside a raw string literal is data, not a test — citing one as a guard \
+         would resolve while nothing enforced the record; found {names:?}"
+    );
+}
+
+/// `#[should_panic]` is an assertion, and it lives where [`body_from`] cannot
+/// see it.
+///
+/// The negative control matters as much as the positive one: if the attribute
+/// scan were widened to "any attribute counts", an assertionless test would
+/// stop being distinguishable from a guarded one, which is the #1858 shape this
+/// file exists to catch.
+#[test]
+fn a_should_panic_test_counts_as_asserting() {
+    let source = r#"
+#[test]
+#[should_panic(expected = "boom")]
+fn a_negative_guard() {
+    reject("nonsense");
+}
+
+#[test]
+#[ignore = "waiting on #1"]
+fn a_silent_test() {
+    reject("nonsense");
+}
+"#;
+    let verdicts = asserts_transitively(&functions_in(source));
+    assert_eq!(
+        verdicts.get("a_negative_guard"),
+        Some(&true),
+        "`#[should_panic]` IS the assertion; the body holds none"
+    );
+    assert_eq!(
+        verdicts.get("a_silent_test"),
+        Some(&false),
+        "a test that neither asserts nor declares a panic must still read as silent"
+    );
+}
+
+/// The generator keeps its own copy of the citation grammar, because the two
+/// crates do not link.
+///
+/// **What this pins is narrower than "the copies agree", and saying otherwise
+/// would be the defect this whole file is about.** It cannot execute the
+/// generator's copy — that binary does not link here — so it checks that the
+/// generator still *carries* a splitter, and separately exercises the reader's
+/// copy on the cases that discriminate the grammar. Agreement itself is held by
+/// the generator's own unit test
+/// (`examples/generate_spec_fixture.rs::the_guard_citation_grammar_admits_a_path_and_nothing_else`),
+/// which runs the same case list against the other copy because that target
+/// sets `test = true`. Two tests over one case list, not one test over two
+/// copies.
+#[test]
+fn the_generator_and_the_ledger_reader_agree_on_the_citation_grammar() {
+    let generator = std::fs::read_to_string(crate_root().join("examples/generate_spec_fixture.rs"))
+        .expect("read the generator");
+    assert!(
+        generator.contains("fn split_guard_citation"),
+        "the generator no longer carries a citation splitter; if the grammar moved somewhere \
+         shared, delete this test rather than leaving it asserting about a copy that is gone"
+    );
+    // The discriminating cases, spelled out so the assertion is about behaviour
+    // rather than about the source text matching itself.
+    for (token, accepted) in [
+        ("tests/it/foo.rs::a_guard_name", true),
+        ("merge::a_guard_name", false),
+        ("tests/it/foo.rs", false),
+        ("tests/it/foo.rs::AGuard", false),
+    ] {
+        assert_eq!(
+            split_guard_citation(token).is_some(),
+            accepted,
+            "{token} must {} parse",
+            if accepted { "" } else { "not" }
+        );
+    }
+}


### PR DESCRIPTION
A `decided` record and the test that enforces its ruling were connected by nothing but prose, and for eight of twenty-five by no prose at all. Rename the guard and the record goes on naming the old one; write no guard at all and the record reads exactly the same as one that has three. This adds the field that makes the difference sayable, and makes saying nothing not an option.

Representation-Change: none. Schema and test only — no file under `src/` is touched at all, the ledger's 28 records keep their statuses, questions, scope sentences, governing clauses, clause lists and rationales byte-for-byte, and the only ledger change is one added field per record.

Refs #1881.

## Census, re-derived at `origin/main` `d4552167`

**28 records, 25 `decided`, 3 `undecided`.** (#1882 is still open, so the ledger has not yet reached the 29/26/3 the brief anticipated.)

How each record pointed at its enforcement before this change:

| mechanism | records |
|---|---:|
| a `<path>::<function>` citation somewhere in the record's prose | 5 |
| a bare `tests/….rs` path — a file, but no proposition | 12 |
| an `equivalence_classes` array — the one structured pointer, already enforced end to end | 4 |
| **nothing, by any mechanism** | **8** |

The first three overlap; the last does not. A bare file path is the interesting middle case: it cannot go stale in any way a reader would notice, because a file that still exists still resolves however far its contents have moved on.

## The field

Required on every record. Exactly one of two keys.

```json
"guard": {
  "tests": [
    "tests/it/ring_segment_wellformedness.rs::the_three_malformed_rings_the_ruling_named_are_now_rejected",
    "tests/it/issue_1578_followup_self_cancelling_rings.rs::the_specs_own_ring_shapes_are_accepted"
  ]
}
```

```json
"guard": {
  "none": "Undecided: the record asks whether a ring naming only interior coordinates must be refused, and answers neither way. `tests/it/ring_segment_wellformedness.rs::a_ring_with_no_telomere_anchor_is_still_accepted` pins today's acceptance, which the record itself calls the status quo rather than a ruling — it would go on passing under one answer and would have to be deleted under the other, so it is not this record's guard."
}
```

The model is `Representation-Change:`: **declining is first-class, and what is rejected is silence.** An absent field is indistinguishable from an unconsidered one, so it does not parse. A blank reason, an empty `tests` list, both keys at once, and an unknown key are all rejected for the same reason one level in — each is the absent case wearing a value.

The citation grammar is deliberately narrow — repo-relative path ending `.rs`, then `::`, then one snake_case identifier — so a citation resolves *mechanically*. `merge::a_guard` does not parse: it names no file, and that is exactly the ambiguity the prose form had.

## Enforcement, modelled on `equivalence_classes`

That is the precedent named in the brief, and it is followed rather than paraphrased: the generator bails on an unknown class id, and the guard that reads it asserts and checks its own vacuity.

- **`generate_spec_fixture`** — the field is declared with **no `serde(default)`**, so a record without it fails the build at parse. Beyond that, `validate_guard_shape` refuses an empty guard, both keys, a blank reason, a citation outside the grammar, and a citation naming a file that is not in this tree. Red-proof: dropping one record's guard block gives `error: parse …overrides.json: missing field 'guard' at line 395 column 5`, `EXIT=1`.
- **`tests/it/common/rulings.rs`** — the one ledger parser gains `Guard`, with a mutation test per malformed shape, in the style the file already uses. No second parser was introduced.
- **`tests/it/ruling_guard_field.rs`** — new, resolves each citation against the tree.

## What the new module checks

| check | what it refuses |
|---|---|
| `every_declared_guard_resolves` | a citation naming a test that is not in the file it names (with a hint when a test of that name lives elsewhere) |
| `no_record_is_guarded_only_by_tests_that_never_run` | a record whose named guards are *all* `#[ignore]`d — naming a deferral is fine, being enforced only by one is not |
| `every_declared_guard_asserts` | a guard that runs and checks nothing (#1858) |
| `an_exemption_reason_names_no_test_that_is_missing` | a dangling citation hidden in the prose of a decline |
| `the_guard_scan_reads_the_tree_and_the_ledger` | vacuity: citation floor, scanned-test floor, and that **both** arms of the field are exercised by the ledger |

What it deliberately does **not** check is whether a named test enforces *this* ruling rather than a neighbouring one. That is a judgement no matcher can make, and pretending otherwise would put a veneer of mechanism over the thing that actually carries it. What the field buys is that the judgement is written down, once, in the ledger, where it can be argued with.

## It composes with #1880; neither subsumes the other

They ask different questions:

- **This** asks whether every record *has* an enforcement story that resolves. It is exhaustive over records by construction.
- **#1880** asks whether the discursive prose *around* a record stays true. It is opportunistic by construction: it judges records that happen to cite a guard, and is structurally blind to the eight that cite none — which is the population that most needs judging.

Both should land. There is one interaction worth stating: `alignment-only-symbol-in-a-description` now carries a `guard` naming the live `an_alignment_only_symbol_is_refused_in_every_mode_for_both_x_and_dash`, while its SCOPE paragraph still names the pre-#1684 title. **That does not close #1881** and is not meant to — the prose sentence is the record's own argument and repairing it is an adjudication. This file reads only the field. The same holds for `derivation-may-not-be-bounded-by-the-inputs-spelling`, whose guard names the two live tests its own rationale cites while the dead third citation stays exactly where it is.

To avoid a merge conflict with #1880, the new checks live in their own module rather than in `ruling_citation_currency.rs`. When #1880 lands, the tree walker and the assertion detector are the obvious things to lift into `common/`; that is a follow-up, not a reason to hold either PR.

## Per-record disposition

Every record was resolved by one of: a test whose **own doc comment names the record id** (the link was authored by the test's author, not inferred here), or a test whose doc states the record's ruling near-verbatim while the module doc names the record. Nothing was retrofitted from a guess.

**Guard found — 24 records, 42 citations.** All 42 resolve, all 42 assert, none is guarded only by `#[ignore]`d tests. Two records name a declared deferral *alongside* a running guard: `exon-junction-dup-converge-from-the-far-side` (`the_decided_target_is_convergence_on_the_near_side`) and `absolute-prohibition-enforcement-stage` (`the_decided_target_is_a_mode_gated_refusal`) — the #1630 item-2 deferral the brief names.

**Exemption declared — 4 records.** Three are the `undecided` ones, where the reason is the same in substance and different in specifics: an undecided record states a conflict and names no side, so there is no ruling for a guard to enforce, and the status-quo pin that exists in two of the three is explicitly *not* the record's guard (it would survive either answer). The fourth is `separation-rule-force-modal-or-negation`, which is `decided` and genuinely unguardable: it grades `general.md:34` as README rule 2 rather than rule 1 and mandates no output — its own closing sentence is that this "changes classification only". No description's normalized form turns on it.

**Unresolvable, left alone — 0.** Worth stating plainly, because the brief expected some and wanted them reported rather than filled: there were none. That is not because the bar was lowered — every citation was read, and the check went red on four separate perturbations before it went green.

## Red-proof

Each arm perturbed and restored with `cp`, verified by `md5` (`60f14114…` before and after, both rounds).

```
these guard citations in tests/fixtures/grammar/hgvs_spec_normalization_overrides.json name a test
that cannot enforce the record. …
  `c-and-n-positions-are-flat-transcript-offsets` names `tests/it/ruling_guard_field.rs::backticked_tokens`:
    no `#[test] fn backticked_tokens` exists anywhere under ["src", "tests"]
  `duplication-must-ranks-the-label-not-the-partition` names `…::no_emitted_insertion_repeats_its_five_prime_flanks`:
    no `#[test] fn no_emitted_insertion_repeats_its_five_prime_flanks` exists anywhere under ["src", "tests"]

these records name guards that are all `#[ignore]`d, so nothing enforces them today. …
  `exon-junction-dup-converge-from-the-far-side` names only ["…::the_decided_target_is_convergence_on_the_near_side"]

these guards run and check nothing, so they cannot fail when the ruling stops holding:
  `c-and-n-positions-are-flat-transcript-offsets` names `tests/it/ruling_guard_field.rs::a_temporary_guard_that_checks_nothing`
    (tests/it/ruling_guard_field.rs:697), whose body asserts nothing

a `guard.none` reason names a test that does not exist:
  `ring-telomere-anchoring`'s exemption names `…::a_ring_with_no_telomere_anchor_is_accepted`
```

**It lands armed, not `#[ignore]`d.** The brief anticipated a red suite and the `#[ignore]`-plus-issue idiom; that turned out not to be needed, because every record could be given either a real guard or a reasoned exemption. Arming it is the stronger outcome and it is green on its own terms — but the four failures above are what makes that a claim rather than an assumption.

### One defect the new tests caught in themselves

The assertion detector's first version scanned the function body *including its declaration line*, so a test named `asserts_nothing_at_all` matched on its own name and reported itself as asserting — the #1858 shape, passed by the check written to catch it. Its negative control caught it before the module was ever run against the ledger. The detector also has to follow a call to a helper defined beside the test: three of the ledger's guards have a body that is one `converges_to(…)` call, and a direct-only matcher called all three assertionless. Both are pinned by `the_assertion_detector_follows_a_local_helper`.

## Ledger safety

The record set-comparison from `CLAUDE.md`, before and after:

```
origin/main records: 28 | HEAD records: 28
dropped from main   : NONE
added on HEAD       : NONE
status changes      : NONE
records whose non-guard fields changed: NONE
census  (records, decided, undecided): (28, 25, 3)
```

`by_input` and `equivalence_classes` are byte-identical, and every record's non-`guard` fields compare equal object-for-object.

**Census pins: unchanged, and checked rather than assumed.** A schema addition that adds no record moves no count. `the_index_is_not_vacuous`'s `(28, 25, 3)`, `clauses_named_by_several_records_are_flagged`'s `30` / `3`, `RULING_STATUSES` and the two `CLAUDE.md` adjudication tables all hold as they stand — all four are functions of record identity, status, or clause citations, none of which this change touches.

## Verification

`cargo fmt --all --check` clean. `cargo clippy --all-features --all-targets -- -D warnings` clean. Spec fixture regenerates (`generate_spec_fixture`, `EXIT=0`, 28 rulings in). Full `cargo nextest run --features dev --lib --test it` green. The Python bindings are not reachable — `git diff --name-only origin/main..HEAD -- src/` is empty, so nothing the bindings surface changed.
