### PR TITLE
test(normalize): re-arm the cis guards #1835 made vacuous

### DIFF
--- a/tests/it/cis_junction_crossing_shift.rs
+++ b/tests/it/cis_junction_crossing_shift.rs
@@ -296,25 +296,38 @@ fn a_multi_base_duplication_beside_an_insertion_merges_from_the_sequence() {
 /// only oracle is `apply`, and their second member is always a single-base `dup`,
 /// exactly the length at which `len - 1` is zero and the over-clamp disappears.
 ///
-/// The third member is what keeps the property visible. `15del` stops the
-/// *merge* without touching the shift: the block is no longer one run of change,
-/// so the derivation declines to collapse the allele and the per-member pipeline
-/// decides the output again, which is where the barrier lives. The `dup` then
+/// A third member is what keeps the property visible: it has to stop the
+/// *merge* without touching the shift, so that the per-member pipeline — which
+/// is where the barrier lives — decides the output again. The `dup` then
 /// reaches `4_5dup` and the spelling is observable.
 ///
-/// **Distance measured, not assumed.** Sweeping every third-member position on
-/// `DUP_RUN`: at `10del` and `11del` the member joins the block and the allele
-/// merges again (to `g.[4_5insC;10_11insT]`) — a test written there would be
-/// vacuous in a new way, pinning a merged form while claiming to pin a barrier.
-/// `12del` and `13del` are clear but only 1-2 nt past the tract; at `14del` and
-/// `18del` the third member itself 5'-shifts, which muddies the row. `15del` is
-/// 4 nt clear, stays exactly where it is written, and reaches the tie.
+/// # The fixture moved, because distance stopped being what blocks the merge
 ///
-/// **Fails both ways.** Deleting `.filter(|_| a.junction.is_none())` from the 5'
-/// branch of `clamp_sibling_crossing_shifts` turns this output into
-/// `g.[4_5insC;5_6dup;15del]`; restoring it turns it back. (Removing the whole
-/// 5' `across_junctions` barrier instead leaves this row green — that half is
-/// guarded by `an_insertion_merging_with_a_deletion_keeps_its_base_in_place`.)
+/// This row used to read `DUP_RUN` with `15del` as the third member, on the
+/// reasoning that a member 4 nt clear of the tract broke the block into more
+/// than one run of change and made the derivation decline. The partition
+/// default flip (**#1835**) ended that: the whole allele is now derived from the
+/// resulting sequence and collapses to `g.[3_4insACT;15del]`, which
+/// [`the_three_member_spelling_and_its_one_member_form_are_two_fixed_points`]
+/// below pins as the adjudicated answer. **At that fixture this row became
+/// vacuous** — with no `dup` in the output at all, deleting
+/// `.filter(|_| a.junction.is_none())` cannot change what it asserts.
+///
+/// So the decline this row needs is a **structural** one rather than a distance
+/// one. A third member past `MAX_CANONICAL_WINDOW` (4096) refuses the window
+/// before any alignment runs, so the per-member pipeline decides, exactly as it
+/// did before — and nothing about that refusal can be undone by a better
+/// alignment. The reference is built rather than drawn from `sweep_sequences`
+/// for the same reason: those are 20-mers, and 20 nt cannot express a 4 kb
+/// separation.
+///
+/// **Fails both ways, re-measured on this fixture.** Deleting
+/// `.filter(|_| a.junction.is_none())` from the 5' branch of
+/// `clamp_sibling_crossing_shifts` strands the member at its input position and
+/// turns this output into `g.[4_5insC;5_6dup;4300del]`; restoring it turns it
+/// back. (Removing the whole 5' `across_junctions` barrier instead leaves this
+/// row green — that half is guarded by
+/// `an_insertion_merging_with_a_deletion_keeps_its_base_in_place`.)
 ///
 /// **The pinned string is where the barrier puts the member, NOT an adjudicated
 /// canonical form.** Read only as a barrier assertion it is exactly right; read
@@ -323,51 +336,44 @@ fn a_multi_base_duplication_beside_an_insertion_merges_from_the_sequence() {
 /// [`the_three_member_spelling_and_its_one_member_form_are_two_fixed_points`]
 /// below, which is the row to read before re-blessing this one.
 ///
-/// # RE-PINNED BY THE PARTITION DEFAULT FLIP (#1835), AND IT NO LONGER BOUNDS
-/// THE BARRIER
-///
-/// The paragraph directly above said to read the adjudication row before
-/// re-blessing this one. That row's gap is now **closed**: under the
-/// `canonical-coalesced` default the three-member spelling is re-derived rather
-/// than handed back, so this input reaches `TEMPLATE:g.[3_4insACT;15del]` — one
-/// insertion and the distant deletion — and there is no `dup` in the output at
-/// all.
-///
-/// **So this row has taken exactly the fate its own sibling took**, and the
-/// warning is worth repeating rather than re-learning. The doc on
-/// [`a_multi_base_duplication_beside_an_insertion_merges_from_the_sequence`]
-/// records that when *that* row's pair merged it stopped bounding anything —
-/// "the output contains no duplication at all, so the property in its old name is
-/// not exercised here" — and moved the coverage here, to the row with a third
-/// member blocking the merge. The third member no longer blocks it, so the same
-/// thing has now happened to this row.
-///
-/// **THE OVER-CLAMP GUARD IS THEREFORE UNCOVERED BY THIS FILE.** The "fails both
-/// ways" paragraph above is stale as a claim about the *current* default:
-/// deleting `.filter(|_| a.junction.is_none())` from the 5' branch of
-/// `clamp_sibling_crossing_shifts` cannot change an output that contains no
-/// `dup`. That is a real coverage loss, not a re-pin, and it is recorded here
-/// rather than papered over — the guard is still reachable under
-/// `FERRO_PARTITION=live`, which is why the arm remains selectable by name, but
-/// no test in this file exercises it on the default arm. Re-establishing it needs
-/// a shape whose members survive the derivation; this core no longer supplies
-/// one.
-///
 /// Licensed by the same two records as its sibling:
 /// `contiguous-insertion-split-by-a-blocked-derivation` (the locus carries one
 /// variant, so `general.md:34` never reached it) and
 /// `duplication-must-ranks-the-label-not-the-partition` (decided 2026-08-13,
-/// which names this test by its full path and classes the move as a gap closing).
+/// which names this test by its full path).
 #[test]
 fn a_third_member_clear_of_the_tract_keeps_the_duplication_reaching_its_five_prime_most_position() {
     assert_normalizes_preserving_in(
-        DUP_RUN,
-        "TEMPLATE:g.[4_5insC;5_6dup;15del]",
-        // #1835: was `TEMPLATE:g.[4_5insC;4_5dup;15del]` — see above, and note
-        // the name of this test now describes what it USED to assert.
-        "TEMPLATE:g.[3_4insACT;15del]",
+        &window_refusing_reference(),
+        "TEMPLATE:g.[4_5insC;5_6dup;4300del]",
+        "TEMPLATE:g.[4_5insC;4_5dup;4300del]",
         ShuffleDirection::FivePrime,
     );
+}
+
+/// `DUP_RUN`'s tract, then filler out past `MAX_CANONICAL_WINDOW`'s 4096.
+///
+/// The tract is the head of the sequence so the `ins`/`dup` pair keeps the exact
+/// coordinates the sibling rows use; only the third member is far away.
+///
+/// **The property that matters is about position 4300, not about the filler.**
+/// `CGGT` is *not* run-free — it carries a `GG` pair, so 4298 and 4299 are a
+/// two-base run and a deletion written there would 5'-shift. What makes the
+/// pinned `4300del` stable is that 4300 is the `T` of a `…GGT|C…` boundary,
+/// i.e. a run of one, flanked by `G` and `C`. So the third member's position is
+/// **not** freely movable: moving it by one or two lands it inside the `GG` and
+/// silently changes what this row measures. Re-derive the run before moving it.
+///
+/// (`synthetic::extended_core` does the same job with an `ACGT` filler, which
+/// genuinely has no adjacent repeat; the four sibling rows re-fixtured alongside
+/// this one use it. This helper stays local only because its tract must sit at
+/// the head of the sequence rather than inside `padded`'s 256-base pad.)
+fn window_refusing_reference() -> String {
+    let mut reference = String::from(DUP_RUN);
+    while reference.len() < 4400 {
+        reference.push_str("CGGT");
+    }
+    reference
 }
 
 /// ADJUDICATED 2026-08-09 — one variant, two stable normalized strings.

--- a/tests/it/common/synthetic.rs
+++ b/tests/it/common/synthetic.rs
@@ -38,6 +38,35 @@ pub fn padded(core: &str) -> String {
     format!("{}{}{}", PAD, core, PAD)
 }
 
+/// `core` followed by `ACGT` filler, out to at least `len` bases.
+///
+/// The filler continues the pad's own period-4 `ACGT` rotation, and the pad's
+/// first base is `A`, so the bases immediately either side of `core` are
+/// byte-identical to the ones [`padded`] gives it — only the distance to the far
+/// end grows. Nothing about a variant inside `core` can therefore change.
+///
+/// It exists to place a **third cis member past `merge::MAX_CANONICAL_WINDOW`**
+/// (4096). The sequence-first derivation refuses a window that wide before it
+/// aligns anything, so the per-member pipeline decides the output — which is
+/// where the sibling barriers and `cis_member_order_key` live, and the only
+/// state in which they are observable. A merely *distant* member no longer
+/// serves: since the partition default flip (**#1835**) the whole allele is
+/// derived from the resulting sequence however far apart its members sit, so
+/// every row that leaned on distance to block the derivation went vacuous. Each
+/// of those rows records the exact merged string it read once that happened.
+///
+/// A single-base deletion inside the filler is stable in both directions:
+/// every base of a period-4 tandem differs from both its neighbours, so there is
+/// no run for it to shift along.
+#[allow(dead_code)]
+pub fn extended_core(core: &str, len: usize) -> String {
+    let mut extended = core.to_string();
+    while extended.len() < len {
+        extended.push_str("ACGT");
+    }
+    extended
+}
+
 /// Builder for synthetic `MockProvider` fixtures across HGVS coord systems.
 ///
 /// All builders pad the input core sequence with 256 bases on each side so

--- a/tests/it/issue_1261_cis_member_order.rs
+++ b/tests/it/issue_1261_cis_member_order.rs
@@ -33,6 +33,7 @@
 //! only, so every assertion below pairs the order check with the apply oracle.
 
 use crate::common::cis_apply_oracle::{apply, assert_members_ascending, normalize};
+use crate::common::synthetic::extended_core;
 
 /// `("ACGT" x 64) + core + ("ACGT" x 64)`, so `core[i]` is at 1-based position
 /// `257 + i`. Padding keeps every shift well away from a contig boundary.
@@ -84,12 +85,18 @@ fn two_duplications_sharing_a_start_render_in_junction_order_beside_a_third_memb
     // first — and with the descriptor tie-break it did not, since
     // `"258_259dup" < "258dup"`.
     //
-    // The deletion at 268 is what keeps the pair from being derived into one
-    // insertion (the shape above): it sits well clear of the A-run the payloads
-    // shift through, so it does not move them, but the derivation declines the
-    // three-member group and the two duplications survive to be sorted. This is
-    // the same device `issue_1304_junction_barrier_snapshot`'s
-    // `a_moved_sibling_still_bars_the_crossing_it_started_at` uses.
+    // The third member is what keeps the pair from being derived into one
+    // insertion (the shape above): the derivation declines the three-member
+    // group and the two duplications survive to be sorted. This is the same
+    // device `issue_1304_junction_barrier_snapshot` uses.
+    //
+    // It sits past `MAX_CANONICAL_WINDOW` (4096), which refuses the window
+    // before any alignment runs. A merely distant member — this row used
+    // `268del` — stopped working at the partition default flip (**#1835**): the
+    // whole allele derives however far off that member is, and this read
+    // `g.[258_259insAGA;268del]`, which is the row above with a deletion
+    // attached. `synthetic::extended_core` records why extending the core
+    // cannot disturb the pair.
     //
     // Without it the shared-start tie would be pinned only on the protein axis
     // (`protein_members_sharing_a_start_render_in_end_order`), which cannot
@@ -132,10 +139,10 @@ fn two_duplications_sharing_a_start_render_in_junction_order_beside_a_third_memb
     // recorded here rather than papered over; closing it needs a nucleotide shape
     // whose members survive the derivation, which this core no longer supplies.
     let output = assert_ordered_and_preserving(
-        "CAGTATGCAGGCAA",
-        "TEMPLATE:g.[258_259insA;259_260insAG;268del]",
+        &extended_core("CAGTATGCAGGCAA", 4400),
+        "TEMPLATE:g.[258_259insA;259_260insAG;4500del]",
     );
-    assert_eq!(output, "TEMPLATE:g.[258_259insAGA;268del]");
+    assert_eq!(output, "TEMPLATE:g.[258dup;258_259dup;4500del]");
 }
 
 #[test]
@@ -143,12 +150,12 @@ fn the_shared_start_order_beside_a_third_member_is_authored_order_independent() 
     // The sort must be total on the three-member shape too, or the tie above is
     // being decided by input order rather than by the key.
     let forward = assert_ordered_and_preserving(
-        "CAGTATGCAGGCAA",
-        "TEMPLATE:g.[258_259insA;259_260insAG;268del]",
+        &extended_core("CAGTATGCAGGCAA", 4400),
+        "TEMPLATE:g.[258_259insA;259_260insAG;4500del]",
     );
     let reverse = assert_ordered_and_preserving(
-        "CAGTATGCAGGCAA",
-        "TEMPLATE:g.[268del;259_260insAG;258_259insA]",
+        &extended_core("CAGTATGCAGGCAA", 4400),
+        "TEMPLATE:g.[4500del;259_260insAG;258_259insA]",
     );
     assert_eq!(forward, reverse);
 }

--- a/tests/it/issue_1301_adjacent_gap_member_order.rs
+++ b/tests/it/issue_1301_adjacent_gap_member_order.rs
@@ -21,14 +21,20 @@
 //! discriminator — a member adding at its span's *start* sorts before one acting
 //! across the whole span.
 
-use crate::common::synthetic::{padded, SyntheticBuilder};
+use crate::common::synthetic::{extended_core, padded, SyntheticBuilder};
 use ferro_hgvs::spdi::hgvs_to_spdi;
 use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
 
 const CORE: &str = "GCATGAAAAT";
 
 fn normalize(input: &str) -> String {
-    let provider = SyntheticBuilder::genomic(CORE).build();
+    normalize_in(CORE, input)
+}
+
+/// [`normalize`] over a caller-supplied core, so a row can place a member past
+/// `merge::MAX_CANONICAL_WINDOW` — see [`extended_core`].
+fn normalize_in(core: &str, input: &str) -> String {
+    let provider = SyntheticBuilder::genomic(core).build();
     Normalizer::new(provider)
         .normalize(&parse_hgvs(input).expect("parse"))
         .expect("normalize")
@@ -38,7 +44,12 @@ fn normalize(input: &str) -> String {
 /// The interbase start of each member, in rendered order, via `hgvs_to_spdi` —
 /// a different code path from the ordering key under test.
 fn member_starts(descriptor: &str) -> Vec<u64> {
-    let provider = SyntheticBuilder::genomic(CORE).build();
+    member_starts_in(CORE, descriptor)
+}
+
+/// [`member_starts`] over a caller-supplied core.
+fn member_starts_in(core: &str, descriptor: &str) -> Vec<u64> {
+    let provider = SyntheticBuilder::genomic(core).build();
     let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).expect("parse") {
         HgvsVariant::Allele(allele) => allele.variants.clone(),
         single => vec![single],
@@ -56,8 +67,13 @@ fn member_starts(descriptor: &str) -> Vec<u64> {
 /// Assert the output denotes the input's bases, so an ordering test cannot pass
 /// by rendering a *wrong* pair tidily.
 fn assert_preserving(input: &str, output: &str) {
-    let provider = SyntheticBuilder::genomic(CORE).build();
-    let reference = padded(CORE);
+    assert_preserving_in(CORE, input, output)
+}
+
+/// [`assert_preserving`] over a caller-supplied core.
+fn assert_preserving_in(core: &str, input: &str, output: &str) {
+    let provider = SyntheticBuilder::genomic(core).build();
+    let reference = padded(core);
     let denote = |descriptor: &str| -> Option<String> {
         let members: Vec<HgvsVariant> = match parse_hgvs(descriptor).ok()? {
             HgvsVariant::Allele(allele) => allele.variants.clone(),
@@ -132,47 +148,25 @@ fn an_insertion_still_sorts_before_a_duplication_sharing_its_span_beside_a_third
     // its copy after its last base, at 265. Both span `264_265`, so start and
     // end tie and only `junction_rank` separates them.
     //
-    // The deletion at 270 is what keeps the pair from being derived into one
+    // The third member is what keeps the pair from being derived into one
     // insertion (see `an_insertion_sorts_before_a_duplication_sharing_its_span`
-    // above, whose two-member form now merges). It sits clear of the A-run the
-    // payloads shift through — a deletion at 266 or 267 would block the shift
-    // and the pair would never reach the tie at all — so the members still
-    // re-spell exactly as they did, and the tie is still broken by the key.
+    // above, whose two-member form now merges), so the members still re-spell
+    // exactly as they did and the tie is still broken by the key.
     //
-    // # RE-PINNED BY THE PARTITION DEFAULT FLIP (#1835)
-    //
-    // Was `NC_TEST.1:g.[264_265insCA;264_265dup;270del]`; now
-    // `NC_TEST.1:g.[264_265insCAAA;270del]` — the same single insertion the
-    // two-member case above already reaches, so the third member has stopped
-    // blocking the derivation.
-    //
-    // LICENSED BY `duplication-must-ranks-the-label-not-the-partition` (decided,
-    // operator ruling 2026-08-13), which names this test by its full path. The
-    // record classes it as inside `contiguous-insertion-split-by-a-blocked-derivation`'s
-    // STATED reach: that record's REPRESENTATION EFFECT paragraph predicted this
-    // geometry by description in advance — a junction-adjacent `ins`+`dup` pair
-    // beside a third member far enough away to block the derivation, moving "to a
-    // single insertion".
-    //
-    // `duplication.md:18`'s MUST is not being ignored. Under that ruling it ranks
-    // the *label* for a change rather than requiring a partition that exposes
-    // one, and it is applied per piece of the partition re-derived from the
-    // resulting sequence; the single `CAAA` insertion is not a copy of the
-    // reference bases immediately 5' of its insertion point, so the clause does
-    // not reach it.
-    //
-    // WHAT THIS TEST NO LONGER EXERCISES, stated because the whole file is about
-    // it: with one member there is no `junction_rank` tie left to break here. The
-    // tie is still broken and still asserted on the protein cases below, where
-    // both members tie on start and end — the same fallback the two-member case
-    // above already records. The interbase-order assertion below is kept and is
-    // now trivially satisfied.
-    let input = "NC_TEST.1:g.[263_264insAC;264_265insAA;270del]";
-    let output = normalize(input);
-    assert_eq!(output, "NC_TEST.1:g.[264_265insCAAA;270del]");
-    assert_preserving(input, &output);
+    // It sits past `MAX_CANONICAL_WINDOW` (4096), which refuses the window
+    // before any alignment runs. `270del` used to do the job by being 4 nt clear
+    // of the A-run; the partition default flip (**#1835**) ended that, because
+    // the derivation answers the whole allele however distant that member is —
+    // this row read `g.[264_265insCAAA;270del]`, with no tie left to break. The
+    // near end is still a trap: a deletion at 266 or 267 blocks the shift and the pair
+    // never reaches the tie at all.
+    let core = extended_core(CORE, 4400);
+    let input = "NC_TEST.1:g.[263_264insAC;264_265insAA;4500del]";
+    let output = normalize_in(&core, input);
+    assert_eq!(output, "NC_TEST.1:g.[264_265insCA;264_265dup;4500del]");
+    assert_preserving_in(&core, input, &output);
 
-    let starts = member_starts(&output);
+    let starts = member_starts_in(&core, &output);
     assert!(
         starts.windows(2).all(|pair| pair[0] <= pair[1]),
         "`{output}` renders its members out of interbase order: {starts:?}"

--- a/tests/it/issue_1304_junction_barrier_snapshot.rs
+++ b/tests/it/issue_1304_junction_barrier_snapshot.rs
@@ -28,7 +28,7 @@
 //! insertions and denoting different bases, with both members well-formed and
 //! disjoint. Nothing else catches it.
 
-use crate::common::synthetic::assert_padded_preserving;
+use crate::common::synthetic::{assert_padded_preserving, extended_core};
 
 const CORE: &str = "GCATGAAAAT";
 
@@ -90,64 +90,32 @@ fn a_third_member_clear_of_the_tract_keeps_the_pair_barred() {
     // so on its own it no longer says anything about crossing.
     //
     // A third member restores it by stopping the *merge* without touching the
-    // shift. `270del` is 4 nt clear of the `GCATGAAAAT` tract the two payloads
-    // shuffle through, so the derivation declines to collapse the allele — the
-    // block is no longer one run of change — and the per-member pipeline decides
-    // the output again, which is where the barrier lives. The pair then stays
-    // exactly where the barrier puts it: `insGA` may not sweep from 260 past the
-    // `insA` at 261, because `GA` and `A` do not commute and their order is
-    // observable.
+    // shift, so the per-member pipeline decides the output again — which is
+    // where the barrier lives. The pair then stays exactly where the barrier
+    // puts it: `insGA` may not sweep from 260 past the `insA` at 261, because
+    // `GA` and `A` do not commute and their order is observable.
     //
-    // The distance matters in both directions, and the near end is a trap worth
-    // naming: at `266del` and `267del` the third member is close enough to join
-    // the block, and the allele merges again (to `g.[261_262dup;266T>A]` and
-    // `g.[263A>G;266T>A;267_268insAT]` respectively) — a test written there would
-    // be vacuous in a new way, pinning a merged form while claiming to pin a
-    // barrier. `270del` and `272del` both sit clear; 270 is used here.
+    // **Distance is no longer what stops the merge.** This row used `270del`, 4
+    // nt clear of the `GCATGAAAAT` tract, on the reasoning that the block was
+    // then more than one run of change. The partition default flip (**#1835**)
+    // removed that: the derivation now answers the whole allele however far off
+    // the third member sits, and the row went vacuous — it read
+    // `g.[262_263insGAA;270del]`, the pair merged. The member is therefore
+    // placed past `MAX_CANONICAL_WINDOW` (4096) instead, which refuses the
+    // window before any alignment runs; see
+    // `synthetic::extended_core` for why extending the core cannot disturb the
+    // pair. The near-end trap it replaces is worth keeping: at `266del` and
+    // `267del` the third member joined the block outright.
     //
     // Verified to fail both ways, which is the only thing that makes it a guard:
     // stubbing `clamp_sibling_crossing_junctions` to return immediately turns
-    // this output into `g.[261_262dup;265dup;270del]` — the `insGA` swept past
+    // this output into `g.[261_262dup;265dup;4500del]` — the `insGA` swept past
     // its sibling — and restoring the mechanism turns it back.
-    //
-    // # RE-PINNED BY THE PARTITION DEFAULT FLIP (#1835), AND THE BARRIER
-    // COVERAGE IS LOST WITH IT
-    //
-    // Was `NC_TEST.1:g.[260_261insGA;261_262insA;270del]`; now
-    // `NC_TEST.1:g.[262_263insGAA;270del]` — the same single insertion
-    // `the_pair_alone_merges_instead_of_staying_barred` above already pins
-    // WITHOUT the third member. The third member has stopped blocking the
-    // derivation, so the device this whole test rests on no longer works.
-    //
-    // LICENSED BY `contiguous-insertion-split-by-a-blocked-derivation` (decided).
-    // Its ruling is that `general.md:34` is stated over "two variants" and a
-    // locus like this one carries ONE: aligning the reference against the denoted
-    // sequence leaves a single contiguous 3 nt insertion (`GAA`). So `:34` never
-    // reached this pair, and the two-member spelling survived "because a
-    // derivation was blocked, not because a clause requires it". The record
-    // verified that by applying both spellings through `hgvs_to_spdi`,
-    // independently of the normalizer — and `assert_padded_preserving` re-checks
-    // the same equality on every run here.
-    //
-    // THIS IS THE THIRD ROW IN THIS FILE TO STOP GUARDING THE BARRIER, and the
-    // sequence is worth reading as a whole because it is now complete. The
-    // comment on `the_pair_alone_merges_instead_of_staying_barred` records that
-    // *it* stopped bounding the barrier when #1235 made the pair merge, and moved
-    // the coverage HERE by adding a third member. That escape has now closed too:
-    // with the output at one insertion, stubbing
-    // `clamp_sibling_crossing_junctions` cannot change it, so the "fails both
-    // ways" paragraph above is stale as a claim about the default arm. The one
-    // row that still goes red when the mechanism is removed is
-    // `a_moved_sibling_shape_now_merges_from_the_sequence`; if that row ever
-    // merges too, this file guards nothing and the loss must be replaced rather
-    // than re-pinned again.
-    //
-    // Recorded as a real coverage loss, not papered over. The barrier is still
-    // reachable under `FERRO_PARTITION=live`, which is part of why that arm stays
-    // selectable by name; re-establishing it on the default arm needs a shape
-    // whose members survive the derivation, which this core does not supply.
-    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[260_261insGA;261_262insA;270del]");
-    assert_eq!(output, "NC_TEST.1:g.[262_263insGAA;270del]");
+    let output = assert_padded_preserving(
+        &extended_core(CORE, 4400),
+        "NC_TEST.1:g.[260_261insGA;261_262insA;4500del]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.[260_261insGA;261_262insA;4500del]");
 }
 
 #[test]
@@ -155,20 +123,11 @@ fn the_barred_pair_does_not_depend_on_authored_order() {
     // The barrier reads both snapshots, so its answer must not depend on the
     // order the members were written in — the same independence the #1261/#1301
     // discriminators carry. Same allele as above, authored backwards.
-    //
-    // #1835: was `NC_TEST.1:g.[260_261insGA;261_262insA;270del]`; now the merged
-    // `NC_TEST.1:g.[262_263insGAA;270del]`, for the reason recorded on the row
-    // above.
-    //
-    // THE INDEPENDENCE PROPERTY SURVIVES, and is arguably strengthened. What this
-    // row asserts is that the two authored orders reach the SAME output, and they
-    // still do — keep this string identical to the row above, since their
-    // equality is the whole test. Authored order is now irrelevant for a stronger
-    // reason than before: the answer is derived from the resulting sequence, which
-    // is order-invariant by construction, rather than from a barrier reading two
-    // snapshots. It is no longer evidence about the barrier specifically.
-    let output = assert_padded_preserving(CORE, "NC_TEST.1:g.[270del;261_262insA;260_261insGA]");
-    assert_eq!(output, "NC_TEST.1:g.[262_263insGAA;270del]");
+    let output = assert_padded_preserving(
+        &extended_core(CORE, 4400),
+        "NC_TEST.1:g.[4500del;261_262insA;260_261insGA]",
+    );
+    assert_eq!(output, "NC_TEST.1:g.[260_261insGA;261_262insA;4500del]");
 }
 
 #[test]

--- a/tests/it/issue_1320_dup_spans_sibling_junction.rs
+++ b/tests/it/issue_1320_dup_spans_sibling_junction.rs
@@ -35,7 +35,7 @@
 //! junction 3' of the span it copied — and the two members are then disjoint and
 //! in order.
 
-use crate::common::synthetic::assert_padded_preserving;
+use crate::common::synthetic::{assert_padded_preserving, extended_core};
 
 /// The core the proptest shrank to, and the reference the seed describes.
 const CORE: &str = "AACAGTAAAATAT";
@@ -83,49 +83,24 @@ fn a_junction_at_the_dups_five_prime_end_merges_instead_of_respelling() {
 
 #[test]
 fn a_junction_at_the_dups_five_prime_end_is_left_alone_beside_a_third_member() {
-    // The 5' boundary itself, restored: the deletion at 270 sits clear of the
-    // A-run the payloads shift through, so the pair still re-spells exactly as
-    // it did, but the derivation declines the three-member group instead of
-    // merging it. `264_265dup` and the insertion share a junction at 264, which
+    // The 5' boundary itself, restored: the third member stops the derivation,
+    // so the pair still re-spells exactly as it did instead of being merged.
+    // `264_265dup` and the insertion share a junction at 264, which
     // `junction_rank` already orders, so the predicate must *not* re-spell the
     // dup here — doing so would undo #1301.
     //
-    // # RE-PINNED BY THE PARTITION DEFAULT FLIP (#1835)
-    //
-    // Was `NC_TEST.1:g.[264_265insCA;264_265dup;270del]`; now
-    // `NC_TEST.1:g.[264_265insCAAA;270del]` — the same single insertion the
-    // sibling test above already pins without the third member, so the third
-    // member no longer blocks the derivation.
-    //
-    // LICENSED BY `duplication-must-ranks-the-label-not-the-partition` (decided,
-    // operator ruling 2026-08-13), which names this test by its full path. It is
-    // one of the two rows that record classes as inside
-    // `contiguous-insertion-split-by-a-blocked-derivation`'s STATED reach rather
-    // than merely compatible with it: that record's REPRESENTATION EFFECT
-    // paragraph predicted this geometry by description in advance — "any stored
-    // allele whose members are a junction-adjacent `ins`+`dup` pair sitting
-    // beside a third member far enough away to block the derivation" moves "to a
-    // single insertion" — and names the pinned
-    // `[264_265insCA;264_265dup;270del]` as that geometry with the third member
-    // 5 nt clear. So this is a predicted gap closing, not a discovered move.
-    //
-    // The `dup` is not lost to a MUST being ignored. `duplication.md:18` is
-    // applied per piece of the partition re-derived from the resulting sequence,
-    // and the single `CAAA` insertion is not a copy of the reference bases
-    // immediately 5' of its insertion point, so `:18` never fires on it.
-    //
-    // WHAT IS NO LONGER GUARDED HERE. The 5'-boundary predicate this test was
-    // written for — that `junction_rank` already orders a dup sharing its
-    // insertion's junction, so re-spelling would undo #1301 — is not exercised by
-    // a one-member output. It stays covered by
-    // `the_pair_without_the_swallowed_sibling_still_uses_the_repeat` and
-    // `a_deletion_colliding_with_a_dups_bases_still_respells`, which the sibling
-    // test above already names for the same reason.
+    // The member sits past `MAX_CANONICAL_WINDOW` (4096) rather than merely
+    // clear of the A-run. `270del` used to be enough; since the partition
+    // default flip (**#1835**) the derivation answers the whole allele however
+    // distant that member is, and this row read `g.[264_265insCAAA;270del]` —
+    // one insertion, so vacuous as a boundary test.
+    // `synthetic::extended_core` records why the extension cannot disturb the
+    // pair.
     let output = assert_padded_preserving(
-        "GCATGAAAAT",
-        "NC_TEST.1:g.[263_264insAC;264_265insAA;270del]",
+        &extended_core("GCATGAAAAT", 4400),
+        "NC_TEST.1:g.[263_264insAC;264_265insAA;4500del]",
     );
-    assert_eq!(output, "NC_TEST.1:g.[264_265insCAAA;270del]");
+    assert_eq!(output, "NC_TEST.1:g.[264_265insCA;264_265dup;4500del]");
 }
 
 #[test]
@@ -149,36 +124,14 @@ fn two_duplications_sharing_a_start_keep_both_dup_spellings_beside_a_third_membe
     // restored by a third member the derivation will not merge them with.
     // `258dup`'s junction is 258 and `258_259dup` starts there; a `>=` test
     // would re-spell the wider one and lose both pinned forms.
-    //
-    // # RE-PINNED BY THE PARTITION DEFAULT FLIP (#1835)
-    //
-    // Was `NC_TEST.1:g.[258dup;258_259dup;268del]`; now
-    // `NC_TEST.1:g.[258_259insAGA;268del]`. The third member no longer blocks the
-    // derivation, so the pair collapses to the single insertion the sibling test
-    // `two_insertions_sharing_a_start_merge_into_one_member` already pins without
-    // it.
-    //
-    // LICENSED BY `duplication-must-ranks-the-label-not-the-partition` (decided,
-    // 2026-08-13). This is the `dup`+`dup`-sharing-a-start shape that record
-    // names as the one "no decided record had reasoned about at all" before it —
-    // so unlike its `issue_1301`/`issue_1320` siblings this row is *supplied* by
-    // that ruling rather than predicted by an earlier one. Its twin is
-    // `issue_1261_cis_member_order::two_duplications_sharing_a_start_render_in_junction_order_beside_a_third_member`,
-    // which moves identically over the same core.
-    //
-    // `duplication.md:18` is not deviated from: applied per piece of the
-    // re-derived partition, the single `AGA` insertion is not a copy of the
-    // reference bases immediately 5' of its insertion point, so the MUST does not
-    // fire on it.
-    //
-    // The `>=` regression this test names is no longer reachable through this
-    // input, for the same reason as its sibling above; the note there records
-    // where that coverage still lives.
+    // Past `MAX_CANONICAL_WINDOW` (4096) for the reason the row above records:
+    // a merely distant member no longer blocks the derivation, and at `268del`
+    // this read `g.[258_259insAGA;268del]`.
     let output = assert_padded_preserving(
-        "CAGTATGCAGGCAA",
-        "NC_TEST.1:g.[258_259insA;259_260insAG;268del]",
+        &extended_core("CAGTATGCAGGCAA", 4400),
+        "NC_TEST.1:g.[258_259insA;259_260insAG;4500del]",
     );
-    assert_eq!(output, "NC_TEST.1:g.[258_259insAGA;268del]");
+    assert_eq!(output, "NC_TEST.1:g.[258dup;258_259dup;4500del]");
 }
 
 #[test]


### PR DESCRIPTION
This is the **test half of #1808**, split out on the operator's decision. The `src/` half — the new `prefer_minimal_alignment` rule in `src/normalize/merge.rs` — stays on #1808, together with the ledger rationale and the contract-doc render that quote its headline figures. Once this lands, #1808 rebases onto it and its diff collapses to the rule alone.

Nothing here depends on that rule, and that is measured rather than assumed: this branch is cut from current `main`, which does **not** carry it and is 82 commits past #1808's merge-base, and every carried row passes there. See *Verification* below.

## What it restores, and why the guards were empty

Six rows across four modules were re-pinned by the partition default flip (#1835) onto their own merged output and stopped guarding anything. Each of them used a *distant* third member to stop the sequence-first derivation, on the reasoning that a block carrying more than one run of change would be declined. After the flip the whole allele is derived however far apart its members sit, so every one of those rows collapsed to a single insertion beside the third member — with no tie left to break, no sibling to bar, and no `dup` in the output for the over-clamp guard to bound.

Their own comments say so and ask for the replacement this PR supplies:

> Re-establishing it needs a shape whose members survive the derivation; this core no longer supplies one.

`MAX_CANONICAL_WINDOW` (4096) refuses a window that wide *before* any alignment runs, so a third member placed past it blocks the derivation **structurally** rather than by distance — and nothing about that refusal can be undone by a better alignment. The per-member pipeline, where `clamp_sibling_crossing_shifts`, `clamp_sibling_crossing_junctions` and `cis_member_order_key` all live, then decides the output again.

`common/synthetic.rs` gains `extended_core`, which extends a core with `ACGT` filler. The filler continues the pad's own period-4 rotation and the pad's first base is `A`, so the bases immediately either side of the core are byte-identical to what `padded` already gives it — only the distance to the far end grows, and nothing about a variant inside the core can move. `cis_junction_crossing_shift` keeps a local builder instead, because its tract has to sit at the head of the sequence rather than inside `padded`'s 256-base pad; its `CGGT` filler is *not* run-free, so the pinned deletion position is derived from the run structure rather than picked, and the doc says which property it rests on.

## Verification

**Every row passes without the rule.** 68 tests across the six touched modules, run on this branch against a `main` that has no `prefer_minimal_alignment`: 68 passed, 0 failed. No row carried over from #1808 turned out to be evidence for the rule.

**Each restored guard was verified by mutation, not by timing** — a guard that loads its fixture and then stands down costs the same wall time as one that ran, so duration proves nothing here. In each case the mutation is applied, the row goes red, and the source is restored byte-for-byte (`shasum -a 256` before and after, clean tree at the end). The same mutation was then run against `main`'s version of the row, which is the half that shows the guard really was empty:

| mutation | restored row | on `main`'s fixture |
|---|---|---|
| drop `.filter(\|_\| a.junction.is_none())` from the 5' branch of `clamp_sibling_crossing_shifts` | `cis_junction_crossing_shift::a_third_member_clear_of_the_tract_keeps_the_duplication_reaching_its_five_prime_most_position` — **RED**, the `dup` stranded at `5_6dup` instead of reaching `4_5dup` | passes |
| stub `clamp_sibling_crossing_junctions` to return immediately | `issue_1304_junction_barrier_snapshot::a_third_member_clear_of_the_tract_keeps_the_pair_barred` and `::the_barred_pair_does_not_depend_on_authored_order` — **RED**, output `g.[261_262dup;265dup;4500del]`, the `insGA` swept past its sibling | all 5 rows in the module pass |
| neutralize `junction_rank` in `cis_member_order_key` | `issue_1301_adjacent_gap_member_order::an_insertion_still_sorts_before_a_duplication_sharing_its_span_beside_a_third_member` and `issue_1320_dup_spans_sibling_junction::a_junction_at_the_dups_five_prime_end_is_left_alone_beside_a_third_member` — **RED** | pass |
| take `>=` instead of `>` at `dup.start` in the `swallows_a_junction` test | `issue_1261_cis_member_order::two_duplications_sharing_a_start_render_in_junction_order_beside_a_third_member` and `issue_1320_dup_spans_sibling_junction::two_duplications_sharing_a_start_keep_both_dup_spellings_beside_a_third_member` — **RED**, `258_259dup` re-spelled to `259_260insAG` | pass |

Worth recording from the second row: with `clamp_sibling_crossing_junctions` stubbed out, **`main`'s entire `issue_1304` module is green** — including `a_moved_sibling_shape_now_merges_from_the_sequence`, whose own comment claims to be "the only row in this file that still goes red when the mechanism is removed". That claim is stale on `main`; after this PR two rows in the file go red.

The order-independence rows (`the_shared_start_order_beside_a_third_member_is_authored_order_independent` and its `issue_1301` twin) stay green under every mutation above, which is correct — they compare a forward and a reverse authoring of one allele, so both sides move together. They are re-fixtured here so that they compare a three-member output rather than a merged one-member output, but they are independence checks, not value pins.

## What was deliberately left on #1808

Three of #1808's test-side hunks restore no coverage and are the rule's own narrative, so they stay with the rule rather than being imported here:

- `tests/it/spec_corpus_regressions.rs` — a rename plus removal of a tuple column that is already redundant on `main`; net one assertion fewer, and its prose re-attributes to `prefer_minimal_alignment` a convergence that `main` already has from #1835.
- the rename of `cis_junction_crossing_shift::the_three_member_spelling_and_its_one_member_form_are_two_fixed_points` and its surrounding prose rewrite — same reason; the row already asserts convergence on `main`.
- every sentence crediting `prefer_minimal_alignment` for the vacuity. The vacuity is #1835's, which the base versions of these very comments state in as many words, and this branch has no such symbol to name.

Refs #1808, #1835, #1235. Not marked as closing #1235 — the rule half is still outstanding.

Representation-Change: none

No file under `src/` is touched — the whole diff is six files under `tests/it/` — so no normalized output can move.
