### PR TITLE
test: anchor cwd-relative fixture reads and guard against reintroduction

### DIFF
--- a/tests/it/biocommons_tests.rs
+++ b/tests/it/biocommons_tests.rs
@@ -32,8 +32,10 @@ fn default_supported() -> bool {
 }
 
 fn load_biocommons_fixtures() -> TestFixture {
-    let content = fs::read_to_string("tests/fixtures/grammar/biocommons.json")
-        .expect("Failed to read biocommons.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/grammar/biocommons.json",
+    ))
+    .expect("Failed to read biocommons.json");
     serde_json::from_str(&content).expect("Failed to parse biocommons.json")
 }
 

--- a/tests/it/clinical_genes_tests.rs
+++ b/tests/it/clinical_genes_tests.rs
@@ -42,8 +42,10 @@ struct ClinicalGeneCase {
 }
 
 fn load_clinical_genes_fixtures() -> ClinicalGenesFixture {
-    let content = fs::read_to_string("tests/fixtures/validation/clinical_genes.json")
-        .expect("Failed to read clinical_genes.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/validation/clinical_genes.json",
+    ))
+    .expect("Failed to read clinical_genes.json");
     serde_json::from_str(&content).expect("Failed to parse clinical_genes.json")
 }
 

--- a/tests/it/clinvar_tests.rs
+++ b/tests/it/clinvar_tests.rs
@@ -66,8 +66,10 @@ struct Statistics {
 }
 
 fn load_clinvar_fixtures() -> ClinVarFixture {
-    let content = fs::read_to_string("tests/fixtures/validation/clinvar.json")
-        .expect("Failed to read clinvar.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/validation/clinvar.json",
+    ))
+    .expect("Failed to read clinvar.json");
     serde_json::from_str(&content).expect("Failed to parse clinvar.json")
 }
 

--- a/tests/it/clinvar_validation.rs
+++ b/tests/it/clinvar_validation.rs
@@ -15,7 +15,7 @@ use std::io::{BufRead, BufReader};
 
 #[test]
 fn test_clinvar_validation() {
-    let file = File::open("tests/fixtures/bulk/hgvs4variation.txt.gz")
+    let file = File::open(crate::common::fixture_gen::fixture_path("tests/fixtures/bulk/hgvs4variation.txt.gz"))
         .expect("ClinVar data not found. Run: curl -o tests/fixtures/bulk/hgvs4variation.txt.gz https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/hgvs4variation.txt.gz");
     let decoder = GzDecoder::new(file);
     let reader = BufReader::new(decoder);

--- a/tests/it/comprehensive_edge_case_tests.rs
+++ b/tests/it/comprehensive_edge_case_tests.rs
@@ -63,8 +63,10 @@ struct TestCase {
 }
 
 fn load_fixtures() -> TestFixture {
-    let content = fs::read_to_string("tests/fixtures/comprehensive_edge_cases.json")
-        .expect("Failed to read comprehensive_edge_cases.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/comprehensive_edge_cases.json",
+    ))
+    .expect("Failed to read comprehensive_edge_cases.json");
     serde_json::from_str(&content).expect("Failed to parse fixture JSON")
 }
 

--- a/tests/it/conformance_summary_generated.rs
+++ b/tests/it/conformance_summary_generated.rs
@@ -13,8 +13,10 @@ use ferro_hgvs::conformance::{biocommons, mutalyzer, summary};
 
 #[test]
 fn mutalyzer_failure_patterns_is_current() {
-    let content = std::fs::read_to_string("tests/fixtures/mutalyzer-normalize/cases.json")
-        .expect("read mutalyzer cases.json");
+    let content = std::fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/mutalyzer-normalize/cases.json",
+    ))
+    .expect("read mutalyzer cases.json");
     let fixture: mutalyzer::Fixture =
         serde_json::from_str(&content).expect("parse mutalyzer cases.json");
     fixture
@@ -29,8 +31,10 @@ fn mutalyzer_failure_patterns_is_current() {
 
 #[test]
 fn biocommons_failure_patterns_is_current() {
-    let content = std::fs::read_to_string("tests/fixtures/biocommons-normalize/cases.json")
-        .expect("read biocommons cases.json");
+    let content = std::fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/biocommons-normalize/cases.json",
+    ))
+    .expect("read biocommons cases.json");
     let fixture: biocommons::Fixture =
         serde_json::from_str(&content).expect("parse biocommons cases.json");
     fixture

--- a/tests/it/cwd_relative_fixture_paths.rs
+++ b/tests/it/cwd_relative_fixture_paths.rs
@@ -1,0 +1,267 @@
+//! Guard against cwd-relative fixture reads (#2019).
+//!
+//! A test's working directory is a property of its **package**, not of the
+//! repository. `cargo nextest` runs a test from the root of the package that
+//! owns it, so a module compiled into the root `ferro-hgvs` package's `it`
+//! target runs from the workspace root, while the *same* module `#[path]`-
+//! included by the `ferro-hgvs-soak-tests` member
+//! (`tests-soak/tests/soak/main.rs`) runs from `tests-soak/`. A fixture read
+//! against a bare relative path therefore works in `it` and breaks the moment
+//! the module is pulled into the soak driver — and it breaks by reporting the
+//! file missing, which reads as an environment problem rather than a path bug.
+//!
+//! The class had been rediscovered three times — `common/bulk_fixtures.rs` and
+//! `common/fixture_gen.rs` during #1977, and `clinvar_hgvs_tests.rs` in CI
+//! *after* #2001's push, on a module that had been correct in `it` for a long
+//! time and became wrong only when compiled into the driver, with no edit to
+//! itself. The fix each time is the same: resolve the fixture through
+//! [`crate::common::fixture_gen::fixture_path`], which anchors on
+//! `CARGO_MANIFEST_DIR` and ascends to the workspace `Cargo.lock`, so it is
+//! correct from either package. This guard stops instance four: it scans every
+//! `tests/it` source and fails on any filesystem read whose direct argument is
+//! a `"tests/fixtures/…"` string literal.
+//!
+//! # What it catches, and what it deliberately does not
+//!
+//! It matches a `"tests/fixtures/…"` literal passed **directly** to a
+//! filesystem-accessing call — `fs::read_to_string("…")`, `File::open("…")`,
+//! and the other accessors in [`FS_ACCESSORS`]. That is exactly the shape the
+//! three prior instances took, and the shape a new test is most likely to
+//! reintroduce by copy-paste.
+//!
+//! It is a token scan, not a parse, so it is a floor rather than a proof. A
+//! path bound to a variable and read one line later (`let p =
+//! Path::new("tests/fixtures/…"); fs::read_to_string(p)`), or composed at run
+//! time (`format!("tests/fixtures/{name}")`), is invisible to it — the fs call
+//! sees an identifier, not the literal. Anchoring those correctly is still
+//! required; this guard simply cannot see them. What it does buy is that the
+//! direct form — the one that keeps recurring — cannot be added in silence, and
+//! the question gets asked. Widening it to chase indirection would trade a
+//! precise, zero-false-positive check for a heuristic one.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// This file. Excluded from the scan because it carries the very literals it
+/// searches for — the `FS_ACCESSORS` names beside `"tests/fixtures/` fragments
+/// in the unit test below — and would otherwise flag itself. Same reasoning as
+/// `generated_fixture_ci_wiring.rs`'s and `oracle_exclude_invariant.rs`'s
+/// self-exclusions.
+const SELF: &str = "cwd_relative_fixture_paths.rs";
+
+/// The prefix that marks a repository-relative fixture path literal.
+const FIXTURE_PREFIX: &str = "tests/fixtures/";
+
+/// The final path segment of a call that touches the filesystem. A
+/// `"tests/fixtures/…"` literal handed directly to one of these resolves
+/// against the process's working directory, which is the bug this guard exists
+/// to prevent. Matching on the final segment lets one entry cover every spelling
+/// of the same call — `fs::read`, `std::fs::read` and a bare imported `read` all
+/// end in `read`; `File::open` and `OpenOptions::new().open` both end in `open`.
+///
+/// Deliberately excluded, because they do not read against the cwd: `new`
+/// (`Path::new`/`PathBuf::from` build a path without touching disk), `join`,
+/// `push`, `fixture_path` (the anchored resolver itself), `present_or_skip` and
+/// `load` (helpers that anchor internally), and `format!` (composes a string).
+const FS_ACCESSORS: &[&str] = &[
+    "read_to_string",
+    "read_to_end",
+    "read",
+    "read_dir",
+    "read_link",
+    "open",
+    "create",
+    "create_new",
+    "write",
+    "metadata",
+    "canonicalize",
+    "remove_file",
+    "copy",
+    "rename",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// A single cwd-relative fixture read: the file it lives in, the 1-based line
+/// number, and the offending literal.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Finding {
+    file: String,
+    line: usize,
+    literal: String,
+}
+
+/// Whether `token` — the identifier immediately preceding the `(` of a call —
+/// names a filesystem accessor, judged by its final `::`-separated segment.
+fn is_fs_accessor(token: &str) -> bool {
+    let last_segment = token.rsplit("::").next().unwrap_or(token);
+    FS_ACCESSORS.contains(&last_segment)
+}
+
+/// Every cwd-relative fixture read in `text`, one [`Finding`] per site.
+///
+/// The scan walks each `"tests/fixtures/…"` literal, steps back over whitespace
+/// to the character before it, and — when that character is the `(` of a call —
+/// reads the call's identifier and asks [`is_fs_accessor`]. A literal that is
+/// not the direct argument of a call (a `const`/`let` binding, or an argument to
+/// `Path::new`, `fixture_path`, `format!`, …) has something other than `(`
+/// there and is skipped.
+///
+/// The walk is over the whole text rather than line-by-line, so it sees through
+/// `rustfmt`'s wrapping: `fs::read_to_string(` on one line and its
+/// `"tests/fixtures/…"` argument on the next is the same finding as the
+/// one-liner. It steps back over intervening whitespace *and* newlines to reach
+/// the `(`.
+fn cwd_relative_fixture_reads(file: &str, text: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let needle = format!("\"{FIXTURE_PREFIX}");
+    let mut search_from = 0;
+    while let Some(rel) = text[search_from..].find(&needle) {
+        let quote_at = search_from + rel;
+        search_from = quote_at + needle.len();
+
+        // Everything before the opening quote, with trailing whitespace (spaces,
+        // newlines, indentation) stripped so a wrapped argument reads the same
+        // as an inline one.
+        let before = text[..quote_at].trim_end();
+        let Some(open_paren) = before.strip_suffix('(') else {
+            continue; // not `call(… "tests/fixtures/…"` — a binding or a non-call arg.
+        };
+        // The call identifier is the run of path characters immediately before
+        // the `(` (again tolerating whitespace between the two).
+        let ident: String = open_paren
+            .trim_end()
+            .chars()
+            .rev()
+            .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == ':')
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        if !is_fs_accessor(&ident) {
+            continue;
+        }
+        // Recover the full literal (to the closing quote) for the message.
+        let after_quote = &text[quote_at + 1..];
+        let literal = after_quote
+            .find('"')
+            .map(|end| &after_quote[..end])
+            .unwrap_or(after_quote);
+        // 1-based line of the opening quote.
+        let line = text[..quote_at].bytes().filter(|&b| b == b'\n').count() + 1;
+        findings.push(Finding {
+            file: file.to_string(),
+            line,
+            literal: literal.to_string(),
+        });
+    }
+    findings
+}
+
+/// `(file name, contents)` for every `.rs` source under `tests/it`, excluding
+/// this file.
+fn integration_test_sources() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut stack = vec![repo_root().join("tests/it")];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+            .filter_map(Result::ok);
+        for entry in entries {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .expect("a file has a name")
+                .to_string_lossy()
+                .into_owned();
+            if name == SELF {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            out.push((name, text));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// No integration-test module may read a fixture against a cwd-relative literal.
+///
+/// The remedy for any finding is to route the literal through
+/// `crate::common::fixture_gen::fixture_path`, which resolves the same path from
+/// either package. See the module docs for why this matters and for what the
+/// scan cannot see.
+#[test]
+fn no_test_reads_a_fixture_against_the_cwd() {
+    let offenders: Vec<Finding> = integration_test_sources()
+        .iter()
+        .flat_map(|(name, text)| cwd_relative_fixture_reads(name, text))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "these fixture reads resolve against the process working directory and \
+         will break when the module is compiled into `ferro-hgvs-soak-tests` \
+         (which runs from `tests-soak/`, not the workspace root). Route each \
+         through `crate::common::fixture_gen::fixture_path(\"…\")`:\n{}",
+        offenders
+            .iter()
+            .map(|f| format!("  {}:{}  {}", f.file, f.line, f.literal))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+}
+
+/// The detector must recognise the shapes it is meant to catch and ignore the
+/// shapes that are already correct — a guard whose matcher silently stops
+/// matching would pass vacuously (see `generated_fixture_ci_wiring.rs`'s minimum
+/// floor for the same concern). This pins both directions against a synthetic
+/// sample rather than against the live tree, so it keeps its meaning after the
+/// tree is swept clean.
+#[test]
+fn the_detector_matches_direct_reads_and_only_those() {
+    let sample = r#"
+        let a = fs::read_to_string("tests/fixtures/a.json").unwrap();
+        let b = std::fs::read_to_string("tests/fixtures/b.json").unwrap();
+        let c = File::open("tests/fixtures/c.gz").unwrap();
+        // rustfmt-wrapped direct read — fs call and its literal on separate
+        // lines. Must STILL be flagged:
+        let m = fs::read_to_string(
+            "tests/fixtures/m.json",
+        ).unwrap();
+        // correctly anchored — must NOT be flagged:
+        let d = fs::read_to_string(fixture_path("tests/fixtures/d.json")).unwrap();
+        let e = fs::read_to_string(crate::common::fixture_gen::fixture_path("tests/fixtures/e.json"));
+        let f = Path::new("tests/fixtures/f.json");
+        let g = format!("tests/fixtures/{name}");
+        const H: &str = "tests/fixtures/h.json";
+        buf.push("tests/fixtures/i.json");
+    "#;
+
+    let flagged: BTreeSet<String> = cwd_relative_fixture_reads("sample.rs", sample)
+        .into_iter()
+        .map(|f| f.literal)
+        .collect();
+
+    let expected: BTreeSet<String> = [
+        "tests/fixtures/a.json",
+        "tests/fixtures/b.json",
+        "tests/fixtures/c.gz",
+        "tests/fixtures/m.json",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    assert_eq!(flagged, expected);
+}

--- a/tests/it/dbsnp_tests.rs
+++ b/tests/it/dbsnp_tests.rs
@@ -108,8 +108,10 @@ impl DbsnpTestReport {
 // ============================================================================
 
 fn load_dbsnp_fixtures() -> DbsnpFixture {
-    let content = fs::read_to_string("tests/fixtures/validation/dbsnp_rsid.json")
-        .expect("Failed to read dbsnp_rsid.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/validation/dbsnp_rsid.json",
+    ))
+    .expect("Failed to read dbsnp_rsid.json");
     serde_json::from_str(&content).expect("Failed to parse dbsnp_rsid.json")
 }
 

--- a/tests/it/edge_case_notation_tests.rs
+++ b/tests/it/edge_case_notation_tests.rs
@@ -86,14 +86,18 @@ struct ProteinStats {
 }
 
 fn load_unusual_notation_fixtures() -> UnusualNotationFixture {
-    let content = fs::read_to_string("tests/fixtures/edge_cases/unusual_notation.json")
-        .expect("Failed to read unusual_notation.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/edge_cases/unusual_notation.json",
+    ))
+    .expect("Failed to read unusual_notation.json");
     serde_json::from_str(&content).expect("Failed to parse unusual_notation.json")
 }
 
 fn load_protein_notation_fixtures() -> ProteinNotationFixture {
-    let content = fs::read_to_string("tests/fixtures/edge_cases/protein_notation.json")
-        .expect("Failed to read protein_notation.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/edge_cases/protein_notation.json",
+    ))
+    .expect("Failed to read protein_notation.json");
     serde_json::from_str(&content).expect("Failed to parse protein_notation.json")
 }
 
@@ -451,8 +455,10 @@ struct ReferenceSeqStats {
 }
 
 fn load_reference_seq_fixtures() -> ReferenceSeqFixture {
-    let content = fs::read_to_string("tests/fixtures/edge_cases/reference_sequences.json")
-        .expect("Failed to read reference_sequences.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/edge_cases/reference_sequences.json",
+    ))
+    .expect("Failed to read reference_sequences.json");
     serde_json::from_str(&content).expect("Failed to parse reference_sequences.json")
 }
 

--- a/tests/it/external_pattern_tests.rs
+++ b/tests/it/external_pattern_tests.rs
@@ -9,8 +9,10 @@ use std::fs;
 
 /// Extract HGVS patterns from biocommons grammar_test.tsv
 fn extract_grammar_test_patterns() -> Vec<(String, bool)> {
-    let content = fs::read_to_string("tests/fixtures/external/biocommons_grammar_test.tsv")
-        .expect("Failed to read biocommons_grammar_test.tsv");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/biocommons_grammar_test.tsv",
+    ))
+    .expect("Failed to read biocommons_grammar_test.tsv");
 
     let mut patterns = Vec::new();
 
@@ -46,8 +48,10 @@ fn extract_grammar_test_patterns() -> Vec<(String, bool)> {
 
 /// Extract HGVS patterns from biocommons gauntlet file
 fn extract_gauntlet_patterns() -> Vec<(String, bool)> {
-    let content = fs::read_to_string("tests/fixtures/external/biocommons_gauntlet.txt")
-        .expect("Failed to read biocommons_gauntlet.txt");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/biocommons_gauntlet.txt",
+    ))
+    .expect("Failed to read biocommons_gauntlet.txt");
 
     let mut patterns = Vec::new();
 
@@ -83,8 +87,10 @@ fn extract_gauntlet_patterns() -> Vec<(String, bool)> {
 
 /// Extract HGVS patterns from biocommons real.tsv
 fn extract_real_tsv_patterns() -> Vec<(String, bool)> {
-    let content = fs::read_to_string("tests/fixtures/external/biocommons_real.tsv")
-        .expect("Failed to read biocommons_real.tsv");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/biocommons_real.tsv",
+    ))
+    .expect("Failed to read biocommons_real.tsv");
 
     let mut patterns = Vec::new();
 
@@ -114,8 +120,10 @@ fn extract_real_tsv_patterns() -> Vec<(String, bool)> {
 
 /// Extract HGVS patterns from mutalyzer test file
 fn extract_mutalyzer_patterns() -> Vec<(String, bool)> {
-    let content = fs::read_to_string("tests/fixtures/external/mutalyzer_patterns.txt")
-        .expect("Failed to read mutalyzer_patterns.txt");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/mutalyzer_patterns.txt",
+    ))
+    .expect("Failed to read mutalyzer_patterns.txt");
 
     let mut patterns = Vec::new();
 
@@ -136,8 +144,10 @@ fn extract_mutalyzer_patterns() -> Vec<(String, bool)> {
 
 /// Extract HGVS patterns from NCBI dbSNP file
 fn extract_ncbi_patterns() -> Vec<(String, bool)> {
-    let content = fs::read_to_string("tests/fixtures/external/ncbi_dbsnp.txt")
-        .expect("Failed to read ncbi_dbsnp.txt");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/ncbi_dbsnp.txt",
+    ))
+    .expect("Failed to read ncbi_dbsnp.txt");
 
     let mut patterns = Vec::new();
 

--- a/tests/it/idempotency_tests.rs
+++ b/tests/it/idempotency_tests.rs
@@ -61,8 +61,10 @@ struct SpecExample {
 
 #[allow(clippy::unnecessary_lazy_evaluations)]
 fn load_edge_cases() -> Vec<String> {
-    let content = fs::read_to_string("tests/fixtures/comprehensive_edge_cases.json")
-        .unwrap_or_else(|_| "{}".to_string());
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/comprehensive_edge_cases.json",
+    ))
+    .unwrap_or_else(|_| "{}".to_string());
     let fixture: EdgeCaseFixture =
         serde_json::from_str(&content).unwrap_or_else(|_| EdgeCaseFixture {
             mutalyzer_edge_cases: None,
@@ -100,8 +102,10 @@ fn load_edge_cases() -> Vec<String> {
 
 fn load_spec_examples() -> Vec<String> {
     crate::common::spec_fixture::ensure_spec_fixture();
-    let content = fs::read_to_string("tests/fixtures/grammar/hgvs_spec_normalization.json")
-        .expect("failed to read hgvs_spec_normalization.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/grammar/hgvs_spec_normalization.json",
+    ))
+    .expect("failed to read hgvs_spec_normalization.json");
     let fixture: HgvsSpecFixture =
         serde_json::from_str(&content).expect("failed to parse hgvs_spec_normalization.json");
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -118,6 +118,7 @@ mod corpus_prohibited_inputs;
 mod coverage_gap_tests;
 mod cross_doc_adjacent_changes;
 mod cross_doc_compliance;
+mod cwd_relative_fixture_paths;
 mod dbsnp_tests;
 mod defect_371_transcript_exit;
 mod defect_non_idempotent_outputs;

--- a/tests/it/mavedb_tests.rs
+++ b/tests/it/mavedb_tests.rs
@@ -64,8 +64,10 @@ struct Variant {
 }
 
 fn load_mavedb_fixtures() -> MaveDbFixture {
-    let content = fs::read_to_string("tests/fixtures/external/mavedb_functional.json")
-        .expect("Failed to read mavedb_functional.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/external/mavedb_functional.json",
+    ))
+    .expect("Failed to read mavedb_functional.json");
     serde_json::from_str(&content).expect("Failed to parse mavedb_functional.json")
 }
 

--- a/tests/it/mutalyzer_grammar_tests.rs
+++ b/tests/it/mutalyzer_grammar_tests.rs
@@ -42,8 +42,10 @@ struct Pattern {
 }
 
 fn load_mutalyzer_grammar_fixtures() -> MutalyzerGrammarFixture {
-    let content = fs::read_to_string("tests/fixtures/grammar/mutalyzer_github.json")
-        .expect("Failed to read mutalyzer_github.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/grammar/mutalyzer_github.json",
+    ))
+    .expect("Failed to read mutalyzer_github.json");
     serde_json::from_str(&content).expect("Failed to parse mutalyzer_github.json")
 }
 

--- a/tests/it/mutalyzer_tests.rs
+++ b/tests/it/mutalyzer_tests.rs
@@ -27,8 +27,10 @@ struct ParsingTestCase {
 }
 
 fn load_mutalyzer_fixtures() -> TestFixture {
-    let content = fs::read_to_string("tests/fixtures/normalization/mutalyzer.json")
-        .expect("Failed to read mutalyzer.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/normalization/mutalyzer.json",
+    ))
+    .expect("Failed to read mutalyzer.json");
     serde_json::from_str(&content).expect("Failed to parse mutalyzer.json")
 }
 

--- a/tests/it/parser_tests.rs
+++ b/tests/it/parser_tests.rs
@@ -33,8 +33,10 @@ struct ParsingTestCase {
 }
 
 fn load_parsing_fixtures() -> ParsingFixtures {
-    let content = fs::read_to_string("tests/fixtures/grammar/parsing.json")
-        .expect("Failed to read parsing fixtures");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/grammar/parsing.json",
+    ))
+    .expect("Failed to read parsing fixtures");
     serde_json::from_str(&content).expect("Failed to parse fixtures JSON")
 }
 

--- a/tests/it/variantvalidator_tests.rs
+++ b/tests/it/variantvalidator_tests.rs
@@ -29,8 +29,10 @@ struct TestCase {
 }
 
 fn load_variantvalidator_fixtures() -> TestFixture {
-    let content = fs::read_to_string("tests/fixtures/validation/variantvalidator.json")
-        .expect("Failed to read variantvalidator.json");
+    let content = fs::read_to_string(crate::common::fixture_gen::fixture_path(
+        "tests/fixtures/validation/variantvalidator.json",
+    ))
+    .expect("Failed to read variantvalidator.json");
     serde_json::from_str(&content).expect("Failed to parse variantvalidator.json")
 }
 


### PR DESCRIPTION
Closes #2019.

Representation-Change: none. Tests only; no watched source file is touched.

## The defect

A test's working directory is a property of its **package**, not the repository. `cargo nextest` runs a module from its package root, so a module compiled into the root `ferro-hgvs` package's `it` target runs from the workspace root, while the *same* module `#[path]`-included by the `ferro-hgvs-soak-tests` member (`tests-soak/tests/soak/main.rs`) runs from `tests-soak/`. A fixture read against a bare relative path therefore works in `it` and breaks the moment the module is pulled into the soak driver — and it breaks by reporting the file missing, which reads as an environment problem rather than a path bug.

The class had been rediscovered three times, the last only after a push reddened CI:

| module | landed in | found by |
|---|---|---|
| `common/bulk_fixtures.rs` | #1977 | during development |
| `common/fixture_gen.rs` | #1977 | during development |
| `clinvar_hgvs_tests.rs` | #2001 | **CI, after the push** |

Measured on `origin/main` (`e16f99ca`): **23 direct `fs::read_to_string` / `File::open` reads on a `"tests/fixtures/…"` literal, across 15 modules**, resolve against the cwd. None is in the soak driver today, so nothing is broken yet — but every module moved in (e.g. #2003's proposal) re-rolls the dice, at the cost of a red CI run rather than a local failure.

## The fix

Route all 23 sites through `common::fixture_gen::fixture_path`, which anchors on `CARGO_MANIFEST_DIR` and ascends to the workspace `Cargo.lock` (which cargo writes only at the workspace root), so it resolves correctly from either package:

```rust
// before
fs::read_to_string("tests/fixtures/external/biocommons_real.tsv")
// after
fs::read_to_string(fixture_gen::fixture_path("tests/fixtures/external/biocommons_real.tsv"))
```

The affected modules: `biocommons_tests`, `clinical_genes_tests`, `clinvar_tests`, `clinvar_validation`, `comprehensive_edge_case_tests`, `conformance_summary_generated`, `dbsnp_tests`, `edge_case_notation_tests`, `external_pattern_tests`, `idempotency_tests`, `mavedb_tests`, `mutalyzer_grammar_tests`, `mutalyzer_tests`, `parser_tests`, `variantvalidator_tests`.

**No fixture content or test semantics change** — only how each path is resolved.

## The guard

New module `cwd_relative_fixture_paths` scans every `tests/it` source and fails on any filesystem read whose direct argument is a `"tests/fixtures/…"` string literal — the exact shape all three prior instances took, and the one a new test is most likely to reintroduce by copy-paste. It stops instance four.

It is a token scan (a floor, not a proof) and its limits are stated in the module docs: a path bound to a variable and read later, or composed at run time, is invisible to it — the fs call sees an identifier, not the literal. It does see through rustfmt's line-wrapping, and `the_detector_matches_direct_reads_and_only_those` pins both directions (the shapes it must catch, and the already-anchored shapes it must not) against a synthetic sample, so the matcher cannot silently stop matching after the tree is swept clean.

**Out of scope, and left for a follow-up:** `conformance_summary_generated` also passes two `Path::new("tests/fixtures/…failure-patterns.md")` values to `summary::check`, and a handful of other modules (`api_comparison_tests`, `spdi_tests`, `annotation_real_format_slices`, …) read fixtures through a `Path::new`/variable indirection. Those are the broader indirect class the issue's census deliberately did not count and this guard does not claim to catch; anchoring them is a separate, larger sweep.

## Verification

```
cargo fmt --all --check                                  # clean
cargo clippy --all-features --all-targets -- -D warnings # clean
cargo nextest run --features dev --no-fail-fast          # 11166 passed, 0 failed, 155 skipped
```

The guard was developed TDD: it flagged exactly the 23 sites (RED) before the sweep, and passes after (GREEN).