### PR TITLE
fix(project): suppress residues past a terminator in the codon-combination path

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -595,6 +595,21 @@ fn combine_cis_substitutions_by_codon(
         }
     }
 
+    // A combined codon that becomes a terminator ends translation: no residue
+    // downstream of it is expressed, so none may appear in the consequence.
+    // `frameshift.md:22` — an immediate stop is the nonsense substitution
+    // `p.(<aa><pos>Ter)`, never a delins or bracket naming a residue past the
+    // stop the same change introduces (`p.[(Val2Ter);(Lys3=)]`, #1905). `changed`
+    // is in ascending residue order (built from the ascending `by_codon`
+    // BTreeMap), so truncating after the first introduced `Ter` drops exactly the
+    // downstream residues while keeping any changed residue 5' of it. A reference
+    // stop that stays a stop is synonymous and never enters `changed`; a
+    // stop-loss already returned `None` above, so the only `Ter` here is a
+    // premature one this combination introduced.
+    if let Some(stop_index) = changed.iter().position(|s| s.alt_aa == AminoAcid::Ter) {
+        changed.truncate(stop_index + 1);
+    }
+
     // No residue changed: the combined product is synonymous, so name every codon
     // the members rewrote — `p.(Leu2=)`, the range `p.(Leu2_Arg3=)`, or the
     // bracket `p.[(Leu2=);(Ala5=)]` when an untouched codon separates them
@@ -14510,6 +14525,61 @@ mod tests {
         use crate::hgvs::edit::Base;
         let s = combine_by_codon_str("ATGGATTATTGCTAA", &[(4, Base::T), (11, Base::A)]);
         assert_eq!(s.as_deref(), Some("NP_X.1:p.[(Asp2Tyr);(Cys4Tyr)]"));
+    }
+
+    /// #1905 (unit): a combined codon that becomes a terminator suppresses every
+    /// downstream residue, because nothing is translated past a stop codon
+    /// (`frameshift.md:22`). Here codon 2 `GAT`→`TAA` (Asp2Ter) via `c.4G>T` +
+    /// `c.6T>A`, and codon 3 `TAT`→`AAT` (Tyr3Asn) via `c.7T>A`. The naive
+    /// combined-codon walk names both — `p.(Asp2_Tyr3delinsTerAsn)`, a delins
+    /// naming Asn3 past the Ter the same change introduces — but the correct
+    /// consequence is the nonsense substitution `p.(Asp2Ter)`.
+    ///
+    /// Asserted at this arm (unit-level) rather than through `project_variant`
+    /// because the public projector normalizes same-codon substitutions before
+    /// they reach this path: two adjacent subs coalesce to a `delins` and a
+    /// separated sub takes the residue-level combiner
+    /// (`combine_cis_members_by_residue`), which already builds the
+    /// terminator-moved product (#1899). This
+    /// arm is reached with raw single-base subs only where DNA-level coalescing
+    /// cannot — e.g. a codon split across an intron — so the invariant "no residue
+    /// past an introduced terminator" is pinned here, on the function that owns it.
+    #[test]
+    fn combine_by_codon_drops_residues_past_an_introduced_terminator() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str(
+            "ATGGATTATTGCTAA",
+            &[(4, Base::T), (6, Base::A), (7, Base::A)],
+        );
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Asp2Ter)"));
+    }
+
+    /// #1905 (unit): the same suppression when the downstream change sits in a
+    /// codon SEPARATED from the terminator by an unchanged residue — the naive
+    /// walk brackets it as `p.[(Asp2Ter);(Cys4Tyr)]`, naming Cys4 past the Ter.
+    /// codon 2 `GAT`→`TAA` (Asp2Ter) via `c.4G>T` + `c.6T>A`, codon 4 `TGC`→`TAC`
+    /// (Cys4Tyr) via `c.11G>A`, codon 3 unchanged.
+    #[test]
+    fn combine_by_codon_drops_separated_residue_past_an_introduced_terminator() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str(
+            "ATGGATTATTGCTAA",
+            &[(4, Base::T), (6, Base::A), (11, Base::A)],
+        );
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Asp2Ter)"));
+    }
+
+    /// #1905 (unit): a residue changed 5' of the introduced terminator is KEPT —
+    /// truncation drops only what lies past the stop, never a residue before it.
+    /// codon 2 `GAT`→`AAT` (Asp2Asn) via `c.4G>A`, codon 3 `TAT`→`TAA` (Tyr3Ter)
+    /// via `c.9T>A`; the stop is the 3'-most changed residue, so the whole
+    /// missense-then-nonsense run survives as `p.(Asp2_Tyr3delinsAsnTer)`. Guards
+    /// against an over-eager `truncate` that would also swallow the 5' change.
+    #[test]
+    fn combine_by_codon_keeps_a_change_before_an_introduced_terminator() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str("ATGGATTATTGCTAA", &[(4, Base::A), (9, Base::A)]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Asp2_Tyr3delinsAsnTer)"));
     }
 
     /// #1076 (unit): a same-codon group that stays synonymous drops out while a


### PR DESCRIPTION
Refs #1905 — deliberately not `Closes`. Measured on the issue's own reproducer members (`c.4G>T`, `c.5T>A`, `c.9A>G` against CDS `ATGGTAAAAGGGCCCTAA`), this arm returns `p.(Val2Ter)` *even with the truncation disabled*, because codon 3 `AAA`->`AAG` is synonymous and a synonymous codon never enters `changed`. So this arm is not the source of the string the issue reports, and the fix is a no-op on that row. The issue's stated acceptance criterion is already satisfied on `main` (`project_cis_net_in_frame_but_mid_shift_stop_takes_the_frameshift_arm` reads `assert_eq!`). Whether #1905 should close is a maintainer call, not this PR's to make.

Representation-Change: none. Confined to the protein-consequence builder in `src/project/projector.rs`; no normalization output moves, and the full spec enumeration and axis-preservation census is unchanged (whole suite green). The only protein strings this can alter replace a spec-forbidden residue named past a terminator with the correct nonsense substitution. No corpus evidence is offered for that arm's reachability, because none is available: `dump_normalized_corpus` emits the `g`, `c` and `cx` axes only and has no protein-consequence axis, so it is structurally incapable of observing any change to this builder. The verdict rests on the builder not being on the normalization path.

## The defect

The substitution-combination arm `combine_cis_substitutions_by_codon` — the path the issue names, taken when every cis member is a lone single-base substitution and two share a codon — built a per-codon consequence list without checking whether an earlier combined codon had already introduced a terminator. So it could emit a protein consequence naming a residue past the stop the same change introduces:

- adjacent downstream codon → `p.(Val2_Lys3delinsTerAsn)` (a delins naming residue 3 past the Ter at 2);
- separated downstream codon → the bracketed form with the past-terminator member suppressed. Note this arm cannot emit a silent `(Lys3=)` member at all: a synonymous codon has `ref_aa == alt_aa` and is excluded at `projector.rs:589`, so the bracket quoted in the issue comes from the caller's per-member fallback, not from here.

Nothing is translated past a stop codon; `frameshift.md:22` requires an immediate stop to be the nonsense substitution `p.(Val2Ter)`, not a form that names residues after it.

## Where it stood on `main`

The sibling *residue-level* combiner (`combine_cis_members_by_residue`) already handles this via its `TerminatorMoved` outcome, added by #1899 (which also carries the `p.[(Val2Ter);(Lys3=)]` comment). That fixed the two-member / mixed-member spelling — so the user-facing reproducer `NM_FSSTOP.1:c.[4_5delinsTA;9A>G]` is already correct through `project_variant`. What #1899 did **not** touch is the all-single-base-substitution codon arm, which stays terminator-blind: a direct unit call still returns `p.(Val2_Lys3delinsTerAsn)`. This PR closes that same class on that arm.

## The fix

After the per-codon walk builds the changed-residue list, truncate it after the first residue whose combined codon became a `Ter`. The list is in ascending residue order (built from the ascending `by_codon` `BTreeMap`), so this drops exactly the residues downstream of the introduced stop while keeping any change 5' of it. A reference stop that stays a stop is synonymous and never enters the list; a stop-loss already declines earlier — so the only terminator reached here is a premature one the combination introduced.

## Unchanged on purpose

- A change 5' of the terminator is kept: `Asp2Asn` + `Tyr3Ter` still renders `p.(Asp2_Tyr3delinsAsnTer)` (guarded by `combine_by_codon_keeps_a_change_before_an_introduced_terminator`).
- All existing codon-arm behaviour (missense, nonsense at a single codon, synonymous, adjacent/separated missense) is untouched (11 pre-existing `combine_by_codon_*` tests still pass).

## Why unit-level tests

The tests pin the invariant on `combine_cis_substitutions_by_codon` directly rather than through `project_variant`, because the public projector normalizes same-codon substitutions before they reach this arm (adjacent subs coalesce to a `delins`; a separated sub takes the residue-level combiner). The arm is reached with raw single-base subs only where DNA-level coalescing cannot — a codon split across an intron — so the property is asserted on the function that owns it. Doc comments record this.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --features dev --no-fail-fast` — `11161 passed, 0 failed, 155 skipped` (bulk-fixture skips)
- New RED→GREEN unit tests: `combine_by_codon_drops_residues_past_an_introduced_terminator`, `combine_by_codon_drops_separated_residue_past_an_introduced_terminator`, `combine_by_codon_keeps_a_change_before_an_introduced_terminator`.
