### PR TITLE
fix(ci): delete the dead nextest ci profile that killed the censuses

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,30 @@
 [profile.default]
 fail-fast = false
 
-[profile.ci]
-test-threads = "num-cpus"
-fail-fast = true
-slow-timeout = { period = "60s", terminate-after = 2 }
-retries = 1
+# There is deliberately no `[profile.ci]`.
+#
+# One existed and was BOTH dead and a trap. Nothing in `.github/` or `scripts/`
+# ever selected it — CI runs the archived binaries directly:
+#
+#     cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
+#       --extract-to . --extract-overwrite --partition hash:<K>/6 -E "..."
+#
+# so its settings described nothing that runs. Worse, anyone who reached for
+# `--profile ci` locally with `FERRO_MANIFEST` set got a deterministic failure
+# rather than a test result: it carried
+#
+#     slow-timeout = { period = "60s", terminate-after = 2 }   # kills at 120s
+#     retries = 1
+#
+# while the two conformance censuses take 200.9s and 187.9s under the default
+# profile. Both are terminated at 120s, retried once, terminated again — 240s of
+# timeout and 0 tests passed, presenting as a test failure rather than as a
+# configuration one.
+#
+# Its other settings did not describe CI either: `fail-fast = true` against CI's
+# archive runs, and `retries = 1` where a normalization suite wants a
+# deterministic result rather than a re-roll.
+#
+# If a CI profile is wanted later, derive it from what `ci.yml` actually runs,
+# and size any `slow-timeout` from the measured cost of the slowest test rather
+# than from a round number.


### PR DESCRIPTION
`.config/nextest.toml` carried a `[profile.ci]` that was both **dead** and a **trap**.

## Dead

Nothing in `.github/` or `scripts/` ever selected it. CI runs the archived binaries directly:

```
cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
  --extract-to . --extract-overwrite --partition hash:<K>/6 -E "..."
```

So its settings described nothing that runs.

## And a trap

Anyone reaching for `--profile ci` locally **with `FERRO_MANIFEST` set** got a deterministic failure rather than a test result. It carried

```toml
slow-timeout = { period = "60s", terminate-after = 2 }   # terminates at 120s
retries = 1
```

while the two conformance censuses measure **200.9 s** and **187.9 s** under the default profile. Both are terminated at 120 s, retried once, and terminated again — **240 s of timeout and 0 tests passed**, presenting as a test failure rather than as a configuration one.

Nobody has hit it because PR CI never sets `FERRO_MANIFEST` (`ci.yml:1153-1158`), so those tests early-return and skip there. The profile and the manifest appear never to have been combined.

Its other settings did not describe CI either: `fail-fast = true` against CI's archive runs, and `retries = 1` where a normalization suite wants a deterministic result rather than a re-roll.

## Why delete rather than repair the timeout

Raising `terminate-after` would fix the symptom and leave a profile that still matches nothing CI does. A comment now records what CI actually runs, so the next person who wants a CI profile derives it from that and sizes any `slow-timeout` from the measured cost of the slowest test rather than from a round number.

If you would rather keep a usable `--profile ci`, the alternative is a one-line change — `terminate-after = 6` (360 s) clears both censuses with headroom. Say so and I will swap it.

Found while measuring local build/test iteration cost.

Representation-Change: none. One file, `.config/nextest.toml`, and the profile it removes was selected by nothing. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`, `src/reference/` or `src/error_handling/` is touched, no test changes, and no normalized output can move.
