### PR TITLE
fix: decline a cds_end past the sequence end instead of panicking

### DIFF
--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -29,8 +29,23 @@ pub fn validate_cds_pos(pos: &CdsPos, transcript: &Transcript) -> Result<(), Fer
     let cds_length = (cds_end - cds_start + 1) as i64;
 
     if pos.utr3 {
-        // 3' UTR position
-        let utr3_length = transcript.sequence_length() - cds_end;
+        // 3' UTR position. `sequence_length()` and `cds_end` are both `u64`, so
+        // a `cds_end` past the sequence end underflows this subtraction and
+        // panics in debug (`attempt to subtract with overflow`). That is a
+        // malformed transcript, not a caller error: cdot's `stop_codon` is
+        // taken verbatim by the loader with no clamp, and 44 of 425,565 shipped
+        // transcripts (all RefSeq GRCh37) have one past their exon-derived
+        // length (#1909). Report it as such rather than aborting the process.
+        let utr3_length = transcript
+            .sequence_length()
+            .checked_sub(cds_end)
+            .ok_or_else(|| FerroError::ConversionError {
+                msg: format!(
+                    "Malformed transcript: CDS end {} is past the sequence end ({})",
+                    cds_end,
+                    transcript.sequence_length()
+                ),
+            })?;
         if pos.base < 1 || pos.base > utr3_length as i64 {
             return Err(FerroError::InvalidCoordinates {
                 msg: format!(
@@ -232,6 +247,46 @@ mod tests {
         assert!(
             validate_cds_pos(&past_negative_limit, &tx).is_err(),
             "offset -1_000_001 is past it"
+        );
+    }
+
+    /// A malformed transcript whose `cds_end` (100) lies past its 12-base
+    /// sequence, the shape #1909 measured on 44 of 425,565 shipped cdot
+    /// transcripts (all RefSeq GRCh37). The loader takes cdot's `stop_codon`
+    /// verbatim with no clamp, so such a `cds_end` reaches `validate_cds_pos`
+    /// unmodified. Mirrors `mapper.rs`'s helper of the same name, kept local
+    /// so this module's tests do not reach into another module's test scope.
+    fn make_cds_end_past_sequence_transcript() -> Transcript {
+        Transcript {
+            id: "NM_SHORTSEQ.1".to_string(),
+            sequence: Some("ATGTTTCTGATT".to_string()), // 12 bases
+            cds_start: Some(1),
+            cds_end: Some(100),
+            exons: vec![Exon::new(1, 1, 12)],
+            ..Default::default()
+        }
+    }
+
+    /// A 3'UTR position (`*N`) against a transcript whose `cds_end` runs past
+    /// the sequence end must return the malformed-transcript error, not panic.
+    ///
+    /// The 3'UTR guard computes `sequence_length() - cds_end`; both operands
+    /// are `u64`, so `12 - 100` underflows and panics (`attempt to subtract
+    /// with overflow`) in debug rather than reporting the malformed transcript
+    /// (#1909). Reaching the `is_err()` assertion at all proves the
+    /// subtraction is checked; asserting the variant proves it returns the
+    /// established `ConversionError` rather than some coordinate-range error
+    /// that would misattribute the fault to the caller's `*N` instead of to
+    /// the transcript.
+    #[test]
+    fn cds_end_past_sequence_end_is_a_malformed_transcript_not_a_panic() {
+        let tx = make_cds_end_past_sequence_transcript();
+
+        let err = validate_cds_pos(&CdsPos::utr3(1), &tx)
+            .expect_err("*1 against a cds_end past the sequence must be an error");
+        assert!(
+            matches!(err, FerroError::ConversionError { .. }),
+            "expected a malformed-transcript ConversionError, got {err:?}"
         );
     }
 

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -853,9 +853,10 @@ mod tests {
     ///
     /// Sequence is 12bp, cds_start = 1, cds_end = 100.
     ///
-    /// Do not reuse this fixture with `validate_cds_pos`: its
-    /// `transcript.sequence_length() - cds_end` is unchecked `u64`
-    /// subtraction, and `12 - 100` here underflows and panics in debug.
+    /// Safe to reuse with `validate_cds_pos`: its 3'UTR guard computes
+    /// `transcript.sequence_length().checked_sub(cds_end)`, so `12 - 100` here
+    /// declines with a malformed-transcript `ConversionError` rather than
+    /// underflowing and panicking in debug (#1909).
     fn make_cds_end_past_sequence_transcript() -> Transcript {
         Transcript {
             id: "NM_SHORTSEQ.1".to_string(),


### PR DESCRIPTION
Closes #1909.

Representation-Change: none. `src/convert/` is not a watched prefix (normalize/hgvs/spdi/project/reference/error_handling); this only converts a debug panic into an error on malformed transcripts and leaves well-formed output untouched.

## The defect

`validate_cds_pos` (`src/convert/coding.rs`) validated a 3'UTR position by computing the 3'UTR length as `transcript.sequence_length() - cds_end`. Both operands are `u64`, so a transcript whose `cds_end` runs past its sequence length underflowed the subtraction and **panicked** in debug (`attempt to subtract with overflow`) instead of returning the existing malformed-transcript error. In release the same subtraction wraps to a nonsense length, silently corrupting the range check.

This is reachable on shipped data. Per #1909's scan of the shipped cdot files, **44 of 425,565** transcripts (all RefSeq GRCh37; 0 in Ensembl GRCh38) carry a `stop_codon` past their exon-derived length, and the loader takes `stop_codon` verbatim with no clamp, so those reach `cds_end` unmodified.

Reproduced on `origin/main` (`e4c53fb2`) with a unit test — panic at `src/convert/coding.rs:33:27: attempt to subtract with overflow`.

## The fix

Use `checked_sub` and, on underflow, return `FerroError::ConversionError` — the same malformed-transcript error the function already returns for a missing CDS/CDS-end, so the house error form is unchanged. Well-formed bounds take the identical path as before.

## Unchanged on purpose

Scoped to the 3'UTR subtraction the issue named. The reversed-bounds shape (`cds_end - cds_start`, line 29) was measured at **0 of 425,565** shipped transcripts and is left as-is, consistent with the issue's scoping and this repo's per-site hardening (cf. #1690, #1087). The loader-side question (whether `prepare` should reject/clamp a `stop_codon` past the transcript end) is deliberately not addressed here.

## Verification

- New regression test `cds_end_past_sequence_end_is_a_malformed_transcript_not_a_panic` (co-located unit test, matching the two existing `validate_cds_pos` tests): asserts it returns `ConversionError`, not a panic and not a coordinate-range error that would misattribute the fault to the caller's `*N`.
- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — 11154 passed, 155 skipped, 0 failed.