### PR TITLE
fix(project): project a genomic cis allele onto the requested transcript

### DIFF
--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -3,7 +3,7 @@
 //! "unavailable" (exit 0) vs "hard failure" (exit 1).
 
 use crate::error::FerroError;
-use crate::hgvs::variant::HgvsVariant;
+use crate::hgvs::variant::{CoordinateAxis, HgvsVariant};
 use crate::normalize::NormalizationWarning;
 use crate::project::{VariantProjection, VariantProjector};
 use crate::reference::ReferenceProvider;
@@ -206,7 +206,15 @@ pub fn project_axis<P: ReferenceProvider + Clone>(
     axis: Axis,
     transcript: Option<&str>,
 ) -> Result<AxisOutcome, ProjectCliError> {
-    if matches!(variant, HgvsVariant::Genome(_)) {
+    // Route every *genomic-axis* input through the genomic dispatch, not just a
+    // lone `HgvsVariant::Genome`. A genomic cis allele
+    // (`NC_…:g.[261del;263_264insA]`) parses to `HgvsVariant::Allele`, whose
+    // accession is a *chromosome*, not a transcript — so the transcript-
+    // coordinate branch below would compare `--transcript` against that
+    // chromosome accession and reject a valid projection (#1562). Keying on the
+    // coordinate axis rather than the variant kind catches the allele (and any
+    // other genomic-axis shape) the same way a lone `g.` variant is caught.
+    if variant.coordinate_axis() == Some(CoordinateAxis::Genomic) {
         return project_axis_genomic(projector, variant, axis, transcript);
     }
 
@@ -741,5 +749,54 @@ mod tests {
             }
             other => panic!("expected Rendered, got {other:?}"),
         }
+    }
+
+    /// #1562: a genomic (`g.`) *cis allele* must project onto the named
+    /// transcript exactly as a lone genomic variant does. Before the fix the CLI
+    /// only routed `HgvsVariant::Genome(_)` through the genomic dispatch; a
+    /// genomic allele parses to `HgvsVariant::Allele`, so it fell through to the
+    /// transcript-coordinate branch, which read the input's *chromosome*
+    /// accession as its "transcript" and rejected `--transcript` for not
+    /// matching it — refusing a valid projection outright.
+    ///
+    /// The assertion is on the projected *member list*, not merely that the call
+    /// succeeds: the whole point of projecting a cis allele is that every member
+    /// is carried through onto the target axis. Two substitutions six bases apart
+    /// stay individual (`general.md:34` — separated by more than one unchanged
+    /// nucleotide), so a projection that dropped or merged a member would fail
+    /// this. The exact string is measured, not inferred.
+    #[test]
+    fn project_axis_genomic_cis_allele_projects_all_members() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NC_000001.11:g.[1002T>A;1008A>C]").unwrap();
+        let outcome = project_axis(&vp, &variant, Axis::Coding, Some("NM_TEST.1")).unwrap();
+        match outcome {
+            AxisOutcome::Rendered {
+                transcript_id,
+                output,
+                ..
+            } => {
+                assert_eq!(transcript_id, "NM_TEST.1");
+                assert_eq!(output, "NC_000001.11(NM_TEST.1):c.[2T>A;9A>C]");
+            }
+            other => panic!("expected Rendered, got {other:?}"),
+        }
+    }
+
+    /// The discriminating half of #1562: routing genomic alleles through the
+    /// genomic dispatch must NOT weaken the mismatch guard for a genuine
+    /// *transcript-coordinate* cis allele. A `c.` allele names its transcript in
+    /// the accession, so a `--transcript` that disagrees with it is still a hard
+    /// error — exactly as for a lone `c.` input.
+    #[test]
+    fn project_axis_coding_cis_allele_transcript_mismatch_is_hard_error() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NM_TEST.1:c.[3dup;6del]").unwrap();
+        let err = project_axis(&vp, &variant, Axis::Protein, Some("NM_OTHER.1")).unwrap_err();
+        assert!(
+            err.0.contains("NM_OTHER.1") && err.0.to_lowercase().contains("match"),
+            "got {}",
+            err.0
+        );
     }
 }


### PR DESCRIPTION
Closes #1562.

Representation-Change: none. Newly enables a projection that was previously refused outright; it converts a hard error into a successful projection and moves no existing normalized output. The change is in `src/cli/project.rs` (CLI dispatch), which is not a watched prefix.

## The defect

`ferro project` refused to project a genomic (`g.`) cis allele onto any transcript axis, while the same transcript projected a lone `g.` variant at the same locus without complaint:

```
$ ferro project --axis c --transcript NM_004006.2 --reference <dir> \
    'NC_000023.11:g.[33211289dup;33211293del]'
ERROR: --transcript NM_004006.2 does not match the input's transcript NC_000023.11
```

The error reports the input's *chromosome* accession as though it were a transcript. The cause is in `project_axis` (`src/cli/project.rs`): it routed only `HgvsVariant::Genome(_)` through the genomic dispatch. A genomic cis allele parses to `HgvsVariant::Allele`, so it fell through to the transcript-coordinate branch, which takes the transcript from `variant.accession().transcript_accession()` — a *chromosome* accession for a genomic allele — and hard-errors when `--transcript` does not match it.

The engine already handles a genomic allele: `project_variant_inner` has an `HgvsVariant::Allele` arm (`src/project/projector.rs`). Only the CLI dispatch guard was wrong.

## The fix

Key the dispatch on the coordinate axis rather than the variant kind: route every genomic-axis input (`coordinate_axis() == Some(CoordinateAxis::Genomic)`) through `project_axis_genomic`, which requires `--transcript` and projects onto it. This is the same idiom the Python bindings already use (`is_genomic`, `src/python.rs`), and it catches the allele — and any other genomic-axis shape (`GenomeRing`, a genomic `Supernumerary`) — exactly as a lone `g.` variant is caught.

## Unchanged on purpose

- A **transcript-coordinate** cis allele (`NM_…:c.[…]`) still names its transcript in the accession, so a `--transcript` that genuinely disagrees with it remains a hard error — pinned by a discriminating test, so the fix cannot silently weaken the mismatch guard.
- `NullAllele`/`UnknownAllele` and mixed-axis alleles resolve to `coordinate_axis() == None` and keep their prior (transcript) path.
- The broadened routing only pulls genomic-axis shapes out of the transcript-coordinate branch — none of which ever carried a transcript accession, so that branch was always wrong for them. No transcript-coordinate input changes path.

## Verification

- `project_axis_genomic_cis_allele_projects_all_members` — a genomic cis allele of two well-separated substitutions projects onto `--transcript` and carries **both members through** onto the coding axis (`NC_000001.11(NM_TEST.1):c.[2T>A;9A>C]`). Asserts the projected member list, per the issue's acceptance criteria; the exact string is measured, not inferred.
- `project_axis_coding_cis_allele_transcript_mismatch_is_hard_error` — the discriminating guard: a `c.` cis allele with a disagreeing `--transcript` is still a hard error.
- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — 11164 passed, 0 failed, 155 skipped.