### PR TITLE
fix(normalize): decline a reversed range rather than reading it as a linear window

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5247,10 +5247,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///
     /// # Returns
     ///
-    /// `Ok(None)` when the caller should fall back to minimal notation: **any**
-    /// fetch failed — the first one or a grown one (a grown failure is not
-    /// allowed to fall back to the truncated attempt that preceded it, which
-    /// would reinstate the walk) — or the growth cap was reached by an edit
+    /// `Ok(None)` when the caller should fall back to minimal notation: the
+    /// range is **reversed**, so it names a wraparound this linear window
+    /// cannot express (#1917, see the guard below); **any** fetch failed — the
+    /// first one or a grown one (a grown failure is not allowed to fall back to
+    /// the truncated attempt that preceded it, which would reinstate the walk);
+    /// or the growth cap was reached by an edit
     /// [`Self::canonicalize_without_shifting`] declines to re-type.
     ///
     /// **Refusing to shift is the only capped answer that is still a fixed
@@ -5281,6 +5283,54 @@ impl<P: ReferenceProvider> Normalizer<P> {
         edit: &NaEdit,
         fetch_end_of: impl Fn(u64) -> u64,
     ) -> Result<Option<WindowedNormalization>, FerroError> {
+        // A reversed range names a wraparound, and this window is linear
+        // (#1917). Refuse it here, where the arithmetic that cannot express it
+        // lives, so the caller takes its minimal-notation fallback.
+        //
+        // `normalize_mito` already gates this at its own axis, for #129, and
+        // states the reason to gate rather than lean on a downstream
+        // fail-safe: the fail-safes hold only for some window sizes. The `g.`
+        // axis never got the same gate, and the ways it failed are all
+        // functions of `start - end` against `window_size`:
+        //
+        // | `start - end`      | before this guard                            |
+        // |--------------------|----------------------------------------------|
+        // | `<= window`        | the fetch succeeds and the subtraction is     |
+        // |                    | fine, so it fails DEEPER, and how depends on  |
+        // |                    | the edit: `dup` slices `ref_seq[start-1..end]` |
+        // |                    | backwards and panics, while `inv` returns `=` |
+        // |                    | — a WRONG ANSWER, not a panic                 |
+        // | `(w, 2w]`          | panic — `end - window_start` underflows below |
+        // | `> 2 * window`     | this fallback, reached by accident: the fetch |
+        // |                    | is `[start-w, end+w)`, which inverts, and the |
+        // |                    | provider rejects it                           |
+        //
+        // So the widest reversed ranges — including both real-corpus rows in
+        // #1917, at 16,885 and 13,685 bases — already took this exit, and the
+        // guard makes the rest agree with them. **The top band is why this is
+        // an output change and not only a crash fix**: censused over every
+        // parseable reversed form against twelve spans, 6 of 24 answered rows
+        // came back wrong rather than panicking — five `inv` claiming `=` for
+        // an inversion, and one `dup` claiming a coordinate past its own
+        // contig's end. `FERRO_ASSERT_SEQUENCE` and `FERRO_ASSERT_IN_BOUNDS`
+        // are the oracles for exactly those two, and neither fires, because no
+        // corpus in either selection feeds a reversed range.
+        //
+        // The guard also relies on no provider rejecting an inverted read,
+        // which the bottom row shows is not a property of the code.
+        //
+        // **Declining is not clamping.** `min(start, end)` would fix the
+        // underflow and nothing else: `normalize_na_edit` would then receive
+        // `rel_start > rel_end` for *every* reversed range and slice backwards,
+        // turning the top row's panic from a narrow band into the whole class.
+        // Anchoring the window is only half a fix because the shuffle, the
+        // alignment and SPDI are each linear-contiguous — `src/spdi/convert.rs`
+        // refuses wraparound by name in four places for exactly this reason.
+        // Circular-aware shuffle modulo contig length remains #129's follow-up.
+        if start > end {
+            return Ok(None);
+        }
+
         // Whether the contig continues past a window is a question about the
         // contig, so the length is read once rather than per attempt.
         let contig_len = self.provider.get_sequence_length(accession).ok();

--- a/tests/it/issue_1917_reversed_range_window.rs
+++ b/tests/it/issue_1917_reversed_range_window.rs
@@ -1,0 +1,251 @@
+//! Issue #1917 — a reversed range panicked in `normalize_in_grown_window`.
+//!
+//! A reversed range (`start > end`) names a **wraparound**: the span runs off
+//! the 3' end of the reference and resumes at base 1. `normalize_in_grown_window`
+//! fetches a linear window and does linear arithmetic on it, so it cannot
+//! express one. It now refuses a reversed range up front and the caller takes
+//! its minimal-notation fallback, which is the gate `normalize_mito` has
+//! carried at its own axis since #129.
+//!
+//! **The `g.` axis failed three different ways, all functions of `start - end`
+//! against `window_size` (default 100).** The issue reported only the middle
+//! band and generalised it as "any reversed range whose span exceeds
+//! `window_size`", which is wrong in both directions — the widest ranges never
+//! panicked, and the narrowest panicked somewhere else entirely:
+//!
+//! | `start - end`  | before the guard                                          |
+//! |----------------|-----------------------------------------------------------|
+//! | `<= w`         | the fetch succeeds and nothing underflows, so it fails    |
+//! |                | deeper, and how depends on the edit: `dup` slices         |
+//! |                | `ref_seq[s..e]` backwards and panics (`slice index starts |
+//! |                | at 99 but ends at 50`), while `inv` returns `=` — a       |
+//! |                | **wrong answer**, not a panic                             |
+//! | `(w, 2w]`      | panic — `end - window_start` underflows                    |
+//! | `> 2w`         | the fallback, by accident: the fetch bounds invert and the |
+//! |                | provider rejects the read                                  |
+//!
+//! Both real-corpus rows in #1917 are in the bottom band (16,885 and 13,685
+//! bases), so they were **already** taking this exit; the guard makes the other
+//! two bands agree with them. Each band is pinned below by a test naming its
+//! arithmetic, so a future `window_size` change cannot quietly move a case out
+//! from under the coverage.
+//!
+//! **A panic was not the only outcome, and that is what this change discloses.**
+//! Censused over every parseable reversed form × twelve spans, 24 rows were
+//! answered: 10 panicked, 8 already declined, and **6 returned a wrong
+//! description** — see `a_reversed_range_no_longer_answers_with_a_wrong_description`.
+//! The issue reported only the panic, so the moving rows are the ones it missed.
+//!
+//! The `m.`/`o.` axes are unaffected — they gate before reaching this helper —
+//! but are pinned here too, because they are where wraparound is
+//! *spec-authorised* (`DNA/deletion.md:17`; `consultation/SVD-WG006.md:15` and
+//! its `J01749.1:o.4344_197dup` example at `:23`) and so are the reason the
+//! answer is "decline", not "reject".
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// The shipped default `NormalizerConfig::window_size`, which every band
+/// boundary below is stated against.
+const WINDOW: u64 = 100;
+
+/// Provider serving one contig of `len` cyclic `ACGT` bases.
+fn provider_len(accession: &str, len: usize) -> JsonProvider {
+    let seq: String = "ACGT".bytes().cycle().take(len).map(char::from).collect();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { accession: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+fn norm(p: &JsonProvider, input: &str) -> String {
+    let v = parse_hgvs(input).unwrap();
+    Normalizer::new(p.clone())
+        .normalize(&v)
+        .unwrap()
+        .to_string()
+}
+
+/// Confirm the default is what the band arithmetic below assumes. Without this
+/// the three band tests still pass if `window_size` changes — they would simply
+/// stop testing the bands they name.
+#[test]
+fn the_bands_below_are_stated_against_the_shipped_window_size() {
+    assert_eq!(
+        ferro_hgvs::normalize::NormalizeConfig::default().window_size,
+        WINDOW,
+        "the reversed-range bands in this module are written against \
+         window_size = {WINDOW}; if the default moved, re-derive them"
+    );
+}
+
+/// **Band 2** — the panic the issue reported. `500 - 300 = 200`, which is in
+/// `(w, 2w]`, so the anchor `500 - 100 = 400` sat past `end` (300) and
+/// `end - window_start` underflowed.
+#[test]
+fn a_reversed_dup_in_the_underflow_band_is_declined() {
+    assert!((WINDOW as i64) < 200 && 200 <= 2 * WINDOW as i64, "band 2");
+    let p = provider_len("NC_TEST.1", 1000);
+    assert_eq!(
+        norm(&p, "NC_TEST.1:g.500_300dup"),
+        "NC_TEST.1:g.500_300dup",
+        "declined, so the description survives as authored — not re-pointed at \
+         the window's first base"
+    );
+}
+
+/// **Band 1** — narrower than the window, so the fetch succeeded and the
+/// subtraction did not underflow. This `dup` failed deeper instead, slicing
+/// `ref_seq[99..50]` for its payload. The issue did not report this band, and
+/// its stated rule ("any span exceeding `window_size`") excludes it.
+///
+/// A panic is only *this edit's* band-1 failure. The same band returns a wrong
+/// answer for `inv`, and for `dup` at a span of 1 (where `s == e` makes the
+/// slice empty and legal) — see
+/// `a_reversed_range_no_longer_answers_with_a_wrong_description`.
+#[test]
+fn a_reversed_dup_narrower_than_the_window_is_declined() {
+    assert!(50 <= WINDOW as i64, "band 1");
+    let p = provider_len("NC_TEST.1", 1000);
+    assert_eq!(norm(&p, "NC_TEST.1:g.350_300dup"), "NC_TEST.1:g.350_300dup");
+}
+
+/// **Band 3** — wider than `2 * window_size`, so the fetch bounds themselves
+/// inverted and `JsonProvider` rejected the read, taking the same fallback the
+/// guard now takes deliberately. This is the band both real-corpus rows sit in,
+/// which is why **those two rows** do not move.
+///
+/// That is a claim about this band, not about the change: six rows in the two
+/// narrower bands *did* move, and
+/// `a_reversed_range_no_longer_answers_with_a_wrong_description` holds them.
+///
+/// It passed before the guard and passes after, and that is the point: it pins
+/// that the guard **did not change** the case that already worked. Reaching the
+/// fallback by a rejected read is not a property of the code — it is a property
+/// of whichever provider is installed, which is the other reason not to rely on
+/// it.
+#[test]
+fn a_reversed_dup_wider_than_twice_the_window_is_unchanged() {
+    assert!(3300 > 2 * WINDOW as i64, "band 3");
+    let p = provider_len("NC_TEST.1", 4000);
+    assert_eq!(
+        norm(&p, "NC_TEST.1:g.3500_200dup"),
+        "NC_TEST.1:g.3500_200dup"
+    );
+}
+
+/// The spec-authorised route, and the reason declining is the right answer
+/// rather than rejecting: `consultation/SVD-WG006.md:23` publishes this exact
+/// description. It gates in `normalize_mito` and never reaches the window
+/// helper, so this is a guard against that gate being removed as redundant.
+#[test]
+fn a_circular_wraparound_dup_is_declined() {
+    let p = provider_len("J01749.1", 5000);
+    assert_eq!(norm(&p, "J01749.1:o.4344_197dup"), "J01749.1:o.4344_197dup");
+}
+
+/// The other half of the spec-authorised set — `DNA/deletion.md:17` names
+/// deletions, and `SVD-WG006.md:15` gives `NC_012920.1:m.16563_13del`. A
+/// reversed `del` is refused at parse on the linear `g.` axis, so the circular
+/// axes are the only route by which one reaches the normalizer at all.
+#[test]
+fn a_circular_wraparound_del_is_declined() {
+    let p = provider_len("NC_012920.1", 16569);
+    assert_eq!(
+        norm(&p, "NC_012920.1:m.16563_13del"),
+        "NC_012920.1:m.16563_13del"
+    );
+}
+
+/// **The two shapes that produced a WRONG ANSWER rather than a panic**, which
+/// is the part of this change that moves output.
+///
+/// A census over every parseable reversed form × twelve spans found 24 answered
+/// rows: 10 panicked, 8 already declined (band 3), and **6 came back with an
+/// answer that was wrong**. Those six are the disclosure — a panic is loud and a
+/// wrong description is not, so these are the rows a consumer could have stored.
+///
+/// Both shapes below are exactly what two of the seam oracles exist to catch,
+/// and neither oracle fired, because no corpus in their selections feeds a
+/// reversed range:
+///
+/// - the `dup` claims `g.4001_4000dup` on a **4000-base** contig — a coordinate
+///   past the end of its own sequence, the `FERRO_ASSERT_IN_BOUNDS` class; and
+/// - the `inv` claims `=` — asserting the sequence is *unchanged* by an
+///   inversion, the `FERRO_ASSERT_SEQUENCE` class.
+///
+/// The `inv` shape is the worse of the two: `=` is a well-formed, in-bounds,
+/// idempotent description, so the other three oracles are satisfied by it too.
+#[test]
+fn a_reversed_range_no_longer_answers_with_a_wrong_description() {
+    let p = provider_len("NC_TEST.1", 4000);
+
+    // Was `g.4001_4000dup` — off the end of a 4000-base contig.
+    assert_eq!(
+        norm(&p, "NC_TEST.1:g.3500_3499dup"),
+        "NC_TEST.1:g.3500_3499dup"
+    );
+
+    // Was `g.3500_3450=` — an identity claim about an inversion.
+    for input in [
+        "NC_TEST.1:g.3500_3499inv",
+        "NC_TEST.1:g.3500_3495inv",
+        "NC_TEST.1:g.3500_3450inv",
+        "NC_TEST.1:g.3500_3401inv",
+        "NC_TEST.1:g.3500_3400inv",
+    ] {
+        let out = norm(&p, input);
+        assert_eq!(out, input);
+        assert!(
+            !out.ends_with('='),
+            "{input} must not come back as an identity"
+        );
+    }
+}
+
+/// Whatever the parser admits on the linear axis must not panic. That set is
+/// `parse_genome_interval_inner`'s `allows_inverted` list — `dup`, `ins`,
+/// `inv`, `dupins` — minus whatever a later check refuses (#1079 refuses the
+/// reversed `ins` anchor, which `test_normalize_inverted_range_insertion_no_panic`
+/// pins).
+///
+/// **This is not an endorsement of that list.** `SVD-WG006.md:33` names
+/// "deletions/duplications" as the authorised scope, and
+/// `check_circular_reversed_range` accordingly admits `del`/`dup`/`delins` and
+/// refuses `ins`/`inv` — on the **circular** axes, where the exception actually
+/// lives. The linear list is close to the complement of it: it admits `ins` and
+/// `inv`, which are spec-silent, and refuses `del`, which is spec-named. That
+/// asymmetry is real and is **#1921**; it is not this change's to settle, and
+/// the guard is correct under either resolution — which is why this test asks
+/// only that what parses reaches an answer, and names no specific set.
+#[test]
+fn every_linear_reversed_form_the_parser_admits_is_declined() {
+    let p = provider_len("NC_TEST.1", 1000);
+    let mut parsed = 0;
+    for input in [
+        "NC_TEST.1:g.500_300dup",
+        "NC_TEST.1:g.500_300inv",
+        "NC_TEST.1:g.500_300insACGT",
+        "NC_TEST.1:g.500_300delinsACGT",
+        "NC_TEST.1:g.500_300dupinsACGT",
+    ] {
+        let Ok(v) = parse_hgvs(input) else { continue };
+        parsed += 1;
+        let result = Normalizer::new(p.clone()).normalize(&v);
+        assert!(
+            result.is_ok(),
+            "{input} parses, so it must reach an answer rather than a panic; got {result:?}"
+        );
+    }
+    // A refusal at parse is a legitimate outcome for any individual row, but if
+    // every row were refused this test would pass while exercising nothing.
+    assert!(
+        parsed > 0,
+        "no reversed linear form parsed — this test asserted nothing"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -38,6 +38,7 @@ mod issue_1796_base_zero_names_no_nucleotide;
 mod issue_1841_option_returning_splice_classifiers;
 mod issue_1870_cds_less_transcript_refusal;
 mod issue_1916_intron_distance_underflow;
+mod issue_1917_reversed_range_window;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Closes #1917.

`normalize_in_grown_window` anchored its fetch on `start` alone and then computed the window-relative end as `end - window_start`. Nothing establishes `start <= end`, so a reversed range — which names a **wraparound** — walked into linear arithmetic that cannot express one.

## The issue reported one of three failures, and generalised it wrongly

The issue's rule was "any reversed range whose span exceeds `window_size` reproduces it". That is wrong in **both** directions: the widest reversed ranges never panicked, and the narrowest panicked somewhere else entirely. All three outcomes are functions of `start - end` against `window_size` (default 100):

| `start - end` | before |
|---|---|
| `<= w` | panic — `normalize_na_edit`'s `dup` arm slices `ref_seq[s..e]` **backwards** (`slice index starts at 99 but ends at 50`) |
| `(w, 2w]` | panic — `end - window_start` underflows (the reported one) |
| `> 2w` | the minimal-notation fallback, **by accident**: the fetch bounds themselves invert and the provider rejects the read |

Both real-corpus rows named in the issue are in the bottom band (16,885 and 13,685 bases), so they were already taking the fallback exit. It follows that the reproducer the issue offers — `g.500_300dup`, span 200 — is the *only* one of its three examples that demonstrates the defect it describes, and it does so for a reason the issue's stated rule does not capture.

## The fix, and why it is not the one the issue proposed

`normalize_mito` has gated this at its own axis since #129, and its comment states the reason to gate rather than lean on a downstream fail-safe: the fail-safes hold only for some window sizes. The `g.` axis never got the same gate. It does now, placed on the shared helper that owns the underflowing arithmetic rather than on the axis, so no future caller can bypass it.

The issue proposed anchoring the window on `min(start, end)` and extending it to `max(start, end)`, "with the reversed-ness of the range preserved in the output". **That is half a fix and the half it omits is worse than the half it does.** It removes the underflow, and then `normalize_na_edit` receives `rel_start > rel_end` for *every* reversed range and slices backwards — widening the top band's panic from a narrow band to the whole class.

And there is nothing for the wider window to do once fetched. The shuffle, the alignment and SPDI are each linear-contiguous; `src/spdi/convert.rs` refuses wraparound by name in four places, saying "SPDI is a single edit and has no representation for circular-contig wraparound". Preserving the reversed-ness of a range *is* declining to shift it. Circular-aware shuffle modulo contig length remains #129's follow-up, and this change does not prejudge it.

Declining is not clamping — the objection the issue raises against saturating the subtraction, that it "would silently re-point the edit at the window's first base", is an objection this fix satisfies rather than one it trades against.

## What moves — a panic was not the only outcome

Censused over every parseable reversed form × twelve spans on a 4000-base contig, **24 rows were answered**: 10 panicked, 8 already declined, and **6 came back with an answer that was wrong**. Those six are the disclosure, and they are the part the issue did not find — a panic is loud, a wrong description is not, so these are the rows a consumer could have stored:

- `g.3500_3499dup` → **`g.4001_4000dup`**, a coordinate past the end of its own 4000-base contig; and
- five `inv` rows (spans 1, 5, 50, 99, 100) → **`=`**, asserting the sequence is *unchanged* by an inversion.

Both are precisely what two of the four seam oracles exist to catch — `FERRO_ASSERT_IN_BOUNDS` and `FERRO_ASSERT_SEQUENCE` respectively — and neither fired, because no corpus in either selection feeds a reversed range. The `inv` shape is the worse of the two: `=` is well-formed, in-bounds and idempotent, so the other three oracles are satisfied by it as well.

All six now return the description as authored, agreeing with the eight rows in the bottom band that already did.

## The corpus measurement is a STRUCTURAL zero, and is reported as one

`examples/dump_normalized_corpus.rs` cannot build the shape this change keys on. It contains no reversed-range construction at all — no `start > end`, no wraparound, and every range it spells is built from an ordered pair — so an A/B over it returns 0 rows moved for the same reason a 20-mer corpus returns 0 declines against `MAX_SPLIT_BLOCK` (#1460) and a single-exon generator returns 0 junction crossings (#1478). Quoting that zero as evidence of safety would be the same error those two issues record.

So the disclosure above rests on the 84-row census, which enumerates the property directly (`start - end` across all three bands × every parseable edit type), not on the corpus dump.

## Also filed

**#1921** — the reversed-range parse gates are near-complementary. The linear `g.` axis admits `dup`/`inv`; the circular `m.`/`o.` axes admit `del`/`delins`/`dup`. SVD-WG006's exception is circular-only, so `inv` — spec-silent everywhere — is admitted on the axis with no exception and refused on the axis that has one. Not settled here: refusing reversed ranges at parse on the linear axis would reject inputs ferro accepts today, including both #1917 corpus rows, and wants its own adjudication record. This guard is correct under either resolution, which is why the new test asks only that what parses reaches an answer and names no specific set.

## Verification

- Full gate **10,791 / 10,791 passed**, `FERRO_MANIFEST` armed, `FERRO_REQUIRE_BULK_FIXTURES=1`, **zero `Skipping:` lines** (the four release-asset fixtures were fetched first, so the ClinVar / CMRG / Paraphase suites really ran rather than skipping green). Exit status read back from the `EXIT=` line written into the log, not from the job notification — the command was a chain ending in `echo`, so the notification reports the echo's status.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `cargo doc --no-deps --features dev` adds no warning naming anything in this diff.
- **Python binding suite run locally — 1,000 passed, 8 skipped.** `cargo nextest` does not reach `tests/python/`, and this touches `src/normalize/`, which is the #1870 shape.
- The gate ran against the committed tree; the three later edits are comment-only, verified by filtering the diff for non-comment changed lines rather than asserted.
- The eight new tests fail on the pre-guard tree in the three ways tabulated above; the guard was disabled in place and the census re-run to produce the before column, then the source restored byte-for-byte from a copy.
- `the_bands_below_are_stated_against_the_shipped_window_size` pins `window_size == 100`, so a future default change fails loudly rather than quietly moving each band test off the band it names.
- `every_linear_reversed_form_the_parser_admits_is_declined` asserts `parsed > 0`, so it cannot pass vacuously if the parser later refuses everything it tries.

Representation-Change: 6 rows move, all from a wrong description to a decline. Measured by census, not by corpus. Over every parseable reversed form x twelve spans on a 4000-base contig, 24 rows were answered before this change: 10 panicked, 8 already declined, and 6 returned a wrong description - one dup answering g.4001_4000dup on a 4000-base contig (past its own end), and five inv rows answering `=`, an identity, for an inversion. Those 6 now return the description as authored, which is what the other 8 already did. The 10 panicking rows are not counted as moved, having had no previous answer to move from. The synthetic corpus measures 0 rows moved and that figure is STRUCTURAL, not evidence: dump_normalized_corpus.rs builds no reversed range anywhere, so it cannot observe this change in principle - the same blindness as #1460 and #1478. Report a structural zero as structural.
