### PR TITLE
docs: mdBook user docs site with an interpretation section

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Docs
 
-# Builds the mdBook user docs as a PR gate. Read the Docs does the actual hosting/deploy
-# via .readthedocs.yaml; this job only validates that the book builds and has no dead
-# internal links (mdbook-linkcheck2). Tool versions are pinned in lockstep with
+# Builds the mdBook user docs on pull requests. Read the Docs does the actual hosting/deploy
+# via .readthedocs.yaml; this job validates that the book builds and that internal links
+# resolve to real pages (mdbook-linkcheck2 — link targets, not fragment anchors). It is
+# advisory unless added to the branch ruleset. Tool versions are pinned in lockstep with
 # .readthedocs.yaml.
 
 on:
@@ -13,6 +14,10 @@ on:
       - "docs/**"
       - ".readthedocs.yaml"
       - ".github/workflows/docs.yml"
+  # Run on merge_group so this context still reports if it is ever added to the
+  # branch ruleset as required — a required check that never runs on merge_group
+  # hangs the first merge-queue entry forever (#1769).
+  merge_group:
 
 permissions:
   contents: read
@@ -23,6 +28,10 @@ concurrency:
 
 jobs:
   build:
+    # Names the status-check context `Docs` rather than the default `build`, which
+    # would collide with ci.yml's already-required `Build` in a ruleset that matches
+    # context strings exactly (differing only in case).
+    name: Docs
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Docs
+
+# Builds the mdBook user docs as a PR gate. Read the Docs does the actual hosting/deploy
+# via .readthedocs.yaml; this job only validates that the book builds and has no dead
+# internal links (mdbook-linkcheck2). Tool versions are pinned in lockstep with
+# .readthedocs.yaml.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".readthedocs.yaml"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+
+      - name: Cache mdBook tools
+        id: cache-tools
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/mdbook
+            ~/.cargo/bin/mdbook-linkcheck2
+          key: mdbook-0.5.2-linkcheck2-0.12.2
+
+      - name: Install mdBook + linkcheck2
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: |
+          cargo install mdbook --version 0.5.2 --locked
+          cargo install mdbook-linkcheck2 --version 0.12.2 --locked
+
+      - name: Build the book (fails on dead internal links)
+        run: cd docs && mdbook build

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ manuscript/
 
 # Local scratch working directory (ad hoc scripts, offline tooling)
 /scratch/
+
+# mdBook build output
+docs/book/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,13 +2,34 @@ version: 2
 
 build:
   os: ubuntu-24.04
+  # A tool entry is required by the Read the Docs schema even when the build is
+  # driven entirely by `commands`. We do not use Python — it is the lightest
+  # always-available toolchain to satisfy the requirement. mdbook and
+  # mdbook-linkcheck2 are installed from prebuilt release binaries below, which
+  # drops the floating `rust: latest` toolchain (RTD has no 1.x selector) and its
+  # multi-minute from-source compile on every build. Prebuilt binaries also let
+  # us verify each download against a pinned checksum. These version pins MUST
+  # stay in lockstep with .github/workflows/docs.yml (which installs the same
+  # versions via cargo, matching how bwa-mem3 splits RTD vs CI).
   tools:
-    rust: "latest"  # RTD has no 1.x selector; rust-toolchain.toml pins the real version.
+    python: "3.12"
   commands:
-    # Pinned to match .github/workflows/docs.yml — keep the two in lockstep.
-    - cargo install mdbook --version 0.5.2 --locked
-    - cargo install mdbook-linkcheck2 --version 0.12.2 --locked
-    - cd docs && mdbook build
-    # With the linkcheck2 backend configured, mdBook writes HTML to book/html/.
+    # mdbook-linkcheck2 is the broken-link checker backend (see docs/book.toml).
+    # We use the fork rather than the original mdbook-linkcheck: the original is
+    # pinned to the mdBook 0.4 backend API and cannot parse mdBook 0.5's
+    # RenderContext. mdBook discovers it as the `linkcheck2` backend by finding
+    # `mdbook-linkcheck2` on PATH (bin/ is prepended below).
+    #
+    # Each binary is downloaded to a file, verified against its pinned SHA-256,
+    # and only then extracted — so a corrupted or tampered download fails the
+    # build with a checksum error instead of being run. The `&&` chain makes any
+    # step's failure (curl, checksum, or tar) abort the command. The checksums
+    # are for the official v0.5.2 / v0.12.2 release tarballs.
+    - mkdir -p bin
+    - curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook.tar.gz && echo "084e4342ba564db270108763e404a7d1f309d932651a22484e93c0dc1a071f6d  bin/mdbook.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook.tar.gz -C bin
+    - curl -fsSL https://github.com/marxin/mdbook-linkcheck2/releases/download/v0.12.2/mdbook-linkcheck2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook-linkcheck2.tar.gz && echo "c68bba37dd07887d308a8c1ccab56aef8250793196e35c0fe517b9c7fbc44c48  bin/mdbook-linkcheck2.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook-linkcheck2.tar.gz -C bin && chmod +x bin/mdbook-linkcheck2
+    - cd docs && PATH="$PWD/../bin:$PATH" mdbook build
+    # With the linkcheck2 output backend configured, mdBook writes the HTML site
+    # to book/html/ (rather than book/), so copy from there.
     - mkdir -p _readthedocs/html
     - cp -r docs/book/html/. _readthedocs/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,34 +2,13 @@ version: 2
 
 build:
   os: ubuntu-24.04
-  # A tool entry is required by the Read the Docs schema even when the build is
-  # driven entirely by `commands`. We do not use Python — it is the lightest
-  # always-available toolchain to satisfy the requirement. mdbook and
-  # mdbook-linkcheck2 are installed from prebuilt release binaries below, which
-  # drops the floating `rust: latest` toolchain (RTD has no 1.x selector) and its
-  # multi-minute from-source compile on every build. Prebuilt binaries also let
-  # us verify each download against a pinned checksum. These version pins MUST
-  # stay in lockstep with .github/workflows/docs.yml (which installs the same
-  # versions via cargo, matching how bwa-mem3 splits RTD vs CI).
   tools:
-    python: "3.12"
+    rust: "latest"  # RTD has no 1.x selector; rust-toolchain.toml pins the real version.
   commands:
-    # mdbook-linkcheck2 is the broken-link checker backend (see docs/book.toml).
-    # We use the fork rather than the original mdbook-linkcheck: the original is
-    # pinned to the mdBook 0.4 backend API and cannot parse mdBook 0.5's
-    # RenderContext. mdBook discovers it as the `linkcheck2` backend by finding
-    # `mdbook-linkcheck2` on PATH (bin/ is prepended below).
-    #
-    # Each binary is downloaded to a file, verified against its pinned SHA-256,
-    # and only then extracted — so a corrupted or tampered download fails the
-    # build with a checksum error instead of being run. The `&&` chain makes any
-    # step's failure (curl, checksum, or tar) abort the command. The checksums
-    # are for the official v0.5.2 / v0.12.2 release tarballs.
-    - mkdir -p bin
-    - curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook.tar.gz && echo "084e4342ba564db270108763e404a7d1f309d932651a22484e93c0dc1a071f6d  bin/mdbook.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook.tar.gz -C bin
-    - curl -fsSL https://github.com/marxin/mdbook-linkcheck2/releases/download/v0.12.2/mdbook-linkcheck2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook-linkcheck2.tar.gz && echo "c68bba37dd07887d308a8c1ccab56aef8250793196e35c0fe517b9c7fbc44c48  bin/mdbook-linkcheck2.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook-linkcheck2.tar.gz -C bin && chmod +x bin/mdbook-linkcheck2
-    - cd docs && PATH="$PWD/../bin:$PATH" mdbook build
-    # With the linkcheck2 output backend configured, mdBook writes the HTML site
-    # to book/html/ (rather than book/), so copy from there.
+    # Pinned to match .github/workflows/docs.yml — keep the two in lockstep.
+    - cargo install mdbook --version 0.5.2 --locked
+    - cargo install mdbook-linkcheck2 --version 0.12.2 --locked
+    - cd docs && mdbook build
+    # With the linkcheck2 backend configured, mdBook writes HTML to book/html/.
     - mkdir -p _readthedocs/html
     - cp -r docs/book/html/. _readthedocs/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    rust: "latest"  # RTD has no 1.x selector; rust-toolchain.toml pins the real version.
+  commands:
+    # Pinned to match .github/workflows/docs.yml — keep the two in lockstep.
+    - cargo install mdbook --version 0.5.2 --locked
+    - cargo install mdbook-linkcheck2 --version 0.12.2 --locked
+    - cd docs && mdbook build
+    # With the linkcheck2 backend configured, mdBook writes HTML to book/html/.
+    - mkdir -p _readthedocs/html
+    - cp -r docs/book/html/. _readthedocs/html/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,33 @@
+[book]
+title = "ferro-hgvs"
+description = "HGVS variant nomenclature parser and normalizer — user documentation"
+authors = ["Fulcrum Genomics"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "book"
+
+[output.html]
+additional-css = ["theme/custom.css"]
+git-repository-url = "https://github.com/fulcrumgenomics/ferro-hgvs"
+edit-url-template = "https://github.com/fulcrumgenomics/ferro-hgvs/edit/main/docs/{path}"
+no-section-label = true
+default-theme = "navy"
+preferred-dark-theme = "navy"
+
+[output.html.search]
+enable = true
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.playground]
+editable = false
+runnable = false
+
+# Broken-link checker (mdbook-linkcheck2, the fork tracking mdBook 0.5). Configured as an
+# output backend so `mdbook build` FAILS on internal dead links — mdBook alone only warns.
+[output.linkcheck2]
+follow-web-links = false

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,6 +8,12 @@ src = "src"
 
 [build]
 build-dir = "book"
+# Fail the build when SUMMARY.md references a page that does not exist, instead of
+# mdBook's default of inventing a stub ("# Ghost page") and exiting 0. Pages are
+# added to the Interpretation section one at a time via a SUMMARY edit, so a
+# misspelled path or a forgotten `git add` must be a hard error — not a published
+# nav chapter whose body is its own title.
+create-missing = false
 
 [output.html]
 additional-css = ["theme/custom.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,6 +3,7 @@ title = "ferro-hgvs"
 description = "HGVS variant nomenclature parser and normalizer — user documentation"
 authors = ["Fulcrum Genomics"]
 language = "en"
+text-direction = "ltr"
 src = "src"
 
 [build]
@@ -10,6 +11,7 @@ build-dir = "book"
 
 [output.html]
 additional-css = ["theme/custom.css"]
+additional-js = ["theme/sidebar-brand.js"]
 git-repository-url = "https://github.com/fulcrumgenomics/ferro-hgvs"
 edit-url-template = "https://github.com/fulcrumgenomics/ferro-hgvs/edit/main/docs/{path}"
 no-section-label = true
@@ -21,11 +23,21 @@ enable = true
 
 [output.html.fold]
 enable = true
-level = 1
+# level = 0 -> every nested section starts collapsed; mdBook's runtime JS expands
+# only the section containing the current page. Matches the fgumi/bwa-mem3 docs.
+level = 0
 
 [output.html.playground]
 editable = false
 runnable = false
+
+# NOTE: no [preprocessor.mermaid] yet. The fgumi/bwa-mem3 docs use mermaid diagrams
+# and wire it in (bwa-mem3 via this stanza + an mdbook-mermaid install in CI/RTD;
+# fgumi via its xtask). ferro's docs currently contain zero mermaid diagrams, so we
+# deliberately do not declare the preprocessor — it would force an mdbook-mermaid
+# dependency into CI/RTD for dead config. When the first diagram lands (e.g. a
+# confluence graph in a shadow-spec page), add the stanza, the theme JS/CSS assets,
+# and the pinned install to .readthedocs.yaml + .github/workflows/docs.yml together.
 
 # Broken-link checker (mdbook-linkcheck2, the fork tracking mdBook 0.5). Configured as an
 # output backend so `mdbook build` FAILS on internal dead links — mdBook alone only warns.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,6 @@
 
 - [CLI reference](cli/overview.md)
 
-# Shadow Spec
+# Interpretation
 
 - [Overview](shadow-spec/index.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,8 @@
+<!-- markdownlint-disable MD042 -->
+# Summary
+
+[Home](index.md)
+
+# Shadow Spec
+
+- [Overview](shadow-spec/index.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,20 @@
 
 [Home](index.md)
 
+# Getting Started
+
+- [Installation](getting-started/installation.md)
+- [Quickstart](getting-started/quickstart.md)
+
+# Guides
+
+- [Normalize variants](guide/normalize-variants.md)
+- [Reference data](guide/reference-data.md)
+
+# Reference
+
+- [CLI reference](cli/overview.md)
+
 # Shadow Spec
 
 - [Overview](shadow-spec/index.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -12,6 +12,7 @@
 
 - [Normalize variants](guide/normalize-variants.md)
 - [Reference data](guide/reference-data.md)
+- [Benchmarking](guide/benchmarking.md)
 
 # Reference
 

--- a/docs/src/cli/overview.md
+++ b/docs/src/cli/overview.md
@@ -1,0 +1,46 @@
+# CLI reference
+
+The `ferro` command groups its work into subcommands. Run `ferro <command> --help` for the full,
+authoritative options of any one — this page is a map, not a substitute.
+
+## Core
+
+| Command | What it does |
+|---|---|
+| `parse` | Parse and validate an HGVS description (no reference needed). |
+| `normalize` | Rewrite descriptions into canonical form (needs a reference). See [Normalize variants](../guide/normalize-variants.md). |
+| `project` | Re-express a variant on a chosen output axis (`g` / `c` / `n` / `p` / `r`). |
+| `explain` | Explain an error or warning code (e.g. `ferro explain W3003`). |
+
+## Reference data
+
+| Command | What it does |
+|---|---|
+| `prepare` | Download and assemble reference data. See [Reference data](../guide/reference-data.md). |
+| `check` | Verify a reference directory is ready (optionally pre-build the cache). |
+| `convert-gff` | Convert a GFF3/GTF annotation to `transcripts.json`. |
+| `build-transcript` | Build a single-exon `transcripts.json` from a FASTA + CDS coordinates. |
+
+## VCF and interchange
+
+| Command | What it does |
+|---|---|
+| `annotate-vcf` | Annotate a VCF file with HGVS notation. |
+| `vcf-to-hgvs` / `hgvs-to-vcf` | Convert between VCF and HGVS. |
+| `extract-hgvs` | Extract HGVS patterns from VEP-annotated VCF files. |
+| `liftover` | Lift genomic coordinates between genome builds. |
+
+## Generation and prediction
+
+| Command | What it does |
+|---|---|
+| `generate` | Generate an HGVS description from components. |
+| `describe` | Generate a description from reference and observed sequences. |
+| `effect` | Predict the protein effect of a variant. |
+| `backtranslate` | Backtranslate a protein variant to possible DNA variants. |
+
+## Common options
+
+Most commands accept `-i/--input <file>` (one description per line), `-o/--output <file>`, and
+`-f/--format <text|json|tsv>`. Commands that normalize also accept `--reference <dir>` and
+`--error-mode <strict|lenient|silent>`.

--- a/docs/src/cli/overview.md
+++ b/docs/src/cli/overview.md
@@ -41,6 +41,7 @@ authoritative options of any one — this page is a map, not a substitute.
 
 ## Common options
 
-Most commands accept `-i/--input <file>` (one description per line), `-o/--output <file>`, and
-`-f/--format <text|json|tsv>`. Commands that normalize also accept `--reference <dir>` and
-`--error-mode <strict|lenient|silent>`.
+Most commands accept `-i/--input <file>` (one description per line) and `-o/--output <file>`. The
+output format is set with `-f/--format`, and the accepted values depend on the command: `text|json`
+for `parse` and `project`, `text|json|tsv` for `normalize`, and `text|json|markdown` for `explain`.
+Commands that normalize also accept `--reference <dir>` and `--error-mode <strict|lenient|silent>`.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,45 @@
+# Installation
+
+ferro ships as a Python package, a Rust crate, and a standalone command-line tool. Install whichever
+fits your workflow — they share the same engine.
+
+## Python
+
+```bash
+pip install ferro-hgvs
+```
+
+Pre-built wheels are available for Linux (x86_64, aarch64), macOS (x86_64 and Apple Silicon), and
+Windows (x86_64) on Python 3.10+.
+
+## Command-line tool
+
+```bash
+cargo install ferro-hgvs
+```
+
+This builds the `ferro` binary from source and places it on your `PATH`. It needs a Rust toolchain
+([rustup](https://rustup.rs/)).
+
+## Rust library
+
+Add the crate to your project:
+
+```toml
+[dependencies]
+ferro-hgvs = "0.14"
+```
+
+## Verify the install
+
+```bash
+ferro parse "NM_000088.3:c.459A>G"
+```
+
+```python
+import ferro_hgvs
+print(ferro_hgvs.parse("NM_000088.3:c.459A>G"))
+```
+
+Parsing needs no reference data. Normalization against real transcripts does — see
+[Reference data](../guide/reference-data.md).

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -38,7 +38,7 @@ ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
 ```python
 import ferro_hgvs
 
-normalizer = ferro_hgvs.Normalizer(reference_json="ferro-reference/cdot.json")
+normalizer = ferro_hgvs.Normalizer.from_manifest("ferro-reference/manifest.json")
 print(normalizer.normalize("NM_000088.3:c.459del"))
 ```
 
@@ -52,7 +52,7 @@ and was accepted anyway (`REFSEQ_MISMATCH`).
 
 These are reported as `warning[CODE]: message` on **stderr** (and in the `warnings` array under
 `--format json`, the `detail` column under `--format tsv`), so a pipeline reading only stdout will
-not see them. Run `ferro explain <CODE>` for what any code means.
+not see them. The `message` on each `warning[CODE]:` line says what the code means.
 
 ## Next steps
 

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart
+
+This walks through parsing a variant, then normalizing one against reference data.
+
+## Parse a variant
+
+Parsing validates a description and returns its structure. It needs no reference data.
+
+```bash
+ferro parse "NM_000088.3:c.459A>G"
+```
+
+```python
+import ferro_hgvs
+
+variant = ferro_hgvs.parse("NM_000088.3:c.459A>G")
+print(variant.variant_type)  # "coding"
+print(variant.reference)     # "NM_000088.3"
+print(str(variant))          # "NM_000088.3:c.459A>G"
+```
+
+## Normalize a variant
+
+Normalization rewrites a description into its canonical form. It needs reference sequences, so first
+prepare a reference (a one-time download — see [Reference data](../guide/reference-data.md)):
+
+```bash
+ferro prepare --output-dir ferro-reference
+ferro check --reference ferro-reference
+```
+
+Then normalize:
+
+```bash
+ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
+```
+
+```python
+import ferro_hgvs
+
+normalizer = ferro_hgvs.Normalizer(reference_json="ferro-reference/cdot.json")
+print(normalizer.normalize("NM_000088.3:c.459del"))
+```
+
+## Read the warnings
+
+Normalization sometimes *repairs* a description in a way the normalized string does not itself
+record — separately reported members merged into one `delins`
+(`MEMBERS_COALESCED_FROM_REPORTED_FORM`), a reference-range insertion payload replaced by the bases
+it denotes (`INSERTED_SEQUENCE_EXPANDED`), or a stated reference base that contradicted the reference
+and was accepted anyway (`REFSEQ_MISMATCH`).
+
+These are reported as `warning[CODE]: message` on **stderr** (and in the `warnings` array under
+`--format json`, the `detail` column under `--format tsv`), so a pipeline reading only stdout will
+not see them. Run `ferro explain <CODE>` for what any code means.
+
+## Next steps
+
+- [Normalize variants](../guide/normalize-variants.md) — batches, files, output formats, error modes.
+- [Reference data](../guide/reference-data.md) — what `ferro prepare` downloads and the optional data.
+- [CLI reference](../cli/overview.md) — every subcommand.

--- a/docs/src/guide/benchmarking.md
+++ b/docs/src/guide/benchmarking.md
@@ -47,7 +47,7 @@ ferro-benchmark normalize mutalyzer -i patterns.txt -o mutalyzer.json \
 ferro-benchmark compare results normalize ferro.json mutalyzer.json -o comparison.json
 ```
 
-Supported tools: `ferro-hgvs`, `mutalyzer`, `biocommons/hgvs`, `hgvs-rs`.
+Supported tool values: `ferro`, `mutalyzer`, `biocommons`, `hgvs-rs`, and `all`.
 
 The Python-based tools (mutalyzer, biocommons/hgvs, seqrepo) run in a [pixi](https://pixi.sh)
 environment defined by the repository's `pixi.toml`; run `pixi shell` to activate it before

--- a/docs/src/guide/benchmarking.md
+++ b/docs/src/guide/benchmarking.md
@@ -1,0 +1,63 @@
+# Benchmarking
+
+ferro ships a benchmark harness for measuring its own throughput and comparing it against other HGVS
+tools (mutalyzer, biocommons/hgvs, hgvs-rs). This guide covers running it; for the published figures
+and full method, see
+[`docs/BENCHMARK_RUNBOOK.md`](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/docs/BENCHMARK_RUNBOOK.md).
+
+## Timing ferro alone
+
+The main `ferro` binary needs no special build. Prepare a reference (see
+[Reference data](reference-data.md)), then time a normalize run:
+
+```bash
+ferro prepare --output-dir data/ferro
+ferro check --reference data/ferro
+ferro normalize -i patterns.txt --reference data/ferro -j 8 -t timing.json
+```
+
+`-t/--timing` writes timing information to JSON. Two things matter for a fair number:
+
+- **Warm the cache first.** `ferro check --reference data/ferro --build-cache` builds the on-disk
+  cdot cache as a setup step, so the one-time build does not land inside the timed region.
+- **Sort the input** by transcript accession (or genomic position). ferro caches each resolved
+  transcript, so sorted input keeps the working set resident and is markedly faster on large
+  batches.
+
+## Comparing against other tools
+
+Tool comparison uses the separate `ferro-benchmark` binary, built with the `benchmark` feature:
+
+```bash
+cargo build --release --features benchmark
+```
+
+`ferro-benchmark` prepares each tool's reference data (reusing ferro's for transcripts), runs
+parse/normalize, and compares results:
+
+```bash
+# Prepare another tool against the same transcript data
+ferro-benchmark prepare mutalyzer --ferro-reference data/ferro --output-dir data/mutalyzer
+
+# Normalize a shared pattern set with each tool
+ferro-benchmark normalize mutalyzer -i patterns.txt -o mutalyzer.json \
+  --mutalyzer-settings data/mutalyzer/mutalyzer_settings.conf
+
+# Compare two tools' outputs
+ferro-benchmark compare results normalize ferro.json mutalyzer.json -o comparison.json
+```
+
+Supported tools: `ferro-hgvs`, `mutalyzer`, `biocommons/hgvs`, `hgvs-rs`.
+
+The Python-based tools (mutalyzer, biocommons/hgvs, seqrepo) run in a [pixi](https://pixi.sh)
+environment defined by the repository's `pixi.toml`; run `pixi shell` to activate it before
+preparing them.
+
+## Reading the numbers honestly
+
+All tools are benchmarked **offline** — reference data preloaded locally, network disabled — so the
+figures measure parse/normalize compute, not per-variant I/O. Out of the box the other tools resolve
+each variant against a remote service (a network round-trip per variant), which is far slower than
+any local figure. That local, offline setup is exactly what `ferro prepare` builds. When you quote a
+benchmark, say which configuration it was measured in, and confirm the run **succeeded and produced
+correct output** before trusting a timing — a crashed run still prints a wall-clock line.

--- a/docs/src/guide/normalize-variants.md
+++ b/docs/src/guide/normalize-variants.md
@@ -63,5 +63,5 @@ ferro normalize -i variants.txt --reference ferro-reference/ -f tsv > normalized
 Regardless of mode, normalization may *repair* a description in a way the output string does not
 record. Those repairs are reported as `warning[CODE]: message` on **stderr** (and in the `warnings`
 array under `-f json`, the `detail` column under `-f tsv`). A pipeline reading only stdout will not
-see them, so capture stderr or use `-f json`/`-f tsv`. Run `ferro explain <CODE>` to learn what a
-code means; use `--ignore` / `--reject` to tune specific codes.
+see them, so capture stderr or use `-f json`/`-f tsv`. The `message` on each `warning[CODE]:` line
+says what the code means; use `--ignore` / `--reject` to tune specific codes.

--- a/docs/src/guide/normalize-variants.md
+++ b/docs/src/guide/normalize-variants.md
@@ -1,0 +1,67 @@
+# Normalize variants
+
+Normalization rewrites a description into its canonical form — 3′-shifting, collapsing equivalent
+spellings, and applying the recommendations' preferred representation. This guide covers batches,
+files, output formats, and error modes.
+
+Normalization needs reference sequences. Prepare a reference first (see
+[Reference data](reference-data.md)) and pass `--reference`.
+
+## A single variant
+
+```bash
+ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
+```
+
+Read from stdin instead:
+
+```bash
+echo "NC_000001.11:g.12345A>G" | ferro normalize --reference ferro-reference/
+```
+
+## A batch from a file
+
+One description per line:
+
+```bash
+ferro normalize -i variants.txt --reference ferro-reference/ -o normalized.txt
+```
+
+**Sort the input by transcript accession (or genomic position) for large batches.** ferro caches
+each resolved transcript, so consecutive variants on the same transcript skip the dominant cost of
+re-reading it. Sorted input keeps the working set resident and is markedly faster.
+
+Use several workers for large batches:
+
+```bash
+ferro normalize -i variants.txt --reference ferro-reference/ -j 8
+```
+
+## Output formats
+
+`-f/--format` selects the output:
+
+- `text` (default) — the normalized description, one per line.
+- `json` — a structured record per input, including a `warnings` array.
+- `tsv` — a table with header `line, input, normalized, changed, status, detail`, plus a summary
+  line on stderr. This is the format for answering *"which of my variants changed?"*
+
+```bash
+ferro normalize -i variants.txt --reference ferro-reference/ -f tsv > normalized.tsv
+```
+
+## Error modes
+
+`--error-mode` controls how strict ferro is about its input and output:
+
+- `strict` (default) — validates that the input conforms to the recommendations and fails on a
+  violation.
+- `lenient` — accepts a wider range of inputs and repairs where it can; fails only when it cannot
+  normalize.
+- `silent` — lenient, but without the diagnostic messages.
+
+Regardless of mode, normalization may *repair* a description in a way the output string does not
+record. Those repairs are reported as `warning[CODE]: message` on **stderr** (and in the `warnings`
+array under `-f json`, the `detail` column under `-f tsv`). A pipeline reading only stdout will not
+see them, so capture stderr or use `-f json`/`-f tsv`. Run `ferro explain <CODE>` to learn what a
+code means; use `--ignore` / `--reject` to tune specific codes.

--- a/docs/src/guide/reference-data.md
+++ b/docs/src/guide/reference-data.md
@@ -1,0 +1,68 @@
+# Reference data
+
+Parsing needs no reference data. Normalization does — it must read the transcript and genome
+sequences a description refers to. `ferro prepare` downloads and assembles them into a reference
+directory.
+
+## Prepare a reference
+
+```bash
+ferro prepare --output-dir ferro-reference
+```
+
+This downloads RefSeq transcripts, genome FASTAs, and cdot metadata, and writes them under
+`ferro-reference/`. A bare `prepare` builds a **RefSeq-only** reference — accessions `NM_` / `NR_` /
+`NP_` / `NG_`.
+
+## Verify it
+
+```bash
+ferro check --reference ferro-reference
+```
+
+Optionally pre-build the on-disk cdot cache as a setup step, so the one-time cache build does not
+slow the start of a real (or timed) run:
+
+```bash
+ferro check --reference ferro-reference --build-cache
+```
+
+## Optional data
+
+Two opt-in flags provision more than RefSeq. Pass them at prepare time; both are incremental, so
+re-running `prepare` over an existing reference adds the requested data and preserves what is already
+there.
+
+**Ensembl support** (accessions `ENST` / `ENSG` / `ENSP`) — downloads Ensembl cdot metadata and cDNA
+FASTAs (~1 GB+); off by default. Without it, an Ensembl input reports "Reference not found":
+
+```bash
+ferro prepare --output-dir ferro-reference --ensembl
+```
+
+**RefSeqGene placements** — derives version-independent `NG_` placements and the
+`NG_`→transcript-version map, required to resolve legacy gene-symbol selectors (`NG_(GENE):c.…`) and
+bare-`NG_` hosted lookups:
+
+```bash
+ferro prepare --output-dir ferro-reference \
+  --derive-ng-placements path/to/ng_accessions.txt
+```
+
+A fully-provisioned reference combines both in one run:
+
+```bash
+ferro prepare --output-dir ferro-reference --ensembl \
+  --derive-ng-placements path/to/ng_accessions.txt
+```
+
+## Using it
+
+Point any normalizing command at the directory:
+
+```bash
+ferro normalize -i variants.txt --reference ferro-reference/
+```
+
+To guard against a reference that has drifted on disk, add `--strict-reference`, which hard-fails if
+the reference's content no longer matches its recorded identity (the default warns and proceeds).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,15 @@
+# ferro-hgvs
+
+A high-performance HGVS variant nomenclature parser and normalizer, written in Rust with Python
+bindings. It supports every HGVS coordinate system (`g` / `c` / `n` / `r` / `p` / `m` / `o`) and
+edit type (substitution, deletion, insertion, duplication, inversion, repeat).
+
+This site is the user-facing documentation. API docs are on [docs.rs](https://docs.rs/ferro-hgvs);
+source is on [GitHub](https://github.com/fulcrumgenomics/ferro-hgvs).
+
+## Shadow Spec
+
+The **[Shadow Spec](shadow-spec/index.md)** is a per-line reading of the HGVS recommendations that
+records exactly how ferro interprets each clause — with runnable example spellings, the form ferro
+normalizes each input to, and links to the governing rulings. It is under construction, one spec
+page at a time.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,12 +4,26 @@ A high-performance HGVS variant nomenclature parser and normalizer, written in R
 bindings. It supports every HGVS coordinate system (`g` / `c` / `n` / `r` / `p` / `m` / `o`) and
 edit type (substitution, deletion, insertion, duplication, inversion, repeat).
 
-This site is the user-facing documentation. API docs are on [docs.rs](https://docs.rs/ferro-hgvs);
-source is on [GitHub](https://github.com/fulcrumgenomics/ferro-hgvs).
+Use it as a Python package, a Rust crate, or a command-line tool. API docs are on
+[docs.rs](https://docs.rs/ferro-hgvs); source is on
+[GitHub](https://github.com/fulcrumgenomics/ferro-hgvs).
+
+## Start here
+
+- **[Installation](getting-started/installation.md)** — `pip install ferro-hgvs`,
+  `cargo install ferro-hgvs`, or the Rust crate.
+- **[Quickstart](getting-started/quickstart.md)** — parse a variant, then normalize one.
+
+## Guides
+
+- **[Normalize variants](guide/normalize-variants.md)** — batches, files, formats, error modes.
+- **[Reference data](guide/reference-data.md)** — what `ferro prepare` downloads, and the optional
+  Ensembl / RefSeqGene data.
+- **[CLI reference](cli/overview.md)** — every subcommand.
 
 ## Shadow Spec
 
 The **[Shadow Spec](shadow-spec/index.md)** is a per-line reading of the HGVS recommendations that
 records exactly how ferro interprets each clause — with runnable example spellings, the form ferro
-normalizes each input to, and links to the governing rulings. It is under construction, one spec
+normalizes each input to, and the reasoning behind each decision. It is under construction, one spec
 page at a time.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,9 +22,9 @@ Use it as a Python package, a Rust crate, or a command-line tool. API docs are o
 - **[Benchmarking](guide/benchmarking.md)** — timing ferro and comparing it against other HGVS tools.
 - **[CLI reference](cli/overview.md)** — every subcommand.
 
-## Shadow Spec
+## Interpretation
 
-The **[Shadow Spec](shadow-spec/index.md)** is a per-line reading of the HGVS recommendations that
-records exactly how ferro interprets each clause — with runnable example spellings, the form ferro
-normalizes each input to, and the reasoning behind each decision. It is under construction, one spec
-page at a time.
+The **[Interpretation](shadow-spec/index.md)** section is a per-line reading of the HGVS
+recommendations that records exactly how ferro interprets each clause — with runnable example
+spellings, the form ferro normalizes each input to, and the reasoning behind each decision. It is
+under construction, one spec page at a time.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,7 @@ Use it as a Python package, a Rust crate, or a command-line tool. API docs are o
 - **[Normalize variants](guide/normalize-variants.md)** — batches, files, formats, error modes.
 - **[Reference data](guide/reference-data.md)** — what `ferro prepare` downloads, and the optional
   Ensembl / RefSeqGene data.
+- **[Benchmarking](guide/benchmarking.md)** — timing ferro and comparing it against other HGVS tools.
 - **[CLI reference](cli/overview.md)** — every subcommand.
 
 ## Shadow Spec

--- a/docs/src/shadow-spec/index.md
+++ b/docs/src/shadow-spec/index.md
@@ -1,0 +1,37 @@
+# Shadow Spec
+
+> **Under construction.** Pages are added one HGVS spec page at a time; this section will fill in
+> as they land.
+
+## What it is
+
+The HGVS recommendations are, in places, silent, ambiguous, or self-contradictory — but a
+normalizer still has to emit one string. The **shadow spec** mirrors the recommendations page for
+page and records, per clause, how ferro reads it.
+
+Each page gives, for a span of the spec:
+
+- the **spec text** it shadows, quoted verbatim;
+- **ferro's reading** of that clause;
+- **example spellings** with a verdict — `recommended` (the form ferro emits), `conformant`
+  (legal, but ferro may rewrite it), `invalid` (refused in strict mode), or `gap` (a known
+  ferro↔spec divergence, pinned to current behavior);
+- the form each input **normalizes to**, and which spellings **converge** on one output;
+- links to the governing **rulings** and README rules, so the *why* is one click away.
+
+## What it is not
+
+It is not a second copy of the rules. The canonical ruleset lives in the project README, and the
+adjudication decisions live in the ruling ledger. The shadow spec **links** to both and never
+restates them — a rule written in two places is a rule that drifts.
+
+## How it stays honest
+
+Every example is executed through ferro by a build check: each spec quote is verified against the
+pinned spec checkout, each spelling is parsed (and strict-refused where marked `invalid`), and each
+`normalizes to` is asserted against a real GRCh38 reference. A wrong verdict, a moved quote, or a
+changed normalization fails the build — so a page cannot claim behavior ferro does not have.
+
+## Pages
+
+_None published yet._ The first page (DNA substitution) is in review.

--- a/docs/src/shadow-spec/index.md
+++ b/docs/src/shadow-spec/index.md
@@ -5,31 +5,53 @@
 
 ## What it is
 
-The HGVS recommendations are, in places, silent, ambiguous, or self-contradictory — but a
-normalizer still has to emit one string. The **shadow spec** mirrors the recommendations page for
-page and records, per clause, how ferro reads it.
+The [HGVS nomenclature recommendations](https://hgvs-nomenclature.org/) are the standard for naming
+sequence variants. They are large and carefully written, but — like any natural-language standard —
+in places they leave a question open, or two passages can be read as pointing different ways. A
+normalizer still has to emit exactly one string. Where ferro has had to settle such a question, we
+record the decision (and, where a passage looks inconsistent, file it upstream with the SVD Working
+Group).
 
-Each page gives, for a span of the spec:
+The **shadow spec** mirrors the recommendations page for page and records, per clause, how ferro
+reads it. Each page gives, for a span of the spec:
 
 - the **spec text** it shadows, quoted verbatim;
 - **ferro's reading** of that clause;
-- **example spellings** with a verdict — `recommended` (the form ferro emits), `conformant`
-  (legal, but ferro may rewrite it), `invalid` (refused in strict mode), or `gap` (a known
-  ferro↔spec divergence, pinned to current behavior);
-- the form each input **normalizes to**, and which spellings **converge** on one output;
-- links to the governing **rulings** and README rules, so the *why* is one click away.
+- **example spellings**, each with the form ferro **normalizes** it to and a verdict describing that
+  output against the recommendations (see below);
+- which spellings **converge** on one output;
+- the **reason** ferro reads the clause the way it does, and a link to the governing decision.
+
+## How to read the verdicts
+
+The recommendations are HGVS's, not ferro's. ferro's job is to take any input and produce the form
+the recommendations prefer. The verdict describes **ferro's output** against that goal:
+
+- **recommended** — ferro's output is the form the HGVS recommendations prefer. This is the target,
+  whether the input was already that form or ferro normalized it there.
+- **conformant** — ferro's output is a valid HGVS string but not *yet* the recommended form. This is
+  a known ferro limitation, and it links to the issue tracking it.
+- **refused** — the input is not valid HGVS; ferro rejects it in strict mode. Refusing is the
+  correct behavior.
+- **bug** — ferro's output is not valid HGVS. This should never happen; where a page shows one, it
+  links to the open defect.
 
 ## What it is not
 
-It is not a second copy of the rules. The canonical ruleset lives in the project README, and the
-adjudication decisions live in the ruling ledger. The shadow spec **links** to both and never
-restates them — a rule written in two places is a rule that drifts.
+It is not a second copy of the rules. The canonical ruleset lives in the project
+[README](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/README.md#normalization-rules), and
+every adjudication is recorded once in the **ruling ledger**
+([`hgvs_spec_normalization_overrides.json`](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json),
+rendered for reading as
+[NORMALIZATION_CONTRACT.md](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/docs/NORMALIZATION_CONTRACT.md)).
+The shadow spec **draws its explanations from the ledger** rather than restating them — a rule
+written in two places is a rule that drifts.
 
 ## How it stays honest
 
 Every example is executed through ferro by a build check: each spec quote is verified against the
-pinned spec checkout, each spelling is parsed (and strict-refused where marked `invalid`), and each
-`normalizes to` is asserted against a real GRCh38 reference. A wrong verdict, a moved quote, or a
+pinned spec checkout, each spelling is parsed (and strict-refused where marked **refused**), and each
+normalized output is asserted against a real GRCh38 reference. A wrong verdict, a moved quote, or a
 changed normalization fails the build — so a page cannot claim behavior ferro does not have.
 
 ## Pages

--- a/docs/src/shadow-spec/index.md
+++ b/docs/src/shadow-spec/index.md
@@ -1,4 +1,4 @@
-# Shadow Spec
+# Interpreting the HGVS Recommendations
 
 > **Under construction.** Pages are added one HGVS spec page at a time; this section will fill in
 > as they land.
@@ -12,10 +12,10 @@ normalizer still has to emit exactly one string. Where ferro has had to settle s
 record the decision (and, where a passage looks inconsistent, file it upstream with the SVD Working
 Group).
 
-The **shadow spec** mirrors the recommendations page for page and records, per clause, how ferro
-reads it. Each page gives, for a span of the spec:
+This section mirrors the recommendations page for page and records, per clause, how ferro reads
+each one. Each page gives, for a span of the spec:
 
-- the **spec text** it shadows, quoted verbatim;
+- the **spec text** it interprets, quoted verbatim;
 - **ferro's reading** of that clause;
 - **example spellings**, each with the form ferro **normalizes** it to and a verdict describing that
   output against the recommendations (see below);
@@ -44,7 +44,7 @@ every adjudication is recorded once in the **ruling ledger**
 ([`hgvs_spec_normalization_overrides.json`](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json),
 rendered for reading as
 [NORMALIZATION_CONTRACT.md](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/docs/NORMALIZATION_CONTRACT.md)).
-The shadow spec **draws its explanations from the ledger** rather than restating them — a rule
+These pages **draw their explanations from the ledger** rather than restating them — a rule
 written in two places is a rule that drifts.
 
 ## How it stays honest

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,0 +1,50 @@
+/* ferro-hgvs docs — light touch over mdBook's navy theme.
+   A teal accent (the shadow-spec palette) and readable measure; nothing heavy. */
+
+:root {
+  --ferro-accent: #0f766e;
+  --ferro-accent-light: #4fd1c5;
+}
+
+.menu-title {
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+/* Accent links and the active sidebar item with ferro's teal. */
+.content a:not(.header),
+.content a:not(.header):visited {
+  color: var(--ferro-accent-light);
+}
+.chapter li.chapter-item a.active {
+  color: var(--ferro-accent-light);
+  font-weight: 600;
+}
+
+/* Comfortable reading measure; wide content scrolls in its own box. */
+.content main {
+  max-width: 46rem;
+}
+.content pre,
+.content .table-wrapper {
+  overflow-x: auto;
+}
+
+/* Tables read as data: tight, ruled, monospaced first column for spellings. */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+.content table td,
+.content table th {
+  padding: 0.4rem 0.7rem;
+}
+.content table td code {
+  white-space: nowrap;
+}
+
+/* Blockquotes carry spec text; give them the accent rail. */
+.content blockquote {
+  border-inline-start: 3px solid var(--ferro-accent);
+}

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,50 +1,874 @@
-/* ferro-hgvs docs — light touch over mdBook's navy theme.
-   A teal accent (the shadow-spec palette) and readable measure; nothing heavy. */
+/* ============================================================
+   Fulcrum Genomics — ferro-hgvs documentation theme
+   Adapted from fgumi's "Lab Readout" theme.
+   ============================================================ */
 
+/* --- Google Fonts: IBM Plex family -------------------------- */
+@import 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,600;0,700;1,400&family=IBM+Plex+Serif:wght@400;600&display=swap';
+
+/* --- Fulcrum Genomics brand palette ------------------------- */
 :root {
-  --ferro-accent: #0f766e;
-  --ferro-accent-light: #4fd1c5;
+    --fg-blue:       #26a8e0;
+    --fg-green:      #38b44a;
+    --fg-pacific:    #1693b9;
+    --fg-sky:        #4dcce8;
+    --fg-teal:       #2fae99;
+    --fg-emerald:    #4dcc68;
+    --fg-forest:     #269e2a;
+    --fg-deep-blue:  #160052;
+    --fg-night-blue: #10003d;
+    --fg-ghost:      #f8f5ff;
+    --fg-gray:       #a5a8a7;
+}
+
+/* --- Body typography ---------------------------------------- */
+
+/* Override mdBook's small root font size */
+html {
+    font-size: 18px !important;
+    scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+}
+
+body {
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: 1rem !important;
+    line-height: 1.75 !important;
+}
+
+code, kbd, pre, samp, .hljs {
+    font-family: 'IBM Plex Mono', monospace !important;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+}
+
+.content main {
+    font-size: 1rem !important;
+    line-height: 1.8 !important;
+}
+
+.content main p,
+.content main li,
+.content main td,
+.content main th {
+    font-size: 1rem !important;
+    line-height: 1.8 !important;
+}
+
+.content main h1 { font-size: 2.1rem !important;  margin-top: 1rem !important; }
+.content main h2 { font-size: 1.55rem !important; margin-top: 2rem !important; margin-bottom: 1rem !important; }
+.content main h3 { font-size: 1.25rem !important; margin-top: 1.5rem !important; }
+.content main h4 { font-size: 1.15rem !important; color: var(--fg-pacific); }
+.content main h5 { font-size: 1rem !important; color: var(--fg-pacific); }
+.content main h6 { font-size: 0.9rem !important; color: var(--fg-pacific); }
+
+/* ============================================================
+   NAVY THEME (default dark)
+   ============================================================ */
+.navy {
+    --bg:                   #fafbff;
+    --fg:                   #1a1a2e;
+    --sidebar-bg:           transparent;   /* handled by gradient */
+    --sidebar-fg:           #e2e8f0;
+    --sidebar-active:       #ffffff;
+    --sidebar-spacer:       rgba(255,255,255,0.08);
+    --scrollbar:            rgba(255,255,255,0.2);
+    --icons:                rgba(255,255,255,0.5);
+    --icons-hover:          var(--fg-sky);
+    --links:                var(--fg-blue);
+    --inline-code-color:    var(--fg-deep-blue);
+    --theme-popup-bg:       #ffffff;
+    --theme-popup-border:   #e0e0f0;
+    --theme-hover:          var(--fg-ghost);
+    --quote-bg:             #e8f6ed;
+    --quote-border:         var(--fg-green);
+    --warning-border:       var(--fg-blue);
+    --table-border-color:   #e0e4f0;
+    --table-header-bg:      #eef6ff;
+    --table-alternate-bg:   #f0f8ff;
+    --searchbar-border-color: var(--fg-blue);
+    --searchbar-bg:         #ffffff;
+    --searchbar-fg:         var(--fg-deep-blue);
+    --searchbar-shadow-color: rgba(38,168,224,0.3);
+    --searchresults-header-fg: var(--fg-gray);
+    --searchresults-border-color: #e0e0f0;
+    --searchresults-li-bg:  var(--fg-ghost);
+    --search-mark-bg:       var(--fg-teal);
+}
+
+/* --- Content area: light, clean ----------------------------- */
+.navy .content main,
+.navy .page-wrapper {
+    background: #fafbff;
+    color: #1a1a2e;
+}
+
+/* ============================================================
+   LIGHT THEME
+   ============================================================ */
+.light {
+    --bg:                   #ffffff;
+    --fg:                   #1a1a2e;
+    --sidebar-bg:           transparent;
+    --sidebar-fg:           #e2e8f0;
+    --sidebar-active:       #ffffff;
+    --sidebar-spacer:       rgba(255,255,255,0.08);
+    --scrollbar:            rgba(255,255,255,0.2);
+    --icons:                rgba(255,255,255,0.5);
+    --icons-hover:          var(--fg-sky);
+    --links:                var(--fg-blue);
+    --inline-code-color:    var(--fg-deep-blue);
+    --theme-popup-bg:       #ffffff;
+    --theme-popup-border:   #e0e0f0;
+    --theme-hover:          var(--fg-ghost);
+    --quote-bg:             #e8f6ed;
+    --quote-border:         var(--fg-green);
+    --warning-border:       var(--fg-blue);
+    --table-border-color:   #e0e4f0;
+    --table-header-bg:      #eef6ff;
+    --table-alternate-bg:   #f0f8ff;
+    --searchbar-border-color: var(--fg-blue);
+    --searchbar-bg:         #ffffff;
+    --searchbar-fg:         var(--fg-deep-blue);
+    --searchbar-shadow-color: rgba(38,168,224,0.3);
+    --searchresults-header-fg: var(--fg-gray);
+    --searchresults-border-color: #e0e0f0;
+    --searchresults-li-bg:  var(--fg-ghost);
+    --search-mark-bg:       var(--fg-teal);
+}
+
+/* ============================================================
+   SIDEBAR — FG Night Blue ➜ Forest Green gradient
+   ============================================================ */
+.sidebar {
+    background: linear-gradient(
+        160deg,
+        #10003d 0%,
+        #160052 35%,
+        #0d2e1a 75%,
+        #0a2214 100%
+    ) !important;
+    border-right: 1px solid rgba(56, 180, 74, 0.2);
+}
+
+.sidebar .sidebar-scrollbox {
+    padding-top: 0.5rem;
+}
+
+/* Sidebar book title */
+.sidebar .sidebar-scrollbox .sidebar-title {
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #ffffff;
+    letter-spacing: 0.02em;
+    padding: 0.75rem 1rem 0.5rem;
+    display: block;
+}
+
+/* All sidebar links */
+.sidebar a {
+    color: rgba(226, 232, 240, 0.95) !important;
+    font-size: 0.875rem;
+    transition: color 0.15s ease, padding-left 0.15s ease;
+}
+
+.sidebar a:hover {
+    color: var(--fg-sky) !important;
+    text-decoration: none;
+}
+
+/* Section header spans (no-link draft chapters like "Getting Started").
+   sidebar-brand.js makes the whole row fold its section on click, so render
+   the header as interactive. */
+.sidebar .chapter-link-wrapper > span {
+    color: var(--fg-blue) !important;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+/* "Home" is the only top-level *link* (every section is a draft-chapter span),
+   so by default it picks up the light-grey link color and looks out of place
+   next to the blue section headers. Color it blue to match when it is not the
+   current page; the active rule below keeps it white + green bar when it is. */
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active) {
+    color: var(--fg-blue) !important;
+}
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active):hover {
+    color: var(--fg-sky) !important;
+}
+
+/* mdBook 0.5 injects the *current* page's in-page headings into the left
+   sidebar as an always-expanded ".on-this-page" outline under the active entry.
+   That makes the active item (e.g. Home) the one thing in the sidebar that
+   cannot be collapsed, clashing with the uniform collapsible sections. Hide it;
+   the page's headings remain visible in the page body itself. */
+.sidebar .on-this-page {
+    display: none !important;
+}
+
+/* Active page — green left-bar accent */
+.sidebar a.active {
+    color: #ffffff !important;
+    position: relative;
+    font-weight: 600;
+}
+
+.sidebar a.active::before {
+    content: '';
+    position: absolute;
+    /* Sit in the left gutter rather than flush against the text, so there is a
+       clear gap between the accent bar and the active label. */
+    left: -0.6rem;
+    top: 0.1rem;
+    bottom: 0.1rem;
+    width: 3px;
+    background: var(--fg-green);
+    border-radius: 0 2px 2px 0;
+}
+
+/* Top-level part titles (User Guide, Tool Reference, Metrics Reference) */
+.sidebar-scrollbox .part-title {
+    color: var(--fg-emerald) !important;
+    font-size: 0.8rem !important;
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 700;
+    margin-top: 1.5rem;
+    padding-left: 0 !important;
+}
+
+/* Sidebar separator lines */
+.sidebar hr {
+    border-color: rgba(56, 180, 74, 0.2);
+    margin: 0.5rem 1rem;
+}
+
+/* ============================================================
+   TOP MENU BAR
+   ============================================================ */
+.menu-bar,
+.menu-bar .menu-bar-sticky-container {
+    background: var(--fg-night-blue) !important;
+    border-bottom: 2px solid var(--fg-green) !important;
 }
 
 .menu-title {
-  font-weight: 650;
-  letter-spacing: -0.01em;
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-weight: 600 !important;
+    letter-spacing: -0.01em !important;
 }
 
-/* Accent links and the active sidebar item with ferro's teal. */
-.content a:not(.header),
-.content a:not(.header):visited {
-  color: var(--ferro-accent-light);
-}
-.chapter li.chapter-item a.active {
-  color: var(--ferro-accent-light);
-  font-weight: 600;
+.menu-bar i.fa,
+.menu-bar .icon-button {
+    color: rgba(255,255,255,0.75) !important;
 }
 
-/* Comfortable reading measure; wide content scrolls in its own box. */
+.menu-bar i.fa:hover,
+.menu-bar .icon-button:hover {
+    color: var(--fg-sky) !important;
+}
+
+/* ============================================================
+   CONTENT AREA
+   ============================================================ */
+
+/* H1: green underline */
+.content main h1 {
+    color: var(--fg-deep-blue);
+    border-bottom: 3px solid var(--fg-green);
+    padding-bottom: 0.4rem;
+    margin-bottom: 1.5rem;
+}
+
+.content main h2 {
+    color: var(--fg-deep-blue);
+    border-bottom: 1px solid #e0e4f0;
+    padding-bottom: 0.25rem;
+}
+
+.content main h3 {
+    color: var(--fg-pacific);
+}
+
+/* Links — FG Blue for visibility, Sky on hover */
+a {
+    color: var(--fg-blue);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--fg-sky);
+    text-decoration: underline;
+}
+
+/* Restore underlines for content links so they remain discoverable in
+   long-form docs. Nav/sidebar/breadcrumb/footer selectors below scope
+   themselves to no-underline explicitly. */
+.content main a {
+    text-decoration: underline;
+}
+
+/* ============================================================
+   BREADCRUMBS
+   ============================================================ */
+.fg-breadcrumb {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--fg-gray);
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.fg-breadcrumb a {
+    color: var(--fg-pacific) !important;
+    text-decoration: none;
+}
+
+.fg-breadcrumb a:hover {
+    color: var(--fg-blue) !important;
+    text-decoration: underline;
+}
+
+.fg-breadcrumb-sep {
+    color: var(--fg-gray);
+    margin: 0 0.1rem;
+    opacity: 0.6;
+}
+
+.fg-breadcrumb-current {
+    color: var(--fg);
+    font-weight: 600;
+}
+
+/* ============================================================
+   CODE
+   ============================================================ */
+
+/* Inline code — high specificity to beat mdBook's theme overrides */
+.content main code,
+.content p code,
+.content li code,
+.content td code,
+.content th code,
+.content h1 code,
+.content h2 code,
+.content h3 code,
+.content h4 code,
+p code,
+li code,
+td code {
+    font-family: 'IBM Plex Mono', monospace !important;
+    background: #dff0fb !important;
+    color: #0d2d52 !important;
+    border: 1px solid #b3d9f0 !important;
+    border-radius: 3px !important;
+    padding: 0.1em 0.4em !important;
+    font-size: 0.9em !important;
+}
+
+/* Code blocks — green left accent */
+pre {
+    border-left: 4px solid var(--fg-green) !important;
+    border-radius: 0 6px 6px 0 !important;
+    background: #f4f8ff !important;
+    box-shadow: inset 0 1px 3px rgba(22, 0, 82, 0.06);
+    padding: 0.75rem 1rem !important;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: #1a1a2e;
+    font-size: 0.875rem;
+    line-height: 1.6;
+}
+
+/* Copy button */
+.copy-button {
+    border: 1px solid var(--fg-green) !important;
+    color: var(--fg-forest) !important;
+    background: rgba(56, 180, 74, 0.2) !important;
+}
+
+.copy-button:hover {
+    background: rgba(56, 180, 74, 0.35) !important;
+}
+
+/* ============================================================
+   TABLES
+   ============================================================ */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.25rem 0;
+    font-size: 0.9rem;
+    box-shadow: 0 1px 4px rgba(22, 0, 82, 0.07);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+table th {
+    background: var(--fg-deep-blue);
+    color: #ffffff;
+    text-align: left;
+    padding: 0.6rem 0.85rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+table td {
+    padding: 0.55rem 0.85rem;
+    border-bottom: 1px solid var(--table-border-color);
+    vertical-align: top;
+}
+
+table tr:last-child td {
+    border-bottom: none;
+}
+
+table tr:nth-child(even) td {
+    background: #f0f8ff;
+}
+
+table tr:hover td {
+    background: #d6ebff;
+}
+
+/* ============================================================
+   BLOCKQUOTES — green accent (notes, tips)
+   ============================================================ */
+blockquote {
+    border-left: 4px solid var(--fg-green) !important;
+    background: #e8f6ed !important;
+    padding: 0.85rem 1.1rem !important;
+    border-radius: 0 6px 6px 0;
+    color: #1a3a28;
+    margin: 1.25rem 0;
+}
+
+blockquote p {
+    margin: 0;
+}
+
+blockquote strong {
+    color: var(--fg-forest);
+}
+
+/* ============================================================
+   SEARCH
+   ============================================================ */
+#searchbar {
+    font-family: 'IBM Plex Mono', monospace !important;
+    border: 1px solid var(--fg-blue);
+    border-radius: 4px;
+    font-size: 0.875rem;
+}
+
+#searchbar:focus {
+    border-color: var(--fg-green);
+    box-shadow: 0 0 0 3px rgba(56, 180, 74, 0.5);
+    outline: 2px solid transparent;
+}
+
+/* ============================================================
+   TOOL REFERENCE (auto-generated pages)
+   ============================================================ */
+
+/* Category labels */
+.tool-category {
+    font-family: 'IBM Plex Mono', monospace;
+    font-weight: 600;
+    color: var(--fg-green);
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    border-bottom: 1px solid rgba(56, 180, 74, 0.3);
+    padding-bottom: 0.3rem;
+}
+
+.tool-description code,
+.metric-description code {
+    font-size: 0.875em;
+}
+
+/* ============================================================
+   LANDING PAGE
+   ============================================================ */
+.hero {
+    text-align: center;
+    padding: 3rem 0 2rem;
+    margin-bottom: 3rem;
+    border-bottom: 1px solid #e0e4f0;
+}
+
+.hero h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--fg-deep-blue);
+    border-bottom: none;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.03em;
+}
+
+.hero h1 span {
+    color: var(--fg-green);
+}
+
+.hero .tagline {
+    font-size: 1.15rem;
+    color: var(--fg-pacific);
+    font-weight: 300;
+}
+
+/* Feature / use-case cards */
+.use-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(1rem, 3vw, 1.5rem);
+    margin: 1.5rem 0;
+}
+
+.use-card {
+    border: 1px solid #e0e4f0;
+    border-top: 4px solid var(--fg-blue);
+    border-radius: 0 0 8px 8px;
+    padding: 1.5rem;
+    background: #fafbff;
+    box-shadow: 0 2px 8px rgba(22, 0, 82, 0.06);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.use-card:hover {
+    box-shadow: 0 4px 16px rgba(22, 0, 82, 0.12);
+    transform: translateY(-2px);
+}
+
+.use-card:nth-child(2) { border-top-color: var(--fg-green); }
+.use-card:nth-child(3) { border-top-color: var(--fg-teal); }
+.use-card:nth-child(4) { border-top-color: var(--fg-pacific); }
+
+.use-card h3 {
+    margin-top: 0;
+    color: var(--fg-deep-blue);
+    font-size: 1rem;
+}
+
+/* ============================================================
+   FG BRANDING INJECTED BY sidebar-brand.js
+   ============================================================ */
+.fg-brand-header {
+    padding: 1.1rem 1rem 0.85rem;
+    border-bottom: 1px solid rgba(56, 180, 74, 0.25);
+    margin-bottom: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.fg-brand-link {
+    display: block;
+    line-height: 0;
+}
+
+.fg-brand-logo {
+    height: 64px;
+    width: auto;
+    display: block;
+    opacity: 0.92;
+    transition: opacity 0.15s ease;
+}
+
+.fg-brand-link:hover .fg-brand-logo {
+    opacity: 1;
+}
+
+.fg-brand-divider {
+    height: 1px;
+    background: rgba(56, 180, 74, 0.2);
+    margin: 0.1rem 0;
+}
+
+.fg-brand-product {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-weight: 700;
+    font-size: 1.2rem;
+    letter-spacing: 0.01em;
+    padding: 0 0.1rem;
+    line-height: 1.2;
+}
+
+.fg-brand-tagline {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: 0.05em;
+    padding: 0 0.1rem;
+}
+
+.fg-brand-corp {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.72rem;
+    color: rgba(77, 204, 104, 0.7) !important;
+    text-decoration: none !important;
+    letter-spacing: 0.02em;
+    margin-top: 0.15rem;
+    transition: color 0.15s ease;
+}
+
+.fg-brand-corp:hover {
+    color: var(--fg-emerald) !important;
+    text-decoration: none !important;
+}
+
+/* ============================================================
+   CONTENT WIDTH & MARGINS
+   ============================================================ */
+
+/* Override mdBook's narrow 750px content column */
+:root {
+    --content-max-width: 98%;
+    --page-padding: 10px;
+}
+
+.content {
+    padding: 0 0.75rem 50px !important;
+}
+
+@media (min-width: 768px) {
+    .content {
+        padding: 0 1.5rem 50px !important;
+    }
+}
+
 .content main {
-  max-width: 46rem;
-}
-.content pre,
-.content .table-wrapper {
-  overflow-x: auto;
+    max-width: 1000px !important;
+    margin-inline-start: 0 !important;
+    margin-inline-end: auto !important;
 }
 
-/* Tables read as data: tight, ruled, monospaced first column for spellings. */
-.content table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.92em;
-}
-.content table td,
-.content table th {
-  padding: 0.4rem 0.7rem;
-}
-.content table td code {
-  white-space: nowrap;
+.page-wrapper {
+    padding-bottom: 3rem;
 }
 
-/* Blockquotes carry spec text; give them the accent rail. */
-.content blockquote {
-  border-inline-start: 3px solid var(--ferro-accent);
+@media (min-width: 1400px) {
+    .content main {
+        max-width: 1200px !important;
+    }
 }
+
+/* ============================================================
+   BYLINE (inline attribution next to h1 on index page)
+   ============================================================ */
+.fg-byline-inline {
+    font-size: 0.7rem;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.55);
+    vertical-align: middle;
+    margin-left: 0.6em;
+    white-space: nowrap;
+}
+
+.fg-byline-inline a {
+    color: rgba(255, 255, 255, 0.55);
+    text-decoration: none;
+}
+
+.fg-byline-inline a:hover {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: none;
+}
+
+/* ============================================================
+   VISIT US SECTION (index.md top + footer on all pages)
+   ============================================================ */
+.fg-visit-us {
+    margin-top: 2.5rem;
+    padding: 1.5rem 1rem 1.25rem;
+    border: 1px solid var(--table-border-color);
+    border-top: 4px solid var(--fg-green);
+    border-radius: 0 0 8px 8px;
+    background: var(--fg-ghost);
+    text-align: center;
+}
+
+.fg-visit-us img {
+    margin: 0 auto 1rem;
+    display: block;
+    max-width: 320px;
+    width: 100%;
+    height: auto;
+}
+
+.fg-footer-logo {
+    display: block;
+    margin: 0 auto 1rem;
+    width: fit-content;
+}
+
+.fg-footer-logo .fg-brand-logo {
+    height: 50px;
+    margin: 0 auto;
+}
+
+.fg-visit-us p {
+    font-size: 1rem;
+    color: var(--fg);
+    margin: 0 auto 1.25rem;
+    max-width: 100%;
+    text-align: center;
+}
+
+.fg-visit-buttons {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.fg-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1.6rem;
+    border-radius: 5px;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-decoration: none !important;
+    transition: filter 0.15s ease, transform 0.15s ease;
+    letter-spacing: 0.02em;
+}
+
+.fg-btn:hover {
+    filter: brightness(1.12);
+    transform: translateY(-1px);
+    text-decoration: none !important;
+}
+
+.fg-btn-green {
+    background: var(--fg-green);
+    color: #ffffff !important;
+}
+
+.fg-btn-blue {
+    background: var(--fg-blue);
+    color: #ffffff !important;
+}
+
+/* Quick links row in footer */
+.fg-footer-links {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    align-items: center;
+    font-size: 0.85rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--table-border-color);
+}
+
+.fg-footer-links a {
+    color: var(--fg-pacific) !important;
+    text-decoration: none;
+}
+
+.fg-footer-links a:hover {
+    color: var(--fg-blue) !important;
+    text-decoration: underline;
+}
+
+.fg-footer-links .fg-footer-sep {
+    color: var(--fg-gray);
+    opacity: 0.5;
+}
+
+/* ============================================================
+   MISC POLISH
+   ============================================================ */
+
+/* Better list spacing in content */
+.content main li {
+    margin-bottom: 0.25rem;
+}
+
+/* Warning/note callouts */
+.warning {
+    border-left: 4px solid var(--fg-blue) !important;
+    background: #eef6ff !important;
+}
+
+/* ============================================================
+   PRINT
+   ============================================================ */
+@media print {
+    .sidebar,
+    .menu-bar,
+    .nav-chapters,
+    .fg-breadcrumb,
+    .fg-page-footer,
+    .fg-visit-us {
+        display: none !important;
+    }
+    .page-wrapper {
+        margin-left: 0 !important;
+    }
+    .content main {
+        max-width: 100% !important;
+    }
+}
+
+/* --- ferro-hgvs two-color title (used in index.md) ----------- */
+.fh-title { font-weight: 700; line-height: 1.1; margin: 0 0 0.4em 0; }
+.fh-title .fh-base { color: var(--fg-blue);  }
+.fh-title .fh-num  { color: var(--fg-green); }
+
+/* --- Sidebar "Related projects" links ---------------------- */
+.fg-related {
+    margin-top: 14px;
+    padding: 10px 14px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.fg-related-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+    margin-bottom: 6px;
+}
+.fg-related-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.fg-related-list li { margin: 4px 0; }
+.fg-related-list a {
+    font-size: 0.85rem;
+    color: var(--fg-sky);
+    text-decoration: none;
+}
+.fg-related-list a:hover { text-decoration: underline; }

--- a/docs/theme/sidebar-brand.js
+++ b/docs/theme/sidebar-brand.js
@@ -145,7 +145,7 @@
         'getting-started':   'Getting Started',
         'guide':             'Guides',
         'cli':               'Reference',
-        'shadow-spec':       'Shadow Spec'
+        'shadow-spec':       'Interpretation'
     };
 
     function injectBreadcrumb() {
@@ -158,7 +158,7 @@
 
         // Key on the TOP-level section, not the immediate parent, so pages that
         // nest below a section (e.g. shadow-spec/recommendations/DNA/…) still get
-        // a "Home › Shadow Spec › page" crumb.
+        // a "Home › Interpretation › page" crumb.
         var si = sectionIndex(segments);
         if (si === -1) return;
         var sectionLabel = SECTION_MAP[segments[si]];

--- a/docs/theme/sidebar-brand.js
+++ b/docs/theme/sidebar-brand.js
@@ -1,0 +1,240 @@
+/**
+ * Fulcrum Genomics — ferro-hgvs sidebar branding, breadcrumbs, footer injection.
+ * Logo SVG is inlined to avoid mdBook asset-path resolution issues.
+ *
+ * Shares the FG docs theme with fgumi and bwa-mem3; the product-specific bits are:
+ *  - product label "ferro" + "-hgvs" (cyan + green)
+ *  - tagline "HGVS variant parsing & normalization"
+ *  - footer links: GitHub, Issues, API docs (docs.rs)
+ *  - breadcrumb section map matches ferro-hgvs SUMMARY top-level sections
+ *  - `docsRoot` is depth-robust (shadow-spec pages nest several levels deep,
+ *    unlike bwa-mem3/fgumi whose content is exactly one level deep)
+ */
+(function () {
+    // Selectively clear only sidebar visibility state (not theme preference).
+    // Bumping this version resets fold/sidebar state for all returning visitors.
+    var SIDEBAR_VERSION = 'ferro-hgvs-1';
+    try {
+        if (window.localStorage &&
+            window.localStorage.getItem('fg-sidebar-version') !== SIDEBAR_VERSION) {
+            window.localStorage.removeItem('sidebar');
+            window.localStorage.setItem('fg-sidebar-version', SIDEBAR_VERSION);
+        }
+    } catch (_e) {
+        // localStorage unavailable (private browsing, restricted contexts);
+        // continue without resetting sidebar state.
+    }
+
+    // (Sibling-project links are listed in the SUMMARY's "Related Projects"
+    // section at the bottom of the sidebar, so they no longer get injected
+    // into the brand header.)
+
+    // ── Official Fulcrum Genomics logo (inline SVG) ───────────────────────────
+    var LOGO_SVG =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 102.33 31.81" class="fg-brand-logo" aria-label="Fulcrum Genomics">' +
+        '<defs><style>.fg-w{fill:#fff}.fg-b{fill:#26a8e0}.fg-g{fill:#38b44a}</style></defs>' +
+        '<path class="fg-w" d="M43.41,17.49h1.43v-4.03h3.92v-1.27h-3.92v-2.78h4.59v-1.35h-6.02v9.42z"/>' +
+        '<path class="fg-w" d="M51.34,14.29c0,.99.34,1.78.98,2.36.63.6,1.42.9,2.37.91.96,0,1.76-.31,2.38-.91.62-.58.95-1.37.96-2.36v-6.23h-1.43v6.07c0,.64-.19,1.13-.54,1.47-.36.35-.82.53-1.38.53s-1.01-.18-1.36-.53c-.36-.34-.55-.82-.56-1.47v-6.07h-1.43v6.23z"/>' +
+        '<path class="fg-w" d="M60.67,17.49h6.02v-1.35h-4.59v-8.07h-1.43v9.42z"/>' +
+        '<path class="fg-w" d="M73.54,14.85c-.4.86-1,1.29-1.8,1.29-.34,0-.62-.07-.87-.21-.25-.12-.44-.28-.59-.47-.19-.2-.31-.47-.37-.79-.07-.33-.1-.95-.1-1.88s.03-1.56.1-1.89c.06-.32.18-.58.37-.78.15-.19.35-.36.59-.48.24-.12.53-.19.87-.2.46,0,.84.14,1.16.39.31.27.52.59.63.97h1.51c-.15-.79-.51-1.45-1.09-1.98-.57-.53-1.31-.8-2.22-.81-.74,0-1.36.19-1.85.53-.5.34-.87.73-1.1,1.16-.14.23-.25.53-.32.9-.06.37-.1,1.1-.1,2.2s.03,1.8.1,2.18c.03.2.08.37.13.5.06.13.12.26.19.41.23.44.59.82,1.1,1.15.5.34,1.11.53,1.85.54.82,0,1.53-.23,2.13-.7.58-.47.98-1.14,1.18-2.02h-1.51z"/>' +
+        '<path class="fg-w" d="M77.98,9.34h2.24c.46,0,.81.1,1.05.29.31.22.46.57.47,1.07,0,.41-.13.75-.39,1.03-.27.3-.67.46-1.2.47h-2.16v-2.86zM76.55,17.49h1.43v-4.03h1.82l1.94,4.03h1.7l-2.18-4.18c1.2-.46,1.8-1.33,1.82-2.61-.03-.87-.34-1.54-.94-2.01-.5-.41-1.13-.62-1.92-.62h-3.68v9.42z"/>' +
+        '<path class="fg-w" d="M84.95,14.29c0,.99.34,1.78.98,2.36.63.6,1.42.9,2.37.91.96,0,1.76-.31,2.38-.91.62-.58.95-1.37.96-2.36v-6.23h-1.43v6.07c0,.64-.19,1.13-.54,1.47-.36.35-.82.53-1.38.53s-1.01-.18-1.36-.53c-.36-.34-.55-.82-.56-1.47v-6.07h-1.43v6.23z"/>' +
+        '<path class="fg-w" d="M94.28,17.49h1.43v-5.87h.03l1.97,4.52h1.19l1.97-4.52h.03v5.87h1.43v-9.42h-1.35l-2.65,6.14-2.7-6.14h-1.34v9.42z"/>' +
+        '<path class="fg-w" d="M45.06,22.21h.99v.25c0,.29-.1.53-.29.71-.19.19-.42.28-.71.28-.17,0-.32-.04-.45-.11-.13-.06-.23-.14-.31-.24-.1-.1-.16-.23-.19-.4-.04-.16-.05-.48-.05-.94s.02-.78.05-.95c.03-.16.09-.29.19-.39.08-.1.18-.18.31-.24.12-.06.27-.1.45-.1.24,0,.43.07.6.2.16.13.27.29.33.48h.78c-.08-.39-.26-.72-.56-.99-.3-.26-.68-.4-1.14-.4-.38,0-.7.09-.96.26-.26.17-.45.36-.57.58-.07.11-.13.26-.16.45-.03.18-.05.55-.05,1.1s.02.9.05,1.09c.02.1.04.19.07.25.03.06.06.13.1.2.12.22.31.41.57.58.26.17.57.26.96.27.49,0,.9-.17,1.23-.49.32-.32.49-.71.5-1.19v-.96h-1.72v.68z"/>' +
+        '<path class="fg-w" d="M51.67,24.12h3.1v-.68h-2.36v-1.38h2.02v-.63h-2.02v-1.34h2.36v-.68h-3.1v4.71z"/>' +
+        '<path class="fg-w" d="M59.49,24.12h.74v-3.35h.01l2.19,3.35h.7v-4.71h-.74v3.35h-.01l-2.2-3.35h-.69v4.71z"/>' +
+        '<path class="fg-w" d="M68.02,21.77c0,.54.02.9.05,1.09.02.1.04.19.07.25.03.06.06.13.1.2.12.22.31.41.57.58.26.17.57.26.96.27.39,0,.71-.1.96-.27.25-.17.44-.36.55-.58.08-.11.14-.27.17-.46.03-.19.04-.55.04-1.09s-.01-.91-.04-1.1c-.03-.19-.09-.33-.17-.45-.11-.22-.3-.41-.55-.58-.26-.17-.58-.26-.96-.26-.38,0-.7.09-.96.26-.26.17-.45.36-.57.58-.07.11-.13.26-.16.45-.03.18-.05.55-.05,1.1zM68.75,21.77c0-.46.02-.78.05-.95.03-.16.09-.29.19-.39.08-.1.18-.18.31-.24.12-.06.27-.1.45-.1.18,0,.33.04.46.1.12.06.22.15.29.24.1.1.16.23.2.39.03.17.05.48.05.95s-.02.78-.05.94c-.04.16-.1.3-.2.4-.07.1-.17.18-.29.24-.13.07-.28.11-.46.11s-.32-.04-.45-.11c-.13-.06-.23-.14-.31-.24-.1-.1-.16-.23-.19-.4-.04-.16-.05-.48-.05-.94z"/>' +
+        '<path class="fg-w" d="M76.37,24.12h.74v-2.94h.01l1.01,2.26h.61l1.01-2.26h.02v2.94h.74v-4.71h-.7l-1.36,3.07-1.39-3.07h-.69v4.71z"/>' +
+        '<rect class="fg-w" x="85.56" y="19.41" width=".74" height="4.71"/>' +
+        '<path class="fg-w" d="M93.84,22.81c-.2.43-.51.64-.93.64-.17,0-.32-.04-.45-.11-.13-.06-.23-.14-.31-.24-.1-.1-.16-.23-.19-.4-.04-.16-.05-.48-.05-.94s.02-.78.05-.95c.03-.16.09-.29.19-.39.08-.1.18-.18.31-.24.12-.06.27-.1.45-.1.24,0,.43.07.6.2.16.13.27.29.33.48h.78c-.08-.39-.26-.72-.56-.99-.3-.26-.68-.4-1.14-.4-.38,0-.7.09-.95.26-.26.17-.45.36-.57.58-.07.11-.13.26-.16.45-.03.18-.05.55-.05,1.1s.02.9.05,1.09c.02.1.04.19.07.25.03.06.06.13.1.2.12.22.31.41.57.58.25.17.57.26.95.27.42,0,.79-.12,1.09-.35.3-.23.5-.57.61-1.01h-.78z"/>' +
+        '<path class="fg-w" d="M99.22,22.98l-.48.54c.52.43,1.13.65,1.85.65,1.11-.01,1.68-.47,1.7-1.37,0-.33-.11-.63-.32-.88-.22-.26-.55-.41-1.01-.47-.23-.03-.41-.05-.55-.07-.24-.04-.41-.12-.52-.23-.11-.11-.16-.23-.16-.37,0-.23.09-.4.24-.51.15-.11.34-.16.57-.16.44,0,.84.13,1.2.36l.41-.59c-.45-.31-.97-.47-1.57-.49-.5,0-.89.13-1.16.38-.28.25-.42.58-.42,1,0,.34.11.63.34.87.22.23.53.38.95.45.23.03.45.06.64.09.43.07.64.28.63.63,0,.43-.33.65-.96.66-.53,0-.99-.16-1.38-.47z"/>' +
+        '<path class="fg-g" d="M21.21,12.15h-10.13v5.54h10.13v1.88c0,1.39.12,3.66-1.3,3.66h-8.83v7.51h2.37c2.03,0,3.87-.25,5.52-.75,1.64-.5,3.04-1.24,4.19-2.21,1.15-.97,2.03-2.14,2.66-3.51.15-.33.29-.68.4-1.04.36-1.11.54-2.33.54-3.66v-7.42h-5.54z"/>' +
+        '<path class="fg-b" d="M13.31,1.07c-2.08,0-3.94.25-5.59.74-1.64.49-3.04,1.22-4.19,2.18-1.15.96-2.02,2.13-2.63,3.51-.6,1.38-.91,2.96-.91,4.74v5.46h5.54v-5.54c0-.82.11-1.69.44-2.44.26-.59.61-1.06,1.1-1.47.64-.54,1.44-.89,2.23-1.12,1.28-.38,2.67-.51,4-.51h13.45V1.07h-13.45zM0,23.23v7.51h5.54v-7.51H0z"/>' +
+        '<rect class="fg-w" x="34.9" width=".42" height="31.81"/>' +
+        '</svg>';
+
+    // ── Footer HTML (injected on all non-index pages) ─────────────────────────
+    // Reuse the inline LOGO_SVG above (with a footer-specific wrapper class)
+    // to avoid relying on an external raw.githubusercontent.com asset.
+    var FOOTER_HTML =
+        '<div class="fg-visit-us fg-page-footer">' +
+        '<a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener" class="fg-footer-logo">' +
+        LOGO_SVG +
+        '</a>' +
+        '<p>Visit us at <a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener">Fulcrum Genomics</a> to learn more about how we build tools for genomic sequence analysis, ferro-hgvs among them.</p>' +
+        '<div class="fg-visit-buttons">' +
+        '<a href="mailto:contact@fulcrumgenomics.com?subject=[GitHub inquiry]" class="fg-btn fg-btn-green">&#9993; Email Us</a>' +
+        '<a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener" class="fg-btn fg-btn-blue">&#127760; Visit Us</a>' +
+        '</div>' +
+        '<div class="fg-footer-links">' +
+        '<a href="https://github.com/fulcrumgenomics/ferro-hgvs" target="_blank" rel="noopener">GitHub</a>' +
+        '<span class="fg-footer-sep">·</span>' +
+        '<a href="https://github.com/fulcrumgenomics/ferro-hgvs/issues" target="_blank" rel="noopener">Issues</a>' +
+        '<span class="fg-footer-sep">·</span>' +
+        '<a href="https://docs.rs/ferro-hgvs" target="_blank" rel="noopener">API docs</a>' +
+        '</div>' +
+        '</div>';
+
+    // Compute the path prefix to reach the docs root from the current page.
+    // All non-index content lives exactly one directory below the docs root,
+    // so non-root pages need "../" and the index needs "".
+    var FERRO_SECTIONS = [
+        'getting-started', 'guide', 'cli', 'shadow-spec'
+    ];
+    // Index of the first path segment that is a top-level section directory, or -1.
+    // Content can nest several levels below a section (e.g. shadow-spec pages), so
+    // the docs root is however many levels deep the current file actually sits.
+    function sectionIndex(segs) {
+        for (var i = 0; i < segs.length; i++) {
+            if (FERRO_SECTIONS.indexOf(segs[i]) !== -1) return i;
+        }
+        return -1;
+    }
+    var docsRoot = (function () {
+        var segs = window.location.pathname.replace(/\.html$/, '').split('/').filter(Boolean);
+        var i = sectionIndex(segs);
+        if (i === -1) return '';
+        // From the current file up to the parent of the section directory.
+        var ups = segs.length - 1 - i;
+        return new Array(ups + 1).join('../');
+    }());
+
+    // ── Sidebar brand injection ───────────────────────────────────────────────
+    function injectBrand() {
+        var scrollbox = document.querySelector('.sidebar-scrollbox');
+        if (!scrollbox || document.querySelector('.fg-brand-header')) return;
+
+        var header = document.createElement('div');
+        header.className = 'fg-brand-header';
+
+        // Logo links home; corporate link is separate below
+        header.innerHTML =
+            '<a href="' + docsRoot + '" class="fg-brand-link">' + LOGO_SVG + '</a>' +
+            '<div class="fg-brand-divider"></div>' +
+            '<span class="fg-brand-product">' +
+            '<span style="color:#26a8e0">ferro</span>' +
+            '<span style="color:#38b44a">-hgvs</span>' +
+            '</span>' +
+            '<span class="fg-brand-tagline">HGVS variant parsing &amp; normalization</span>' +
+            '<a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener" class="fg-brand-corp">' +
+            'Fulcrum Genomics &#8599;' +
+            '</a>';
+
+        scrollbox.insertBefore(header, scrollbox.firstChild);
+    }
+
+    // ── Footer injection ──────────────────────────────────────────────────────
+    // Skip on the index/landing page; the index has its own marketing layout.
+    function injectFooter() {
+        if (document.querySelector('.fg-page-footer')) return;
+        var path = window.location.pathname;
+        var isIndexPage =
+            path === '/' ||
+            /\/index\.html$/.test(path) ||
+            /\/$/.test(path);
+        if (isIndexPage) return;
+        var main = document.querySelector('.content main');
+        if (!main) return;
+        var wrapper = document.createElement('div');
+        wrapper.innerHTML = FOOTER_HTML;
+        main.appendChild(wrapper.firstChild);
+    }
+
+    // ── Breadcrumb injection ──────────────────────────────────────────────────
+    var SECTION_MAP = {
+        'getting-started':   'Getting Started',
+        'guide':             'Guides',
+        'cli':               'Reference',
+        'shadow-spec':       'Shadow Spec'
+    };
+
+    function injectBreadcrumb() {
+        var main = document.querySelector('.content main');
+        if (!main || document.querySelector('.fg-breadcrumb')) return;
+
+        var path = window.location.pathname;
+        var segments = path.replace(/\.html$/, '').split('/').filter(Boolean);
+        if (segments.length < 2) return; // root or single-segment: no breadcrumb
+
+        // Key on the TOP-level section, not the immediate parent, so pages that
+        // nest below a section (e.g. shadow-spec/recommendations/DNA/…) still get
+        // a "Home › Shadow Spec › page" crumb.
+        var si = sectionIndex(segments);
+        if (si === -1) return;
+        var sectionLabel = SECTION_MAP[segments[si]];
+        if (!sectionLabel) return;
+
+        var h1 = main.querySelector('h1');
+        var pageTitle = h1 ? h1.textContent.trim() : segments[segments.length - 1].replace(/-/g, ' ');
+
+        var sep = '<span class="fg-breadcrumb-sep">&#8250;</span>';
+        var html = '<a href="' + docsRoot + '">Home</a>' + sep;
+        html += '<span>' + sectionLabel + '</span>';
+        var currentSpan = document.createElement('span');
+        currentSpan.className = 'fg-breadcrumb-current';
+        currentSpan.setAttribute('aria-current', 'page');
+        currentSpan.textContent = pageTitle;
+
+        var crumb = document.createElement('nav');
+        crumb.className = 'fg-breadcrumb';
+        crumb.setAttribute('aria-label', 'breadcrumb');
+        crumb.innerHTML = html + sep;
+        crumb.appendChild(currentSpan);
+
+        if (h1) {
+            main.insertBefore(crumb, h1);
+        } else {
+            main.insertBefore(crumb, main.firstChild);
+        }
+    }
+
+    // ── Menu bar title coloring ───────────────────────────────────────────────
+    function colorMenuTitle() {
+        var title = document.querySelector('.menu-title');
+        if (!title || title.querySelector('span')) return;
+        var text = title.textContent;
+        // "ferro-hgvs" → "ferro" cyan + "-hgvs" green
+        if (text === 'ferro-hgvs' || text.indexOf('ferro-hgvs') === 0) {
+            title.innerHTML =
+                '<span style="color:#26a8e0">ferro</span>' +
+                '<span style="color:#38b44a">-hgvs</span>' +
+                '<span class="fg-byline-inline">by <a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener">Fulcrum Genomics &#8599;</a></span>';
+        }
+    }
+
+    // ── Whole-row fold for draft-chapter section headers ──────────────────────
+    // Section headers (Getting Started, User Guide, ...) are mdBook "draft
+    // chapters": non-link <span>s that fold their children. mdBook only wires
+    // its fold handler to the small ❱ arrow (a.chapter-fold-toggle), so by
+    // default clicking the header *text* does nothing. Delegate clicks at the
+    // document level (the TOC is injected asynchronously by mdBook's toc.js, so
+    // a stable ancestor is the reliable place to listen) and forward a click on
+    // anywhere in a draft header row to that existing toggle -- reusing mdBook's
+    // own fold logic and persistence rather than reimplementing it.
+    function enableDraftHeaderFold() {
+        document.addEventListener('click', function (e) {
+            // Real anchors (child page links, the ❱ arrow itself, brand links)
+            // handle their own clicks -- don't hijack or double-toggle them.
+            if (e.target.closest('a')) return;
+            var wrapper = e.target.closest('.chapter-link-wrapper');
+            if (!wrapper) return;
+            var toggle = wrapper.querySelector('a.chapter-fold-toggle');
+            if (toggle) toggle.click();
+        });
+    }
+
+    // ── Init ──────────────────────────────────────────────────────────────────
+    function init() {
+        injectBrand();
+        injectFooter();
+        injectBreadcrumb();
+        colorMenuTitle();
+        enableDraftHeaderFold();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
Scaffolds an mdBook user-documentation site, published on Read the Docs, following the same pattern fgumi and bwa-mem3 use (mdBook + mdbook-linkcheck2, navy theme, RTD builds via `.readthedocs.yaml`, GitHub CI validates only).

Contents:
- `docs/book.toml`, `docs/src/{SUMMARY.md,index.md}`, and the shared Fulcrum Genomics house theme (`docs/theme/custom.css` + `docs/theme/sidebar-brand.js`, matching fgumi/bwa-mem3).
- An **"under construction" Interpretation section** (`docs/src/shadow-spec/index.md`) — a per-clause reading of the HGVS recommendations recording how ferro interprets each one. Pages land one spec page at a time.
- `.readthedocs.yaml` (pinned mdBook 0.5.2 + mdbook-linkcheck2 0.12.2) and a `Docs` CI workflow that builds the book as a PR gate (dead internal links fail via linkcheck2).

No behavior change; docs and CI only. The first interpretation page (DNA substitution) is stacked in a follow-up PR. The `shadow-spec/` path and the `shadow_spec` test identifiers are the section's internal codename; the user-facing name is "Interpretation".

Representation-Change: none. Docs and CI only; no watched source file is touched.
