### PR TITLE
test(normalize): denote each row under its own accession, not a hardcoded one

### DIFF
--- a/tests/it/issue_1307_terminal_dup_respell.rs
+++ b/tests/it/issue_1307_terminal_dup_respell.rs
@@ -424,6 +424,16 @@ fn the_merged_output_denotes_the_inputs_bases() {
     // where the wrapped spelling would have been tempting, so it is the axis
     // where a wrong composition is most plausible — checking only `g.` would
     // leave the riskier half to a string comparison.
+    //
+    // Each row normalizes under **its own** accession. That is not cosmetic: the
+    // loop used to normalize every row under a hardcoded `NC_TEST.1` while
+    // verifying under the row's accession, so the two `m.` rows were served a
+    // provider holding no sequence for the accession they name, and the merge
+    // that this test exists to check never ran on them. Measured on #1987 —
+    // `m.[24dup;24C>G]` came back as `m.[24C>G;24dup]`, a reorder, where
+    // normalizing under `NC_012920.1` reaches the merged `m.23_24insG` that
+    // `the_circular_axis_gets_the_same_answer` pins. A reorder is
+    // sequence-preserving, so the check passed while asking nothing.
     for (accession, input) in [
         ("NC_TEST.1", "NC_TEST.1:g.[24dup;24C>G]"),
         ("NC_TEST.1", "NC_TEST.1:g.[24C>G;24dup]"),
@@ -431,7 +441,7 @@ fn the_merged_output_denotes_the_inputs_bases() {
         ("NC_012920.1", "NC_012920.1:m.[24dup;24C>G]"),
         ("NC_012920.1", "NC_012920.1:m.[24dup;24delinsGG]"),
     ] {
-        let output = normalize("NC_TEST.1", SEQUENCE, input);
+        let output = normalize(accession, SEQUENCE, input);
         assert_denotes_the_same_bases(accession, SEQUENCE, input, &output);
     }
 }


### PR DESCRIPTION
Closes #1987

`the_merged_output_denotes_the_inputs_bases` (`tests/it/issue_1307_terminal_dup_respell.rs:422`) loops over five `(accession, input)` pairs, passing each row's own accession to the verifier while normalizing every row under a hardcoded `NC_TEST.1`. The two `m.` rows were therefore normalized against a provider holding no sequence for the accession they name, so the sequence-level denotation check — the thing this test exists to add over a string comparison — never ran on the circular axis. The test's own doc comment calls `m.` the riskier half and says exactly that it must not be left to a string comparison.

## Measured before changing anything

The issue asks for the one-line fix to be measured rather than assumed green, because a red result would be a real finding on the circular axis and would want its own issue. It is **green**:

```
Summary [0.037s] 1 test run: 1 passed, 6529 skipped
```

The more useful measurement is what the two `m.` rows were doing before. Normalizing each input both ways:

| input | under hardcoded `NC_TEST.1` | under its own `NC_012920.1` |
|---|---|---|
| `NC_012920.1:m.[24dup;24C>G]` | `m.[24C>G;24dup]` | `m.23_24insG` |
| `NC_012920.1:m.[24dup;24delinsGG]` | `m.[24delinsGG;24dup]` | `m.[24delinsGG;24dup]` |

The first row's "merged output" was never merged — it came back as a bare reorder, because the provider could not serve the accession. A reorder is sequence-preserving, so `assert_denotes_the_same_bases` passed while asking nothing of the composition. That is the silent pass the issue describes, and it is why the fix is not cosmetic. The merged form the first row now checks is the one `the_circular_axis_gets_the_same_answer` (`:253`) already pins as a string; this PR restores the **bases** check on it, and duplicates nothing.

## The rows are shown to exercise the applier, not merely to pass

Per the issue's acceptance criterion, the circular composition was deliberately corrupted (locally, temporarily, not committed) and the assertion fires on each row, on the denoted bases rather than on the spelling:

```
`NC_012920.1:m.[24dup;24C>G]` -> `NC_012920.1:m.23_24insC` no longer denotes the input's bases
  left: "TTTTTTTTTAATATATTTTAATACC"
 right: "TTTTTTTTTAATATATTTTAATAGC"

`NC_012920.1:m.[24dup;24delinsGG]` -> `NC_012920.1:m.[24delinsGA;24dup]` no longer denotes the input's bases
  left: "TTTTTTTTTAATATATTTTAATAGAC"
 right: "TTTTTTTTTAATATATTTTAATAGGC"
```

Each was run separately, because the first row panicking masks the second.

## Verification

Run with `FERRO_REQUIRE_BULK_FIXTURES=1` after `scripts/fetch-test-fixtures.sh`, and with `FERRO_MANIFEST` pointed at a prepared reference (so the reference-aware suites are armed rather than skipping):

| gate | status |
|---|---|
| `cargo nextest run --features dev --no-fail-fast` | 11059 run, 11058 passed, **1 failed**, 151 skipped |
| `cargo fmt --all --check` | pass |
| `cargo clippy --all-features --all-targets -- -D warnings` | pass |

Zero `Skipping:` lines in the test log, and the bulk suites ran armed (`cmrg_exhaustive_tests` 51.9 s, not the near-instant time an absent fixture gives). All nine tests in the touched module pass, including the changed one.

**The one failure is pre-existing and unrelated** — `multi_member_cis_axis::axis_normalized`, which measures `unwindowed: 89` against a pinned `90`. It reproduces identically with this PR's change fully reverted to the base commit's file:

```
left:  AxisCensus { rows: 592, declined: 6, not_idempotent: 0, unwindowed: 89, ... }
right: AxisCensus { rows: 592, declined: 6, not_idempotent: 0, unwindowed: 90, ... }
```

That census is a function of `src/`, which this PR does not touch, and it is invisible to PR CI because CI does not provision `FERRO_MANIFEST` — the test early-returns and reports green. Flagging it here rather than folding a pin move into a test-only PR.

Representation-Change: none. Tests only; no file under a watched directory is touched and no expectation was re-blessed.
