### PR TITLE
fix(scripts): read the whole trailer value in the contradicted-decline tripwire

### DIFF
--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -518,6 +518,49 @@ def find_declaration(text: str) -> str | None:
     return declarations[0] if declarations else None
 
 
+#: A line that ends a trailer's value because it opens something the value cannot own:
+#: another column-0 trailer token, a Markdown heading, or an HTML comment (GitHub appends
+#: CodeRabbit's summary after the trailer, opening `<!-- ... -->`).
+#:
+#: A deliberately SEPARATE copy of the terminator in
+#: `inject_representation_disclosure.disclosure_value`. This checker shares no code with
+#: `check_changelog_grouping.py` or the injector that imports from it, so the two decline
+#: rules can be wrong independently (#1555). The column-0 rule this extends is this module's
+#: own `TRAILER_RE`, so no fourth copy of *that* is minted.
+CONTINUATION_END_RE = re.compile(r"^([A-Za-z][A-Za-z0-9-]*:[ \t]|#{1,6}\s|<!--)")
+
+
+def full_declaration_value(text: str) -> str | None:
+    """Return the first trailer's value with its continuation lines, or `None`.
+
+    `find_declaration` returns only the first line, because `TRAILER_RE` stops at the
+    newline. This repo's trailers are routinely multi-line with UNINDENTED continuation lines
+    -- `git interpret-trailers --parse` reports no trailers at all for #1537/#1535/#1547 --
+    so a decline on the first line can hide a contradicting `<n> rows move` on a later one
+    (#1854). The contradicted-decline tripwire must read the whole value, not the first
+    clause, or the disclosure is filed as `none` and never reaches the changelog.
+
+    The value runs from the trailer to the next line it cannot own -- a column-0 trailer
+    token, a Markdown heading, or the HTML comment GitHub appends -- the same bound
+    `inject_representation_disclosure.disclosure_value` uses, arrived at independently rather
+    than imported. Fenced regions are blanked first, matching `find_declarations`, so a
+    continuation quoted inside a fence is not scavenged into the value.
+    """
+    first = find_declaration(text)
+    if first is None:
+        return None
+    lines = strip_fenced(text).splitlines()
+    start = next(index for index, line in enumerate(lines) if TRAILER_RE.match(line))
+    collected = [first]
+    for line in lines[start + 1 :]:
+        if CONTINUATION_END_RE.match(line):
+            break
+        collected.append(line.rstrip())
+    while collected and not collected[-1].strip():
+        collected.pop()
+    return "\n".join(collected)
+
+
 def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
     """
     Decide whether `changed` is adequately declared by `declaration_text`.
@@ -666,11 +709,17 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
             "Measure with: cargo run --release --features dev --example dump_normalized_corpus"
         )
 
-    if declines(declaration):
-        claim = contradicted_decline(declaration)
+    # The tripwire must read the WHOLE trailer value, not just its first line: a decline on
+    # line 1 can hide a `<n> rows move` on an unindented continuation line (#1854), and
+    # `declaration` above is truncated at the newline by `TRAILER_RE`. `declarations` is
+    # non-empty here, so a full value exists.
+    full_value = full_declaration_value(declaration_text)
+    assert full_value is not None
+    if declines(full_value):
+        claim = contradicted_decline(full_value)
         if claim is not None:
             return False, (
-                f"This trailer declines and then describes a move:\n\n  {declaration}\n\n"
+                f"This trailer declines and then describes a move:\n\n  {full_value}\n\n"
                 f"The verdict is the first word, so this is filed as `none` and the "
                 f"disclosure -- {claim!r} -- never reaches the changelog. Nobody is told, "
                 "which is the failure this whole mechanism exists to prevent.\n\n"
@@ -684,11 +733,11 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
             )
         return (
             True,
-            f"Declared `Representation-Change: {declaration}` over {len(watched)} watched file(s).",
+            f"Declared `Representation-Change: {full_value}` over {len(watched)} watched file(s).",
         )
     return (
         True,
-        f"Declared a representation change over {len(watched)} watched file(s): {declaration}",
+        f"Declared a representation change over {len(watched)} watched file(s): {full_value}",
     )
 
 

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -560,6 +560,92 @@ def test_a_real_disclosure_is_not_a_contradiction() -> None:
 
 
 # ---------------------------------------------------------------------------
+# A decline may not hide a move on a continuation line (#1854)
+#
+# `TRAILER_RE` stops the value at the first newline, and this repo's trailers
+# are routinely multi-line with UNINDENTED continuation lines, so reading only
+# the first line let a decline on line 1 hide a `<n> rows move` on line 2 — the
+# contradiction the tripwire exists to catch, evaded by a newline. The value
+# runs to the next thing it cannot own: a column-0 trailer token, a Markdown
+# heading, or the HTML comment GitHub appends (CodeRabbit's summary).
+# ---------------------------------------------------------------------------
+
+
+def test_full_declaration_value_reads_continuation_lines() -> None:
+    """The whole value, not just the first clause."""
+    body = "Representation-Change: none.\n  150 rows of 85,642 move, all 3'-direction.\n"
+    assert (
+        check_representation_change.full_declaration_value(body)
+        == "none.\n  150 rows of 85,642 move, all 3'-direction."
+    )
+
+
+def test_full_declaration_value_stops_at_the_next_trailer_token() -> None:
+    """A following column-0 `Token: ` line ends the value; it is not part of the decline."""
+    body = "Representation-Change: none. Tests only.\nCloses: #1854\n"
+    assert check_representation_change.full_declaration_value(body) == "none. Tests only."
+
+
+def test_full_declaration_value_stops_at_an_appended_coderabbit_summary() -> None:
+    """GitHub appends CodeRabbit's summary after the trailer; it must not be scavenged."""
+    body = (
+        "Representation-Change: none. Tests only.\n"
+        "  and here is why it is safe.\n"
+        "<!-- This is an auto-generated comment: release notes by coderabbit.ai -->\n"
+        "## Summary by CodeRabbit\n"
+        "- Tests: added coverage.\n"
+    )
+    assert (
+        check_representation_change.full_declaration_value(body)
+        == "none. Tests only.\n  and here is why it is safe."
+    )
+
+
+def test_full_declaration_value_is_none_without_a_trailer() -> None:
+    assert check_representation_change.full_declaration_value("Just a body.\n") is None
+
+
+def test_a_decline_that_moves_on_a_continuation_line_fails() -> None:
+    """The #1854 reproducer: a decline on line 1, a move on the continuation line.
+
+    `find_declarations` truncates the value at the newline, so before the fix `check` read
+    `none.`, found no movement claim, and passed the contradicted decline green — the
+    disclosure filed as `none`, never reaching the changelog, nobody told. That is the one
+    direction this mechanism must never fail in.
+    """
+    body = "Representation-Change: none.\n  150 rows of 85,642 move, all 3'-direction.\n"
+    ok, message = check(["src/normalize/merge.rs"], body)
+    assert not ok, "a decline that describes a move on a continuation line must be refused"
+    assert "declines and then describes a move" in message
+    assert "150 rows of 85,642 move" in message, "the message must quote the hidden move"
+
+
+def test_a_multiline_decline_with_only_a_reason_still_passes() -> None:
+    """The continuation is an ordinary reason, not a move — so it is still a clean decline.
+
+    The discriminator: extending the value must not turn a legitimate multi-line decline
+    into a false contradiction.
+    """
+    body = (
+        "Representation-Change: none.\n"
+        "  Comments and one new test module only; no watched file changes behaviour.\n"
+    )
+    ok, _ = check(["src/normalize/merge.rs"], body)
+    assert ok, "a multi-line decline whose continuation is a reason must pass"
+
+
+def test_a_real_multiline_disclosure_still_passes() -> None:
+    """A move declared on line 1 with detail on the continuation is not a contradiction."""
+    body = (
+        "Representation-Change: 577 rows move, 360 merge / 205 split / 12 respell.\n"
+        "  Previously-accepted inputs, so a real migration for the consumer.\n"
+    )
+    ok, message = check(["src/spdi/mod.rs"], body)
+    assert ok
+    assert "577 rows move" in message
+
+
+# ---------------------------------------------------------------------------
 # #1647: the count is the count, never the denominator
 #
 # The guard used to read "the number immediately before `rows`" as the moving
@@ -705,6 +791,13 @@ def test_the_two_decline_rules_agree_value_by_value() -> None:
         "no rows move",
         "none, except two rows that merge",
         "nothing moves",
+        # Multi-line values (#1854). The checker now reads the whole trailer, and git-cliff
+        # matches its footer rule against the whole footer, so both must reach the same
+        # verdict on a value that spans lines — a decline with a continued reason, and a
+        # move with a continued detail. `none.` opens the exclusion rule's `[.;:—–][\s\S]*`
+        # tail, so the continuation does not change the verdict for either side.
+        "none.\n  Comments and one new test module only; no watched file changes behaviour.",
+        "577 rows move, 360 merge.\n  Previously-accepted inputs, so a real migration.",
     ]
     for value in values:
         by_changelog = changelog_rule.search(f"Representation-Change: {value}") is not None


### PR DESCRIPTION
Closes #1854.

## The defect

The `Representation-Change:` PR-body checker's contradicted-decline tripwire read only the trailer's **first line**. `TRAILER_RE` captures the value with `\S.*?$` under `MULTILINE`, so the value stops at the first newline, and this repo's trailers are routinely multi-line with **unindented** continuation lines. So a decline on line 1 with a contradicting movement claim on a continuation line slipped through green:

```
  Representation-Change: none.
  150 rows of 85,642 move, all 3'-direction.
```

`check(["src/normalize/merge.rs"], body)` returned `(True, …)` — filed as `none`, the disclosure never reaching the changelog and nobody told, which is the one direction the tripwire's own docstring says it must never fail in. Reproduced on `origin/main` at `17cc8185`: `find_declarations` yields `['none.']`, `contradicted_decline('none.')` is `None`, so the check passes; fed the whole value, `contradicted_decline` returns `'150 rows of 85,642 move'`.

## The fix

Route `declines` / `contradicted_decline` in `check()` over the whole trailer value instead of the first line. New `full_declaration_value` extends the first line to the next line the value cannot own — a column-0 trailer token, a Markdown heading, or the HTML comment GitHub appends (CodeRabbit's summary) — the same bound the injector's `disclosure_value` already uses. It is carried as a **separate copy** so the checker keeps sharing no code with `check_changelog_grouping.py` (#1555), and it reuses this module's own `TRAILER_RE`, so no fourth copy of the column-0 rule is minted. Fenced regions are blanked first, matching `find_declarations`.

## Scope: only the checker, deliberately not the audit

The issue notes `check_changelog_grouping.opens_with_a_decline` shares the truncation. I did **not** change the audit, on measurement. The audit's job is to check that the rendered changelog is consistent with what git-cliff did, and its `trailer_value`-based rule already mirrors git-cliff's line-anchored exclusion. Extending it to read the full value makes it disagree with git-cliff and fire on **honest** declines: measured over `v0.12.0..HEAD`, an extended `opens_with_a_decline` newly flags two merged declines — `08f3024d` (`none` + review-fix prose) and `abd4cbe3` (`none` + a "Measured, not assumed" note) — neither a move. That is exactly the "widening fires on honest declines" failure this tripwire's history is a list of. The enforcement point is the PR-body checker, which now rejects the contradicted decline before it can be merged.

## Unchanged on purpose

- A legitimate multi-line decline whose continuation is a reason still passes (`none.\n  Comments and one test module only.`).
- A real multi-line disclosure (`577 rows move…\n  Previously-accepted…`) still passes.
- The decline vocabulary parity with `release-plz.toml` and `CONTRIBUTING.md` is unchanged (`test_decline_vocabulary_matches_the_changelog_config`, `test_the_two_decline_rules_agree_value_by_value` extended with multi-line values, `test_contributing_documents_the_same_decline_vocabulary` all pass).

## Verification

- `ruff check scripts/ tests/python/` — pass (EXIT 0)
- `ruff format --check scripts/ tests/python/` — pass (EXIT 0)
- `mypy --strict` on `scripts/check_representation_change.py` (mypy 1.20.2, pyproject error codes) — pass (EXIT 0). Note CI's `check-typing` only covers `python/ferro_hgvs`; `scripts/` is stdlib-only and out of that scope.
- `pytest tests/python/test_representation_change_trailer.py` — 169 pass (EXIT 0), including 7 new #1854 tests.
- End-to-end: the checker CLI exits 1 on the reproducer body and 0 on a clean multi-line decline.

Representation-Change: none
