### PR TITLE
docs(readme): equal block length does not make the column correspondence unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,13 @@ Rules 2 and 3 depend on the spec **determining an answer**, and sometimes it doe
   prefers an insertion for inverted copies. No single output satisfies both.
 - **The same clause has two versions.** `general.md`'s current text and its forthcoming NOTE give
   opposite answers for variants separated by one nucleotide.
-- **The variant's decomposition is not recoverable.** For an equal-length block the column
-  correspondence is unique, so "two variants separated by N nucleotides" is a fact about the
-  variant. For an unequal-length block there is no correspondence — recovering one means *choosing*
-  an alignment, and the spec does not say which. There is no derivable form to converge on.
+- **The variant's decomposition is not recoverable.** Recovering one means *choosing* an alignment,
+  and the spec does not say which, so there is no derivable form to converge on. **Block length does
+  not settle it**: an equal-length block can still carry a balanced del+ins pair, so its column
+  correspondence need not be unique — `CAG -> AGA` is equal length with edit distance 2, not the
+  position-wise 3. What decides whether a reference base is unchanged is whether **every minimal
+  alignment** matches it, so the property to key on is edit distance against block length, never
+  length alone. See `rulings[unchanged-is-read-over-every-minimal-alignment]`.
 - **The preference keys on information a normalizer does not hold.** A "frequently occurring
   variant" (`RNA/delins.md:41`); a repeat "variable in the population" (`RNA/repeated.md:33`,
   `protein/repeated.md:22`); two variants "reported (or might occur) individually" (`DNA/delins.md:83`).


### PR DESCRIPTION
Representation-Change: none. One paragraph of `README.md`. No `src/` file is touched and no output moves.

## The defect

`README.md`'s normalization ruleset lists the cases where rules 2 and 3 cannot be honoured because the spec determines no answer. One bullet claimed the opposite for equal-length blocks:

> For an equal-length block the column correspondence is unique, so "two variants separated by N nucleotides" is a fact about the variant.

**That is false**, and the decided ruling `unchanged-is-read-over-every-minimal-alignment` says so in terms, with the arithmetic rather than an argument:

```
CAG -> AGA        position-wise:            C->A, A->G, G->A      cost 3
                  del C, A=A, G=G, ins A                          cost 2   <- minimal
```

Equal length, and an indel alignment strictly cheaper than the position-wise one — so the correspondence is not unique and the changed-column set is not a fact about the variant. That record holds a reference base unchanged iff **every minimal alignment** matches it, and states that the property to key a generator on is **edit distance against block length**, never length alone.

The bullet's conclusion and its unequal-length half were already right. Only the discriminator is corrected, and the record is cited so the next reader lands on the reasoning rather than re-deriving it.

## Why this matters beyond a wording fix

`README.md` is the canonical ruleset — `adjudication-precedence-order` makes it the authority, and makes it part of its ruling that the rules live in one place. The claim sat in the list of cases with "no derivable form to converge on", so it was actively steering people toward the wrong discriminator, and at least one branch has already built a proposed ruling on it.

## This does NOT adjudicate anything

It corrects a factual statement against an already-decided record. It takes no position on **#1904** / **#1878**, whose proposed ruling rests on the claim being corrected here — that is an open operator decision, and this PR neither settles it nor prejudges it. If the operator revisits `unchanged-is-read-over-every-minimal-alignment`, this bullet should move with it.

## Three further instances, deliberately left alone

Found while checking for other copies. **None is touched here**, because each belongs to something in flight or to an adjudication rather than to a documentation fix:

1. **`tests/it/weight_bound_worked_examples.rs:69`** — *"For a net-zero block the column correspondence is unique, so which columns changed is a fact rather than a choice"*. Same general claim, same falsity. That module is one of the red tests on #1904's branch and its own message invites the flip, so it belongs to that decision.
2. **`rulings[derivation-may-not-be-bounded-by-the-inputs-spelling]`** — *"The four are EQUAL-LENGTH blocks, where the column correspondence is unique and so the changed-column set is a fact rather than a choice"*. This one may be **locally true** — uniqueness can hold for those four specific rows even though it does not hold in general — but it is phrased as the general rule. Editing a decided record's stated ground is an adjudication, not housekeeping. (Note #1920 also touches this record, for an unrelated citation.)
3. **`tests/it/issue_1284_transcript_axis_collision.rs:76`** — already correct: it records the claim as **withdrawn** and reproduces the `CAG -> AGA` arithmetic. Left as the model the other two should follow.

For completeness: `src/normalize/merge.rs:5180` was corrected by #1899 and now carries an explicit *"Do not restate that as 'an equal-length block has no gap to place'"*. Two nearby comments (`:14540`, `:16027`) still use that phrasing, but in a **cost** context where the narrower claim is sound — `best_alignment` declines to look, which bounds the search — so they are wording rather than substance, and `merge.rs` is currently contested by two open PRs.

## Verification

- `generate_tool_support_tables -- --check` → `GTS_EXIT=0`. `README.md` is a committed generated-artifact target, so this confirms the edit is outside every generated block and the tables still match.
- `cargo test --features dev --test it -- readme ruleset clause_ruling_index normalization_contract_doc claude_md` → **24 passed**, `TESTS_EXIT=0`.
- No ledger record, generated fixture or contract doc changed, so nothing needed regenerating or re-blessing.
