### PR TITLE
perf(normalize): bound insertion→dup/repeat rotation scan to linear time

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -358,6 +358,19 @@ pub fn insertion_to_repeat(
         return None;
     }
 
+    // #1846: the same early exit `insertion_to_duplication` carries, for the
+    // same reason. This loop rotates and rebuilds a `base_unit.len()`-byte `Vec`
+    // once per base of the unit; when the unit outgrows `ref_seq` every
+    // rotation's `find_tandem_extent` returns `None`, so `best` is already
+    // `None` and the Θ(unit²) work is guaranteed futile. An aperiodic payload
+    // returns above (`added_copies == 1` routes to the dup path), so this fires
+    // only for a payload that really is 2+ copies of an oversized unit — e.g.
+    // two copies of a multi-megabase unit — which the `added_copies` guard does
+    // not bound. See the fuller note on `insertion_to_duplication`.
+    if base_unit.len() > ref_seq.len() {
+        return None;
+    }
+
     // The c.-context codon gate (repeated.md: unit_len % 3 == 0) is applied
     // inside `normalize_repeat` below, not here — see the delegation note.
 
@@ -742,6 +755,23 @@ pub(crate) fn insertion_to_duplication(
     let added_copies = inserted_seq.len() / base_unit.len();
     if added_copies != 1 {
         // 2+-copy insertions are handled by `insertion_to_repeat`.
+        return None;
+    }
+
+    // #1846: bail before the rotation scan when the unit cannot fit the window.
+    // Every rotation below has length `base_unit.len()`, and `find_tandem_extent`
+    // skips every anchor once `anchor + unit.len() > ref_seq.len()` — so a unit
+    // longer than `ref_seq` matches no anchor in any rotation, and `best` is
+    // already determined to stay `None`. Without this exit the loop still runs
+    // `base_unit.len()` iterations, each allocating and filling a
+    // `base_unit.len()`-byte `Vec`, i.e. Θ(L²) bytes copied to reach that fixed
+    // `None`. A spec-legal `ins[ACC:g.A_B]` expands to a payload of the named
+    // range's length (a 38-char cross-reference named 10.8 MB), so an unbounded
+    // scan here never terminates on such input; the early exit makes it O(L).
+    // `ref_seq` is the fetched shuffle window (default 100 bases, grown by
+    // `normalize_in_grown_window`), so this fires only far above any window the
+    // normalizer actually uses and cannot change which inputs convert to a dup.
+    if base_unit.len() > ref_seq.len() {
         return None;
     }
 
@@ -6493,6 +6523,121 @@ mod tests {
         assert_eq!(
             (got.unit.as_slice(), got.start, got.end),
             (&b"TCC"[..], 6, 8)
+        );
+    }
+
+    /// #1846: a payload whose smallest repeat unit is longer than the reference
+    /// window cannot convert — no rotation can match a tract that does not fit —
+    /// so both conversions decline. Pins the *output* the linear early exit
+    /// preserves, on inputs small enough to read at a glance.
+    #[test]
+    fn insertion_conversions_decline_when_the_unit_outgrows_the_window_1846() {
+        // Window shorter than the (aperiodic, single-copy) payload: dup path.
+        let ref_seq = b"ACGT";
+        assert!(
+            insertion_to_duplication(ref_seq, 1, b"ACGTAC", ShuffleDirection::ThreePrime).is_none()
+        );
+        assert!(
+            insertion_to_duplication(ref_seq, 1, b"ACGTAC", ShuffleDirection::FivePrime).is_none()
+        );
+        // Two copies of a 6-base unit that is itself longer than the window:
+        // repeat path (`added_copies == 2`).
+        assert!(insertion_to_repeat(
+            ref_seq,
+            1,
+            b"ACGTAAACGTAA",
+            false,
+            None,
+            ShuffleDirection::ThreePrime
+        )
+        .is_none());
+    }
+
+    /// #1846 boundary guard: a unit whose length exactly EQUALS the reference
+    /// window must still convert — `find_tandem_extent` accepts anchor 0 there
+    /// (`0 + unit.len() == ref_seq.len()`, not `>`). This pins that the early
+    /// exit is strict `>` and not `>=`; a `>=` would silently decline this real
+    /// single-copy duplication while passing every other test.
+    #[test]
+    fn insertion_to_duplication_converts_when_the_unit_exactly_fills_the_window_1846() {
+        // `ACGT` inserted at the 3' end duplicates the whole 4-base window.
+        let ref_seq = b"ACGT";
+        let got = insertion_to_duplication(ref_seq, 3, b"ACGT", ShuffleDirection::ThreePrime)
+            .expect("a single-copy dup of the whole window must still convert");
+        assert_eq!(got.unit, b"ACGT");
+        assert_eq!((got.start, got.end), (1, 4));
+    }
+
+    /// #1846: `insertion_to_duplication` must not scan every rotation of the
+    /// expanded insert payload. When the smallest repeat unit is longer than the
+    /// reference window, `find_tandem_extent` skips every anchor (it needs
+    /// `anchor + unit.len() <= ref_seq.len()`), so no rotation can match and the
+    /// result is *determined* to be `None` — but the pre-#1846 loop still
+    /// allocated and filled a payload-sized `Vec` on each of `payload.len()`
+    /// iterations, i.e. Θ(L²) bytes copied to reach a `None` already fixed. A
+    /// spec-legal `ins[ACC:g.A_B]` expands to that whole named range, so this
+    /// never terminated on a megabase cross-reference insert.
+    ///
+    /// Measured on the unfixed code, this doubled from ~1.0 s at L=200 kb to
+    /// ~5.7 s at L=400 kb (≈4-6x per doubling); the early exit makes it O(L).
+    /// The wall-clock bound is a loud backstop against a quadratic regression,
+    /// generous by ~three orders of magnitude over the linear cost (a few ms) so
+    /// it cannot flake on a loaded machine.
+    #[test]
+    fn insertion_to_duplication_does_not_rescan_a_megabase_payload_1846() {
+        let ref_seq = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        // Aperiodic, single-copy: `smallest_repeat_unit` returns the whole
+        // payload, so `added_copies == 1` and the rotation loop is the hot path.
+        let mut payload = vec![b'A'; 2_000_000];
+        payload[0] = b'C';
+        let start = std::time::Instant::now();
+        let got = insertion_to_duplication(ref_seq, 30, &payload, ShuffleDirection::ThreePrime);
+        let elapsed = start.elapsed();
+        assert!(
+            got.is_none(),
+            "a payload longer than the reference window cannot be a duplication"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "insertion_to_duplication took {elapsed:?} on a 2 Mb payload — the O(payload^2) \
+             rotation scan is back"
+        );
+    }
+
+    /// #1846 sibling: `insertion_to_repeat` carries the identical rotation loop,
+    /// reached when the payload is two or more copies of its unit. Two copies of
+    /// a 1 Mb aperiodic unit exercises it, and the same early exit applies — the
+    /// unit outgrows the window, so every rotation's `find_tandem_extent`
+    /// returns `None` and the result is a determined `None` in O(unit) rather
+    /// than Θ(unit²).
+    #[test]
+    fn insertion_to_repeat_does_not_rescan_a_megabase_payload_1846() {
+        let ref_seq = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        // Two copies of a 1 Mb aperiodic unit: `smallest_repeat_unit` returns the
+        // 1 Mb unit and `added_copies == 2`, so the rotation loop runs.
+        let unit_len = 1_000_000;
+        let mut unit = vec![b'A'; unit_len];
+        unit[0] = b'C';
+        let mut payload = unit.clone();
+        payload.extend_from_slice(&unit);
+        let start = std::time::Instant::now();
+        let got = insertion_to_repeat(
+            ref_seq,
+            30,
+            &payload,
+            false,
+            None,
+            ShuffleDirection::ThreePrime,
+        );
+        let elapsed = start.elapsed();
+        assert!(
+            got.is_none(),
+            "a repeat unit longer than the reference window cannot match a tract"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "insertion_to_repeat took {elapsed:?} on a 2 Mb payload — the O(payload^2) \
+             rotation scan is back"
         );
     }
 


### PR DESCRIPTION
Closes #1846.

Representation-Change: none. Output-preserving by construction — the early exit returns `None` exactly where the pre-existing loop was already determined to return `None`; classification is unchanged, verified by unit tests (the outgrows-window decline and the exactly-fills-window conversion both hold before and after). The guard fires only for a repeat unit longer than the fetched shuffle window, a payload size the synthetic corpus cannot build, so a corpus diff is a structural zero rather than a measurement.

## The defect

`insertion_to_duplication` (and its deliberate symmetric sibling `insertion_to_repeat`) scan every cyclic rotation of the *expanded* insert payload, rebuilding a payload-sized `Vec` on each of `unit.len()` iterations — Θ(L²) bytes copied and L allocations of L bytes. A spec-legal `ins[ACC:g.A_B]` resolves the cross-reference to the whole named range, so a megabase insert never terminates and grows RSS to gigabytes. The two corpus rows that stall (per #1846):

- `NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]` (payload 10.8 MB)
- the same with a trailing `inv`

Measured on the unfixed code (debug unit test, aperiodic single-copy payload): ~1.0 s at L=200 kb → ~5.7 s at L=400 kb, i.e. ~5.6× per doubling — quadratic. Extrapolated, the corpus's 10.8 MB payload is ~52 min per row.

## The fix

`find_tandem_extent` skips every candidate anchor once `anchor + unit.len() > ref_seq.len()`. Every rotation has length `base_unit.len()`, so when the unit is longer than the reference window **no** rotation can match any anchor — `best` stays `None` and the function is already determined to return `None`, after paying L allocations of L bytes for it. Bail before the loop:

```rust
if base_unit.len() > ref_seq.len() {
    return None;
}
```

Applied to **both** functions — `insertion_to_repeat` carries the identical loop, reached when the payload is 2+ copies of an oversized unit (an aperiodic payload returns earlier via the `added_copies == 1` route to the dup path). Detection goes from Θ(L²) to O(L). `ref_seq` here is the fetched shuffle window (default 100 bases, grown by `normalize_in_grown_window`), so the guard fires only far above any window the normalizer actually uses.

## Unchanged on purpose (the discriminating cases)

- The guard is strict `>`, not `>=`: a unit whose length exactly equals the window still matches at anchor 0 (`0 + unit.len() == ref_seq.len()`, which `find_tandem_extent` accepts), so it is a real single-copy duplication. `insertion_to_duplication_converts_when_the_unit_exactly_fills_the_window_1846` pins that it still converts — a `>=` over-generalization would silently decline it while passing every other test.
- `insertion_conversions_decline_when_the_unit_outgrows_the_window_1846` pins that both paths decline when the unit outgrows the window (the classification the early exit preserves).

## Verification

```
cargo fmt --all --check                                   # clean
cargo clippy --all-features --all-targets -- -D warnings  # clean
cargo nextest run --features dev --no-fail-fast           # 11173 passed, 0 failed, 155 skipped
```

The two 2 Mb / 2×1 Mb payload guards (`*_does_not_rescan_a_megabase_payload_1846`) complete in ~0.04 s each on the fix and would hang on the quadratic version.