### PR TITLE
test: enumerate minimal alignments, so the unchanged-base rule can be computed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1439,11 +1439,11 @@ jobs:
     name: Idempotency soak (${{ matrix.shard }}/8)
     # Only the optimized archive, NOT `test-build`. Every test the selection
     # below reaches lives in `tests/it/{cis_allele_confluence,
-    # from_sequences, normalize_idempotency}_proptest.rs`, and none reads the
-    # generated spec fixture or shells out to the staged generators — so the
-    # shards need neither of those artifacts, and waiting on the job that
-    # produces them would put the dev-profile compile back on the soak's
-    # critical path.
+    # from_sequences, minimal_alignment_enumeration,
+    # normalize_idempotency}_proptest.rs`, and none reads the generated spec
+    # fixture or shells out to the staged generators — so the shards need
+    # neither of those artifacts, and waiting on the job that produces them
+    # would put the dev-profile compile back on the soak's critical path.
     #
     # `from_sequences_proptest.rs` joined this selection by being named
     # `*proptest*`, which is worth stating because the filter is by name: a new
@@ -1452,6 +1452,15 @@ jobs:
     # fixture — so the two claims above still hold, and it earns its place here
     # (`the_direction_does_not_decide_describability` held for 256 cases and
     # failed at 20,000). Re-check both claims when adding another.
+    #
+    # `minimal_alignment_enumeration_proptest.rs` joined the same way, and was
+    # re-checked rather than assumed: its eight properties are pure functions of
+    # a generated `(reference, alternate)` byte pair, reading no provider and no
+    # fixture. Its cost was measured too, because the enumerator it exercises is
+    # exponential in block length — `PROPTEST_CASES=125000` over the module
+    # costs 56.7 s wall in the *test* profile, i.e. before this job's ~5.4x
+    # optimization. That is bounded by its own `MAX_BLOCK_LEN` of 6; raising it
+    # is a soak-cost decision, not only a coverage one.
     needs: test-build-soak
     runs-on: ubuntu-latest
     strategy:

--- a/tests/it/common/minimal_alignment.rs
+++ b/tests/it/common/minimal_alignment.rs
@@ -1,0 +1,495 @@
+//! Enumerate every minimal alignment of a `(reference, alternate)` block, and
+//! report which reference bases are matched in **all** of them.
+//!
+//! # What this is for
+//!
+//! `rulings[unchanged-is-read-over-every-minimal-alignment]` (in
+//! `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`) decides
+//! that
+//!
+//! > a reference base is unchanged iff it is matched in EVERY MINIMAL
+//! > alignment of the block.
+//!
+//! Until this module existed, that rule was applied by reading and by hand
+//! argument: nothing in the repo could *compute* it. An intersection over a set
+//! nobody enumerates is not a checkable claim, and the arithmetic has been got
+//! wrong more than once. [`minimal_alignments`] enumerates the set and takes
+//! the intersection, so "is this base unchanged?" has an answer a test can
+//! assert on.
+//!
+//! # This is an instrument, not a normalizer input
+//!
+//! Nothing under `src/` calls this and nothing should. It lives in
+//! `tests/it/common/` for three reasons:
+//!
+//! - **No production consumer.** Normalization decides its own partition
+//!   through `src/normalize/seqfirst/align.rs`. Adding a second entry point to
+//!   `src/` that only tests call would be crate surface kept alive by an
+//!   `#[allow(dead_code)]`.
+//! - **A deliberately different notion sits next door.** That module's
+//!   `Dominators` asks "is one `(ref, alt)` **cell** a match on every minimal
+//!   path?", which is strictly stronger than the record's question and,
+//!   per the record, *not a bug* — the two notions differ on purpose. Putting
+//!   an exponential column-based enumerator beside the linear cell-based one
+//!   would invite exactly the confusion the record was written to end.
+//! - **Exponential by construction.** The optimal-alignment count of an
+//!   all-mismatch block grows by a factor approaching 5.83 per base, so this is
+//!   unfit for a hot path however it were written. See
+//!   [`DEFAULT_ALIGNMENT_CAP`].
+//!
+//! # The closed form this checks against
+//!
+//! `issue_1539_split_member_separation::forced_unchanged_columns` computes the
+//! same set in `Θ(n·m)` without materialising an alignment, and is the detector
+//! the record names as where the ruling came from. It is a gate, so it needs to
+//! be fast; this is an instrument, so it needs to be *inspectable* — it can say
+//! how many alignments there are and what each of them matches, which a
+//! closed form cannot. The two are kept as separate implementations on purpose
+//! so each can check the other, and
+//! `minimal_alignment_enumeration_proptest::the_closed_form_and_the_enumerator_agree`
+//! asserts they do.
+//!
+//! # The record does not state its cost model
+//!
+//! This is the gap the module makes visible. Two things point at substitution
+//! cost 1 — the record's own worked example (`CAG -> AGA`, "position-wise:
+//! cost 3" over three substitutions), and the closed-form detector above, which
+//! hardcodes it — but neither is a ruling, and the two plausible models
+//! **disagree**: on the `1420-v4` block (`ATGC -> GCTG`)
+//! [`CostModel::Levenshtein`] calls two reference bases unchanged while
+//! [`CostModel::SubstitutionCostsTwo`] calls one. So the model is a required
+//! parameter here rather than a default, and
+//! `minimal_alignment_enumeration::the_two_cost_models_disagree_on_1420_v4`
+//! pins both answers without picking a winner.
+
+/// One step of an alignment: the label on one column.
+///
+/// `Ord` is derived so a caller can sort alignments to check for duplicates;
+/// the order is the declaration order and carries no meaning of its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Step {
+    /// Reference and alternate bases agree; consumes one of each.
+    Match,
+    /// Reference and alternate bases differ; consumes one of each.
+    Sub,
+    /// Consumes a reference base with no alternate base.
+    Del,
+    /// Consumes an alternate base with no reference base.
+    Ins,
+}
+
+/// How much each column costs.
+///
+/// Both models price a match at 0 and each indel at 1; they differ only on a
+/// substitution. **Neither is "the" model** — see the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CostModel {
+    /// Unit-cost Levenshtein: a substitution costs 1.
+    ///
+    /// This is what the record's own worked example implies (`CAG -> AGA`,
+    /// "position-wise: cost 3" over three substitutions), and it is the model
+    /// `src/normalize/seqfirst/align.rs` builds its DAG under.
+    Levenshtein,
+    /// A substitution costs 2 — exactly what deleting the reference base and
+    /// inserting the alternate one costs.
+    ///
+    /// Under this model a `Sub` column is never *cheaper* than the `Del`+`Ins`
+    /// pair that denotes the same thing, only tied. The tie is kept rather than
+    /// removed, because dropping the `Sub` step is a third model and the point
+    /// of this module is to make the choice visible instead of folding models
+    /// together. Keeping it changes the **count** — `ATGC -> GCTG` enumerates 6
+    /// optimal alignments with the tied `Sub` step and 4 without it — but
+    /// provably not the **unchanged set**: swapping a `Sub` column for the
+    /// `Del`+`Ins` pair preserves both the cost and the set of matched
+    /// reference offsets, so the intersection is identical either way.
+    SubstitutionCostsTwo,
+}
+
+impl CostModel {
+    /// Every model, so a caller can sweep them rather than naming one.
+    pub const ALL: [CostModel; 2] = [CostModel::Levenshtein, CostModel::SubstitutionCostsTwo];
+
+    /// The cost of a column pairing two unequal bases.
+    pub fn substitution_cost(self) -> u32 {
+        match self {
+            CostModel::Levenshtein => 1,
+            CostModel::SubstitutionCostsTwo => 2,
+        }
+    }
+
+    /// The cost of `step`, under this model.
+    pub fn step_cost(self, step: Step) -> u32 {
+        match step {
+            Step::Match => 0,
+            Step::Sub => self.substitution_cost(),
+            Step::Del | Step::Ins => 1,
+        }
+    }
+}
+
+/// The most optimal alignments [`minimal_alignments`] will enumerate before
+/// refusing.
+///
+/// # Why a cap at all, and why it is an error rather than a truncation
+///
+/// The unchanged set is an **intersection**, so dropping alignments can only
+/// *add* offsets to it. A silently truncated enumeration would therefore be
+/// wrong in the unsafe direction — bases would look unchanged that are not,
+/// which is precisely the misreading the record exists to prevent. So
+/// exceeding the cap returns [`CapExceeded`] and no set at all.
+///
+/// # Why 65536
+///
+/// The count grows exponentially, so the cap's job is to fail loudly rather
+/// than to be generous — one more base costs roughly six times the budget, and
+/// four more costs a thousand times, so no reachable value changes which blocks
+/// this can answer for. Measured, on an all-mismatch block `A^n -> C^n` under
+/// [`CostModel::SubstitutionCostsTwo`] (the central Delannoy numbers, the worst
+/// case at each length):
+///
+/// | `n` | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+/// |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+/// | optimal alignments | 3 | 13 | 63 | 321 | 1683 | 8989 | 48639 | 265729 | 1462563 |
+///
+/// 65536 is the largest round value that still fits a 7-base all-mismatch
+/// block, and enumerating that many costs a few megabytes and a few
+/// milliseconds — small enough that the cap never fires on the blocks this
+/// instrument is for. The record's worked examples and the reported
+/// `1420`/`1421` blocks are 3-5 bases and enumerate in single digits.
+///
+/// A caller that needs a different bound names it with
+/// [`minimal_alignments_capped`], which is also how the refusal itself is
+/// tested.
+pub const DEFAULT_ALIGNMENT_CAP: usize = 65_536;
+
+/// Enumeration hit the cap, so no unchanged set can be reported.
+///
+/// The minimal `cost` is still known — it comes from the dynamic-programming
+/// grid, which is polynomial and always completes — so the cost is reported
+/// even though the alignment set is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapExceeded {
+    /// The model the refused enumeration was run under.
+    pub model: CostModel,
+    /// The minimal edit cost, which is computable regardless of the cap.
+    pub cost: u32,
+    /// The bound that was exceeded.
+    pub cap: usize,
+}
+
+impl std::fmt::Display for CapExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "more than {} minimal alignments at cost {} under {:?}; \
+             no unchanged set reported, because an intersection over a \
+             truncated set is too permissive",
+            self.cap, self.cost, self.model
+        )
+    }
+}
+
+/// Every minimal alignment of one `(reference, alternate)` block, and what they
+/// agree on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MinimalAlignments {
+    model: CostModel,
+    cost: u32,
+    alignments: Vec<Vec<Step>>,
+    unchanged: Vec<u32>,
+}
+
+impl MinimalAlignments {
+    /// The model this was computed under.
+    pub fn model(&self) -> CostModel {
+        self.model
+    }
+
+    /// The minimal edit cost.
+    pub fn cost(&self) -> u32 {
+        self.cost
+    }
+
+    /// How many distinct optimal alignments there are.
+    ///
+    /// Reported because "unique" and "several that happen to agree" are
+    /// different situations: the first pins one reading of the block, the
+    /// second means the unchanged set is a genuine intersection and the
+    /// alternate coordinates it pairs with are *not* pinned. That distinction
+    /// is what separates this notion from the cell-based one — see the module
+    /// docs.
+    pub fn count(&self) -> usize {
+        self.alignments.len()
+    }
+
+    /// Whether exactly one alignment attains the minimal cost.
+    pub fn is_unique(&self) -> bool {
+        self.alignments.len() == 1
+    }
+
+    /// Reference offsets matched in **every** minimal alignment — the record's
+    /// "unchanged" set. Ascending, deduplicated.
+    pub fn unchanged(&self) -> &[u32] {
+        &self.unchanged
+    }
+
+    /// Every optimal alignment, as its sequence of columns, in a deterministic
+    /// order (diagonal before deletion before insertion, depth first).
+    pub fn alignments(&self) -> &[Vec<Step>] {
+        &self.alignments
+    }
+
+    /// Reference offsets that alignment `index` matches, ascending.
+    ///
+    /// [`unchanged`](Self::unchanged) is the intersection of this over every
+    /// index.
+    ///
+    /// # Panics
+    ///
+    /// If `index >= self.count()`.
+    pub fn matched_reference_offsets(&self, index: usize) -> Vec<u32> {
+        matched_reference_offsets(&self.alignments[index])
+    }
+}
+
+/// Enumerate the minimal alignments of `reference -> alternate` under `model`,
+/// capped at [`DEFAULT_ALIGNMENT_CAP`].
+pub fn minimal_alignments(
+    reference: &[u8],
+    alternate: &[u8],
+    model: CostModel,
+) -> Result<MinimalAlignments, CapExceeded> {
+    minimal_alignments_capped(reference, alternate, model, DEFAULT_ALIGNMENT_CAP)
+}
+
+/// As [`minimal_alignments`], with a caller-chosen bound on how many optimal
+/// alignments will be enumerated before refusing.
+///
+/// A `cap` of 0 refuses everything, which is a legitimate way to ask only for
+/// the cost.
+pub fn minimal_alignments_capped(
+    reference: &[u8],
+    alternate: &[u8],
+    model: CostModel,
+    cap: usize,
+) -> Result<MinimalAlignments, CapExceeded> {
+    let grid = SuffixCosts::build(reference, alternate, model);
+    let cost = grid.at(0, 0);
+    let alignments = enumerate(reference, alternate, model, &grid, cap).ok_or(CapExceeded {
+        model,
+        cost,
+        cap,
+    })?;
+    debug_assert!(
+        !alignments.is_empty(),
+        "every block has at least one alignment"
+    );
+    let unchanged = intersect_matched_reference_offsets(reference.len(), &alignments);
+    Ok(MinimalAlignments {
+        model,
+        cost,
+        alignments,
+        unchanged,
+    })
+}
+
+/// Reference offsets where `reference` and `alternate` agree **position-wise**,
+/// i.e. under the correspondence `i <-> i`.
+///
+/// This is the reading the record rules out, kept here so tests can state the
+/// difference rather than assert it by hand. Offsets past the shorter of the
+/// two are never matched, so the two sequences need not be the same length.
+///
+/// Neither this set nor [`MinimalAlignments::unchanged`] contains the other in
+/// general — see `minimal_alignment_enumeration::neither_notion_contains_the_other`.
+pub fn position_wise_matches(reference: &[u8], alternate: &[u8]) -> Vec<u32> {
+    reference
+        .iter()
+        .zip(alternate.iter())
+        .enumerate()
+        .filter(|(_, (r, a))| r == a)
+        .map(|(i, _)| i as u32)
+        .collect()
+}
+
+/// Reference offsets an alignment matches, ascending.
+fn matched_reference_offsets(alignment: &[Step]) -> Vec<u32> {
+    let mut matched = Vec::new();
+    let mut ref_offset = 0u32;
+    for &step in alignment {
+        match step {
+            Step::Match => {
+                matched.push(ref_offset);
+                ref_offset += 1;
+            }
+            Step::Sub | Step::Del => ref_offset += 1,
+            Step::Ins => {}
+        }
+    }
+    matched
+}
+
+/// The intersection of [`matched_reference_offsets`] over every alignment.
+fn intersect_matched_reference_offsets(ref_len: usize, alignments: &[Vec<Step>]) -> Vec<u32> {
+    let mut present = vec![true; ref_len];
+    for alignment in alignments {
+        let mut here = vec![false; ref_len];
+        for offset in matched_reference_offsets(alignment) {
+            here[offset as usize] = true;
+        }
+        for (keep, seen) in present.iter_mut().zip(here) {
+            *keep &= seen;
+        }
+    }
+    present
+        .into_iter()
+        .enumerate()
+        .filter(|(_, keep)| *keep)
+        .map(|(i, _)| i as u32)
+        .collect()
+}
+
+/// `costs[i][j]` = the minimal cost of aligning `reference[i..]` to
+/// `alternate[j..]`.
+///
+/// Suffix rather than prefix costs, so the enumerator can walk **forwards**
+/// from `(0, 0)` taking any edge that keeps the running total minimal. That
+/// makes every depth-first branch productive: each one reaches the sink, so the
+/// search never explores a dead end and the cap bounds real work rather than
+/// wasted work.
+struct SuffixCosts {
+    width: usize,
+    costs: Vec<u32>,
+}
+
+impl SuffixCosts {
+    fn build(reference: &[u8], alternate: &[u8], model: CostModel) -> Self {
+        let n = reference.len();
+        let m = alternate.len();
+        let width = m + 1;
+        let mut costs = vec![0u32; (n + 1) * width];
+        // Aligning a suffix against nothing costs one indel per base.
+        for i in 0..=n {
+            costs[i * width + m] = (n - i) as u32;
+        }
+        for j in 0..=m {
+            costs[n * width + j] = (m - j) as u32;
+        }
+        for i in (0..n).rev() {
+            for j in (0..m).rev() {
+                let diagonal = if reference[i] == alternate[j] {
+                    0
+                } else {
+                    model.substitution_cost()
+                };
+                costs[i * width + j] = (diagonal + costs[(i + 1) * width + j + 1])
+                    .min(1 + costs[(i + 1) * width + j])
+                    .min(1 + costs[i * width + j + 1]);
+            }
+        }
+        Self { width, costs }
+    }
+
+    fn at(&self, i: usize, j: usize) -> u32 {
+        self.costs[i * self.width + j]
+    }
+}
+
+/// One frame of the explicit depth-first stack.
+struct Frame {
+    i: usize,
+    j: usize,
+    /// Which of the three out-edges to try next: 0 diagonal, 1 deletion,
+    /// 2 insertion.
+    next_edge: u8,
+}
+
+/// Depth-first enumeration of every optimal alignment; `None` once more than
+/// `cap` of them have been found.
+///
+/// Iterative rather than recursive on purpose: recursion depth would be
+/// `reference.len() + alternate.len()`, which a long forced run of matches
+/// reaches even though it yields a single alignment, so the stack depth would
+/// be bounded by the *inputs* rather than by the cap.
+fn enumerate(
+    reference: &[u8],
+    alternate: &[u8],
+    model: CostModel,
+    grid: &SuffixCosts,
+    cap: usize,
+) -> Option<Vec<Vec<Step>>> {
+    let n = reference.len();
+    let m = alternate.len();
+    let mut alignments: Vec<Vec<Step>> = Vec::new();
+    let mut path: Vec<Step> = Vec::new();
+    let mut stack = vec![Frame {
+        i: 0,
+        j: 0,
+        next_edge: 0,
+    }];
+
+    while let Some(&Frame { i, j, next_edge }) = stack.last() {
+        if i == n && j == m {
+            alignments.push(path.clone());
+            if alignments.len() > cap {
+                return None;
+            }
+            stack.pop();
+            if !stack.is_empty() {
+                path.pop();
+            }
+            continue;
+        }
+
+        let mut descended = None;
+        let mut edge = next_edge;
+        while edge < 3 {
+            let candidate = match edge {
+                0 if i < n && j < m => {
+                    let step = if reference[i] == alternate[j] {
+                        Step::Match
+                    } else {
+                        Step::Sub
+                    };
+                    Some((i + 1, j + 1, step))
+                }
+                1 if i < n => Some((i + 1, j, Step::Del)),
+                2 if j < m => Some((i, j + 1, Step::Ins)),
+                _ => None,
+            };
+            edge += 1;
+            if let Some((next_i, next_j, step)) = candidate {
+                if model.step_cost(step) + grid.at(next_i, next_j) == grid.at(i, j) {
+                    descended = Some((next_i, next_j, step));
+                    break;
+                }
+            }
+        }
+
+        // `edge` has advanced past every option tried, so this frame resumes
+        // after the one it just took.
+        stack
+            .last_mut()
+            .expect("the frame just read is still on the stack")
+            .next_edge = edge;
+
+        match descended {
+            Some((next_i, next_j, step)) => {
+                path.push(step);
+                stack.push(Frame {
+                    i: next_i,
+                    j: next_j,
+                    next_edge: 0,
+                });
+            }
+            None => {
+                stack.pop();
+                if !stack.is_empty() {
+                    path.pop();
+                }
+            }
+        }
+    }
+
+    Some(alignments)
+}

--- a/tests/it/common/mod.rs
+++ b/tests/it/common/mod.rs
@@ -15,6 +15,12 @@
 //!   bulk parser fixtures (cmrg, paraphase, clinvar 500K + unique). See
 //!   `failure_expectations.rs` for the snapshot shape and contract;
 //!   tracking issue: #174.
+//! - `minimal_alignment`: enumerates every minimal alignment of a
+//!   `(reference, alternate)` block and intersects them, so
+//!   `rulings[unchanged-is-read-over-every-minimal-alignment]`'s "unchanged
+//!   iff matched in every minimal alignment" can be computed rather than
+//!   argued. The cost model is an explicit parameter because the record does
+//!   not state one.
 //! - `manifest`: the sibling of `bulk_fixtures` for the other input that can
 //!   go missing without anything going red — a ferro-prepared reference. Every
 //!   reference-aware guard skips green without one, so
@@ -43,6 +49,7 @@ pub mod cis_apply_oracle;
 pub mod failure_expectations;
 pub mod fixture_gen;
 pub mod manifest;
+pub mod minimal_alignment;
 pub mod rulings;
 pub mod spec_enumeration;
 pub mod spec_fixture;

--- a/tests/it/issue_1539_split_member_separation.rs
+++ b/tests/it/issue_1539_split_member_separation.rs
@@ -80,7 +80,26 @@ const MAX_ALIGNMENT_CELLS: usize = 4_000_000;
 /// is the correct bias for a gate that blocks merges.
 ///
 /// Returns `None` when the matrix would exceed [`MAX_ALIGNMENT_CELLS`].
-fn forced_unchanged_columns(reference: &[u8], payload: &[u8]) -> Option<Vec<bool>> {
+///
+/// # Relationship to `common::minimal_alignment`
+///
+/// This is the closed form of the notion
+/// `rulings[unchanged-is-read-over-every-minimal-alignment]` decides on, and it
+/// is the detector that record names as where the ruling came from. It reaches
+/// the answer in `Θ(n·m)` without ever materialising an alignment, which is
+/// what makes it usable as a gate.
+///
+/// `common::minimal_alignment` reaches the same answer the other way — by
+/// enumerating every minimal alignment and intersecting — and is
+/// correspondingly exponential. The two are kept separate rather than one
+/// rewritten in terms of the other precisely so that each can check the other;
+/// `minimal_alignment_enumeration_proptest::the_closed_form_and_the_enumerator_agree`
+/// asserts they do. Note this function is hardcoded to substitution cost 1,
+/// which is the model that record's own worked example implies but never
+/// states.
+///
+/// `pub(crate)` only so that cross-check can name it.
+pub(crate) fn forced_unchanged_columns(reference: &[u8], payload: &[u8]) -> Option<Vec<bool>> {
     let (n, m) = (reference.len(), payload.len());
     if (n + 1).checked_mul(m + 1)? > MAX_ALIGNMENT_CELLS {
         return None;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -428,6 +428,8 @@ mod lrg_inference_tests;
 mod m_shift_matrix;
 mod mavedb_tests;
 mod merge_consecutive_edits_tests;
+mod minimal_alignment_enumeration;
+mod minimal_alignment_enumeration_proptest;
 mod mito_circular_audit;
 mod mito_heteroplasmy_audit;
 mod mosaic_chimeric_compact;

--- a/tests/it/minimal_alignment_enumeration.rs
+++ b/tests/it/minimal_alignment_enumeration.rs
@@ -1,0 +1,408 @@
+//! Pins `rulings[unchanged-is-read-over-every-minimal-alignment]`'s own data
+//! against the enumerator that implements it.
+//!
+//! The record decides that **a reference base is unchanged iff it is matched in
+//! every minimal alignment of the block**, and argues that decision through
+//! four worked cases. Until `common::minimal_alignment` existed, those cases
+//! were arithmetic nobody could re-run: the rule quantifies over *all* minimal
+//! alignments and nothing enumerated them. Every case the record states is
+//! reproduced below, so a change to the instrument that stopped agreeing with
+//! the ruling would go red rather than quietly redefining "unchanged".
+//!
+//! # This module changes no behaviour
+//!
+//! Nothing here normalizes, and nothing under `src/` reads the enumerator. The
+//! record's rule is *applied* by `src/normalize/`; what was missing was a way
+//! to **check** an application of it. These tests are that check and nothing
+//! more.
+//!
+//! # The record does not say which cost model governs
+//!
+//! It is inferable from the record's own worked example — `CAG -> AGA`,
+//! "position-wise: cost 3" over three substitutions, so a substitution costs 1
+//! — but it is never written down, and the two plausible models disagree on a
+//! real reported block. [`the_two_cost_models_disagree_on_1420_v4`] is the
+//! record of that gap. It picks no winner, deliberately: which model governs is
+//! an open adjudication, and pinning both answers is what keeps the question
+//! answerable later instead of being settled by whichever model an instrument
+//! happened to hardcode.
+
+use crate::common::minimal_alignment::{
+    minimal_alignments, minimal_alignments_capped, position_wise_matches, CostModel, Step,
+    DEFAULT_ALIGNMENT_CAP,
+};
+
+/// Assert cost, alignment count and unchanged set at once, so a failure names
+/// all three rather than stopping at the first.
+#[track_caller]
+fn assert_block(
+    reference: &[u8],
+    alternate: &[u8],
+    model: CostModel,
+    expected_cost: u32,
+    expected_count: usize,
+    expected_unchanged: &[u32],
+) {
+    let report = minimal_alignments(reference, alternate, model).unwrap_or_else(|exceeded| {
+        panic!(
+            "{} -> {} under {model:?}: {exceeded}",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alternate),
+        )
+    });
+    assert_eq!(
+        (report.cost(), report.count(), report.unchanged()),
+        (expected_cost, expected_count, expected_unchanged),
+        "{} -> {} under {model:?}: (cost, alignments, unchanged)",
+        String::from_utf8_lossy(reference),
+        String::from_utf8_lossy(alternate),
+    );
+}
+
+/// **The record's headline case.** `CAG -> AGA` is equal length, and equal
+/// length does not imply no indel.
+///
+/// The record states it directly:
+///
+/// ```text
+/// position-wise:            C->A, A->G, G->A            cost 3
+/// del C, A=A, G=G, ins A                                cost 2   <- minimal
+/// ```
+///
+/// So reference offsets 1 and 2 are unchanged, the two changes *are* separated
+/// by them, and `general.md:34` describes them individually. The position-wise
+/// reading, which matches nothing at all here, is the one the record says has no
+/// authority behind it.
+///
+/// Identical under both cost models, which is why the record could argue from
+/// it without stating a model.
+#[test]
+fn cag_to_aga_is_a_del_plus_ins_around_two_unchanged_bases() {
+    for model in CostModel::ALL {
+        assert_block(b"CAG", b"AGA", model, 2, 1, &[1, 2]);
+    }
+
+    assert_eq!(
+        position_wise_matches(b"CAG", b"AGA"),
+        Vec::<u32>::new(),
+        "the position-wise reading matches nothing, which is the whole point"
+    );
+
+    let report = minimal_alignments(b"CAG", b"AGA", CostModel::Levenshtein).unwrap();
+    assert!(
+        report.is_unique(),
+        "one minimal alignment, so nothing to agree on"
+    );
+    assert_eq!(
+        report.alignments()[0],
+        vec![Step::Del, Step::Match, Step::Match, Step::Ins],
+        "the record spells this alignment out: del C, A=A, G=G, ins A"
+    );
+}
+
+/// **The case that forced the column/cell distinction.** `GACA -> AGAT`.
+///
+/// The record's argument: the minimal alignments "both match ref offset 1, but
+/// to different alt offsets, so the cell-based notion sees nothing while the
+/// base is unchanged either way." The intersection here is exactly one
+/// reference offset, and no single match *edge* is common to all the
+/// alignments — which is why `Dominators::matched_ref()` (cell-based) and the
+/// record's clause (column-based) give different answers on it, and why the
+/// record insists that is a notion mismatch rather than a bug.
+///
+/// # The record says "the two cost-3 alignments"; there are three
+///
+/// Measured, not inferred: under substitution cost 1 this block has **three**
+/// distinct minimal alignments, whose matched-reference sets are `{1, 3}`,
+/// `{0, 1}` and `{0, 1}`. Two of the three agree on their matched set, which is
+/// the most likely reading behind the record's "two" — it is a count of
+/// distinct outcomes, not of alignments.
+///
+/// The discrepancy is pinned rather than resolved because **the record's
+/// conclusion is unaffected**: reference offset 1 is matched in all three, so
+/// the intersection is `{1}` on either count. This test records the arithmetic
+/// so nobody re-derives it a fourth time.
+#[test]
+fn gaca_to_agat_intersects_to_one_base_across_three_alignments() {
+    assert_block(b"GACA", b"AGAT", CostModel::Levenshtein, 3, 3, &[1]);
+
+    let report = minimal_alignments(b"GACA", b"AGAT", CostModel::Levenshtein).unwrap();
+    let matched: Vec<Vec<u32>> = (0..report.count())
+        .map(|i| report.matched_reference_offsets(i))
+        .collect();
+    assert_eq!(
+        matched,
+        vec![vec![1, 3], vec![0, 1], vec![0, 1]],
+        "three alignments, two distinct matched-reference outcomes"
+    );
+    assert!(
+        !report.is_unique(),
+        "this is the case where the unchanged set is a genuine intersection"
+    );
+
+    // Under the other model the block costs 4 and agrees on nothing at all.
+    assert_block(b"GACA", b"AGAT", CostModel::SubstitutionCostsTwo, 4, 9, &[]);
+}
+
+/// `1420-v2`: the `TEMPLATE` block at 38-41, `TTGC -> ATTG`.
+///
+/// The `g.[37dup;41del]` / `g.38_41delinsATTG` pair in
+/// `reported_confluence_pairs::REPORTED_PAIRS`. Exactly one optimal alignment,
+/// so the unchanged set is pinned rather than intersected, and the two cost
+/// models agree — this block says nothing about the open model question.
+///
+/// Reference offsets 0-2 are unchanged, i.e. `g.38`, `g.39` and `g.40`; the
+/// change is an insertion before the block and a deletion of `g.41`.
+#[test]
+fn template_38_41_is_one_alignment_over_three_unchanged_bases() {
+    for model in CostModel::ALL {
+        assert_block(b"TTGC", b"ATTG", model, 2, 1, &[0, 1, 2]);
+    }
+
+    let report = minimal_alignments(b"TTGC", b"ATTG", CostModel::Levenshtein).unwrap();
+    assert_eq!(
+        report.alignments()[0],
+        vec![Step::Ins, Step::Match, Step::Match, Step::Match, Step::Del],
+        "insert A, then TTG matches, then delete C"
+    );
+    assert_eq!(
+        position_wise_matches(b"TTGC", b"ATTG"),
+        vec![1],
+        "the position-wise reading finds one agreeing base, while three of the \
+         four are unchanged"
+    );
+}
+
+/// `1420-v3`: the `TEMPLATE` block at 37-40, `ATTG -> CATT`.
+///
+/// The same shape as `1420-v2` one base upstream — an insertion before the
+/// block and a deletion at its end — and like it, unique and model-independent.
+/// Kept as its own case because it is a separate reported row, not because it
+/// exercises anything `1420-v2` does not.
+#[test]
+fn template_37_40_is_one_alignment_over_three_unchanged_bases() {
+    for model in CostModel::ALL {
+        assert_block(b"ATTG", b"CATT", model, 2, 1, &[0, 1, 2]);
+    }
+
+    let report = minimal_alignments(b"ATTG", b"CATT", CostModel::Levenshtein).unwrap();
+    assert_eq!(
+        report.alignments()[0],
+        vec![Step::Ins, Step::Match, Step::Match, Step::Match, Step::Del],
+    );
+}
+
+/// **`1420-v4` is where the two cost models disagree, and the record does not
+/// say which one governs.**
+///
+/// The `TEMPLATE` block at 21-24, `ATGC -> GCTG`
+/// (`g.[21delinsGC;24del]` / `g.21_24delinsGCTG`).
+///
+/// | model | cost | alignments | unchanged (block) | unchanged (genomic) |
+/// |---|---:|---:|---|---|
+/// | substitution costs 1 | 3 | 2 | `{1, 2}` | `g.22`, `g.23` |
+/// | substitution costs 2 | 4 | 6 | `{2}` | `g.23` |
+///
+/// Under one model `g.22` is an unchanged base and the changes either side of
+/// it are "separated by one or more nucleotides", so `general.md:34` describes
+/// them individually. Under the other it is not, and they are consecutive.
+/// **That is a difference in what the spec clause says about this block, from a
+/// parameter the record never fixes.**
+///
+/// # Nothing here picks a winner
+///
+/// The record's own worked example implies substitution cost 1, but implication
+/// is not a ruling, and `rulings[adjudication-precedence-order]` is the register
+/// for escalating a residue like this — not a test module. So both answers are
+/// pinned, in full, and this doc comment is the record that the question is
+/// open. If it is later decided, this test is where the decision lands and what
+/// it has to be reconciled against.
+#[test]
+fn the_two_cost_models_disagree_on_1420_v4() {
+    assert_block(b"ATGC", b"GCTG", CostModel::Levenshtein, 3, 2, &[1, 2]);
+    assert_block(
+        b"ATGC",
+        b"GCTG",
+        CostModel::SubstitutionCostsTwo,
+        4,
+        6,
+        &[2],
+    );
+
+    let unit = minimal_alignments(b"ATGC", b"GCTG", CostModel::Levenshtein).unwrap();
+    let paired = minimal_alignments(b"ATGC", b"GCTG", CostModel::SubstitutionCostsTwo).unwrap();
+    assert_ne!(
+        unit.unchanged(),
+        paired.unchanged(),
+        "if these ever agree the disagreement this test exists to record has \
+         been resolved by a change to the instrument, which is the one way it \
+         must not be resolved"
+    );
+
+    // And the position-wise reading agrees with neither, matching nothing at
+    // all — so the block has three readings and no two of them coincide.
+    assert_eq!(position_wise_matches(b"ATGC", b"GCTG"), Vec::<u32>::new());
+}
+
+/// Identical sequences: zero cost, one alignment, every base unchanged.
+///
+/// The degenerate end of the rule, and the one shape where the position-wise
+/// reading and the minimal-alignment reading are *guaranteed* to coincide
+/// rather than merely happening to. Elsewhere the two are incomparable — see
+/// [`neither_notion_contains_the_other`].
+#[test]
+fn identical_sequences_leave_every_base_unchanged() {
+    for model in CostModel::ALL {
+        assert_block(
+            b"ACGTACGT",
+            b"ACGTACGT",
+            model,
+            0,
+            1,
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+        );
+    }
+    assert_eq!(
+        position_wise_matches(b"ACGTACGT", b"ACGTACGT"),
+        (0..8).collect::<Vec<u32>>()
+    );
+}
+
+/// A block with no shared base at all: nothing is unchanged under either model.
+///
+/// The counts diverge sharply even though the sets agree. Under substitution
+/// cost 1 the four substitutions are the only minimal alignment; under
+/// substitution cost 2 each of them ties with a deletion/insertion pair, and
+/// every interleaving of the result is optimal — 321 alignments for a four-base
+/// block, the central Delannoy number `D(4, 4)`. That is the growth
+/// [`DEFAULT_ALIGNMENT_CAP`] exists to bound.
+#[test]
+fn a_block_with_no_shared_base_leaves_nothing_unchanged() {
+    assert_block(b"AAAA", b"TTTT", CostModel::Levenshtein, 4, 1, &[]);
+    assert_block(
+        b"AAAA",
+        b"TTTT",
+        CostModel::SubstitutionCostsTwo,
+        8,
+        321,
+        &[],
+    );
+}
+
+/// Empty blocks, a pure deletion and a pure insertion.
+#[test]
+fn empty_and_single_sided_blocks_are_handled() {
+    for model in CostModel::ALL {
+        assert_block(b"", b"", model, 0, 1, &[]);
+        assert_block(b"A", b"", model, 1, 1, &[]);
+        assert_block(b"", b"A", model, 1, 1, &[]);
+        assert_block(b"ACGT", b"", model, 4, 1, &[]);
+    }
+}
+
+/// **Neither notion contains the other**, so the record's rule cannot be
+/// approximated by the position-wise reading in either direction.
+///
+/// Measured by brute force over every `{A, C}` pair up to length 5 under
+/// substitution cost 1: of 1364 equal-length pairs, 384 disagree — 178 have an
+/// unchanged base that is not a position-wise match, and 250 have a
+/// position-wise match that is not unchanged. Both witnesses below come from
+/// that sweep.
+///
+/// This is worth pinning because the natural guess is that one set bounds the
+/// other, and a property test written on that guess passes vacuously or fails
+/// mysteriously. It does neither: the two are simply incomparable.
+#[test]
+fn neither_notion_contains_the_other() {
+    // Unchanged but not position-wise matched: offset 1 is matched in every
+    // minimal alignment of `ACA -> CAC`, and `A != C` position-wise.
+    let report = minimal_alignments(b"ACA", b"CAC", CostModel::Levenshtein).unwrap();
+    assert_eq!(report.unchanged(), &[1]);
+    assert_eq!(position_wise_matches(b"ACA", b"CAC"), Vec::<u32>::new());
+
+    // Position-wise matched but not unchanged: `AAC -> ACA` agrees at offset 0,
+    // yet no reference base survives every minimal alignment.
+    let report = minimal_alignments(b"AAC", b"ACA", CostModel::Levenshtein).unwrap();
+    assert_eq!(report.unchanged(), &[] as &[u32]);
+    assert_eq!(position_wise_matches(b"AAC", b"ACA"), vec![0]);
+}
+
+/// **The two models are incomparable too** — neither's unchanged set contains
+/// the other's.
+///
+/// `1420-v4` gives one direction (substitution cost 1 sees `{1, 2}`, cost 2 sees
+/// `{2}`). `AAC -> CAA` gives the other, which is the direction that is easy to
+/// assume away: the *stricter-looking* model reports **more** unchanged bases,
+/// because pricing a substitution at 2 removes alignments from the optimal set
+/// and an intersection over fewer alignments is larger.
+#[test]
+fn neither_cost_model_bounds_the_other() {
+    let unit = minimal_alignments(b"AAC", b"CAA", CostModel::Levenshtein).unwrap();
+    let paired = minimal_alignments(b"AAC", b"CAA", CostModel::SubstitutionCostsTwo).unwrap();
+    assert_eq!(unit.unchanged(), &[1]);
+    assert_eq!(paired.unchanged(), &[0, 1]);
+}
+
+/// Exceeding the cap is an error, never a truncated answer.
+///
+/// A silently truncated enumeration would make the intersection **too
+/// permissive** — bases would be reported unchanged that some unenumerated
+/// minimal alignment does not match — which is wrong in exactly the direction
+/// the record was written to prevent. So the refusal is checked directly, and
+/// checked to still report the cost, which the polynomial grid always knows.
+#[test]
+fn exceeding_the_cap_refuses_rather_than_truncating() {
+    let exceeded = minimal_alignments_capped(
+        b"AAAA",
+        b"TTTT",
+        CostModel::SubstitutionCostsTwo,
+        320, // one below this block's 321
+    )
+    .expect_err("321 alignments must not fit under a cap of 320");
+    assert_eq!(exceeded.cap, 320);
+    assert_eq!(
+        exceeded.cost, 8,
+        "the cost is known even when the set is not"
+    );
+    assert_eq!(exceeded.model, CostModel::SubstitutionCostsTwo);
+
+    // One more, and it fits.
+    let report = minimal_alignments_capped(b"AAAA", b"TTTT", CostModel::SubstitutionCostsTwo, 321)
+        .expect("321 alignments fit under a cap of 321");
+    assert_eq!(report.count(), 321);
+
+    // A cap of zero is a legitimate way to ask only for the cost.
+    let cost_only = minimal_alignments_capped(b"CAG", b"AGA", CostModel::Levenshtein, 0)
+        .expect_err("a cap of zero admits no alignment");
+    assert_eq!(cost_only.cost, 2);
+}
+
+/// The default cap is large enough for every case this module pins, and the
+/// margin is stated rather than assumed.
+#[test]
+fn every_pinned_case_fits_well_inside_the_default_cap() {
+    let worst = [
+        (&b"CAG"[..], &b"AGA"[..]),
+        (b"GACA", b"AGAT"),
+        (b"TTGC", b"ATTG"),
+        (b"ATTG", b"CATT"),
+        (b"ATGC", b"GCTG"),
+        (b"AAAA", b"TTTT"),
+    ]
+    .into_iter()
+    .flat_map(|(r, a)| CostModel::ALL.map(move |m| (r, a, m)))
+    .map(|(r, a, m)| {
+        minimal_alignments(r, a, m)
+            .expect("every pinned case fits the default cap")
+            .count()
+    })
+    .max()
+    .expect("the list is not empty");
+
+    assert_eq!(worst, 321, "`AAAA -> TTTT` under substitution cost 2");
+    assert!(
+        worst * 4 < DEFAULT_ALIGNMENT_CAP,
+        "the default cap ({DEFAULT_ALIGNMENT_CAP}) should leave headroom over \
+         the worst pinned case ({worst})"
+    );
+}

--- a/tests/it/minimal_alignment_enumeration.rs
+++ b/tests/it/minimal_alignment_enumeration.rs
@@ -343,6 +343,157 @@ fn neither_cost_model_bounds_the_other() {
     assert_eq!(paired.unchanged(), &[0, 1]);
 }
 
+/// **The four rows another decided record calls SPEC-CONFORMANT are all
+/// position-wise readings, and not one of them is minimal.**
+///
+/// `rulings[derivation-may-not-be-bounded-by-the-inputs-spelling]` justifies four
+/// moved rows on the ground that "the four are EQUAL-LENGTH blocks, where the
+/// column correspondence is unique and so the changed-column set is a fact
+/// rather than a choice", and then applies `DNA/delins.md:15`/`:16`/`:17` to the
+/// changed columns that ground yields. The record *this* module pins falsifies
+/// it: equal length does not make the correspondence unique, and on these four
+/// it does not even make position-wise minimal.
+///
+/// Two `decided` records resting on contradictory premises is the thing no guard
+/// was watching, so this is that guard. It asserts the arithmetic rather than the
+/// disposition — which of the two forms ferro should emit is an adjudication and
+/// is not settled here.
+///
+/// | row's block | position-wise | minimal | unchanged |
+/// |---|---:|---:|---|
+/// | `TTTTTTTAAT -> ATTTTTTTAA` | cost 3 | **cost 2**, 1 alignment | `{0..=8}` |
+/// | `CAG -> AGA` | cost 3 | **cost 2**, 1 alignment | `{1, 2}` |
+/// | `AATA -> TAAT` | cost 3 | **cost 2**, 1 alignment | `{0, 1, 2}` |
+/// | `GTAAAA -> TAAAAG` | cost 3 | **cost 2**, 1 alignment | `{1..=5}` |
+///
+/// All four are one shape: one base inserted at one end of the block and a
+/// **different** base deleted at the other, everything between matching. That is
+/// why every row is **model-independent** — with no substitution in the optimal
+/// alignment there is no substitution to price, so the open question
+/// [`the_two_cost_models_disagree_on_1420_v4`] records cannot arise here.
+///
+/// Not a *rotation*, which would re-insert the base it removed: only the
+/// `GTAAAA -> TAAAAG` row below is one. An earlier revision of this comment
+/// called all of them rotations, which is false for the four that matter and
+/// true only for the row that is not one of them.
+///
+/// The fourth block is not one of the four. The record files it among "the
+/// fifteen ... unequal-length blocks", and it is equal length 6/6 — pinned here
+/// so that miscount cannot be re-derived as a fact.
+#[test]
+fn the_weight_bound_records_four_rows_are_position_wise_readings() {
+    /// One block, and the two readings of it that the two records disagree
+    /// about. Named fields rather than a tuple because `unchanged` and
+    /// `position_wise` are the same type and transposing them would invert
+    /// exactly the claim this test exists to make.
+    struct Row {
+        reference: &'static [u8],
+        alternate: &'static [u8],
+        /// Matched in **every** minimal alignment — the ruling's notion.
+        unchanged: &'static [u32],
+        /// Matched by pairing column *i* against column *i*.
+        position_wise: &'static [u32],
+    }
+
+    let rows = [
+        // `cis_junction_crossing_shift::the_five_prime_junction_barrier_does_not_over_clamp`
+        // — `TEMPLATE:g.3_12`, from `TRACT`.
+        Row {
+            reference: b"TTTTTTTAAT",
+            alternate: b"ATTTTTTTAA",
+            unchanged: &[0, 1, 2, 3, 4, 5, 6, 7, 8],
+            position_wise: &[1, 2, 3, 4, 5, 6, 8],
+        },
+        // `issue_1284_transcript_axis_collision::a_noncoding_del_dup_collision_is_repaired`
+        // and `normalize_reparse_invariant::a_del_beside_a_dup_re_spells_instead_of_colliding`
+        // — one block reached from two unrelated inputs, and the record's own
+        // headline case above.
+        Row {
+            reference: b"CAG",
+            alternate: b"AGA",
+            unchanged: &[1, 2],
+            position_wise: &[],
+        },
+        // `cis_confluence_adjudication::two_adjacent_members_that_both_consume_reference_are_one_delins`
+        // — `NM_TEST.1:c.10_13`, from `CORE`. Note this row's position-wise
+        // changed columns are {0, 2, 3}: TWO groups separated by one matching
+        // base, not one run. So the position-wise reading does not yield the
+        // spanning `c.10_13delinsTAAT` either — it yields
+        // `c.[10A>T;12_13delinsAT]`. This row is therefore not the clean
+        // position-wise-against-minimal contrast the other three are.
+        Row {
+            reference: b"AATA",
+            alternate: b"TAAT",
+            unchanged: &[0, 1, 2],
+            position_wise: &[1],
+        },
+        // Filed by the record among the UNEQUAL-length fifteen, and equal 6/6.
+        Row {
+            reference: b"GTAAAA",
+            alternate: b"TAAAAG",
+            unchanged: &[1, 2, 3, 4, 5],
+            position_wise: &[2, 3, 4],
+        },
+    ];
+
+    for Row {
+        reference,
+        alternate,
+        unchanged,
+        position_wise,
+    } in rows
+    {
+        assert_eq!(
+            reference.len(),
+            alternate.len(),
+            "{} -> {}: the record's premise is about EQUAL-length blocks",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alternate),
+        );
+
+        for model in CostModel::ALL {
+            // Cost 2 with equal lengths and no substitution: one insertion and
+            // one deletion, so the answer cannot depend on the substitution
+            // price.
+            assert_block(reference, alternate, model, 2, 1, unchanged);
+        }
+
+        assert_eq!(
+            position_wise_matches(reference, alternate),
+            position_wise,
+            "{} -> {}: position-wise matches",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alternate),
+        );
+
+        // The whole point: the position-wise reading is NOT one of the minimal
+        // alignments, so the changed-column set the record derived from it is a
+        // choice and not a fact. Position-wise costs one substitution per
+        // mismatched column; minimal costs 2.
+        let position_wise_cost = (reference.len() - position_wise.len()) as u32;
+        assert!(
+            position_wise_cost > 2,
+            "{} -> {}: position-wise costs {position_wise_cost}, which must \
+             exceed the minimal cost of 2 for this row to witness anything",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alternate),
+        );
+
+        // And it disagrees about which bases survive, in the direction that
+        // matters: the minimal reading finds MORE unchanged bases, so the
+        // record's derivation describes more change than the sequence requires.
+        let minimal: std::collections::BTreeSet<u32> = unchanged.iter().copied().collect();
+        let positional: std::collections::BTreeSet<u32> = position_wise.iter().copied().collect();
+        assert!(
+            positional.is_subset(&minimal) && positional != minimal,
+            "{} -> {}: the position-wise matches must be a strict subset of the \
+             unchanged set",
+            String::from_utf8_lossy(reference),
+            String::from_utf8_lossy(alternate),
+        );
+    }
+}
+
 /// Exceeding the cap is an error, never a truncated answer.
 ///
 /// A silently truncated enumeration would make the intersection **too
@@ -388,6 +539,9 @@ fn every_pinned_case_fits_well_inside_the_default_cap() {
         (b"ATTG", b"CATT"),
         (b"ATGC", b"GCTG"),
         (b"AAAA", b"TTTT"),
+        (b"TTTTTTTAAT", b"ATTTTTTTAA"),
+        (b"AATA", b"TAAT"),
+        (b"GTAAAA", b"TAAAAG"),
     ]
     .into_iter()
     .flat_map(|(r, a)| CostModel::ALL.map(move |m| (r, a, m)))

--- a/tests/it/minimal_alignment_enumeration_proptest.rs
+++ b/tests/it/minimal_alignment_enumeration_proptest.rs
@@ -1,0 +1,379 @@
+//! Property tests for `common::minimal_alignment`.
+//!
+//! `minimal_alignment_enumeration` pins the record's own worked cases, which
+//! checks the instrument against the six blocks whose answers are already
+//! written down. These properties check the other direction: that the
+//! enumerator is internally coherent on inputs nobody chose, so a pinned case
+//! cannot be right by accident.
+//!
+//! # What is asserted, and what deliberately is not
+//!
+//! | property | why it is checkable |
+//! |---|---|
+//! | every emitted alignment is well formed and costs the reported minimum | recomputes the cost from the columns, independently of the DP grid |
+//! | the emitted alignments are pairwise distinct | a duplicate would inflate the count without changing the intersection, which is the one error the count cannot reveal |
+//! | `unchanged` is exactly the intersection of the per-alignment matched sets | the record's definition, restated against the emitted set |
+//! | the enumerator agrees with #1539's closed-form detector | a second implementation of the same notion, by a route that never enumerates |
+//! | the cap refuses iff the set does not fit, and otherwise changes nothing | a truncated intersection is too *permissive*, so this is the safety property |
+//! | reversing both blocks mirrors the answer | catches a DP or backtrack asymmetry, which a symmetric corpus would hide |
+//! | `cost(sub = 1) <= cost(sub = 2) <= 2 * cost(sub = 1)` | the two models are related even where their unchanged sets are not |
+//! | on equal-length blocks the minimal cost never exceeds the position-wise cost | the record's premise, stated as an inequality |
+//!
+//! **The brief for this module proposed one further property — that `unchanged`
+//! is always a subset of the position-wise matched set — and it is FALSE.**
+//! Brute force over every `{A, C}` pair up to length 5 under substitution cost 1
+//! finds 178 counterexamples to that containment and 250 to its converse; the
+//! record's own `CAG -> AGA` is one of the first, with `unchanged = {1, 2}` and
+//! no position-wise match at all. The two notions are incomparable, which is a
+//! stronger statement of the record's headline claim than "they can differ", and
+//! it is pinned with witnesses in
+//! `minimal_alignment_enumeration::neither_notion_contains_the_other`. A
+//! proptest cannot assert that a difference *exists*, so it is not attempted
+//! here — asserting the false containment would have gone red on roughly one
+//! generated pair in four.
+
+use crate::common::minimal_alignment::{
+    minimal_alignments, minimal_alignments_capped, position_wise_matches, CostModel, Step,
+    DEFAULT_ALIGNMENT_CAP,
+};
+use proptest::prelude::*;
+
+/// The longest block either side may be.
+///
+/// Six, so that the worst case stays comfortably inside
+/// [`DEFAULT_ALIGNMENT_CAP`] and the properties can assert enumeration
+/// *succeeds* rather than tolerating a refusal — a tolerated refusal is how a
+/// property test goes vacuous. The worst case at length `n` is an all-mismatch
+/// block under substitution cost 2, which has `D(n, n)` optimal alignments (the
+/// central Delannoy numbers): 8989 at `n = 6`, against a cap of 65536. Chosen
+/// for runtime rather than for the cap, which would admit `n = 7`.
+const MAX_BLOCK_LEN: usize = 6;
+
+/// Bases to draw from.
+///
+/// Two alphabets rather than one. `ACGT` is the realistic draw, but at length
+/// six a four-letter alphabet rarely produces a block whose minimal alignment
+/// is interesting — most pairs share nothing and the answer is trivial. The
+/// two-letter draw concentrates the generator on repeat-like blocks, which is
+/// where several minimal alignments compete and the intersection actually does
+/// work.
+fn block_alphabet() -> impl Strategy<Value = Vec<u8>> {
+    prop_oneof![Just(b"AC".to_vec()), Just(b"ACGT".to_vec()),]
+}
+
+/// A `(reference, alternate)` pair with independently drawn lengths.
+fn block_pair() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+    block_alphabet().prop_flat_map(|alphabet| {
+        let base = prop::sample::select(alphabet);
+        (
+            prop::collection::vec(base.clone(), 0..=MAX_BLOCK_LEN),
+            prop::collection::vec(base, 0..=MAX_BLOCK_LEN),
+        )
+    })
+}
+
+/// A `(reference, alternate)` pair of equal length — the shape the record's
+/// headline claim is about, since equal length is what makes the position-wise
+/// reading look available.
+fn equal_length_pair() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+    block_alphabet().prop_flat_map(|alphabet| {
+        (0..=MAX_BLOCK_LEN).prop_flat_map(move |len| {
+            let base = prop::sample::select(alphabet.clone());
+            (
+                prop::collection::vec(base.clone(), len..=len),
+                prop::collection::vec(base, len..=len),
+            )
+        })
+    })
+}
+
+/// Every model, so each property sweeps both rather than picking one.
+fn cost_model() -> impl Strategy<Value = CostModel> {
+    prop::sample::select(CostModel::ALL.to_vec())
+}
+
+/// Reference offsets an alignment matches, recomputed here rather than read
+/// back from the report, so the properties do not check the instrument against
+/// itself.
+fn matched_reference_offsets(alignment: &[Step]) -> Vec<u32> {
+    let mut matched = Vec::new();
+    let mut offset = 0u32;
+    for &step in alignment {
+        match step {
+            Step::Match => {
+                matched.push(offset);
+                offset += 1;
+            }
+            Step::Sub | Step::Del => offset += 1,
+            Step::Ins => {}
+        }
+    }
+    matched
+}
+
+proptest! {
+    /// **Every emitted alignment is a well-formed alignment of exactly these two
+    /// blocks, and costs the reported minimum.**
+    ///
+    /// The cost is recomputed from the columns, so this checks the enumerated
+    /// paths against the dynamic-programming grid rather than against
+    /// themselves. `Match` and `Sub` are checked to agree with the bases they
+    /// pair, which is what makes the matched-offset bookkeeping downstream
+    /// meaningful.
+    #[test]
+    fn every_emitted_alignment_is_well_formed_and_minimal(
+        (reference, alternate) in block_pair(),
+        model in cost_model(),
+    ) {
+        let report = minimal_alignments(&reference, &alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+
+        for alignment in report.alignments() {
+            let mut i = 0usize;
+            let mut j = 0usize;
+            let mut cost = 0u32;
+            for &step in alignment {
+                cost += model.step_cost(step);
+                match step {
+                    Step::Match => {
+                        prop_assert_eq!(
+                            reference[i], alternate[j],
+                            "a Match column pairs unequal bases at ({}, {})", i, j
+                        );
+                        i += 1;
+                        j += 1;
+                    }
+                    Step::Sub => {
+                        prop_assert_ne!(
+                            reference[i], alternate[j],
+                            "a Sub column pairs equal bases at ({}, {})", i, j
+                        );
+                        i += 1;
+                        j += 1;
+                    }
+                    Step::Del => i += 1,
+                    Step::Ins => j += 1,
+                }
+            }
+            prop_assert_eq!(i, reference.len(), "the alignment did not consume the reference");
+            prop_assert_eq!(j, alternate.len(), "the alignment did not consume the alternate");
+            prop_assert_eq!(cost, report.cost(), "an emitted alignment is not minimal");
+        }
+    }
+
+    /// **No alignment is emitted twice.**
+    ///
+    /// A duplicate would inflate `count()` while leaving `unchanged()` correct,
+    /// so it is invisible to every other property here — and `count()` is what
+    /// separates "one alignment pins this" from "several agree", which is the
+    /// distinction the record turns on.
+    #[test]
+    fn the_emitted_alignments_are_pairwise_distinct(
+        (reference, alternate) in block_pair(),
+        model in cost_model(),
+    ) {
+        let report = minimal_alignments(&reference, &alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let mut seen: Vec<&Vec<Step>> = report.alignments().iter().collect();
+        seen.sort_unstable();
+        let before = seen.len();
+        seen.dedup();
+        prop_assert_eq!(seen.len(), before, "an alignment was enumerated more than once");
+        prop_assert_eq!(report.count(), before, "count() disagrees with alignments()");
+    }
+
+    /// **`unchanged` is exactly the intersection of the per-alignment matched
+    /// reference offsets** — the record's definition, restated.
+    #[test]
+    fn unchanged_is_the_intersection_over_every_minimal_alignment(
+        (reference, alternate) in block_pair(),
+        model in cost_model(),
+    ) {
+        let report = minimal_alignments(&reference, &alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+
+        let mut intersection: Option<Vec<u32>> = None;
+        for alignment in report.alignments() {
+            let matched = matched_reference_offsets(alignment);
+            intersection = Some(match intersection {
+                None => matched,
+                Some(so_far) => so_far.into_iter().filter(|o| matched.contains(o)).collect(),
+            });
+        }
+        let expected = intersection.unwrap_or_default();
+        prop_assert_eq!(report.unchanged(), expected.as_slice());
+
+        // And every unchanged offset really is a reference offset.
+        for &offset in report.unchanged() {
+            prop_assert!((offset as usize) < reference.len());
+        }
+    }
+
+    /// **The cap refuses exactly when the set does not fit, and otherwise
+    /// changes nothing.**
+    ///
+    /// This is the safety property. Because `unchanged` is an intersection,
+    /// enumerating fewer alignments can only *add* offsets to it, so a
+    /// silently truncated answer would report bases as unchanged that are not.
+    /// A cap one below the true count must therefore refuse, and a cap at the
+    /// true count must give bit-identical output to the uncapped call.
+    #[test]
+    fn the_cap_refuses_rather_than_truncating(
+        (reference, alternate) in block_pair(),
+        model in cost_model(),
+    ) {
+        let report = minimal_alignments(&reference, &alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let count = report.count();
+
+        let exact = minimal_alignments_capped(&reference, &alternate, model, count)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&exact, &report, "a cap at the exact count changed the answer");
+
+        let tight = minimal_alignments_capped(&reference, &alternate, model, count - 1);
+        let exceeded = tight.expect_err("a cap below the true count must refuse");
+        prop_assert_eq!(exceeded.cap, count - 1);
+        prop_assert_eq!(exceeded.cost, report.cost(), "the cost survives a refusal");
+        prop_assert_eq!(exceeded.model, model);
+    }
+
+    /// **Reversing both blocks mirrors the answer.**
+    ///
+    /// Edit distance is invariant under reversal, so the alignment count must be
+    /// too and each unchanged offset `i` must become `len - 1 - i`. A backtrack
+    /// that preferred one end — a 5'/3' bias smuggled into the enumerator —
+    /// would break this while leaving every pinned case, all of which are
+    /// checked in one direction only, entirely green.
+    #[test]
+    fn reversing_both_blocks_mirrors_the_answer(
+        (reference, alternate) in block_pair(),
+        model in cost_model(),
+    ) {
+        let forward = minimal_alignments(&reference, &alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+
+        let reversed_reference: Vec<u8> = reference.iter().rev().copied().collect();
+        let reversed_alternate: Vec<u8> = alternate.iter().rev().copied().collect();
+        let backward = minimal_alignments(&reversed_reference, &reversed_alternate, model)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+
+        prop_assert_eq!(forward.cost(), backward.cost());
+        prop_assert_eq!(forward.count(), backward.count());
+
+        let last = reference.len() as u32;
+        let mut mirrored: Vec<u32> = backward
+            .unchanged()
+            .iter()
+            .map(|&offset| last - 1 - offset)
+            .collect();
+        mirrored.sort_unstable();
+        prop_assert_eq!(forward.unchanged(), mirrored.as_slice());
+    }
+
+    /// **`cost(sub = 1) <= cost(sub = 2) <= 2 * cost(sub = 1)`.**
+    ///
+    /// The two models are incomparable on their unchanged sets — which is the
+    /// gap `the_two_cost_models_disagree_on_1420_v4` records — but not
+    /// unrelated: every column costs at least as much under the second model,
+    /// and any alignment can trade each substitution for a deletion and an
+    /// insertion at exactly double the price.
+    #[test]
+    fn the_two_cost_models_bracket_each_other(
+        (reference, alternate) in block_pair(),
+    ) {
+        let unit = minimal_alignments(&reference, &alternate, CostModel::Levenshtein)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let paired = minimal_alignments(&reference, &alternate, CostModel::SubstitutionCostsTwo)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert!(unit.cost() <= paired.cost());
+        prop_assert!(paired.cost() <= 2 * unit.cost());
+    }
+
+    /// **The enumerator and the closed form agree on every block.**
+    ///
+    /// `issue_1539_split_member_separation::forced_unchanged_columns` computes
+    /// the same notion in `Θ(n·m)` and without materialising an alignment: it
+    /// marks a column changeable when *some* minimum-cost path deletes or
+    /// mismatches it. That detector is the one
+    /// `rulings[unchanged-is-read-over-every-minimal-alignment]` names as where
+    /// the ruling came from, so agreement with it is agreement with the record's
+    /// working definition — reached by a genuinely different route, since one
+    /// side never enumerates and the other never inspects the grid.
+    ///
+    /// It is hardcoded to substitution cost 1, so only
+    /// [`CostModel::Levenshtein`] is comparable. That is itself the strongest
+    /// evidence available about which model the record intends, and it is still
+    /// not a ruling — see
+    /// `minimal_alignment_enumeration::the_two_cost_models_disagree_on_1420_v4`.
+    #[test]
+    fn the_closed_form_and_the_enumerator_agree(
+        (reference, alternate) in block_pair(),
+    ) {
+        let report = minimal_alignments(&reference, &alternate, CostModel::Levenshtein)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let closed_form = crate::issue_1539_split_member_separation::forced_unchanged_columns(
+            &reference,
+            &alternate,
+        )
+        .expect("these blocks are far below the closed form's own matrix cap");
+
+        let from_closed_form: Vec<u32> = closed_form
+            .iter()
+            .enumerate()
+            .filter(|(_, forced)| **forced)
+            .map(|(i, _)| i as u32)
+            .collect();
+        prop_assert_eq!(
+            report.unchanged(),
+            from_closed_form.as_slice(),
+            "{:?} -> {:?}: the enumerator and the closed form disagree",
+            String::from_utf8_lossy(&reference),
+            String::from_utf8_lossy(&alternate),
+        );
+    }
+
+    /// **On an equal-length block the minimal cost never exceeds the
+    /// position-wise cost** — the record's premise, as an inequality.
+    ///
+    /// The position-wise correspondence is always *an* alignment of two blocks
+    /// of the same length, so it can never beat the minimum. When it is strictly
+    /// beaten, the block is one where the record's rule and the position-wise
+    /// reading may disagree — `CAG -> AGA` being the smallest instance. The
+    /// inequality holds either way, which is why this is the assertable half.
+    #[test]
+    fn on_equal_length_blocks_the_minimum_never_exceeds_the_position_wise_cost(
+        (reference, alternate) in equal_length_pair(),
+    ) {
+        let position_wise_cost = (reference.len() - position_wise_matches(&reference, &alternate).len()) as u32;
+        for model in CostModel::ALL {
+            let report = minimal_alignments(&reference, &alternate, model)
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            prop_assert!(
+                report.cost() <= position_wise_cost * model.substitution_cost(),
+                "{:?} -> {:?} under {model:?}: minimal cost {} exceeds the position-wise cost {}",
+                String::from_utf8_lossy(&reference),
+                String::from_utf8_lossy(&alternate),
+                report.cost(),
+                position_wise_cost * model.substitution_cost(),
+            );
+        }
+    }
+}
+
+/// The `MAX_BLOCK_LEN` bound above is only sound if the worst case at that
+/// length fits the default cap. Checked rather than asserted in prose, since a
+/// later change to either constant would otherwise make every property above
+/// tolerate a refusal it currently rules out.
+#[test]
+fn the_generator_bound_stays_inside_the_default_cap() {
+    let worst_reference = vec![b'A'; MAX_BLOCK_LEN];
+    let worst_alternate = vec![b'C'; MAX_BLOCK_LEN];
+    let report = minimal_alignments(
+        &worst_reference,
+        &worst_alternate,
+        CostModel::SubstitutionCostsTwo,
+    )
+    .expect("the worst case at MAX_BLOCK_LEN must fit the default cap");
+    assert_eq!(report.count(), 8989, "the central Delannoy number D(6, 6)");
+    assert!(report.count() < DEFAULT_ALIGNMENT_CAP);
+}


### PR DESCRIPTION
`rulings[unchanged-is-read-over-every-minimal-alignment]` decides that **a reference base is unchanged iff every minimal alignment of the block matches it**. Nothing in the repo could compute that. The rule quantifies over *all* minimal alignments and nothing enumerated them, so every question of the form "is this base unchanged?" was re-derived by hand — and the record itself exists because two agents re-derived it differently within one hour on 2026-08-14. An intersection over a set nobody enumerates is not a checkable claim.

This adds the instrument, its pinned cases, and its properties. It wires into nothing.

## What it is

`tests/it/common/minimal_alignment.rs` takes a `(reference, alternate)` byte pair and an explicit cost model, and returns the minimal edit cost, **every** optimal alignment, the reference offsets matched in all of them (the record's "unchanged" set), and how many alignments there were.

```rust
let report = minimal_alignments(b"CAG", b"AGA", CostModel::Levenshtein)?;
report.cost();        // 2
report.count();       // 1
report.is_unique();   // true
report.unchanged();   // [1, 2]
report.alignments();  // [[Del, Match, Match, Ins]]
```

The count is reported because "unique" and "several that happen to agree" are different situations, and that distinction is exactly what separates this notion from the cell-based one the record contrasts it with.

It lives in test-support rather than `src/` for three reasons, all on the module: nothing under `src/` calls it or should; the production alignment DAG next door implements a deliberately *different* (cell-based) notion, and putting a second one beside it invites the confusion the record was written to end; and enumeration is exponential by construction, so it is unfit for a hot path however it were written.

## The cap is an error, never a truncation

Past `DEFAULT_ALIGNMENT_CAP` (65536) the call returns `Err(CapExceeded)` rather than a partial set. The unchanged set is an **intersection**, so dropping alignments can only *add* offsets to it — a silent truncation would report bases as unchanged that are not, which is wrong in exactly the direction the record exists to prevent. The cost is still reported, since the DP grid is polynomial and always completes.

65536 fits a 7-base all-mismatch block. The growth is the central Delannoy numbers under substitution cost 2 — 321 at n=4, 8989 at n=6, 48639 at n=7, 265729 at n=8 — so one more base costs roughly six times the budget and no reachable cap changes which blocks this can answer for. The cap's job is to fail loudly, not to be generous.

## The record does not state its cost model, and the two candidates disagree

This is the most valuable thing the instrument makes visible, and it is **not adjudicated here**.

Two things point at substitution cost 1: the record's own worked example (`CAG -> AGA`, "position-wise: cost 3" over three substitutions), and `issue_1539_split_member_separation::forced_unchanged_columns` — the closed-form detector the record names as where the ruling came from — which hardcodes it. Neither is a ruling.

And the two models disagree on a real reported block. On `1420-v4` (`ATGC -> GCTG`, the `TEMPLATE` block at `g.21_24`):

| model | cost | alignments | unchanged (block) | unchanged (genomic) |
|---|---:|---:|---|---|
| substitution costs 1 | 3 | 2 | `{1, 2}` | `g.22`, `g.23` |
| substitution costs 2 | 4 | 6 | `{2}` | `g.23` |

Under one model `g.22` is an unchanged base and the changes either side of it are "separated by one or more nucleotides", so `general.md:34` describes them individually. Under the other they are consecutive. That is a difference in what the spec clause says about this block, from a parameter the record never fixes.

Both answers are pinned in `the_two_cost_models_disagree_on_1420_v4`, with a doc comment saying the record is silent and that the test is the record of that gap. Picking a winner is an adjudication and belongs in the ledger, per `rulings[adjudication-precedence-order]` — not in a test module.

## What is pinned

Every case the record argues from, plus the degenerate ends. The three `1420` blocks are read off the real `TEMPLATE` contig in `reported_confluence_pairs`, not retyped.

| case | model | cost | alignments | unchanged |
|---|---|---:|---:|---|
| `CAG -> AGA` (record's headline) | both | 2 | 1 | `{1, 2}` |
| `GACA -> AGAT` (forced the column/cell distinction) | sub=1 | 3 | 3 | `{1}` |
| `GACA -> AGAT` | sub=2 | 4 | 9 | `{}` |
| `TTGC -> ATTG` (`1420-v2`, `g.38_41`) | both | 2 | 1 | `{0, 1, 2}` |
| `ATTG -> CATT` (`1420-v3`, `g.37_40`) | both | 2 | 1 | `{0, 1, 2}` |
| `ATGC -> GCTG` (`1420-v4`, `g.21_24`) | sub=1 / sub=2 | 3 / 4 | 2 / 6 | `{1, 2}` / `{2}` |
| `ACGTACGT -> ACGTACGT` | both | 0 | 1 | all |
| `AAAA -> TTTT` | sub=1 / sub=2 | 4 / 8 | 1 / 321 | `{}` |
| empty, pure del, pure ins | both | — | 1 | `{}` |

## Two things the instrument found

**The record says `GACA -> AGAT` has "the two cost-3 alignments"; there are three.** Their matched-reference sets are `{1, 3}`, `{0, 1}` and `{0, 1}` — two of the three agree, which is the likeliest reading behind the "two". Pinned rather than resolved, because the record's conclusion is unaffected: offset 1 is matched in all three, so the intersection is `{1}` on either count.

**The position-wise reading and the minimal-alignment reading are incomparable, not merely different.** Neither set contains the other. Brute force over every `{A, C}` pair up to length 5 under substitution cost 1 finds 178 counterexamples to one containment and 250 to its converse; `CAG -> AGA` is among the first, with `unchanged = {1, 2}` and no position-wise match at all. The same holds between the two cost models, in both directions. Both are pinned with witnesses in `neither_notion_contains_the_other` and `neither_cost_model_bounds_the_other`. This is a stronger statement of the record's headline claim than "they can differ", and it means a property test written on the natural guess that one bounds the other would be red on roughly one generated pair in four.

## Properties

`minimal_alignment_enumeration_proptest` sweeps both models over random pairs and asserts: every emitted alignment is well formed and its cost recomputed from the columns equals the reported minimum; the alignments are pairwise distinct; `unchanged` is exactly the intersection of the per-alignment matched sets; the cap refuses iff the set does not fit and otherwise changes nothing; reversing both blocks mirrors the answer; `cost(sub=1) <= cost(sub=2) <= 2 * cost(sub=1)`; and on equal-length blocks the minimal cost never exceeds the position-wise cost.

The eighth is a **cross-oracle**: `forced_unchanged_columns` reaches the same set in `Θ(n·m)` without materialising an alignment, so agreeing with it is agreeing with the record's working definition by a genuinely different route — one side never enumerates, the other never inspects the grid. It is made `pub(crate)` for that and is otherwise untouched.

## The soak, re-checked rather than assumed

`ci.yml`'s soak selects by name, so a `*proptest*` module lands in a 1M-case job without anyone choosing it — the comment there asks for two claims to be re-checked, and they were. The properties are pure functions of a generated byte pair: no provider, no fixture, no generated spec artifact. Cost was measured too, because the enumerator is exponential: `PROPTEST_CASES=125000` over the module costs **56.7 s wall in the test profile**, i.e. before that job's ~5.4x optimization, bounded by the generator's own `MAX_BLOCK_LEN` of 6. The comment now records all of it.

## Gate

`cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo nextest run --features dev --lib --test it`, and `actionlint` on the workflow change — all clean.

Representation-Change: none. This adds a test-support utility and its tests; it wires into no normalization path, moves no output, and re-pins no census.
