### PR TITLE
fix(corpus): straddle the gate that fires, and import the bound instead of restating it

### DIFF
--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -65,8 +65,9 @@
 //!    quote the zero.
 //! 4. **…and only at the scale it builds them** (#1460). The families are drawn
 //!    against 20-mers, so a change gated on *length* rather than on shape sees the
-//!    same path on both sides no matter how many families exist. #1403 caps a
-//!    partition at `MAX_SPLIT_BLOCK` (1024) and measured a guaranteed zero here
+//!    same path on both sides no matter how many families exist. #1403 capped a
+//!    partition at `MAX_SPLIT_BLOCK` — **1024 at the time**, 4096 since #1899
+//!    derived it from `MAX_CANONICAL_WINDOW` — and measured a guaranteed zero here
 //!    even after the conflict families landed. `long_corpus_sequences` is the
 //!    answer, and it is deliberately narrow: two cores, one family, 16 rows. Adding
 //!    scale is expensive in a way adding a family is not — check the dump cost
@@ -140,7 +141,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
-use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection};
+use ferro_hgvs::normalize::{NormalizeConfig, ShuffleDirection, MAX_CANONICAL_BLOCK};
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::reference::MockProvider;
 use ferro_hgvs::{parse_hgvs, Normalizer};
@@ -636,25 +637,66 @@ const PROTEIN_FAMILIES: &[(&str, &str)] = &[
 /// of the block being partitioned, not on how its members are arranged.
 const LONG_FAMILY: (&str, &str) = (
     "long_block_inversion",
-    "#1403 — a near-palindromic block straddling the MAX_SPLIT_BLOCK cap",
+    "#1403 — a near-palindromic block straddling the canonical block limit",
 );
 
-/// The long cores, as `(label, sequence)`. Two lengths that straddle the cap the
-/// normalizer applies at 1024 bases (`merge::MAX_SPLIT_BLOCK`): one block that
-/// fits under it and one that does not, which is the pair a change to the cap moves
-/// between. The exact boundary is the one `partition_block`'s own comment records —
-/// 1024 confluent, 1026 not.
+/// The long cores, as `(label, sequence)`: one block the canonicalizer accepts
+/// and one it refuses, which is the pair a change to the limit moves between.
 ///
-/// The **label** is what lands in the dump's `reference` column, not the sequence:
-/// a kilobase core would otherwise be repeated verbatim on every row of the dump.
-/// Labels are as good a row identity as the sequence — they only have to be unique
-/// and stable — and the short-core rows are untouched, so no existing key moves.
+/// # Derived from the constant, never restated (#1925)
+///
+/// These used to be the literals `[1024, 1100]`, straddling `MAX_SPLIT_BLOCK`
+/// when that was `1024`. #1899 derived that cap from `MAX_CANONICAL_WINDOW`,
+/// taking it to **4096**, and both cores landed on the same side of it — so the
+/// one family whose point is *size* stopped measuring size, and the guard below
+/// went on passing because it restated `1024` as a literal of its own.
+///
+/// Two things changed as a result, and the second matters more than the first.
+/// The lengths are now computed from [`MAX_CANONICAL_BLOCK`], so the pair cannot
+/// be left behind again. And they straddle the limit that **actually fires on
+/// the shipping path** — the padded-window test — rather than `MAX_SPLIT_BLOCK`,
+/// whose only functional reader also demands `reference.len() != result.len()`
+/// and so was never reachable by this family's equal-length `inv` at any size.
+///
+/// # The gate measures the CHANGED INTERVAL, not the core length
+///
+/// This is the trap, and the first attempt at this fix fell into it: cores of
+/// exactly `MAX_CANONICAL_BLOCK` and `+2` produced **byte-identical behaviour**,
+/// because the interval the window is built around runs from the first differing
+/// base to the last, and [`near_palindromic_core`] puts those
+/// [`EDGE_PERTURBATION`] bases in from each end. So a core of `n` presents a
+/// changed interval of `n - 2 * EDGE_PERTURBATION`, and cores straddling the
+/// limit give intervals that are both comfortably under it.
+///
+/// Measured before and after: at cores `[3840, 3842]` both rows normalized
+/// identically (`g.257_4096inv` and `g.257_4098inv` each collapsing to four
+/// substitutions); the corpus straddled nothing while looking like it did. The
+/// cores below are offset so the **intervals** land at the limit and one base
+/// past it.
+///
+/// The margin is `2`, not `1`: [`near_palindromic_core`] refuses an odd length,
+/// and the limit itself is even.
+///
+/// The **label** is what lands in the dump's `reference` column, not the
+/// sequence: a kilobase core would otherwise be repeated verbatim on every row.
+/// Labels are as good a row identity as the sequence — they only have to be
+/// unique and stable.
 fn long_corpus_sequences() -> Vec<(String, String)> {
-    [1024usize, 1100]
+    let at_limit = MAX_CANONICAL_BLOCK as usize + 2 * EDGE_PERTURBATION;
+    [at_limit, at_limit + 2]
         .into_iter()
         .map(|len| (format!("nearpalindrome_{len}"), near_palindromic_core(len)))
         .collect()
 }
+
+/// How far in from each end [`near_palindromic_core`] breaks the palindrome.
+///
+/// Load-bearing for [`long_corpus_sequences`], not a free parameter: it sets the
+/// gap between a core's length and the width of the changed interval the
+/// normalizer's window is actually built around (`len - 2 * EDGE_PERTURBATION`),
+/// which is what decides whether the long cores straddle the gate or merely look
+/// as though they do.
+const EDGE_PERTURBATION: usize = 10;
 
 /// A near-palindromic core: an exact reverse-complement palindrome with two
 /// positions perturbed, so inverting the whole core changes exactly **four** bases
@@ -690,7 +732,7 @@ fn near_palindromic_core(len: usize) -> String {
     // reverse complement, so two of them give the four the shape is named for.
     let mirror: Vec<u8> = (0..half).rev().map(|i| complement(seq[i])).collect();
     seq.extend(mirror);
-    for offset in [10, half + 7] {
+    for offset in [EDGE_PERTURBATION, half + 7] {
         seq[offset] = complement(seq[offset]);
     }
     String::from_utf8(seq).expect("ACGT is valid UTF-8")
@@ -1014,8 +1056,8 @@ fn dump(seeds: u32) -> Vec<Row> {
             // `EXON_SPANS` is a fixed 7/7/6 split of a **20-base** core, chosen
             // so the junctions land inside the shapes the short corpus builds.
             // `multi_exon_provider` hands `Transcript::new` the whole core
-            // regardless, so on a 1024-base core the transcript declares 1024
-            // bases while its exon table maps 20 and `spliced_genomic` emits
+            // regardless, so on a long core the transcript declares the core's
+            // full length while its exon table maps 20 and `spliced_genomic` emits
             // only those 20 — every position past 20 is declared and unmapped.
             // Rows drawn against that provider are not wrong-looking (all eight
             // came out as fixed points) but they are not measuring anything
@@ -1653,7 +1695,7 @@ fn provider_for(axis: &str, core: &str) -> MockProvider {
 /// Split out of [`normalize_one`] so [`dump`] can build it **once per cell**
 /// instead of once per row. `provider_for` is not cheap: every call re-pads the
 /// core with 512 bases (`padded`), and the coding and multi-exon axes also build a
-/// `Transcript` — on the 1024-base long cores that is a ~1.5 kB copy per input, and
+/// `Transcript` — on the long cores that is a multi-kilobase copy per input, and
 /// the corpus has tens of thousands of rows. Nothing about it varies with the row.
 fn normalizer_for(axis: &str, core: &str, direction: ShuffleDirection) -> Normalizer<MockProvider> {
     Normalizer::with_config(
@@ -2117,8 +2159,8 @@ mod tests {
             .collect();
         let mut label_keyed = 0usize;
         for row in dump(2) {
-            // A label is not over `ACGT` — `revcomp_sep0_at0` and
-            // `nearpalindrome_1024` both fail this — so it is the one predicate
+            // A label is not over `ACGT` — `revcomp_sep0_at0` and any
+            // `nearpalindrome_<n>` both fail this — so it is the one predicate
             // that separates the two kinds of string without consulting the map.
             //
             // The alphabet is per-axis, and that is load-bearing rather than a
@@ -2365,20 +2407,45 @@ mod tests {
         parse_hgvs(input).map(|v| of(&v)).unwrap_or(0)
     }
 
-    /// The corpus must build a block past the normalizer's split cap (#1460).
+    /// The corpus must build a block past the normalizer's length gate (#1460).
     ///
-    /// The cap is a *length* gate — `merge.rs` returns the un-partitioned whole
-    /// block once either side exceeds `MAX_SPLIT_BLOCK` — so a corpus of 20-mers
-    /// takes the same path on both sides of any change to it, by construction.
-    /// That is why #1403 measured `0 of 18,432` here and why the zero was
-    /// guaranteed rather than informative. Fixing #1456 added the shapes that were
-    /// missing; this adds the scale.
+    /// The gate is a *length* one — `canonicalize_from_sequence` pads the changed
+    /// interval and refuses once the window exceeds `MAX_CANONICAL_WINDOW` — so a
+    /// corpus of 20-mers takes the same path on both sides of any change to it, by
+    /// construction. That is why #1403 measured `0 of 18,432` here and why the zero
+    /// was guaranteed rather than informative. Fixing #1456 added the shapes that
+    /// were missing; this adds the scale.
+    ///
+    /// # The bound is IMPORTED, and that is the whole point (#1925)
+    ///
+    /// This test used to open `const SPLIT_CAP: u64 = 1024;` with a comment saying
+    /// to update it by hand if the constant moved. The constant moved — #1899 took
+    /// `MAX_SPLIT_BLOCK` to 4096 — and this kept passing on `1100 > 1024` while
+    /// both long cores sat below the real gate. **A guard that restates the value
+    /// it guards cannot observe that value changing**, and a comment asking a
+    /// future reader to notice is not a mitigation; it is the defect written down.
+    ///
+    /// It also now names the gate that fires on the shipping path.
+    /// `MAX_SPLIT_BLOCK`'s only functional reader additionally requires
+    /// `reference.len() != result.len()`, and this family's whole-core `inv` is
+    /// equal-length, so it could never have tripped that cap at any size — the
+    /// assertion was measuring a threshold this corpus cannot reach even when the
+    /// number is right.
+    ///
+    /// # …and the STRADDLE is asserted, not left to the cores' arithmetic
+    ///
+    /// Importing the bound fixes half of it. The other half is that the two long
+    /// cores must land on **opposite sides** of the gate, which is a relation
+    /// between them and not a property of either — no length assertion can see
+    /// it, because the gate reads the changed interval and a length assertion
+    /// reads the core. The third assertion below pins that relation directly,
+    /// and it is the one that fails if the `2 * EDGE_PERTURBATION` offset in
+    /// [`long_corpus_sequences`] is dropped.
     #[test]
     fn the_corpus_emits_a_block_past_the_split_cap() {
-        // `MAX_SPLIT_BLOCK` is crate-private (`src/normalize/merge.rs`), so
-        // the bound is restated rather than imported. If it ever moves, this test
-        // is measuring the wrong threshold and should be updated with it.
-        const SPLIT_CAP: u64 = 1024;
+        use std::collections::BTreeSet;
+
+        let split_cap = MAX_CANONICAL_BLOCK as u64;
         let rows = dump(1);
         let genomic: Vec<&Row> = rows.iter().filter(|row| row.axis == "g").collect();
         let longest = genomic
@@ -2387,8 +2454,8 @@ mod tests {
             .max()
             .unwrap_or(0);
         assert!(
-            longest > SPLIT_CAP,
-            "the longest block the corpus builds is {longest} bases, under the {SPLIT_CAP}-base \
+            longest > split_cap,
+            "the longest block the corpus builds is {longest} bases, under the {split_cap}-base \
              split cap — so every row takes the same path on both sides of a change to it"
         );
 
@@ -2401,18 +2468,57 @@ mod tests {
         const SENTINELS: [&str; 3] = ["<parse-error>", "<declined>", "<panic>"];
         let past_cap: Vec<&&Row> = genomic
             .iter()
-            .filter(|row| longest_span(&row.input) > SPLIT_CAP)
+            .filter(|row| longest_span(&row.input) > split_cap)
             .collect();
-        let measured = past_cap
+        let measured: Vec<&Row> = past_cap
             .iter()
             .filter(|row| !SENTINELS.contains(&row.output.as_str()))
-            .count();
+            .map(|row| **row)
+            .collect();
         assert!(
-            measured > 0,
-            "all {} rows past the {SPLIT_CAP}-base cap normalized to a sentinel, so the corpus \
+            !measured.is_empty(),
+            "all {} rows past the {split_cap}-base cap normalized to a sentinel, so the corpus \
              builds the scale but measures nothing at it: {:?}",
             past_cap.len(),
             past_cap.iter().map(|r| &r.output).collect::<Vec<_>>()
+        );
+
+        // Measuring *at* the scale is still not STRADDLING the gate, and neither
+        // assertion above can tell those apart. Both read a **length** —
+        // `longest_span` is the span the input names, which is the core — while
+        // the gate reads the **changed interval**, which `near_palindromic_core`
+        // leaves `2 * EDGE_PERTURBATION` bases narrower than the core it is cut
+        // from. Drop that offset from `long_corpus_sequences` and the cores sit
+        // at exactly the limit and `+2`, with *both* intervals comfortably under
+        // it: `longest` is still past the cap, neither row is a sentinel, and the
+        // two cores derive identically. The corpus would straddle nothing while
+        // every assertion above stayed green — #1925 recurring one level up, and
+        // measured: that sabotage passes without this.
+        //
+        // So pin the RELATION between the cores rather than either core's size.
+        // The verdict is read off the output's spelling, which is how the dump
+        // reports it: an accepted block is re-derived into substitutions, a
+        // refused one keeps its `inv` (trimmed to the changed interval, but an
+        // `inv` still).
+        let refused: BTreeSet<&str> = measured
+            .iter()
+            .filter(|row| row.output.ends_with("inv"))
+            .map(|row| row.reference.as_str())
+            .collect();
+        let derived: BTreeSet<&str> = measured
+            .iter()
+            .filter(|row| !row.output.ends_with("inv"))
+            .map(|row| row.reference.as_str())
+            .collect();
+        assert!(
+            !refused.is_empty() && !derived.is_empty() && refused != derived,
+            "every past-cap core reached the same verdict (re-derived: {derived:?}, kept as \
+             `inv`: {refused:?}), so the long family straddles nothing — the gate reads the \
+             CHANGED INTERVAL, `len - 2 * EDGE_PERTURBATION`, and not the core length: {:?}",
+            measured
+                .iter()
+                .map(|row| (&row.reference, &row.input, &row.output))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1896,6 +1896,45 @@ const MAX_CANONICAL_WINDOW: i64 = 4096;
 /// Padding either side of the changed interval, giving the 3'-shift room.
 const CANONICAL_PAD: i64 = 128;
 
+/// Widest changed interval the sequence-first canonicalizer will accept, in
+/// reference columns — **the length gate that actually fires on the shipping
+/// path**.
+///
+/// It is a consequence, not a choice: `canonicalize_from_sequence` pads the
+/// changed interval by [`CANONICAL_PAD`] on each side and refuses when the
+/// resulting window exceeds [`MAX_CANONICAL_WINDOW`], so a block of this width
+/// is the widest that still fits. Stated here because the primitive is a
+/// *window* width while everything that wants to reason about coverage — a
+/// corpus, a guard, a bug report — is asking about a *block*, and re-deriving
+/// `4096 - 2 * 128` by hand at each of those sites is how the two drift.
+///
+/// # This is exported for measurement, and why that matters
+///
+/// [`MAX_SPLIT_BLOCK`] reads like the length gate and is not one any more:
+/// `past_the_split_cap` is its only functional reader, it additionally requires
+/// `reference.len() != result.len()`, and since the cap became
+/// [`MAX_CANONICAL_WINDOW`] the window test above refuses such a block one step
+/// earlier on every axis. So a corpus that straddles `MAX_SPLIT_BLOCK` measures
+/// nothing about the shipping path. `examples/dump_normalized_corpus.rs` did
+/// exactly that, against a **restated literal** of `1024` that stayed green when
+/// the constant moved to 4096 (#1925) — which is why this is a `pub` constant
+/// the corpus imports rather than a number its guard repeats.
+///
+/// # What checks it, and what does not
+///
+/// `the_corpus_emits_a_block_past_the_split_cap` imports this and asserts the
+/// corpus builds a block wider than it *and* that such a row actually
+/// normalizes rather than landing on a sentinel. That is a real check on the
+/// corpus, and it is **not** a check that this constant equals the gate: both
+/// sides read the same definition, so they cannot disagree.
+///
+/// Nothing currently pins the equality behaviourally — a test driving
+/// `canonicalize_from_sequence` at exactly this width and at one base wider,
+/// asserting the first is canonicalized and the second refused, is the check
+/// that would, and it is not written. Stated rather than left implied, because
+/// a derived constant reads like it has been verified and this one has not.
+pub const MAX_CANONICAL_BLOCK: i64 = MAX_CANONICAL_WINDOW - 2 * CANONICAL_PAD;
+
 /// Longest **length-changing** block the canonicalizer will attempt to
 /// partition.
 ///

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -73,6 +73,14 @@ pub use merge::{partition_decline_counts, PartitionDeclineCounts};
 #[cfg(debug_assertions)]
 pub use merge::partition_blocks_cut;
 
+// The widest changed block `canonicalize_from_sequence` will accept, so a
+// corpus can straddle the gate that actually fires instead of restating a
+// literal beside it. NOT gated on `dev`: the reason this exists is that a guard
+// which repeats the number cannot notice the number moving (#1925), and a
+// constant present in only some builds re-creates that gap for anyone building
+// without the feature. See `merge::MAX_CANONICAL_BLOCK`.
+pub use merge::MAX_CANONICAL_BLOCK;
+
 // The refusal a binary should print and exit on when `FERRO_PARTITION` named an
 // arm this build has not got. A library cannot refuse from
 // `canonicalize_from_sequence` -- it is infallible -- so the refusal is offered


### PR DESCRIPTION
Closes #1925.

`long_block_inversion` is the one corpus family whose point is **size** rather than geometry (#1460). It had stopped measuring size, and the guard that exists to say so kept passing.

## What broke, and why nothing noticed

#1899 derived `MAX_SPLIT_BLOCK` from `MAX_CANONICAL_WINDOW`, taking it **1024 → 4096**. The long cores stayed `[1024, 1100]`, chosen — the comment said so — as "the pair a change to the cap moves between". Both landed under the new cap.

`the_corpus_emits_a_block_past_the_split_cap` did not notice, because it opened:

```rust
const SPLIT_CAP: u64 = 1024;
```

with a comment telling a future reader to update it by hand if the constant moved. `1100 > 1024` held, so it stayed green. **A guard that restates the value it guards cannot observe that value changing**, and the instruction to notice is the defect written down, not a mitigation.

That raise is mine, and so is failing to move this family with it.

## Three changes, ascending by what they buy

**1. Import the bound.** `MAX_CANONICAL_BLOCK` is exported and the guard imports it. Deliberately *not* `dev`-gated: a constant present in only some builds re-creates the gap it exists to close.

**2. Target the gate that actually fires.** `past_the_split_cap` is the only functional reader of `MAX_SPLIT_BLOCK` in `src/` — every other occurrence is a comment or a unit-test fixture — and it additionally requires `reference.len() != result.len()`. This family emits a whole-core `inv` and the equal-length substitutions competing with it, so it **could never have tripped that cap at any size**, even with the right number. #1899's own doc says the shipping path cannot reach it at all, the window test refusing first. So the guard now names the gate that does fire: `MAX_CANONICAL_WINDOW - 2 * CANONICAL_PAD` = 3840.

**3. Straddle the changed INTERVAL, not the core length.** This is the part reasoning got wrong. Cores of exactly the limit and `+2` produce **byte-identical rows** — measured, both `g.257_4096inv` and `g.257_4098inv` collapsing to four substitutions — because the window is built from the first differing base to the last, and `near_palindromic_core` sets those `EDGE_PERTURBATION` bases in from each end. A core of `n` presents an interval of `n - 20`, so cores straddling 3840 give intervals comfortably under it. The corpus straddled nothing while looking like it did.

Offsetting by `2 * EDGE_PERTURBATION` puts the intervals at the limit and one past it, and the two rows now differ in kind:

| core | interval | `g.` inv row |
|---|---|---|
| `nearpalindrome_3860` | 3840 | `g.257_4116inv` → `g.[267T>A;2179C>G;2194C>G;4106T>A]` — **derived** |
| `nearpalindrome_3862` | 3842 | `g.257_4118inv` → `g.267_4108inv` — **refused**, trimmed only |

`EDGE_PERTURBATION` is now a named constant rather than a literal `10` inside the core builder, because it is load-bearing for this relation.

## Sabotaged, and one sabotage found a hole

Restoring the 1024-era cores `[1024, 1100]` makes the guard fail:

```
the longest block the corpus builds is 1100 bases, under the 3840-base split cap
  — so every row takes the same path on both sides of a change to it
```

That is the message that should have fired when #1899 landed.

The second sabotage — dropping the `2 * EDGE_PERTURBATION` offset, so the cores sit at exactly `MAX_CANONICAL_BLOCK` and `+2` — **passed, and should not have.** Both remaining assertions read a *length* (the span the input names, i.e. the core) while the gate reads the *changed interval*, `2 * EDGE_PERTURBATION` bases narrower; with the offset gone both intervals land under the limit, both cores derive identically, and the guard stayed green while the corpus straddled nothing. Part 3 was the only part nothing asserted — the same defect this PR is about, one level up.

The guard now pins the straddle itself: among the past-cap rows that actually normalized, at least one core must have been re-derived into substitutions and at least one must have kept its `inv`, and not the same core for both. It fails from both sides — `(re-derived: {"nearpalindrome_3842"}, kept as inv: {})` with the offset dropped, and `(re-derived: {}, kept as inv: {"nearpalindrome_3864", "nearpalindrome_3866"})` with it widened so both cores clear the gate.

## What is deliberately NOT claimed

`MAX_CANONICAL_BLOCK`'s doc says so in its own words: the guard and the constant read one definition, so they cannot disagree, and **nothing pins the constant against the gate behaviourally**. The check that would — driving `canonicalize_from_sequence` at exactly this width and one base wider, asserting accept then refuse — is not written, and `canonicalize_from_sequence` has no unit-test harness in `merge.rs` today. Stated rather than implied, because a derived constant reads as though it has been verified.

## Verification

- Full gate **10,810 / 10,810**, `FERRO_MANIFEST` armed, `FERRO_REQUIRE_BULK_FIXTURES=1`, zero `Skipping:` lines. Exit status read back from the `EXIT=` line in the log, not from the job notification.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- The corpus example's own 42 tests pass; the dump runs end to end (85,642 rows, ~20 s).
- Python binding suite: 1,000 passed, 8 skipped — `cargo nextest` does not reach it and this touches `src/normalize/`.

Representation-Change: none. Measured, not assumed. This adds a `pub const` and its re-export under `src/normalize/`, and otherwise changes only `examples/dump_normalized_corpus.rs`, which is the measuring instrument rather than a code path ferro normalizes through - the new constant has no `src/` reader, so no logic under any watched directory changes behaviour, and the full gate passes against every pinned value including both spec_conformance_axis censuses and case_harvest. The corpus dump itself does change, deliberately and only in the two `long_block_inversion` cores: the family's row count and shape are unchanged, the two `reference` labels move from nearpalindrome_1024/1100 to nearpalindrome_3860/3862, and one of the two rows now reaches a refusal it previously did not. That is the instrument being repaired, not ferro's output moving - any before/after dump comparison spanning this commit should expect those rows to differ and no others.

