### PR TITLE
perf(ci): build the soak archive from a driver package, not the whole `it` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,7 +593,12 @@ jobs:
           # eviction.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: clippy
-      - run: cargo clippy --features dev --all-targets -- -D warnings
+      # `--workspace` because `default-members` is the root package alone (see
+      # `Cargo.toml`), so without it the `ferro-hgvs-soak-tests` driver — the one
+      # `test-build-soak` compiles — is linted by nothing. It is the only member,
+      # and it compiles a dozen modules that `--features dev` does not reach here
+      # anyway, so the added cost is one small test target.
+      - run: cargo clippy --workspace --features dev --all-targets -- -D warnings
 
   clippy-all-features:
     # Lints the feature-gated code that `--features dev` never compiles —
@@ -964,9 +969,33 @@ jobs:
   # 0.355s under this one — 5.4x. The other jobs run each test once and would
   # only pay the longer compile.
   #
-  # Only the `it` binary is built (`--test it`): every test the soak selects
-  # with `-E 'test(proptest)'` lives there, so compiling the rest of the test
-  # targets at `opt-level = 3` would be pure cost.
+  # ONE PACKAGE IS BUILT, AND IT IS NOT `ferro-hgvs`'s `it` TARGET. This job used
+  # to build `--test it`, which compiles the whole 139k-line `it` crate — 6,217
+  # tests — at `opt-level = 3` so that about 45 of them can run. Measured on an
+  # M2 Max, `user` CPU with the workspace artifacts scrubbed the way `rust-cache`
+  # scrubs them here, deps warm: 394.8s for the `it` archive, of which the
+  # library is a minority. The rest was the driver, and the runtime
+  # `opt-level = 3` buys comes from optimizing the LIBRARY.
+  #
+  # Cargo profile overrides are keyed on the PACKAGE, never on the target, so
+  # `[profile.soak.package.ferro-hgvs]` reaches the lib, the bins and the `it`
+  # test target alike — there is no way to spell "library optimized, driver
+  # cheap" while both are one package. `ferro-hgvs-soak-tests` is that second
+  # package: `tests-soak/tests/soak/main.rs` `#[path]`-includes the modules the
+  # three consuming jobs select — plus, separately marked, any module one of
+  # those reaches into — while the modules themselves stay under `tests/it/` and
+  # stay declared in `tests/it/main.rs`.
+  #
+  # NOTE the package is NOT dropped to a lower `opt-level`, which is the half of
+  # #1964 the measurement refused; the table and the reasoning are on
+  # `[profile.soak]` in `Cargo.toml`. The saving is from compiling ~9k lines
+  # instead of 139k, not from optimizing them less.
+  #
+  # `tests/it/soak_package_membership.rs` polices both directions: a module CI
+  # selects from this archive that is not compiled into it would be negated by
+  # `test`/`test-oracle` and run nowhere while CI got faster, and a module
+  # compiled into it that nothing selects and nothing references is dead compile
+  # cost on the critical path.
   #
   # `debug-assertions` and `overflow-checks` stay ON in the profile (see
   # Cargo.toml) so this buys speed without quietly weakening what the soak
@@ -1047,11 +1076,12 @@ jobs:
         # No `--features dev`. That feature pulls in `web-service` (axum, tokio,
         # tower, tracing) and `benchmark` (reqwest, rusqlite, tokio-postgres,
         # futures) — an entire dependency tree compiled at `opt-level = 3` to
-        # produce one test binary that never touches any of it. `tests/it`
-        # gates only 2 of its ~360 modules on the feature and neither the soak
-        # nor the sweeps selects one, so the selections are unchanged: verified
-        # by listing both under each feature set, `test(proptest)` resolves to
-        # 20 tests either way and the sweep filter to 44.
+        # produce one test binary that never touches any of it. None of the ten
+        # modules this package compiles is gated on the feature and none of the
+        # three consuming jobs selects a gated one, so the selections are
+        # unchanged: verified by listing under each feature set,
+        # `test(proptest)` resolves to 20 tests either way and the sweep filter
+        # to 44.
         #
         # Both numbers have been stale before, in opposite directions and for
         # different reasons, which is why the re-measure commands are published
@@ -1064,10 +1094,10 @@ jobs:
         # "either way" — which held through both drifts and still holds; the
         # totals are incidental to it. Re-measure rather than trust them:
         #
-        #   cargo nextest list --test it -E 'test(proptest)' | wc -l
-        #   cargo nextest list --test it -E "$SWEEP_FILTER" | wc -l
+        #   cargo nextest list -p ferro-hgvs-soak-tests -E 'test(proptest)' | wc -l
+        #   cargo nextest list -p ferro-hgvs-soak-tests -E "$SWEEP_FILTER" | wc -l
         run: |
-          cargo nextest archive --cargo-profile soak --test it \
+          cargo nextest archive --cargo-profile soak -p ferro-hgvs-soak-tests \
             --archive-file nextest-soak.tar.zst
       - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         if: steps.soak-archive.outputs.cache-hit != 'true'
@@ -1489,10 +1519,13 @@ jobs:
     # Only the optimized archive, NOT `test-build`. Every test the selection
     # below reaches lives in `tests/it/{cis_allele_confluence,
     # from_sequences, minimal_alignment_enumeration,
-    # normalize_idempotency}_proptest.rs`, and none reads the generated spec
-    # fixture or shells out to the staged generators — so the shards need
-    # neither of those artifacts, and waiting on the job that produces them
-    # would put the dev-profile compile back on the soak's critical path.
+    # normalize_idempotency}_proptest.rs` — all four of which
+    # `tests-soak/tests/soak/main.rs` compiles, which is what puts them in this
+    # archive at all now that it holds one package rather than the whole `it`
+    # binary — and none reads the generated spec fixture or shells out to the
+    # staged generators — so the shards need neither of those artifacts, and
+    # waiting on the job that produces them would put the dev-profile compile
+    # back on the soak's critical path.
     #
     # `from_sequences_proptest.rs` joined this selection by being named
     # `*proptest*`, which is worth stating because the filter is by name: a new
@@ -1584,8 +1617,12 @@ jobs:
   #   repeat_span_sibling_overlap        40.44s -> 5.29s   7.6x
   #   issue_1254_sibling_crossing_shift  20.14s -> 2.32s   8.7x
   #
-  # They cost nothing extra to build: all three live in `tests/it/`, so they are
-  # already inside the archive `test-build-soak` produces for the soak.
+  # All three live in `tests/it/` and are `#[path]`-included by
+  # `tests-soak/tests/soak/main.rs`, so they are inside the archive
+  # `test-build-soak` produces alongside the soak's own modules — one archive for
+  # the three jobs, not one per job. Adding a fourth sweep means naming it there
+  # as well as in `SWEEP_FILTER`; `tests/it/soak_package_membership.rs` fails if
+  # only one of the two is done.
   #
   # Running them ONLY here, with both oracles on, loses no coverage. The oracles
   # add assertions at `normalize_core_checked`'s exit and change no behaviour, so
@@ -1702,10 +1739,13 @@ jobs:
   # file is absent, and this job has no crate to build from. `bulk-fixtures` is
   # needed for the three corpus tests in that same module.
   #
-  # Verified archive-safe the way `soak` and `sweeps` are: all three modules
-  # live in `tests/it/`, so they are already inside the archive
-  # `test-build-soak` produces, none is gated on the `dev` feature, and none
-  # reads `CARGO_BIN_EXE_ferro`.
+  # Verified archive-safe the way `soak` and `sweeps` are: all three modules live
+  # in `tests/it/` and are `#[path]`-included by `tests-soak/tests/soak/main.rs`,
+  # so they are inside the archive `test-build-soak` produces, none is gated on
+  # the `dev` feature, and none reads `CARGO_BIN_EXE_ferro`. A module named in
+  # `CENSUS_FILTER` but missing from that driver would be negated here and absent
+  # from the archive, i.e. run nowhere;
+  # `tests/it/soak_package_membership.rs` is what makes that loud.
   censuses:
     name: Slow censuses (optimized)
     needs: [test-build-soak, spec-fixtures, fixtures]
@@ -1896,7 +1936,8 @@ jobs:
       - run: cargo clippy --release -- -D warnings
       # The featureless guard (#1505). Every other Rust job in this workflow
       # either passes `--features dev` / `--all-features`, or is scoped to the
-      # integration binary (`test-build-soak`'s `--test it`). So the DEFAULT
+      # soak driver package (`test-build-soak`'s
+      # `-p ferro-hgvs-soak-tests`). So the DEFAULT
       # feature set's unit tests — the `#[cfg(test)]` modules under `src/` — are
       # compiled NOWHERE in CI, and a call from one of them into feature-gated
       # code cannot turn any job red.

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -39,8 +39,8 @@ jobs:
   # eight compiled the whole test suite from scratch AND ran both spec
   # generators first — eight full builds, and ~52s of fixture generation per
   # shard for an artifact no proptest module reads. This mirrors what PR CI's
-  # `test-build-soak` does instead: build once, archive the `it` binary, and let
-  # the shards download it.
+  # `test-build-soak` does instead: build once, archive the soak driver package,
+  # and let the shards download it.
   #
   # `--cargo-profile soak` matters more here than anywhere: measured at 5,000
   # cases, a confluence property costs 1.90s of user CPU in the test profile
@@ -115,12 +115,18 @@ jobs:
           cache-bin: "false"
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - name: Build soak archive
-        # No `--features dev` — see the same step in ci.yml. The feature drags
+        # `-p ferro-hgvs-soak-tests`, not `--test it` — see the same step in
+        # ci.yml for why that package exists. The three proptest modules this
+        # workflow's shards select are `#[path]`-included by
+        # `tests-soak/tests/soak/main.rs`, so they are in the archive; nothing
+        # else in `tests/it/` is compiled at `opt-level = 3` to get them there.
+        #
+        # No `--features dev`, also as in ci.yml. The feature drags
         # `web-service` and `benchmark` into an `opt-level = 3` build for a
         # binary that uses neither, and `test(proptest)` resolves to the same
         # 10 tests with or without it.
         run: |
-          cargo nextest archive --cargo-profile soak --test it \
+          cargo nextest archive --cargo-profile soak -p ferro-hgvs-soak-tests \
             --archive-file nextest-soak.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,25 @@ cargo test --features dev            # Alternative
 cargo nextest run -E 'test(parse)'   # Run specific tests by name pattern
 ```
 
+**Those commands do not build `ferro-hgvs-soak-tests`, and they do not need to.**
+That workspace member (`tests-soak/`) is the driver CI's optimized-archive jobs
+run; it `#[path]`-includes the modules those jobs select, which remain under
+`tests/it/` and remain
+declared in `tests/it/main.rs`, so the commands above still run every one of
+them, from the `it` binary. It is out of `default-members` precisely so nothing
+above changes and no module is run twice locally. Build the driver itself only
+when you have touched one of the modules it includes, a `tests/it/common/` helper they
+reach, or the profile:
+
+```bash
+cargo nextest run -p ferro-hgvs-soak-tests
+```
+
+The one thing it exercises that `it` cannot: that binary's working directory is
+`tests-soak/`, not the workspace root, so a helper resolving a fixture against
+the cwd goes red there and passes in `it`. Fixture paths go through
+`common::fixture_gen::fixture_path` for that reason.
+
 #### Fast local iteration — two knobs, both measured
 
 A one-line test edit costing two minutes is not the crate being big; it is two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferro-hgvs-soak-tests"
+version = "0.0.0"
+dependencies = [
+ "ferro-hgvs",
+ "flate2",
+ "proptest",
+ "rayon",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,25 @@ autoexamples = false
 autobins = false
 autobenches = false
 
+# One member, `tests-soak`, which owns the test driver the optimized-archive CI
+# jobs run. It exists because cargo profile overrides are keyed on the PACKAGE
+# and never on the target: `[profile.soak.package.ferro-hgvs]` reaches this
+# package's lib, its bins AND its `it` test target alike, so while that driver
+# was a target of this package there was no way to optimize the code under test
+# without also optimizing 139k lines of loops-and-`format!` around it. See
+# `tests-soak/tests/soak/main.rs`.
+#
+# `default-members` is this package alone, deliberately, so nothing about a
+# local `cargo build` / `cargo nextest run` / `cargo llvm-cov` changes: the
+# member's modules are `#[path]`-included from `tests/it/` and are still
+# declared in `tests/it/main.rs`, so they keep running from the `it` binary
+# exactly as before. Build the member explicitly with `-p
+# ferro-hgvs-soak-tests`.
+[workspace]
+members = ["tests-soak"]
+default-members = ["."]
+resolver = "2"
+
 [lib]
 name = "ferro_hgvs"
 # cdylib is required for Python bindings (built via maturin)
@@ -485,6 +504,40 @@ opt-level = 3
 [profile.dev.package.flate2]
 opt-level = 3
 
+# `test-build-soak` builds this profile so that `soak`, `sweeps` and `censuses`
+# run against an optimized `libferro_hgvs`: their work is compute-bound and a
+# constant factor on the library is multiplied a million times over.
+#
+# THE TEST DRIVER IS NOT LOWERED, and that is a measured answer rather than an
+# omission — #1964 asked for exactly such an override and the measurement refused
+# it. Recorded here so it is not re-derived.
+#
+# The premise was that the driver is loops and `format!`, so it could sit at a
+# low `opt-level` while `ferro-hgvs` stayed at 3. That became expressible with
+# #1964's split — `ferro-hgvs-soak-tests` is its own package, and profile
+# overrides are keyed on the package — and it does not pay. Measured on an M2 Max
+# (12 core), `user` CPU seconds because wall clock on a shared machine is not
+# reproducible; deps warm and the workspace artifacts scrubbed every rep the way
+# `rust-cache` scrubs them in CI. Build is the median of 5 reps, run the mean of
+# 2; "sweeps" is that job's selection at `FERRO_SWEEP_SEEDS=full` with all four
+# oracles armed, "censuses" is both of that job's steps:
+#
+#   driver opt-level | build (soak archive) | run: sweeps | run: censuses
+#   -----------------+----------------------+-------------+---------------
+#   3 (as shipped)   |                105.7 |       139.8 |          90.2
+#   2                |                105.1 |       141.2 |          89.7
+#   1                |                101.1 |       143.9 |          92.8
+#   0                |                 85.5 |       240.9 |         109.2
+#
+# So `opt-level = 0` buys ~20s of compile and gives back ~101s of run; 1 and 2
+# are a wash in both directions. The compile column is flat because of the
+# *other* half of #1964: this package compiles ~8k lines where the `it` crate is
+# 139k, so there is little left for a lower `opt-level` to save. The comparison
+# that pays is against what this job used to build — `--test it`, 394.8s — and
+# that is the split, not the `opt-level`.
+#
+# `debug-assertions` and `overflow-checks` stay ON so this buys speed without
+# quietly weakening what the soak checks.
 [profile.soak]
 inherits = "test"
 opt-level = 3

--- a/tests-soak/Cargo.toml
+++ b/tests-soak/Cargo.toml
@@ -1,0 +1,36 @@
+# The test driver for the three jobs that run off the optimized archive.
+#
+# WHY THIS IS ITS OWN PACKAGE, and not a second `[[test]]` target of the root
+# package: cargo profile overrides are keyed on the PACKAGE, never on the
+# target. `[profile.soak.package.ferro-hgvs]` applies to `ferro-hgvs`'s lib, its
+# bins AND its `it` test target alike — measured, not assumed — so while the
+# driver lived in `tests/it/` there was no way to say "the code under test at
+# `opt-level = 3`, the loops-and-`format!` driver cheaply". A separate package is
+# the only unit that override can address.
+#
+# It compiles the module files IN PLACE under `tests/it/` via `#[path]` rather
+# than owning copies of them; see `tests/soak/main.rs` for why.
+[package]
+name = "ferro-hgvs-soak-tests"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.87"
+license = "MIT"
+description = "Test driver for ferro-hgvs's optimized-archive CI jobs (soak, sweeps, censuses)"
+publish = false
+
+# No `src/`: this package exists only to own the `tests/soak` target and the
+# profile override that addresses it. Cargo is happy with a package whose sole
+# target is an integration test.
+
+[dependencies]
+ferro-hgvs = { path = ".." }
+
+# The direct dependencies of the modules `tests/soak/main.rs` compiles and
+# of the four `tests/it/common/` helpers they reach through. Kept at the same
+# requirements as the root manifest's, so one lockfile entry serves both.
+flate2 = "1.0"
+proptest = "1.0"
+rayon = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/tests-soak/tests/soak/main.rs
+++ b/tests-soak/tests/soak/main.rs
@@ -1,0 +1,185 @@
+//! The test driver for the three CI jobs that run off the optimized archive:
+//! `soak`, `sweeps` and `censuses`.
+//!
+//! # Why this binary exists
+//!
+//! `test-build-soak` builds one archive at `opt-level = 3` because the work
+//! those three jobs do is compute-bound — eight shards of 125,000 proptest
+//! cases, three exhaustive cross-products, three censuses — and a constant
+//! factor on the code under test is multiplied a million times over. It used to
+//! build that archive as `--test it`, which compiles the WHOLE 139k-line `it`
+//! crate (6,217 tests) at `opt-level = 3` so that about 45 of them can run.
+//!
+//! Measured on this machine in `user` CPU seconds, since wall clock here is
+//! not reproducible: rebuilding the `it` binary alone costs 251.9s while
+//! rebuilding `libferro_hgvs` and then `it` costs 368.6s — so the library is
+//! ~32% of that job and the test driver ~68%. The runtime `opt-level = 3` buys
+//! comes from optimizing the LIBRARY; the driver is loops and `format!`.
+//!
+//! Cargo profile overrides are keyed on the package and not on the target, so
+//! `[profile.soak.package.ferro-hgvs]` reaches `ferro-hgvs`'s lib, its bins and
+//! its `it` test target alike. A separate package is therefore the only unit
+//! that can be addressed on its own — hence this one, and hence
+//! `[profile.soak.package.ferro-hgvs-soak-tests]` in the root manifest.
+//!
+//! # Why the modules are `#[path]`-included rather than moved here
+//!
+//! Every module below is compiled from its file under `tests/it/`, unmoved, and
+//! is STILL declared in `tests/it/main.rs`. That is deliberate on three counts:
+//!
+//! * **The guards that scan by directory keep working.** `sweep_filter_invariant`,
+//!   `oracle_exclude_invariant`, `generated_fixture_ci_wiring`,
+//!   `ruling_citation_currency` and `ruling_guard_field` all enumerate `.rs`
+//!   files under `tests/it/` (or under `tests/`) and each fails in the
+//!   *flattering* direction — a module that leaves the scan simply stops being
+//!   policed. Moving `spec_conformance_axis.rs`, which carries 54 spec
+//!   citations, out of `tests/` would have silently emptied two of them.
+//! * **The ruling ledger cites test files by path.** Two `decided` records name
+//!   guards in `tests/it/cis_junction_crossing_shift.rs` and
+//!   `tests/it/spec_conformance_axis.rs`; moving the files would have meant
+//!   editing the adjudication ledger to chase a build-layout change.
+//! * **`issue_1615_denoted_sequence_oracle` is run twice on purpose** — un-armed
+//!   in `test`, armed in `sweeps` (see `ci.yml`). It stays in the `it` binary
+//!   for the first and is compiled here for the second, which is exactly what
+//!   an in-place include gives for free.
+//!
+//! A fourth consequence is worth stating because it is the one that would have
+//! failed silently: **the pinned proptest seeds keep replaying, unmoved.**
+//! `tests/proptest-regressions/*.txt` are RNG seeds resolved from `file!()`, and
+//! proptest walks up from the source file to the directory holding `main.rs`,
+//! then writes its `proptest-regressions` sibling. Because `#[path]` leaves the
+//! `..` segments in `file!()` and the filesystem resolves them, this binary
+//! resolves
+//! `tests-soak/tests/soak/../../../tests/proptest-regressions/<module>.txt` —
+//! the same committed file `it` reads. Verified by appending an unparsable line
+//! and reading back the path proptest named in its warning. Had they moved,
+//! nothing would have gone red: those seeds are checked in NO other job, since
+//! `test` and `test-oracle` both negate `test(proptest)`.
+//!
+//! The cost of the choice is that membership here is a second list that can
+//! drift out of step with `ci.yml`'s filters. That is closed by
+//! `tests/it/soak_package_membership.rs`, which fails when a module CI selects
+//! from this archive is not compiled into it — the failure that would otherwise
+//! be silent, because such a module is negated by `test`/`test-oracle`, absent
+//! from this binary, and therefore run nowhere while CI gets faster.
+//!
+//! # Running it locally
+//!
+//! It is not in `default-members`, so a plain `cargo nextest run --features dev`
+//! does not build it and the local suite is unchanged — those same modules still
+//! run from the `it` binary. To exercise this binary itself:
+//!
+//! ```text
+//! cargo nextest run -p ferro-hgvs-soak-tests
+//! cargo nextest archive --cargo-profile soak -p ferro-hgvs-soak-tests \
+//!     --archive-file nextest-soak.tar.zst
+//! ```
+
+// The shared helpers the modules below reach through `crate::common::…`,
+// `#[path]`-included from `tests/it/common/` for the same reason the test
+// modules are. `#[path]` on a top-level `mod` resolves against the directory of
+// the file declaring it, i.e. `tests-soak/tests/soak/`.
+//
+// `allow(dead_code)` for the reason `tests/it/common/mod.rs` gives: each binary
+// that includes the tree compiles all of it and uses a different subset, so the
+// unused-item warnings are per-binary noise. This binary uses a much smaller
+// subset than `it` does.
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/bulk_fixtures.rs"]
+mod bulk_fixtures;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/cis_apply_oracle.rs"]
+mod cis_apply_oracle;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/fixture_gen.rs"]
+mod fixture_gen;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/manifest.rs"]
+mod manifest;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/minimal_alignment.rs"]
+mod minimal_alignment;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/spec_fixture.rs"]
+mod spec_fixture;
+#[allow(dead_code)]
+#[path = "../../../tests/it/common/synthetic.rs"]
+mod synthetic;
+
+/// The `crate::common::<helper>` façade the included files are written against.
+///
+/// They are compiled here byte-for-byte as `tests/it` compiles them, so the
+/// path they use has to resolve here too. Re-exported rather than declared
+/// inside this module so that every `#[path]` above is relative to one
+/// directory instead of two.
+mod common {
+    pub(crate) use super::{
+        bulk_fixtures, cis_apply_oracle, fixture_gen, manifest, minimal_alignment, spec_fixture,
+        synthetic,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// The modules the three jobs select. Each list is kept in step with `ci.yml` by
+// `tests/it/soak_package_membership.rs`.
+// ---------------------------------------------------------------------------
+
+// `soak` — `-E 'test(proptest)'`, eight shards of 125,000 cases each.
+#[path = "../../../tests/it/cis_allele_confluence_proptest.rs"]
+mod cis_allele_confluence_proptest;
+#[path = "../../../tests/it/from_sequences_proptest.rs"]
+mod from_sequences_proptest;
+#[path = "../../../tests/it/minimal_alignment_enumeration_proptest.rs"]
+mod minimal_alignment_enumeration_proptest;
+#[path = "../../../tests/it/normalize_idempotency_proptest.rs"]
+mod normalize_idempotency_proptest;
+
+// `sweeps` — `-E "$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)"`.
+#[path = "../../../tests/it/cis_junction_crossing_shift.rs"]
+mod cis_junction_crossing_shift;
+#[path = "../../../tests/it/issue_1254_sibling_crossing_shift.rs"]
+mod issue_1254_sibling_crossing_shift;
+#[path = "../../../tests/it/issue_1615_denoted_sequence_oracle.rs"]
+mod issue_1615_denoted_sequence_oracle;
+#[path = "../../../tests/it/repeat_span_sibling_overlap.rs"]
+mod repeat_span_sibling_overlap;
+
+// `censuses` — `-E "$CENSUS_FILTER"`, split over the job's two steps by whether
+// the seam oracles may be armed.
+#[path = "../../../tests/it/issue_1542_direction_symmetry.rs"]
+mod issue_1542_direction_symmetry;
+#[path = "../../../tests/it/normalize_axis_preserving.rs"]
+mod normalize_axis_preserving;
+#[path = "../../../tests/it/spec_conformance_axis.rs"]
+mod spec_conformance_axis;
+
+// ---------------------------------------------------------------------------
+// SUPPORT: compiled because a module above reaches into it, NOT because any job
+// selects it. Its own tests run from `it`, where they always have.
+//
+// `tests/it/soak_package_membership.rs` distinguishes the two categories by
+// derivation rather than by a marker here: anything this file compiles that no
+// job selects must be named as `crate::<module>::` by something else this file
+// compiles. So the exemption cannot be claimed, only earned — and it lapses the
+// moment the reference goes away, which is what keeps this from becoming a
+// place to park dead compile cost on the critical path.
+// ---------------------------------------------------------------------------
+
+// `minimal_alignment_enumeration_proptest::the_closed_form_and_the_enumerator_agree`
+// cross-checks the enumerator against
+// `issue_1539_split_member_separation::forced_unchanged_columns`, the Θ(n·m)
+// closed-form detector.
+//
+// THE TWO IMPLEMENTATIONS ARE KEPT APART ON PURPOSE, so the obvious tidy-up —
+// move the function next to its sibling in `common/minimal_alignment.rs` and
+// drop this include — is the one thing not to do. `common/minimal_alignment.rs`
+// says so in its own doc, and the `unchanged-is-read-over-every-minimal-alignment`
+// ruling names this symbol BY PATH as the detector the ruling came from. That
+// path appears in the ledger's rationale, in the blessed
+// `docs/NORMALIZATION_CONTRACT.md` rendered from it, and in the helper's doc —
+// so relocating the function to satisfy a build-layout constraint would falsify
+// a `decided` record's prose in three places and force a contract re-bless.
+// Compiling 1117 lines of test module is the cheaper side of that trade by a
+// wide margin.
+#[path = "../../../tests/it/issue_1539_split_member_separation.rs"]
+mod issue_1539_split_member_separation;

--- a/tests/it/clinvar_hgvs_tests.rs
+++ b/tests/it/clinvar_hgvs_tests.rs
@@ -43,7 +43,7 @@ fn load_fixture_bytes(filename: &str) -> Option<Vec<u8>> {
     let path = format!("tests/fixtures/bulk/{}", filename);
     // Absent means "skip" locally and "fail" under `FERRO_REQUIRE_BULK_FIXTURES`,
     // which CI sets — see `common::bulk_fixtures`.
-    crate::common::bulk_fixtures::present_or_skip(&path)?;
+    let path = crate::common::bulk_fixtures::present_or_skip(&path)?;
     // See cmrg_exhaustive_tests::load_fixture_bytes for why we
     // decompress to a Vec and use `from_slice`.
     let file = File::open(&path).unwrap_or_else(|e| panic!("Failed to open {}: {}", filename, e));

--- a/tests/it/cmrg_exhaustive_tests.rs
+++ b/tests/it/cmrg_exhaustive_tests.rs
@@ -45,7 +45,7 @@ fn load_fixture_bytes() -> Option<Vec<u8>> {
     let path = "tests/fixtures/validation/cmrg_genes_exhaustive.json.gz";
     // Absent means "skip" locally and "fail" under `FERRO_REQUIRE_BULK_FIXTURES`,
     // which CI sets — see `common::bulk_fixtures`.
-    crate::common::bulk_fixtures::present_or_skip(path)?;
+    let path = crate::common::bulk_fixtures::present_or_skip(path)?;
     // Decompress to an in-memory Vec, then deser via `from_slice` rather
     // than `from_reader` over a streaming gzip pipeline. Empirically ~5x
     // faster on this fixture (34s -> 7s in debug mode) — `from_slice`

--- a/tests/it/common/bulk_fixtures.rs
+++ b/tests/it/common/bulk_fixtures.rs
@@ -29,7 +29,7 @@
 //! fetches the fixtures, so absence can no longer masquerade as a pass; it stays
 //! unset locally, where skipping is the useful default.
 
-use std::path::Path;
+use std::path::PathBuf;
 
 /// The environment variable that promotes a fixture-absence skip to a failure.
 pub const REQUIRE_ENV: &str = "FERRO_REQUIRE_BULK_FIXTURES";
@@ -85,11 +85,27 @@ fn missing_fixture_message(path: &str) -> String {
 
 /// Read a gzip-compressed bulk fixture's presence, applying the policy above.
 ///
-/// `Some(())` when the file exists; `None` after recording the skip (or after
-/// panicking, under `FERRO_REQUIRE_BULK_FIXTURES`).
-pub fn present_or_skip(path: &str) -> Option<()> {
-    if Path::new(path).exists() {
-        return Some(());
+/// `path` is relative to the WORKSPACE ROOT, and the resolved absolute path is
+/// what comes back — so the caller opens the file this function tested for,
+/// rather than re-resolving the same string against its own working directory.
+///
+/// **That is the whole reason it returns a path.** It used to answer `Some(())`
+/// and leave each caller to `File::open(path)`, which agreed only while every
+/// caller's process ran with the workspace root as its cwd. `#[cfg(test)]`
+/// callers no longer all do: nextest sets a test binary's cwd to its own
+/// PACKAGE root, and `normalize_axis_preserving` is compiled into
+/// `ferro-hgvs-soak-tests` as well as into `it` (see
+/// `tests-soak/tests/soak/main.rs`), where the same relative string would name
+/// `tests-soak/tests/fixtures/…`. Under `FERRO_REQUIRE_BULK_FIXTURES` that is a
+/// loud failure; without it, it is the silent one this module exists to
+/// prevent — three corpora reported absent and skipped green.
+///
+/// `None` after recording the skip (or after panicking, under
+/// `FERRO_REQUIRE_BULK_FIXTURES`).
+pub fn present_or_skip(path: &str) -> Option<PathBuf> {
+    let resolved = crate::common::fixture_gen::fixture_path(path);
+    if resolved.exists() {
+        return Some(resolved);
     }
     absent(path);
     None
@@ -116,9 +132,18 @@ fn the_missing_fixture_message_names_the_path_and_the_remedy() {
 }
 
 /// A fixture that exists is never a skip, whatever the variable says.
+///
+/// It also pins the resolution: the answer must be the workspace-root copy,
+/// which is what makes this test meaningful in `ferro-hgvs-soak-tests`, whose
+/// working directory is `tests-soak/` rather than the workspace root. Before
+/// `present_or_skip` resolved the path itself, this assertion failed there —
+/// which is how the silent-skip hazard on the bulk corpora was found.
 #[test]
 fn an_existing_bulk_fixture_path_is_present() {
-    assert_eq!(present_or_skip("tests/fixtures/README.md"), Some(()));
+    let resolved = present_or_skip("tests/fixtures/README.md")
+        .expect("tests/fixtures/README.md is committed and must resolve");
+    assert!(resolved.is_absolute(), "{resolved:?} is not absolute");
+    assert!(resolved.is_file(), "{resolved:?} is not a file");
 }
 
 /// The predicate's contract, pinned against the spellings CI and a developer

--- a/tests/it/common/fixture_gen.rs
+++ b/tests/it/common/fixture_gen.rs
@@ -12,7 +12,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 /// Serializes regeneration attempts within a single test binary, across both
 /// fixtures. Cross-binary races are made safe by writing to a per-process temp
@@ -21,12 +21,46 @@ use std::sync::Mutex;
 /// mutex is safe.
 static GEN_LOCK: Mutex<()> = Mutex::new(());
 
-/// Absolute path to a generated fixture, rooted at `CARGO_MANIFEST_DIR` so it is
-/// independent of the test's working directory.
+/// The workspace root, which every path in this module is relative to.
+///
+/// **Not `CARGO_MANIFEST_DIR` directly, and the difference is the whole reason
+/// this function exists.** That macro names the package this file is compiled
+/// INTO, and it is compiled into two of them: the root `ferro-hgvs` package's
+/// `it` target, and the `ferro-hgvs-soak-tests` member, which `#[path]`-includes
+/// this file (see `tests-soak/tests/soak/main.rs`). For the first it already
+/// names the workspace root; for the second it names `<root>/tests-soak`, and
+/// every fixture path built from it would be wrong by one directory — silently,
+/// because a missing generated fixture is *regenerated* rather than reported,
+/// so the failure would be a nested `cargo run` writing into a directory nobody
+/// reads.
+///
+/// The root is found by ascending to the first ancestor holding `Cargo.lock`,
+/// which cargo writes at the workspace root and never in a member. Resolved once
+/// and cached: it is read on every fixture lookup and the answer cannot change
+/// within a process.
+fn workspace_root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        loop {
+            if dir.join("Cargo.lock").is_file() {
+                return dir;
+            }
+            assert!(
+                dir.pop(),
+                "no Cargo.lock in any ancestor of {} — the workspace root cannot \
+                 be located, so no generated-fixture path can be built",
+                env!("CARGO_MANIFEST_DIR")
+            );
+        }
+    })
+}
+
+/// Absolute path to a generated fixture, rooted at the workspace root so it is
+/// independent of the test's working directory *and* of which package the
+/// caller was compiled into.
 pub fn fixture_path(relative: &str) -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.push(relative);
-    p
+    workspace_root().join(relative)
 }
 
 /// Ensure `path` exists, regenerating it via
@@ -107,7 +141,12 @@ fn ensure_generated(
         return;
     }
 
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    // The workspace root, not this package's directory: the generators are
+    // `[[bin]]`/`[[example]]` targets of `ferro-hgvs`, so a nested `cargo run`
+    // has to start where that package is the default one. From
+    // `ferro-hgvs-soak-tests`'s own directory it would fail with "no bin target
+    // named `generate_spec_fixture`".
+    let manifest_dir = workspace_root();
     let dir = path.parent().expect("fixture path has a parent directory");
     let tmp = dir.join(format!("{tmp_stem}.{}.tmp", std::process::id()));
 
@@ -149,5 +188,42 @@ fn ensure_generated(
     } else if let Err(err) = std::fs::rename(&tmp, path) {
         let _ = std::fs::remove_file(&tmp);
         assert!(path.exists(), "failed to install generated {label}: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The root every fixture path hangs off must be the WORKSPACE root, not
+    /// the including package's directory.
+    ///
+    /// This compiles into both binaries that include this file, so it is
+    /// asserted once per package — which is the point: the `it` copy would pass
+    /// under the old `CARGO_MANIFEST_DIR` reading too, and the
+    /// `ferro-hgvs-soak-tests` copy is the one that would not. A regression
+    /// here does not go red on its own, it makes `ensure_spec_fixture`
+    /// regenerate into a directory nobody reads.
+    #[test]
+    fn the_fixture_root_is_the_workspace_root_from_either_package() {
+        let root = workspace_root();
+        assert!(
+            root.join("Cargo.lock").is_file(),
+            "{} holds no Cargo.lock",
+            root.display()
+        );
+        let manifest = std::fs::read_to_string(root.join("Cargo.toml"))
+            .unwrap_or_else(|e| panic!("read {}/Cargo.toml: {e}", root.display()));
+        assert!(
+            manifest.lines().any(|line| line.trim() == "[workspace]"),
+            "{} holds a Cargo.toml with no [workspace] table, so it is a member \
+             directory rather than the workspace root",
+            root.display()
+        );
+        assert!(
+            fixture_path("tests/fixtures/grammar").is_dir(),
+            "the generated-fixture directory does not resolve from {}",
+            root.display()
+        );
     }
 }

--- a/tests/it/issue_1539_split_member_separation.rs
+++ b/tests/it/issue_1539_split_member_separation.rs
@@ -35,7 +35,6 @@
 //! sees real reference bases, needs no `FERRO_MANIFEST`, and cannot skip.
 
 use std::collections::BTreeSet;
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use ferro_hgvs::conformance::reference_window::{WindowFixture, WindowProvider};
@@ -47,6 +46,14 @@ use ferro_hgvs::reference::transcript::Transcript;
 use ferro_hgvs::spdi::convert::hgvs_to_spdi;
 use ferro_hgvs::{parse_hgvs, FerroError, HgvsVariant, Normalizer, ReferenceProvider};
 
+// Workspace-root-relative, and resolved through
+// `common::fixture_gen::fixture_path` rather than opened as written. nextest
+// sets a test binary's working directory to its own PACKAGE root, and this
+// module is compiled into two packages — `ferro-hgvs`'s `it` target and the
+// `ferro-hgvs-soak-tests` driver, which reaches
+// `forced_unchanged_columns` for `minimal_alignment_enumeration_proptest`'s
+// cross-check. In the second the cwd is `tests-soak/`, where these paths name
+// nothing.
 const INPUTS_TXT: &str = "tests/fixtures/split-member-separation/inputs.txt";
 const WINDOWS_JSON: &str = "tests/fixtures/split-member-separation/reference-windows.json";
 const REGENERATE: &str =
@@ -417,8 +424,9 @@ fn codon_resolver<P: ReferenceProvider>(
 /// lines ignored. `examples/extract_split_member_separation_windows.rs` applies
 /// the identical rule when capturing the windows.
 fn inputs() -> Vec<String> {
+    let path = crate::common::fixture_gen::fixture_path(INPUTS_TXT);
     let content =
-        std::fs::read_to_string(INPUTS_TXT).unwrap_or_else(|e| panic!("read {INPUTS_TXT}: {e}"));
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {INPUTS_TXT}: {e}"));
     content
         .lines()
         .map(str::trim)
@@ -428,7 +436,7 @@ fn inputs() -> Vec<String> {
 }
 
 fn window_fixture() -> WindowFixture {
-    WindowFixture::from_json_path(Path::new(WINDOWS_JSON))
+    WindowFixture::from_json_path(&crate::common::fixture_gen::fixture_path(WINDOWS_JSON))
         .unwrap_or_else(|e| panic!("load {WINDOWS_JSON}: {e}"))
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -507,6 +507,7 @@ mod ruling_citation_currency;
 mod ruling_guard_field;
 mod sequence_normalize;
 mod service_tools_tests;
+mod soak_package_membership;
 mod spdi_dup_recovery;
 mod spdi_tests;
 mod spec_canonical_locks;

--- a/tests/it/normalize_axis_preserving.rs
+++ b/tests/it/normalize_axis_preserving.rs
@@ -107,8 +107,8 @@ struct SpecRow {
 fn load_gzipped(path: &str) -> Option<Vec<u8>> {
     // Absent means "skip" locally and "fail" under `FERRO_REQUIRE_BULK_FIXTURES`,
     // which CI sets — see `common::bulk_fixtures`.
-    crate::common::bulk_fixtures::present_or_skip(path)?;
-    let file = File::open(path).unwrap_or_else(|e| panic!("failed to open {path}: {e}"));
+    let resolved = crate::common::bulk_fixtures::present_or_skip(path)?;
+    let file = File::open(&resolved).unwrap_or_else(|e| panic!("failed to open {path}: {e}"));
     let mut buf = Vec::new();
     GzDecoder::new(file)
         .read_to_end(&mut buf)

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -493,8 +493,16 @@ fn the_local_oracle_runner_selects_exactly_what_ci_selects() {
 /// `and not ($SWEEP_FILTER)` inverts the job from "the suite minus the three
 /// sweeps" to "only the three sweeps", i.e. ~8,900 tests down to ~30, which is
 /// the quiet-narrowing failure the runner's own header warns about.
+/// **Its name may not contain `proptest`, and that is not cosmetic.** `test()`
+/// is a substring predicate over the whole test name, so a function carrying
+/// that token is selected by the `soak` job's `-E 'test(proptest)'` and negated
+/// by `test` and `test-oracle` — which used to mean this assertion about
+/// `ci.yml` ran only inside the 1M-case soak, and now that the soak archive
+/// holds only the modules `tests-soak/tests/soak/main.rs` compiles, would mean
+/// it ran nowhere at all. `tests/it/soak_package_membership.rs` fails on any
+/// such name.
 #[test]
-fn the_ci_oracle_selection_negates_proptest_the_sweeps_and_the_corpus_modules() {
+fn the_ci_oracle_selection_negates_the_property_tests_the_sweeps_and_the_corpus_modules() {
     let selection = ci_oracle_selection();
     assert!(
         selection.contains("not test(proptest)"),

--- a/tests/it/paraphase_exhaustive_tests.rs
+++ b/tests/it/paraphase_exhaustive_tests.rs
@@ -46,7 +46,7 @@ fn load_fixture_bytes() -> Option<Vec<u8>> {
     let path = "tests/fixtures/validation/paraphase_genes_exhaustive.json.gz";
     // Absent means "skip" locally and "fail" under `FERRO_REQUIRE_BULK_FIXTURES`,
     // which CI sets — see `common::bulk_fixtures`.
-    crate::common::bulk_fixtures::present_or_skip(path)?;
+    let path = crate::common::bulk_fixtures::present_or_skip(path)?;
     // See cmrg_exhaustive_tests::load_fixture_bytes for why we
     // decompress to a Vec and use `from_slice`.
     let file = File::open(path).expect("Failed to open paraphase_genes_exhaustive.json.gz");

--- a/tests/it/soak_package_membership.rs
+++ b/tests/it/soak_package_membership.rs
@@ -1,0 +1,379 @@
+//! Liveness check for the pairing between the optimized archive and the jobs
+//! that run off it.
+//!
+//! `test-build-soak` no longer archives the whole `it` binary. It archives one
+//! test target owned by the `ferro-hgvs-soak-tests` package, whose driver
+//! (`tests-soak/tests/soak/main.rs`) `#[path]`-includes exactly the modules the
+//! three consuming jobs — `soak`, `sweeps`, `censuses` — select. That buys the
+//! compile-time saving the split exists for, and it introduces one list that can
+//! drift: the driver's.
+//!
+//! **The drift fails silently and in the flattering direction.** A module named
+//! in `SWEEP_FILTER` or `CENSUS_FILTER`, or matching the `soak` job's
+//! `test(proptest)`, is NEGATED by `test` and `test-oracle`. If it is not also
+//! compiled into the soak driver, it is in no archive that any job selects, so
+//! it runs **nowhere** — and nothing goes red. `--no-tests=fail` on each of the
+//! three jobs catches a selection that matches *nothing*, never one module of
+//! four going missing. This is the same shape as `sweep_filter_invariant`'s
+//! unnamed-consumer case and as `census_filter_invariant`'s unrun-module case,
+//! one level further out: those two ask whether the FILTERS agree with the jobs,
+//! and this one asks whether the BINARY agrees with the filters.
+//!
+//! The converse is cheaper but still worth failing on: a module compiled into
+//! the driver that no job selects is paid for on the critical path — the exact
+//! cost the split was made to remove — while contributing nothing. With one
+//! earned exception, which the driver has to demonstrate rather than assert: a
+//! module another compiled module names as `crate::<module>::` is a link-time
+//! dependency, not dead weight. See
+//! [`the_soak_driver_compiles_nothing_the_archive_jobs_do_not_select`].
+//!
+//! # Why this reads `ci.yml` itself rather than sharing a helper
+//!
+//! The fourth file in `tests/it/` to parse `ci.yml`, and deliberately so, for
+//! the reason `census_filter_invariant.rs` sets out at length: these are
+//! liveness guards, a bug in one shared extractor would neuter all of them at
+//! once, and it would do so by returning an empty selection — which makes every
+//! assertion vacuous rather than red. Each guard asserts its own read is
+//! non-empty, so four independent readers are four independent chances to
+//! notice.
+//!
+//! # The one thing it does not see
+//!
+//! `test(X)` is a substring predicate over the whole test NAME, so it can match
+//! a test function rather than a module — `test(proptest)` would select a
+//! `fn …_proptest()` sitting in a module this driver does not compile. The scan
+//! below expands each term over module names only. There is no such function
+//! today (asserted by [`no_test_function_hides_behind_a_module_level_term`]),
+//! which is what keeps the module-level reading complete.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// The workflow this file is entirely about.
+const CI_YML: &str = ".github/workflows/ci.yml";
+
+/// The soak driver, whose `#[path]` list is the membership under test.
+const SOAK_DRIVER: &str = "tests-soak/tests/soak/main.rs";
+
+/// The jobs that run off the archive `test-build-soak` produces. Every module
+/// any of them selects has to be compiled into it.
+const ARCHIVE_CONSUMERS: &[&str] = &["soak", "sweeps", "censuses"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn ci_text() -> String {
+    std::fs::read_to_string(repo_root().join(CI_YML)).expect("ci.yml is readable")
+}
+
+/// A `>-` folded scalar from `ci.yml`'s top-level `env:`, folded back to one
+/// line, or `None` when no such key exists.
+fn ci_filter(key: &str) -> Option<String> {
+    let ci = ci_text();
+    let mut lines = ci.lines();
+    let header = lines
+        .by_ref()
+        .find(|line| line.trim_start().starts_with(&format!("{key}:")))?;
+
+    let inline = header
+        .split_once(':')
+        .map(|(_, value)| value.trim())
+        .unwrap_or_default();
+    if !inline.is_empty() && !inline.starts_with(['>', '|']) {
+        return Some(inline.to_string());
+    }
+    assert!(
+        inline.starts_with(['>', '|']),
+        "{key} is neither a block scalar nor an inline value: {header:?}"
+    );
+
+    let key_indent = header.len() - header.trim_start().len();
+    let mut value = String::new();
+    for line in lines {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent <= key_indent {
+            break;
+        }
+        value.push(' ');
+        value.push_str(line.trim());
+    }
+    assert!(
+        !value.trim().is_empty(),
+        "{key} parsed as empty; ci.yml's formatting changed"
+    );
+    Some(value)
+}
+
+/// Every `-E "…"` selection a top-level job hands to nextest, in file order,
+/// with each `$VAR` reference expanded from `ci.yml`'s own `env:` block.
+///
+/// Expanding rather than reading the variables separately is what makes the
+/// scan agree with what the runner actually selects: `sweeps` passes
+/// `"$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)"`, and only the
+/// expansion carries both halves.
+fn selections_in(job: &str) -> Vec<String> {
+    let ci = ci_text();
+    let header = format!("  {job}:");
+    let mut lines = ci.lines().skip_while(|line| *line != header);
+    assert!(
+        lines.next().is_some(),
+        "ci.yml defines no `{job}` job; this guard cannot see what it runs"
+    );
+    let body: Vec<&str> = lines
+        // A non-blank, non-comment line back at job-key indent ends the block.
+        .take_while(|line| {
+            line.starts_with("    ") || line.trim().is_empty() || line.trim_start().starts_with('#')
+        })
+        .collect();
+
+    body.iter()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .filter_map(|line| {
+            let at = line.find("-E \"").or_else(|| line.find("-E '"))?;
+            let quote = line.as_bytes()[at + 3] as char;
+            let rest = &line[at + 4..];
+            rest.find(quote).map(|end| expand_vars(&rest[..end]))
+        })
+        .collect()
+}
+
+/// Substitute every `$NAME` in a selection with that key's value from `ci.yml`'s
+/// `env:` block.
+fn expand_vars(selection: &str) -> String {
+    let mut out = selection.to_string();
+    while let Some(at) = out.find('$') {
+        let name: String = out[at + 1..]
+            .chars()
+            .take_while(|c| c.is_ascii_uppercase() || *c == '_')
+            .collect();
+        assert!(
+            !name.is_empty(),
+            "a bare `$` in a ci.yml selection: {selection}"
+        );
+        let value = ci_filter(&name).unwrap_or_else(|| {
+            panic!("selection references ${name}, which ci.yml does not define")
+        });
+        out.replace_range(at..at + 1 + name.len(), &value);
+    }
+    out
+}
+
+/// The `test(...)` terms of a nextest filter expression.
+fn terms_in(filter: &str) -> Vec<String> {
+    filter
+        .match_indices("test(")
+        .filter_map(|(at, _)| {
+            let rest = &filter[at + "test(".len()..];
+            rest.find(')').map(|end| rest[..end].trim().to_string())
+        })
+        .collect()
+}
+
+/// Every top-level module of `tests/it/`, by name.
+fn it_modules() -> BTreeSet<String> {
+    std::fs::read_dir(repo_root().join("tests/it"))
+        .expect("tests/it is readable")
+        .filter_map(|entry| {
+            let path = entry.expect("readable dir entry").path();
+            let name = path.file_name()?.to_str()?;
+            name.strip_suffix(".rs").map(str::to_string)
+        })
+        .collect()
+}
+
+/// The modules the three archive-consuming jobs select, by expanding each
+/// `test(X)` term over the module names it matches.
+///
+/// `test(X)` is a substring predicate, which is why `test(proptest)` — the whole
+/// of the `soak` job's selection — resolves to three modules without being
+/// special-cased here.
+fn modules_selected_from_the_archive() -> BTreeSet<String> {
+    let modules = it_modules();
+    let mut selected = BTreeSet::new();
+    for job in ARCHIVE_CONSUMERS {
+        let selections = selections_in(job);
+        assert!(
+            !selections.is_empty(),
+            "the `{job}` job passes no -E selection to nextest; its shape changed \
+             and this guard cannot see what it runs"
+        );
+        for selection in selections {
+            for term in terms_in(&selection) {
+                let matched: Vec<&String> = modules.iter().filter(|m| m.contains(&term)).collect();
+                assert!(
+                    !matched.is_empty(),
+                    "the `{job}` job selects `test({term})`, which matches no module \
+                     under tests/it/ — a rename, or a filter this guard can no \
+                     longer read"
+                );
+                selected.extend(matched.into_iter().cloned());
+            }
+        }
+    }
+    selected
+}
+
+/// The modules `tests-soak/tests/soak/main.rs` compiles, read from its `#[path]`
+/// attributes.
+///
+/// The helpers under `tests/it/common/` are excluded: they are infrastructure
+/// the modules reach through, not things a job selects.
+fn soak_driver_modules() -> BTreeSet<String> {
+    let text = std::fs::read_to_string(repo_root().join(SOAK_DRIVER))
+        .unwrap_or_else(|e| panic!("read {SOAK_DRIVER}: {e}"));
+    let needle = "#[path = \"../../../tests/it/";
+    let mut found = BTreeSet::new();
+    let mut rest = text.as_str();
+    while let Some(at) = rest.find(needle) {
+        let after = &rest[at + needle.len()..];
+        let end = after
+            .find('"')
+            .expect("a #[path] attribute closes its string");
+        let relative = &after[..end];
+        rest = &after[end..];
+        if let Some(name) = relative.strip_suffix(".rs") {
+            if !name.contains('/') {
+                found.insert(name.to_string());
+            }
+        }
+    }
+    assert!(
+        !found.is_empty(),
+        "{SOAK_DRIVER} declares no tests/it module; its `#[path]` form changed and \
+         every assertion in this file would be vacuous"
+    );
+    found
+}
+
+/// Every module the three jobs select must be compiled into the archive they
+/// select it from.
+#[test]
+fn every_module_the_archive_jobs_select_is_compiled_into_the_soak_driver() {
+    let selected = modules_selected_from_the_archive();
+    let compiled = soak_driver_modules();
+
+    let missing: Vec<&String> = selected.difference(&compiled).collect();
+    assert!(
+        missing.is_empty(),
+        "ci.yml's `soak` / `sweeps` / `censuses` jobs select these modules from the \
+         optimized archive, but {SOAK_DRIVER} does not compile them into it: \
+         {missing:?}\n\
+         `test` and `test-oracle` negate every one of them, so they run in NO job \
+         — CI stays green and gets faster, which is the coverage deletion this \
+         guard exists to make loud.\n\
+         Add a `#[path = \"../../../tests/it/<module>.rs\"] mod <module>;` to that \
+         file."
+    );
+}
+
+/// …and nothing else it cannot account for, or the critical path pays to compile
+/// a module no job runs.
+///
+/// **A module no job selects is allowed exactly one justification: something
+/// else the driver compiles reaches into it.** `minimal_alignment_enumeration_proptest`
+/// cross-checks the enumerator against
+/// `crate::issue_1539_split_member_separation::forced_unchanged_columns`, so that
+/// module has to be in the binary for the selected one to link — while nothing
+/// selects its own ~40 tests, which go on running from `it`.
+///
+/// The exemption is **derived, not declared**. A marker comment in the driver
+/// would be a claim this test then trusts; requiring a `crate::<module>::`
+/// reference from a compiled sibling makes the driver *demonstrate* the need,
+/// and makes the exemption lapse by itself the moment the reference is deleted.
+/// That is what stops "support module" becoming a place to park dead compile
+/// cost on the workflow's critical path, which is the cost this package was
+/// split out to remove.
+#[test]
+fn the_soak_driver_compiles_nothing_the_archive_jobs_do_not_select() {
+    let selected = modules_selected_from_the_archive();
+    let compiled = soak_driver_modules();
+
+    // What every compiled module's source says, so a reference can be looked for
+    // across the whole binary rather than only in the selected half — a support
+    // module may legitimately be reached by another support module.
+    let sources: Vec<(String, String)> = compiled
+        .iter()
+        .map(|module| {
+            let path = repo_root().join(format!("tests/it/{module}.rs"));
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            (module.clone(), text)
+        })
+        .collect();
+
+    let mut unaccounted = Vec::new();
+    for module in compiled.difference(&selected) {
+        let needle = format!("crate::{module}::");
+        let reached_by: Vec<&str> = sources
+            .iter()
+            .filter(|(name, text)| name != module && text.contains(&needle))
+            .map(|(name, _)| name.as_str())
+            .collect();
+        if reached_by.is_empty() {
+            unaccounted.push(module.clone());
+        }
+    }
+
+    assert!(
+        unaccounted.is_empty(),
+        "{SOAK_DRIVER} compiles these modules, no `soak` / `sweeps` / `censuses` \
+         selection reaches them, and no module it compiles names them as \
+         `crate::<module>::` either: {unaccounted:?}\n\
+         They are pure compile cost on the workflow's critical path, which is the \
+         cost this package was split out to remove. Drop them, or select them."
+    );
+}
+
+/// The scan reads `test(X)` over module names, so a test FUNCTION whose name
+/// carries one of those terms would be selected by a job and invisible here.
+///
+/// Closed by forbidding the shape rather than by widening the matcher: a
+/// function named for one of these terms outside the modules the driver
+/// compiles would be negated by `test` / `test-oracle` and absent from the
+/// archive, i.e. run nowhere, which is the same silent loss the two tests above
+/// exist for.
+#[test]
+fn no_test_function_hides_behind_a_module_level_term() {
+    let terms: BTreeSet<String> = ARCHIVE_CONSUMERS
+        .iter()
+        .flat_map(|job| selections_in(job))
+        .flat_map(|selection| terms_in(&selection))
+        .collect();
+    assert!(!terms.is_empty(), "no job selects on a test() term");
+
+    let compiled = soak_driver_modules();
+    let mut offenders = Vec::new();
+    for module in it_modules() {
+        if compiled.contains(&module) {
+            continue;
+        }
+        let path = repo_root().join(format!("tests/it/{module}.rs"));
+        let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {module}: {e}"));
+        for line in text.lines() {
+            let Some(at) = line.find("fn ") else { continue };
+            if !line.trim_start().starts_with("fn ") && !line.trim_start().starts_with("pub fn ") {
+                continue;
+            }
+            let name: String = line[at + 3..]
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            for term in &terms {
+                if name.contains(term.as_str()) {
+                    offenders.push(format!("{module}::{name} matches test({term})"));
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these functions live outside the soak driver but carry a name one of the \
+         archive jobs selects on, so they would be negated by `test` / \
+         `test-oracle` and absent from the archive — run nowhere: {offenders:#?}\n\
+         Rename them, or compile their module into {SOAK_DRIVER}."
+    );
+}


### PR DESCRIPTION
Closes #1964.

#1960 has merged and this is rebased onto `main`; `git log --oneline origin/main..HEAD` is one commit.

## The problem, measured

`test-build-soak` compiled the whole 139k-line `it` crate — 6,217 tests — at `opt-level = 3` so that its three consumers (`soak`, `sweeps`, `censuses`) could run 88 of them.

All figures are `user` CPU seconds on an M2 Max (12 core). Wall clock on that machine is not reproducible — several agent sessions run concurrently — and the same run showed 71–109s of wall for a stable ~395s of CPU, so wall is not quoted anywhere below. Dependencies are warm and the workspace artifacts are scrubbed before every rep, which is what `rust-cache` does in this job (it caches dependencies only and deletes workspace artifacts, so CI pays a full `ferro-hgvs` + driver compile every run). sccache is disabled for every measurement: this machine routes rustc through it globally, and the compile then happens in the sccache server rather than in a child, so `/usr/bin/time` under-reports by ~40× — the first pass at this measurement read 6.19s for a build that really cost ~250s.

| | build the soak archive |
|---|---:|
| before (`--test it`) | **394.8** (402.05 / 387.54) |
| after (`-p ferro-hgvs-soak-tests`) | **105.7** (median of 5: 105.99 / 105.67 / 104.87 / 105.81 / 105.12) |
| `libferro_hgvs` alone, same profile | 79.2 – 101.5 |

A **73% reduction**, and what is left is essentially the code under test: the library alone accounts for most of the 105.7s, which is irreducible — it is the thing `opt-level = 3` exists to optimize.

Runtime is unchanged. The sweeps selection, which is the largest and by far the most stable term, costs **139.8s** from the new archive against **140.3s** from the old one.

### On the real runner

Step-level, so job overhead (checkout, toolchain, nextest install, artifact upload) is not counted, and comparing only runs whose archive cache **missed** — a hit skips the build step entirely and reads as 0s, which is why two recent base-branch runs show 22s and 28s and are not comparable:

| | `Build soak archive` step |
|---|---:|
| base branch, run 31849010009 | 161s |
| this PR, run 31902502874 | **88s** |

A 45% cut on `test-build-soak`, which is the head of the critical path since `soak`, `sweeps` and `censuses` all `needs:` it. (An earlier revision of this branch measured 75s; the driver has since gained the fourth proptest module and the support module it reaches.) The three consumers are green on the settled run 31902588946: sweeps 77s, censuses 87s, soak shard 1/8 53s.

## Why it needs a package

Cargo profile overrides are keyed on the **package**, never on the target. That is verified rather than assumed — with `[profile.soak.package.rootpkg] opt-level = 3` and a profile default of 0, `cargo build -v` shows `opt-level=3` on the root package's lib **and** on its `it` test target, while a sibling member's test target gets the default. So while the driver was a target of `ferro-hgvs` there was no way to spell "code under test optimized, driver cheap".

## The `opt-level` measurement — a negative result

The issue asked for `[profile.soak.package.<driver>] opt-level = <low>`. **The measurement refuses it, and the override is not in this PR.** The rationale and the table are recorded on `[profile.soak]` in `Cargo.toml` so it is not re-derived.

| driver `opt-level` | build | run: sweeps | run: censuses |
|---:|---:|---:|---:|
| **3 (as shipped)** | **105.7** | **139.8** | **90.2** |
| 2 | 105.1 | 141.2 | 89.7 |
| 1 | 101.1 | 143.9 | 92.8 |
| 0 | 85.5 | **240.9** | 109.2 |

Builds are medians of 5 interleaved reps, runs the mean of 2. `opt-level = 0` buys ~20s of compile and gives back ~101s of run; 1 and 2 are a wash in both directions. The compile column is flat because of the *other* half of the change: the package compiles ~8k lines where `it` is 139k, so there is little left for a lower `opt-level` to save. **The split is what pays, not the `opt-level`.**

## The modules do not move

`tests-soak/tests/soak/main.rs` `#[path]`-includes the ten modules the three jobs select. The files stay under `tests/it/` and stay declared in `tests/it/main.rs`. That was chosen over relocating them because moving would have cost, silently in most cases:

* **Five guards scan by directory** — `sweep_filter_invariant`, `oracle_exclude_invariant`, `generated_fixture_ci_wiring`, `ruling_citation_currency`, `ruling_guard_field` — and each fails in the *flattering* direction: a module that leaves the scan simply stops being policed. `spec_conformance_axis.rs` carries 54 spec citations.
* **The ruling ledger cites test files by path.** `canonical-form-choice-when-both-legal` and `coding-axis-merges-are-a-disclosed-general-34-deviation` name guards in `tests/it/cis_junction_crossing_shift.rs` and `tests/it/spec_conformance_axis.rs`. Moving the files would have meant editing the adjudication ledger — and re-blessing `docs/NORMALIZATION_CONTRACT.md` — to chase a build-layout change.
* **`issue_1615_denoted_sequence_oracle` is run twice on purpose.** In place, it stays in `it` for the un-armed `test` run and is compiled here for the armed `sweeps` run, which is exactly what an in-place include gives for free.
* **The pinned proptest seeds keep replaying, unmoved.** `#[path]` leaves the `..` segments in `file!()` and the filesystem resolves them, so this binary resolves `tests-soak/tests/soak/../../../tests/proptest-regressions/<module>.txt` — the same committed file `it` reads. Verified empirically, by appending an unparsable line and reading back the path proptest named in its warning:

  ```
  proptest: /…/issue-1964/tests-soak/tests/soak/../../../tests/proptest-regressions/cis_allele_confluence_proptest.txt:51: unparsable line, ignoring
  ```

  Worth stating because had they moved, nothing would have gone red: those seeds are checked in **no** other job, since `test` and `test-oracle` both negate `test(proptest)`.

## What the indirection opens, and what closes it

Membership in the driver is a second list that can drift from `ci.yml`'s filters, and the drift is silent and flattering: a module named in `SWEEP_FILTER` or `CENSUS_FILTER`, or matching `test(proptest)`, is negated by `test` and `test-oracle` — so if it is not also compiled into the driver it runs in **no job**, and CI gets faster. `--no-tests=fail` catches a selection matching *nothing*, never one module of four going missing.

`tests/it/soak_package_membership.rs` is the guard, in both directions plus one:

1. every module the three jobs select must be compiled into the driver;
2. the driver must compile nothing they do not select (that is pure cost on the critical path);
3. no test **function** outside the driver may carry a name one of those `test(…)` substring terms matches — the hole the module-level reading would otherwise leave.

It reads `ci.yml` itself rather than sharing an extractor with the three guards that already do, for the reason `census_filter_invariant.rs` sets out at length: a bug in a shared extractor neuters all of them at once, and does it by returning an empty selection, which makes every assertion vacuous rather than red.

Guard (3) found a live instance on this base. `oracle_exclude_invariant::the_ci_oracle_selection_negates_proptest_the_sweeps_and_the_corpus_modules` carries the token `proptest` in its **name**, so `test(proptest)` selected it and `test`/`test-oracle` negated it — meaning an assertion about `ci.yml`'s shape was running only inside the 1M-case soak job, and after this change would have run nowhere. Renamed to `…negates_the_property_tests_…`, so it now runs in `test` and `test-oracle` where it belongs.

## Count-based partition proof

Test-name **sets**, not just counts, listed from the two real archives (`cargo nextest list --archive-file`, runnable tests, no `--features dev` — the archive is built without it):

| selection | before (`--test it`) | after (`-p ferro-hgvs-soak-tests`) |
|---|---:|---:|
| total in archive | 6174 | **121** |
| `soak`: `test(proptest)` | 29 | 29 |
| `sweeps`: `$SWEEP_FILTER + test(issue_1615_…)` | 54 | 54 |
| `censuses`: `$CENSUS_FILTER` | 13 | 13 |
| **selected total** | **96** | **96** |
| carried but selected by no job | 6078 | 25 |

Both columns are measured on this branch, so the packaging change is isolated: **every job selects exactly the same tests**, and the archive carrying them shrinks from 6174 to 121.

The 25 the driver carries that no job selects are the `#[cfg(test)]` units inside the `tests/it/common/` helpers it includes, plus `issue_1539_split_member_separation`'s own tests. Checked rather than asserted — every one of the 25 has a counterpart in the `it` binary, so none is stranded:

```
comm -23 <soak unselected> <it tests, common:: prefix normalised>   ->   (empty)
```

One test does change job, and only one: `oracle_exclude_invariant::the_ci_oracle_selection_negates_proptest_…` carried the token `proptest` in its **name**, so `test(proptest)` selected it and `test`/`test-oracle` negated it — an assertion about `ci.yml`'s shape was running only inside the 1M-case soak job. Renamed to `…negates_the_property_tests_…`, it now runs in `test` and `test-oracle`.

On the `it` side nothing left the binary, so the `test` / `test-oracle` selections are unaffected. With `--features dev`, `it` holds 6373 runnable tests and they partition exactly:

```
test job selection 6287 + proptest 29 + sweeps modules 44 + census modules 13 = 6373
```

`issue_1615_denoted_sequence_oracle`'s tests sit inside the 6287 — `test` does not negate that module — which is the deliberate double-run preserved.

## The fourth proptest module, and the one module compiled for it

`main` gained `minimal_alignment_enumeration_proptest` after this branch was cut. The `soak` job selects `test(proptest)`, so a driver holding only the original three would have deleted that module's 1M-case coverage on merge — silently, since `test`/`test-oracle` negate it. **`soak_package_membership` caught exactly that**, which is what it is for.

It needs two things the driver lacked: `common::minimal_alignment` (a helper, no `crate::` deps, included alongside the others) and `crate::issue_1539_split_member_separation::forced_unchanged_columns` — a `pub(crate)` fn in a full test module, used by `the_closed_form_and_the_enumerator_agree`.

**The tempting fix is to move that function beside its sibling in `common/minimal_alignment.rs`, and it is the wrong trade.** The `unchanged-is-read-over-every-minimal-alignment` ruling names the symbol **by path** as the detector the ruling came from — in its rationale, in the blessed `docs/NORMALIZATION_CONTRACT.md` rendered from it, and in the helper's own doc. Relocating it for a build-layout reason would falsify a `decided` record's prose in three places and force a contract re-bless, which is the class of cost this PR's whole design avoids. The two implementations are also kept independent on purpose so each checks the other.

So the module is compiled as **support**: no job selects it, and its own tests go on running from `it`. That needed the second membership test reframed rather than exempted — and the reframing is the interesting part:

> A compiled module no job selects must be named as `crate::<module>::` by another compiled module.

The exemption is **derived, not declared**. A marker comment in the driver would be a claim the test then trusts; requiring a real reference makes the driver *demonstrate* the need, and makes the exemption lapse by itself the moment the reference is deleted — so "support module" cannot become a place to park dead compile cost on the critical path. Verified by sabotage: parking an unreferenced `spdi_tests` in the driver fails the test by name.

## The one behavioural fix this surfaced

`bulk_fixtures::present_or_skip` now returns the **resolved** path instead of `Some(())`, and its four callers open that.

nextest sets a test binary's working directory to its own **package** root. Every caller did `present_or_skip(path)?` and then `File::open(path)` with the same cwd-relative string, which agreed only while that package root was the workspace root. From `ferro-hgvs-soak-tests` the cwd is `tests-soak/`, so `normalize_axis_preserving`'s three bulk-corpus tests would have resolved `tests/fixtures/bulk/…` under `tests-soak/`, found nothing, and — without `FERRO_REQUIRE_BULK_FIXTURES` — **skipped green**, deleting the ClinVar, CMRG and Paraphase axis coverage while the job got faster. Resolving inside `present_or_skip` makes presence and open agree by construction. `bulk_fixtures::an_existing_bulk_fixture_path_is_present` is what caught it, and now pins the resolution.

`issue_1539_split_member_separation` needed the same treatment for the same reason once it entered the driver: its two committed fixture paths (`tests/fixtures/split-member-separation/…`) were opened cwd-relative, so from `tests-soak/` four of its tests died on a missing file. They now resolve through `common::fixture_gen::fixture_path` too. That one fails loudly rather than skipping, but it is the same latent assumption.

## Also changed

* `nightly-soak.yml` builds the same package (it is the unseeded counterpart and archived `--test it` too).
* The `Clippy` job takes `--workspace`: `default-members` is the root package alone, so without it the new driver would be linted by nothing.
* `common::fixture_gen` resolves the workspace root by ascending to the `Cargo.lock` holder rather than trusting `CARGO_MANIFEST_DIR`, which names whichever package the file was compiled into. A unit test pins it, and runs once per including package.

## Verification

* `cargo fmt --all -- --check` — clean.
* `cargo clippy --workspace --features dev --all-targets -- -D warnings` — clean.
* `actionlint` and `zizmor` on both changed workflows — no findings.
* `cargo nextest run --features dev --no-fail-fast` — **11026 passed**, 0 failed (151 `#[ignore]`d).
* `cargo nextest run -p ferro-hgvs-soak-tests --no-fail-fast` — **121 passed**, 0 failed.
* `cargo build --profile soak -p ferro-hgvs-soak-tests --tests` — compiles. Note the `--tests`: this package has no lib and no bins, so a plain `cargo build -p` builds nothing and exits 0.
* The CI-reading invariants (`soak_package_membership`, `census_filter_invariant`, `oracle_exclude_invariant`, `sweep_filter_invariant`, `generator_completeness`) plus `fixture_gen`: 25 tests, all passing.
* `git status --porcelain tests/proptest-regressions/` clean after running the driver's proptests — no seed appended, no stray regressions directory under `tests-soak/`.

Representation-Change: none. No file under `src/` is touched at all — the change is a cargo package boundary, two workflow invocations and a test-harness path resolution, and the count-based partition above shows the same tests running with the same selections.


