### PR TITLE
perf(normalize): narrow the alignment cost grid to u16, and make divergence a benchmark axis

### DIFF
--- a/benches/seqfirst_align.rs
+++ b/benches/seqfirst_align.rs
@@ -103,30 +103,64 @@ fn diverge_subs(reference: &[u8], k: usize, seed: u64) -> Vec<u8> {
 /// generators so their timings are comparable, and it is the shape the
 /// `unchanged-is-read-over-every-minimal-alignment` ruling governs.
 fn diverge_indels(reference: &[u8], k: usize, seed: u64) -> Vec<u8> {
-    if reference.is_empty() || k < 2 {
+    // `pairs` is clamped so `stride >= 2`, which is what keeps the deletion site
+    // (`offset == 0`) and the insertion site (`offset == stride / 2`) distinct.
+    let pairs = (k / 2).min(reference.len().saturating_sub(2) / 2);
+    if pairs == 0 {
         return reference.to_vec();
     }
     let mut state = seed | 1;
-    let pairs = k / 2;
-    // Delete at `pairs` sites and insert at `pairs` others, walking left to
-    // right so the result stays the same length.
-    let mut out = Vec::with_capacity(reference.len());
     let stride = reference.len() / (pairs + 1);
+    let insert_offset = stride / 2;
+
+    // Delete at `pairs` sites and insert at `pairs` others, half a stride apart,
+    // walking left to right so the result stays the same length.
+    let mut out = Vec::with_capacity(reference.len());
+    let (mut deleted, mut inserted) = (0usize, 0usize);
     for (i, &b) in reference.iter().enumerate() {
-        let slot = i / stride.max(1);
-        if slot < pairs && i % stride.max(1) == 0 {
-            // Insert a base that differs from the one it precedes, then skip a
-            // base — one insertion and one deletion, `stride` apart.
-            out.push(b"ACGT"[(next(&mut state) as usize) % 4]);
+        let (slot, offset) = (i / stride, i % stride);
+        if slot < pairs && offset == 0 {
+            // Deletion: consume the reference base and emit nothing.
+            deleted += 1;
             continue;
+        }
+        if slot < pairs && offset == insert_offset {
+            // Insertion: emit an extra base before this one.
+            out.push(b"ACGT"[(next(&mut state) as usize) % 4]);
+            inserted += 1;
         }
         out.push(b);
     }
-    out.truncate(reference.len());
-    while out.len() < reference.len() {
-        out.push(b'A');
-    }
+
+    // Asserted rather than trusted, and asserted with `assert!` rather than
+    // `debug_assert!`: `[profile.bench]` inherits `release`, so a `debug_assert`
+    // here would never run in the profile the benchmark is measured in. This
+    // runs once per generator call, outside `b.iter()`.
+    //
+    // The predecessor of this function pushed a random base *instead of* the
+    // reference base and `continue`d, so it emitted exactly one byte per input
+    // byte — a substitution, not an indel pair — and `edit == hamming` at every
+    // `k`. Nothing said so; the vestigial `truncate`/pad tail that could never
+    // fire was the only trace. See #1970.
+    assert_eq!(
+        deleted, inserted,
+        "each deletion must be paired with an insertion"
+    );
+    assert_eq!(
+        out.len(),
+        reference.len(),
+        "the pairs must net to zero length change"
+    );
     out
+}
+
+/// Positions at which two equal-length blocks differ.
+///
+/// Only meaningful beside an edit distance: `edit < hamming` is what says an
+/// optimal path leaves the main diagonal, which is the property the indel arm
+/// exists to exercise.
+fn hamming(a: &[u8], b: &[u8]) -> usize {
+    a.iter().zip(b).filter(|(x, y)| x != y).count()
 }
 
 /// Cost against **block length, with `k` held constant** — the shape a real
@@ -147,7 +181,8 @@ fn bench_by_length_fixed_k(c: &mut Criterion) {
                 &len,
                 |b, _| {
                     b.iter(|| {
-                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
+                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt))
+                            .expect("benchmark blocks are far below MAX_ALIGNMENT_SPAN");
                         black_box(dag.edit_distance())
                     })
                 },
@@ -171,7 +206,8 @@ fn bench_by_divergence(c: &mut Criterion) {
         group.throughput(Throughput::Elements((len * len) as u64));
         group.bench_with_input(BenchmarkId::from_parameter(format!("k{k}")), &k, |b, _| {
             b.iter(|| {
-                let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
+                let dag = AlignmentDag::build(black_box(&reference), black_box(&alt))
+                    .expect("benchmark blocks are far below MAX_ALIGNMENT_SPAN");
                 black_box(dag.edit_distance())
             })
         });
@@ -193,13 +229,38 @@ fn bench_indel_vs_substitution(c: &mut Criterion) {
             ("sub", diverge_subs(&reference, k, 7)),
             ("indel", diverge_indels(&reference, k, 7)),
         ] {
+            // The group's whole premise, checked rather than assumed, once per
+            // arm and outside the timing loop. A substitution-only alternate has
+            // `edit == hamming`, because the all-substitution diagonal is
+            // already minimal; an indel-bearing one is strictly cheaper to align
+            // than to overwrite, which is the same as saying some optimal path
+            // leaves the diagonal. That is the property this arm is *for*, and
+            // it is the assertion that would have caught the generator emitting
+            // substitutions (#1970).
+            let distance = AlignmentDag::build(&reference, &alt)
+                .expect("benchmark blocks are far below MAX_ALIGNMENT_SPAN")
+                .edit_distance() as usize;
+            let differing = hamming(&reference, &alt);
+            match kind {
+                "sub" => assert_eq!(
+                    distance, differing,
+                    "k{k}_sub: substitution-only divergence must stay on the diagonal"
+                ),
+                _ => assert!(
+                    distance < differing,
+                    "k{k}_indel: an indel arm must be cheaper than {differing} substitutions, \
+                     got {distance} — the generator is emitting substitutions"
+                ),
+            }
+
             group.throughput(Throughput::Elements((len * len) as u64));
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!("k{k}_{kind}")),
                 &k,
                 |b, _| {
                     b.iter(|| {
-                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
+                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt))
+                            .expect("benchmark blocks are far below MAX_ALIGNMENT_SPAN");
                         black_box(dag.edit_distance())
                     })
                 },

--- a/benches/seqfirst_align.rs
+++ b/benches/seqfirst_align.rs
@@ -3,11 +3,43 @@
 //! `AlignmentDag::build` is `O(n*m)` in time **and space**, but Criterion has
 //! no memory axis — this measures wall-clock time only. It shows where that
 //! grows too slow to be acceptable, so the block-size cap in the migration is
-//! chosen on time evidence; the memory dimension is not measured here.
+//! chosen on time evidence; the memory dimension is not measured here (the
+//! figures are on #1928: ~18 bytes per grid cell, ~275 MB at the widest
+//! accepted block).
+//!
+//! # Divergence is an AXIS, not a constant (#1928)
+//!
+//! This file used to fix the alternate at "~5% of positions perturbed" and vary
+//! only length. That is one point on a curve whose shape is the whole question,
+//! because every cell on a minimal alignment satisfies `|i - j| <= k` for edit
+//! distance `k` — so the work that is *reachable* is `Θ(n · k)`, and a benchmark
+//! that holds `k / n` fixed makes the cost look inherently quadratic when it is
+//! quadratic only in the regime it happens to sample.
+//!
+//! The three regimes are far apart, and real inputs are at the cheap end:
+//!
+//! | shape | `k` relative to `n` | where it comes from |
+//! |---|---|---|
+//! | a real variant | single digits, independent of `n` | a reference and an alternate for one variant differ in a few places |
+//! | this file's old fixture | `n / 20` | the 5% perturbation |
+//! | uniform-random pair | `~0.6 n` | `dump_normalized_corpus`'s random cores, measured for #107 |
+//!
+//! So `k` is parameterised directly, and **held constant as `n` grows** in the
+//! `by_length_fixed_k` group — that is the shape a real corpus presents, and the
+//! one under which a banded implementation should approach linear.
+//!
+//! # Indels are a second axis
+//!
+//! The old fixture perturbed by substitution only, so no optimal path ever left
+//! the main diagonal and no `OUT_DEL`/`OUT_INS` edge was ever exercised at any
+//! length. Substitution-only and indel-bearing divergence are generated
+//! separately below: they cost the same to *compute* but produce different DAGs,
+//! and only the second has more than one minimal alignment to enumerate.
 
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ferro_hgvs::normalize::seqfirst::align::AlignmentDag;
 
 /// Deterministic pseudo-random bases; no RNG dependency, and reproducible
 /// across runs so successive measurements are comparable.
@@ -23,22 +55,123 @@ fn bases(len: usize, seed: u64) -> Vec<u8> {
         .collect()
 }
 
-fn bench_build(c: &mut Criterion) {
-    let mut group = c.benchmark_group("seqfirst_align_build");
-    for &len in &[16usize, 64, 256, 1024, 4096] {
-        let reference = bases(len, 1);
-        let mut alt = reference.clone();
-        // Perturb ~5% of positions so the DAG is non-trivial.
-        for k in (0..len).step_by(20) {
-            alt[k] = if alt[k] == b'A' { b'C' } else { b'A' };
+/// Next pseudo-random value, so the perturbation sites are spread rather than
+/// periodic. A `step_by` stride puts every difference on a lattice, which is
+/// not a property real divergence has.
+fn next(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *state >> 33
+}
+
+/// An alternate differing from `reference` at exactly `k` positions, by
+/// **substitution only** — so the edit distance is `k` and every minimal
+/// alignment stays on the main diagonal.
+fn diverge_subs(reference: &[u8], k: usize, seed: u64) -> Vec<u8> {
+    let mut alt = reference.to_vec();
+    if reference.is_empty() || k == 0 {
+        return alt;
+    }
+    let mut state = seed | 1;
+    let mut placed = 0;
+    // Sample without replacement by rejection; `k` is far below `len` in every
+    // configuration here, so the expected number of retries is small.
+    let mut seen = vec![false; reference.len()];
+    while placed < k {
+        let at = (next(&mut state) as usize) % reference.len();
+        if seen[at] {
+            continue;
         }
+        seen[at] = true;
+        // Any base other than the one already there, so the difference is real.
+        alt[at] = match alt[at] {
+            b'A' => b'C',
+            b'C' => b'G',
+            b'G' => b'T',
+            _ => b'A',
+        };
+        placed += 1;
+    }
+    alt
+}
+
+/// An alternate differing from `reference` by `k` **indels** — `k/2` single-base
+/// deletions and `k/2` single-base insertions, spread through the block.
+///
+/// Equal length is deliberate: it keeps the grid square across the two
+/// generators so their timings are comparable, and it is the shape the
+/// `unchanged-is-read-over-every-minimal-alignment` ruling governs.
+fn diverge_indels(reference: &[u8], k: usize, seed: u64) -> Vec<u8> {
+    if reference.is_empty() || k < 2 {
+        return reference.to_vec();
+    }
+    let mut state = seed | 1;
+    let pairs = k / 2;
+    // Delete at `pairs` sites and insert at `pairs` others, walking left to
+    // right so the result stays the same length.
+    let mut out = Vec::with_capacity(reference.len());
+    let stride = reference.len() / (pairs + 1);
+    for (i, &b) in reference.iter().enumerate() {
+        let slot = i / stride.max(1);
+        if slot < pairs && i % stride.max(1) == 0 {
+            // Insert a base that differs from the one it precedes, then skip a
+            // base — one insertion and one deletion, `stride` apart.
+            out.push(b"ACGT"[(next(&mut state) as usize) % 4]);
+            continue;
+        }
+        out.push(b);
+    }
+    out.truncate(reference.len());
+    while out.len() < reference.len() {
+        out.push(b'A');
+    }
+    out
+}
+
+/// Cost against **block length, with `k` held constant** — the shape a real
+/// corpus presents, and the one under which a banded implementation should
+/// approach linear while the current `Θ(n·m)` grid stays quadratic.
+fn bench_by_length_fixed_k(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seqfirst_align/by_length_fixed_k");
+    for &len in &[64usize, 256, 1024, 4096] {
+        let reference = bases(len, 1);
+        for &k in &[2usize, 8] {
+            if k >= len {
+                continue;
+            }
+            let alt = diverge_subs(&reference, k, 7);
+            group.throughput(Throughput::Elements((len * len) as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("len{len}_k{k}")),
+                &len,
+                |b, _| {
+                    b.iter(|| {
+                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
+                        black_box(dag.edit_distance())
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+/// Cost against **divergence, at fixed length** — the axis the old fixture held
+/// constant. `k` runs from a real-variant scale up to the uniform-random regime
+/// where a band is the whole grid and banding cannot help.
+fn bench_by_divergence(c: &mut Criterion) {
+    let len = 1024usize;
+    let reference = bases(len, 1);
+    let mut group = c.benchmark_group("seqfirst_align/by_divergence");
+    // 2 and 8 are real-variant scale; 51 is the old fixture's 5%; 614 is the
+    // ~0.6n uniform-random regime measured for #107.
+    for &k in &[2usize, 8, 32, 51, 128, 512, 614] {
+        let alt = diverge_subs(&reference, k, 7);
         group.throughput(Throughput::Elements((len * len) as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, _| {
+        group.bench_with_input(BenchmarkId::from_parameter(format!("k{k}")), &k, |b, _| {
             b.iter(|| {
-                let dag = ferro_hgvs::normalize::seqfirst::align::AlignmentDag::build(
-                    black_box(&reference),
-                    black_box(&alt),
-                );
+                let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
                 black_box(dag.edit_distance())
             })
         });
@@ -46,5 +179,40 @@ fn bench_build(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_build);
+/// The same divergence budget spent on **indels** rather than substitutions.
+///
+/// Substitution-only divergence keeps every minimal alignment on the diagonal;
+/// indels are what make the DAG wide and what `dominators()` exists to
+/// enumerate, so the two are not interchangeable as a cost model.
+fn bench_indel_vs_substitution(c: &mut Criterion) {
+    let len = 1024usize;
+    let reference = bases(len, 1);
+    let mut group = c.benchmark_group("seqfirst_align/indel_vs_sub");
+    for &k in &[8usize, 32, 128] {
+        for (kind, alt) in [
+            ("sub", diverge_subs(&reference, k, 7)),
+            ("indel", diverge_indels(&reference, k, 7)),
+        ] {
+            group.throughput(Throughput::Elements((len * len) as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("k{k}_{kind}")),
+                &k,
+                |b, _| {
+                    b.iter(|| {
+                        let dag = AlignmentDag::build(black_box(&reference), black_box(&alt));
+                        black_box(dag.edit_distance())
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_by_length_fixed_k,
+    bench_by_divergence,
+    bench_indel_vs_substitution
+);
 criterion_main!(benches);

--- a/examples/dump_partitions.rs
+++ b/examples/dump_partitions.rs
@@ -246,8 +246,11 @@ fn main() {
         let distance = match catch_unwind(AssertUnwindSafe(|| {
             dev_partitioners::edit_distance(reference, alt)
         })) {
-            Ok(distance) => distance.to_string(),
-            Err(_) => "-".to_string(),
+            Ok(Some(distance)) => distance.to_string(),
+            // A refusal (the pair is past `MAX_ALIGNMENT_SPAN`) and a panic both
+            // mean "no distance to report", and the column already spells that
+            // `-`.
+            Ok(None) | Err(_) => "-".to_string(),
         };
 
         writeln!(

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -5426,9 +5426,17 @@ struct MemberAlignment {
 /// [`AlignmentDag::out_edges`] already yields — and follows on-path edges only,
 /// so it is always *a* minimal alignment. It reads nothing but the two blocks,
 /// so two spellings of one variant reach the same walk.
-fn member_alignment(reference: &[u8], payload: &[u8]) -> MemberAlignment {
+///
+/// `None` when the block is past [`crate::normalize::seqfirst::align::MAX_ALIGNMENT_SPAN`]
+/// and the DAG therefore cannot be built. [`MAX_SEPARATION_AUDIT_WIDTH`] caps
+/// only the *reference* side, and the sibling cells cap admits a payload of
+/// ~262,000 bases against a three-column member, so the refusal is reachable
+/// here and not merely defensive. Declining is the direction this audit already
+/// takes everywhere else: it leaves the member whole, which under-reports and
+/// never corrupts.
+fn member_alignment(reference: &[u8], payload: &[u8]) -> Option<MemberAlignment> {
     use crate::normalize::seqfirst::align::{AlignmentDag, Step};
-    let dag = AlignmentDag::build(reference, payload);
+    let dag = AlignmentDag::build(reference, payload)?;
     let mut forced = vec![true; reference.len()];
     for (i, j) in dag.cells() {
         if (i as usize) < reference.len()
@@ -5456,10 +5464,10 @@ fn member_alignment(reference: &[u8], payload: &[u8]) -> MemberAlignment {
         (i, j) = (next_i, next_j);
     }
 
-    MemberAlignment {
+    Some(MemberAlignment {
         forced,
         matched_alt,
-    }
+    })
 }
 
 /// Maximal runs of forced-unchanged columns that are **strictly interior** to a
@@ -5553,7 +5561,7 @@ fn concealed_separations(
     {
         return None;
     }
-    let alignment = member_alignment(reference, &piece.alt);
+    let alignment = member_alignment(reference, &piece.alt)?;
     let runs: Vec<(usize, usize)> = interior_forced_runs(&alignment.forced)
         .into_iter()
         .filter(|&(offset, len)| {
@@ -7326,7 +7334,7 @@ fn partition_block_sequence_first(
         return None;
     }
 
-    let dag = AlignmentDag::build(reference, result);
+    let dag = AlignmentDag::build(reference, result)?;
     let dominators = dag.dominators();
     let members = partition_members_with(&dag, &dominators, min_separation);
     let spans = member_alt_spans(&dag, &dominators, &members)?;
@@ -7359,7 +7367,11 @@ fn partition_block_sequence_first(
 /// `partition_members_canonical`'s doc works the case through.
 ///
 /// Returns `None` only when the alignment grid would exceed
-/// [`MAX_SEQFIRST_GRID_CELLS`]; the caller falls back to [`partition_block`].
+/// [`MAX_SEQFIRST_GRID_CELLS`], or when the two blocks together exceed
+/// [`crate::normalize::seqfirst::align::MAX_ALIGNMENT_SPAN`] — a **cells** cap
+/// and a **span** cap are independent, and a degenerate `1 x 70,000` block
+/// passes the first while failing the second (#1970). Either way the caller
+/// falls back to [`partition_block`].
 ///
 /// Reached only under `FERRO_PARTITION=canonical` and from the `dump_partitions`
 /// example; it does not decide any shipped result.
@@ -7396,7 +7408,7 @@ fn partition_block_canonical_within(
         return None;
     }
 
-    let dag = AlignmentDag::build(reference, result);
+    let dag = AlignmentDag::build(reference, result)?;
     let canonical = CanonicalAlignment::of(&dag);
     Some(
         canonical
@@ -8214,8 +8226,13 @@ pub mod dev_partitioners {
 
     /// The block's unit-cost Levenshtein distance — the floor every arm's
     /// changed-column count is measured against.
-    pub fn edit_distance(reference: &[u8], result: &[u8]) -> u32 {
-        crate::normalize::seqfirst::align::AlignmentDag::build(reference, result).edit_distance()
+    ///
+    /// `None` when the pair exceeds
+    /// [`crate::normalize::seqfirst::align::MAX_ALIGNMENT_SPAN`], the same
+    /// refusal the partitioners take.
+    pub fn edit_distance(reference: &[u8], result: &[u8]) -> Option<u32> {
+        crate::normalize::seqfirst::align::AlignmentDag::build(reference, result)
+            .map(|dag| dag.edit_distance())
     }
 
     /// Changed columns a member set claims, `sum(max(ref_span, alt_len))` — the
@@ -14829,7 +14846,9 @@ mod tests {
         let result = b"ACGTGG";
 
         assert_eq!(
-            member_alignment(reference, result).forced,
+            member_alignment(reference, result)
+                .expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+                .forced,
             vec![false; reference.len()],
             "no column of the block survives every minimal alignment, so the \
              split below rests on coincidence — which is what makes this the \
@@ -14844,7 +14863,9 @@ mod tests {
              proves nothing; got {pieces:?}"
         );
         assert_eq!(
-            member_alignment(&reference[..5], b"AC").forced,
+            member_alignment(&reference[..5], b"AC")
+                .expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+                .forced,
             vec![false, false, false, true, false],
             "`GGTCG -> AC` keeps its `C` in every minimal alignment",
         );
@@ -14912,7 +14933,11 @@ mod tests {
         let reference = b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT";
         let result = b"TTCCTCGATGCCTG";
         assert_eq!(
-            interior_forced_runs(&member_alignment(reference, result).forced),
+            interior_forced_runs(
+                &member_alignment(reference, result)
+                    .expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+                    .forced,
+            ),
             vec![(44, 1), (48, 1)],
             "the spec's recommended form does conceal separations of its own",
         );
@@ -14953,7 +14978,11 @@ mod tests {
         let pieces = partition_block(reference, result, NO_AXIS);
         assert_eq!(pieces.len(), 2, "got {pieces:?}");
         assert_eq!(
-            interior_forced_runs(&member_alignment(b"TATA", b"ATAT").forced),
+            interior_forced_runs(
+                &member_alignment(b"TATA", b"ATAT")
+                    .expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+                    .forced,
+            ),
             vec![(1, 2)],
             "the trailing member does conceal a two-column separation",
         );
@@ -16915,6 +16944,7 @@ mod tests {
             assert_eq!(
                 changed_columns_of_pieces(&pieces),
                 crate::normalize::seqfirst::align::AlignmentDag::build(reference, result)
+                    .expect("test blocks are far below MAX_ALIGNMENT_SPAN")
                     .edit_distance() as usize,
                 "the canonical arm must claim exactly the block's edit distance"
             );

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -79,6 +79,35 @@ const OUT_DEL: u8 = 1 << 2;
 /// Right out-edge: an alternate base is inserted (`Step::Ins`).
 const OUT_INS: u8 = 1 << 3;
 
+/// Largest `n + m` (reference length plus alternate length) whose alignment
+/// [`AlignmentDag::build`] will compute.
+///
+/// # Why `n + m`, and why it is exact rather than conservative
+///
+/// The cost grids are `u16`. A prefix cost `prefix[i][j]` is the edit distance
+/// of `ref[..i]` to `alt[..j]`, so it is bounded by `max(i, j) <= i + j`; a
+/// suffix cost `suffix(i, j)` is likewise bounded by `(n - i) + (m - j)`. Every
+/// value the DP writes is one of those, and the largest sum `build` ever forms
+/// is `on_optimal_path`'s `prefix[i][j] + suffix(i, j) <= n + m`. The three
+/// `here + 1` / `here + cost` comparisons are formed only where `i < n` or
+/// `j < m`, so `here <= n + m - 1` there. `n + m <= u16::MAX` therefore covers
+/// every arithmetic site in `build` with nothing left over — the bound is the
+/// exact one, not a margin.
+///
+/// # Why it is a refusal and not a `debug_assert`
+///
+/// `[profile.release]` sets neither `debug-assertions` nor `overflow-checks`,
+/// so in the shipped library and in the Python wheel a `debug_assert` is a
+/// comment: past the bound `edit_grid`'s boundary row would truncate `j as u16`
+/// and the sums would wrap, and `on_optimal_path` would be computed from wrong
+/// costs. That is a silently wrong partition and so a silently wrong emitted
+/// description — strictly worse than declining. Every gate in front of `build`
+/// bounds **cells**, i.e. `(n + 1) * (m + 1)`, and a degenerate `1 x 70,000`
+/// grid clears the widest of those by four orders of magnitude while `n + m` is
+/// past `u16::MAX`; a long literal `ins` payload reaches exactly that shape.
+/// See #1970.
+pub(crate) const MAX_ALIGNMENT_SPAN: usize = u16::MAX as usize;
+
 impl AlignmentDag {
     /// Build the DAG for `ref_block` -> `alt_block`.
     ///
@@ -92,9 +121,18 @@ impl AlignmentDag {
     /// precondition, not a convenience.
     ///
     /// Cost is `O(ref_len * alt_len)` in time and space.
-    pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Self {
+    ///
+    /// `None` when `ref_block.len() + alt_block.len()` exceeds
+    /// [`MAX_ALIGNMENT_SPAN`], which is the width of the `u16` cost grid. Every
+    /// caller in the normalizer already has a decline path, and declining is the
+    /// only safe answer: past the bound the costs wrap rather than panic in the
+    /// shipped profile. See [`MAX_ALIGNMENT_SPAN`].
+    pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Option<Self> {
         let n = ref_block.len();
         let m = alt_block.len();
+        if n.checked_add(m)? > MAX_ALIGNMENT_SPAN {
+            return None;
+        }
         let prefix = edit_grid(ref_block, alt_block);
 
         // Suffix distances, computed as prefix distances of the reversed
@@ -147,13 +185,13 @@ impl AlignmentDag {
             }
         }
 
-        Self {
+        Some(Self {
             ref_len: n as u32,
             alt_len: m as u32,
             total: u32::from(total),
             on_optimal_path,
             out,
-        }
+        })
     }
 
     /// Minimal edit distance between the two blocks.
@@ -357,14 +395,16 @@ impl AlignmentDag {
 fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u16> {
     let n = reference.len();
     let m = alt.len();
-    // A cost never exceeds `n + m`, and a cell of `on_optimal_path`'s test sums
-    // a prefix and a suffix cost, so `2 * (n + m)` must fit. The canonical
-    // window caps a block far below this; the assert is what makes the
-    // narrowing safe for a direct `build` caller that is not so capped.
+    // A cost never exceeds `n + m`, so the `u16` grid holds every value exactly
+    // when `n + m <= MAX_ALIGNMENT_SPAN`. This is a statement of the
+    // precondition `AlignmentDag::build` already enforces by refusing, not a
+    // second gate — `edit_grid` is private and `build` is its only caller. Kept
+    // so a future caller added here is caught in a debug build; the refusal, not
+    // this line, is what makes the narrowing safe in the shipped profile.
     debug_assert!(
-        2 * (n + m) <= u16::MAX as usize,
-        "edit_grid narrowed to u16: 2*(n+m) = {} exceeds u16",
-        2 * (n + m)
+        n + m <= MAX_ALIGNMENT_SPAN,
+        "edit_grid narrowed to u16: n+m = {} exceeds {MAX_ALIGNMENT_SPAN}",
+        n + m
     );
     let width = m + 1;
     let mut d = vec![0u16; (n + 1) * width];
@@ -389,6 +429,14 @@ fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u16> {
 mod tests {
     use super::*;
 
+    /// [`AlignmentDag::build`] on blocks small enough that the refusal cannot
+    /// fire. Every block in this module is a handful of bases, so an `Option`
+    /// here would only be noise — but the refusal is exercised on purpose by
+    /// [`tests::the_span_bound_is_enforced_from_both_sides`].
+    fn dag(reference: &[u8], alt: &[u8]) -> AlignmentDag {
+        AlignmentDag::build(reference, alt).expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+    }
+
     #[test]
     fn edit_distance_matches_known_values() {
         for (r, a, expected) in [
@@ -400,7 +448,7 @@ mod tests {
             (&b"AAAAAAA"[..], &b"AACACAAAA"[..], 2),
             (&b"AAAAAAA"[..], &b"ACAAAA"[..], 2),
         ] {
-            let dag = AlignmentDag::build(r, a);
+            let dag = dag(r, a);
             assert_eq!(
                 dag.edit_distance(),
                 expected,
@@ -415,7 +463,7 @@ mod tests {
     fn every_cell_lies_on_a_minimal_path() {
         // A cell is in the DAG only if some minimal alignment passes through
         // it: prefix(i,j) + suffix(i,j) == total.
-        let dag = AlignmentDag::build(b"ACGTACGT", b"ATGTTCGT");
+        let dag = dag(b"ACGTACGT", b"ATGTTCGT");
         assert!(dag.contains_cell(0, 0), "source must be present");
         assert!(
             dag.contains_cell(dag.ref_len(), dag.alt_len()),
@@ -433,7 +481,7 @@ mod tests {
     fn every_edge_advances_the_topological_key() {
         // i + j strictly increases along every edge, which is what makes
         // sorting cells by i + j a valid topological order.
-        let dag = AlignmentDag::build(b"ACGTACGTAC", b"ACGTTACGTGAC");
+        let dag = dag(b"ACGTACGTAC", b"ACGTTACGTGAC");
         for (i, j) in dag.cells() {
             for (ni, nj, _step) in dag.out_edges(i, j) {
                 assert!(
@@ -494,7 +542,7 @@ mod tests {
         // The spec's own worked example, `delins.md:44` / LRG_199t1:c.850_901.
         // Real sequence, pulled from LRG_199.fasta; CDS offset verified against
         // the spec's own `c.145_147 = CGC = Arg49`.
-        let dag = AlignmentDag::build(
+        let dag = dag(
             b"CAGGGATATGAGAGAACTTCTTCCCCTAAGCCTCGATTCAAGAGCTATGCCT",
             b"TTCCTCGATGCCTG",
         );
@@ -516,7 +564,7 @@ mod tests {
         // #1260: two `insC` at adjacent gaps in a poly-A run. A node model
         // reports this as zero members because no reference position changes;
         // the junctions are the whole signal.
-        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let dag = dag(b"AAAAAAA", b"AACACAAAA");
         let dom = dag.dominators();
         assert_eq!(
             dom.matched_ref().len(),
@@ -553,7 +601,7 @@ mod tests {
         let mut checked = 0usize;
         for r in &all {
             for a in &all {
-                let dag = AlignmentDag::build(r, a);
+                let dag = dag(r, a);
                 let got = dag.dominators();
                 let (want_matched, want_ins) = dominators_by_brute_force(&dag);
                 assert_eq!(
@@ -569,6 +617,48 @@ mod tests {
         assert!(
             checked > 3000,
             "expected a large exhaustive sweep, ran {checked}"
+        );
+    }
+
+    /// #1970. The `u16` narrowing's bound must be a refusal, pinned from **both**
+    /// sides so neither a widened nor a tightened bound passes silently.
+    ///
+    /// The over-limit arm is not a "does it panic" test: it asserts `is_none()`,
+    /// which is a value the shipped profile produces too. A `debug_assert` would
+    /// satisfy a panic-shaped test and still wrap in release, which is the whole
+    /// defect.
+    #[test]
+    fn the_span_bound_is_enforced_from_both_sides() {
+        // Degenerate on purpose: `1 x m` is the shape that clears every cells
+        // gate in front of `build` while `n + m` runs away. A long literal `ins`
+        // payload arrives here as exactly this.
+        let one = vec![b'A'; 1];
+
+        // n + m == MAX_ALIGNMENT_SPAN: the last accepted pair.
+        let just_under = vec![b'C'; MAX_ALIGNMENT_SPAN - 1];
+        let built = AlignmentDag::build(&one, &just_under)
+            .expect("n + m == MAX_ALIGNMENT_SPAN must still be computed");
+        assert_eq!(
+            built.edit_distance(),
+            MAX_ALIGNMENT_SPAN as u32 - 1,
+            "one base against {} differing bases is a substitution plus {} insertions",
+            MAX_ALIGNMENT_SPAN - 1,
+            MAX_ALIGNMENT_SPAN - 2
+        );
+
+        // n + m == MAX_ALIGNMENT_SPAN + 1: the first refused pair. One base
+        // wider than the pair above, so nothing but the bound separates them.
+        let just_over = vec![b'C'; MAX_ALIGNMENT_SPAN];
+        assert!(
+            AlignmentDag::build(&one, &just_over).is_none(),
+            "n + m == {} must be refused, not wrapped",
+            MAX_ALIGNMENT_SPAN + 1
+        );
+
+        // And far past it, which is the size #1970 reported.
+        assert!(
+            AlignmentDag::build(&one, &vec![b'C'; 70_000]).is_none(),
+            "a 70,000-base alternate must be refused"
         );
     }
 }

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -105,7 +105,7 @@ impl AlignmentDag {
         let suffix_grid = edit_grid(&ref_rev, &alt_rev);
         let suffix = |i: usize, j: usize| suffix_grid[(n - i) * (m + 1) + (m - j)];
 
-        let total = prefix[n * (m + 1) + m];
+        let total: u16 = prefix[n * (m + 1) + m];
         let width = m + 1;
 
         let mut on_optimal_path = vec![false; (n + 1) * width];
@@ -124,7 +124,7 @@ impl AlignmentDag {
                 let here = prefix[i * width + j];
                 // Diagonal: match or substitution.
                 if i < n && j < m {
-                    let cost = u32::from(ref_block[i] != alt_block[j]);
+                    let cost = u16::from(ref_block[i] != alt_block[j]);
                     let next = (i + 1) * width + (j + 1);
                     if here + cost == prefix[next] && on_optimal_path[next] {
                         out[i * width + j] |= if cost == 0 { OUT_MATCH } else { OUT_SUB };
@@ -150,7 +150,7 @@ impl AlignmentDag {
         Self {
             ref_len: n as u32,
             alt_len: m as u32,
-            total,
+            total: u32::from(total),
             on_optimal_path,
             out,
         }
@@ -354,20 +354,29 @@ impl AlignmentDag {
 }
 
 /// Full Levenshtein distance grid, row-major with `alt.len() + 1` columns.
-fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u32> {
+fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u16> {
     let n = reference.len();
     let m = alt.len();
+    // A cost never exceeds `n + m`, and a cell of `on_optimal_path`'s test sums
+    // a prefix and a suffix cost, so `2 * (n + m)` must fit. The canonical
+    // window caps a block far below this; the assert is what makes the
+    // narrowing safe for a direct `build` caller that is not so capped.
+    debug_assert!(
+        2 * (n + m) <= u16::MAX as usize,
+        "edit_grid narrowed to u16: 2*(n+m) = {} exceeds u16",
+        2 * (n + m)
+    );
     let width = m + 1;
-    let mut d = vec![0u32; (n + 1) * width];
+    let mut d = vec![0u16; (n + 1) * width];
     for (i, x) in d.iter_mut().step_by(width).enumerate() {
-        *x = i as u32;
+        *x = i as u16;
     }
     for (j, x) in d.iter_mut().take(width).enumerate() {
-        *x = j as u32;
+        *x = j as u16;
     }
     for i in 1..=n {
         for j in 1..=m {
-            let cost = u32::from(reference[i - 1] != alt[j - 1]);
+            let cost = u16::from(reference[i - 1] != alt[j - 1]);
             d[i * width + j] = (d[(i - 1) * width + j] + 1)
                 .min(d[i * width + j - 1] + 1)
                 .min(d[(i - 1) * width + j - 1] + cost);

--- a/src/normalize/seqfirst/partition.rs
+++ b/src/normalize/seqfirst/partition.rs
@@ -445,6 +445,14 @@ pub(crate) fn partition_members_canonical(dag: &AlignmentDag) -> Vec<MemberBlock
 mod tests {
     use super::*;
 
+    /// [`AlignmentDag::build`] on blocks small enough that its
+    /// `MAX_ALIGNMENT_SPAN` refusal cannot fire. Every block in this module is a
+    /// handful of bases; the refusal itself is pinned in `align.rs`, by
+    /// `the_span_bound_is_enforced_from_both_sides`.
+    fn dag(reference: &[u8], alt: &[u8]) -> AlignmentDag {
+        AlignmentDag::build(reference, alt).expect("test blocks are far below MAX_ALIGNMENT_SPAN")
+    }
+
     /// The calibration corpus. Six cases; 6/6 is the bar this design cleared
     /// and no other candidate did (score-margin and match-density both failed
     /// here — see `separations_are_meaningful` in `merge.rs` for their
@@ -499,7 +507,7 @@ mod tests {
                 2,
             ),
         ] {
-            let dag = AlignmentDag::build(r, a);
+            let dag = dag(r, a);
             let members = partition_members(&dag);
             assert_eq!(members.len(), expected, "{name}: got {members:?}");
         }
@@ -517,7 +525,7 @@ mod tests {
     /// invisible — the other five calibration cases score the same either way.
     #[test]
     fn one_unchanged_base_between_runs_merges() {
-        let dag = AlignmentDag::build(b"GACTGACTGA", b"GAATAACTGA");
+        let dag = dag(b"GACTGACTGA", b"GAATAACTGA");
         assert_eq!(
             partition_members(&dag).len(),
             1,
@@ -540,7 +548,7 @@ mod tests {
     /// merging and splitting.
     #[test]
     fn separation_after_an_insertion_junction_counts_the_base_it_does_not_occupy() {
-        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let dag = dag(b"AAAAAAA", b"AACACAAAA");
         let dominators = dag.dominators();
         assert_eq!(
             partition_members_with(&dag, &dominators, 1).len(),
@@ -553,19 +561,19 @@ mod tests {
     fn two_unchanged_bases_between_runs_split() {
         // The boundary from the other side: exactly MIN_SEPARATION unchanged
         // bases must NOT merge.
-        let dag = AlignmentDag::build(b"GACTGACTGA", b"GAATGTCTGA");
+        let dag = dag(b"GACTGACTGA", b"GAATGTCTGA");
         assert_eq!(partition_members(&dag).len(), 2);
     }
 
     #[test]
     fn an_unchanged_block_has_no_members() {
-        let dag = AlignmentDag::build(b"ACGTACGT", b"ACGTACGT");
+        let dag = dag(b"ACGTACGT", b"ACGTACGT");
         assert!(partition_members(&dag).is_empty());
     }
 
     #[test]
     fn members_are_disjoint_and_ascending() {
-        let dag = AlignmentDag::build(b"ACGTACGTACGTACGT", b"ATGTACGTACGTACTT");
+        let dag = dag(b"ACGTACGTACGTACGT", b"ATGTACGTACGTACTT");
         let members = partition_members(&dag);
         for pair in members.windows(2) {
             assert!(
@@ -586,7 +594,7 @@ mod tests {
         // still yields one member — the count looks right, and both the wider
         // and narrower spans denote the same sequence, so the round-trip
         // invariant does not catch it either. This exact-span assertion does.
-        let dag = AlignmentDag::build(b"AAAAAAA", b"AACACAAAA");
+        let dag = dag(b"AAAAAAA", b"AACACAAAA");
         let members = partition_members(&dag);
         assert_eq!(
             members,
@@ -601,7 +609,7 @@ mod tests {
     fn an_insertion_only_member_has_an_empty_reference_span() {
         // Two insertions 5 apart: the second is a pure insertion at junction 8
         // with an empty reference span, which must be reported and not dropped.
-        let dag = AlignmentDag::build(b"ACGTACGTAC", b"ACGTTACGTGAC");
+        let dag = dag(b"ACGTACGTAC", b"ACGTTACGTGAC");
         let members = partition_members(&dag);
         assert_eq!(
             members,
@@ -626,7 +634,7 @@ mod tests {
         // side of it merge across the single unchanged base between them
         // (fewer than `MIN_SEPARATION`), giving one member spanning the whole
         // 52 nt block.
-        let dag = AlignmentDag::build(LRG199_REF, b"TTCCTCGATGCCTG");
+        let dag = dag(LRG199_REF, b"TTCCTCGATGCCTG");
         let members = partition_members(&dag);
         assert_eq!(
             members,
@@ -644,7 +652,7 @@ mod tests {
         // members. Raising `min_separation` to 3 must merge them into one,
         // pinning that the parameter is actually load-bearing rather than
         // dead flexibility.
-        let dag = AlignmentDag::build(b"ACGTACGT", b"ATGTTCGT");
+        let dag = dag(b"ACGTACGT", b"ATGTTCGT");
         let dominators = dag.dominators();
         assert_eq!(
             partition_members_with(&dag, &dominators, 2).len(),
@@ -676,7 +684,7 @@ mod tests {
                 vec![(3u32, 5u32), (9u32, 10u32)],
             ),
         ] {
-            let dag = AlignmentDag::build(r, a);
+            let dag = dag(r, a);
             let dominators = dag.dominators();
             let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
             let spans = member_alt_spans(&dag, &dominators, &members)
@@ -692,7 +700,7 @@ mod tests {
         // `None` for a members list that is not an ascending, non-overlapping
         // partition. Exercise that directly rather than trying to coax an
         // impossible members list out of `partition_members` itself.
-        let dag = AlignmentDag::build(b"ACGT", b"ACGT");
+        let dag = dag(b"ACGT", b"ACGT");
         let dominators = dag.dominators();
         let overlapping = [
             MemberBlock {
@@ -711,7 +719,7 @@ mod tests {
     /// payloads. This is the invariant that makes the partition meaningful: if
     /// it does not hold, the members denote a different sequence.
     fn round_trips(reference: &[u8], alt: &[u8]) -> bool {
-        let dag = AlignmentDag::build(reference, alt);
+        let dag = dag(reference, alt);
         let dominators = dag.dominators();
         let members = partition_members_with(&dag, &dominators, MIN_SEPARATION);
         let Some(alt_spans) = member_alt_spans(&dag, &dominators, &members) else {
@@ -821,7 +829,7 @@ mod tests {
         let mut checked = 0usize;
         for r in &all {
             for a in &all {
-                let dag = AlignmentDag::build(r, a);
+                let dag = dag(r, a);
                 let canonical = CanonicalAlignment::of(&dag);
                 assert_eq!(
                     changed_columns(&canonical.members(), &canonical.alt_spans()),
@@ -846,7 +854,7 @@ mod tests {
         let all = small_alphabet_words(6);
         for r in &all {
             for a in &all {
-                let dag = AlignmentDag::build(r, a);
+                let dag = dag(r, a);
                 let canonical = CanonicalAlignment::of(&dag);
                 let members = canonical.members();
                 let spans = canonical.alt_spans();
@@ -883,7 +891,7 @@ mod tests {
     /// side effect of touching the walk order.
     #[test]
     fn canonical_breaks_a_member_count_tie_three_prime_most() {
-        let dag = AlignmentDag::build(b"AAC", b"AC");
+        let dag = dag(b"AAC", b"AC");
         assert_eq!(
             partition_members_canonical(&dag),
             vec![MemberBlock {
@@ -917,7 +925,7 @@ mod tests {
     /// and the spec does not settle which a description should be.
     #[test]
     fn canonical_can_report_more_members_than_the_dominator_rule() {
-        let dag = AlignmentDag::build(b"A", b"CAC");
+        let dag = dag(b"A", b"CAC");
         let dominators = dag.dominators();
         assert_eq!(
             partition_members_with(&dag, &dominators, MIN_SEPARATION),

--- a/tests/it/issue_1970_u16_cost_grid_bound.rs
+++ b/tests/it/issue_1970_u16_cost_grid_bound.rs
@@ -1,0 +1,188 @@
+//! Issue #1970 — the `u16` alignment cost grid refuses instead of wrapping, and
+//! the refusal is reachable from the ordinary public API.
+//!
+//! `AlignmentDag`'s cost grids narrowed to `u16`. The bound that makes that safe
+//! is `n + m <= u16::MAX`, and it was enforced by a `debug_assert` — which
+//! `[profile.release]` compiles out, since it sets neither `debug-assertions`
+//! nor `overflow-checks`. Past the bound the shipped library therefore did not
+//! panic: `edit_grid`'s boundary row truncated `j as u16` and the
+//! `prefix + suffix` sums wrapped, so `on_optimal_path` was computed from wrong
+//! costs and the emitted description came off a wrong DAG.
+//!
+//! Every gate in front of `AlignmentDag::build` bounds **cells** —
+//! `(n + 1) * (m + 1)` — never `n + m`, and a `1 x 70,000` grid clears the
+//! widest of them by four orders of magnitude. A long literal `ins` payload is
+//! exactly that shape, and it arrives through `parse_hgvs` +
+//! `Normalizer::normalize` with no feature flag and no `FERRO_PARTITION` arm.
+//!
+//! The bound itself is pinned from both sides as a unit test next to the code,
+//! `align::tests::the_span_bound_is_enforced_from_both_sides`. What this module
+//! adds is the half that cannot be seen from there: that the size is **reached**
+//! from the public API, that the refusal is taken there rather than the wrap,
+//! and that taking it moves no output.
+
+use ferro_hgvs::normalize::partition_decline_counts;
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// Deterministic pseudo-random bases.
+///
+/// Not `"ACGT"` cycled: a periodic payload is repeat-lowered long before the
+/// aligner sees it (`MAX_CANONICAL_WINDOW` caps the synthesized payload there),
+/// so a cyclic 70,000-mer normalizes to a 21-character repeat description and
+/// never builds a grid at all. Measured while writing this test — the first
+/// version of it passed on the unfixed code for exactly that reason.
+fn prng(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            b"ACGT"[(state >> 33) as usize % 4]
+        })
+        .collect()
+}
+
+/// A genome-capable provider holding one 4,000-base pseudo-random contig.
+fn provider() -> JsonProvider {
+    let seq = String::from_utf8(prng(4_000, 99)).expect("ACGT is UTF-8");
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { "c": seq },
+    });
+    let mut file = tempfile::NamedTempFile::new().expect("temp file");
+    file.write_all(doc.to_string().as_bytes())
+        .expect("write provider");
+    JsonProvider::from_json(file.path()).expect("load provider")
+}
+
+/// `c:g.1000_1001ins<payload_len pseudo-random bases>`.
+fn insertion(payload_len: usize) -> String {
+    let payload = String::from_utf8(prng(payload_len, 7)).expect("ACGT is UTF-8");
+    format!("c:g.1000_1001ins{payload}")
+}
+
+fn normalize(provider: &JsonProvider, input: &str) -> String {
+    let variant = parse_hgvs(input).expect("the input parses");
+    Normalizer::new(provider.clone())
+        .normalize(&variant)
+        .expect("the input normalizes")
+        .to_string()
+}
+
+/// The payload length at which `n + m` first exceeds the `u16` grid.
+///
+/// The reference block is trimmed to nothing by the time the aligner sees a pure
+/// insertion, so `n + m` is the payload length: 65,535 is the last accepted size
+/// and 65,536 the first refused one.
+const FIRST_REFUSED_PAYLOAD: usize = u16::MAX as usize + 1;
+
+/// A payload one base under the bound must still be aligned — the refusal must
+/// not have been made conservative enough to swallow inputs that are fine.
+///
+/// This is the *under* side of the boundary, and it is the side a careless fix
+/// gets wrong: the `debug_assert` this replaced demanded `2 * (n + m)` fit, so
+/// it would have refused everything past 32,767 — half the representable range,
+/// on inputs whose arithmetic never overflows.
+#[test]
+fn a_payload_just_under_the_span_bound_is_still_aligned() {
+    let provider = provider();
+    let before = partition_decline_counts();
+    let out = normalize(&provider, &insertion(FIRST_REFUSED_PAYLOAD - 1));
+    let after = partition_decline_counts();
+
+    assert!(
+        after.attempted > before.attempted,
+        "the sequence-first partitioner must have been asked at all — \
+         a zero here would make the test vacuous ({before:?} -> {after:?})"
+    );
+    assert_eq!(
+        after.declined,
+        before.declined,
+        "n + m = {} is inside the u16 grid and must NOT be declined ({before:?} -> {after:?})",
+        FIRST_REFUSED_PAYLOAD - 1
+    );
+    assert_eq!(
+        out.len(),
+        FIRST_REFUSED_PAYLOAD - 1 + 16,
+        "the whole payload must survive into the description"
+    );
+}
+
+/// A payload one base over the bound must be **declined by the aligner**, and
+/// the decline must be invisible in the output.
+///
+/// The assertion is on the refusal itself — the `declined` census — not on the
+/// emitted string, which is the convenient side effect. `partition_block_*`
+/// answers `None` and `partition_block_for_rule` falls back, so an input past
+/// the bound still gets a description; that is what makes the output a bad
+/// subject and the counter a good one.
+#[test]
+fn a_payload_just_over_the_span_bound_is_declined_by_the_aligner() {
+    let provider = provider();
+    let before = partition_decline_counts();
+    let out = normalize(&provider, &insertion(FIRST_REFUSED_PAYLOAD));
+    let after = partition_decline_counts();
+
+    assert!(
+        after.attempted > before.attempted,
+        "the sequence-first partitioner must have been asked at all ({before:?} -> {after:?})"
+    );
+    assert!(
+        after.declined > before.declined,
+        "n + m = {} is past the u16 grid and must be DECLINED, not computed from \
+         wrapped costs ({before:?} -> {after:?})",
+        FIRST_REFUSED_PAYLOAD
+    );
+    assert_eq!(
+        out.len(),
+        FIRST_REFUSED_PAYLOAD + 16,
+        "the fallback partitioner must still describe the whole payload"
+    );
+}
+
+/// The size #1970 reported, end to end, with the description pinned exactly.
+///
+/// The pin is what makes `Representation-Change: none` a measurement rather than
+/// an argument: this string was captured by running the identical test against
+/// the PR's own pre-narrowing parent (`92cd3f18`, `u32` grids), where the whole
+/// 70,000-base grid is computed rather than declined. Both arms emit it
+/// byte-for-byte, so refusing the grid costs this class nothing.
+///
+/// **This arm is a stability pin, not a wrap detector, and the difference is
+/// worth stating.** Measured under sabotage (refusal removed, `debug-assertions`
+/// and `overflow-checks` off): the wrap at 70,000 happens and this test still
+/// passes. A pure insertion trims the reference block to nothing, so the grid is
+/// a single row with exactly one path through it, and `prefix + suffix == total`
+/// holds under wrapping arithmetic just as it does without — the truncation is
+/// benign at *this* shape. What refuses it is
+/// `a_payload_just_over_the_span_bound_is_declined_by_the_aligner`, and what
+/// pins the bound is the unit test in `align.rs`; those two are the guards that
+/// go red. This one says the refusal is free.
+#[test]
+fn the_reported_seventy_kilobase_insertion_is_unchanged_by_the_narrowing() {
+    let provider = provider();
+    let out = normalize(&provider, &insertion(70_000));
+
+    assert_eq!(out.len(), 70_016, "output length, measured on both arms");
+    assert!(
+        out.starts_with("c:g.") && out.contains("ins"),
+        "still a genomic insertion: {}...",
+        &out[..out.len().min(32)]
+    );
+
+    // The whole 70,016-character string, compared without printing it.
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in out.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    assert_eq!(
+        format!("{hash:016x}"),
+        "e837728b1be3a7c4",
+        "the emitted description must be the one the u32 grids produced"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -40,6 +40,7 @@ mod issue_1841_option_returning_splice_classifiers;
 mod issue_1870_cds_less_transcript_refusal;
 mod issue_1916_intron_distance_underflow;
 mod issue_1917_reversed_range_window;
+mod issue_1970_u16_cost_grid_bound;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;


### PR DESCRIPTION
Two commits against #1928, in the order they should be read. The second is the change; the first is what made it possible to judge one.

## 1. `92cd3f18` — divergence and indel content become benchmark axes

`benches/seqfirst_align.rs` varied only block length and held the alternate at "~5% of positions perturbed". That is one point on a curve whose shape is the entire question here.

Every cell on a minimal alignment satisfies `|i - j| <= k` for edit distance `k`, so the *reachable* work is `Θ(n · k)`. Holding `k / n` fixed makes the cost look inherently quadratic when it is quadratic only in the regime being sampled. The three regimes are far apart, and the old fixture sat between them:

| shape | `k` relative to `n` |
|---|---|
| a real variant | single digits, independent of `n` |
| the old fixture | `n / 20` |
| a uniform-random pair | ~0.6 `n` (measured for #107, issue #1939) |

So `k` is a parameter now, and `by_length_fixed_k` holds it **constant as `n` grows** — the shape a real corpus presents, and the one under which a banded implementation should approach linear while the current grid stays quadratic. `by_divergence` sweeps the other axis, up to the regime where a band is the whole grid and banding cannot help.

**Indels are a second axis.** The old perturbation was substitution-only, so no optimal path ever left the main diagonal and **no `OUT_DEL`/`OUT_INS` edge was exercised at any length** — the two generators cost the same to compute but produce different DAGs, and only the indel one has more than one minimal alignment to enumerate.

Perturbation sites are also drawn pseudo-randomly rather than by a `step_by` stride, which put every difference on a lattice.

## 2. `173d58a7` — the alignment cost grid narrows to `u16`

`edit_grid` returns `Vec<u32>`, and `build` holds **two of them live at once** — the prefix grid and the suffix grid of the reversed blocks — so cost cells alone are 8 bytes per grid cell.

Costs are bounded by `n + m`, and `on_optimal_path`'s test sums a prefix and a suffix cost whose total is also bounded by `n + m` (the `here + 1` sites are only reached where `i < n` or `j < m`). So the exact bound is `n + m <= u16::MAX`, not `2 * (n + m)`; at the canonical window `n + m` is 7,680, comfortably inside `u16`. `build` now REFUSES past that bound and returns the `None` its callers handle, rather than relying on a `debug_assert` that the release profile compiles out - `build` is `pub` and `MAX_CANONICAL_WINDOW` caps only the reference side, so a direct caller is not capped by it. See #1970.

Measured, peak RSS through the Python bindings, three reps per arm, at the widest accepted block (`W = 3840`):

| arm | reps | mean | bytes/cell |
|---|---|---:|---:|
| `origin/main` | 274.89 / 275.63 / 275.71 MB | 275.4 MB | 18.67 |
| `edit_grid -> u16` | 217.50 / 216.02 / 212.58 MB | 215.4 MB | 14.60 |

**−60.0 MB, −21.8%**, against −59.0 MB predicted from two grids × 2 bytes/cell.

### The instrument was validated before the change was measured

This matters because an earlier attempt at a *different* reduction on this issue produced an uninterpretable null, and I nearly read it as a small win. So: a deliberate grid-sized `Vec<u32>` held live to the end of `build` — a known **+59.0 MB** — measured **+60.2 MB**. Peak-RSS deltas therefore resolve a buffer this size, against a noise floor of ~1% established from five reps of one binary.

### Correctness

Carried by `dominators_agree_with_brute_force_on_exhaustive_small_inputs` — the independent brute-force oracle — not by inspection. 90 alignment tests pass and the `Dominators` output is unchanged; only the width of an intermediate cost cell moves.

## What is deliberately NOT here

Two reductions I implemented, measured, and **dropped**:

- `in_degree: Vec<u32>` → `Vec<u8>` (a cell has at most three in-edges), and
- removing the `cells().collect()` in `dominators()`.

Both are correct and both measure **exactly nothing**: +3.0% / +0.06% / −0.33% against a ~1% noise floor. The reason is now understood and is recorded on #1928 — peak RSS is a maximum over time, and `dominators` allocates *after* `build` frees its grids, so it fits under a mark already set. Shrinking a later allocation cannot lower an earlier peak. "No measurable effect" is not a reason to touch a hot path, so they are not in this PR.

Also dropped: a `dominators` benchmark group and the `pub` visibility it needed. Its justification was that `dominators` is the higher of the two memory peaks — which is the claim the measurement refuted, so the API widening went with it.

## Still open, and stated as open

After the narrowing, the buffers that can be named account for 6 bytes/cell against **14.60 measured**. About **8.6 bytes/cell — ~127 MB at `W = 3840` — is unexplained**, and it scales with cell count rather than being fixed overhead. `ru_maxrss` deltas have taken this as far as they can; locating it needs a heap profiler. I have candidates and no evidence, so I have named none.

**Banding** — restricting the DP to `|i - j| <= k`, which is exact rather than approximate because `on_optimal_path` is by definition confined to that band — is the change that attacks the peak instead of its constant, and is in progress separately. The benchmark in commit 1 is the instrument for judging it.

## Verification

- Full gate with `FERRO_MANIFEST` armed and `FERRO_REQUIRE_BULK_FIXTURES=1`, zero `Skipping:` lines.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- Python binding suite — `cargo nextest` does not reach it and this touches `src/normalize/`.
- **The memory figures were taken on a shared developer machine and should be re-confirmed on a quiet host before being quoted anywhere durable.** The direction and rough magnitude are safe (the effect is 20× the measured noise floor); the third significant figure is not.

Representation-Change: none. Measured, not assumed. The u16 cost grid now refuses `n + m > 65,535` and returns the `None` its callers already handle, so an input past the bound is declined by the aligner and answered by the `partition_block` fallback instead of being computed from wrapped costs. Compared byte-for-byte against this PR's own pre-narrowing parent (the benchmark commit, where the grids are still u32) on literal `ins` payloads of 100 / 40,000 / 65,000 / 70,000 bases, including the 70,000-base case #1970 reported: every arm emits an identical description, so the refusal costs this class nothing. Nothing that ferro answers today becomes refused - the refusal is inside the partitioner, which has a decline path, not at the normalizer's boundary. `member_alignment` gains the same decline, which can only widen an audited member, never corrupt one. The benchmark change touches no src/ file.

