### PR TITLE
feat: add sequence_normalize() helper

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -969,6 +969,53 @@ class Normalizer:
         """
         ...
 
+    def sequence_normalize(
+        self,
+        description: str,
+        *,
+        max_grid_cells: int | None = None,
+        normalize: bool = False,
+    ) -> str:
+        """Re-derive a description from the bases it denotes.
+
+        The "one canonical description per variant" round trip, as a single
+        call: express the variant as a padded reference/alternate window
+        (``to_sequences``), derive a description from those bases alone
+        (``from_sequences``), and — while a member still rests on a window edge
+        that can still move — double the pad and retry. Two spellings of one
+        variant therefore reach one description, decided by the observed bases
+        rather than by how either was written.
+
+        The loop reads ``DerivedDescription``'s two per-side flags apart, so a
+        placement pinned to the sequence's own start or end is recognised as
+        settled rather than chased.
+
+        Args:
+            description: The HGVS description to re-derive. Its axis must be one
+                ``from_sequences`` emits — genomic ``g.`` (and ``m.`` on the two
+                rCRS mitochondrial accessions); any other is refused.
+            max_grid_cells: As ``from_sequences``.
+            normalize: Route the derived description through ``normalize``
+                before returning it. Defaults to False, which yields the
+                alignment-derived form (conformant + deterministic) rather than
+                ferro's recommended form. Set True for the recommended,
+                reference-anchored form.
+
+        Returns:
+            The canonical HGVS description, as a string.
+
+        Raises:
+            ParseError: ``description`` does not parse.
+            ValueError: for a ``max_grid_cells`` of 0, as ``from_sequences``.
+            NormalizationError: everything else — a variant with no single
+                resulting sequence, a non-genomic axis, a grid over
+                ``max_grid_cells``, or a placement still resting on the edge of
+                the widest window the loop reads (a repeat tract whose shift
+                depends on how much reference is read). Plus any refusal from
+                ``normalize`` when ``normalize=True``.
+        """
+        ...
+
 # ============================================================================
 # SPDI Classes
 # ============================================================================
@@ -1602,6 +1649,29 @@ class DerivedDescription:
         flush with the tract is flagged and still gives the same answer a
         whole-sequence derivation gives. A flagged answer is never wrong — it
         denotes the same bases and carries the same canonical SPDI.
+        """
+        ...
+
+    @property
+    def bounded_at_start(self) -> bool:
+        """Whether a member rests on the window's 5' edge.
+
+        ``placement_bounded_by_window`` is ``bounded_at_start or
+        bounded_at_end``; this says whether the 5' side specifically is the one
+        on an edge. A caller widening a window one side at a time reads it to
+        decide whether widening 5' could move the answer — and, together with
+        the window already starting at base 1, to recognise a placement pinned
+        to the sequence start that no widening can move.
+        """
+        ...
+
+    @property
+    def bounded_at_end(self) -> bool:
+        """Whether a member rests on the window's 3' edge.
+
+        The 3' counterpart of ``bounded_at_start``; see it. A placement on the
+        3' edge of a window that already ends at the sequence's last base is
+        settled by the sequence, not the window.
         """
         ...
 

--- a/src/normalize/from_sequences.rs
+++ b/src/normalize/from_sequences.rs
@@ -163,8 +163,23 @@ impl FromSequencesOptions {
 pub struct DerivedDescription {
     /// The description.
     pub variant: HgvsVariant,
+    /// Whether a member rests on the window's **5' edge**.
+    ///
+    /// Ask [`Self::placement_bounded_by_window`] for the plain "could this move
+    /// at all" answer; this and [`Self::bounded_at_end`] say *which* side, which
+    /// is what a caller widening one side at a time needs.
+    pub bounded_at_start: bool,
+    /// Whether a member rests on the window's **3' edge**.
+    ///
+    /// The 3' counterpart of [`Self::bounded_at_start`]; see it.
+    pub bounded_at_end: bool,
+}
+
+impl DerivedDescription {
     /// Whether a member's placement was bounded by the window rather than
-    /// settled by the sequence — i.e. it rests on an edge of the bases supplied.
+    /// settled by the sequence — i.e. it rests on *either* edge of the bases
+    /// supplied. The OR of [`Self::bounded_at_start`] and
+    /// [`Self::bounded_at_end`].
     ///
     /// **This is a "could move" flag, not a "is wrong" flag**, and it is
     /// deliberately conservative in that direction. Distinguishing a placement
@@ -172,12 +187,6 @@ pub struct DerivedDescription {
     /// requires knowing what lies outside the window — the reference — which
     /// this function does not read. So it reports the uncertainty rather than
     /// resolving it.
-    ///
-    /// The stronger reading is measurably false, which is why this wording is
-    /// laboured: over a 4-base `A` run at 12-15, the window `9-15` is flagged
-    /// and is nonetheless the same answer a whole-sequence derivation gives,
-    /// while `9-14` is flagged and is placed one base earlier. Both are pinned
-    /// in `tests/it/from_sequences_window_condition.rs`.
     ///
     /// And note what a flagged answer is *not*: it is never wrong. `g.14del`
     /// and `g.15del` over that run denote the same bases and share a canonical
@@ -190,7 +199,10 @@ pub struct DerivedDescription {
     /// that both contain the whole interval over which the change can be placed
     /// derive the same description, and a window that cuts that interval places
     /// the change at its own edge instead.
-    pub placement_bounded_by_window: bool,
+    #[must_use]
+    pub fn placement_bounded_by_window(&self) -> bool {
+        self.bounded_at_start || self.bounded_at_end
+    }
 }
 
 /// Derive an HGVS description from a reference/alternate sequence pair.
@@ -293,7 +305,8 @@ pub fn from_sequences_detailed(
 
     Ok(DerivedDescription {
         variant,
-        placement_bounded_by_window: block.placement_bounded_by_window,
+        bounded_at_start: block.bounded_at_start,
+        bounded_at_end: block.bounded_at_end,
     })
 }
 
@@ -1038,7 +1051,7 @@ mod tests {
         )
         .expect("derives");
         assert!(
-            !interior.placement_bounded_by_window,
+            !interior.placement_bounded_by_window(),
             "an interior deletion must not flag: {}",
             interior.variant
         );
@@ -1052,10 +1065,82 @@ mod tests {
         )
         .expect("derives");
         assert!(
-            edge.placement_bounded_by_window,
+            edge.placement_bounded_by_window(),
             "a deletion flush with the window end must flag: {}",
             edge.variant
         );
+    }
+
+    /// The combined flag says *that* a member is on an edge; the per-side flags
+    /// say *which*. A deletion in a homopolymer that fills the window rolls, by
+    /// default, to the 3' edge — so `bounded_at_end` alone must fire, and a
+    /// caller widening one side at a time must not be told to widen 5'.
+    #[test]
+    fn a_deletion_at_the_three_prime_edge_flags_only_that_side() {
+        let d = from_sequences_detailed(
+            "NC_TEST.1",
+            5,
+            "AAAA",
+            "AAA",
+            &FromSequencesOptions::default(),
+        )
+        .expect("derives");
+        assert!(d.bounded_at_end, "3' edge must flag: {}", d.variant);
+        assert!(!d.bounded_at_start, "5' edge must not flag: {}", d.variant);
+        assert!(d.placement_bounded_by_window(), "OR must hold");
+    }
+
+    /// The 5' mirror: under 5'-shuffle the same deletion rolls to the window's
+    /// 5' edge instead, so `bounded_at_start` alone fires. This is the side a
+    /// window pinned to base 1 has permanently, and the reason
+    /// `sequence_normalize` reads the two flags apart.
+    #[test]
+    fn a_deletion_at_the_five_prime_edge_flags_only_that_side() {
+        let d = from_sequences_detailed(
+            "NC_TEST.1",
+            5,
+            "AAAA",
+            "AAA",
+            &FromSequencesOptions::default().with_direction(ShuffleDirection::FivePrime),
+        )
+        .expect("derives");
+        assert!(d.bounded_at_start, "5' edge must flag: {}", d.variant);
+        assert!(!d.bounded_at_end, "3' edge must not flag: {}", d.variant);
+        assert!(d.placement_bounded_by_window(), "OR must hold");
+    }
+
+    /// A change spanning the whole window rests on both edges at once, so both
+    /// per-side flags fire. Neither side can be dismissed as settled, which is
+    /// what makes a two-sided widen the right response.
+    #[test]
+    fn a_change_filling_the_window_flags_both_sides() {
+        let d = from_sequences_detailed(
+            "NC_TEST.1",
+            5,
+            "ACGT",
+            "TGCA",
+            &FromSequencesOptions::default(),
+        )
+        .expect("derives");
+        assert!(d.bounded_at_start, "5' edge must flag: {}", d.variant);
+        assert!(d.bounded_at_end, "3' edge must flag: {}", d.variant);
+    }
+
+    /// An interior change touches neither edge, so both per-side flags — and
+    /// therefore the combined flag — are clear.
+    #[test]
+    fn an_interior_change_flags_neither_side() {
+        let d = from_sequences_detailed(
+            "NC_TEST.1",
+            5,
+            "TAAAAG",
+            "TAAAG",
+            &FromSequencesOptions::default(),
+        )
+        .expect("derives");
+        assert!(!d.bounded_at_start, "5' edge must not flag: {}", d.variant);
+        assert!(!d.bounded_at_end, "3' edge must not flag: {}", d.variant);
+        assert!(!d.placement_bounded_by_window(), "OR must be clear");
     }
 
     /// The same four arguments give the same string. Asserted rather than

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1894,7 +1894,12 @@ pub(crate) fn coalesce_protein_adjacent_changes(
 const MAX_CANONICAL_WINDOW: i64 = 4096;
 
 /// Padding either side of the changed interval, giving the 3'-shift room.
-const CANONICAL_PAD: i64 = 128;
+///
+/// `pub(crate)` because it is also the pad every *caller-facing* derivation
+/// starts from — `Normalizer::sequence_normalize`'s `START_PAD` and the
+/// `pad = 128` default on the Python `to_sequences` binding — so the three
+/// cannot be allowed to drift apart.
+pub(crate) const CANONICAL_PAD: i64 = 128;
 
 /// Longest **length-changing** block the canonicalizer will attempt to
 /// partition.
@@ -9383,11 +9388,11 @@ pub(crate) enum BlockDecline {
 pub(crate) struct DerivedBlock {
     /// The rendered members, in ascending order.
     pub(crate) members: Vec<HgvsVariant>,
-    /// Whether any member rests on an edge of the window.
-    ///
-    /// Exactly when a wider window could move the answer, so it is reported to
-    /// the caller rather than absorbed.
-    pub(crate) placement_bounded_by_window: bool,
+    /// Whether a member rests on the window's **5' edge** (`ref_start == 0`).
+    pub(crate) bounded_at_start: bool,
+    /// Whether a member rests on the window's **3' edge**
+    /// (`ref_end == reference.len()`).
+    pub(crate) bounded_at_end: bool,
     /// Whether a **pure insertion** rests on the window's 5' edge.
     ///
     /// HGVS anchors an insertion between two positions (`insertion.md`), so a
@@ -9451,7 +9456,8 @@ pub(crate) fn derive_block_members(
     if lo == hi_ref && lo == hi_alt {
         return Ok(DerivedBlock {
             members: Vec::new(),
-            placement_bounded_by_window: false,
+            bounded_at_start: false,
+            bounded_at_end: false,
             anchors_before_window: false,
         });
     }
@@ -9503,9 +9509,8 @@ pub(crate) fn derive_block_members(
 
     // Read after the three passes above, not before: each can move a piece onto
     // or off the edge, and the answer that matters is about what is emitted.
-    let placement_bounded_by_window = pieces
-        .iter()
-        .any(|piece| piece.ref_start == 0 || piece.ref_end == reference.len());
+    let bounded_at_start = pieces.iter().any(|piece| piece.ref_start == 0);
+    let bounded_at_end = pieces.iter().any(|piece| piece.ref_end == reference.len());
 
     // A piece claiming no reference bases is a pure insertion; at offset 0 its
     // only HGVS anchor lies before the window. See `DerivedBlock`.
@@ -9529,7 +9534,8 @@ pub(crate) fn derive_block_members(
     .ok_or(BlockDecline::WouldNotRender)?;
     Ok(DerivedBlock {
         members,
-        placement_bounded_by_window,
+        bounded_at_start,
+        bounded_at_end,
         anchors_before_window,
     })
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2486,6 +2486,159 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
     }
 
+    /// Re-derive a description from the bases it denotes, so two spellings of one
+    /// variant reach one description — the "one canonical description per
+    /// variant" round trip, as a single call.
+    ///
+    /// # Errors
+    ///
+    /// Three sources, and the last is this method's own:
+    ///
+    /// - Whatever [`Self::to_sequences`] declines — a multi-molecule or null
+    ///   allele, members on different accessions, members that overlap, an edit
+    ///   SPDI cannot represent, or a span wider than
+    ///   [`crate::spdi::MAX_APPLY_WINDOW`].
+    /// - Whatever
+    ///   [`from_sequences_detailed`](crate::normalize::from_sequences::from_sequences_detailed)
+    ///   declines at the **widest window the loop
+    ///   reached**. A refusal that a wider window would have answered —
+    ///   the pure insertion anchoring 5' of the window is the one that occurs
+    ///   here — is retried rather than propagated, so what surfaces is the
+    ///   refusal that survived every widening this loop could do.
+    /// - A placement still resting on a growable edge at `MAX_PAD`: a repeat
+    ///   tract running past what the derivation can read, where how far the
+    ///   change shifts depends on how much reference is read.
+    ///
+    /// Plus any refusal from [`Self::normalize`] when `normalize` is true.
+    pub fn sequence_normalize(
+        &self,
+        variant: &HgvsVariant,
+        options: &crate::normalize::from_sequences::FromSequencesOptions,
+        normalize: bool,
+    ) -> Result<HgvsVariant, FerroError> {
+        use crate::normalize::from_sequences::from_sequences_detailed;
+
+        /// The pad the loop starts at, which is the pad the normalizer's own
+        /// derivation uses (`merge::CANONICAL_PAD`).
+        ///
+        /// **Not 1.** `dup` typing reads the reference bases immediately 5' of
+        /// an insertion point, so a duplication whose 5' copy lies outside the
+        /// window is derived as an `ins` instead — and that mis-typed `ins`
+        /// rests on *neither* window edge, so both `bounded_*` flags are clear
+        /// and the loop below would return it without ever widening. Starting
+        /// wide enough to type a duplication is what makes `g.7_14dup` and
+        /// `g.14_15ins<the same 8 bases>` converge. See `to_sequences`, whose
+        /// body records the ten `all-dup` corpus classes that measured it.
+        const START_PAD: u64 = crate::normalize::merge::CANONICAL_PAD as u64;
+        /// The widest window the loop will ask for on a side that is still
+        /// moving, before declining.
+        const MAX_PAD: u64 = crate::spdi::MAX_SHIFT_TRACT;
+
+        let mut pad = START_PAD;
+        // The previous iteration's window bounds, 1-based inclusive. Used to
+        // tell a side the provider simply could not widen further from one still
+        // moving: if an edge did not move under a larger pad, widening it again
+        // is futile, and that is a stall as much as reaching the sequence end is.
+        //
+        // It is the fallback for a provider whose length is not knowable, not a
+        // second opinion on one that is: `get_sequence_length` carries a trait
+        // default that always errors (`provider.rs:424`), and
+        // `apply_to_reference_padded` treats that as non-fatal on purpose, so a
+        // provider that serves bases perfectly well may answer neither. This
+        // loop must terminate for such a provider too.
+        let mut prev_bounds: Option<(u64, u64)> = None;
+        // The first refusal seen while a side could still grow. Reported only if
+        // no widening ever settled it, so a genuinely window-independent refusal
+        // still surfaces with its original wording.
+        let mut deferred: Option<FerroError> = None;
+        loop {
+            let pair = self.to_sequences(variant, pad)?;
+
+            // Read before the derivation, not after: the derivation can refuse
+            // *because* the window is too narrow, and the error path needs to
+            // know whether widening is still on the table.
+            let seq_len = self.provider.get_sequence_length(&pair.accession).ok();
+            let window_start = pair.position;
+            let window_end = pair.position + pair.reference.len() as u64 - 1;
+
+            // A side has stalled when widening it can no longer move the answer:
+            // its window edge is the sequence's own terminus, the provider could
+            // not serve the wider span it was asked for (`window_is_final`), OR a
+            // wider pad on the previous pass failed to move that edge. A member
+            // on a stalled side rests on the sequence, not on our window, so it
+            // is final however it is flagged.
+            let five_prime_stalled =
+                window_start == 1 || prev_bounds.is_some_and(|(ps, _)| window_start >= ps);
+            let three_prime_stalled = seq_len.is_some_and(|len| window_end >= len)
+                || !pair.window_is_final
+                || prev_bounds.is_some_and(|(_, pe)| window_end <= pe);
+            let can_still_grow = !five_prime_stalled || !three_prime_stalled;
+
+            let derived = match from_sequences_detailed(
+                &pair.accession,
+                pair.position,
+                &pair.reference,
+                &pair.alternate,
+                options,
+            ) {
+                Ok(derived) => derived,
+                // A refusal is not necessarily final. `from_sequences` declines a
+                // derived insertion whose only HGVS anchor lies 5' of the first
+                // base supplied, and that refusal's own text says to supply more
+                // 5' flank — which is precisely what this loop does. So widen and
+                // ask again while either side can still grow, and keep the first
+                // refusal to report if none of them helped.
+                Err(err) => {
+                    if !can_still_grow || pad >= MAX_PAD {
+                        return Err(deferred.unwrap_or(err));
+                    }
+                    deferred.get_or_insert(err);
+                    prev_bounds = Some((window_start, window_end));
+                    pad = pad.saturating_mul(2).min(MAX_PAD);
+                    continue;
+                }
+            };
+
+            // Only a side that is BOTH bounded and still growable keeps the loop
+            // going. This is the per-side condition: a variant at position 1 has
+            // `five_prime_stalled` from the first fetch, so its 5' edge never
+            // forces a widen — the loop reacts to the 3' side alone.
+            let unsettled_5prime = derived.bounded_at_start && !five_prime_stalled;
+            let unsettled_3prime = derived.bounded_at_end && !three_prime_stalled;
+
+            if !unsettled_5prime && !unsettled_3prime {
+                return if normalize {
+                    self.normalize(&derived.variant)
+                } else {
+                    Ok(derived.variant)
+                };
+            }
+
+            if pad >= MAX_PAD {
+                let side = match (unsettled_5prime, unsettled_3prime) {
+                    (true, true) => "both edges",
+                    (true, false) => "its 5' edge",
+                    (false, true) => "its 3' edge",
+                    (false, false) => {
+                        unreachable!("returned above when neither side is unsettled")
+                    }
+                };
+                return Err(FerroError::UnsupportedVariant {
+                    variant_type: format!(
+                        "{variant}: cannot derive a window-settled description — its \
+                         placement still rests on {side} of a window padded {MAX_PAD} bases \
+                         on each side that has not reached the sequence end, so it sits in a \
+                         repeat tract running past what the derivation reads, and how far it \
+                         shifts depends on how much reference is read"
+                    ),
+                });
+            }
+
+            prev_bounds = Some((window_start, window_end));
+            pad = pad.saturating_mul(2).min(MAX_PAD);
+        }
+    }
+
     /// An encoding-invariant SPDI key for this variant, derived from the bases it
     /// results in rather than from how it was written (#1159).
     ///

--- a/src/python.rs
+++ b/src/python.rs
@@ -1524,14 +1524,48 @@ impl PyDerivedDescription {
     /// it denotes the same bases and carries the same canonical SPDI.
     #[getter]
     fn placement_bounded_by_window(&self) -> bool {
-        self.inner.placement_bounded_by_window
+        self.inner.placement_bounded_by_window()
+    }
+
+    /// Whether a member rests on the window's **5' edge**.
+    ///
+    /// `placement_bounded_by_window` is `bounded_at_start or bounded_at_end`;
+    /// this says whether the 5' side specifically is the one on an edge. A
+    /// caller widening a window one side at a time reads it to decide whether
+    /// widening 5' could move the answer — and, together with the window already
+    /// starting at base 1, to recognise a placement pinned to the sequence start
+    /// that no widening can move.
+    #[getter]
+    fn bounded_at_start(&self) -> bool {
+        self.inner.bounded_at_start
+    }
+
+    /// Whether a member rests on the window's **3' edge**.
+    ///
+    /// The 3' counterpart of `bounded_at_start`; see it. A placement on the 3'
+    /// edge of a window that already ends at the sequence's last base is settled
+    /// by the sequence, not the window.
+    #[getter]
+    fn bounded_at_end(&self) -> bool {
+        self.inner.bounded_at_end
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "DerivedDescription(variant={:?}, placement_bounded_by_window={})",
+            "DerivedDescription(variant={:?}, placement_bounded_by_window={}, \
+             bounded_at_start={}, bounded_at_end={})",
             self.inner.variant.to_string(),
-            if self.inner.placement_bounded_by_window {
+            if self.inner.placement_bounded_by_window() {
+                "True"
+            } else {
+                "False"
+            },
+            if self.inner.bounded_at_start {
+                "True"
+            } else {
+                "False"
+            },
+            if self.inner.bounded_at_end {
                 "True"
             } else {
                 "False"
@@ -1661,7 +1695,9 @@ fn from_sequences(
 /// edge.
 ///
 /// Returns:
-///     DerivedDescription with `variant` and `placement_bounded_by_window`.
+///     DerivedDescription with `variant`, `placement_bounded_by_window`, and the
+///     two per-side flags it is the OR of — `bounded_at_start` and
+///     `bounded_at_end`.
 #[pyfunction]
 #[pyo3(signature = (accession, position, reference, alternate, *, max_grid_cells=None))]
 #[pyo3(text_signature = "(accession, position, reference, alternate, *, max_grid_cells=None)")]
@@ -2119,6 +2155,55 @@ impl PyNormalizer {
         })
         .map(|inner| PyHgvsVariant { inner })
         .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
+    }
+
+    /// Re-derive a description from the bases it denotes: the "one canonical
+    /// description per variant" round trip, as a single call.
+    ///
+    /// Args:
+    ///     description: The HGVS description to re-derive. Its axis must be one
+    ///         `from_sequences` emits — genomic `g.` (and `m.` on the two rCRS
+    ///         mitochondrial accessions); any other is refused.
+    ///     max_grid_cells: As `from_sequences`.
+    ///     normalize: Route the derived description through `normalize` before
+    ///         returning it. Defaults to False, which yields the
+    ///         alignment-derived form (conformant + deterministic) rather than
+    ///         ferro's recommended form. Set True for the recommended,
+    ///         reference-anchored form.
+    ///
+    /// Returns:
+    ///     The canonical HGVS description, as a string.
+    ///
+    /// Raises:
+    ///     ParseError: `description` does not parse.
+    ///     ValueError: for a `max_grid_cells` of 0, as `from_sequences`.
+    ///     NormalizationError: everything else — a variant with no single
+    ///         resulting sequence, a non-genomic axis, a grid over
+    ///         `max_grid_cells`, or a placement still resting on the edge of the
+    ///         widest window the loop reads (a repeat tract whose shift depends
+    ///         on how much reference is read). Plus any refusal from `normalize`
+    ///         when `normalize=True`. A refusal that a wider window would answer
+    ///         — the pure insertion anchoring 5' of the window — is retried by
+    ///         the loop rather than raised.
+    #[pyo3(signature = (description, *, max_grid_cells=None, normalize=false))]
+    #[pyo3(text_signature = "(description, *, max_grid_cells=None, normalize=False)")]
+    fn sequence_normalize(
+        &self,
+        py: Python<'_>,
+        description: &str,
+        max_grid_cells: Option<usize>,
+        normalize: bool,
+    ) -> PyResult<String> {
+        // Parsed before detaching, as in `normalize`: it touches no reference,
+        // so it keeps the `ParseError` mapping a plain `?` rather than threading
+        // a two-variant error enum through the closure.
+        let variant = parse_hgvs(description)
+            .map_err(|e| ferro_typed("ParseError", format!("Parse error: {e}"), &e))?;
+        let options = from_sequences_options(max_grid_cells, self.config.shuffle_direction)?;
+        let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
+        py.detach(|| normalizer.sequence_normalize(&variant, &options, normalize))
+            .map(|inner| inner.to_string())
+            .map_err(|e| ferro_typed("NormalizationError", format!("{e}"), &e))
     }
 
     /// Normalize an HGVS variant

--- a/tests/it/from_sequences_reported_pairs.rs
+++ b/tests/it/from_sequences_reported_pairs.rs
@@ -116,7 +116,8 @@ fn derive(
         &options,
     )
     .unwrap_or_else(|e| panic!("from_sequences({spelling}, pad={pad}): {e}"));
-    (derived.variant, derived.placement_bounded_by_window)
+    let bounded = derived.placement_bounded_by_window();
+    (derived.variant, bounded)
 }
 
 /// **A zero-pad window refuses an insertion resting on its 5' edge**, and says

--- a/tests/it/from_sequences_window_condition.rs
+++ b/tests/it/from_sequences_window_condition.rs
@@ -92,7 +92,7 @@ fn derive(lo: u64, reference: &str, alternate: &str) -> (String, bool) {
     .unwrap_or_else(|e| panic!("from_sequences at {lo} over {reference} -> {alternate}: {e}"));
     (
         derived.variant.to_string(),
-        derived.placement_bounded_by_window,
+        derived.placement_bounded_by_window(),
     )
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -489,6 +489,7 @@ mod rewrite_target_corpus;
 mod rna_coding_consistency;
 mod rna_spl_marker;
 mod ruling_citation_currency;
+mod sequence_normalize;
 mod service_tools_tests;
 mod spdi_dup_recovery;
 mod spdi_tests;

--- a/tests/it/sequence_normalize.rs
+++ b/tests/it/sequence_normalize.rs
@@ -1,0 +1,179 @@
+//! `Normalizer::sequence_normalize`: the "one canonical description per variant"
+//! round trip, and its per-side widening loop.
+//!
+//! `sequence_normalize` expresses a variant as a padded reference/alternate
+//! window (`to_sequences`), derives a description from those bases alone
+//! (`from_sequences`), and — while a member still rests on a window edge that
+//! can still move — doubles the pad and retries. Two spellings of one variant
+//! therefore reach one description, decided by the observed bases.
+//!
+//! The loop reads the two per-side flags apart, so a placement pinned to the
+//! sequence's own start (5') or end (3') is recognised as settled rather than
+//! chased: a variant at position 1 of a long contig does not widen 5' forever
+//! against an edge that cannot move.
+//!
+//! Every test builds a genomic `JsonProvider` over one synthetic contig, since
+//! `sequence_normalize` reads the reference (unlike the free `from_sequences`).
+
+use ferro_hgvs::{parse_hgvs, FromSequencesOptions, JsonProvider, Normalizer, ShuffleDirection};
+use std::io::Write;
+
+/// A genome-capable provider over one contig named `NC_TEST.1` carrying `seq`.
+///
+/// The name is genomic on purpose: `from_sequences` (which this method calls)
+/// emits `g.` and refuses a transcript/protein accession, so a non-genomic
+/// contig name would be rejected before any derivation.
+fn provider(seq: &str) -> JsonProvider {
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { "NC_TEST.1": seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// Run `sequence_normalize` over a parsed description, returning the string.
+fn seqnorm(
+    nz: &Normalizer<JsonProvider>,
+    desc: &str,
+    direction: ShuffleDirection,
+    normalize: bool,
+) -> String {
+    let variant = parse_hgvs(desc).unwrap_or_else(|e| panic!("parse {desc}: {e}"));
+    let options = FromSequencesOptions::default().with_direction(direction);
+    nz.sequence_normalize(&variant, &options, normalize)
+        .unwrap_or_else(|e| panic!("sequence_normalize {desc}: {e}"))
+        .to_string()
+}
+
+/// Three spellings of one deletion in a 300-base run reach one description, and
+/// reaching it requires the loop to widen: the run is far longer than the
+/// 128-base start pad (`merge::CANONICAL_PAD`), so a single fetch cannot contain
+/// the whole roll.
+#[test]
+fn confluence_and_widening_over_a_long_interior_run() {
+    // unique(10) + A*300 (positions 11..=310) + unique(12).
+    let seq = format!("GCTAGCTAGC{}GCTAGCTAGCTA", "A".repeat(300));
+    let nz = Normalizer::new(provider(&seq));
+
+    // Delete one A from anywhere in the run: one variant, three spellings. All
+    // must land on the 3'-most placement, 310.
+    for spelling in [
+        "NC_TEST.1:g.11del",
+        "NC_TEST.1:g.160del",
+        "NC_TEST.1:g.310del",
+    ] {
+        assert_eq!(
+            seqnorm(&nz, spelling, ShuffleDirection::ThreePrime, false),
+            "NC_TEST.1:g.310del",
+            "{spelling} did not converge on the 3'-most placement",
+        );
+    }
+}
+
+/// A duplication and the insertion spelling of the same variant converge — the
+/// case a narrow first window gets silently wrong.
+///
+/// `dup` typing reads the reference bases immediately 5' of the insertion point
+/// (`duplication.md:18`), so a window that does not reach them derives an `ins`
+/// instead. That mis-typed `ins` rests on **neither** window edge, so both
+/// `bounded_*` flags are clear and the loop returns it without ever widening —
+/// there is no flag for "the answer is wrong for a reason the edges cannot
+/// show". Starting the loop at `merge::CANONICAL_PAD` rather than at a bare
+/// couple of bases is what makes the two spellings agree; with a 1-base start
+/// pad `g.14_15insACGTACGT` comes back unchanged while `g.7_14dup` does not.
+#[test]
+fn a_duplication_and_its_insertion_spelling_converge() {
+    // unique(6) + ACGTACGT (positions 7..=14) + unique(6).
+    let seq = "GCTAGC".to_string() + "ACGTACGT" + "TCGATC";
+    let nz = Normalizer::new(provider(&seq));
+
+    for spelling in ["NC_TEST.1:g.7_14dup", "NC_TEST.1:g.14_15insACGTACGT"] {
+        assert_eq!(
+            seqnorm(&nz, spelling, ShuffleDirection::ThreePrime, false),
+            "NC_TEST.1:g.7_14dup",
+            "{spelling} did not converge on the duplication spelling",
+        );
+    }
+}
+
+/// A run reaching the contig's 3' end settles by the sequence, not the window:
+/// the 3' edge is the last base there is, so the loop returns rather than
+/// declining or widening past it.
+#[test]
+fn a_run_reaching_the_three_prime_end_settles_by_the_sequence() {
+    // unique(10) + A*40 (positions 11..=50, the contig ends inside the run).
+    let seq = format!("GCTAGCTAGC{}", "A".repeat(40));
+    let nz = Normalizer::new(provider(&seq));
+
+    assert_eq!(
+        seqnorm(
+            &nz,
+            "NC_TEST.1:g.15del",
+            ShuffleDirection::ThreePrime,
+            false
+        ),
+        "NC_TEST.1:g.50del",
+        "a deletion in a contig-terminal run must roll to the last base",
+    );
+}
+
+/// The case the per-side split exists for: a variant whose placement is pinned
+/// to position 1. Under 5'-shuffle a deletion in a run at the contig start rolls
+/// to base 1, resting on the 5' edge of a window that already begins there — a
+/// stall, not an overrun. The loop must return `g.1del`, not chase an edge that
+/// cannot move nor decline it as unbounded.
+#[test]
+fn a_run_at_the_contig_start_settles_at_position_one_under_five_prime() {
+    // A*40 (positions 1..=40, the contig begins inside the run) + unique(10).
+    let seq = format!("{}GCTAGCTAGC", "A".repeat(40));
+    let nz = Normalizer::new(provider(&seq));
+
+    assert_eq!(
+        seqnorm(&nz, "NC_TEST.1:g.20del", ShuffleDirection::FivePrime, false),
+        "NC_TEST.1:g.1del",
+        "a 5'-shuffled deletion in a contig-initial run must settle at base 1",
+    );
+}
+
+/// `normalize = true` routes the derived description through `normalize`. For a
+/// placement already at its 3'-most, reference-anchored base that is a no-op, so
+/// the result matches the `normalize = false` derivation — what this pins is
+/// that the routing runs without error and returns the same settled variant.
+#[test]
+fn normalize_true_routes_through_normalize() {
+    let seq = format!("GCTAGCTAGC{}GCTAGCTAGCTA", "A".repeat(300));
+    let nz = Normalizer::new(provider(&seq));
+
+    assert_eq!(
+        seqnorm(&nz, "NC_TEST.1:g.11del", ShuffleDirection::ThreePrime, true),
+        "NC_TEST.1:g.310del",
+    );
+}
+
+/// An interior tract longer than the widest window the loop will read is
+/// declined, not answered over a truncated window: where the change shifts to
+/// would depend on how much reference was read, which is exactly the
+/// non-confluence the widening removes. The message names the offending side.
+#[test]
+fn an_unbounded_interior_tract_is_declined() {
+    // A run longer than MAX_SHIFT_TRACT (32768), flanked by unique sequence on
+    // both sides so neither edge is ever the contig's own — the loop can never
+    // settle the 3' side, and reaches the pad ceiling.
+    let seq = format!("GCTAGCTAGC{}GCTAGCTAGCTA", "A".repeat(40_000));
+    let nz = Normalizer::new(provider(&seq));
+
+    let variant = parse_hgvs("NC_TEST.1:g.15del").unwrap();
+    let options = FromSequencesOptions::default().with_direction(ShuffleDirection::ThreePrime);
+    let err = nz
+        .sequence_normalize(&variant, &options, false)
+        .expect_err("an unbounded interior tract must be declined");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("3' edge") && msg.contains("window-settled"),
+        "the refusal must name the unsettled side: {msg}",
+    );
+}

--- a/tests/python/test_sequence_normalize.py
+++ b/tests/python/test_sequence_normalize.py
@@ -1,0 +1,188 @@
+"""``Normalizer.sequence_normalize`` and ``DerivedDescription``'s per-side flags.
+
+``sequence_normalize`` expresses a variant as a padded reference/alternate window
+(``to_sequences``), derives a description from those bases alone
+(``from_sequences``), and — while a member still rests on a window edge that can
+still move — doubles the pad and retries. Two spellings of one variant therefore
+reach one description, decided by the observed bases.
+
+The properties themselves are judged in Rust, over
+``tests/it/sequence_normalize.rs`` and the cis corpus. What is checked here is
+what only the binding can get wrong: the keyword-only signature, that
+``normalize`` is threaded through rather than accepted and dropped, which
+exception class comes out of which failure, and that the two new
+``DerivedDescription`` getters are wired to the fields they name rather than
+both to ``placement_bounded_by_window``.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+# 1-based:                    1..=10        11..=310        311..=322
+#
+# A 300-base `A` run flanked by unique sequence on both sides. The run is far
+# longer than the 128-base start pad, so a single fetch cannot contain the whole
+# roll and the widening loop has to run.
+LONG_RUN = "GCTAGCTAGC" + "A" * 300 + "GCTAGCTAGCTA"
+
+# 1-based:            1..=6      7..=14     15..=20
+#
+# `ACGTACGT` at 7-14, so the same variant can be spelled as a duplication of
+# 7_14 or as an insertion of those eight bases after 14.
+DUP_CONTIG = "GCTAGC" + "ACGTACGT" + "TCGATC"
+
+
+def _normalizer(sequence: str) -> ferro_hgvs.Normalizer:
+    """A genome-capable provider over one synthetic contig named ``NC_TEST.1``.
+
+    The name is genomic on purpose: ``from_sequences``, which
+    ``sequence_normalize`` calls, emits ``g.`` and refuses a transcript or
+    protein accession, so a non-genomic contig name would be rejected before any
+    derivation.
+
+    There is no ``direction=`` here because the bindings no longer take one —
+    3' is the only direction ferro shifts. The 5'-shuffle half of the per-side
+    split is therefore only reachable from Rust, and is pinned there by
+    ``tests/it/sequence_normalize.rs``.
+    """
+    payload = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {"NC_TEST.1": sequence},
+    }
+    path = Path(tempfile.mkdtemp()) / "reference.json"
+    path.write_text(json.dumps(payload))
+    return ferro_hgvs.Normalizer(reference_json=str(path))
+
+
+# ---------------------------------------------------------------------------
+# Confluence
+# ---------------------------------------------------------------------------
+
+
+def test_three_spellings_of_one_deletion_converge():
+    """The headline contract, at the binding: one variant, three spellings, one
+    description — and reaching it requires the loop to widen past its start pad."""
+    normalizer = _normalizer(LONG_RUN)
+    results = {
+        normalizer.sequence_normalize(spelling)
+        for spelling in ("NC_TEST.1:g.11del", "NC_TEST.1:g.160del", "NC_TEST.1:g.310del")
+    }
+    assert results == {"NC_TEST.1:g.310del"}
+
+
+def test_a_duplication_and_its_insertion_spelling_converge():
+    """The shape a narrow first window gets silently wrong.
+
+    ``dup`` typing reads the reference bases immediately 5' of the insertion
+    point, so a window that does not reach them derives an ``ins`` instead — and
+    that mis-typed ``ins`` rests on neither window edge, so neither per-side flag
+    fires and the loop would return it without widening.
+    """
+    normalizer = _normalizer(DUP_CONTIG)
+    assert normalizer.sequence_normalize("NC_TEST.1:g.7_14dup") == "NC_TEST.1:g.7_14dup"
+    assert normalizer.sequence_normalize("NC_TEST.1:g.14_15insACGTACGT") == "NC_TEST.1:g.7_14dup"
+
+
+def test_a_run_reaching_the_contig_end_settles_by_the_sequence():
+    """A stall, not an overrun. The run reaches the contig's last base, so the 3'
+    edge the placement rests on is the sequence's own — the loop must return
+    rather than widen past it or decline it as unbounded."""
+    normalizer = _normalizer("GCTAGCTAGC" + "A" * 40)
+    assert normalizer.sequence_normalize("NC_TEST.1:g.15del") == "NC_TEST.1:g.50del"
+
+
+# ---------------------------------------------------------------------------
+# The signature
+# ---------------------------------------------------------------------------
+
+
+def test_max_grid_cells_and_normalize_are_keyword_only():
+    normalizer = _normalizer(LONG_RUN)
+    with pytest.raises(TypeError):
+        normalizer.sequence_normalize("NC_TEST.1:g.11del", 4096)  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        normalizer.sequence_normalize("NC_TEST.1:g.11del", normalize_flag=True)  # type: ignore[call-arg]
+
+
+def test_normalize_true_reaches_the_normalizer():
+    """``normalize`` must be threaded through, not accepted and dropped. For a
+    placement already at its 3'-most, reference-anchored base the pass is a
+    no-op, so what this pins is that the routing runs and returns the same
+    settled variant rather than raising."""
+    normalizer = _normalizer(LONG_RUN)
+    assert (
+        normalizer.sequence_normalize("NC_TEST.1:g.11del", normalize=True) == "NC_TEST.1:g.310del"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Which exception comes out of which failure
+# ---------------------------------------------------------------------------
+
+
+def test_an_unparseable_description_raises_parse_error():
+    normalizer = _normalizer(LONG_RUN)
+    with pytest.raises(ferro_hgvs.ParseError):
+        normalizer.sequence_normalize("not an hgvs description")
+
+
+def test_a_zero_grid_budget_raises_value_error():
+    """Checked at the binding and outside the ``FerroError`` hierarchy, as for
+    ``from_sequences``."""
+    normalizer = _normalizer(LONG_RUN)
+    with pytest.raises(ValueError):
+        normalizer.sequence_normalize("NC_TEST.1:g.11del", max_grid_cells=0)
+
+
+def test_an_unknown_accession_raises_normalization_error():
+    normalizer = _normalizer(LONG_RUN)
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        normalizer.sequence_normalize("NC_ABSENT.1:g.11del")
+
+
+# ---------------------------------------------------------------------------
+# The two new DerivedDescription getters
+# ---------------------------------------------------------------------------
+
+
+def test_the_per_side_flags_are_wired_to_their_own_fields():
+    """Both getters returning ``placement_bounded_by_window`` would pass any test
+    that only checks the OR, so each side is asserted alone — on two pairs whose
+    answers differ, and without reaching for a shuffle direction the bindings no
+    longer expose.
+
+    A substitution flush against one end of the window rests on that edge and no
+    other, which separates the two flags under the only direction there is.
+    """
+    # Changed base at the window's last position: 3' edge only.
+    derived = ferro_hgvs.from_sequences_detailed("NC_TEST.1", 5, "ACGT", "ACGA")
+    assert derived.bounded_at_end is True
+    assert derived.bounded_at_start is False
+    assert derived.placement_bounded_by_window is True
+
+    # Changed base at the window's first position: 5' edge only.
+    derived = ferro_hgvs.from_sequences_detailed("NC_TEST.1", 5, "ACGT", "TCGT")
+    assert derived.bounded_at_start is True
+    assert derived.bounded_at_end is False
+    assert derived.placement_bounded_by_window is True
+
+
+def test_an_interior_change_flags_neither_side():
+    derived = ferro_hgvs.from_sequences_detailed("NC_TEST.1", 5, "TAAAAG", "TAAAG")
+    assert derived.bounded_at_start is False
+    assert derived.bounded_at_end is False
+    assert derived.placement_bounded_by_window is False
+
+
+def test_the_repr_names_all_three_flags():
+    derived = ferro_hgvs.from_sequences_detailed("NC_TEST.1", 5, "ACGT", "ACGA")
+    text = repr(derived)
+    assert "placement_bounded_by_window=True" in text
+    assert "bounded_at_start=False" in text
+    assert "bounded_at_end=True" in text


### PR DESCRIPTION
### Summary
This PR adds sequence-based normalization for an HGVS variant (with optional standard `normalize()` afterwards), guaranteeing confluence when normalizing string-derived variants to a single representation.

### Implementation
* `sequence_normalize()` wraps `to_sequence()` and `from_sequence()`, handling logic revolving around iterative doubling of the padding to ensure convergence to a single representation.
* `placement_bounded_by_window` was split into `bounded_at_start` and `bounded_at_end` to assist in determine whether the window needs to keep growing or not

### Review follow-ups

* **The loop starts at `merge::CANONICAL_PAD` (128), not at 1.** `dup` typing reads the reference bases immediately 5' of an insertion point, so a window that does not reach them derives an `ins` instead — and that mis-typed `ins` rests on *neither* window edge, so both `bounded_*` flags are clear and the loop returned it without ever widening. There is no flag for "wrong for a reason the edges cannot show", so the only defence is starting wide enough to type a duplication. Measured on the new `a_duplication_and_its_insertion_spelling_converge`: at a 1-base start pad `g.14_15insACGTACGT` came back unchanged while `g.7_14dup` did not — the exact non-confluence this PR exists to remove. `CANONICAL_PAD` is now `pub(crate)` so the three places that must agree on 128 (the normalizer's own derivation, this loop, the `pad=128` default on the Python `to_sequences` binding) cannot drift apart.
* **A narrow-window refusal is retried rather than propagated.** `from_sequences` declines a derived insertion whose only HGVS anchor lies 5' of the first base supplied, and that refusal's own text says to supply more 5' flank — which is precisely what this loop does. The `?` turned a widenable window into a terminal error. It now widens while either side can still grow and reports the first refusal only if none of them helped.
* **`get_sequence_length` is no longer required.** It carries a trait default that always errors, and `apply_to_reference_padded` treats that as non-fatal on purpose ("an out-of-tree provider that serves bases perfectly well may not implement it"). The loop hard-failed on it one line after `to_sequences` had already succeeded for such a provider. The lookup is now optional, with `SequencePair::window_is_final` and the existing `prev_bounds` fallback carrying termination.
* **Python surface completed.** `bounded_at_start` / `bounded_at_end` and `Normalizer.sequence_normalize` are added to `python/ferro_hgvs/__init__.pyi`, the `from_sequences_detailed` docstring names all three attributes, and `tests/python/test_sequence_normalize.py` covers the binding-only failure modes (keyword-only signature, `normalize` threading, which exception class comes out of which failure, and that the two getters are wired to their own fields rather than both to the OR).
* **Rebased onto current `main` (39 commits).** The branch predated the removal of the Python `direction=` keyword from `Normalizer.__new__` and `from_sequences_detailed` ("3' is the only direction ferro shifts"), and CI builds the merge ref, so the new Python tests were compiled against bindings the branch could not see. The Rust `ShuffleDirection` instrument survives, so `tests/it/sequence_normalize.rs` still pins both shuffle directions; the Python file drops `direction=` and separates the two per-side flags with substitutions flush against opposite window edges instead.
* Docs and formatting: `# Errors` on `sequence_normalize`, a per-field doc on `bounded_at_end` in both structs, the pad-ceiling refusal no longer calls `MAX_PAD` the window's total width (`to_sequences` pads both sides), the stale "128-base start pad" comment now matches the constant, and `cargo fmt --all`.

Representation-Change: none. `placement_bounded_by_window()` is the OR of the two new fields and `any(p.start == 0 || p.end == len)` is identical to `any(p.start == 0) || any(p.end == len)`, so the split is value-identical for every input; `sequence_normalize` is a new entry point with no previously-shipped output. Nothing already emitted changes.
