### PR TITLE
fix(reference): decline an intron distance the offset cannot measure

### DIFF
--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -942,16 +942,17 @@ pub struct IntronPosition {
 //   would take the identical `Option` treatment; it was simply outside an
 //   approved break. Do not read the `bool` argument above as covering it.
 // - `distance_from_donor` / `distance_from_acceptor` ALREADY return `Option<u64>`,
-//   so they have a decline channel and do not use it. Worse than a fabricated
-//   band: the cross-boundary arm computes `intron_length - offset.unsigned_abs()`,
-//   an unchecked `u64` subtraction that underflows for ANY magnitude exceeding
-//   the intron — panicking under `overflow-checks` and wrapping to a colossal
-//   "distance" in release. `unsigned_abs` closed the ladder's overflow in #1767
-//   and left this subtraction untouched, so the hardening pass is incomplete
-//   here rather than deliberately scoped.
+//   so they had a decline channel and did not use it. **Closed by #1916**: the
+//   cross-boundary arm computed `intron_length - offset.unsigned_abs()`, an
+//   unchecked `u64` subtraction that underflowed for ANY magnitude exceeding the
+//   intron — panicking under `overflow-checks` and wrapping to a colossal
+//   "distance" in release. Both now route through `measured_offset` and decline.
+//   `unsigned_abs` closed the ladder's overflow in #1767 and left that
+//   subtraction untouched, so the hardening pass was incomplete there rather
+//   than deliberately scoped.
 //
-// Neither is reachable from a string entry point today; both are reachable by a
-// library caller, because every field of this struct is `pub`.
+// `splice_site_type` is not reachable from a string entry point today; it is
+// reachable by a library caller, because every field of this struct is `pub`.
 impl IntronPosition {
     /// Check if this is a deep intronic position (>50bp from nearest exon)
     pub fn is_deep_intronic(&self) -> bool {
@@ -1009,25 +1010,77 @@ impl IntronPosition {
         }
     }
 
+    /// `offset` read as a measured distance in bases from [`Self::boundary`],
+    /// or `None` where it measures nothing (#1916).
+    ///
+    /// Two regimes decline, and neither is a computation that could be made to
+    /// succeed by clamping — in both, *no* distance follows from the record:
+    ///
+    /// - **An unknown-offset sentinel** (`c.N+?` / `c.N-?`). Per
+    ///   [`is_unknown_offset`] these denote a position unbounded in one
+    ///   direction, "from which no distance can be derived at all". #1767
+    ///   applied that to [`IntronicConsequence::from_cds_pos`] and #1841 to
+    ///   [`IntronicRegion::from_offset`] and
+    ///   [`EffectPredictor::classify_splice_variant`]; the two callers below
+    ///   already returned `Option`, so they needed no API break to say it.
+    /// - **A magnitude exceeding `intron_length`.** The record asserts a
+    ///   position inside an intron of that length sitting further than that
+    ///   from one of its own boundaries. No position in the intron does, so the
+    ///   record is self-inconsistent and neither distance is derivable from it.
+    ///   Offsets are 1-based from their boundary, so a magnitude of exactly
+    ///   `intron_length` is the far-edge base and still answers; `+ 1` is the
+    ///   first base of the flanking exon and declines.
+    ///
+    /// **Postcondition: `result <= intron_length`.** That is what makes the
+    /// cross-boundary subtraction in both callers total, and it is why the
+    /// magnitude test lives here rather than at the one arm that underflowed —
+    /// screening only that arm would leave the two functions disagreeing about
+    /// one position, `distance_from_donor() == None` beside
+    /// `distance_from_acceptor() == Some(300)`.
+    ///
+    /// A position produced by [`Transcript::find_intron_at_genomic`] always
+    /// satisfies both conditions: it maintains `dist_to_5prime + dist_to_3prime
+    /// == intron_length + 1` with both terms at least 1, and never mints a
+    /// sentinel. So this declines only for a record a library caller built by
+    /// hand — which every field of this struct being `pub` permits.
+    ///
+    /// [`is_unknown_offset`]: crate::hgvs::parser::position::is_unknown_offset
+    /// [`IntronicConsequence::from_cds_pos`]: crate::convert::noncoding::IntronicConsequence::from_cds_pos
+    /// [`IntronicRegion::from_offset`]: crate::convert::noncoding::IntronicRegion::from_offset
+    /// [`EffectPredictor::classify_splice_variant`]: crate::effect::EffectPredictor::classify_splice_variant
+    fn measured_offset(&self) -> Option<u64> {
+        if crate::hgvs::parser::position::is_unknown_offset(self.offset) {
+            return None;
+        }
+        let magnitude = self.offset.unsigned_abs();
+        (magnitude <= self.intron_length).then_some(magnitude)
+    }
+
     /// Get distance from splice donor (5' end of intron)
+    ///
+    /// `None` when [`Self::measured_offset`] declines — the offset states no
+    /// distance, so neither does this.
     pub fn distance_from_donor(&self) -> Option<u64> {
+        let measured = self.measured_offset()?;
         match self.boundary {
-            IntronBoundary::FivePrime => Some(self.offset.unsigned_abs()),
-            IntronBoundary::ThreePrime => {
-                // Distance = intron_length - distance_from_3prime
-                Some(self.intron_length - self.offset.unsigned_abs())
-            }
+            IntronBoundary::FivePrime => Some(measured),
+            // Distance = intron_length - distance_from_3prime. Total: the
+            // postcondition of `measured_offset` is `measured <= intron_length`.
+            IntronBoundary::ThreePrime => Some(self.intron_length - measured),
         }
     }
 
     /// Get distance from splice acceptor (3' end of intron)
+    ///
+    /// `None` when [`Self::measured_offset`] declines — the offset states no
+    /// distance, so neither does this.
     pub fn distance_from_acceptor(&self) -> Option<u64> {
+        let measured = self.measured_offset()?;
         match self.boundary {
-            IntronBoundary::ThreePrime => Some(self.offset.unsigned_abs()),
-            IntronBoundary::FivePrime => {
-                // Distance = intron_length - distance_from_5prime
-                Some(self.intron_length - self.offset.unsigned_abs())
-            }
+            IntronBoundary::ThreePrime => Some(measured),
+            // Distance = intron_length - distance_from_5prime. Total for the
+            // same reason as its mirror image above.
+            IntronBoundary::FivePrime => Some(self.intron_length - measured),
         }
     }
 }

--- a/tests/it/issue_1916_intron_distance_underflow.rs
+++ b/tests/it/issue_1916_intron_distance_underflow.rs
@@ -1,0 +1,301 @@
+//! Issue #1916 — `IntronPosition::distance_from_donor` / `distance_from_acceptor`
+//! must decline an offset they cannot measure, rather than underflow on it.
+//!
+//! Both functions compute the *cross-boundary* distance as
+//! `intron_length - offset.unsigned_abs()` on two `u64`s. When the magnitude
+//! exceeds `intron_length` that underflows: `attempt to subtract with overflow`
+//! under `overflow-checks` (the `dev`, `test` and `soak` profiles all enable
+//! it), and in release a wrap to a value near `u64::MAX` returned as a distance
+//! in bases from a splice site.
+//!
+//! This is the residue of #1767. That PR made this struct's five *predicates*
+//! total by reading `offset` through `unsigned_abs` rather than `abs`, and the
+//! block comment it left on `src/reference/transcript.rs` names these two
+//! functions as the part it did not finish — noting that they "ALREADY return
+//! `Option<u64>`, so they have a decline channel and do not use it".
+//! `issue_1767_unknown_offset_splice_classifiers::the_intron_position_predicates_are_total`
+//! builds the very record that reproduces this (`offset: i64::MIN`,
+//! `intron_length: 1_000`) and calls only the five predicates.
+//!
+//! **Two regimes reach the subtraction, and the answer to both is a refusal.**
+//!
+//! * `offset.unsigned_abs() > intron_length` — the record claims a position
+//!   inside an intron of length `intron_length` sitting further than that from
+//!   one of its own boundaries. No position in that intron does. The record is
+//!   self-inconsistent and no distance to *either* boundary follows from it.
+//! * `offset` is an unknown-offset sentinel (`c.N+?` / `c.N-?`). Per
+//!   `is_unknown_offset`'s own contract these "denote a position unbounded in
+//!   one direction, from which no distance can be derived at all" — the ruling
+//!   #1767 applied to `IntronicConsequence::from_cds_pos` and #1841 to
+//!   `IntronicRegion::from_offset` and `EffectPredictor::classify_splice_variant`.
+//!
+//! **Why not `saturating_sub`.** A clamp would answer `Some(0)`, and `0` is the
+//! single worst value available: it reads as *at the splice site*, so every
+//! downstream band (`is_canonical_splice_site`, `SpliceSiteType::DonorCanonical`,
+//! `IntronicConsequence::SpliceDonorVariant`, HIGH impact) would promote an
+//! unmeasurable offset to the most clinically significant answer there is. It
+//! would also only fix the arm that panics: the *same*-boundary arm returns
+//! `Some(offset.unsigned_abs())` unconditionally and never underflows, so
+//! clamping the other one leaves the two functions disagreeing about one
+//! position — `distance_from_donor() == None` beside
+//! `distance_from_acceptor() == Some(300)`. Hence
+//! [`the_two_distances_never_disagree_about_resolvability`], which is the
+//! assertion that forbids a one-armed fix.
+//!
+//! The refusal must not reach a position the library can actually produce, so
+//! [`every_derived_intronic_position_still_answers`] walks every genomic base of
+//! a real two-intron transcript through `find_intron_at_genomic` and requires an
+//! answer at each one. That is the negative control for the whole change: it
+//! fails if the guard is drawn even one base too tight.
+
+use ferro_hgvs::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+use ferro_hgvs::reference::transcript::{
+    Exon, GenomeBuild, IntronBoundary, IntronPosition, ManeStatus, Strand, Transcript,
+};
+
+/// Both unknown-offset sentinels, so `+?` and `-?` are covered symmetrically —
+/// #1767's own lesson that a guard keyed on `i64::MIN` alone leaves its
+/// neighbour passing by accident rather than by decision.
+const SENTINELS: [i64; 2] = [OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE];
+
+fn intron_position(boundary: IntronBoundary, offset: i64, intron_length: u64) -> IntronPosition {
+    IntronPosition {
+        intron_number: 1,
+        boundary,
+        offset,
+        tx_boundary_pos: 100,
+        intron_length,
+    }
+}
+
+/// A two-intron transcript with genomic coordinates on every exon, built
+/// programmatically so no fixture is committed. Whichever strand is asked for,
+/// the two genomic gaps between the exons are 1101..=1200 (100 bases) and
+/// 1301..=1600 (300 bases) — deliberately different lengths, so a guard
+/// accidentally keyed on one of them fails on the other.
+///
+/// The exon layout is strand-specific because `compute_introns` derives an
+/// intron's genomic span differently per strand: on `Minus` it reads
+/// `downstream.genomic_end + 1 ..= upstream.genomic_start - 1`, so transcript
+/// order must run *down* the genome or the span comes out inverted and is
+/// dropped (`ge >= gs` fails), leaving `find_intron_at_genomic` with nothing to
+/// find.
+fn two_intron_transcript(strand: Strand) -> Transcript {
+    let exons = match strand {
+        // Transcript order ascends the genome.
+        Strand::Plus => vec![
+            Exon::with_genomic(1, 1, 100, 1001, 1100),
+            Exon::with_genomic(2, 101, 200, 1201, 1300),
+            Exon::with_genomic(3, 201, 300, 1601, 1700),
+        ],
+        // Transcript order descends the genome; the gaps are the same two.
+        _ => vec![
+            Exon::with_genomic(1, 1, 100, 1601, 1700),
+            Exon::with_genomic(2, 101, 200, 1201, 1300),
+            Exon::with_genomic(3, 201, 300, 1001, 1100),
+        ],
+    };
+    Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        strand,
+        "A".repeat(300),
+        Some(1),
+        Some(300),
+        exons,
+        Some("chrTEST".to_string()),
+        Some(1001),
+        Some(1700),
+        GenomeBuild::GRCh38,
+        ManeStatus::default(),
+        None,
+        None,
+    )
+}
+
+/// The two genomic ranges the transcript above leaves between its exons, with
+/// the length each intron therefore has.
+const INTRON_SPANS: [(u64, u64, u64); 2] = [(1101, 1200, 100), (1301, 1600, 300)];
+
+/// The defect as reported: a *measured* offset larger than the intron it names.
+/// Panicked at `transcript.rs:1029` before the fix (`100 - 300`); in release it
+/// returned `Some(18446744073709551516)`.
+#[test]
+fn a_measured_offset_larger_than_the_intron_is_declined() {
+    let pos = intron_position(IntronBoundary::FivePrime, 300, 100);
+    assert_eq!(
+        pos.distance_from_acceptor(),
+        None,
+        "a position 300 bases 3' of the donor is not inside a 100-base intron, \
+         so it has no distance to that intron's acceptor"
+    );
+
+    let pos = intron_position(IntronBoundary::ThreePrime, -300, 100);
+    assert_eq!(
+        pos.distance_from_donor(),
+        None,
+        "the mirror image: 300 bases 5' of the acceptor of a 100-base intron"
+    );
+}
+
+/// The boundary of the guard, stated as three adjacent magnitudes so a fix that
+/// is off by one is caught.
+///
+/// Offsets are 1-based from their boundary, so a magnitude of exactly
+/// `intron_length` names the intron's far-edge base — still inside the intron,
+/// and still answerable. The `Some(0)` it yields is the shipped arithmetic's
+/// own answer for that base, not a clamp: a magnitude of `intron_length + 1`
+/// names the first base of the flanking exon and declines.
+#[test]
+fn the_guard_fires_exactly_where_the_magnitude_leaves_the_intron() {
+    let length = 100;
+    for (offset, expected) in [(99u64, Some(1u64)), (100, Some(0)), (101, None)] {
+        let pos = intron_position(IntronBoundary::FivePrime, offset as i64, length);
+        assert_eq!(
+            pos.distance_from_acceptor(),
+            expected,
+            "offset {offset} against an intron of length {length}"
+        );
+    }
+}
+
+/// An unknown-offset sentinel states no distance in *either* direction, so both
+/// arms of both functions must decline — including the same-boundary arm, which
+/// never underflowed and answered `Some(9223372036854775807)`.
+#[test]
+fn an_unknown_offset_sentinel_is_declined_from_either_boundary() {
+    for offset in SENTINELS {
+        for boundary in [IntronBoundary::FivePrime, IntronBoundary::ThreePrime] {
+            let pos = intron_position(boundary, offset, 1_000);
+            assert_eq!(
+                pos.distance_from_donor(),
+                None,
+                "offset {offset} from {boundary:?} states no distance to the donor"
+            );
+            assert_eq!(
+                pos.distance_from_acceptor(),
+                None,
+                "offset {offset} from {boundary:?} states no distance to the acceptor"
+            );
+        }
+    }
+}
+
+/// The assertion a one-armed fix cannot satisfy. The two functions describe one
+/// position, so they must agree on whether that position is resolvable at all —
+/// clamping only the arm that panics leaves `None` beside `Some(300)` for the
+/// same record.
+#[test]
+fn the_two_distances_never_disagree_about_resolvability() {
+    let offsets = [
+        i64::MIN,
+        i64::MIN + 1,
+        OFFSET_UNKNOWN_NEGATIVE,
+        -1_000_000,
+        -301,
+        -300,
+        -100,
+        -1,
+        0,
+        1,
+        100,
+        300,
+        301,
+        1_000_000,
+        i64::MAX - 1,
+        OFFSET_UNKNOWN_POSITIVE,
+    ];
+    for boundary in [IntronBoundary::FivePrime, IntronBoundary::ThreePrime] {
+        for offset in offsets {
+            for length in [0u64, 1, 100, 300, u64::MAX] {
+                let pos = intron_position(boundary, offset, length);
+                // Totality first: neither call may panic for any `i64`.
+                let donor = pos.distance_from_donor();
+                let acceptor = pos.distance_from_acceptor();
+                assert_eq!(
+                    donor.is_some(),
+                    acceptor.is_some(),
+                    "{boundary:?} offset {offset} length {length}: one distance \
+                     resolved and the other did not, for the same position"
+                );
+            }
+        }
+    }
+}
+
+/// The negative control, and the reason this change moves no in-tree behaviour:
+/// **every** position the library can actually derive must still answer.
+///
+/// `find_intron_at_genomic` maintains `dist_to_5prime + dist_to_3prime ==
+/// intron_length + 1` with both terms at least 1, so a derived `IntronPosition`
+/// always satisfies `offset.unsigned_abs() <= intron_length`. This walks every
+/// genomic base of both introns, on both strands, and requires `Some` from both
+/// functions at each one — so a guard drawn one base too tight fails here rather
+/// than silently narrowing the API.
+#[test]
+fn every_derived_intronic_position_still_answers() {
+    for strand in [Strand::Plus, Strand::Minus] {
+        let transcript = two_intron_transcript(strand);
+        let mut checked = 0usize;
+
+        for (g_start, g_end, length) in INTRON_SPANS {
+            for genomic_pos in g_start..=g_end {
+                let (_, pos) = transcript
+                    .find_intron_at_genomic(genomic_pos)
+                    .unwrap_or_else(|| {
+                        panic!("{genomic_pos} is inside intron {g_start}..={g_end}")
+                    });
+                assert_eq!(pos.intron_length, length, "at {genomic_pos} on {strand:?}");
+
+                let donor = pos.distance_from_donor().unwrap_or_else(|| {
+                    panic!(
+                        "a derived position ({genomic_pos} on {strand:?}, offset {}) must have \
+                         a donor distance",
+                        pos.offset
+                    )
+                });
+                let acceptor = pos.distance_from_acceptor().unwrap_or_else(|| {
+                    panic!(
+                        "a derived position ({genomic_pos} on {strand:?}, offset {}) must have \
+                         an acceptor distance",
+                        pos.offset
+                    )
+                });
+
+                // The shipped arithmetic, restated as an invariant rather than
+                // re-implemented: the two distances partition the intron.
+                assert_eq!(
+                    donor + acceptor,
+                    length,
+                    "at {genomic_pos} on {strand:?}, offset {}",
+                    pos.offset
+                );
+                checked += 1;
+            }
+        }
+
+        // A zero here would make every assertion above vacuous.
+        assert_eq!(
+            checked,
+            INTRON_SPANS
+                .iter()
+                .map(|(_, _, l)| *l as usize)
+                .sum::<usize>(),
+            "every intronic base on {strand:?} must have been visited"
+        );
+    }
+}
+
+/// The shipped semantics of the answering path are unchanged. Pinned here as
+/// well as in `transcript.rs`'s own unit test, because the fix rewrites the
+/// bodies of both functions and this is the arithmetic it must not move.
+#[test]
+fn the_answering_path_keeps_its_shipped_arithmetic() {
+    let pos = intron_position(IntronBoundary::FivePrime, 10, 500);
+    assert_eq!(pos.distance_from_donor(), Some(10));
+    assert_eq!(pos.distance_from_acceptor(), Some(490));
+
+    let pos = intron_position(IntronBoundary::ThreePrime, -10, 500);
+    assert_eq!(pos.distance_from_acceptor(), Some(10));
+    assert_eq!(pos.distance_from_donor(), Some(490));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -37,6 +37,7 @@ mod issue_1767_unknown_offset_splice_classifiers;
 mod issue_1796_base_zero_names_no_nucleotide;
 mod issue_1841_option_returning_splice_classifiers;
 mod issue_1870_cds_less_transcript_refusal;
+mod issue_1916_intron_distance_underflow;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Closes #1916

`IntronPosition::distance_from_donor` and `IntronPosition::distance_from_acceptor` computed the cross-boundary distance as `intron_length - offset.unsigned_abs()` — an unchecked `u64` subtraction. Any offset magnitude exceeding `intron_length` underflowed it: `attempt to subtract with overflow` under `overflow-checks` (the `dev`, `test` and `soak` profiles all enable it), and in release a wrap to a value near `u64::MAX` returned as a **distance in bases from a splice site**.

This is the residue #1767 left. That PR made this struct's five predicates total by reading `offset` through `unsigned_abs` rather than `abs`, and the block comment it wrote on `src/reference/transcript.rs` names these two functions as the part it did not finish — that they "ALREADY return `Option<u64>`, so they have a decline channel and do not use it". Its guard `the_intron_position_predicates_are_total` builds the exact record that reproduces this (`offset: i64::MIN`, `intron_length: 1_000`) and calls only the five predicates.

## Root cause

Two regimes reach the subtraction, and in both the record states no distance at all:

- **`offset.unsigned_abs() > intron_length`** — the record asserts a position inside an intron of length `intron_length` sitting further than that from one of its own boundaries. No position in that intron does. The record is self-inconsistent, and no distance to *either* boundary follows from it.
- **`offset` is an unknown-offset sentinel** (`c.N+?` / `c.N-?`). Per `is_unknown_offset`'s own contract these "denote a position unbounded in one direction, from which no distance can be derived at all" — the ruling #1767 applied to `IntronicConsequence::from_cds_pos` and #1841 took a public-API break to apply to `IntronicRegion::from_offset` and `EffectPredictor::classify_splice_variant`.

## Why a refusal rather than a clamp

Two reasons, and the second is the one that shapes the diff.

**`saturating_sub` would answer `Some(0)`, which is the worst value available here.** `0` reads as *at the splice site*: `is_canonical_splice_site`, `SpliceSiteType::DonorCanonical`, `IntronicConsequence::SpliceDonorVariant` and HIGH impact all key off small magnitudes, so a clamp would promote an unmeasurable offset to the most clinically significant answer the API can give. A wrong offset silently rendered as a canonical splice-site hit is worse than the panic it replaces.

**A clamp would also fix only one of the two arms.** The *same*-boundary arm — `distance_from_donor` on a `FivePrime` position — returns `Some(offset.unsigned_abs())` unconditionally and never underflowed, so it needed no clamp and would have kept answering. The result would be the two functions disagreeing about one position: `distance_from_donor() == None` beside `distance_from_acceptor() == Some(300)`, for the same record. So the magnitude test lives in a shared `measured_offset` helper that both arms of both functions consult, and `the_two_distances_never_disagree_about_resolvability` is the assertion that forbids a one-armed fix. Both functions already return `Option`, so no API break is needed to say any of this.

## Boundary, and the negative control

Offsets are 1-based from their boundary, so a magnitude of exactly `intron_length` names the intron's far-edge base — inside the intron, and still answerable. `intron_length + 1` names the first base of the flanking exon and declines. `the_guard_fires_exactly_where_the_magnitude_leaves_the_intron` pins all three adjacent magnitudes so an off-by-one fails.

The refusal must not reach anything the library can actually derive. `find_intron_at_genomic` — the only in-tree producer, reached via `CoordinateMapper::get_intron_position` and thence `src/vcf/to_hgvs.rs` — maintains `dist_to_5prime + dist_to_3prime == intron_length + 1` with both terms at least 1, so a derived `IntronPosition` always satisfies `offset.unsigned_abs() <= intron_length` and never carries a sentinel. `every_derived_intronic_position_still_answers` walks **every** genomic base of both introns of a programmatically built two-intron transcript, on both strands, requires `Some` from both functions at each one, and asserts `donor + acceptor == intron_length` throughout. It asserts its own visit count so a zero cannot pass as a result. That test passes both before and after the fix, which is what makes it the control.

The two introns are deliberately different lengths (100 and 300 bases) so a guard accidentally keyed on one fails on the other. No fixture is committed — the transcript is built in the test.

## Reachability

Not reachable from a string entry point; reachable by any library caller, because every field of `IntronPosition` is `pub` and the struct is exported from `ferro_hgvs::reference::transcript`. That is the same reachability argument #1767 accepted for the five predicates on this same struct, and both `tests/it/issue_1767_unknown_offset_splice_classifiers.rs` and `src/convert/noncoding.rs`'s unit tests construct one directly.

## Class sweep

Swept the surrounding class — unchecked `-` on unsigned operands near `unsigned_abs()`, `abs_diff`, `len()` and coordinate arithmetic — and triaged every hit, so a reader can tell a swept finding from an unswept one.

| site | verdict |
|---|---|
| `reference/transcript.rs:1018`, `:1029` | **confirmed** — this PR |
| `normalize/mod.rs:5308` `end - window_start` | **confirmed, filed separately as #1917** — reversed range (SVD-WG006 wraparound `dup`), different root cause and opposite correct answer; see below |
| `convert/coding.rs:30` `cds_end - cds_start + 1` | **confirmed, out of scope** — inverted-CDS record, same class as the open `fix/mapping-u64-underflow` work on `data/mapping.rs`; flagged rather than folded in |
| every other `unsigned_abs()` in `src/` | dismissed — each feeds a *comparison* (`> 50`, `<= 2`, a band ladder), never a subtraction |
| `reference/transcript.rs:865` | dismissed — magnitude feeds `checked_add` / `checked_sub` |
| `benchmark/cache.rs:4115`, `:4120` | dismissed — guarded by `cds_start >= *exon_start` in the same condition |
| `data/cdot.rs:1167`, `:1183`, `:1186` | dismissed — each guarded by the enclosing branch (`offset <= cds_start`, `tx_pos < cds_start`) |
| `conformance/spec_corpus.rs:769` | dismissed — guarded by `one_based < cds_start` |
| `normalize/mod.rs:12974`–`:12978` (revcomp flip) | dismissed — the `in_window` check immediately above bounds every operand by `seq_len` |
| `normalize/mod.rs:12994` (`unflip_intronic_positions`) | dismissed — all four callers pass positions `normalize_na_edit` returned against the same window; a caller-derived invariant, not an enforced one |
| the three `abs_diff` sites in `normalize/merge.rs` | dismissed — `abs_diff` is total by construction |
| `benchmark/compare.rs:3934` | dismissed — `i64` arithmetic behind the `benchmark` feature, not unsigned |

**#1917 is deliberately not folded into this PR.** The two share a shape — an unchecked `u64` subtraction whose operand order is not guaranteed — but not a root cause, and the correct answers point in opposite directions. #1916's operand-order violation arises from a self-inconsistent record, about which nothing true can be said, so the fix is to refuse. #1917's arises from a **legal** input (`NC_000012.11:g.110593351_110576466dup`, `NC_000016.9:g.23634775_23621090dup`) that the window computation does not account for; refusing would reject a spelling SVD-WG006 admits, so the fix is to anchor the window on `min(start, end)` instead. They also have different blast radii: this PR touches `src/reference/` and moves nothing, while #1917 touches `src/normalize/` and moves those rows from panic to an output — a disclosure that has to be measured on its own.

Representation-Change: none. No in-tree caller reads either function outside tests, and every position `find_intron_at_genomic` can derive still answers — pinned by `every_derived_intronic_position_still_answers`, which walks every intronic base on both strands and passes both before and after. The change only converts a panic (release: a `u64::MAX`-adjacent distance) into the `None` both signatures already admit.

## Verification

- `cargo nextest run --features dev --no-fail-fast` — see the run recorded on the PR.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- The four new assertions fail on the parent commit (2 of the 6 tests in the file pass there: both are controls describing behaviour this change must not move).
