### PR TITLE
fix(normalize): re-present a contig-start insertion instead of refusing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose bases are genuinely undetermined — an uncertain or range repeat count, a CDS position range
   carrying intronic offsets, or an external reference SPDI cannot dereference — still declines the
   whole insert.
+- **A `from_sequences` derivation whose insertion rolls to the contig's first base is now
+  re-anchored rather than refused.** When the observed window begins at position 1 — a variant
+  anchored at `1A>C`/`1A>T`, say — the 5'-shuffle can roll a pure insertion in an ambiguous run
+  onto interbase 0, whose only HGVS spelling names position 0, a base that does not exist. Because
+  the window already starts at the accession's first base, `sequence_normalize` cannot widen the 5'
+  flank to escape it, so these derivations were dropped with "the derivation places an inserted
+  payload immediately 5' of the window's first base". Interbase 0 and interbase 1 denote the same
+  sequence whenever the payload's leading base equals the terminal base (the insertion sits in a
+  run reaching the terminus), so the insertion is now presented at the leftmost *nameable*
+  interbase — `1_2ins…`, the payload rotated one base — which is the terminal analogue of the
+  3'-most rule. A payload that genuinely cannot cross the first base still refuses, since it names a
+  sequence no in-window placement does.
 
 ## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,16 +122,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole insert.
 - **A `from_sequences` derivation whose insertion rolls to the contig's first base is now
   re-anchored rather than refused.** When the observed window begins at position 1 — a variant
-  anchored at `1A>C`/`1A>T`, say — the 5'-shuffle can roll a pure insertion in an ambiguous run
-  onto interbase 0, whose only HGVS spelling names position 0, a base that does not exist. Because
-  the window already starts at the accession's first base, `sequence_normalize` cannot widen the 5'
-  flank to escape it, so these derivations were dropped with "the derivation places an inserted
-  payload immediately 5' of the window's first base". Interbase 0 and interbase 1 denote the same
-  sequence whenever the payload's leading base equals the terminal base (the insertion sits in a
-  run reaching the terminus), so the insertion is now presented at the leftmost *nameable*
-  interbase — `1_2ins…`, the payload rotated one base — which is the terminal analogue of the
-  3'-most rule. A payload that genuinely cannot cross the first base still refuses, since it names a
-  sequence no in-window placement does.
+  anchored at `1A>C`/`1A>T`, say — the 5'-shuffle can roll a pure insertion onto interbase 0, whose
+  only HGVS spelling names position 0, a base that does not exist. Because the window already starts
+  at the accession's first base, `sequence_normalize` cannot widen the 5' flank to escape it, so
+  these derivations were dropped with "the derivation places an inserted payload immediately 5' of
+  the window's first base". There are now two escapes, one per shape:
+  - **The insertion crosses the terminal base unchanged** (an ambiguous run reaching the terminus,
+    base 1 itself not changed): it is presented at the leftmost *nameable* interbase — `1_2ins…`,
+    the payload rotated one base — the terminal analogue of the 3'-most rule.
+  - **Base 1 is itself rewritten** (a dense substitution stack, the primer/adapter-artifact shape):
+    the leading insertion is folded rightward into a single span anchored at base 1, so
+    `g.[1A>C;2T>A;3G>T]` derives to `g.1_3inv` (the span is a reverse complement) and
+    `g.[1G>C;2T>A;3G>T]` to `g.1_3delinsCAT`. This is the span form Mutalyzer emits for the same
+    inputs (`g.1_5delinsCAAGA`, `g.1_3inv`), reached without needing an interbase 5' of position 1.
+
+  A pure insertion genuinely *before* base 1 with no piece to fold into still refuses, since it
+  names a sequence no in-window placement does.
 
 ## [0.13.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.13.0...v0.13.1) - 2026-08-08
 

--- a/src/normalize/from_sequences.rs
+++ b/src/normalize/from_sequences.rs
@@ -1131,13 +1131,44 @@ mod tests {
         assert_eq!(derived.to_string(), "NC_TEST.1:g.1_2insTA");
     }
 
-    /// The escape is not a blanket amnesty for interbase 0: a payload that
-    /// cannot cross the terminal base (`alt[0] != reference[0]`) is genuinely an
-    /// insertion *before* base 1, denoting a sequence no other placement does,
-    /// and still refuses with the 5'-anchor message. Here a leading `G` sits
-    /// before a `C`, so there is no run to shuffle along.
+    /// **Case (1) with a neighbour**, which every other contig-start fixture
+    /// here lacks: they all drive a *lone* insertion, so none of them can
+    /// observe what the escape does to the piece list beside it.
+    ///
+    /// `ACG` -> `AACT` is the tightest reachable shape. The partition is one
+    /// inserted `A` plus a substitution at base 3; the 5'-shuffle rolls the
+    /// insertion off interbase 1 onto interbase 0 (legal, `alt[0] ==
+    /// reference[0]`), so case (1) fires and re-presents it at interbase 1 —
+    /// where it renders as `1dup`, the payload being a copy of base 1 — with
+    /// `3G>T` still standing beside it.
+    ///
+    /// What this pins is that the escape leaves the piece list in the shape
+    /// `coalesce_adjacent_pieces` and `shrink_pieces_to_differences` had put it
+    /// in. `verify_round_trip` cannot: it re-applies the members and compares
+    /// *bases*, and an un-coalesced pair re-applies to `AACT` exactly as a
+    /// coalesced one does. Shape is not a question it asks.
     #[test]
-    fn a_contig_start_insertion_that_cannot_cross_the_terminus_still_refuses() {
+    fn a_contig_start_escape_keeps_its_neighbour_separate() {
+        let derived = from_sequences(
+            "NC_TEST.1",
+            1,
+            "ACG",
+            "AACT",
+            &FromSequencesOptions::default().with_direction(ShuffleDirection::FivePrime),
+        )
+        .expect("the run insertion escapes to interbase 1 rather than refusing");
+        assert_eq!(derived.to_string(), "NC_TEST.1:g.[1dup;3G>T]");
+    }
+
+    /// A pure insertion before base 1 with **no piece to fold into** is a
+    /// genuine insertion at a non-existent anchor and still refuses. Here the
+    /// whole block is a single inserted `G` (`CATATG` -> `GCATATG` share the
+    /// suffix `CATATG`), so there is no following delins to absorb it, and the
+    /// leading base is not itself rewritten — the span-form escape does not
+    /// apply. The base-1-rewriting span form is covered in the
+    /// `sequence_normalize` integration suite, which drives this same path.
+    #[test]
+    fn a_lone_contig_start_insertion_still_refuses() {
         let err = from_sequences(
             "NC_TEST.1",
             1,

--- a/src/normalize/from_sequences.rs
+++ b/src/normalize/from_sequences.rs
@@ -1109,6 +1109,49 @@ mod tests {
         assert!(d.placement_bounded_by_window(), "OR must hold");
     }
 
+    /// **Contig-start escape.** An insertion in an ambiguous run reaching the
+    /// accession's first base has no 5'-most HGVS anchor — the 5'-shuffle rolls
+    /// it to interbase 0, which is spelled `0_1ins…` and names a position that
+    /// does not exist. Because `w_lo == 1` here, that interbase *is* the contig
+    /// start, so widening cannot rescue it. It is instead re-presented at the
+    /// leftmost nameable interbase (offset 1), the terminal analogue of the
+    /// 3'-most rule: inserting `AT` before base 1 equals inserting `TA` before
+    /// base 2, and only the latter can be written. This is the shape the real
+    /// run's `1A>C`/`1A>T`-anchored multi-substitution alleles hit.
+    #[test]
+    fn a_contig_start_insertion_escapes_to_the_leftmost_nameable_interbase() {
+        let derived = from_sequences(
+            "NC_TEST.1",
+            1,
+            "ATATATG",
+            "ATATATATG",
+            &FromSequencesOptions::default().with_direction(ShuffleDirection::FivePrime),
+        )
+        .expect("the ambiguous-run insertion escapes to interbase 1 rather than refusing");
+        assert_eq!(derived.to_string(), "NC_TEST.1:g.1_2insTA");
+    }
+
+    /// The escape is not a blanket amnesty for interbase 0: a payload that
+    /// cannot cross the terminal base (`alt[0] != reference[0]`) is genuinely an
+    /// insertion *before* base 1, denoting a sequence no other placement does,
+    /// and still refuses with the 5'-anchor message. Here a leading `G` sits
+    /// before a `C`, so there is no run to shuffle along.
+    #[test]
+    fn a_contig_start_insertion_that_cannot_cross_the_terminus_still_refuses() {
+        let err = from_sequences(
+            "NC_TEST.1",
+            1,
+            "CATATG",
+            "GCATATG",
+            &FromSequencesOptions::default().with_direction(ShuffleDirection::FivePrime),
+        )
+        .expect_err("an insertion genuinely before base 1 has no HGVS anchor");
+        assert!(
+            err.to_string().contains("5' of the window's first base"),
+            "{err}"
+        );
+    }
+
     /// A change spanning the whole window rests on both edges at once, so both
     /// per-side flags fire. Neither side can be dismissed as settled, which is
     /// what makes a two-sided widen the right response.

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -9733,6 +9733,48 @@ pub(crate) fn derive_block_members(
     coalesce_adjacent_pieces(&mut pieces);
     shrink_pieces_to_differences(&mut pieces, reference);
 
+    // Contig-start escape: rescue the one pure insertion that has no HGVS
+    // anchor from the one window where the anchor genuinely does not exist.
+    //
+    // When `w_lo == 1` the window begins at the accession's first base, so
+    // `reference[0]` *is* the contig's first base — not merely the first base
+    // this call was handed. A pure insertion the 5'-shuffle rolled to interbase
+    // 0 would then be spelled `0_1ins…`, naming a position that does not exist
+    // rather than one this caller simply did not supply (`DerivedBlock`).
+    //
+    // But interbase 0 and interbase 1 denote the *same* sequence whenever the
+    // payload's leading base equals the terminal base `reference[0]`: the
+    // insertion sits in an ambiguous run reaching the terminus, and inserting
+    // `alt` before base 1 equals inserting `rotate_left(1)(alt)` before base 2
+    // (the algebra is `alt[0] == reference[0]`, exactly `shuffle`'s own 3'-step
+    // predicate). When it holds, present the insertion at the leftmost
+    // *nameable* interbase — offset 1 — instead of refusing. This is the
+    // terminal analogue of the 3'-most rule: the 5'-most position is off the
+    // sequence, so the run's leftmost expressible position stands in for it.
+    //
+    // Guarded to `w_lo == 1` alone. At any interior window the correct answer is
+    // to widen the 5' flank (`Normalizer::sequence_normalize` does), not to
+    // relabel; only at the true contig start is widening impossible and the
+    // relabel forced. A payload that cannot cross the terminal base
+    // (`alt[0] != reference[0]`) is genuinely an insertion before base 1 and
+    // still refuses. `verify_round_trip` re-applies the escaped members, so a
+    // mis-step here surfaces as an error rather than a wrong sequence.
+    if w_lo == 1 {
+        let next_is_clear = pieces.get(1).is_none_or(|next| next.ref_start >= 1);
+        if next_is_clear {
+            if let Some(first) = pieces.first_mut() {
+                let is_pure_insertion =
+                    first.ref_start == 0 && first.ref_end == 0 && !first.alt.is_empty();
+                let crosses_terminus = reference.first() == first.alt.first();
+                if is_pure_insertion && crosses_terminus {
+                    first.alt.rotate_left(1);
+                    first.ref_start = 1;
+                    first.ref_end = 1;
+                }
+            }
+        }
+    }
+
     // Read after the three passes above, not before: each can move a piece onto
     // or off the edge, and the answer that matters is about what is emitted.
     let bounded_at_start = pieces.iter().any(|piece| piece.ref_start == 0);

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -9733,44 +9733,106 @@ pub(crate) fn derive_block_members(
     coalesce_adjacent_pieces(&mut pieces);
     shrink_pieces_to_differences(&mut pieces, reference);
 
-    // Contig-start escape: rescue the one pure insertion that has no HGVS
-    // anchor from the one window where the anchor genuinely does not exist.
+    // Contig-start escape: rescue the pure insertion the 5'-shuffle rolled to
+    // interbase 0 from the one window where the anchor genuinely does not exist.
     //
     // When `w_lo == 1` the window begins at the accession's first base, so
     // `reference[0]` *is* the contig's first base — not merely the first base
-    // this call was handed. A pure insertion the 5'-shuffle rolled to interbase
-    // 0 would then be spelled `0_1ins…`, naming a position that does not exist
-    // rather than one this caller simply did not supply (`DerivedBlock`).
+    // this call was handed. A pure insertion at interbase 0 would then be
+    // spelled `0_1ins…`, naming a position that does not exist rather than one
+    // this caller simply did not supply (`DerivedBlock`). There are two ways
+    // out, and they denote different things:
     //
-    // But interbase 0 and interbase 1 denote the *same* sequence whenever the
-    // payload's leading base equals the terminal base `reference[0]`: the
-    // insertion sits in an ambiguous run reaching the terminus, and inserting
-    // `alt` before base 1 equals inserting `rotate_left(1)(alt)` before base 2
-    // (the algebra is `alt[0] == reference[0]`, exactly `shuffle`'s own 3'-step
-    // predicate). When it holds, present the insertion at the leftmost
-    // *nameable* interbase — offset 1 — instead of refusing. This is the
-    // terminal analogue of the 3'-most rule: the 5'-most position is off the
-    // sequence, so the run's leftmost expressible position stands in for it.
+    // **(1) The insertion crosses the terminal base unchanged**
+    // (`alt[0] == reference[0]`). It sits in an ambiguous run reaching the
+    // terminus — base 1 itself is *not* changed — so inserting `alt` before
+    // base 1 equals inserting `rotate_left(1)(alt)` before base 2 (exactly
+    // `shuffle`'s own 3'-step predicate). Present it at the leftmost *nameable*
+    // interbase, offset 1: a genuine insertion, kept as one. This is the
+    // terminal analogue of the 3'-most rule.
     //
-    // Guarded to `w_lo == 1` alone. At any interior window the correct answer is
-    // to widen the 5' flank (`Normalizer::sequence_normalize` does), not to
-    // relabel; only at the true contig start is widening impossible and the
-    // relabel forced. A payload that cannot cross the terminal base
-    // (`alt[0] != reference[0]`) is genuinely an insertion before base 1 and
-    // still refuses. `verify_round_trip` re-applies the escaped members, so a
-    // mis-step here surfaces as an error rather than a wrong sequence.
+    // **(2) The insertion cannot cross the terminal base**
+    // (`alt[0] != reference[0]`), so base 1 is itself rewritten. HGVS has no
+    // interbase 5' of base 1 to hang the payload on, but the *span* form needs
+    // none: fold the leading insertion rightward into the next piece, absorbing
+    // the unchanged reference between them, to make one delins anchored at
+    // base 1 (`0_next.ref_end`). This is what Mutalyzer emits for these dense,
+    // base-1-overwriting substitution stacks — `g.1_5delinsCAAGA` — and a
+    // resulting reverse-complement span is retyped to `inv` downstream by
+    // `retype_inversions`, matching its `g.1_3inv` too. A leading insertion with
+    // no piece to fold into is a true insertion before base 1 and still refuses.
+    //
+    // Both are guarded to `w_lo == 1`: at any interior window the answer is to
+    // widen the 5' flank (`Normalizer::sequence_normalize` does), not to
+    // relabel. `verify_round_trip` re-applies the emitted members, so a mis-step
+    // here surfaces as an error rather than a wrong sequence.
     if w_lo == 1 {
-        let next_is_clear = pieces.get(1).is_none_or(|next| next.ref_start >= 1);
-        if next_is_clear {
-            if let Some(first) = pieces.first_mut() {
-                let is_pure_insertion =
-                    first.ref_start == 0 && first.ref_end == 0 && !first.alt.is_empty();
-                let crosses_terminus = reference.first() == first.alt.first();
-                if is_pure_insertion && crosses_terminus {
-                    first.alt.rotate_left(1);
-                    first.ref_start = 1;
-                    first.ref_end = 1;
-                }
+        let leading_insertion_at_zero = pieces
+            .first()
+            .is_some_and(|p| p.ref_start == 0 && p.ref_end == 0 && !p.alt.is_empty());
+        if leading_insertion_at_zero {
+            let crosses_terminus = reference.first() == pieces[0].alt.first();
+            // Stated as the invariant it is, rather than as the `next_is_clear`
+            // guard it used to be. `coalesce_adjacent_pieces` ran two statements
+            // above and merges any second piece whose `ref_start` equals
+            // `pieces[0].ref_end`, which is `0` here — so a surviving `pieces[1]`
+            // always starts at 1 or beyond and the guard could never exclude
+            // anything. As a condition it gated case (1) and not case (2),
+            // which read as a distinction between the two and is not one; as an
+            // assertion it says why the invariant holds and fails loudly if
+            // `coalesce_adjacent_pieces` ever stops holding it. With it gone the
+            // `else if`'s own `!crosses_terminus` is the negation of the `if`,
+            // so that goes too.
+            debug_assert!(
+                pieces.get(1).is_none_or(|next| next.ref_start >= 1),
+                "coalesce_adjacent_pieces should have merged a piece abutting the \
+                 leading insertion",
+            );
+            let mut escaped = false;
+            if crosses_terminus {
+                // Case (1): the leftmost nameable interbase stands in for the
+                // 5'-most position that is off the sequence.
+                let first = &mut pieces[0];
+                first.alt.rotate_left(1);
+                first.ref_start = 1;
+                first.ref_end = 1;
+                escaped = true;
+            } else if pieces.len() >= 2 {
+                // Case (2): fold `insP` + (unchanged `reference[0..gap]`) +
+                // `next` into one delins anchored at base 1.
+                let next = pieces.remove(1);
+                let mut alt = std::mem::take(&mut pieces[0].alt);
+                alt.extend_from_slice(&reference[0..next.ref_start]);
+                alt.extend_from_slice(&next.alt);
+                pieces[0].ref_start = 0;
+                pieces[0].ref_end = next.ref_end;
+                pieces[0].alt = alt;
+                escaped = true;
+            }
+            // Re-establish what the two passes above established, because this
+            // block ran *after* them and both escapes move a piece: case (1)
+            // takes the leading insertion from interbase 0 to interbase 1, where
+            // a `pieces[1]` starting at 1 would abut it, and
+            // `coalesce_adjacent_pieces` — the enforcement point for
+            // `delins.md:16` — has already gone past. `verify_round_trip` cannot
+            // stand in for this: it re-applies the members and compares *bases*,
+            // and `g.[1_2insA;2G>C]` and `g.2delinsAC` re-apply identically. The
+            // invariant is about shape, which it does not look at.
+            //
+            // Measured as a no-op on today's partitioner — over an exhaustive
+            // 3-letter sweep (reference lengths 3-6 against observed lengths
+            // 2-7, ~3.5M pairs) plus 400k randomised 4-letter cases, case (1)
+            // fired 61,428 times, 57,594 of them with a second piece, and the
+            // nearest such piece ever started at `ref_start == 2`. So the
+            // adjacency is not reachable through `partition_block_for_derivation`
+            // as it stands, and this re-run changed the piece list zero times.
+            // It is kept because the invariant is the escape's obligation and
+            // not the partitioner's: a partition that placed the insertion at
+            // interbase 0 beside a piece at 1 would otherwise emit an
+            // un-coalesced member pair silently.
+            if escaped {
+                coalesce_adjacent_pieces(&mut pieces);
+                shrink_pieces_to_differences(&mut pieces, reference);
             }
         }
     }

--- a/tests/it/sequence_normalize.rs
+++ b/tests/it/sequence_normalize.rs
@@ -139,6 +139,29 @@ fn a_run_at_the_contig_start_settles_at_position_one_under_five_prime() {
     );
 }
 
+/// A multi-substitution allele whose leftmost edit sits at position 1 normalizes
+/// rather than being dropped at the contig-start boundary. This is the real-run
+/// shape (`1A>C`/`1A>T`-anchored primer/adapter reads): `to_sequences` pads the
+/// window, but the 5' side already begins at the accession's first base, so it
+/// cannot widen. The three changed columns are contiguous, so the canonical
+/// derivation coalesces them into one `delins` — the point is it settles on that
+/// form in both shuffle directions rather than failing at the boundary.
+#[test]
+fn a_multi_substitution_anchored_at_position_one_normalizes() {
+    // 1-based:  123456789
+    //           GTGCTAGCT   (first three bases GTG match 1G>C;2T>A;3G>T)
+    let seq = "GTGCTAGCT";
+    let nz = Normalizer::new(provider(seq));
+
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            seqnorm(&nz, "NC_TEST.1:g.[1G>C;2T>A;3G>T]", direction, false),
+            "NC_TEST.1:g.1_3delinsCAT",
+            "a position-1-anchored multi-substitution must normalize, not drop ({direction:?})",
+        );
+    }
+}
+
 /// `normalize = true` routes the derived description through `normalize`. For a
 /// placement already at its 3'-most, reference-anchored base that is a no-op, so
 /// the result matches the `normalize = false` derivation — what this pins is

--- a/tests/it/sequence_normalize.rs
+++ b/tests/it/sequence_normalize.rs
@@ -143,21 +143,36 @@ fn a_run_at_the_contig_start_settles_at_position_one_under_five_prime() {
 /// rather than being dropped at the contig-start boundary. This is the real-run
 /// shape (`1A>C`/`1A>T`-anchored primer/adapter reads): `to_sequences` pads the
 /// window, but the 5' side already begins at the accession's first base, so it
-/// cannot widen. The three changed columns are contiguous, so the canonical
-/// derivation coalesces them into one `delins` — the point is it settles on that
-/// form in both shuffle directions rather than failing at the boundary.
+/// cannot widen. The derivation can decompose a base-1-overwriting change into a
+/// leading insertion at interbase 0 — which has no HGVS anchor — so that leading
+/// piece is folded rightward into a span anchored at base 1 rather than refused.
+///
+/// This is the class Mutalyzer emits as a single `g.1_3inv` / `g.1_5delinsCAAGA`.
+/// ferro reaches the same span form (its member separation may split a tail, but
+/// nothing is dropped), and a reverse-complement span is retyped to `inv`.
 #[test]
 fn a_multi_substitution_anchored_at_position_one_normalizes() {
     // 1-based:  123456789
-    //           GTGCTAGCT   (first three bases GTG match 1G>C;2T>A;3G>T)
-    let seq = "GTGCTAGCT";
-    let nz = Normalizer::new(provider(seq));
+    //           ATGCTAGCT   (first three bases ATG; 1A>C;2T>A;3G>T rewrites base 1)
+    // ATG -> CAT is a reverse complement, so it types as `inv` — Mutalyzer's form.
+    let inv_seq = "ATGCTAGCT";
+    let inv_nz = Normalizer::new(provider(inv_seq));
+
+    // 1-based:  123456789
+    //           GTGCTAGCT   (GTG -> CAT is not a reverse complement: a span delins)
+    let delins_seq = "GTGCTAGCT";
+    let delins_nz = Normalizer::new(provider(delins_seq));
 
     for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
         assert_eq!(
-            seqnorm(&nz, "NC_TEST.1:g.[1G>C;2T>A;3G>T]", direction, false),
+            seqnorm(&inv_nz, "NC_TEST.1:g.[1A>C;2T>A;3G>T]", direction, false),
+            "NC_TEST.1:g.1_3inv",
+            "a base-1 reverse-complement stack must type as inv, not drop ({direction:?})",
+        );
+        assert_eq!(
+            seqnorm(&delins_nz, "NC_TEST.1:g.[1G>C;2T>A;3G>T]", direction, false),
             "NC_TEST.1:g.1_3delinsCAT",
-            "a position-1-anchored multi-substitution must normalize, not drop ({direction:?})",
+            "a base-1 substitution stack must keep the span form, not drop ({direction:?})",
         );
     }
 }


### PR DESCRIPTION
### Summary

Re-presents a pure insertion that 5'-shuffles onto interbase 0 of a window beginning at the accession's first base, instead of refusing it with "5' of the window's first base".

### Attribution

Authored by **Tim Dunn** (@TimD1). This branch reproduces the work of #1957 on a fresh branch under `origin`, because `maintainerCanModify` is `false` on the original and it could not be updated in place. Authorship is preserved on both commits; only the `committer` differs.

### Stacking — a deliberate change from the original

The original #1957 was based on #1942. This branch is based on **#1967** (`td/td_allow-repeats-to-spdi`) instead, skipping #1942.

#1942 is not being reproduced as-is: #1837 landed the same behaviour on `main` roughly seven hours after #1942 was written, and its remaining half (replacing `triples_are_disjoint` with an inline watermark) is a separate question deferred to #1749. See #1968 for the part of #1942 that is preserved.

This re-basing is safe rather than convenient, and was checked rather than assumed. #1957 touches `CHANGELOG.md`, `src/normalize/from_sequences.rs`, `src/normalize/merge.rs` and `tests/it/sequence_normalize.rs` — and **zero** lines of `src/spdi/apply.rs`, where #1942's change lives. Both commits applied with no source conflict; the only conflict was in `CHANGELOG.md`, because the original changelog commit bundles #1942's entry together with this one. That entry was dropped here since #1942 is not in this stack. Because "applies cleanly" is necessary and not sufficient, the full suite was run on this branch, not just its three targeted tests.

### Notes

Representation-Change: a pure insertion that 5'-shuffles onto interbase 0 of a window beginning at the accession's first base is now re-presented at the leftmost nameable interbase (`g.1_2insTA`) or folded into a base-1-anchored delins, instead of refusing with "5' of the window's first base".
  Previously-refused inputs therefore start producing a description; no description ferro already emitted is spelled differently, because the escape fires only where the old path errored. A lone insertion genuinely before base 1, with no piece to absorb it, still refuses.
  Bounded to `w_lo == 1` — at any interior window the answer remains to widen the 5' flank, not to relabel.

