### PR TITLE
feat(rulings): give the ledger a home for a clause-free house choice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -936,6 +936,15 @@ adjudications and do not need records.
 - **undecided** — a first-class state. The generator refuses an `undecided` record that names a
   governing clause, so an open question cannot smuggle in a ruling nobody made. Prefer an honest
   `undecided` record to no record.
+- **house-choice** — `decided`, and **ours rather than the spec's**: a `rulings` record carrying a
+  `house_choice` object, made under `README.md` rule 5's silent limb or rule 6, naming **no**
+  governing and no deviated-from clause. The generator and the ledger reader both refuse one that
+  names either, mirroring the `undecided` refusal — that arm stops a record claiming more certainty
+  than the project has, this one stops it claiming more authority than the spec gave it. Use it
+  whenever the honest statement is "the recommendations do not reach this and we picked X"; the
+  alternative is what happened to the minimal-alignment rule, which had no home here and grew six
+  drifting prose restatements instead. It must say what was considered and rejected, and the record
+  is never citable as conformance.
 
 **A test that merely pins today's output is not an adjudication record.** It is a change
 detector, and this repo has already been bitten by the difference —

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -187,6 +187,88 @@ mod overrides {
         Undecided,
     }
 
+    /// The `README.md` rule a clause-free house choice is made under.
+    ///
+    /// Only two rules can carry one, and naming which is the whole point of the
+    /// field: rule 5's *silent* limb says in terms that ferro "decides under
+    /// rule 6 and violates nothing", and rule 6 is where the maintainers choose
+    /// among conformant forms. Neither is a claim about what the recommendations
+    /// require. A free-text field here would let a record write "the spec" into
+    /// the slot reserved for "our own judgement", which is the exact
+    /// substitution [`HouseChoice`] exists to make unrepresentable.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub enum HouseRule {
+        /// `README.md` rule 5, **silent** limb — the recommendations are merely
+        /// incomplete here, so ferro decides under rule 6 and violates nothing.
+        /// Filing upstream is a feature request, not a bug report.
+        RuleFiveSilent,
+        /// `README.md` rule 6 — among multiple conformant forms, the maintainers
+        /// choose. Use this when every competing form is already conformant and
+        /// no clause ranks them.
+        RuleSix,
+    }
+
+    /// A ruling that is **ours**, not the spec's.
+    ///
+    /// # Why the ledger needed a shape it did not have
+    ///
+    /// Before this field the ledger could record two things: a settled reading
+    /// of a clause (`decided`, with a `governing` clause) and an unsettled
+    /// conflict (`undecided`, with two clauses and no verdict). It could not
+    /// record the third and commonest state — *the recommendations are silent
+    /// here and we picked X* — because [`validate_ruling_shape`] requires a
+    /// `decided` record to name a clause it holds to govern.
+    ///
+    /// The consequence was measured rather than predicted: the rule that a
+    /// reference base is unchanged iff **every** minimum-edit-distance alignment
+    /// matches it had no home here and instead lived as prose in six separate
+    /// places in `src/` and `tests/`, which then drifted apart. An
+    /// HGVS-committee-perspective review of the same rule called it "an
+    /// implementer's choice the recommendations neither require nor forbid" and
+    /// objected specifically to its being presented as *compliance*.
+    ///
+    /// # What it must state, and why each part
+    ///
+    /// * [`Self::under`] — which `README.md` rule the choice is made under. A
+    ///   house choice that cannot name its own authority is not a house choice,
+    ///   it is an unrecorded preference.
+    /// * [`Self::considered_and_rejected`] — what was weighed and put aside.
+    ///   The best quality of the existing records is that they record
+    ///   *refutations*: `MIN_SEPARATION_NO_FRAME`, `apply_coding_codon_exception`
+    ///   and half the ledger's rationales exist because a plausible belief was
+    ///   killed by measurement and the belief would otherwise recur. A house
+    ///   choice with no rejected alternative is a conclusion with its reasoning
+    ///   deleted, and the next reader re-derives the alternative from scratch.
+    ///
+    /// # What it may NOT state
+    ///
+    /// A `governing` clause, or a `deviates_from` clause. Both are refused by
+    /// [`validate_ruling_shape`], symmetrically with the way an `undecided`
+    /// record is refused for naming either. The asymmetry to notice is that the
+    /// `undecided` refusal stops a record claiming *more certainty* than the
+    /// project has, and this one stops a record claiming *more authority* than
+    /// the spec gave it — overclaiming spec authority being the disease this
+    /// field was added to treat. Making it unrepresentable is worth more than
+    /// discouraging it in prose, because the prose is what drifted.
+    ///
+    /// A house choice still cites at least one clause, like every other record.
+    /// That is deliberate and is **not** a contradiction of "clause-free": the
+    /// honest way to assert that the recommendations are silent on a point is to
+    /// name the clauses you read and say why none of them reaches, which is
+    /// exactly what [`Self::considered_and_rejected`] is for. A record allowed
+    /// to assert silence while naming nothing it examined would be an
+    /// unfalsifiable claim about the spec.
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct HouseChoice {
+        /// The `README.md` rule the choice is made under.
+        pub under: HouseRule,
+        /// What was considered and rejected in reaching it, in prose. Must not
+        /// be blank.
+        pub considered_and_rejected: String,
+    }
+
     /// A record of how the project reads the spec where the spec conflicts with
     /// itself, and of what it has *not* decided.
     ///
@@ -216,6 +298,15 @@ mod overrides {
         /// that has not chosen a side has not deviated from one either.
         #[serde(default)]
         pub deviates_from: Vec<String>,
+        /// Present when the ruling is **ours** rather than the spec's: the
+        /// recommendations are silent on the point and the project chose under
+        /// `README.md` rule 5's silent limb or rule 6. See [`HouseChoice`].
+        ///
+        /// Mutually exclusive with [`Self::governing`] and
+        /// [`Self::deviates_from`], and refused on an `undecided` record —
+        /// enforced by [`validate_ruling_shape`], not by convention.
+        #[serde(default)]
+        pub house_choice: Option<HouseChoice>,
         /// Why. For an undecided record: what the project has and has not
         /// established, and what would settle it.
         pub rationale: String,
@@ -871,6 +962,12 @@ mod decisions {
         pub governing: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         pub deviates_from: Vec<String>,
+        /// Carried through so the generated fixture states, per record, whether
+        /// its ruling rests on the recommendations or on the project's own
+        /// judgement. Omitted when absent, so no existing record's serialization
+        /// moves.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub house_choice: Option<overrides::HouseChoice>,
         pub rationale: String,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         pub applies_to: Vec<String>,
@@ -958,9 +1055,56 @@ mod decisions {
                 );
             }
         }
+        // A house choice is checked BEFORE the status match, so that a record
+        // which is both `undecided` and a house choice is refused for the reason
+        // that names the contradiction rather than falling through to the
+        // clause-count arm and being told something true but unhelpful.
+        if let Some(house) = &ruling.house_choice {
+            if ruling.status != overrides::RulingStatus::Decided {
+                anyhow::bail!(
+                    "{owner}: a `house_choice` on a non-`decided` record — a choice that has been \
+                     made is decided by definition, and a record that has not chosen has no house \
+                     choice to record"
+                );
+            }
+            // The refusal this field was added for. A house choice asserts that
+            // the recommendations do not reach the point; naming a clause that
+            // governs asserts that one does. Both cannot be true, and the
+            // failure mode that matters is the one where the second is written
+            // down and then cited as compliance.
+            if ruling.governing.is_some() {
+                anyhow::bail!(
+                    "{owner}: a `house_choice` names a governing clause. A house choice is made \
+                     under `README.md` rule 5's silent limb or rule 6, which are what the project \
+                     does where the recommendations do NOT decide — so it cannot also hold a \
+                     clause to govern. Either drop `house_choice` and rule on the clause, or drop \
+                     `governing` and record why no clause reaches"
+                );
+            }
+            if !ruling.deviates_from.is_empty() {
+                anyhow::bail!(
+                    "{owner}: a `house_choice` names a deviated-from clause. There is nothing to \
+                     deviate from where the recommendations are silent; a clause that reaches the \
+                     point far enough to be departed from is a clause that reaches it"
+                );
+            }
+            if house.considered_and_rejected.trim().is_empty() {
+                anyhow::bail!(
+                    "{owner}: a `house_choice` must say what was considered and rejected. A \
+                     conclusion with its alternatives deleted is re-derived from scratch by the \
+                     next reader, which is what these records exist to prevent"
+                );
+            }
+        }
         match ruling.status {
-            overrides::RulingStatus::Decided if ruling.governing.is_none() => {
-                anyhow::bail!("{owner}: a `decided` ruling must name the clause it holds to govern")
+            overrides::RulingStatus::Decided
+                if ruling.governing.is_none() && ruling.house_choice.is_none() =>
+            {
+                anyhow::bail!(
+                    "{owner}: a `decided` ruling must name the clause it holds to govern, or \
+                     declare itself a `house_choice` under `README.md` rule 5's silent limb or \
+                     rule 6"
+                )
             }
             // The whole point of the `undecided` state is that nobody has
             // ruled. A governing clause — or a deviated-from one, which
@@ -1261,6 +1405,7 @@ mod decisions {
                 clauses: ruling.clauses.clone(),
                 governing: ruling.governing.clone(),
                 deviates_from: ruling.deviates_from.clone(),
+                house_choice: ruling.house_choice.clone(),
                 rationale: ruling.rationale.clone(),
                 applies_to: ruling.applies_to.clone(),
                 equivalence_classes: ruling.equivalence_classes.clone(),
@@ -1341,12 +1486,23 @@ mod decisions {
                 clauses: clauses.iter().map(|c| citation(c)).collect(),
                 governing: governing.map(str::to_string),
                 deviates_from: deviates_from.iter().map(|c| c.to_string()).collect(),
+                house_choice: None,
                 rationale: "because".to_string(),
                 applies_to: Vec::new(),
                 equivalence_classes: Vec::new(),
                 guard: Some(guard_citing(&[
                     "examples/generate_spec_fixture.rs::a_guard",
                 ])),
+            }
+        }
+
+        /// A well-formed [`overrides::HouseChoice`], for the tests below.
+        fn house(under: overrides::HouseRule) -> overrides::HouseChoice {
+            overrides::HouseChoice {
+                under,
+                considered_and_rejected: "the position-wise reading, rejected because it is \
+                                          not cheaper"
+                    .to_string(),
             }
         }
 
@@ -1399,6 +1555,102 @@ mod decisions {
                     .is_ok()
             );
             assert!(validate_ruling_shape("r", &ruling(Decided, &["a.md:1"], None, &[])).is_err());
+        }
+
+        /// The build must refuse a house choice that claims spec authority.
+        ///
+        /// This is the mirror of [`an_undecided_ruling_must_put_both_sides_on_the_record`]
+        /// and is written the same way — positive control first, then one
+        /// mutation per refusal — because the two arms guard opposite
+        /// overclaims. An `undecided` record naming a governing clause claims
+        /// the project decided something it did not; a `house_choice` naming one
+        /// claims the *spec* decided something it did not. The second is the
+        /// costlier of the two here: a governing clause is quotable, so once one
+        /// is written down the choice starts being cited as compliance.
+        #[test]
+        fn a_house_choice_may_not_claim_spec_authority() {
+            use overrides::HouseRule::{RuleFiveSilent, RuleSix};
+            use overrides::RulingStatus::{Decided, Undecided};
+
+            // Positive control: a decided record with NO governing clause is
+            // legal exactly when it declares itself a house choice. The second
+            // assertion is the one that makes the first mean anything — without
+            // the `house_choice` the same record is refused.
+            let mut choice = ruling(Decided, &["a.md:1"], None, &[]);
+            choice.house_choice = Some(house(RuleSix));
+            assert!(
+                validate_ruling_shape("r", &choice).is_ok(),
+                "positive control"
+            );
+            let mut bare = choice.clone();
+            bare.house_choice = None;
+            assert!(validate_ruling_shape("r", &bare).is_err());
+
+            // Rule 5's silent limb is the other admissible authority.
+            let mut silent_limb = choice.clone();
+            silent_limb.house_choice = Some(house(RuleFiveSilent));
+            assert!(validate_ruling_shape("r", &silent_limb).is_ok());
+
+            // The refusal this field exists for.
+            let mut governs = choice.clone();
+            governs.governing = Some("a.md:1".to_string());
+            assert!(validate_ruling_shape("r", &governs).is_err());
+
+            // …and its sibling: a clause reaching far enough to be departed from
+            // is a clause that reaches.
+            let mut deviates = ruling(Decided, &["a.md:1", "b.md:2"], None, &["b.md:2"]);
+            deviates.house_choice = Some(house(RuleSix));
+            assert!(validate_ruling_shape("r", &deviates).is_err());
+
+            // A choice that has been made is decided by definition.
+            let mut unsettled = ruling(Undecided, &["a.md:1", "b.md:2"], None, &[]);
+            unsettled.house_choice = Some(house(RuleSix));
+            assert!(validate_ruling_shape("r", &unsettled).is_err());
+
+            // A conclusion with its alternatives deleted.
+            let mut mute = choice.clone();
+            mute.house_choice = Some(overrides::HouseChoice {
+                under: RuleSix,
+                considered_and_rejected: "   ".to_string(),
+            });
+            assert!(validate_ruling_shape("r", &mute).is_err());
+        }
+
+        /// `under` is a closed enum, so a record cannot write "the spec" into
+        /// the slot reserved for the project's own authority.
+        ///
+        /// Checked at *deserialize*, which is the only place it can be checked:
+        /// by the time [`validate_ruling_shape`] runs the value is already one
+        /// of the two variants. A free-text field would have made this
+        /// unenforceable, which is why it is not one.
+        #[test]
+        fn the_house_rule_is_a_closed_set() {
+            let with = |under: &str| {
+                serde_json::from_value::<overrides::HouseChoice>(serde_json::json!({
+                    "under": under,
+                    "considered_and_rejected": "something",
+                }))
+            };
+            assert!(with("rule-six").is_ok());
+            assert!(with("rule-five-silent").is_ok());
+            assert!(with("general.md:34").is_err());
+            assert!(with("rule-2").is_err());
+        }
+
+        /// An absent `house_choice` deserializes, so every existing record is
+        /// unaffected by the field being added.
+        #[test]
+        fn an_absent_house_choice_deserializes() {
+            let parsed: overrides::Ruling = serde_json::from_value(serde_json::json!({
+                "id": "a-record",
+                "status": "decided",
+                "question": "does a record predating the field still parse?",
+                "rationale": "it must, or adding the field re-statuses the whole ledger",
+                "governing": "a.md:1",
+                "clauses": [{ "clause": "a.md:1", "quote": "q" }],
+            }))
+            .expect("a record with no `house_choice` must deserialize");
+            assert!(parsed.house_choice.is_none());
         }
 
         #[test]

--- a/tests/it/adjudication_prose_regrowth.rs
+++ b/tests/it/adjudication_prose_regrowth.rs
@@ -1,0 +1,487 @@
+//! Adjudication-shaped prose in `src/` and `tests/` must point at a ruling
+//! record — a shrink-only ratchet against the thing that has already happened
+//! once.
+//!
+//! # The failure this exists for, measured
+//!
+//! One implementer's choice — that a reference base is unchanged iff **every**
+//! minimum-edit-distance alignment matches it — had no home in the ledger,
+//! because a `decided` record was required to name a governing spec clause and
+//! this choice has none. So it was written down where it was needed instead, and
+//! by 2026-08-14 it existed as **six** independent prose restatements across
+//! `src/` and `tests/`. They drifted apart, three of them into the flatly false
+//! generalisation that an equal-length block's column correspondence is unique;
+//! reconciling them cost several days of adjudication. An HGVS
+//! committee-perspective review of the same rule called it "an implementer's
+//! choice the recommendations neither require nor forbid" and objected to its
+//! being presented as compliance.
+//!
+//! The ledger now has a home for such a choice — `house_choice`, see
+//! `generate_spec_fixture`'s `overrides::HouseChoice` — and the known sites have
+//! been pointed at their record. A one-time cleanup regrows. This is the ratchet
+//! that makes the seventh restatement cost a deliberate act.
+//!
+//! # What it checks
+//!
+//! Every contiguous comment block under `src/` and `tests/` whose text matches
+//! one of [`ADJUDICATION_PHRASES`] must **name a ledger record id** somewhere in
+//! that same block, or the block's file must carry a row in [`REGROWTH_EXEMPT`].
+//!
+//! The exemption list is **shrink-only**, on the pattern `LEDGER_EXEMPT` in
+//! `tests/it/generator_completeness.rs` already established here: a row whose
+//! site no longer flags fails the test and must be deleted, so the list cannot
+//! rot into a general excuse for files nobody reads.
+//!
+//! # What it is NOT, because the obvious design does not survive measurement
+//!
+//! The natural way to build this is the inverse of `clause_ruling_index.rs`:
+//! flag a comment that cites a clause the ledger governs and names no record
+//! within N lines. **That predicate was measured over this tree and is
+//! unusable** — 707 comment lines in 144 files, and 517 lines carrying a
+//! choice/precedence verb with no nearby record. Most are the legitimate habit
+//! of quoting the clause a piece of code implements. A guard whose first run
+//! flags 700 lines is argued with once and disabled, and then there is no guard.
+//!
+//! The allowlist form does not transfer at that scale either, and the reason is
+//! worth keeping: `LEDGER_EXEMPT` in `generator_completeness.rs` works because
+//! it is ~15 rows keyed on a **file path**, which is a stable identifier. A
+//! clause-keyed scan would need hundreds of rows keyed on a **site** —
+//! `file:line` churns on every edit above it, `(file, sentence)` churns exactly
+//! when you reword, and bare `file` is too coarse (one row on `src/normalize/merge.rs`
+//! would cover ~124 flagged lines and hide every distinct site inside one
+//! exemption).
+//!
+//! So what transfers from `generator_completeness.rs` is the **ratchet
+//! discipline** — adding a row is a legitimate, reviewed act; silence is not —
+//! and not the predicate. This file keeps the discipline and replaces the
+//! predicate with a narrow phrase list, measured below. Its first run over the
+//! tree flagged **three** blocks in total, of which one is exempt. The
+//! coarse-key hazard is closed rather than accepted: an exemption row may cover
+//! **one** flagged block, and a second block in the same file fails the test
+//! (see [`adjudication_shaped_prose_points_at_a_ruling_record_or_is_allowlisted`]).
+//!
+//! # Read the reach honestly — this is a floor, not a proof
+//!
+//! Stating the limits is not a disclaimer, it is the operating manual. A guard
+//! whose reach is overstated gets cited for coverage it does not provide, which
+//! is the same defect as the prose it polices.
+//!
+//! * **It cannot reach the clause-citing class at all**, and that class is real:
+//!   an audit of this tree on 2026-08-14 found fifteen sites where prose decides
+//!   something, and **nine** of them are invisible to every existing guard. The
+//!   707 lines above are not covered here and are not covered anywhere. This
+//!   file closes one shape, not the problem.
+//!
+//! * **It is a substring scan over comment text.** It cannot tell an
+//!   adjudication from a sentence that happens to contain one of the phrases,
+//!   and it cannot see an adjudication written in words nobody has used yet.
+//! * **[`ADJUDICATION_PHRASES`] is deliberately narrow and was chosen by
+//!   measurement, not by taste.** Every candidate was run over the whole tree
+//!   first. Phrases that read adjudicative but are ordinary here — "is
+//!   canonical" (26 blocks), "the canonical form is" (24), "must be described
+//!   as" (4, all of them quoting `DNA/duplication.md:18`), "the spec forbids"
+//!   (10), "is a fact about the" (8) — were **rejected**, because a guard with
+//!   dozens of false positives is argued with once and disabled the next time.
+//!   What survived is the family that states an *ontological* claim about
+//!   representation: that something is a fact rather than a choice, or that a
+//!   column correspondence is unique. That family had **three** hits in the
+//!   whole tree, which is what makes it usable.
+//! * **Comments only.** Prose inside an `assert!`/`panic!` message is not
+//!   scanned, and that is a known miss with a named instance:
+//!   `reported_confluence_pairs.rs`'s assertion message used to *instruct* a
+//!   future maintainer to delete an assertion, which is adjudication in the most
+//!   consequential possible place. Reaching it needs the string literals
+//!   attributed to their enclosing item, which is parsing rather than reading.
+//! * **The pointer test is "does this block name a record id", not "does it name
+//!   the *right* record".** Relevance is a judgement; membership is checkable.
+//! * **Quoting a claim in order to withdraw it still flags.** That is why
+//!   `issue_1284_transcript_axis_collision.rs` is on the exemption list rather
+//!   than being a bug in the detector — it quotes the withdrawn claim verbatim,
+//!   which is the right way to record a withdrawal and reads identically to
+//!   asserting it.
+//!
+//! # Siblings, and the gap between them
+//!
+//! * `ruling_citation_currency.rs` — prose that cites a record and contradicts
+//!   its status. It only sees prose that *already* cites one.
+//! * `clause_ruling_index.rs` — clause to record, for the reader who never
+//!   looked the record up. Its own docs name the limit: "the person who never
+//!   looked the record up writes no citation for it to check."
+//!
+//! Every existing ledger guard — those two plus `claude_md_adjudication_tables`,
+//! `normalization_contract_doc`, `ledger_clause_jurisdiction`,
+//! `ruling_guard_field` and `readme_normalization_rules` — fires only on prose
+//! that already names a record, or on the ledger's own contents. **The class that
+//! cost this project a week names no record and cites no clause**: the falsified
+//! equal-length premise was a bare assertion. This file is the only one that can
+//! see that shape, which is the whole of its claim to exist, and the reason its
+//! key is a phrase rather than a citation.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::common::rulings;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The phrases that mark a comment block as deciding what the correct output
+/// **is**, rather than explaining what the code does.
+///
+/// Matched case-insensitively against the block's text with its comment markers
+/// stripped and its line breaks collapsed to single spaces, so a phrase that
+/// wraps across two comment lines still matches.
+///
+/// The selection rule, which is the part worth keeping: a phrase belongs here
+/// only if it asserts that a representational question has an answer
+/// independent of anyone's choice — "a fact rather than a choice", "the
+/// correspondence is unique" — or announces a choice in the first person. Both
+/// shapes are claims a ruling record should be carrying. A phrase that merely
+/// names an outcome ("the canonical form is `g.262dup`") explains a case and is
+/// not an adjudication, which is why the obvious candidates are absent; see the
+/// module docs for the measured counts that got them rejected.
+const ADJUDICATION_PHRASES: &[&str] = &[
+    "a fact rather than a choice",
+    "a choice rather than a fact",
+    "a fact and not a choice",
+    "a choice and not a fact",
+    "a fact, not a choice",
+    "a choice, not a fact",
+    "is a fact about the variant",
+    "are a fact about the variant",
+    "correspondence is unique",
+    "well defined without an alignment",
+    "well-defined without an alignment",
+    "we choose",
+    "we rule that",
+    "is the correct output",
+    "is the correct form",
+    "are the correct output",
+];
+
+/// Sites that match [`ADJUDICATION_PHRASES`], name no record, and are
+/// deliberately left as they are. `(repo-relative path, why)`.
+///
+/// **Shrink-only.** A row whose file no longer flags is reported as stale and
+/// must be deleted; the list may not grow without the growth being a reviewed
+/// line of this file. Seeded on 2026-08-14 with the tree as it stood after the
+/// known sites were repointed at their record.
+///
+/// Keyed by **file**, not by line, so an unrelated edit above a site does not
+/// invalidate the row — a line-keyed list would go stale on every rebase and be
+/// deleted for being noisy rather than for being wrong.
+const REGROWTH_EXEMPT: &[(&str, &str)] = &[(
+    "tests/it/issue_1284_transcript_axis_collision.rs",
+    "quotes the withdrawn claim verbatim in order to withdraw it — the block \
+     reads \"an intermediate revision of this branch read that as …\" and then \
+     states the refutation. Recording a withdrawal by reproducing what was \
+     withdrawn is the right shape, and it is indistinguishable to a substring \
+     scan from asserting it",
+)];
+
+/// Every `.rs` file under `src/` and `tests/`, repo-relative.
+///
+/// `examples/` is deliberately out of scope: a generator's comments describe a
+/// measurement, and the two directories this file polices are the ones whose
+/// prose a reader reaches for when asking what ferro's output *should* be.
+fn scanned_sources() -> Vec<PathBuf> {
+    let root = repo_root();
+    let mut files = Vec::new();
+    for directory in ["src", "tests"] {
+        collect_rust_sources(&root.join(directory), &root, &mut files);
+    }
+    files.sort();
+    assert!(
+        files.len() > 100,
+        "the source scan found only {} files, which cannot be right for this tree — a scan that \
+         silently finds nothing passes vacuously",
+        files.len()
+    );
+    files
+}
+
+fn collect_rust_sources(directory: &Path, root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_sources(&path, root, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(
+                path.strip_prefix(root)
+                    .expect("a scanned path is under the repo root")
+                    .to_path_buf(),
+            );
+        }
+    }
+}
+
+/// One contiguous run of comment lines: its 1-based first line, and its text
+/// with the markers stripped and the line breaks collapsed.
+struct CommentBlock {
+    line: usize,
+    text: String,
+}
+
+/// Split a file into its contiguous comment blocks.
+///
+/// The block — rather than the line — is the unit of judgement, and that is the
+/// opposite choice from `ruling_citation_currency.rs`, deliberately. That file
+/// reads a *status word* next to a citation, where a two-line window measurably
+/// picks up the neighbouring record's word and reports a contradiction that does
+/// not exist. Here the question is whether a paragraph that decides something
+/// also points at a record, and the citation is almost never on the same
+/// physical line as the claim — line scoping would flag every correctly-cited
+/// paragraph in the tree.
+fn comment_blocks(source: &str) -> Vec<CommentBlock> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut blocks = Vec::new();
+    let mut index = 0;
+    while index < lines.len() {
+        if !lines[index].trim_start().starts_with("//") {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        let mut text = String::new();
+        while index < lines.len() && lines[index].trim_start().starts_with("//") {
+            let stripped = lines[index]
+                .trim_start()
+                .trim_start_matches('/')
+                .trim_start_matches('!')
+                .trim();
+            text.push_str(stripped);
+            text.push(' ');
+            index += 1;
+        }
+        blocks.push(CommentBlock {
+            line: start + 1,
+            text,
+        });
+    }
+    blocks
+}
+
+/// The phrases a block matches, if any.
+fn adjudication_phrases_in(text: &str) -> Vec<&'static str> {
+    let lowered = text.to_ascii_lowercase();
+    ADJUDICATION_PHRASES
+        .iter()
+        .filter(|phrase| lowered.contains(**phrase))
+        .copied()
+        .collect()
+}
+
+/// Whether a block points at the ledger.
+///
+/// Membership, not relevance: the block must contain the id of a record the
+/// ledger actually has. A bare `rulings[...]` with a made-up id does not count,
+/// which is the same standard `ruling_citation_currency.rs` holds citations to.
+fn names_a_record(text: &str, ids: &BTreeSet<String>) -> bool {
+    ids.iter().any(|id| text.contains(id.as_str()))
+}
+
+/// Every flagged site in the tree: `(path, line, phrases)`.
+fn flagged_sites(ids: &BTreeSet<String>) -> Vec<(PathBuf, usize, Vec<&'static str>)> {
+    let root = repo_root();
+    let mut sites = Vec::new();
+    for relative in scanned_sources() {
+        // This file states the phrases in order to look for them, so it matches
+        // itself on every one. Excluding it by path is the only honest option —
+        // any cleverer rule (skip `const` blocks, skip the module docs) would be
+        // a hole another file could climb through.
+        if relative == Path::new(SELF_RELATIVE_PATH) {
+            continue;
+        }
+        let source = std::fs::read_to_string(root.join(&relative))
+            .unwrap_or_else(|e| panic!("read {}: {e}", relative.display()));
+        for block in comment_blocks(&source) {
+            let phrases = adjudication_phrases_in(&block.text);
+            if phrases.is_empty() || names_a_record(&block.text, ids) {
+                continue;
+            }
+            sites.push((relative.clone(), block.line, phrases));
+        }
+    }
+    sites
+}
+
+/// This file, so the scan can skip its own statement of the phrases.
+const SELF_RELATIVE_PATH: &str = "tests/it/adjudication_prose_regrowth.rs";
+
+// --------------------------------------------------------------------------
+// Tests.
+// --------------------------------------------------------------------------
+
+/// The ratchet. Adjudication-shaped prose points at a record, or its file is
+/// named here with a reason.
+#[test]
+fn adjudication_shaped_prose_points_at_a_ruling_record_or_is_allowlisted() {
+    let exempt: BTreeMap<&str, &str> = REGROWTH_EXEMPT.iter().copied().collect();
+    assert_eq!(
+        exempt.len(),
+        REGROWTH_EXEMPT.len(),
+        "REGROWTH_EXEMPT has a duplicate path; one row would shadow another while the count \
+         still looked right"
+    );
+    for (path, reason) in REGROWTH_EXEMPT {
+        assert!(
+            !reason.trim().is_empty(),
+            "REGROWTH_EXEMPT row {path:?} states no reason; an exemption that does not say why \
+             is the silence this file exists to make expensive"
+        );
+        assert!(
+            repo_root().join(path).is_file(),
+            "REGROWTH_EXEMPT names {path:?}, which is not a file in this tree"
+        );
+    }
+
+    let ids: BTreeSet<String> = rulings::records().into_iter().map(|r| r.id).collect();
+    let sites = flagged_sites(&ids);
+
+    let mut covered: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+    let mut undeclared = Vec::new();
+    for (path, line, phrases) in &sites {
+        let key = path.display().to_string();
+        match exempt.get_key_value(key.as_str()) {
+            Some((path, _)) => {
+                covered
+                    .entry(path)
+                    .or_default()
+                    .push(format!("{key}:{line}  {phrases:?}"));
+            }
+            None => undeclared.push(format!("{key}:{line}  {phrases:?}")),
+        }
+    }
+
+    // A row is keyed by FILE, which is the only key that survives editing. The
+    // cost of that key is that one row can silently cover several distinct
+    // sites — measured elsewhere in this tree as the reason a clause-keyed
+    // version of this guard is unusable, since a single row on
+    // `src/normalize/merge.rs` would cover ~124 flagged lines. Cap it at one:
+    // a second flagged block in an exempt file has not been reviewed by whoever
+    // wrote the row, and an exemption that grows silently is the shape this file
+    // exists to make expensive.
+    let overloaded: Vec<String> = covered
+        .iter()
+        .filter(|(_, sites)| sites.len() > 1)
+        .map(|(path, sites)| {
+            format!(
+                "{path} covers {} sites:\n    {}",
+                sites.len(),
+                sites.join("\n    ")
+            )
+        })
+        .collect();
+    assert!(
+        overloaded.is_empty(),
+        "a REGROWTH_EXEMPT row may cover at most one flagged block; these cover more, so the \
+         row's stated reason cannot have been written about all of them. Fix the new site, or \
+         rewrite the row's reason to cover both and split the phrase list if they differ:\n  {}",
+        overloaded.join("\n  ")
+    );
+
+    // Shrink-only, reported first so a PR that repoints a site is told to delete
+    // its row rather than being told twice about the same file.
+    let stale: Vec<&str> = exempt
+        .keys()
+        .filter(|key| !covered.contains_key(**key))
+        .copied()
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "REGROWTH_EXEMPT is shrink-only and these rows no longer describe the tree — the site \
+         now cites a record, or the prose is gone. Delete them: {stale:?}"
+    );
+
+    assert!(
+        undeclared.is_empty(),
+        "prose here decides what the correct representation is and points at no ruling record.\n\
+         \n\
+         Record the decision instead of restating it. If the recommendations settle it, add a \
+         `rulings` record naming the governing clause; if they are silent, add one with a \
+         `house_choice` under `README.md` rule 5's silent limb or rule 6 — see \
+         `generate_spec_fixture`'s `overrides::HouseChoice`. Then cite the record's id here \
+         rather than repeating its content, because a rule written in several places is how \
+         this project's rulings have drifted apart before.\n\
+         \n\
+         If this is a false positive — the phrase is incidental, or the block quotes a claim in \
+         order to withdraw it — add the file to REGROWTH_EXEMPT with the reason.\n\
+         \n  {}",
+        undeclared.join("\n  ")
+    );
+}
+
+/// The detector fires on the shape it was built for, and stays silent on the
+/// shapes that look like it.
+///
+/// Pinned against synthetic text rather than against the tree, so it keeps
+/// meaning something once the tree's own instances are cleaned up — the same
+/// reason `issue_1615_denoted_sequence_oracle.rs` pins recorded triples instead
+/// of re-normalizing.
+#[test]
+fn the_detector_fires_on_an_ontological_claim_and_not_on_an_explained_outcome() {
+    let ids: BTreeSet<String> = ["a-test-record".to_string()].into_iter().collect();
+    let judge = |text: &str| {
+        let blocks = comment_blocks(text);
+        assert_eq!(blocks.len(), 1, "the fixture is one block");
+        let phrases = adjudication_phrases_in(&blocks[0].text);
+        (!phrases.is_empty(), names_a_record(&blocks[0].text, &ids))
+    };
+
+    // The disease: an ontological claim about representation, cited to nothing.
+    assert_eq!(
+        judge("// For an equal-length block the column correspondence is unique,\n// so which columns changed is a fact rather than a choice.\n"),
+        (true, false)
+    );
+    // The same claim, pointed at a record. Flagged and covered.
+    //
+    // The fixture id is spelled bare rather than in the `rulings[…]` form, and
+    // the word that would make it a citation is kept off the line, so that
+    // `ruling_citation_currency.rs`'s scan — which reads *this* file like any
+    // other — does not report a synthetic id as a citation of a record the
+    // ledger does not have. `common/rulings.rs` keeps its own fixture out of
+    // that scan's way the same way, and for the same reason.
+    assert_eq!(
+        judge("// Which columns changed is a fact rather than a choice only\n// under the decided `a-test-record`.\n"),
+        (true, true)
+    );
+    // The phrase wrapping across two comment lines still matches, which is why
+    // the block rather than the line is the unit.
+    assert_eq!(
+        judge("// … so which columns changed is a fact\n// rather than a choice.\n"),
+        (true, false)
+    );
+
+    // Explaining an outcome is not adjudicating one. These are the shapes that
+    // made the broader phrase lists unusable; if any of them starts flagging,
+    // the list has been widened past what this file can carry.
+    for benign in [
+        "// The bug returned the unshifted `g.258dup`; the canonical form is `g.262dup`.\n",
+        "// `duplication.md:18` — \"when a variant can be described as a duplication, it must be\n// described as a duplication\" — is a MUST.\n",
+        "// `delinsATG` is canonical; must NOT be matched.\n",
+        "// Nothing in the spec ranks the two, so no rule is being broken.\n",
+        "// `ATG` is the only `Met` codon, so this is not a choice.\n",
+    ] {
+        assert!(!judge(benign).0, "false positive on: {benign}");
+    }
+}
+
+/// `//!` and `///` and `//` all read as comments, and a non-comment line ends
+/// the block.
+///
+/// The second half is the load-bearing one: without it a whole file would be one
+/// block, and a single citation anywhere in it would launder every claim in it.
+#[test]
+fn a_comment_block_ends_at_the_first_non_comment_line() {
+    let blocks = comment_blocks(
+        "//! module doc\nuse std::fmt;\n\n/// item doc\nfn f() {}\n    // indented\n    let x = 1;\n",
+    );
+    let starts: Vec<usize> = blocks.iter().map(|b| b.line).collect();
+    assert_eq!(starts, vec![1, 4, 6]);
+    assert_eq!(blocks[0].text.trim(), "module doc");
+    assert_eq!(blocks[2].text.trim(), "indented");
+}

--- a/tests/it/common/rulings.rs
+++ b/tests/it/common/rulings.rs
@@ -166,6 +166,71 @@ impl Guard {
     }
 }
 
+/// The `README.md` rule a clause-free house choice is made under.
+///
+/// A closed set of two, mirroring `generate_spec_fixture`'s `overrides::HouseRule`.
+/// Free text here would let a record write a spec clause into the slot reserved
+/// for the project's own authority, which is the substitution [`HouseChoice`]
+/// exists to prevent.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HouseRule {
+    /// `README.md` rule 5, silent limb — the recommendations are incomplete
+    /// here, so ferro decides under rule 6 and violates nothing.
+    RuleFiveSilent,
+    /// `README.md` rule 6 — among multiple conformant forms, the maintainers
+    /// choose.
+    RuleSix,
+}
+
+impl HouseRule {
+    /// The ledger's own spelling, which is also what rendered output uses.
+    pub fn token(self) -> &'static str {
+        match self {
+            HouseRule::RuleFiveSilent => "rule-five-silent",
+            HouseRule::RuleSix => "rule-six",
+        }
+    }
+
+    /// Human-readable form, for rendered documents.
+    pub fn label(self) -> &'static str {
+        match self {
+            HouseRule::RuleFiveSilent => "`README.md` rule 5 (silent limb)",
+            HouseRule::RuleSix => "`README.md` rule 6",
+        }
+    }
+
+    /// Parse the ledger's spelling. `None` for anything outside the closed set.
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "rule-five-silent" => Some(HouseRule::RuleFiveSilent),
+            "rule-six" => Some(HouseRule::RuleSix),
+            _ => None,
+        }
+    }
+}
+
+/// A ruling that is the project's own, made where the recommendations are
+/// silent.
+///
+/// See `generate_spec_fixture`'s `overrides::HouseChoice` for the full
+/// reasoning; the short version is that the ledger previously had no way to say
+/// "no clause reaches this and we chose X", so such choices lived as prose in
+/// `src/` and `tests/` and drifted apart there.
+///
+/// Carrying it as a *record* rather than as a `status` value is deliberate: a
+/// house choice is `decided` — a choice has been made — and the two published
+/// tables (`CLAUDE.md`, `docs/NORMALIZATION_CONTRACT.md`) partition the ledger
+/// by status. A third status would have re-partitioned both and made every
+/// house choice read as a species of open question, which is the opposite of
+/// what it is.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HouseChoice {
+    /// The `README.md` rule the choice is made under.
+    pub under: HouseRule,
+    /// What was weighed and put aside in reaching it. Never blank.
+    pub considered_and_rejected: String,
+}
+
 /// Splits a guard citation into the file it names and the function within it.
 ///
 /// The grammar is deliberately narrow — a repo-relative path ending in `.rs`,
@@ -241,6 +306,16 @@ pub struct Record {
     /// What enforces this record's ruling, or its stated reason that nothing
     /// does. Required — see [`Guard`].
     pub guard: Guard,
+    /// Present when the ruling is the project's own rather than the spec's —
+    /// see [`HouseChoice`]. `None` for every record that rules on a clause.
+    ///
+    /// Exposed rather than folded into [`Self::governing`]'s absence because the
+    /// two are different states and conflating them is what the field exists to
+    /// stop: a `decided` record with no governing clause used to be
+    /// unrepresentable, and `normalization_contract_doc.rs` publishes the note
+    /// "an open record names a conflict without choosing a side" for a missing
+    /// governing clause — which would be exactly wrong on a house choice.
+    pub house_choice: Option<HouseChoice>,
     /// Every clause the record names, in the ledger's own order, each tagged
     /// with the role the record's verdict fields give it.
     pub citations: Vec<Citation>,
@@ -441,6 +516,62 @@ fn guard_from(record: &serde_json::Value, id: &str) -> Guard {
     }
 }
 
+/// The `house_choice` field of one record, if it carries one.
+///
+/// Absence is the ordinary case and reads as `None`; anything present is
+/// validated in full, for the reason [`guard_from`] gives about a present
+/// self-contradictory field. The two required keys are checked explicitly
+/// rather than by a permissive `get`-and-default, because a house choice that
+/// silently lost its `considered_and_rejected` would publish a conclusion with
+/// its reasoning deleted and nothing would fail.
+fn house_choice_from(record: &serde_json::Value, id: &str) -> Option<HouseChoice> {
+    let value = match record.get("house_choice") {
+        None | Some(serde_json::Value::Null) => return None,
+        Some(value) => value,
+    };
+    let object = value
+        .as_object()
+        .unwrap_or_else(|| panic!("record {id} has a non-object `house_choice`: {value}"));
+    for key in object.keys() {
+        assert!(
+            key == "under" || key == "considered_and_rejected",
+            "record {id} has an unknown `house_choice` key {key:?}; only `under` and \
+             `considered_and_rejected` parse"
+        );
+    }
+    let under_token = required_str(
+        value,
+        "under",
+        &format!("the `house_choice` of record {id}"),
+    );
+    let under = HouseRule::from_token(under_token).unwrap_or_else(|| {
+        panic!(
+            "record {id} makes its house choice under {under_token:?}, which is not one of \
+             {:?}. `under` names the `README.md` rule the project chose under, never a spec \
+             clause — a house choice that could name a clause here would be claiming the \
+             authority it exists to disclaim",
+            [
+                HouseRule::RuleFiveSilent.token(),
+                HouseRule::RuleSix.token()
+            ]
+        )
+    });
+    let considered_and_rejected = required_str(
+        value,
+        "considered_and_rejected",
+        &format!("the `house_choice` of record {id}"),
+    );
+    assert!(
+        !considered_and_rejected.trim().is_empty(),
+        "record {id} has a blank `house_choice.considered_and_rejected`; a house choice with no \
+         rejected alternative is a conclusion with its reasoning deleted"
+    );
+    Some(HouseChoice {
+        under,
+        considered_and_rejected: considered_and_rejected.to_string(),
+    })
+}
+
 /// Every record in a parsed ledger document.
 ///
 /// Split from [`records`] so the malformed-input cases below can drive it
@@ -558,6 +689,39 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
 
             let guard = guard_from(record, &id);
 
+            // A house choice states that no clause reaches the point. The two
+            // verdict fields state that one does. Refused here as well as in the
+            // generator because this reader is what the committed tests and both
+            // published documents are built from: a record that reached them
+            // carrying both would be rendered as a house choice *and* indexed as
+            // a governing authority for the clause it names.
+            let house_choice = house_choice_from(record, &id);
+            if house_choice.is_some() {
+                assert!(
+                    status == "decided",
+                    "record {id} carries a `house_choice` but is {status:?}; a choice that has \
+                     been made is decided by definition"
+                );
+                if let Some(governing) = governing {
+                    panic!(
+                        "record {id} is a `house_choice` and names {governing:?} as governing. A \
+                         house choice is what the project does where the recommendations do NOT \
+                         decide, so it cannot also hold a clause to govern"
+                    );
+                }
+                assert!(
+                    deviates_from.is_empty(),
+                    "record {id} is a `house_choice` and names {deviates_from:?} as deviated \
+                     from; there is nothing to deviate from where the recommendations are silent"
+                );
+            } else {
+                assert!(
+                    status != "decided" || governing.is_some(),
+                    "record {id} is decided but names neither a governing clause nor a \
+                     `house_choice`"
+                );
+            }
+
             Record {
                 id,
                 status,
@@ -568,6 +732,7 @@ fn records_from_value(value: &serde_json::Value, origin: &str) -> Vec<Record> {
                 guard,
                 citations,
                 governing: governing.map(str::to_string),
+                house_choice,
             }
         })
         .collect();
@@ -632,6 +797,122 @@ fn a_well_formed_document_parses() {
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].status, "decided");
     assert_eq!(records[0].citations[0].role, Role::Governing);
+}
+
+/// A record whose ruling is the project's own, for the house-choice cases.
+///
+/// Built by *removing* `governing` from the valid record rather than by writing
+/// a second literal, so the two fixtures cannot drift into disagreeing about
+/// everything except the field under test.
+fn one_house_choice_record() -> serde_json::Value {
+    let mut document = one_valid_record();
+    let record = &mut document["rulings"][0];
+    record
+        .as_object_mut()
+        .expect("the fixture record is an object")
+        .remove("governing");
+    record["house_choice"] = serde_json::json!({
+        "under": "rule-six",
+        "considered_and_rejected": "the alternative form, rejected for a stated reason",
+    });
+    document
+}
+
+/// The positive control for the house-choice arm, and its discriminator.
+///
+/// The second half is what gives the first any force: with the `house_choice`
+/// removed the very same record is refused, so "decided with no governing
+/// clause" is legal *because of* the declaration and not by accident.
+#[test]
+fn a_house_choice_record_parses_and_is_the_only_clause_free_decided_shape() {
+    let records = records_from_value(&one_house_choice_record(), "<test>");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].status, "decided");
+    assert!(records[0].governing.is_none());
+    let choice = records[0]
+        .house_choice
+        .as_ref()
+        .expect("the record declares a house choice");
+    assert_eq!(choice.under, HouseRule::RuleSix);
+    // Every clause it names is context, never an authority.
+    assert!(records[0].citations.iter().all(|c| c.role == Role::Cited));
+}
+
+#[test]
+#[should_panic(expected = "names neither a governing clause nor a `house_choice`")]
+fn a_decided_record_with_no_governing_clause_and_no_house_choice_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]
+        .as_object_mut()
+        .expect("record")
+        .remove("house_choice");
+    records_from_value(&document, "<test>");
+}
+
+/// The refusal the field exists for: a house choice may not claim that a clause
+/// governs. Overclaiming spec authority is what turned one implementer's choice
+/// into six prose restatements presented as compliance.
+#[test]
+#[should_panic(expected = "names \"docs/a.md:1\" as governing")]
+fn a_house_choice_that_claims_a_governing_clause_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["governing"] = serde_json::json!("docs/a.md:1");
+    records_from_value(&document, "<test>");
+}
+
+/// The sibling refusal: a clause that reaches far enough to be departed from is
+/// a clause that reaches.
+#[test]
+#[should_panic(expected = "as deviated from")]
+fn a_house_choice_that_deviates_from_a_clause_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["deviates_from"] = serde_json::json!(["docs/a.md:1"]);
+    records_from_value(&document, "<test>");
+}
+
+#[test]
+#[should_panic(expected = "decided by definition")]
+fn an_undecided_house_choice_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["status"] = serde_json::json!("undecided");
+    document["rulings"][0]["clauses"] = serde_json::json!([
+        { "clause": "docs/a.md:1", "quote": "a quoted clause" },
+        { "clause": "docs/b.md:2", "quote": "another quoted clause" },
+    ]);
+    records_from_value(&document, "<test>");
+}
+
+/// `under` names a `README.md` rule and nothing else — in particular not a spec
+/// clause, which is the value a drifting record would most plausibly reach for.
+#[test]
+#[should_panic(expected = "which is not one of")]
+fn a_house_choice_under_a_spec_clause_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["house_choice"]["under"] = serde_json::json!("docs/a.md:1");
+    records_from_value(&document, "<test>");
+}
+
+#[test]
+#[should_panic(expected = "blank `house_choice.considered_and_rejected`")]
+fn a_house_choice_with_nothing_rejected_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["house_choice"]["considered_and_rejected"] = serde_json::json!("  ");
+    records_from_value(&document, "<test>");
+}
+
+#[test]
+#[should_panic(expected = "unknown `house_choice` key")]
+fn an_unknown_house_choice_key_is_rejected() {
+    let mut document = one_house_choice_record();
+    document["rulings"][0]["house_choice"]["governing"] = serde_json::json!("docs/a.md:1");
+    records_from_value(&document, "<test>");
+}
+
+/// Absence reads as absence, so every record predating the field is unaffected.
+#[test]
+fn an_absent_house_choice_reads_as_none() {
+    let records = records_from_value(&one_valid_record(), "<test>");
+    assert!(records[0].house_choice.is_none());
 }
 
 /// An id outside the citation grammar is rejected. Not cosmetic: the scan
@@ -797,9 +1078,17 @@ fn an_absent_applies_to_reads_as_none() {
 /// An explicit `null` verdict field still means "not set" — that is a
 /// legitimate JSON spelling of absent, and the ledger's own records simply omit
 /// the keys.
+///
+/// Driven on an `undecided` record because that is the status for which "both
+/// verdict fields absent" is the *correct* shape. It used to be driven on the
+/// `decided` fixture, which now trips the rule that a decided record names
+/// either a governing clause or a `house_choice` — a rule that did not exist
+/// when this test was written, and whose absence is what made a clause-free
+/// decided ruling unrepresentable in the first place.
 #[test]
 fn a_null_verdict_field_reads_as_absent() {
     let mut document = one_valid_record();
+    document["rulings"][0]["status"] = serde_json::json!("undecided");
     document["rulings"][0]["governing"] = serde_json::Value::Null;
     document["rulings"][0]["deviates_from"] = serde_json::Value::Null;
     let records = records_from_value(&document, "<test>");

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -76,7 +76,22 @@ struct Ruling {
     governing: Option<String>,
     #[serde(default)]
     deviates_from: Vec<String>,
+    /// Present when the record's ruling is the project's own rather than the
+    /// spec's — see `generate_spec_fixture`'s `overrides::HouseChoice`. Such a
+    /// record is `decided` and names **no** governing clause, which is the one
+    /// shape this test used to reject outright.
+    #[serde(default)]
+    house_choice: Option<HouseChoice>,
     rationale: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HouseChoice {
+    /// `rule-five-silent` or `rule-six`; the generator's enum refuses anything
+    /// else at deserialize, so this is a string here only because the fixture is
+    /// read back untyped.
+    under: String,
+    considered_and_rejected: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1423,11 +1438,50 @@ fn ruling_records_are_intact() {
         );
         let cited: std::collections::BTreeSet<&str> =
             ruling.clauses.iter().map(|c| c.clause.as_str()).collect();
+        // The other half of the load-bearing pair below. A `house_choice` says
+        // the recommendations do not reach the point and the project chose under
+        // `README.md` rule 5's silent limb or rule 6; naming a clause that
+        // governs — or one deviated from, which requires the clause to reach —
+        // takes that choice and dresses it as compliance. That is the exact
+        // failure the field was added for, so it is checked here and not only in
+        // the generator.
+        if let Some(house) = &ruling.house_choice {
+            assert_eq!(
+                ruling.status, "decided",
+                "ruling {:?} carries a house choice but is not decided; a choice that has been \
+                 made is decided by definition",
+                ruling.id
+            );
+            assert!(
+                ruling.governing.is_none() && ruling.deviates_from.is_empty(),
+                "ruling {:?} is a house choice yet names a governing or deviated-from clause — \
+                 a choice made where the recommendations are silent must not be recorded as a \
+                 reading of one",
+                ruling.id
+            );
+            assert!(
+                matches!(house.under.as_str(), "rule-five-silent" | "rule-six"),
+                "ruling {:?} makes its house choice under {:?}, which is not a `README.md` rule \
+                 that admits one",
+                ruling.id,
+                house.under
+            );
+            assert!(
+                !house.considered_and_rejected.trim().is_empty(),
+                "ruling {:?} is a house choice that rejects nothing; the refutation is the half \
+                 of a record that stops the belief recurring",
+                ruling.id
+            );
+        }
         match ruling.status.as_str() {
+            // A house choice is the one `decided` shape with no governing
+            // clause. Everything else must name one.
+            "decided" if ruling.house_choice.is_some() => {}
             "decided" => {
                 let governing = ruling.governing.as_deref().unwrap_or_else(|| {
                     panic!(
-                        "ruling {:?} is decided but names no governing clause",
+                        "ruling {:?} is decided but names neither a governing clause nor a \
+                         house choice",
                         ruling.id
                     )
                 });

--- a/tests/it/ledger_clause_jurisdiction.rs
+++ b/tests/it/ledger_clause_jurisdiction.rs
@@ -568,6 +568,9 @@ fn record(
         question: format!("A synthetic record for {id}."),
         equivalence_classes: Vec::new(),
         guard: rulings::Guard::Declined("a synthetic record, enforced by this file".to_string()),
+        // Not a house choice: every case here names a governing clause, which is
+        // the shape a house choice may not take.
+        house_choice: None,
         rationale: rationale.to_string(),
         applies_to: applies_to.iter().map(|s| s.to_string()).collect(),
         citations: clauses

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -45,6 +45,7 @@ mod repeat_lowering_sibling_junction;
 mod residual_above_cap_confluence;
 mod stranded_identity_member;
 
+mod adjudication_prose_regrowth;
 mod allele_grammar_corners;
 mod allele_trans_phase;
 mod allele_unknown_phase;

--- a/tests/it/minimal_alignment_enumeration.rs
+++ b/tests/it/minimal_alignment_enumeration.rs
@@ -467,9 +467,13 @@ fn the_weight_bound_records_four_rows_are_position_wise_readings() {
         );
 
         // The whole point: the position-wise reading is NOT one of the minimal
-        // alignments, so the changed-column set the record derived from it is a
-        // choice and not a fact. Position-wise costs one substitution per
-        // mismatched column; minimal costs 2.
+        // alignments, so the changed-column set
+        // `rulings[derivation-may-not-be-bounded-by-the-inputs-spelling]`
+        // derived from it is a choice and not a fact. That is
+        // `rulings[unchanged-is-read-over-every-minimal-alignment]` applied to
+        // these four rows, not a reading taken here — read that record, which
+        // is the only place the rule is stated. Position-wise costs one
+        // substitution per mismatched column; minimal costs 2.
         let position_wise_cost = (reference.len() - position_wise.len()) as u32;
         assert!(
             position_wise_cost > 2,

--- a/tests/it/normalization_contract_doc.rs
+++ b/tests/it/normalization_contract_doc.rs
@@ -439,14 +439,39 @@ fn render_record(record: &Record) -> String {
         );
     }
 
+    // A house choice and an open question both reach the loop below with no
+    // governing clause, and the reason differs completely — one has chosen and
+    // has no clause to choose *under*, the other has a clause and has not
+    // chosen. The published note must not tell the reader the wrong one, so the
+    // house-choice case is stated here and the empty-governing note is suppressed
+    // for it.
+    let empty_governing_note = match &record.house_choice {
+        Some(choice) => {
+            let _ = writeln!(
+                out,
+                "**House choice.** This ruling is the project's own, made under {} where the \
+                 recommendations do not decide. It cites no governing clause and must never be \
+                 quoted as conformance.\n",
+                choice.under.label()
+            );
+            let _ = writeln!(
+                out,
+                "**Considered and rejected.** {}\n",
+                collapse(&choice.considered_and_rejected)
+            );
+            None
+        }
+        None => Some(
+            "**Governing clause.** None. An open record names a conflict without choosing a \
+             side, and the generator refuses to build one that names an authority.",
+        ),
+    };
+
     for (role, heading, empty_note) in [
         (
             Role::Governing,
             "**Governing clause.**",
-            Some(
-                "**Governing clause.** None. An open record names a conflict without choosing a \
-                 side, and the generator refuses to build one that names an authority.",
-            ),
+            empty_governing_note,
         ),
         (Role::DeviatesFrom, "**Deviates from.**", None),
         (Role::Cited, "**Also cited.**", None),

--- a/tests/it/reported_confluence_pairs.rs
+++ b/tests/it/reported_confluence_pairs.rs
@@ -391,15 +391,31 @@ fn the_1420_v2_pair_does_not_converge_by_re_derivation() {
     // a `dup` where `general.md:56` ranks a substitution above it. That is a
     // README rule-2 preference miss, disclosed in the PR trailer, pinned in
     // `reported_partition_verdicts.rs` (`1420-v2/span` -> `Gap`, the pair ->
-    // `NeitherReaches`, `OPEN_GAPS` 12 -> 13) and filed as issue #1878. Closing
-    // #1878 should move the span back onto `MERGED_ACROSS_UNCHANGED` below —
-    // which is why that string stays named here rather than being deleted.
+    // `NeitherReaches`, `OPEN_GAPS` 12 -> 13) and filed as issue #1878.
+    //
+    // WHAT THE DISPOSITION OF #1878 IS, THIS FILE DOES NOT SAY. An earlier
+    // revision of this comment and of the assertion message below told a future
+    // maintainer what to do when the span reaches the merged form again — re-pin
+    // the verdicts, lower `OPEN_GAPS`, delete the assertion — as though that
+    // outcome were already agreed. It is not. Prescribing the reversal of a
+    // decision nobody has taken is the same failure as restating a rule in a
+    // second place: the next agent follows the instruction and the decision gets
+    // made by whoever wrote the comment.
+    //
+    // The relevant rule is recorded, and is the record to read rather than this
+    // comment: `rulings[unchanged-is-read-over-every-minimal-alignment]` settles
+    // what "unchanged" means for `general.md:34`'s separation test, and
+    // explicitly leaves unmeasured which blocks it moves. Whether #1878 and
+    // #1904 should change what these spellings normalize to is the operator's
+    // call, and until it is made the assertions below stay as they are and this
+    // string stays named rather than deleted.
     const SPAN: &str = "TEMPLATE:g.38_41delinsATTG";
     const CIS: &str = "TEMPLATE:g.[37dup;41del]";
     const CIS_OUTPUT: &str = "TEMPLATE:g.[37dup;41del]";
     const CIS_OUTPUT_FIVE_PRIME: &str = "TEMPLATE:g.[36dup;41del]";
-    // The form #1420 asks for, and the form a merge across the unchanged 39
-    // would produce. Not currently reached by either spelling; see #1878.
+    // The form #1420 asks for, and the form a merge across the unchanged
+    // nucleotides would produce. Not currently reached by either spelling; see
+    // #1878 and #1904.
     const MERGED_ACROSS_UNCHANGED: &str = "TEMPLATE:g.[38T>A;40_41delinsTG]";
 
     for direction in DIRECTIONS {
@@ -426,10 +442,13 @@ fn the_1420_v2_pair_does_not_converge_by_re_derivation() {
         assert_ne!(
             span, MERGED_ACROSS_UNCHANGED,
             "{direction:?}: the `1420-v2` span spelling now reaches #1420's \
-             wanted form again. If that is issue #1878 being fixed, this is the \
-             good news — re-pin `1420-v2/span` to `Canonical`, the pair to \
-             `OneReaches`, and `OPEN_GAPS` back to 12, and delete this \
-             assertion in the same change",
+             wanted form again. That is a REPRESENTATION CHANGE on a row this \
+             family pins, not a result this assertion has pre-approved: the \
+             disposition of #1878 / #1904 is undecided, and \
+             `rulings[unchanged-is-read-over-every-minimal-alignment]` leaves \
+             the affected set unmeasured. Say which change produced it and put \
+             the disposition to the operator; do not re-pin the verdicts and \
+             delete this assertion on the strength of the string alone",
         );
     }
 }

--- a/tests/it/reported_partition_verdicts.rs
+++ b/tests/it/reported_partition_verdicts.rs
@@ -1642,10 +1642,24 @@ fn every_reported_pair_is_still_one_variant_by_equivalence() {
 /// three #1420 rows whose replacement is the same length as the span it
 /// replaces.
 ///
-/// Equal length is what makes the changed/unchanged column pattern well defined
-/// without an alignment, which is why only #1420 appears here: #1419's rows are
-/// net deletions and #1421's are net insertions, so their columns do not line
-/// up one-to-one and the pattern is a choice rather than a fact.
+/// **The premise this doc used to state is false, and the ledger says so.** It
+/// read "equal length is what makes the changed/unchanged column pattern well
+/// defined without an alignment", with #1419's net deletions and #1421's net
+/// insertions excluded because "their columns do not line up one-to-one".
+/// `rulings[unchanged-is-read-over-every-minimal-alignment]` records the
+/// counter-example directly: `CAG -> AGA` is equal length and still has edit
+/// distance 2, so a position-wise reading of an equal-length block is not
+/// automatically the minimal one and "which columns changed" is not settled by
+/// the lengths matching. Read the record rather than this comment; it is the
+/// only place the rule is stated.
+///
+/// What is true, and is all this table needs, is narrower: these three rows are
+/// the ones whose replacement is the same length as its span, so a
+/// **position-wise** column pattern can be written down for them at all. That
+/// pattern is what [`reported_spans_change_the_columns_the_reports_state`]
+/// computes and checks against the reference. Whether it is also the minimal
+/// alignment's pattern is the record's question, not this table's, and no
+/// assertion here turns on the answer.
 const EQUAL_LENGTH_SPANS: &[(&str, usize, &str, &str)] = &[
     ("1420-v2", 38, "TTGC", "ATTG"),
     ("1420-v3", 37, "ATTG", "CATT"),
@@ -1654,13 +1668,20 @@ const EQUAL_LENGTH_SPANS: &[(&str, usize, &str, &str)] = &[
 
 /// The #1420 arguments are checked against the reference, not taken on trust.
 ///
-/// Each row's canonical form follows from *which columns change*: v2 and v3
-/// have an unchanged interior column, so delins.md:17 separates them; v4 has
-/// none, so delins.md:16 coalesces it. That distinction is the reason v4's
-/// correction points the opposite way to v2's and v3's, and it is the one part
-/// of #1420's reasoning that is a fact about the sequence rather than a reading
-/// of the recommendations — so it is computed here rather than asserted in a
-/// comment.
+/// #1420's own reasoning runs off *which columns change*: v2 and v3 have an
+/// unchanged interior column, so `delins.md:17` separates them; v4 has none, so
+/// `delins.md:16` coalesces it. That distinction is the reason v4's correction
+/// points the opposite way to v2's and v3's, and it is computed here rather
+/// than asserted in a comment.
+///
+/// **What is computed is the position-wise pattern**, which is a fact about
+/// these strings. It is *not* the same thing as which bases are unchanged in
+/// the sense `general.md:34` keys on — that notion is column-based over every
+/// minimal alignment and is settled by
+/// `rulings[unchanged-is-read-over-every-minimal-alignment]`, which also records
+/// why an equal-length block does not settle it by itself. Nothing here asserts
+/// the two coincide; the assertion is only that the position-wise pattern is
+/// what #1420 says it is.
 #[test]
 fn reported_spans_change_the_columns_the_reports_state() {
     // `X` = changed, `.` = unchanged, one character per position in the span.

--- a/tests/it/weight_bound_worked_examples.rs
+++ b/tests/it/weight_bound_worked_examples.rs
@@ -65,9 +65,10 @@
 //! changed that the input left alone. The bound refuses it, and the per-member
 //! pipeline answers instead — which is why the output is the input.
 //!
-//! **This row is NOT protection — adjudicated 2026-08-10, by measurement.** For
-//! a net-zero block the column correspondence is unique, so *which columns
-//! changed* is a fact rather than a choice:
+//! **This row is NOT protection — adjudicated 2026-08-10, by measurement.** The
+//! columns below are the **position-wise** ones, which is what a net-zero block
+//! lets you write down; they are not, by themselves, an answer to which bases
+//! `general.md:34` counts as unchanged:
 //!
 //! ```text
 //! pos      2  3  4  5  6  7  8  9 10 11 12
@@ -86,6 +87,17 @@
 //! cannot apply to a `g.` description, which has no amino acid. **So the derived
 //! form is exactly what the spec's stated rules produce, and the input is a
 //! spelling they never generate.**
+//!
+//! **This passage used to argue that from the wrong premise, and the premise is
+//! settled elsewhere.** It read "for a net-zero block the column correspondence
+//! is unique, so *which columns changed* is a fact rather than a choice", stated
+//! as a general truth about equal-length blocks. It is not one:
+//! `rulings[unchanged-is-read-over-every-minimal-alignment]` records `CAG ->
+//! AGA` as an equal-length block with edit distance 2, where the position-wise
+//! reading is *not* minimal and two of the three bases are unchanged. That
+//! record is the only statement of the rule; do not restate it here. For **this**
+//! block the position-wise reading happens to be the one the derivation takes,
+//! which is all the worked example needs and all it now claims.
 //!
 //! The weights make the refusal vivid: the input spells `1 + 1 = 2`, the
 //! derivation `max(4,4) + max(5,5) = 9`. `9 > 2`, so the bound refuses — even


### PR DESCRIPTION
## Why

The `rulings` ledger can record two things: a settled reading of a clause (`decided`, with a `governing` clause) and an unsettled conflict (`undecided`, two clauses, no verdict). It cannot record the third and commonest state — *the recommendations are silent here and we chose X* — because a `decided` record is required to name a clause it holds to govern. Measured on `origin/main`: 31 records, 28 `decided` / 3 `undecided`, every `decided` one citing a governing clause and all three clause-free ones `undecided`.

`README.md` rule 5's silent limb says in terms that ferro "decides under rule 6 and violates nothing", so the ledger cannot express a state its own ruleset names.

That state went somewhere. The rule that a reference base is unchanged iff **every** minimum-edit-distance alignment matches it had no record, so it was written as prose where it was needed and ended up as six restatements across `src/` and `tests/`. Three of them drifted into the flatly false generalisation that an equal-length block's column correspondence is unique. Reconciling them cost several days. An HGVS committee-perspective review of the same rule called it "an implementer's choice the recommendations neither require nor forbid" and objected to its being presented as compliance.

## What this adds

**A `house_choice` object on a ruling record.** It carries `under` — a closed set of two, `rule-five-silent` or `rule-six`, never a spec clause — and `considered_and_rejected`, which must not be blank. A record carrying one is `decided` and names no governing clause.

**The overclaim is unrepresentable, not discouraged.** `generate_spec_fixture` and `tests/it/common/rulings.rs` both refuse a `house_choice` that names a `governing` or a `deviates_from` clause, and refuse one on a non-`decided` record. This mirrors the existing `undecided` refusal deliberately: that arm stops a record claiming more *certainty* than the project has, this one stops it claiming more *authority* than the spec gave it. The second is the costlier direction here, because a governing clause is quotable — once one is written down the choice starts being cited as conformance.

Sabotaged and verified rather than asserted. Adding a `house_choice` to a record that already names a governing clause:

```
error: ruling "duplication-must-ranks-the-label-not-the-partition": a `house_choice` names a
governing clause. A house choice is made under `README.md` rule 5's silent limb or rule 6, which
are what the project does where the recommendations do NOT decide — so it cannot also hold a
clause to govern. …
```

and the generator exits 1. The positive arm was probed the same way: a well-formed clause-free house choice builds, exits 0, and reaches the generated fixture.

**A regrowth ratchet**, `tests/it/adjudication_prose_regrowth.rs`. A one-time cleanup regrows, so comment prose that decides what the correct representation is must name a ledger record id, or its file must carry a row in a shrink-only `REGROWTH_EXEMPT`.

The obvious predicate — the inverse of `clause_ruling_index`, flag a comment citing a governed clause with no record nearby — was measured first and rejected: **707** comment lines in 144 files, most of them the legitimate habit of quoting the clause a piece of code implements. A guard that flags 700 lines on its first run is argued with once and then disabled. What ships is a narrow phrase list, chosen by measuring every candidate over the whole tree, keyed on prose that makes an *ontological* claim about representation ("a fact rather than a choice", "the correspondence is unique"). It flags **three** blocks in the entire tree; one is exempt with a stated reason. Phrases that read adjudicative but are ordinary here — "is canonical" (26 blocks), "the canonical form is" (24), "must be described as" (4, all quoting `DNA/duplication.md:18`) — are rejected on the same measurement, and the module says so.

An exemption row is keyed by file, because that is the only key that survives editing; the cost of that key is capped by failing when one row covers more than one flagged block.

## What it does not reach, stated on the module

Every existing ledger guard fires only on prose that already names a record, or on the ledger's own contents. This one is keyed on a phrase instead, which is why it can see the class that named nothing — but it is a substring scan over comments, it cannot see prose inside an `assert!` message, and it does not touch the 707-line clause-citing class at all. Those limits are in the module docs rather than in this description, so they cannot rot separately from the code.

## What this deliberately does NOT do

**No ledger record is added, changed or re-statused: 31 records in, 31 out, same ids, same statuses.** The one candidate house choice — the minimal-alignment rule — already has a `decided` record naming a governing clause, added hours before this branch. Adding a second record for the same rule would be the drift failure this PR exists to close, and deciding whether that record overclaims is the disposition of #1878 / #1904, which is not a contributor's call.

**No assertion changes behaviour.** The three sites are repointed at the record instead of restating it, and `reported_confluence_pairs.rs` stops *instructing* a future maintainer to re-pin the verdicts and delete an assertion when a form it names is reached — an outcome nobody has agreed to. The assertions themselves are untouched.

Left alone deliberately: `src/normalize/merge.rs` (contested by two open PRs), `README.md:232-234` (in flight), and `issue_1284_transcript_axis_collision.rs`, which is the model to imitate and is exempt only because it quotes the withdrawn claim verbatim in order to withdraw it.

## Gate

`cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings` and `cargo nextest run --features dev --lib --test it --no-fail-fast` all clean, and `docs/NORMALIZATION_CONTRACT.md` is unchanged because no record moved.

Representation-Change: none. Ledger schema, one new test module and prose; no file under `src/` is touched, and no ledger record is added or changed.
