### PR TITLE
perf(ci): move the three slow censuses onto the optimized archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,51 @@ env:
   SWEEP_FILTER: >-
     test(cis_junction_crossing_shift) + test(repeat_span_sibling_overlap)
     + test(issue_1254_sibling_crossing_shift)
+  # The slow census modules, owned by the `censuses` job and excluded from the
+  # `test` / `test-oracle` partitions. Same shape as `SWEEP_FILTER` above and
+  # for the same reason; the difference is what the job does with them.
+  #
+  # WHY THEY MOVED. `--partition hash:K/N` assigns a test by a hash of its NAME,
+  # so it balances shard *counts* and is blind to cost — the property already
+  # recorded on `sweeps`, where all three exhaustive sweeps hashed into one
+  # shard. These four hashed into the two slowest jobs and made the workflow's
+  # critical path a single test. Measured on run 31845625298 (`044f085a`):
+  #
+  #                                             Test (K/6)   Test oracle (K/4)
+  #   issue_1542_direction_symmetry               155.7s (3)         240.3s (1)
+  #   spec_conformance_axis (5 tests)             338.0s              excluded
+  #   normalize_axis_preserving (4 tests)         119.3s (1,3,5)      313.0s (1,3)
+  #
+  # `Test oracle (1/4)` ran 328s against 132-160s for its siblings and finished
+  # 83s after every other job in the workflow, so the run's wall clock was one
+  # unlucky hash draw. A shard's wall can never fall below its slowest single
+  # test, so re-sharding cannot fix it — which is why `test-oracle`'s own
+  # comment below, having chosen N=4 to separate the two bulk corpora, names
+  # exactly this carve-out as the robust alternative. This is that alternative.
+  #
+  # AND WHY THE JOB, NOT THE JOB BOUNDARY, IS THE WIN. `censuses` consumes the
+  # OPTIMIZED archive `test-build-soak` produces, which is where `sweeps`
+  # measured 7.6-8.7x on work of exactly this shape (compute-bound cross
+  # products over `MockProvider`). A carve-out onto the standard debug archive
+  # would move the same 240s to a different runner and buy ~50s.
+  #
+  # THE PARTITION INVARIANT is `SWEEP_FILTER`'s, verbatim: the counts drift as
+  # tests are added, the sum must not. `censuses` selects ON this filter and
+  # passes `--no-tests=fail`, so a rename that made it match nothing reddens
+  # there rather than quietly emptying the job, while `test` and `test-oracle`
+  # negate it and would just widen. `tests/it/census_filter_invariant.rs` closes
+  # the half neither of those catches — a module named here that NEITHER of the
+  # job's two steps selects would be negated everywhere and run nowhere.
+  #
+  # NOTE the overlap with `ORACLE_EXCLUDE` below: `spec_conformance_axis` is in
+  # both, and deliberately. `ORACLE_EXCLUDE` is a statement about which
+  # instrument may be armed, and `oracle_exclude_invariant.rs` demands that
+  # every spec-corpus module appear there; this filter is a statement about
+  # where a module runs. Removing it from either would be wrong for a reason the
+  # other does not cover.
+  CENSUS_FILTER: >-
+    test(issue_1542_direction_symmetry) + test(normalize_axis_preserving)
+    + test(spec_conformance_axis)
   # The spec-corpus modules, excluded from `test-oracle` ONLY. They run in full
   # in the plain `test` job; this is not a coverage exemption, it is a statement
   # about which instrument may be armed while another is measuring.
@@ -1193,44 +1238,48 @@ jobs:
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
             --partition hash:${{ matrix.shard }}/6 \
-            -E "not test(proptest) and not ($SWEEP_FILTER)"
+            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($CENSUS_FILTER)"
 
   # The idempotency oracle re-run. Deliberately EXCLUDES the proptest modules:
   # their own property already *is* `norm(norm(x)) == norm(x)`, which is exactly
   # what the oracle asserts, so re-rolling thousands of random cases here checks
   # nothing the plain run did not already check — it just cost ~80s of every CI
   # run. The deep random coverage lives in the `soak` job below instead.
-  # FOUR shards, and the number is CHOSEN rather than conventional.
+  # FOUR shards. The number was once load-bearing and no longer is — worth
+  # recording, because the reasoning it rested on is the reasoning that produced
+  # `CENSUS_FILTER`.
   #
   # `--partition hash:K/N` assigns each test by a hash of its NAME, so it
   # balances test *counts* and is blind to duration. At N=3 the two bulk
-  # axis-preservation corpora — the two slowest tests in the repository under the
-  # oracles — both hashed into shard 1, every run, deterministically:
+  # axis-preservation corpora — then the two slowest tests in the repository
+  # under the oracles — both hashed into shard 1, every run, deterministically:
   #
   #     Test oracle (1/3)  242s     <- axis_is_preserved_over_the_{cmrg,clinvar_unique}_corpus
   #     Test oracle (2/3)   94s
   #     Test oracle (3/3)   77s
   #
   # 413s of work split 242/94/77 instead of ~138 each, so the job's critical path
-  # was one unlucky draw.
+  # was one unlucky draw. N=4 separated them (cmrg -> 1, clinvar_unique -> 3).
   #
-  # N=4 separates them (cmrg -> 1, clinvar_unique -> 3). That is measured, not
-  # hoped for, and it is re-derivable — N=5 also separates them and N=6 puts them
-  # back together, so the number is not monotone and cannot be reasoned about:
+  # **That fix did not hold, and could not have.** The shard count is chosen
+  # against one snapshot of the test-NAME set, and every added or renamed test
+  # re-rolls the whole assignment. #1840 added `issue_1542_direction_symmetry`,
+  # it hashed onto shard 1 next to the cmrg corpus, and the job went back to
+  # 328s against 132-160s for its siblings — the same failure the shard count
+  # had been picked to avoid, two months later and by a different draw.
   #
-  #     for K in 1 2 3 4; do
-  #       cargo nextest list --features dev --test it --partition "hash:$K/4" \
-  #         -E 'test(axis_is_preserved_over_the_cmrg_corpus) or
-  #             test(axis_is_preserved_over_the_clinvar_unique_corpus)'
-  #     done
+  # So the robust alternative this comment used to name and decline — "giving
+  # `normalize_axis_preserving` a job of its own and negating it here" — was
+  # taken instead. It is `CENSUS_FILTER` and the `censuses` job, and it also
+  # carries `issue_1542_direction_symmetry` and `spec_conformance_axis`. Its
+  # cost was the three-file change this comment warned about (`ci.yml`,
+  # `scripts/run_oracle_suite.sh`, `tests/it/oracle_exclude_invariant.rs`), and
+  # that was the right price: a negation is stable under a re-roll and a shard
+  # count is not.
   #
-  # **This placement is a property of the whole test-NAME set, so adding or
-  # renaming tests re-rolls it.** If this job's shards go lopsided again, re-run
-  # the loop above before assuming anything else changed. The robust alternative
-  # — giving `normalize_axis_preserving` a job of its own and negating it here —
-  # was not taken because this job's `-E` is re-derived by BOTH
-  # `scripts/run_oracle_suite.sh` and `tests/it/oracle_exclude_invariant.rs`, so
-  # a fourth negation term is a three-file change; the shard count is not.
+  # N stays at 4. Nothing now depends on which shard a particular test lands in,
+  # so the number is once again merely conventional; it is left alone because
+  # changing it re-rolls every assignment for no measured gain.
   test-oracle:
     name: Test oracle (${{ matrix.shard }}/4)
     needs: [test-build, spec-fixtures, fixtures]
@@ -1409,7 +1458,7 @@ jobs:
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
             --partition hash:${{ matrix.shard }}/4 \
-            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE)"
+            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE) and not ($CENSUS_FILTER)"
 
   # 1,000,000-case idempotency soak on every PR, split 8 ways.
   #
@@ -1613,6 +1662,91 @@ jobs:
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)"
 
+  # `CENSUS_FILTER`'s modules, moved off the `test` / `test-oracle` partitions
+  # and onto the optimized archive. See that filter's own comment for why they
+  # moved; this one is about how the job preserves what they were doing.
+  #
+  # TWO STEPS, because the modules do not agree about the oracles and the
+  # difference is not a detail:
+  #
+  #   * ARMED runs what `test-oracle` ran, with the same three flags and no
+  #     fourth. An armed run strictly subsumes the un-armed one — the oracles
+  #     add assertions at `normalize_core_checked`'s exit and change no
+  #     behaviour — which is the same argument `sweeps` makes, so dropping the
+  #     plain-`test` copy of these two modules loses nothing.
+  #   * UN-ARMED runs `spec_conformance_axis`, which is in `ORACLE_EXCLUDE` and
+  #     must stay that way: it COUNTS the non-idempotent outputs
+  #     `FERRO_ASSERT_IDEMPOTENT` panics on, and a panicking row is filed
+  #     `declined` and never reaches the family's output set — which does not
+  #     redden the census, it FLATTERS it. That module ran only in the plain
+  #     `test` job before, so this step reproduces it exactly.
+  #
+  # `FERRO_ASSERT_SEQUENCE` is set by NEITHER step, which is what makes this a
+  # move rather than a change of instrument. `sweeps` does set it, so these
+  # modules could not simply be appended there.
+  #
+  # No `submodules: true`: none of the three modules names a path under
+  # `assets/` (the spec worked-examples citation gate, which does, stays in
+  # `test`). `spec-fixtures` IS needed —
+  # `normalize_axis_preserving::axis_is_preserved_over_the_spec_fixture` calls
+  # `ensure_spec_fixture`, which regenerates via a nested `cargo run` when the
+  # file is absent, and this job has no crate to build from. `bulk-fixtures` is
+  # needed for the three corpus tests in that same module.
+  #
+  # Verified archive-safe the way `soak` and `sweeps` are: all three modules
+  # live in `tests/it/`, so they are already inside the archive
+  # `test-build-soak` produces, none is gated on the `dev` feature, and none
+  # reads `CARGO_BIN_EXE_ferro`.
+  censuses:
+    name: Slow censuses (optimized)
+    needs: [test-build-soak, spec-fixtures, fixtures]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive-soak
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: spec-fixtures
+          path: tests/fixtures/grammar/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bulk-fixtures
+          path: tests/fixtures/
+      - name: Run the censuses that need the oracles armed
+        env:
+          # The three `test-oracle` sets, and only those three. See that job for
+          # what each asserts and why `FERRO_ASSERT_SEQUENCE` is not among them.
+          FERRO_ASSERT_IDEMPOTENT: "1"
+          FERRO_ASSERT_REPARSE: "1"
+          FERRO_ASSERT_IN_BOUNDS: "1"
+          # Absence of a bulk fixture must FAIL here, never skip — the same
+          # reason as in `test`. `normalize_axis_preserving`'s three corpus
+          # tests `return` early on a missing file, so without this a
+          # `bulk-fixtures` artifact that failed to arrive would delete the
+          # ClinVar, CMRG and Paraphase axis coverage and report a *faster*
+          # green run.
+          FERRO_REQUIRE_BULK_FIXTURES: "1"
+        # `--no-tests=fail` for the reason spelled out on `soak` and `sweeps`:
+        # this step names its modules explicitly, so a rename is exactly the
+        # edit that would drop a census from CI silently.
+        run: |
+          cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite --no-tests=fail \
+            -E "test(issue_1542_direction_symmetry) + test(normalize_axis_preserving)"
+      - name: Run the census that may not be measured with an oracle armed
+        # No `FERRO_ASSERT_*` here, deliberately, and no bulk fixtures: this
+        # module builds its corpus in code (`conformance::spec_corpus`) and
+        # reads nothing from disk.
+        run: |
+          cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
+            --extract-to . --extract-overwrite --no-tests=fail \
+            -E "test(spec_conformance_axis)"
+
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.
   # Aggregator that reports the `Test` status context.
@@ -1630,7 +1764,7 @@ jobs:
   test-required:
     name: Test
     runs-on: ubuntu-latest
-    needs: [test, test-oracle, soak, sweeps]
+    needs: [test, test-oracle, soak, sweeps, censuses]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
     if: always()
@@ -1641,10 +1775,12 @@ jobs:
           echo "test-oracle     = ${{ needs.test-oracle.result }}"
           echo "soak            = ${{ needs.soak.result }}"
           echo "sweeps          = ${{ needs.sweeps.result }}"
+          echo "censuses        = ${{ needs.censuses.result }}"
           if [ "${{ needs.test.result }}" != "success" ] \
             || [ "${{ needs.test-oracle.result }}" != "success" ] \
             || [ "${{ needs.soak.result }}" != "success" ] \
-            || [ "${{ needs.sweeps.result }}" != "success" ]; then
+            || [ "${{ needs.sweeps.result }}" != "success" ] \
+            || [ "${{ needs.censuses.result }}" != "success" ]; then
             echo "::error::one or more test jobs did not succeed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,9 +186,10 @@ path now excludes it the same way, from the same source of truth.
 
 **The runner reads the whole `-E` selection and the flag set out of `ci.yml`**,
 so neither can drift into a second copy. "Whole" is load-bearing: `test-oracle`
-negates `test(proptest)` and `SWEEP_FILTER` as well as `ORACLE_EXCLUDE`, and a
-runner that negated only the last of them would run the proptest modules and the
-three exhaustive sweeps while reporting itself as mirroring that job. So the
+negates `test(proptest)`, `SWEEP_FILTER` and `CENSUS_FILTER` as well as
+`ORACLE_EXCLUDE`, and a runner that negated only `ORACLE_EXCLUDE` would run the
+proptest modules, the three exhaustive sweeps and the three slow censuses while
+reporting itself as mirroring that job. So the
 shape of the expression is read too, and only its variable references are
 expanded — rebuilding it here from a hardcoded `not test(proptest) and not (…)`
 would trade today's drift for tomorrow's.
@@ -319,14 +320,16 @@ on `merge::first_out_of_bounds_coordinate`. In brief:
 
 Like the two above it, compiled out in release (`#[cfg(debug_assertions)]`) and
 read once into a `OnceLock`. CI sets **these three** together, in the sharded
-`test-oracle` job and the `sweeps` job (those two and nowhere else — the plain
-`test` and `soak` jobs run without the flags); the nightly sets it too, where it
-is the only place the check runs against true transcript and contig lengths.
+`test-oracle` job, the `sweeps` job, and the **armed step** of the `censuses`
+job (those three and nowhere else — the plain `test` and `soak` jobs run without
+the flags, and `censuses`' second step deliberately runs `spec_conformance_axis`
+un-armed); the nightly sets it too, where it is the only place the check runs
+against true transcript and contig lengths.
 
 **The fourth flag is not set in all of those places, so do not read "all four"
 off this paragraph.** `FERRO_ASSERT_SEQUENCE` runs in `sweeps` and in the
-nightly, and deliberately not in `test-oracle` — the reason, and what currently
-keeps it out, are under
+nightly, and deliberately not in `test-oracle` or in `censuses` — the reason, and
+what currently keeps it out, are under
 [Where it runs, and the one place it deliberately does not](#normalization-denoted-sequence-oracle)
 below and in `ci.yml`'s comment on the `test-oracle` job.
 
@@ -408,11 +411,15 @@ four when on — one provider fetch and two splices per normalization — so it 
 last in `assert_seam_oracles`, after the cheaper and more specific checks have
 had their chance to name the fault more precisely.
 
-**Where it runs, and the one place it deliberately does not.** `sweeps` sets it
+**Where it runs, and the two places it deliberately does not.** `sweeps` sets it
 (gating, measured green over the full corpus) and the nightly sets it
-(non-gating). `test-oracle` does **not**, which makes it the only job where the
-set of four is incomplete. Two rows in that job's selection used to fire, and
-both were real disagreements inside ferro rather than noise:
+(non-gating). `test-oracle` does **not**, which is why the set of four is
+incomplete there. `censuses`' armed step does not either, and for a derived
+reason rather than a second one: that step exists to run what `test-oracle` ran,
+on a faster archive, so it inherits that job's flag set exactly — arming a fourth
+oracle there would make the move a change of instrument. Two rows in
+`test-oracle`'s selection used to fire, and both were real disagreements inside
+ferro rather than noise:
 
 | row | what disagreed | state |
 |---|---|---|

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -158,6 +158,7 @@ oracle_flags() {
 
 EXCLUDE="$(folded_scalar ORACLE_EXCLUDE)"
 SWEEPS="$(folded_scalar SWEEP_FILTER)"
+CENSUSES="$(folded_scalar CENSUS_FILTER)"
 TEMPLATE="$(oracle_selection_template)"
 # A read loop rather than `mapfile`, which is bash 4+: stock macOS still ships
 # bash 3.2 as /bin/bash, and a script that dies on `mapfile: command not found`
@@ -186,6 +187,16 @@ if [[ -z "$SWEEPS" ]]; then
     echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
     exit 1
 fi
+# `CENSUS_FILTER`'s modules moved to the `censuses` job, which runs them on the
+# optimized archive; `test-oracle` negates them. An empty read here would put
+# them back into a local armed run -- not a known-red wall like an empty
+# `ORACLE_EXCLUDE`, but ~9 minutes of debug-profile census this script is not
+# meant to run, which reads as a hang rather than as a misconfiguration.
+if [[ -z "$CENSUSES" ]]; then
+    echo "error: could not read CENSUS_FILTER from $CI_YML." >&2
+    echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
+    exit 1
+fi
 if [[ -z "$TEMPLATE" ]]; then
     echo "error: could not read test-oracle's -E selection from $CI_YML." >&2
     echo "  Its formatting changed; fix the awk in this script rather than inlining a copy." >&2
@@ -196,6 +207,7 @@ fi
 # `eval`, so nothing in `ci.yml` can execute here.
 SELECTION="${TEMPLATE//\$SWEEP_FILTER/$SWEEPS}"
 SELECTION="${SELECTION//\$ORACLE_EXCLUDE/$EXCLUDE}"
+SELECTION="${SELECTION//\$CENSUS_FILTER/$CENSUSES}"
 
 # Refuse a selection still naming a variable. A new `$FOO` in that expression
 # would otherwise reach nextest literally -- which either errors obscurely or,
@@ -210,6 +222,7 @@ fi
 if [[ "${1:-}" == "--print-selection" ]]; then
     printf 'ORACLE_EXCLUDE=%s\n' "$EXCLUDE"
     printf 'SWEEP_FILTER=%s\n' "$SWEEPS"
+    printf 'CENSUS_FILTER=%s\n' "$CENSUSES"
     printf 'SELECTION=%s\n' "$SELECTION"
     for flag in "${FLAGS[@]}"; do printf 'FLAG=%s\n' "$flag"; done
     exit 0

--- a/tests/it/census_filter_invariant.rs
+++ b/tests/it/census_filter_invariant.rs
@@ -1,0 +1,248 @@
+//! Liveness check for the pairing between `CENSUS_FILTER` and the job that owns it.
+//!
+//! `ci.yml`'s `CENSUS_FILTER` names the slow census modules that moved off the
+//! `test` / `test-oracle` partitions and onto the optimized archive. `test` and
+//! `test-oracle` **negate** it; the `censuses` job **selects** on it, in two
+//! steps — one with the seam oracles armed, one without, because
+//! `spec_conformance_axis` may not be measured with `FERRO_ASSERT_IDEMPOTENT`
+//! set (it counts the very rows that oracle panics on).
+//!
+//! **The failure mode is the silent, flattering kind, and there are two of it.**
+//!
+//! A module named in `CENSUS_FILTER` but selected by *neither* step is negated
+//! everywhere and run **nowhere**. Nothing goes red. CI gets *faster*, which
+//! reads as the improvement this filter exists to deliver rather than as the
+//! coverage deletion it is. That is the same shape as `sweep_filter_invariant`'s
+//! unnamed-consumer case, and the same shape as #1460 / #1478, where a corpus
+//! that could not build a thing reported its absence as a zero.
+//!
+//! A module selected by a step but *not* named in `CENSUS_FILTER` fails the
+//! other way: it is not negated, so it runs in `censuses` **and** in the shard
+//! that hashes it, paying for it twice while looking like a carve-out.
+//!
+//! Neither is caught by the guards already in place. `--no-tests=fail` on each
+//! step catches a selection matching nothing, i.e. a rename that empties a whole
+//! step; it cannot see one module of three going missing. `CENSUS_FILTER`'s own
+//! comment records the partition against `test` / `test-oracle`, which is a
+//! claim about the negated side.
+//!
+//! Modelled on `sweep_filter_invariant.rs` and `oracle_exclude_invariant.rs`,
+//! which make the same class of silent config rot loud for the sweep-seed knob
+//! and the oracle exclusion.
+//!
+//! # Why this reads `ci.yml` itself rather than sharing a helper
+//!
+//! This is the third file in `tests/it/` to parse a folded scalar out of
+//! `ci.yml`, and the duplication is deliberate. These three are *liveness*
+//! guards: a bug in one shared extractor would neuter all three at once, and it
+//! would do so in the flattering direction — an extractor that silently returned
+//! an empty filter makes every one of them vacuous rather than red. Each guard
+//! asserts its own read is non-empty, so three independent readers are three
+//! independent chances to notice.
+
+use std::path::PathBuf;
+
+/// The workflow this file is entirely about.
+const CI_YML: &str = ".github/workflows/ci.yml";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn ci_text() -> String {
+    std::fs::read_to_string(repo_root().join(CI_YML)).expect("ci.yml is readable")
+}
+
+/// A `>-` folded scalar from `ci.yml`'s top-level `env:`, folded back to one line.
+///
+/// Reading only the first line would silently exempt whichever module happens to
+/// sit on a continuation line — and `CENSUS_FILTER` spans two, so a first-line
+/// read would exempt `spec_conformance_axis` specifically.
+fn ci_filter(key: &str) -> String {
+    let ci = ci_text();
+    let mut lines = ci.lines();
+    let header = lines
+        .by_ref()
+        .find(|line| line.trim_start().starts_with(&format!("{key}:")))
+        .unwrap_or_else(|| panic!("ci.yml defines {key}"));
+
+    // An inline value is returned rather than merely tolerated: a perfectly
+    // valid `CENSUS_FILTER: test(a) + test(b)` must not parse as empty and make
+    // every assertion below vacuous.
+    let inline = header
+        .split_once(':')
+        .map(|(_, value)| value.trim())
+        .unwrap_or_default();
+    if !inline.is_empty() && !inline.starts_with(['>', '|']) {
+        return inline.to_string();
+    }
+    assert!(
+        inline.starts_with(['>', '|']),
+        "{key} is neither a block scalar nor an inline value: {header:?}"
+    );
+
+    let key_indent = header.len() - header.trim_start().len();
+    let mut value = String::new();
+    for line in lines {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent <= key_indent {
+            break;
+        }
+        value.push(' ');
+        value.push_str(line.trim());
+    }
+    assert!(
+        !value.trim().is_empty(),
+        "{key} parsed as empty; ci.yml's formatting changed"
+    );
+    value
+}
+
+/// The body lines of one top-level job block, by its YAML key.
+///
+/// Blank and comment lines are kept, because they do not end a block — the
+/// `censuses` job's steps are separated by both, and a `take_while` that stopped
+/// at the first one would read only its first step and never see the second
+/// selection.
+fn job_lines(job: &str) -> Vec<String> {
+    let ci = ci_text();
+    let header = format!("  {job}:");
+    let mut lines = ci.lines().skip_while(|line| *line != header);
+    assert!(
+        lines.next().is_some(),
+        "ci.yml defines no `{job}` job; this guard cannot see what it runs"
+    );
+    lines
+        // A non-blank, non-comment line back at job-key indent ends the block.
+        .take_while(|line| {
+            line.starts_with("    ") || line.trim().is_empty() || line.trim_start().starts_with('#')
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+/// Every `-E "…"` selection a job hands to nextest, in file order.
+///
+/// Comment lines are dropped here rather than in [`job_lines`], so a `-E` that
+/// has been commented out is not counted as a live selection while still
+/// bounding the block correctly.
+fn selections_in(job: &str) -> Vec<String> {
+    job_lines(job)
+        .iter()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .filter_map(|line| {
+            let at = line.find("-E \"")? + "-E \"".len();
+            let rest = &line[at..];
+            rest.find('"').map(|end| rest[..end].to_string())
+        })
+        .collect()
+}
+
+/// Module names a nextest filter expression names via `test(...)`.
+fn modules_named_in(filter: &str) -> Vec<String> {
+    filter
+        .match_indices("test(")
+        .filter_map(|(at, _)| {
+            let rest = &filter[at + "test(".len()..];
+            rest.find(')').map(|end| rest[..end].trim().to_string())
+        })
+        .collect()
+}
+
+/// The `censuses` job must actually run every module the filter reserves for it.
+///
+/// Without this, a module dropped from the job's two steps — or renamed in one
+/// place and not the other — is negated by `test` and `test-oracle` and selected
+/// by nothing, so it runs in no job at all and CI reports a faster green run.
+#[test]
+fn every_module_named_in_the_census_filter_is_run_by_the_censuses_job() {
+    let named = modules_named_in(&ci_filter("CENSUS_FILTER"));
+    assert!(
+        !named.is_empty(),
+        "CENSUS_FILTER names no modules; its formatting changed and every \
+         assertion in this file would be vacuous"
+    );
+
+    let selections = selections_in("censuses");
+    assert!(
+        !selections.is_empty(),
+        "the `censuses` job passes no -E selection to nextest; its shape changed \
+         and this guard cannot see what it runs"
+    );
+    let selected: Vec<String> = selections
+        .iter()
+        .flat_map(|s| modules_named_in(s))
+        .collect();
+
+    let unrun: Vec<&String> = named.iter().filter(|m| !selected.contains(m)).collect();
+    assert!(
+        unrun.is_empty(),
+        "ci.yml's CENSUS_FILTER reserves these modules for the `censuses` job, but \
+         none of that job's steps selects them: {unrun:?}\n\
+         `test` and `test-oracle` negate CENSUS_FILTER, so a module here runs in NO \
+         job — CI stays green and gets faster, which is the coverage loss this \
+         guard exists to make loud.\n\
+         Either add them to a step's -E in the `censuses` job, or remove them from \
+         CENSUS_FILTER so the shards run them again."
+    );
+}
+
+/// …and it must run nothing else, or that module is paid for twice.
+///
+/// A step selecting a module absent from `CENSUS_FILTER` does not lose coverage
+/// — it duplicates it. The module still hashes into a `test` shard, so the
+/// carve-out adds a runner without removing any work, which is the opposite of
+/// what the job is for.
+#[test]
+fn the_censuses_job_runs_nothing_the_census_filter_does_not_reserve() {
+    let named = modules_named_in(&ci_filter("CENSUS_FILTER"));
+    let selected: Vec<String> = selections_in("censuses")
+        .iter()
+        .flat_map(|s| modules_named_in(s))
+        .collect();
+    assert!(
+        !selected.is_empty(),
+        "the `censuses` job selects no modules; its shape changed"
+    );
+
+    let unreserved: Vec<&String> = selected.iter().filter(|m| !named.contains(m)).collect();
+    assert!(
+        unreserved.is_empty(),
+        "the `censuses` job selects these modules, but CENSUS_FILTER does not \
+         name them: {unreserved:?}\n\
+         `test` and `test-oracle` negate CENSUS_FILTER, so anything missing from it \
+         still runs in whichever shard hashes it — these modules are being run \
+         twice, and the carve-out is costing a runner without saving one."
+    );
+}
+
+/// No module may be selected by both of the job's steps.
+///
+/// The two steps differ only in whether the seam oracles are armed, so a module
+/// in both runs its whole corpus twice inside one job — which is exactly the
+/// duplication the move was made to remove, relocated rather than removed.
+#[test]
+fn no_module_is_selected_by_both_of_the_jobs_steps() {
+    let selections = selections_in("censuses");
+    assert_eq!(
+        selections.len(),
+        2,
+        "the `censuses` job is documented as two steps — one with the seam oracles \
+         armed and one without, because spec_conformance_axis may not be measured \
+         with FERRO_ASSERT_IDEMPOTENT set. It now has {} selection(s); if that is \
+         deliberate, this guard needs updating along with the job's comment.",
+        selections.len()
+    );
+
+    let armed = modules_named_in(&selections[0]);
+    let unarmed = modules_named_in(&selections[1]);
+    let both: Vec<&String> = armed.iter().filter(|m| unarmed.contains(m)).collect();
+    assert!(
+        both.is_empty(),
+        "these modules are selected by BOTH of the `censuses` job's steps, so their \
+         corpora run twice in one job: {both:?}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -63,6 +63,7 @@ mod bulk_fixture_tests;
 mod case_harvest;
 mod cdot_coordinate_basis_layers;
 mod cds_utr3_crossing_shift_idempotency;
+mod census_filter_invariant;
 mod cis_adjudication_enumeration;
 mod cis_allele_confluence_proptest;
 mod cis_confluence_adjudication;

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -353,11 +353,12 @@ fn test_oracle_job_lines() -> Vec<String> {
 /// The complete `-E` expression `test-oracle` hands to nextest, with `ci.yml`'s
 /// two variable references expanded.
 ///
-/// The job negates three things — the proptest modules, `SWEEP_FILTER` and
-/// `ORACLE_EXCLUDE` — and the runner first shipped negating only the last of
-/// them, so a local "as CI runs it" also executed the proptest modules and the
-/// three exhaustive sweeps. Comparing only the exclusion could not see that,
-/// which is why the whole expression is compared here.
+/// The job negates four things — the proptest modules, `SWEEP_FILTER`,
+/// `ORACLE_EXCLUDE` and `CENSUS_FILTER` — and the runner first shipped negating
+/// only the second-to-last of them, so a local "as CI runs it" also executed the
+/// proptest modules and the three exhaustive sweeps. Comparing only the
+/// exclusion could not see that, which is why the whole expression is compared
+/// here.
 fn ci_oracle_selection() -> String {
     let template = test_oracle_job_lines()
         .iter()
@@ -370,7 +371,8 @@ fn ci_oracle_selection() -> String {
 
     let expanded = template
         .replace("$SWEEP_FILTER", ci_filter("SWEEP_FILTER").trim())
-        .replace("$ORACLE_EXCLUDE", ci_filter("ORACLE_EXCLUDE").trim());
+        .replace("$ORACLE_EXCLUDE", ci_filter("ORACLE_EXCLUDE").trim())
+        .replace("$CENSUS_FILTER", ci_filter("CENSUS_FILTER").trim());
     assert!(
         !expanded.contains('$'),
         "test-oracle's -E selection references a variable this test does not expand: {expanded}"


### PR DESCRIPTION
Closes #1955.

**Measured on this branch's own run, [31849010009](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31849010009) — 33/33 green. Workflow wall 491s -> 314s, a 36% cut, and the bottleneck has moved.** The measured table is at the bottom; the baseline throughout is run [31845625298](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31845625298).

## The measurement

`Test oracle (1/4)` is the whole workflow's critical path — 328s, finishing 83s after every other job — and its tail is two exhaustive censuses that #1840 added the day before, still on the debug archive.

```
     8 ->    134  ( 126s)  Spec fixtures and generated docs   <- gates the fan-out
     3 ->    119  ( 116s)  Build test archive
   156 ->    484  ( 328s)  Test oracle (1/4)                  <- critical path
   170 ->    401  ( 231s)  Test (3/6)
   487 ->    491  (   4s)  Test (aggregator)
```

Across every job they run in:

| total | where | test |
|---:|---|---|
| 396s | `Test (3/6)` 155.7s + `Test oracle (1/4)` 240.3s | `issue_1542_direction_symmetry::…shuffle_direction` |
| 338s | `Test` shards 2/3/4/5 | `spec_conformance_axis` (5 tests) |
| 432s | `Test` 1/3/5 119.3s + `Test oracle` 1/3 313.0s | `normalize_axis_preserving` (4 tests) |

`--partition hash:K/N` assigns by a hash of the test NAME, so it balances shard counts and is blind to cost. `Test oracle (1/4)` ran 697s of >=5s test work in 328s of wall — 2.1x effective concurrency, against 2.5x on shard 2/4. The tail runs alone with three idle cores, and a shard's wall can never fall below its slowest single test, so re-sharding cannot fix it.

The crowding is measurable on a test that did not change. `axis_is_preserved_over_the_cmrg_corpus` on oracle shard 1:

| run | base | cmrg |
|---|---|---:|
| 31839189774 | before #1840 | **79.0s** |
| 31839468759 | #1840's own merge group | **107.5s** |
| 31845625298 | current | **172.8s** |

It is 53.2s in the unarmed `Test (1/6)`. Both censuses and the cmrg corpus drive `rayon`, and nextest already runs ~4 tests concurrently on a 4-vCPU runner — so rayon inside a test adds no throughput, it oversubscribes.

## What this does

Adds `CENSUS_FILTER` and a `censuses` job on the **optimized** archive, exactly as `sweeps` was built. `test` and `test-oracle` negate the filter; `censuses` selects on it with `--no-tests=fail`.

This is not a new idea — `test-oracle`'s own comment named it and declined it:

> The robust alternative — giving `normalize_axis_preserving` a job of its own and negating it here — was not taken because this job's `-E` is re-derived by BOTH `scripts/run_oracle_suite.sh` and `tests/it/oracle_exclude_invariant.rs`, so a fourth negation term is a three-file change; the shard count is not.

The shard count was the cheaper fix and it did not hold. N=4 was chosen to separate the two bulk corpora; #1840 added a test, the hash re-rolled, and the job went back to 328s by a different draw. A negation is stable under a re-roll and a shard count is not, so the three-file change is now the right price. That comment is rewritten to record it.

**The job boundary is not the win — the archive is.** `sweeps` measured 7.6-8.7x moving work of exactly this shape onto `--cargo-profile soak`. A carve-out onto the debug archive would move the same 240s to a different runner and buy ~50s.

**Two steps, because the modules disagree about the oracles.**

- **Armed** (`issue_1542_direction_symmetry`, `normalize_axis_preserving`) runs what `test-oracle` ran — the same three flags, no fourth. An armed run strictly subsumes the un-armed one, which is the argument `sweeps` already makes, so dropping the plain-`test` copy loses nothing.
- **Un-armed** (`spec_conformance_axis`) reproduces the plain-`test` run exactly. That module is in `ORACLE_EXCLUDE` and stays there: it COUNTS the non-idempotent outputs `FERRO_ASSERT_IDEMPOTENT` panics on, and a panicking row is filed `declined` and never reaches the family's output set — which does not redden the census, it flatters it. It is in both filters deliberately; they answer different questions (*which instrument may be armed* vs *where a module runs*), and `oracle_exclude_invariant` demands the first.

`FERRO_ASSERT_SEQUENCE` is set by neither step, which is what makes this a move and not a change of instrument. `sweeps` does set it, so these modules could not simply be appended there.

## Verified

Selections partition exactly, over the soak archive's own binary (`--test it`, no `dev` feature — the archive `censuses` consumes):

```
base            6012   not test(proptest) and not (SWEEP_FILTER)
minus census    5999   … and not (CENSUS_FILTER)
census filter     13
  armed step       8
  unarmed step     5
5999 + 13 == 6012        nothing falls between the jobs, nothing runs twice
   8 +  5 == 13          both steps together cover the filter
```

All 13 resolve inside the soak archive, so none needed the `dev` feature and none had to be left behind.

`tests/it/census_filter_invariant.rs` (new) closes the two holes neither `--no-tests=fail` nor the partition comment can see: a module in `CENSUS_FILTER` that **no** step selects is negated everywhere and runs nowhere — CI stays green and gets *faster*, which reads as this PR working rather than as coverage deleted — and a module a step selects that the filter does not name runs twice. It also pins the job at two steps, so collapsing them would fail rather than silently arm `spec_conformance_axis`.

**Both steps pass under `--cargo-profile soak`, run exactly as the job runs them** — the armed one with the three `FERRO_ASSERT_*` flags, the un-armed one bare. `spec_conformance_axis`'s seventeen-field pins are green in both directions at `opt-level = 3`, which is the assertion that mattered: none of them moved.

```
armed    1 test  passed   issue_1542_direction_symmetry            7.9s
unarmed  5 tests passed   spec_conformance_axis                   30.3s  (28.9 / 30.3 for the two censuses)
```

**Do not read those as the CI projection** — this is a 12-core dev box against a 4-vCPU runner, and every one of these tests is rayon-parallel, so the ratio here flatters the move. They establish that the tests pass at `opt-level = 3` with the oracles armed, and nothing about how long CI will take. `normalize_axis_preserving`'s three corpus tests could not be run locally at all (the bulk fixtures are release assets and are absent here); CI is the first place they run on this branch.

15/15 green locally across the three CI-reading guards, including `oracle_exclude_invariant::the_local_oracle_runner_selects_exactly_what_ci_selects`, which is what proves the shell script and the Rust re-derivation agree on the new four-term expression. `cargo fmt`, `actionlint` and `zizmor` clean.

## Measured

Per test, baseline -> this run, each still under the flags it ran under before:

| test | before | after | |
|---|---:|---:|---:|
| `issue_1542_direction_symmetry` (armed) | 240.3s | **39.7s** | 6.1x |
| `spec_conformance_axis::three_prime_conformance_census` | 140.6s | **22.4s** | 6.3x |
| `spec_conformance_axis::five_prime_conformance_census` | 128.3s | **23.6s** | 5.4x |
| `normalize_axis_preserving::…cmrg_corpus` (armed) | 172.8s | **39.2s** | 4.4x |
| `normalize_axis_preserving::…clinvar_unique_corpus` (armed) | 99.3s | **33.7s** | 2.9x |

Per job:

| job | before | after |
|---|---:|---:|
| `Test oracle (1/4)` | 328s | **102s** |
| `Test (5/6)` | 189s | **62s** |
| `Test (3/6)` | 231s | **112s** |
| `Test (2/6)` | 203s | **90s** |
| `Test oracle (3/4)` | 160s | **105s** |
| `Slow censuses (optimized)` | — | **90s** (39.7 armed + 23.7 un-armed + ~27 setup) |
| **workflow wall** | **491s** | **314s** |

**The two shards that carried none of the moved tests are the control**: `Test oracle (4/4)` 149s -> 143s and `Test (6/6)` 87s -> 82s, i.e. ~5% run-to-run noise, against 20-70% on the shards that lost work. The run was not uniformly faster — `Build` went 213s -> 226s and `Build soak archive` 159s -> 192s — so the drops are attributable rather than ambient.

**The corpus tests really ran.** Zero `Skipping:` lines in the job log, `FERRO_REQUIRE_BULK_FIXTURES=1` set, and the 39.2s/33.7s timings are three orders of magnitude off a skip. `spec_conformance_axis`'s pins are green in both directions at `opt-level = 3`; none moved.

## The bottleneck moved, and it is not what the projection said

The projection had `Test (3/6)` as the next critical path at ~165s, bounded by `merge.rs`'s unit half of #1840's pair. **That is not what happened.** `Test (3/6)` came in at 112s, and the tail of the workflow is now entirely on the soak side:

```
     1 ->    193  ( 192s)  Build soak archive (optimized)   <- the new gate
   197 ->    307  ( 110s)  Exhaustive sweeps                <- the new critical path
   199 ->    289  (  90s)  Slow censuses (optimized)
   311 ->    314  (   3s)  Test (aggregator)
```

So the floor is now `test-build-soak` (192s of `opt-level = 3` compile, SHA-keyed and therefore a miss on every new commit) plus `sweeps` (110s) — about 305s, and this run came in at 314s. **The workflow is within ~10s of what its current job graph allows**, and nothing in the `test` / `test-oracle` fan-out is on the critical path any more.

Two consequences for what to do next, neither of which is in this PR:

- **`merge.rs`'s unit half is no longer the binding constraint.** It is still 149.6s in `Test (3/6)` and 95.8s in `Test oracle (3/4)`, but both jobs now finish 90s before the tail does, so moving it would buy nothing until the soak side moves first. It also still cannot move cheaply — `test-build-soak` archives `--test it` only, and `canonicalize_from_sequence_with_rule` / `partition_rule_from_env` / `PARTITION_RULE_NAMES` are private to `merge.rs`. Adding `--lib` to that archive is now *actively* the wrong move: it lengthens the very job that has become the gate.
- **The next real lever is the soak archive build itself**, which was 159s on the baseline and 192s here, and is on the critical path in a way it was not before this PR. Worth its own issue rather than a rider on this one.

**The fan-out gate improved for reasons unrelated to this PR** and should not be credited to it: `spec-fixtures` ran 126s -> 101s and `test-build` 116s -> 100s, so the shards started at ~105s instead of ~150s. That is ambient, and it is why the per-job control pairs above matter more than the headline number.

## The compile audit

Asked for alongside the wall-clock work: what does the fan-out recompile, and is any of it shareable? Measured on the same run, counting `Compiling`/`Checking` lines per job (after stripping ANSI — `CARGO_TERM_COLOR: always` means the naive `grep -c 'Compiling '` returns 0 on a job that compiled 316 crates).

**The fan-out recompiles nothing.** 19 of 33 jobs — all six `test` shards, all four `test-oracle`, all eight `soak`, and `sweeps` — compile zero crates; they consume prebuilt nextest archives. `censuses` joins them.

**Seven jobs compile, and each compiles `ferro-hgvs` exactly once.** `Swatinem/rust-cache` restores the dependency tree, so the count per job is 1 (7 in `spec-fixtures`, which builds seven generator targets):

| job | profile / features | `ferro-hgvs` |
|---|---|---:|
| Clippy | dev check, default | 53s |
| Clippy (all features) | dev check, all | 54s |
| Spec fixtures | dev, `dev` | 30s |
| Build test archive | test, `dev` | 82s |
| Python Wheel Test | release, `python` | 103s |
| Build soak archive | soak (`opt-level = 3`), default | 118s |
| Build | release clippy + test + release build | ~170s |

**There is no redundant recompilation to remove.** Those are seven different artifacts — profile x feature-set x target-kind — and no cache can share them. `sccache` does not help either: `ferro-hgvs` is a single crate, so any `src/` edit invalidates the whole entry, and the dependencies it would otherwise cache are the ones `rust-cache` already holds. `CARGO_INCREMENTAL` is a dead end for the same reason plus a second one — `rust-cache` deliberately deletes workspace artifacts, so incremental state never survives a job.

**Corrected after reading step timings rather than log lines.** An earlier revision of this section named `Build`'s `cargo clippy --release` as ~2m24s of duplicated work. It is **14s**. Two `Finished` lines in that job's log were mapped to the wrong steps; the GitHub step API is authoritative, and it reads:

| step | |
|---|---:|
| `cargo build --release` | **152s** |
| `cargo test --no-run --lib --bins` | 31s |
| `Swatinem/rust-cache` restore | 17s |
| `cargo clippy --release -- -D warnings` | **14s** |

So there is no meaningful clippy duplication to remove. The 152s is a genuine full-LTO link — `[profile.release]` sets `lto = true` and `codegen-units = 1` — and `Python Wheel Test` performs a second one (111s, `python` feature). Those are the two expensive compiles outside the archives, they are not duplicates of each other, and neither is on the critical path today (`Build` ends at 227s against a 314s wall).

Representation-Change: none. `.github/workflows/ci.yml`, `scripts/run_oracle_suite.sh` and two files under `tests/it/` only. No file under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`, `src/reference/` or `src/error_handling/` is touched, no test's body or assertions change, and no normalized output can move — every test named here runs the same corpus with the same flags, on a different runner and at a different `opt-level`.
