### PR TITLE
ci: bound every PR-gating job with a timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,49 @@ env:
     + test(defect_non_idempotent_outputs)
     + test(issue_1715_rna_alignment_symbol_reach)
 
+# Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
+# 360-minute default, so a wedged runner holds a PR for six hours: observed on
+# #1977 (run 31905255274, attempt 1), where `Test (2/6)` sat in its nextest step
+# for 72 minutes against the same shard's 65-second step on the run's own second
+# attempt, while the other 32 jobs were green, and would have run to 360.
+#
+# The tiers are deliberately loose, because the failure that matters here is a
+# timeout that fires on legitimate work. `.config/nextest.toml` records the
+# precedent: a `slow-timeout = { period = "60s", terminate-after = 2 }` killed
+# the real censuses at 120s, and that is why there is no `[profile.ci]`. These
+# bound a hang; they are not a budget, and nothing should be tuned to fit them.
+#
+#   60  compiles Rust, so a cold cache is on the table
+#       (build, clippy{,-all-features}, spec-fixtures, test-build{,-soak},
+#        python-wheel-test, and coverage.yml's `coverage` and `doctests`)
+#   30  downloads a prebuilt archive and runs tests (test, test-oracle,
+#       sweeps, censuses, soak)
+#   15  lint/aux, none of which compiles Rust
+#
+# Sizing, re-derived 2026-08-15 across every ATTEMPT of the last 40 completed
+# `ci.yml` runs, 60 `coverage.yml` runs and 40 `lint-workflows.yml` runs — via
+# `/runs/{id}/attempts/{n}/jobs`, because the default `/runs/{id}/jobs` returns
+# only the latest attempt and so hides exactly the wedged runs this bounds.
+# Each tier is at least 5x ITS OWN slowest observed member; the multiple is
+# per-tier and is never taken against a workflow-wide maximum:
+#
+#     60  `Code Coverage (2/4)`  713s  ->  5.05x
+#     30  `Test oracle (2/4)`    179s  -> 10.1x
+#     15  `Format`                25s  ->   36x
+#
+# Every one of those runs is WARM-cache; no cold-cache figure was measured. The
+# 60 tier's headroom is therefore a deliberate allowance for a build that has to
+# compile the dependency tree from scratch, not a measured multiple. Re-derive
+# from measurement before tightening any of them.
+#
+# `coverage.yml`'s third job calls `report-failure.yml` via `uses:`, and GitHub
+# rejects `timeout-minutes` on a job that does that; the callee's own `report`
+# job carries the 15 instead. Do not "fix" the apparent omission.
 jobs:
   abi3-floor-consistency:
     name: abi3 floor ↔ requires-python
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -281,6 +320,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -295,6 +335,7 @@ jobs:
   python-lint:
     name: Python Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       # `uv sync --no-install-project` below deliberately skips building the
       # project, but a bare `uv run` re-installs it — and for this maturin
@@ -343,6 +384,7 @@ jobs:
   representation-change:
     name: Representation change declared
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # `pull_request` only. The check reads the PR description, which is what becomes the
     # squash commit body and therefore what git-cliff's footer rule matches. A push to
     # `main` has no equivalent to read, and by then the declaration is already merged.
@@ -450,6 +492,7 @@ jobs:
   merge-commit-signature:
     name: Merge commit signature
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # `merge_group` only. This is a question about the commit the QUEUE built: a pull
     # request head is a different object that never reaches `main`, and by `push: main` the
     # commit has already been accepted, so the answer there is always yes.
@@ -532,6 +575,7 @@ jobs:
   changelog-grouping:
     name: Changelog grouping audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Not on `merge_group`. This job judges what a SQUASH will render, and it gets there
     # by synthesizing that squash commit from the PR title and description (the step
     # below). A merge group carries the branch's intermediate commits, un-squashed, and
@@ -643,6 +687,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -720,6 +765,7 @@ jobs:
     # cannot see.
     name: Clippy (all features)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -756,6 +802,7 @@ jobs:
   spec-fixtures:
     name: Spec fixtures and generated docs
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -987,6 +1034,7 @@ jobs:
   test-build:
     name: Build test archive
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       # The Test jobs build and LINK the integration-test binary. With full
       # debuginfo (dev/test profile default `debug = true`) the linked
@@ -1114,6 +1162,7 @@ jobs:
   test-build-soak:
     name: Build soak archive (optimized)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1247,6 +1296,7 @@ jobs:
   fixtures:
     name: Fetch bulk test fixtures
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1293,6 +1343,7 @@ jobs:
     name: Test (${{ matrix.shard }}/6)
     needs: [test-build, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
@@ -1424,6 +1475,7 @@ jobs:
     name: Test oracle (${{ matrix.shard }}/4)
     needs: [test-build, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
@@ -1655,6 +1707,7 @@ jobs:
     # is a soak-cost decision, not only a coverage one.
     needs: test-build-soak
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -1743,6 +1796,7 @@ jobs:
     name: Exhaustive sweeps
     needs: test-build-soak
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1860,6 +1914,7 @@ jobs:
     name: Slow censuses (optimized)
     needs: [test-build-soak, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1923,6 +1978,7 @@ jobs:
   test-required:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [test, test-oracle, soak, sweeps, censuses]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
@@ -1951,6 +2007,7 @@ jobs:
   python-wheel-test:
     name: Python Wheel Test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1997,6 +2054,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,6 +49,7 @@ jobs:
   coverage:
     name: Code Coverage (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -173,6 +174,11 @@ jobs:
   doctests:
     name: Doctests
     runs-on: ubuntu-latest
+    # 60, not 15: `cargo test --doc` compiles Rust, which is ci.yml's stated
+    # criterion for that tier. The cache above is restore-only on a PR and is
+    # shared with `main`'s entry, so a cold full build is on the table here even
+    # though the 60 warm runs measured for the sizing table peak at 151s.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -48,6 +48,7 @@ jobs:
   lint:
     name: zizmor + actionlint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -73,6 +73,7 @@ jobs:
   report:
     name: Open or update the tracking issue
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
A job with no `timeout-minutes` inherits GitHub's 360-minute default. This adds one to every job in the workflows that gate a PR: `ci.yml` (20 jobs), `coverage.yml`, `lint-workflows.yml` and `report-failure.yml`.

Representation-Change: none

## Why

On #1977, `Test (2/6)` sat in its nextest step for **71 minutes** against a **76-second** norm while the other 32 jobs were green. Nothing would have stopped it until 360 minutes — six hours of a blocked PR and a held runner, for a job whose real ceiling is under two minutes. I cancelled it by hand; on the re-run the same job passed in ~76s, and the tree was already proven good (that head is a re-signed copy of `87024a1c`, which has two green CI runs), so it was a wedged runner rather than anything in the PR.

`audit-pr-runs.yml` already carries this argument for its own job, in its own words — *"a `gh` call that hangs would otherwise sit against the 6-hour default limit"*. This generalizes a decision the repo has already made once.

## Sizing, and why it is loose

The failure mode that matters here is **a timeout firing on legitimate work**, not a hang running long. `.config/nextest.toml` records what that costs: a `slow-timeout = { period = "60s", terminate-after = 2 }` killed the real censuses at 120s, and that is why there is deliberately no `[profile.ci]`. These values bound a hang; they are not a budget, and nothing should be tuned to fit them.

| tier | jobs | rationale |
|---|---|---|
| **60** | `build`, `clippy`, `clippy-all-features`, `spec-fixtures`, `test-build`, `test-build-soak`, `python-wheel-test`, and `coverage.yml`'s `coverage` | compiles Rust, so a cold cache is on the table |
| **30** | `test`, `test-oracle`, `sweeps`, `censuses`, `soak` | downloads a prebuilt archive and runs tests |
| **15** | `abi3-floor-consistency`, `format`, `python-lint`, `representation-change`, `merge-commit-signature`, `changelog-grouping`, `fixtures`, `test-required`, `lint`, `report`, `doctests` | lint/aux; every one under 25s observed |

Each value is at least **5x** the slowest run observed across six CI runs on 2026-08-15. The slowest job in `ci.yml` was `Test oracle (1/4)` at **345s**, against a 60-minute tier; `coverage.yml`'s shards peak at **588s**, which is why `coverage` is 60 rather than 30. The rule is written into the header comment so a future edit re-derives from measurement instead of guessing.

## Scope

Nightly, release, fuzz, external-validation, publish, deploy-local and prune workflows are **left alone**. The same argument applies to them, but sizing needs their own measurements — `release-wheels` builds across platforms and `external-validation` hits the network — and guessing would violate the rule this PR is establishing.

## Verification

- `actionlint` clean across all workflows. It caught a real mistake first: `audit-pr-runs.yml` already had `timeout-minutes: 10` and the initial pass added a duplicate. `yaml.safe_load` accepted that silently (last-wins) — only the linter saw it. That file is reverted and untouched here.
- Every inserted line was asserted to sit directly after its job's `runs-on`, including the matrix jobs where a `strategy:` block intervenes.
- All five workflows parse.
