### PR TITLE
ci: bound nightly, release and fuzz workflow jobs with timeout-minutes

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -24,8 +24,15 @@ env:
   CONFIG_FILE: /opt/ferro-web/service.toml
 
 jobs:
+  # `timeout-minutes` so this cannot inherit GitHub's 360-minute default. This is
+  # the half #1994 scoped out (see #2004). 90 = >5x the slowest SUCCESSFUL run
+  # observed (767s, measured 2026-08-16 over the last 7 runs; the typical run is
+  # ~390s). It builds the `ferro-web` release binary and deploys it on a
+  # self-hosted runner, so the extra headroom over the 60 Rust-build tier is a
+  # deliberate allowance for self-hosted variance. Bounds a hang, not a budget.
   build-and-deploy:
     runs-on: [self-hosted, linux, x64, ferro-deploy]
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -22,10 +22,32 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
+# 360-minute default. This is the half #1994 scoped out (see #2004): #1994
+# bounded the PR-gating workflows and deferred this one because it hits the
+# network and needed its own measurements. This is a weekly schedule, so nobody
+# watches a green run — the worse place to leave a job able to hang for six hours.
+#
+# Values are at least 5x the slowest SUCCESSFUL run observed for that job,
+# measured 2026-08-16 across the last 8 completed runs, then rounded up. The
+# failure that matters here is a bound firing on legitimate work, so — with
+# every job either compiling Rust or fetching from third-party APIs — the
+# headroom is deliberate. These bound a hang, they are not a budget.
+#
+#   90  run-standard-tests: compiles Rust AND fetches bulk fixtures over the
+#       network; peaks at 1044s (17.4m), whose 5x already exceeds the 60 tier.
+#   60  fetch-api-data (711s, network to Mutalyzer/VariantValidator/NCBI) and
+#       run-comparison-tests (compiles Rust, so a cold cache is on the table).
+#  120  fetch-external-databases: its three network fetches (LOVD, MaveDB,
+#       CIViC) EACH already carry a step-level `timeout-minutes: 30`, so the job
+#       bound must exceed their combined 90-minute budget or it would kill a run
+#       the steps consider legitimate. Job wall clock is 33s in practice.
+#   15  summary (6s), which only downloads a report and posts it.
 jobs:
   fetch-api-data:
     name: Fetch External API Data
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: ${{ github.event.inputs.skip_api_fetch != 'true' }}
 
     steps:
@@ -94,6 +116,7 @@ jobs:
   run-comparison-tests:
     name: Run API Comparison Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [fetch-api-data]
     if: always()
 
@@ -241,6 +264,7 @@ jobs:
   run-standard-tests:
     name: Run Standard Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -299,6 +323,9 @@ jobs:
   fetch-external-databases:
     name: Fetch External Database Data
     runs-on: ubuntu-latest
+    # 120, not 30: the three fetch steps below each carry `timeout-minutes: 30`,
+    # so the job must be able to outlast their combined 90-minute step budget.
+    timeout-minutes: 120
     if: ${{ github.event.inputs.skip_api_fetch != 'true' }}
 
     steps:
@@ -355,6 +382,7 @@ jobs:
   summary:
     name: Generate Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [run-comparison-tests, run-standard-tests]
     if: always()
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,9 +19,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # The `fuzz` job carries a `timeout-minutes`; without one it inherits GitHub's
+  # 360-minute default. This is the half #1994 scoped out (see #2004): a nightly
+  # schedule nobody watches is the worse place to leave a six-hour hang.
+  #
+  # 60 = at least 5x the slowest SUCCESSFUL run observed (296s, measured
+  # 2026-08-16 over the last 8 nightlies). The fuzz step itself is ALREADY
+  # self-bounded — `timeout "${FUZZ_SECONDS}s" cargo +nightly fuzz run` with
+  # FUZZ_SECONDS defaulting to 300 — so this job bound exists to cap the
+  # surrounding nightly toolchain install and target build, not the fuzzing. A
+  # `workflow_dispatch` run with a large `fuzz_seconds` may need this raised.
+  # (`report-failure` is a reusable-workflow `uses:` call, on which GitHub
+  # rejects `timeout-minutes`; the callee's own `report` job carries one.)
   fuzz:
     name: Fuzz Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -32,6 +32,25 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
+# 360-minute default. This is the half #1994 scoped out (see #2004): #1994
+# bounded the PR-gating workflows, and #2010 added a step-level stall bound to
+# the soak step here but left the jobs themselves unbounded. This is a nightly
+# schedule, so nobody watches a green run — the worse place to leave a six-hour
+# hang. Values are at least 5x the slowest SUCCESSFUL run observed for that job,
+# measured 2026-08-16 over the last 8 nightlies, then rounded up. These bound a
+# hang, they are not a budget.
+#
+#   60  build: `cargo nextest archive` under `--cargo-profile soak`, so it
+#       compiles Rust and a cold cache is on the table (297s, matching ci.yml's
+#       `test-build-soak`).
+#   30  soak: downloads the prebuilt archive and runs proptest (76s). It also
+#       runs through `scripts/run_nextest_archive.sh`, whose default
+#       `NEXTEST_STALL_TIMEOUT` is 25m, so this MUST be > 25 or the job bound
+#       fires before the step's stall bound can annotate the phase — a property
+#       `issue_2000_nextest_stall_phase::the_step_bound_fires_before_every_job_bound`
+#       asserts. 30 matches ci.yml's `soak`.
+#   15  report: opens/updates the tracking issue on failure only.
 jobs:
   # One optimized build, fanned out to all eight shards.
   #
@@ -49,6 +68,7 @@ jobs:
   build:
     name: Build soak archive (optimized)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -138,6 +158,7 @@ jobs:
     name: Unseeded soak (${{ matrix.shard }}/8)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       # Let every shard finish: with independent random streams, one shard
       # failing says nothing about the others, and the extra failures are
@@ -211,6 +232,7 @@ jobs:
   report:
     name: Report soak failures
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: soak
     if: failure()
     permissions:

--- a/.github/workflows/prune-ci-caches.yml
+++ b/.github/workflows/prune-ci-caches.yml
@@ -44,9 +44,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # `timeout-minutes` so this cannot inherit GitHub's 360-minute default. This is
+  # the half #1994 scoped out (see #2004). 15 = far more than 5x the slowest
+  # SUCCESSFUL run observed (48s, measured 2026-08-16 over the last 5 runs); the
+  # job only makes `gh` API calls to prune caches, so a hang is a stuck request.
   prune:
     name: Prune per-commit CI caches
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
       # How many of each per-commit family to keep. Enough that a re-run of a

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # `timeout-minutes` so this cannot inherit GitHub's 360-minute default. This is
+  # the half #1994 scoped out (see #2004). 60 = far more than 5x the slowest
+  # SUCCESSFUL run observed (208s, measured 2026-08-16 over the last 15 runs).
+  # release-plz walks the release cycle's history running `cargo package` at each
+  # commit, so it compiles Rust and a large cycle can run well past the typical
+  # ~3.5m — hence the generous bound rather than a tight one.
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -52,6 +52,22 @@ concurrency:
 # deleted. Widening this to something like `contains(…, 'v')` would additionally
 # re-admit `test-fixtures-v1`, which is what the paragraph above is about.
 
+# Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
+# 360-minute default, so a wedged runner holds a slot for six hours. This is the
+# half #1994 scoped out (see #2004): #1994 bounded the PR-gating workflows and
+# deferred the nightly/release/fuzz families because they needed their own
+# measurements rather than ci.yml's.
+#
+# Each value is at least 5x the slowest SUCCESSFUL run observed for that job,
+# measured 2026-08-16 across the last 8 completed release runs, then rounded up.
+# The failure that matters here is a bound firing on legitimate work, so the
+# headroom is deliberate — these bound a hang, they are not a budget.
+#
+#   60  the three wheel builds compile Rust (maturin), so a cold cache is on the
+#       table: macOS peaks at 531s (6.8x), Windows 348s, Linux 229s.
+#   15  everything else — sdist (31s), check-metadata (15s), the smoke matrices
+#       (<=36s: install + import a prebuilt wheel), upload (9s), and the two
+#       PyPI jobs (publish 76s, verify 31s: network to the index).
 jobs:
   # abi3 wheels: one wheel per (OS, arch) tagged `cp310-abi3`, runs on
   # every CPython >= 3.10. The `-i python<X>` flag is omitted so maturin
@@ -63,6 +79,7 @@ jobs:
     name: Linux ${{ matrix.target }} ${{ matrix.manylinux }}
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +120,7 @@ jobs:
     name: macOS ${{ matrix.target }}
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +162,7 @@ jobs:
     name: Windows
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -168,6 +187,7 @@ jobs:
     name: sdist
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -188,6 +208,7 @@ jobs:
     name: Check package metadata
     needs: [linux, macos, windows, sdist]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -220,6 +241,7 @@ jobs:
         runner: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-14, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -277,6 +299,7 @@ jobs:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -312,6 +335,7 @@ jobs:
     name: Upload to GitHub Release
     needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
@@ -336,6 +360,7 @@ jobs:
     # on every tag (v0.4.0 through v0.7.0 all failed here).
     needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'release'
     environment:
       name: pypi
@@ -368,6 +393,7 @@ jobs:
     name: Verify PyPI install
     needs: [publish-pypi]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'release'
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
Closes #2004.

Representation-Change: none

## What

Adds a `timeout-minutes` to every job in the workflows #1994 deferred, so a wedged runner cannot hold a slot for GitHub's 360-minute default. This is the other half of #1994, which bounded the PR-gating workflows (`ci.yml`, `coverage.yml`, `lint-workflows.yml`, `report-failure.yml`) and left the nightly/release/fuzz families for their own measurements. 22 job-level bounds across 7 workflows.

## Sizing

Each value is at least **5x** the slowest **successful** run observed for that job, measured 2026-08-16 across recent history, then rounded up. Following #1994, the failure mode that matters is a bound firing on legitimate work, so these bound a hang — they are not a budget. Every value is documented inline in a header comment on its workflow.

| workflow | job(s) → minutes | basis |
|---|---|---|
| `release-wheels.yml` | linux/macos/windows → **60**; sdist, check-metadata, smoke-test, smoke-test-musllinux, upload, publish-pypi, verify-pypi → **15** | 3 wheel builds compile Rust (macOS peak 531s → 6.8x); the rest install/import a prebuilt wheel or hit PyPI (≤76s) |
| `external-validation.yml` | fetch-api-data → **60**; run-comparison-tests → **60**; run-standard-tests → **90**; fetch-external-databases → **120**; summary → **15** | see notes below |
| `nightly-soak.yml` | build → **60**; soak → **30**; report → **15** | build compiles Rust (297s, = ci.yml `test-build-soak`); soak runs the prebuilt archive (76s, = ci.yml `soak`) |
| `fuzz.yml` | fuzz → **60** | 296s peak; the fuzz step is already self-bounded by `timeout ${FUZZ_SECONDS}s` (default 300s), so the job bound only caps the surrounding toolchain install + build |
| `prune-ci-caches.yml` | prune → **15** | 48s; `gh` API calls only |
| `publish.yml` | release → **60** | 208s; release-plz walks history running `cargo package`, so it compiles Rust |
| `deploy-local.yml` | build-and-deploy → **90** | 767s peak (typical ~390s); self-hosted release build + deploy, extra headroom for self-hosted variance |

Notable non-tier values:

- **`fetch-external-databases` = 120**, not 30: its three network fetches (LOVD, MaveDB, CIViC) EACH already carry a step-level `timeout-minutes: 30`, so the job bound must exceed their combined 90-minute step budget or it would kill a run the steps consider legitimate. Job wall clock is 33s in practice.
- **`run-standard-tests` = 90**: it both compiles Rust and fetches bulk fixtures over the network; its 1044s peak makes 5x already exceed the 60-minute Rust-compile tier.
- **`soak` = 30**: it runs through `scripts/run_nextest_archive.sh`, whose default `NEXTEST_STALL_TIMEOUT` is 25m, so the job bound MUST be > 25 or the job dies before the step's stall bound can annotate the phase — a property `issue_2000_nextest_stall_phase::the_step_bound_fires_before_every_job_bound` asserts. 30 matches ci.yml's `soak`.

## Left unbounded on purpose

The reusable-workflow `report-failure` jobs in `external-validation.yml` and `fuzz.yml` are `uses:` calls; GitHub rejects `timeout-minutes` on such a job and the callee's own `report` job (bounded at 15 by #1994) carries it. This matches the convention #1994 recorded for `coverage.yml`.

## Verification

- `actionlint` clean across all workflows; `zizmor .github/workflows/` reports no findings — both run exactly as `lint-workflows.yml` invokes them.
- All 7 files parse as YAML.
- The Rust workflow-parsing guards pass: `issue_2000_nextest_stall_phase` (incl. `the_step_bound_fires_before_every_job_bound`, which now sees soak=30 > 25), `release_tag_gate` (parses `release-wheels.yml`), and `workflow_gh_repo_context` — 21 tests, all green.
- No `uses:` pin, trigger, step, `permissions`, or cache key was touched — only `timeout-minutes:` keys and header comments were added (+108 / -0).