### PR TITLE
fix: stop tx_to_genomic from collapsing n.*N onto its in-transcript sibling

### DIFF
--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -528,12 +528,15 @@ impl<'a> CoordinateMapper<'a> {
     /// `c.`/`n.` number.
     ///
     /// `None` is not exclusively that answer, though, so do not read it as
-    /// "unaligned" without ruling the other two out: it is also returned for a
-    /// non-positive `tx_pos.base`, and for a `Strand::Unknown` transcript,
-    /// whose bases are all reported unaligned however complete its exon table
-    /// is. A caller using `tx_to_genomic(..).is_some()` as its definition of
-    /// "aligned" — `tests/it/axis_frame_disagreement.rs`'s genome-frame walk
-    /// does — is relying on the transcript having a known strand.
+    /// "unaligned" without ruling the others out: it is also returned for a
+    /// non-positive `tx_pos.base` (5' of the transcript), for an `n.*N`
+    /// downstream position (`TxPos::downstream`, 3' of the transcript — the two
+    /// termini decline symmetrically, #1950), and for a `Strand::Unknown`
+    /// transcript, whose bases are all reported unaligned however complete its
+    /// exon table is. A caller using `tx_to_genomic(..).is_some()` as its
+    /// definition of "aligned" — `tests/it/axis_frame_disagreement.rs`'s
+    /// genome-frame walk does — is relying on the transcript having a known
+    /// strand.
     pub fn tx_to_genomic(&self, tx_pos: &TxPos) -> Result<Option<u64>, FerroError> {
         // Check if transcript has genomic coordinates
         if !self.transcript.has_genomic_coords() {
@@ -545,6 +548,21 @@ impl<'a> CoordinateMapper<'a> {
         // Find which exon contains this transcript position
         // Only positive transcript positions can be in exons
         if tx_pos.base < 1 {
+            return Ok(None);
+        }
+
+        // `n.*N` (`TxPos::downstream`) names a base past the transcript's last
+        // one, so it is covered by no exon — the exact 3' mirror of the `base < 1`
+        // decline just above, which covers positions 5' of the transcript. Reading
+        // only `base` here collapsed `n.5` and `n.*5` onto one coordinate (#1950);
+        // decline instead, via this method's existing `Ok(None)` "not covered by
+        // an exon" channel rather than an error. The signature difference is why
+        // this differs from the sibling `tx_to_cds`, which has no `Option` and so
+        // must `Err` on the same input. `background/numbering.md:52` numbers the
+        // `n.` axis only n.1..n.<length> and `:54` forbids describing a base
+        // beyond a transcript against that transcript, so there is no in-frame
+        // genomic coordinate to answer with.
+        if tx_pos.downstream {
             return Ok(None);
         }
         let tx_base = tx_pos.base as u64;
@@ -721,7 +739,29 @@ impl<'a> CoordinateMapper<'a> {
             return self
                 .tx_to_genomic(tx_pos)?
                 .ok_or_else(|| FerroError::ConversionError {
-                    msg: format!("Position {} not found in exons", tx_pos.base),
+                    // `tx_to_genomic` declines for four distinct reasons (see its
+                    // doc comment), and only one of them is "no exon covers this
+                    // base". Naming the exon lookup unconditionally mis-diagnosed
+                    // the others — most visibly `n.*N`, where the base itself sits
+                    // squarely inside an exon and the `*` is what makes it
+                    // unmappable, so `n.*5` reported "Position 5 not found in
+                    // exons" about a position that is in one. Report the position
+                    // as it is spelled, and say only what is actually known: no
+                    // genomic coordinate could be derived.
+                    msg: if tx_pos.downstream {
+                        format!(
+                            "Position n.*{} is 3' of the transcript's last base, so it has no \
+                             genomic coordinate",
+                            tx_pos.base
+                        )
+                    } else {
+                        format!(
+                            "Position {} has no genomic coordinate: no exon carrying genomic \
+                             coordinates covers it, it lies 5' of the transcript, or the \
+                             transcript's strand is unknown",
+                            tx_pos.base
+                        )
+                    },
                 });
         }
 
@@ -1366,6 +1406,60 @@ mod tests {
         assert_eq!(mapper.tx_to_genomic(&TxPos::new(1)).unwrap(), Some(3009));
         // tx 10 -> genomic 3000
         assert_eq!(mapper.tx_to_genomic(&TxPos::new(10)).unwrap(), Some(3000));
+    }
+
+    /// `n.5` and `n.*5` are different positions — the second names a base five
+    /// nucleotides 3' of the transcript's last base — and must not collapse onto
+    /// one genomic coordinate. `tx_to_genomic` previously read only `TxPos.base`
+    /// and never `TxPos.downstream`, so both answered the exon-5 coordinate 1004.
+    ///
+    /// The in-transcript position keeps its coordinate; the downstream position
+    /// declines (`Ok(None)`), the same 3'-mirror answer the method already gives
+    /// for a position 5' of the transcript (`base < 1`). See #1950.
+    #[test]
+    fn tx_to_genomic_does_not_collapse_downstream_onto_its_in_transcript_sibling() {
+        let tx = make_genomic_transcript_plus();
+        let mapper = CoordinateMapper::new(&tx);
+
+        // n.5 is exon-1 base 5 -> genomic 1000 + (5 - 1) = 1004.
+        let in_transcript = mapper.tx_to_genomic(&TxPos::new(5)).unwrap();
+        assert_eq!(
+            in_transcript,
+            Some(1004),
+            "n.5 maps to its exonic coordinate"
+        );
+
+        // n.*5 lies past the transcript's last base and is covered by no exon.
+        let downstream = mapper.tx_to_genomic(&TxPos::downstream(5)).unwrap();
+        assert_eq!(
+            downstream, None,
+            "n.*5 is 3' of the transcript and must not resolve to an exon coordinate"
+        );
+
+        assert_ne!(
+            in_transcript, downstream,
+            "n.5 and n.*5 are distinct positions and must not share a genomic coordinate"
+        );
+    }
+
+    /// The collapse and its fix are strand-independent: on a minus-strand
+    /// transcript `n.5` and `n.*5` must likewise not share a coordinate.
+    #[test]
+    fn tx_to_genomic_declines_downstream_on_minus_strand() {
+        let tx = make_genomic_transcript_minus();
+        let mapper = CoordinateMapper::new(&tx);
+
+        // Minus strand: n.5 is exon-1 base 5 -> genomic 3009 - (5 - 1) = 3005.
+        let in_transcript = mapper.tx_to_genomic(&TxPos::new(5)).unwrap();
+        assert_eq!(
+            in_transcript,
+            Some(3005),
+            "n.5 maps to its exonic coordinate"
+        );
+
+        let downstream = mapper.tx_to_genomic(&TxPos::downstream(5)).unwrap();
+        assert_eq!(downstream, None, "n.*5 is past the transcript and declines");
+        assert_ne!(in_transcript, downstream);
     }
 
     #[test]

--- a/tests/it/downstream_flag_and_offset_sentinel.rs
+++ b/tests/it/downstream_flag_and_offset_sentinel.rs
@@ -20,24 +20,37 @@
 //! axis" is not "every renderer", and "the conversion seam" is not "every
 //! caller that flattens a position".
 //!
-//! # A THIRD drop route is KNOWN, MEASURED, AND DELIBERATELY LEFT OPEN
+//! # A THIRD drop route was KNOWN, MEASURED AND DEFERRED — and is now CLOSED
 //!
 //! `CoordinateMapper::tx_to_genomic` — the direct sibling of the `tx_to_cds`
-//! this file's first section fixes, on the same type — reads `tx_pos.base` and
-//! screens only `base < 1`. It never consults `downstream`. Measured on a
-//! single exon at tx 1..10 / genome 1000..1009:
+//! this file's first section fixes, on the same type — read `tx_pos.base` and
+//! screened only `base < 1`. It never consulted `downstream`. Measured on a
+//! single exon at tx 1..10 / genome 1000..1009, as this file first recorded it:
 //!
 //! ```text
 //! tx_to_genomic(n.5)  = Ok(Some(1004))
 //! tx_to_genomic(n.*5) = Ok(Some(1004))     <- collapse, same as the two fixed here
 //! ```
 //!
-//! It is **not fixed here** because its blast radius is not the service layer's:
-//! it has production callers in `vcf/from_hgvs.rs` (`convert_tx`, the library's
-//! own n.→VCF path), `normalize/mod.rs`, `equivalence/checker.rs` and three more
-//! inside `mapper.rs` itself, and its return type (`Result<Option<u64>, _>`)
-//! makes "decline" and "error" two different answers that want their own
-//! decision. That is a change owing its own measurement and disclosure.
+//! It was **deliberately not fixed here**, because its blast radius is not the
+//! service layer's: it has production callers in `vcf/from_hgvs.rs`
+//! (`convert_tx`, the library's own n.→VCF path), `normalize/mod.rs`,
+//! `equivalence/checker.rs` and three more inside `mapper.rs` itself, and its
+//! return type (`Result<Option<u64>, _>`) makes "decline" and "error" two
+//! different answers that wanted their own decision. That deferral is kept here
+//! as provenance, not as a live statement: the change it was owed is **#1950**,
+//! and it took the decline.
+//!
+//! **So the collapse above is history.** `tx_to_genomic` now returns `Ok(None)`
+//! for a `downstream`-flagged position — the exact 3' mirror of the `base < 1`
+//! decline it already made 5' of the transcript — so `n.5` keeps its exonic
+//! coordinate and `n.*5` resolves to none. The guards that pin it live beside
+//! that method rather than in this file, in `src/convert/mapper.rs`'s own
+//! `mod tests`:
+//! `tx_to_genomic_does_not_collapse_downstream_onto_its_in_transcript_sibling`
+//! (plus strand — `Some(1004)` against `None`, and the two asserted distinct)
+//! and `tx_to_genomic_declines_downstream_on_minus_strand` (the same on the
+//! minus strand — `Some(3005)` against `None`).
 //!
 //! Recorded here rather than left to be re-found: an earlier census of this
 //! defect enumerated **13** other marker-consulting sites and concluded the two


### PR DESCRIPTION
Closes #1950.

## The defect

`CoordinateMapper::tx_to_genomic` (`src/convert/mapper.rs`) read only `TxPos.base` and never `TxPos.downstream`, so `n.5` and `n.*5` — two distinct positions — collapsed onto one genomic coordinate:

```
tx_to_genomic(n.5)   -> Ok(Some(1004))
tx_to_genomic(n.*5)  -> Ok(Some(1004))   # wrong: the 3'UTR-past-end flag is dropped
```

`n.*N` (`TxPos::downstream`) names a base past the transcript's last one, which is covered by no exon.

## The fix

Decline `n.*N` via the method's existing `Ok(None)` "not covered by an exon" channel, placed right beside the pre-existing `base < 1` decline:

```
tx_to_genomic(n.5)   -> Ok(Some(1004))
tx_to_genomic(n.*5)  -> Ok(None)
```

This makes the two transcript termini symmetric: the method already declines with `Ok(None)` for a position 5' of the transcript (`base < 1`), and `n.*N` is the exact 3' mirror. `background/numbering.md:52` numbers the `n.` axis only `n.1..n.<length>` and `:54` forbids describing a base beyond a transcript against that transcript, so there is no in-frame genomic coordinate to answer with.

**Why `Ok(None)`, not `Err` like the sibling `tx_to_cds` (#1762).** The two methods differ precisely because their signatures do. `tx_to_cds` returns `CdsPos` with no `Option`, so its only decline channel is `Err`. `tx_to_genomic` returns `Option<u64>` and already uses `Ok(None)` for the 5'-mirror case; erroring on the 3' side while declining on the 5' side would be an inconsistency *within the same method*, which is worse than the cross-method difference (each method uses its natural decline mechanism).

## Unchanged on purpose

- **The intronic sibling `tx_to_genomic_with_intron` keeps its control flow; only its diagnostic changed.** It was verified not to produce a wrong coordinate for downstream inputs: its non-intronic branch delegates to the now-fixed `tx_to_genomic` (and errors via `ok_or_else`), and its intronic branch (`n.*N+M`) already errors because `intronic_to_genomic` finds no such boundary. The wrong-coordinate class had exactly one site (`tx_to_genomic`); adding a guard elsewhere would be untestable defensive code.
- **In-transcript and 5' positions are untouched** — only `downstream` inputs change.

- **One error string is corrected** (user-visible, but not a representation change). `tx_to_genomic_with_intron`'s non-intronic branch reported `Position {base} not found in exons`. For `n.*5` that read `Position 5 not found in exons` — but position 5 *is* in an exon; the `*` is what makes it unmappable, so the message named the wrong cause. It now distinguishes the downstream case explicitly, and the general case no longer asserts one of `tx_to_genomic`'s four `Ok(None)` routes as though it were the only one. Control flow is untouched, and no test asserts on that string (`found in exons` appears only at the two `mapper.rs` sites and two unrelated literals in `service/handlers/vcf_convert.rs`). The identical string at `cds_to_genomic_with_intron` is deliberately left alone: its `TxPos` comes from `cds_to_tx`, which sets `downstream: false` as a documented decision, so the mis-diagnosis is unreachable there.

## Reachability

Qualified, and stated so severity is not overread. `n.*N` is refused at parse in every mode by #1748, so the collapsing spelling cannot arrive through a parsed description. `TxPos` is public API and constructible directly, so a Rust caller building the struct can reach this route — defence-in-depth rather than a live service defect.

## Representation stability

Representation-Change: none. `src/convert/` is not a watched path, and `tx_to_genomic` is exercised only by `downstream`-flagged positions here, which are parse-blocked in every mode; no normalized output moves.

## Verification

- New regression tests, both strand orientations: `tx_to_genomic_does_not_collapse_downstream_onto_its_in_transcript_sibling` (plus, `n.5`→`Some(1004)`, `n.*5`→`None`) and `tx_to_genomic_declines_downstream_on_minus_strand` (minus, `n.5`→`Some(3005)`, `n.*5`→`None`). Both pin exact coordinates and assert the two do not share one.
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and `cargo nextest run --features dev --no-fail-fast` all pass locally.


