### PR TITLE
docs(cdot): name all three shipped cdot files in the six-field census comment

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -574,7 +574,8 @@ impl RawCdotTranscript {
         // surfacing the corruption (#1924; the drop was documented at
         // `reference/validate.rs`). Refusal is checkable; a displaced coordinate
         // is not. Every one of the 12,207,712 exon rows across 1,254,949
-        // cdot-0.2.32 GRCh38 builds carries all six fields, so a shorter or
+        // builds — the three shipped cdot-0.2.32 files (RefSeq and Ensembl
+        // GRCh38, plus GRCh37) — carries all six fields, so a shorter or
         // non-numeric row is malformed input, not a supported shape.
         //
         // The `gap_info` field (index 5) is deliberately *not* required: a valid


### PR DESCRIPTION
Split out of #2042, which merged from the merge queue while this line was still being corrected.

## What

The comment in `RawCdotTranscript::from_genome_build` (`src/data/cdot.rs:576-577`) labels its census:

> Every one of the 12,207,712 exon rows across 1,254,949 **cdot-0.2.32 GRCh38 builds** carries all six fields

The scan behind that figure covered **three** files, not one:

| file | builds |
|---|---:|
| RefSeq GRCh38 | 482,519 |
| RefSeq GRCh37 | 197,846 |
| Ensembl GRCh38 | 574,584 |
| **total** | **1,254,949** |

The total is correct. The label undersells what was measured, and reads as though GRCh37 went unchecked — which matters here, because GRCh37 is where the malformed row that motivated #2042 actually lives.

## Why it is a separate PR

The same mislabel appeared in three places: this comment, #2042's commit message, and #2042's description. The description was corrected before merge and the commit message is discarded by the squash, so this comment is the only copy that reached `main`. #2042 was enqueued and merged while the fix was still being gated, so the push was rejected with `GH006: ... queued for merging cannot be updated` — correctly, since dequeuing someone else's merge to land a comment change would have been the wrong trade.

## Verification

`cargo fmt --all --check` clean. Comment-only: no code, no test, no generated artifact is touched.

Representation-Change: none. A comment label in `src/data/cdot.rs`; no code path, output or pinned value is touched.