### PR TITLE
fix(scripts): stop reading a fenced trailer as a representation declaration

### DIFF
--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -104,6 +104,83 @@ TRAILER_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+#: Opens or closes a Markdown code fence: three or more backticks or tildes, indented by at
+#: most three spaces (CommonMark's limit before it becomes an indented code block).
+FENCE_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+
+def fence_match(line: str) -> re.Match[str] | None:
+    """Match a fence line, honouring CommonMark's backtick-info restriction.
+
+    A backtick fence's info string may not itself contain a backtick — otherwise an inline
+    code span could open a block. Tilde fences carry no such restriction. `FENCE_RE` alone
+    accepts both, so ```` ```a`b ```` reads as an opener here while CommonMark (and GitHub,
+    and git-cliff's eventual reader) treat it as ordinary text.
+
+    Getting this wrong fails closed rather than open — a spurious opener blanks the rest of
+    the body, so a real declaration goes unseen and the author is refused rather than
+    credited with a disclosure they did not write. That is the safe direction, and it is
+    still the wrong answer.
+    """
+    match = FENCE_RE.match(line)
+    if match is None:
+        return None
+    if match.group("fence")[0] == "`" and "`" in match.group("info"):
+        return None
+    return match
+
+
+def fenced_line_numbers(text: str) -> set[int]:
+    """Return the 1-based line numbers inside a fenced code block, fences included.
+
+    `TRAILER_RE` anchors at column 0 and knows nothing about Markdown, so a trailer quoted
+    inside a fence reads as a real declaration (#1929). That is the one decoration that
+    reaches column 0 with its text intact — an inline code span, `**bold**`, `> blockquote`
+    and a four-space indent are all caught already, and correctly *fail* with a near-miss
+    hint. This one **passed**, which is worse: the author is recorded as disclosing a
+    migration they explicitly said they had not worked out.
+
+    `CONTRIBUTING.md` publishes three such blocks, so the text that triggers it is
+    copy-pasteable straight out of the contributor documentation — which is exactly how it
+    would be met in practice, by someone quoting the docs to ask what to write.
+
+    The closing fence must use the same character and be at least as long as the opener, so
+    a ```` ```` ```` block may contain ```` ``` ```` lines — the shape the issue reproduced
+    with. An unclosed fence runs to the end of the text, which is CommonMark's rule and the
+    safe direction here: it withholds a declaration rather than inventing one.
+    """
+    inside: set[int] = set()
+    open_fence: str | None = None
+    for number, line in enumerate(text.splitlines(), 1):
+        match = fence_match(line)
+        if open_fence is None:
+            if match is not None:
+                open_fence = match.group("fence")
+                inside.add(number)
+            continue
+        inside.add(number)
+        if (
+            match is not None
+            and match.group("fence")[0] == open_fence[0]
+            and len(match.group("fence")) >= len(open_fence)
+            and not match.group("info").strip()
+        ):
+            open_fence = None
+    return inside
+
+
+def strip_fenced(text: str) -> str:
+    """Blank every fenced line, preserving line count so numbering still lines up.
+
+    Blanking rather than deleting is what lets `find_near_misses` report a fenced trailer at
+    its real line number in the same pass.
+    """
+    fenced = fenced_line_numbers(text)
+    return "\n".join(
+        "" if number in fenced else line for number, line in enumerate(text.splitlines(), 1)
+    )
+
+
 #: Values that declare "this moves nothing". Anything else is read as a description of
 #: what moved, which is what lands in the changelog.
 NONE_VALUES = frozenset({"none", "no", "n/a", "na"})
@@ -218,6 +295,44 @@ def find_declarations(text: str) -> list[str]:
 
     Plural because *how many* there are is itself a verdict — see `check`. One trailer is
     the only shape whose meaning both this checker and `release-plz.toml` agree on.
+
+    Fenced regions are blanked first (#1929), so quoting `CONTRIBUTING.md`'s own example is
+    not read as a declaration. The fenced line is not merely ignored — `find_near_misses`
+    reports it, because someone who pasted the documented form is asking a question rather
+    than staying silent.
+
+    **This is not the set git-cliff sees** — use `find_trailers_as_git_cliff_would` for
+    that. The two must stay separate; see its docstring for why collapsing them re-opens
+    the hole this fix closed.
+    """
+    return [match.group("value") for match in TRAILER_RE.finditer(strip_fenced(text))]
+
+
+def find_trailers_as_git_cliff_would(text: str) -> list[str]:
+    """Return every column-0 trailer, **fenced ones included**.
+
+    `git_conventional` parses footers with no Markdown awareness at all — any `word:` line
+    is a footer token, which is the same property that makes a prose body shred its footer
+    parsing (see `inject_representation_disclosure.py`). So a trailer inside a fence is
+    invisible to a reader and fully visible to the changelog.
+
+    **The sibling scripts are deliberately NOT made fence-aware**, and that is the same
+    reasoning rather than an oversight. `check_changelog_grouping.py` keeps its own copy of
+    the column-0 pattern and `inject_representation_disclosure.py` imports it from there;
+    both read *commit messages* and exist to check or reproduce what git-cliff actually did.
+    Teaching them about fences would make them disagree with the changelog they audit, which
+    is the opposite of their job. Only the PR-body checker chooses a *value*, and only that
+    choice needed narrowing.
+
+    That is why the duplicate refusal in `check` counts *this* set rather than
+    `find_declarations`. Making both fence-aware looks tidier and is a safety regression:
+    a body carrying a quoted example **beside** a real trailer would then pass here while
+    git-cliff still saw two footers, and the quoted 577-row example could land in the
+    changelog under an author who declared `none`. The refusal is what forces the author to
+    indent or remove the quotation, which is the escape hatch `CONTRIBUTING.md` documents.
+
+    So the split is deliberate and the asymmetry is the point: **fenced text may not BE the
+    declaration, but it still COUNTS toward how many the changelog will see.**
     """
     return [match.group("value") for match in TRAILER_RE.finditer(text)]
 
@@ -369,9 +484,23 @@ def find_near_misses(text: str) -> list[tuple[int, str, str]]:
     if find_declarations(text):
         return []
 
+    fenced = fenced_line_numbers(text)
     misses: list[tuple[int, str, str]] = []
     for number, line in enumerate(text.splitlines(), 1):
         if TRAILER_RE.match(line):
+            # Column 0 and well formed, so the only thing keeping it from being a
+            # declaration is the fence around it (#1929). Report it rather than passing over
+            # it: this shape is almost always someone quoting `CONTRIBUTING.md` to ask what
+            # to write, and silence would be indistinguishable from having declared nothing.
+            if number in fenced:
+                misses.append(
+                    (
+                        number,
+                        line.strip(),
+                        "inside a fenced code block, so it is documentation rather than a "
+                        "declaration; move it to column 0 outside any ``` or ~~~ block",
+                    )
+                )
             continue
         match = NEAR_MISS_RE.match(line)
         if match is None:
@@ -397,7 +526,10 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
 
     1. the message carries **more than one** trailer (#1573) — checked first, and ahead of
        the watched-file test, because two trailers are a disagreement with how the
-       *changelog* files the commit, which applies to every commit;
+       *changelog* files the commit, which applies to every commit. Cases 1 and 2 are not
+       exclusive: when every one of those trailers is fenced, case 1's refusal carries
+       case 2's near-miss lines as well, because "delete the superseded trailer" names
+       nothing the author wrote;
     2. the message carries a **near miss** and no readable trailer — a line that looks like
        a declaration but that none of the three consumers can see. Also ahead of the
        watched-file test, and for the same reason as case 1;
@@ -422,10 +554,15 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
     # grouping, which applies to every commit, not only to the ones touching a watched
     # directory. This job already runs on every PR.
     declarations = find_declarations(declaration_text)
-    if len(declarations) > 1:
-        listed = "\n".join(f"  Representation-Change: {value}" for value in declarations)
-        return False, (
-            f"{len(declarations)} `Representation-Change:` trailers found:\n{listed}\n\n"
+    # Counted as GIT-CLIFF would count them, fenced examples included: the refusal exists
+    # because this checker reads the first trailer while git-cliff matches every footer, and
+    # git-cliff cannot see a fence. Counting the fence-aware set here would let a quoted
+    # example sit beside a real `none` and still reach the changelog (#1929).
+    as_git_cliff_sees = find_trailers_as_git_cliff_would(declaration_text)
+    if len(as_git_cliff_sees) > 1:
+        listed = "\n".join(f"  Representation-Change: {value}" for value in as_git_cliff_sees)
+        message = (
+            f"{len(as_git_cliff_sees)} `Representation-Change:` trailers found:\n{listed}\n\n"
             "Keep exactly one. Two trailers do not mean anything consistent, because this\n"
             "check and the changelog resolve them differently: this check reads the FIRST\n"
             "trailer, while git-cliff matches its footer rule against EVERY footer and takes\n"
@@ -436,6 +573,38 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
             "Delete the superseded trailer, or indent it if it is quoted as an example --\n"
             "an indented line is a continuation of the value above it, not a new trailer."
         )
+        # An EMPTY `declarations` here means every trailer git-cliff counted is fenced —
+        # `find_declarations` reads the same pattern over `strip_fenced`, so the two sets
+        # differ by exactly the fenced lines. Without this arm that author is told to
+        # "keep exactly one" and to "delete the superseded trailer" about text they wrote
+        # as *documentation*, and which a Markdown reader renders as code. The advice
+        # happens to work — indenting inside the fence drops the line from `TRAILER_RE` —
+        # but naming the wrong construct is what sends someone hunting for a declaration
+        # they never made. `CONTRIBUTING.md` publishes three such blocks, so quoting two of
+        # them to ask which form applies is the ordinary way into this path.
+        #
+        # `find_near_misses` is the half that holds the right diagnosis and it is
+        # unreachable from here otherwise: the duplicate refusal returns first, and the
+        # near-miss scan below stands down as soon as one readable trailer exists. Append
+        # rather than fall through, because BOTH facts are true and only together do they
+        # explain the refusal — the count is what git-cliff will see, and the fence is why
+        # the author cannot see it.
+        if not declarations:
+            fenced = find_near_misses(declaration_text)
+            if fenced:
+                fenced_lines = "\n".join(
+                    f"  line {number}: {line}\n    -> {reason}" for number, line, reason in fenced
+                )
+                message += (
+                    "\n\nEvery one of them is inside a fenced code block, so none of them is a\n"
+                    "declaration you can see -- but git-cliff has no Markdown awareness and\n"
+                    f"counts all {len(as_git_cliff_sees)}:\n\n"
+                    f"{fenced_lines}\n\n"
+                    "So there is nothing to delete here. Indent the quoted lines inside the\n"
+                    "fence to keep them out of the count, and write your real declaration at\n"
+                    "column 0 outside any block."
+                )
+        return False, message
 
     # Also refused BEFORE the watched-file test, and for the same reason as the case above:
     # the harm is in what the *changelog* renders, which applies to every commit. Putting it

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -30,6 +30,9 @@ find_declarations = check_representation_change.find_declarations
 find_near_misses = check_representation_change.find_near_misses
 watched_files = check_representation_change.watched_files
 WATCHED_PREFIXES = check_representation_change.WATCHED_PREFIXES
+fenced_line_numbers = check_representation_change.fenced_line_numbers
+find_trailers_as_git_cliff_would = check_representation_change.find_trailers_as_git_cliff_would
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 # ---------------------------------------------------------------------------
@@ -1079,4 +1082,202 @@ def test_the_decline_exclusion_precedes_the_inclusion() -> None:
     )
     assert not any(word in inclusion for word in check_representation_change.NONE_VALUES), (
         f"the second rule is {inclusion!r}, which looks like the exclusion -- the two are reversed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A fenced trailer is documentation, not a declaration (#1929)
+# ---------------------------------------------------------------------------
+
+
+def test_a_fenced_trailer_is_not_a_declaration() -> None:
+    """The #1929 reproducer: quoting the docs must not file a disclosure.
+
+    This is the one decoration that reached column 0 with its text intact, so unlike an
+    inline code span or a blockquote it did not merely go unread — it was read as REAL, and
+    the author was recorded as disclosing a 577-row migration they said in the same body
+    they had not worked out. A false disclosure, not a missed one.
+    """
+    body = (
+        "This PR refactors a helper.\n\n"
+        "For reference, CONTRIBUTING.md says the trailer looks like:\n\n"
+        "```\n"
+        "Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell.\n"
+        "  Previously-accepted inputs, so a real migration for the consumer.\n"
+        "```\n\n"
+        "I have not worked out the disclosure for this change yet.\n"
+    )
+    assert find_declaration(body) is None
+    passed, message = check(["src/normalize/mod.rs"], body)
+    assert not passed
+    assert "fenced code block" in message
+
+
+def test_a_fenced_trailer_is_reported_as_a_near_miss_not_as_silence() -> None:
+    """Someone who pasted the documented form is asking a question, not staying silent."""
+    body = "x\n\n```\nRepresentation-Change: none\n```\n"
+    misses = find_near_misses(body)
+    assert len(misses) == 1
+    line_number, line, reason = misses[0]
+    assert line_number == 4
+    assert line.startswith("Representation-Change:")
+    assert "fenced" in reason and "column 0" in reason
+
+
+@pytest.mark.parametrize(
+    "opener,closer",
+    [("```", "```"), ("~~~", "~~~"), ("````", "````"), ("```rust", "```")],
+)
+def test_every_fence_spelling_hides_a_trailer(opener: str, closer: str) -> None:
+    body = f"x\n\n{opener}\nRepresentation-Change: 9 rows move\n{closer}\n"
+    assert find_declaration(body) is None
+
+
+def test_a_longer_fence_may_contain_a_shorter_one() -> None:
+    """The shape the issue reproduced with: a ```` block quoting a ``` block."""
+    body = "x\n\n````markdown\n```\nRepresentation-Change: 577 rows move\n```\n````\n"
+    assert find_declaration(body) is None
+
+
+def test_a_backtick_opener_whose_info_carries_a_backtick_is_not_a_fence() -> None:
+    """CommonMark forbids a backtick in a BACKTICK fence's info string; tildes allow it.
+
+    Without that restriction an inline code span opens a block, so a line like
+    ```` ```see `none` below ```` reads as an opener and blanks everything after it — the
+    real declaration below included. It fails closed (the author is refused rather than
+    credited with a disclosure they never wrote), which is the safe direction and still
+    the wrong answer.
+
+    Both halves are asserted because only together do they show the rule is about the
+    fence CHARACTER and not about backticks in info strings generally.
+    """
+    body = "```see `none` below\n\nRepresentation-Change: none. Tests only.\n"
+    assert find_declaration(body) == "none. Tests only."
+    passed, _ = check(["src/normalize/mod.rs"], body)
+    assert passed
+
+    # A tilde fence has no such restriction, so this one genuinely opens and swallows it.
+    tilde = "~~~see `none` below\n\nRepresentation-Change: none. Tests only.\n"
+    assert find_declaration(tilde) is None
+
+
+def test_an_unclosed_fence_runs_to_the_end() -> None:
+    """CommonMark's rule, and the safe direction: withhold rather than invent."""
+    body = "x\n\n```\nRepresentation-Change: 577 rows move\n"
+    assert find_declaration(body) is None
+
+
+def test_a_real_trailer_after_a_closed_fence_still_counts() -> None:
+    """The fence must not swallow the rest of the body."""
+    body = "```\nsome code\n```\n\nRepresentation-Change: none. Tests only.\n"
+    assert find_declaration(body) == "none. Tests only."
+    passed, _ = check(["src/normalize/mod.rs"], body)
+    assert passed
+
+
+def test_a_fenced_example_beside_a_real_trailer_is_still_refused() -> None:
+    """The safety property that makes the fence-aware set the WRONG one to count.
+
+    `git_conventional` has no Markdown awareness — any `word:` line is a footer token — so
+    git-cliff sees the fenced example too. Were the duplicate refusal made fence-aware, this
+    body would pass here while the changelog still had two footers to choose from, and the
+    quoted 577-row example could land under an author who declared `none`.
+
+    So a fenced trailer may not BE the declaration and still COUNTS toward how many the
+    changelog will see. The refusal is what forces the author to indent or drop the quote.
+    """
+    body = (
+        "```\n"
+        "Representation-Change: 577 rows move\n"
+        "```\n\n"
+        "Representation-Change: none. Tests only.\n"
+    )
+    assert find_declaration(body) == "none. Tests only."
+    assert len(find_trailers_as_git_cliff_would(body)) == 2
+    passed, message = check(["src/normalize/mod.rs"], body)
+    assert not passed
+    assert "trailers found" in message
+
+
+def test_two_fenced_examples_and_no_real_trailer_are_refused_naming_the_fence() -> None:
+    """The one path where the fenced case does not get the fenced message.
+
+    `check` counts trailers as git-cliff would — fences included, deliberately — and
+    refuses on more than one BEFORE the near-miss scan runs. When *every* counted trailer
+    is fenced, that refusal is the one the author meets, and its advice ("Keep exactly
+    one", "Delete the superseded trailer") names a construct they never wrote: a Markdown
+    reader sees two code blocks. The advice happens to work, since indenting inside the
+    fence drops the line from `TRAILER_RE`, but it sends the author looking for a
+    declaration they have not made.
+
+    The body is not contrived. `CONTRIBUTING.md` publishes three such blocks and the whole
+    premise of #1929 is someone quoting the docs to ask what to write; quoting two of them
+    is how you ask WHICH form applies.
+
+    Both halves of the refusal are asserted, because both are true and neither alone
+    explains it: the count is what the changelog will see, and the fence is why the author
+    cannot see it.
+    """
+    body = (
+        "Which of these should I write?\n\n"
+        "```\n"
+        "Representation-Change: none\n"
+        "```\n\n"
+        "or\n\n"
+        "```\n"
+        "Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell.\n"
+        "```\n"
+    )
+    assert find_declaration(body) is None, "neither example is readable, so nothing is declared"
+    assert len(find_trailers_as_git_cliff_would(body)) == 2, "git-cliff counts both"
+
+    passed, message = check(["src/normalize/mod.rs"], body)
+    assert not passed
+    assert "trailers found" in message, "the duplicate count is still reported"
+    assert "fenced code block" in message, (
+        "the duplicate refusal fired without naming the fence, so the author is told to "
+        f"delete a trailer that is not one; message was:\n{message}"
+    )
+    assert "nothing to delete here" in message
+
+
+def test_the_fenced_note_is_absent_when_a_real_trailer_is_among_the_duplicates() -> None:
+    """The negative control for the arm above: a readable trailer means real duplicates.
+
+    Here `Delete the superseded trailer` is exactly right, so the fenced note must not be
+    appended — it would tell an author with a genuine duplicate that there is nothing to
+    delete.
+    """
+    body = (
+        "```\n"
+        "Representation-Change: 577 rows move\n"
+        "```\n\n"
+        "Representation-Change: none. Tests only.\n"
+    )
+    passed, message = check(["src/normalize/mod.rs"], body)
+    assert not passed
+    assert "trailers found" in message
+    assert "nothing to delete here" not in message
+
+
+def test_contributing_md_s_own_examples_are_not_read_as_declarations() -> None:
+    """Run the checker over the contributor documentation itself.
+
+    The issue's suggested guard, and it is stronger than a hand-copied fixture: it keeps
+    working when the docs are rewritten. `CONTRIBUTING.md` publishes the trailer's form in
+    fenced blocks, so before #1929 its own text — pasted by someone asking what to write —
+    filed a disclosure.
+    """
+    contributing = (_REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "Representation-Change:" in contributing, "the docs stopped documenting the trailer"
+    fenced = fenced_line_numbers(contributing)
+    quoted_in_a_fence = [
+        number
+        for number, line in enumerate(contributing.splitlines(), 1)
+        if line.startswith("Representation-Change:") and number in fenced
+    ]
+    assert quoted_in_a_fence, "expected CONTRIBUTING.md to publish the form inside a fence"
+    assert find_declaration(contributing) is None, (
+        "CONTRIBUTING.md's own examples are read as a declaration; "
+        f"fenced trailer lines were {quoted_in_a_fence}"
     )


### PR DESCRIPTION
Closes #1929.

`TRAILER_RE` anchors at column 0 and knows nothing about Markdown, so a `Representation-Change:` line **inside a fenced code block** was read as a real declaration. `CONTRIBUTING.md` publishes the trailer's form in fenced blocks, so the text that triggers this is copy-pasteable straight out of the contributor documentation — which is exactly how it would be met in practice, by someone quoting the docs to ask what to write.

**That is a false disclosure, not a missed one.** A body declaring nothing and merely quoting the example produced:

| | before |
|---|---|
| `find_declaration` | `577 rows move, 360 merge / 205 split / 12 respell.` |
| `check(...)` | **passes** |
| `find_near_misses` | `[]` — nothing flagged |

So the required check went green and the author was recorded as disclosing a 577-row migration they said, in the same body, they had not worked out.

Every other decoration was already handled and fails loudly with a near-miss hint — inline code span, `**bold**`, `> blockquote`, four-space indent. A fence is the one shape that reaches column 0 with its text intact.

## The fix

Fenced regions are blanked before the declaration is chosen, **preserving line numbers** so the fenced line is *reported* as a near-miss rather than passed over in silence:

```
line 6: Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell.
  -> inside a fenced code block, so it is documentation rather than a declaration;
     move it to column 0 outside any ``` or ~~~ block
```

Someone who pasted the documented form is asking a question, not staying silent, and the message names the fix.

Fence tracking follows CommonMark where it matters: the closing fence must use the same character and be at least as long as the opener (so a ```` ```` ```` block may quote ```` ``` ```` lines — the shape the issue reproduced with), and an unclosed fence runs to end of text, which withholds a declaration rather than inventing one.

## The part that is deliberately *not* symmetric

**The duplicate refusal counts the UNSTRIPPED set**, and that asymmetry is the point.

`git_conventional` parses footers with no Markdown awareness — any `word:` line is a footer token — so git-cliff sees a fenced trailer too. Making both halves fence-aware looks tidier and is a **safety regression**: a body carrying a quoted example *beside* a real `none` would then pass here while the changelog still had two footers to choose from, and the quoted 577-row example could land under an author who declined.

So: **fenced text may not BE the declaration, but it still COUNTS toward how many the changelog will see.** The refusal is what forces the author to indent or drop the quotation, which is the escape hatch `CONTRIBUTING.md` already documents. I nearly shipped the symmetric version; the four-shape table below is what caught it.

| body | verdict |
|---|---|
| fenced example only | **refused**, with the near-miss hint (this is #1929) |
| fenced example + real trailer | **refused** — 2 trailers, as git-cliff would see |
| real trailer alone | passes |
| two real trailers | refused |

**The sibling scripts are left alone for the same reason.** `check_changelog_grouping.py` keeps its own copy of the column-0 pattern and `inject_representation_disclosure.py` imports it from there; both read *commit messages* and exist to check or reproduce what git-cliff actually did. Teaching them about fences would make them disagree with the changelog they audit. (The issue said the audit imports from the checker — it is the other way round; corrected here so the next reader does not propagate the fix into the wrong place.)

## Tests

Twelve. Ten were verified against the fence-strip: reverting it turns exactly those ten red and nothing else. Two cover the path where the fenced case did *not* get the fenced message — two fenced examples and no real trailer, which hits the duplicate refusal before the near-miss scan runs. One of those two fails without the fix (the message never says "fence"); the other is its negative control, asserting that a genuine duplicate is still told to delete one.

The strongest is the one the issue suggested: **run the checker over `CONTRIBUTING.md` itself** and assert its own examples are not read as a declaration. Unfixed, that test reports the live documentation declaring `c.<cds_end>_*1ins<A> now renders as`. That is the defect demonstrated against shipped docs rather than a hand-copied fixture, and the guard keeps working when the docs are rewritten.

## Verification

`ruff check` and `ruff format --check` clean. `pytest tests/python/test_representation_change_trailer.py` — **161 passed**. Against the live tree, `find_declaration` now returns `None` for both `CONTRIBUTING.md` and `CLAUDE.md`.

Representation-Change: none. Tooling only — this changes which PR-body text the checker reads as a declaration, and no `src/` file is touched.

