### PR TITLE
docs(normalize): correct partition_rule() # Panics call-site count (three, not two)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -2629,7 +2629,7 @@ impl PartitionRule {
     ///
     /// # Why this is a method with an exhaustive `match`
     ///
-    /// Both call sites used to spell this inline as
+    /// This used to be spelled inline at its call sites as
     /// `matches!(rule, Canonical | CanonicalCoalesced)`. A **positive** arm list
     /// is silently wrong for the next arm added: an arm missing from it takes
     /// the `else` branch, which is `live` behaviour, on an arm that does not cut
@@ -2919,10 +2919,12 @@ pub fn partition_switch_startup_error() -> Option<String> {
 /// # Panics
 ///
 /// In a **debug** build, if `FERRO_PARTITION` names an arm this build does not
-/// have. Both call sites are inside [`canonicalize_from_sequence`], which is
-/// infallible and sits deep under every public normalization entry point, so
-/// there is no `Result` to return the rejection through without threading one
-/// the length of the pipeline. A panic there is the honest alternative for a
+/// have. Every call site is either [`canonicalize_from_sequence`] — the sole
+/// production caller, which is infallible and sits deep under every public
+/// normalization entry point, so there is no `Result` to return the rejection
+/// through without threading one the length of the pipeline — or a
+/// `#[cfg(test)]` pin that asserts on the returned rule directly. A panic
+/// there is the honest alternative for a
 /// build somebody is measuring in: it fires once, at the first normalized
 /// variant, before any output exists to be mistaken for a measurement. See
 /// [`partition_rule_from_env`] for why silence was not an option, and


### PR DESCRIPTION
Closes #1875.

Representation-Change: none

## The defect

`partition_rule()`'s `# Panics` doc comment in `src/normalize/merge.rs` claimed:

> Both call sites are inside [`canonicalize_from_sequence`], which is infallible …

Both parts are wrong. `partition_rule()` is a private fn, so its call sites are the crate's, and there are **three**, not two:

- `src/normalize/merge.rs:3200` — the body of `canonicalize_from_sequence` (the sole *production* caller, infallible, deep under every public normalization entry point).
- `src/normalize/merge.rs:16074` — `#[cfg(test)] fn the_two_surfaces_cut_with_a_pinned_pair_of_rules()`.
- `src/normalize/merge.rs:17114` — `#[cfg(test)] fn the_suite_runs_on_the_default_rule()`.

So only one of the three is inside `canonicalize_from_sequence`; the other two are test pins that assert on the returned rule directly.

## The fix

Reword the `# Panics` section to name the invariant that actually carries the panic-vs-`Result` reasoning — every call site is either the infallible `canonicalize_from_sequence` (the sole production caller) or a `#[cfg(test)]` pin — rather than a count that goes stale on the next caller, per the issue's suggested fix.

In the same pass, the sibling `cuts_with_canonical()` doc said "Both call sites used to spell this inline as `matches!(rule, Canonical | CanonicalCoalesced)`". That is a past-tense claim (the method has since grown to four callers), and the count adds nothing to the extraction rationale it supports. Generalised to a count-free form ("This used to be spelled inline at its call sites …").

## Unchanged on purpose

Docs/comment-only. No behavior change — `partition_rule()`, `cuts_with_canonical()`, and every caller are byte-identical.

## Representation stability

None. The diff touches only doc comments; no normalized output can move.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo nextest run --features dev` — `11158 tests run: 11158 passed (11 slow), 155 skipped`, exit 0.
- Call-site enumeration confirmed via `grep` over `src/`, `tests/`, `examples/` (private fn, so callers are in-crate only; three invocations, matching the corrected text).