### PR TITLE
perf(ci): take the last two heavy censuses off the debug shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,9 @@ env:
   # WHY THEY MOVED. `--partition hash:K/N` assigns a test by a hash of its NAME,
   # so it balances shard *counts* and is blind to cost — the property already
   # recorded on `sweeps`, where all three exhaustive sweeps hashed into one
-  # shard. These four hashed into the two slowest jobs and made the workflow's
-  # critical path a single test. Measured on run 31845625298 (`044f085a`):
+  # shard. The three below hashed into the two slowest jobs and made the
+  # workflow's critical path a single test. Measured on run 31845625298
+  # (`044f085a`):
   #
   #                                             Test (K/6)   Test oracle (K/4)
   #   issue_1542_direction_symmetry               155.7s (3)         240.3s (1)
@@ -102,6 +103,20 @@ env:
   # test, so re-sharding cannot fix it — which is why `test-oracle`'s own
   # comment below, having chosen N=4 to separate the two bulk corpora, names
   # exactly this carve-out as the robust alternative. This is that alternative.
+  #
+  # The fourth member joined later and its figures are from a DIFFERENT run,
+  # 31909112992 — not comparable row-for-row with the three above, and subject
+  # to the same cross-run spread recorded on `ORACLE_ONLY_FILTER` below:
+  #
+  #   clinvar_hgvs_tests (2 tests)                 37.2s (2,6)         62.3s (2,4)
+  #
+  # Its two tests hash into FOUR different shards between the two matrices, so
+  # ~99s of work leaves them — but only the 54.9s copy in `Test oracle (2/4)`
+  # was on the critical path, which is why the wall-clock saving is much smaller
+  # than the work removed. It is also the only member that is a PARSER
+  # benchmark rather than a normalization census: it never reaches
+  # `canonicalize_from_sequence`, so the optimized archive's gains land on its
+  # gzip decode, JSON deserialization and `parse_hgvs` instead.
   #
   # AND WHY THE JOB, NOT THE JOB BOUNDARY, IS THE WIN. `censuses` consumes the
   # OPTIMIZED archive `test-build-soak` produces, which is where `sweeps`
@@ -125,7 +140,39 @@ env:
   # other does not cover.
   CENSUS_FILTER: >-
     test(issue_1542_direction_symmetry) + test(normalize_axis_preserving)
-    + test(spec_conformance_axis)
+    + test(spec_conformance_axis) + test(clinvar_hgvs_tests)
+
+  # Negated from `test` ONLY. These run in `test-oracle` with the three seam
+  # oracles armed, and an armed run strictly subsumes an un-armed one — the
+  # oracles add assertions at `normalize_core_checked`'s exit and change no
+  # behaviour. That is the same argument `censuses` makes for dropping the
+  # plain-`test` copy of the modules it took, and `sweeps` before it; the only
+  # difference here is that the destination is an existing job rather than a
+  # new one.
+  #
+  # WHY NOT `CENSUS_FILTER`: that filter is negated from BOTH shards and the
+  # `censuses` job selects it off the SOAK archive, which is built
+  # `-p ferro-hgvs-soak-tests` and therefore contains no `src/` unit tests at
+  # all. `merge::tests::direction_symmetry` is a `#[cfg(test)]` module inside
+  # `src/normalize/merge.rs`, so naming it in `CENSUS_FILTER` would negate it
+  # from both shards and then select nothing — deleting the census outright.
+  # `--no-tests=fail` would not catch that, because the step's other terms
+  # still match. This variable exists precisely because that trap is silent.
+  #
+  # It is the unit half of #1840's pair. #1955 moved the integration half
+  # (`issue_1542_direction_symmetry`) to `censuses` and left this one running in
+  # BOTH shards.
+  #
+  # NO PER-TEST COST IS PINNED HERE, deliberately. That test measured 93.8s
+  # (`Test (3/6)`, un-armed) and 85.2s (`Test oracle (3/4)`, armed) on run
+  # 31909112992, and 46.8s in the same armed shard on run 31911822856 an hour
+  # later — a 2x spread on one test, so any single figure in a committed comment
+  # is one the next reader cannot reproduce, and pinning one invites a carve-out
+  # decision to be made from noise. What is stable is the SHAPE: `Test (3/6)`
+  # was a shard wearing one test, its whole nextest summary within ~1s of that
+  # single test's time. That, not a number, is why the carve-out exists.
+  ORACLE_ONLY_FILTER: >-
+    test(merge::tests::direction_symmetry)
   # The spec-corpus modules, excluded from `test-oracle` ONLY. They run in full
   # in the plain `test` job; this is not a coverage exemption, it is a statement
   # about which instrument may be armed while another is measuring.
@@ -1378,7 +1425,7 @@ jobs:
           cargo nextest run --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
             --partition hash:${{ matrix.shard }}/6 \
-            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($CENSUS_FILTER)"
+            -E "not test(proptest) and not ($SWEEP_FILTER) and not ($CENSUS_FILTER) and not ($ORACLE_ONLY_FILTER)"
 
   # The idempotency oracle re-run. Deliberately EXCLUDES the proptest modules:
   # their own property already *is* `norm(norm(x)) == norm(x)`, which is exactly
@@ -1896,7 +1943,7 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
-            -E "test(issue_1542_direction_symmetry) + test(normalize_axis_preserving)"
+            -E "test(issue_1542_direction_symmetry) + test(normalize_axis_preserving) + test(clinvar_hgvs_tests)"
       - name: Run the census that may not be measured with an oracle armed
         # No `FERRO_ASSERT_*` here, deliberately, and no bulk fixtures: this
         # module builds its corpus in code (`conformance::spec_corpus`) and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "flate2",
  "proptest",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/tests-soak/Cargo.toml
+++ b/tests-soak/Cargo.toml
@@ -32,5 +32,7 @@ ferro-hgvs = { path = ".." }
 flate2 = "1.0"
 proptest = "1.0"
 rayon = "1.10"
+# `clinvar_hgvs_tests` only; it classifies parse failures by pattern.
+regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tests-soak/tests/soak/main.rs
+++ b/tests-soak/tests/soak/main.rs
@@ -91,6 +91,9 @@ mod bulk_fixtures;
 #[path = "../../../tests/it/common/cis_apply_oracle.rs"]
 mod cis_apply_oracle;
 #[allow(dead_code)]
+#[path = "../../../tests/it/common/failure_expectations.rs"]
+mod failure_expectations;
+#[allow(dead_code)]
 #[path = "../../../tests/it/common/fixture_gen.rs"]
 mod fixture_gen;
 #[allow(dead_code)]
@@ -114,8 +117,8 @@ mod synthetic;
 /// directory instead of two.
 mod common {
     pub(crate) use super::{
-        bulk_fixtures, cis_apply_oracle, fixture_gen, manifest, minimal_alignment, spec_fixture,
-        synthetic,
+        bulk_fixtures, cis_apply_oracle, failure_expectations, fixture_gen, manifest,
+        minimal_alignment, spec_fixture, synthetic,
     };
 }
 
@@ -152,6 +155,13 @@ mod issue_1542_direction_symmetry;
 mod normalize_axis_preserving;
 #[path = "../../../tests/it/spec_conformance_axis.rs"]
 mod spec_conformance_axis;
+// A parser benchmark rather than a normalization census — it never reaches
+// `canonicalize_from_sequence` — which is exactly why it belongs here: its cost
+// is a constant factor on gzip decode, JSON deserialization and `parse_hgvs`,
+// and the soak profile lowers all three. It was the second-heaviest test in
+// `Test oracle (2/4)` at 54.9s, on the shard that ended that job last.
+#[path = "../../../tests/it/clinvar_hgvs_tests.rs"]
+mod clinvar_hgvs_tests;
 
 // ---------------------------------------------------------------------------
 // SUPPORT: compiled because a module above reaches into it, NOT because any job

--- a/tests/it/clinvar_hgvs_tests.rs
+++ b/tests/it/clinvar_hgvs_tests.rs
@@ -11,10 +11,10 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
 use std::time::Instant;
 
 use crate::common::failure_expectations::{enforce, FixtureCheck};
+use crate::common::fixture_gen;
 
 const CLINVAR_500K_FAILURE_EXPECTATIONS_PATH: &str =
     "tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json";
@@ -160,7 +160,14 @@ fn test_clinvar_hgvs_500k_benchmark() {
     );
 
     enforce(
-        Path::new(CLINVAR_500K_FAILURE_EXPECTATIONS_PATH),
+        // Resolved against the workspace root, not the cwd: nextest sets the cwd
+        // to the PACKAGE root, and this module is compiled into
+        // `ferro-hgvs-soak-tests` as well as into `it`, where that root is
+        // `tests-soak/`. A bare relative path resolves there and the snapshot is
+        // reported missing — loudly, but in the one binary that cannot be run
+        // from the workspace root. Same reason `common::bulk_fixtures` and
+        // `common::fixture_gen` resolve their own paths this way.
+        &fixture_gen::fixture_path(CLINVAR_500K_FAILURE_EXPECTATIONS_PATH),
         "UPDATE_FAILURE_EXPECTATIONS",
         FixtureCheck {
             total_inputs: total,
@@ -239,7 +246,9 @@ fn test_clinvar_hgvs_unique_benchmark() {
     eprintln!("\n========================================\n");
 
     enforce(
-        Path::new(CLINVAR_UNIQUE_FAILURE_EXPECTATIONS_PATH),
+        // See the note on the 500k call above: workspace-root-relative, because
+        // this module now also compiles into the soak driver.
+        &fixture_gen::fixture_path(CLINVAR_UNIQUE_FAILURE_EXPECTATIONS_PATH),
         "UPDATE_FAILURE_EXPECTATIONS",
         FixtureCheck {
             total_inputs: total,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -464,6 +464,7 @@ mod normalize_tests;
 mod normalize_warning_seam;
 mod one_unknown_offset_sentinel_definition;
 mod oracle_exclude_invariant;
+mod oracle_only_filter_invariant;
 mod paraphase_exhaustive_tests;
 mod parser_tests;
 mod partition_switch_wiring;

--- a/tests/it/oracle_only_filter_invariant.rs
+++ b/tests/it/oracle_only_filter_invariant.rs
@@ -1,0 +1,347 @@
+//! Liveness check for `ORACLE_ONLY_FILTER` — the filter negated from `test` and
+//! from `test` alone.
+//!
+//! The claim it encodes is narrow and load-bearing: these tests do not need an
+//! un-armed copy, **because they still run armed in `test-oracle`**. The whole
+//! saving rests on that second clause, and nothing else in the repository
+//! checks it. Negating the filter from `test-oracle` as well is a one-token
+//! edit that reads like tidying, turns both shards green, makes them *faster*,
+//! and deletes the census — the failure direction this repository keeps hitting
+//! (see `tests/it/soak_package_membership.rs` and the bulk-fixture skip-green
+//! note in `CLAUDE.md`).
+//!
+//! So the assertions are, in order of what they defend:
+//!
+//! 1. The filter parses non-empty. Every other assertion here is vacuous
+//!    against an empty filter, and an empty one would ALSO make `test`'s
+//!    `and not ()` select everything — silently undoing the change while
+//!    looking correct.
+//! 2. `test` negates it. Otherwise nothing was saved.
+//! 3. `test-oracle` does **not** negate it, and does not exclude it by any
+//!    other route either. This is the coverage guarantee.
+//! 4. It is not also named in `CENSUS_FILTER`. That combination is the specific
+//!    trap the `ci.yml` comment describes: `CENSUS_FILTER` is negated from both
+//!    shards and selected off the soak archive, which contains no `src/` unit
+//!    tests, so a unit test named there would run nowhere at all.
+//! 5. Every term it names still resolves to modules that exist. A rename fails
+//!    safe — the filter matches nothing, `test` negates nothing, and the
+//!    duplicate quietly returns to the debug shard — but that is the same
+//!    silent config rot the file exists for, and it is what the `WHY NOT
+//!    CENSUS_FILTER` paragraph is guarding against elsewhere.
+//!
+//! # Both assertions 3 and 4 compare terms in BOTH directions, deliberately
+//!
+//! `test(P)` is a **substring predicate on the test's name**: nextest matches
+//! when `P` is contained in the name, not the reverse. So asking only whether
+//! the foreign filter's *text* contains this filter's *module path* — the
+//! obvious spelling, and the one this file shipped with — fires only on a
+//! verbatim duplication of the full path, and misses the natural spelling
+//! entirely.
+//!
+//! Concretely: `test(direction_symmetry)` added to `ORACLE_EXCLUDE` is the
+//! spelling every entry there already uses. nextest then excludes
+//! `normalize::merge::tests::direction_symmetry::…` from `test-oracle`, `test`
+//! already negates it here, and the census runs **nowhere** — while
+//! `"…test(direction_symmetry)…".contains("merge::tests::direction_symmetry")`
+//! is `false`, so a one-directional guard passes. That is precisely the failure
+//! this file was written to catch.
+//!
+//! Hence: extract the `test(...)` terms from **both** sides and require that
+//! neither contains the other. The wider term wins whichever way round it is
+//! written, so both directions are needed. `soak_package_membership.rs` uses
+//! the same containment direction when it expands a term over module names.
+//!
+//! This file reads `ci.yml` as text rather than parsing YAML, for the reason
+//! `census_filter_invariant.rs` gives: the repository has no YAML dependency in
+//! its test tree, and the helpers below are shaped to that file's folded
+//! scalars. It duplicates those helpers deliberately — two independent readers
+//! of the same file are two chances to notice a formatting change, and sharing
+//! them would mean a single parse bug silently disarming both guards.
+
+use std::path::PathBuf;
+
+/// The workflow this file is entirely about.
+const CI_YML: &str = ".github/workflows/ci.yml";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn ci_text() -> String {
+    std::fs::read_to_string(repo_root().join(CI_YML)).expect("ci.yml is readable")
+}
+
+/// A `>-` folded scalar from `ci.yml`'s top-level `env:`, folded back to one line.
+fn ci_filter(key: &str) -> String {
+    let ci = ci_text();
+    let mut lines = ci.lines();
+    let header = lines
+        .by_ref()
+        .find(|line| line.trim_start().starts_with(&format!("{key}:")))
+        .unwrap_or_else(|| panic!("ci.yml defines {key}"));
+
+    let inline = header
+        .split_once(':')
+        .map(|(_, value)| value.trim())
+        .unwrap_or_default();
+    if !inline.is_empty() && !inline.starts_with(['>', '|']) {
+        return inline.to_string();
+    }
+    assert!(
+        inline.starts_with(['>', '|']),
+        "{key} is neither a block scalar nor an inline value: {header:?}"
+    );
+
+    let key_indent = header.len() - header.trim_start().len();
+    let mut value = String::new();
+    for line in lines {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent <= key_indent {
+            break;
+        }
+        value.push(' ');
+        value.push_str(line.trim());
+    }
+    assert!(
+        !value.trim().is_empty(),
+        "{key} parsed as empty; ci.yml's formatting changed"
+    );
+    value
+}
+
+/// The body lines of one top-level job block, by its YAML key.
+fn job_lines(job: &str) -> Vec<String> {
+    let ci = ci_text();
+    let header = format!("  {job}:");
+    let mut lines = ci.lines().skip_while(|line| *line != header);
+    assert!(
+        lines.next().is_some(),
+        "ci.yml defines no `{job}` job; this guard cannot see what it runs"
+    );
+    lines
+        .take_while(|line| {
+            line.starts_with("    ") || line.trim().is_empty() || line.trim_start().starts_with('#')
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+/// Every `-E "…"` selection a job hands to nextest, in file order.
+fn selections_in(job: &str) -> Vec<String> {
+    job_lines(job)
+        .iter()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .filter_map(|line| {
+            let at = line.find("-E \"")? + "-E \"".len();
+            let rest = &line[at..];
+            rest.find('"').map(|end| rest[..end].to_string())
+        })
+        .collect()
+}
+
+/// The `test(...)` terms of a nextest filter expression, in file order.
+///
+/// Named `terms_in` rather than `modules_named_in` (its `census_filter_invariant.rs`
+/// counterpart) because what a term names is a **substring of a test path**, not
+/// necessarily a module: `merge::tests::direction_symmetry` is three segments of
+/// one, and `direction_symmetry` on its own would match the same tests. Treating
+/// these as opaque strings and comparing them both ways round is the whole point
+/// of the checks below.
+fn terms_in(filter: &str) -> Vec<String> {
+    filter
+        .match_indices("test(")
+        .filter_map(|(at, _)| {
+            let rest = &filter[at + "test(".len()..];
+            rest.find(')').map(|end| rest[..end].trim().to_string())
+        })
+        .filter(|term| !term.is_empty())
+        .collect()
+}
+
+/// The terms of one `ci.yml` filter, asserted non-empty.
+///
+/// An empty list would make every loop below vacuous — the flattering direction,
+/// and the one this whole file exists to keep loud.
+fn required_terms_in(key: &str) -> Vec<String> {
+    let terms = terms_in(&ci_filter(key));
+    assert!(
+        !terms.is_empty(),
+        "{key} yields no test(...) terms; ci.yml's formatting changed and the \
+         checks reading it would be vacuous"
+    );
+    terms
+}
+
+/// Every `.rs` file under a directory, recursively.
+fn rust_sources_under(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(rust_sources_under(&path));
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            found.push(path);
+        }
+    }
+    found
+}
+
+/// Assertion 1: the filter is non-empty.
+///
+/// Split out from the assertions that use it so a formatting change in `ci.yml`
+/// reports as "the filter stopped parsing" rather than as "the shards stopped
+/// negating it", which would send the reader to the wrong file.
+#[test]
+fn the_oracle_only_filter_parses_to_something() {
+    let filter = ci_filter("ORACLE_ONLY_FILTER");
+    assert!(
+        filter.contains("test("),
+        "ORACLE_ONLY_FILTER names no test: {filter:?}"
+    );
+}
+
+/// Assertion 2: `test` negates it, or the change saved nothing.
+#[test]
+fn the_test_job_negates_the_oracle_only_filter() {
+    let selections = selections_in("test");
+    assert!(
+        !selections.is_empty(),
+        "the `test` job hands nextest no -E selection; this guard is blind"
+    );
+    assert!(
+        selections
+            .iter()
+            .all(|s| s.contains("not ($ORACLE_ONLY_FILTER)")),
+        "the `test` job does not negate ORACLE_ONLY_FILTER, so nothing was \
+         moved off that shard: {selections:?}"
+    );
+}
+
+/// Assertion 3, the one that matters: `test-oracle` still runs them.
+///
+/// The saving is only legitimate because an armed run subsumes an un-armed one.
+/// If `test-oracle` ever negates this filter too — or excludes it through
+/// `ORACLE_EXCLUDE`, which is the same thing by another spelling — the census
+/// runs nowhere, both shards go green, and both get *faster*.
+#[test]
+fn the_test_oracle_job_still_runs_what_the_test_job_dropped() {
+    let selections = selections_in("test-oracle");
+    assert!(
+        !selections.is_empty(),
+        "the `test-oracle` job hands nextest no -E selection; this guard is blind"
+    );
+    assert!(
+        selections.iter().all(|s| !s.contains("ORACLE_ONLY_FILTER")),
+        "`test-oracle` mentions ORACLE_ONLY_FILTER. It must not: the `test` job \
+         drops these tests only because this job still runs them armed. \
+         Negating here deletes the census while turning both shards green and \
+         faster: {selections:?}"
+    );
+
+    // The same deletion, spelled through the other exclusion mechanism.
+    //
+    // Compared TERM against TERM and in both directions, because `test(P)` is a
+    // substring predicate on the test's name: an `ORACLE_EXCLUDE` entry spelled
+    // `test(direction_symmetry)` — the spelling every entry there already uses —
+    // excludes this module without ever containing its full path. See the module
+    // doc comment.
+    assert_terms_do_not_overlap("ORACLE_EXCLUDE", |ours, theirs| {
+        format!(
+            "`{ours}` (ORACLE_ONLY_FILTER) and `{theirs}` (ORACLE_EXCLUDE) select \
+             overlapping tests: `test(P)` matches any test whose name CONTAINS P, \
+             so one of these terms subsumes the other. Those tests are negated \
+             from `test` by ORACLE_ONLY_FILTER and excluded from `test-oracle` by \
+             ORACLE_EXCLUDE — they run NOWHERE, both shards go green, and both get \
+             faster. That is the failure this file exists to catch."
+        )
+    });
+}
+
+/// Assertions 3b and 4, which differ only in the filter they read.
+///
+/// For every term of `ORACLE_ONLY_FILTER` and every term of the foreign filter,
+/// neither may contain the other. Containment either way means nextest's
+/// substring predicate selects overlapping tests, which is what the two callers'
+/// messages then explain the consequence of.
+fn assert_terms_do_not_overlap(foreign_key: &str, message: impl Fn(&str, &str) -> String) {
+    let ours = required_terms_in("ORACLE_ONLY_FILTER");
+    let theirs = required_terms_in(foreign_key);
+    for our_term in &ours {
+        for their_term in &theirs {
+            assert!(
+                !our_term.contains(their_term.as_str()) && !their_term.contains(our_term.as_str()),
+                "{}",
+                message(our_term, their_term)
+            );
+        }
+    }
+}
+
+/// Assertion 4: not also in `CENSUS_FILTER`, which would route it to an archive
+/// that cannot contain it.
+///
+/// `CENSUS_FILTER` is negated from both shards and selected by `censuses` off
+/// the soak archive, built `-p ferro-hgvs-soak-tests`. That archive holds the
+/// soak driver's test target and nothing else — in particular no `#[cfg(test)]`
+/// module from under `src/`. A unit test named in both filters is therefore
+/// negated everywhere and selected nowhere, and `--no-tests=fail` does not
+/// notice because the step's other terms still match.
+#[test]
+fn no_oracle_only_test_is_also_claimed_by_the_censuses_job() {
+    assert_terms_do_not_overlap("CENSUS_FILTER", |ours, theirs| {
+        format!(
+            "`{ours}` (ORACLE_ONLY_FILTER) and `{theirs}` (CENSUS_FILTER) select \
+             overlapping tests — `test(P)` matches any test whose name CONTAINS P. \
+             CENSUS_FILTER is negated from both shards and selected off the soak \
+             archive, which contains no `src/` unit tests, so those tests are \
+             negated everywhere and selected nowhere. `--no-tests=fail` does not \
+             notice, because the step's other terms still match."
+        )
+    });
+}
+
+/// Assertion 5: the filter still names something that exists.
+///
+/// `the_oracle_only_filter_parses_to_something` asserts only that the string
+/// contains `test(`. Rename the module and the filter matches nothing: `test`
+/// negates nothing, `test-oracle` runs it as before, and the duplicate quietly
+/// returns to the debug shard. That direction is *safe* — no coverage is lost —
+/// which is why it is a separate, weaker assertion rather than folded into the
+/// three above. It is still silent config rot, and it silently un-does the
+/// change this filter was added to make.
+///
+/// The check is deliberately cheap and structural: every `::`-separated segment
+/// of each term must be declared as a module somewhere under `src/`. It does not
+/// shell out to `cargo nextest list` — nothing else in `tests/it/` does, and a
+/// guard that needs a built archive to answer is a guard that gets disabled.
+#[test]
+fn every_oracle_only_term_still_names_a_module_that_exists() {
+    let sources: Vec<String> = rust_sources_under(&repo_root().join("src"))
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .collect();
+    assert!(
+        !sources.is_empty(),
+        "no sources read from src/; this guard cannot see what exists"
+    );
+
+    for term in required_terms_in("ORACLE_ONLY_FILTER") {
+        for segment in term.split("::") {
+            let declaration = format!("mod {segment}");
+            assert!(
+                sources.iter().any(|text| text.contains(&declaration)),
+                "ORACLE_ONLY_FILTER names `test({term})`, but no `{declaration}` \
+                 is declared anywhere under src/. A rename fails SAFE — the filter \
+                 matches nothing, so `test` negates nothing and the test runs in \
+                 both shards again — but the carve-out this variable exists for is \
+                 silently gone. Update the filter, or drop it."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Takes the last two heavy censuses off the debug-archive shards, which is where the wall now sits.

Representation-Change: none

## Where the wall is now

#1977 moved the soak chain off the critical path. Measured on run 31909112992, the first `main` run after it landed, the binding jobs are the two debug-archive test shards:

| job | job time | nextest summary | its heaviest test |
|---|---:|---:|---|
| `Test (3/6)` | 149s | 94.8s | **93.8s** — `merge::tests::direction_symmetry` |
| `Test oracle (2/4)` | 141s | 101.1s | 61.4s — `cis_confluence_axis` |
| `Build` | 242s | — | (starts at t=4, ends 246; the floor after this change) |

`Test (3/6)` was a shard wearing one test: 93.8s of a 94.8s summary. `Test (1/6)`, with a comparable test count, is 26.4s.

## The unit half of #1840, still running twice

That 93.8s test is `normalize::merge::tests::direction_symmetry`. #1955 moved the **integration** half (`issue_1542_direction_symmetry`) to `censuses` and left this one running in **both** shards — 93.8s un-armed in `test` and 85.2s armed in `test-oracle` on run 31909112992, though see **Measured effect** for why no single per-test figure here is reproducible.

**It cannot go to `censuses`, and the way it fails is silent.** That job selects `CENSUS_FILTER` off the soak archive, which is built `-p ferro-hgvs-soak-tests` and contains **no `src/` unit tests at all**. Naming a unit test there negates it from both shards and then selects nothing — deleting the census while turning both shards green *and faster*. `--no-tests=fail` does not catch it, because the step's other terms still match.

So this adds `ORACLE_ONLY_FILTER`, negated from `test` alone. It rests on the subsumption argument `censuses` and `sweeps` already make: an armed run adds assertions at `normalize_core_checked`'s exit and changes no behaviour, so the un-armed copy is redundant while the armed one runs. The subsumption claim is about **assertions**, not cost: in the base run the armed copy was in fact 9% cheaper than the un-armed one, and `clinvar` ran 1.8x the other way — cross-shard timing noise dominates any armed/un-armed effect.

`tests/it/oracle_only_filter_invariant.rs` guards the clause the saving actually rests on — **that `test-oracle` still runs what `test` dropped** — plus the two ways that could be undone (negating the filter there too, or excluding the module via `ORACLE_EXCLUDE`) and the `CENSUS_FILTER` trap above. Nothing else in the repository checks any of it, and each failure direction is one that turns CI green and faster.

## `clinvar_hgvs_tests` by the ordinary route

Second-heaviest test in `Test oracle (2/4)` at 54.9s, moved via `CENSUS_FILTER` as #1955 intended that filter to be used. It is a **parser** benchmark, not a normalization census — it never reaches `canonicalize_from_sequence` — so the soak profile's gains land directly on its gzip decode, JSON deserialization and `parse_hgvs`. It reaches `common::failure_expectations`, now compiled into the driver, and `regex`, now declared by `tests-soak`.

## Measured effect

The PR's own `pull_request` run (`31911822856`) had already produced the answer, so this reports it rather than projecting one.

| | base run `31909112992` | head run `31911822856` |
|---|---:|---:|
| run wall | 297s | **260s** |
| `Build` | 242s, ends 21:23:28 | 216s, ends 22:23:04 |
| last job to finish | `Test (3/6)`, ends 21:24:11 | **`Test oracle (4/4)`, 137s, ends 22:23:31** |
| `Test (3/6)` summary | 94.8s | **37.7s** |
| `Test oracle (2/4)` summary | 101.1s | 87.4s |
| `Test oracle (4/4)` summary | 73.8s | 99.1s |

**~37s of wall — and `Build` is not the floor.** The binding job after this change is `Test oracle (4/4)`, ending **27s after `Build`**, so an earlier draft's "no further carve-out helps until `Build` itself is addressed" does not hold on this PR's own evidence. The `Test (3/6)` prediction was right (37.7s against a predicted ~40s); the ceiling was not.

**A ceiling should not be projected from one run's per-test figures at all.** `merge::tests::direction_symmetry` measured 93.8s un-armed in `Test (3/6)` and 85.2s armed in `Test oracle (3/4)` on the base run, and 46.8s in that same armed shard an hour later — a 2x spread on one test. `Build` itself moved 242 to 216s over the same interval. That is why `ci.yml`'s new comment pins no per-test cost.

One caveat, stated because the point is about method: the base row is a `push` run on `main` and the head row a `pull_request` run on the merge ref, so this is not a perfectly controlled A/B. It does not rescue a ceiling — the 27s overshoot past `Build` is well outside anything the intervening merge accounts for.


I measured that separately and am **not** proposing it: dropping `lto` from the release profile inflates the binary from 8.61 MB to 9.72 MB, i.e. from 82% to 93% of the job's own 10 MB gate, and makes that gate measure a binary that is not the one shipped.

## Verification

- `cargo nextest list` confirms `test(merge::tests::direction_symmetry)` matches the unit test and **not** `issue_1542_direction_symmetry` — the fact that makes this a move rather than a deletion.
- `cargo clippy --workspace --features dev --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `cargo build --tests -p ferro-hgvs-soak-tests` compiles (`--tests` matters: the package has no lib or bins, so a plain `cargo build -p` is a no-op that exits 0).
- All 20 selection/membership guards pass, including the four new ones.

One defect worth recording because the diff hides it: inserting the new `#[path]` module split `fixture_gen`'s `#[allow(dead_code)]` from its `#[path]` line, rebinding the attribute to the new module and leaving `fixture_gen` bare. It surfaced as a `dead_code` error in an unrelated module, and was confirmed as caused-here rather than pre-existing by running the same clippy invocation against a pristine checkout of the base.

