### PR TITLE
docs(tests): record that one stray symbol reclassifies the whole inserted run

### DIFF
--- a/tests/it/corpus_alphabet_and_intronic_validity.rs
+++ b/tests/it/corpus_alphabet_and_intronic_validity.rs
@@ -35,7 +35,21 @@
 //! alphanumeric following matches it, and becomes
 //! `InsertedSequence::Named("X")`, which `Display`s verbatim. This is not
 //! `X`-specific — any lone uppercase letter that is not otherwise consumed
-//! hits the same arm — which one test below pins directly. `-` fails every
+//! hits the same arm — which one test below pins directly.
+//!
+//! **That describes one of the two arms that produce `Named`, and it
+//! understates the reach — corrected 2026-08-11.** `parse_inserted_sequence`
+//! dispatches on the *first* byte, so `X…` takes the arm above, but an
+//! **IUPAC** first byte takes the `is_iupac_base` arm, which walks the whole
+//! run and sets `has_non_iupac` on any uppercase byte that is not an IUPAC
+//! base. So a run that is literal apart from one stray symbol is reclassified
+//! *wholesale*: `g.10delinsACGTX` is `Named("ACGTX")`, not `Literal(ACGT)` plus
+//! a rejected `X`, and the same holds with the stray at the start or in the
+//! middle. No corpus row exercises that shape, so the prohibited-row counts
+//! quoted for `standards.md:39` are lone-`X` counts. Measured and pinned in
+//! `tests/it/issue_1627_named_element_alphabet_reach.rs`.
+//!
+//! `-` fails every
 //! arm (not `[`, `(`, digit/`*`, IUPAC, or uppercase) and is left unconsumed,
 //! which is why `c.10delins-` is rejected: not because `-` is recognized as a
 //! gap symbol and refused, but because it is simply never consumed.


### PR DESCRIPTION
The module note in `tests/it/corpus_alphabet_and_intronic_validity.rs` describes only one of the two arms of `parse_inserted_sequence` that can produce `InsertedSequence::Named`, and so understates which spellings reach it.

`parse_inserted_sequence` dispatches on the **first** byte. `X…` takes the lone-uppercase arm the note already describes. But an **IUPAC** first byte takes the `is_iupac_base` arm, which walks the whole run and sets `has_non_iupac` on any uppercase byte that is not an IUPAC base — so a run that is literal apart from one stray symbol is reclassified *wholesale*:

```
g.10delinsACGTX   ->  Named("ACGTX")        (not Literal(ACGT) plus a rejected X)
```

and the same holds with the stray at the start or in the middle.

The consequence is what makes this worth stating in this file specifically: **no corpus row exercises that shape**, so the prohibited-row counts quoted here for `standards.md:39` are lone-`X` counts, not counts of every row that reaches the named-element fallback. A reader taking those counts as the full reach of the fallback would be wrong, and nothing on the page said so.

The behaviour itself is already measured and pinned on `main` by `tests/it/issue_1627_named_element_alphabet_reach.rs` (`a_literal_run_with_one_stray_symbol_is_reclassified_whole`, landed in #1684). Only this note lagged. No behaviour, no test, and no count changes here.

Provenance: the correction was measured on 2026-08-11 on an unmerged branch whose test half landed separately via #1684; this recovers the half that did not.

Representation-Change: none. Doc comment in a test module only — no `src/` change, no output movement, no pinned value touched.
