### PR TITLE
fix(data): populate MappingInfo::transcript_id on the g. to c. path

### DIFF
--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -22,6 +22,17 @@ pub struct MappingResult<T> {
 #[derive(Debug, Clone, Default)]
 pub struct MappingInfo {
     /// The transcript used for mapping.
+    ///
+    /// Every [`CoordinateMapper`] method that returns a [`MappingResult`]
+    /// populates this on success, in both directions, with the accession the
+    /// caller asked the mapping to be performed against. (`new`, `cdot` and
+    /// `find_overlapping_transcripts` return no `MappingInfo` at all.)
+    ///
+    /// It stays `Option` for backwards compatibility of a `pub` field, not
+    /// because of the [`Default`] derive above — `String` implements
+    /// [`Default`], so the derive would be satisfied either way. A `None`
+    /// therefore means the value was default-constructed rather than produced
+    /// by a successful mapping (#1895).
     pub transcript_id: Option<String>,
     /// Exon number(s) involved.
     pub exon_numbers: Vec<u32>,
@@ -519,11 +530,32 @@ impl CoordinateMapper {
         genome_pos: &GenomePos,
         transcript_id: &str,
     ) -> Result<(CdsPos, MappingInfo), FerroError> {
-        // No in-tree consumer reads `MappingInfo::transcript_id`, so it is left
-        // None: that avoids a `String::from` allocation per call (~400 calls per
-        // SNP project_all on chr17 fan-out). `transcript_id` is still named in
-        // the inverted-CDS refusal below, which allocates only on the error path.
-        let mut info = MappingInfo::default();
+        // Populated on every success, matching `cds_pos_to_genome_pos` and the
+        // field's own documentation (#1895).
+        //
+        // This used to be left `None` to avoid a `String::from` per call (~400
+        // calls per SNP `project_all` on a chr17 fan-out), on the ground that no
+        // in-tree consumer reads it. Two things retire that reasoning:
+        //
+        // - `MappingInfo` is `pub` and re-exported from `crate::data`, so "no
+        //   in-tree consumer" is not the bar. An external consumer reading a
+        //   documented `Option<String>` could not tell "this path does not
+        //   populate it" from "no transcript could be determined" — and the
+        //   sibling direction, `cds_pos_to_genome_pos`, allocates the same
+        //   string unconditionally, so the contract was direction-dependent and
+        //   said so nowhere.
+        // - The saving is ~0.3% of the work it sits inside. Measured in a
+        //   release build, interleaved A/B over a 400-transcript fan-out
+        //   repeated 500 times: 36.5 ns/call without, 51.9 ns/call with
+        //   (min-of-10) — so this line costs +15.4 ns. But the unit a fan-out
+        //   actually repeats is a whole per-transcript projection, and
+        //   `VariantProjector::project` costs 4,596 ns (min-of-5, spread 1.4%)
+        //   on a 9-base mock transcript — a floor for a real one. +15.4 ns
+        //   against >=4,596 ns is +0.33% of a fan-out, or better.
+        let mut info = MappingInfo {
+            transcript_id: Some(transcript_id.to_string()),
+            ..Default::default()
+        };
 
         // Check if position is in an exon. `locate_genome_pos` returns both
         // the exon and the converted tx position in a single scan; before
@@ -996,6 +1028,138 @@ mod tests {
             end.base,
             end.offset.unwrap_or(0),
         );
+    }
+
+    fn cds(base: i64) -> CdsPos {
+        CdsPos {
+            base,
+            offset: None,
+            utr3: false,
+            special: None,
+        }
+    }
+
+    /// #1895: `MappingInfo::transcript_id` is `pub` on a re-exported struct and
+    /// its doc comment promises the transcript the mapping used, so every
+    /// [`CoordinateMapper`] success path must actually carry it.
+    ///
+    /// Before #1895 the g. -> c. direction (`genome_pos_to_cds_pos`) left it
+    /// `None` while the c. -> g. direction populated it, so the contract was
+    /// direction-dependent and undocumented — an external consumer could not
+    /// tell "this path does not populate it" from "no transcript could be
+    /// determined". Every row below whose method reaches `genome_pos_to_cds_pos`
+    /// fails without that fix.
+    ///
+    /// Deliberately covers both directions, both strands, both the single-
+    /// position and the interval entry points, and every exonic region kind
+    /// (`CdsPosition::{Cds, FivePrimeUtr, ThreePrimeUtr}`) plus the intronic
+    /// arm, because the field is set in one place per direction and a future
+    /// refactor that splits either one would otherwise be free to drop it on a
+    /// single arm.
+    ///
+    /// One arm is absent, and its absence is structural rather than an
+    /// oversight: both of `create_test_mapper`'s transcripts put `cds_end`
+    /// inside their last exon, so no intron flanks a 3'UTR boundary and the
+    /// intronic-3'UTR arm — the one carrying the inverted-CDS refusal — is
+    /// unreachable from this fixture. Reaching it needs a third transcript.
+    #[test]
+    fn every_mapping_success_reports_the_transcript_it_used() {
+        let mapper = create_test_mapper();
+
+        // (label, accession, the resulting MappingInfo)
+        let observed: Vec<(&str, &str, MappingInfo)> = vec![
+            (
+                "cds_to_genome (CDS, plus)",
+                "NM_TEST.1",
+                mapper.cds_to_genome("NM_TEST.1", &cds(1)).unwrap().info,
+            ),
+            (
+                "cds_to_genome_on_build (CDS, plus)",
+                "NM_TEST.1",
+                mapper
+                    .cds_to_genome_on_build("NM_TEST.1", &cds(1), None)
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "cds_interval_to_genome (plus)",
+                "NM_TEST.1",
+                mapper
+                    .cds_interval_to_genome("NM_TEST.1", &CdsInterval::new(cds(1), cds(51)))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_to_cds (exonic CDS, plus)",
+                "NM_TEST.1",
+                mapper
+                    .genome_to_cds("NM_TEST.1", &GenomePos::new(1050))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_to_cds_on_build (exonic CDS, plus)",
+                "NM_TEST.1",
+                mapper
+                    .genome_to_cds_on_build("NM_TEST.1", &GenomePos::new(1050), None)
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_to_cds (5'UTR, plus)",
+                "NM_TEST.1",
+                mapper
+                    .genome_to_cds("NM_TEST.1", &GenomePos::new(1020))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                // Exon 3 is genome [3000, 3150] = tx [300, 450] and `cds_end`
+                // is tx 400, so genome 3105 is tx 405 — six bases into the
+                // 3'UTR (`c.*6`).
+                "genome_to_cds (exonic 3'UTR, plus)",
+                "NM_TEST.1",
+                mapper
+                    .genome_to_cds("NM_TEST.1", &GenomePos::new(3105))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_to_cds (intronic, plus)",
+                "NM_TEST.1",
+                mapper
+                    .genome_to_cds("NM_TEST.1", &GenomePos::new(1500))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_to_cds (intronic, minus)",
+                "NM_MINUS.1",
+                mapper
+                    .genome_to_cds("NM_MINUS.1", &GenomePos::new(2205))
+                    .unwrap()
+                    .info,
+            ),
+            (
+                "genome_interval_to_cds (intron-flanked, minus)",
+                "NM_MINUS.1",
+                mapper
+                    .genome_interval_to_cds(
+                        "NM_MINUS.1",
+                        &GenomeInterval::new(GenomePos::new(1995), GenomePos::new(2205)),
+                    )
+                    .unwrap()
+                    .info,
+            ),
+        ];
+
+        for (label, accession, info) in &observed {
+            assert_eq!(
+                info.transcript_id.as_deref(),
+                Some(*accession),
+                "{label}: MappingInfo::transcript_id must name the transcript the mapping used",
+            );
+        }
     }
 
     /// Build a mapper with a single-exon transcript carrying a CIGAR


### PR DESCRIPTION
Closes #1895

`MappingInfo::transcript_id` is `pub` on a struct re-exported from `crate::data`, and its doc comment says it is "the transcript used for mapping". `CoordinateMapper::genome_pos_to_cds_pos` left it `None` on every success, so an external consumer reading a documented `Option<String>` got `None` from every `genome_to_cds` / `genome_to_cds_on_build` / `genome_interval_to_cds` call and had no way to tell that apart from "the mapper could not determine one".

This populates it. The issue offered four options; the reasoning for picking this one is below, including the measurement, because the comment that justified leaving it `None` cited a real cost on a real hot path.

## The asymmetry the issue does not mention

The two directions did not agree. `cds_pos_to_genome_pos` — the c. -> g. half of the same `impl`, on the same accession, ten lines of setup away — has always populated the field, unconditionally:

```rust
let mut info = MappingInfo {
    transcript_id: Some(transcript_id.to_string()),
    ..Default::default()
};
```

So the field was not "never populated"; it was populated in one direction and not the other, and nothing said so. That is worse than either consistent answer, and it removes most of the force of the performance argument: the allocation the g. -> c. path was avoiding is one the c. -> g. path already pays.

## Why not the other options

- **Fix the doc instead.** This would have to document the asymmetry rather than remove it — "populated by `cds_to_genome`, not by `genome_to_cds`" — which is a strange contract to pin deliberately, and it leaves the caller with a field they still cannot use.
- **Drop the field.** A breaking change to a re-exported type, to remove information the caller plausibly wants and which one direction already computes.
- **Borrow it (`Option<&str>` + lifetime, or a handle).** Also breaking — `MappingInfo` and `MappingResult<T>` are both re-exported and would both gain a lifetime — and it is not free either: `CdotMapper` stores its accessions as `String` map keys, so making this allocation-free would mean changing that storage to `Arc<str>` as well. That is a large change to buy back the 15 ns measured below.

## Measurement

The comment cited "~400 calls per SNP `project_all` on chr17 fan-out", so I reproduced that shape rather than asserting the allocation is cheap. Release build, interleaved A/B, two binaries built from the two revisions of the crate and run alternately; every run asserts its own success count (200,000 mappings) and a checksum over the returned c. coordinates, so a crashed or short-circuited run cannot read as a fast one.

**Numerator** — 400 transcripts overlapping one genomic position, one `genome_to_cds` each, repeated 500 times, 10 runs per arm:

| arm | min ns/call | median | `transcript_id` populated |
|---|---:|---:|---:|
| without | 36.49 | 38.09 | 0 / 200,000 |
| with | 51.90 | 53.33 | 200,000 / 200,000 |

So the line costs **+15.4 ns/call**, or +6.2 us per 400-transcript fan-out. In isolation that is a ~42% slowdown of `genome_to_cds`, which is why the original comment is not unreasonable.

**Denominator** — but `genome_to_cds` is not the unit a fan-out repeats. `project_all` runs a whole projection per transcript, so `VariantProjector::project` is one unit of the fan-out. Measured on `benches/projection.rs`'s `plus_projector` (a 9-base single-exon mock transcript with an in-memory provider — i.e. a floor for a real chr17 transcript), 20,000 iterations, 5 runs:

**4,596 ns per projection** (min of 5; runs spanned 4,563-4,629 ns, spread 1.4%).

+15.4 ns against >= 4,596 ns is **+0.33% of a fan-out, or better**. The measurement is recorded on the code so the next person does not have to re-derive it.

## Test

`data::mapping::tests::every_mapping_success_reports_the_transcript_it_used` asserts the field names the requested accession across all six public `CoordinateMapper` entry points, both directions, both strands, and the CDS / 5'UTR / intronic / interval region kinds. Verified as a guard rather than assumed: reverting the production change to `MappingInfo::default()` fails it on the first g. -> c. row (`left: None, right: Some("NM_TEST.1")`), and it passes with the change.

It deliberately covers rows that already passed (the c. -> g. ones), because the field is set in exactly one place per direction and a refactor that splits either one would otherwise be free to drop it on a single arm.

## Scope

No behaviour changes. Nothing in the tree reads `MappingInfo::transcript_id` — the many `.transcript_id` hits in `src/project/projector.rs` and `src/data/projection.rs` are on `TranscriptProjection` / `VariantProjection`, a different struct — `MappingInfo` has no serde derive, and it is not exposed through the Python bindings, so no rendered output moves.

Representation-Change: none. `src/data/` only; populates a public field no code path reads and no output renders.
