### PR TITLE
fix(normalize): drop a cross-region identity member covered by a sibling

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -12945,8 +12945,21 @@ pub(crate) fn drop_identity_members_covered_by_siblings<P: ReferenceProvider>(
             (0..members.len()).filter(|&j| j != i).any(|j| {
                 spans[j].as_ref().is_some_and(|s| {
                     s.blocks_shift
-                        && s.region == span.region
                         && s.accession == span.accession
+                        // No `s.region == span.region` gate (#1512). This pass
+                        // only *compares* two spans — its sole mutation is
+                        // `members.retain(..)` below and it never writes a
+                        // coordinate onto the `c.`/`n.` axis — so it must read the
+                        // sequence coordinates #1506 gave `MemberSpan`, in which
+                        // any two members of one molecule are comparable, rather
+                        // than refusing the comparison whenever the two sit in
+                        // different regions. A region gate here re-created the
+                        // #1512 blindness: a `c.*1=` identity covered by a
+                        // `c.15_*1dup` (whose span starts in the CDS) was kept, and
+                        // the allele then claimed `c.*1` twice. The overlap below
+                        // is on the sequence coordinates, which are correct across
+                        // the boundary; the accession test above still keeps
+                        // members of different molecules apart.
                         // Both spans forward. A reversed `<high>_<low>` range is
                         // SVD-WG006's circular deletion/duplication form, and
                         // `cis_axis_parts` hands the endpoints over raw, so one

--- a/tests/it/issue_1512_cross_region_identity_coverage.rs
+++ b/tests/it/issue_1512_cross_region_identity_coverage.rs
@@ -1,0 +1,121 @@
+//! #1512 — `drop_identity_members_covered_by_siblings` was blind to a covering
+//! sibling in a different region, so a cancelled identity member that a sibling
+//! demonstrably claims survived, leaving two members on one position.
+//!
+//! The pass drops an identity member (`c.X=`) when a `blocks_sibling_shift`
+//! sibling's span overlaps it — an identity beside a sibling that claims the same
+//! bases is a contradiction, two members on one position, which the apply oracle
+//! declines. After #1506 gave `MemberSpan` sequence coordinates so that any two
+//! members of one molecule are comparable across a region boundary, the coverage
+//! predicate still gated on `s.region == span.region`. That is a **reader
+//! declining a cross-region interval**, the #1512 family: the pass only compares
+//! two spans (its one mutation is `members.retain(...)`, it never writes an axis
+//! coordinate), so it must use the sequence coordinates it now has, not refuse
+//! the comparison whenever the two members sit in different regions.
+//!
+//! Measured on `CORE` under a `1..=15` CDS. `c.15` is the last CDS base and
+//! `c.*1` the first 3'UTR base, so a sibling starting at `c.15` and reaching
+//! `c.*1` — or one authored at `c.*1` — crosses the boundary and its start
+//! region differs from a `c.*1=` identity's:
+//!
+//! ```text
+//! c.[15=;15_*1dup]    ->  c.15_*1dup     both members in the CDS; already dropped
+//! c.[*1=;15_*1dup]    ->  c.[15_*1dup;*1=]   PRE-FIX: identity in the 3'UTR survives
+//! ```
+//!
+//! The `15_*1dup` copies `c.15` and `c.*1`, so under `blocks_sibling_shift` it
+//! names `c.*1`; the `*1=` names it too. Same accession, overlapping sequence
+//! coordinates, different start regions — so the identity was kept and the
+//! rendered allele claimed `c.*1` twice.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Under a `1..=15` CDS, `c.15` is `C` and `c.*1` is `T` (positions 15 and 16 of
+/// this core).
+const CORE: &str = "GCGCTAGTCTCGCCCTGTTA";
+
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let length = CORE.len() as u64;
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        Strand::Plus,
+        CORE.to_string(),
+        Some(1),
+        Some(15),
+        vec![Exon::new(1, 1, length)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(input: &str, direction: ShuffleDirection) -> String {
+    let variant = parse_hgvs(input).expect("input must parse");
+    Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default().with_direction(direction),
+    )
+    .normalize(&variant)
+    .expect("normalization must succeed")
+    .to_string()
+}
+
+/// The bug. A `c.*1=` identity in the 3'UTR is covered by a `c.15_*1dup` whose
+/// span starts one base earlier, in the CDS. The two members claim `c.*1`, so the
+/// identity is a cancellation residue to drop — exactly as the in-region control
+/// below already does — and the sequence-preserving output is the duplication
+/// alone.
+#[test]
+fn a_cross_region_identity_covered_by_a_duplication_is_dropped() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize("NM_TEST.1:c.[*1=;15_*1dup]", direction),
+            "NM_TEST.1:c.15_*1dup",
+            "the 3'UTR identity is covered by the boundary-crossing dup and must \
+             be dropped ({direction:?})"
+        );
+    }
+}
+
+/// The in-region control. Both members sit in the CDS, so this dropped correctly
+/// before the fix and must keep doing so — it is what makes the cross-region case
+/// above a boundary problem rather than a coverage-logic one.
+#[test]
+fn an_in_region_identity_covered_by_a_duplication_is_dropped() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        assert_eq!(
+            normalize("NM_TEST.1:c.[15=;15_*1dup]", direction),
+            "NM_TEST.1:c.15_*1dup",
+            "the in-region identity coverage must be unaffected ({direction:?})"
+        );
+    }
+}
+
+/// The discriminating control against over-generalising the fix. Removing the
+/// region gate must not drop an identity that no sibling *overlaps*: the `c.*3=`
+/// identity sits in the 3'UTR and the `c.1_2dup` in the CDS — a cross-region
+/// pair, now visible to each other, whose sequence coordinates do not intersect
+/// (`*3` is well 3' of the duplicated CDS bases). The overlap test must decline,
+/// so the identity survives. A fix that dropped it would be deleting the overlap
+/// check, not the region check. The identity's survival is the whole property;
+/// the dup's own 3'/5' landing spot is orthogonal shuffle behaviour, so this
+/// asserts the member is present rather than pinning the full allele.
+#[test]
+fn a_cross_region_identity_nothing_overlaps_survives() {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let out = normalize("NM_TEST.1:c.[*3=;1_2dup]", direction);
+        assert!(
+            out.contains("*3="),
+            "an uncovered identity must survive however its cross-region sibling \
+             shuffles; got {out} ({direction:?})"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -291,6 +291,7 @@ mod issue_1487_canonical_window_overflow;
 mod issue_1491_soft_masked_repeat_normalization;
 mod issue_1492_anchor_decline_names_the_caller_span;
 mod issue_1508_overlap_across_region_boundary;
+mod issue_1512_cross_region_identity_coverage;
 mod issue_1513_adjacent_junction_insertions;
 mod issue_1517_inv_priority_over_delins;
 mod issue_1536_cds_boundary_delins;


### PR DESCRIPTION
Closes #1512.

Representation-Change: `NM_TEST.1:c.[*1=;15_*1dup]` now normalizes to `NM_TEST.1:c.15_*1dup` — a cis identity member covered by a sibling whose span *starts* in a different region is dropped rather than kept. Previously accepted, so this is a migration on paper for a consumer keying on the normalized string; the old output named `c.*1` twice, which the apply oracle declines, so the migration is from a wrong string to a right one. 0 of 95,614 corpus rows move, and that is a STRUCTURAL zero rather than evidence of safety: `identity_member` is the only family feeding an identity in, and it always places its sibling two bases clear (`[{p(s)}_{p(s+1)}=;{p(s+3)}…]`), so no corpus row ever reaches the overlap test this change relaxes.

## The sweep, and which instances were already fixed

#1512 asks for a sweep of readers that return `None` on a cross-region interval (an interval spanning more than one region), listing three confirmed instances. Two are already fixed on `main`:

| instance | site | state on `main` |
|---|---|---|
| #1482 / #1506 | `merge::member_span` (was `join_pos`) | **fixed** — merged #1506; `member_span` converts a boundary-crossing span onto the sequence axis via `region_span_delta` |
| #1508 / #1511 | `overlap.rs` — `cds_range` / `tx_range` / `rna_range` | **fixed** — merged #1511; the detectors rank regions with `AxisPos` instead of refusing cross-region ranges |
| **open** | `merge::drop_identity_members_covered_by_siblings` | **fixed here** |

This PR closes the one still open.

## The defect

`drop_identity_members_covered_by_siblings` drops an identity member (`c.X=`) when a `blocks_sibling_shift` sibling's span overlaps it — an identity beside a sibling that claims the same bases is a contradiction (two members on one position), which the apply oracle declines. Its covered-overlap predicate gated on `s.region == span.region`.

Since #1506 gave `MemberSpan` sequence coordinates — the representation in which any two members of one molecule are comparable across a region boundary — that gate is a *reader declining a cross-region interval*. The pass is a pure **comparer**: its only mutation is `members.retain(..)` and it never writes a coordinate onto the `c.`/`n.` axis, so per the issue's own rule it must use the sequence coordinates it now has rather than refuse the comparison whenever the two members sit in different regions.

Measured on a 20-base transcript, CDS `1..=15` (so `c.15` is the last CDS base and `c.*1` the first 3'UTR base):

```text
c.[15=;15_*1dup]  ->  c.15_*1dup           both members in the CDS; already dropped
c.[*1=;15_*1dup]  ->  c.[15_*1dup;*1=]     PRE-FIX: the 3'UTR identity survives
```

The `15_*1dup` copies `c.15` and `c.*1`, so under `blocks_sibling_shift` it names `c.*1`; the `*1=` names it too. Same accession, overlapping sequence coordinates, different **start** regions — so the region gate refused the comparison and the rendered allele claimed `c.*1` twice.

## The fix

Remove the `s.region == span.region` gate from the covered-overlap predicate. The overlap test that follows already runs on the sequence coordinates (correct across the boundary), and the `s.accession == span.accession` test above still keeps members of different molecules apart. Post-fix, `c.[*1=;15_*1dup]` converges to `c.15_*1dup`, matching its in-region twin.

### Scope: the issue was right about the symptom and off about the mechanism, and that bounds the fix

The issue's literal example — a *boundary-crossing* identity (`c.15_*1=`) covered by a `c.*1` sibling — is **not** reachable by removing the region gate alone. A crossing identity is not even recognised as an identity: the pass's `is_identity` check routes through `cis_axis_parts` → `join_pos`, which still returns `None` for a cross-region interval, so the member never enters the coverage test. Forcing it visible (switching `is_identity` to `member_axis_endpoints`) was tried and reverted: it turns 4 previously-*declined* CDS-end cases into non-idempotent outputs, tripping the deliberately-pinned known-defect suite (`defect_non_idempotent_outputs`, `spec_corpus_regressions::an_insertion_at_the_cds_end_is_not_a_fixed_point`). That is the CDS-end `c.72`/`c.*1` defect family the repo documents; it is out of scope for this correctness fix. This PR fixes the region-gate instance — a covering sibling in a different region from a same-region identity — and leaves the crossing-identity recognition to the issue's own "make the decline explicit in the type" follow-up.

## Unchanged on purpose

- `an_in_region_identity_covered_by_a_duplication_is_dropped` — the in-region coverage still drops, unaffected.
- `a_cross_region_identity_nothing_overlaps_survives` — `c.[*3=;1_2dup]` (identity in the 3'UTR, dup in the CDS, non-overlapping) keeps its identity. Removing the region gate deletes only the region check, not the overlap check.

## Verification (rebased onto current `origin/main`, `d3eb64a2`)

- `cargo fmt --all --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --features dev --no-fail-fast` (`FERRO_SWEEP_SEEDS=full`) — 11,218 passed (the lone failure was a stale gitignored generated spec fixture; regenerated with `generate_spec_fixture`, then green)
- `scripts/run_oracle_suite.sh` (`FERRO_ASSERT_IDEMPOTENT` / `FERRO_ASSERT_REPARSE` / `FERRO_ASSERT_IN_BOUNDS`, `FERRO_SWEEP_SEEDS=full`) — 11,059 passed
- `examples/dump_normalized_corpus` A/B at base vs candidate — 0 of 95,614 rows move
- The new regression test fails on the base (`c.[*1=;15_*1dup]` → `c.[15_*1dup;*1=]`) and passes with the fix.
