### PR TITLE
docs(ci): re-measure the denoted-sequence oracle; #1690 is no longer a blocker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1504,7 +1504,8 @@ jobs:
         #     reaches `cds_to_tx`'s unchecked `cds_start as i64 + pos.base - 1`
         #     on an `i64::MAX`-adjacent `c.` coordinate. That module already
         #     records the measurement and names the site; the open issue is
-        #     **#1690**. The three are
+        #     **#1690**, since CLOSED — see the re-measurement below. The three
+        #     are
         #     `a_lone_member_at_an_extreme_coordinate_…`,
         #     `an_extreme_coordinate_…` and
         #     `two_adjacent_members_at_the_top_of_the_range_…`.
@@ -1522,19 +1523,42 @@ jobs:
         #   Two further notes from the same measurement, so it is not re-run to
         #   rediscover them. With `FERRO_MANIFEST` also set — which this job does
         #   NOT set, so CI does not see these — six `mutalyzer_normalize_tests`
-        #   axis tests fail too, on real `NG_` geometry, e.g.
+        #   axis tests failed too, on real `NG_` geometry, e.g.
         #   `NG_012337.1(NM_012459.2):c.4_5insGTA` -> `c.5_6insTAG`, where the
         #   input applies `GTAA` and the output `ATAG` over `[34, 35)`: an
         #   insertion shifted 3' past a base its first payload base does not
         #   match. Those axes early-return without the manifest, which is why
-        #   they read as 11 failures with it and 5 without. And the proof the
+        #   they read as 11 failures with it and 5 without.
+        #
+        #   THAT HALF IS ALSO STALE as of #1990. Re-run at `c9207d7e` with the
+        #   manifest armed: `10901 passed, 3 failed`. All six
+        #   `mutalyzer_normalize_tests` axes now PASS. The extra row over the
+        #   manifest-less run is `multi_member_cis_axis::axis_normalized`, which
+        #   is NOT an oracle fire — it fails identically with
+        #   `FERRO_ASSERT_SEQUENCE` UNSET (measured), on a census pin that reads
+        #   `unwindowed: 89` against a pinned 90 while `sequence_changed` stays
+        #   0. That is the HEAD-drift this repo already documents for that pin,
+        #   and it is orthogonal to arming this flag.
+        #
+        #   And the proof the
         #   flag is not a no-op over this selection is
         #   `issue_1615_denoted_sequence_oracle::the_seam_compares_when_the_flag_is_set`,
         #   which is IN this selection and asserts the oracle's `compared`
         #   counter is non-zero; it skips by design when the flag is unset.
         #
-        #   So arming this is blocked on #1690 and on a home for
-        #   `stranded_identity_member` — NOT on another measurement.
+        #   RE-MEASURED once #1690 closed (#1990), same selection and flags, no
+        #   `--partition` and no `FERRO_MANIFEST`, on `c9207d7e`:
+        #
+        #     Summary [179.827s] 10904 tests run: 10902 passed, 2 failed, 306 skipped
+        #
+        #   The three `issue_1487_canonical_window_overflow` rows are GONE — all
+        #   8 tests in that module pass — and NOTHING NEW fired. The 2 survivors
+        #   are both `stranded_identity_member`, on the row quoted above:
+        #   `every_stranded_identity_is_non_confluent_with_its_surviving_member`
+        #   and `the_wider_multi_member_census_is_what_the_header_says`.
+        #
+        #   So arming this is blocked on a home for `stranded_identity_member`,
+        #   and on that alone — #1690 is closed and is no longer a blocker.
         #
         #     This row replaced an earlier one on the same issue
         #     (`NM_000492.4:c.1520_1522del` -> `c.1521_1523del`), and the swap is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,14 +449,41 @@ two-row check above:
   `attempt to add with overflow` at `src/convert/mapper.rs:114`: arming the flag
   routes the output through `hgvs_to_spdi`, which reaches `cds_to_tx`'s unchecked
   `cds_start as i64 + pos.base - 1` on an `i64::MAX`-adjacent `c.` coordinate.
-  The open issue is **#1690**.
+  The issue was **#1690**, **since CLOSED** — the two arms that can overflow now
+  `checked_add` and return a `ConversionError`.
 - **2x `stranded_identity_member`** — a genuine fire, of #1281's "denotes no
   sequence" shape, on a module that exists to PIN a defect (#1655's stranded
   derived identity). That is the class `ORACLE_EXCLUDE` already documents: a test
   pinning a defect and an oracle aborting on it cannot both run.
 
-So arming it is blocked on **#1690** and on finding a home for
-`stranded_identity_member` — **not** on another measurement. Do not read "both
+**Re-measured after #1690 closed (#1990), and only one of the two classes
+survives.** Same selection, same flags, no `--partition` and no `FERRO_MANIFEST`
+— `c9207d7e`, 94 commits past the run above:
+
+```
+Summary [179.827s] 10904 tests run: 10902 passed, 2 failed, 306 skipped
+```
+
+The three `issue_1487_canonical_window_overflow` rows are **gone** — all 8 tests
+in that module pass — and **nothing new fired**. The 2 survivors are both
+`stranded_identity_member`, still the recorded row:
+
+| test | the row it fires on |
+|---|---|
+| `every_stranded_identity_is_non_confluent_with_its_surviving_member` | input `TEMPLATE:g.[10_11insAT;11_12inv;12_13insA]`, output `g.[11_12insTA;11_12=;12_13insA]` |
+| `the_wider_multi_member_census_is_what_the_header_says` | the same row, reached through the wider census |
+
+**The `FERRO_MANIFEST` half of that measurement is stale too.** The same run with
+the manifest armed reads `10901 passed, 3 failed` — all six
+`mutalyzer_normalize_tests` axes now **pass**, and the one extra row is
+`multi_member_cis_axis::axis_normalized`, which is **not an oracle fire**: it
+fails identically with `FERRO_ASSERT_SEQUENCE` **unset** (measured as a control),
+on a census pin reading `unwindowed: 89` against a pinned `90` while
+`sequence_changed` stays `0`. That is the HEAD-drift this file already documents
+for that pin, and it is orthogonal to arming the flag.
+
+So arming it is blocked on finding a home for `stranded_identity_member`, and on
+that alone — **#1690 is closed and is no longer a blocker.** Do not read "both
 rows are green" as "it can be armed". `ci.yml`'s comment on the `test-oracle`
 job carries the full triage, including what a run with `FERRO_MANIFEST` set adds.
 Suppressing a row would still hollow out the oracle; that has not changed.

--- a/scripts/run_oracle_suite.sh
+++ b/scripts/run_oracle_suite.sh
@@ -65,6 +65,12 @@
 # `stranded_identity_member` (a real fire on a module that PINS a defect). The
 # blocking rows are no longer #1618/#1619, both of which are closed and green;
 # see `test-oracle`'s own comment in `ci.yml` for the full triage.
+#
+# RE-MEASURED on `c9207d7e` once #1690 closed (#1990), same selection and flags:
+# `10904 tests run: 10902 passed, 2 failed, 306 skipped`. The 3
+# `issue_1487_canonical_window_overflow` rows are GONE and nothing new fired, so
+# the remaining blocker is `stranded_identity_member` alone -- #1690 is closed
+# and is no longer one.
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/it/oracle_exclude_invariant.rs
+++ b/tests/it/oracle_exclude_invariant.rs
@@ -310,7 +310,8 @@ const LOCAL_RUNNER: &str = "scripts/run_oracle_suite.sh";
 /// locally and green in CI. Note those rows are no longer #1618/#1619, which are
 /// both closed: a selection-wide run at `674e9c8b` put the count at 5, in
 /// `issue_1487_canonical_window_overflow` (issue #1690) and
-/// `stranded_identity_member`.
+/// `stranded_identity_member`. Re-measured at `c9207d7e` once #1690 closed
+/// (#1990) the count is 2, all of it `stranded_identity_member`.
 fn test_oracle_job_flags() -> Vec<String> {
     test_oracle_job_lines()
         .into_iter()
@@ -528,7 +529,8 @@ fn the_ci_oracle_selection_negates_proptest_the_sweeps_and_the_corpus_modules() 
 /// `test-oracle` deliberately withholds it — makes the runner red on rows no PR
 /// caused, which teaches the operator to ignore it. That is not hypothetical:
 /// arming it over this exact selection at `674e9c8b` is red, 5 tests, so a
-/// runner that armed it ahead of the job would be red on every PR.
+/// runner that armed it ahead of the job would be red on every PR. Still red at
+/// `c9207d7e` (#1990), at 2 tests rather than 5 — #1690 closed the other 3.
 #[test]
 fn the_local_oracle_runner_arms_exactly_the_flags_test_oracle_arms() {
     let runner_flags = local_runner_selection().flags;


### PR DESCRIPTION
`CLAUDE.md`, `ci.yml` and `scripts/run_oracle_suite.sh` all recorded that arming `FERRO_ASSERT_SEQUENCE` in the `test-oracle` job was blocked on **#1690** and on finding a home for `stranded_identity_member`. #1690 is closed, so half of that blocker set named a closed issue. This is the re-measurement, plus the doc correction that follows from it. No CI behaviour changes.

## What was run

`test-oracle`'s selection, read out of `ci.yml` by `scripts/run_oracle_suite.sh --print-selection` rather than rebuilt by hand, with that job's three flags plus `FERRO_ASSERT_SEQUENCE=1`, `FERRO_REQUIRE_BULK_FIXTURES=1`, no `--partition`, at `c9207d7e` (94 commits past the `674e9c8b` baseline). Zero `Skipping:` lines in both runs, so the bulk suites were armed rather than silently absent.

## Result, on `test-oracle`'s selection, without `FERRO_MANIFEST`

```
10904 tests run: 10902 passed, 2 failed, 306 skipped
```

against the recorded `10383 run / 10378 passed / 5 failed / 289 skipped` at `674e9c8b`.

- **The 3 `issue_1487_canonical_window_overflow` rows are gone.** All 8 tests in that module pass. #1690's fix holds.
- **Nothing new fired.**
- The 2 survivors are both `stranded_identity_member`, on the row `ci.yml` already quotes — input `TEMPLATE:g.[10_11insAT;11_12inv;12_13insA]`, output `TEMPLATE:g.[11_12insTA;11_12=;12_13insA]`:
  - `every_stranded_identity_is_non_confluent_with_its_surviving_member`
  - `the_wider_multi_member_census_is_what_the_header_says`

## The `FERRO_MANIFEST` half was stale too

With the manifest armed the same selection reads `10901 passed, 3 failed`. All six `mutalyzer_normalize_tests` axes now **pass**, contrary to what `ci.yml` recorded. The one extra row is `multi_member_cis_axis::axis_normalized`, and it is **not an oracle fire**: run as a control with `FERRO_ASSERT_SEQUENCE` **unset**, it fails identically, on a census pin reading `unwindowed: 89` against a pinned `90` while `sequence_changed` stays `0`. That is the HEAD-drift already documented for that pin (34 `src/` commits since it last moved), and it is orthogonal to this flag.

## The flag is NOT armed

`stranded_identity_member` still fires, so the measurement is still red and `test-oracle`'s `env:` is untouched — verified by parsing the workflow: it still carries exactly `FERRO_ASSERT_IDEMPOTENT`, `FERRO_ASSERT_REPARSE`, `FERRO_ASSERT_IN_BOUNDS`, `FERRO_REQUIRE_BULK_FIXTURES`. `censuses` inherits that flag set exactly, so arming would change two jobs.

The remaining blocker is `stranded_identity_member` alone — a module that exists to *pin* a defect (#1655, #1829, #1815), which is the `ORACLE_EXCLUDE` class: a test pinning a defect and an oracle aborting on it cannot both run. That is a scoping decision, not a measurement.

## Counts are labelled by scope

`ORACLE_EXCLUDE`'s modules and `test-oracle`'s selection have each produced a "5 failures" figure for unrelated reasons. Every number here is on `test-oracle`'s selection and says so.

## Verification

`scripts/run_oracle_suite.sh --print-selection` is byte-identical before and after the `ci.yml` comment edits, and the guards that read these files at runtime pass: `oracle_exclude_invariant`, `adjudication_prose_regrowth`, `ruling_citation_currency`, `normalization_contract_doc` — 32 tests run, 32 passed.

Representation-Change: none. Documentation and CI comments only; no `src/` change, no normalization behaviour touched, and no workflow `env:` or selection altered.

Closes #1990
