### PR TITLE
docs: correct measurement-doctrine advice on pub(crate) reachability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1056,16 +1056,55 @@ derived from `MAX_CANONICAL_WINDOW`), raised from `1024` by #1899. The corpus's 
 between". The cap moved, both cores landed on the same side, and `1100 > 1024` kept the guard
 green. It even carries a comment instructing the reader to update the literal if the constant
 moves; **that comment is the defect, not a mitigation.** A guard that restates the value it guards
-cannot observe that value changing. Import the constant. If it is private, make it `pub(crate)` —
-that is cheaper than the class of failure it buys out of. Filed as #1925.
+cannot observe that value changing. Import the constant. `dump_normalized_corpus` is a genuine
+`[[example]]`, so it links the library as an **external crate** (`use ferro_hgvs::…`) and can see
+only the library's `pub` API — **`pub(crate)` is unreachable from there.** A private item must be
+made `pub`, with `#[doc(hidden)]` on the re-export to keep it off the public documentation
+surface; `src/lib.rs`'s `ShuffleDirection` re-export is the worked pattern.
 
-**2. A zero whose instrument cannot vary the property.** `examples/dump_normalized_corpus.rs`
-has now been blind six times — geometry (#1456), scale (#1460), sequence structure (#1517),
-transcript geometry (#1478), molecule type (#1606), and reversed ranges (#1917) — and its own
-header records the governing fact: **fixing one blindness does not reveal the next.** Each time,
-a `0` was available to quote as safety. So before quoting one, **name the property your change
-keys on and show the generator can vary it.** A zero you cannot attribute to the change is a
+**Do not gate such a re-export behind `dev`.** The tree has already decided that, for this very
+constant, and `src/normalize/mod.rs` gives the reason in as many words: "**NOT gated on `dev`**:
+… a constant present in only some builds re-creates that gap for anyone building without the
+feature." A feature gate buys back the documentation surface at the price of reintroducing the
+restated literal wherever the feature is off — which is the failure this shape is about, moved
+rather than removed. Where a gate genuinely is unavoidable the consumer must **refuse** in a build
+that lacks the item rather than report a zero: `partition_blocks_cut` is `#[cfg(debug_assertions)]`
+and `measure_spec_conformance_per_arm.rs` does exactly that.
+
+Making the item `pub` is cheaper than the class of failure it buys out of. Filed as #1925, which
+made `MAX_CANONICAL_BLOCK` `pub` and imported it here.
+
+**2. A zero whose instrument cannot vary the property.** `examples/dump_normalized_corpus.rs` has
+been blind in each of the ways below, and its own header records the governing fact: **fixing one
+blindness does not reveal the next.**
+
+This is the maintained list — the generator's header points here for it, and states no count of
+its own on purpose, because **a count of blindnesses is itself a number that goes stale every time
+the thing it counts happens** (#1947), which is the failure this whole section is about. So this
+list carries no total either. **Add a row; do not increment a number.**
+
+| blind to | issue | recorded in `dump_normalized_corpus.rs` |
+|---|---|---|
+| member geometry | #1456 | header item 3 |
+| scale — 20-mer cores never reach the split cap | #1460 | header item 4 |
+| sequence structure — a random core cannot be asked for a coincidence pattern | #1517 | header item 5 |
+| transcript geometry — a single exon with `CDS_START = 1` | #1478 | header, the chain under item 6 |
+| molecule type — no `p.` row at all until the protein axis | #1606 | header item 6 |
+| reversed ranges | #1917 | header, the #1947 correction |
+| a repeat placed beside a sibling it could collide with | #1749 | the `repeat_beside_a_sibling` family comment |
+| that family shipping able to build only *growing* repeats | #1752 | header, the #1947 correction |
+| direction — every lone `delins` was equal-length or a net insertion, so a net-deletion rule was structurally unreachable | #1610 | the `lone_net_deletion_delins` family comment |
+
+Each time, a `0` was available to quote as safety. So before quoting one, **name the property your
+change keys on and show the generator can vary it.** A zero you cannot attribute to the change is a
 claim about the instrument. Report a structural zero *as* structural, in those words.
+
+**The ordinals written inside the generator disagree with each other and with this table, and that
+is settled rather than pending.** `PROTEIN_FAMILIES` calls itself "the fourth instance" and
+`repeat_beside_a_sibling` "the fifth", each counting a chain that omits #1517 and #1917;
+`lone_net_deletion_delins` then declines to claim an ordinal at all, on the stated ground that "a
+third restatement is how that drift got started". Do not renumber them into agreement — that is
+the increment this section forbids. Read those ordinals as prose and this table as the inventory.
 
 **3. A rule generalised from the one case you reproduced.** #1917 reported an underflow and stated
 the rule as "any reversed range whose span exceeds `window_size`". Measured, the failure is three

--- a/src/conformance/protein_corpus.rs
+++ b/src/conformance/protein_corpus.rs
@@ -49,11 +49,15 @@
 //!
 //! # The structural-blindness audit
 //!
-//! Five blindnesses have been found in this repository's generators, each
-//! invisible until the one before it was fixed. A protein stratum is exactly the
-//! kind of generator that acquires a sixth, so every property it varies is named
-//! here **and demonstrated by a test**, and every property it provably cannot
-//! reach is stated as a limit rather than left to read as coverage.
+//! Structural blindnesses have been found in this repository's generators
+//! repeatedly, each invisible until the one before it was fixed; the maintained
+//! inventory is `CLAUDE.md`'s, under "Assert the property. Measure the count.
+//! Never let a count BE the property". **No count is restated here** — one would
+//! go stale on the next instance, which is the very failure that section is
+//! about. A protein stratum is exactly the kind of generator that acquires
+//! another, so every property it varies is named here **and demonstrated by a
+//! test**, and every property it provably cannot reach is stated as a limit
+//! rather than left to read as coverage.
 //!
 //! | property | varied by | demonstrated by |
 //! |---|---|---|
@@ -102,7 +106,8 @@
 //! That is measured rather than assumed: `shape_is_inert_for_the_protein_axis`
 //! in `tests/it/protein_conformance_axis.rs` reports whether any row's outcome
 //! differs across the three geometries. A measured inertness is a fact about the
-//! axis worth recording; an *assumed* one would be the sixth blindness.
+//! axis worth recording; an *assumed* one would be another entry on the
+//! blindness inventory.
 //!
 //! # What a green run does NOT say
 //!

--- a/tests/it/protein_conformance_axis.rs
+++ b/tests/it/protein_conformance_axis.rs
@@ -830,8 +830,9 @@ fn the_indeterminate_column_has_a_non_empty_denominator() {
 /// no codons of its own", from which it follows that the exon layout under a
 /// protein should not change what a `p.` description normalizes to. That is a
 /// claim about the axis, and this test measures it rather than assuming it —
-/// assuming it would be the sixth structural blindness, since the corpus varies
-/// phase and strand precisely so a junction-sensitive defect *could* show.
+/// assuming it would be another entry on `CLAUDE.md`'s structural-blindness
+/// inventory, since the corpus varies phase and strand precisely so a
+/// junction-sensitive defect *could* show.
 ///
 /// The assertion is on the measured verdict, so if the answer ever changes the
 /// test fails and the corpus's geometry dimension stops being decoration.


### PR DESCRIPTION
Closes #1961.

Representation-Change: none

## The defect

The "Assert the property. Measure the count. Never let a count BE the property" section of `CLAUDE.md` (added by #1927) advised, of a constant an example needs to read:

> Import the constant. If it is private, make it `pub(crate)` …

That does not work for the case the section is about. `dump_normalized_corpus` is a genuine `[[example]]` in `Cargo.toml`, so it links the library as an **external crate** (`use ferro_hgvs::…`). `pub(crate)` is not reachable from an external crate, so following the advice leaves the example unable to see the constant.

## The fix

State the reachable options accurately: the item must be `pub`, optionally with `#[doc(hidden)]` or a `dev`-feature-gated re-export to keep it off the public documentation surface. This is exactly what #1925 did — it made `MAX_CANONICAL_BLOCK` `pub` (`src/normalize/merge.rs`, re-exported `pub use` from `src/normalize/mod.rs`) and imported it into the example.

### Verification of the reachability claim

- `dump_normalized_corpus` is `[[example]]` in `Cargo.toml` (`name = "dump_normalized_corpus"`, `required-features = ["dev"]`).
- The example reads the constant as an external-crate import: `use ferro_hgvs::normalize::{…, MAX_CANONICAL_BLOCK};`.
- `MAX_CANONICAL_BLOCK` is `pub const` in `src/normalize/merge.rs` and `pub use`-re-exported from `src/normalize/mod.rs` — i.e. `pub`, never `pub(crate)`. A `pub(crate)` item would not compile through that `use`.

## Second, smaller item (reconciled now that #1923 has merged)

The same section said the generator had been "blind six times", but the corpus header — rewritten by #1947 to state no count and defer to `CLAUDE.md` as the maintained list — names a further blindness: the `repeat_beside_a_sibling` family, which first shipped able to build only *growing* repeats (#1752). The maintained list is updated to seven and that instance added.

## Unchanged on purpose

- The two adjudication tables and the ruling ledger are untouched; `claude_md_adjudication_tables` parses only those tables and is unaffected.
- No `src/`, `tests/`, or example source changes — docs/comment only.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo nextest run --features dev` — `11226 passed, 155 skipped, 0 failed` (includes `claude_md_adjudication_tables::*` and `dump_normalized_corpus::*`).