### PR TITLE
test(spdi): pin the flush-insertion rule against a deletion and an inversion

### DIFF
--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -1574,4 +1574,51 @@ mod tests {
              the `r.` member is what selects `AlphabetMode::Rna`"
         );
     }
+    /// The flush rule is geometric, not kind-specific: an insertion at the 5'
+    /// edge of a **deletion** or an **inversion** composes as cleanly as the one
+    /// against a substitution pinned in `issue_1831_applier_member_order`, because the edit 3' of the junction is
+    /// applied first and the zero-width insertion then lands exactly at the
+    /// span's start rather than inside it.
+    ///
+    /// Bases 11-13 of the fixture are `CAT`. `g.11_13del` removes them, so the
+    /// window `CAT` becomes just the inserted `AC`; `g.11_13inv` reverses `CAT`
+    /// to `ATG`, so the window becomes `AC` + `ATG`. Both spellings of each
+    /// allele give one sequence — the tie-break sorts by deletion width, not
+    /// input order — so this asserts every member ordering, the property that
+    /// would regress first if the sort key changed.
+    #[test]
+    fn an_insertion_flush_against_a_deletion_or_inversion_applies() {
+        for (descriptor, resulting) in [
+            ("NC_KEY.1:g.[10_11insAC;11_13del]", "AC"),
+            ("NC_KEY.1:g.[11_13del;10_11insAC]", "AC"),
+            ("NC_KEY.1:g.[10_11insAC;11_13inv]", "ACATG"),
+            ("NC_KEY.1:g.[11_13inv;10_11insAC]", "ACATG"),
+        ] {
+            let variant = parse_hgvs(descriptor).expect("fixture must parse");
+            let applied = apply_to_reference(&variant, &provider())
+                .unwrap_or_else(|e| panic!("`{descriptor}` must apply: {e}"));
+            assert_eq!(applied.start, 10, "0-based interbase start of base 11");
+            assert_eq!(applied.reference, "CAT", "bases 11-13 of the fixture");
+            assert_eq!(
+                applied.resulting, resulting,
+                "`{descriptor}`: the insertion lands 5' of the span, which then \
+                 rewrites its own bases"
+            );
+        }
+    }
+
+    /// The interior rule holds for an inversion just as it does for a deletion:
+    /// an insertion whose junction falls *inside* the reversed span has no
+    /// defined position and is declined.
+    ///
+    /// `g.11_12insAC` sits at the junction 11|12, interior to `g.10_13inv`
+    /// (bases 10-13), so the pair denotes no single sequence.
+    #[test]
+    fn an_insertion_interior_to_an_inversion_declines() {
+        let variant = parse_hgvs("NC_KEY.1:g.[10_13inv;11_12insAC]").expect("must parse");
+        assert!(
+            apply_to_reference(&variant, &provider()).is_err(),
+            "an insertion interior to an inversion has no single resulting sequence"
+        );
+    }
 }


### PR DESCRIPTION
### Summary

Pins the applier's flush-insertion rule against a **deletion** and an **inversion**, and the interior-inversion refusal — coverage for behaviour `main` already has.

### Attribution

Authored by **Tim Dunn** (@TimD1), lifted from #1942 (`f3d382b4`). Authorship is preserved on the commit; only the committer differs.

### Why this is split out of #1942

#1942 was written against a base that did not yet contain #1837, which landed on `main` about seven hours later and fixed the same defect (#1831) by a different mechanism. Its premise — that these shapes "were declined as an overlapping-member conflict" — is **no longer true against current `main`**.

That was measured, not inferred. Both of #1942's test functions were applied verbatim to unmodified `origin/main` with **none** of its source changes, and both pass:

```
PASS  spdi::apply::tests::an_insertion_interior_to_an_inversion_declines
PASS  spdi::apply::tests::an_insertion_flush_against_a_deletion_or_inversion_applies
2 tests run: 2 passed
```

The passing function carries all four cases — deletion and inversion, in both member orders — each asserting on `applied.resulting`, and the fixture was checked first so the expected `ACATG` could genuinely fail (`NC_KEY.1` bases 11–13 are `CAT`, reverse-complement `ATG`).

So #1942 had no behavioural delta left, only two contributions: this test coverage, which `#1837` delivered but never pinned, and the replacement of `triples_are_disjoint` with an inline watermark. The former is here; the latter is deferred to **#1749**, where "one overlap definition" is the actual open question, rather than riding along inside a bugfix.

### Adaptation by us

The commit could not be cherry-picked: `f3d382b4` also carries a rustfmt reflow of `sort_by_key` from one line to five, which current `main` already has byte-for-byte at both call sites, so the hunk is redundant and its context no longer matches. The two test functions were taken verbatim instead and committed with `--author` preserving Tim Dunn.

One clause of the doc comment was adjusted: it referred to a sibling test as "above" that exists only in #1942's *other* commit, and `main`'s `apply.rs` has no flush-vs-substitution test at all. It now names `issue_1831_applier_member_order`, where that case actually lives. Keeping it verbatim would have shipped a pointer to nothing.

The change is test-only, established mechanically rather than by eye: `mod tests` begins at line 1119 and the sole added hunk is lines 1577–1623.

### Notes

Representation-Change: none. Both assertions already hold on `main` — #1837 delivered the behaviour and never pinned it — so no input produces a different description; this adds the missing coverage for the inversion case and the interior-inversion refusal.
