### PR TITLE
perf(normalize): five allocation and formatting wins on the normalization hot path

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1341,11 +1341,14 @@ fn rna_simple_range(interval: &crate::hgvs::interval::RnaInterval) -> Option<Sel
 ///   why a total order is used rather than a stable sort keyed on position
 ///   alone — the latter would leave same-position members in input order, which
 ///   is the exact order-dependence #1098 is about.
-pub(crate) fn cis_member_order_key(
+///
+/// **This function is the positional part of that key** — everything before the
+/// descriptor. [`cis_member_order_cmp`] adds the descriptor tie-break on top,
+/// and only when it is going to decide.
+pub(crate) fn cis_member_order_prefix(
     v: &HgvsVariant,
-) -> (String, SelfCancellingPoint, SelfCancellingPoint, u8, String) {
-    let accession = v.accession().map(Accession::full).unwrap_or_default();
-    let descriptor = format!("{v}");
+) -> (SmolStr, SelfCancellingPoint, SelfCancellingPoint, u8) {
+    let accession = v.accession().map(Accession::full_smol).unwrap_or_default();
     // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
     // field order, which is exactly the comparison this key wants, so the points
     // go in whole rather than flattened into six scalars.
@@ -1355,13 +1358,28 @@ pub(crate) fn cis_member_order_key(
     // because that is what "sorts last" spells.
     let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
     let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
-    (accession, start, end, junction_rank(v), descriptor)
+    (accession, start, end, junction_rank(v))
+}
+
+/// Compare two cis members by the total order described on
+/// [`cis_member_order_prefix`].
+///
+/// Exactly the lexicographic comparison of
+/// `(cis_member_order_prefix(v), format!("{v}"))`: a tuple consults its last
+/// component only when every earlier one ties, so moving the render into
+/// `then_with` cannot change the order. It changes the cost — the descriptor is
+/// the whole member rendered, and the sort used to derive it for every member on
+/// every comparison, once per pass of the allele fixed-point loop.
+pub(crate) fn cis_member_order_cmp(a: &HgvsVariant, b: &HgvsVariant) -> std::cmp::Ordering {
+    cis_member_order_prefix(a)
+        .cmp(&cis_member_order_prefix(b))
+        .then_with(|| a.to_string().cmp(&b.to_string()))
 }
 
 /// Where within its own span a member adds sequence: `0` at the span's start,
 /// `1` at its end.
 ///
-/// Breaks a tie that [`cis_member_order_key`]'s `end` cannot (#1301). An
+/// Breaks a tie that [`cis_member_order_cmp`]'s `end` cannot (#1301). An
 /// insertion's span *is* the gap it fills, so `264_265insCA` adds at interbase
 /// 264; a duplication places its copy after its last base, so `264_265dup` adds
 /// at 265. The two share both endpoints, and without this the order fell to the
@@ -1415,7 +1433,7 @@ fn junction_rank(v: &HgvsVariant) -> u8 {
 /// positions, or a non-positional arm such as a null/unknown-allele marker).
 /// Reuses the per-axis range extractors that back the self-cancelling detector.
 ///
-/// The end is what breaks a start tie in [`cis_member_order_key`]; see that
+/// The end is what breaks a start tie in [`cis_member_order_cmp`]; see that
 /// function's docs for why the start alone is not a sufficient discriminator.
 fn cis_member_range(v: &HgvsVariant) -> Option<SelfCancellingRange> {
     match v {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1343,12 +1343,30 @@ fn rna_simple_range(interval: &crate::hgvs::interval::RnaInterval) -> Option<Sel
 ///   is the exact order-dependence #1098 is about.
 ///
 /// **This function is the positional part of that key** — everything before the
-/// descriptor. [`cis_member_order_cmp`] adds the descriptor tie-break on top,
+/// descriptor. `cis_member_order_cmp` adds the descriptor tie-break on top,
 /// and only when it is going to decide.
+/// **Test-only, and deliberately so.** Nothing ships this form: both sorts run
+/// behind a single-accession gate, so the accession component is constant across
+/// every comparison they make and `cis_member_order_cmp_within_accession` is what
+/// they call. This is retained as the *reference* the shipped comparator is
+/// checked against — see
+/// `dropping_the_accession_is_the_same_order_within_one_accession` — because a
+/// claim that two orders agree needs both orders to exist.
+#[cfg(test)]
 pub(crate) fn cis_member_order_prefix(
     v: &HgvsVariant,
 ) -> (SmolStr, SelfCancellingPoint, SelfCancellingPoint, u8) {
     let accession = v.accession().map(Accession::full_smol).unwrap_or_default();
+    let (start, end, rank) = cis_member_position_key(v);
+    (accession, start, end, rank)
+}
+
+/// `cis_member_order_prefix` without the accession.
+///
+/// Both callers of the order gate on every member sharing one accession before
+/// they sort, so within a sort that component is the same value for every key
+/// and can decide no comparison — see [`cis_member_order_cmp_within_accession`].
+fn cis_member_position_key(v: &HgvsVariant) -> (SelfCancellingPoint, SelfCancellingPoint, u8) {
     // `SelfCancellingPoint` derives `Ord` over `(region, base, offset)` in that
     // field order, which is exactly the comparison this key wants, so the points
     // go in whole rather than flattened into six scalars.
@@ -1358,11 +1376,11 @@ pub(crate) fn cis_member_order_prefix(
     // because that is what "sorts last" spells.
     let sentinel = SelfCancellingPoint::new(true, i64::MAX, i64::MAX);
     let (start, end) = cis_member_range(v).unwrap_or((sentinel, sentinel));
-    (accession, start, end, junction_rank(v))
+    (start, end, junction_rank(v))
 }
 
 /// Compare two cis members by the total order described on
-/// [`cis_member_order_prefix`].
+/// `cis_member_order_prefix`.
 ///
 /// Exactly the lexicographic comparison of
 /// `(cis_member_order_prefix(v), format!("{v}"))`: a tuple consults its last
@@ -1370,16 +1388,41 @@ pub(crate) fn cis_member_order_prefix(
 /// `then_with` cannot change the order. It changes the cost — the descriptor is
 /// the whole member rendered, and the sort used to derive it for every member on
 /// every comparison, once per pass of the allele fixed-point loop.
+#[cfg(test)]
 pub(crate) fn cis_member_order_cmp(a: &HgvsVariant, b: &HgvsVariant) -> std::cmp::Ordering {
     cis_member_order_prefix(a)
         .cmp(&cis_member_order_prefix(b))
         .then_with(|| a.to_string().cmp(&b.to_string()))
 }
 
+/// `cis_member_order_cmp` for a member list already known to share a single
+/// accession.
+///
+/// **Identical ordering at such a call site, by construction.** The accession is
+/// the key's first component, and if every member renders the same accession
+/// then that component is equal in every comparison the sort makes, so it can
+/// decide none of them; dropping it leaves the remaining components — and the
+/// descriptor tie-break — to give exactly the order the full key gives.
+///
+/// The point is the cost. `sort_cis_members_by_genomic_order` establishes the
+/// single-accession precondition and then sorts, so the full key rendered both
+/// members' accessions on **every comparison** — `O(n log n)` renders of a value
+/// that was constant across the whole sort, once per pass of the allele
+/// fixed-point loop. On a 100-member allele that is thousands of renders per
+/// normalization; on the two-member alleles the sweep draws it is four.
+pub(crate) fn cis_member_order_cmp_within_accession(
+    a: &HgvsVariant,
+    b: &HgvsVariant,
+) -> std::cmp::Ordering {
+    cis_member_position_key(a)
+        .cmp(&cis_member_position_key(b))
+        .then_with(|| a.to_string().cmp(&b.to_string()))
+}
+
 /// Where within its own span a member adds sequence: `0` at the span's start,
 /// `1` at its end.
 ///
-/// Breaks a tie that [`cis_member_order_cmp`]'s `end` cannot (#1301). An
+/// Breaks a tie that `cis_member_order_cmp`'s `end` cannot (#1301). An
 /// insertion's span *is* the gap it fills, so `264_265insCA` adds at interbase
 /// 264; a duplication places its copy after its last base, so `264_265dup` adds
 /// at 265. The two share both endpoints, and without this the order fell to the
@@ -1433,7 +1476,7 @@ fn junction_rank(v: &HgvsVariant) -> u8 {
 /// positions, or a non-positional arm such as a null/unknown-allele marker).
 /// Reuses the per-axis range extractors that back the self-cancelling detector.
 ///
-/// The end is what breaks a start tie in [`cis_member_order_cmp`]; see that
+/// The end is what breaks a start tie in `cis_member_order_cmp`; see that
 /// function's docs for why the start alone is not a sufficient discriminator.
 fn cis_member_range(v: &HgvsVariant) -> Option<SelfCancellingRange> {
     match v {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -7,7 +7,7 @@ use super::edit::{NaEdit, ProteinEdit};
 use super::interval::{CdsInterval, GenomeInterval, ProtInterval, RnaInterval, TxInterval};
 use super::uncertainty::Mu;
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, SmolStrBuilder};
 use std::fmt;
 use std::sync::Arc;
 
@@ -541,6 +541,19 @@ impl Accession {
         collect_written(|out| self.write_full(out))
     }
 
+    /// [`Self::full`] as a [`SmolStr`], for the callers that only *hold* the
+    /// rendered accession to compare it.
+    ///
+    /// `SmolStr` inlines up to 23 bytes, and every real accession fits —
+    /// `NM_000088.3` is 11, `ENST00000357033.8` is 17 — so this renders without
+    /// touching the heap where `full()` allocates a `String` every time. Only a
+    /// compound `genomic(transcript)` reference spills, and that falls back to
+    /// exactly what `full()` would have done. Equality and ordering are the
+    /// str's, so a `SmolStr` key compares identically to the `String` it replaces.
+    pub(crate) fn full_smol(&self) -> SmolStr {
+        collect_written_smol(|out| self.write_full(out))
+    }
+
     /// [`Self::base`], written straight into `out` rather than through a
     /// temporary `String`.
     ///
@@ -634,11 +647,30 @@ impl Accession {
     /// stripping any genomic context wrapper. For compound references like
     /// `NC_000013.11(NM_004119.3)`, this returns just `"NM_004119.3"`.
     pub fn transcript_accession(&self) -> String {
+        collect_written(|out| self.write_transcript_accession(out))
+    }
+
+    /// [`Self::transcript_accession`] as a [`SmolStr`], for the provider lookups
+    /// on the normalization hot path.
+    ///
+    /// Same reasoning as [`Self::full_smol`]: a provider key is used as a `&str`
+    /// and never mutated, so the inline form serves every caller while skipping
+    /// the allocation. Both spellings share
+    /// [`Self::write_transcript_accession`], so they cannot drift.
+    pub(crate) fn transcript_accession_smol(&self) -> SmolStr {
+        collect_written_smol(|out| self.write_transcript_accession(out))
+    }
+
+    /// [`Self::transcript_accession`], written straight into `out`.
+    ///
+    /// The single source of truth for both the `String` and the [`SmolStr`]
+    /// spelling, in the same style as [`Self::write_full`].
+    fn write_transcript_accession(&self, out: &mut impl fmt::Write) -> fmt::Result {
         // Assembly/chromosome notation (e.g. GRCh38(chr1)) uses base() directly
         if self.is_assembly_ref() {
-            return self.base();
+            return self.write_base(out);
         }
-        collect_written(|out| self.write_versioned(out))
+        self.write_versioned(out)
     }
 }
 
@@ -663,6 +695,19 @@ fn collect_written(produce: impl FnOnce(&mut String) -> fmt::Result) -> String {
     let mut out = String::with_capacity(TYPICAL_ACCESSION_LEN);
     produce(&mut out).expect("writing into a String is infallible");
     out
+}
+
+/// [`collect_written`]'s counterpart for the callers that want a [`SmolStr`].
+///
+/// `SmolStrBuilder` accumulates into a stack buffer and only spills to a
+/// `String` if the total exceeds the inline capacity, so an accession that fits
+/// — every real one — is rendered with no allocation at all. Writing into it
+/// cannot fail, so the `Result` is asserted rather than propagated, exactly as
+/// above.
+fn collect_written_smol(produce: impl FnOnce(&mut SmolStrBuilder) -> fmt::Result) -> SmolStr {
+    let mut out = SmolStrBuilder::new();
+    produce(&mut out).expect("writing into a SmolStrBuilder is infallible");
+    out.finish()
 }
 
 impl fmt::Display for Accession {

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -900,7 +900,7 @@ fn simple_range_for_variant(v: &HgvsVariant) -> Option<(Region, i64, i64)> {
 /// Raw location `(region, start, end)` for a sub-variant, regardless of edit
 /// kind. Unlike [`simple_range_for_variant`] it does not filter by edit kind or
 /// swap insertion endpoints — it is the positional fallback used by
-/// [`cis_merge_order_key`] to place non-merge-eligible members (`dup` / `inv` /
+/// [`cis_merge_order_cmp`] to place non-merge-eligible members (`dup` / `inv` /
 /// `repeat` / …) into genomic order too, so a merge barrier lands at its own
 /// coordinate instead of wherever it was authored.
 fn location_range_for_variant(v: &HgvsVariant) -> Option<(Region, i64, i64)> {
@@ -919,7 +919,7 @@ fn location_range_for_variant(v: &HgvsVariant) -> Option<(Region, i64, i64)> {
 /// fires every valid merge regardless of input order.
 ///
 /// The primary axis is the merge **anchor**'s `(end, start)` (not the display
-/// start point [`crate::hgvs::variant::cis_member_order_key`] uses): an edit
+/// start point [`crate::hgvs::variant::cis_member_order_cmp`] uses): an edit
 /// ending at `X` must precede one starting at `X + 1`, and — crucially for a
 /// co-located ins/del — a span edit *at* a locus `p` must precede an insertion
 /// in the gap 3' of it. Insertions anchor as `[p + 1, p]`, so their `end = p`
@@ -932,22 +932,41 @@ fn location_range_for_variant(v: &HgvsVariant) -> Option<(Region, i64, i64)> {
 /// order total so it never falls back to input order. Members with no simple
 /// location (special/uncertain/offset-only positions this pass cannot place)
 /// get a `no_position` sentinel and sort last, still deterministically.
-fn cis_merge_order_key(v: &HgvsVariant) -> (bool, Region, i64, i64, String) {
-    let descriptor = format!("{v}");
+///
+/// **This function is the positional part of that order — everything before the
+/// descriptor.** [`cis_merge_order_cmp`] applies the descriptor tie-break on top
+/// of it, and only when it is going to decide; this half reads no strings at
+/// all.
+fn cis_merge_order_prefix(v: &HgvsVariant) -> (bool, Region, i64, i64) {
     // Prefer the merge anchor (insertion endpoints swapped to `[p + 1, p]`);
     // fall back to the raw location for non-merge-eligible kinds.
     match simple_range_for_variant(v).or_else(|| location_range_for_variant(v)) {
-        Some((region, anchor_start, anchor_end)) => {
-            (false, region, anchor_end, anchor_start, descriptor)
-        }
+        Some((region, anchor_start, anchor_end)) => (false, region, anchor_end, anchor_start),
         // `Region::Genome` is an unused placeholder here — `no_position == true`
         // already segregates these, and the `i64::MAX` ties defer to the
         // descriptor tie-break.
-        None => (true, Region::Genome, i64::MAX, i64::MAX, descriptor),
+        None => (true, Region::Genome, i64::MAX, i64::MAX),
     }
 }
 
-/// Sort cis members into the canonical merge order (see [`cis_merge_order_key`])
+/// Compare two cis members by the canonical merge order.
+///
+/// Exactly the lexicographic comparison of
+/// `(cis_merge_order_prefix(v), format!("{v}"))` — a tuple's ordering consults
+/// its last component only when every earlier one ties, so deferring the render
+/// to `then_with` cannot change the order. What it changes is the cost: the
+/// descriptor is the *whole member*, rendered, and `sort_by_key` re-derives its
+/// key on every comparison, so the previous form rendered every member of every
+/// allele at least twice per sort — and this sort runs once per pass of the
+/// allele fixed-point loop, beside a second one on the same members
+/// (`sort_cis_members_by_genomic_order`).
+fn cis_merge_order_cmp(a: &HgvsVariant, b: &HgvsVariant) -> std::cmp::Ordering {
+    cis_merge_order_prefix(a)
+        .cmp(&cis_merge_order_prefix(b))
+        .then_with(|| a.to_string().cmp(&b.to_string()))
+}
+
+/// Sort cis members into the canonical merge order (see [`cis_merge_order_cmp`])
 /// so `merge_consecutive_edits` is input-order-independent (#1103).
 ///
 /// A no-op unless every member shares a single accession: `merge_consecutive_edits`
@@ -965,7 +984,7 @@ pub(crate) fn sort_cis_members_for_merge(variants: &mut [HgvsVariant]) {
             .iter()
             .all(|v| v.accession().map(|a| a.full_smol()) == first_accession);
     if single_accession {
-        variants.sort_by_key(cis_merge_order_key);
+        variants.sort_by(cis_merge_order_cmp);
     }
 }
 

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -919,7 +919,7 @@ fn location_range_for_variant(v: &HgvsVariant) -> Option<(Region, i64, i64)> {
 /// fires every valid merge regardless of input order.
 ///
 /// The primary axis is the merge **anchor**'s `(end, start)` (not the display
-/// start point [`crate::hgvs::variant::cis_member_order_cmp`] uses): an edit
+/// start point `cis_member_order_cmp` uses): an edit
 /// ending at `X` must precede one starting at `X + 1`, and — crucially for a
 /// co-located ins/del — a span edit *at* a locus `p` must precede an insertion
 /// in the gap 3' of it. Insertions anchor as `[p + 1, p]`, so their `end = p`

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -16,6 +16,7 @@ use crate::normalize::shuffle::shuffle;
 use crate::normalize::{boundary_delins_bases, BoundarySide, SequenceEnds};
 use crate::reference::ReferenceProvider;
 use crate::sequence::complement_base;
+use smol_str::SmolStr;
 
 /// Coordinate-system region used as the merge-eligibility key.
 ///
@@ -558,7 +559,7 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     //     1-based position `N` maps to transcript position `cds_start + N - 1`
     //     (delta = `cds_start - 1`) — the same mapping `lookup_codon_middle_ref`
     //     uses. Both regions have been restricted to the positive body above.
-    let accession = template_accession.transcript_accession();
+    let accession = template_accession.transcript_accession_smol();
     // Only the offset matters here — this collapse has no codon exception to
     // gate, so the frame's `reading_frame` half is not consulted.
     let Some(delta) = axis_frame(kind, &template_accession, provider).map(|frame| frame.delta)
@@ -784,7 +785,7 @@ fn merged_anchor_restates_reference<P: ReferenceProvider>(
     // runs before any comparison — or the bases fetched below are simply the
     // wrong ones, and a member that merely *looks* like a cancellation against
     // them would be dropped.
-    let provider_key = accession.transcript_accession();
+    let provider_key = accession.transcript_accession_smol();
     let Some(delta) = region_sequence_delta(region, &provider_key, provider) else {
         return false;
     };
@@ -958,11 +959,11 @@ fn cis_merge_order_key(v: &HgvsVariant) -> (bool, Region, i64, i64, String) {
 pub(crate) fn sort_cis_members_for_merge(variants: &mut [HgvsVariant]) {
     let first_accession = variants
         .first()
-        .and_then(|v| v.accession().map(|a| a.full()));
+        .and_then(|v| v.accession().map(|a| a.full_smol()));
     let single_accession = first_accession.is_some()
         && variants
             .iter()
-            .all(|v| v.accession().map(|a| a.full()) == first_accession);
+            .all(|v| v.accession().map(|a| a.full_smol()) == first_accession);
     if single_accession {
         variants.sort_by_key(cis_merge_order_key);
     }
@@ -1445,7 +1446,7 @@ fn lookup_codon_middle_ref<P: ReferenceProvider>(
         return None;
     }
     let tx = provider
-        .get_transcript(&accession.transcript_accession())
+        .get_transcript(&accession.transcript_accession_smol())
         .ok()?;
     let cds_start = tx.cds_start?;
     let tx_idx_1based = cds_start.checked_add(cds_axis as u64)?.checked_sub(1)?;
@@ -3210,7 +3211,7 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     }
 
     let frame = axis_frame(kind, &template_accession, provider)?;
-    let accession = template_accession.transcript_accession();
+    let accession = template_accession.transcript_accession_smol();
 
     // `general.md:44` exempts deletions and duplications around an exon/exon
     // junction from the 3' rule on the transcript axes, and the per-member
@@ -4366,7 +4367,7 @@ fn authored_reference_mismatch<P: ReferenceProvider>(
         .flatten();
     let edit = rewritten.as_ref().unwrap_or(edit);
 
-    let provider_key = accession.transcript_accession();
+    let provider_key = accession.transcript_accession_smol();
     let delta = region_sequence_delta(region, &provider_key, provider)?;
     // Checked, like every other coordinate conversion in this file: `s`/`e`
     // come off a parsed description and `delta` off the record's CDS bounds, so
@@ -4662,7 +4663,7 @@ fn axis_frame<P: ReferenceProvider>(
         }),
         CisKind::Cds => {
             let tx = provider
-                .get_transcript(&accession.transcript_accession())
+                .get_transcript(&accession.transcript_accession_smol())
                 .ok()?;
             Some(AxisFrame {
                 delta: i64::try_from(tx.cds_start?).ok()? - 1,
@@ -4677,7 +4678,7 @@ fn axis_frame<P: ReferenceProvider>(
         // `fetch_ref_for_canonical_split` does for the same case.
         CisKind::Rna => {
             let cds_start = provider
-                .get_transcript(&accession.transcript_accession())
+                .get_transcript(&accession.transcript_accession_smol())
                 .ok()
                 .and_then(|tx| tx.cds_start);
             match cds_start {
@@ -10110,13 +10111,21 @@ struct MemberSpan {
     /// The member's accession as written, used to decide whether two members
     /// sit on the same reference. Keeps any genomic-context wrapper, so
     /// members differing only in that wrapper are not treated as siblings.
-    accession: String,
+    ///
+    /// A [`SmolStr`] rather than a `String`: this is only ever compared, and
+    /// every real accession is short enough to live inline, so the ten passes
+    /// that each read every member's span no longer allocate to do it. See
+    /// [`Accession::full_smol`].
+    accession: SmolStr,
     /// The same accession reduced to the bare form a provider is keyed by, per
     /// `Accession::transcript_accession`. `accession` itself may carry a
     /// wrapper (`NC_000013.11(BRCA2)`) that no provider has an entry for, so a
     /// lookup through it would silently fail and skip the rewrite; every other
     /// provider lookup in this module already reduces first.
-    provider_key: String,
+    ///
+    /// [`SmolStr`] for the same reason as `accession` above; it is handed to the
+    /// provider as a `&str` and never mutated.
+    provider_key: SmolStr,
     /// The region the span **starts** in. For a member wholly inside one region
     /// this is its region; for one crossing a boundary it is where the span
     /// begins, which is the axis its written coordinates are numbered on.
@@ -10222,7 +10231,7 @@ fn member_span<P: ReferenceProvider>(
 ) -> Option<MemberSpan> {
     let (accession, (start_region, axis_start), (end_region, axis_end), edit) =
         member_axis_endpoints(v, kind)?;
-    let provider_key = accession.transcript_accession();
+    let provider_key = accession.transcript_accession_smol();
     // One delta per *distinct* region, not one per endpoint. `region_span_delta`
     // resolves the transcript through the provider, so asking twice for the
     // region both endpoints almost always share is a duplicated hash lookup on
@@ -10258,7 +10267,7 @@ fn member_span<P: ReferenceProvider>(
     let start = start_delta.checked_add(axis_start)?;
     let end = end_delta.checked_add(axis_end)?;
     Some(MemberSpan {
-        accession: accession.full(),
+        accession: accession.full_smol(),
         provider_key,
         region: start_region,
         start,
@@ -10494,7 +10503,7 @@ fn repeat_would_land_off_its_unit<P: ReferenceProvider>(
         })
         .collect();
 
-    let provider_key = accession.transcript_accession();
+    let provider_key = accession.transcript_accession_smol();
     // `region_sequence_delta`, not the `region_span_delta` behind `MemberSpan`:
     // the span reader widens to regions with *virtual* positions so a member
     // there is still visible to its siblings, and no bases can be read through
@@ -13006,7 +13015,7 @@ fn member_out_of_bounds_coordinate<P: ReferenceProvider>(
     member: &HgvsVariant,
     provider: &P,
 ) -> Option<OutOfBoundsCoordinate> {
-    let accession = member.accession()?.transcript_accession();
+    let accession = member.accession()?.transcript_accession_smol();
     let length = provider.get_sequence_length(&accession).ok()?;
     let ceiling = i64::try_from(length).ok()?;
     readable_endpoints(member)
@@ -13020,7 +13029,7 @@ fn member_out_of_bounds_coordinate<P: ReferenceProvider>(
             // `g.0_1` (#1282) are the same family as the ones that produce
             // `g.24_25`.
             (position < 1 || position > ceiling).then(|| OutOfBoundsCoordinate {
-                accession: accession.clone(),
+                accession: accession.to_string(),
                 position,
                 length,
                 member: member.to_string(),

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2023,7 +2023,10 @@ fn sort_cis_members_by_genomic_order(members: &mut [HgvsVariant]) {
             .iter()
             .all(|m| m.accession().map(|a| a.full_smol()) == first_accession);
     if single_accession {
-        members.sort_by(crate::hgvs::variant::cis_member_order_cmp);
+        // The single-accession gate just above is exactly the precondition the
+        // accession-free comparator needs, so this is the same order for less
+        // work — see `cis_member_order_cmp_within_accession`.
+        members.sort_by(crate::hgvs::variant::cis_member_order_cmp_within_accession);
     }
 }
 
@@ -15938,6 +15941,48 @@ mod tests {
             cis_member_order_cmp(&sub, &del),
             std::cmp::Ordering::Equal,
             "members sharing a start must still compare as distinct (total order)"
+        );
+    }
+
+    /// `sort_cis_members_by_genomic_order` drops the accession from the
+    /// comparison because it has just established that every member has the same
+    /// one. Pin both halves of that: identical to the full comparator when the
+    /// accessions agree, and — the reason it is not the default — genuinely
+    /// different when they do not, so the substitution stays tied to the gate.
+    #[test]
+    fn dropping_the_accession_is_the_same_order_within_one_accession() {
+        use crate::hgvs::variant::{cis_member_order_cmp, cis_member_order_cmp_within_accession};
+
+        let same: Vec<_> = [
+            "NC_000001.11:g.10A>G",
+            "NC_000001.11:g.10del",
+            "NC_000001.11:g.5_7del",
+            "NC_000001.11:g.20_21insAA",
+            "NC_000001.11:g.20dup",
+        ]
+        .iter()
+        .map(|s| parse_hgvs(s).unwrap())
+        .collect();
+        for a in &same {
+            for b in &same {
+                assert_eq!(
+                    cis_member_order_cmp(a, b),
+                    cis_member_order_cmp_within_accession(a, b),
+                    "`{a}` vs `{b}` ordered differently with and without the accession, \
+                     though both members carry the same one"
+                );
+            }
+        }
+
+        // Across accessions the two disagree, which is why the accession-free
+        // form is reachable only from behind the single-accession gate: a member
+        // on the later molecule at an earlier position sorts *after* by the full
+        // key and *before* without it.
+        let later_molecule = parse_hgvs("NC_000002.12:g.5A>G").unwrap();
+        assert_ne!(
+            cis_member_order_cmp(&later_molecule, &same[0]),
+            cis_member_order_cmp_within_accession(&later_molecule, &same[0]),
+            "the accession must still be what separates two molecules"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4836,12 +4836,23 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // input-order-independent, but a narrowing of the #395 verbatim
         // contract for that shift-emergent case.) Same-junction insertions are
         // already returned verbatim above (#1004), so they never reach here.
+        //
+        // The coincident-bounds half is read out of `all_warnings` rather than
+        // re-derived. `raw_conflicts` above is `detect_overlap_conflicts` on
+        // these same two arguments, `allele` is borrowed immutably and nothing
+        // between the two points can touch it, and a non-empty result returned
+        // before reaching here — so a second call is a pure function on
+        // unchanged inputs whose answer is already known to be the empty vector.
+        // It is not free: that pass is quadratic in the member count and renders
+        // an accession per member per pair.
+        debug_assert!(
+            raw_conflicts.is_empty(),
+            "a conflicting allele returns above, so the coincident-bounds pass \
+             cannot have anything left to report here"
+        );
         let input_has_overlap_conflict = all_warnings
             .iter()
-            .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }))
-            || crate::normalize::overlap::detect_overlap_conflicts(&allele.variants, allele.phase)
-                .iter()
-                .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
+            .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
         let reorder_before_merge = is_cis && !allele.uncertain && !input_has_overlap_conflict;
 
         let mut current = allele.variants.clone();

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2002,7 +2002,7 @@ fn resolve_special_cds_pos(
 }
 
 /// Sort cis-allele members into genomic (coordinate) order using the total
-/// order `cis_member_order_key` (#1098). A no-op unless every member shares a
+/// order `cis_member_order_cmp` (#1098). A no-op unless every member shares a
 /// single accession — a mixed-accession bracketed allele (`[NC_…;NM_…]`,
 /// #218/#219) has no cross-molecule genomic order to canonicalize to, so those
 /// are left in authored order. The key is total (the rendered descriptor is the
@@ -2023,10 +2023,7 @@ fn sort_cis_members_by_genomic_order(members: &mut [HgvsVariant]) {
             .iter()
             .all(|m| m.accession().map(|a| a.full_smol()) == first_accession);
     if single_accession {
-        members.sort_by(|a, b| {
-            crate::hgvs::variant::cis_member_order_key(a)
-                .cmp(&crate::hgvs::variant::cis_member_order_key(b))
-        });
+        members.sort_by(crate::hgvs::variant::cis_member_order_cmp);
     }
 }
 
@@ -5102,7 +5099,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // leaving members in input order meant two inputs for the same allele
         // (`[a;b]` vs `[b;a]`) normalized to two different strings, breaking use
         // of the normalized descriptor as a stable key. Sort by a *total* order
-        // (`cis_member_order_key`) so the result is deterministic even when two
+        // (`cis_member_order_cmp`) so the result is deterministic even when two
         // members share a start.
         //
         // Basis: for DNA the spec discusses listing haplotype members "in
@@ -15909,26 +15906,27 @@ mod tests {
         // rendered descriptor), so member order never falls back to input
         // order. This is why a total order beats a stable sort keyed on start
         // alone.
-        use crate::hgvs::variant::cis_member_order_key;
+        use crate::hgvs::variant::{cis_member_order_cmp, cis_member_order_prefix};
 
         let sub = parse_hgvs("NC_000001.11:g.10A>G").unwrap();
         let del = parse_hgvs("NC_000001.11:g.10del").unwrap();
 
-        let key_sub = cis_member_order_key(&sub);
-        let key_del = cis_member_order_key(&del);
-
         // Same accession, same start point, and — since both are one base wide
-        // — the same end point too, so every positional field of the key ties
-        // and only the descriptor can separate them (#1261 added the end).
+        // — the same end point too, so every positional field ties and only the
+        // descriptor can separate them (#1261 added the end).
         assert_eq!(
-            (&key_sub.0, key_sub.1, key_sub.2),
-            (&key_del.0, key_del.1, key_del.2),
+            cis_member_order_prefix(&sub),
+            cis_member_order_prefix(&del),
             "the two members must share the whole positional portion of the key"
         );
-        // ...but distinct keys overall, via the rendered-descriptor tie-break.
+        // ...but they still compare as distinct, via the rendered-descriptor
+        // tie-break — which is also what pins that the deferred render actually
+        // runs when the prefix ties, rather than the comparison stopping at
+        // `Equal` and letting the sort fall back to input order.
         assert_ne!(
-            key_sub, key_del,
-            "members sharing a start must still get distinct keys (total order)"
+            cis_member_order_cmp(&sub, &del),
+            std::cmp::Ordering::Equal,
+            "members sharing a start must still compare as distinct (total order)"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2017,11 +2017,11 @@ fn resolve_special_cds_pos(
 fn sort_cis_members_by_genomic_order(members: &mut [HgvsVariant]) {
     let first_accession = members
         .first()
-        .and_then(|m| m.accession().map(|a| a.full()));
+        .and_then(|m| m.accession().map(|a| a.full_smol()));
     let single_accession = first_accession.is_some()
         && members
             .iter()
-            .all(|m| m.accession().map(|a| a.full()) == first_accession);
+            .all(|m| m.accession().map(|a| a.full_smol()) == first_accession);
     if single_accession {
         members.sort_by(|a, b| {
             crate::hgvs::variant::cis_member_order_key(a)

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -32,6 +32,7 @@ use crate::hgvs::variant::{AllelePhase, HgvsVariant, LocEdit};
 use crate::normalize::footprint::WriteFootprint;
 use crate::normalize::merge::Region;
 use crate::normalize::NormalizationWarning;
+use smol_str::SmolStr;
 
 /// One position on a transcript-relative axis, ordered the way the axis reads.
 ///
@@ -175,7 +176,7 @@ pub(crate) fn detect_overlap_conflicts(
             .expect("group_key established a renderable location");
 
         warnings.push(NormalizationWarning::OverlapConflict {
-            accession: key.accession.clone(),
+            accession: key.accession.to_string(),
             coordinate_system: key.coord_system.to_string(),
             location: location_str,
             edit_kinds,
@@ -255,7 +256,7 @@ pub(crate) fn detect_overlap_conflicts(
                 .filter_map(|&idx| member_kind(&variants[idx]).map(|s| s.to_string()))
                 .collect();
             warnings.push(NormalizationWarning::OverlapConflict {
-                accession: first_accession.clone(),
+                accession: first_accession.to_string(),
                 coordinate_system: coord_system.to_string(),
                 location: location_for_variant(first)
                     .expect("member_footprint established a renderable location"),
@@ -281,9 +282,17 @@ pub(crate) fn detect_overlap_conflicts(
 /// an N-padded deletion over an uncertain range, …).
 fn member_footprint(
     variant: &HgvsVariant,
-) -> Option<(&'static str, String, WriteFootprint<AxisPos>)> {
+) -> Option<(&'static str, SmolStr, WriteFootprint<AxisPos>)> {
     let (coord_system, start, end) = simple_span(variant)?;
-    let accession = variant.accession()?.to_string();
+    // Rendered into a `SmolStr`, which is inline for every real accession, and
+    // identical bytes: `full_smol` drives the same writer `Display` does.
+    //
+    // This is the one place the accession is rendered for this whole module —
+    // #1749 collapsed four call sites into this one — and the *inner* loop of
+    // `detect_overlap_conflicts` calls it, so a `String` here is an allocation
+    // per **pair** of members. It is only ever compared; the owned form is built
+    // where a warning is actually emitted.
+    let accession = variant.accession()?.full_smol();
     let edit = inner_edit(variant)?;
     let footprint = match edit {
         // Rewrite the span they name, and leave bases standing there.
@@ -502,14 +511,14 @@ fn junction_overlaps(
     /// `repeat` lands there. `kind` is the label the emitted warning reports.
     struct Insertion {
         idx: usize,
-        accession: String,
+        accession: SmolStr,
         coord_system: &'static str,
         gap: AxisPos,
         kind: &'static str,
     }
     struct Span {
         idx: usize,
-        accession: String,
+        accession: SmolStr,
         coord_system: &'static str,
         start: AxisPos,
         end: AxisPos,
@@ -585,7 +594,7 @@ fn junction_overlaps(
     // its own spelling rather than labelling the whole group `ins`.
     /// `(accession, coordinate system, gap)` — one zero-width junction on one
     /// molecule. The ranked gap carries its own region (#1508).
-    type JunctionKey = (String, &'static str, AxisPos);
+    type JunctionKey = (SmolStr, &'static str, AxisPos);
     /// The members writing at a junction, as `(index into `variants`, kind)`.
     type Occupants = Vec<(usize, &'static str)>;
 
@@ -606,7 +615,7 @@ fn junction_overlaps(
         let location = location_for_variant(&variants[occupants[0].0])
             .expect("same-junction occupant has a renderable location");
         warnings.push(NormalizationWarning::OverlapConflict {
-            accession: accession.clone(),
+            accession: accession.to_string(),
             coordinate_system: coord_system.to_string(),
             location,
             edit_kinds: occupants.iter().map(|(_, k)| k.to_string()).collect(),
@@ -664,7 +673,7 @@ fn junction_overlaps(
             continue;
         }
         warnings.push(NormalizationWarning::OverlapConflict {
-            accession: span.accession.clone(),
+            accession: span.accession.to_string(),
             coordinate_system: span.coord_system.to_string(),
             location: location_for_variant(&variants[span.idx])
                 .expect("span edit has a renderable location"),
@@ -685,7 +694,12 @@ fn junction_overlaps(
 /// rather than collapsing.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct GroupKey {
-    accession: String,
+    /// A [`SmolStr`], not a `String`: this is a map key and a comparand, never
+    /// mutated, and every real accession fits the inline capacity — so grouping
+    /// an allele's members no longer allocates one string per member. `SmolStr`
+    /// orders as the `str` does, so the `BTreeMap` iteration order this pass's
+    /// determinism rests on is unchanged.
+    accession: SmolStr,
     coord_system: &'static str,
     /// Ranked endpoints, which subsume the old separate `region` field: two
     /// members coincide only if both ends agree, and a ranked position already


### PR DESCRIPTION
Five allocation- and formatting-shaped optimizations on the normalization hot path, driven by the profile in #1972. One commit per optimization, each independently reviewable and revertable.

## What the profile said, and what actually paid

#1972 named `_platform_memmove` at 8.02% self, string formatting at 7.47% aggregated, `member_span` at 5.38% inclusive, and called `HgvsVariant`'s copy cost "the most promising single library target".

The copy cost turned out not to be the enum's own moves. `HgvsVariant` is 560 bytes because `RnaFusionVariant` is 560 and sets the width for the six 424-byte single-locus arms; boxing that arm takes the enum to 432 (-23%) and **measured -1.4% ± 3.5% — indistinguishable from zero**. What did pay, every time, was removing the *heap payloads* those moves carry: rendered accessions, rendered descriptors, and a pass run twice.

## Measured

Two workloads, because they exercise different regimes:

**A. The profiled test.** `cis_junction_crossing_shift::no_two_member_allele_normalizes_to_a_different_sequence`, soak profile, `FERRO_SWEEP_SEEDS=12`, `RAYON_NUM_THREADS=1`, **user CPU**, 30 rounds interleaving every stage binary inside each round, reported as the mean of the per-round *paired* deltas. Wall clock is unusable on this machine (load 55-160 from concurrent builds; a measured A/A spread of 9.5-15.2 s wall against 14.6-15.1 s user CPU).

**B. `benches/benchmarks.rs`'s `allele_scaling` group at 100 members**, leave-one-out: each variant is HEAD with exactly one commit's file reverted, so the difference is that one change. This is where the per-member and pairwise passes actually cost something — the sweep's alleles have two members.

| # | optimization | mechanism | A: sweep | B: 100-member allele |
|---|---|---|---|---|
| 1 | accessions -> `SmolStr` | `member_span` allocated two `String`s per call and ~10 sibling passes read every member's span per pass | **-4.96%** (sd 6.18, 4.4σ) | — |
| 2 | deferred descriptor tie-break | `sort_by_key` re-derived a key containing `format!("{v}")` on every comparison | **-4.11%** (sd 6.60, 3.4σ) | — |
| 3 | one coincident-bounds pass | the second `detect_overlap_conflicts` call was a pure function on unchanged inputs already known to be empty | **-2.85%** (sd 5.14, 3.0σ) | — |
| 4 | overlap pass compares without allocating | `to_string()` per member *and* per pair in a quadratic loop | -0.30% (one pair there) | **-39% to -47%** |
| 5 | accession dropped from a fixed comparison | the sort gates on one accession, then rendered and compared it on every comparison anyway | **-0.21%** (sd 0.64, n=40, 95% CI [-0.41, -0.01]) | not resolvable |
| | **cumulative** | | **-14.7%** (see note) | **-54% to -64%** |

The cumulative sweep figure is for the seven-change chain the per-stage numbers were measured on; two of those seven were then dropped (below) and each contributed under 1%, so the shipped five account for essentially all of it.

**#5 is the weakest of the five and the table says so.** Its effect is `O(n log n)` in the member count and the sweep's alleles have two members, so -0.21% is that change's *floor*, not its typical value. The regime where it scales is the same one #4 shows -43% in, and that regime could not be measured here: criterion on the 100-member benches returned standard deviations of 26-140% while the machine sat at load 100-160, so no honest number exists for it. It is included on a measured (if small) win plus a mechanism that only grows; a reviewer who wants it out has a clean single revert.

Representation-Change: none.

Every change is behaviour-preserving by construction, and each commit says how:

- `SmolStr` equality and ordering are the `str`'s, and the new spellings share the existing accession writers, so the rendered bytes are identical.
- A tuple's ordering consults its last component only when every earlier one ties, so moving the descriptor render behind `then_with` is the same total order.
- The second `detect_overlap_conflicts` call is a pure function of inputs the early return has already established produce an empty result.
- Dropping the accession from a comparison the caller has just fixed to one value cannot change any comparison that sort makes; `dropping_the_accession_is_the_same_order_within_one_accession` pins the agreement, and pins that the two forms *do* differ across molecules so the substitution stays tied to its gate.

**Corpus:** `examples/dump_normalized_corpus.rs`, this branch (`9ab82b8c`) against its merge base (`7fe41b46`) and against current `origin/main` (`254768e3`) — **86,398 rows, 0 moved, across all 22 shape families**, with all three dumps byte-identical. What that does and does not cover: the harness builds cis alleles on 20-mers plus the protein axis and two designed long/revcomp families, so it exercises every path these changes touch — but it is a claim about those families, not a library-wide rate. These changes are not scoped to a shape, they are scoped to *how a string is built*, and the same rendering seams are on every row the corpus does build.

One part of the zero is structural and is named as such: every accession this corpus emits is 9-10 bytes, so **0 of 86,398 rows** carry an accession past `SmolStr`'s 23-byte inline capacity. The heap-spill arm of optimization #1 is therefore unmeasured here — it is a wash by construction (it spills to the same `String` `full()` built), but the corpus cannot witness it. The multi-member paths are measured properly: 66,518 rows (77.0%) carry two or more members and 4,634 carry three or more, which is what #2, #4 and #5 run over. Optimization #3's `debug_assert!` is compiled out under `--release`, so this run is not evidence for that premise; the immutable `&AlleleVariant` borrow is.

## Dropped, with the number that killed each

- **Box `RnaFusionVariant`** (enum 560 -> 432 bytes): -1.4%, paired SD 8.6% over six seeds=full reps. Not resolvable.
- **Count the tie-break's pieces instead of building them** (`best_alignment` allocated a `Vec<Column>` + `Vec<Piece>` per candidate gap position): three independent 15-round runs gave -3.54%, +3.68%, +0.18%, and a 30-round run gave **-0.16% ± 1.04%**.
- **`edit_grid` row slices, no reversed-block copies**: **-0.70% ± 1.07%** on the sweep and ~0 on the allele benches.
- **Junction clamp's member snapshot taken lazily**: -1.92% ± 1.06% on one 30-round run, **-0.30% ± 0.57%** on an independent 37-round run; pooled -0.66% ± 0.50%. Not resolved either way.

All four are strictly work-reducing and all four are neutral to this machine's resolution, so they are not here — a neutral change to `src/normalize/` is risk without upside.

## Gate

All on the shipped tree, each step's `EXIT=` read back out of its own log rather than inferred from a chain's status:

* `cargo fmt --check` — `EXIT=0`
* `cargo clippy --features dev --all-targets -- -D warnings` — `EXIT=0`
* `cargo nextest run --features dev --no-fail-fast` — `EXIT=0`, **10970 passed, 0 failed**, 151 skipped
* `pytest tests/python/` against a `maturin develop --features python` build — **1048 passed, 8 skipped**, `EXIT=0`. `cargo nextest` does not reach the bindings and this branch changes `src/normalize/` and `src/hgvs/`, so the Python suite is not optional here.

Closes #1972



