### PR TITLE
fix(normalize): report REFSEQ_MISMATCH at a coordinate, not a window offset

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5229,6 +5229,97 @@ struct WindowedNormalization {
     warnings: Vec<NormalizationWarning>,
 }
 
+/// Where the 1-based span [`Normalizer::normalize_na_edit`] is handed sits,
+/// relative to a coordinate a reader can act on.
+///
+/// That function indexes `ref_seq` from `start`, so its positions are always in
+/// the frame of the *slice it was given*. For most callers the slice is the
+/// whole sequence the description addresses and the two coincide; for the
+/// callers that fetch a window they do not, and a diagnostic built from the raw
+/// numbers reports the window's own offsets as if they were coordinates
+/// (#1612 — `NC_000001.11:g.201C>T` reported `100-100`).
+///
+/// # What the rendered coordinate promises
+///
+/// **The 1-based inclusive span on the reference sequence that was actually
+/// read**, in that sequence's own numbering — not the description's axis. That
+/// is the promise the cis producer already documents and implements
+/// (`merge::authored_reference_mismatch`, "the sequence-axis span, via
+/// `region_sequence_delta`"), and the two must agree because the dedupe in
+/// `normalize_core` is keyed on nothing but this string. So a `c.5C>T` on a
+/// transcript whose CDS starts at 21 reports `25-25`, the transcript offset,
+/// on both producers — that is deliberate and is not what #1612 is about.
+///
+/// On `g.`/`m.` the sequence read is the contig, so the span *is* the
+/// description's own coordinate. On `c.`/`n.`/`r.` the sequence read is the
+/// transcript, so it is the transcript offset. In both cases the accession is
+/// the one the description names, and the bare `<start>-<end>` form is
+/// unambiguous.
+///
+/// [`Self::GenomicWindow`] is the case where it is not: an intronic or
+/// boundary-spanning transcript description is shuffled against the **genomic
+/// contig**, which is not the sequence its accession names. A bare number there
+/// would be a coordinate in a space the reader has no way to guess, so that
+/// arm qualifies it with the contig accession. Nothing dedupes against it — the
+/// cis producer declines every offset position (`merge::simple_cds_pos`), so no
+/// duplicate of an intronic finding can exist to match.
+#[derive(Debug, Clone, Copy)]
+enum MismatchFrame<'a> {
+    /// The slice is the whole sequence the description addresses, so the span
+    /// is already the coordinate to report. Every transcript-axis caller.
+    SequenceAxis,
+    /// The slice is a window opening `window_start` bases into that sequence
+    /// (0-based), so `sequence = window_relative + window_start` — the same
+    /// reconstruction [`WindowedNormalization`] documents for the *result*
+    /// positions, applied to the reported ones.
+    Window { window_start: u64 },
+    /// The slice is a window on the genomic contig `accession`, opening at
+    /// 1-based `seq_start`, and flipped into transcript view when `strand` is
+    /// minus. The reported coordinate is genomic and says so.
+    GenomicWindow {
+        accession: &'a str,
+        seq_start: u64,
+        strand: Strand,
+        window_len: u64,
+    },
+}
+
+impl MismatchFrame<'_> {
+    /// Render the 1-based inclusive slice-relative span `[start, end]` as the
+    /// coordinate a reader should be shown.
+    fn render(&self, start: u64, end: u64) -> String {
+        match *self {
+            Self::SequenceAxis => format!("{start}-{end}"),
+            Self::Window { window_start } => format!(
+                "{}-{}",
+                start.saturating_add(window_start),
+                end.saturating_add(window_start)
+            ),
+            Self::GenomicWindow {
+                accession,
+                seq_start,
+                strand,
+                window_len,
+            } => {
+                // The same unflip the caller applies to the *result* positions,
+                // so the two cannot drift. Clamped rather than trusted: the
+                // helper subtracts from `window_len`, and every span reaching
+                // here is in-window by construction (`flip_intronic_for_strand`
+                // refuses otherwise), but a clamp costs nothing and a debug
+                // overflow panic in a diagnostic path costs a lot.
+                let (lo, hi) = unflip_intronic_positions(
+                    strand,
+                    window_len,
+                    start.min(window_len),
+                    end.min(window_len),
+                );
+                let genomic = |rel: u64| rel.saturating_add(seq_start).saturating_sub(1);
+                format!("{accession}:{}-{}", genomic(lo), genomic(hi))
+            }
+        }
+    }
+}
+
 impl<P: ReferenceProvider> Normalizer<P> {
     /// Clamp a window-fetch upper bound to the contig length.
     ///
@@ -5344,6 +5435,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 // reading frame; both callers passed this before the growth
                 // loop was factored out of them.
                 CodonGate::NotApplicable,
+                MismatchFrame::Window { window_start },
             )?;
 
             let seq_len = ref_seq.len() as u64;
@@ -5463,6 +5555,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // Same reasoning as the growth loop's own call: neither axis
             // reaching here carries a reading frame.
             CodonGate::NotApplicable,
+            MismatchFrame::Window {
+                window_start: slice_start,
+            },
         )?;
 
         // Extent claim, arrived at from the other direction — an `ins` or `dup`
@@ -6577,8 +6672,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
             tx_start,
             tx_end,
         );
-        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, gate)?;
+        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                seq,
+                edit,
+                tx_start,
+                tx_end,
+                &boundaries,
+                gate,
+                MismatchFrame::SequenceAxis,
+            )?;
 
         // Substitutions are validated-then-returned-unchanged by
         // `normalize_na_edit`'s `Substitution` arm; nothing downstream (axis
@@ -6700,8 +6803,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 ShuffleDirection::ThreePrime => cheap_right,
             };
             let (left_clamp_fired, right_clamp_fired) = if direction_could_clamp {
-                let (exon_only_start, exon_only_end, _exon_only_edit, _exon_only_warnings) =
-                    self.normalize_na_edit(seq, edit, tx_start, tx_end, &exon_only, gate)?;
+                let (exon_only_start, exon_only_end, _exon_only_edit, _exon_only_warnings) = self
+                    .normalize_na_edit(
+                    seq,
+                    edit,
+                    tx_start,
+                    tx_end,
+                    &exon_only,
+                    gate,
+                    MismatchFrame::SequenceAxis,
+                )?;
                 let exon_only_start_0 = exon_only_start.saturating_sub(1);
                 (
                     cheap_left && exon_only_start_0 < boundaries.left,
@@ -7307,6 +7418,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             tx_end,
             &boundaries,
             CodonGate::NotApplicable,
+            MismatchFrame::SequenceAxis,
         )?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
@@ -9067,8 +9179,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let gate = CodonGate::for_input_span(cds_info, tx_start, tx_end);
         // `mut` bindings are #1202's (its transcript-bound clamp rewrites these
         // in place).
-        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, gate)?;
+        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                seq,
+                edit,
+                tx_start,
+                tx_end,
+                &boundaries,
+                gate,
+                MismatchFrame::SequenceAxis,
+            )?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
         // substitutions are validated-then-returned-unchanged by
@@ -10064,6 +10184,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             CodonGate::NotApplicable,
+            // The bases read here are the CONTIG's, not the transcript the
+            // description names, and `work_*` are offsets into a window that
+            // is reverse-complemented on a minus-strand transcript. So the
+            // reported coordinate is genomic and is qualified by the contig
+            // accession — see [`MismatchFrame::GenomicWindow`] (#1612).
+            MismatchFrame::GenomicWindow {
+                accession: chromosome,
+                seq_start,
+                strand: transcript.strand,
+                window_len: work_seq.len() as u64,
+            },
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -10247,6 +10378,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             CodonGate::NotApplicable,
+            // The bases read here are the CONTIG's, not the transcript the
+            // description names, and `work_*` are offsets into a window that
+            // is reverse-complemented on a minus-strand transcript. So the
+            // reported coordinate is genomic and is qualified by the contig
+            // accession — see [`MismatchFrame::GenomicWindow`] (#1612).
+            MismatchFrame::GenomicWindow {
+                accession: chromosome,
+                seq_start,
+                strand: transcript.strand,
+                window_len: work_seq.len() as u64,
+            },
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -10414,6 +10556,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             CodonGate::NotApplicable,
+            // The bases read here are the CONTIG's, not the transcript the
+            // description names, and `work_*` are offsets into a window that
+            // is reverse-complemented on a minus-strand transcript. So the
+            // reported coordinate is genomic and is qualified by the contig
+            // accession — see [`MismatchFrame::GenomicWindow`] (#1612).
+            MismatchFrame::GenomicWindow {
+                accession: chromosome,
+                seq_start,
+                strand: transcript.strand,
+                window_len: work_seq.len() as u64,
+            },
         )?;
 
         let (new_rel_start, new_rel_end) = unflip_intronic_positions(
@@ -10863,6 +11016,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             CodonGate::NotApplicable,
+            // The bases read here are the CONTIG's, not the transcript the
+            // description names, and `work_*` are offsets into a window that
+            // is reverse-complemented on a minus-strand transcript. So the
+            // reported coordinate is genomic and is qualified by the contig
+            // accession — see [`MismatchFrame::GenomicWindow`] (#1612).
+            MismatchFrame::GenomicWindow {
+                accession: chromosome,
+                seq_start,
+                strand: transcript.strand,
+                window_len: work_seq.len() as u64,
+            },
         )?;
 
         let (new_rel_start, new_rel_end) = unflip_intronic_positions(
@@ -10899,6 +11063,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Core normalization for nucleic acid edits
     ///
     /// Returns (new_start, new_end, new_edit, warnings)
+    ///
+    /// `frame` says where `start`/`end` sit relative to something a reader can
+    /// act on; it is used only to render a diagnostic coordinate and never
+    /// influences the normalization itself. See [`MismatchFrame`] — every
+    /// caller must state it, because a caller that hands this function a
+    /// *window* and says nothing is exactly how #1612 shipped.
+    ///
+    /// `too_many_arguments`: `frame` is the eighth and takes it one over the
+    /// threshold. It is deliberately a **parameter** rather than something
+    /// derived here — this function cannot see whether `ref_seq` is a whole
+    /// sequence or a window, which is why the wrong coordinate shipped at all,
+    /// and only the caller can answer. Bundling it with `boundaries`/`gate`
+    /// into a context struct was the alternative; it buys nothing semantically
+    /// (the three are independent) and would re-touch fourteen call sites.
+    #[allow(clippy::too_many_arguments)]
     fn normalize_na_edit(
         &self,
         ref_seq: &[u8],
@@ -10910,6 +11089,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `input_span_is_coding()` for the input edit's own span,
         // `span_is_coding(a, b)` for any other (a shuffled tract, say).
         gate: CodonGate,
+        frame: MismatchFrame<'_>,
     ) -> Result<(u64, u64, NaEdit, Vec<NormalizationWarning>), FerroError> {
         let mut warnings = Vec::new();
 
@@ -10958,8 +11138,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     // interpolates the *outer* one, and two `edit`s a line apart
                     // meaning different things is a trap.
                     Some(delins) => {
-                        let (delins_start, delins_end, canonical, delins_warnings) =
-                            self.normalize_na_edit(ref_seq, &delins, 1, 1, boundaries, gate)?;
+                        let (delins_start, delins_end, canonical, delins_warnings) = self
+                            .normalize_na_edit(ref_seq, &delins, 1, 1, boundaries, gate, frame)?;
                         warnings.extend(delins_warnings);
                         Ok((delins_start, delins_end, canonical, warnings))
                     }
@@ -11023,7 +11203,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             warnings.push(NormalizationWarning::RefSeqMismatch {
                 stated_ref: validation.stated_ref.unwrap_or_default(),
                 actual_ref: validation.actual_ref.unwrap_or_default(),
-                position: format!("{}-{}", start, end),
+                // NOT `start`/`end`: those are offsets into whatever slice this
+                // function was handed, and for a windowed caller that is not a
+                // coordinate anyone can act on. `frame` converts them back.
+                // (#1612 — this used to report `100-100` for `g.201C>T`, and
+                // the same string is strict mode's `FerroError::ReferenceMismatch`
+                // `location` and the key the cis dedupe matches on.)
+                position: frame.render(start, end),
                 corrected,
                 details: validation.warning,
             });
@@ -11095,7 +11281,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             sequence: InsertedSequence::Literal(Sequence::new(expanded)),
                         };
                         let (new_start, new_end, new_edit, mut child_warnings) = self
-                            .normalize_na_edit(ref_seq, &literal, start, end, boundaries, gate)?;
+                            .normalize_na_edit(
+                                ref_seq, &literal, start, end, boundaries, gate, frame,
+                            )?;
                         warnings.append(&mut child_warnings);
                         return Ok((new_start, new_end, new_edit, warnings));
                     }
@@ -11153,7 +11341,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         sequence: None,
                         length: None,
                     };
-                    return self.normalize_na_edit(ref_seq, &del, start, end, boundaries, gate);
+                    return self
+                        .normalize_na_edit(ref_seq, &del, start, end, boundaries, gate, frame);
                 }
 
                 // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
@@ -11238,6 +11427,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     e0 as u64,
                                     boundaries,
                                     gate,
+                                    frame,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -11298,6 +11488,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     (after_index + 1) as u64,
                                     boundaries,
                                     gate,
+                                    frame,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -11343,6 +11534,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     e0 as u64,
                                     boundaries,
                                     gate,
+                                    frame,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -11553,7 +11745,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             // transcript, so the same CDS bounds (#1185).
                             let (rec_start, rec_end, rec_edit, mut rec_warnings) = self
                                 .normalize_na_edit(
-                                    ref_seq, &ins_edit, ins_start, ins_end, boundaries, gate,
+                                    ref_seq, &ins_edit, ins_start, ins_end, boundaries, gate, frame,
                                 )?;
                             warnings.append(&mut rec_warnings);
                             return Ok((rec_start, rec_end, rec_edit, warnings));
@@ -12116,6 +12308,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 let (rec_start, rec_end, rec_edit, mut rec_warnings) = self
                                     .normalize_na_edit(
                                         ref_seq, &ins_edit, ins_start, ins_end, boundaries, gate,
+                                        frame,
                                     )?;
                                 let mut merged = warnings;
                                 merged.append(&mut rec_warnings);

--- a/src/normalize/validate.rs
+++ b/src/normalize/validate.rs
@@ -561,7 +561,13 @@ fn validate_single_base(stated: &Base, ref_seq: &[u8], pos: u64) -> ValidationRe
     if idx >= ref_seq.len() {
         return ValidationResult::mismatch(
             stated.to_char().to_string(),
-            format!("(position {} out of range)", pos),
+            // No coordinate here, deliberately (#1612). `pos` indexes the slice
+            // this function was handed, which for a windowed caller is not a
+            // coordinate any reader can act on — the same defect the warning's
+            // `position` field carried. That field now renders the span through
+            // `MismatchFrame`, so it already names where this happened and
+            // restating it from the raw index could only contradict it.
+            "(position out of range)".to_string(),
         );
     }
 
@@ -586,14 +592,12 @@ fn validate_sequence(stated: &[Base], ref_seq: &[u8], start: u64, end: u64) -> V
 
     if end_idx > ref_seq.len() {
         let stated_str: String = stated.iter().map(|b| b.to_char()).collect();
-        return ValidationResult::mismatch(stated_str, format!("(position {} out of range)", end));
+        // Coordinate-free for the reason on `validate_single_base` (#1612).
+        return ValidationResult::mismatch(stated_str, "(position out of range)".to_string());
     }
     if start_idx > end_idx {
         let stated_str: String = stated.iter().map(|b| b.to_char()).collect();
-        return ValidationResult::mismatch(
-            stated_str,
-            format!("(inverted range: start {} > end {})", start, end),
-        );
+        return ValidationResult::mismatch(stated_str, "(inverted range)".to_string());
     }
 
     let actual_bytes = &ref_seq[start_idx..end_idx];
@@ -640,10 +644,14 @@ fn validate_stated_length(declared: u64, start: u64, end: u64) -> ValidationResu
     if declared == span {
         ValidationResult::ok()
     } else {
-        ValidationResult::mismatch(
-            format!("length {declared}"),
-            format!("span {span} ({start}_{end})"),
-        )
+        // `span {span}` and no endpoints (#1612). `start`/`end` index the slice
+        // the caller handed in, so on the windowed callers the old
+        // `span 2 (100_101)` restated a window offset in HGVS range notation —
+        // for `g.201_202del5` the very same warning read `at 201-202` beside
+        // `span 2 (100_101)`, contradicting itself. The endpoints are the
+        // warning's `position` field's job and it renders them correctly; the
+        // width is what this check is about.
+        ValidationResult::mismatch(format!("length {declared}"), format!("span {span}"))
     }
 }
 

--- a/tests/it/issue_1612_refseq_mismatch_coordinate.rs
+++ b/tests/it/issue_1612_refseq_mismatch_coordinate.rs
@@ -1,0 +1,716 @@
+//! Issue #1612 — `REFSEQ_MISMATCH` must not report a window-relative offset as
+//! if it were a coordinate.
+//!
+//! `Normalizer::normalize_na_edit` indexes the slice it is handed, so its
+//! `start`/`end` are in the frame of that slice. Most callers hand it the whole
+//! sequence the description addresses, and for those the two coincide. The
+//! genomic and mitochondrial callers hand it a **fetched window**, and nothing
+//! converted the pair back before it was formatted into the warning's
+//! `position` field. Measured on `main` before the fix, against a 400-base
+//! `ACGT`-cycling contig whose base 201 is `A`:
+//!
+//! ```text
+//! NC_000001.11:g.201C>T   ->  reference sequence mismatch at 100-100
+//! ```
+//!
+//! `100` is `201 - window_start`, with `window_start = 201 - window_size`. The
+//! mismatch is real; only the coordinate was wrong.
+//!
+//! # What the field promises
+//!
+//! **The 1-based inclusive span on the reference sequence that was actually
+//! read**, in that sequence's own numbering. That is what the cis producer
+//! (`merge::authored_reference_mismatch`) already documented and implemented —
+//! "the sequence-axis span, via `region_sequence_delta`" — and the two must
+//! agree, because the duplicate-suppression in `normalize_core` is keyed on
+//! this string and nothing else.
+//!
+//! So the promise is deliberately **not** "the description's own axis". A
+//! `c.5C>T` on a transcript whose CDS starts at 21 reports the transcript
+//! offset `25-25` on both producers; moving it to `5-5` would have been a
+//! second wrong answer and would have broken the dedupe. Those axes were
+//! already correct and are pinned below so a future change cannot quietly
+//! "fix" them apart.
+//!
+//! # Three things this actually repairs
+//!
+//! 1. The genomic/mitochondrial coordinate itself.
+//! 2. The `location` of strict mode's `FerroError::ReferenceMismatch`, which is
+//!    the same string.
+//! 3. The dedupe against the cis producer, which had silently stopped matching
+//!    on the genomic axis — a two-member allele with two distinct mismatches
+//!    reported **four** warnings, two of them at the *same* fabricated
+//!    `100-100`, because each member is windowed about itself.
+//!
+//! The intronic and boundary-spanning transcript paths are a fourth case and a
+//! different answer: they shuffle against the genomic **contig**, which is not
+//! the sequence the accession names, so a bare number there would be a
+//! coordinate in a space the reader cannot guess. Those report the genomic span
+//! qualified by the contig accession. Nothing dedupes against them —
+//! `merge::simple_cds_pos` declines every offset position, so no cis-side
+//! duplicate of an intronic finding can exist.
+
+use std::io::Write;
+
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, FerroError, JsonProvider, MockProvider, NormalizeConfig, Normalizer};
+
+/// The fixture alphabet, shared by every provider below: base `n` (1-based) is
+/// `"ACGT"[(n - 1) % 4]`.
+fn base_at(pos1: usize) -> char {
+    ['A', 'C', 'G', 'T'][(pos1 - 1) % 4]
+}
+
+/// A genome-capable provider serving one `len`-base `ACGT`-cycling contig.
+fn genomic_provider(contig: &str, len: usize) -> JsonProvider {
+    let seq: String = (1..=len).map(base_at).collect();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// Every `RefSeqMismatch` position in `warnings`, in order.
+fn mismatch_positions(warnings: &[NormalizationWarning]) -> Vec<String> {
+    warnings
+        .iter()
+        .filter_map(|w| match w {
+            NormalizationWarning::RefSeqMismatch { position, .. } => Some(position.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The single `RefSeqMismatch` in `warnings`, or a panic naming what was there.
+fn sole_mismatch(warnings: &[NormalizationWarning]) -> &NormalizationWarning {
+    let mut found = warnings
+        .iter()
+        .filter(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. }));
+    let first = found
+        .next()
+        .unwrap_or_else(|| panic!("expected a RefSeqMismatch; got {warnings:?}"));
+    assert!(
+        found.next().is_none(),
+        "expected exactly one RefSeqMismatch; got {warnings:?}"
+    );
+    first
+}
+
+/// Normalize leniently and hand back the warnings.
+fn lenient_warnings<P>(provider: P, input: &str) -> Vec<NormalizationWarning>
+where
+    P: ferro_hgvs::reference::ReferenceProvider,
+{
+    let variant = parse_hgvs(input).unwrap();
+    Normalizer::with_config(provider, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&variant)
+        .unwrap_or_else(|e| panic!("lenient must accept `{input}`: {e:?}"))
+        .warnings
+}
+
+/// The bases the inputs below assume. Asserted rather than trusted, so a change
+/// to `base_at` fails here — where the cause is obvious — rather than
+/// downstream as a mystery about coordinates.
+#[test]
+fn the_fixture_carries_the_bases_the_inputs_assume() {
+    assert_eq!(base_at(201), 'A', "the g. reproducer states C over an A");
+    assert_eq!(base_at(300), 'T', "the second cis member states G over a T");
+    assert_eq!(base_at(314), 'C', "the plus-strand intronic base");
+    assert_eq!(
+        base_at(395),
+        'G',
+        "the minus-strand intronic base, genomic view"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The reported issue
+// ---------------------------------------------------------------------------
+
+/// The issue's own reproducer. `g.201` is `A`; stating `C` is a real mismatch,
+/// and it must be reported at `201-201` rather than at the window offset
+/// `100-100`.
+#[test]
+fn a_genomic_mismatch_reports_the_genomic_coordinate() {
+    let warnings = lenient_warnings(
+        genomic_provider("NC_000001.11", 400),
+        "NC_000001.11:g.201C>T",
+    );
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        stated_ref,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!("sole_mismatch only returns this variant")
+    };
+
+    assert_eq!(position, "201-201", "warning: {warning}");
+    assert_eq!((stated_ref.as_str(), actual_ref.as_str()), ("C", "A"));
+    // The rendered message is the user-visible surface, and it is what the CLI
+    // prints, so pin it too rather than only the field behind it.
+    assert!(
+        warning
+            .to_string()
+            .starts_with(r#"reference sequence mismatch at 201-201: stated "C", actual "A""#),
+        "rendered message: {warning}"
+    );
+}
+
+/// The same string is strict mode's `FerroError::ReferenceMismatch` `location`,
+/// so a caller parsing it to point at the offending base is pointed at `g.201`.
+#[test]
+fn strict_mode_locates_the_error_at_the_same_coordinate() {
+    let variant = parse_hgvs("NC_000001.11:g.201C>T").unwrap();
+    let err = Normalizer::with_config(
+        genomic_provider("NC_000001.11", 400),
+        NormalizeConfig::strict(),
+    )
+    .normalize(&variant)
+    .expect_err("strict must reject a wrong-ref substitution");
+
+    match err {
+        FerroError::ReferenceMismatch {
+            location,
+            expected,
+            found,
+        } => {
+            assert_eq!(location, "201-201");
+            assert_eq!((expected.as_str(), found.as_str()), ("C", "A"));
+        }
+        other => panic!("expected ReferenceMismatch, got {other:?}"),
+    }
+}
+
+/// The mitochondrial axis reaches the same windowed helper
+/// (`normalize_in_grown_window`) and carried the same defect.
+#[test]
+fn a_mitochondrial_mismatch_reports_the_mitochondrial_coordinate() {
+    let warnings = lenient_warnings(genomic_provider("NC_012920.1", 400), "NC_012920.1:m.201C>T");
+    assert_eq!(mismatch_positions(&warnings), vec!["201-201".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// The dedupe the wrong coordinate had broken
+// ---------------------------------------------------------------------------
+
+/// Two cis members, each misstating its own reference base, must produce
+/// **two** warnings — one per member, at the member's own coordinate.
+///
+/// Before the fix this produced **four**: the cis producer's `201-201` and
+/// `300-300`, plus two per-member warnings *both* reading `100-100`, because
+/// each member is windowed about itself and so lands at the same relative
+/// offset. `normalize_core`'s suppression is keyed on `position` alone, so
+/// neither of the real findings matched the fabricated ones and every mismatch
+/// was reported twice — while the two fabricated coordinates were, on their
+/// face, indistinguishable from each other.
+#[test]
+fn each_genomic_cis_member_is_reported_exactly_once() {
+    let warnings = lenient_warnings(
+        genomic_provider("NC_000001.11", 400),
+        "NC_000001.11:g.[201C>T;300G>A]",
+    );
+    let mut positions = mismatch_positions(&warnings);
+    positions.sort();
+    assert_eq!(
+        positions,
+        vec!["201-201".to_string(), "300-300".to_string()],
+        "one warning per misstating member, at its own coordinate; got {warnings:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The axes that were already right, and must stay where they are
+// ---------------------------------------------------------------------------
+
+/// A coding transcript whose CDS starts at 21, so the `c.` axis and the
+/// transcript-sequence axis differ by 20 and a confusion between them is
+/// visible.
+fn coding_transcript_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let seq: String = (1..=300).map(base_at).collect();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        Some(seq),
+        Some(21),
+        Some(200),
+        vec![Exon::new(1, 1, 300)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// `c.`, `n.` and `r.` all address the transcript sequence directly, so their
+/// positions were never window-relative and must not move.
+///
+/// `c.5` is transcript offset 25 (`cds_start = 21`), whose base is `A`; stating
+/// `C` mismatches. The reported span is `25-25` — the **sequence-axis** span,
+/// which is what the cis producer reports for the same member and therefore
+/// what the dedupe requires. Re-spelling it as `5-5` would look like a fix and
+/// would break that agreement, so it is pinned here as a deliberate answer
+/// rather than left to be re-derived.
+#[test]
+fn transcript_axes_report_the_sequence_axis_span_unchanged() {
+    for (input, expected) in [
+        ("NM_TEST.1:c.5C>T", "25-25"),
+        ("NM_TEST.1:n.25C>T", "25-25"),
+        ("NM_TEST.1:r.5c>u", "25-25"),
+    ] {
+        let warnings = lenient_warnings(coding_transcript_provider(), input);
+        assert_eq!(
+            mismatch_positions(&warnings),
+            vec![expected.to_string()],
+            "`{input}` must report the transcript-sequence span; got {warnings:?}"
+        );
+    }
+}
+
+/// The agreement itself, rather than the two halves separately: a `c.` cis
+/// allele whose members both misstate is reported once per member, which can
+/// only happen if the per-member and cis producers spell the position
+/// identically.
+#[test]
+fn each_coding_cis_member_is_reported_exactly_once() {
+    let warnings = lenient_warnings(coding_transcript_provider(), "NM_TEST.1:c.[5C>T;7A>G]");
+    let mut positions = mismatch_positions(&warnings);
+    positions.sort();
+    assert_eq!(
+        positions,
+        vec!["25-25".to_string(), "27-27".to_string()],
+        "got {warnings:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The case where the sequence read is not the one the accession names
+// ---------------------------------------------------------------------------
+
+/// A two-exon transcript with genomic backing, on `strand`. Exon 1 covers
+/// transcript 1..10 and exon 2 covers 11..22; the genomic placement is chosen
+/// so `c.10+5` lands on a base whose coordinate is checkable by hand.
+fn intronic_provider(
+    accession: &str,
+    contig: &str,
+    strand: Strand,
+    exon1: (u64, u64),
+    exon2: (u64, u64),
+) -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(contig, (1..=1000).map(base_at).collect::<String>());
+    let lo = exon1.0.min(exon2.0);
+    let hi = exon1.1.max(exon2.1);
+    provider.add_transcript(Transcript::new(
+        accession.to_string(),
+        Some("INTR".to_string()),
+        strand,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        Some(1),
+        Some(22),
+        vec![
+            Exon::with_genomic(1, 1, 10, exon1.0, exon1.1),
+            Exon::with_genomic(2, 11, 22, exon2.0, exon2.1),
+        ],
+        Some(contig.to_string()),
+        Some(lo),
+        Some(hi),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// An intronic description is shuffled against the genomic contig, so the span
+/// it reports is genomic — and says so, because the accession the description
+/// names is a transcript and a bare number would be unreadable.
+///
+/// Plus strand: exon 1 is transcript 1..10 at genomic 300..309, so transcript
+/// position 10 is genomic 309 and `c.10+5` is genomic **314**. Stating `A`
+/// there misstates a `C`. Before the fix this read `101-101`, the offset into a
+/// window opening at genomic 214.
+#[test]
+fn a_plus_strand_intronic_mismatch_names_the_contig_span() {
+    let provider = intronic_provider("NM_INTR.1", "chr_i", Strand::Plus, (300, 309), (400, 411));
+    let warnings = lenient_warnings(provider.clone(), "NM_INTR.1:c.10+5delA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_i:314-314", "warning: {warning}");
+    // Independent of the coordinate arithmetic above: whatever base the warning
+    // reports as actual must be the base standing at the coordinate it reports.
+    assert_eq!(actual_ref.as_str(), "C");
+    assert_eq!(base_at(314), 'C');
+
+    // A two-base span keeps both endpoints, and they stay in genomic order.
+    let warnings = lenient_warnings(provider, "NM_INTR.1:c.10+5_10+6delAA");
+    assert_eq!(
+        mismatch_positions(&warnings),
+        vec!["chr_i:314-315".to_string()]
+    );
+}
+
+/// Minus strand, where the window is additionally reverse-complemented before
+/// the shuffle sees it — so the relative offset is not even in the same
+/// direction as the contig.
+///
+/// Exon 1 is transcript 1..10 at genomic 400..409 read backwards, so transcript
+/// position 10 is genomic 400 and `c.10+5` — five bases further along the
+/// transcript — is genomic **395**. The contig's base there is `G`; the
+/// transcript reads its reverse complement, `C`, which is what the warning must
+/// report as actual. That pairing is the independent check on the coordinate:
+/// only the right genomic position revcomps to the reported base.
+#[test]
+fn a_minus_strand_intronic_mismatch_names_the_contig_span() {
+    let provider = intronic_provider("NM_MINUS.1", "chr_m", Strand::Minus, (400, 409), (300, 311));
+    let warnings = lenient_warnings(provider.clone(), "NM_MINUS.1:c.10+5delA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_m:395-395", "warning: {warning}");
+    assert_eq!(base_at(395), 'G', "the contig's own base");
+    assert_eq!(
+        actual_ref.as_str(),
+        "C",
+        "the transcript reads the reverse complement of the contig base at the \
+         coordinate the warning names"
+    );
+
+    // Still low-to-high in genomic order, which is the opposite end of the
+    // transcript's `10+5_10+6`.
+    let warnings = lenient_warnings(provider, "NM_MINUS.1:c.10+5_10+6delAA");
+    assert_eq!(
+        mismatch_positions(&warnings),
+        vec!["chr_m:394-395".to_string()]
+    );
+}
+
+/// The `n.` mirror of the plus/minus intronic pair above.
+///
+/// `normalize_intronic_tx` builds its own `MismatchFrame::GenomicWindow` —
+/// the `c.` path's does not stand in for it, and a wrong `seq_start` in either
+/// one is invisible to the other. `n.10+5` is the same locus as `c.10+5` here
+/// (`cds_start = 1`), so the coordinates below are the ones the `c.` tests
+/// already state, arrived at through a different function.
+#[test]
+fn an_intronic_noncoding_mismatch_names_the_contig_span() {
+    let plus = intronic_provider("NM_INTR.1", "chr_i", Strand::Plus, (300, 309), (400, 411));
+    let warnings = lenient_warnings(plus.clone(), "NM_INTR.1:n.10+5delA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_i:314-314", "warning: {warning}");
+    // The same independent pairing the `c.` tests make: the base reported as
+    // actual must be the base standing at the coordinate reported.
+    assert_eq!(actual_ref.as_str(), "C");
+    assert_eq!(base_at(314), 'C');
+
+    let warnings = lenient_warnings(plus, "NM_INTR.1:n.10+5_10+6delAA");
+    assert_eq!(
+        mismatch_positions(&warnings),
+        vec!["chr_i:314-315".to_string()]
+    );
+
+    // Minus strand, where the window is reverse-complemented before the shuffle
+    // sees it, so a `seq_start` error and a flip error are separable.
+    let minus = intronic_provider("NM_MINUS.1", "chr_m", Strand::Minus, (400, 409), (300, 311));
+    let warnings = lenient_warnings(minus, "NM_MINUS.1:n.10+5delA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_m:395-395", "warning: {warning}");
+    assert_eq!(base_at(395), 'G', "the contig's own base");
+    assert_eq!(
+        actual_ref.as_str(),
+        "C",
+        "the transcript reads the reverse complement of the contig base at the \
+         coordinate the warning names"
+    );
+}
+
+/// The reverse complement of `bases`, so a minus-strand expectation is derived
+/// from the contig rather than transcribed by hand.
+fn revcomp(bases: &str) -> String {
+    bases
+        .chars()
+        .rev()
+        .map(|b| match b {
+            'A' => 'T',
+            'C' => 'G',
+            'G' => 'C',
+            'T' => 'A',
+            other => other,
+        })
+        .collect()
+}
+
+/// The contig's own bases over the 1-based inclusive span `[lo, hi]`.
+fn contig_bases(lo: usize, hi: usize) -> String {
+    (lo..=hi).map(base_at).collect()
+}
+
+/// A span with one **exonic** and one intronic endpoint does not reach the
+/// intronic path at all — it is `normalize_boundary_spanning_cds`, a third
+/// `GenomicWindow` construction site with its own `seq_start`.
+///
+/// `c.9` is genomic 308 and `c.10+2` is genomic 311 on the plus-strand fixture,
+/// so the four bases actually read are `g.308_311`. The transcript is CDS-only
+/// (`cds_start = 1`), which is what lets the `n.` mirror below name the same
+/// locus and so compare like with like.
+#[test]
+fn a_boundary_spanning_coding_mismatch_names_the_contig_span() {
+    let plus = intronic_provider("NM_INTR.1", "chr_i", Strand::Plus, (300, 309), (400, 411));
+    let warnings = lenient_warnings(plus, "NM_INTR.1:c.9_10+2delAAAA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_i:308-311", "warning: {warning}");
+    assert_eq!(
+        actual_ref.as_str(),
+        contig_bases(308, 311),
+        "the bases reported as actual must be the contig's own bases over the \
+         span the warning names",
+    );
+
+    // Minus strand: exon 1 is transcript 1..10 at genomic 400..409 read
+    // backwards, so `c.9` is genomic 401 and `c.10+2` is genomic 398.
+    let minus = intronic_provider("NM_MINUS.1", "chr_m", Strand::Minus, (400, 409), (300, 311));
+    let warnings = lenient_warnings(minus, "NM_MINUS.1:c.9_10+2delAAAA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_m:398-401", "warning: {warning}");
+    assert_eq!(
+        actual_ref.as_str(),
+        revcomp(&contig_bases(398, 401)),
+        "the transcript reads the reverse complement of the contig bases over \
+         the span the warning names",
+    );
+}
+
+/// The `n.` mirror of the test above — `normalize_boundary_spanning_tx`, the
+/// fourth and last `GenomicWindow` site. Same locus, same expected span,
+/// different function.
+#[test]
+fn a_boundary_spanning_noncoding_mismatch_names_the_contig_span() {
+    let plus = intronic_provider("NM_INTR.1", "chr_i", Strand::Plus, (300, 309), (400, 411));
+    let warnings = lenient_warnings(plus, "NM_INTR.1:n.9_10+2delAAAA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_i:308-311", "warning: {warning}");
+    assert_eq!(actual_ref.as_str(), contig_bases(308, 311));
+
+    let minus = intronic_provider("NM_MINUS.1", "chr_m", Strand::Minus, (400, 409), (300, 311));
+    let warnings = lenient_warnings(minus, "NM_MINUS.1:n.9_10+2delAAAA");
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+    assert_eq!(position, "chr_m:398-401", "warning: {warning}");
+    assert_eq!(actual_ref.as_str(), revcomp(&contig_bases(398, 401)));
+}
+
+// ---------------------------------------------------------------------------
+// The second, independent window offset: the growth cap
+// ---------------------------------------------------------------------------
+
+/// Flanking bases either side of the tract in [`capped_growth_provider`]. A
+/// multiple of 4 so the cyclic `ACGT` lead ends on `T` rather than on the
+/// tract's own base, which would extend the run.
+const CAPPED_FLANK: usize = 64;
+
+/// Long enough that the geometric growth in `normalize_in_grown_window`
+/// exhausts `MAX_SHUFFLE_FETCH_WINDOW` (64 KiB) with contig left to read on
+/// both sides of the positions below — which is the only way to reach
+/// `canonicalize_without_shifting`. Modelled on
+/// `tests/it/issue_1691_homopolymer_convergence.rs`, which uses 70_000 for the
+/// same purpose; this is larger so that a position can sit a full window past
+/// the tract's 5' end and still be a window short of its 3' end.
+const CAPPED_TRACT: usize = 200_000;
+
+/// One contig: `CAPPED_FLANK` bases of cyclic `ACGT`, then `CAPPED_TRACT` `A`s,
+/// then `CAPPED_FLANK` bases of cyclic `CGTA`. Base `CAPPED_FLANK + 1` is the
+/// first `A` of the tract, so stating any other base there is a mismatch.
+fn capped_growth_provider(contig: &str) -> JsonProvider {
+    let lead: String = "ACGT".chars().cycle().take(CAPPED_FLANK).collect();
+    let tract: String = std::iter::repeat_n('A', CAPPED_TRACT).collect();
+    let trail: String = "CGTA".chars().cycle().take(CAPPED_FLANK).collect();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: format!("{lead}{tract}{trail}") },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// Past the growth cap the warning is built by
+/// `canonicalize_without_shifting`, which normalizes against a **slice** of the
+/// window it was handed and so carries a *second* frame offset
+/// (`slice_start = window_start + lo`). It is not a refactor of the growth
+/// loop's own `MismatchFrame::Window`: it adds `lo`, so a correct growth loop
+/// says nothing about it, and a wrong `lo` reproduces #1612 exactly — a
+/// plausible number in a user-facing coordinate with nothing red.
+///
+/// Two positions, because the two terms of that sum are separable:
+///
+/// - `g.65`, one base into the tract, is closer to the contig start than the
+///   64 KiB cap, so the window opens at base 1 and `window_start` is **0**.
+///   Only `lo` can move the answer.
+/// - `g.100000` is a full cap-width into the contig, so `window_start` is
+///   non-zero **and** `lo` is added on top of it. A frame that carried either
+///   term alone lands somewhere else.
+///
+/// Both must come back unshifted — that is the capped answer's signature, and
+/// asserting it is what pins these two inputs to this path rather than to the
+/// growth loop's own site. A position the growth loop *can* settle (`g.150000`
+/// below) shifts to the tract's 3' end instead.
+#[test]
+fn a_capped_growth_mismatch_reports_the_contig_coordinate() {
+    let provider = capped_growth_provider("c");
+    let first = CAPPED_FLANK + 1;
+
+    for authored in [first, 100_000] {
+        let input = format!("c:g.{authored}delC");
+        let variant = parse_hgvs(&input).unwrap();
+        let outcome = Normalizer::with_config(provider.clone(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&variant)
+            .unwrap_or_else(|e| panic!("lenient must accept `{input}`: {e:?}"));
+
+        assert_eq!(
+            outcome.result.to_string(),
+            format!("c:g.{authored}del"),
+            "`{input}` must come back unshifted; a shifted answer means the \
+             growth cap was never reached and this test is not on the path it \
+             claims to cover",
+        );
+        assert_eq!(
+            mismatch_positions(&outcome.warnings),
+            vec![format!("{authored}-{authored}")],
+            "`{input}` must report the contig coordinate; got {:?}",
+            outcome.warnings,
+        );
+    }
+
+    // The control: far enough from the tract's 3' end that the grown window
+    // contains the shuffle's resting place, so this one never reaches the cap
+    // and its warning comes from the growth loop's own frame. It shifts.
+    let input = "c:g.150000delG";
+    let warnings = lenient_warnings(provider, input);
+    assert_eq!(
+        mismatch_positions(&warnings),
+        vec!["150000-150000".to_string()],
+        "{input}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The same window offsets, reached through the validator's own message text
+// ---------------------------------------------------------------------------
+
+/// `validate_stated_length` built the *same* window offsets into the warning's
+/// `actual_ref`, in HGVS range notation. With `position` repaired the two
+/// halves of one warning contradicted each other — measured on
+/// `g.201_202del5`:
+///
+/// ```text
+/// at 201-202: stated "length 5", actual "span 2 (100_101)"
+/// ```
+///
+/// The endpoints are `position`'s job and it now states them correctly, so the
+/// restatement is dropped rather than duplicated. The width, which is what this
+/// check is actually about, stays.
+#[test]
+fn a_numeric_length_mismatch_states_the_width_and_no_window_offset() {
+    let warnings = lenient_warnings(
+        genomic_provider("NC_000001.11", 400),
+        "NC_000001.11:g.201_202del5",
+    );
+    let warning = sole_mismatch(&warnings);
+    let NormalizationWarning::RefSeqMismatch {
+        position,
+        stated_ref,
+        actual_ref,
+        ..
+    } = warning
+    else {
+        unreachable!()
+    };
+
+    assert_eq!(position, "201-202");
+    assert_eq!(
+        (stated_ref.as_str(), actual_ref.as_str()),
+        ("length 5", "span 2")
+    );
+    let rendered = warning.to_string();
+    assert!(
+        !rendered.contains("100"),
+        "no window offset may survive anywhere in the message: {rendered}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -285,6 +285,7 @@ mod issue_1578_followup_equivalence_rungs;
 mod issue_1578_followup_ring_declines;
 mod issue_1578_followup_self_cancelling_rings;
 mod issue_1578_ring_validator_escapes;
+mod issue_1612_refseq_mismatch_coordinate;
 mod issue_1615_denoted_sequence_oracle;
 mod issue_1619_flat_transcript_frame;
 mod issue_1629_error_mode_is_not_a_warning_gate;

--- a/tests/it/normalize_warning_seam.rs
+++ b/tests/it/normalize_warning_seam.rs
@@ -187,23 +187,19 @@ fn the_inserted_sequence_expansion_warning_reaches_the_cli() {
 /// where the description is *accepted* despite contradicting the reference, and
 /// so the one where silence is most costly.
 ///
-/// The rendered position is **not** pinned. On this input the message reads
-/// `at 100-100` for a variant at `g.201`, which looks like a window-relative
-/// offset leaking into a user-facing coordinate. That is recorded as a separate
-/// finding rather than frozen here: pinning it would make a legitimate fix to
-/// the coordinate fail this test for the wrong reason.
+/// The rendered position used to be left unpinned here. On this input the
+/// message read `at 100-100` for a variant at `g.201` — a window-relative
+/// offset leaking into a user-facing coordinate — and freezing it would have
+/// made the eventual repair fail this test for the wrong reason.
 ///
-/// Confirmed and filed as **#1612**. It is built at `src/normalize/mod.rs:8806`
-/// from the *fetched window's* `start`/`end`, which nothing converts back onto
-/// the description's own axis — unlike the cis producer at
-/// `src/normalize/merge.rs:3362`, which re-bases through `region_sequence_delta`
-/// and documents itself as reporting the sequence-axis span. The field is not
-/// diagnostic-only: it is also the `location` of strict mode's
-/// `FerroError::ReferenceMismatch` (`mod.rs:2418`), so a fix has to move both
-/// renderings and stay agreed with the cis producer, whose warnings are built to
-/// be indistinguishable so the `position`-keyed dedupe at `mod.rs:2854` can drop
-/// the duplicate. That is why it is not repaired here, where the scope is the
-/// seam rather than the warning's contents.
+/// That finding was filed as **#1612** and is now **fixed**, so the coordinate
+/// is pinned: the warning is built from the fetched window's `start`/`end`, and
+/// those are converted back through `MismatchFrame` before they are formatted.
+/// `tests/it/issue_1612_refseq_mismatch_coordinate.rs` owns the full guard —
+/// every axis, the strict-mode `FerroError::ReferenceMismatch` `location` (the
+/// same string), and the agreement with the cis producer that the
+/// `position`-keyed dedupe depends on. What is pinned *here* is only that the
+/// repaired coordinate reaches the CLI, which is this file's own subject.
 #[test]
 fn the_reference_mismatch_warning_reaches_the_cli() {
     let (_dir, reference) = fixture();
@@ -212,8 +208,9 @@ fn the_reference_mismatch_warning_reaches_the_cli() {
 
     assert!(ok, "lenient must accept the mismatch; stderr: {stderr}");
     assert!(
-        stderr.contains("warning[REFSEQ_MISMATCH]: reference sequence mismatch at "),
-        "the mismatch must be disclosed under its code; stderr: {stderr}"
+        stderr.contains("warning[REFSEQ_MISMATCH]: reference sequence mismatch at 201-201:"),
+        "the mismatch must be disclosed under its code, at the coordinate the \
+         input names (#1612); stderr: {stderr}"
     );
     assert!(
         stderr.contains(r#"stated "C", actual "A""#),


### PR DESCRIPTION
Closes #1612

`REFSEQ_MISMATCH` reported the offset into the **fetched reference window** as if it were a coordinate. Against a contig whose base 201 is `A`, `NC_000001.11:g.201C>T` said:

```
warning[REFSEQ_MISMATCH]: reference sequence mismatch at 100-100: stated "C", actual "A" (corrected=false)
```

`100` is `201 - window_start`. The mismatch is real; only the coordinate was wrong. It now reads `at 201-201`.

## What the field promises, and why the transcript axes do not move

`normalize_na_edit` indexes the slice it is handed, so its `start`/`end` are always in that slice's frame. Most callers hand it the whole sequence the description addresses; the genomic and mitochondrial callers hand it a window, and nothing converted the pair back.

The promise the field already carries — stated and implemented by the cis producer, `merge::authored_reference_mismatch` ("the sequence-axis span, via `region_sequence_delta`") — is **the 1-based inclusive span on the reference sequence that was actually read, in that sequence's own numbering**. It is deliberately *not* the description's own axis, and the two producers must agree because the duplicate-suppression in `normalize_core` is keyed on this string and nothing else.

So `c.5C>T` on a transcript whose CDS starts at 21 reports the transcript offset `25-25`, on both producers, before and after this change. Re-spelling it `5-5` would have been a second wrong answer and would have broken the dedupe; it is now pinned so a later change cannot "fix" the two apart.

## Per axis

| axis | sequence read | reported | changed |
|---|---|---|---|
| `g.`, `m.` | the contig | `201-201` — the contig coordinate, which is also the description's own | **yes**, was the window offset |
| `c.`, `n.`, `r.` (exonic) | the transcript | `25-25` — the transcript offset | no, already correct |
| `c.`, `n.` intronic / boundary-spanning | the genomic **contig** | `chr_i:314-314` — the genomic span, qualified by the contig accession | **yes**, was a window offset in a reverse-complemented frame on minus-strand transcripts |

The intronic row is the case where a faithful conversion to the description's own axis is not available: the bases are read from a contig the accession does not name, and the shuffle frame is reverse-complemented on a minus strand. A bare number there would be a coordinate in a space the reader has no way to guess, so that arm names the space. Nothing dedupes against it — `merge::simple_cds_pos` declines every offset position, so no cis-side duplicate of an intronic finding can exist.

A new `MismatchFrame` makes every caller state where its span sits, so the conversion happens where the answer is known. It is a parameter rather than something derived inside `normalize_na_edit`, because that function cannot see whether `ref_seq` is a whole sequence or a window — which is exactly how the wrong coordinate shipped.

## Three things this repairs, not one

1. The coordinate itself.
2. The `location` of strict mode's `FerroError::ReferenceMismatch`, which is the same string. A caller parsing it to point at the offending base was pointed at the wrong one.
3. **The dedupe against the cis producer, which had silently stopped matching on the genomic axis.** `NC_000001.11:g.[201C>T;300G>A]`, two members each misstating its own base, produced **four** warnings — the cis producer's `201-201` and `300-300`, plus two per-member warnings *both* reading `100-100`, because each member is windowed about itself. Neither real finding matched the fabricated ones, so every mismatch was reported twice, and the two fabricated coordinates were on their face indistinguishable from each other. It now produces two.

## The sibling defect

`validate_reference` built the same window offsets into the warning's `actual_ref` text, in HGVS range notation. Repairing `position` on its own left one warning contradicting itself — measured on `g.201_202del5`:

```
at 201-202: stated "length 5", actual "span 2 (100_101)"
```

Three messages carried a raw index (`validate_stated_length`'s `(start_end)`, and the "position N out of range" / "inverted range: start N > end M" strings). The endpoints are `position`'s job and it now states them correctly, so the restatements are dropped rather than duplicated; the width, which is what the length check is about, stays (`actual "span 2"`). No test pinned any of those strings.

`CanonicalSplitSkipped` is the other warning built nearby and is **not** affected: it is constructed in `apply_canonical_split` from `fetch_ref_for_canonical_split`'s genuine HGVS coordinates, not from `normalize_na_edit`'s relative pair.

## Guard

`tests/it/issue_1612_refseq_mismatch_coordinate.rs` — 10 tests covering the issue's reproducer, the strict-mode `location`, `m.`, the genomic and coding cis dedupes, the transcript axes staying put, both intronic strands, and the length message. Verified as a real guard by reverting each production line and re-running: reverting `position: frame.render(start, end)` fails 7 of the 10 (the 3 that pass are the fixture check and the two transcript-axis tests, which are correctly unaffected); reverting the `span {span}` message fails the 10th.

The intronic coordinates are cross-checked independently of my own arithmetic: the warning's `actual_ref` must be the base standing at the coordinate the warning names — the contig base on the plus strand, its reverse complement on the minus strand.

`tests/it/normalize_warning_seam.rs` recorded this defect deliberately and left the position unpinned so a fix would not have to fight a frozen wrong value. That comment is replaced and the CLI-level assertion now pins `at 201-201`.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo nextest run --features dev --no-fail-fast` (10757 passed, 0 failed, post-rebase), and the Python suite via `maturin develop --features python` + `pytest tests/python/` (991 passed, 8 skipped). Exit statuses read back from each run's own log rather than from a completion notification.

Representation-Change: The emitted WARNING SET changes on cis alleles; no normalized output moves (0 rows respell).
  This is NOT a diagnostic-only change, and the previous `none` verdict was wrong.
  `ValidationResult::valid` is untouched and the new `frame` argument is read at exactly one place — where the
  warning string is built — so no normalization decision and no normalized string moves. What moves is the
  set of warnings a consumer receives, plus the text of the ones that survive.
  (1) WARNING SET. The `REFSEQ_MISMATCH` `position` string is the sole key of the cis-allele duplicate
  suppression (`src/normalize/mod.rs:4160-4182`), so repairing the coordinate changes how many warnings
  survive. Measured on `NC_000001.11:g.[201C>T;300G>A]` over a 400-base ACGT-cycling contig: 4 warnings
  before (`["100-100","100-100","201-201","300-300"]`), 2 after (`["201-201","300-300"]`) — pinned by
  `each_genomic_cis_member_is_reported_exactly_once`. A consumer reading `ferro normalize -f json`'s
  `warnings` array, or the Python `NormalizationWarning` list, sees two entries where it saw four.
  (2) TEXT, on five surfaces beyond `Display`, four of them machine-readable: strict mode's
  `FerroError::ReferenceMismatch.location`; the serde-serialized benchmark record `RefMismatchInfo.position`
  (`src/benchmark/types.rs:94-103`); the Python bindings' `PyNormalizationWarning.message`
  (`src/python.rs:2446-2456`, public API); `ferro normalize -f json`'s `warnings` array
  (`src/bin/ferro.rs:1804`); and `ferro project`'s `ProjectionWarning.message` (`src/cli/project.rs:54-59`),
  which participates in `AxisOutcome`'s derived `PartialEq`/`Eq` (`:77`). Enumerated by route rather than by
  consumer. No route branches on or substring-matches the text, and grep over `src/` and `tests/` finds no
  test or fixture pinning the old wording.
  Not claimed from suite greenness. With the three `validate.rs` message changes reverted, 228 tests ran and
  228 passed (EXIT=0) — nothing guards them, so a green suite is no evidence about them, and two of the three
  remain unguarded after this PR.

