### PR TITLE
docs(normalize): correct comments still calling PartitionRule::Live the shipped rule

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2717,8 +2717,10 @@ const _: () = assert!(DERIVED_BLOCK_PARTITION_RULE.cuts_with_canonical());
 
 /// Read a [`PartitionRule`] from what `FERRO_PARTITION` was set to.
 ///
-/// Unset and empty yield [`PartitionRule::Live`], the shipped rule. Anything
-/// else that is not an arm name is an **error**, not a fallback.
+/// Unset and empty yield [`DEFAULT_PARTITION_RULE`], the shipped rule —
+/// [`PartitionRule::CanonicalCoalesced`] since #1835's flip, and
+/// [`PartitionRule::Live`] up to and including v0.14.0. Anything else that is
+/// not an arm name is an **error**, not a fallback.
 ///
 /// # Why this refuses rather than warning
 ///
@@ -2780,8 +2782,9 @@ fn partition_rule_from_env(value: Option<&str>) -> Result<PartitionRule, String>
 /// # Why this is not `.ok()`
 ///
 /// [`std::env::var`] returns `Err` for two unrelated reasons and `.ok()`
-/// collapses both to `None` — but `None` is the **unset** case, which is
-/// legitimately `live`. So a value that *was* set, to bytes that are not UTF-8,
+/// collapses both to `None` — but `None` is the **unset** case, which
+/// legitimately selects the default ([`DEFAULT_PARTITION_RULE`]). So a value
+/// that *was* set, to bytes that are not UTF-8,
 /// selected the shipped rule and said nothing: exactly the silent fallback the
 /// rejection in [`partition_rule_from_env`] exists to remove, reachable through
 /// a door that function never sees. A bake-off whose `FERRO_PARTITION` was
@@ -2886,7 +2889,7 @@ fn partition_rule_outcome() -> &'static Result<PartitionRule, String> {
 /// # The residual, stated rather than hidden
 ///
 /// An embedder that neither calls this nor runs a debug build gets
-/// [`PartitionRule::Live`] for a refused value. That is the shipped rule under
+/// [`DEFAULT_PARTITION_RULE`] for a refused value. That is the shipped rule under
 /// no name at all rather than under a candidate's, and it is strictly safer than
 /// the abort it replaces — but it is only *reported* if somebody asks. Every
 /// binary **and every example** in this repository asks, and
@@ -3015,7 +3018,7 @@ pub fn partition_decline_counts() -> PartitionDeclineCounts {
 /// `examples/measure_spec_conformance_per_arm.rs` does.
 ///
 /// **Debug builds only**, like the four normalization oracles and for the same
-/// reason: the shipped `Live` path must not grow a per-block atomic to serve a
+/// reason: the shipped path must not grow a per-block atomic to serve a
 /// measurement. Release builds do not have this function.
 ///
 /// **Unstable, like the switch it measures.** It is expected to be removed with
@@ -7455,8 +7458,10 @@ fn partition_block_sequence_first(
 /// passes the first while failing the second (#1970). Either way the caller
 /// falls back to [`partition_block`].
 ///
-/// Reached only under `FERRO_PARTITION=canonical` and from the `dump_partitions`
-/// example; it does not decide any shipped result.
+/// Reached under `FERRO_PARTITION=canonical` or `canonical-coalesced` — the
+/// latter the shipped default since #1835 — and from the `dump_partitions`
+/// example. So it decides **every** shipped result except the blocks it declines
+/// on (an oversized grid or span, above), which fall back to [`partition_block`].
 fn partition_block_canonical(reference: &[u8], result: &[u8]) -> Option<Vec<Piece>> {
     partition_block_canonical_within(reference, result, MAX_SEQFIRST_GRID_CELLS)
 }
@@ -8034,8 +8039,11 @@ fn payload_coalesce_applies(rule: PartitionRule, kind: CisKind) -> bool {
 /// whose every spelling moves together stays converged, so those zeros are a
 /// statement about confluence and emphatically not about representation
 /// stability — the 1,471 / 1,304 figure above is the one that measures that.
-/// Shipped output does not move at all: `FERRO_PARTITION` unset is
-/// [`PartitionRule::Live`], which never reached this pass.
+/// When this was measured, shipped output did not move at all, because an unset
+/// `FERRO_PARTITION` selected [`PartitionRule::Live`], which never reached this
+/// pass. #1835 has since made [`PartitionRule::CanonicalCoalesced`] the default —
+/// a canonical arm this pass does run on ([`PartitionRule::cuts_with_canonical`])
+/// — so it now reaches the shipped path.
 ///
 /// # A narrower cut was looked for, and the search FAILED
 ///
@@ -8270,7 +8278,11 @@ pub mod dev_partitioners {
             .collect()
     }
 
-    /// The shipped rule: `partition_block`'s single-gap alignment search.
+    /// The `live` rule: `partition_block`'s single-gap alignment search.
+    ///
+    /// The shipped default up to and including v0.14.0; opt-in via
+    /// `FERRO_PARTITION=live` since #1835 flipped the default to
+    /// `PartitionRule::CanonicalCoalesced`.
     ///
     /// Never declines — an unsplittable block comes back as one spanning member.
     ///
@@ -15699,8 +15711,13 @@ mod tests {
             "an arm that answered must not be recorded as having declined"
         );
 
-        // `Live` has no decline path, so it is not counted at all — the shipped
-        // configuration pays no atomic per block.
+        // `Live` has no decline path, so it is not counted at all. That is no
+        // longer a statement about the shipped configuration: #1835 flipped
+        // `DEFAULT_PARTITION_RULE` to `CanonicalCoalesced`, which is one of the
+        // arms that *does* decline, so the shipped path bumps
+        // `SEQFIRST_ATTEMPTED` on every block and `SEQFIRST_DECLINED` on every
+        // fallback. The uncounted arm is now reached only by
+        // `FERRO_PARTITION=live`.
         let live = partition_block_for_rule(
             PartitionRule::Live,
             b"ACGTACGT",
@@ -16061,7 +16078,7 @@ mod tests {
         /// surfaces agree", which is a stronger guarantee than it gives.
         ///
         /// Fails by design during a deliberate `FERRO_PARTITION=…` run, for the
-        /// reason `the_suite_runs_on_the_live_rule` gives. The environment
+        /// reason `the_suite_runs_on_the_default_rule` gives. The environment
         /// guard is repeated here so that failure names its cause rather than
         /// reading as a drifted pin.
         #[test]


### PR DESCRIPTION
Closes #1912.

## The defect

#1835 (`feat(normalize)!: make canonical-coalesced the default partition rule`) flipped the default partition rule from `PartitionRule::Live` to `PartitionRule::CanonicalCoalesced`, but left several doc comments in `src/normalize/merge.rs` still describing `Live` as the shipped/default/unset rule. Two stated the opposite of what the code does:

- `partition_block_canonical`'s doc said it "does not decide any shipped result" — it is dispatched from `Canonical | CanonicalCoalesced` (`merge.rs:3057`), and `CanonicalCoalesced` is the default, so it decides *every* shipped result except the blocks it declines.
- `partition_rule_from_env`'s doc said an unset/empty `FERRO_PARTITION` yields `Live` — the code returns `DEFAULT_PARTITION_RULE` (`= CanonicalCoalesced`).

## The fix

Docs only. Seven comments corrected to describe the real shipped rule, referencing `DEFAULT_PARTITION_RULE` where the code does and dating the flip to #1835 (`Live` shipped up to and including v0.14.0):

1. `partition_rule_from_env` — unset/empty yield `DEFAULT_PARTITION_RULE`.
2. `partition_rule_env_value` — the unset case selects the default, not `live`.
3. `partition_switch_startup_error` — a refused value (non-debug build) falls to `DEFAULT_PARTITION_RULE`, per `partition_rule_from_outcome`.
4. `partition_block_canonical` — reached under `FERRO_PARTITION=canonical` or `canonical-coalesced` (the default), decides every shipped result except declined blocks (grid/span cap → `partition_block`).
5. compensating-gap coalesce doc — this pass is scoped to both canonical arms (`cuts_with_canonical`), so post-flip it reaches the shipped path; the "shipped output does not move" note is now framed as the pre-flip measurement it was.
6. `dev_partitioners::live` — relabelled the `live` arm as opt-in (`FERRO_PARTITION=live`), not the shipped rule.
7. `PARTITION_BLOCKS_CUT` counter doc — "the shipped path", not "the shipped `Live` path".

The issue named the first four; the other three (`partition_rule_env_value`, the coalesce doc, and the counter doc) are the identical defect class, all predate #1835, and were not updated by the flip.

## Unchanged on purpose

The `FERRO_PARTITION=live` refusal message (`merge.rs:~2767`) still names `live` and is left as-is — it is a runtime string asserted by `partition_switch_wiring`'s test (`merge.rs:~17086`), and its refusal reasoning survives the flip. Changing it would be a behaviour change, outside "docs only".

## Verification

- `cargo fmt --check` — clean.
- `cargo nextest run --features dev` — `11158 passed, 155 skipped` (EXIT=0).

Representation-Change: none. Docs/comment-only change; no watched-file behaviour is touched.