### PR TITLE
feat(normalize): gate the render-time reference against what the pipeline got

### DIFF
--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -3753,6 +3753,391 @@ mod tests {
         }
     }
 
+    /// Rows this gate must not normalize, because normalizing them aborts the
+    /// process under the `Test oracle` job's own flags.
+    ///
+    /// **These are normalizer defects that this corpus revealed, not flakes and not
+    /// rows the gate is allowed to be indifferent about.** Each is filed, each is
+    /// labelled `high`/`bug`, and each names the oracle it trips:
+    ///
+    /// - **#2036** — `FERRO_ASSERT_IDEMPOTENT`. Normalizing a long tract is not a
+    ///   fixed point: every pass walks three more bases 5' and increments the copy
+    ///   count (`g.558_559insACGACG` -> `g.460_558ACG[35]` -> `g.457_558ACG[36]`).
+    ///   Found by `long_tract_window_provenance` on its first armed run, which is
+    ///   the window-provenance defect that family was built to find.
+    /// - **#2037** — `FERRO_ASSERT_IN_BOUNDS`. Combining two members at `c.1` shifts
+    ///   the insertion point 5' off the coordinate space
+    ///   (`c.[1dup;1T>A]` -> `c.-1_1insA`, naming position 0 of a 20-base transcript).
+    ///
+    /// **Why an exclusion here rather than a weakened oracle.** The oracles panic
+    /// *inside* `normalize`, so a row that trips one takes the whole test binary with
+    /// it — and this gate re-normalizes each row **itself**, outside the `catch_unwind`
+    /// that [`normalize_through`] wraps `dump`'s own pass in. So the choice is not
+    /// between checking and not checking these rows; it is between the gate answering
+    /// its own question and the gate aborting on someone else's defect. Suppressing the
+    /// oracle, or dropping the rows from the corpus, would instead destroy the evidence
+    /// the two issues rest on.
+    ///
+    /// The list is **shrink-only**: every entry must still be produced by the corpus,
+    /// asserted below, so a row that stops being generated — or a defect that gets
+    /// fixed and re-admits its row — fails here instead of rotting into a blanket
+    /// exemption.
+    const ORACLE_TRIPPING_INPUTS: &[(&str, &str)] = &[
+        ("NC_TEST.1:g.456_457insACGACG", "#2036"),
+        ("NC_TEST.1:g.558_559insACGACG", "#2036"),
+        ("NC_TEST.1:g.582_583insACGACG", "#2036"),
+        ("NC_TEST.1:g.585_586insACGACG", "#2036"),
+        ("NC_TEST.1:g.756_757insACGACG", "#2036"),
+        ("NM_TEST.1:c.[1dup;1T>A]", "#2037"),
+        ("NM_TEST.1:c.[1dup;1C>A]", "#2037"),
+    ];
+
+    /// The reference a render-time mint would rebuild, against the one the
+    /// per-member pipeline was actually handed (#1946).
+    ///
+    /// **This is the gate on relocating the repeat mint.** `render::mint_reference_for`
+    /// has to reconstruct, from a settled member and a provider, what
+    /// `normalize_na_edit` was given — and `ref_seq` is not one thing: the whole
+    /// spliced transcript on `c.`/`r.`/`n.`, a window on `g.`/`m.`, and a genomic
+    /// window on the intronic and junction-crossing paths.
+    ///
+    /// # The comparison is per call site, and the first revision of it was vacuous
+    ///
+    /// The recorder hands back **every** `ref_seq` a normalization used: one per
+    /// member of a cis allele, one per growth attempt, one per
+    /// `FERRO_ASSERT_IDEMPOTENT` verification pass, and one per recursive re-entry
+    /// (`normalize_na_edit` calls itself from eight arms, always with the same
+    /// `ref_seq`). This gate's first revision asked whether **some** entry in that
+    /// union matched the rebuilt reference — `seen.iter().any(..)` — and reported
+    /// `3903 / 3903` (re-measured on this base; it shipped as `3865/3865` against an
+    /// older one). That number could not have read much else: on any row with a
+    /// transcript-axis member the whole-transcript entry is somewhere in the union,
+    /// so `any` matched for the same reason on every row. Turning it into `all` read
+    /// `3761 / 3903` — **142 members diverge, every one on the multi-exon `cx`
+    /// axis** — and that is not the tightening it looks like either: different
+    /// members of a legitimate multi-member allele genuinely see different windows,
+    /// so `all` over the union goes red on correct behaviour.
+    ///
+    /// Those 142 are the whole story, and per-site selection resolves them rather
+    /// than hiding them. Every one sits on a row that records **both** a `Cds`
+    /// call handed the 20-base spliced transcript **and** a `BoundarySpanning` call
+    /// handed a ~200-base genomic window — `NM_TESTX.1:c.6_11inv` records
+    /// `[Cds@d0=20, BoundarySpanning@d0=206, Cds@d0=20, BoundarySpanning@d0=206]`,
+    /// because `normalize_cds` tries the spliced frame and then re-normalizes across
+    /// the exon junction in genomic coordinates. The mint's whole-transcript rebuild
+    /// agrees with the `Cds` call byte-for-byte; the 206 belongs to a site the mint
+    /// does not model at all, and is counted below rather than matched.
+    ///
+    /// Neither is the right question. The right question is per **call site**, which
+    /// is why [`NaEditReference`] carries one: for each of the two shapes
+    /// `mint_reference_for` claims to model, compare the set of references **it**
+    /// builds against the set the pipeline was handed **at the sites that shape
+    /// models**, at depth 0. Set equality in both directions, so an extra reference
+    /// on either side fails — which is what makes a mis-attributed entry (a
+    /// junction-crossing window filed under `Cds`) fail rather than pass.
+    ///
+    /// # What is asserted
+    ///
+    /// 1. **Every recorded call is attributed.** A depth-0 call at
+    ///    [`NaEditCallSite::Unattributed`] means a normalizer entry point reaches
+    ///    `normalize_na_edit` without a site guard, and every conclusion below is
+    ///    then about a subset nobody delimited. Asserted zero.
+    /// 2. **The recorder did not truncate.** A capped buffer that silently drops
+    ///    entries looks exactly like a set that never contained them.
+    /// 3. **The whole-transcript sets are equal.** The reference is served entire on
+    ///    `c.`/`r.`/`n.`, so there is no window to choose and no reason for a rebuilt
+    ///    reference to differ by a byte from the one the pipeline indexed — nor for
+    ///    the pipeline to have used one the mint does not build. That is a property,
+    ///    statable without any measured number. Asserted over the rows where it is
+    ///    answerable, with the answerable-row count asserted non-zero so `0 of 0`
+    ///    cannot pass as a result.
+    /// 4. **One whole transcript per row.** The set is asserted to be a *singleton*
+    ///    wherever it is non-empty, which is the "nothing to choose" claim stated
+    ///    directly rather than assumed.
+    ///
+    /// # What is reported, and why it is not asserted
+    ///
+    /// **The genomic frame.** It cannot be byte-equal by construction: the pipeline's
+    /// window is centred on the *input* position and a render stage only has the
+    /// settled one, and the two do not even share a left edge —
+    /// `normalize_in_grown_window` fetches from `start - w` where `mint_reference_for`
+    /// fetches from `start - 1 - w`. So the question there is containment, and
+    /// pinning today's ratio would make the count *be* the property.
+    ///
+    /// **The frames the mint does not model.** A `c.` member whose span crosses an
+    /// exon/exon junction, or which sits in an intron, is normalized against a
+    /// *genomic* window by `normalize_boundary_spanning_cds` / `normalize_intronic_cds`
+    /// — `mint_reference_for` returns the spliced transcript for it, because that is
+    /// what its `CisKind` says. Those rows are counted under
+    /// `rows_using_an_unmodelled_frame` rather than being folded into a match, and a
+    /// row whose transcript-side calls were **only** at such a site is excluded from
+    /// assertion 3 (there is no whole-transcript call to compare against) and counted
+    /// under `rows_with_no_modelled_call`. That is the next piece of work, and naming
+    /// it as a population is the difference between an open gap and a hidden one.
+    ///
+    /// # Measured over `dump(1)`
+    ///
+    /// Read the run's own `MINT-REFERENCE` line rather than this table; it is here so
+    /// a reader knows the order of magnitude and which buckets exist.
+    ///
+    /// | population | result |
+    /// |---|---|
+    /// | rows where the whole-transcript sets are compared | see the printed line — **asserted equal** |
+    /// | genomic-frame members at least as wide as the widest witnessed window | reported |
+    /// | members with no rebuildable reference | reported |
+    /// | rows using a frame `mint_reference_for` does not model | reported |
+    /// | held out (#2036, #2037) | 7 rows |
+    ///
+    /// **Every asserted figure is identical with the three `FERRO_ASSERT_*` flags set
+    /// and unset, measured both ways** — same 2209 rows compared, same zero
+    /// mismatches, same `1586 / 2344`, same zero unattributed calls. One *reported*
+    /// counter does move: `rows_using_an_unmodelled_frame` reads **102** unarmed and
+    /// **103** armed, because `FERRO_ASSERT_IDEMPOTENT`'s verification pass is a
+    /// second normalization whose own depth-0 calls are recorded too, and on one row
+    /// it reaches a junction-crossing site the first pass did not. That is a fact
+    /// about the corpus rather than about the mint, and it is stated rather than
+    /// smoothed over: a counter over a *union* is exactly what stays flag-sensitive,
+    /// which is why the assertions are over per-site sets instead.
+    ///
+    /// That distinction is worth stating because a still-earlier revision did
+    /// **not** have it: it compared against the *narrowest* reference in the union,
+    /// and `FERRO_ASSERT_IDEMPOTENT`'s verification pass contributes narrower entries,
+    /// so its genomic figure read `2344/2344` in `Test oracle` and `2274/2344` in
+    /// `Test` (measured against that revision's own base — do not carry those two
+    /// numbers onto this one) — a gate whose number improves when you arm the oracles
+    /// is measuring the oracles. Selecting by call site and depth removes that
+    /// dependence at the
+    /// source: the verification pass's calls are depth-0 calls of a second
+    /// normalization, and they land in the same sets as the first pass's, which for
+    /// the transcript frame is the *same* whole transcript and for the genomic frame
+    /// is folded into the same maximum.
+    ///
+    /// Seven rows are held out; see [`ORACLE_TRIPPING_INPUTS`], which names the issue
+    /// behind each.
+    #[test]
+    fn the_render_time_reference_matches_what_the_pipeline_was_given() {
+        use ferro_hgvs::normalize::{
+            mint_reference_for, na_edit_references_overflowed, reference_digest,
+            take_na_edit_references, MintFrame, NaEditCallSite, NaEditReferenceRecording,
+            MINT_WINDOW,
+        };
+        use std::collections::BTreeSet;
+
+        /// The sites at which the pipeline is handed a whole transcript. These are
+        /// exactly the sites [`MintFrame::WholeTranscript`] models.
+        const WHOLE_TRANSCRIPT_SITES: &[NaEditCallSite] =
+            &[NaEditCallSite::Cds, NaEditCallSite::Tx, NaEditCallSite::Rna];
+        /// The sites at which the pipeline is handed a `g.`/`m.` window. These are
+        /// exactly the sites [`MintFrame::GenomicWindow`] models.
+        const GENOMIC_WINDOW_SITES: &[NaEditCallSite] =
+            &[NaEditCallSite::GrownWindow, NaEditCallSite::UnshiftedWindow];
+        /// Sites the mint does not model at all: a genomic window reached from a
+        /// transcript-axis description.
+        const UNMODELLED_SITES: &[NaEditCallSite] =
+            &[NaEditCallSite::Intronic, NaEditCallSite::BoundarySpanning];
+
+        let mut tx_rows_compared = 0usize;
+        let mut tx_row_mismatches: Vec<String> = Vec::new();
+        let mut rows_with_no_modelled_call = 0usize;
+        let mut rows_using_an_unmodelled_frame = 0usize;
+        let mut rows_with_a_declined_member = 0usize;
+        let mut unattributed_calls = 0usize;
+        let (mut g_total, mut g_contained, mut g_unwitnessed) = (0usize, 0usize, 0usize);
+        let mut no_reference = 0usize;
+        let mut held_out_seen: BTreeSet<&str> = BTreeSet::new();
+
+        // Built BEFORE arming: `dump` normalizes the whole corpus itself, and those
+        // normalizations are not the ones this gate is asking about. Arming first
+        // fills the buffer with them, which the cap assertion below catches.
+        let rows = dump(1);
+
+        // Armed once for the whole walk. Recording is off by default, so nothing
+        // outside this test pays for it or accumulates into it.
+        let _recording = NaEditReferenceRecording::arm();
+
+        for row in rows {
+            if row.axis == "p" {
+                continue;
+            }
+            // Held out BEFORE normalizing: the oracles abort inside `normalize`, and
+            // this gate's own call is not wrapped in `catch_unwind`.
+            if let Some((held, _)) = ORACLE_TRIPPING_INPUTS
+                .iter()
+                .find(|(input, _)| *input == row.input)
+            {
+                held_out_seen.insert(*held);
+                continue;
+            }
+            let provider = provider_for(row.axis, &row.core);
+            let direction = match row.direction {
+                "5prime" => ShuffleDirection::FivePrime,
+                _ => ShuffleDirection::ThreePrime,
+            };
+            let normalizer = Normalizer::with_config(
+                provider_for(row.axis, &row.core),
+                NormalizeConfig::default().with_direction(direction),
+            );
+            let Ok(input) = parse_hgvs(&row.input) else {
+                continue;
+            };
+            let _ = take_na_edit_references();
+            let normalized = normalizer.normalize(&input);
+            // Drained unconditionally, and *before* the `else { continue }`. A
+            // refused normalization still records the references it was handed
+            // before it refused, and leaving them in the buffer bleeds them into
+            // the next row's set — which the cap assertion below caught, and which
+            // the union-based revision of this gate could not have.
+            let seen = take_na_edit_references();
+            let Ok(output) = normalized else {
+                continue;
+            };
+            if seen.is_empty() {
+                continue;
+            }
+
+            // Only depth-0 calls: the eight recursive arms re-enter with the same
+            // `ref_seq`, so counting them would weight one entry point by how many
+            // rewrites it happened to take.
+            let entry_calls = || seen.iter().filter(|e| e.depth == 0);
+            unattributed_calls += entry_calls()
+                .filter(|e| e.site == NaEditCallSite::Unattributed)
+                .count();
+            let witnessed_tx: BTreeSet<(usize, u64)> = entry_calls()
+                .filter(|e| WHOLE_TRANSCRIPT_SITES.contains(&e.site))
+                .map(|e| (e.len, e.digest))
+                .collect();
+            let widest_genomic = entry_calls()
+                .filter(|e| GENOMIC_WINDOW_SITES.contains(&e.site))
+                .map(|e| e.len)
+                .max();
+            let unmodelled: BTreeSet<NaEditCallSite> = entry_calls()
+                .filter(|e| UNMODELLED_SITES.contains(&e.site))
+                .map(|e| e.site)
+                .collect();
+            if !unmodelled.is_empty() {
+                rows_using_an_unmodelled_frame += 1;
+            }
+
+            let members: Vec<_> = match &output {
+                ferro_hgvs::hgvs::variant::HgvsVariant::Allele(a) => a.variants.clone(),
+                other => vec![other.clone()],
+            };
+            let mut built_tx: BTreeSet<(usize, u64)> = BTreeSet::new();
+            let mut declined_here = false;
+            for member in &members {
+                let Some(built) = mint_reference_for(member, &provider, MINT_WINDOW) else {
+                    no_reference += 1;
+                    declined_here = true;
+                    continue;
+                };
+                let digest = reference_digest(&built.bases);
+                match built.frame {
+                    MintFrame::WholeTranscript => {
+                        built_tx.insert((built.bases.len(), digest));
+                    }
+                    MintFrame::GenomicWindow => {
+                        g_total += 1;
+                        // The pipeline's window is centred elsewhere and starts one
+                        // base 3' of this one, so identity is not the question;
+                        // whether the rebuilt window is at least as wide as the
+                        // **widest** the pipeline used at a site this frame models
+                        // is. Widest, because `insertion_to_repeat` walks outward
+                        // bounded by `ref_seq.len()` — a mint is only safe if it is
+                        // at least as wide as every window the pipeline used.
+                        match widest_genomic {
+                            Some(widest) if built.bases.len() >= widest => g_contained += 1,
+                            Some(_) => {}
+                            // The mint built a genomic window for a member the
+                            // pipeline never handed one to. Counted, not passed.
+                            None => g_unwitnessed += 1,
+                        }
+                    }
+                }
+            }
+            if declined_here {
+                rows_with_a_declined_member += 1;
+            }
+
+            // The whole-transcript comparison is answerable only when the pipeline
+            // made a whole-transcript call and every member was minted. A row whose
+            // transcript-side work happened entirely in a frame the mint does not
+            // model has nothing to compare against, and saying so is the point.
+            if witnessed_tx.is_empty() && !built_tx.is_empty() {
+                rows_with_no_modelled_call += 1;
+            } else if !witnessed_tx.is_empty() && !declined_here {
+                tx_rows_compared += 1;
+                if built_tx != witnessed_tx && tx_row_mismatches.len() < 12 {
+                    tx_row_mismatches.push(format!(
+                        "axis={} input={} built={:?} witnessed={:?} unmodelled_sites={:?}",
+                        row.axis,
+                        row.input,
+                        built_tx.iter().map(|(l, _)| *l).collect::<Vec<_>>(),
+                        witnessed_tx.iter().map(|(l, _)| *l).collect::<Vec<_>>(),
+                        unmodelled,
+                    ));
+                } else if built_tx != witnessed_tx {
+                    tx_row_mismatches.push(String::from("<further mismatches elided>"));
+                }
+                assert!(
+                    witnessed_tx.len() == 1,
+                    "the reference is served whole on `c.`/`r.`/`n.`, so one \
+                     normalization cannot have been handed two different \
+                     whole-transcript references: {} saw {:?}",
+                    row.input,
+                    witnessed_tx.iter().map(|(l, _)| *l).collect::<Vec<_>>(),
+                );
+            }
+        }
+
+        eprintln!(
+            "MINT-REFERENCE whole-transcript sets equal on {tx_rows_compared} rows \
+             ({} mismatching); genomic {g_contained}/{g_total} at least as wide \
+             ({g_unwitnessed} unwitnessed); {no_reference} members had no rebuildable \
+             reference across {rows_with_a_declined_member} rows; \
+             {rows_using_an_unmodelled_frame} rows used a frame the mint does not model, \
+             {rows_with_no_modelled_call} of them with no modelled call at all; \
+             {unattributed_calls} unattributed calls; {} rows held out",
+            tx_row_mismatches.len(),
+            ORACLE_TRIPPING_INPUTS.len()
+        );
+
+        // Shrink-only: a held-out row the corpus no longer builds must be removed from
+        // the list deliberately, not left as a silent exemption.
+        let expected: BTreeSet<&str> = ORACLE_TRIPPING_INPUTS.iter().map(|(i, _)| *i).collect();
+        assert_eq!(
+            held_out_seen,
+            expected,
+            "the held-out list has drifted from the corpus; entries never produced: {:?}",
+            expected.difference(&held_out_seen).collect::<Vec<_>>()
+        );
+
+        assert!(
+            !na_edit_references_overflowed(),
+            "the reference recorder hit its cap, so every set above is a truncation \
+             of the real one and a missing entry is indistinguishable from a mismatch"
+        );
+        assert_eq!(
+            unattributed_calls, 0,
+            "a normalizer entry point reached `normalize_na_edit` without a \
+             `NaEditSiteGuard`, so the site selection below is over a population \
+             nobody delimited"
+        );
+        assert!(
+            tx_rows_compared > 0,
+            "no row reached the whole-transcript comparison, so the equality \
+             assertion below is vacuous"
+        );
+        assert!(
+            tx_row_mismatches.is_empty(),
+            "a render-time mint must rebuild exactly the whole-transcript references \
+             the pipeline was handed at the sites this frame models: the reference is \
+             served whole on `c.`/`r.`/`n.`, so there is no window to choose and \
+             nothing to disagree about. {} of {tx_rows_compared} rows disagree:\n{}",
+            tx_row_mismatches.len(),
+            tx_row_mismatches.join("\n"),
+        );
+    }
+
     /// The long tracts bracket the normalizer's own window, on both sides.
     ///
     /// **This is the property the family exists for, so it is asserted rather than

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -31,6 +31,14 @@ pub(crate) mod footprint;
 pub(crate) mod merge;
 mod overlap;
 pub(crate) mod render;
+// The render stage is internal, but `examples/dump_normalized_corpus.rs` is an
+// external crate and the #1946 reference gate lives there, so the three items it
+// needs are re-exported by name. `#[doc(hidden)]`, and *only* these three — the
+// module itself was briefly widened to `pub`, which put `render_canonical_spelling`
+// and the module's own design notes on the public documentation surface for the
+// sake of a test. `src/lib.rs`'s `ShuffleDirection` re-export is the pattern.
+#[doc(hidden)]
+pub use render::{mint_reference_for, MintFrame, MintReference, MINT_WINDOW};
 pub mod rules;
 // `pub` only under the `dev` feature (test/bench builds), so the
 // `seqfirst_align` criterion benchmark — an external crate — can reach
@@ -2122,6 +2130,268 @@ fn denoted_sequence_self_check_enabled() -> bool {
             .map(|v| !v.is_empty() && v != "0")
             .unwrap_or(false)
     })
+}
+
+// Every `ref_seq` handed to `Normalizer::normalize_na_edit` during one
+// normalization, **attributed to the call that was handed it** (#1946).
+//
+// Test-only, and it exists to answer one question that cannot be answered any
+// other way: does a reference rebuilt from a settled member match the one the
+// per-member pipeline was given? That is the gate on relocating the repeat mint
+// into `render::render_canonical_spelling` -- a stage that receives only the final
+// member list has to reconstruct this, and `ref_seq` is not one thing. It is the
+// whole spliced transcript on c./r./n., a growing window on g./m., and a
+// reverse-complemented genomic window on the intronic paths.
+//
+// **The attribution is the whole point, and a flat list of `(len, digest)` was
+// not enough to be worth having.** One normalization records a reference per
+// member of a cis allele, per growth attempt of the `g.`/`m.` window, per
+// `FERRO_ASSERT_IDEMPOTENT` verification pass, and per recursive re-entry --
+// `normalize_na_edit` calls itself from eight arms, always with the same
+// `ref_seq`, so the list is longer than the number of distinct references by a
+// wide and irregular margin. A gate that asked whether *some* entry matched
+// therefore answered yes for any member on a transcript axis whatever the mint
+// rebuilt, because the whole-transcript entry is always somewhere in the union.
+// Recording the site, the depth and the call id lets the gate ask the question it
+// means: does the mint match the reference **the call it is modelling** was
+// given?
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NaEditCallSite {
+    /// A call made outside any instrumented entry point. Reaching this is a gap
+    /// in the instrumentation rather than a fact about normalization, so the
+    /// gate counts it rather than folding it into a real site.
+    Unattributed,
+    /// `normalize_cds` — the whole spliced transcript, served entire.
+    Cds,
+    /// `normalize_tx` — the whole transcript, served entire.
+    Tx,
+    /// `normalize_rna` — the whole transcript, served entire.
+    Rna,
+    /// `normalize_intronic_cds` / `normalize_intronic_tx` — a genomic window,
+    /// reverse-complemented on the minus strand.
+    Intronic,
+    /// `normalize_boundary_spanning_cds` / `normalize_boundary_spanning_tx` — a
+    /// genomic window around a span that crosses an exon/exon junction, so the
+    /// spliced transcript is the wrong frame to shuffle in.
+    BoundarySpanning,
+    /// `normalize_in_grown_window` — the `g.`/`m.` window, at whatever width the
+    /// growth loop had reached when this attempt ran.
+    GrownWindow,
+    /// `canonicalize_without_shifting` — the fallback the growth loop takes when
+    /// it hits its cap.
+    UnshiftedWindow,
+}
+
+/// One `ref_seq` handed to one [`Normalizer::normalize_na_edit`] call.
+///
+/// `len` and `digest` identify the bytes; the other three identify the call, so
+/// a reader can select the calls it is entitled to compare against instead of
+/// searching the union.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NaEditReference {
+    /// Monotonic within one recording window, in call order.
+    pub call: u32,
+    /// The call this one recursed out of, or `None` at an entry point.
+    pub parent: Option<u32>,
+    /// `0` for a call made directly by an entry point, `n` for the `n`th
+    /// recursive re-entry beneath it.
+    pub depth: u32,
+    /// Which entry point's frame this call is in.
+    pub site: NaEditCallSite,
+    /// `ref_seq.len()`.
+    pub len: usize,
+    /// [`reference_digest`] of `ref_seq`.
+    pub digest: u64,
+}
+
+/// Ceiling on retained entries, so an unarmed-by-accident recording cannot grow
+/// without bound. A single row's normalization records tens of entries; this is
+/// three orders of magnitude above that, and an overrun is reported by
+/// [`na_edit_references_overflowed`] rather than silently truncating a set the
+/// gate then reads as complete.
+#[cfg(debug_assertions)]
+const NA_EDIT_REFERENCE_CAP: usize = 4096;
+
+#[cfg(debug_assertions)]
+thread_local! {
+    static NA_EDIT_REFERENCES: std::cell::RefCell<Vec<NaEditReference>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+    /// Off by default, so an ordinary normalization records nothing at all.
+    static NA_EDIT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static NA_EDIT_OVERFLOWED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static NA_EDIT_SITE: std::cell::Cell<NaEditCallSite> =
+        const { std::cell::Cell::new(NaEditCallSite::Unattributed) };
+    /// Call ids of the frames currently on the stack; its length is the depth
+    /// and its last element is the parent.
+    static NA_EDIT_FRAMES: std::cell::RefCell<Vec<u32>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+    static NA_EDIT_NEXT_CALL: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// FNV-1a over `bases`. Cheap, and only ever compared against itself.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub fn reference_digest(bases: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bases {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Arms the recorder for as long as it is held, and clears it on both edges.
+///
+/// Recording is **off** unless a test asks for it: the buffer is a debug-build
+/// diagnostic for one gate, and a normalization that nobody is measuring must not
+/// pay for it or accumulate into it.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+#[must_use = "recording stops when the guard is dropped"]
+pub struct NaEditReferenceRecording {
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+#[cfg(debug_assertions)]
+impl NaEditReferenceRecording {
+    /// Arm the recorder on this thread.
+    pub fn arm() -> Self {
+        reset_na_edit_recorder();
+        NA_EDIT_ARMED.with(|a| a.set(true));
+        Self {
+            _not_send: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for NaEditReferenceRecording {
+    fn drop(&mut self) {
+        NA_EDIT_ARMED.with(|a| a.set(false));
+        reset_na_edit_recorder();
+    }
+}
+
+#[cfg(debug_assertions)]
+fn reset_na_edit_recorder() {
+    NA_EDIT_REFERENCES.with(|r| r.borrow_mut().clear());
+    NA_EDIT_FRAMES.with(|f| f.borrow_mut().clear());
+    NA_EDIT_NEXT_CALL.with(|c| c.set(0));
+    NA_EDIT_OVERFLOWED.with(|o| o.set(false));
+}
+
+/// Clear the recorder and return what it held. Test-only.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub fn take_na_edit_references() -> Vec<NaEditReference> {
+    NA_EDIT_NEXT_CALL.with(|c| c.set(0));
+    NA_EDIT_REFERENCES.with(|r| r.borrow_mut().drain(..).collect())
+}
+
+/// Whether the recorder hit [`NA_EDIT_REFERENCE_CAP`] since the last take.
+///
+/// A truncated set is indistinguishable from a complete one to a reader that
+/// only sees the vector, and "the entry I was looking for is not here" is exactly
+/// the shape a truncation takes — so the gate asks.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub fn na_edit_references_overflowed() -> bool {
+    NA_EDIT_OVERFLOWED.with(std::cell::Cell::get)
+}
+
+/// Marks every `normalize_na_edit` call made while it is held as belonging to
+/// `site`. Restores the enclosing site on drop, so a nested entry point (the
+/// boundary-spanning path is reached from `normalize_cds`) does not leak.
+#[must_use = "the site is only marked for as long as the guard is held"]
+pub(crate) struct NaEditSiteGuard {
+    #[cfg(debug_assertions)]
+    previous: NaEditCallSite,
+}
+
+impl NaEditSiteGuard {
+    #[cfg(debug_assertions)]
+    pub(crate) fn enter(site: NaEditCallSite) -> Self {
+        Self {
+            previous: NA_EDIT_SITE.with(|s| s.replace(site)),
+        }
+    }
+
+    /// A zero-sized no-op in release, where the recorder does not exist.
+    #[cfg(not(debug_assertions))]
+    pub(crate) fn enter(_site: NaEditCallSite) -> Self {
+        Self {}
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for NaEditSiteGuard {
+    fn drop(&mut self) {
+        NA_EDIT_SITE.with(|s| s.set(self.previous));
+    }
+}
+
+/// Records `ref_seq` against the call now being entered, and pops that call on
+/// drop. A guard rather than a bare call because `normalize_na_edit` returns from
+/// a dozen places, several of them through `?`.
+#[must_use = "the frame is only open for as long as the guard is held"]
+pub(crate) struct NaEditFrameGuard {
+    #[cfg(debug_assertions)]
+    pushed: bool,
+}
+
+impl NaEditFrameGuard {
+    #[cfg(debug_assertions)]
+    pub(crate) fn enter(ref_seq: &[u8]) -> Self {
+        if !NA_EDIT_ARMED.with(std::cell::Cell::get) {
+            return Self { pushed: false };
+        }
+        let call = NA_EDIT_NEXT_CALL.with(|c| {
+            let next = c.get();
+            c.set(next.saturating_add(1));
+            next
+        });
+        let (parent, depth) = NA_EDIT_FRAMES.with(|f| {
+            let frames = f.borrow();
+            (frames.last().copied(), frames.len() as u32)
+        });
+        let entry = NaEditReference {
+            call,
+            parent,
+            depth,
+            site: NA_EDIT_SITE.with(std::cell::Cell::get),
+            len: ref_seq.len(),
+            digest: reference_digest(ref_seq),
+        };
+        NA_EDIT_REFERENCES.with(|r| {
+            let mut v = r.borrow_mut();
+            if v.len() < NA_EDIT_REFERENCE_CAP {
+                v.push(entry);
+            } else {
+                NA_EDIT_OVERFLOWED.with(|o| o.set(true));
+            }
+        });
+        NA_EDIT_FRAMES.with(|f| f.borrow_mut().push(call));
+        Self { pushed: true }
+    }
+
+    /// A zero-sized no-op in release, where the recorder does not exist.
+    #[cfg(not(debug_assertions))]
+    pub(crate) fn enter(_ref_seq: &[u8]) -> Self {
+        Self {}
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for NaEditFrameGuard {
+    fn drop(&mut self) {
+        if self.pushed {
+            NA_EDIT_FRAMES.with(|f| {
+                f.borrow_mut().pop();
+            });
+        }
+    }
 }
 
 /// Normalizations the denoted-sequence oracle looked at but could not compare.
@@ -5853,6 +6123,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         edit: &NaEdit,
         fetch_end_of: impl Fn(u64) -> u64,
     ) -> Result<Option<WindowedNormalization>, FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed the g./m. window at this attempt's width,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::GrownWindow);
         // A reversed range names a wraparound, and this window is linear
         // (#1917). Refuse it here, where the arithmetic that cannot express it
         // lives, so the caller takes its minimal-notation fallback.
@@ -6015,6 +6288,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end: u64,
         edit: &NaEdit,
     ) -> Result<Option<WindowedNormalization>, FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed the un-grown fallback window,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::UnshiftedWindow);
         // A repeat's canonical form IS an extent claim, so there is no
         // travel-free part of it to salvage: `normalize_repeat` would report the
         // slice's own edges as the tract's. Hand it back untouched.
@@ -6440,6 +6716,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &CdsVariant,
         manufactured: &mut Vec<ManufacturedJunctionExit>,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed the whole spliced transcript,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::Cds);
         // #972 Task 5: a transcript whose 5' CDS is annotated incomplete
         // (`cds_start_NF`) has no confirmed ATG, so `c.1` is undefined
         // against it and it is not an HGVS-recommended `c.` reference
@@ -7854,6 +8133,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &TxVariant,
         manufactured: &mut Vec<ManufacturedJunctionExit>,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed the whole transcript,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::Tx);
         // Can't normalize variants with unknown edits or positions
         let edit = match variant.loc_edit.edit.inner() {
             Some(e) => e,
@@ -9534,6 +9816,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &crate::hgvs::variant::RnaVariant,
         manufactured: &mut Vec<ManufacturedJunctionExit>,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed the whole transcript,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::Rna);
         use crate::hgvs::interval::RnaInterval;
         use crate::hgvs::variant::{LocEdit, RnaVariant};
 
@@ -10681,6 +10966,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end_pos: &CdsPos,
         edit: &NaEdit,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed a genomic window, reverse-complemented on the minus strand,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::Intronic);
         use crate::convert::CoordinateMapper;
 
         // #1012: warn-and-degrade when the reference carries no genomic data.
@@ -10909,6 +11197,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end_pos: &TxPos,
         edit: &NaEdit,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed a genomic window, reverse-complemented on the minus strand,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::Intronic);
         use crate::convert::CoordinateMapper;
 
         // #1012: warn-and-degrade when the reference carries no genomic data —
@@ -11106,6 +11397,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end_pos: &CdsPos,
         edit: &NaEdit,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed a genomic window across the junction,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::BoundarySpanning);
         use crate::convert::CoordinateMapper;
 
         // #1012: warn-and-degrade when the reference carries no genomic data.
@@ -11599,6 +11893,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end_pos: &TxPos,
         edit: &NaEdit,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // #1946: every `normalize_na_edit` call below is handed a genomic window across the junction,
+        // and the reference gate must be able to say so.
+        let _na_edit_site = NaEditSiteGuard::enter(NaEditCallSite::BoundarySpanning);
         use crate::convert::CoordinateMapper;
 
         // #1012: warn-and-degrade when the reference carries no genomic data —
@@ -11756,6 +12053,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         gate: CodonGate,
         frame: MismatchFrame<'_>,
     ) -> Result<(u64, u64, NaEdit, Vec<NormalizationWarning>), FerroError> {
+        // Held for the whole body: this is what attributes every recursive
+        // re-entry below to the call it recursed out of (#1946).
+        let _na_edit_frame = NaEditFrameGuard::enter(ref_seq);
         let mut warnings = Vec::new();
 
         // An insertion resting at interbase 0 — "before base 1" — reaches here

--- a/src/normalize/render.rs
+++ b/src/normalize/render.rs
@@ -138,6 +138,181 @@ pub(crate) fn render_canonical_spelling<P: ReferenceProvider>(
     let _ = (members, provider);
 }
 
+/// Which of the per-member pipeline's two reference shapes a [`MintReference`]
+/// rebuilds (#1946).
+///
+/// This is what the reference gate keys its comparison on. It is derived from the
+/// member's `CisKind` and from nothing else —
+/// an earlier revision inferred the same distinction from the *contents* of the
+/// rebuilt reference (`complete && offset == 0`), which happened to agree only
+/// because a genomic window's padding is narrower than the transcript-flanking
+/// pad, and would have started disagreeing the moment either constant moved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MintFrame {
+    /// `c.`/`r.`/`n.` — the entire transcript, exactly as `normalize_cds`,
+    /// `normalize_rna` and `normalize_tx` serve it. There is no window to choose.
+    WholeTranscript,
+    /// `g.`/`m.` — a window around the member's own span.
+    GenomicWindow,
+}
+
+/// The reference a render-time mint is evaluated against, and the frame its
+/// positions live in (#1946).
+///
+/// `ref_seq` is **not one thing** in the per-member pipeline — it is the entire
+/// spliced transcript on `c.`/`r.`/`n.`, a growing window on `g.`/`m.`, and a
+/// reverse-complemented genomic window on the intronic paths — so a stage that
+/// receives only a settled member list has to rebuild it deliberately rather than
+/// substitute one uniform window. Doing the latter silently truncates tract
+/// discovery near an edge: `insertion_to_repeat` walks outward bounded only by
+/// `ref_seq.len()`.
+#[derive(Debug, Clone)]
+pub struct MintReference {
+    /// Reference bases, **exactly as the pipeline's own fetch produces them**.
+    ///
+    /// Deliberately not case-normalized here: byte-equality with what
+    /// `normalize_na_edit` was handed is the property the gate asserts, so this
+    /// has to inherit each path's own convention rather than impose one.
+    /// `fetch_canonical_window` upper-cases, so [`MintFrame::GenomicWindow`]
+    /// bases are upper-case; a transcript's bases are served verbatim, so
+    /// [`MintFrame::WholeTranscript`] bases are whatever the provider holds.
+    /// (This field's doc claimed "upper-cased" flatly, which was true of neither
+    /// the transcript branch nor of the growth loop it is compared against —
+    /// `normalize_in_grown_window` passes `provider.get_sequence(..).as_bytes()`
+    /// with no case fold at all.)
+    pub bases: Vec<u8>,
+    /// Which shape this is. Ask this, not the flags below, when the question is
+    /// "which pipeline call does this model".
+    pub frame: MintFrame,
+    /// A 1-based **sequence** position `p` indexes `bases[(p - 1 - offset)]`.
+    /// Zero when `bases` starts at the sequence's own first base.
+    pub offset: i64,
+    /// The 5' edge of `bases` is the sequence's own start, so there is nothing
+    /// further 5' for a tract walk to reach.
+    pub at_sequence_start: bool,
+    /// The 3' edge of `bases` is the sequence's own end, so there is nothing
+    /// further 3' for a tract walk to reach.
+    ///
+    /// Separate from [`Self::at_sequence_start`] on purpose: the predicate this
+    /// replaces (`complete`) was set from a 3'-clamped fetch alone and then
+    /// documented as "`bases` is the complete reference", which is a strictly
+    /// stronger claim than the code checked — a window clamped only at the
+    /// contig end reported itself complete while its 5' side sat in the interior.
+    pub at_sequence_end: bool,
+}
+
+impl MintReference {
+    /// Whether `bases` is the entire reference sequence, so no edge can truncate
+    /// a tract walk and there is nothing to grow into on either side.
+    #[must_use]
+    pub fn is_whole_sequence(&self) -> bool {
+        self.at_sequence_start && self.at_sequence_end
+    }
+}
+
+/// Half-width of the first genomic window, matching `NormalizeConfig`'s default.
+pub const MINT_WINDOW: i64 = 100;
+
+/// Rebuild the reference a settled `member`'s mint should be evaluated against.
+///
+/// **Unused by `render_canonical_spelling` on purpose.** This lands with its
+/// equivalence test and nothing else: the gate on relocating the repeat mint is
+/// whether a reference rebuilt here matches what the per-member pipeline was given,
+/// and that question is answered before any mint moves.
+///
+/// Mirrors the existing callers rather than unifying them:
+///
+/// - **`c.`/`r.`/`n.`** — the whole transcript, exactly as `normalize_cds`,
+///   `normalize_rna` and `normalize_tx` pass it. [`MintReference::is_whole_sequence`]
+///   holds, so no growth is possible or needed.
+/// - **`g.`/`m.`** — a window, whose edges are flagged individually. Growth is the
+///   caller's business and is **triggered differently from
+///   `normalize_in_grown_window`**: that loop grows when the *shuffle* runs to an
+///   edge, and at render time there is no shuffle, so a render-time mint must grow
+///   when the *tract walk* reaches one.
+///
+/// # What this does NOT model, and why the gate has to say so
+///
+/// A `c.` member whose span crosses an exon/exon junction, or which sits in an
+/// intron, is **not** normalized against the spliced transcript: `normalize_cds`
+/// hands it to `normalize_boundary_spanning_cds` or `normalize_intronic_cds`, which
+/// fetch a *genomic* window and shuffle there. This function returns the whole
+/// transcript for such a member, because that is what its `CisKind` says — so for
+/// those members it rebuilds a reference the pipeline's junction-crossing call was
+/// never given.
+///
+/// That is a real gap in this function, and the gate reports it as its own
+/// population rather than letting it hide inside a match: see
+/// `the_render_time_reference_matches_what_the_pipeline_was_given`, which selects
+/// the recorded calls by [`NaEditCallSite`](crate::normalize::NaEditCallSite) and
+/// counts members whose depth-0 calls were all at a site this function does not
+/// model. Closing it means minting the same genomic window those two paths build,
+/// and is the next step rather than a widening to do in passing.
+///
+/// # Measured over `dump(1)`
+///
+/// Comparing what this rebuilds against what `normalize_na_edit` was actually
+/// handed (recorded by `normalize::take_na_edit_references`), selecting by call
+/// site — the figures are printed by the gate and are quoted in its doc comment
+/// rather than here, so that one measurement has one home. What is worth stating
+/// on the function is the shape of the answer: the whole-transcript frame is
+/// asserted **byte-identical**, the genomic frame is **reported** and cannot be
+/// byte-equal by construction (the pipeline's window is centred on the *input*
+/// position, and it starts one base 3' of this one — `normalize_in_grown_window`
+/// fetches from `start - w` where this fetches from `start - 1 - w`).
+pub fn mint_reference_for<P: ReferenceProvider>(
+    member: &HgvsVariant,
+    provider: &P,
+    half_width: i64,
+) -> Option<MintReference> {
+    use crate::normalize::merge::{
+        cis_axis_parts, cis_kind_of, fetch_canonical_window, region_sequence_delta, CisKind,
+    };
+
+    let kind = cis_kind_of(member)?;
+    let (accession, region, axis_start, axis_end, _edit) = cis_axis_parts(member, kind)?;
+    let key = accession.transcript_accession();
+
+    // Transcript axes: the reference is served whole, so there is no window to
+    // choose. Keyed on the kind, which is what decides the frame — never on the
+    // shape of what came back.
+    if !matches!(kind, CisKind::Genome | CisKind::Mt) {
+        let transcript = provider.get_transcript_for_variant(member).ok()?;
+        let bases = transcript.sequence.as_deref()?.as_bytes().to_vec();
+        return Some(MintReference {
+            bases,
+            frame: MintFrame::WholeTranscript,
+            offset: 0,
+            at_sequence_start: true,
+            at_sequence_end: true,
+        });
+    }
+
+    // Genomic: a window around the member's own span, in sequence coordinates.
+    let delta = region_sequence_delta(region, &key, provider)?;
+    let (lo, hi) = (
+        axis_start.min(axis_end) + delta,
+        axis_start.max(axis_end) + delta,
+    );
+    let start0 = (lo - 1 - half_width).max(0);
+    let end0 = hi + half_width;
+    if end0 <= start0 {
+        return None;
+    }
+    let bases = fetch_canonical_window(provider, &key, start0, end0)?;
+    // A short read means the fetch ran off the contig, which is the only way to
+    // learn the 3' edge without a second provider round-trip. The 5' edge is
+    // decidable from `start0` alone.
+    let at_sequence_end = (bases.len() as i64) < end0 - start0;
+    Some(MintReference {
+        bases,
+        frame: MintFrame::GenomicWindow,
+        offset: start0,
+        at_sequence_start: start0 == 0,
+        at_sequence_end,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Refs #1946. Step 2 of increment 4, and it is a **measurement**, not a move: nothing is relocated, the corpus dump is byte-identical, and `mint_reference_for` is unused by `render_canonical_spelling`.

Deliberately not `Closes #1946`. #1974 shipped increments 0–4 and declined to close for the same reason: these are the measurement instrument and the empty seam, not the change. The behavioural work #1946 describes — `collect_canonical_edits` dropping a whole cis allele on a non-literal insertion payload, `lower_repeat_edits` undoing repeat notation mid-pipe, `demote_repeats_spanning_siblings` undoing a per-member decision no sibling context reaches — is entirely unstarted.

Rebased with `git rebase --onto origin/main 454a91e4` now that #1974 has merged. That replays this PR's one real commit and none of #1974's six already-squashed ones; it applied clean.

## The question

Relocating the three repeat mints into the render stage requires that stage to rebuild, from a settled member and a provider, the `ref_seq` the per-member pipeline was handed — and `ref_seq` is **not one thing**. It is the whole spliced transcript on `c.`/`r.`/`n.`, a growing window on `g.`/`m.`, and a genomic window on the intronic and junction-crossing paths. `insertion_to_repeat` walks outward bounded only by `ref_seq.len()`, so substituting one uniform window silently truncates a tract into a smaller copy count.

Until this PR that comparison could not be made at all, because nothing recorded what the pipeline was given.

## The first revision of this gate was vacuous, and that is the interesting part

The recorder's first form was a flat `Vec<(usize, u64)>` and the gate asked whether **some** entry in it matched the rebuilt reference:

```rust
seen.iter().any(|(l, d)| ...)
```

`seen` is the union of every reference the whole normalization used — one per member of a cis allele, one per growth attempt, one per `FERRO_ASSERT_IDEMPOTENT` verification pass, and one per recursive re-entry (`normalize_na_edit` calls itself from **eight** arms, always with the same `ref_seq`). On any row carrying a transcript-axis member the whole-transcript entry is somewhere in that union, so `any` matched for the same reason on every row and the gate reported `3903 / 3903` — re-measured on this base; it shipped as `3865/3865` against an older one.

`all` in its place reads `3761 / 3903`: **142 members diverge, every one on the multi-exon `cx` axis.** But `all` is not the fix — different members of a legitimate multi-member allele genuinely see different windows, so it would go red on correct behaviour.

**The sabotage the PR shipped with proved the assertion was *wired*, not that it was *tight*.** Mutating `mint_reference_for` to return one base short changes the *built* digest, so `any` finds nothing and the gate goes red. That test passes identically against an assertion that can never fail for any other reason. It is exactly how this shipped.

## What replaced it: per-call-site attribution

`NA_EDIT_REFERENCES` now records a struct rather than a pair:

```rust
pub struct NaEditReference {
    pub call: u32,            // monotonic, in call order
    pub parent: Option<u32>,  // the call this one recursed out of
    pub depth: u32,           // 0 at an entry point
    pub site: NaEditCallSite, // WHICH entry point handed this down
    pub len: usize,
    pub digest: u64,
}
```

`NaEditSiteGuard` is entered at each of the nine normalizer entry points that reach `normalize_na_edit` (`normalize_cds`, `normalize_tx`, `normalize_rna`, `normalize_intronic_{cds,tx}`, `normalize_boundary_spanning_{cds,tx}`, `normalize_in_grown_window`, `canonicalize_without_shifting`), and `NaEditFrameGuard` is held for the whole body of `normalize_na_edit` so recursive re-entries carry their parent's id and a depth. Both are RAII, because that function returns from a dozen places and several of them through `?`.

The gate then compares **sets, per frame, at depth 0 only**:

- `MintFrame::WholeTranscript` against the calls at `Cds` / `Tx` / `Rna`, asserted **equal in both directions**, and the witnessed set asserted to be a **singleton** — which is the "there is nothing to choose when the reference is served whole" claim stated directly instead of assumed.
- `MintFrame::GenomicWindow` against the calls at `GrownWindow` / `UnshiftedWindow`, reported.

Set equality is what makes a *mis-attributed* entry fail: a junction-crossing window filed under `Cds` lands in the witnessed set and the mint has nothing to match it with.

## The 142 `cx` members: provably fine, and the real gap is now named

Every one of those 142 sits on a row that records **both** frames. `NM_TESTX.1:c.6_11inv` records

```
Cds@d0#0=20  BoundarySpanning@d0#1=206  Cds@d0#2=20  BoundarySpanning@d0#3=206
```

because `normalize_cds` tries the 20-base spliced transcript and then re-normalizes across the exon junction in a ~200-base genomic window. The mint's whole-transcript rebuild agrees with the `Cds` call **byte-for-byte**; the 206 belongs to a call site the mint does not model at all.

Measured containment: the 68 distinct inputs behind those 142 members are a **subset** (`comm -23` → 0) of the 74 inputs / 102 rows the repaired gate counts under `rows_using_an_unmodelled_frame`. So the divergence is fully explained by one gap, and that gap now has a name, a count, and a paragraph on `mint_reference_for` saying it is the next step rather than a widening to do in passing.

## What is asserted, and what is only reported

Unmodified tree:

```
MINT-REFERENCE whole-transcript sets equal on 2209 rows (0 mismatching);
genomic 1586/2344 at least as wide (0 unwitnessed);
681 members had no rebuildable reference across 625 rows;
102 rows used a frame the mint does not model, 0 of them with no modelled call at all;
0 unattributed calls; 7 rows held out
```

| assertion | why it is a property and not a number |
|---|---|
| whole-transcript sets equal, over 2209 rows | the reference is served whole on `c.`/`r.`/`n.`, so a rebuilt one has nothing to disagree about — and the pipeline cannot have used one the mint does not build |
| the witnessed whole-transcript set is a singleton | one normalization cannot be handed two different whole transcripts |
| `unattributed_calls == 0` | every recorded call is inside a known entry point, so the site selection is over a population somebody delimited |
| the recorder did not overflow its cap | a truncated set is indistinguishable from a mismatch |
| `tx_rows_compared > 0` | `0 of 0` cannot pass as a result |
| `ORACLE_TRIPPING_INPUTS` is shrink-only | an exemption for a row that stopped existing is how a held-out list rots into a blanket one |

The genomic half stays **reported**. It cannot be byte-equal by construction: the pipeline's window is centred on the *input* position, and the two do not even share a left edge — `normalize_in_grown_window` fetches from `start - w` where `mint_reference_for` fetches from `start - 1 - w`. Pinning today's ratio would make the count *be* the property.

## Two latent defects the cap assertion caught

Neither was visible in the shipped form, because an uncapped buffer cannot report truncation:

1. The gate never drained the recorder on the `normalize` **Err** path, so a refused row's references bled into the next row's comparison set.
2. `for row in dump(1)` evaluated `dump` **after** arming, so the entire corpus's own normalizations were recorded before the first comparison ran.

Both are fixed, and the fix is the assertion rather than the discipline.

## The gate is proved TIGHT, not merely wired

Each mutation applied, run, then restored — `shasum -a 256` equal to a pre-edit copy on all three files, checked. "Old gate" is the shipped `any()` over the flat union, replicated in the same binary so both are measured on one run.

| # | mutation | this gate | the shipped `any()` gate |
|---|---|---|---|
| 0 | unmodified | **GREEN** — 2209 rows compared, 0 mismatching | `3903 / 3903` — passes |
| 1 | mint returns one base short (the PR's own sabotage) | **RED** — 2209 / 2209 rows mismatch | `0 / 3903` — RED |
| 2a | mint returns the right length, wrong content (reversed) | **RED** — 2209 / 2209 rows mismatch | `0 / 3903` — RED |
| 2b | mint returns the **genomic window** — a reference the pipeline really used, at the wrong site | **RED** — 28 rows mismatch | `3851 / 3903` — RED |
| 3 | attribution mis-associated: `normalize_boundary_spanning_*`'s calls filed under `Cds` | **RED** — the singleton assertion fires: `NM_TESTX.1:c.6_11inv saw [20, 206]` | **blind** |

Row 3 is the one that separates them, and its "blind" is by construction rather than by measurement: the mutation changes only the `site` label, and the shipped gate reads `len` and `digest` only, so its input is byte-identical to row 0's. It is stated as a mechanism because the replica's counter never printed — the singleton assertion panics first. Everything else in the table is measured.

Row 2b is worth reading as a limit rather than a win: both gates catch it, and neither is a strict improvement on the other there (this one flags 28 rows, the old one 52 members). The tightening is row 3 and the vacuity at row 0.

## Seven review findings folded into the same pass

1. **`pub mod render` narrowed back to `pub(crate)`.** The module was widened to expose two test-only items, which put `render_canonical_spelling` and the module's design notes on the public documentation surface. Replaced with a `#[doc(hidden)] pub use render::{mint_reference_for, MintFrame, MintReference, MINT_WINDOW}` — exactly the four items the example needs, on the `ShuffleDirection` precedent in `src/lib.rs`.
2. **`MintReference::bases` said "upper-cased" and was not.** The **doc** was wrong, and fixing the code would have been worse: byte-equality with the pipeline is the property, and neither side case-folds a transcript (`normalize_cds` passes `transcript.sequence.as_bytes()`), while `normalize_in_grown_window` does not case-fold its genomic window either although `fetch_canonical_window` does. The field now states each path's own convention and why it must not impose one.
3. **`complete` was set from a 3'-clamped fetch and documented as "the complete reference".** Replaced by `at_sequence_start` / `at_sequence_end` with `is_whole_sequence()` over both, so the flag no longer claims more than it checks.
4. **The frame split keyed on `built.complete && built.offset == 0`.** That is safe only because `PAD_OFFSET` (256) exceeds `MINT_WINDOW` (100) — an accident. It now keys on a `MintFrame` derived from `CisKind`, which is the thing it means.
5. **A comment citing `2274` where everything else said `1586`.** Both figures belong to an earlier revision's base; the surrounding text now says so and stops mixing them with this one's.
6. **Rustdoc spliced mid-bullet-list** on `mint_reference_for` — the `# Measured` heading sat between the `c.` bullet and the `g.` bullet. Repaired, and the measured figures moved to the gate, so one measurement has one home.
7. **`NA_EDIT_REFERENCES` was an unbounded `Vec` that every debug normalization appended to.** Recording is now **off** unless a test holds a `NaEditReferenceRecording` guard, the buffer is capped at 4096 entries, and an overrun is reported by `na_edit_references_overflowed()` and asserted rather than silently truncating. Measured: the deepest single row records **21** entries.

## Verification

Run on the rebased tip, over `origin/main` at `9b6dcf87`, with **zero `Skipping:` lines** in the log — so the ClinVar, CMRG and Paraphase suites were armed rather than skipping green (`test_cmrg_exhaustive_benchmark` alone takes 99.6s).

| gate | `EXIT=` read back out of its own log |
|---|---|
| `cargo nextest run --features dev --no-fail-fast` | `EXIT=0` — **11279 run, 11279 passed**, 152 skipped |
| `cargo clippy --all-features --all-targets -- -D warnings` | `EXIT=0` |
| `cargo fmt --all --check` | `EXIT=0` |
| the gate test with `FERRO_ASSERT_IDEMPOTENT` / `_REPARSE` / `_IN_BOUNDS` armed | `EXIT=0`, every **asserted** figure unchanged |

**Flag stability, honestly.** Every asserted figure is identical armed and unarmed. One *reported* counter is not: `rows_using_an_unmodelled_frame` reads 102 unarmed and 103 armed, because the idempotency oracle's verification pass is a second normalization whose depth-0 calls are recorded too, and on one row it reaches a junction-crossing site the first pass did not. A counter over a union is exactly what stays flag-sensitive — which is the argument for asserting over per-site sets, restated as a measurement.

**What was NOT re-measured.** The `Representation-Change: none` claim below rests on a diff-scope argument rather than on a fresh two-revision corpus dump: `src/normalize/mod.rs` and `src/normalize/render.rs` have **zero removed lines** against `origin/main`, every `NA_EDIT_*` symbol is referenced only inside the recorder block (`mod.rs:2215-2391`), the nine added statements inside normalizer bodies are guard bindings that write a thread-local and nothing reads, and the example's whole diff is one hunk **inside `mod tests`** — `main`, `dump` and every family builder are untouched.

Representation-Change: none. 0 corpus rows move. `mint_reference_for` is unused by `render_canonical_spelling`; the recorder is `#[cfg(debug_assertions)]`, disarmed by default and write-only; and the nine `NaEditSiteGuard`s only set a thread-local `Cell` that nothing in the normalizer reads.
