### PR TITLE
perf(normalize): band the sequence-first alignment DP

### DIFF
--- a/benches/seqfirst_align.rs
+++ b/benches/seqfirst_align.rs
@@ -1,11 +1,20 @@
 //! Sizing the sequence-first DP.
 //!
-//! `AlignmentDag::build` is `O(n*m)` in time **and space**, but Criterion has
-//! no memory axis — this measures wall-clock time only. It shows where that
-//! grows too slow to be acceptable, so the block-size cap in the migration is
-//! chosen on time evidence; the memory dimension is not measured here (the
-//! figures are on #1928: ~18 bytes per grid cell, ~275 MB at the widest
-//! accepted block).
+//! `AlignmentDag::build` **allocates** `O(n*m)` and, since the band landed,
+//! **fills** only `O((n+m)*k)`. Criterion has no memory axis, so this measures
+//! wall-clock time only, and the block-size cap in the migration is chosen on
+//! time evidence.
+//!
+//! The memory dimension is **not** measured here; the figures are on #1928, and
+//! note they moved when the cost grid narrowed to `u16`: **14.60 bytes per grid
+//! cell, 215.4 MB** at the widest accepted block (`W = 3840`), down from 18.67
+//! and 275.4 MB. This header carried the older pair until the banding change.
+//!
+//! Because the allocation is unnarrowed while the fill is narrowed, a timing
+//! here is partly an allocator measurement: at `n = 4096` the banded arm runs at
+//! roughly memory bandwidth, and two groups that compute the *same* thing can
+//! differ several-fold purely on whether a large arena has already been faulted
+//! in. Compare each group against its own baseline, never across groups.
 //!
 //! # Divergence is an AXIS, not a constant (#1928)
 //!

--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -18,6 +18,82 @@
 //!
 //! There is also **no seeding from the input's own alignment** — that would
 //! reintroduce input-relativity by a new route.
+//!
+//! # The DP is banded, and the band is exact (#1928)
+//!
+//! A cell `(i, j)` sits on diagonal `d = i - j`. Reaching it from the source
+//! costs at least `|d|`, because every step off the main diagonal is an indel;
+//! reaching the sink from it costs at least `|delta - d|`, where
+//! `delta = ref_len - alt_len`. So every cell on an alignment of cost `k`
+//! satisfies `|d| + |delta - d| <= k`.
+//!
+//! `on_optimal_path` **is** the set of cells lying on some minimal alignment, so
+//! every cell this module retains already satisfies that bound for `k` = the
+//! edit distance. Computing only the band is therefore a **cost** change and not
+//! a semantic one: the retained cells, the out-edge masks and
+//! [`AlignmentDag::dominators`] come out bit-identical to what the full
+//! `(n + 1) x (m + 1)` sweep produces. That is not left to the argument: the
+//! five `the_band_agrees_with_the_full_grid_*` tests keep the pre-band
+//! implementation verbatim and diff the two builds field by field.
+//!
+//! **They are not redundant with the oracles already here.** Deliberately
+//! widening the band's acceptance test by one — so a band one doubling too
+//! narrow is accepted — is caught *only* by those tests:
+//! `dominators_agree_with_brute_force_on_exhaustive_small_inputs` passes, because
+//! the brute-force probe is computed from the DAG itself and a systematically
+//! narrowed DAG is internally consistent. An oracle that reads the artefact
+//! cannot see the artefact being too small.
+//!
+//! The band is found by doubling `k` until the band-confined distance no longer
+//! exceeds its own band, which costs at most twice the final pass. The **DP** is
+//! then `Θ((n + m) · k)` rather than `Θ(n · m)`.
+//!
+//! # `build` as a whole is not, and the measurement says so (#1928)
+//!
+//! **Storage is unchanged** — the grids keep their full `(n + 1) x (m + 1)`
+//! shape and their `i * width + j` addressing. So `build` still *allocates and
+//! zeroes* `Θ(n · m)` even though it now *fills* `Θ((n + m) · k)`, and past a
+//! certain width that allocation is the whole cost.
+//!
+//! Measured on a quiet dedicated c7i.4xlarge (x86_64, 4 kB pages), criterion
+//! against the immediately preceding commit, so banding is the only variable.
+//! **Ratios only** — absolute wall-clock is not comparable across hosts, and the
+//! raw figures are in `campaigns/2026-08-14-1928-banded-dp-benchmark-protocol.md`
+//! with the run that produced them:
+//!
+//! | n (k = 2) | speedup | cell-count ratio |
+//! |---:|---:|---:|
+//! | 256 | 37.0x | 74x |
+//! | 1024 | 6.6x | 293x |
+//! | 4096 | 7.9x | 1171x |
+//!
+//! The cell-count column is **derived, not measured**, and is reproducible from
+//! this file: at `n = 4096, k = 2` the full grids take `2 * 4097^2 = 33,570,818`
+//! cell-writes against the band's 28,675 — counting *both* the prefix and suffix
+//! grids and the doubling ladder's discarded `k = 1` pass. So geometry
+//! **over-predicts the measured speedup by ~148x**, and the gap widens with `n`
+//! (only ~2x at `n = 256`). At `n = 4096` `build` allocates ~101 MB of grids, and
+//! 101 MB / 20 ms is ~5 GB/s — i.e. the banded time is essentially all
+//! allocation and none of it DP.
+//!
+//! Two things follow, and neither is obvious from the code:
+//!
+//! - **Do not quote a single speedup.** `by_length_fixed_k/len1024_k2` and
+//!   `by_divergence/k2` are the *same* computation and measured **5.8x apart**,
+//!   because the latter runs after the `n = 4096` cases have already faulted in a
+//!   large arena. Banded timings are sensitive to allocator state in a way the
+//!   unbanded ones were not (their baselines differ by only 15%).
+//! - **Narrowing the storage to the band is now the lever**, not a tidy-up. It is
+//!   a separate change with a real refactor behind it; see [`AlignmentDag::build`].
+//!
+//! Whether that unfilled allocation costs resident *memory* is **not measured
+//! here** — criterion has no memory axis, and the peak-RSS harness was not run
+//! against this commit. Do not read the time win as a memory win.
+//!
+//! At high divergence the band is the whole grid and the doubling search is
+//! overhead paid for nothing: at `n = 1024`, `k = 614` (~0.6n, the uniform-random
+//! regime) this is **11.2% slower**, having still been 1.56x faster at `k = 512`.
+//! Real variants sit at single-digit `k`, which is the regime the corpus presents.
 
 /// One step of an alignment, as an edge in the DAG.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,6 +129,14 @@ pub struct AlignmentDag {
     /// ever the only thing keeping it alive under `dev` too.
     #[cfg_attr(not(feature = "dev"), allow(dead_code))]
     total: u32,
+    /// Lower bound (inclusive) on `i - j` for the diagonals [`AlignmentDag::build`]
+    /// examined. Every on-path cell lies inside `band_lo ..= band_hi`; a cell
+    /// outside was never written and so reads `false` from `on_optimal_path`,
+    /// which is what makes [`AlignmentDag::cells`] safe to clip to the same
+    /// range.
+    band_lo: i64,
+    /// Upper bound (inclusive) on `i - j`; see [`AlignmentDag::band_lo`].
+    band_hi: i64,
     /// Row-major `(ref_len + 1) x (alt_len + 1)`; `true` when the cell lies on
     /// at least one minimal alignment.
     on_optimal_path: Vec<bool>,
@@ -98,15 +182,119 @@ const OUT_INS: u8 = 1 << 3;
 ///
 /// `[profile.release]` sets neither `debug-assertions` nor `overflow-checks`,
 /// so in the shipped library and in the Python wheel a `debug_assert` is a
-/// comment: past the bound `edit_grid`'s boundary row would truncate `j as u16`
-/// and the sums would wrap, and `on_optimal_path` would be computed from wrong
-/// costs. That is a silently wrong partition and so a silently wrong emitted
-/// description — strictly worse than declining. Every gate in front of `build`
+/// comment: past the bound the grid fill's boundary row would truncate `j as
+/// u16` and the sums would wrap, and `on_optimal_path` would be computed from
+/// wrong costs. That is a silently wrong partition and so a silently wrong
+/// emitted description — strictly worse than declining. Every gate in front of
+/// `build`
 /// bounds **cells**, i.e. `(n + 1) * (m + 1)`, and a degenerate `1 x 70,000`
 /// grid clears the widest of those by four orders of magnitude while `n + m` is
 /// past `u16::MAX`; a long literal `ins` payload reaches exactly that shape.
 /// See #1970.
 pub(crate) const MAX_ALIGNMENT_SPAN: usize = u16::MAX as usize;
+/// Cost of a cell no path *confined to the band* reaches.
+///
+/// It never survives to be read as a real cost: every cell the band admits is
+/// reachable by a staircase that stays inside the band, so this exists only to
+/// keep the `min` total at the band's edges, where one or two of the three
+/// predecessors lie outside it.
+const UNREACHED: u16 = u16::MAX;
+
+/// `ceil(x / 2)`, for a possibly negative `x`.
+fn ceil_half(x: i64) -> i64 {
+    (x + 1).div_euclid(2)
+}
+
+/// `floor(x / 2)`, for a possibly negative `x`.
+fn floor_half(x: i64) -> i64 {
+    x.div_euclid(2)
+}
+
+/// The diagonals an alignment of cost at most `k` can occupy, as inclusive
+/// bounds on `i - j`.
+///
+/// From `|d| + |delta - d| <= k` (see the module header), with
+/// `delta = ref_len - alt_len`:
+///
+/// ```text
+/// ceil((delta - k) / 2)  <=  d  <=  floor((delta + k) / 2)
+/// ```
+///
+/// `lo + hi == delta` exactly, so the interval is symmetric about `delta / 2`.
+/// That is not decoration: reversing both blocks maps diagonal `d` to
+/// `delta - d`, so the *same* interval bands the suffix grid and no second
+/// derivation is needed.
+///
+/// `k` must be at least `|delta|` — no alignment is cheaper than the length
+/// difference, and below that the interval excludes the source or the sink.
+fn band_for(ref_len: usize, alt_len: usize, k: usize) -> (i64, i64) {
+    let delta = ref_len as i64 - alt_len as i64;
+    let k = k as i64;
+    debug_assert!(
+        k >= delta.abs(),
+        "band k = {k} is below |ref_len - alt_len| = {}",
+        delta.abs()
+    );
+    let (lo, hi) = (ceil_half(delta - k), floor_half(delta + k));
+    debug_assert_eq!(lo + hi, delta, "the band must be symmetric about delta/2");
+    (lo, hi)
+}
+
+/// The columns row `i` occupies inside the band `lo ..= hi`, clamped to the
+/// grid. Never empty for a `k >= |delta|` band.
+fn row_span(i: usize, lo: i64, hi: i64, alt_len: usize) -> (usize, usize) {
+    debug_assert!(lo <= 0 && hi >= 0, "the band must contain diagonal 0");
+    let row = i as i64;
+    let first = (row - hi).max(0) as usize;
+    let last = (row - lo).min(alt_len as i64) as usize;
+    debug_assert!(first <= last, "row {i} has an empty band span");
+    (first, last)
+}
+
+/// Levenshtein cost grid restricted to diagonals `lo ..= hi`, written into
+/// `grid` (row-major, `alt.len() + 1` columns — the *full* grid's shape).
+///
+/// Cells outside the band are **left untouched**, which is the whole point and
+/// is why nothing may read them. Each predecessor is guarded by an explicit
+/// in-band test rather than by pre-filling the grid with a sentinel: that
+/// pre-fill would put back the `Θ(n·m)` pass the band exists to remove.
+///
+/// Safe to call repeatedly on one buffer with a widening band, which is what the
+/// doubling search in [`AlignmentDag::build`] does — a wider band is a superset,
+/// and every cell of it is recomputed here in dependency order.
+fn fill_edit_grid_banded(reference: &[u8], alt: &[u8], lo: i64, hi: i64, grid: &mut [u16]) {
+    let n = reference.len();
+    let m = alt.len();
+    let width = m + 1;
+    for i in 0..=n {
+        let (first, last) = row_span(i, lo, hi, m);
+        let row = i as i64;
+        for j in first..=last {
+            if i == 0 && j == 0 {
+                grid[0] = 0;
+                continue;
+            }
+            let col = j as i64;
+            let mut best = UNREACHED;
+            // Diagonal: same `d`, so in band whenever this cell is.
+            if i > 0 && j > 0 {
+                let cost = u16::from(reference[i - 1] != alt[j - 1]);
+                best = best.min(grid[(i - 1) * width + (j - 1)].saturating_add(cost));
+            }
+            // Up (a reference base deleted). Its diagonal is `(i - 1) - j`,
+            // one below this cell's, so it is in band iff `row - col > lo`.
+            if i > 0 && row - col > lo {
+                best = best.min(grid[(i - 1) * width + j].saturating_add(1));
+            }
+            // Left (an alternate base inserted). Its diagonal is `i - (j - 1)`,
+            // one above this cell's, so it is in band iff `row - col < hi`.
+            if j > 0 && row - col < hi {
+                best = best.min(grid[i * width + (j - 1)].saturating_add(1));
+            }
+            grid[i * width + j] = best;
+        }
+    }
+}
 
 impl AlignmentDag {
     /// Build the DAG for `ref_block` -> `alt_block`.
@@ -120,65 +308,142 @@ impl AlignmentDag {
     /// yields a pure insertion at ref `1`. Trimming is therefore a
     /// precondition, not a convenience.
     ///
-    /// Cost is `O(ref_len * alt_len)` in time and space.
-    ///
     /// `None` when `ref_block.len() + alt_block.len()` exceeds
     /// [`MAX_ALIGNMENT_SPAN`], which is the width of the `u16` cost grid. Every
     /// caller in the normalizer already has a decline path, and declining is the
     /// only safe answer: past the bound the costs wrap rather than panic in the
     /// shipped profile. See [`MAX_ALIGNMENT_SPAN`].
+    ///
+    /// The refusal is checked **before** the band is derived, so it bounds the
+    /// whole computation and not merely the fill: `k` itself is bounded by
+    /// `n + m`, and every value the banded DP writes is a prefix or suffix cost
+    /// under the same bound as the full sweep. Banding narrows which cells are
+    /// visited, never how large a cost can get.
+    ///
+    /// # Cost
+    ///
+    /// The **DP** is `Θ((n + m) · k)` for `k` the edit distance — it visits only
+    /// the band of diagonals a minimal alignment can occupy (module header), and
+    /// the doubling search for `k` costs at most twice its final pass. At
+    /// `k ≈ 0.6 n` (a uniform-random pair) the band is essentially the whole
+    /// grid and this degenerates to the previous `Θ(n·m)`, plus the doubling's
+    /// constant — measured at `n = 1024`, that is 1.56x *faster* still at
+    /// `k = 512` and 11.2% *slower* at `k = 614`.
+    ///
+    /// **`build` as a whole is not `Θ((n + m) · k)`, because space is still
+    /// `Θ(n · m)`** — deliberately, at this step: the grids keep their full
+    /// `(n + 1) x (m + 1)` shape and their `i * width + j` addressing, so
+    /// `index`, `contains_cell`, `out_edges` and `dominators`'s in-degree table
+    /// are untouched. So the allocation is unnarrowed while the fill is narrowed,
+    /// and past a certain width the allocation is the entire cost: the measured
+    /// speedup at `n = 4096, k = 2` is **7.9x against a ~1171x cell-count
+    /// ratio**. Narrowing the *storage* to the band is a separate change with a
+    /// real refactor behind it, and the module header's table is the argument for
+    /// doing it.
+    ///
+    /// # What this does to resident memory is UNMEASURED — do not infer it
+    ///
+    /// The untouched part of a zero-initialised `Vec` is never resident, so a
+    /// banded write pattern could in principle shrink peak RSS by itself. Whether
+    /// it does **depends on the page size**, and the answer differs across the
+    /// two platforms this project builds on:
+    ///
+    /// - **16 kB pages** (Apple silicon): a grid row is 7.7 kB at the canonical
+    ///   window, so a row is *under* one page and consecutive rows share pages.
+    ///   The band crosses every row, so every page is faulted in regardless and
+    ///   banding the computation should save nothing.
+    /// - **4 kB pages** (the Linux host the timings above come from): a row spans
+    ///   ~2 pages, and the band is diagonal — row `i` touches columns near `i`,
+    ///   hence only *one* of that row's pages. So a substantial fraction of each
+    ///   grid may never be faulted.
+    ///
+    /// Both are predictions from geometry. **Neither has been measured**:
+    /// criterion has no memory axis, and the peak-RSS harness was not run against
+    /// this commit on either page size. Do not cite the time win as a memory win,
+    /// and do not carry the 16 kB conclusion onto a 4 kB host.
     pub fn build(ref_block: &[u8], alt_block: &[u8]) -> Option<Self> {
         let n = ref_block.len();
         let m = alt_block.len();
         if n.checked_add(m)? > MAX_ALIGNMENT_SPAN {
             return None;
         }
-        let prefix = edit_grid(ref_block, alt_block);
+        let width = m + 1;
+        let cell_count = (n + 1) * width;
+        let delta = (n as i64 - m as i64).unsigned_abs() as usize;
+        // The band at which every diagonal is in play. Reaching it terminates
+        // the loop on an exact answer whatever the doubling does, so the
+        // convergence test below is an optimisation and not the only exit.
+        let widest = (n + m).max(1);
+
+        let mut prefix = vec![0u16; cell_count];
+        // No alignment costs less than the length difference, so that is the
+        // narrowest band worth trying; `max(1)` keeps a diagonal of width one
+        // for the equal-length case.
+        let mut k = delta.max(1).min(widest);
+        let (mut lo, mut hi) = band_for(n, m, k);
+        loop {
+            fill_edit_grid_banded(ref_block, alt_block, lo, hi, &mut prefix);
+            // Confining the DP can only overestimate, so a distance the band
+            // itself admits is the true one: every cell of every minimal
+            // alignment then lies inside `lo ..= hi`, and the band-confined
+            // value at each of them is its true value.
+            if prefix[n * width + m] as usize <= k || k >= widest {
+                break;
+            }
+            k = (2 * k).min(widest);
+            (lo, hi) = band_for(n, m, k);
+        }
+        let total: u16 = prefix[n * width + m];
 
         // Suffix distances, computed as prefix distances of the reversed
         // blocks: `suffix(i, j)` is the cost of aligning `ref[i..]` to
-        // `alt[j..]`.
+        // `alt[j..]`. Reversal maps diagonal `d` to `delta - d`, and the band is
+        // symmetric about `delta / 2`, so it carries over unchanged.
         let ref_rev: Vec<u8> = ref_block.iter().rev().copied().collect();
         let alt_rev: Vec<u8> = alt_block.iter().rev().copied().collect();
-        let suffix_grid = edit_grid(&ref_rev, &alt_rev);
-        let suffix = |i: usize, j: usize| suffix_grid[(n - i) * (m + 1) + (m - j)];
+        let mut suffix_grid = vec![0u16; cell_count];
+        fill_edit_grid_banded(&ref_rev, &alt_rev, lo, hi, &mut suffix_grid);
+        let suffix = |i: usize, j: usize| suffix_grid[(n - i) * width + (m - j)];
 
-        let total: u16 = prefix[n * (m + 1) + m];
-        let width = m + 1;
-
-        let mut on_optimal_path = vec![false; (n + 1) * width];
+        let mut on_optimal_path = vec![false; cell_count];
         for i in 0..=n {
-            for j in 0..=m {
-                on_optimal_path[i * width + j] = prefix[i * width + j] + suffix(i, j) == total;
+            let (first, last) = row_span(i, lo, hi, m);
+            for j in first..=last {
+                on_optimal_path[i * width + j] =
+                    prefix[i * width + j].saturating_add(suffix(i, j)) == total;
             }
         }
 
-        let mut out = vec![0u8; (n + 1) * width];
+        let mut out = vec![0u8; cell_count];
         for i in 0..=n {
-            for j in 0..=m {
+            let (first, last) = row_span(i, lo, hi, m);
+            for j in first..=last {
                 if !on_optimal_path[i * width + j] {
                     continue;
                 }
                 let here = prefix[i * width + j];
+                // `on_optimal_path` is tested *first* in each pair below. A
+                // neighbour outside the band holds an unwritten `prefix` cell,
+                // and its `false` flag is what keeps that cell from being read.
                 // Diagonal: match or substitution.
                 if i < n && j < m {
                     let cost = u16::from(ref_block[i] != alt_block[j]);
                     let next = (i + 1) * width + (j + 1);
-                    if here + cost == prefix[next] && on_optimal_path[next] {
+                    if on_optimal_path[next] && here + cost == prefix[next] {
                         out[i * width + j] |= if cost == 0 { OUT_MATCH } else { OUT_SUB };
                     }
                 }
                 // Down: deletion of a reference base.
                 if i < n {
                     let next = (i + 1) * width + j;
-                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                    if on_optimal_path[next] && here + 1 == prefix[next] {
                         out[i * width + j] |= OUT_DEL;
                     }
                 }
                 // Right: insertion of an alternate base.
                 if j < m {
                     let next = i * width + (j + 1);
-                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                    if on_optimal_path[next] && here + 1 == prefix[next] {
                         out[i * width + j] |= OUT_INS;
                     }
                 }
@@ -189,6 +454,8 @@ impl AlignmentDag {
             ref_len: n as u32,
             alt_len: m as u32,
             total: u32::from(total),
+            band_lo: lo,
+            band_hi: hi,
             on_optimal_path,
             out,
         })
@@ -230,12 +497,22 @@ impl AlignmentDag {
     /// Emitted by walking anti-diagonals (`d = i + j`) directly, rather than
     /// collecting every on-path cell and sorting it — diagonal order is
     /// already topological, so no sort is needed.
+    ///
+    /// Each anti-diagonal is further clipped to the band `build` examined: with
+    /// `j = d - i`, the constraint `band_lo <= i - j <= band_hi` is
+    /// `2i - d` in that range, i.e. `i` in
+    /// `ceil((d + band_lo) / 2) ..= floor((d + band_hi) / 2)`. Nothing is lost —
+    /// a cell outside the band was never written and so is `false` in
+    /// `on_optimal_path` — the clip removes scanning, not cells. That is what
+    /// takes this walk from `Θ(n·m)` to `Θ((n + m) · k)`.
     pub(crate) fn cells(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        let (lo, hi) = (self.band_lo, self.band_hi);
         (0..=self.ref_len + self.alt_len)
             .flat_map(move |d| {
-                let i_min = d.saturating_sub(self.alt_len);
-                let i_max = d.min(self.ref_len);
-                (i_min..=i_max).map(move |i| (i, d - i))
+                let diag = i64::from(d);
+                let i_min = i64::from(d.saturating_sub(self.alt_len)).max(ceil_half(diag + lo));
+                let i_max = i64::from(d.min(self.ref_len)).min(floor_half(diag + hi));
+                (i_min..=i_max).map(move |i| (i as u32, (diag - i) as u32))
             })
             .filter(move |&(i, j)| self.contains_cell(i, j))
     }
@@ -329,14 +606,14 @@ impl AlignmentDag {
     /// set, and whenever that count falls to one, that single edge is on every
     /// path.
     ///
-    /// `Θ(n·m)` — no worse than `build()`'s own cost. `cells()` walks the full
-    /// `(ref_len + 1) x (alt_len + 1)` grid once to filter the on-path cells
-    /// (`V` of them) in topological order, and the in-degree table below is
-    /// sized to that same grid, so this pass cannot beat `Θ(n·m)` regardless of
-    /// how few cells are actually on-path; on top of that it is `O(V + E)` to
-    /// sweep. Deliberately not the per-edge reachability probe the calibration
-    /// prototype used — that is `O(E)` per edge, which is fine for a 52 nt
-    /// block and not for production. The probe survives as the test oracle.
+    /// The sweep is `O(V + E)`, and since #1928 `cells()` walks only the band —
+    /// `Θ((n + m) · k)` — rather than filtering the whole grid. What is still
+    /// `Θ(n·m)` here is the `in_degree` table, which is sized to the full grid
+    /// because `index` addresses the full grid; it is a zeroed allocation of
+    /// which only band cells are ever touched. Deliberately not the per-edge
+    /// reachability probe the calibration prototype used — that is `O(E)` per
+    /// edge, which is fine for a 52 nt block and not for production. The probe
+    /// survives as the test oracle.
     pub(crate) fn dominators(&self) -> Dominators {
         let mut result = Dominators::default();
         let sink = (self.ref_len, self.alt_len);
@@ -356,7 +633,7 @@ impl AlignmentDag {
             crossing -= i64::from(in_degree[self.index(i, j)]);
             // Counted, not collected. The edge itself is only needed on the
             // `crossing == 1` branch below, and that is rare; collecting on every
-            // cell put a heap allocation back on the `Θ(n·m)` sweep that the flat
+            // cell put a heap allocation back on the sweep that the flat
             // adjacency exists to keep off it.
             let out_degree = self.out_edges(i, j).count();
             crossing += out_degree as i64;
@@ -389,40 +666,6 @@ impl AlignmentDag {
         result.forced_ins_junctions.dedup();
         result
     }
-}
-
-/// Full Levenshtein distance grid, row-major with `alt.len() + 1` columns.
-fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u16> {
-    let n = reference.len();
-    let m = alt.len();
-    // A cost never exceeds `n + m`, so the `u16` grid holds every value exactly
-    // when `n + m <= MAX_ALIGNMENT_SPAN`. This is a statement of the
-    // precondition `AlignmentDag::build` already enforces by refusing, not a
-    // second gate — `edit_grid` is private and `build` is its only caller. Kept
-    // so a future caller added here is caught in a debug build; the refusal, not
-    // this line, is what makes the narrowing safe in the shipped profile.
-    debug_assert!(
-        n + m <= MAX_ALIGNMENT_SPAN,
-        "edit_grid narrowed to u16: n+m = {} exceeds {MAX_ALIGNMENT_SPAN}",
-        n + m
-    );
-    let width = m + 1;
-    let mut d = vec![0u16; (n + 1) * width];
-    for (i, x) in d.iter_mut().step_by(width).enumerate() {
-        *x = i as u16;
-    }
-    for (j, x) in d.iter_mut().take(width).enumerate() {
-        *x = j as u16;
-    }
-    for i in 1..=n {
-        for j in 1..=m {
-            let cost = u16::from(reference[i - 1] != alt[j - 1]);
-            d[i * width + j] = (d[(i - 1) * width + j] + 1)
-                .min(d[i * width + j - 1] + 1)
-                .min(d[(i - 1) * width + j - 1] + cost);
-        }
-    }
-    d
 }
 
 #[cfg(test)]
@@ -490,6 +733,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Every word of length `len` over a two-letter alphabet.
+    fn words(len: u32) -> Vec<Vec<u8>> {
+        if len == 0 {
+            return vec![Vec::new()];
+        }
+        let mut out = Vec::new();
+        for shorter in words(len - 1) {
+            for base in *b"AC" {
+                let mut w = shorter.clone();
+                w.push(base);
+                out.push(w);
+            }
+        }
+        out
     }
 
     /// Brute-force oracle: an edge is a dominator iff deleting it disconnects
@@ -583,20 +842,6 @@ mod tests {
         // Exhaustive over a 2-letter alphabet, lengths 0..=5 both sides. Small
         // alphabet and short blocks maximise alternative minimal alignments,
         // which is where a wrong dominator rule shows up.
-        fn words(len: u32) -> Vec<Vec<u8>> {
-            if len == 0 {
-                return vec![Vec::new()];
-            }
-            let mut out = Vec::new();
-            for shorter in words(len - 1) {
-                for base in *b"AC" {
-                    let mut w = shorter.clone();
-                    w.push(base);
-                    out.push(w);
-                }
-            }
-            out
-        }
         let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
         let mut checked = 0usize;
         for r in &all {
@@ -659,6 +904,394 @@ mod tests {
         assert!(
             AlignmentDag::build(&one, &vec![b'C'; 70_000]).is_none(),
             "a 70,000-base alternate must be refused"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // #1928: the band is a COST change. These guard that claim directly.
+    // ------------------------------------------------------------------
+
+    /// The **pre-band** build, kept verbatim as the differential oracle: a full
+    /// `(n + 1) x (m + 1)` Levenshtein grid, its reverse, the
+    /// `prefix + suffix == total` membership test and the out-edge masks,
+    /// exactly as this module computed them before the band was introduced.
+    ///
+    /// Deliberately a second implementation rather than "the banded code run
+    /// with a full band" — running one implementation with two parameter values
+    /// tests the parameters, not the algorithm, and every band-specific
+    /// off-by-one would cancel.
+    fn full_grid_build(ref_block: &[u8], alt_block: &[u8]) -> AlignmentDag {
+        fn edit_grid(reference: &[u8], alt: &[u8]) -> Vec<u16> {
+            let n = reference.len();
+            let m = alt.len();
+            let width = m + 1;
+            let mut d = vec![0u16; (n + 1) * width];
+            for (i, x) in d.iter_mut().step_by(width).enumerate() {
+                *x = i as u16;
+            }
+            for (j, x) in d.iter_mut().take(width).enumerate() {
+                *x = j as u16;
+            }
+            for i in 1..=n {
+                for j in 1..=m {
+                    let cost = u16::from(reference[i - 1] != alt[j - 1]);
+                    d[i * width + j] = (d[(i - 1) * width + j] + 1)
+                        .min(d[i * width + j - 1] + 1)
+                        .min(d[(i - 1) * width + j - 1] + cost);
+                }
+            }
+            d
+        }
+
+        let n = ref_block.len();
+        let m = alt_block.len();
+        let width = m + 1;
+        let prefix = edit_grid(ref_block, alt_block);
+        let ref_rev: Vec<u8> = ref_block.iter().rev().copied().collect();
+        let alt_rev: Vec<u8> = alt_block.iter().rev().copied().collect();
+        let suffix_grid = edit_grid(&ref_rev, &alt_rev);
+        let suffix = |i: usize, j: usize| suffix_grid[(n - i) * width + (m - j)];
+        let total: u16 = prefix[n * width + m];
+
+        let mut on_optimal_path = vec![false; (n + 1) * width];
+        for i in 0..=n {
+            for j in 0..=m {
+                on_optimal_path[i * width + j] = prefix[i * width + j] + suffix(i, j) == total;
+            }
+        }
+        let mut out = vec![0u8; (n + 1) * width];
+        for i in 0..=n {
+            for j in 0..=m {
+                if !on_optimal_path[i * width + j] {
+                    continue;
+                }
+                let here = prefix[i * width + j];
+                if i < n && j < m {
+                    let cost = u16::from(ref_block[i] != alt_block[j]);
+                    let next = (i + 1) * width + (j + 1);
+                    if here + cost == prefix[next] && on_optimal_path[next] {
+                        out[i * width + j] |= if cost == 0 { OUT_MATCH } else { OUT_SUB };
+                    }
+                }
+                if i < n {
+                    let next = (i + 1) * width + j;
+                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                        out[i * width + j] |= OUT_DEL;
+                    }
+                }
+                if j < m {
+                    let next = i * width + (j + 1);
+                    if here + 1 == prefix[next] && on_optimal_path[next] {
+                        out[i * width + j] |= OUT_INS;
+                    }
+                }
+            }
+        }
+        AlignmentDag {
+            ref_len: n as u32,
+            alt_len: m as u32,
+            total: u32::from(total),
+            // The whole grid, expressed as a band, so `cells()` scans all of it
+            // and the two walks are compared like for like.
+            band_lo: -(m as i64),
+            band_hi: n as i64,
+            on_optimal_path,
+            out,
+        }
+    }
+
+    /// Assert the banded build and the pre-band build agree on everything the
+    /// DAG exposes: the distance, the retained cell set, every out-edge mask,
+    /// the topological walk, and `dominators()`. Returns the edit distance so a
+    /// caller can assert which `k` it actually exercised.
+    fn assert_band_matches_full_grid(r: &[u8], a: &[u8]) -> u32 {
+        // `build` refuses past `MAX_ALIGNMENT_SPAN` (#1970); every fixture here is
+        // far below it, so a `None` is a bug in the fixture, not a decline to test.
+        let banded = AlignmentDag::build(r, a)
+            .expect("differential fixtures are far below MAX_ALIGNMENT_SPAN");
+        let full = full_grid_build(r, a);
+        let label = format!(
+            "{:?} -> {:?}",
+            String::from_utf8_lossy(r),
+            String::from_utf8_lossy(a)
+        );
+        assert_eq!(banded.total, full.total, "edit distance differs on {label}");
+        assert_eq!(
+            banded.on_optimal_path, full.on_optimal_path,
+            "retained cell set differs on {label}"
+        );
+        assert_eq!(banded.out, full.out, "out-edge masks differ on {label}");
+        assert_eq!(
+            banded.cells().collect::<Vec<_>>(),
+            full.cells().collect::<Vec<_>>(),
+            "topological cell walk differs on {label}"
+        );
+        assert_eq!(
+            banded.dominators(),
+            full.dominators(),
+            "dominators differ on {label}"
+        );
+        banded.total
+    }
+
+    /// Deterministic pseudo-random stream; no RNG dependency, so any failure
+    /// reproduces from the seed named at the call site.
+    fn next(state: &mut u64) -> u64 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *state >> 33
+    }
+
+    /// `alt`, mutated by `edits` single-base changes drawn from `state` — a mix
+    /// of substitutions, deletions and insertions, so the alternate is not
+    /// confined to the main diagonal.
+    fn apply_random_edits(reference: &[u8], edits: usize, state: &mut u64) -> Vec<u8> {
+        let mut alt = reference.to_vec();
+        for _ in 0..edits {
+            if alt.is_empty() {
+                alt.push(b"ACGT"[(next(state) as usize) % 4]);
+                continue;
+            }
+            let at = (next(state) as usize) % alt.len();
+            match next(state) % 3 {
+                0 => alt[at] = b"ACGT"[(next(state) as usize) % 4],
+                1 => {
+                    alt.remove(at);
+                }
+                _ => alt.insert(at, b"ACGT"[(next(state) as usize) % 4]),
+            }
+        }
+        alt
+    }
+
+    #[test]
+    fn the_band_agrees_with_the_full_grid_on_exhaustive_small_inputs() {
+        // The same exhaustive corpus the brute-force dominator oracle uses:
+        // every word over a 2-letter alphabet up to length 5, both sides. It
+        // covers the empty block on either side, equal and unequal lengths, and
+        // `k` all the way to `n`, since a 2-letter alphabet makes short blocks
+        // maximally ambiguous.
+        let all: Vec<Vec<u8>> = (0..=5u32).flat_map(words).collect();
+        let mut checked = 0usize;
+        let mut widest_k = 0u32;
+        for r in &all {
+            for a in &all {
+                widest_k = widest_k.max(assert_band_matches_full_grid(r, a));
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 3000,
+            "expected a large exhaustive sweep, ran {checked}"
+        );
+        assert_eq!(
+            widest_k, 5,
+            "the sweep must reach k == n (a block wholly replaced), saw {widest_k}"
+        );
+    }
+
+    #[test]
+    fn the_band_agrees_with_the_full_grid_at_the_shape_boundaries() {
+        // The cases the doubling search is most likely to get wrong, named one
+        // by one rather than left to a random draw: both blocks empty, either
+        // block empty, a pure insertion, a pure deletion, a length ratio far
+        // from one (so `|delta|` and not the divergence sets the initial band),
+        // and equal-length blocks sharing no base at all.
+        for (r, a, what) in [
+            (&b""[..], &b""[..], "both empty"),
+            (&b""[..], &b"ACGT"[..], "reference empty — a pure insertion"),
+            (&b"ACGT"[..], &b""[..], "alternate empty — a pure deletion"),
+            (&b"A"[..], &b""[..], "one base deleted"),
+            (&b""[..], &b"A"[..], "one base inserted"),
+            (&b"ACGTACGT"[..], &b"ACGTACGT"[..], "k = 0"),
+            (&b"ACGTACGT"[..], &b"ACGTACGA"[..], "k = 1, a substitution"),
+            (&b"ACGTACGT"[..], &b"ACGTACG"[..], "k = 1, a deletion"),
+            (&b"ACGTACGT"[..], &b"ACGTACGTA"[..], "k = 1, an insertion"),
+            (
+                &b"AAAAAAAAAAAAAAAAAAAA"[..],
+                &b"AAA"[..],
+                "delta = 17 with k = delta",
+            ),
+            (
+                &b"AAA"[..],
+                &b"AAAAAAAAAAAAAAAAAAAA"[..],
+                "delta = -17 with k = delta",
+            ),
+            (
+                &b"AAAAAAAAAAAAAAAAAAAA"[..],
+                &b"CCC"[..],
+                "delta = 17 with k > delta",
+            ),
+            (
+                &b"AAAAAAAA"[..],
+                &b"CCCCCCCC"[..],
+                "equal length, k = n, no shared base",
+            ),
+            (
+                &b"ACGTACGTACGT"[..],
+                &b"TGCATGCATGCA"[..],
+                "equal length, maximal substitution divergence",
+            ),
+        ] {
+            let k = assert_band_matches_full_grid(r, a);
+            // The assertion above is the guard; this only records that the case
+            // exercised the `k` its name claims, so a rewritten fixture cannot
+            // silently stop covering the boundary.
+            let expected = match what {
+                "k = 0" => Some(0),
+                "k = 1, a substitution" | "k = 1, a deletion" | "k = 1, an insertion" => Some(1),
+                "one base deleted" | "one base inserted" => Some(1),
+                "both empty" => Some(0),
+                _ => None,
+            };
+            if let Some(expected) = expected {
+                assert_eq!(k, expected, "case {what:?} no longer has k = {expected}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_band_agrees_with_the_full_grid_at_every_doubling_boundary() {
+        // The doubling schedule is 1, 2, 4, 8, 16, ... so the interesting `k`
+        // are the powers of two and their neighbours: one below converges a
+        // round early, one above forces the extra widening. Substitutions are
+        // spaced so the distance is exactly the number of them, which is
+        // asserted rather than assumed — the point of the test is that a
+        // *named* `k` was exercised.
+        let mut state = 0x1928_u64 | 1;
+        let reference: Vec<u8> = (0..256)
+            .map(|_| b"ACGT"[(next(&mut state) as usize) % 4])
+            .collect();
+        for k in [0usize, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33] {
+            let mut alt = reference.clone();
+            for slot in 0..k {
+                // Spaced far apart, so no cheaper indel-bearing alignment
+                // exists and the distance really is `k`.
+                let at = slot * 7 + 3;
+                alt[at] = match alt[at] {
+                    b'A' => b'C',
+                    b'C' => b'G',
+                    b'G' => b'T',
+                    _ => b'A',
+                };
+            }
+            let seen = assert_band_matches_full_grid(&reference, &alt);
+            assert_eq!(
+                seen as usize, k,
+                "the fixture for k = {k} no longer has that edit distance"
+            );
+        }
+    }
+
+    #[test]
+    fn the_band_agrees_with_the_full_grid_across_the_whole_divergence_range() {
+        // Randomised, and deliberately spanning the range the band cannot
+        // narrow: from `k = 0` (identical blocks, one diagonal) through single
+        // digits (a real variant) to a uniform-random alternate of unrelated
+        // length, where `k` approaches `n` and the band is the whole grid.
+        let mut state = 0xBA4D_u64 | 1;
+        let mut checked = 0usize;
+        let mut saw_zero = false;
+        let mut saw_near_n = false;
+        for &n in &[0usize, 1, 2, 5, 9, 16, 33, 64] {
+            let reference: Vec<u8> = (0..n)
+                .map(|_| b"ACGT"[(next(&mut state) as usize) % 4])
+                .collect();
+            for trial in 0..24usize {
+                let alt: Vec<u8> = if trial >= 20 {
+                    // An unrelated alternate of unrelated length: the
+                    // `k ≈ 0.6n` regime, plus a `delta` the band must centre on.
+                    let len = if n == 0 {
+                        0
+                    } else {
+                        1 + (next(&mut state) as usize) % (2 * n)
+                    };
+                    (0..len)
+                        .map(|_| b"ACGT"[(next(&mut state) as usize) % 4])
+                        .collect()
+                } else {
+                    apply_random_edits(&reference, trial.min(n), &mut state)
+                };
+                let k = assert_band_matches_full_grid(&reference, &alt);
+                saw_zero |= k == 0;
+                saw_near_n |= n > 0 && k as usize >= n;
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 192, "expected the full sweep, ran {checked}");
+        assert!(saw_zero, "the sweep never exercised k = 0");
+        assert!(saw_near_n, "the sweep never exercised k >= n");
+    }
+
+    #[test]
+    fn the_band_agrees_with_the_full_grid_at_a_realistic_block_size() {
+        // The regime the change exists for, and the one small blocks cannot
+        // show: hundreds of bases with a single-digit edit distance, where the
+        // band is a sliver of the grid rather than most of it. Unequal lengths
+        // are included because the indel edits change the block length.
+        let mut state = 0xB4E1_u64 | 1;
+        let reference: Vec<u8> = (0..512)
+            .map(|_| b"ACGT"[(next(&mut state) as usize) % 4])
+            .collect();
+        for k in [0usize, 1, 2, 4, 8, 16] {
+            let alt = apply_random_edits(&reference, k, &mut state);
+            assert_band_matches_full_grid(&reference, &alt);
+        }
+    }
+
+    /// The band must be NARROW, not merely correct.
+    ///
+    /// Every `the_band_agrees_with_the_full_grid_*` test above asserts that the
+    /// banded build **agrees** with the full-grid one — and a full-width band
+    /// satisfies all of them trivially. So a change that quietly stopped
+    /// narrowing (a doubling seeded at `widest`, a sign slip in `ceil_half`, a
+    /// "simplification" of `band_for`) would leave the entire suite green while
+    /// deleting the optimization outright. Nothing else in the crate would
+    /// notice: the only other signal is a criterion run, and CI does not do one.
+    ///
+    /// This is the mirror of the hazard the module header records in the other
+    /// direction. A band one doubling too *narrow* is caught by the differential
+    /// tests; a band too *wide* is caught by nothing, and that is the direction a
+    /// well-meaning refactor actually takes.
+    ///
+    /// Checked against a deliberate sabotage rather than assumed: forcing
+    /// `band_for` to return the full-width band (`k = n + m`) leaves the module
+    /// at **95 passed, 1 failed** — this test being the one failure, with all
+    /// five differential tests and the brute-force dominator oracle still green.
+    #[test]
+    fn the_band_is_narrow_at_low_divergence_so_a_no_op_regression_is_caught() {
+        // `band_for` directly: at a real-variant edit distance the band is a
+        // handful of diagonals regardless of how long the blocks are.
+        for &n in &[256usize, 1024, 4096] {
+            let (lo, hi) = band_for(n, n, 2);
+            let width = hi - lo + 1;
+            assert_eq!(
+                width, 3,
+                "band is {width} diagonals at n={n}, k=2; expected a 3-diagonal sliver"
+            );
+        }
+        // Unequal lengths: the band tracks `delta`, so it stays narrow while
+        // being centred away from the main diagonal.
+        let (lo, hi) = band_for(1024, 1020, 8);
+        assert_eq!((lo, hi), (-2, 6), "the band must centre on delta/2 = 2");
+
+        // And the walk the band drives must visit `O((n + m) * k)` cells, not
+        // `O(n * m)` — the property the cell-count column in the module header
+        // claims, checked rather than asserted in prose.
+        let mut state = 0x1928_u64 | 1;
+        let reference: Vec<u8> = (0..1024)
+            .map(|_| b"ACGT"[(next(&mut state) as usize) % 4])
+            .collect();
+        let alt = apply_random_edits(&reference, 2, &mut state);
+        let dag = AlignmentDag::build(&reference, &alt)
+            .expect("1024 + 1024 is far below MAX_ALIGNMENT_SPAN");
+        let visited = dag.cells().count();
+        let grid = (reference.len() + 1) * (alt.len() + 1);
+        assert!(
+            visited * 100 < grid,
+            "cells() visited {visited} of {grid} cells — that is grid-scale, so \
+             the band is not narrowing the walk"
         );
     }
 }


### PR DESCRIPTION
Advances #1928. **No longer stacked — #1952 has merged** (`e93652c5`), so this is now a single commit against `main`, two files.

**Rebased twice on 2026-08-15.** First onto #1952's branch head (`d5961dad`), which added the `MAX_ALIGNMENT_SPAN` refusal for #1970 and fixed `diverge_indels` — both touched the code this PR rewrites, so that reconciliation is described under *Composing with the span refusal* below rather than left as a silent merge. Then, once #1952 squash-merged, with `git rebase --onto origin/main d5961dad` to drop the three commits `main` had absorbed.

Worth stating because it reads alarmingly and is not: between those two steps GitHub reported this PR `CONFLICTING / DIRTY`. That is the **stacked-PR-whose-base-merged** shape, not a textual conflict — the base's commits are on `main` under a different sha, so a plain `git rebase origin/main` would try to replay them and die, while `--onto` past the merged base replays only this PR's own commit. It did so cleanly, with no conflicts.

The rebase is verified by content rather than by ancestry, because a force-push after a rebase can never be a fast-forward and the usual `--is-ancestor` test therefore proves nothing:

```
$ git range-diff d5961dad..5ae5aaa0 origin/main..HEAD
1:  5ae5aaa0 = 1:  d6b846ab perf(normalize): band the sequence-first alignment DP
```

`=` means this commit is byte-identical in content on both sides. The three commits the push drops are #1952's own, which `main` absorbed as the squash `e93652c5`.

Confines the sequence-first alignment DP to the diagonals a minimal alignment can occupy. **Storage is deliberately left at full `(n+1) x (m+1)` shape**, which turns out to be the headline result rather than a footnote — see the measurement below.

## The band, and why it is exact rather than heuristic

A cell `(i, j)` on diagonal `d = i - j` costs at least `|d|` to reach from the source and at least `|delta - d|` to reach the sink from, so every cell on an alignment of cost `k` satisfies `|d| + |delta - d| <= k`, i.e.

```
ceil((delta - k) / 2)  <=  d  <=  floor((delta + k) / 2)
```

`k` is **found, not chosen**: doubling from `max(|delta|, 1)` until the band-confined distance no longer exceeds its own band. Confining the DP can only over-estimate, so a distance the band itself admits is provably the true one; at `k = n + m` the band is the whole grid, so the ladder terminates exactly. There is no seed, no anchor, and no tie-break — `on_optimal_path` **is** the set of cells on some minimal alignment, and every such cell is inside the band by construction. The DAG comes out bit-identical.

`lo + hi == delta` holds by parity, which is load-bearing rather than decorative: reversing both blocks maps `d -> delta - d`, so the *same* interval bands the suffix grid with no second derivation.

## Correctness

Five differential tests keep the **pre-band implementation verbatim** as a second implementation — not "the banded code with a full band", which would test the parameter rather than the algorithm — and diff distance, `on_optimal_path`, `out`, the `cells()` walk and `dominators()`. They cover exhaustive small inputs, the named shape boundaries (empty blocks, pure ins/del, `k=0`, `k=1`, `|delta|=17` both signs), every doubling boundary, the whole divergence range, and a 512-base block at sliver-band widths.

**Three sabotages were run to prove the harness discriminates**, and one produced a finding worth more than the change: accepting a band one doubling too narrow is caught **only** by the differential tests. `dominators_agree_with_brute_force_on_exhaustive_small_inputs` *passes* on it, because that probe is computed from the DAG itself — a uniformly shrunken DAG is internally consistent. Filed separately as **#1959**.

A sixth test asserts the band is **narrow**, not merely correct. Every differential test passes trivially against a full-width band, so without it a refactor that stopped narrowing would delete the optimization with the whole suite green. Verified by sabotage: forcing a full-width band gives **95 passed, 1 failed**, that test being the one failure.

## Measured — and the geometry over-predicts by ~148x

Quiet dedicated `c7i.4xlarge` (x86_64, 4 kB pages), criterion against this PR's own base, so banding is the only variable. **Noise floor established first from the same binary against itself: −1.0% to +3.9%**, with a +2–4% bias against whichever arm runs later (the banded one). Criterion's own significance test reported "Performance has regressed" at p = 0.00 on that self-comparison five times, so its verdict line is not used here — only magnitudes against the measured floor.

| n (k = 2) | speedup | cell-count ratio |
|---:|---:|---:|
| 256 | 37.0x | 74x |
| 1024 | 6.6x | 293x |
| 4096 | **7.9x** | **1171x** |

Against divergence at n = 1024: 33.3x at `k=2`, 13.3x at `k=32`, 5.1x at `k=128`, 1.56x at `k=512`, and **0.90x (11.2% slower) at `k=614`** — the uniform-random regime where the band is the whole grid and the ladder is overhead paid for nothing. Real variants sit at single-digit `k`.

**The interesting number is the gap.** At `n = 4096` the band writes ~1171x fewer cells and runs only 7.9x faster, because `build` still allocates and zeroes ~101 MB of full-size grids: 101 MB / 20 ms is ~5 GB/s, i.e. the banded time is essentially all allocation and no DP. So this commit converts `build` from compute-bound to **allocation-bound**, and narrowing the *storage* to the band is now the lever rather than a tidy-up.

Two consequences recorded in the code because they are not obvious:

- **Do not quote a single speedup.** `by_length_fixed_k/len1024_k2` and `by_divergence/k2` are the *same* computation and measured **5.8x apart**, purely on whether a large arena had already been faulted in. Their unbanded baselines differ by only 15%.
- **Peak memory is not measured here.** Criterion has no memory axis and the RSS harness was not run against this commit. The time win is not a memory win, and the doc says so. The page-size reasoning differs between 16 kB (Apple silicon) and the 4 kB Linux host that produced these numbers; both are stated as predictions, neither as a result.

## Composing with the span refusal (#1970)

`build` is now `Option<Self>`, refusing past `MAX_ALIGNMENT_SPAN`. That is checked **before** the band is derived, so it bounds the whole computation and not merely the fill: `k` is itself bounded by `n + m`, and every value the banded DP writes is a prefix or suffix cost under the same bound as the full sweep. Banding narrows which cells are *visited*, never how large a cost can *get*.

Two consequences, both verified rather than argued:

- **`the_span_bound_is_enforced_from_both_sides` passes unchanged** against the banded build. Its accepted-boundary case is a `1 x 65,534` alignment, where the sentinel `UNREACHED = u16::MAX` sits exactly one above the largest real cost — and the banded fill's `saturating_add` makes that boundary strictly safer than the unbanded `+` it replaces.
- The pre-band `debug_assert!(2 * (n + m) < UNREACHED)` this PR originally carried is **deleted**, not kept alongside. It was both weaker (a `debug_assert` in a profile that disables them) and wrong about the bound — the exact one is `n + m <= u16::MAX`, which #1970's analysis derives.

The module-level `edit_grid` is removed, since `fill_edit_grid_banded` replaces it. It survives *only* inside the differential harness, which is precisely where the pre-band implementation belongs.

## Also in this commit

`benches/seqfirst_align.rs`'s header carried `~18 bytes per grid cell, ~275 MB`, which #1952 superseded when it narrowed the grid to `u16` (14.60 B/cell, 215.4 MB). That staleness is the base's rather than this PR's, but it sits in a header this commit is already rewriting, and leaving a known-wrong figure in a file being edited is worse than fixing it out of band.

The base's `diverge_indels` fix is **inherited, not duplicated** — this PR's header edits and that fix merged cleanly, and the indel arm now generates genuine indel pairs rather than substitutions.

That has a consequence for what this PR may claim. The EC2 run above predates the fix, so its `indel_vs_sub` group was comparing substitutions against substitutions; **no figure from that group is quoted here, and none should be** until it is re-run. The two groups that *are* quoted — `by_length_fixed_k` and `by_divergence` — both draw from `diverge_subs`, which was correct throughout, so they stand.

## Verification

Re-run in full **after** the rebase onto `main`, not carried over from the pre-rebase head:

- `cargo nextest run --features dev --no-fail-fast` — **11,036 passed**, 0 failed, with the prepared reference **armed** (`FERRO_MANIFEST` set to a manifest confirmed present) and `FERRO_REQUIRE_BULK_FIXTURES=1`, all four bulk fixtures digest-verified. **Zero `Skipping:` lines**, so the reference-aware suites genuinely ran rather than standing down.
- Python — **1,059 passed**. `cargo nextest` does not reach `tests/python/`, and this PR touches `src/normalize/`, so a green Rust gate says nothing about the bindings on its own.
- `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- Both gitignored spec artifacts regenerated first. A rebase never updates them, and a stale one fails as `enumeration_replays_recorded_behavior`, which reads like a destroyed ruling rather than like its own staleness.

Every figure above was read back out of the run's own `EXIT_` lines rather than from the job's exit status, since the driver ends in an `echo` and would report 0 regardless.

Representation-Change: none. Measured, not assumed. The DAG is bit-identical — retained cells, out-edge masks and `dominators()` all diff clean against the pre-band implementation over exhaustive small inputs, every doubling boundary and the whole divergence range, and the full gate passes with every existing pinned value unchanged. No description ferro emits can move, because nothing here changes which cells lie on a minimal alignment - only which cells are examined to find them.

