### PR TITLE
docs(normalize): correct the changed_columns_of_pieces comment

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -18288,11 +18288,14 @@ mod tests {
                 [(0, 1, b"".as_slice()), (3, 4, b"".as_slice())]
             );
             // Two columns, against the four the spanning `delins` this replaced
-            // claimed. The count is pinned by value here rather than against the
-            // block's own Levenshtein distance: `minimal_changed_columns` is the
-            // helper that would state minimality directly, and it arrives with
-            // the separate change that derives the weight bound's ceiling from
-            // the block instead of the input.
+            // claimed. The count is pinned by value rather than derived because
+            // no helper states the block's minimality directly. The
+            // input-relative measure that once bounded a derivation by the
+            // input's own weight (`changed_columns_of_edits`) was deleted
+            // outright by #1899, under
+            // `rulings[derivation-may-not-be-bounded-by-the-inputs-spelling]`,
+            // and nothing sequence-derived was added to replace it — so a
+            // literal is the honest statement of what this split costs.
             assert_eq!(changed_columns_of_pieces(&pieces), 2);
         }
 


### PR DESCRIPTION
The comment above the `changed_columns_of_pieces(&pieces) == 2` assertion promised `minimal_changed_columns` — "the helper that would state minimality directly" — and said it would arrive with a separate change deriving the weight bound's ceiling from the block instead of the input. That helper never arrived.

What actually happened: PR #1899 deleted the input-relative weight bound (`changed_columns_of_edits`) outright, under `rulings[derivation-may-not-be-bounded-by-the-inputs-spelling]`, and did not add a sequence-derived measure to replace it. So no helper states the block's minimality directly, and pinning the split's column count by value is the honest statement of what the split costs. The rewritten comment says that, matching the sibling doc comment on `changed_columns_of_pieces` which already attributes the deletion to the same ruling.

Comment-only change inside the `#[cfg(test)]` module; no behavior change.

Closes #1940

Representation-Change: none