### PR TITLE
fix: allow ref span insertions when converting to SPDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a provider-backed path (`sequence_normalize`, `to_spdi`, `canonical_spdi`, apply-to-reference)
   needed its bases. It now reads those bases from the reference exactly as `del`/`dup`/`delins`
   read their omitted bases, so `sequence_normalize` re-derives the literal `g.100_101insCGTA…`
-  form. `delins` with a same-reference range insert is resolved on the same path.
+  form. `delins` with a same-reference range insert is resolved on the same path. The payload is
+  read on the **axis the description is written on**: a `c.` (and a coding `r.`) payload gets the
+  same `cds_start + N - 1` shift the location already gets, so `NM_000532.5:c.156_157ins180_188`
+  resolves to `insGCGAGGAAA` — the bases `normalize` names — rather than to the transcript-offset
+  span 36 bases 5' of it. `n.`/`g.`/`m.`/`o.` payloads are transcript/genomic offsets already and
+  are read unshifted.
 
 ## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Default::default()` was the only reachable constructor — the two documented knobs could not be
   set by any downstream caller.
 
+### Fixed
+
+- **Reference-span insertions are now resolved rather than refused.** An insertion whose bases are
+  named by position in the same reference — `g.100_101ins50_57`, and its inverted form
+  `g.100_101ins50_57inv` — was rejected as "insertion sequence is not a literal sequence" whenever
+  a provider-backed path (`sequence_normalize`, `to_spdi`, `canonical_spdi`, apply-to-reference)
+  needed its bases. It now reads those bases from the reference exactly as `del`/`dup`/`delins`
+  read their omitted bases, so `sequence_normalize` re-derives the literal `g.100_101insCGTA…`
+  form. `delins` with a same-reference range insert is resolved on the same path.
+
 ## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
 
 ### Representation changes

--- a/src/equivalence/key.rs
+++ b/src/equivalence/key.rs
@@ -191,10 +191,11 @@ impl Ord for SpdiKey {
 /// - **A stated deletion that disagrees with the reference** — the description
 ///   and the provider cannot both be right, and picking one would key the
 ///   variant off bases it does not describe.
-/// - **Edits SPDI cannot represent.** Inserted-range payloads
-///   (`g.10_11ins20_30`), uncertain or unspecified inserted lengths (`ins(10)`),
-///   named elements (`insAluYb8`), and intronic `c.`/`n.`/`r.` offsets, which
-///   SPDI has no notation for.
+/// - **Edits SPDI cannot represent.** Uncertain or unspecified inserted lengths
+///   (`ins(10)`), named elements (`insAluYb8`), and intronic `c.`/`n.`/`r.`
+///   offsets, which SPDI has no notation for. (A same-reference position-range
+///   insert — `g.10_11ins20_30`, `ins20_30inv` — *does* key: its bases are read
+///   from the reference exactly as `del`/`dup` read their omitted bases.)
 /// - **Reference bases the provider cannot serve** — an absent accession, or a
 ///   window it declines. A key derived from a truncated window is a *different*
 ///   key, not a smaller one.
@@ -404,7 +405,6 @@ mod tests {
                 "stated base disagrees with the reference",
             ),
             ("NC_ABSENT.1:g.3A>G", "the provider cannot serve the bases"),
-            ("NC_KEY.1:g.10_11ins20_30", "inserted-range payload"),
             ("NC_KEY.1:g.10_11ins(10)", "unspecified inserted length"),
         ] {
             assert_eq!(
@@ -440,6 +440,21 @@ mod tests {
     #[test]
     fn a_stated_insertion_order_still_keys() {
         assert!(key("NC_KEY.1:g.5_6insAC").is_some());
+    }
+
+    /// A same-reference position-range insert names its bases by position, so
+    /// once the provider resolves them (as `del`/`dup` resolve their omitted
+    /// bases) it keys off exactly those bases. The 40-base contig holds
+    /// `GGCATTAGCCT` at 9..=19, so `g.5_6ins9_19` and the literal spelling of
+    /// the same bases must reach one key.
+    #[test]
+    fn a_same_reference_range_insert_keys_off_its_resolved_bases() {
+        let ranged = key("NC_KEY.1:g.5_6ins9_19").expect("a resolvable range insert keys");
+        let literal = key("NC_KEY.1:g.5_6insGGCATTAGCCT").expect("the literal spelling keys");
+        assert_eq!(
+            ranged, literal,
+            "a range insert must key off the bases it names, not its spelling"
+        );
     }
 
     #[test]

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -3172,6 +3172,56 @@ mod tests {
         assert_eq!(spdi.insertion, "CGT");
     }
 
+    /// A same-reference position-range insertion (`ins{start}_{end}`) names its
+    /// inserted bases by position rather than spelling them, so `hgvs_to_spdi`
+    /// must read them from the reference — exactly as `del`/`dup` read their
+    /// omitted bases. On the `ACGT…` contig positions 5..=8 hold `ACGT`.
+    #[test]
+    fn a_reference_span_insertion_reads_its_bases_from_the_reference() {
+        let hgvs = parse_hgvs("NC_000001.11:g.10_11ins5_8").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &identity_provider()).unwrap();
+        // SPDI interbase position 10 sits AFTER 1-based base 10 (#390).
+        assert_eq!(spdi.position, 10);
+        assert_eq!(spdi.deletion, "");
+        assert_eq!(spdi.insertion, "ACGT");
+    }
+
+    /// The inverted form (`ins{start}_{end}inv`) inserts the reverse complement
+    /// of the named span. Positions 5..=7 hold `ACG`, whose reverse complement
+    /// is `CGT` (a non-palindromic span, so the inversion is observable).
+    #[test]
+    fn an_inverted_reference_span_insertion_reads_the_reverse_complement() {
+        let hgvs = parse_hgvs("NC_000001.11:g.10_11ins5_7inv").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &identity_provider()).unwrap();
+        assert_eq!(spdi.position, 10);
+        assert_eq!(spdi.deletion, "");
+        assert_eq!(spdi.insertion, "CGT");
+    }
+
+    /// A range insert names bases in the reference, so without a provider to
+    /// read them the conversion must decline rather than invent them.
+    #[test]
+    fn a_reference_span_insertion_without_a_provider_is_declined() {
+        let hgvs = parse_hgvs("NC_000001.11:g.10_11ins5_8").unwrap();
+        let result = hgvs_to_spdi_simple(&hgvs);
+        assert!(
+            matches!(result, Err(ConversionError::MissingReferenceData { .. })),
+            "a same-reference range insert cannot be resolved without a provider: {result:?}"
+        );
+    }
+
+    /// The `delins` arm resolves a same-reference range insert on the same path,
+    /// fetching both the deleted span and the inserted span from the reference.
+    /// del at 10..=12 is `CGT`; ins 5..=8 is `ACGT`.
+    #[test]
+    fn a_reference_span_delins_reads_both_spans_from_the_reference() {
+        let hgvs = parse_hgvs("NC_000001.11:g.10_12delins5_8").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &identity_provider()).unwrap();
+        assert_eq!(spdi.position, 9);
+        assert_eq!(spdi.deletion, "CGT");
+        assert_eq!(spdi.insertion, "ACGT");
+    }
+
     #[test]
     fn an_unspelled_identity_fetches_on_the_non_genomic_axes_too() {
         // The arm is shared by g./m./n./r./c., and the r. path additionally

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -86,6 +86,7 @@ use crate::hgvs::variant::{
     Accession, CdsVariant, CircularVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant,
     RnaVariant, TxVariant,
 };
+use crate::normalize::rules::InsCoordKind;
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
 use crate::sequence::reverse_complement;
@@ -241,19 +242,115 @@ fn position_range_insert(seq: &InsertedSequence) -> Option<(u64, u64, bool)> {
     }
 }
 
+/// Translate one insert-payload coordinate from the axis it is **written** on
+/// onto the transcript axis the SPDI is emitted on.
+///
+/// A payload position is spelled in the description's own coordinate system —
+/// `c.156_157ins180_188` names `c.180` through `c.188`, not transcript 180
+/// through 188 — while the accession this function's caller fetches against is
+/// the flat transcript. So on a CDS-relative axis the payload needs exactly the
+/// `cds_start + N - 1` shift [`resolve_cds_to_tx`] already applies to the
+/// *location*, and it is routed through the same [`CoordinateMapper::cds_to_tx`]
+/// so the two cannot drift apart (the property #390-follow-up / #944 established
+/// for `r.*N` and `c.*N`, and #1619's flat frame preserved).
+///
+/// Only plain positive positions arrive here: the `u64` `PositionRange` shape
+/// cannot carry a `-N`, `*N` or intronic offset — the parser lands those in
+/// `CdsPositionRange`, which this path does not accept.
+fn resolve_payload_position(
+    accession: &str,
+    transcript: &Transcript,
+    pos: u64,
+    coord: &str,
+) -> Result<u64, ConversionError> {
+    let base = i64::try_from(pos).map_err(|_| ConversionError::InvalidPosition {
+        description: format!(
+            "{coord}. insert payload position {pos} on {accession} exceeds the addressable range"
+        ),
+    })?;
+    let mapper = CoordinateMapper::new(transcript);
+    let tx = mapper.cds_to_tx(&CdsPos::new(base)).map_err(|e| {
+        ConversionError::MissingReferenceData {
+            description: format!(
+                "could not resolve {coord}. insert payload position {pos} on {accession} \
+                 to a transcript position: {e}"
+            ),
+        }
+    })?;
+    let one_based = ensure_positive_tx(tx.base, coord, pos)?;
+    if one_based > transcript.sequence_length() {
+        return Err(ConversionError::InvalidPosition {
+            description: format!(
+                "{coord}. insert payload position {pos} on {accession} resolves to transcript \
+                 base {one_based}, past the transcript 3' end (length {})",
+                transcript.sequence_length()
+            ),
+        });
+    }
+    Ok(one_based)
+}
+
+/// Translate an insert payload's `(start, end)` span onto the transcript axis,
+/// per the axis the enclosing description is written on.
+///
+/// `Direct` (`g.`/`m.`/`o.`/`n.`) passes the positions through unchanged — a
+/// genomic coordinate and a non-coding transcript coordinate are already offsets
+/// on the accession being fetched. `Cds` shifts through the transcript's CDS
+/// start. `Rna` follows the associated DNA numbering — CDS-relative on a coding
+/// transcript, transcript-relative on a non-coding one — which is the same split
+/// [`resolve_rna_pos`] makes for the *location*, so a payload and a location on
+/// one description are read in one frame.
+fn resolve_payload_span<P>(
+    accession: &str,
+    start: u64,
+    end: u64,
+    kind: InsCoordKind,
+    provider: &P,
+) -> Result<(u64, u64), ConversionError>
+where
+    P: ReferenceProvider + ?Sized,
+{
+    let coord = match kind {
+        InsCoordKind::Direct => return Ok((start, end)),
+        InsCoordKind::Cds => "c",
+        InsCoordKind::Rna => "r",
+    };
+    let transcript =
+        provider
+            .get_transcript(accession)
+            .map_err(|e| ConversionError::MissingReferenceData {
+                description: format!(
+                    "could not load transcript {accession} to resolve the {coord}. insert \
+                     payload {start}_{end}: {e}"
+                ),
+            })?;
+    // `r.` on a non-coding transcript has no CDS to be relative to, so its
+    // positions are already transcript offsets. Mirrors `resolve_rna_pos`.
+    if kind == InsCoordKind::Rna && transcript.cds_start.is_none() {
+        return Ok((start, end));
+    }
+    Ok((
+        resolve_payload_position(accession, &transcript, start, coord)?,
+        resolve_payload_position(accession, &transcript, end, coord)?,
+    ))
+}
+
 /// Resolve a same-reference position-range insert (`ins50_57`, `ins50_57inv`)
 /// to its literal bases by reading them from the reference, mirroring how the
 /// omitted bases of `del`/`dup`/`delins` are fetched.
 ///
-/// `start`/`end` are 1-based inclusive coordinates on `accession`; `invert`
-/// reverse-complements the slice (for the `…inv` form). Returns `Ok(None)` when
-/// `seq` is not a position-range insert, so the caller can fall back to literal
-/// handling. Returns an error when the shape is a range but no provider is
-/// available to read it, or the provider cannot serve the span.
+/// `start`/`end` are 1-based inclusive coordinates **in the enclosing
+/// description's own coordinate system**, translated onto the fetch axis by
+/// [`resolve_payload_span`] before the read; `invert` reverse-complements the
+/// slice (for the `…inv` form). Returns `Ok(None)` when `seq` is not a
+/// position-range insert, so the caller can fall back to literal handling.
+/// Returns an error when the shape is a range but no provider is available to
+/// read it, or the provider cannot serve the span.
 fn resolve_position_range_insert<P>(
     seq: &InsertedSequence,
     accession: &str,
     alphabet: AlphabetMode,
+    kind: InsCoordKind,
     provider: Option<&P>,
 ) -> Result<Option<String>, ConversionError>
 where
@@ -268,7 +365,8 @@ where
              a provider is required to read them"
         ),
     })?;
-    let bases = fetch_reference_bases(provider, accession, start, end)?;
+    let (fetch_start, fetch_end) = resolve_payload_span(accession, start, end, kind, provider)?;
+    let bases = fetch_reference_bases(provider, accession, fetch_start, fetch_end)?;
     let bases = if invert {
         reverse_complement(&bases)
     } else {
@@ -659,6 +757,7 @@ fn genome_to_spdi_simple(variant: &GenomeVariant) -> Result<SpdiVariant, Convers
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         None::<&dyn ReferenceProvider>,
     )
 }
@@ -701,6 +800,7 @@ fn mt_to_spdi_simple(variant: &MtVariant) -> Result<SpdiVariant, ConversionError
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         None::<&dyn ReferenceProvider>,
     )
 }
@@ -761,6 +861,7 @@ fn tx_to_spdi_simple(variant: &TxVariant) -> Result<SpdiVariant, ConversionError
         end_tx,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         None::<&dyn ReferenceProvider>,
     )
 }
@@ -781,6 +882,7 @@ fn rna_to_spdi_simple(variant: &RnaVariant) -> Result<SpdiVariant, ConversionErr
         end_pos,
         edit,
         AlphabetMode::Rna,
+        InsCoordKind::Rna,
         None::<&dyn ReferenceProvider>,
     )
 }
@@ -808,6 +910,7 @@ fn genome_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         Some(provider),
     )
 }
@@ -852,6 +955,7 @@ fn mt_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         Some(provider),
     )
 }
@@ -893,6 +997,7 @@ fn circular_to_spdi_simple(variant: &CircularVariant) -> Result<SpdiVariant, Con
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         None::<&dyn ReferenceProvider>,
     )
 }
@@ -937,6 +1042,7 @@ fn circular_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_pos,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         Some(provider),
     )
 }
@@ -966,6 +1072,7 @@ fn cds_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_tx,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Cds,
         Some(provider),
     )
 }
@@ -995,6 +1102,7 @@ fn tx_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_tx,
         edit,
         AlphabetMode::Dna,
+        InsCoordKind::Direct,
         Some(provider),
     )
 }
@@ -1024,6 +1132,7 @@ fn rna_to_spdi_with_provider<P: ReferenceProvider + ?Sized>(
         end_tx,
         edit,
         AlphabetMode::Rna,
+        InsCoordKind::Rna,
         Some(provider),
     )
 }
@@ -1621,6 +1730,7 @@ fn emit_spdi_for_edit<P>(
     end_one_based: u64,
     edit: &NaEdit,
     alphabet: AlphabetMode,
+    ins_coords: InsCoordKind,
     provider: Option<&P>,
 ) -> Result<SpdiVariant, ConversionError>
 where
@@ -1655,21 +1765,22 @@ where
             // SPDI cannot dereference), and shapes that *are* determinable but
             // are not expanded here yet (an exact `Repeat` such as `insA[10]`).
             // Both currently decline; only the first is a hard limit.
-            let ins_str =
-                match resolve_position_range_insert(inserted, &sequence, alphabet, provider)? {
-                    Some(resolved) => resolved,
-                    None => {
-                        let literal = inserted_sequence_to_string(inserted).ok_or_else(|| {
-                            ConversionError::MissingReferenceData {
-                                description: "insertion sequence is neither a literal sequence \
+            let ins_str = match resolve_position_range_insert(
+                inserted, &sequence, alphabet, ins_coords, provider,
+            )? {
+                Some(resolved) => resolved,
+                None => {
+                    let literal = inserted_sequence_to_string(inserted).ok_or_else(|| {
+                        ConversionError::MissingReferenceData {
+                            description: "insertion sequence is neither a literal sequence \
                                               nor a same-reference position range; this shape is \
                                               not yet encodable as SPDI"
-                                    .to_string(),
-                            }
-                        })?;
-                        apply_alphabet(&literal, alphabet)
-                    }
-                };
+                                .to_string(),
+                        }
+                    })?;
+                    apply_alphabet(&literal, alphabet)
+                }
+            };
             // SPDI is 0-based interbase: position N is the boundary
             // AFTER 1-based base N (equivalently between 1-based bases
             // N and N+1). For HGVS `g.{start}_{start+1}ins{seq}` the
@@ -1747,22 +1858,22 @@ where
             // `Repeat` such as `insA[10]`). Both decline as `UnsupportedEditType`
             // for now — matching the sibling arms — but only the first is a hard
             // limit.
-            let ins_str =
-                match resolve_position_range_insert(ins_seq, &sequence, alphabet, provider)? {
-                    Some(resolved) => resolved,
-                    None => {
-                        let literal = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
-                            ConversionError::UnsupportedEditType {
-                                description:
-                                    "delins inserted sequence is neither a literal sequence \
+            let ins_str = match resolve_position_range_insert(
+                ins_seq, &sequence, alphabet, ins_coords, provider,
+            )? {
+                Some(resolved) => resolved,
+                None => {
+                    let literal = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
+                        ConversionError::UnsupportedEditType {
+                            description: "delins inserted sequence is neither a literal sequence \
                                      nor a same-reference position range; this shape is not yet \
                                      encodable as SPDI"
-                                        .to_string(),
-                            }
-                        })?;
-                        apply_alphabet(&literal, alphabet)
-                    }
-                };
+                                .to_string(),
+                        }
+                    })?;
+                    apply_alphabet(&literal, alphabet)
+                }
+            };
             let del_str = match deleted {
                 Some(seq) => sequence_to_string(seq),
                 None => match provider {
@@ -4868,6 +4979,72 @@ mod tests {
         let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
         assert_eq!(spdi.position, 6);
         assert_eq!(spdi.insertion, "ATG");
+    }
+
+    // ----- position-range insert payloads are read on the DESCRIPTION'S axis --
+    //
+    // A payload span is spelled in the enclosing description's own coordinate
+    // system, so on `c.` (and on a coding `r.`) it needs the same
+    // `cds_start + N - 1` shift the *location* gets — and on `n.` it needs no
+    // shift at all. Reading it unshifted is a silent wrong-bases answer that no
+    // genomic test can see, because on `g.` the two frames coincide.
+    //
+    // `make_test_provider`'s `NM_TEST.1` has `cds_start = 6`, and tx 3..=5 reads
+    // `AAA` while tx 8..=10 (== `c.3_5`) reads `CCC`. Every assertion below is
+    // chosen so the shifted and unshifted answers differ.
+
+    #[test]
+    fn a_cds_axis_range_insert_reads_its_payload_on_the_cds_axis() {
+        let provider = make_test_provider();
+        let hgvs = parse_hgvs("NM_TEST.1:c.1_2ins3_5").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
+        // c.1_2 -> tx 6_7 -> SPDI interbase 6 (boundary AFTER 1-based 6; #390).
+        assert_eq!(spdi.position, 6);
+        assert_eq!(
+            spdi.insertion, "CCC",
+            "c.3_5 is tx 8..=10; reading tx 3..=5 unshifted would give AAA"
+        );
+    }
+
+    #[test]
+    fn a_cds_axis_range_delins_reads_its_payload_on_the_cds_axis() {
+        let provider = make_test_provider();
+        let hgvs = parse_hgvs("NM_TEST.1:c.1_3delins3_5").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
+        // c.1_3 -> tx 6_8 -> SPDI 5; the deleted bases are tx 6..=8 == TGC.
+        assert_eq!(spdi.position, 5);
+        assert_eq!(spdi.deletion, "TGC");
+        assert_eq!(
+            spdi.insertion, "CCC",
+            "the delins arm resolves its payload on the same axis as the ins arm"
+        );
+    }
+
+    #[test]
+    fn a_coding_rna_axis_range_insert_reads_its_payload_cds_relative() {
+        let provider = make_test_provider();
+        // On a coding transcript `r.N` denotes the same base as `c.N`, which
+        // `resolve_rna_pos` already honours for the location. The payload must
+        // agree, or one description is read in two frames.
+        let hgvs = parse_hgvs("NM_TEST.1:r.1_2ins3_5").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
+        assert_eq!(spdi.position, 6);
+        assert_eq!(spdi.insertion, "CCC");
+    }
+
+    #[test]
+    fn a_noncoding_axis_range_insert_reads_its_payload_unshifted() {
+        let provider = make_test_provider();
+        // The negative control: `n.` positions ARE transcript offsets, so the
+        // same payload spelling must read different bases from the `c.` case
+        // above. Without this the fix could be a blanket shift and still pass.
+        let hgvs = parse_hgvs("NM_TEST.1:n.1_2ins3_5").unwrap();
+        let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
+        assert_eq!(spdi.position, 1);
+        assert_eq!(
+            spdi.insertion, "AAA",
+            "n.3_5 is tx 3..=5; shifting it by cds_start would give CCC"
+        );
     }
 
     #[test]

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1655,13 +1655,11 @@ where
             // SPDI cannot dereference), and shapes that *are* determinable but
             // are not expanded here yet (an exact `Repeat` such as `insA[10]`).
             // Both currently decline; only the first is a hard limit.
-            let ins_str = match resolve_position_range_insert(
-                inserted, &sequence, alphabet, provider,
-            )? {
-                Some(resolved) => resolved,
-                None => {
-                    let literal =
-                        inserted_sequence_to_string(inserted).ok_or_else(|| {
+            let ins_str =
+                match resolve_position_range_insert(inserted, &sequence, alphabet, provider)? {
+                    Some(resolved) => resolved,
+                    None => {
+                        let literal = inserted_sequence_to_string(inserted).ok_or_else(|| {
                             ConversionError::MissingReferenceData {
                                 description: "insertion sequence is neither a literal sequence \
                                               nor a same-reference position range; this shape is \
@@ -1669,21 +1667,16 @@ where
                                     .to_string(),
                             }
                         })?;
-                    apply_alphabet(&literal, alphabet)
-                }
-            };
+                        apply_alphabet(&literal, alphabet)
+                    }
+                };
             // SPDI is 0-based interbase: position N is the boundary
             // AFTER 1-based base N (equivalently between 1-based bases
             // N and N+1). For HGVS `g.{start}_{start+1}ins{seq}` the
             // matching SPDI position is `start_one_based` directly
             // (NOT the -1 conversion used for substitution/deletion,
             // which references a specific base). Closes #390 item 1.
-            Ok(SpdiVariant::new(
-                sequence,
-                start_one_based,
-                "",
-                ins_str,
-            ))
+            Ok(SpdiVariant::new(sequence, start_one_based, "", ins_str))
         }
         NaEdit::Duplication {
             sequence: dup_seq, ..
@@ -1754,13 +1747,11 @@ where
             // `Repeat` such as `insA[10]`). Both decline as `UnsupportedEditType`
             // for now — matching the sibling arms — but only the first is a hard
             // limit.
-            let ins_str = match resolve_position_range_insert(
-                ins_seq, &sequence, alphabet, provider,
-            )? {
-                Some(resolved) => resolved,
-                None => {
-                    let literal =
-                        inserted_sequence_to_string(ins_seq).ok_or_else(|| {
+            let ins_str =
+                match resolve_position_range_insert(ins_seq, &sequence, alphabet, provider)? {
+                    Some(resolved) => resolved,
+                    None => {
+                        let literal = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
                             ConversionError::UnsupportedEditType {
                                 description:
                                     "delins inserted sequence is neither a literal sequence \
@@ -1769,9 +1760,9 @@ where
                                         .to_string(),
                             }
                         })?;
-                    apply_alphabet(&literal, alphabet)
-                }
-            };
+                        apply_alphabet(&literal, alphabet)
+                    }
+                };
             let del_str = match deleted {
                 Some(seq) => sequence_to_string(seq),
                 None => match provider {

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -218,6 +218,65 @@ fn inserted_sequence_to_string(seq: &InsertedSequence) -> Option<String> {
     }
 }
 
+/// A same-reference position-range insert, decomposed to `(start, end, invert)`
+/// 1-based inclusive coordinates, or `None` when `seq` is not one.
+///
+/// Recognises the bare `PositionRange`/`PositionRangeInv` variants and the
+/// single-part `Complex([PositionRange | PositionRangeInv])` shape the parser
+/// produces for range inserts — both denote one contiguous slice of the same
+/// accession. Multi-part `Complex` payloads, external references and every
+/// non-range variant return `None`, so the caller keeps its existing handling
+/// for them.
+fn position_range_insert(seq: &InsertedSequence) -> Option<(u64, u64, bool)> {
+    use crate::hgvs::edit::InsertedPart;
+    match seq {
+        InsertedSequence::PositionRange { start, end } => Some((*start, *end, false)),
+        InsertedSequence::PositionRangeInv { start, end } => Some((*start, *end, true)),
+        InsertedSequence::Complex(parts) => match parts.as_slice() {
+            [InsertedPart::PositionRange { start, end }] => Some((*start, *end, false)),
+            [InsertedPart::PositionRangeInv { start, end }] => Some((*start, *end, true)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Resolve a same-reference position-range insert (`ins50_57`, `ins50_57inv`)
+/// to its literal bases by reading them from the reference, mirroring how the
+/// omitted bases of `del`/`dup`/`delins` are fetched.
+///
+/// `start`/`end` are 1-based inclusive coordinates on `accession`; `invert`
+/// reverse-complements the slice (for the `…inv` form). Returns `Ok(None)` when
+/// `seq` is not a position-range insert, so the caller can fall back to literal
+/// handling. Returns an error when the shape is a range but no provider is
+/// available to read it, or the provider cannot serve the span.
+fn resolve_position_range_insert<P>(
+    seq: &InsertedSequence,
+    accession: &str,
+    alphabet: AlphabetMode,
+    provider: Option<&P>,
+) -> Result<Option<String>, ConversionError>
+where
+    P: ReferenceProvider + ?Sized,
+{
+    let Some((start, end, invert)) = position_range_insert(seq) else {
+        return Ok(None);
+    };
+    let provider = provider.ok_or_else(|| ConversionError::MissingReferenceData {
+        description: format!(
+            "position-range insertion {start}_{end} names bases in the same reference; \
+             a provider is required to read them"
+        ),
+    })?;
+    let bases = fetch_reference_bases(provider, accession, start, end)?;
+    let bases = if invert {
+        reverse_complement(&bases)
+    } else {
+        bases
+    };
+    Ok(Some(apply_alphabet(&bases, alphabet)))
+}
+
 /// Helper to get start position from an interval.
 fn get_start_pos(interval: &Interval<GenomePos>) -> Option<u64> {
     interval.start.inner().map(|p| p.base)
@@ -1585,11 +1644,34 @@ where
             apply_alphabet(&alternative.to_string(), alphabet),
         )),
         NaEdit::Insertion { sequence: inserted } => {
-            let ins_str = inserted_sequence_to_string(inserted).ok_or_else(|| {
-                ConversionError::MissingReferenceData {
-                    description: "insertion sequence is not a literal sequence".to_string(),
+            // An inserted sequence reaches SPDI when its exact bases are known.
+            // Two shapes are handled here: a literal, and a same-reference range
+            // insert (`ins50_57`, `ins50_57inv`), which is resolved from the
+            // reference first — exactly as `del`/`dup` resolve their omitted
+            // bases — before falling back to the literal path. The fallback
+            // rejects everything else, which is a mix of two cases: shapes whose
+            // bases are genuinely undetermined (`Count` `ins10`, `Range`
+            // `ins(10_20)`, `Uncertain` `ins(?)`, and named/external references
+            // SPDI cannot dereference), and shapes that *are* determinable but
+            // are not expanded here yet (an exact `Repeat` such as `insA[10]`).
+            // Both currently decline; only the first is a hard limit.
+            let ins_str = match resolve_position_range_insert(
+                inserted, &sequence, alphabet, provider,
+            )? {
+                Some(resolved) => resolved,
+                None => {
+                    let literal =
+                        inserted_sequence_to_string(inserted).ok_or_else(|| {
+                            ConversionError::MissingReferenceData {
+                                description: "insertion sequence is neither a literal sequence \
+                                              nor a same-reference position range; this shape is \
+                                              not yet encodable as SPDI"
+                                    .to_string(),
+                            }
+                        })?;
+                    apply_alphabet(&literal, alphabet)
                 }
-            })?;
+            };
             // SPDI is 0-based interbase: position N is the boundary
             // AFTER 1-based base N (equivalently between 1-based bases
             // N and N+1). For HGVS `g.{start}_{start+1}ins{seq}` the
@@ -1600,7 +1682,7 @@ where
                 sequence,
                 start_one_based,
                 "",
-                apply_alphabet(&ins_str, alphabet),
+                ins_str,
             ))
         }
         NaEdit::Duplication {
@@ -1660,19 +1742,36 @@ where
             deleted_length: _,
             substitution_reference: None,
         } => {
-            // Closes #394 item 3. Non-literal delins inserted sequences
-            // (any `InsertedSequence` variant other than `Literal`) are
-            // a shape SPDI cannot encode, not a missing-reference
-            // problem. Matches the sibling arms for Repeat / Inversion /
-            // Conversion which already use `UnsupportedEditType` for the
-            // same category.
-            let ins_str = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
-                ConversionError::UnsupportedEditType {
-                    description: "delins inserted sequence is not a literal sequence; \
-                                  non-literal inserts cannot be encoded as SPDI"
-                        .to_string(),
+            // Closes #394 item 3. An inserted sequence reaches SPDI when its
+            // exact bases are known. Two shapes are handled: a literal, and a
+            // same-reference position-range insert (`delins50_57`,
+            // `delins50_57inv`), resolved from the reference exactly as
+            // `del`/`dup` resolve their omitted bases. The fallback rejects
+            // everything else, which is a mix: shapes whose bases are genuinely
+            // undetermined (`Count` `ins10`, `Range` `ins(10_20)`, `Uncertain`,
+            // and named/external references SPDI cannot dereference), and shapes
+            // that *are* determinable but are not expanded here yet (an exact
+            // `Repeat` such as `insA[10]`). Both decline as `UnsupportedEditType`
+            // for now — matching the sibling arms — but only the first is a hard
+            // limit.
+            let ins_str = match resolve_position_range_insert(
+                ins_seq, &sequence, alphabet, provider,
+            )? {
+                Some(resolved) => resolved,
+                None => {
+                    let literal =
+                        inserted_sequence_to_string(ins_seq).ok_or_else(|| {
+                            ConversionError::UnsupportedEditType {
+                                description:
+                                    "delins inserted sequence is neither a literal sequence \
+                                     nor a same-reference position range; this shape is not yet \
+                                     encodable as SPDI"
+                                        .to_string(),
+                            }
+                        })?;
+                    apply_alphabet(&literal, alphabet)
                 }
-            })?;
+            };
             let del_str = match deleted {
                 Some(seq) => sequence_to_string(seq),
                 None => match provider {
@@ -1690,7 +1789,7 @@ where
                 sequence,
                 spdi_pos,
                 apply_alphabet(&del_str, alphabet),
-                apply_alphabet(&ins_str, alphabet),
+                ins_str,
             ))
         }
         NaEdit::Identity {

--- a/tests/it/sequence_normalize.rs
+++ b/tests/it/sequence_normalize.rs
@@ -177,3 +177,52 @@ fn an_unbounded_interior_tract_is_declined() {
         "the refusal must name the unsettled side: {msg}",
     );
 }
+
+/// A reference-span insertion (`ins{start}_{end}`) names its inserted bases by
+/// position in the same reference rather than spelling them. `sequence_normalize`
+/// reads the reference, so it must resolve those bases and re-derive the literal
+/// description — closing the gap where a range insert was refused as "not a
+/// literal sequence".
+#[test]
+fn a_reference_span_insertion_resolves_to_its_literal_bases() {
+    // 1-based:  1234567890123456789012
+    //           AAAACGTAAAAATTTTGGGGCC
+    // Positions 5..=8 carry "CGTA"; the insertion site (12_13) sits in unique
+    // flanking sequence so the re-derived description cannot shuffle.
+    let seq = "AAAACGTAAAAATTTTGGGGCC";
+    let nz = Normalizer::new(provider(seq));
+
+    assert_eq!(
+        seqnorm(
+            &nz,
+            "NC_TEST.1:g.12_13ins5_8",
+            ShuffleDirection::ThreePrime,
+            false,
+        ),
+        "NC_TEST.1:g.12_13insCGTA",
+        "a reference-span insertion must resolve to the bases it names",
+    );
+}
+
+/// The inverted form (`ins{start}_{end}inv`) inserts the reverse complement of
+/// the named span.
+#[test]
+fn an_inverted_reference_span_insertion_resolves_to_the_reverse_complement() {
+    let seq = "AAAACGTAAAAATTTTGGGGCC";
+    let nz = Normalizer::new(provider(seq));
+
+    // Positions 5..=8 are "CGTA"; reverse complement is "TACG". Inserting it at
+    // 12_13 lands in a run that lets the derivation shuffle 3' to the equivalent
+    // canonical `g.13_14insACGT` — the point pinned here is that the range insert
+    // is resolved to its literal bases at all, not refused.
+    assert_eq!(
+        seqnorm(
+            &nz,
+            "NC_TEST.1:g.12_13ins5_8inv",
+            ShuffleDirection::ThreePrime,
+            false,
+        ),
+        "NC_TEST.1:g.13_14insACGT",
+        "an inverted reference-span insertion must resolve to the reverse complement",
+    );
+}


### PR DESCRIPTION
### Summary

Resolves a same-reference position-range insertion (`g.100_101ins50_57`, its `inv` and `delins` spellings) to its literal bases when converting to SPDI, instead of refusing it as "not a literal sequence".

### Attribution

Authored by **Tim Dunn** (@TimD1). This branch reproduces the work of #1933 on a fresh branch under `origin`, because `maintainerCanModify` is `false` on the original and it could not be updated in place. Authorship is preserved on every commit; only the committer differs.

Stacked on #1965 (`td/td_add-sequence-normalize-helper`), mirroring the original stack.

### Adaptation by us

One commit of ours, `fix(spdi): read a range-insert payload on the description's own axis`.

`resolve_position_range_insert` passed the payload's raw coordinates to `fetch_reference_bases`, which reads offsets off the accession with no CDS shift — but by the time that arm runs, a `c.` (or coding `r.`) *location* has already been through `resolve_cds_to_tx` / `resolve_rna_pos`, so the SPDI is emitted on the flat transcript. The payload was therefore read `cds_start - 1` bases 5' of what it names. Measured against the prepared reference on `NM_000532.5` (`cds_start = 37`):

```
NG_008939.1(NM_000532.5):c.156_157ins180_188
  normalize     -> c.156_157insGCGAGGAAA        (transcript 216..=224)
  hgvs_to_spdi  -> NM_000532.5:192::GGGAGGGGG   (transcript 180..=188)  <- wrong
```

`g.`/`m.`/`o.`/`n.` were unaffected, because their positions already are offsets on the accession being fetched — which is why the genomic tests that shipped with the change could not see it. The payload span is now translated through the same `CoordinateMapper::cds_to_tx` the location uses, with `Rna` resolved coding-aware exactly as `resolve_rna_pos` does. Four hermetic regression tests cover the axis, including an `n.` negative control that fails if the translation is applied as a blanket shift; all four were verified to fail against the unfixed helper.

### Notes

Representation-Change: a same-reference position-range insert (`g.100_101ins50_57`, its `inv` and `delins` spellings, and the single-part bracketed form) now resolves to its literal bases through `hgvs_to_spdi` instead of being refused.
  No normalized HGVS string moves — nothing under `src/normalize/` reaches `src/spdi/convert.rs`, and the normalizer already expanded these payloads through `rules::expand_inserted_sequence`; what changes is which descriptions are convertible, not what a convertible one converts to. On the `c.` and `r.` axes the payload span is resolved through the same coordinate mapping as the location, so a coding-axis range insert names the bases it says it does.
  18 of the 9,949,738 rows across the four release-asset corpora carry the shape. Every affected input was previously rejected, so no consumer holds a stored old value; the visible consequence is those rows leaving `unkeyable` for a `group_by_spdi_key` bucket.
