### PR TITLE
refactor(hgvs): collapse the two range-insert spellings behind one accessor

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -402,6 +402,39 @@ impl InsertedSequence {
         }
     }
 
+    /// Decompose a same-reference position-range payload to
+    /// `(start, end, inverted)` 1-based inclusive coordinates, or `None` when
+    /// this is not one.
+    ///
+    /// An all-numeric same-reference range has **two** AST spellings that the
+    /// parser mints interchangeably and that [`Display`](fmt::Display) renders
+    /// identically: the bare [`PositionRange`](InsertedSequence::PositionRange) /
+    /// [`PositionRangeInv`](InsertedSequence::PositionRangeInv) variant, and the
+    /// single-part `Complex([PositionRange | PositionRangeInv])` shape (the
+    /// parser wraps `parse_cds_position_range`'s result in `Complex` but falls
+    /// through to the bare variant for `parse_simple_count`). Both denote one
+    /// contiguous slice of the same accession, so this is the single place that
+    /// collapses them — consumers call it rather than re-deriving the match, and
+    /// so cannot disagree about which spelling they handle (#1986).
+    ///
+    /// Multi-part `Complex` payloads, [`CdsPositionRange`](InsertedPart::CdsPositionRange)
+    /// (intronic-offset / UTR-marker ranges), external references,
+    /// [`SpecialPositionRange`](InsertedSequence::SpecialPositionRange) and every
+    /// non-range variant return `None`, so the caller keeps its existing
+    /// handling for them.
+    pub fn as_position_range(&self) -> Option<(u64, u64, bool)> {
+        match self {
+            InsertedSequence::PositionRange { start, end } => Some((*start, *end, false)),
+            InsertedSequence::PositionRangeInv { start, end } => Some((*start, *end, true)),
+            InsertedSequence::Complex(parts) => match parts.as_slice() {
+                [InsertedPart::PositionRange { start, end }] => Some((*start, *end, false)),
+                [InsertedPart::PositionRangeInv { start, end }] => Some((*start, *end, true)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Get the bases if this is a literal sequence
     /// Returns None for count, range, repeat, complex, or empty variants
     pub fn bases(&self) -> Option<&[Base]> {
@@ -2365,6 +2398,69 @@ mod tests {
         assert_eq!(
             render(&fs, ProteinRenderStyle::default()),
             format!("{}", fs)
+        );
+    }
+
+    /// The parser mints an all-numeric same-reference range payload in two AST
+    /// spellings — the bare `PositionRange`/`PositionRangeInv` variant and the
+    /// single-part `Complex([PositionRange | PositionRangeInv])` — that Display
+    /// identically. `as_position_range` is the one accessor consumers share so
+    /// they cannot disagree about which spelling they handle (#1986).
+    #[test]
+    fn as_position_range_collapses_both_spellings() {
+        let bare_fwd = InsertedSequence::PositionRange {
+            start: 100,
+            end: 200,
+        };
+        let complex_fwd = InsertedSequence::Complex(vec![InsertedPart::PositionRange {
+            start: 100,
+            end: 200,
+        }]);
+        // The two spellings are display-equivalent, which is why they are so easy
+        // to confuse — the difference is only in the AST.
+        assert_eq!(bare_fwd.to_string(), complex_fwd.to_string());
+        assert_ne!(bare_fwd, complex_fwd);
+        assert_eq!(bare_fwd.as_position_range(), Some((100, 200, false)));
+        assert_eq!(complex_fwd.as_position_range(), Some((100, 200, false)));
+
+        let bare_inv = InsertedSequence::PositionRangeInv { start: 45, end: 90 };
+        let complex_inv =
+            InsertedSequence::Complex(vec![InsertedPart::PositionRangeInv { start: 45, end: 90 }]);
+        assert_eq!(bare_inv.to_string(), complex_inv.to_string());
+        assert_eq!(bare_inv.as_position_range(), Some((45, 90, true)));
+        assert_eq!(complex_inv.as_position_range(), Some((45, 90, true)));
+
+        // Anything that is not a lone same-reference range is not one, so the
+        // caller keeps its own handling.
+        assert_eq!(
+            InsertedSequence::Literal(Sequence::from_str("ATG").unwrap()).as_position_range(),
+            None
+        );
+        assert_eq!(
+            InsertedSequence::Complex(vec![
+                InsertedPart::PositionRange { start: 1, end: 2 },
+                InsertedPart::PositionRange { start: 5, end: 6 },
+            ])
+            .as_position_range(),
+            None
+        );
+        assert_eq!(
+            InsertedSequence::Complex(vec![InsertedPart::CdsPositionRange("244-8_249".into())])
+                .as_position_range(),
+            None
+        );
+        // A special-position range carries `GenomePos` endpoints, not the `u64`
+        // this accessor decomposes to, so it is deliberately not one — the doc
+        // comment names it, and the `PositionRangeInv` note at the enum warns a
+        // future author to keep it in mind.
+        assert_eq!(
+            InsertedSequence::SpecialPositionRange {
+                start: GenomePos::new(100),
+                end: GenomePos::new(200),
+                inverted: true,
+            }
+            .as_position_range(),
+            None
         );
     }
 }

--- a/src/project/rna.rs
+++ b/src/project/rna.rs
@@ -16,7 +16,7 @@
 //! existing `RnaVariant` Display path; this module only builds the value.
 
 use crate::convert::mapper::CoordinateMapper;
-use crate::hgvs::edit::{InsertedPart, InsertedSequence, NaEdit, Sequence};
+use crate::hgvs::edit::{InsertedSequence, NaEdit, Sequence};
 use crate::hgvs::interval::{CdsInterval, RnaInterval};
 use crate::hgvs::location::{CdsPos, RnaPos, TxPos};
 use crate::hgvs::variant::{AlleleVariant, HgvsVariant, LocEdit, RnaVariant};
@@ -172,23 +172,16 @@ fn resolve_range_bases(
 
 /// Resolve a position-range insert against the transcript sequence, in CDS
 /// coordinates, to a literal `InsertedSequence` (DNA bases; Display applies T→U +
-/// lowercase). Handles the bare `PositionRange`/`PositionRangeInv` variants and the
-/// single-part `Complex([PositionRange | PositionRangeInv])` shape the parser
-/// produces for `delins191_194inv` — both collapse to a single `Literal`. Inserts
-/// that aren't a resolvable same-reference position range pass through unchanged.
+/// lowercase). Both AST spellings of a same-reference range (bare and single-part
+/// `Complex`) are collapsed by [`InsertedSequence::as_position_range`], then
+/// resolved to a single `Literal`. Inserts that aren't a resolvable same-reference
+/// position range pass through unchanged.
 fn resolve_range_insert(
     ins: &InsertedSequence,
     transcript: &Transcript,
 ) -> Option<InsertedSequence> {
-    let (start, end, invert) = match ins {
-        InsertedSequence::PositionRange { start, end } => (*start, *end, false),
-        InsertedSequence::PositionRangeInv { start, end } => (*start, *end, true),
-        InsertedSequence::Complex(parts) => match parts.as_slice() {
-            [InsertedPart::PositionRange { start, end }] => (*start, *end, false),
-            [InsertedPart::PositionRangeInv { start, end }] => (*start, *end, true),
-            _ => return Some(ins.clone()),
-        },
-        other => return Some(other.clone()),
+    let Some((start, end, invert)) = ins.as_position_range() else {
+        return Some(ins.clone());
     };
     Some(InsertedSequence::Literal(resolve_range_bases(
         start, end, invert, transcript,

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -219,29 +219,6 @@ fn inserted_sequence_to_string(seq: &InsertedSequence) -> Option<String> {
     }
 }
 
-/// A same-reference position-range insert, decomposed to `(start, end, invert)`
-/// 1-based inclusive coordinates, or `None` when `seq` is not one.
-///
-/// Recognises the bare `PositionRange`/`PositionRangeInv` variants and the
-/// single-part `Complex([PositionRange | PositionRangeInv])` shape the parser
-/// produces for range inserts — both denote one contiguous slice of the same
-/// accession. Multi-part `Complex` payloads, external references and every
-/// non-range variant return `None`, so the caller keeps its existing handling
-/// for them.
-fn position_range_insert(seq: &InsertedSequence) -> Option<(u64, u64, bool)> {
-    use crate::hgvs::edit::InsertedPart;
-    match seq {
-        InsertedSequence::PositionRange { start, end } => Some((*start, *end, false)),
-        InsertedSequence::PositionRangeInv { start, end } => Some((*start, *end, true)),
-        InsertedSequence::Complex(parts) => match parts.as_slice() {
-            [InsertedPart::PositionRange { start, end }] => Some((*start, *end, false)),
-            [InsertedPart::PositionRangeInv { start, end }] => Some((*start, *end, true)),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 /// Translate one insert-payload coordinate from the axis it is **written** on
 /// onto the transcript axis the SPDI is emitted on.
 ///
@@ -422,7 +399,7 @@ fn resolve_position_range_insert<P>(
 where
     P: ReferenceProvider + ?Sized,
 {
-    let Some((start, end, invert)) = position_range_insert(seq) else {
+    let Some((start, end, invert)) = seq.as_position_range() else {
         return Ok(None);
     };
     read_reference_span(accession, start, end, invert, alphabet, kind, provider).map(Some)


### PR DESCRIPTION
Closes #1986.

Representation-Change: none. Parser-boundary/consumer accessor only; no parse output, `Display`, or normalized output changes. The single-part `Complex` spelling and the bare variant already `Display` identically, and the AST is untouched — this only unifies how two existing consumers read it.

## The defect

An all-numeric same-reference range payload has **two AST spellings** the parser mints interchangeably, from the same first-byte dispatch arm (`b'0'..=b'9' | b'*'`, `src/hgvs/parser/edit.rs`):

- the bare `InsertedSequence::PositionRange` / `PositionRangeInv` variant (from `parse_simple_count`), and
- the single-part `Complex([PositionRange | PositionRangeInv])` shape (from `parse_cds_position_range`, wrapped in `Complex`).

Both denote one contiguous slice of the same accession, and `Display` renders them identically (`Complex` unbrackets a single part). Which spelling a description gets is decided by which of two parsers accepted it, not by anything about the payload.

Two consumers had each **independently re-derived the same collapse**, each with its own doc comment explaining the same asymmetry:

- `src/spdi/convert.rs::position_range_insert`
- the head of `src/project/rna.rs::resolve_range_insert`

That is the tax the issue describes: every new consumer must rediscover the duplication, and forgetting one spelling fails silently because the other keeps working. (The third site the issue named, `src/spdi/convert.rs` handling *neither* spelling, was since patched by #1966 — it now handles both, i.e. it grew a third copy of the collapse. The root cause — no single place that decides — remained.)

## The fix

Add one accessor on the type that owns the two spellings:

```rust
pub fn as_position_range(&self) -> Option<(u64, u64, bool)>
```

on `InsertedSequence`, decomposing both spellings to `(start, end, inverted)`. Route both consumers through it and delete the two hand-rolled matches. The collapse now lives in exactly one place with one doc comment; a new consumer is pointed at the accessor.

I chose the single accessor over minting one spelling at the parser boundary because the accessor is the zero-risk option: it changes no AST, so it cannot move any parse/display/normalized output, and it is what the issue's "and/or" explicitly permits.

## Unchanged on purpose

- **Behavior is preserved exactly.** `as_position_range` returns `None` for the same inputs the old matches skipped (multi-part `Complex`, `CdsPositionRange`, external refs, `SpecialPositionRange`, and every non-range variant), so both consumers keep their existing fall-through handling.
- **`src/normalize/rules.rs` is left alone.** It handles the payload by fetching bases per-part (`append_part_bases` for the `Complex` side, separate bare arms), not by decomposing to `(start, end, inverted)`, so it is not the duplicated collapse this change targets.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — **11163 passed, 155 skipped**.
- New unit test `hgvs::edit::tests::as_position_range_collapses_both_spellings` pins that both spellings display identically yet are distinct AST values, that the accessor collapses both (forward and inverted), and that the documented non-range inputs (`Literal`, multi-part `Complex`, `CdsPositionRange`, `SpecialPositionRange`) return `None`.