### PR TITLE
fix(changelog): correct #1835's flip disclosure, and make a merged one correctable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,21 @@ Four things belong in it, and the last is the one a consumer actually acts on:
    it is a migration. This distinction cannot be recovered later — nobody
    reading the diff in six months can tell — so it has to be written down now.
 
+**Do not name a release version in the trailer.** Which release carries your
+change is not knowable when you write it: `release-plz.toml` sets
+`features_always_increment_minor`, so what a `feat:` cuts depends on the base
+version at release time, a `feat:` landing before yours moves it, and a cycle can
+be re-cut. Say **"to reproduce output from before this change"**, not "to
+reproduce pre-vX.Y.Z output". The version-free form is correct under every cut
+and loses nothing, because the changelog heading the trailer is quoted under
+already names the release the reader is holding.
+
+This is the house form because it has already been got wrong the other way:
+#1835's trailer told consumers to pin `FERRO_PARTITION=live` to reproduce
+**pre-v0.15.0** output, for a change shipping in **v0.14.0** ([#1886]) —
+which reads to a consumer as "this lands next cycle" rather than "this is the
+release you are reading", and could not be fixed in the trailer once merged.
+
 Two related habits, from `CLAUDE.md`:
 
 - **"Fixes non-confluence" is not a sufficient description.** Confluence (two
@@ -203,6 +218,7 @@ whatever its type, so a `fix:` that correctly declined is not listed under
 
 [#1556]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1556
 [#1557]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1557
+[#1886]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1886
 
 ### Changelog
 
@@ -222,6 +238,14 @@ CI runs the `--check` form in the `Changelog grouping audit` job, so a release P
 Two consequences for how you write the trailer. Keep it **at column 0 and undecorated** — no backticks, no `>`, no `-`/`*`/`+`, no `#`, no emphasis, and the separator is a hyphen. Anything else and the line is prose: an indented `Representation-Change:` is a continuation of the line above it to git, to release-plz and to both checkers, and a code-spanned one is invisible to all three at once. This is not pedantry about formatting — you would have declared something and nobody would be told, which is the exact failure the trailer exists to prevent — so the checker now refuses a line that looks like a declaration it cannot read, names the character responsible, and does so on every PR rather than only on the ones touching a watched directory. To show the form as an *example* rather than declare it, indent the line — and keep your real, unindented declaration above it, because that is what tells the checker the indented one is a quotation. An indented line on its own is reported as a near miss rather than read as an example, which is the right answer: nothing distinguishes it from a declaration that will never be read. And know that "put it last" is advice the tooling cannot rely on: GitHub appends CodeRabbit's summary after your description, so the script stops the value at the next column-0 trailer token, Markdown heading or HTML comment rather than at the end of the message. Do not put a heading inside the disclosure.
 
 A section that has already been released is a different matter: a release only prepends to `CHANGELOG.md`, leaving earlier sections untouched, and the GitHub release body is never revisited once its tag exists. So a retrospective note — a consolidated representation summary for a release whose commits predate this convention, say — can be added afterwards, by editing the released section and `gh release edit <tag>`. That is the escape hatch for a cycle that shipped without trailers; it is not a substitute for declaring changes as you make them, because nobody can reconstruct the rejected-vs-accepted distinction after the fact.
+
+**Correcting a disclosure that is already merged is a third case, and hand-editing `CHANGELOG.md` is the wrong tool for it.** A trailer cannot be corrected once its commit is on `main` — that would mean rewriting released history — and an edited changelog copy fails twice over: release-plz discards it the next time it regenerates the pending section, and `inject_representation_disclosure.py --check` reports it as drift against the trailer it no longer matches, which is red CI. The durable surface is the injector itself, because it re-renders the block on every run. Register the correction in its `EDITORIAL_CORRECTIONS` table, keyed by PR number, and re-run the script:
+
+```bash
+python scripts/inject_representation_disclosure.py
+```
+
+It is appended under the bullet after the trailer's own words, inside the same blockquote, and `--check` then demands it. One limit to know before you reach for it: the injector *judges* a block that is already on disk rather than rewriting it, so registering a correction against an already-rendered bullet is reported as drift. That resolves itself in the pending section, which release-plz regenerates on every push to `main`; a **released** section is never regenerated, so there you delete the stale block from `CHANGELOG.md` and let the re-run write it back with the correction attached. Two constraints, both load-bearing. Each paragraph must **open by naming itself editorial and citing the issue that raised it** — the release checklist turns on whose words a disclosure carries, and inside the block the label is the only thing that answers it. And a correction states a **fact the trailer got wrong or left out**; it is not a place to re-word, summarise or improve a disclosure, which is what keeps "the trailer's own text" a claim a reader can rely on. Append a paragraph rather than rewriting one, so two corrections to one disclosure conflict visibly instead of silently overwriting each other.
 
 ### Submitting a Pull Request
 

--- a/scripts/inject_representation_disclosure.py
+++ b/scripts/inject_representation_disclosure.py
@@ -40,6 +40,23 @@ about the decline vocabulary.
 The bullet is matched to its commit by the **PR number** GitHub puts in the squash subject,
 which is the one token both sides are guaranteed to share.
 
+## Correcting a disclosure that is already merged
+
+A trailer lives in a commit message, so once it is on `main` it cannot be corrected without
+rewriting released history. The changelog copy, on the other hand, is **rendered by this
+script on every run** -- which makes the script, not `CHANGELOG.md`, the place a correction
+has to live. `EDITORIAL_CORRECTIONS` below is that register: an entry is appended under its
+bullet after the trailer's own words, inside the same blockquote, opening with a label that
+says whose words it is. Hand-editing `CHANGELOG.md` instead fails twice over -- release-plz
+discards it when it regenerates the pending section, and `--check` reports it as drift
+against the trailer.
+
+The first of those two reaches only the **pending** section. A released section is never
+regenerated, so registering a correction against a block that is already on disk is
+*reported* as drift rather than repaired -- `inject` judges an existing block, it does not
+rewrite one. Remove that block from `CHANGELOG.md` first and the re-run attaches the
+correction with it.
+
 ## Usage
 
     python scripts/inject_representation_disclosure.py --check      # CI: is CHANGELOG.md current?
@@ -84,6 +101,56 @@ HEADING_RE = re.compile(r"^(?P<hashes>#{2,})\s+(?P<title>.*\S)\s*$")
 
 #: The PR number GitHub writes into a squash subject, in the bullet's link or bare.
 PR_RE = re.compile(r"\(#(?P<number>\d+)\)|\[#(?P<linked>\d+)\]")
+
+#: Editorial corrections to a merged disclosure, keyed by PR number, one string per
+#: paragraph.
+#:
+#: **Why this is a register and not a `CHANGELOG.md` edit.** The trailer is immutable once
+#: its commit is on `main`, and correcting it would mean rewriting released history. Editing
+#: the changelog copy instead fails twice: release-plz regenerates the pending section on
+#: every push to `main`, and `--check` reports the edited block as drift against the trailer
+#: it no longer matches. What *is* durable is this script -- it re-renders the block on every
+#: run, so a correction registered here survives every regeneration and is what `--check`
+#: then demands.
+#:
+#: **The trailer's own words stay verbatim.** A correction is rendered as a further
+#: paragraph in the same blockquote and must open by naming itself as editorial and citing
+#: the issue that raised it, because whose words these are is the distinction the release
+#: checklist turns on -- not which block they sit in.
+#:
+#: **Add an entry only to correct a statement of fact**: something the trailer got wrong, or
+#: a cost it did not disclose. Not to summarise it, re-word it, or improve its prose. Append
+#: a paragraph rather than rewriting one, so two corrections to one disclosure conflict
+#: visibly instead of overwriting each other.
+EDITORIAL_CORRECTIONS: dict[str, list[str]] = {
+    "1835": [
+        "**Editorial correction (#1886) — not the trailer's words.** The trailer names\n"
+        "`pre-v0.15.0` as the output `FERRO_PARTITION=live` reproduces. The release carrying\n"
+        "this change is the one heading this section, so read that as *output from before\n"
+        "this change* — every release up to and including v0.13.1. `release-plz.toml` sets\n"
+        "`features_always_increment_minor`, so which release a `feat:` lands in is not\n"
+        "knowable when its trailer is written; naming one is now against house style, and\n"
+        "`CONTRIBUTING.md` asks for the version-free phrasing instead.",
+        "**Editorial correction (#1886) — not the trailer's words.** The trailer discloses\n"
+        "confluence only. The flip also moves **2 rows of 932** on the HGVS spec corpus,\n"
+        "measured per arm at `45820926` against a prepared GRCh38 reference, 3' direction,\n"
+        "with the two rows #1846 cannot terminate on excluded: `live` 646, `shadow` 646,\n"
+        "`canonical` 642, **`canonical-coalesced` — the new default — 644**. Two rows stop\n"
+        "matching the spec's stated form and none starts, and both are named here because\n"
+        "the bare count reads as a regression and neither row is one. `DNA/delins.md`\n"
+        "publishes one variant as two corpus rows — the spanning\n"
+        "`c.850_901delinsTTCCTCGATGCCTG` that `:47` recommends, and the split `:46` calls\n"
+        'its "alternative description" — and both echoed themselves before; the new\n'
+        "default converges the split onto the spanning form, which is what any change that\n"
+        "converges a published pair must cost. The other row,\n"
+        "`LRG_199t1:c.992_1004delinsAC`, is harvested from `consultation/SVD-WG010.md` —\n"
+        "the **rejected** proposal, whose answer `tests/it/spec_worked_example_rules.rs`\n"
+        "already pins as one ferro must not produce — and the new default no longer echoes\n"
+        "it either. Read this as neither more nor less conformant: the measurement supports\n"
+        "neither claim. 3' only, because #1879 removes the 5' direction from the public\n"
+        "surface in this same release.",
+    ],
+}
 
 
 def squash_commits(repo: Path) -> dict[str, str]:
@@ -216,6 +283,28 @@ def wrap_disclosure(value: str) -> list[str]:
     return [f"{DISCLOSURE_PREFIX}{line}".rstrip() for line in value.splitlines()]
 
 
+def wrap_correction(paragraphs: list[str]) -> list[str]:
+    """Render `EDITORIAL_CORRECTIONS` paragraphs as further lines of the same blockquote.
+
+    Inside the trailer's own blockquote rather than beside it, deliberately. A correction
+    that a reader can meet without the statement it corrects is worse than none, and every
+    other placement can be separated from it: a paragraph after the block is dropped the next
+    time release-plz regenerates the section, and one before it re-orders on the next
+    trailer.
+
+    What keeps the trailer's words distinguishable is therefore the **label**, which each
+    paragraph carries, not the block boundary -- so each paragraph is separated by a bare
+    `  >` and must open by naming itself. That is also why this returns the separator: a
+    correction lazily continuing the trailer's last line would read as the author's own
+    sentence, which is the one thing this must never do.
+    """
+    lines: list[str] = []
+    for paragraph in paragraphs:
+        lines.append(DISCLOSURE_PREFIX.rstrip())
+        lines.extend(f"{DISCLOSURE_PREFIX}{line}".rstrip() for line in paragraph.splitlines())
+    return lines
+
+
 def inject(changelog: str, by_pr: dict[str, str]) -> tuple[str, list[str], list[str]]:
     """Return `(rewritten changelog, changed bullets, problems)`.
 
@@ -280,21 +369,26 @@ def inject(changelog: str, by_pr: dict[str, str]) -> tuple[str, list[str], list[
             )
             continue
 
-        wanted = wrap_disclosure(value)
+        wanted = wrap_disclosure(value) + wrap_correction(EDITORIAL_CORRECTIONS.get(number, []))
         if existing:
             # Already carried a block: judge it rather than trust it. The trailer in the
-            # commit message is the single source of truth — editing the changelog copy
-            # instead makes the two disagree with nothing to notice, which is the failure
-            # this whole script exists to remove. Fix by correcting the trailer and
-            # re-running, not by editing `CHANGELOG.md`.
+            # commit message is the single source of truth for its own words — editing the
+            # changelog copy instead makes the two disagree with nothing to notice, which is
+            # the failure this whole script exists to remove. Fix by correcting the trailer
+            # and re-running, not by editing `CHANGELOG.md`; and where the trailer is already
+            # merged and so cannot be corrected, by registering the correction in
+            # `EDITORIAL_CORRECTIONS`, which is rendered here and so cannot be regenerated
+            # away.
             if existing != wanted:
                 problems.append(
                     f"#{number}'s disclosure in the changelog no longer matches its "
-                    "`Representation-Change:` trailer. The trailer is the source of "
-                    "truth; re-run `python scripts/inject_representation_disclosure.py` "
-                    "after correcting it.\n"
+                    "`Representation-Change:` trailer (plus any registered editorial "
+                    "correction). Those two are the source of truth, and a re-run judges an "
+                    "existing block rather than rewriting it: revert the changelog edit, or "
+                    "delete the block and let release-plz or a re-run of "
+                    "`python scripts/inject_representation_disclosure.py` re-attach it.\n"
                     f"  changelog says: {_flatten(existing)[:160]!r}\n"
-                    f"  trailer says:   {_flatten(wanted)[:160]!r}"
+                    f"  should say:     {_flatten(wanted)[:160]!r}"
                 )
             continue
 

--- a/tests/python/test_inject_representation_disclosure.py
+++ b/tests/python/test_inject_representation_disclosure.py
@@ -9,11 +9,18 @@ and each of which fails silently:
 - where the value **ends** (a CodeRabbit block appended after the trailer is not the value);
 - that a bullet with **no** matching commit or **no** trailer is reported rather than skipped;
 - that a second run is a **no-op**, since release-plz regenerates the section on every push.
+
+`EDITORIAL_CORRECTIONS` (#1886) is tested to the same standard and for the same reason. It
+exists because a merged trailer cannot be corrected, so the correction has to be re-rendered
+on every run rather than written into `CHANGELOG.md` once -- which makes "a second run is a
+no-op" and "a hand-edit is drift" load-bearing for it too, not merely nice.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -176,7 +183,7 @@ def test_stdout_and_check_are_refused_together():
     assert excinfo.value.code != 0
 
 
-def test_write_mode_refuses_before_writing_when_a_bullet_is_unresolvable(tmp_path):
+def test_write_mode_refuses_before_writing_when_a_bullet_is_unresolvable(tmp_path, monkeypatch):
     """A partial artifact is not a better outcome than no artifact.
 
     The write used to happen before the exit code was computed, so a run with one resolvable
@@ -192,14 +199,220 @@ def test_write_mode_refuses_before_writing_when_a_bullet_is_unresolvable(tmp_pat
     changelog.write_text(two_bullets, encoding="utf-8")
     before = changelog.read_text(encoding="utf-8")
 
-    # #1234 resolves; #4321 does not.
-    module.squash_commits = lambda _repo: {
-        "1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"
-    }
+    # #1234 resolves; #4321 does not. Stubbed through `monkeypatch` rather than by rebinding
+    # `module.squash_commits` directly: a bare rebind is never undone, so every test after
+    # this one in the module silently sees a two-entry history instead of the repository's.
+    monkeypatch.setattr(
+        module,
+        "squash_commits",
+        lambda _repo: {
+            "1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"
+        },
+    )
     code = module.main(["--changelog", str(changelog)])
 
     assert code == 2
     assert changelog.read_text(encoding="utf-8") == before, "wrote a partially injected file"
+
+
+TRAILERED = {"1234": "fix: move a thing (#1234)\n\nRepresentation-Change: 3 rows move.\n"}
+
+
+@pytest.fixture
+def one_correction(monkeypatch):
+    """Register a correction for #1234 for the duration of a test."""
+    monkeypatch.setattr(
+        module,
+        "EDITORIAL_CORRECTIONS",
+        {"1234": ["**Editorial correction (#4321).** It was 4 rows, not 3."]},
+    )
+
+
+def test_nothing_is_attached_for_a_pr_with_no_registered_correction():
+    """The default is silence. A mechanism that decorated every disclosure would dilute the
+    label that makes a correction recognisable as one."""
+    rewritten, _, problems = module.inject(SECTION, TRAILERED)
+    assert problems == []
+    assert "Editorial correction" not in rewritten
+
+
+def test_a_registered_correction_is_attached_below_the_trailers_own_words(one_correction):
+    """Below, and separated -- the trailer's words must stay readable as the trailer's.
+
+    The separator is not cosmetic: without a blank quote line the correction would be a lazy
+    continuation of the trailer's last paragraph, i.e. it would render as the author's own
+    closing sentence, which is the one thing a correction must never look like.
+    """
+    rewritten, changed, problems = module.inject(SECTION, TRAILERED)
+
+    assert problems == []
+    assert changed == ["#1234"]
+    body = rewritten.splitlines()
+    start = body.index("  > 3 rows move.")
+    assert body[start + 1] == "  >"
+    assert body[start + 2] == "  > **Editorial correction (#4321).** It was 4 rows, not 3."
+
+
+def test_a_correction_is_idempotent(one_correction):
+    """release-plz regenerates the section on every push to `main`, so the correction is
+    re-attached rather than written once -- which only works if re-running is a no-op."""
+    once, _, _ = module.inject(SECTION, TRAILERED)
+    twice, changed, problems = module.inject(once, TRAILERED)
+
+    assert twice == once
+    assert changed == []
+    assert problems == []
+
+
+@pytest.fixture
+def two_corrections(monkeypatch):
+    """Register a *two*-paragraph correction, which is the shape actually shipped.
+
+    `EDITORIAL_CORRECTIONS["1835"]` holds two paragraphs, so the second iteration of
+    `wrap_correction`'s loop -- the one that emits a bare `  >` *between* corrections, and
+    that `_is_disclosure_line`'s second arm has to collect back for idempotence -- is the
+    only path the real register uses and was the one path no test ran.
+    """
+    monkeypatch.setattr(
+        module,
+        "EDITORIAL_CORRECTIONS",
+        {
+            "1234": [
+                "**Editorial correction (#4321).** It was 4 rows, not 3.",
+                "**Editorial correction (#5678).** The count excludes two declined rows.",
+            ]
+        },
+    )
+
+
+def test_two_corrections_are_each_separated_and_each_labelled(two_corrections):
+    """Appending rather than rewriting is the register's stated contract, so two corrections
+    to one disclosure must both survive, in order, each behind its own bare `  >`."""
+    rewritten, changed, problems = module.inject(SECTION, TRAILERED)
+
+    assert problems == []
+    assert changed == ["#1234"]
+    body = rewritten.splitlines()
+    start = body.index("  > 3 rows move.")
+    assert body[start + 1 : start + 6] == [
+        "  >",
+        "  > **Editorial correction (#4321).** It was 4 rows, not 3.",
+        "  >",
+        "  > **Editorial correction (#5678).** The count excludes two declined rows.",
+        "",
+    ]
+
+
+def test_two_corrections_are_idempotent(two_corrections):
+    """The separator between two corrections is a bare `  >`, which only `_is_disclosure_line`'s
+    second arm matches. Miss it and the re-read stops at the first paragraph break, so the
+    block reads back short and is reported as drift against a changelog nothing touched."""
+    once, _, _ = module.inject(SECTION, TRAILERED)
+    twice, changed, problems = module.inject(once, TRAILERED)
+
+    assert twice == once
+    assert changed == []
+    assert problems == []
+
+
+def test_deleting_a_registered_correction_from_the_changelog_is_reported_as_drift(
+    one_correction,
+):
+    """The register is the source of truth for a correction exactly as the commit message is
+    for the trailer, so an edited changelog copy has to fail `--check` the same way. Without
+    this, a correction could be silently removed from the released section it corrects."""
+    injected, _, _ = module.inject(SECTION, TRAILERED)
+    tampered = "\n".join(
+        line for line in injected.splitlines() if "Editorial correction" not in line
+    )
+
+    _, changed, problems = module.inject(tampered + "\n", TRAILERED)
+
+    assert changed == []
+    assert len(problems) == 1
+    assert "no longer matches" in problems[0]
+
+
+def test_every_registered_correction_names_itself_and_cites_an_issue():
+    """A guard on the real register, not on a fixture.
+
+    Inside the trailer's blockquote the label is the *only* thing separating editorial text
+    from the author's own words, so a paragraph that omits it silently converts a correction
+    into an apparent part of the disclosure -- the precise failure this mechanism exists to
+    avoid. Checked here rather than left to review, because it is checkable.
+
+    The cite is matched as `(#<digits>)` rather than by prefix: a bare `**Editorial
+    correction (#` names no issue at all and would otherwise pass, which is the half of the
+    label a reader actually follows.
+    """
+    for number, paragraphs in module.EDITORIAL_CORRECTIONS.items():
+        assert paragraphs, f"#{number} registers an empty correction"
+        for paragraph in paragraphs:
+            assert re.match(r"\*\*Editorial correction \(#\d+\)", paragraph), (
+                f"#{number}: a correction must open by naming itself editorial and citing "
+                f"the issue that raised it; got {paragraph[:60]!r}"
+            )
+
+
+def _repository_is_shallow() -> bool:
+    """Is this checkout missing history? `git log` then answers about one commit, not the repo."""
+    probe = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return probe.stdout.strip() == "true"
+
+
+def test_every_registered_correction_key_is_a_pr_number():
+    """Hermetic half of the key check, so it runs everywhere the suite does.
+
+    `inject` reads the register through `EDITORIAL_CORRECTIONS.get(number, [])` and `number`
+    comes from `bullet_pr_number`, which returns the digits out of `(#N)` / `[#N]`. A key that
+    is not those digits -- `"#1835"`, `"1835 "`, `"PR-1835"` -- can never match any bullet, and
+    the failure is total silence: nothing renders, nothing is reported, `--check` stays green.
+    """
+    for number in module.EDITORIAL_CORRECTIONS:
+        assert number.isdigit(), (
+            f"{number!r} is registered in EDITORIAL_CORRECTIONS but is not a bare PR number, "
+            "so `bullet_pr_number` can never produce it and the correction is unreachable"
+        )
+
+
+def test_every_registered_correction_names_a_pr_that_carries_a_trailer():
+    """The half that needs history: the key must name a real, trailered PR.
+
+    A transposed digit passes the hermetic check above and is still silent -- and the
+    changelog cannot answer it either, because a correction is routinely registered while its
+    bullet is still unrendered, in the window before release-plz cuts the section. What *is*
+    checkable is the commit: the key must name a PR in this history whose squash message
+    carries a `Representation-Change:` trailer, which is the only kind of bullet a correction
+    can ever attach to.
+
+    Skipped, loudly and by name, on a shallow checkout. `actions/checkout` defaults to
+    `fetch-depth: 1` and only the two jobs that need `<latest tag>..HEAD` override it
+    (`ci.yml:335`, `:395`); `Python Wheel Test`, which is where this file runs in CI, does
+    not -- so `squash_commits` would see one commit there and this would fail for the
+    environment rather than for the register. It arms in every full clone, which is where a
+    key is typed and where the pre-push hooks run.
+    """
+    if _repository_is_shallow():
+        pytest.skip("shallow checkout: `git log` cannot see the commit a key names")
+
+    by_pr = module.squash_commits(REPO_ROOT)
+    for number in module.EDITORIAL_CORRECTIONS:
+        message = by_pr.get(number)
+        assert message is not None, (
+            f"#{number} has a registered editorial correction but no commit in this history "
+            "cites it -- check the PR number for a typo"
+        )
+        assert module.disclosure_value(message) is not None, (
+            f"#{number} has a registered editorial correction but its commit carries no "
+            "`Representation-Change:` trailer, so it can never appear under a "
+            "Representation changes bullet"
+        )
 
 
 def test_a_multi_paragraph_disclosure_is_not_reported_as_drift_against_itself():


### PR DESCRIPTION
Closes #1886.

`750f2334` (#1835) is the largest representation change the project has made, and `scripts/inject_representation_disclosure.py` quotes its `Representation-Change:` trailer verbatim into the v0.14.0 changelog. That trailer names the wrong release and is silent about a conformance cost — and it cannot be edited, because it lives in a merged commit message.

## Where the fix had to land, and why not `CHANGELOG.md`

Three surfaces were candidates and two of them are dead ends:

- **The trailer.** Immutable. Correcting it means rewriting released history.
- **`CHANGELOG.md`.** Fails twice over. `publish.yml` runs release-plz on every push to `main` and release-plz regenerates the pending section of an open release PR, so a hand-written note is silently discarded at the next merge; and `inject_representation_disclosure.py --check` reports an edited block as drift against the trailer it no longer matches, which is exit 2 and red CI.
- **The injector.** Durable, because it re-renders the block on *every* run. So the correction is registered there, in a new `EDITORIAL_CORRECTIONS` table keyed by PR number, and is re-attached every time release-plz regenerates the section. `--check` then demands it rather than reporting it as drift.

It renders after the trailer's own words, inside the same blockquote, separated by a bare `  >` and opening with a label that names it editorial and cites this issue. Inside the block deliberately: a correction a reader can meet without the statement it corrects is worse than none, and every placement *outside* the block can be separated from it — one after it is dropped on the next regeneration, one before it re-orders on the next trailer. What keeps the trailer's words identifiable as the trailer's is therefore the label, which a test enforces on the real register rather than leaving to review. The bare `  >` separator is load-bearing too: without it a correction is a lazy continuation of the trailer's last paragraph and renders as the author's own closing sentence.

Note this is *not* the mechanism #1886 measured (a non-`  > `-prefixed line after the block, which passes both halves of `Changelog grouping audit` because `_is_disclosure_line` does not collect it). That works for a one-off hand edit of an already-tagged section; it does not survive a regeneration, and the release PR is still open.

## 1. The wrong release

The trailer closes by telling consumers to pin `FERRO_PARTITION=live` to reproduce **pre-v0.15.0** output. Verified rather than taken on faith: `Cargo.toml` is at `0.13.1`, `release-plz.toml` sets `features_always_increment_minor = true`, and the open release PR #1888 is titled `chore: release v0.14.0` and bumps `Cargo.toml` to `0.14.0`. So a consumer reading the v0.14.0 changelog is pointed at a release that does not exist yet.

`CONTRIBUTING.md` now adopts the version-free house form — *"to reproduce output from before this change"* — under **Declaring a representation change**, with the mechanism (which release a `feat:` cuts is not knowable when the trailer is written) and #1835 as the worked example of getting it wrong.

## 2. The undisclosed conformance cost

**Re-measured here, not copied.** `examples/measure_spec_conformance_per_arm`, one process per arm, `--direction three-prime`, against the prepared GRCh38 reference, at `45820926` (`origin/main` at branch time). `--only-inputs` names 932 of the fixture's 934 rows: the two excluded are `NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]` and its `inv` sibling, which #1846 measures as Θ(payload²) in a 10.8 Mb expanded insert and which do not terminate.

| arm | 3' conforms of 932 |
|---|---|
| `live` | 646 |
| `shadow` | 646 |
| `canonical` | 642 |
| **`canonical-coalesced`** (the new default) | **644** |

Every run: `completeness {attempted: 932, succeeded: 932, dropped: 0}`, `reached_partitioner = 232` (so the arm was genuinely exercised — a zero there would mean the census measured nothing about the arms), `unevaluable = 40`, `EXIT=0`.

### These are 4 lower than #1886's table, and the difference is arm-independent

#1886 records 650 / 650 / 646 / 648. Mine are exactly 4 lower on **all four** arms, so the shape is identical — `live == shadow`, `canonical-coalesced = canonical + 2`, and the number the disclosure turns on, **`live - canonical-coalesced = 2`, reproduces exactly**.

The uniform −4 is #1882, which merged after #1886's measurement was taken: it refuses a `c.` description whose reference resolves no CDS. Five corpus rows are now refused on `NM_004006.1` (`has no CDS start`), and exactly four of them carried a non-null `spec_expected` and so had been scoring as `preserved` — `c.123=`, `c.5697del`, `c.761_762insN[5]` and `c.[123=;456=;789=]`. The fifth, `c.-128354C>T`, has `spec_expected: null` and cost nothing. #1882's own commit message names `refseq.md:145`'s `NM_004006.1:c.5697del` as being in its moving set.

The changelog correction quotes the numbers measured at `45820926`, since that is the base the release is being cut from.

### The 2 rows, named — because the count alone reads as a regression and neither row is one

Diffing per-row output between `live` and `canonical-coalesced`: 8 rows change output, **2 stop matching the spec's stated form and 0 start**.

**Row 1 — the `DNA/delins.md` pair.** Both rows are harvested from `docs/recommendations/DNA/delins.md`:

| corpus row | `live` | `canonical-coalesced` |
|---|---|---|
| `c.[850_869del;874_881del;887_897del;901_902insG]` | echoes itself (`preserved`) | `NM_004006.2:c.850_901delinsTTCCTCGATGCCTG` (`diverges`) |
| `LRG_199t1:c.850_901delinsTTCCTCGATGCCTG` | echoes itself (`preserved`) | echoes itself (`preserved`) |

`spec_expected` defaults to a row's own input, so `preserved` is a round trip. The spec publishes one variant as two rows — the spanning delins `:47` recommends, and the split `:46` calls its "alternative description" — and both echoed. Converging them onto one canonical form must cost exactly one echo, whichever form wins. The winner here is the spanning form the spec recommends.

**Row 2 — `LRG_199t1:c.992_1004delinsAC`, which is not from the recommendations at all.** Its `source_kind` is `consultation`, `working_group: SVD-WG010`, harvested from `docs/consultation/SVD-WG010.md:50` — the **rejected** proposal. `tests/it/spec_worked_example_rules.rs`'s `W58` already pins that spelling as one ferro must *not* produce from the split input; under the new default ferro no longer echoes it back either, emitting `c.[992_993del;995_997del;999_1004del]`.

So #1886's summary — "each loses its echo by adopting the sibling spelling `DNA/delins.md:47` recommends" — holds for row 1 and **not** for row 2, which is a different shape with a different provenance. The correction says so rather than repeating it. Per #1886 it does **not** say "more conformant"; it does not say "less" either, because the measurement supports neither.

The 5' column is omitted throughout: #1879 removes that direction from the public surface in this same release.

## Left for #1885

The trailer's own closing statement — that the real-corpus row count over ClinVar/CMRG/Paraphase is owed and tracked as #1885 — is untouched, and the register takes paragraphs by append, so #1885's figure lands as a further paragraph rather than a rewrite of either of these.

## Verification

- `python3 scripts/inject_representation_disclosure.py --check` on this branch: `EXIT=0` (no-op — `CHANGELOG.md` here holds only released sections).
- Rendered end to end against a copy of #1888's own `CHANGELOG.md`: 34 disclosures attached, `EXIT=0`; the correction lands under #1835's bullet; a second run and `--check` are both `EXIT=0` (idempotent, which is what makes it survive regeneration).
- `python3 scripts/check_changelog_grouping.py`: `EXIT=0`, "Representation changes section is consistent with the trailers".
- `pytest tests/python/test_inject_representation_disclosure.py tests/python/test_changelog_grouping.py tests/python/test_representation_change_trailer.py`: 186 passed.
- `ruff check` / `ruff format --check` over `scripts/` and `tests/python/`, `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`: all clean.

Five new tests: nothing is attached for a PR with no registered correction; a registered one lands below the trailer with its separator; re-running is a no-op; deleting it from the changelog is reported as drift; and every paragraph in the real register opens by naming itself editorial and citing an issue.

Representation-Change: none. Documentation and a changelog-rendering script; nothing under `src/normalize/`, `src/hgvs/`, `src/spdi/` or `src/project/` is touched, no normalized output moves, and no expectation was re-blessed. The conformance figures quoted above are a measurement of the already-merged #1835, not of this change.
