### PR TITLE
docs(changelog): register #1885's real-corpus figure on #1835's disclosure

### DIFF
--- a/scripts/inject_representation_disclosure.py
+++ b/scripts/inject_representation_disclosure.py
@@ -149,6 +149,18 @@ EDITORIAL_CORRECTIONS: dict[str, list[str]] = {
         "it either. Read this as neither more nor less conformant: the measurement supports\n"
         "neither claim. 3' only, because #1879 removes the 5' direction from the public\n"
         "surface in this same release.",
+        "**Editorial correction (#1885) — not the trailer's words.** The real-corpus row\n"
+        "count this trailer defers is now measured. Over all four bulk corpora in full —\n"
+        "**9,949,738** stored ClinVar, CMRG and Paraphase expressions, each normalized\n"
+        "through both arms of one build — **11,491 normalized strings move (0.115%)**:\n"
+        "11,476 respellings whose SPDI key is unchanged, 15 whose denotation SPDI cannot\n"
+        "key, and **0 that denote different bases**. No row starts or stops normalizing.\n"
+        "A further 9,418 rows (0.095%) are excluded by a deterministic coordinate-span\n"
+        "bound rather than found unchanged — the #1846 cost defect, which cannot\n"
+        "terminate on them — and are recorded as excluded rather than folded into the\n"
+        "total. The measurement keys on which partitioner cuts the block, a property\n"
+        "86.5% of the corpus reaches, so the zero above is a measured zero and not a\n"
+        "structural one.",
     ],
 }
 


### PR DESCRIPTION
Closes #1913.

Representation-Change: none. This registers a paragraph of changelog prose; no `src/` file is touched and no normalized output moves. The figure it publishes was measured by #1900, which is where the behaviour question was settled.

## What this is

#1835 (the `canonical-coalesced` partition default flip) owes a real-corpus row count under `README.md` rule 7 — the ruling `delins-recommendation-reach-when-the-input-arrives-split` says in terms that the disclosure is owed by the change that makes that arm the default.

#1900 measured it and landed the figure in that ruling record, published through `docs/NORMALIZATION_CONTRACT.md`. It deliberately left the changelog alone, because #1897 was open against the same disclosure and had not yet merged — its `EDITORIAL_CORRECTIONS` register is the durable surface, since `CHANGELOG.md` is regenerated by release-plz on every push to `main` and the trailer itself is in an immutable commit.

Both have now merged, so this is the append they were both waiting on. It is the whole of the follow-up; nothing else is owed on #1885.

## The figure

Over all four bulk corpora in full — **9,949,738** stored ClinVar, CMRG and Paraphase expressions, each normalized through both arms of one build — **11,491 normalized strings move (0.115%)**: 11,476 respellings whose SPDI key is unchanged, 15 whose denotation SPDI cannot key, and **0 that denote different bases**. No row starts or stops normalizing.

Two qualifications travel with it, both in the registered text rather than only here:

- **9,418 rows (0.095%) are excluded, not found unchanged.** A deterministic coordinate-span bound drops them ahead of normalization because #1846 cannot terminate on them. They are recorded as excluded rather than folded into the total, since an exclusion counted as "did not move" is the failure mode this disclosure exists to avoid.
- **The zero is measured, not structural.** The measurement keys on which partitioner cuts the block — the property the flip actually changes — and 86.5% of the corpus reaches it. `examples/dump_normalized_corpus.rs` was not used, so none of its three recorded blindnesses (#1456, #1460, #1478) applies here.

## Why append rather than rewrite

The register takes paragraphs by append, which is what makes this safe to land after #1897: both of #1886's corrections stay exactly as written, the three paragraphs read in the order they were owed, and two edits to the same key would conflict visibly rather than silently overwrite.

## Verification

- `pytest tests/python/test_inject_representation_disclosure.py` — 23 passed. That includes `test_every_registered_correction_names_itself_and_cites_an_issue`, the guard on the real register, which the new paragraph satisfies by opening `**Editorial correction (#1885)`.
- `ruff check` and `ruff format --check` on the touched file — both clean.
- The register loads and reports three paragraphs under `1835`, in the intended order.
