### PR TITLE
fix(reference): synthesize a record-less parent block-by-block across alignment gaps

### DIFF
--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1988,34 +1988,43 @@ impl MultiFastaProvider {
         // named `LRG_<N>g`); 164 of them were quietly served chromosome bases in
         // place of their frozen record. The callers now gate on `own_record`.
         //
-        // Map both endpoints onto the chromosome; on a minus-strand placement
-        // the parent runs antiparallel, so the low parent position maps to the
-        // *higher* `NC_` coordinate.
-        let (nc_a, nc_b) = match (
-            placement.parent_to_nc(start + 1),
-            placement.parent_to_nc(end),
-        ) {
-            (Some(a), Some(b)) => (a, b),
-            _ => {
-                return Err(FerroError::InvalidCoordinates {
-                    msg: format!(
-                        "parent window [{start}, {end}) falls outside the placed span on {}",
-                        placement.nc.full()
-                    ),
-                });
+        // Assemble the window block-by-block through the placement's alignment
+        // rather than as one contiguous `NC_` slice (#1926). A prior version
+        // mapped only the two endpoints and fetched everything between them,
+        // which silently sliced *across* any `<diff>` gap: a chromosome-only
+        // (`other_ins`) run got swept in (too many bases) and a parent-only
+        // (`lrg_ins`) run got dropped (too few), shifting every base past the
+        // gap. `parent_window_nc_ranges` walks the gap list, returning the
+        // chromosome sub-ranges that skip chromosome-only runs, and declining
+        // (via `None`) a window whose parent-only bases have no chromosome
+        // image to synthesize from. Latent on the shipped reference — 0 of
+        // 1 294 LRG records reach this path — but a wrong-but-well-formed
+        // sequence is exactly the class this guards against.
+        let ranges = placement
+            .parent_window_nc_ranges(start + 1, end)
+            .ok_or_else(|| FerroError::InvalidCoordinates {
+                msg: format!(
+                    "parent window [{start}, {end}) falls outside the placed span, or crosses a \
+                     parent-only alignment gap whose bases are absent from {}",
+                    placement.nc.full()
+                ),
+            })?;
+        let mut synthesized = String::new();
+        for (nc_lo, nc_hi) in ranges {
+            // 1-based inclusive [nc_lo, nc_hi] → 0-based half-open for the
+            // fetch. Each range is ascending on the chromosome; on the minus
+            // strand its bases run antiparallel to the parent, so
+            // reverse-complementing each range in parent-ascending block order
+            // reconstructs the parent 5'→3'.
+            let bases = self.get_genomic_sequence(&placement.nc.full(), nc_lo - 1, nc_hi)?;
+            match placement.strand {
+                crate::reference::Strand::Minus => {
+                    synthesized.push_str(&crate::sequence::reverse_complement(&bases))
+                }
+                _ => synthesized.push_str(&bases),
             }
-        };
-        let (nc_lo, nc_hi) = if nc_a <= nc_b {
-            (nc_a, nc_b)
-        } else {
-            (nc_b, nc_a)
-        };
-        // 1-based inclusive [nc_lo, nc_hi] → 0-based half-open for the fetch.
-        let bases = self.get_genomic_sequence(&placement.nc.full(), nc_lo - 1, nc_hi)?;
-        Ok(match placement.strand {
-            crate::reference::Strand::Minus => crate::sequence::reverse_complement(&bases),
-            _ => bases,
-        })
+        }
+        Ok(synthesized)
     }
 
     /// Build a `Transcript` for `id` whose bases are synthesized from the genome
@@ -4920,6 +4929,168 @@ mod tests {
         );
         // The last placed base must be readable at that length.
         assert_eq!(provider.get_sequence("LRG_997", 13, 14).unwrap(), "A");
+    }
+
+    // ------------------------------------------------------------------
+    // A record-less parent synthesized ACROSS an alignment gap (#1926)
+    // ------------------------------------------------------------------
+
+    /// A record-less parent whose placement carries a **chromosome-only**
+    /// (`other_ins`) gap must have those chromosome bases *dropped* when its
+    /// sequence is synthesized — they are not part of the parent — rather than
+    /// swept up in one contiguous slice across the gap (#1926).
+    ///
+    /// Genome `NC_TEST.1` is `AAAACCCCGGGGTTTT…` (1-based: 1-4 `A`, 5-8 `C`,
+    /// 9-12 `G`, …). `LRG_996` maps parent `1..=8` onto `NC_TEST.1:1..=10`
+    /// with a 2-base `other_ins` at chromosome `5..=6`, so parent `1..=4` →
+    /// `nc 1..=4` (`AAAA`) and parent `5..=8` → `nc 7..=10` (`CCGG`); the two
+    /// chromosome bases `5..=6` (`CC`) belong to no parent coordinate.
+    ///
+    /// So the parent sequence is `AAAACCGG` (8 bases). The contiguous-slice
+    /// defect maps the two endpoints (`nc 1` and `nc 10`) and fetches
+    /// `nc 1..=10` = `AAAACCCCGG` — 10 bases, two too many, with every base
+    /// past the gap shifted. Exact strings, because the lengths alone (8 vs 10)
+    /// already discriminate and the base identities pin *which* bases.
+    #[test]
+    fn a_record_less_parent_drops_a_chromosome_only_gap_when_synthesized() {
+        let (mut provider, dir) = build_provider_with_test_genome();
+        let xml_dir = dir.path().join("lrg");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        std::fs::write(
+            xml_dir.join("LRG_996.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_TEST.1" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="8" other_start="1" other_end="10" strand="1">
+                  <diff type="other_ins" lrg_start="4" lrg_end="5" other_start="5" other_end="6" lrg_sequence="-" other_sequence="CC" />
+                </mapping_span>
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        provider.lrg_xml_dir = Some(xml_dir);
+
+        // Discriminator: no `LRG_996g` record, so synthesis (not a FASTA read)
+        // serves it, and the placement genuinely carries the gap.
+        assert!(provider.own_record("LRG_996").is_none());
+        let placement = provider
+            .genomic_placement(&crate::hgvs::variant::Accession::new("LRG", "996", None))
+            .expect("placed");
+        assert_eq!(placement.gaps.len(), 1, "the fixture must carry the gap");
+
+        assert_eq!(
+            provider.get_sequence("LRG_996", 0, 8).unwrap(),
+            "AAAACCGG",
+            "the chromosome-only run must be skipped, not sliced across contiguously"
+        );
+        // The gap-crossing sub-window on its own: parent 3..=6 → nc 3,4,7,8 =
+        // `AACC`, never the contiguous `nc 3..=6` = `AACC`… (here they coincide
+        // in bases but not length past the gap, so also pin the 5' tail).
+        assert_eq!(
+            provider.get_sequence("LRG_996", 0, 4).unwrap(),
+            "AAAA",
+            "the aligned 5' block before the gap is served unchanged"
+        );
+        assert_eq!(
+            provider.get_sequence("LRG_996", 4, 8).unwrap(),
+            "CCGG",
+            "the aligned 3' block after the gap is served from beyond the skipped run"
+        );
+    }
+
+    /// A record-less parent whose placement carries a **parent-only**
+    /// (`lrg_ins`) gap has bases the chromosome does not carry, so a window
+    /// crossing that gap cannot be synthesized and must **decline** — never a
+    /// contiguous slice that silently drops the unfetchable parent bases and
+    /// shifts everything past them (#1926).
+    ///
+    /// `LRG_995` maps parent `1..=8` onto `NC_TEST.1:1..=6` with a 2-base
+    /// `lrg_ins` at parent `5..=6`, so parent `1..=4` → `nc 1..=4` and parent
+    /// `7..=8` → `nc 5..=6`, while parent `5..=6` exist only in the parent.
+    /// A window covering them (offsets `0..8`, i.e. parent `1..=8`) has no
+    /// honest chromosome image; the contiguous-slice defect maps `nc 1` and
+    /// `nc 6` and serves `AAAACC` — 6 bases for an 8-base window.
+    #[test]
+    fn a_record_less_parent_declines_a_window_crossing_a_parent_only_gap() {
+        let (mut provider, dir) = build_provider_with_test_genome();
+        let xml_dir = dir.path().join("lrg");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        std::fs::write(
+            xml_dir.join("LRG_995.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_TEST.1" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="8" other_start="1" other_end="6" strand="1">
+                  <diff type="lrg_ins" lrg_start="5" lrg_end="6" other_start="4" other_end="5" lrg_sequence="AA" other_sequence="-" />
+                </mapping_span>
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        provider.lrg_xml_dir = Some(xml_dir);
+
+        assert!(provider.own_record("LRG_995").is_none());
+        let placement = provider
+            .genomic_placement(&crate::hgvs::variant::Accession::new("LRG", "995", None))
+            .expect("placed");
+        assert_eq!(placement.gaps.len(), 1, "the fixture must carry the gap");
+
+        // The two aligned blocks on their own are fine.
+        assert_eq!(provider.get_sequence("LRG_995", 0, 4).unwrap(), "AAAA");
+        assert_eq!(provider.get_sequence("LRG_995", 6, 8).unwrap(), "CC");
+        // A window that includes the parent-only bases cannot be synthesized.
+        assert!(
+            provider.get_sequence("LRG_995", 0, 8).is_err(),
+            "parent-only bases have no chromosome image and must not be fabricated \
+             by slicing across the gap"
+        );
+    }
+
+    /// The gap-aware synthesis must honour the **minus** strand too: within
+    /// each aligned block the chromosome bases run antiparallel to the parent,
+    /// so each block is reverse-complemented, and a chromosome-only run between
+    /// blocks is still dropped (#1926).
+    ///
+    /// `LRG_994` maps parent `1..=8` onto `NC_TEST.1:1..=10` on the minus
+    /// strand with a 2-base `other_ins` at chromosome `5..=6`. On the minus
+    /// strand parent `1` maps to the *higher* chromosome endpoint (`nc 10`):
+    /// parent `1..=4` → `nc 10,9,8,7` and parent `5..=8` → `nc 4,3,2,1`, the
+    /// chromosome-only run at `nc 5..=6` sitting between the two blocks.
+    /// `NC_TEST.1` is `…A(1-4) C(5-8) G(9-12)…`, so the parent bases are
+    /// `revcomp(nc10 G)=C, revcomp(nc9 G)=C, revcomp(nc8 C)=G, revcomp(nc7 C)=G`
+    /// then `revcomp(nc4 A)=T, revcomp(nc3 A)=T, revcomp(nc2 A)=T,
+    /// revcomp(nc1 A)=T` → `CCGGTTTT`.
+    #[test]
+    fn a_record_less_minus_strand_parent_drops_a_chromosome_only_gap() {
+        let (mut provider, dir) = build_provider_with_test_genome();
+        let xml_dir = dir.path().join("lrg");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        std::fs::write(
+            xml_dir.join("LRG_994.xml"),
+            r#"
+              <mapping coord_system="GRCh38" other_id="NC_TEST.1" type="main_assembly">
+                <mapping_span lrg_start="1" lrg_end="8" other_start="1" other_end="10" strand="-1">
+                  <diff type="other_ins" lrg_start="4" lrg_end="5" other_start="5" other_end="6" lrg_sequence="-" other_sequence="CC" />
+                </mapping_span>
+              </mapping>
+            "#,
+        )
+        .unwrap();
+        provider.lrg_xml_dir = Some(xml_dir);
+
+        assert!(provider.own_record("LRG_994").is_none());
+        let placement = provider
+            .genomic_placement(&crate::hgvs::variant::Accession::new("LRG", "994", None))
+            .expect("placed");
+        assert_eq!(
+            placement.strand,
+            crate::reference::transcript::Strand::Minus
+        );
+        assert_eq!(placement.gaps.len(), 1);
+
+        assert_eq!(
+            provider.get_sequence("LRG_994", 0, 8).unwrap(),
+            "CCGGTTTT",
+            "minus-strand blocks are reverse-complemented and the gap still dropped"
+        );
     }
 
     // ----------------------------------------------------------------------

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -452,6 +452,64 @@ impl GenomicPlacement {
         }
         None
     }
+
+    /// The chromosome (`NC_`) sub-ranges to fetch to reconstruct the parent
+    /// bases for the 1-based inclusive parent window `[parent_lo, parent_hi]`,
+    /// in parent-ascending (output) order.
+    ///
+    /// This is what lets sequence synthesis honour the `<diff>` list rather
+    /// than taking one contiguous chromosome slice across a gap (#1926). A
+    /// [`ChromosomeOnly`](AlignmentGapKind::ChromosomeOnly) run inside the
+    /// window is *dropped* — its chromosome bases belong to no parent
+    /// coordinate, so the ranges skip over it, and the fetched bases assemble
+    /// to exactly `parent_hi - parent_lo + 1` of them.
+    ///
+    /// Returns `None` when any parent coordinate in the window has no
+    /// chromosome image: it lies outside the placed span, or inside a
+    /// [`ParentOnly`](AlignmentGapKind::ParentOnly) run whose bases the
+    /// chromosome simply does not carry (so they cannot be synthesized and the
+    /// caller must decline rather than slice across them). Both are detected by
+    /// the covered-count check: the aligned blocks intersecting the window must
+    /// account for *every* one of its coordinates.
+    ///
+    /// Each `(nc_lo, nc_hi)` is a 1-based inclusive **ascending** chromosome
+    /// range. On the minus strand a range's chromosome bases run antiparallel
+    /// to the parent, so the caller reverse-complements each range's bases; the
+    /// ranges themselves are returned in parent-ascending order regardless of
+    /// strand, matching the block-iteration order.
+    pub(crate) fn parent_window_nc_ranges(
+        &self,
+        parent_lo: u64,
+        parent_hi: u64,
+    ) -> Option<Vec<(u64, u64)>> {
+        if parent_hi < parent_lo {
+            return Some(Vec::new());
+        }
+        let want = (parent_hi - parent_lo).checked_add(1)?;
+        let mut ranges: Vec<(u64, u64)> = Vec::new();
+        let mut covered: u64 = 0;
+        for block in self.blocks() {
+            let block_last = block.parent_start.checked_add(block.len)?.checked_sub(1)?;
+            let intersect_lo = parent_lo.max(block.parent_start);
+            let intersect_hi = parent_hi.min(block_last);
+            if intersect_lo > intersect_hi {
+                continue;
+            }
+            let consumed_lo = block
+                .nc_consumed
+                .checked_add(intersect_lo - block.parent_start)?;
+            let consumed_hi = block
+                .nc_consumed
+                .checked_add(intersect_hi - block.parent_start)?;
+            // On the minus strand ascending parent maps to descending
+            // chromosome, so order the endpoints into an ascending fetch range.
+            let a = self.nc_at(consumed_lo)?;
+            let b = self.nc_at(consumed_hi)?;
+            ranges.push((a.min(b), a.max(b)));
+            covered = covered.checked_add(intersect_hi - intersect_lo + 1)?;
+        }
+        (covered == want).then_some(ranges)
+    }
 }
 
 /// Trait for providing reference sequence data
@@ -1247,6 +1305,57 @@ mod placement_tests {
                 assert_eq!(mapped, 9 - parent_only, "{strand:?} {gaps:?}");
             }
         }
+    }
+
+    #[test]
+    fn parent_window_nc_ranges_walks_the_gap_list_instead_of_slicing_across_it() {
+        // No gaps: one contiguous range, exactly the old single-slice behaviour
+        // — this is what keeps every gapless placement byte-identical (#1926).
+        assert_eq!(
+            placement(Strand::Plus).parent_window_nc_ranges(2, 5),
+            Some(vec![(1001, 1004)])
+        );
+
+        // A chromosome-only run inside the window is dropped: two ranges that
+        // skip nc 1004..=1006, together covering all 9 parent coordinates.
+        let cg = gapped(
+            Strand::Plus,
+            vec![AlignmentGap::chromosome_only(4, 3)],
+            1011,
+        );
+        assert_eq!(
+            cg.parent_window_nc_ranges(1, 9),
+            Some(vec![(1000, 1003), (1007, 1011)])
+        );
+
+        // A window crossing a parent-only run declines — those parent bases
+        // have no chromosome image to synthesize from.
+        let pg = gapped(Strand::Plus, vec![AlignmentGap::parent_only(5, 3)], 1008);
+        assert_eq!(pg.parent_window_nc_ranges(1, 12), None);
+        // …but a window wholly on one side of it maps fine.
+        assert_eq!(pg.parent_window_nc_ranges(1, 4), Some(vec![(1000, 1003)]));
+        assert_eq!(pg.parent_window_nc_ranges(8, 12), Some(vec![(1004, 1008)]));
+
+        // Minus strand: ranges come back in parent-ascending block order (the
+        // low-parent block's HIGH chromosome range first), and each is still an
+        // ascending fetch range for the caller to reverse-complement.
+        let cg_minus = gapped(
+            Strand::Minus,
+            vec![AlignmentGap::chromosome_only(4, 3)],
+            1011,
+        );
+        assert_eq!(
+            cg_minus.parent_window_nc_ranges(1, 9),
+            Some(vec![(1008, 1011), (1000, 1004)])
+        );
+
+        // A window past the placed extent declines rather than fabricating.
+        assert_eq!(placement(Strand::Plus).parent_window_nc_ranges(1, 10), None);
+        // An empty window is an empty plan, never an error.
+        assert_eq!(
+            placement(Strand::Plus).parent_window_nc_ranges(5, 4),
+            Some(Vec::new())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1926.

## The defect

`synthesize_parent_sequence` (`src/reference/multi_fasta.rs`) serves the bases of a genomic parent (`NG_`/`LRG_`) that has a chromosomal placement but no FASTA record of its own, by mapping the requested parent-frame window onto the chromosome and reading those `NC_` bases. It mapped only the **two endpoints** of the window and then fetched one **contiguous** `NC_` slice between them — so any LRG `<diff>` gap between the endpoints was sliced straight across. The result is well-formed, in-bounds, and wrong, with every base past the gap shifted:

| gap kind | requested window | bases returned (buggy) |
|---|---|---|
| chromosome-only (`other_ins`) | 20 | **22** (the chromosome-only run swept in) |
| parent-only (`lrg_ins`) | 22 | **20** (the parent-only run silently dropped) |

Nothing downstream refuses it, so a normalizer would happily shift against fabricated/shifted bases.

## The fix

Walk the placement's aligned blocks instead of assuming the parent interval between two mapped endpoints is contiguous — the same block model the projection path already uses (`GenomicPlacement`'s gap list, #1833).

- New `GenomicPlacement::parent_window_nc_ranges(parent_lo, parent_hi)` returns the ascending chromosome sub-ranges to fetch for a parent window, in parent-ascending (output) order. A **chromosome-only** run inside the window is dropped (the ranges skip it); a window whose coordinates include a **parent-only** run — bases the chromosome does not carry — returns `None`, since they cannot be synthesized. Both are caught by a covered-count check (the intersecting blocks must account for every parent coordinate). All arithmetic is checked, so a public, malformed gap list fails closed rather than answering from a half-applied walk.
- `synthesize_parent_sequence` assembles the window from those ranges, reverse-complementing each range in block order on the minus strand, and declines (`InvalidCoordinates`) when the plan is `None` — matching the existing precedent that unplaced coordinates must error rather than be fabricated.

## Unchanged on purpose

The **gapless** case yields a single range identical to the previous contiguous slice, so every gapless placement — all `NG_` placements and 1 248 of the 1 294 LRG records — is byte-identical. The parent-only decline and the chromosome-only drop are pinned as exact-string / `is_err` regression tests (plus + minus strand), and a focused unit test pins `parent_window_nc_ranges` in isolation (gapless equivalence, gap drop, parent-only decline, out-of-span decline).

## Representation stability

Representation-Change: none. The only behavioural change is to the gapped record-less parent-synthesis path. The gapless path is byte-identical (a single fetch range), and **0 of the 1 294** shipped LRG records reach the gapped path (all have their own `LRG_<N>g` record; every `NG_` placement is gapless). No shipped input's normalized output moves; the fix corrects only a latent wrong-but-well-formed sequence. Off the shipped reference, two movements do occur and are stated here rather than left implicit: a window spanning a chromosome-only run is previously-accepted-now-different (it serves the correctly-aligned bases instead of a shifted slice), and a window crossing a parent-only run is previously-accepted-now-refused. Neither is reachable on any reference this project ships. `spec_conformance_axis` (the corpus census) is `JsonProvider`-backed and never exercises LRG placement synthesis, so it is untouched.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — **11173 passed, 0 failed**, 155 skipped.
- `scripts/run_oracle_suite.sh` (mirrors CI's `test-oracle` job) — **11013 passed, 0 failed**, 315 skipped.
- The bare `FERRO_ASSERT_IDEMPOTENT=1 …` full-suite run shows the 7 failures that are red on clean `origin/main` and excluded by `ORACLE_EXCLUDE` (4 `defect_non_idempotent_outputs`, `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`, the 2 `spec_conformance_axis` censuses) — pre-existing, not introduced here.
